### PR TITLE
Update entrypoint.sh

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -75,6 +75,7 @@ do
         # but skip it for if directory already has proper premissions, cause recursive chown may be slow
         if [ "$(stat -c %u "$dir")" != "$USER" ] || [ "$(stat -c %g "$dir")" != "$GROUP" ]; then
             chown -R "$USER:$GROUP" "$dir"
+        fi
     elif ! $gosu test -d "$dir" -a -w "$dir" -a -r "$dir"; then
         echo "Necessary directory '$dir' isn't accessible by user with id '$USER'"
         exit 1

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -72,6 +72,7 @@ do
 
     if [ "$DO_CHOWN" = "1" ]; then
         # ensure proper directories permissions
+        # but skip it for if directory already has proper premissions, cause recursive chown may be slow
         if [ "$(stat -c %u "$dir")" != "$USER" ] || [ "$(stat -c %g "$dir")" != "$GROUP" ]; then
             chown -R "$USER:$GROUP" "$dir"
     elif ! $gosu test -d "$dir" -a -w "$dir" -a -r "$dir"; then

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -72,7 +72,8 @@ do
 
     if [ "$DO_CHOWN" = "1" ]; then
         # ensure proper directories permissions
-        chown -R "$USER:$GROUP" "$dir"
+        if [ "$(stat -c %u "$dir")" != "$USER" ] || [ "$(stat -c %g "$dir")" != "$GROUP" ]; then
+            chown -R "$USER:$GROUP" "$dir"
     elif ! $gosu test -d "$dir" -a -w "$dir" -a -r "$dir"; then
         echo "Necessary directory '$dir' isn't accessible by user with id '$USER'"
         exit 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update `chown` cmd check in clickhouse-server docker entrypoint. It fixes the bug that cluster pod restart failed (or timeout) on kubernetes.

Detailed description / Documentation draft:
We build clickhouse cluster in k8s by clickhouse-operator. 
clickhouse-server.log is mounted by emptydir on the path `/var/log/clickhouse-server`.
It causes the file system error called `Necessary directory '/var/log/clickhouse-server' isn't owned by user with id '101' `  when  CLICKHOUSE_DO_NOT_CHOWN is set to true(1).
Because emptydir file and dir is owned by root when it started, it has to run the chown cmd.
But it will take a long time to run chown cmd when the cluster has much data (in table data dir), the cluster cannot even restart because of  `initialDelaySeconds`
So It's necessary to check if the file owner and usergroup is clickhouse(101) before running chown cmd.

