### PR TITLE
Check hash function at table creation

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -130,6 +130,7 @@ struct Settings;
     M(UInt64, max_concurrent_queries, 0, "Max number of concurrently executed queries related to the MergeTree table (0 - disabled). Queries will still be limited by other max_concurrent_queries settings.", 0) \
     M(UInt64, min_marks_to_honor_max_concurrent_queries, 0, "Minimal number of marks to honor the MergeTree-level's max_concurrent_queries (0 - disabled). Queries will still be limited by other max_concurrent_queries settings.", 0) \
     M(UInt64, min_bytes_to_rebalance_partition_over_jbod, 0, "Minimal amount of bytes to enable part rebalance over JBOD array (0 - disabled).", 0) \
+    M(Bool, check_sample_column_is_correct, true, "Check columns or columns by hash for sampling are unsigned integer.", 0) \
     \
     /** Experimental/work in progress feature. Unsafe for production. */ \
     M(UInt64, part_moves_between_shards_enable, 0, "Experimental/Incomplete feature to move parts between shards. Does not take into account sharding expressions.", 0) \

--- a/tests/queries/0_stateless/00907_set_index_with_nullable_and_low_cardinality_bug.sql
+++ b/tests/queries/0_stateless/00907_set_index_with_nullable_and_low_cardinality_bug.sql
@@ -8,8 +8,7 @@ CREATE TABLE null_lc_set_index (
   INDEX test_user_idx (user) TYPE set(0) GRANULARITY 8192
 ) ENGINE=MergeTree
   PARTITION BY toYYYYMMDD(timestamp)
-  ORDER BY (timestamp, action, cityHash64(user))
-  SAMPLE BY cityHash64(user);
+  ORDER BY (timestamp, action, cityHash64(user));
 INSERT INTO null_lc_set_index VALUES (1550883010, 'subscribe', 'alice');
 INSERT INTO null_lc_set_index VALUES (1550883020, 'follow', 'bob');
 

--- a/tests/queries/0_stateless/01942_create_table_with_sample.sql
+++ b/tests/queries/0_stateless/01942_create_table_with_sample.sql
@@ -1,0 +1,15 @@
+CREATE DATABASE IF NOT EXISTS test_sample;
+
+CREATE TABLE IF NOT EXISTS test_sample.sample_incorrect
+(`x` UUID)
+ENGINE = MergeTree
+ORDER BY tuple(x)
+SAMPLE BY x;  -- { serverError 59 }
+
+CREATE TABLE IF NOT EXISTS test_sample.sample_correct
+(`x` String)
+ENGINE = MergeTree
+ORDER BY tuple(sipHash64(x))
+SAMPLE BY sipHash64(x);
+
+DROP DATABASE test_sample;

--- a/tests/queries/0_stateless/01942_create_table_with_sample.sql
+++ b/tests/queries/0_stateless/01942_create_table_with_sample.sql
@@ -6,10 +6,13 @@ ENGINE = MergeTree
 ORDER BY tuple(x)
 SAMPLE BY x;  -- { serverError 59 }
 
+DROP TABLE IF EXISTS test_sample.sample_correct;
 CREATE TABLE IF NOT EXISTS test_sample.sample_correct
 (`x` String)
 ENGINE = MergeTree
 ORDER BY tuple(sipHash64(x))
 SAMPLE BY sipHash64(x);
+
+DROP TABLE test_sample.sample_correct;
 
 DROP DATABASE test_sample;

--- a/tests/queries/0_stateless/01942_create_table_with_sample.sql
+++ b/tests/queries/0_stateless/01942_create_table_with_sample.sql
@@ -1,18 +1,14 @@
-CREATE DATABASE IF NOT EXISTS test_sample;
-
-CREATE TABLE IF NOT EXISTS test_sample.sample_incorrect
+CREATE TABLE IF NOT EXISTS sample_incorrect
 (`x` UUID)
 ENGINE = MergeTree
 ORDER BY tuple(x)
 SAMPLE BY x;  -- { serverError 59 }
 
-DROP TABLE IF EXISTS test_sample.sample_correct;
-CREATE TABLE IF NOT EXISTS test_sample.sample_correct
+DROP TABLE IF EXISTS sample_correct;
+CREATE TABLE IF NOT EXISTS sample_correct
 (`x` String)
 ENGINE = MergeTree
 ORDER BY tuple(sipHash64(x))
 SAMPLE BY sipHash64(x);
 
-DROP TABLE test_sample.sample_correct;
-
-DROP DATABASE test_sample;
+DROP TABLE sample_correct;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check hash function at table creation, not at sampling.
Add settings in MergeTreeSettings, if someone create a table with incorrect sampling column but sampling never be used, disable this settings for starting the server without exception.

closes #822