### PR TITLE
Hold context in HedgedConnections to prevent use-after-free on settings.

### DIFF
--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -3,6 +3,7 @@
 #include <Client/HedgedConnections.h>
 #include <Common/ProfileEvents.h>
 #include <Interpreters/ClientInfo.h>
+#include <Interpreters/Context.h>
 
 namespace ProfileEvents
 {
@@ -21,13 +22,14 @@ namespace ErrorCodes
 
 HedgedConnections::HedgedConnections(
     const ConnectionPoolWithFailoverPtr & pool_,
-    const Settings & settings_,
+    ContextPtr context_,
     const ConnectionTimeouts & timeouts_,
     const ThrottlerPtr & throttler_,
     PoolMode pool_mode,
     std::shared_ptr<QualifiedTableName> table_to_check_)
-    : hedged_connections_factory(pool_, &settings_, timeouts_, table_to_check_)
-    , settings(settings_)
+    : hedged_connections_factory(pool_, &context_->getSettingsRef(), timeouts_, table_to_check_)
+    , context(std::move(context_))
+    , settings(context->getSettingsRef())
     , drain_timeout(settings.drain_timeout)
     , allow_changing_replica_until_first_data_packet(settings.allow_changing_replica_until_first_data_packet)
     , throttler(throttler_)

--- a/src/Client/HedgedConnections.h
+++ b/src/Client/HedgedConnections.h
@@ -72,7 +72,7 @@ public:
     };
 
     HedgedConnections(const ConnectionPoolWithFailoverPtr & pool_,
-                      const Settings & settings_,
+                      ContextPtr context_,
                       const ConnectionTimeouts & timeouts_,
                       const ThrottlerPtr & throttler,
                       PoolMode pool_mode,
@@ -188,6 +188,7 @@ private:
     Packet last_received_packet;
 
     Epoll epoll;
+    ContextPtr context;
     const Settings & settings;
 
     /// The following two fields are from settings but can be referenced outside the lifetime of

--- a/src/DataStreams/RemoteQueryExecutor.cpp
+++ b/src/DataStreams/RemoteQueryExecutor.cpp
@@ -102,7 +102,7 @@ RemoteQueryExecutor::RemoteQueryExecutor(
             if (main_table)
                 table_to_check = std::make_shared<QualifiedTableName>(main_table.getQualifiedName());
 
-            return std::make_shared<HedgedConnections>(pool, current_settings, timeouts, throttler, pool_mode, table_to_check);
+            return std::make_shared<HedgedConnections>(pool, context, timeouts, throttler, pool_mode, table_to_check);
         }
 #endif
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Will hopefully fix this race:
```
==================
WARNING: ThreadSanitizer: data race (pid=7)
  Read of size 8 at 0x7b8c00656850 by thread T428:
    #0 Poco::Timespan::totalMilliseconds() const obj-x86_64-linux-gnu/../contrib/poco/Foundation/include/Poco/Timespan.h:195:9 (clickhouse+0x9725184)
    #1 DB::SettingFieldTimespan<(DB::SettingFieldTimespanUnit)0>::totalMilliseconds() const obj-x86_64-linux-gnu/../src/Core/SettingsFields.h:130:71 (clickhouse+0x9725184)
    #2 DB::ConnectionPool::get(DB::ConnectionTimeouts const&, DB::Settings const*, bool) obj-x86_64-linux-gnu/../src/Client/ConnectionPool.h:85:69 (clickhouse+0x9725184)
    #3 DB::ConnectionEstablisher::run(PoolWithFailoverBase<DB::IConnectionPool>::TryResult&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) obj-x86_64-linux-gnu/../src/Client/ConnectionEstablisher.cpp:37:30 (clickhouse+0x150f868b)
    #4 DB::ConnectionEstablisherAsync::Routine::operator()(boost::context::fiber&&) obj-x86_64-linux-gnu/../src/Client/ConnectionEstablisher.cpp:138:61 (clickhouse+0x150f9fa3)
    #5 std::__1::enable_if<!(std::is_member_pointer<std::__1::decay<DB::ConnectionEstablisherAsync::Routine&>::type>::value), std::__1::result_of<DB::ConnectionEstablisherAsync::Routine& (boost::context::fiber&&)>::type>::type boost::context::detail::invoke<DB::ConnectionEstablisherAsync::Routine&, boost::context::fiber>(DB::ConnectionEstablisherAsync::Routine&, boost::context::fiber&&) obj-x86_64-linux-gnu/../contrib/boost/boost/context/detail/invoke.hpp:41:12 (clickhouse+0x150fc161)
    #6 boost::context::detail::fiber_capture_record<boost::context::fiber, FiberStack&, DB::ConnectionEstablisherAsync::Routine>::run() obj-x86_64-linux-gnu/../contrib/boost/boost/context/fiber_ucontext.hpp:291:17 (clickhouse+0x150fc161)
    #7 void boost::context::detail::fiber_entry_func<boost::context::detail::fiber_capture_record<boost::context::fiber, FiberStack&, DB::ConnectionEstablisherAsync::Routine> >(void*) obj-x86_64-linux-gnu/../contrib/boost/boost/context/fiber_ucontext.hpp:72:13 (clickhouse+0x150fb0f9)
    #8 <null> <null> (libc.so.6+0x5e65f)

  Previous write of size 8 at 0x7b8c00656850 by thread T252:
    #0 Poco::Timespan::Timespan(Poco::Timespan const&) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Timespan.cpp:54:2 (clickhouse+0x18651108)
    #1 DB::SettingFieldTimespan<(DB::SettingFieldTimespanUnit)0>::SettingFieldTimespan(DB::SettingFieldTimespan<(DB::SettingFieldTimespanUnit)0> const&) obj-x86_64-linux-gnu/../src/Core/SettingsFields.h:96:8 (clickhouse+0x96ce466)
    #2 DB::SettingsTraits::Data::Data(DB::SettingsTraits::Data const&) obj-x86_64-linux-gnu/../src/Core/Settings.h:588:1 (clickhouse+0x96ce466)
    #3 DB::BaseSettings<DB::SettingsTraits>::BaseSettings(DB::BaseSettings<DB::SettingsTraits> const&) obj-x86_64-linux-gnu/../src/Core/BaseSettings.h:42:7 (clickhouse+0x9770ce7)
    #4 DB::Settings::Settings(DB::Settings const&) obj-x86_64-linux-gnu/../src/Core/Settings.h:594:8 (clickhouse+0x9770ce7)
    #5 DB::Context::Context(DB::Context const&) obj-x86_64-linux-gnu/../src/Interpreters/Context.cpp:530:10 (clickhouse+0x13dd42ee)
    #6 DB::Context::createCopy(std::__1::shared_ptr<DB::Context const> const&) obj-x86_64-linux-gnu/../src/Interpreters/Context.cpp:561:41 (clickhouse+0x13dd6ea5)
    #7 DB::Context::createCopy(std::__1::shared_ptr<DB::Context> const&) obj-x86_64-linux-gnu/../src/Interpreters/Context.cpp:573:12 (clickhouse+0x13dd6ea5)
    #8 DB::TCPHandler::runImpl() obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:93:26 (clickhouse+0x151ac599)
    #9 DB::TCPHandler::run() obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:1650:9 (clickhouse+0x151bda27)
    #10 Poco::Net::TCPServerConnection::start() obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerConnection.cpp:43:3 (clickhouse+0x184d6582)
    #11 Poco::Net::TCPServerDispatcher::run() obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerDispatcher.cpp:115:20 (clickhouse+0x184d6d0f)
    #12 Poco::PooledThread::run() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:199:14 (clickhouse+0x1864d361)
    #13 Poco::(anonymous namespace)::RunnableHolder::run() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:55:11 (clickhouse+0x1864b7ef)
    #14 Poco::ThreadImpl::runnableEntry(void*) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_POSIX.cpp:345:27 (clickhouse+0x18649f67)

  Location is heap block of size 6824 at 0x7b8c00656400 allocated by thread T252:
    #0 operator new(unsigned long) <null> (clickhouse+0x95b92a7)
    #1 DB::Context::createCopy(std::__1::shared_ptr<DB::Context const> const&) obj-x86_64-linux-gnu/../src/Interpreters/Context.cpp:561:37 (clickhouse+0x13dd6e97)
    #2 DB::Context::createCopy(std::__1::shared_ptr<DB::Context> const&) obj-x86_64-linux-gnu/../src/Interpreters/Context.cpp:573:12 (clickhouse+0x13dd6e97)
    #3 DB::TCPHandler::runImpl() obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:93:26 (clickhouse+0x151ac599)
    #4 DB::TCPHandler::run() obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:1650:9 (clickhouse+0x151bda27)
    #5 Poco::Net::TCPServerConnection::start() obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerConnection.cpp:43:3 (clickhouse+0x184d6582)
    #6 Poco::Net::TCPServerDispatcher::run() obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerDispatcher.cpp:115:20 (clickhouse+0x184d6d0f)
    #7 Poco::PooledThread::run() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:199:14 (clickhouse+0x1864d361)
    #8 Poco::(anonymous namespace)::RunnableHolder::run() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:55:11 (clickhouse+0x1864b7ef)
    #9 Poco::ThreadImpl::runnableEntry(void*) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_POSIX.cpp:345:27 (clickhouse+0x18649f67)

  Thread T428 (tid=0, running) created by thread T560 at:
    #0 boost::context::detail::fiber_activation_record* boost::context::detail::create_fiber1<boost::context::fiber, FiberStack&, DB::ConnectionEstablisherAsync::Routine>(FiberStack&, DB::ConnectionEstablisherAsync::Routine&&) obj-x86_64-linux-gnu/../contrib/boost/boost/context/fiber_ucontext.hpp:345:26 (clickhouse+0x150fb02b)
    #1 boost::context::fiber::fiber<FiberStack&, DB::ConnectionEstablisherAsync::Routine>(std::__1::allocator_arg_t, FiberStack&, DB::ConnectionEstablisherAsync::Routine&&) obj-x86_64-linux-gnu/../contrib/boost/boost/context/fiber_ucontext.hpp:434:15 (clickhouse+0x150fa210)
    #2 DB::ConnectionEstablisherAsync::resume() obj-x86_64-linux-gnu/../src/Client/ConnectionEstablisher.cpp:160:17 (clickhouse+0x150fa210)
    #3 DB::HedgedConnectionsFactory::resumeConnectionEstablisher(int, DB::Connection*&) obj-x86_64-linux-gnu/../src/Client/HedgedConnectionsFactory.cpp:263:55 (clickhouse+0x1510d8ad)
    #4 DB::HedgedConnectionsFactory::startNewConnectionImpl(DB::Connection*&) obj-x86_64-linux-gnu/../src/Client/HedgedConnectionsFactory.cpp:202:17 (clickhouse+0x1510c5d9)
    #5 DB::HedgedConnectionsFactory::startNewConnection(DB::Connection*&) obj-x86_64-linux-gnu/../src/Client/HedgedConnectionsFactory.cpp:130:19 (clickhouse+0x1510c5d9)
    #6 DB::HedgedConnections::startNewReplica() obj-x86_64-linux-gnu/../src/Client/HedgedConnections.cpp:468:72 (clickhouse+0x150ffff8)
    #7 DB::HedgedConnections::getReadyReplicaLocation(std::__1::function<void (int, Poco::Timespan, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>) obj-x86_64-linux-gnu/../src/Client/HedgedConnections.cpp:333:13 (clickhouse+0x150ffff8)
    #8 DB::HedgedConnections::drain() obj-x86_64-linux-gnu/../src/Client/HedgedConnections.cpp:256:36 (clickhouse+0x150ff518)
    #9 DB::ConnectionCollector::drainConnections(DB::IConnections&) obj-x86_64-linux-gnu/../src/DataStreams/ConnectionCollector.cpp:78:37 (clickhouse+0x13b50cf8)
    #10 DB::AsyncDrainTask::operator()() const obj-x86_64-linux-gnu/../src/DataStreams/ConnectionCollector.cpp:48:9 (clickhouse+0x13b516ee)
    #11 decltype(std::__1::forward<DB::AsyncDrainTask&>(fp)()) std::__1::__invoke<DB::AsyncDrainTask&>(DB::AsyncDrainTask&) obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3676:1 (clickhouse+0x13b516ee)
    #12 void std::__1::__invoke_void_return_wrapper<void>::__call<DB::AsyncDrainTask&>(DB::AsyncDrainTask&) obj-x86_64-linux-gnu/../contrib/libcxx/include/__functional_base:348:9 (clickhouse+0x13b516ee)
    #13 std::__1::__function::__default_alloc_func<DB::AsyncDrainTask, void ()>::operator()() obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1608:12 (clickhouse+0x13b516ee)
    #14 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::AsyncDrainTask, void ()> >(std::__1::__function::__policy_storage const*) obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2089:16 (clickhouse+0x13b516ee)
    #15 std::__1::__function::__policy_func<void ()>::operator()() const obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2221:16 (clickhouse+0x9661310)
    #16 std::__1::function<void ()>::operator()() const obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2560:12 (clickhouse+0x9661310)
    #17 ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::__1::__list_iterator<ThreadFromGlobalPool, void*>) obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:266:17 (clickhouse+0x9661310)
    #18 bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()::operator()() const obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:136:73 (clickhouse+0x9664540)
    #19 decltype(std::__1::forward<bool>(fp)(std::__1::forward<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&>(fp0)...)) std::__1::__invoke_constexpr<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&>(bool&&, bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&...) obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3682:1 (clickhouse+0x9664540)
    #20 decltype(auto) std::__1::__apply_tuple_impl<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&, std::__1::tuple<>&>(bool&&, bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&, std::__1::__tuple_indices<std::__1::tuple<>&...>) obj-x86_64-linux-gnu/../contrib/libcxx/include/tuple:1415:1 (clickhouse+0x9664540)
    #21 decltype(auto) std::__1::apply<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&, std::__1::tuple<>&>(bool&&, bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&) obj-x86_64-linux-gnu/../contrib/libcxx/include/tuple:1424:1 (clickhouse+0x9664540)
    #22 ThreadFromGlobalPool::ThreadFromGlobalPool<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(bool&&, bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...)::'lambda'()::operator()() obj-x86_64-linux-gnu/../src/Common/ThreadPool.h:182:13 (clickhouse+0x9664540)
    #23 decltype(std::__1::forward<bool>(fp)(std::__1::forward<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(fp0)...)) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(bool&&, bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...)::'lambda'()&>(bool&&, bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...) obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3676:1 (clickhouse+0x96644a1)
    #24 void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(bool&&, bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...)::'lambda'()&>(bool&&...) obj-x86_64-linux-gnu/../contrib/libcxx/include/__functional_base:348:9 (clickhouse+0x96644a1)
    #25 std::__1::__function::__default_alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(bool&&, bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...)::'lambda'(), void ()>::operator()() obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:1608:12 (clickhouse+0x96644a1)
    #26 void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(bool&&, bool ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<bool>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...)::'lambda'(), void ()> >(std::__1::__function::__policy_storage const*) obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2089:16 (clickhouse+0x96644a1)
    #27 std::__1::__function::__policy_func<void ()>::operator()() const obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2221:16 (clickhouse+0x965ebd5)
    #28 std::__1::function<void ()>::operator()() const obj-x86_64-linux-gnu/../contrib/libcxx/include/functional:2560:12 (clickhouse+0x965ebd5)
    #29 ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:266:17 (clickhouse+0x965ebd5)
    #30 void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()::operator()() const obj-x86_64-linux-gnu/../src/Common/ThreadPool.cpp:136:73 (clickhouse+0x9661f58)
    #31 decltype(std::__1::forward<void>(fp)(std::__1::forward<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(fp0)...)) std::__1::__invoke<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(void&&, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...) obj-x86_64-linux-gnu/../contrib/libcxx/include/type_traits:3676:1 (clickhouse+0x9661f58)
    #32 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(std::__1::tuple<void, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>&, std::__1::__tuple_indices<>) obj-x86_64-linux-gnu/../contrib/libcxx/include/thread:280:5 (clickhouse+0x9661f58)
    #33 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()> >(void*) obj-x86_64-linux-gnu/../contrib/libcxx/include/thread:291:5 (clickhouse+0x9661f58)

  Thread T252 'TCPHandler' (tid=369, running) created by thread T149 at:
    #0 pthread_create <null> (clickhouse+0x952a6cb)
    #1 Poco::ThreadImpl::startImpl(Poco::SharedPtr<Poco::Runnable, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::Runnable> >) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_POSIX.cpp:202:6 (clickhouse+0x186499f7)
    #2 Poco::Thread::start(Poco::Runnable&) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:128:2 (clickhouse+0x1864b1ac)
    #3 Poco::PooledThread::start() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:85:10 (clickhouse+0x1864f727)
    #4 Poco::ThreadPool::getThread() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:461:14 (clickhouse+0x1864f727)
    #5 Poco::ThreadPool::startWithPriority(Poco::Thread::Priority, Poco::Runnable&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:365:2 (clickhouse+0x1864fb07)
    #6 Poco::Net::TCPServerDispatcher::enqueue(Poco::Net::StreamSocket const&) obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerDispatcher.cpp:152:17 (clickhouse+0x184d728a)
    #7 Poco::Net::TCPServer::run() obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServer.cpp:148:21 (clickhouse+0x184d5e07)
    #8 Poco::(anonymous namespace)::RunnableHolder::run() obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:55:11 (clickhouse+0x1864b7ef)
    #9 Poco::ThreadImpl::runnableEntry(void*) obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_POSIX.cpp:345:27 (clickhouse+0x18649f67)

SUMMARY: ThreadSanitizer: data race obj-x86_64-linux-gnu/../contrib/poco/Foundation/include/Poco/Timespan.h:195:9 in Poco::Timespan::totalMilliseconds() const
==================
```