### PR TITLE
Support multiple keys for encrypted disk

### DIFF
--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -25,8 +25,9 @@ public:
         const String & name_,
         DiskPtr wrapped_disk_,
         const String & path_on_wrapped_disk_,
-        FileEncryption::Algorithm encryption_algorithm_,
-        const String & key_);
+        const std::unordered_map<UInt64, String> & keys_,
+        UInt64 current_key_id_,
+        FileEncryption::Algorithm current_algorithm_);
 
     const String & getName() const override { return name; }
     const String & getPath() const override { return disk_absolute_path; }
@@ -224,11 +225,14 @@ private:
         return disk_path + path;
     }
 
+    String getKey(UInt64 key_id) const;
+
     String name;
     String disk_path;
     String disk_absolute_path;
-    FileEncryption::Algorithm encryption_algorithm;
-    String key;
+    std::unordered_map<UInt64, String> keys;
+    UInt64 current_key_id;
+    FileEncryption::Algorithm current_algorithm;
 };
 
 }

--- a/src/IO/FileEncryptionCommon.h
+++ b/src/IO/FileEncryptionCommon.h
@@ -69,6 +69,7 @@ private:
     UInt128 counter = 0;
 };
 
+
 /// Encrypts or decrypts data.
 class Encryptor
 {
@@ -100,6 +101,31 @@ private:
     /// The current position in the data stream from the very beginning of data.
     size_t offset = 0;
 };
+
+
+/// File header which is stored at the beginning of encrypted files.
+struct Header
+{
+    Algorithm algorithm = Algorithm::AES_128_CTR;
+
+    /// Identifier of the key to encrypt or decrypt this file.
+    UInt64 key_id = 0;
+
+    /// Hash of the key to encrypt or decrypt this file.
+    UInt8 key_hash = 0;
+
+    InitVector init_vector;
+
+    /// The size of this header in bytes, including reserved bytes.
+    static constexpr const size_t kSize = 64;
+
+    void read(ReadBuffer & in);
+    void write(WriteBuffer & out) const;
+};
+
+/// Calculates the hash of a passed key.
+/// 1 byte is enough because this hash is used only for the first check.
+UInt8 calculateKeyHash(const String & key);
 
 }
 }

--- a/src/IO/ReadBufferFromEncryptedFile.h
+++ b/src/IO/ReadBufferFromEncryptedFile.h
@@ -19,9 +19,9 @@ public:
     ReadBufferFromEncryptedFile(
         size_t buffer_size_,
         std::unique_ptr<ReadBufferFromFileBase> in_,
-        FileEncryption::Algorithm encryption_algorithm_,
         const String & key_,
-        const FileEncryption::InitVector & init_vector_);
+        const FileEncryption::Header & header_,
+        size_t offset_ = 0);
 
     off_t seek(off_t off, int whence) override;
     off_t getPosition() override;

--- a/src/IO/WriteBufferFromEncryptedFile.h
+++ b/src/IO/WriteBufferFromEncryptedFile.h
@@ -20,9 +20,8 @@ public:
     WriteBufferFromEncryptedFile(
         size_t buffer_size_,
         std::unique_ptr<WriteBufferFromFileBase> out_,
-        FileEncryption::Algorithm encryption_algorithm_,
         const String & key_,
-        const FileEncryption::InitVector & init_vector_,
+        const FileEncryption::Header & header_,
         size_t old_file_size = 0);
     ~WriteBufferFromEncryptedFile() override;
 
@@ -40,8 +39,8 @@ private:
     bool finished = false;
     std::unique_ptr<WriteBufferFromFileBase> out;
 
-    FileEncryption::InitVector iv;
-    bool flush_iv = false;
+    FileEncryption::Header header;
+    bool flush_header = false;
 
     FileEncryption::Encryptor encryptor;
 };

--- a/tests/integration/test_encrypted_disk/test.py
+++ b/tests/integration/test_encrypted_disk/test.py
@@ -1,27 +1,37 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException
+from helpers.test_tools import assert_eq_with_retry
 
 
 FIRST_PART_NAME = "all_1_1_0"
 
-@pytest.fixture(scope="module")
-def cluster():
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node",
+                            main_configs=["configs/storage.xml"],
+                            tmpfs=["/disk:size=100M"],
+                            with_minio=True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
     try:
-        cluster = ClickHouseCluster(__file__)
-        node = cluster.add_instance("node",
-                                    main_configs=["configs/storage.xml"],
-                                    tmpfs=["/disk:size=100M"],
-                                    with_minio=True)
         cluster.start()
         yield cluster
     finally:
         cluster.shutdown()
 
 
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    try:
+        yield
+    finally:
+        node.query("DROP TABLE IF EXISTS encrypted_test NO DELAY")
+
+
 @pytest.mark.parametrize("policy", ["encrypted_policy", "encrypted_policy_key192b", "local_policy", "s3_policy"])
-def test_encrypted_disk(cluster, policy):
-    node = cluster.instances["node"]
+def test_encrypted_disk(policy):
     node.query(
         """
         CREATE TABLE encrypted_test (
@@ -41,12 +51,9 @@ def test_encrypted_disk(cluster, policy):
     node.query("OPTIMIZE TABLE encrypted_test FINAL")
     assert node.query(select_query) == "(0,'data'),(1,'data'),(2,'data'),(3,'data')"
 
-    node.query("DROP TABLE IF EXISTS encrypted_test NO DELAY")
-
 
 @pytest.mark.parametrize("policy, destination_disks", [("local_policy", ["disk_local_encrypted", "disk_local_encrypted2", "disk_local_encrypted_key192b", "disk_local"]), ("s3_policy", ["disk_s3_encrypted", "disk_s3"])])
-def test_part_move(cluster, policy, destination_disks):
-    node = cluster.instances["node"]
+def test_part_move(policy, destination_disks):
     node.query(
         """
         CREATE TABLE encrypted_test (
@@ -70,12 +77,10 @@ def test_part_move(cluster, policy, destination_disks):
         assert("Part '{}' is already on disk '{}'".format(FIRST_PART_NAME, destination_disk) in str(exc.value))
 
     assert node.query(select_query) == "(0,'data'),(1,'data')"
-    node.query("DROP TABLE IF EXISTS encrypted_test NO DELAY")
 
 
 @pytest.mark.parametrize("policy,encrypted_disk", [("local_policy", "disk_local_encrypted"), ("s3_policy", "disk_s3_encrypted")])
-def test_optimize_table(cluster, policy, encrypted_disk):
-    node = cluster.instances["node"]
+def test_optimize_table(policy, encrypted_disk):
     node.query(
         """
         CREATE TABLE encrypted_test (
@@ -104,4 +109,76 @@ def test_optimize_table(cluster, policy, encrypted_disk):
 
     assert node.query(select_query) == "(0,'data'),(1,'data'),(2,'data'),(3,'data')"
 
-    node.query("DROP TABLE IF EXISTS encrypted_test NO DELAY")
+
+# Test adding encryption key on the fly.
+def test_add_key():
+    def make_storage_policy_with_keys(policy_name, keys):
+        node.exec_in_container(["bash", "-c" , """cat > /etc/clickhouse-server/config.d/storage_policy_{policy_name}.xml << EOF
+<?xml version="1.0"?>
+<yandex>
+    <storage_configuration>
+        <disks>
+            <{policy_name}_disk>
+                <type>encrypted</type>
+                <disk>disk_local</disk>
+                <path>{policy_name}_dir/</path>
+                {keys}
+            </{policy_name}_disk>
+        </disks>
+        <policies>
+            <{policy_name}>
+                <volumes>
+                    <main>
+                        <disk>{policy_name}_disk</disk>
+                    </main>
+                </volumes>
+            </{policy_name}>
+         </policies>
+    </storage_configuration>
+</yandex>
+EOF""".format(policy_name=policy_name, keys=keys)])
+        node.query("SYSTEM RELOAD CONFIG")
+
+    # Add some data to an encrypted disk.
+    node.query("SELECT policy_name FROM system.storage_policies")
+    make_storage_policy_with_keys("encrypted_policy_multikeys", "<key>firstfirstfirstf</key>")
+    assert_eq_with_retry(node, "SELECT policy_name FROM system.storage_policies WHERE policy_name='encrypted_policy_multikeys'", "encrypted_policy_multikeys")
+    
+    node.query("""
+        CREATE TABLE encrypted_test (
+            id Int64,
+            data String
+        ) ENGINE=MergeTree()
+        ORDER BY id
+        SETTINGS storage_policy='encrypted_policy_multikeys'
+        """)
+
+    node.query("INSERT INTO encrypted_test VALUES (0,'data'),(1,'data')")
+    select_query = "SELECT * FROM encrypted_test ORDER BY id FORMAT Values"
+    assert node.query(select_query) == "(0,'data'),(1,'data')"
+
+    # Add a second key and start using it.
+    make_storage_policy_with_keys("encrypted_policy_multikeys", """
+        <key id="0">firstfirstfirstf</key>
+        <key id="1">secondsecondseco</key>
+        <current_key_id>1</current_key_id>
+    """)
+    node.query("INSERT INTO encrypted_test VALUES (2,'data'),(3,'data')")
+
+    # Now "(0,'data'),(1,'data')" is encrypted with the first key and "(2,'data'),(3,'data')" is encrypted with the second key.
+    # All data are accessible.
+    assert node.query(select_query) == "(0,'data'),(1,'data'),(2,'data'),(3,'data')"
+
+    # Try to replace the first key with something wrong, and check that "(0,'data'),(1,'data')" cannot be read.
+    make_storage_policy_with_keys("encrypted_policy_multikeys", """
+        <key id="0">wrongwrongwrongw</key>
+        <key id="1">secondsecondseco</key>
+        <current_key_id>1</current_key_id>
+    """)
+
+    expected_error = "Wrong key"
+    assert expected_error in node.query_and_get_error(select_query)
+
+    # Detach the part encrypted with the wrong key and check that another part containing "(2,'data'),(3,'data')" still can be read.
+    node.query("ALTER TABLE encrypted_test DETACH PART '{}'".format(FIRST_PART_NAME))
+    assert node.query(select_query) == "(2,'data'),(3,'data')"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Improvement

Changelog entry:
Support multiple keys for encrypted disk. Display error message if the key is probably wrong.
(see https://github.com/ClickHouse/ClickHouse/pull/26465#issuecomment-882015970)