### PR TITLE
Merge memory parts first, then disk parts.

### DIFF
--- a/src/Storages/MergeTree/CombinedMergeSelector.cpp
+++ b/src/Storages/MergeTree/CombinedMergeSelector.cpp
@@ -5,11 +5,7 @@
 
 namespace DB
 {
-
-
-CombinedMergeSelector::PartsRange CombinedMergeSelector::select(
-    const PartsRanges & parts_ranges,
-    const size_t max_total_size_to_merge)
+CombinedMergeSelector::PartsRange CombinedMergeSelector::select(const PartsRanges & parts_ranges, const size_t max_total_size_to_merge)
 {
     const CombinedMergeSelector::PartsRange & partsRange = memoryMergeSelector.select(parts_ranges, max_total_size_to_merge);
     if (partsRange.empty())

--- a/src/Storages/MergeTree/CombinedMergeSelector.cpp
+++ b/src/Storages/MergeTree/CombinedMergeSelector.cpp
@@ -1,0 +1,21 @@
+#include <Storages/MergeTree/CombinedMergeSelector.h>
+
+#include <cmath>
+
+
+namespace DB
+{
+
+
+CombinedMergeSelector::PartsRange CombinedMergeSelector::select(
+    const PartsRanges & parts_ranges,
+    const size_t max_total_size_to_merge)
+{
+    const CombinedMergeSelector::PartsRange & partsRange = memoryMergeSelector.select(parts_ranges, max_total_size_to_merge);
+    if (partsRange.empty())
+        return simpleMergeSelector.select(parts_ranges, max_total_size_to_merge);
+    else
+        return partsRange;
+}
+
+}

--- a/src/Storages/MergeTree/CombinedMergeSelector.h
+++ b/src/Storages/MergeTree/CombinedMergeSelector.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Storages/MergeTree/MergeSelector.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Storages/MergeTree/MemoryMergeSelector.h>
+#include <Storages/MergeTree/SimpleMergeSelector.h>
+
+
+namespace DB
+{
+
+/**
+ *  1. combine Memory and Simple merge-selector
+ *  2. first memory, then disk
+ */
+class CombinedMergeSelector : public IMergeSelector
+{
+public:
+    explicit CombinedMergeSelector(const MergeTreeSettingsPtr settings_) :
+        memoryMergeSelector(settings_), simpleMergeSelector(settings_)
+    {
+
+    }
+
+    PartsRange select(
+        const PartsRanges & parts_ranges,
+        const size_t max_total_size_to_merge) override;
+
+private:
+    MemoryMergeSelector memoryMergeSelector;
+    SimpleMergeSelector simpleMergeSelector;
+};
+
+}

--- a/src/Storages/MergeTree/CombinedMergeSelector.h
+++ b/src/Storages/MergeTree/CombinedMergeSelector.h
@@ -1,14 +1,13 @@
 #pragma once
 
+#include <Storages/MergeTree/MemoryMergeSelector.h>
 #include <Storages/MergeTree/MergeSelector.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
-#include <Storages/MergeTree/MemoryMergeSelector.h>
 #include <Storages/MergeTree/SimpleMergeSelector.h>
 
 
 namespace DB
 {
-
 /**
  *  1. combine Memory and Simple merge-selector
  *  2. first memory, then disk
@@ -16,15 +15,10 @@ namespace DB
 class CombinedMergeSelector : public IMergeSelector
 {
 public:
-    explicit CombinedMergeSelector(const MergeTreeSettingsPtr settings_) :
-        memoryMergeSelector(settings_), simpleMergeSelector(settings_)
-    {
+    explicit CombinedMergeSelector(const MergeTreeSettingsPtr settings_)
+        : memoryMergeSelector(settings_), simpleMergeSelector(settings_) { }
 
-    }
-
-    PartsRange select(
-        const PartsRanges & parts_ranges,
-        const size_t max_total_size_to_merge) override;
+    PartsRange select(const PartsRanges & parts_ranges, const size_t max_total_size_to_merge) override;
 
 private:
     MemoryMergeSelector memoryMergeSelector;

--- a/src/Storages/MergeTree/MemoryMergeSelector.cpp
+++ b/src/Storages/MergeTree/MemoryMergeSelector.cpp
@@ -111,7 +111,7 @@ MemoryMergeSelector::PartsRange MemoryMergeSelector::select(
     Estimator estimator;
 
     int idx = parts_ranges.size() -1 ;
-    bool printDebug = false;
+//    bool printDebug = false;
     while (idx >=0)
     {
         auto & parts_range = parts_ranges[idx];
@@ -120,11 +120,11 @@ MemoryMergeSelector::PartsRange MemoryMergeSelector::select(
         if(part->getType() != MergeTreeDataPartType::IN_MEMORY)
             break;
 
-        if (part->storage.getStorageID().table_name.ends_with("t_num"))
-            printDebug = true;
+//        if (part->storage.getStorageID().table_name.ends_with("t_num"))
+//            printDebug = true;
 
-        if(printDebug)
-            dumpPartsInfo(parts_range, "candidate segments: ");
+//        if(printDebug)
+//            dumpPartsInfo(parts_range, "candidate segments: ");
 
         selectWithinPartition(parts_range, max_total_size_to_merge, estimator, settings);
 
@@ -132,8 +132,8 @@ MemoryMergeSelector::PartsRange MemoryMergeSelector::select(
         --idx;
     }
 
-    if(printDebug)
-        dumpPartsInfo(estimator.getBest(), "selected part range: ");
+//    if(printDebug)
+//        dumpPartsInfo(estimator.getBest(), "selected part range: ");
 
     return estimator.getBest();
 }

--- a/src/Storages/MergeTree/MemoryMergeSelector.cpp
+++ b/src/Storages/MergeTree/MemoryMergeSelector.cpp
@@ -25,7 +25,8 @@ struct Estimator
             best_begin = begin;
             best_end = end;
         }
-        else if(current_len == part_count){
+        else if(current_len == part_count)
+        {
             double current_score = sum_size;
             if (!min_score || current_score < min_score)
             {
@@ -74,6 +75,9 @@ void selectWithinPartition(
         else
             break;
     }
+    /// fix
+    if (range_begin < 0) range_begin = 0;
+
     estimator.consider(parts.begin() + range_begin, parts.begin() + range_end, sum_size);
 
 

--- a/src/Storages/MergeTree/MemoryMergeSelector.cpp
+++ b/src/Storages/MergeTree/MemoryMergeSelector.cpp
@@ -1,94 +1,89 @@
-#include <Storages/MergeTree/MergeTreeData.h>
-#include <Storages/MergeTree/MemoryMergeSelector.h>
 #include <cmath>
+#include <Storages/MergeTree/MemoryMergeSelector.h>
+#include <Storages/MergeTree/MergeTreeData.h>
 
 
 namespace DB
 {
-
 namespace
 {
-
-/** Estimates best set of parts to merge within passed alternatives.
+    /** Estimates best set of parts to merge within passed alternatives.
   * within specified length limits, return the longest part segments with minimal total size.
   */
-struct Estimator
-{
-    using Iterator = MemoryMergeSelector::PartsRange::const_iterator;
-
-    void consider(Iterator begin, Iterator end, size_t sum_size)
+    struct Estimator
     {
-        size_t current_len = end - begin;
-        if (current_len > part_count)
+        using Iterator = MemoryMergeSelector::PartsRange::const_iterator;
+
+        void consider(Iterator begin, Iterator end, size_t sum_size)
         {
-            part_count = current_len;
-            best_begin = begin;
-            best_end = end;
-        }
-        else if(current_len == part_count)
-        {
-            double current_score = sum_size;
-            if (!min_score || current_score < min_score)
+            size_t current_len = end - begin;
+            if (current_len > part_count)
             {
-                min_score = current_score;
+                part_count = current_len;
                 best_begin = begin;
                 best_end = end;
             }
+            else if (current_len == part_count)
+            {
+                double current_score = sum_size;
+                if (!min_score || current_score < min_score)
+                {
+                    min_score = current_score;
+                    best_begin = begin;
+                    best_end = end;
+                }
+            }
         }
-    }
 
-    MemoryMergeSelector::PartsRange getBest() const
+        MemoryMergeSelector::PartsRange getBest() const { return MemoryMergeSelector::PartsRange(best_begin, best_end); }
+
+        double min_score = 0;
+        size_t part_count = 0;
+        Iterator best_begin{};
+        Iterator best_end{};
+    };
+
+    void selectWithinPartition(
+        const MemoryMergeSelector::PartsRange & parts,
+        const size_t max_total_size_to_merge,
+        Estimator & estimator,
+        const MemoryMergeSelector::Settings & settings)
     {
-        return MemoryMergeSelector::PartsRange(best_begin, best_end);
-    }
-
-    double min_score = 0;
-    size_t part_count = 0;
-    Iterator best_begin {};
-    Iterator best_end {};
-};
-
-void selectWithinPartition(
-    const MemoryMergeSelector::PartsRange & parts,
-    const size_t max_total_size_to_merge,
-    Estimator & estimator,
-    const MemoryMergeSelector::Settings & settings)
-{
-    size_t memory_part_count = 0;
-    auto iter = parts.rbegin();
-    while(iter != parts.rend())
-    {
-        const MergeTreeData::DataPartPtr & part = *(static_cast<const MergeTreeData::DataPartPtr *>((*iter).data));
-
-        if (part->getType() != MergeTreeDataPartType::IN_MEMORY)
-            break;
-        else /// prevent SimpleMergeSelector merging InMemory parts.
+        size_t memory_part_count = 0;
+        auto iter = parts.rbegin();
+        while (iter != parts.rend())
         {
-            auto & part_info = const_cast<MemoryMergeSelector::Part &>(*iter);
-            part_info.shall_participate_in_merges = false;
+            const MergeTreeData::DataPartPtr & part = *(static_cast<const MergeTreeData::DataPartPtr *>((*iter).data));
 
-            memory_part_count++;
+            if (part->getType() != MergeTreeDataPartType::IN_MEMORY)
+                break;
+            else /// prevent SimpleMergeSelector merging InMemory parts.
+            {
+                auto & part_info = const_cast<MemoryMergeSelector::Part &>(*iter);
+                part_info.shall_participate_in_merges = false;
+
+                memory_part_count++;
+            }
+            iter++;
         }
-        iter++;
+
+        if (memory_part_count < settings.min_parts_to_merge)
+            return;
+
+        int idx = parts.size() - 1;
+        size_t selected_count = 0;
+        size_t sum_size = 0;
+        while (true)
+        {
+            sum_size += parts[idx].size;
+            selected_count++;
+            if (selected_count > settings.max_parts_to_merge || sum_size > max_total_size_to_merge || selected_count == memory_part_count)
+                break;
+
+            idx--;
+        }
+        estimator.consider(parts.begin() + idx, parts.end(), sum_size);
     }
-
-    if (memory_part_count < settings.min_parts_to_merge)
-        return;
-
-    int idx = parts.size() - 1;
-    size_t selected_count = 0;
-    size_t sum_size = 0;
-    while (true)
-    {
-        sum_size  += parts[idx].size;
-        selected_count++;
-        if (selected_count > settings.max_parts_to_merge || sum_size > max_total_size_to_merge || selected_count == memory_part_count)
-            break;
-
-        idx--;
-    }
-    estimator.consider(parts.begin() + idx, parts.end(), sum_size);
-}
 }
 
 void MemoryMergeSelector::dumpPartsInfo(const MemoryMergeSelector::PartsRange & parts, String prefix)
@@ -98,33 +93,31 @@ void MemoryMergeSelector::dumpPartsInfo(const MemoryMergeSelector::PartsRange & 
     {
         const MergeTreeData::DataPartPtr treeDataPart = *(static_cast<const MergeTreeData::DataPartPtr *>(part.data));
         const auto info = treeDataPart->info;
-        debug_buf << info.getPartName() << ", " << info.min_block << "," << info.max_block << ", " << info.level <<
-                ", " << info.mutation << ", should merge:" << part.shall_participate_in_merges << std::endl;
+        debug_buf << info.getPartName() << ", " << info.min_block << "," << info.max_block << ", " << info.level << ", " << info.mutation
+                  << ", should merge:" << part.shall_participate_in_merges << std::endl;
     }
     LOG_DEBUG(log, "\n----- {} \n {}---------\n", prefix, debug_buf.str());
 }
 
-MemoryMergeSelector::PartsRange MemoryMergeSelector::select(
-    const PartsRanges & parts_ranges,
-    const size_t max_total_size_to_merge)
+MemoryMergeSelector::PartsRange MemoryMergeSelector::select(const PartsRanges & parts_ranges, const size_t max_total_size_to_merge)
 {
     Estimator estimator;
 
-    int idx = parts_ranges.size() -1 ;
-//    bool printDebug = false;
-    while (idx >=0)
+    int idx = parts_ranges.size() - 1;
+    //    bool printDebug = false;
+    while (idx >= 0)
     {
         auto & parts_range = parts_ranges[idx];
         const MergeTreeData::DataPartPtr & part = *(static_cast<const MergeTreeData::DataPartPtr *>(parts_range.back().data));
         /// InMemory parts lie in the right side of the list.
-        if(part->getType() != MergeTreeDataPartType::IN_MEMORY)
+        if (part->getType() != MergeTreeDataPartType::IN_MEMORY)
             break;
 
-//        if (part->storage.getStorageID().table_name.ends_with("t_num"))
-//            printDebug = true;
+        //        if (part->storage.getStorageID().table_name.ends_with("t_num"))
+        //            printDebug = true;
 
-//        if(printDebug)
-//            dumpPartsInfo(parts_range, "candidate segments: ");
+        //        if(printDebug)
+        //            dumpPartsInfo(parts_range, "candidate segments: ");
 
         selectWithinPartition(parts_range, max_total_size_to_merge, estimator, settings);
 
@@ -132,8 +125,8 @@ MemoryMergeSelector::PartsRange MemoryMergeSelector::select(
         --idx;
     }
 
-//    if(printDebug)
-//        dumpPartsInfo(estimator.getBest(), "selected part range: ");
+    //    if(printDebug)
+    //        dumpPartsInfo(estimator.getBest(), "selected part range: ");
 
     return estimator.getBest();
 }

--- a/src/Storages/MergeTree/MemoryMergeSelector.cpp
+++ b/src/Storages/MergeTree/MemoryMergeSelector.cpp
@@ -1,0 +1,128 @@
+#include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/MemoryMergeSelector.h>
+#include <cmath>
+
+
+namespace DB
+{
+
+namespace
+{
+
+/** Estimates best set of parts to merge within passed alternatives.
+  * within specified length limits, return the longest part segments with minimal total size.
+  */
+struct Estimator
+{
+    using Iterator = MemoryMergeSelector::PartsRange::const_iterator;
+
+    void consider(Iterator begin, Iterator end, size_t sum_size)
+    {
+        size_t current_len = end - begin;
+        if (current_len > part_count)
+        {
+            part_count = current_len;
+            best_begin = begin;
+            best_end = end;
+        }
+        else if(current_len == part_count){
+            double current_score = sum_size;
+            if (!min_score || current_score < min_score)
+            {
+                min_score = current_score;
+                best_begin = begin;
+                best_end = end;
+            }
+        }
+    }
+
+    MemoryMergeSelector::PartsRange getBest() const
+    {
+        return MemoryMergeSelector::PartsRange(best_begin, best_end);
+    }
+
+    double min_score = 0;
+    size_t part_count = 0;
+    Iterator best_begin {};
+    Iterator best_end {};
+};
+
+void selectWithinPartition(
+    const MemoryMergeSelector::PartsRange & parts,
+    const size_t max_total_size_to_merge,
+    Estimator & estimator,
+    const MemoryMergeSelector::Settings & settings)
+{
+    size_t parts_size = parts.size();
+    if (parts_size < settings.min_parts_to_merge)
+        return;
+
+    size_t range_end = parts_size;
+    int range_begin = range_end - 1;
+
+    size_t sum_size = 0;
+    while (range_begin >= 0)
+    {
+        const MergeTreeData::DataPartPtr part = *(static_cast<const MergeTreeData::DataPartPtr *>(parts[range_begin].data));
+
+        if (part->getType() != MergeTreeDataPartType::IN_MEMORY)
+            break;
+
+        sum_size  += parts[range_begin].size;
+        if (range_end - range_begin <= settings.max_parts_to_merge && sum_size <= max_total_size_to_merge)
+            --range_begin;
+        else
+            break;
+    }
+    estimator.consider(parts.begin() + range_begin, parts.begin() + range_end, sum_size);
+
+
+}
+}
+
+void MemoryMergeSelector::dumpPartsInfo(const MemoryMergeSelector::PartsRange & parts, String prefix)
+{
+    std::ostringstream debug_buf;
+    for (const IMergeSelector::Part & part : parts)
+    {
+        const MergeTreeData::DataPartPtr treeDataPart = *(static_cast<const MergeTreeData::DataPartPtr *>(part.data));
+        const auto info = treeDataPart->info;
+        debug_buf << info.partition_id << ", " << info.min_block << "," << info.max_block << ", " << info.level << ", " << info.mutation
+                  << std::endl;
+    }
+    LOG_DEBUG(log, "------------{} part info: \n {}", prefix, debug_buf.str());
+}
+
+MemoryMergeSelector::PartsRange MemoryMergeSelector::select(
+    const PartsRanges & parts_ranges,
+    const size_t max_total_size_to_merge)
+{
+    Estimator estimator;
+
+    int idx = parts_ranges.size() -1 ;
+    bool printDebug = false;
+    while (idx >=0)
+    {
+        const auto & parts_range = parts_ranges[idx];
+        const MergeTreeData::DataPartPtr & part = *(static_cast<const MergeTreeData::DataPartPtr *>(parts_range.back().data));
+        if(part->getType() != MergeTreeDataPartType::IN_MEMORY) break;
+
+        if (part->storage.getStorageID().table_name.ends_with("t_num"))
+            printDebug = true;
+
+        if(printDebug)
+            dumpPartsInfo(parts_range, "candidate segments: ");
+
+        selectWithinPartition(parts_range, max_total_size_to_merge, estimator, settings);
+
+
+        --idx;
+    }
+
+    if(printDebug)
+        dumpPartsInfo(estimator.getBest(), "selected part range: ");
+
+    return estimator.getBest();
+}
+
+}

--- a/src/Storages/MergeTree/MemoryMergeSelector.h
+++ b/src/Storages/MergeTree/MemoryMergeSelector.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <common/logger_useful.h>
+#include <Storages/MergeTree/MergeSelector.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
+
+
+
+namespace DB
+{
+
+/**
+ *  1. only handle parts in memory.
+ *  2. aggressive, merge as many as possible in one merging operation.
+ *  3. modified from LevelMergeSelector.
+ */
+class MemoryMergeSelector : public IMergeSelector
+{
+
+public:
+    struct Settings
+    {
+        size_t min_parts_to_merge = 10;
+        size_t max_parts_to_merge = 100;
+
+        Settings() = default;
+
+        Settings(MergeTreeSettingsPtr mergeTreeSettings)
+        {
+            min_parts_to_merge = mergeTreeSettings->min_parts_to_merge;
+            max_parts_to_merge = mergeTreeSettings->max_parts_to_merge;
+        }
+    };
+
+    explicit MemoryMergeSelector(const Settings & settings_) : settings(settings_),
+        log(&Poco::Logger::get("MemoryMergeSelector")){}
+
+    PartsRange select(const PartsRanges & parts_ranges, const size_t max_total_size_to_merge) override;
+
+    void dumpPartsInfo(const MemoryMergeSelector::PartsRange & parts, String prefix);
+
+private:
+    const Settings settings;
+    Poco::Logger * log;
+};
+
+}

--- a/src/Storages/MergeTree/MemoryMergeSelector.h
+++ b/src/Storages/MergeTree/MemoryMergeSelector.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <common/logger_useful.h>
 #include <Storages/MergeTree/MergeSelector.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
-
+#include <common/logger_useful.h>
 
 
 namespace DB
 {
-
 /**
  *  1. only handle parts in memory.
  *  2. aggressive, merge as many as possible in one merging operation.
@@ -16,7 +14,6 @@ namespace DB
  */
 class MemoryMergeSelector : public IMergeSelector
 {
-
 public:
     struct Settings
     {
@@ -32,8 +29,7 @@ public:
         }
     };
 
-    explicit MemoryMergeSelector(const Settings & settings_) : settings(settings_),
-        log(&Poco::Logger::get("MemoryMergeSelector")){}
+    explicit MemoryMergeSelector(const Settings & settings_) : settings(settings_), log(&Poco::Logger::get("MemoryMergeSelector")) { }
 
     PartsRange select(const PartsRanges & parts_ranges, const size_t max_total_size_to_merge) override;
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterInMemory.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterInMemory.cpp
@@ -21,8 +21,8 @@ MergeTreeDataPartWriterInMemory::MergeTreeDataPartWriterInMemory(
 void MergeTreeDataPartWriterInMemory::write(
     const Block & block, const IColumn::Permutation * permutation)
 {
-    if (part_in_memory->block)
-        throw Exception("DataPartWriterInMemory supports only one write", ErrorCodes::LOGICAL_ERROR);
+//    if (part_in_memory->block)
+//        throw Exception("DataPartWriterInMemory supports only one write", ErrorCodes::LOGICAL_ERROR);
 
     Block primary_key_block;
     if (settings.rewrite_primary_key)

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -26,7 +26,7 @@ struct Settings;
     M(UInt64, index_granularity, 8192, "How many rows correspond to one primary key value.", 0) \
     \
     /** Data storing format settings. */ \
-    M(UInt64, min_bytes_for_wide_part, 10485760, "Minimal uncompressed size in bytes to create part in wide format instead of compact", 0) \
+    M(UInt64, min_bytes_for_wide_part, 0, "Minimal uncompressed size in bytes to create part in wide format instead of compact", 0) \
     M(UInt64, min_rows_for_wide_part, 0, "Minimal number of rows to create part in wide format instead of compact", 0) \
     M(UInt64, min_bytes_for_compact_part, 0, "Experimental. Minimal uncompressed size in bytes to create part in compact format instead of saving it in RAM", 0) \
     M(UInt64, min_rows_for_compact_part, 0, "Experimental. Minimal number of rows to create part in compact format instead of saving it in RAM", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -53,7 +53,10 @@ struct Settings;
     M(Bool, fsync_part_directory, false, "Do fsync for part directory after all part operations (writes, renames, etc.).", 0) \
     M(UInt64, write_ahead_log_bytes_to_fsync, 100ULL * 1024 * 1024, "Amount of bytes, accumulated in WAL to do fsync.", 0) \
     M(UInt64, write_ahead_log_interval_ms_to_fsync, 100, "Interval in milliseconds after which fsync for WAL is being done.", 0) \
-    M(Bool, in_memory_parts_insert_sync, false, "If true insert of part with in-memory format will wait for fsync of WAL", 0) \
+    M(Bool, in_memory_parts_insert_sync, false, "If true insert of part with in-memory format will wait for fsync of WAL", 0)       \
+    M(String, merge_part_select_strategy, "Simple", "part selection strategy: Simple(SimpleMergeSelector), Level(LevelMergeSector).", 0)   \
+    M(UInt64, min_parts_to_merge, 5, "The minimal number of parts to merge for MemoryMergeSelector", 0)  \
+    M(UInt64, max_parts_to_merge, 100, "The maximal number of parts to merge for MemoryMergeSelector", 0)     \
     \
     /** Inserts settings. */ \
     M(UInt64, parts_to_delay_insert, 150, "If table contains at least that many active parts in single partition, artificially slow down insert into table.", 0) \

--- a/src/Storages/MergeTree/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/SimpleMergeSelector.cpp
@@ -160,14 +160,6 @@ void selectWithinPartition(
         if (begin > 1000)
             break;
 
-//        const MergeTreeData::DataPartPtr & part = *(static_cast<const MergeTreeData::DataPartPtr *>(parts[begin].data));
-//        if (part->storage.getStorageID().table_name.ends_with("t_num"))
-//        {
-//            std::cout<< part->name << ", " <<parts[begin].shall_participate_in_merges<< std::endl;
-//        }
-//        std::cout<<std::endl;
-
-
         if (!parts[begin].shall_participate_in_merges)
             continue;
 

--- a/src/Storages/MergeTree/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/SimpleMergeSelector.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <iostream>
+#include "MergeTreeData.h"
 
 
 namespace DB
@@ -158,6 +159,14 @@ void selectWithinPartition(
         /// If too many parts, select only from first, to avoid complexity.
         if (begin > 1000)
             break;
+
+//        const MergeTreeData::DataPartPtr & part = *(static_cast<const MergeTreeData::DataPartPtr *>(parts[begin].data));
+//        if (part->storage.getStorageID().table_name.ends_with("t_num"))
+//        {
+//            std::cout<< part->name << ", " <<parts[begin].shall_participate_in_merges<< std::endl;
+//        }
+//        std::cout<<std::endl;
+
 
         if (!parts[begin].shall_participate_in_merges)
             continue;

--- a/src/Storages/MergeTree/SimpleMergeSelector.h
+++ b/src/Storages/MergeTree/SimpleMergeSelector.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Storages/MergeTree/MergeSelector.h>
-
+#include <Storages/MergeTree/MergeTreeSettings.h>
 
 /**
 We have a set of data parts that is dynamically changing - new data parts are added and there is background merging process.
@@ -26,7 +26,7 @@ Then we need some balance between optimization of these two metrics.
 But some optimizations may improve both metrics.
 
 For example, we can look at the "merge tree" - the tree of data parts that were merged.
-If the tree is perfectly balanced then its depth is proportonal to the log(data size),
+If the tree is perfectly balanced then its depth is proportional to the log(data size),
 the total amount of work is proportional to data_size * log(data_size)
 and the write amplification is proportional to log(data_size).
 If it's not balanced (e.g. every new data part is always merged with existing data parts),
@@ -77,7 +77,7 @@ That's why I still believe that there are many opportunities to optimize the mer
 Please do not mix the task with a similar task in other LSM-based systems (like RocksDB).
 Their problem statement is subtly different. Our set of data parts is consisted of data parts
 that are completely independent in stored data. Ranges of primary keys in data parts can intersect.
-When doing SELECT we read from all data parts. INSERTed data parts comes with unknown size...
+When doing SELECT we read from all data parts. Inserted data parts comes with unknown size...
 */
 
 namespace DB
@@ -88,6 +88,9 @@ class SimpleMergeSelector final : public IMergeSelector
 public:
     struct Settings
     {
+        Settings() = default;
+        Settings(MergeTreeSettingsPtr ) {}
+
         /// Zero means unlimited.
         size_t max_parts_to_merge_at_once = 100;
 

--- a/tests/integration/test_merge_memory_parts/configs/merge_tree_settings.xml
+++ b/tests/integration/test_merge_memory_parts/configs/merge_tree_settings.xml
@@ -1,0 +1,13 @@
+<yandex>
+    <merge_tree>
+        <min_rows_for_compact_part>10000</min_rows_for_compact_part>
+        <min_rows_for_wide_part>100000</min_rows_for_wide_part>
+        <in_memory_parts_enable_wal>1</in_memory_parts_enable_wal>
+        <old_parts_lifetime>30</old_parts_lifetime>
+
+        <!--simple, default; Level; Combined-->
+        <merge_part_select_strategy>Combined</merge_part_select_strategy>
+        <min_parts_to_merge>5</min_parts_to_merge>
+        <max_parts_to_merge>20</max_parts_to_merge>
+    </merge_tree>
+</yandex>

--- a/tests/integration/test_merge_memory_parts/test.py
+++ b/tests/integration/test_merge_memory_parts/test.py
@@ -1,0 +1,94 @@
+import pytest
+import time
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance('instance', main_configs=['configs/merge_tree_settings.xml'])
+q = instance.query
+path_to_data = '/var/lib/clickhouse/'
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        q('CREATE DATABASE test')     # Different path in shadow/ with Atomic
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture
+def partition_table_simple(started_cluster):
+    q("DROP TABLE IF EXISTS test.t_num")
+    q("CREATE TABLE test.t_num (id Int64) ENGINE=MergeTree() ORDER BY (id) ")
+    yield
+
+    q('DROP TABLE test.partition')
+
+
+def test_part_type(partition_table_simple):
+    q("insert into test.t_num select number from system.numbers limit 10")
+    res = q("select count(1) from system.parts where database='test' and table='t_num' and part_type='InMemory'")
+    assert res == '1'
+
+    q("insert into test.t_num select number from system.numbers limit 10000")
+    res = q("select count(1) from system.parts where database='test' and table='t_num' and part_type='Compact'")
+    assert res == '1'
+
+    q("insert into test.t_num select number from system.numbers limit 100000")
+    res = q("select count(1) from system.parts where database='test' and table='t_num' and part_type='Wide'")
+    assert res == '1'
+
+def test_part_merge(partition_table_simple):
+    # memory to memory
+    for i in range(4):
+        q(f"insert into test.t_num select number from system.numbers limit {i * 10}, 10")
+    res = q("select count(1) from system.parts where database='test' and table='t_num' and part_type='InMemory'")
+    assert res == '4'
+
+    q(f"system stop merges test.t_num")
+    for i in range(4, 5):
+        q(f"insert into test.t_num select number from system.numbers limit {i * 10}, 10")
+    q("system start merges test.t_num")
+    time.sleep(1)
+    res = q("select sum(rows), count(1) from system.parts where database='test' and table='t_num' and part_type='InMemory' group by part_type")
+    assert TSV(res) == TSV("50\t1")
+
+    # memory to compact
+    q(f"system stop merges test.t_num")
+    for i in range(5, 10):
+        q(f"insert into test.t_num select number from system.numbers limit {i * 2000}, 2000")
+    q("system start merges test.t_num")
+    time.sleep(1)
+    res = q("select count(1) from system.parts where database='test' and table='t_num' and part_type='Compact'")
+    assert res == '1'
+    res = q("select count(1) from system.parts where database='test' and table='t_num' and part_type='InMemory'")
+    assert res == '0'
+
+    # compact to wide and memory parts only get processed by Memory Selector.
+    for i in range(10, 20):
+        q(f"insert into test.t_num select number from system.numbers limit {i * 20000}, 20000")
+    for i in range(20, 24):
+        q(f"insert into test.t_num select number from system.numbers limit {i * 20}, 20000")
+
+    q("optimize table test.t_num")
+    time.sleep(1)
+    res = q("select count(1) from system.parts where database='test' and table='t_num' and part_type='Wide'")
+    assert res > 1
+    res = q("select count(1) from system.parts where database='test' and table='t_num' and part_type='InMemory'")
+    assert res == '4'
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry:
"CombinedMergeSelector" first chooses memory parts aggressively.  If no more parts need to be merged, then it proceeds with the disk parts using "SimpleMergeSelector".

Since "SimpleMergeSelector" is rather complex, a  "CombinedMergeSelector" is written to merge memory parts first. If no more memory parts need merging, then it calls "SimpleMergeSelector" to do the rest job. When the number of memory parts does not meet specified threshod, its "shall_participate_in_merges" state is set to false to prevent "SimpleMergeSelector" choosing them. So all parts first accumulated in memory, then transformed to disk with corresponding part type.


Detailed description / Documentation draft:
Currently problems:  a) "SimpleMergeSelector" always choose memory parts merged with disk parts even it has only a few rows; b) The resulted part must be saved in disk.

1. a new configuration item "merge_part_select_strategy" is added to choose different merging selection strategy as shown below.
```
   <merge_tree>
        <min_rows_for_compact_part>10000</min_rows_for_compact_part>
        <min_rows_for_wide_part>100000</min_rows_for_wide_part>
        <in_memory_parts_enable_wal>1</in_memory_parts_enable_wal>
        <old_parts_lifetime>30</old_parts_lifetime>
        <!--Simple, default; Level; Combined-->
        <merge_part_select_strategy>Combined</merge_part_select_strategy>
        <min_parts_to_merge>5</min_parts_to_merge>
        <max_parts_to_merge>20</max_parts_to_merge>
    </merge_tree>
```
2. MemoryMergeSelector only selects parts in memory. It chooses as many parts as possible  which meet the limits, such as min_parts_to_merge, max_parts_to_merge, etc. 
