### PR TITLE
Experiment with sharing file descriptors

### DIFF
--- a/src/IO/OpenedFile.cpp
+++ b/src/IO/OpenedFile.cpp
@@ -1,0 +1,67 @@
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <Common/ProfileEvents.h>
+#include <Common/Exception.h>
+#include <IO/OpenedFile.h>
+
+
+namespace ProfileEvents
+{
+    extern const Event FileOpen;
+}
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int FILE_DOESNT_EXIST;
+    extern const int CANNOT_OPEN_FILE;
+    extern const int CANNOT_CLOSE_FILE;
+}
+
+
+void OpenedFile::open(int flags)
+{
+    ProfileEvents::increment(ProfileEvents::FileOpen);
+
+    fd = ::open(file_name.c_str(), (flags == -1 ? 0 : flags) | O_RDONLY | O_CLOEXEC);
+
+    if (-1 == fd)
+        throwFromErrnoWithPath("Cannot open file " + file_name, file_name,
+            errno == ENOENT ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE);
+}
+
+
+std::string OpenedFile::getFileName() const
+{
+    return file_name;
+}
+
+
+OpenedFile::OpenedFile(const std::string & file_name_, int flags)
+    : file_name(file_name_)
+{
+    open(flags);
+}
+
+
+OpenedFile::~OpenedFile()
+{
+    if (fd != -1)
+        close();    /// Exceptions will lead to std::terminate and that's Ok.
+}
+
+
+void OpenedFile::close()
+{
+    if (0 != ::close(fd))
+        throw Exception("Cannot close file", ErrorCodes::CANNOT_CLOSE_FILE);
+
+    fd = -1;
+    metric_increment.destroy();
+}
+
+}
+

--- a/src/IO/OpenedFile.h
+++ b/src/IO/OpenedFile.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <Common/CurrentMetrics.h>
+#include <memory>
+
+
+namespace CurrentMetrics
+{
+    extern const Metric OpenFileForRead;
+}
+
+
+namespace DB
+{
+
+/// RAII for readonly opened file descriptor.
+class OpenedFile
+{
+public:
+    OpenedFile(const std::string & file_name_, int flags);
+    ~OpenedFile();
+
+    /// Close prematurally.
+    void close();
+
+    int getFD() const { return fd; }
+    std::string getFileName() const;
+
+private:
+    std::string file_name;
+    int fd = -1;
+
+    CurrentMetrics::Increment metric_increment{CurrentMetrics::OpenFileForRead};
+
+    void open(int flags);
+};
+
+}
+

--- a/src/IO/OpenedFileCache.h
+++ b/src/IO/OpenedFileCache.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <map>
+#include <mutex>
+
+#include <Core/Types.h>
+#include <Common/ProfileEvents.h>
+#include <IO/OpenedFile.h>
+
+
+namespace ProfileEvents
+{
+    extern const Event OpenedFileCacheHits;
+    extern const Event OpenedFileCacheMisses;
+}
+
+namespace DB
+{
+
+
+/** Cache of opened files for reading.
+  * It allows to share file descriptors when doing reading with 'pread' syscalls on readonly files.
+  * Note: open/close of files is very cheap on Linux and we should not bother doing it 10 000 times a second.
+  * (This may not be the case on Windows with WSL. This is also not the case if strace is active. Neither when some eBPF is loaded).
+  * But sometimes we may end up opening one file multiple times, that increases chance exhausting opened files limit.
+  */
+class OpenedFileCache
+{
+private:
+    using Key = std::pair<std::string /* path */, int /* flags */>;
+
+    using OpenedFileWeakPtr = std::weak_ptr<OpenedFile>;
+    using Files = std::map<Key, OpenedFileWeakPtr>;
+
+    Files files;
+    std::mutex mutex;
+
+public:
+    using OpenedFilePtr = std::shared_ptr<OpenedFile>;
+
+    OpenedFilePtr get(const std::string & path, int flags)
+    {
+        Key key(path, flags);
+
+        std::lock_guard lock(mutex);
+
+        auto [it, inserted] = files.emplace(key, OpenedFilePtr{});
+        if (!inserted)
+            if (auto res = it->second.lock())
+                return res;
+
+        OpenedFilePtr res
+        {
+            new OpenedFile(path, flags),
+            [key, this](auto ptr)
+            {
+                {
+                    std::lock_guard another_lock(mutex);
+                    files.erase(key);
+                }
+                delete ptr;
+            }
+        };
+
+        it->second = res;
+        return res;
+    }
+};
+
+using OpenedFileCachePtr = std::shared_ptr<OpenedFileCache>;
+
+}
+
+

--- a/src/IO/ReadBufferFromFile.cpp
+++ b/src/IO/ReadBufferFromFile.cpp
@@ -88,4 +88,7 @@ void ReadBufferFromFile::close()
     metric_increment.destroy();
 }
 
+
+OpenedFileCache ReadBufferFromFilePReadWithCache::cache;
+
 }

--- a/src/IO/ReadBufferFromFile.h
+++ b/src/IO/ReadBufferFromFile.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <IO/ReadBufferFromFileDescriptor.h>
+#include <IO/OpenedFileCache.h>
 #include <Common/CurrentMetrics.h>
 
 #ifndef O_DIRECT
 #define O_DIRECT 00040000
 #endif
+
 
 namespace CurrentMetrics
 {
@@ -57,6 +59,33 @@ public:
         : ReadBufferFromFile(file_name_, buf_size, flags, existing_memory, alignment)
     {
         use_pread = true;
+    }
+};
+
+
+/** Similar to ReadBufferFromFilePRead but also transparently shares open file descriptors.
+  */
+class ReadBufferFromFilePReadWithCache : public ReadBufferFromFileDescriptorPRead
+{
+private:
+    static OpenedFileCache cache;
+
+    std::string file_name;
+    OpenedFileCache::OpenedFilePtr file;
+
+public:
+    ReadBufferFromFilePReadWithCache(const std::string & file_name_, size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE, int flags = -1,
+        char * existing_memory = nullptr, size_t alignment = 0)
+        : ReadBufferFromFileDescriptorPRead(-1, buf_size, existing_memory, alignment),
+        file_name(file_name_)
+    {
+        file = cache.get(file_name, flags);
+        fd = file->getFD();
+    }
+
+    std::string getFileName() const override
+    {
+        return file_name;
     }
 };
 

--- a/src/IO/createReadBufferFromFileBase.cpp
+++ b/src/IO/createReadBufferFromFileBase.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
         /// Attempt to open a file with O_DIRECT
         try
         {
-            auto res = std::make_unique<ReadBufferFromFile>(
+            auto res = std::make_unique<ReadBufferFromFilePReadWithCache>(
                 filename, buffer_size, (flags == -1 ? O_RDONLY | O_CLOEXEC : flags) | O_DIRECT, existing_memory, alignment);
             ProfileEvents::increment(ProfileEvents::CreatedReadBufferDirectIO);
             return res;
@@ -92,7 +92,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
 #endif
 
     ProfileEvents::increment(ProfileEvents::CreatedReadBufferOrdinary);
-    return std::make_unique<ReadBufferFromFile>(filename, buffer_size, flags, existing_memory, alignment);
+    return std::make_unique<ReadBufferFromFilePReadWithCache>(filename, buffer_size, flags, existing_memory, alignment);
 }
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Share file descriptors in concurrent reads of the same files. There is no noticeable performance difference on Linux. But the number of opened files will be significantly (10..100 times) lower on typical servers and it makes operations easier. See #26214.
