### PR TITLE
Fix flaky test `mutation_stuck_after_replace_partition`

### DIFF
--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.reference
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.reference
@@ -4,8 +4,8 @@
 4	4
 mt	0	0_1_1_0	2
 rmt	0	0_0_0_0	2
-1	1
-2	2
+1	s1
+2	s2
 mt	0	0_1_1_0	2
 rmt	0	0_3_3_0	2
 0000000000	UPDATE s = concat(\'s\', toString(n)) WHERE 1	[]	0	1

--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
@@ -5,12 +5,13 @@ create table mt (n UInt64, s String) engine = MergeTree partition by intDiv(n, 1
 insert into mt values (3, '3'), (4, '4');
 
 create table rmt (n UInt64, s String) engine = ReplicatedMergeTree('/clickhouse/test_01149_{database}/rmt', 'r1') partition by intDiv(n, 10) order by n;
-insert into rmt values (1,'1'), (2, '2');
+insert into rmt values (1, '1'), (2, '2');
 
 select * from rmt;
 select * from mt;
 select table, partition_id, name, rows from system.parts where database=currentDatabase() and table in ('mt', 'rmt') and active=1 order by table, name;
 
+SET mutations_sync = 1;
 alter table rmt update s = 's'||toString(n) where 1;
 
 select * from rmt;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
