### PR TITLE
Add new functions currentRoles(), enabledRoles(), defaultRoles().

### DIFF
--- a/src/Access/EnabledRolesInfo.h
+++ b/src/Access/EnabledRolesInfo.h
@@ -10,7 +10,7 @@
 namespace DB
 {
 
-/// Information about a role.
+/// Information about roles enabled for a user at some specific time.
 struct EnabledRolesInfo
 {
     boost::container::flat_set<UUID> current_roles;

--- a/src/Functions/currentRoles.cpp
+++ b/src/Functions/currentRoles.cpp
@@ -1,0 +1,88 @@
+#include <Functions/IFunction.h>
+#include <Functions/FunctionFactory.h>
+#include <Interpreters/Context.h>
+#include <Access/AccessControlManager.h>
+#include <Access/EnabledRolesInfo.h>
+#include <Access/User.h>
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnConst.h>
+#include <Columns/ColumnString.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypeArray.h>
+
+
+namespace DB
+{
+
+namespace
+{
+    enum class Kind
+    {
+        CURRENT_ROLES,
+        ENABLED_ROLES,
+        DEFAULT_ROLES,
+    };
+
+    template <Kind kind>
+    class FunctionCurrentRoles : public IFunction
+    {
+    public:
+        static constexpr auto name = (kind == Kind::CURRENT_ROLES) ? "currentRoles" : ((kind == Kind::ENABLED_ROLES) ? "enabledRoles" : "defaultRoles");
+        static FunctionPtr create(const ContextPtr & context) { return std::make_shared<FunctionCurrentRoles>(context); }
+
+        String getName() const override { return name; }
+
+        explicit FunctionCurrentRoles(const ContextPtr & context)
+        {
+            if constexpr (kind == Kind::CURRENT_ROLES)
+            {
+                role_names = context->getRolesInfo()->getCurrentRolesNames();
+            }
+            else if constexpr (kind == Kind::ENABLED_ROLES)
+            {
+                role_names = context->getRolesInfo()->getEnabledRolesNames();
+            }
+            else
+            {
+                static_assert(kind == Kind::DEFAULT_ROLES);
+                const auto & manager = context->getAccessControlManager();
+                if (auto user = context->getUser())
+                    role_names = manager.tryReadNames(user->granted_roles.findGranted(user->default_roles));
+            }
+
+            /// We sort the names because the result of the function should not depend on the order of UUIDs.
+            std::sort(role_names.begin(), role_names.end());
+        }
+
+        size_t getNumberOfArguments() const override { return 0; }
+        bool isDeterministic() const override { return false; }
+
+        DataTypePtr getReturnTypeImpl(const DataTypes & /*arguments*/) const override
+        {
+            return std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());
+        }
+
+        ColumnPtr executeImpl(const ColumnsWithTypeAndName &, const DataTypePtr &, size_t input_rows_count) const override
+        {
+            auto col_res = ColumnArray::create(ColumnString::create());
+            ColumnString & res_strings = typeid_cast<ColumnString &>(col_res->getData());
+            ColumnArray::Offsets & res_offsets = col_res->getOffsets();
+            for (const String & role_name : role_names)
+                res_strings.insertData(role_name.data(), role_name.length());
+            res_offsets.push_back(res_strings.size());
+            return ColumnConst::create(std::move(col_res), input_rows_count);
+        }
+
+    private:
+        Strings role_names;
+    };
+}
+
+void registerFunctionCurrentRoles(FunctionFactory & factory)
+{
+    factory.registerFunction<FunctionCurrentRoles<Kind::CURRENT_ROLES>>();
+    factory.registerFunction<FunctionCurrentRoles<Kind::ENABLED_ROLES>>();
+    factory.registerFunction<FunctionCurrentRoles<Kind::DEFAULT_ROLES>>();
+}
+
+}

--- a/src/Functions/registerFunctionsMiscellaneous.cpp
+++ b/src/Functions/registerFunctionsMiscellaneous.cpp
@@ -10,6 +10,7 @@ class FunctionFactory;
 void registerFunctionCurrentDatabase(FunctionFactory &);
 void registerFunctionCurrentUser(FunctionFactory &);
 void registerFunctionCurrentProfiles(FunctionFactory &);
+void registerFunctionCurrentRoles(FunctionFactory &);
 void registerFunctionHostName(FunctionFactory &);
 void registerFunctionFQDN(FunctionFactory &);
 void registerFunctionVisibleWidth(FunctionFactory &);
@@ -87,6 +88,7 @@ void registerFunctionsMiscellaneous(FunctionFactory & factory)
     registerFunctionCurrentDatabase(factory);
     registerFunctionCurrentUser(factory);
     registerFunctionCurrentProfiles(factory);
+    registerFunctionCurrentRoles(factory);
     registerFunctionHostName(factory);
     registerFunctionFQDN(factory);
     registerFunctionVisibleWidth(factory);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- New Feature

Changelog entry:
Add new functions `currentRoles()`, `enabledRoles()`, `defaultRoles()`.

`currentRoles()` returns the names of the roles which are current for the current user. The command `SET ROLE` could be used to change the current roles, by default the current roles are returned by the function `defaultRoles()` called when the current user logins.

`enabledRoles()` returns the names of the current roles merged with those roles which are granted to some of the current roles.

`defaultRoles()` returns the names of the roles which are set as current when the current user logins. The command `SET DEFAULT ROLE TO <current_user>` could be used to change the default roles, by default the default roles are all the roles which are granted to a user.