### PR TITLE
01946_test_wrong_host_name_access: Clear DNS in the end

### DIFF
--- a/tests/queries/0_stateless/01946_test_wrong_host_name_access.sh
+++ b/tests/queries/0_stateless/01946_test_wrong_host_name_access.sh
@@ -16,3 +16,5 @@ ${CLICKHOUSE_CLIENT} --query "SELECT 1" --user dns_fail_1 --host ${MYHOSTNAME}
 ${CLICKHOUSE_CLIENT} --query "SELECT 2" --user dns_fail_2 --host ${MYHOSTNAME}
 
 ${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS dns_fail_1, dns_fail_2"
+
+${CLICKHOUSE_CLIENT} --query "SYSTEM DROP DNS CACHE"


### PR DESCRIPTION
Leaves a better env and avoids future errors in the logs

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Leaves a better env and avoids future errors in the logs

See https://github.com/ClickHouse/ClickHouse/issues/26711