### PR TITLE
Fix 01600_quota_by_forwarded_ip

### DIFF
--- a/tests/queries/0_stateless/01600_quota_by_forwarded_ip.sh
+++ b/tests/queries/0_stateless/01600_quota_by_forwarded_ip.sh
@@ -28,7 +28,7 @@ CREATE QUOTA quota_by_forwarded_ip KEYED BY forwarded_ip_address FOR RANDOMIZED 
 echo '--- Test with quota by immediate IP ---'
 
 while true; do
-    $CLICKHOUSE_CLIENT --user quoted_by_ip --query "SELECT count() FROM numbers(10)" 2>/dev/null || break
+    ${CLICKHOUSE_CURL} --fail -sS "${CLICKHOUSE_URL}&user=quoted_by_ip" -d "SELECT count() FROM numbers(10)" 2>/dev/null || break
 done | uniq
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&user=quoted_by_ip" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'

--- a/tests/queries/0_stateless/01600_quota_by_forwarded_ip.sh
+++ b/tests/queries/0_stateless/01600_quota_by_forwarded_ip.sh
@@ -6,20 +6,14 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 $CLICKHOUSE_CLIENT -n --query "
-DROP USER IF EXISTS quoted_by_ip;
-DROP USER IF EXISTS quoted_by_forwarded_ip;
+CREATE USER quoted_by_ip_${CLICKHOUSE_DATABASE};
+CREATE USER quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE};
 
-DROP QUOTA IF EXISTS quota_by_ip;
-DROP QUOTA IF EXISTS quota_by_forwarded_ip;
+GRANT SELECT, CREATE ON *.* TO quoted_by_ip_${CLICKHOUSE_DATABASE};
+GRANT SELECT, CREATE ON *.* TO quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE};
 
-CREATE USER quoted_by_ip;
-CREATE USER quoted_by_forwarded_ip;
-
-GRANT SELECT, CREATE ON *.* TO quoted_by_ip;
-GRANT SELECT, CREATE ON *.* TO quoted_by_forwarded_ip;
-
-CREATE QUOTA quota_by_ip KEYED BY ip_address FOR RANDOMIZED INTERVAL 1 YEAR MAX QUERIES = 1 TO quoted_by_ip;
-CREATE QUOTA quota_by_forwarded_ip KEYED BY forwarded_ip_address FOR RANDOMIZED INTERVAL 1 YEAR MAX QUERIES = 1 TO quoted_by_forwarded_ip;
+CREATE QUOTA quota_by_ip_${CLICKHOUSE_DATABASE} KEYED BY ip_address FOR RANDOMIZED INTERVAL 1 YEAR MAX QUERIES = 1 TO quoted_by_ip_${CLICKHOUSE_DATABASE};
+CREATE QUOTA quota_by_forwarded_ip_${CLICKHOUSE_DATABASE} KEYED BY forwarded_ip_address FOR RANDOMIZED INTERVAL 1 YEAR MAX QUERIES = 1 TO quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE};
 "
 
 # Note: the test can be flaky if the randomized interval will end while the loop is run. But with year long interval it's unlikely.
@@ -28,39 +22,39 @@ CREATE QUOTA quota_by_forwarded_ip KEYED BY forwarded_ip_address FOR RANDOMIZED 
 echo '--- Test with quota by immediate IP ---'
 
 while true; do
-    ${CLICKHOUSE_CURL} --fail -sS "${CLICKHOUSE_URL}&user=quoted_by_ip" -d "SELECT count() FROM numbers(10)" 2>/dev/null || break
+    ${CLICKHOUSE_CURL} --fail -sS "${CLICKHOUSE_URL}&user=quoted_by_ip_${CLICKHOUSE_DATABASE}" -d "SELECT count() FROM numbers(10)" 2>/dev/null || break
 done | uniq
 
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&user=quoted_by_ip" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&user=quoted_by_ip_${CLICKHOUSE_DATABASE}" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
 
 # X-Forwarded-For is ignored for quota by immediate IP address
-${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 1.2.3.4' -sS "${CLICKHOUSE_URL}&user=quoted_by_ip" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
+${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 1.2.3.4' -sS "${CLICKHOUSE_URL}&user=quoted_by_ip_${CLICKHOUSE_DATABASE}" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
 
 
 echo '--- Test with quota by forwarded IP ---'
 
 while true; do
-    $CLICKHOUSE_CLIENT --user quoted_by_forwarded_ip --query "SELECT count() FROM numbers(10)" 2>/dev/null || break
+    ${CLICKHOUSE_CURL} --fail -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE}" -d "SELECT count() FROM numbers(10)" 2>/dev/null || break
 done | uniq
 
-${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE}" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
 
 # X-Forwarded-For is respected for quota by forwarded IP address
 while true; do
-    ${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 1.2.3.4' -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip" -d "SELECT count() FROM numbers(10)" | grep -oP '^10$' || break
+    ${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 1.2.3.4' -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE}" -d "SELECT count() FROM numbers(10)" | grep -oP '^10$' || break
 done | uniq
 
-${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 1.2.3.4' -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
+${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 1.2.3.4' -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE}" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
 
 # Only the last IP address is trusted
-${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 5.6.7.8, 1.2.3.4' -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
+${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 5.6.7.8, 1.2.3.4' -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE}" -d "SELECT count() FROM numbers(10)" | grep -oF 'exceeded'
 
-${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 1.2.3.4, 5.6.7.8' -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip" -d "SELECT count() FROM numbers(10)"
+${CLICKHOUSE_CURL} -H 'X-Forwarded-For: 1.2.3.4, 5.6.7.8' -sS "${CLICKHOUSE_URL}&user=quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE}" -d "SELECT count() FROM numbers(10)"
 
 $CLICKHOUSE_CLIENT -n --query "
-DROP QUOTA IF EXISTS quota_by_ip;
+DROP QUOTA IF EXISTS quota_by_ip_${CLICKHOUSE_DATABASE};
 DROP QUOTA IF EXISTS quota_by_forwarded_ip;
 
-DROP USER IF EXISTS quoted_by_ip;
-DROP USER IF EXISTS quoted_by_forwarded_ip;
+DROP USER IF EXISTS quoted_by_ip_${CLICKHOUSE_DATABASE};
+DROP USER IF EXISTS quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE};
 "


### PR DESCRIPTION
The test was assuming clickhouse-local and curl would connect using the same address

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

The test "warms up" the quota until it triggers the first error and then launches the test checking for the expected result. The issue it has is that the warm up is done using clickhouse-client and the tests themselves by using curl, and that's only valid if both programs use the same source ip to connect to the server.

This isn't always true.

Example from the tests:
* Connection from curl:
```
HTTP Request for HTTPHandler-factory. Method: POST, Address: [::ffff:127.0.0.1]:54272, User-Agent: curl/7.78.0, Length: 31, Content Type: application/x-www-form-urlencoded, Transfer Encoding: identity, X-Forwarded-For: (none)
```

* Connection from the ch client:
```
2021.07.29 17:45:50.189055 [ 677103 ] {} <Trace> TCPHandlerFactory: TCP Request. Address: [::1]:49184
2021.07.29 17:45:50.189125 [ 677103 ] {} <Debug> TCPHandler: Connected ClickHouse client version 21.9.0, revision: 54449, user: default.
```

To avoid this, do both the warmup and the test using curl.