### PR TITLE
Partial backport for HDFS zero copy replication (settings names)

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -170,7 +170,7 @@ void Service::processQuery(const HTMLForm & params, ReadBuffer & /*body*/, Write
 
         bool try_use_s3_copy = false;
 
-        if (data_settings->allow_s3_zero_copy_replication
+        if (data_settings->allow_remote_fs_zero_copy_replication
                 && client_protocol_version >= REPLICATION_PROTOCOL_VERSION_WITH_PARTS_S3_COPY)
         { /// if source and destination are in the same S3 storage we try to use S3 CopyObject request first
             int send_s3_metadata = parse<int>(params.get("send_s3_metadata", "0"));
@@ -426,7 +426,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::fetchPart(
 
     Disks disks_s3;
 
-    if (!data_settings->allow_s3_zero_copy_replication)
+    if (!data_settings->allow_remote_fs_zero_copy_replication)
         try_use_s3_copy = false;
 
     if (try_use_s3_copy)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2750,8 +2750,8 @@ void MergeTreeData::swapActivePart(MergeTreeData::DataPartPtr part_copy)
             if (active_part_it == data_parts_by_info.end())
                 throw Exception("Cannot swap part '" + part_copy->name + "', no such active part.", ErrorCodes::NO_SUCH_DATA_PART);
 
-            /// We do not check allow_s3_zero_copy_replication here because data may be shared
-            /// when allow_s3_zero_copy_replication turned on and off again
+            /// We do not check allow_remote_fs_zero_copy_replication here because data may be shared
+            /// when allow_remote_fs_zero_copy_replication turned on and off again
 
             original_active_part->force_keep_shared_data = false;
 

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -201,7 +201,7 @@ MergeTreeData::DataPartPtr MergeTreePartsMover::clonePart(const MergeTreeMoveEnt
 
     auto disk = moving_part.reserved_space->getDisk();
     const String directory_to_move = "moving";
-    if (settings->allow_s3_zero_copy_replication)
+    if (settings->allow_remote_fs_zero_copy_replication)
     {
         /// Try to fetch part from S3 without copy and fallback to default copy
         /// if it's not possible

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -74,7 +74,7 @@ struct Settings;
     M(Seconds, prefer_fetch_merged_part_time_threshold, 3600, "If time passed after replication log entry creation exceeds this threshold and sum size of parts is greater than \"prefer_fetch_merged_part_size_threshold\", prefer fetching merged part from replica instead of doing merge locally. To speed up very long merges.", 0) \
     M(UInt64, prefer_fetch_merged_part_size_threshold, 10ULL * 1024 * 1024 * 1024, "If sum size of parts exceeds this threshold and time passed after replication log entry creation is greater than \"prefer_fetch_merged_part_time_threshold\", prefer fetching merged part from replica instead of doing merge locally. To speed up very long merges.", 0) \
     M(Seconds, execute_merges_on_single_replica_time_threshold, 0, "When greater than zero only a single replica starts the merge immediately, others wait up to that amount of time to download the result instead of doing merges locally. If the chosen replica doesn't finish the merge during that amount of time, fallback to standard behavior happens.", 0) \
-    M(Seconds, s3_execute_merges_on_single_replica_time_threshold, 3 * 60 * 60, "When greater than zero only a single replica starts the merge immediatelys when merged part on S3 storage and 'allow_s3_zero_copy_replication' is enabled.", 0) \
+    M(Seconds, remote_fs_execute_merges_on_single_replica_time_threshold, 3 * 60 * 60, "When greater than zero only a single replica starts the merge immediatelys when merged part on shared storage and 'allow_remote_fs_zero_copy_replication' is enabled.", 0) \
     M(Seconds, try_fetch_recompressed_part_timeout, 7200, "Recompression works slow in most cases, so we don't start merge with recompression until this timeout and trying to fetch recompressed part from replica which assigned this merge with recompression.", 0) \
     M(Bool, always_fetch_merged_part, 0, "If true, replica never merge parts and always download merged parts from other replicas.", 0) \
     M(UInt64, max_suspicious_broken_parts, 10, "Max broken parts, if more - deny automatic deletion.", 0) \
@@ -123,7 +123,7 @@ struct Settings;
     M(UInt64, concurrent_part_removal_threshold, 100, "Activate concurrent part removal (see 'max_part_removal_threads') only if the number of inactive data parts is at least this.", 0) \
     M(String, storage_policy, "default", "Name of storage disk policy", 0) \
     M(Bool, allow_nullable_key, false, "Allow Nullable types as primary keys.", 0) \
-    M(Bool, allow_s3_zero_copy_replication, false, "Allow Zero-copy replication over S3", 0) \
+    M(Bool, allow_remote_fs_zero_copy_replication, false, "Allow Zero-copy replication over remote fs", 0) \
     M(Bool, remove_empty_parts, true, "Remove empty parts after they were pruned by TTL, mutation, or collapsing merge algorithm", 0) \
     M(Bool, assign_part_uuids, false, "Generate UUIDs for parts. Before enabling check that all replicas support new format.", 0) \
     M(Int64, max_partitions_to_read, -1, "Limit the max number of partitions that can be accessed in one query. <= 0 means unlimited. This setting is the default that can be overridden by the query-level setting with the same name.", 0) \

--- a/src/Storages/MergeTree/ReplicatedMergeTreeMergeStrategyPicker.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeMergeStrategyPicker.h
@@ -52,7 +52,7 @@ public:
     /// and we may need to do a fetch (or postpone) instead of merge
     bool shouldMergeOnSingleReplica(const ReplicatedMergeTreeLogEntryData & entry) const;
 
-    /// return true if s3_execute_merges_on_single_replica_time_threshold feature is active
+    /// return true if remote_fs_execute_merges_on_single_replica_time_threshold feature is active
     /// and we may need to do a fetch (or postpone) instead of merge
     bool shouldMergeOnSingleReplicaS3Shared(const ReplicatedMergeTreeLogEntryData & entry) const;
 
@@ -72,7 +72,7 @@ private:
     uint64_t getEntryHash(const ReplicatedMergeTreeLogEntryData & entry) const;
 
     std::atomic<time_t> execute_merges_on_single_replica_time_threshold = 0;
-    std::atomic<time_t> s3_execute_merges_on_single_replica_time_threshold = 0;
+    std::atomic<time_t> remote_fs_execute_merges_on_single_replica_time_threshold = 0;
     std::atomic<time_t> last_refresh_time = 0;
 
     std::mutex mutex;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -608,7 +608,7 @@ void StorageReplicatedMergeTree::createNewZooKeeperNodes()
     zookeeper->createIfNotExists(replica_path + "/mutation_pointer", String());
 
     /// Nodes for zero-copy S3 replication
-    if (storage_settings.get()->allow_s3_zero_copy_replication)
+    if (storage_settings.get()->allow_remote_fs_zero_copy_replication)
     {
         zookeeper->createIfNotExists(zookeeper_path + "/zero_copy_s3", String());
         zookeeper->createIfNotExists(zookeeper_path + "/zero_copy_s3/shared", String());
@@ -1728,7 +1728,7 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
     future_merged_part.updatePath(*this, reserved_space);
     future_merged_part.merge_type = entry.merge_type;
 
-    if (storage_settings_ptr->allow_s3_zero_copy_replication)
+    if (storage_settings_ptr->allow_remote_fs_zero_copy_replication)
     {
         if (auto disk = reserved_space->getDisk(); disk->getType() == DB::DiskType::Type::S3)
         {
@@ -1740,7 +1740,7 @@ bool StorageReplicatedMergeTree::tryExecuteMerge(const LogEntry & entry)
                 if (replica_to_execute_merge)
                 {
                     LOG_DEBUG(log,
-                        "Prefer fetching part {} from replica {} due s3_execute_merges_on_single_replica_time_threshold",
+                        "Prefer fetching part {} from replica {} due remote_fs_execute_merges_on_single_replica_time_threshold",
                         entry.new_part_name, replica_to_execute_merge.value());
                     return false;
                 }
@@ -7300,7 +7300,7 @@ bool StorageReplicatedMergeTree::tryToFetchIfShared(
     const String & path)
 {
     const auto data_settings = getSettings();
-    if (!data_settings->allow_s3_zero_copy_replication)
+    if (!data_settings->allow_remote_fs_zero_copy_replication)
         return false;
 
     if (disk->getType() != DB::DiskType::Type::S3)

--- a/tests/integration/test_replicated_merge_tree_s3/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_replicated_merge_tree_s3/configs/config.d/storage_conf.xml
@@ -21,7 +21,7 @@
 
     <merge_tree>
         <min_bytes_for_wide_part>0</min_bytes_for_wide_part>
-        <allow_s3_zero_copy_replication>0</allow_s3_zero_copy_replication>
+        <allow_remote_fs_zero_copy_replication>0</allow_remote_fs_zero_copy_replication>
     </merge_tree>
 
     <remote_servers>

--- a/tests/integration/test_replicated_merge_tree_s3_zero_copy/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_replicated_merge_tree_s3_zero_copy/configs/config.d/storage_conf.xml
@@ -21,7 +21,7 @@
 
     <merge_tree>
         <min_bytes_for_wide_part>0</min_bytes_for_wide_part>
-        <allow_s3_zero_copy_replication>1</allow_s3_zero_copy_replication>
+        <allow_remote_fs_zero_copy_replication>1</allow_remote_fs_zero_copy_replication>
     </merge_tree>
 
     <remote_servers>

--- a/tests/integration/test_s3_zero_copy_replication/configs/config.d/s3.xml
+++ b/tests/integration/test_s3_zero_copy_replication/configs/config.d/s3.xml
@@ -66,7 +66,7 @@
     <merge_tree>
         <min_bytes_for_wide_part>1024</min_bytes_for_wide_part>
         <old_parts_lifetime>1</old_parts_lifetime>
-        <allow_s3_zero_copy_replication>1</allow_s3_zero_copy_replication>
+        <allow_remote_fs_zero_copy_replication>1</allow_remote_fs_zero_copy_replication>
     </merge_tree>
 
     <remote_servers>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Rename setting.


Detailed description / Documentation draft:

allow_s3_zero_copy_replication renamed to allow_remote_fs_zero_copy_replication.
s3_execute_merges_on_single_replica_time_threshold renamed to remote_fs_execute_merges_on_single_replica_time_threshold.
See https://github.com/ClickHouse/ClickHouse/pull/25918
