### PR TITLE
Try fix timeout in functional tests with pytest

### DIFF
--- a/tests/queries/query_test.py
+++ b/tests/queries/query_test.py
@@ -12,6 +12,7 @@ SKIP_LIST = [
     # these couple of tests hangs everything
     "00600_replace_running_query",
     "00987_distributed_stack_overflow",
+    "01954_clickhouse_benchmark_multiple_long",
 
     # just fail
     "00133_long_shard_memory_tracker_and_exception_safety",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
After merging #26607 all `Functional stateless tests (pytest)` tasks fail with timeout. Seems like `01954_clickhouse_benchmark_multiple_long` does not work with pytest.

