### PR TITLE
Fix possible mutation stuck due to race with DROP_RANGE

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -281,6 +281,8 @@ void ReplicatedMergeTreeQueue::updateStateOnQueueEntryRemoval(
                 current_parts.remove(*drop_range_part_name);
 
             virtual_parts.remove(*drop_range_part_name);
+
+            removeCoveredPartsFromMutations(*drop_range_part_name, /*remove_part = */ true, /*remove_covered_parts = */ false);
         }
 
         if (entry->type == LogEntry::DROP_RANGE)


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
[RFC] Fix possible mutation stack due to race with DROP_RANGE

Detailed description / Documentation draft:
After #25884 parts that was dropped (DROP_RANGE) will not be removed
from old mutations and this will stuck the mutation.

Interesting, that this mutation may continue after some merge.

Cc: @alesapin 
Cc: @qoega (this should fix `test_replicated_mutations` integration test)
Fixes: #25884