### PR TITLE
ParallelFormattingOutputFormat: Use mutex to handle the join to the collector_thread

### DIFF
--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
@@ -172,6 +172,7 @@ private:
     ThreadPool pool;
     // Collecting all memory to original ReadBuffer
     ThreadFromGlobalPool collector_thread;
+    std::mutex collector_thread_mutex;
 
     std::exception_ptr background_exception = nullptr;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ParallelFormattingOutputFormat: Use mutex to handle the join to the collector_thread (https://github.com/ClickHouse/ClickHouse/issues/26694)

Detailed description / Documentation draft:

Fixes https://github.com/ClickHouse/ClickHouse/issues/26694