### PR TITLE
Do not start new hedged connection if query was already canceled.

### DIFF
--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -479,6 +479,15 @@ void HedgedConnections::checkNewReplica()
     Connection * connection = nullptr;
     HedgedConnectionsFactory::State state = hedged_connections_factory.waitForReadyConnections(connection);
 
+    if (cancelled)
+    {
+        /// Do not start new connection if query is already canceled.
+        if (connection)
+            connection->disconnect();
+
+        state = HedgedConnectionsFactory::State::CANNOT_CHOOSE;
+    }
+
     processNewReplicaState(state, connection);
 
     /// Check if we don't need to listen hedged_connections_factory file descriptor in epoll anymore.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes #26815

Now, ConnectionCollector makes connection live longer than query. It means we cannot use resources not owned by connection in `drain`.