### PR TITLE
#26640 change kafka engine max consumers from 16 to 48

### DIFF
--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -748,7 +748,7 @@ void registerStorageKafka(StorageFactory & factory)
 
         auto num_consumers = kafka_settings->kafka_num_consumers.value;
 
-        if (num_consumers > 16)
+        if (num_consumers > 48)
         {
             throw Exception("Number of consumers can not be bigger than 16", ErrorCodes::BAD_ARGUMENTS);
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve the high performance machine to use the kafka engine. and it can recuce the query node work load.


Detailed description / Documentation draft:
The high performance machine like 96 Cores/256GB can use 48 consumer thread to consume the Kafka data. 


By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
