### PR TITLE
Storage Dictionary quoted names fix

### DIFF
--- a/src/Interpreters/ExternalDictionariesLoader.cpp
+++ b/src/Interpreters/ExternalDictionariesLoader.cpp
@@ -81,8 +81,12 @@ DictionaryStructure ExternalDictionariesLoader::getDictionaryStructure(const std
 
 std::string ExternalDictionariesLoader::resolveDictionaryName(const std::string & dictionary_name, const std::string & current_database_name) const
 {
+    bool has_dictionary = has(dictionary_name);
+    if (has_dictionary)
+        return dictionary_name;
+
     std::string resolved_name = resolveDictionaryNameFromDatabaseCatalog(dictionary_name);
-    bool has_dictionary = has(resolved_name);
+    has_dictionary = has(resolved_name);
 
     if (!has_dictionary)
     {

--- a/src/Storages/StorageDictionary.cpp
+++ b/src/Storages/StorageDictionary.cpp
@@ -167,7 +167,8 @@ Pipe StorageDictionary::read(
     const size_t max_block_size,
     const unsigned /*threads*/)
 {
-    auto dictionary = getContext()->getExternalDictionariesLoader().getDictionary(dictionary_name, local_context);
+    auto registered_dictionary_name = location == Location::SameDatabaseAndNameAsDictionary ? getStorageID().getInternalDictionaryName() : dictionary_name;
+    auto dictionary = getContext()->getExternalDictionariesLoader().getDictionary(registered_dictionary_name, local_context);
     auto stream = dictionary->getBlockInputStream(column_names, max_block_size);
     /// TODO: update dictionary interface for processors.
     return Pipe(std::make_shared<SourceFromInputStream>(stream));

--- a/tests/queries/0_stateless/01948_dictionary_quoted_database_name.reference
+++ b/tests/queries/0_stateless/01948_dictionary_quoted_database_name.reference
@@ -1,0 +1,2 @@
+0	Value
+0	Value

--- a/tests/queries/0_stateless/01948_dictionary_quoted_database_name.sql
+++ b/tests/queries/0_stateless/01948_dictionary_quoted_database_name.sql
@@ -1,0 +1,38 @@
+DROP DATABASE IF EXISTS `01945.db`;
+CREATE DATABASE `01945.db`;
+
+CREATE TABLE `01945.db`.test_dictionary_values
+(
+	id UInt64,
+	value String
+) ENGINE=TinyLog;
+
+INSERT INTO `01945.db`.test_dictionary_values VALUES (0, 'Value');
+
+CREATE DICTIONARY `01945.db`.test_dictionary
+(
+    id UInt64,
+    value String
+)
+PRIMARY KEY id
+LAYOUT(DIRECT())
+SOURCE(CLICKHOUSE(DB '01945.db' TABLE 'test_dictionary_values'));
+
+SELECT * FROM `01945.db`.test_dictionary;
+DROP DICTIONARY `01945.db`.test_dictionary;
+
+CREATE DICTIONARY `01945.db`.`test_dictionary.test`
+(
+    id UInt64,
+    value String
+)
+PRIMARY KEY id
+LAYOUT(DIRECT())
+SOURCE(CLICKHOUSE(DB '01945.db' TABLE 'test_dictionary_values'));
+
+SELECT * FROM `01945.db`.`test_dictionary.test`;
+DROP DICTIONARY `01945.db`.`test_dictionary.test`;
+
+
+DROP TABLE `01945.db`.test_dictionary_values;
+DROP DATABASE `01945.db`;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix issues with `CREATE DICTIONARY` query if dictionary name or database name was quoted. Closes #26491.
