### PR TITLE
Connection pool cache

### DIFF
--- a/src/Client/ConnectionPool.cpp
+++ b/src/Client/ConnectionPool.cpp
@@ -1,0 +1,81 @@
+#include <Client/ConnectionPool.h>
+
+#include <boost/functional/hash.hpp>
+
+namespace DB
+{
+
+ConnectionPoolPtr ConnectionPoolFactory::get(
+    unsigned max_connections,
+    String host,
+    UInt16 port,
+    String default_database,
+    String user,
+    String password,
+    String cluster,
+    String cluster_secret,
+    String client_name,
+    Protocol::Compression compression,
+    Protocol::Secure secure,
+    Int64 priority)
+{
+    Key key{
+        max_connections, host, port, default_database, user, password, cluster, cluster_secret, client_name, compression, secure, priority};
+
+    std::unique_lock lock(mutex);
+    auto it = pool.find(key);
+    ConnectionPoolPtr ret;
+    if (it != pool.end())
+        ret = it->second.lock();
+
+    if (!ret)
+    {
+        ret = std::make_shared<ConnectionPool>(
+            max_connections,
+            host,
+            port,
+            default_database,
+            user,
+            password,
+            cluster,
+            cluster_secret,
+            client_name,
+            compression,
+            secure,
+            priority);
+        if (it == pool.end())
+            pool.emplace(key, ConnectionPoolWeakPtr(ret));
+        else
+            it->second = ConnectionPoolWeakPtr(ret);
+    }
+    return ret;
+}
+
+size_t ConnectionPoolFactory::KeyHash::operator()(const ConnectionPoolFactory::Key & k) const
+{
+    using boost::hash_combine;
+    using boost::hash_value;
+    size_t seed = 0;
+    hash_combine(seed, hash_value(k.max_connections));
+    hash_combine(seed, hash_value(k.host));
+    hash_combine(seed, hash_value(k.port));
+    hash_combine(seed, hash_value(k.default_database));
+    hash_combine(seed, hash_value(k.user));
+    hash_combine(seed, hash_value(k.password));
+    hash_combine(seed, hash_value(k.cluster));
+    hash_combine(seed, hash_value(k.cluster_secret));
+    hash_combine(seed, hash_value(k.client_name));
+    hash_combine(seed, hash_value(k.compression));
+    hash_combine(seed, hash_value(k.secure));
+    hash_combine(seed, hash_value(k.priority));
+    return seed;
+}
+
+
+ConnectionPoolFactory & ConnectionPoolFactory::instance()
+{
+    static ConnectionPoolFactory ret;
+    return ret;
+}
+
+}

--- a/src/Client/ConnectionPool.h
+++ b/src/Client/ConnectionPool.h
@@ -180,7 +180,7 @@ public:
 private:
     mutable std::mutex mutex;
     using ConnectionPoolWeakPtr = std::weak_ptr<IConnectionPool>;
-    std::unordered_map<Key, ConnectionPoolWeakPtr, KeyHash> pool;
+    std::unordered_map<Key, ConnectionPoolWeakPtr, KeyHash> pools;
 };
 
 inline bool operator==(const ConnectionPoolFactory::Key & lhs, const ConnectionPoolFactory::Key & rhs)

--- a/src/Client/ConnectionPool.h
+++ b/src/Client/ConnectionPool.h
@@ -135,4 +135,60 @@ private:
 
 };
 
+/**
+ * Connection pool factory. Responsible for creating new connection pools and reuse existing ones.
+ */
+class ConnectionPoolFactory final : private boost::noncopyable
+{
+public:
+    struct Key
+    {
+        unsigned max_connections;
+        String host;
+        UInt16 port;
+        String default_database;
+        String user;
+        String password;
+        String cluster;
+        String cluster_secret;
+        String client_name;
+        Protocol::Compression compression;
+        Protocol::Secure secure;
+        Int64 priority;
+    };
+
+    struct KeyHash
+    {
+        size_t operator()(const ConnectionPoolFactory::Key & k) const;
+    };
+
+    static ConnectionPoolFactory & instance();
+
+    ConnectionPoolPtr
+    get(unsigned max_connections,
+        String host,
+        UInt16 port,
+        String default_database,
+        String user,
+        String password,
+        String cluster,
+        String cluster_secret,
+        String client_name,
+        Protocol::Compression compression,
+        Protocol::Secure secure,
+        Int64 priority);
+private:
+    mutable std::mutex mutex;
+    using ConnectionPoolWeakPtr = std::weak_ptr<IConnectionPool>;
+    std::unordered_map<Key, ConnectionPoolWeakPtr, KeyHash> pool;
+};
+
+inline bool operator==(const ConnectionPoolFactory::Key & lhs, const ConnectionPoolFactory::Key & rhs)
+{
+    return lhs.max_connections == rhs.max_connections && lhs.host == rhs.host && lhs.port == rhs.port
+        && lhs.default_database == rhs.default_database && lhs.user == rhs.user && lhs.password == rhs.password
+        && lhs.cluster == rhs.cluster && lhs.cluster_secret == rhs.cluster_secret && lhs.client_name == rhs.client_name
+        && lhs.compression == rhs.compression && lhs.secure == rhs.secure && lhs.priority == rhs.priority;
+}
+
 }

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -329,7 +329,7 @@ Clusters::Impl Clusters::getContainer() const
 Cluster::Cluster(const Poco::Util::AbstractConfiguration & config,
                  const Settings & settings,
                  const String & config_prefix_,
-                 const String & cluster_name)
+                 const String & cluster_name) : name(cluster_name)
 {
     auto config_prefix = config_prefix_ + "." + cluster_name;
 
@@ -366,7 +366,7 @@ Cluster::Cluster(const Poco::Util::AbstractConfiguration & config,
             if (address.is_local)
                 info.local_addresses.push_back(address);
 
-            ConnectionPoolPtr pool = std::make_shared<ConnectionPool>(
+            auto pool = ConnectionPoolFactory::instance().get(
                 settings.distributed_connections_pool_size,
                 address.host_name, address.port,
                 address.default_database, address.user, address.password,
@@ -439,7 +439,7 @@ Cluster::Cluster(const Poco::Util::AbstractConfiguration & config,
 
             for (const auto & replica : replica_addresses)
             {
-                auto replica_pool = std::make_shared<ConnectionPool>(
+                auto replica_pool = ConnectionPoolFactory::instance().get(
                     settings.distributed_connections_pool_size,
                     replica.host_name, replica.port,
                     replica.default_database, replica.user, replica.password,
@@ -502,7 +502,7 @@ Cluster::Cluster(const Settings & settings, const std::vector<std::vector<String
 
         for (const auto & replica : current)
         {
-            auto replica_pool = std::make_shared<ConnectionPool>(
+            auto replica_pool = ConnectionPoolFactory::instance().get(
                         settings.distributed_connections_pool_size,
                         replica.host_name, replica.port,
                         replica.default_database, replica.user, replica.password,
@@ -606,7 +606,7 @@ Cluster::Cluster(Cluster::ReplicasAsShardsTag, const Cluster & from, const Setti
             if (address.is_local)
                 info.local_addresses.push_back(address);
 
-            ConnectionPoolPtr pool = std::make_shared<ConnectionPool>(
+            auto pool = ConnectionPoolFactory::instance().get(
                 settings.distributed_connections_pool_size,
                 address.host_name,
                 address.port,

--- a/src/Interpreters/Cluster.h
+++ b/src/Interpreters/Cluster.h
@@ -265,6 +265,8 @@ private:
 
     size_t remote_shard_count = 0;
     size_t local_shard_count = 0;
+
+    String name;
 };
 
 using ClusterPtr = std::shared_ptr<Cluster>;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Allow to reuse connections of shards among different clusters. It also avoids creating new connections when using `cluster` table function.

Detailed description / Documentation draft:

.