### PR TITLE
Set client query kind for mysql and postgresql handler

### DIFF
--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -95,7 +95,7 @@ void MySQLHandler::run()
     connection_context->getClientInfo().interface = ClientInfo::Interface::MYSQL;
     connection_context->setDefaultFormat("MySQLWire");
     connection_context->getClientInfo().connection_id = connection_id;
-    connection_context.getClientInfo().query_kind = ClientInfo::QueryKind::INITIAL_QUERY;
+    connection_context->getClientInfo().query_kind = ClientInfo::QueryKind::INITIAL_QUERY;
 
     in = std::make_shared<ReadBufferFromPocoSocket>(socket());
     out = std::make_shared<WriteBufferFromPocoSocket>(socket());

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -95,6 +95,7 @@ void MySQLHandler::run()
     connection_context->getClientInfo().interface = ClientInfo::Interface::MYSQL;
     connection_context->setDefaultFormat("MySQLWire");
     connection_context->getClientInfo().connection_id = connection_id;
+    connection_context.getClientInfo().query_kind = ClientInfo::QueryKind::INITIAL_QUERY;
 
     in = std::make_shared<ReadBufferFromPocoSocket>(socket());
     out = std::make_shared<WriteBufferFromPocoSocket>(socket());

--- a/src/Server/PostgreSQLHandler.cpp
+++ b/src/Server/PostgreSQLHandler.cpp
@@ -55,6 +55,7 @@ void PostgreSQLHandler::run()
     connection_context->makeSessionContext();
     connection_context->getClientInfo().interface = ClientInfo::Interface::POSTGRESQL;
     connection_context->setDefaultFormat("PostgreSQLWire");
+    connection_context.getClientInfo().query_kind = ClientInfo::QueryKind::INITIAL_QUERY;
 
     try
     {

--- a/src/Server/PostgreSQLHandler.cpp
+++ b/src/Server/PostgreSQLHandler.cpp
@@ -55,7 +55,7 @@ void PostgreSQLHandler::run()
     connection_context->makeSessionContext();
     connection_context->getClientInfo().interface = ClientInfo::Interface::POSTGRESQL;
     connection_context->setDefaultFormat("PostgreSQLWire");
-    connection_context.getClientInfo().query_kind = ClientInfo::QueryKind::INITIAL_QUERY;
+    connection_context->getClientInfo().query_kind = ClientInfo::QueryKind::INITIAL_QUERY;
 
     try
     {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Set client query kind for mysql and postgresql handler

Detailed description / Documentation draft:
- Set client query kind for mysql and postgresql handler