### PR TITLE
Less logging in AsynchronousMetrics

### DIFF
--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -546,13 +546,16 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
             Int64 peak = total_memory_tracker.getPeak();
             Int64 new_amount = data.resident;
 
-            LOG_DEBUG(&Poco::Logger::get("AsynchronousMetrics"),
-                "MemoryTracking: was {}, peak {}, will set to {} (RSS), difference: {}",
-                ReadableSize(amount),
-                ReadableSize(peak),
-                ReadableSize(new_amount),
-                ReadableSize(new_amount - amount)
-            );
+            Int64 difference = new_amount - amount;
+
+            /// Log only if difference is high. This is for convenience. The threshold is arbitrary.
+            if (difference >= 1048576 || difference <= -1048576)
+                LOG_TRACE(&Poco::Logger::get("AsynchronousMetrics"),
+                    "MemoryTracking: was {}, peak {}, will set to {} (RSS), difference: {}",
+                    ReadableSize(amount),
+                    ReadableSize(peak),
+                    ReadableSize(new_amount),
+                    ReadableSize(difference));
 
             total_memory_tracker.set(new_amount);
             CurrentMetrics::set(CurrentMetrics::MemoryTracking, new_amount);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
