### PR TITLE
optimize the low cardinality column merge process

### DIFF
--- a/src/Columns/ColumnLowCardinality.h
+++ b/src/Columns/ColumnLowCardinality.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <unordered_map>
 #include <Columns/IColumn.h>
 #include <Columns/IColumnUnique.h>
 #include <Common/typeid_cast.h>
@@ -78,6 +79,12 @@ public:
 
     void insert(const Field & x) override;
     void insertDefault() override;
+
+    void mergeGatherColumn(const IColumn &src, std::unordered_map<UInt64, UInt64> &trans);
+    void loadDictionaryFrom(const IColumn & src);
+    void insertIndexFrom(const IColumn & src, size_t n);
+    void insertIndexRangeFrom(const IColumn & src, size_t start, size_t length);
+    void transformIndex(std::unordered_map<UInt64, UInt64>& trans, size_t max_size);
 
     void insertFrom(const IColumn & src, size_t n) override;
     void insertFromFullColumn(const IColumn & src, size_t n);
@@ -271,6 +278,7 @@ public:
 
         void updateWeakHash(WeakHash32 & hash, WeakHash32 & dict_hash) const;
 
+        void transformIndex(std::unordered_map<UInt64, UInt64>& trans, size_t max_size);
     private:
         WrappedPtr positions;
         size_t size_of_type = 0;

--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -60,7 +60,7 @@ public:
                                                                      size_t max_dictionary_size) override;
     size_t uniqueInsertData(const char * pos, size_t length) override;
     size_t uniqueDeserializeAndInsertFromArena(const char * pos, const char *& new_pos) override;
-    bool isEmpty() const override { return (column_holder->size() > numSpecialValues()); }
+    bool isEmpty() const override { return !(column_holder->size() > numSpecialValues()); }
     void insertWithGetTransIndex(const IColumn & src, size_t start, size_t length, std::unordered_map<UInt64, UInt64>& trans) override;
 
     size_t getDefaultValueIndex() const override { return 0; }
@@ -319,7 +319,7 @@ void ColumnUnique<ColumnType>::insertWithGetTransIndex(const IColumn & src, size
                         ", got " + src.getName(), ErrorCodes::ILLEGAL_COLUMN);
 
     auto column = getRawColumnPtr();
-    for (size_t row = start; row < length; ++row)
+    for (size_t row = start; row < (length + start); ++row)
     {
         if (null_map && (*null_map)[row])
             continue;

--- a/src/Columns/IColumnUnique.h
+++ b/src/Columns/IColumnUnique.h
@@ -32,6 +32,8 @@ public:
     virtual const UInt64 * tryGetSavedHash() const = 0;
 
     size_t size() const override { return getNestedNotNullableColumn()->size(); }
+    virtual bool isEmpty() const = 0;
+    virtual void insertWithGetTransIndex(const IColumn & src, size_t start, size_t length, std::unordered_map<UInt64, UInt64>& trans) = 0;
 
     /// Appends new value at the end of column (column's size is increased by 1).
     /// Is used to transform raw strings to Blocks (for example, inside input format parsers)

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -478,6 +478,8 @@ class IColumn;
     M(Bool, query_plan_enable_optimizations, true, "Apply optimizations to query plan", 0) \
     M(UInt64, query_plan_max_optimizations_to_apply, 10000, "Limit the total number of optimizations applied to query plan. If zero, ignored. If limit reached, throw exception", 0) \
     M(Bool, query_plan_filter_push_down, true, "Allow to push down filter by predicate query plan step", 0) \
+    M(Bool, enable_low_cardinality_merge_new_algo, true, "Whether use the new merge algorithm during part merge for low cardinality column", 0) \
+    M(UInt64, max_rows_low_cardinality_merge_new_algo, 500000000, "Max threshold rows to use new low cardinality merge algorithm", 0) \
     \
     M(UInt64, limit, 0, "Limit on read rows from the most 'end' result for select query, default 0 means no limit length", 0) \
     M(UInt64, offset, 0, "Offset on read rows from the most 'end' result for select query", 0) \

--- a/src/DataStreams/ColumnGathererStream.cpp
+++ b/src/DataStreams/ColumnGathererStream.cpp
@@ -19,8 +19,9 @@ namespace ErrorCodes
 
 ColumnGathererStream::ColumnGathererStream(
         const String & column_name_, const BlockInputStreams & source_streams, ReadBuffer & row_sources_buf_,
-        size_t block_preferred_size_)
+        bool enable_low_cardinality_merge_new_algo_, size_t block_preferred_size_)
     : column_name(column_name_), sources(source_streams.size()), row_sources_buf(row_sources_buf_)
+    , enable_low_cardinality_merge_new_algo(enable_low_cardinality_merge_new_algo_)
     , block_preferred_size(block_preferred_size_), log(&Poco::Logger::get("ColumnGathererStream"))
 {
     if (source_streams.empty())
@@ -47,6 +48,8 @@ ColumnGathererStream::ColumnGathererStream(
         else if (header.getByName(column_name).column->getName() != column.column->getName())
             throw Exception("Column types don't match", ErrorCodes::INCOMPATIBLE_COLUMNS);
     }
+
+    LOG_DEBUG(log, "Merge low cardinality column use new algo: {}", enable_low_cardinality_merge_new_algo);
 }
 
 
@@ -110,5 +113,90 @@ void ColumnGathererStream::readSuffixImpl()
             column_name, static_cast<double>(profile_info.bytes) / profile_info.rows, seconds,
             profile_info.rows / seconds, ReadableSize(profile_info.bytes / seconds));
 }
+
+void ColumnGathererStream::gatherLowCardinality(ColumnLowCardinality &column_res)
+{
+    if (!enable_low_cardinality_merge_new_algo)
+    {
+        gather(column_res);
+        return ;
+    }
+
+    row_sources_buf.nextIfAtEnd();
+    RowSourcePart * row_source_pos = reinterpret_cast<RowSourcePart *>(row_sources_buf.position());
+    RowSourcePart * row_sources_end = reinterpret_cast<RowSourcePart *>(row_sources_buf.buffer().end());
+
+    size_t cur_block_preferred_size = static_cast<size_t>(row_sources_end - row_source_pos);
+    column_res.reserve(cur_block_preferred_size);
+
+    if (cardinalityDict)
+        column_res.loadDictionaryFrom(*cardinalityDict);
+
+    while (row_source_pos < row_sources_end)
+    {
+        RowSourcePart row_source = *row_source_pos;
+        size_t source_num = row_source.getSourceNum();
+        Source & source = sources[source_num];
+        bool source_skip = row_source.getSkipFlag();
+        ++row_source_pos;
+
+        if (source.pos >= source.size) /// Fetch new block from source_num part
+        {
+            fetchNewBlock(source, source_num);
+            column_res.mergeGatherColumn(*source.column, source.index_map);
+            if (!source.index_map.empty())
+            {
+                auto *low_ref = const_cast<IColumn *>(source.column);
+                auto *low_src = typeid_cast<ColumnLowCardinality *>(low_ref);
+                low_src->transformIndex(source.index_map, column_res.getDictionary().size());
+            }
+        }
+
+        size_t len = 1;
+        size_t max_len = std::min(static_cast<size_t>(row_sources_end - row_source_pos), source.size - source.pos); // interval should be in the same block
+        while (len < max_len && row_source_pos->data == row_source.data)
+        {
+            ++len;
+            ++row_source_pos;
+        }
+
+        row_sources_buf.position() = reinterpret_cast<char *>(row_source_pos);
+
+        if (!source_skip)
+        {
+            if (len == 1)
+                column_res.insertIndexFrom(*source.column, source.pos);
+            else
+                column_res.insertIndexRangeFrom(*source.column, source.pos, len);
+        }
+
+        source.pos += len;
+    }
+
+    bool need_save_dict = false;
+    for (auto &ref : sources)
+    {
+        if (ref.pos >= ref.size)
+        {
+            ref.index_map.clear();
+        }
+        else
+        {
+            need_save_dict = true;
+        }
+    }
+
+    if (need_save_dict)
+    {
+        LOG_DEBUG(log, "save dict size: {}", column_res.getDictionary().size());
+        cardinalityDict = column_res.cloneEmpty();
+        (typeid_cast<ColumnLowCardinality *>(cardinalityDict.get()))->loadDictionaryFrom(column_res);
+    }
+    else
+    {
+        cardinalityDict = nullptr;
+    }
+}
+
 
 }

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -1066,7 +1066,9 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMergerMutator::mergePartsToTempor
             }
 
             rows_sources_read_buf.seek(0, 0);
-            ColumnGathererStream column_gathered_stream(column_name, column_part_streams, rows_sources_read_buf);
+            bool enable_new_algo = data.getContext()->getSettingsRef().enable_low_cardinality_merge_new_algo && (data.getContext()->getSettingsRef().max_rows_low_cardinality_merge_new_algo > rows_written);
+
+            ColumnGathererStream column_gathered_stream(column_name, column_part_streams, rows_sources_read_buf, enable_new_algo);
 
             MergedColumnOnlyOutputStream column_to(
                 new_data_part,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Optimized the low cardinality column merge process for the vertical merge algorithm. 

Detailed description / Documentation draft:
The improvement focus on the low cardinality column merge process, and implemented a new way to gather the low cardinality column during vertical merge.
Before the improvement, during vertical merge, each block would be gathered from several parts, and each insert would compute the dictionary, and each assembled block would cost many times dictionary compute / index cut etc.
And this PR improve that by build a shared dictionary among the merged parts. The index of the merged parts will be transformed based on the shared dictionary, and then during the merge process only insert the index to the result column.

A little performance test:

```
CREATE TABLE default.LCDict
(
    `d2` UInt32,
    `d1` UInt32,
    `uintlc` LowCardinality(UInt64),
    `fltlc` LowCardinality(Float64),
    `strlc` LowCardinality(String)
)
ENGINE = MergeTree
PARTITION BY d2
ORDER BY (d2, d1)
SETTINGS index_granularity = 8192, vertical_merge_algorithm_min_rows_to_activate = 100000, vertical_merge_algorithm_min_columns_to_activate = 2, min_bytes_for_wide_part = 10000


INSERT INTO LCDict  SELECT intDiv(number, 5000000) AS d2,number AS d1,  (rand64() % 7000 +1)*10000 AS uint,    uint * pi() as flt, ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'][rand()%10+1] AS str FROM numbers(50000000) order by rand()

**Before**:
2021.07.19 17:52:25.304170 [ 2388944 ] {f565d0cc-a597-453b-8fe5-f2a7d8c0f9cd} <Debug> ColumnGathererStream: Gathered column uintlc (2.859778113188539 bytes/elem.) in 0.344000575 sec., 3231791.1096514883 rows/sec., 8.81 MiB/sec.
2021.07.19 17:52:25.664465 [ 2388944 ] {f565d0cc-a597-453b-8fe5-f2a7d8c0f9cd} <Debug> ColumnGathererStream: Gathered column fltlc (2.859778113188539 bytes/elem.) in 0.356000595 sec., 3122854.3311844748 rows/sec., 8.52 MiB/sec.
2021.07.19 17:52:25.956497 [ 2388944 ] {f565d0cc-a597-453b-8fe5-f2a7d8c0f9cd} <Debug> ColumnGathererStream: Gathered column strlc (1.0022343393857185 bytes/elem.) in 0.288000481 sec., 3860194.941827198 rows/sec., 3.69 MiB/sec.
2021.07.19 17:52:25.957880 [ 2388944 ] {f565d0cc-a597-453b-8fe5-f2a7d8c0f9cd} <Debug> default.LCDict (7bfa27cc-9106-4f5a-bbfa-27cc91066f5a) (MergerMutator): Merge sorted 1111738 rows, containing 5 columns (2 merged, 3 gathered) in 1.1057698 sec., 1005397.3259172026 rows/sec., 26.01 MiB/sec.

**After the improvement**:
2021.07.19 17:54:02.875385 [ 2391020 ] {d59e2e5b-3f9a-474a-b9c1-d7230599766e} <Debug> ColumnGathererStream: Gathered column uintlc (2.1006459287798154 bytes/elem.) in 0.120000201 sec., 9274742.798139146 rows/sec., 18.58 MiB/sec.
2021.07.19 17:54:03.000718 [ 2391020 ] {d59e2e5b-3f9a-474a-b9c1-d7230599766e} <Debug> ColumnGathererStream: Gathered column fltlc (2.1006459287798154 bytes/elem.) in 0.120000201 sec., 9274742.798139146 rows/sec., 18.58 MiB/sec.
2021.07.19 17:54:03.036786 [ 2391020 ] {d59e2e5b-3f9a-474a-b9c1-d7230599766e} <Debug> ColumnGathererStream: Gathered column strlc (1.0002479848980792 bytes/elem.) in 0.032000054 sec., 34780285.058268964 rows/sec., 33.18 MiB/sec.
2021.07.19 17:54:03.038090 [ 2391020 ] {d59e2e5b-3f9a-474a-b9c1-d7230599766e} <Debug> default.LCDict (7bfa27cc-9106-4f5a-bbfa-27cc91066f5a) (MergerMutator): Merge sorted 1112971 rows, containing 5 columns (2 merged, 3 gathered) in 0.392421579 sec., 2836161.565926526 rows/sec., 73.32 MiB/sec.

```

The test result shows more efficient after the improvement, especially with many low cardinality columns, and the gathered block assembled scrappy from many parts.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
