### PR TITLE
Add simple validation for partition id before drop partition

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3214,7 +3214,11 @@ String MergeTreeData::getPartitionIDFromQuery(const ASTPtr & ast, ContextPtr loc
     const auto & partition_ast = ast->as<ASTPartition &>();
 
     if (!partition_ast.value)
+    {
+        if (!MergeTreePartInfo::validatePartitionID(partition_ast.id, format_version))
+            throw Exception("Invalid partition format: " + partition_ast.id, ErrorCodes::INVALID_PARTITION_VALUE);
         return partition_ast.id;
+    }
 
     if (format_version < MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING)
     {

--- a/src/Storages/MergeTree/MergeTreePartInfo.h
+++ b/src/Storages/MergeTree/MergeTreePartInfo.h
@@ -86,6 +86,9 @@ struct MergeTreePartInfo
         return static_cast<UInt64>(max_block - min_block + 1);
     }
 
+    /// Simple sanity check for partition ID. Checking that it's not too long or too short, doesn't contain a lot of '_'.
+    static bool validatePartitionID(const String & partition_id, MergeTreeDataFormatVersion format_version);
+
     static MergeTreePartInfo fromPartName(const String & part_name, MergeTreeDataFormatVersion format_version);  // -V1071
 
     static bool tryParsePartName(const String & part_name, MergeTreePartInfo * part_info, MergeTreeDataFormatVersion format_version);

--- a/tests/queries/0_stateless/01925_broken_partition_id_zookeeper.sql
+++ b/tests/queries/0_stateless/01925_broken_partition_id_zookeeper.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS broken_partition;
+
+CREATE TABLE broken_partition
+(
+    date Date,
+    key UInt64
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/test_01925_{database}/rmt', 'r1')
+ORDER BY tuple()
+PARTITION BY date;
+
+ALTER TABLE broken_partition DROP PARTITION ID '20210325_0_13241_6_12747';
+
+ALTER TABLE broken_partition DROP PARTITION ID '20210325_0_13241_6_12747';
+
+DROP TABLE IF EXISTS broken_partition;

--- a/tests/queries/0_stateless/01925_broken_partition_id_zookeeper.sql
+++ b/tests/queries/0_stateless/01925_broken_partition_id_zookeeper.sql
@@ -9,8 +9,8 @@ ENGINE = ReplicatedMergeTree('/clickhouse/test_01925_{database}/rmt', 'r1')
 ORDER BY tuple()
 PARTITION BY date;
 
-ALTER TABLE broken_partition DROP PARTITION ID '20210325_0_13241_6_12747';
+ALTER TABLE broken_partition DROP PARTITION ID '20210325_0_13241_6_12747'; --{serverError 248}
 
-ALTER TABLE broken_partition DROP PARTITION ID '20210325_0_13241_6_12747';
+ALTER TABLE broken_partition DROP PARTITION ID '20210325_0_13241_6_12747'; --{serverError 248}
 
 DROP TABLE IF EXISTS broken_partition;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now partition ID in queries like `ALTER TABLE ... PARTITION ID xxx` validates for correctness. Fixes #25718.
