### PR TITLE
Fix flaky test 01622_defaults_for_url_engine

### DIFF
--- a/tests/queries/0_stateless/01622_defaults_for_url_engine.sh
+++ b/tests/queries/0_stateless/01622_defaults_for_url_engine.sh
@@ -7,8 +7,6 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 PORT="$(($RANDOM%63000+2001))"
 
-TEMP_FILE="${CLICKHOUSE_TMP}/01622_defaults_for_url_engine.tmp"
-
 function thread1
 {
     while true; do
@@ -19,7 +17,7 @@ function thread1
 function thread2
 {
     while true; do
-        $CLICKHOUSE_CLIENT --input_format_defaults_for_omitted_fields=1 -q "SELECT * FROM url('http://127.0.0.1:$1/', JSONEachRow, 'a int, b int default 7, c default a + b') format Values"
+        $CLICKHOUSE_CLIENT --input_format_defaults_for_omitted_fields=1 -q "SELECT * FROM url('http://127.0.0.1:$1/', JSONEachRow, 'a int, b int default 7, c default a + b') format Values" | grep -F '(1,7,8)' && break
     done
 }
 
@@ -27,11 +25,11 @@ function thread2
 export -f thread1;
 export -f thread2;
 
-TIMEOUT=5
+TIMEOUT=60
 
 timeout $TIMEOUT bash -c "thread1 $PORT" > /dev/null 2>&1 &
-timeout $TIMEOUT bash -c "thread2 $PORT" 2> /dev/null > $TEMP_FILE &
+PID=$!
 
-wait
+bash -c "thread2 $PORT" 2> /dev/null | grep -q -F '(1,7,8)' && echo "Ok" && kill -9 $PID
 
-grep -q '(1,7,8)' $TEMP_FILE && echo "Ok"
+wait >/dev/null 2>&1


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


| check_name | test_name | test_status | check_start_time | report_url |
|:-|:-|:-|-:|:-|
| Functional stateless tests (ubsan) | 01622_defaults_for_url_engine | FAIL | 2021-07-20 01:04:00 | https://clickhouse-test-reports.s3.yandex.net/0/2c3c32951449c095127695bde1e0d8f087f0cdd7/functional_stateless_tests_(ubsan).html |
| Functional stateless tests (thread) | 01622_defaults_for_url_engine | FAIL | 2021-07-09 10:20:57 | https://clickhouse-test-reports.s3.yandex.net/0/581e79ced94234baad0a288e70b5d84bb0fd46fe/functional_stateless_tests_(thread).html |
| Functional stateless tests (release, wide parts enabled) | 01622_defaults_for_url_engine | FAIL | 2021-07-09 05:14:45 | https://clickhouse-test-reports.s3.yandex.net/0/3190e70a3ea83f80d2478fca33a7f867c6606dbf/functional_stateless_tests_(release,_wide_parts_enabled).html |
| Functional stateless tests (debug) | 01622_defaults_for_url_engine | FAIL | 2021-06-12 01:48:58 | https://clickhouse-test-reports.s3.yandex.net/0/16114c38c78eb4edb5525823dfa16d85209a064e/functional_stateless_tests_(debug).html |
| Functional stateless tests (ANTLR debug) | 01622_defaults_for_url_engine | FAIL | 2021-06-06 21:52:01 | https://clickhouse-test-reports.s3.yandex.net/0/f59f444ac66091f729627468ae2ab8bdc870c663/functional_stateless_tests_(antlr_debug).html |
| Functional stateless tests (release, DatabaseOrdinary) | 01622_defaults_for_url_engine | FAIL | 2021-05-15 12:57:52 | https://clickhouse-test-reports.s3.yandex.net/0/32a96779f5ae52167c19caa3eb657b0c8e420433/functional_stateless_tests_(release,_databaseordinary).html |
| Functional stateless tests (memory) | 01622_defaults_for_url_engine | FAIL | 2021-04-21 11:26:59 | https://clickhouse-test-reports.s3.yandex.net/0/71c27a4dc03c53d10c63b6c7c38b908954faf014/functional_stateless_tests_(memory).html |
| Functional stateless tests (release, DatabaseOrdinary) | 01622_defaults_for_url_engine | FAIL | 2021-04-02 09:06:00 | https://clickhouse-test-reports.s3.yandex.net/0/61d47947268d56f4e6af3022f02af5f697faab22/functional_stateless_tests_(release,_databaseordinary).html |

The reason is that sometimes five seconds is not enough.