### PR TITLE
Fix rare logical race in `cloneReplica(...)`

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2781,6 +2781,16 @@ void StorageReplicatedMergeTree::cloneReplica(const String & source_replica, Coo
         }
     }
 
+    {
+        /// Check "is_lost" version after retrieving queue and parts.
+        /// If version has changed, then replica most likely has been dropped and parts set is inconsistent,
+        /// so throw exception and retry cloning.
+        Coordination::Stat is_lost_stat_new;
+        zookeeper->get(fs::path(source_path) / "is_lost", &is_lost_stat_new);
+        if (is_lost_stat_new.version != source_is_lost_stat.version)
+            throw Exception(ErrorCodes::REPLICA_STATUS_CHANGED, "Cannot clone {}, because it suddenly become lost", source_replica);
+    }
+
     tryRemovePartsFromZooKeeperWithRetries(parts_to_remove_from_zk);
 
     auto local_active_parts = getDataParts();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed rare bug in lost replica recovery that may cause replicas to diverge.


Detailed description / Documentation draft:
https://clickhouse-test-reports.s3.yandex.net/26051/1a470fb777d1658d24b042f85e216d78c2bd78a8/functional_stateless_tests_(release,_databasereplicated).html#fail1
