### PR TITLE
Make sure table is readonly when restarting fails.

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -90,6 +90,8 @@ void ReplicatedMergeTreeRestartingThread::run()
                     /// The exception when you try to zookeeper_init usually happens if DNS does not work. We will try to do it again.
                     tryLogCurrentException(log, __PRETTY_FUNCTION__);
 
+                    /// Here we're almost sure the table is already readonly, but it doesn't hurt to enforce it.
+                    setReadonly();
                     if (first_time)
                         storage.startup_event.set();
                     task->scheduleAfter(retry_period_ms);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make sure table is in readonly state when restarting fails.


Detailed description / Documentation draft:
.
