### PR TITLE
add more debug to window transform

### DIFF
--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -982,8 +982,6 @@ static void assertSameColumns(const Columns & left_all,
         assert(typeid(*left_column).hash_code()
             == typeid(*right_column).hash_code());
 
-        fmt::print(stderr, "{}\n", typeid(*left_column).name());
-
         if (isColumnConst(*left_column))
         {
             Field left_value = assert_cast<const ColumnConst &>(*left_column).getField();


### PR DESCRIPTION
The idea of working with input chunks with different structures doesn't
seem sane. Assert that they are totally equal.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
