### PR TITLE
Better integration tests

### DIFF
--- a/tests/integration/test_backward_compatibility/test_detach_part_wrong_partition_id.py
+++ b/tests/integration/test_backward_compatibility/test_detach_part_wrong_partition_id.py
@@ -2,7 +2,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(__file__, name="detach")
 # Version 21.6.3.14 has incompatible partition id for tables with UUID in partition key.
 node_21_6 = cluster.add_instance('node_21_6', image='yandex/clickhouse-server', tag='21.6.3.14', stay_alive=True, with_installed_binary=True)
 

--- a/tests/integration/test_replicated_mutations/test.py
+++ b/tests/integration/test_replicated_mutations/test.py
@@ -23,27 +23,27 @@ node5 = cluster.add_instance('node5', macros={'cluster': 'test3'}, main_configs=
 
 all_nodes = [node1, node2, node3, node4, node5]
 
+def prepare_cluster():
+    for node in all_nodes:
+        node.query("DROP TABLE IF EXISTS test_mutations SYNC")
+
+    for node in [node1, node2, node3, node4]:
+        node.query("""
+        CREATE TABLE test_mutations(d Date, x UInt32, i UInt32)
+        ENGINE ReplicatedMergeTree('/clickhouse/{cluster}/tables/test/test_mutations', '{instance}')
+        ORDER BY x
+        PARTITION BY toYYYYMM(d)
+        SETTINGS number_of_free_entries_in_pool_to_execute_mutation=0
+        """)
+
+    node5.query(
+        "CREATE TABLE test_mutations(d Date, x UInt32, i UInt32) ENGINE MergeTree() ORDER BY x PARTITION BY toYYYYMM(d)")
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
         cluster.start()
-
-        for node in all_nodes:
-            node.query("DROP TABLE IF EXISTS test_mutations")
-
-        for node in [node1, node2, node3, node4]:
-            node.query("""
-            CREATE TABLE test_mutations(d Date, x UInt32, i UInt32)
-            ENGINE ReplicatedMergeTree('/clickhouse/{cluster}/tables/test/test_mutations', '{instance}')
-            ORDER BY x
-            PARTITION BY toYYYYMM(d)
-            SETTINGS number_of_free_entries_in_pool_to_execute_mutation=0
-            """)
-
-        node5.query(
-            "CREATE TABLE test_mutations(d Date, x UInt32, i UInt32) ENGINE MergeTree() ORDER BY x PARTITION BY toYYYYMM(d)")
-
         yield cluster
 
     finally:
@@ -165,6 +165,8 @@ def wait_for_mutations(nodes, number_of_mutations):
 
 
 def test_mutations(started_cluster):
+    prepare_cluster()
+
     DURATION_SECONDS = 30
     nodes = [node1, node2]
 
@@ -212,6 +214,8 @@ def test_mutations(started_cluster):
     ]
 )
 def test_mutations_dont_prevent_merges(started_cluster, nodes):
+    prepare_cluster()
+
     for year in range(2000, 2016):
         rows = ''
         date_str = '{}-01-{}'.format(year, random.randint(1, 10))

--- a/tests/integration/test_version_update_after_mutation/test.py
+++ b/tests/integration/test_version_update_after_mutation/test.py
@@ -86,7 +86,7 @@ def test_upgrade_while_mutation(start_cluster):
     node3.restart_with_latest_version(signal=9)
 
     # checks for readonly
-    exec_query_with_retry(node3, "OPTIMIZE TABLE mt1", retry_count=60)
+    exec_query_with_retry(node3, "OPTIMIZE TABLE mt1", sleep_time=5, retry_count=60)
 
     node3.query("ALTER TABLE mt1 DELETE WHERE id > 100000", settings={"mutations_sync": "2"})
     # will delete nothing, but previous async mutation will finish with this query


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:
1) test_backward_compatibility/test_detach_part_wrong_partition_id.py had same cluster name like test.py cluster. 
failed here https://clickhouse-test-reports.s3.yandex.net/0/168edaed73cc1e75130e0e1c31efb5b924271c47/integration_tests_(release).html
2) test_replicated_mutations/test.py was not ready to be repeated on the same cluster
3) test_version_update_after_mutation/test.py I hope had not enough time to stop being readonly


By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
