### PR TITLE
fix lagInFrame for nullable types

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -74,7 +74,7 @@ AggregateFunctionPtr AggregateFunctionFactory::get(
     /// If one of the types is Nullable, we apply aggregate function combinator "Null".
 
     if (std::any_of(type_without_low_cardinality.begin(), type_without_low_cardinality.end(),
-            [](const auto & type) { return type->isNullable(); }))
+        [](const auto & type) { return type->isNullable(); }))
     {
         AggregateFunctionCombinatorPtr combinator = AggregateFunctionCombinatorFactory::instance().tryFindSuffix("Null");
         if (!combinator)

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1475,12 +1475,21 @@ struct WindowFunctionLagLeadInFrame final : public WindowFunction
             return;
         }
 
-        if (!argument_types[0]->equals(*argument_types[2]))
+        const auto supertype = getLeastSupertype({argument_types[0], argument_types[2]});
+        if (!supertype)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "The default value type '{}' is not the same as the argument type '{}'",
-                argument_types[2]->getName(),
-                argument_types[0]->getName());
+                "There is no supertype for the argument type '{}' and the default value type '{}'",
+                argument_types[0]->getName(),
+                argument_types[2]->getName());
+        }
+        if (!argument_types[0]->equals(*supertype))
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "The supertype '{}' for the argument type '{}' and the default value type '{}' is not the same as the argument type",
+                supertype->getName(),
+                argument_types[0]->getName(),
+                argument_types[2]->getName());
         }
 
         if (argument_types.size() > 3)
@@ -1533,9 +1542,13 @@ struct WindowFunctionLagLeadInFrame final : public WindowFunction
             if (argument_types.size() > 2)
             {
                 // Column with default values is specified.
-                to.insertFrom(*current_block.input_columns[
-                            workspace.argument_column_indices[2]],
-                    transform->current_row.row);
+                // The conversion through Field is inefficient, but we accept
+                // subtypes of the argument type as a default value (for convenience),
+                // and it's a pain to write conversion that respects ColumnNothing
+                // and ColumnConst and so on.
+                const IColumn & default_column = *current_block.input_columns[
+                    workspace.argument_column_indices[2]].get();
+                to.insert(default_column[transform->current_row.row]);
             }
             else
             {
@@ -1572,40 +1585,49 @@ void registerWindowFunctions(AggregateFunctionFactory & factory)
     // to a (rows between unbounded preceding and unbounded following) frame,
     // instead of adding separate logic for them.
 
-    factory.registerFunction("rank", [](const std::string & name,
+    const AggregateFunctionProperties properties = {
+        // By default, if an aggregate function has a null argument, it will be
+        // replaced with AggregateFunctionNothing. We don't need this behavior
+        // e.g. for lagInFrame(number, 1, null).
+        .returns_default_when_only_null = true,
+        // This probably doesn't make any difference for window functions because
+        // it is an Aggregator-specific setting.
+        .is_order_dependent = true };
+
+    factory.registerFunction("rank", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionRank>(name, argument_types,
                 parameters);
-        });
+        }, properties});
 
-    factory.registerFunction("dense_rank", [](const std::string & name,
+    factory.registerFunction("dense_rank", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionDenseRank>(name, argument_types,
                 parameters);
-        });
+        }, properties});
 
-    factory.registerFunction("row_number", [](const std::string & name,
+    factory.registerFunction("row_number", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionRowNumber>(name, argument_types,
                 parameters);
-        });
+        }, properties});
 
-    factory.registerFunction("lagInFrame", [](const std::string & name,
+    factory.registerFunction("lagInFrame", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionLagLeadInFrame<false>>(
                 name, argument_types, parameters);
-        });
+        }, properties});
 
-    factory.registerFunction("leadInFrame", [](const std::string & name,
+    factory.registerFunction("leadInFrame", {[](const std::string & name,
             const DataTypes & argument_types, const Array & parameters, const Settings *)
         {
             return std::make_shared<WindowFunctionLagLeadInFrame<true>>(
                 name, argument_types, parameters);
-        });
+        }, properties});
 }
 
 }

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1475,10 +1475,10 @@ struct WindowFunctionLagLeadInFrame final : public WindowFunction
             return;
         }
 
-        if (!getLeastSupertype({argument_types[0], argument_types[2]}))
+        if (!argument_types[0]->equals(*argument_types[2]))
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "The default value type '{}' is not convertible to the argument type '{}'",
+                "The default value type '{}' is not the same as the argument type '{}'",
                 argument_types[2]->getName(),
                 argument_types[0]->getName());
         }
@@ -1491,8 +1491,7 @@ struct WindowFunctionLagLeadInFrame final : public WindowFunction
         }
     }
 
-    DataTypePtr getReturnType() const override
-    { return argument_types[0]; }
+    DataTypePtr getReturnType() const override { return argument_types[0]; }
 
     bool allocatesMemoryInArena() const override { return false; }
 

--- a/tests/queries/0_stateless/01571_window_functions.reference
+++ b/tests/queries/0_stateless/01571_window_functions.reference
@@ -15,3 +15,20 @@ select count() over (rows between 1 + 1 preceding and 1 + 1 following) from numb
 3
 -- signed and unsigned in offset do not cause logical error
 select count() over (rows between 2 following and 1 + -1 following) FROM numbers(10); -- { serverError 36 }
+-- default arguments of lagInFrame can be a subtype of the argument
+select number,
+    lagInFrame(toNullable(number), 2, null) over w,
+    lagInFrame(number, 2, 1) over w
+from numbers(10)
+window w as (order by number)
+;
+0	\N	1
+1	\N	1
+2	0	0
+3	1	1
+4	2	2
+5	3	3
+6	4	4
+7	5	5
+8	6	6
+9	7	7

--- a/tests/queries/0_stateless/01571_window_functions.sql
+++ b/tests/queries/0_stateless/01571_window_functions.sql
@@ -7,3 +7,11 @@ select count() over (rows between 1 + 1 preceding and 1 + 1 following) from numb
 
 -- signed and unsigned in offset do not cause logical error
 select count() over (rows between 2 following and 1 + -1 following) FROM numbers(10); -- { serverError 36 }
+
+-- default arguments of lagInFrame can be a subtype of the argument
+select number,
+    lagInFrame(toNullable(number), 2, null) over w,
+    lagInFrame(number, 2, 1) over w
+from numbers(10)
+window w as (order by number)
+;

--- a/tests/queries/0_stateless/01591_window_functions.reference
+++ b/tests/queries/0_stateless/01591_window_functions.reference
@@ -1056,10 +1056,25 @@ settings max_block_size = 3;
 15	3	15	0	15	15	15
 -- careful with auto-application of Null combinator
 select lagInFrame(toNullable(1)) over ();
-0
+\N
 select lagInFrameOrNull(1) over (); -- { serverError 36 }
-select intDiv(1, NULL) x, toTypeName(x), max(x) over ();
-\N	Nullable(Nothing)	\N
+-- this should give the same error as `select max(Null::Nullable(Nothing))`
+select intDiv(1, NULL) x, toTypeName(x), max(x) over (); -- { serverError 43 }
+-- to make lagInFrame return null for out-of-frame rows, cast the argument to
+-- Nullable; otherwise, it returns default values.
+SELECT
+    number,
+    lagInFrame(toNullable(number), 1) OVER w,
+    lagInFrame(toNullable(number), 2) OVER w,
+    lagInFrame(number, 1) OVER w,
+    lagInFrame(number, 2) OVER w
+FROM numbers(4)
+WINDOW w AS (ORDER BY number ASC)
+;
+0	\N	\N	0	0
+1	0	\N	0	0
+2	1	0	1	0
+3	2	1	2	1
 -- case-insensitive SQL-standard synonyms for any and anyLast
 select
     number,

--- a/tests/queries/0_stateless/01591_window_functions.reference
+++ b/tests/queries/0_stateless/01591_window_functions.reference
@@ -1058,8 +1058,9 @@ settings max_block_size = 3;
 select lagInFrame(toNullable(1)) over ();
 \N
 select lagInFrameOrNull(1) over (); -- { serverError 36 }
--- this should give the same error as `select max(Null::Nullable(Nothing))`
-select intDiv(1, NULL) x, toTypeName(x), max(x) over (); -- { serverError 43 }
+-- this is the same as `select max(Null::Nullable(Nothing))`
+select intDiv(1, NULL) x, toTypeName(x), max(x) over ();
+\N	Nullable(Nothing)	\N
 -- to make lagInFrame return null for out-of-frame rows, cast the argument to
 -- Nullable; otherwise, it returns default values.
 SELECT

--- a/tests/queries/0_stateless/01591_window_functions.sql
+++ b/tests/queries/0_stateless/01591_window_functions.sql
@@ -379,7 +379,19 @@ settings max_block_size = 3;
 -- careful with auto-application of Null combinator
 select lagInFrame(toNullable(1)) over ();
 select lagInFrameOrNull(1) over (); -- { serverError 36 }
-select intDiv(1, NULL) x, toTypeName(x), max(x) over ();
+-- this should give the same error as `select max(Null::Nullable(Nothing))`
+select intDiv(1, NULL) x, toTypeName(x), max(x) over (); -- { serverError 43 }
+-- to make lagInFrame return null for out-of-frame rows, cast the argument to
+-- Nullable; otherwise, it returns default values.
+SELECT
+    number,
+    lagInFrame(toNullable(number), 1) OVER w,
+    lagInFrame(toNullable(number), 2) OVER w,
+    lagInFrame(number, 1) OVER w,
+    lagInFrame(number, 2) OVER w
+FROM numbers(4)
+WINDOW w AS (ORDER BY number ASC)
+;
 
 -- case-insensitive SQL-standard synonyms for any and anyLast
 select

--- a/tests/queries/0_stateless/01591_window_functions.sql
+++ b/tests/queries/0_stateless/01591_window_functions.sql
@@ -379,8 +379,8 @@ settings max_block_size = 3;
 -- careful with auto-application of Null combinator
 select lagInFrame(toNullable(1)) over ();
 select lagInFrameOrNull(1) over (); -- { serverError 36 }
--- this should give the same error as `select max(Null::Nullable(Nothing))`
-select intDiv(1, NULL) x, toTypeName(x), max(x) over (); -- { serverError 43 }
+-- this is the same as `select max(Null::Nullable(Nothing))`
+select intDiv(1, NULL) x, toTypeName(x), max(x) over ();
 -- to make lagInFrame return null for out-of-frame rows, cast the argument to
 -- Nullable; otherwise, it returns default values.
 SELECT


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/26115

`lagInFrame(x)` still returns default value of the type if the row is out of frame, but you can write `lagInFrame(toNullable(x))` to get Nulls.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)