### PR TITLE
Activate current host as ephemeral node in zookeeper

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1413,11 +1413,12 @@ if (ThreadFuzzer::instance().isEffective())
         {
             /// DDL worker should be started after all tables were loaded
             String ddl_zookeeper_path = config().getString("distributed_ddl.path", "/clickhouse/task_queue/ddl/");
+            String host_zookeeper_path = config().getString("distributed_ddl.host_path", "/clickhouse/task_queue/host/");
             int pool_size = config().getInt("distributed_ddl.pool_size", 1);
             if (pool_size < 1)
                 throw Exception("distributed_ddl.pool_size should be greater then 0", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
             global_context->setDDLWorker(std::make_unique<DDLWorker>(pool_size, ddl_zookeeper_path, global_context, &config(),
-                                                                     "distributed_ddl", "DDLWorker", &CurrentMetrics::MaxDDLEntryID));
+                                                                     "distributed_ddl", host_zookeeper_path, "DDLWorker", &CurrentMetrics::MaxDDLEntryID));
         }
 
         for (auto & server : *servers)

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1008,6 +1008,9 @@
         <!-- Path in ZooKeeper to queue with DDL queries -->
         <path>/clickhouse/task_queue/ddl</path>
 
+        <!-- Path in ZooKeeper to host's status -->
+        <host_path>/clickhouse/task_queue/host</host_path>
+
         <!-- Settings from this profile will be used to execute DDL queries -->
         <!-- <profile>default</profile> -->
 
@@ -1023,6 +1026,9 @@
 
         <!-- Controls how often cleanup should be performed (in seconds) -->
         <!-- <cleanup_delay_period>60</cleanup_delay_period> -->
+
+        <!-- Controls how often activate host should be performed (in seconds) -->
+        <!-- <activate_host_period>60</activate_host_period> -->
 
         <!-- Controls how many tasks could be in the queue -->
         <!-- <max_tasks_in_queue>1000</max_tasks_in_queue> -->


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Activate current host as ephemeral node in zookeeper.

Detailed description / Documentation draft:
#25412

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
