### PR TITLE
Fix excessive connect attempts with skip_unavailable_shards

### DIFF
--- a/src/DataStreams/RemoteBlockInputStream.cpp
+++ b/src/DataStreams/RemoteBlockInputStream.cpp
@@ -38,11 +38,6 @@ void RemoteBlockInputStream::init()
     query_executor.setLogger(log);
 }
 
-void RemoteBlockInputStream::readPrefix()
-{
-    query_executor.sendQuery();
-}
-
 void RemoteBlockInputStream::cancel(bool kill)
 {
     if (kill)

--- a/src/DataStreams/RemoteBlockInputStream.h
+++ b/src/DataStreams/RemoteBlockInputStream.h
@@ -52,9 +52,6 @@ public:
 
     void setMainTable(StorageID main_table_) { query_executor.setMainTable(std::move(main_table_)); }
 
-    /// Sends query (initiates calculation) before read()
-    void readPrefix() override;
-
     /// Prevent default progress notification because progress' callback is called by its own.
     void progress(const Progress & /*value*/) override {}
 

--- a/tests/queries/0_stateless/01956_skip_unavailable_shards_excessive_attempts.reference
+++ b/tests/queries/0_stateless/01956_skip_unavailable_shards_excessive_attempts.reference
@@ -1,0 +1,1 @@
+Connection failed at try №1,

--- a/tests/queries/0_stateless/01956_skip_unavailable_shards_excessive_attempts.sh
+++ b/tests/queries/0_stateless/01956_skip_unavailable_shards_excessive_attempts.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=trace
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+opts=(
+    "--connections_with_failover_max_tries=1"
+    "--skip_unavailable_shards=1"
+)
+$CLICKHOUSE_CLIENT --query "select * from remote('255.255.255.255', system.one)" "${opts[@]}" 2>&1 | grep -o 'Connection failed at try.*,'


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix excessive (x2) connect attempts with skip_unavailable_shards

Detailed description / Documentation draft:
Before this patch the query was sent from
RemoteBlockInputStream::readPrefix() and also from
RemoteBlockInputStream::read().

And since in case of skip_unavailable_shards=1 connection errors are
ignored, it tries to do x2 connect attempts.

Fix this, but removing RemoteBlockInputStream::readPrefix().

Fixes: #26511

*P.S. marked as Improvement by intention, since this is not the common case and to avoid backports*