### PR TITLE
Less verbose RocksDB logs #26252

### DIFF
--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -275,6 +275,10 @@ void StorageEmbeddedRocksDB::initDb()
     rocksdb::DB * db;
     options.create_if_missing = true;
     options.compression = rocksdb::CompressionType::kZSTD;
+
+    /// It is too verbose by default, and in fact we don't care about rocksdb logs at all.
+    options.info_log_level = rocksdb::ERROR_LEVEL;
+
     rocksdb::Status status = rocksdb::DB::Open(options, rocksdb_dir, &db);
 
     if (status != rocksdb::Status::OK())


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Less verbose internal RocksDB logs. This closes #26252.


No tests will be provided for this change.