### PR TITLE
Improve test compatibility (00646_url_engine and 01854_HTTP_dict_decompression)

### DIFF
--- a/tests/queries/0_stateless/00646_url_engine.python
+++ b/tests/queries/0_stateless/00646_url_engine.python
@@ -26,7 +26,7 @@ CLICKHOUSE_PORT_HTTP = os.environ.get('CLICKHOUSE_PORT_HTTP', '8123')
 # accessible from clickhouse server.
 #####################################################################################
 
-# IP-address of this host accessible from outside world.
+# IP-address of this host accessible from the outside world. Get the first one
 HTTP_SERVER_HOST = subprocess.check_output(['hostname', '-i']).decode('utf-8').strip().split()[0]
 HTTP_SERVER_PORT = get_local_port(HTTP_SERVER_HOST)
 

--- a/tests/queries/0_stateless/00646_url_engine.python
+++ b/tests/queries/0_stateless/00646_url_engine.python
@@ -27,7 +27,7 @@ CLICKHOUSE_PORT_HTTP = os.environ.get('CLICKHOUSE_PORT_HTTP', '8123')
 #####################################################################################
 
 # IP-address of this host accessible from outside world.
-HTTP_SERVER_HOST = subprocess.check_output(['hostname', '-i']).decode('utf-8').strip()
+HTTP_SERVER_HOST = subprocess.check_output(['hostname', '-i']).decode('utf-8').strip().split()[0]
 HTTP_SERVER_PORT = get_local_port(HTTP_SERVER_HOST)
 
 # IP address and port of the HTTP server started from this script.

--- a/tests/queries/0_stateless/01854_HTTP_dict_decompression.python
+++ b/tests/queries/0_stateless/01854_HTTP_dict_decompression.python
@@ -36,12 +36,12 @@ HTTP_SERVER_PORT = get_local_port(HTTP_SERVER_HOST)
 HTTP_SERVER_ADDRESS = (HTTP_SERVER_HOST, HTTP_SERVER_PORT)
 HTTP_SERVER_URL_STR = 'http://' + ':'.join(str(s) for s in HTTP_SERVER_ADDRESS) + "/"
 
-# Because we need to check content of file.csv we can create this content and avoid reading csv
+# Because we need to check the content of file.csv we can create this content and avoid reading csv
 CSV_DATA = "Hello, 1\nWorld, 2\nThis, 152\nis, 9283\ntesting, 2313213\ndata, 555\n"
 
 
 # Choose compression method
-# (Will change during test, need to check standart data sending, to make sure that nothing broke)
+# (Will change during test, need to check standard data sending, to make sure that nothing broke)
 COMPRESS_METHOD = 'none'
 ADDING_ENDING = ''
 ENDINGS = ['.gz', '.xz']

--- a/tests/queries/0_stateless/01854_HTTP_dict_decompression.python
+++ b/tests/queries/0_stateless/01854_HTTP_dict_decompression.python
@@ -28,7 +28,7 @@ CLICKHOUSE_PORT_HTTP = os.environ.get('CLICKHOUSE_PORT_HTTP', '8123')
 # accessible from clickhouse server.
 #####################################################################################
 
-# IP-address of this host accessible from outside world. Get the first one
+# IP-address of this host accessible from the outside world. Get the first one
 HTTP_SERVER_HOST = subprocess.check_output(['hostname', '-i']).decode('utf-8').strip().split()[0]
 HTTP_SERVER_PORT = get_local_port(HTTP_SERVER_HOST)
 

--- a/tests/queries/0_stateless/01854_HTTP_dict_decompression.python
+++ b/tests/queries/0_stateless/01854_HTTP_dict_decompression.python
@@ -28,19 +28,19 @@ CLICKHOUSE_PORT_HTTP = os.environ.get('CLICKHOUSE_PORT_HTTP', '8123')
 # accessible from clickhouse server.
 #####################################################################################
 
-# IP-address of this host accessible from outside world.
-HTTP_SERVER_HOST = subprocess.check_output(['hostname', '-i']).decode('utf-8').strip()
+# IP-address of this host accessible from outside world. Get the first one
+HTTP_SERVER_HOST = subprocess.check_output(['hostname', '-i']).decode('utf-8').strip().split()[0]
 HTTP_SERVER_PORT = get_local_port(HTTP_SERVER_HOST)
 
 # IP address and port of the HTTP server started from this script.
 HTTP_SERVER_ADDRESS = (HTTP_SERVER_HOST, HTTP_SERVER_PORT)
 HTTP_SERVER_URL_STR = 'http://' + ':'.join(str(s) for s in HTTP_SERVER_ADDRESS) + "/"
 
-# Because we need to check content of file.csv we can create this content and avoid reading csv 
+# Because we need to check content of file.csv we can create this content and avoid reading csv
 CSV_DATA = "Hello, 1\nWorld, 2\nThis, 152\nis, 9283\ntesting, 2313213\ndata, 555\n"
 
 
-# Choose compression method 
+# Choose compression method
 # (Will change during test, need to check standart data sending, to make sure that nothing broke)
 COMPRESS_METHOD = 'none'
 ADDING_ENDING = ''
@@ -88,7 +88,7 @@ class HttpProcessor(SimpleHTTPRequestHandler):
 
     def do_GET(self):
         self._set_headers()
-    
+
         if COMPRESS_METHOD == 'none':
             self.wfile.write(CSV_DATA.encode())
         else:
@@ -120,7 +120,7 @@ def test_select(dict_name="", schema="word String, counter UInt32", requests=[],
         if i > 2:
             ADDING_ENDING = ENDINGS[i-3]
             SEND_ENCODING = False
-        
+
         if dict_name:
             get_ch_answer("drop dictionary if exists {}".format(dict_name))
             get_ch_answer('''CREATE DICTIONARY {} ({})


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

These tests assume that `hostname -i` returns only 1 ip address which isn't necessarily true:

```bash
$ hostname -i
127.0.0.1 192.168.1.193
```

This leads to failures when running the tests locally:

```
00646_url_engine:                                                       [ FAIL ] - return code 1
Traceback (most recent call last):
  File "/mnt/ch/ClickHouse/tests/queries/0_stateless/00646_url_engine.python", line 31, in <module>
    HTTP_SERVER_PORT = get_local_port(HTTP_SERVER_HOST)
  File "/mnt/ch/ClickHouse/tests/queries/0_stateless/00646_url_engine.python", line 17, in get_local_port
    fd.bind((host, 0))
socket.gaierror: [Errno -2] Name or service not known
, result:
```

To fix it get the first address if there is more than one.