### PR TITLE
Remove unneeded mutex during connection draining

### DIFF
--- a/src/DataStreams/RemoteQueryExecutor.cpp
+++ b/src/DataStreams/RemoteQueryExecutor.cpp
@@ -434,16 +434,13 @@ void RemoteQueryExecutor::finish(std::unique_ptr<ReadContext> * read_context)
 
     /// Send the request to abort the execution of the request, if not already sent.
     tryCancel("Cancelling query because enough data has been read", read_context);
+    /// Try to drain connections asynchronously.
+    if (auto conn = ConnectionCollector::enqueueConnectionCleanup(pool, connections))
     {
-        /// Finish might be called in multiple threads. Make sure we release connections in thread-safe way.
-        std::lock_guard guard(connection_draining_mutex);
-        if (auto conn = ConnectionCollector::enqueueConnectionCleanup(pool, connections))
-        {
-            /// Drain connections synchronously.
-            CurrentMetrics::Increment metric_increment(CurrentMetrics::ActiveSyncDrainedConnections);
-            ConnectionCollector::drainConnections(*conn);
-            CurrentMetrics::add(CurrentMetrics::SyncDrainedConnections, 1);
-        }
+        /// Drain connections synchronously.
+        CurrentMetrics::Increment metric_increment(CurrentMetrics::ActiveSyncDrainedConnections);
+        ConnectionCollector::drainConnections(*conn);
+        CurrentMetrics::add(CurrentMetrics::SyncDrainedConnections, 1);
     }
     finished = true;
 }

--- a/src/DataStreams/RemoteQueryExecutor.h
+++ b/src/DataStreams/RemoteQueryExecutor.h
@@ -168,10 +168,6 @@ private:
     std::atomic<bool> was_cancelled { false };
     std::mutex was_cancelled_mutex;
 
-    /** Thread-safe connection draining.
-      */
-    std::mutex connection_draining_mutex;
-
     /** An exception from replica was received. No need in receiving more packets or
       * requesting to cancel query execution
       */


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Remove unneeded mutex during connection draining.


Detailed description / Documentation draft:
.