### PR TITLE
Enabling all TestFlows modules except LDAP after Kerberos merge.

### DIFF
--- a/tests/testflows/regression.py
+++ b/tests/testflows/regression.py
@@ -7,14 +7,9 @@ append_path(sys.path, ".")
 from helpers.common import Pool, join, run_scenario
 from helpers.argparser import argparser
 
-xfails = {
-    "kerberos/config/principal and realm specified/:": [(Fail, "https://github.com/ClickHouse/ClickHouse/issues/26197")],
-}
-
 @TestModule
 @Name("clickhouse")
 @ArgumentParser(argparser)
-@XFails(xfails)
 def regression(self, local, clickhouse_binary_path, stress=None, parallel=None):
     """ClickHouse regression.
     """
@@ -29,13 +24,13 @@ def regression(self, local, clickhouse_binary_path, stress=None, parallel=None):
         try:
             run_scenario(pool, tasks, Feature(test=load("example.regression", "regression")), args)
             # run_scenario(pool, tasks, Feature(test=load("ldap.regression", "regression")), args)
-            # run_scenario(pool, tasks, Feature(test=load("rbac.regression", "regression")), args)
-            # run_scenario(pool, tasks, Feature(test=load("aes_encryption.regression", "regression")), args)
-            # run_scenario(pool, tasks, Feature(test=load("map_type.regression", "regression")), args)
-            # run_scenario(pool, tasks, Feature(test=load("window_functions.regression", "regression")), args)
-            # run_scenario(pool, tasks, Feature(test=load("datetime64_extended_range.regression", "regression")), args)
+            run_scenario(pool, tasks, Feature(test=load("rbac.regression", "regression")), args)
+            run_scenario(pool, tasks, Feature(test=load("aes_encryption.regression", "regression")), args)
+            run_scenario(pool, tasks, Feature(test=load("map_type.regression", "regression")), args)
+            run_scenario(pool, tasks, Feature(test=load("window_functions.regression", "regression")), args)
+            run_scenario(pool, tasks, Feature(test=load("datetime64_extended_range.regression", "regression")), args)
             run_scenario(pool, tasks, Feature(test=load("kerberos.regression", "regression")), args)
-            # run_scenario(pool, tasks, Feature(test=load("extended_precision_data_types.regression", "regression")), args)
+            run_scenario(pool, tasks, Feature(test=load("extended_precision_data_types.regression", "regression")), args)
         finally:
             join(tasks)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enabling all TestFlows modules except LDAP after Kerberos merge.

Detailed description / Documentation draft:
Enabling all TestFlows modules except LDAP after Kerberos merge.
