### PR TITLE
Check aggregate function parameters in -Merge combinator

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionMerge.h
+++ b/src/AggregateFunctions/AggregateFunctionMerge.h
@@ -36,8 +36,12 @@ public:
         const DataTypeAggregateFunction * data_type = typeid_cast<const DataTypeAggregateFunction *>(argument.get());
 
         if (!data_type || data_type->getFunctionName() != nested_func->getName())
-            throw Exception("Illegal type " + argument->getName() + " of argument for aggregate function " + getName(),
-                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument for aggregate function {}",
+                            argument->getName(), getName());
+
+        if (data_type->getParameters() != getParameters())
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument for aggregate function {}: "
+                            "parameters mismatch", argument->getName(), getName());
     }
 
     String getName() const override

--- a/src/AggregateFunctions/AggregateFunctionMerge.h
+++ b/src/AggregateFunctions/AggregateFunctionMerge.h
@@ -35,13 +35,9 @@ public:
     {
         const DataTypeAggregateFunction * data_type = typeid_cast<const DataTypeAggregateFunction *>(argument.get());
 
-        if (!data_type || data_type->getFunctionName() != nested_func->getName())
-            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument for aggregate function {}",
-                            argument->getName(), getName());
-
-        if (data_type->getParameters() != getParameters())
-            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument for aggregate function {}: "
-                            "parameters mismatch", argument->getName(), getName());
+        if (!data_type || !nested_func->haveSameStateRepresentation(*data_type->getFunction()))
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument for aggregate function {}, "
+                            "expected {} or equivalent type", argument->getName(), getName(), getStateType()->getName());
     }
 
     String getName() const override

--- a/src/AggregateFunctions/AggregateFunctionQuantile.h
+++ b/src/AggregateFunctions/AggregateFunctionQuantile.h
@@ -105,6 +105,11 @@ public:
             return res;
     }
 
+    bool haveSameStateRepresentation(const IAggregateFunction & rhs) const override
+    {
+        return getName() == rhs.getName() && this->haveEqualArgumentTypes(rhs);
+    }
+
     bool allocatesMemoryInArena() const override { return false; }
 
     void add(AggregateDataPtr __restrict place, const IColumn ** columns, size_t row_num, Arena *) const override

--- a/src/AggregateFunctions/AggregateFunctionSequenceMatch.h
+++ b/src/AggregateFunctions/AggregateFunctionSequenceMatch.h
@@ -179,6 +179,11 @@ public:
         this->data(place).deserialize(buf);
     }
 
+    bool haveSameStateRepresentation(const IAggregateFunction & rhs) const override
+    {
+        return this->getName() == rhs.getName() && this->haveEqualArgumentTypes(rhs);
+    }
+
 private:
     enum class PatternActionType
     {

--- a/src/AggregateFunctions/AggregateFunctionSequenceNextNode.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSequenceNextNode.cpp
@@ -31,10 +31,10 @@ namespace
 
 template <typename T>
 inline AggregateFunctionPtr createAggregateFunctionSequenceNodeImpl(
-    const DataTypePtr data_type, const DataTypes & argument_types, SequenceDirection direction, SequenceBase base)
+    const DataTypePtr data_type, const DataTypes & argument_types, const Array & parameters, SequenceDirection direction, SequenceBase base)
 {
     return std::make_shared<SequenceNextNodeImpl<T, NodeString<max_events_size>>>(
-        data_type, argument_types, base, direction, min_required_args);
+        data_type, argument_types, parameters, base, direction, min_required_args);
 }
 
 AggregateFunctionPtr
@@ -116,17 +116,17 @@ createAggregateFunctionSequenceNode(const std::string & name, const DataTypes & 
 
     WhichDataType timestamp_type(argument_types[0].get());
     if (timestamp_type.idx == TypeIndex::UInt8)
-        return createAggregateFunctionSequenceNodeImpl<UInt8>(data_type, argument_types, direction, base);
+        return createAggregateFunctionSequenceNodeImpl<UInt8>(data_type, argument_types, parameters, direction, base);
     if (timestamp_type.idx == TypeIndex::UInt16)
-        return createAggregateFunctionSequenceNodeImpl<UInt16>(data_type, argument_types, direction, base);
+        return createAggregateFunctionSequenceNodeImpl<UInt16>(data_type, argument_types, parameters, direction, base);
     if (timestamp_type.idx == TypeIndex::UInt32)
-        return createAggregateFunctionSequenceNodeImpl<UInt32>(data_type, argument_types, direction, base);
+        return createAggregateFunctionSequenceNodeImpl<UInt32>(data_type, argument_types, parameters, direction, base);
     if (timestamp_type.idx == TypeIndex::UInt64)
-        return createAggregateFunctionSequenceNodeImpl<UInt64>(data_type, argument_types, direction, base);
+        return createAggregateFunctionSequenceNodeImpl<UInt64>(data_type, argument_types, parameters, direction, base);
     if (timestamp_type.isDate())
-        return createAggregateFunctionSequenceNodeImpl<DataTypeDate::FieldType>(data_type, argument_types, direction, base);
+        return createAggregateFunctionSequenceNodeImpl<DataTypeDate::FieldType>(data_type, argument_types, parameters, direction, base);
     if (timestamp_type.isDateTime())
-        return createAggregateFunctionSequenceNodeImpl<DataTypeDateTime::FieldType>(data_type, argument_types, direction, base);
+        return createAggregateFunctionSequenceNodeImpl<DataTypeDateTime::FieldType>(data_type, argument_types, parameters, direction, base);
 
     throw Exception{"Illegal type " + argument_types.front().get()->getName()
             + " of first argument of aggregate function " + name + ", must be Unsigned Number, Date, DateTime",

--- a/src/AggregateFunctions/AggregateFunctionSequenceNextNode.h
+++ b/src/AggregateFunctions/AggregateFunctionSequenceNextNode.h
@@ -175,11 +175,12 @@ public:
     SequenceNextNodeImpl(
         const DataTypePtr & data_type_,
         const DataTypes & arguments,
+        const Array & parameters_,
         SequenceBase seq_base_kind_,
         SequenceDirection seq_direction_,
         size_t min_required_args_,
         UInt64 max_elems_ = std::numeric_limits<UInt64>::max())
-        : IAggregateFunctionDataHelper<SequenceNextNodeGeneralData<Node>, Self>({data_type_}, {})
+        : IAggregateFunctionDataHelper<SequenceNextNodeGeneralData<Node>, Self>({data_type_}, parameters_)
         , seq_base_kind(seq_base_kind_)
         , seq_direction(seq_direction_)
         , min_required_args(min_required_args_)
@@ -192,6 +193,11 @@ public:
     String getName() const override { return "sequenceNextNode"; }
 
     DataTypePtr getReturnType() const override { return data_type; }
+
+    bool haveSameStateRepresentation(const IAggregateFunction & rhs) const override
+    {
+        return this->getName() == rhs.getName() && this->haveEqualArgumentTypes(rhs);
+    }
 
     AggregateFunctionPtr getOwnNullAdapter(
         const AggregateFunctionPtr & nested_function, const DataTypes & arguments, const Array & params,

--- a/src/AggregateFunctions/IAggregateFunction.cpp
+++ b/src/AggregateFunctions/IAggregateFunction.cpp
@@ -50,4 +50,21 @@ String IAggregateFunction::getDescription() const
 
     return description;
 }
+
+bool IAggregateFunction::haveEqualArgumentTypes(const IAggregateFunction & rhs) const
+{
+    return std::equal(argument_types.begin(), argument_types.end(),
+                      rhs.argument_types.begin(), rhs.argument_types.end(),
+                      [](const auto & t1, const auto & t2) { return t1->equals(*t2); });
+}
+
+bool IAggregateFunction::haveSameStateRepresentation(const IAggregateFunction & rhs) const
+{
+    bool res = getName() == rhs.getName()
+        && parameters == rhs.parameters
+        && haveEqualArgumentTypes(rhs);
+    assert(res == (getStateType()->getName() == rhs.getStateType()->getName()));
+    return res;
+}
+
 }

--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -74,6 +74,16 @@ public:
     /// Get the data type of internal state. By default it is AggregateFunction(name(params), argument_types...).
     virtual DataTypePtr getStateType() const;
 
+    /// Returns true if two aggregate functions have the same state representation in memory and the same serialization,
+    /// so state of one aggregate function can be safely used with another.
+    /// Examples:
+    ///  - quantile(x), quantile(a)(x), quantile(b)(x) - parameter doesn't affect state and used for finalization only
+    ///  - foo(x) and fooIf(x) - If combinator doesn't affect state
+    /// By default returns true only if functions have exactly the same names, combinators and parameters.
+    virtual bool haveSameStateRepresentation(const IAggregateFunction & rhs) const;
+
+    bool haveEqualArgumentTypes(const IAggregateFunction & rhs) const;
+
     /// Get type which will be used for prediction result in case if function is an ML method.
     virtual DataTypePtr getReturnTypeToPredict() const
     {

--- a/src/DataTypes/DataTypeAggregateFunction.h
+++ b/src/DataTypes/DataTypeAggregateFunction.h
@@ -33,6 +33,8 @@ public:
     const char * getFamilyName() const override { return "AggregateFunction"; }
     TypeIndex getTypeId() const override { return TypeIndex::AggregateFunction; }
 
+    Array getParameters() const { return parameters; }
+
     bool canBeInsideNullable() const override { return false; }
 
     DataTypePtr getReturnType() const { return function->getReturnType(); }

--- a/tests/queries/0_stateless/00905_field_with_aggregate_function_state.sql
+++ b/tests/queries/0_stateless/00905_field_with_aggregate_function_state.sql
@@ -1,4 +1,4 @@
 with (select sumState(1)) as s select sumMerge(s);
 with (select sumState(number) from (select * from system.numbers limit 10)) as s select sumMerge(s);
-with (select quantileState(0.5)(number) from (select * from system.numbers limit 10)) as s select quantileMerge(s);
+with (select quantileState(0.5)(number) from (select * from system.numbers limit 10)) as s select quantileMerge(0.5)(s);
 

--- a/tests/queries/0_stateless/00905_field_with_aggregate_function_state.sql
+++ b/tests/queries/0_stateless/00905_field_with_aggregate_function_state.sql
@@ -1,4 +1,4 @@
 with (select sumState(1)) as s select sumMerge(s);
 with (select sumState(number) from (select * from system.numbers limit 10)) as s select sumMerge(s);
-with (select quantileState(0.5)(number) from (select * from system.numbers limit 10)) as s select quantileMerge(0.5)(s);
+with (select quantileState(0.5)(number) from (select * from system.numbers limit 10)) as s select quantileMerge(s);
 

--- a/tests/queries/0_stateless/01632_group_array_msan.sql
+++ b/tests/queries/0_stateless/01632_group_array_msan.sql
@@ -1,1 +1,4 @@
-SELECT groupArrayMerge(1048577)(y * 1048576) FROM (SELECT groupArrayState(9223372036854775807)(x) AS y FROM (SELECT 1048576 AS x)) FORMAT Null;
+SELECT groupArrayMerge(1048577)(y * 1048576) FROM (SELECT groupArrayState(9223372036854775807)(x) AS y FROM (SELECT 1048576 AS x)) FORMAT Null; -- { serverError 43 }
+SELECT groupArrayMerge(1048577)(y * 1048576) FROM (SELECT groupArrayState(1048577)(x) AS y FROM (SELECT 1048576 AS x)) FORMAT Null;
+SELECT groupArrayMerge(9223372036854775807)(y * 1048576) FROM (SELECT groupArrayState(9223372036854775807)(x) AS y FROM (SELECT 1048576 AS x)) FORMAT Null;
+SELECT quantileResampleMerge(0.5, 257, 65536, 1)(tuple(*).1) FROM (SELECT quantileResampleState(0.10, 1, 2, 42)(number, number) FROM numbers(100)); -- { serverError 43 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not allow to apply parametric aggregate function with `-Merge` combinator to aggregate function state if state was produced by aggregate function with different parameters. For example, state of `fooState(42)(x)` cannot be finalized with `fooMerge(s)` or `fooMerge(123)(s)`, parameters must be specified explicitly like `fooMerge(42)(s)` and must be equal. It does not affect some special aggregate functions like `quantile` and `sequence*` that use parameters for finalization only.


Detailed description / Documentation draft:
https://clickhouse-test-reports.s3.yandex.net/26814/304c3679129280fd0b31dca75d3624ef92134e4f/fuzzer_msan/report.html#fail1

https://gist.github.com/tavplubix/e09167386391e7ec8e21842f0d5869f5

`-Resample` combinator determines number of intervals (and size of nested aggregate function states array) based on parameters. `quantileResampleMerge(0.5, 257, 65536, 1)(s)` expects array of size `65279` and tries to read it, however, `quantileResampleState(0.50, 1, 2, 42)(x)` produces array of size `1`.

Probably there are more complicated cases and the simplest solution is just to forbid mismatching parameters. Also mismatching parameters of `-State` and `-Merge` aggregate functions do not make any sense in general case.