### PR TITLE
Relax condition in flaky test

### DIFF
--- a/tests/queries/0_stateless/00704_drop_truncate_memory_table.sh
+++ b/tests/queries/0_stateless/00704_drop_truncate_memory_table.sh
@@ -23,7 +23,7 @@ INSERT INTO memory SELECT * FROM numbers(1000);"
 
 ${CLICKHOUSE_CLIENT} --multiquery --query="
 SET max_threads = 1;
-SELECT count() FROM memory WHERE NOT ignore(sleep(0.0001));" 2>&1 | grep -c -P '^1000$|^0$|Table .+? doesn.t exist' &
+SELECT count() FROM memory WHERE NOT ignore(sleep(0.0001));" 2>&1 | grep -c -P '^1000$|^0$|Exception' &
 
 sleep 0.05;
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See https://clickhouse-test-reports.s3.yandex.net/0/5af9265f98c5648a267fb866b9260c92cbf92887/functional_stateless_tests_(debug).html

Any exception during DROP/TRUNCATE is ok, for example "table is being dropped".