### PR TITLE
Fix one possible cause of tests flakiness

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -663,7 +663,7 @@ void InterpreterSystemQuery::syncReplica(ASTSystemQuery &)
         {
             LOG_ERROR(log, "SYNC REPLICA {}: Timed out!", table_id.getNameForLogs());
             throw Exception(
-                    "SYNC REPLICA " + table_id.getNameForLogs() + ": command timed out! "
+                    "SYNC REPLICA " + table_id.getNameForLogs() + ": command timed out. "
                     "See the 'receive_timeout' setting", ErrorCodes::TIMEOUT_EXCEEDED);
         }
         LOG_TRACE(log, "SYNC REPLICA {}: OK", table_id.getNameForLogs());

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -49,6 +49,7 @@ MESSAGES_TO_RETRY = [
     "ConnectionPoolWithFailover: Connection failed at try",
     "DB::Exception: New table appeared in database being dropped or detached. Try again",
     "is already started to be removing by another replica right now",
+    "Shutdown is called for table", # It happens in SYSTEM SYNC REPLICA query if session with ZooKeeper is being reinitialized.
     DISTRIBUTED_DDL_TIMEOUT_MSG # FIXME
 ]
 

--- a/tests/queries/0_stateless/01154_move_partition_long.sh
+++ b/tests/queries/0_stateless/01154_move_partition_long.sh
@@ -117,8 +117,9 @@ timeout $TIMEOUT bash -c drop_part_thread &
 wait
 
 for ((i=0; i<16; i++)) do
-    $CLICKHOUSE_CLIENT -q "SYSTEM SYNC REPLICA dst_$i" &
-    $CLICKHOUSE_CLIENT -q "SYSTEM SYNC REPLICA src_$i" 2>/dev/null &
+    # The size of log is big, so increase timeout.
+    $CLICKHOUSE_CLIENT --receive_timeout 600 -q "SYSTEM SYNC REPLICA dst_$i" &
+    $CLICKHOUSE_CLIENT --receive_timeout 600 -q "SYSTEM SYNC REPLICA src_$i" 2>/dev/null &
 done
 wait
 echo "Replication did not hang"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://clickhouse-test-reports.s3.yandex.net/0/72ed5e0dfbcbf38bbc3e4ae5febea491a7b58ce1/functional_stateless_tests_(release,_databaseordinary)/test_run.txt.out.log
and https://clickhouse-test-reports.s3.yandex.net/0/8f1d7e67ca46488983e2a65c1320e0a8391e4728/functional_stateless_tests_(ubsan)/test_run.txt.out.log