### PR TITLE
Avro string for ClickHouse String

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -1130,17 +1130,18 @@ The table below shows supported data types and how they match ClickHouse [data t
 | `boolean`, `int`, `long`, `float`, `double` | [Int64](../sql-reference/data-types/int-uint.md), [UInt64](../sql-reference/data-types/int-uint.md)                   | `long`                       |
 | `boolean`, `int`, `long`, `float`, `double` | [Float32](../sql-reference/data-types/float.md)                                                                       | `float`                      |
 | `boolean`, `int`, `long`, `float`, `double` | [Float64](../sql-reference/data-types/float.md)                                                                       | `double`                     |
-| `bytes`, `string`, `fixed`, `enum`          | [String](../sql-reference/data-types/string.md)                                                                       | `bytes`                      |
+| `bytes`, `string`, `fixed`, `enum`          | [String](../sql-reference/data-types/string.md)                                                                       | `bytes` or `string` \*       |
 | `bytes`, `string`, `fixed`                  | [FixedString(N)](../sql-reference/data-types/fixedstring.md)                                                          | `fixed(N)`                   |
 | `enum`                                      | [Enum(8\|16)](../sql-reference/data-types/enum.md)                                                                    | `enum`                       |
 | `array(T)`                                  | [Array(T)](../sql-reference/data-types/array.md)                                                                      | `array(T)`                   |
 | `union(null, T)`, `union(T, null)`          | [Nullable(T)](../sql-reference/data-types/date.md)                                                                    | `union(null, T)`             |
 | `null`                                      | [Nullable(Nothing)](../sql-reference/data-types/special-data-types/nothing.md)                                        | `null`                       |
-| `int (date)` \*                             | [Date](../sql-reference/data-types/date.md)                                                                           | `int (date)` \*              |
-| `long (timestamp-millis)` \*                | [DateTime64(3)](../sql-reference/data-types/datetime.md)                                                              | `long (timestamp-millis)` \* |
-| `long (timestamp-micros)` \*                | [DateTime64(6)](../sql-reference/data-types/datetime.md)                                                              | `long (timestamp-micros)` \* |
+| `int (date)` \**                            | [Date](../sql-reference/data-types/date.md)                                                                           | `int (date)` \**             |
+| `long (timestamp-millis)` \**               | [DateTime64(3)](../sql-reference/data-types/datetime.md)                                                              | `long (timestamp-millis)` \* |
+| `long (timestamp-micros)` \**               | [DateTime64(6)](../sql-reference/data-types/datetime.md)                                                              | `long (timestamp-micros)` \* |
 
-\* [Avro logical types](https://avro.apache.org/docs/current/spec.html#Logical+Types)
+\* `bytes` is default, controlled by [output_format_avro_string_column_pattern](../operations/settings/settings.md#settings-output_format_avro_string_column_pattern)
+\** [Avro logical types](https://avro.apache.org/docs/current/spec.html#Logical+Types)
 
 Unsupported Avro data types: `record` (non-root), `map`
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1738,7 +1738,7 @@ Default value: 0.
 
 ## optimize_functions_to_subcolumns {#optimize-functions-to-subcolumns}
 
-Enables or disables optimization by transforming some functions to reading subcolumns. This reduces the amount of data to read. 
+Enables or disables optimization by transforming some functions to reading subcolumns. This reduces the amount of data to read.
 
 These functions can be transformed:
 
@@ -1968,6 +1968,13 @@ Type: unsigned int
 Possible values: 32 (32 bytes) - 1073741824 (1 GiB)
 
 Default value: 32768 (32 KiB)
+
+## output_format_avro_string_column_pattern {#output_format_avro_string_column_pattern}
+
+Regexp of column names of type String to output as Avro `string` (default is `bytes`).
+RE2 syntax is supported.
+
+Type: string
 
 ## format_avro_schema_registry_url {#format_avro_schema_registry_url}
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -524,6 +524,7 @@ class IColumn;
     M(Bool, input_format_values_accurate_types_of_literals, true, "For Values format: when parsing and interpreting expressions using template, check actual type of literal to avoid possible overflow and precision issues.", 0) \
     M(Bool, input_format_avro_allow_missing_fields, false, "For Avro/AvroConfluent format: when field is not found in schema use default value instead of error", 0) \
     M(URI, format_avro_schema_registry_url, "", "For AvroConfluent format: Confluent Schema Registry URL.", 0) \
+    M(String, output_format_avro_string_column_pattern, "", "For Avro format: regexp of String columns to select as AVRO string.", 0) \
     \
     M(Bool, output_format_json_quote_64bit_integers, true, "Controls quoting of 64-bit integers in JSON output format.", 0) \
     \

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -60,6 +60,7 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.avro.output_codec = settings.output_format_avro_codec;
     format_settings.avro.output_sync_interval = settings.output_format_avro_sync_interval;
     format_settings.avro.schema_registry_url = settings.format_avro_schema_registry_url.toString();
+    format_settings.avro.string_column_pattern = settings.output_format_avro_string_column_pattern.toString();
     format_settings.csv.allow_double_quotes = settings.format_csv_allow_double_quotes;
     format_settings.csv.allow_single_quotes = settings.format_csv_allow_single_quotes;
     format_settings.csv.crlf_end_of_line = settings.output_format_csv_crlf_end_of_line;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -61,6 +61,7 @@ struct FormatSettings
         String output_codec;
         UInt64 output_sync_interval = 16 * 1024;
         bool allow_missing_fields = false;
+        String string_column_pattern;
     } avro;
 
     struct CSV
@@ -169,4 +170,3 @@ struct FormatSettings
 };
 
 }
-

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -41,6 +41,7 @@
 #include <avro/ValidSchema.hh>
 #include <avro/Writer.hh>
 
+#include <re2/re2.h>
 
 namespace DB
 {
@@ -48,7 +49,35 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
     extern const int BAD_ARGUMENTS;
+    extern const int CANNOT_COMPILE_REGEXP;
 }
+
+class AvroSerializerTraits
+{
+public:
+    bool isStringAsString(const String & column_name)
+    {
+        return RE2::PartialMatch/*FullMatch*/(column_name, string_to_string_regexp);
+    }
+
+    AvroSerializerTraits(const FormatSettings & settings_)
+        : string_to_string_regexp(settings_.avro.string_column_pattern)
+    {
+        if (!string_to_string_regexp.ok())
+            throw DB::Exception(
+                "Avro: cannot compile re2: " + settings_.avro.string_column_pattern + ", error: " + string_to_string_regexp.error()
+                    + ". Look at https://github.com/google/re2/wiki/Syntax for reference.",
+                DB::ErrorCodes::CANNOT_COMPILE_REGEXP);
+    }
+
+    ~AvroSerializerTraits()
+    {
+    }
+
+private:
+    const RE2 string_to_string_regexp;
+};
+
 
 class OutputStreamWriteBufferAdapter : public avro::OutputStream
 {
@@ -75,7 +104,7 @@ private:
 };
 
 
-AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeFn(DataTypePtr data_type, size_t & type_name_increment)
+AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeFn(DataTypePtr data_type, size_t & type_name_increment, const String & column_name)
 {
     ++type_name_increment;
 
@@ -161,11 +190,20 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
             }};
         }
         case TypeIndex::String:
-            return {avro::BytesSchema(), [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
-            {
-                const StringRef & s = assert_cast<const ColumnString &>(column).getDataAt(row_num);
-                encoder.encodeBytes(reinterpret_cast<const uint8_t *>(s.data), s.size);
-            }};
+            if (traits->isStringAsString(column_name))
+                return {avro::StringSchema(), [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
+                           {
+                               const StringRef & s = assert_cast<const ColumnString &>(column).getDataAt(row_num);
+                               encoder.encodeString(s.toString());
+                           }
+                };
+            else
+                return {avro::BytesSchema(), [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
+                           {
+                               const StringRef & s = assert_cast<const ColumnString &>(column).getDataAt(row_num);
+                               encoder.encodeBytes(reinterpret_cast<const uint8_t *>(s.data), s.size);
+                           }
+                };
         case TypeIndex::FixedString:
         {
             auto size = data_type->getSizeOfValueInMemory();
@@ -223,7 +261,7 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
         case TypeIndex::Array:
         {
             const auto & array_type = assert_cast<const DataTypeArray &>(*data_type);
-            auto nested_mapping = createSchemaWithSerializeFn(array_type.getNestedType(), type_name_increment);
+            auto nested_mapping = createSchemaWithSerializeFn(array_type.getNestedType(), type_name_increment, column_name);
             auto schema = avro::ArraySchema(nested_mapping.schema);
             return {schema, [nested_mapping](const IColumn & column, size_t row_num, avro::Encoder & encoder)
             {
@@ -249,7 +287,7 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
         case TypeIndex::Nullable:
         {
             auto nested_type = removeNullable(data_type);
-            auto nested_mapping = createSchemaWithSerializeFn(nested_type, type_name_increment);
+            auto nested_mapping = createSchemaWithSerializeFn(nested_type, type_name_increment, column_name);
             if (nested_type->getTypeId() == TypeIndex::Nothing)
             {
                 return nested_mapping;
@@ -278,7 +316,7 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
         case TypeIndex::LowCardinality:
         {
             const auto & nested_type = removeLowCardinality(data_type);
-            auto nested_mapping = createSchemaWithSerializeFn(nested_type, type_name_increment);
+            auto nested_mapping = createSchemaWithSerializeFn(nested_type, type_name_increment, column_name);
             return {nested_mapping.schema, [nested_mapping](const IColumn & column, size_t row_num, avro::Encoder & encoder)
             {
                 const auto & col = assert_cast<const ColumnLowCardinality &>(column);
@@ -294,7 +332,8 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
 }
 
 
-AvroSerializer::AvroSerializer(const ColumnsWithTypeAndName & columns)
+AvroSerializer::AvroSerializer(const ColumnsWithTypeAndName & columns, std::unique_ptr<AvroSerializerTraits> traits_)
+    : traits(std::move(traits_))
 {
     avro::RecordSchema record_schema("row");
 
@@ -303,7 +342,7 @@ AvroSerializer::AvroSerializer(const ColumnsWithTypeAndName & columns)
     {
         try
         {
-            auto field_mapping = createSchemaWithSerializeFn(column.type, type_name_increment);
+            auto field_mapping = createSchemaWithSerializeFn(column.type, type_name_increment, column.name);
             serialize_fns.push_back(field_mapping.serialize);
             //TODO: verify name starts with A-Za-z_
             record_schema.addField(column.name, field_mapping.schema);
@@ -314,7 +353,7 @@ AvroSerializer::AvroSerializer(const ColumnsWithTypeAndName & columns)
             throw;
         }
     }
-    schema.setSchema(record_schema);
+    valid_schema.setSchema(record_schema);
 }
 
 void AvroSerializer::serializeRow(const Columns & columns, size_t row_num, avro::Encoder & encoder)
@@ -350,7 +389,7 @@ AvroRowOutputFormat::AvroRowOutputFormat(
     WriteBuffer & out_, const Block & header_, const RowOutputFormatParams & params_, const FormatSettings & settings_)
     : IRowOutputFormat(header_, out_, params_)
     , settings(settings_)
-    , serializer(header_.getColumnsWithTypeAndName())
+    , serializer(header_.getColumnsWithTypeAndName(), std::make_unique<AvroSerializerTraits>(settings))
     , file_writer(
         std::make_unique<OutputStreamWriteBufferAdapter>(out_),
         serializer.getSchema(),

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -55,12 +55,7 @@ namespace ErrorCodes
 class AvroSerializerTraits
 {
 public:
-    bool isStringAsString(const String & column_name)
-    {
-        return RE2::FullMatch(column_name, string_to_string_regexp);
-    }
-
-    AvroSerializerTraits(const FormatSettings & settings_)
+    explicit AvroSerializerTraits(const FormatSettings & settings_)
         : string_to_string_regexp(settings_.avro.string_column_pattern)
     {
         if (!string_to_string_regexp.ok())
@@ -68,6 +63,11 @@ public:
                 "Avro: cannot compile re2: " + settings_.avro.string_column_pattern + ", error: " + string_to_string_regexp.error()
                     + ". Look at https://github.com/google/re2/wiki/Syntax for reference.",
                 DB::ErrorCodes::CANNOT_COMPILE_REGEXP);
+    }
+
+    bool isStringAsString(const String & column_name)
+    {
+        return RE2::FullMatch(column_name, string_to_string_regexp);
     }
 
     ~AvroSerializerTraits()

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -70,9 +70,7 @@ public:
         return RE2::FullMatch(column_name, string_to_string_regexp);
     }
 
-    ~AvroSerializerTraits()
-    {
-    }
+    ~AvroSerializerTraits() = default;
 
 private:
     const RE2 string_to_string_regexp;

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -57,7 +57,7 @@ class AvroSerializerTraits
 public:
     bool isStringAsString(const String & column_name)
     {
-        return RE2::PartialMatch/*FullMatch*/(column_name, string_to_string_regexp);
+        return RE2::FullMatch(column_name, string_to_string_regexp);
     }
 
     AvroSerializerTraits(const FormatSettings & settings_)
@@ -192,17 +192,17 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
         case TypeIndex::String:
             if (traits->isStringAsString(column_name))
                 return {avro::StringSchema(), [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
-                           {
-                               const StringRef & s = assert_cast<const ColumnString &>(column).getDataAt(row_num);
-                               encoder.encodeString(s.toString());
-                           }
+                    {
+                        const StringRef & s = assert_cast<const ColumnString &>(column).getDataAt(row_num);
+                        encoder.encodeString(s.toString());
+                    }
                 };
             else
                 return {avro::BytesSchema(), [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
-                           {
-                               const StringRef & s = assert_cast<const ColumnString &>(column).getDataAt(row_num);
-                               encoder.encodeBytes(reinterpret_cast<const uint8_t *>(s.data), s.size);
-                           }
+                    {
+                        const StringRef & s = assert_cast<const ColumnString &>(column).getDataAt(row_num);
+                        encoder.encodeBytes(reinterpret_cast<const uint8_t *>(s.data), s.size);
+                    }
                 };
         case TypeIndex::FixedString:
         {

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.h
@@ -18,11 +18,13 @@ namespace DB
 {
 class WriteBuffer;
 
+class AvroSerializerTraits;
+
 class AvroSerializer
 {
 public:
-    AvroSerializer(const ColumnsWithTypeAndName & columns);
-    const avro::ValidSchema & getSchema() const { return schema; }
+    AvroSerializer(const ColumnsWithTypeAndName & columns, std::unique_ptr<AvroSerializerTraits>);
+    const avro::ValidSchema & getSchema() const { return valid_schema; }
     void serializeRow(const Columns & columns, size_t row_num, avro::Encoder & encoder);
 
 private:
@@ -34,10 +36,11 @@ private:
     };
 
     /// Type names for different complex types (e.g. enums, fixed strings) must be unique. We use simple incremental number to give them different names.
-    static SchemaWithSerializeFn createSchemaWithSerializeFn(DataTypePtr data_type, size_t & type_name_increment);
+    /*static*/ SchemaWithSerializeFn createSchemaWithSerializeFn(DataTypePtr data_type, size_t & type_name_increment, const String & column_name);
 
     std::vector<SerializeFn> serialize_fns;
-    avro::ValidSchema schema;
+    avro::ValidSchema valid_schema;
+    std::unique_ptr<AvroSerializerTraits> traits;
 };
 
 class AvroRowOutputFormat : public IRowOutputFormat

--- a/tests/queries/0_stateless/01060_avro.reference
+++ b/tests/queries/0_stateless/01060_avro.reference
@@ -58,3 +58,9 @@ not found
 0
 1000
 147
+= string column pattern
+"русская строка"
+Ok
+1	0
+1	1
+1	1

--- a/tests/queries/0_stateless/01060_avro.sh
+++ b/tests/queries/0_stateless/01060_avro.sh
@@ -89,3 +89,22 @@ ${CLICKHOUSE_LOCAL} -q "select toInt64(number) as a from numbers(1000)  format A
 
 # type supported via conversion
 ${CLICKHOUSE_LOCAL}  -q "select toInt16(123) as a format Avro" | wc -c | tr -d ' '
+
+echo '=' string column pattern
+${CLICKHOUSE_LOCAL} -q "select 'русская строка' as a  format Avro SETTINGS output_format_avro_string_column_pattern = 'a'" | ${CLICKHOUSE_LOCAL} --input-format Avro --output-format CSV -S "a String" -q 'select * from table'
+
+# it is expected that invalid UTF-8 can be created
+${CLICKHOUSE_LOCAL} -q "select '\x61\xF0\x80\x80\x80b' as a  format Avro" > /dev/null && echo Ok
+
+A_NEEDLE="'\"name\":\"a\",\"type\":\"string\"'"
+B_NEEDLE="'\"name\":\"b\",\"type\":\"string\"'"
+PATTERNQUERY="select 'русская строка' as a, 'русская строка' as b format Avro SETTINGS output_format_avro_string_column_pattern ="
+
+PATTERNPATTERN="'a'"
+${CLICKHOUSE_LOCAL} -q "$PATTERNQUERY $PATTERNPATTERN" | ${CLICKHOUSE_LOCAL} --structure "avro_raw String" --input-format LineAsString  -q "select countSubstrings(avro_raw, $A_NEEDLE), countSubstrings(avro_raw, $B_NEEDLE) from table"
+
+PATTERNPATTERN="'a|b'"
+${CLICKHOUSE_LOCAL} -q "$PATTERNQUERY $PATTERNPATTERN" | ${CLICKHOUSE_LOCAL} --structure "avro_raw String" --input-format LineAsString  -q "select countSubstrings(avro_raw, $A_NEEDLE), countSubstrings(avro_raw, $B_NEEDLE) from table"
+
+PATTERNPATTERN="'.*'"
+${CLICKHOUSE_LOCAL} -q "$PATTERNQUERY $PATTERNPATTERN" | ${CLICKHOUSE_LOCAL} --structure "avro_raw String" --input-format LineAsString  -q "select countSubstrings(avro_raw, $A_NEEDLE), countSubstrings(avro_raw, $B_NEEDLE) from table"

--- a/tests/queries/0_stateless/01060_avro.sh
+++ b/tests/queries/0_stateless/01060_avro.sh
@@ -101,10 +101,10 @@ B_NEEDLE="'\"name\":\"b\",\"type\":\"string\"'"
 PATTERNQUERY="select 'русская строка' as a, 'русская строка' as b format Avro SETTINGS output_format_avro_string_column_pattern ="
 
 PATTERNPATTERN="'a'"
-${CLICKHOUSE_LOCAL} -q "$PATTERNQUERY $PATTERNPATTERN" | ${CLICKHOUSE_LOCAL} --structure "avro_raw String" --input-format LineAsString  -q "select countSubstrings(avro_raw, $A_NEEDLE), countSubstrings(avro_raw, $B_NEEDLE) from table"
+${CLICKHOUSE_LOCAL} -q "$PATTERNQUERY $PATTERNPATTERN" | tr -d '\n' | ${CLICKHOUSE_LOCAL} --structure "avro_raw String" --input-format LineAsString  -q "select countSubstrings(avro_raw, $A_NEEDLE), countSubstrings(avro_raw, $B_NEEDLE) from table"
 
 PATTERNPATTERN="'a|b'"
-${CLICKHOUSE_LOCAL} -q "$PATTERNQUERY $PATTERNPATTERN" | ${CLICKHOUSE_LOCAL} --structure "avro_raw String" --input-format LineAsString  -q "select countSubstrings(avro_raw, $A_NEEDLE), countSubstrings(avro_raw, $B_NEEDLE) from table"
+${CLICKHOUSE_LOCAL} -q "$PATTERNQUERY $PATTERNPATTERN" | tr -d '\n' | ${CLICKHOUSE_LOCAL} --structure "avro_raw String" --input-format LineAsString  -q "select countSubstrings(avro_raw, $A_NEEDLE), countSubstrings(avro_raw, $B_NEEDLE) from table"
 
 PATTERNPATTERN="'.*'"
-${CLICKHOUSE_LOCAL} -q "$PATTERNQUERY $PATTERNPATTERN" | ${CLICKHOUSE_LOCAL} --structure "avro_raw String" --input-format LineAsString  -q "select countSubstrings(avro_raw, $A_NEEDLE), countSubstrings(avro_raw, $B_NEEDLE) from table"
+${CLICKHOUSE_LOCAL} -q "$PATTERNQUERY $PATTERNPATTERN" | tr -d '\n' | ${CLICKHOUSE_LOCAL} --structure "avro_raw String" --input-format LineAsString  -q "select countSubstrings(avro_raw, $A_NEEDLE), countSubstrings(avro_raw, $B_NEEDLE) from table"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added `output_format_avro_string_column_pattern` setting to put specified String columns to Avro as string instead of default bytes. Implements [#22414](https://github.com/ClickHouse/ClickHouse/issues/22414).

Detailed description / Documentation draft:
output_format_avro_string_column_pattern setting to control if a String column put to Avro as bytes (default) or as string.
