### PR TITLE
Fix keeper bench compilation

### DIFF
--- a/programs/library-bridge/SharedLibraryHandlerFactory.cpp
+++ b/programs/library-bridge/SharedLibraryHandlerFactory.cpp
@@ -6,6 +6,7 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
 }
 

--- a/utils/keeper-bench/Runner.cpp
+++ b/utils/keeper-bench/Runner.cpp
@@ -181,7 +181,8 @@ std::vector<std::shared_ptr<Coordination::ZooKeeper>> Runner::getConnections()
             "", /*identity*/
             Poco::Timespan(0, 30000 * 1000),
             Poco::Timespan(0, 1000 * 1000),
-            Poco::Timespan(0, 10000 * 1000)));
+            Poco::Timespan(0, 10000 * 1000),
+            nullptr));
     }
 
     return zookeepers;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

https://github.com/ClickHouse/ClickHouse/pull/26129 broke it when it added a new parameter to the constructor (the zookeeper log).