### PR TITLE
SET PROFILE applies constraints too.

### DIFF
--- a/src/Access/SettingsProfilesInfo.cpp
+++ b/src/Access/SettingsProfilesInfo.cpp
@@ -32,7 +32,13 @@ SettingsProfilesInfo::getConstraintsAndProfileIDs(const std::shared_ptr<const Se
     auto res = std::make_shared<SettingsConstraintsAndProfileIDs>(manager);
     res->current_profiles = profiles;
 
-    res->constraints = previous ? previous->constraints : constraints;
+    if (previous)
+    {
+        res->constraints = previous->constraints;
+        res->constraints.merge(constraints);
+    }
+    else
+        res->constraints = constraints;
 
     if (previous)
     {

--- a/tests/integration/test_settings_profile/test.py
+++ b/tests/integration/test_settings_profile/test.py
@@ -214,11 +214,14 @@ def test_show_profiles():
 
 
 def test_set_profile():
-    instance.query("CREATE SETTINGS PROFILE P1 SETTINGS max_memory_usage=10000000001")
+    instance.query("CREATE SETTINGS PROFILE P1 SETTINGS max_memory_usage=10000000001 MAX 20000000002")
 
     session_id = new_session_id()
     instance.http_query("SET profile='P1'", user='robin', params={'session_id':session_id})
     assert instance.http_query("SELECT getSetting('max_memory_usage')", user='robin', params={'session_id':session_id}) == "10000000001\n"
+
+    expected_error = "max_memory_usage shouldn't be greater than 20000000002"
+    assert expected_error in instance.http_query_and_get_error("SET max_memory_usage=20000000003", user='robin', params={'session_id':session_id})
 
 
 def test_changing_default_profiles_affects_new_sessions_only():


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Improvement

Changelog entry:
SET PROFILE now applies constraints too if they're set for a passed profile.