### PR TITLE
Print trace from std::terminate exception line-by-line to make it grep easier

### DIFF
--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -259,10 +259,24 @@ private:
     Poco::Logger * log;
     BaseDaemon & daemon;
 
-    void onTerminate(const std::string & message, UInt32 thread_num) const
+    void onTerminate(std::string_view message, UInt32 thread_num) const
     {
+	    size_t pos = message.find('\n');
+
         LOG_FATAL(log, "(version {}{}, {}) (from thread {}) {}",
-            VERSION_STRING, VERSION_OFFICIAL, daemon.build_id_info, thread_num, message);
+            VERSION_STRING, VERSION_OFFICIAL, daemon.build_id_info, thread_num, message.substr(0, pos));
+
+        while (pos != std::string_view::npos)
+        {
+            ++pos;
+            size_t next_pos = message.find('\n', pos);
+            size_t size = next_pos;
+            if (next_pos != std::string_view::npos)
+                size = next_pos - pos;
+
+            LOG_FATAL(log, "{}", message.substr(pos, size));
+            pos = next_pos;
+        }
     }
 
     void onFault(

--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -266,6 +266,7 @@ private:
         LOG_FATAL(log, "(version {}{}, {}) (from thread {}) {}",
             VERSION_STRING, VERSION_OFFICIAL, daemon.build_id_info, thread_num, message.substr(0, pos));
 
+        /// Print trace from std::terminate exception line-by-line to make it easy for grep.
         while (pos != std::string_view::npos)
         {
             ++pos;

--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -261,7 +261,7 @@ private:
 
     void onTerminate(std::string_view message, UInt32 thread_num) const
     {
-	    size_t pos = message.find('\n');
+        size_t pos = message.find('\n');
 
         LOG_FATAL(log, "(version {}{}, {}) (from thread {}) {}",
             VERSION_STRING, VERSION_OFFICIAL, daemon.build_id_info, thread_num, message.substr(0, pos));


### PR DESCRIPTION

Changelog category (leave one):

- Not for changelog (changelog entry is not required)

