### PR TITLE
Remove MySQLWireContext

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -433,7 +433,7 @@ void LocalServer::processQueries()
 
         try
         {
-            executeQuery(read_buf, write_buf, /* allow_into_outfile = */ true, context, {}, finalize_progress);
+            executeQuery(read_buf, write_buf, /* allow_into_outfile = */ true, context, {}, {}, finalize_progress);
         }
         catch (...)
         {

--- a/src/Core/MySQL/MySQLClient.cpp
+++ b/src/Core/MySQL/MySQLClient.cpp
@@ -24,16 +24,15 @@ namespace ErrorCodes
 }
 
 MySQLClient::MySQLClient(const String & host_, UInt16 port_, const String & user_, const String & password_)
-    : host(host_), port(port_), user(user_), password(std::move(password_))
+    : host(host_), port(port_), user(user_), password(std::move(password_)),
+      client_capabilities(CLIENT_PROTOCOL_41 | CLIENT_PLUGIN_AUTH | CLIENT_SECURE_CONNECTION)
 {
-    mysql_context.client_capabilities = CLIENT_PROTOCOL_41 | CLIENT_PLUGIN_AUTH | CLIENT_SECURE_CONNECTION;
 }
 
 MySQLClient::MySQLClient(MySQLClient && other)
     : host(std::move(other.host)), port(other.port), user(std::move(other.user)), password(std::move(other.password))
-    , mysql_context(other.mysql_context)
+    , client_capabilities(other.client_capabilities)
 {
-    mysql_context.sequence_id = 0;
 }
 
 void MySQLClient::connect()
@@ -57,7 +56,8 @@ void MySQLClient::connect()
 
     in = std::make_shared<ReadBufferFromPocoSocket>(*socket);
     out = std::make_shared<WriteBufferFromPocoSocket>(*socket);
-    packet_endpoint = mysql_context.makeEndpoint(*in, *out);
+    packet_endpoint = MySQLProtocol::PacketEndpoint::create(*in, *out, sequence_id);
+
     handshake();
 }
 
@@ -69,7 +69,7 @@ void MySQLClient::disconnect()
         socket->close();
     socket = nullptr;
     connected = false;
-    mysql_context.sequence_id = 0;
+    sequence_id = 0;
 }
 
 /// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html
@@ -88,10 +88,10 @@ void MySQLClient::handshake()
     String auth_plugin_data = native41.getAuthPluginData();
 
     HandshakeResponse handshake_response(
-        mysql_context.client_capabilities, MAX_PACKET_LENGTH, charset_utf8, user, "", auth_plugin_data, mysql_native_password);
+        client_capabilities, MAX_PACKET_LENGTH, charset_utf8, user, "", auth_plugin_data, mysql_native_password);
     packet_endpoint->sendPacket<HandshakeResponse>(handshake_response, true);
 
-    ResponsePacket packet_response(mysql_context.client_capabilities, true);
+    ResponsePacket packet_response(client_capabilities, true);
     packet_endpoint->receivePacket(packet_response);
     packet_endpoint->resetSequenceId();
 
@@ -106,7 +106,7 @@ void MySQLClient::writeCommand(char command, String query)
     WriteCommand write_command(command, query);
     packet_endpoint->sendPacket<WriteCommand>(write_command, true);
 
-    ResponsePacket packet_response(mysql_context.client_capabilities);
+    ResponsePacket packet_response(client_capabilities);
     packet_endpoint->receivePacket(packet_response);
     switch (packet_response.getType())
     {
@@ -125,7 +125,7 @@ void MySQLClient::registerSlaveOnMaster(UInt32 slave_id)
     RegisterSlave register_slave(slave_id);
     packet_endpoint->sendPacket<RegisterSlave>(register_slave, true);
 
-    ResponsePacket packet_response(mysql_context.client_capabilities);
+    ResponsePacket packet_response(client_capabilities);
     packet_endpoint->receivePacket(packet_response);
     packet_endpoint->resetSequenceId();
     if (packet_response.getType() == PACKET_ERR)

--- a/src/Core/MySQL/MySQLClient.h
+++ b/src/Core/MySQL/MySQLClient.h
@@ -45,7 +45,9 @@ private:
     String password;
 
     bool connected = false;
-    MySQLWireContext mysql_context;
+    uint8_t sequence_id = 0;
+    uint32_t client_capabilities = 0;
+
     const UInt8 charset_utf8 = 33;
     const String mysql_native_password = "mysql_native_password";
 

--- a/src/Core/MySQL/PacketEndpoint.cpp
+++ b/src/Core/MySQL/PacketEndpoint.cpp
@@ -68,15 +68,4 @@ String PacketEndpoint::packetToText(const String & payload)
 
 }
 
-
-MySQLProtocol::PacketEndpointPtr MySQLWireContext::makeEndpoint(WriteBuffer & out)
-{
-    return MySQLProtocol::PacketEndpoint::create(out, sequence_id);
-}
-
-MySQLProtocol::PacketEndpointPtr MySQLWireContext::makeEndpoint(ReadBuffer & in, WriteBuffer & out)
-{
-    return MySQLProtocol::PacketEndpoint::create(in, out, sequence_id);
-}
-
 }

--- a/src/Core/MySQL/PacketEndpoint.h
+++ b/src/Core/MySQL/PacketEndpoint.h
@@ -58,14 +58,4 @@ using PacketEndpointPtr = std::shared_ptr<PacketEndpoint>;
 
 }
 
-struct MySQLWireContext
-{
-    uint8_t sequence_id = 0;
-    uint32_t client_capabilities = 0;
-    size_t max_packet_size = 0;
-
-    MySQLProtocol::PacketEndpointPtr makeEndpoint(WriteBuffer & out);
-    MySQLProtocol::PacketEndpointPtr makeEndpoint(ReadBuffer & in, WriteBuffer & out);
-};
-
 }

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -208,9 +208,6 @@ BlockOutputStreamPtr FormatFactory::getOutputStreamParallelIfPossible(
     WriteCallback callback,
     const std::optional<FormatSettings> & _format_settings) const
 {
-    if (context->getMySQLProtocolContext() && name != "MySQLWire")
-        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "MySQL protocol does not support custom output formats");
-
     const auto & output_getter = getCreators(name).output_processor_creator;
 
     const Settings & settings = context->getSettingsRef();
@@ -315,9 +312,6 @@ OutputFormatPtr FormatFactory::getOutputFormatParallelIfPossible(
     if (!output_getter)
         throw Exception(ErrorCodes::FORMAT_IS_NOT_SUITABLE_FOR_OUTPUT, "Format {} is not suitable for output (with processors)", name);
 
-    if (context->getMySQLProtocolContext() && name != "MySQLWire")
-        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "MySQL protocol does not support custom output formats");
-
     auto format_settings = _format_settings ? *_format_settings : getFormatSettings(context);
 
     const Settings & settings = context->getSettingsRef();
@@ -359,8 +353,11 @@ OutputFormatPtr FormatFactory::getOutputFormat(
     RowOutputFormatParams params;
     params.callback = std::move(callback);
 
-    auto format_settings = _format_settings
-        ? *_format_settings : getFormatSettings(context);
+    auto format_settings = _format_settings ? *_format_settings : getFormatSettings(context);
+
+    /// If we're handling MySQL protocol connection right now then MySQLWire is only allowed output format.
+    if (format_settings.mysql_wire.sequence_id && (name != "MySQLWire"))
+        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "MySQL protocol does not support custom output formats");
 
     /** TODO: Materialization is needed, because formats can use the functions `IDataType`,
       *  which only work with full columns.

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -133,6 +133,13 @@ struct FormatSettings
 
     struct
     {
+        uint32_t client_capabilities = 0;
+        size_t max_packet_size = 0;
+        uint8_t * sequence_id = nullptr; /// Not null if it's MySQLWire output format used to handle MySQL protocol connections.
+    } mysql_wire;
+
+    struct
+    {
         std::string regexp;
         std::string escaping_rule;
         bool skip_unmatched = false;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2727,18 +2727,4 @@ PartUUIDsPtr Context::getIgnoredPartUUIDs() const
     return ignored_part_uuids;
 }
 
-void Context::setMySQLProtocolContext(MySQLWireContext * mysql_context)
-{
-    assert(session_context.lock().get() == this);
-    assert(!mysql_protocol_context);
-    assert(mysql_context);
-    mysql_protocol_context = mysql_context;
-}
-
-MySQLWireContext * Context::getMySQLProtocolContext() const
-{
-    assert(!mysql_protocol_context || session_context.lock().get());
-    return mysql_protocol_context;
-}
-
 }

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -119,8 +119,6 @@ using ThrottlerPtr = std::shared_ptr<Throttler>;
 class ZooKeeperMetadataTransaction;
 using ZooKeeperMetadataTransactionPtr = std::shared_ptr<ZooKeeperMetadataTransaction>;
 
-struct MySQLWireContext;
-
 /// Callback for external tables initializer
 using ExternalTablesInitializer = std::function<void(ContextPtr)>;
 
@@ -299,8 +297,6 @@ private:
                                                     /// to DatabaseOnDisk::commitCreateTable(...) or IStorage::alter(...) without changing
                                                     /// thousands of signatures.
                                                     /// And I hope it will be replaced with more common Transaction sometime.
-
-    MySQLWireContext * mysql_protocol_context = nullptr;
 
     Context();
     Context(const Context &);
@@ -796,11 +792,6 @@ public:
     void initZooKeeperMetadataTransaction(ZooKeeperMetadataTransactionPtr txn, bool attach_existing = false);
     /// Returns context of current distributed DDL query or nullptr.
     ZooKeeperMetadataTransactionPtr getZooKeeperMetadataTransaction() const;
-
-    /// Caller is responsible for lifetime of mysql_context.
-    /// Used in MySQLHandler for session context.
-    void setMySQLProtocolContext(MySQLWireContext * mysql_context);
-    MySQLWireContext * getMySQLProtocolContext() const;
 
     PartUUIDsPtr getPartUUIDs() const;
     PartUUIDsPtr getIgnoredPartUUIDs() const;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -31,6 +31,7 @@
 #include <Parsers/queryNormalization.h>
 #include <Parsers/queryToString.h>
 
+#include <Formats/FormatFactory.h>
 #include <Storages/StorageInput.h>
 
 #include <Access/EnabledQuota.h>
@@ -949,6 +950,7 @@ void executeQuery(
     bool allow_into_outfile,
     ContextMutablePtr context,
     std::function<void(const String &, const String &, const String &, const String &)> set_result_details,
+    const std::optional<FormatSettings> & output_format_settings,
     std::function<void()> before_finalize_callback)
 {
     PODArray<char> parse_buf;
@@ -1020,7 +1022,7 @@ void executeQuery(
                 ? getIdentifierName(ast_query_with_output->format)
                 : context->getDefaultFormat();
 
-            auto out = context->getOutputStreamParallelIfPossible(format_name, *out_buf, streams.in->getHeader());
+            auto out = FormatFactory::instance().getOutputStreamParallelIfPossible(format_name, *out_buf, streams.in->getHeader(), context, {}, output_format_settings);
 
             /// Save previous progress callback if any. TODO Do it more conveniently.
             auto previous_progress_callback = context->getProgressCallback();
@@ -1066,7 +1068,7 @@ void executeQuery(
                     return std::make_shared<MaterializingTransform>(header);
                 });
 
-                auto out = context->getOutputFormatParallelIfPossible(format_name, *out_buf, pipeline.getHeader());
+                auto out = FormatFactory::instance().getOutputFormatParallelIfPossible(format_name, *out_buf, pipeline.getHeader(), context, {}, output_format_settings);
                 out->setAutoFlush();
 
                 /// Save previous progress callback if any. TODO Do it more conveniently.

--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -16,8 +16,9 @@ void executeQuery(
     ReadBuffer & istr,                  /// Where to read query from (and data for INSERT, if present).
     WriteBuffer & ostr,                 /// Where to write query output to.
     bool allow_into_outfile,            /// If true and the query contains INTO OUTFILE section, redirect output to that file.
-    ContextMutablePtr context,                 /// DB, tables, data types, storage engines, functions, aggregate functions...
+    ContextMutablePtr context,          /// DB, tables, data types, storage engines, functions, aggregate functions...
     std::function<void(const String &, const String &, const String &, const String &)> set_result_details, /// If a non-empty callback is passed, it will be called with the query id, the content-type, the format, and the timezone.
+    const std::optional<FormatSettings> & output_format_settings = std::nullopt, /// Format settings for output format, will be calculated from the context if not set.
     std::function<void()> before_finalize_callback = {} /// Will be set in output format to be called before finalize.
 );
 

--- a/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
@@ -1,7 +1,11 @@
 #include <Processors/Formats/Impl/MySQLOutputFormat.h>
-#include <Interpreters/ProcessList.h>
+#include <Core/MySQL/PacketsGeneric.h>
+#include <Core/MySQL/PacketsProtocolText.h>
 #include <Formats/FormatFactory.h>
+#include <Formats/FormatSettings.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
+
 
 namespace DB
 {
@@ -13,24 +17,18 @@ using namespace MySQLProtocol::ProtocolText;
 
 MySQLOutputFormat::MySQLOutputFormat(WriteBuffer & out_, const Block & header_, const FormatSettings & settings_)
     : IOutputFormat(header_, out_)
-    , format_settings(settings_)
+    , client_capabilities(settings_.mysql_wire.client_capabilities)
 {
+    /// MySQlWire is a special format that is usually used as output format for MySQL protocol connections.
+    /// In this case we have a correct `sequence_id` stored in `settings_.mysql_wire`.
+    /// But it's also possible to specify MySQLWire as output format for clickhouse-client or clickhouse-local.
+    /// There is no `sequence_id` stored in `settings_.mysql_wire` in this case, so we create a dummy one.
+    sequence_id = settings_.mysql_wire.sequence_id ? settings_.mysql_wire.sequence_id : &dummy_sequence_id;
 }
 
 void MySQLOutputFormat::setContext(ContextPtr context_)
 {
     context = context_;
-    /// MySQlWire is a special format that is usually used as output format for MySQL protocol connections.
-    /// In this case we have to use the corresponding session context to set correct sequence_id.
-    mysql_context = getContext()->getMySQLProtocolContext();
-    if (!mysql_context)
-    {
-        /// But it's also possible to specify MySQLWire as output format for clickhouse-client or clickhouse-local.
-        /// There is no MySQL protocol context in this case, so we create dummy one.
-        own_mysql_context.emplace();
-        mysql_context = &own_mysql_context.value();
-    }
-    packet_endpoint = mysql_context->makeEndpoint(out);
 }
 
 void MySQLOutputFormat::initialize()
@@ -39,12 +37,15 @@ void MySQLOutputFormat::initialize()
         return;
 
     initialized = true;
+
     const auto & header = getPort(PortKind::Main).getHeader();
     data_types = header.getDataTypes();
 
     serializations.reserve(data_types.size());
     for (const auto & type : data_types)
         serializations.emplace_back(type->getDefaultSerialization());
+
+    packet_endpoint = MySQLProtocol::PacketEndpoint::create(out, *sequence_id);
 
     if (header.columns())
     {
@@ -56,7 +57,7 @@ void MySQLOutputFormat::initialize()
             packet_endpoint->sendPacket(getColumnDefinition(column_name, data_types[i]->getTypeId()));
         }
 
-        if (!(mysql_context->client_capabilities & Capability::CLIENT_DEPRECATE_EOF))
+        if (!(client_capabilities & Capability::CLIENT_DEPRECATE_EOF))
         {
             packet_endpoint->sendPacket(EOFPacket(0, 0));
         }
@@ -66,7 +67,6 @@ void MySQLOutputFormat::initialize()
 
 void MySQLOutputFormat::consume(Chunk chunk)
 {
-
     initialize();
 
     for (size_t i = 0; i < chunk.getNumRows(); i++)
@@ -94,11 +94,9 @@ void MySQLOutputFormat::finalize()
 
     const auto & header = getPort(PortKind::Main).getHeader();
     if (header.columns() == 0)
-        packet_endpoint->sendPacket(
-            OKPacket(0x0, mysql_context->client_capabilities, affected_rows, 0, 0, "", human_readable_info), true);
-    else if (mysql_context->client_capabilities & CLIENT_DEPRECATE_EOF)
-        packet_endpoint->sendPacket(
-            OKPacket(0xfe, mysql_context->client_capabilities, affected_rows, 0, 0, "", human_readable_info), true);
+        packet_endpoint->sendPacket(OKPacket(0x0, client_capabilities, affected_rows, 0, 0, "", human_readable_info), true);
+    else if (client_capabilities & CLIENT_DEPRECATE_EOF)
+        packet_endpoint->sendPacket(OKPacket(0xfe, client_capabilities, affected_rows, 0, 0, "", human_readable_info), true);
     else
         packet_endpoint->sendPacket(EOFPacket(0, 0), true);
 }

--- a/src/Processors/Formats/Impl/MySQLOutputFormat.h
+++ b/src/Processors/Formats/Impl/MySQLOutputFormat.h
@@ -3,11 +3,9 @@
 #include <Processors/Formats/IRowOutputFormat.h>
 #include <Core/Block.h>
 
-#include <Core/MySQL/Authentication.h>
-#include <Core/MySQL/PacketsGeneric.h>
-#include <Core/MySQL/PacketsConnection.h>
-#include <Core/MySQL/PacketsProtocolText.h>
-#include <Formats/FormatSettings.h>
+#include <Core/MySQL/PacketEndpoint.h>
+#include <Processors/Formats/IOutputFormat.h>
+
 
 namespace DB
 {
@@ -15,6 +13,7 @@ namespace DB
 class IColumn;
 class IDataType;
 class WriteBuffer;
+struct FormatSettings;
 
 /** A stream for outputting data in a binary line-by-line format.
   */
@@ -32,15 +31,14 @@ public:
     void flush() override;
     void doWritePrefix() override { initialize(); }
 
+private:
     void initialize();
 
-private:
     bool initialized = false;
-
-    std::optional<MySQLWireContext> own_mysql_context;
-    MySQLWireContext * mysql_context = nullptr;
+    uint32_t client_capabilities = 0;
+    uint8_t * sequence_id = nullptr;
+    uint8_t dummy_sequence_id = 0;
     MySQLProtocol::PacketEndpointPtr packet_endpoint;
-    FormatSettings format_settings;
     DataTypes data_types;
     Serializations serializations;
 };

--- a/src/Server/MySQLHandler.h
+++ b/src/Server/MySQLHandler.h
@@ -32,7 +32,7 @@ public:
 
     void run() final;
 
-private:
+protected:
     CurrentMetrics::Increment metric_increment{CurrentMetrics::MySQLConnection};
 
     /// Enables SSL, if client requested.
@@ -52,33 +52,25 @@ private:
     virtual void finishHandshakeSSL(size_t packet_size, char * buf, size_t pos, std::function<void(size_t)> read_bytes, MySQLProtocol::ConnectionPhase::HandshakeResponse & packet);
 
     IServer & server;
-
-protected:
     Poco::Logger * log;
-
-    MySQLWireContext connection_context_mysql;
-    ContextMutablePtr connection_context;
-
-    MySQLProtocol::PacketEndpointPtr packet_endpoint;
-
-private:
     UInt64 connection_id = 0;
 
-    size_t server_capability_flags = 0;
-    size_t client_capability_flags = 0;
+    uint32_t server_capabilities = 0;
+    uint32_t client_capabilities = 0;
+    size_t max_packet_size = 0;
+    uint8_t sequence_id = 0;
 
-protected:
-    std::unique_ptr<MySQLProtocol::Authentication::IPlugin> auth_plugin;
+    MySQLProtocol::PacketEndpointPtr packet_endpoint;
+    ContextMutablePtr connection_context;
 
-    std::shared_ptr<ReadBuffer> in;
-    std::shared_ptr<WriteBuffer> out;
-
-    bool secure_connection = false;
-
-private:
     using ReplacementFn = std::function<String(const String & query)>;
     using Replacements = std::unordered_map<std::string, ReplacementFn>;
     Replacements replacements;
+
+    std::unique_ptr<MySQLProtocol::Authentication::IPlugin> auth_plugin;
+    std::shared_ptr<ReadBuffer> in;
+    std::shared_ptr<WriteBuffer> out;
+    bool secure_connection = false;
 };
 
 #if USE_SSL


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Not for changelog

A raw pointer to `MySQLWireContext` in `Context` doesn't look good and also it makes difficult to implement sessions, so I've decided to remove it.

This functionality is required for https://github.com/ClickHouse/ClickHouse/pull/22415