### PR TITLE
Use hedged requests, again

### DIFF
--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -353,6 +353,11 @@ bool HedgedConnections::resumePacketReceiver(const HedgedConnections::ReplicaLoc
         if (offset_states[location.offset].active_connection_count == 0 && !offset_states[location.offset].next_replica_in_process)
             throw NetException("Receive timeout expired", ErrorCodes::SOCKET_TIMEOUT);
     }
+    else if (std::holds_alternative<std::exception_ptr>(res))
+    {
+        finishProcessReplica(replica_state, true);
+        std::rethrow_exception(std::move(std::get<std::exception_ptr>(res)));
+    }
 
     return false;
 }

--- a/src/Client/PacketReceiver.h
+++ b/src/Client/PacketReceiver.h
@@ -31,7 +31,7 @@ public:
     }
 
     /// Resume packet receiving.
-    std::variant<int, Packet, Poco::Timespan> resume()
+    std::variant<int, Packet, Poco::Timespan, std::exception_ptr> resume()
     {
         /// If there is no pending data, check receive timeout.
         if (!connection->hasReadPendingData() && !checkReceiveTimeout())
@@ -43,7 +43,7 @@ public:
         /// Resume fiber.
         fiber = std::move(fiber).resume();
         if (exception)
-            std::rethrow_exception(std::move(exception));
+            return std::move(exception);
 
         if (is_read_in_process)
             return epoll.getFileDescriptor();

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -57,7 +57,7 @@ class IColumn;
     M(Seconds, tcp_keep_alive_timeout, 0, "The time in seconds the connection needs to remain idle before TCP starts sending keepalive probes", 0) \
     M(Milliseconds, hedged_connection_timeout_ms, DBMS_DEFAULT_HEDGED_CONNECTION_TIMEOUT_MS, "Connection timeout for establishing connection with replica for Hedged requests", 0) \
     M(Milliseconds, receive_data_timeout_ms, DBMS_DEFAULT_RECEIVE_DATA_TIMEOUT_MS, "Connection timeout for receiving first packet of data or packet with positive progress from replica", 0) \
-    M(Bool, use_hedged_requests, false, "Use hedged requests for distributed queries", 0) \
+    M(Bool, use_hedged_requests, true, "Use hedged requests for distributed queries", 0) \
     M(Bool, allow_changing_replica_until_first_data_packet, false, "Allow HedgedConnections to change replica until receiving first data packet", 0) \
     M(Milliseconds, queue_max_wait_ms, 0, "The wait time in the request queue, if the number of concurrent requests exceeds the maximum.", 0) \
     M(Milliseconds, connection_pool_max_wait_ms, 0, "The wait time when the connection pool is full.", 0) \


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable `use_hedged_requests` setting that allows to mitigate tail latencies on large clusters.