### PR TITLE
Draft: Don't build set for indices when analyzing a query

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -248,6 +248,9 @@
     M(S3WriteRequestsThrottling, "Number of 429 and 503 errors in POST, DELETE, PUT and PATCH requests to S3 storage.") \
     M(S3WriteRequestsRedirects, "Number of redirects in POST, DELETE, PUT and PATCH requests to S3 storage.") \
     M(QueryMemoryLimitExceeded, "Number of times when memory limit exceeded for query.") \
+    \
+    M(SleepFunctionCalls, "Number of times a sleep function (sleep, sleepEachRow) has been called.") \
+    M(SleepFunctionMicroseconds, "Time spent sleeping due to a sleep function call.") \
 
 
 namespace ProfileEvents

--- a/src/Functions/sleep.h
+++ b/src/Functions/sleep.h
@@ -5,11 +5,17 @@
 #include <Columns/ColumnConst.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Common/FieldVisitorConvertToNumber.h>
+#include <Common/ProfileEvents.h>
 #include <Common/assert_cast.h>
 #include <common/sleep.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context_fwd.h>
 
+namespace ProfileEvents
+{
+extern const Event SleepFunctionCalls;
+extern const Event SleepFunctionMicroseconds;
+}
 
 namespace DB
 {
@@ -91,8 +97,11 @@ public:
             if (seconds > 3.0)   /// The choice is arbitrary
                 throw Exception("The maximum sleep time is 3 seconds. Requested: " + toString(seconds), ErrorCodes::TOO_SLOW);
 
-            UInt64 microseconds = seconds * (variant == FunctionSleepVariant::PerBlock ? 1 : size) * 1e6;
+            UInt64 count = (variant == FunctionSleepVariant::PerBlock ? 1 : size);
+            UInt64 microseconds = seconds * count * 1e6;
             sleepForMicroseconds(microseconds);
+            ProfileEvents::increment(ProfileEvents::SleepFunctionCalls, count);
+            ProfileEvents::increment(ProfileEvents::SleepFunctionMicroseconds, microseconds);
         }
 
         /// convertToFullColumn needed, because otherwise (constant expression case) function will not get called on each columns.

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -609,7 +609,7 @@ Block InterpreterSelectQuery::getSampleBlockImpl()
 
     query_info.query = query_ptr;
     query_info.has_window = query_analyzer->hasWindow();
-    if (storage)
+    if (storage && !options.only_analyze)
     {
         auto & query = getSelectQuery();
         query_analyzer->makeSetsForIndex(query.where());

--- a/tests/queries/0_stateless/01946_profile_sleep.reference
+++ b/tests/queries/0_stateless/01946_profile_sleep.reference
@@ -1,0 +1,6 @@
+{"'SLEEP #1 CHECK'":"SLEEP #1 CHECK","calls":"1","microseconds":"1000"}
+{"'SLEEP #2 CHECK'":"SLEEP #2 CHECK","calls":"1","microseconds":"1000"}
+{"'SLEEP #3 CHECK'":"SLEEP #3 CHECK","calls":"1","microseconds":"1000"}
+{"'SLEEP #4 CHECK'":"SLEEP #4 CHECK","calls":"2","microseconds":"2000"}
+{"'SLEEP #5 CHECK'":"SLEEP #5 CHECK","calls":"0","microseconds":"0"}
+{"'SLEEP #6 CHECK'":"SLEEP #6 CHECK","calls":"10","microseconds":"10000"}

--- a/tests/queries/0_stateless/01946_profile_sleep.sql
+++ b/tests/queries/0_stateless/01946_profile_sleep.sql
@@ -1,0 +1,63 @@
+SET log_queries=1;
+SET log_profile_events=true;
+
+SELECT 'SLEEP #1 TEST', sleep(0.001) FORMAT Null;
+SYSTEM FLUSH LOGS;
+SELECT 'SLEEP #1 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
+FROM system.query_log
+WHERE query like '%SELECT ''SLEEP #1 TEST''%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+SELECT 'SLEEP #2 TEST', sleep(0.001) FROM numbers(2) FORMAT Null;
+SYSTEM FLUSH LOGS;
+SELECT 'SLEEP #2 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
+FROM system.query_log
+WHERE query like '%SELECT ''SLEEP #2 TEST''%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+SELECT 'SLEEP #3 TEST', sleepEachRow(0.001) FORMAT Null;
+SYSTEM FLUSH LOGS;
+SELECT 'SLEEP #3 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
+FROM system.query_log
+WHERE query like '%SELECT ''SLEEP #3 TEST''%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+SELECT 'SLEEP #4 TEST', sleepEachRow(0.001) FROM numbers(2) FORMAT Null;
+SYSTEM FLUSH LOGS;
+SELECT 'SLEEP #4 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
+FROM system.query_log
+WHERE query like '%SELECT ''SLEEP #4 TEST''%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+
+CREATE VIEW sleep_view AS SELECT sleepEachRow(0.001) FROM system.numbers;
+SYSTEM FLUSH LOGS;
+SELECT 'SLEEP #5 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
+FROM system.query_log
+WHERE query like '%CREATE VIEW sleep_view AS%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+SELECT 'SLEEP #6 TEST', sleepEachRow(0.001) FROM sleep_view LIMIT 10 FORMAT Null;
+SYSTEM FLUSH LOGS;
+SELECT 'SLEEP #6 CHECK', ProfileEvents['SleepFunctionCalls'] as calls, ProfileEvents['SleepFunctionMicroseconds'] as microseconds
+FROM system.query_log
+WHERE query like '%SELECT ''SLEEP #6 TEST''%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;

--- a/tests/queries/0_stateless/01946_profile_sleep.sql
+++ b/tests/queries/0_stateless/01946_profile_sleep.sql
@@ -61,3 +61,5 @@ WHERE query like '%SELECT ''SLEEP #6 TEST''%'
   AND current_database = currentDatabase()
   AND event_date >= yesterday()
     FORMAT JSONEachRow;
+
+DROP TABLE sleep_view;

--- a/tests/queries/0_stateless/01947_mv_subquery.reference
+++ b/tests/queries/0_stateless/01947_mv_subquery.reference
@@ -1,0 +1,6 @@
+{"test":"1947 #1 CHECK - TRUE","sleep_calls":"0","sleep_microseconds":"0"}
+{"test":"1947 #2 CHECK - TRUE","sleep_calls":"2","sleep_microseconds":"2000"}
+{"test":"1947 #3 CHECK - TRUE","sleep_calls":"0","sleep_microseconds":"0"}
+{"test":"1947 #1 CHECK - FALSE","sleep_calls":"0","sleep_microseconds":"0"}
+{"test":"1947 #2 CHECK - FALSE","sleep_calls":"2","sleep_microseconds":"2000"}
+{"test":"1947 #3 CHECK - FALSE","sleep_calls":"0","sleep_microseconds":"0"}

--- a/tests/queries/0_stateless/01947_mv_subquery.sql
+++ b/tests/queries/0_stateless/01947_mv_subquery.sql
@@ -17,7 +17,7 @@ LEFT JOIN
     SELECT id, sum(delta) as deltas_sum FROM dst
     WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
     GROUP BY id
-)
+) _a
 USING (id);
 
 -- Inserting 2 numbers should require 2 calls to sleep
@@ -27,13 +27,13 @@ INSERT into src SELECT number + 100 as id, 1 FROM numbers(2);
 DESCRIBE ( SELECT '1947 #3 QUERY - TRUE',
                   id,
                   src.value - deltas_sum as delta
-           FROM src
-                    LEFT JOIN
+            FROM src
+            LEFT JOIN
                 (
                     SELECT id, sum(delta) as deltas_sum FROM dst
                     WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
                     GROUP BY id
-                    )
+                ) _a
                 USING (id)
     ) FORMAT Null;
 
@@ -82,13 +82,13 @@ SELECT
     id,
     src.value - deltas_sum as delta
 FROM src
-         LEFT JOIN
-     (
-         SELECT id, sum(delta) as deltas_sum FROM dst
-         WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
-         GROUP BY id
-         )
-     USING (id);
+LEFT JOIN
+(
+    SELECT id, sum(delta) as deltas_sum FROM dst
+    WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
+    GROUP BY id
+) _a
+USING (id);
 
 -- Inserting 2 numbers should require 2 calls to sleep
 INSERT into src SELECT number + 200 as id, 1 FROM numbers(2);
@@ -97,14 +97,14 @@ INSERT into src SELECT number + 200 as id, 1 FROM numbers(2);
 DESCRIBE ( SELECT '1947 #3 QUERY - FALSE',
                   id,
                   src.value - deltas_sum as delta
-           FROM src
-                    LEFT JOIN
-                (
-                    SELECT id, sum(delta) as deltas_sum FROM dst
-                    WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
-                    GROUP BY id
-                    )
-                USING (id)
+            FROM src
+            LEFT JOIN
+            (
+                SELECT id, sum(delta) as deltas_sum FROM dst
+                WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
+                GROUP BY id
+            ) _a
+            USING (id)
     ) FORMAT Null;
 
 SYSTEM FLUSH LOGS;

--- a/tests/queries/0_stateless/01947_mv_subquery.sql
+++ b/tests/queries/0_stateless/01947_mv_subquery.sql
@@ -1,0 +1,145 @@
+SET log_queries=1;
+SET log_profile_events=true;
+
+CREATE TABLE src Engine=MergeTree ORDER BY id AS SELECT number as id, toInt32(1) as value FROM numbers(1);
+CREATE TABLE dst (id UInt64, delta Int64) Engine=MergeTree ORDER BY id;
+
+-- First we try with default values (https://github.com/ClickHouse/ClickHouse/issues/9587)
+SET use_index_for_in_with_subqueries = 1;
+
+CREATE MATERIALIZED VIEW src2dst_true TO dst AS
+SELECT
+       id,
+       src.value - deltas_sum as delta
+FROM src
+LEFT JOIN
+(
+    SELECT id, sum(delta) as deltas_sum FROM dst
+    WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
+    GROUP BY id
+)
+USING (id);
+
+-- Inserting 2 numbers should require 2 calls to sleep
+INSERT into src SELECT number + 100 as id, 1 FROM numbers(2);
+
+-- Describe should not need to call sleep
+DESCRIBE ( SELECT '1947 #3 QUERY - TRUE',
+                  id,
+                  src.value - deltas_sum as delta
+           FROM src
+                    LEFT JOIN
+                (
+                    SELECT id, sum(delta) as deltas_sum FROM dst
+                    WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
+                    GROUP BY id
+                    )
+                USING (id)
+    ) FORMAT Null;
+
+
+SYSTEM FLUSH LOGS;
+
+SELECT '1947 #1 CHECK - TRUE' as test,
+       ProfileEvents['SleepFunctionCalls'] as sleep_calls,
+       ProfileEvents['SleepFunctionMicroseconds'] as sleep_microseconds
+FROM system.query_log
+WHERE query like '%CREATE MATERIALIZED VIEW src2dst_true%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+SELECT '1947 #2 CHECK - TRUE' as test,
+       ProfileEvents['SleepFunctionCalls'] as sleep_calls,
+       ProfileEvents['SleepFunctionMicroseconds'] as sleep_microseconds
+FROM system.query_log
+WHERE query like '%INSERT into src SELECT number + 100 as id, 1 FROM numbers(2)%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+SELECT '1947 #3 CHECK - TRUE' as test,
+       ProfileEvents['SleepFunctionCalls'] as sleep_calls,
+       ProfileEvents['SleepFunctionMicroseconds'] as sleep_microseconds
+FROM system.query_log
+WHERE query like '%DESCRIBE ( SELECT ''1947 #3 QUERY - TRUE'',%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+DROP TABLE src2dst_true;
+
+
+-- Retry the same but using use_index_for_in_with_subqueries = 0
+
+SET use_index_for_in_with_subqueries = 0;
+
+CREATE MATERIALIZED VIEW src2dst_false TO dst AS
+SELECT
+    id,
+    src.value - deltas_sum as delta
+FROM src
+         LEFT JOIN
+     (
+         SELECT id, sum(delta) as deltas_sum FROM dst
+         WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
+         GROUP BY id
+         )
+     USING (id);
+
+-- Inserting 2 numbers should require 2 calls to sleep
+INSERT into src SELECT number + 200 as id, 1 FROM numbers(2);
+
+-- Describe should not need to call sleep
+DESCRIBE ( SELECT '1947 #3 QUERY - FALSE',
+                  id,
+                  src.value - deltas_sum as delta
+           FROM src
+                    LEFT JOIN
+                (
+                    SELECT id, sum(delta) as deltas_sum FROM dst
+                    WHERE id IN (SELECT id FROM src WHERE not sleepEachRow(0.001))
+                    GROUP BY id
+                    )
+                USING (id)
+    ) FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT '1947 #1 CHECK - FALSE' as test,
+       ProfileEvents['SleepFunctionCalls'] as sleep_calls,
+       ProfileEvents['SleepFunctionMicroseconds'] as sleep_microseconds
+FROM system.query_log
+WHERE query like '%CREATE MATERIALIZED VIEW src2dst_false%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+SELECT '1947 #2 CHECK - FALSE' as test,
+       ProfileEvents['SleepFunctionCalls'] as sleep_calls,
+       ProfileEvents['SleepFunctionMicroseconds'] as sleep_microseconds
+FROM system.query_log
+WHERE query like '%INSERT into src SELECT number + 200 as id, 1 FROM numbers(2)%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+SELECT '1947 #3 CHECK - FALSE' as test,
+       ProfileEvents['SleepFunctionCalls'] as sleep_calls,
+       ProfileEvents['SleepFunctionMicroseconds'] as sleep_microseconds
+FROM system.query_log
+WHERE query like '%DESCRIBE ( SELECT ''1947 #3 QUERY - FALSE'',%'
+  AND type > 1
+  AND current_database = currentDatabase()
+  AND event_date >= yesterday()
+    FORMAT JSONEachRow;
+
+DROP TABLE src2dst_false;
+
+DROP TABLE src;
+DROP TABLE dst;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't build sets for indices when analyzing a query

Detailed description / Documentation draft:

Fixes https://github.com/ClickHouse/ClickHouse/issues/9587. This improves materialized views (creation and execution) and DESC (subquery) calls when the query contains a optimizable `IN()` call and it's enabled (`use_index_for_in_with_subqueries` which is 1 by default) as it removes unnecessary work.

**Note that it's using https://github.com/ClickHouse/ClickHouse/pull/26320 for testing**, so that PR would need to be reviewed / merged first, or find a different way to test this. I'll rebase it when ready, so marking this as draft until then. The only new commit is c2f0d7c514147e416f07a5e81feb6751626f7e0d.