### PR TITLE
Fix `assumeNotNull` docs

### DIFF
--- a/docs/en/sql-reference/functions/functions-for-nulls.md
+++ b/docs/en/sql-reference/functions/functions-for-nulls.md
@@ -211,7 +211,7 @@ SELECT nullIf(1, 2);
 
 ## assumeNotNull {#assumenotnull}
 
-Results in an equivalent non-`Nullable` value for a [Nullable](../../sql-reference/data-types/nullable.md) type, defaulting to the zero-value for the type in case the original value is `NULL`
+Results in an equivalent non-`Nullable` value for a [Nullable](../../sql-reference/data-types/nullable.md) type. In case the original value is `NULL` the result is undetermined. See also `ifNull` and `coalesce` functions.
 
 ``` sql
 assumeNotNull(x)

--- a/docs/en/sql-reference/functions/functions-for-nulls.md
+++ b/docs/en/sql-reference/functions/functions-for-nulls.md
@@ -211,7 +211,7 @@ SELECT nullIf(1, 2);
 
 ## assumeNotNull {#assumenotnull}
 
-Results in a value of type [Nullable](../../sql-reference/data-types/nullable.md) for a non- `Nullable`, if the value is not `NULL`.
+Results in an equivalent non-`Nullable` value for a [Nullable](../../sql-reference/data-types/nullable.md) type, defaulting to the zero-value for the type in case the original value is `NULL`
 
 ``` sql
 assumeNotNull(x)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
* Documentation (changelog entry is not required)


#### Detailed description / Documentation draft:

assumeNotNull behaves the opposite of what was described in the doc before this patch.

Translations for the doc should also be reviewed.