### PR TITLE
Lock mutex before access to std::cerr in clickhouse-benchmark

### DIFF
--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -271,7 +271,8 @@ private:
 
             if (max_time > 0 && total_watch.elapsedSeconds() >= max_time)
             {
-                std::cout << "Stopping launch of queries. Requested time limit is exhausted.\n";
+                std::cout << "Stopping launch of queries."
+                          << " Requested time limit " << max_time << " seconds is exhausted.\n";
                 return false;
             }
 
@@ -368,8 +369,7 @@ private:
             {
                 extracted = queue.tryPop(query, 100);
 
-                if (shutdown
-                    || (max_iterations && queries_executed == max_iterations))
+                if (shutdown || (max_iterations && queries_executed == max_iterations))
                 {
                     return;
                 }
@@ -382,6 +382,7 @@ private:
             }
             catch (...)
             {
+                std::lock_guard lock(mutex);
                 std::cerr << "An error occurred while processing the query '"
                           << query << "'.\n";
                 if (!continue_on_errors)

--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -383,8 +383,8 @@ private:
             catch (...)
             {
                 std::lock_guard lock(mutex);
-                std::cerr << "An error occurred while processing the query '"
-                          << query << "'.\n";
+                std::cerr << "An error occurred while processing the query " << "'" << query << "'"
+                          << ": " << getCurrentExceptionMessage(false) << std::endl;
                 if (!continue_on_errors)
                 {
                     shutdown = true;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Examples of failure (all 3 the same):
* https://clickhouse-test-reports.s3.yandex.net/0/4f1926550b44e1b763d997c06b6e630ef8d846e5/integration_tests_(thread)/integration_run_parallel3_0.log
* https://clickhouse-test-reports.s3.yandex.net/0/3bcef76a9ddca7875f69f25c7b1c3d30000397b5/integration_tests_(thread)/integration_run_parallel3_0.log
* https://clickhouse-test-reports.s3.yandex.net/0/0304cf20417a85afaffaec1d99289f54b4f0b182/integration_tests_(thread)/integration_run_parallel3_0.log