### PR TITLE
#26640 change kafka engine max consumers from 16 to physical cpu cores

### DIFF
--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -34,6 +34,7 @@
 #include <Common/typeid_cast.h>
 #include <common/logger_useful.h>
 #include <Common/quoteString.h>
+#include <Common/getNumberOfPhysicalCPUCores.h>
 #include <Interpreters/Context.h>
 #include <Processors/Sources/SourceFromInputStream.h>
 #include <librdkafka/rdkafka.h>
@@ -747,10 +748,11 @@ void registerStorageKafka(StorageFactory & factory)
         #undef CHECK_KAFKA_STORAGE_ARGUMENT
 
         auto num_consumers = kafka_settings->kafka_num_consumers.value;
+        auto physical_cpu_cores = getNumberOfPhysicalCPUCores();
 
-        if (num_consumers > 16)
+        if (num_consumers > physical_cpu_cores)
         {
-            throw Exception("Number of consumers can not be bigger than 16", ErrorCodes::BAD_ARGUMENTS);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Number of consumers can not be bigger than {}", physical_cpu_cores);
         }
         else if (num_consumers < 1)
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

**Changelog category (leave one):**

Improvement

**Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):**

Improve the high performance machine to use the kafka engine. and it can recuce the query node work load.

**Detailed description / Documentation draft:**

The high performance machine like 96 Cores/256GB can use 48 consumer thread to consume the Kafka data.

Fixes: #26640