### PR TITLE
Fix rabbitmq shutdown in case rabbitmq setup was not started

### DIFF
--- a/src/Storages/RabbitMQ/RabbitMQHandler.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQHandler.cpp
@@ -57,11 +57,13 @@ void RabbitMQHandler::iterateLoop()
 /// initial RabbitMQ setup - at this point there is no background loop thread.
 void RabbitMQHandler::startBlockingLoop()
 {
+    LOG_DEBUG(log, "Started blocking loop.");
     uv_run(loop, UV_RUN_DEFAULT);
 }
 
 void RabbitMQHandler::stopLoop()
 {
+    LOG_DEBUG(log, "Implicit loop stop.");
     uv_stop(loop);
 }
 

--- a/src/Storages/RabbitMQ/ReadBufferFromRabbitMQConsumer.h
+++ b/src/Storages/RabbitMQ/ReadBufferFromRabbitMQConsumer.h
@@ -56,7 +56,11 @@ public:
     ChannelPtr & getChannel() { return consumer_channel; }
     void setupChannel();
     bool needChannelUpdate();
-    void closeChannel() { consumer_channel->close(); }
+    void closeChannel()
+    {
+        if (consumer_channel)
+            consumer_channel->close();
+    }
 
     void updateQueues(std::vector<String> & queues_) { queues = queues_; }
     size_t queuesCount() { return queues.size(); }

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -265,6 +265,9 @@ size_t StorageRabbitMQ::getMaxBlockSize() const
 
 void StorageRabbitMQ::initRabbitMQ()
 {
+    if (stream_cancelled)
+        return;
+
     if (use_user_setup)
     {
         queues.emplace_back(queue_base);
@@ -704,10 +707,6 @@ void StorageRabbitMQ::shutdown()
     while (!connection->closed() && cnt_retries++ != RETRIES_MAX)
         event_handler->iterateLoop();
 
-    /// Should actually force closure, if not yet closed, but it generates distracting error logs
-    //if (!connection->closed())
-    //    connection->close(true);
-
     for (size_t i = 0; i < num_created_consumers; ++i)
         popReadBuffer();
 }
@@ -719,6 +718,22 @@ void StorageRabbitMQ::cleanupRabbitMQ() const
 {
     if (use_user_setup)
         return;
+
+    if (!event_handler->connectionRunning())
+    {
+        String queue_names;
+        for (const auto & queue : queues)
+        {
+            if (!queue_names.empty())
+                queue_names += ", ";
+            queue_names += queue;
+        }
+        LOG_WARNING(log,
+                    "RabbitMQ clean up not done, because there is no connection in table's shutdown."
+                    "There are {} queues ({}), which might need to be deleted manually. Exchanges will be auto-deleted",
+                    queues.size(), queue_names);
+        return;
+    }
 
     AMQP::TcpChannel rabbit_channel(connection.get());
     for (const auto & queue : queues)

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2032,6 +2032,20 @@ def test_rabbitmq_queue_consume(rabbitmq_cluster):
     instance.query('DROP TABLE test.rabbitmq_queue')
 
 
+def test_rabbitmq_drop_table_with_unfinished_setup(rabbitmq_cluster):
+    rabbitmq_cluster.pause_container('rabbitmq1')
+    instance.query('''
+        CREATE TABLE test.drop (key UInt64, value UInt64)
+            ENGINE = RabbitMQ
+            SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_exchange_name = 'drop',
+                     rabbitmq_format = 'JSONEachRow';
+    ''')
+    time.sleep(5)
+    instance.query('DROP TABLE test.drop;')
+    rabbitmq_cluster.unpause_container('rabbitmq1')
+
+
 if __name__ == '__main__':
     cluster.start()
     input("Cluster created, press any key to destroy...")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash in rabbitmq shutdown in case rabbitmq setup was not started. Closes https://github.com/ClickHouse/ClickHouse/issues/26504.