### PR TITLE
Set insert_quorum_timeout to 1 minute for tests.

### DIFF
--- a/tests/config/users.d/timeouts.xml
+++ b/tests/config/users.d/timeouts.xml
@@ -4,6 +4,8 @@
             <!-- Default HTTP timeout is 30 minutes. Set it to 1 minute. -->
             <http_send_timeout>60</http_send_timeout>
             <http_receive_timeout>60</http_receive_timeout>
+            <!-- 1 minute (default is 10 minutes) -->
+            <insert_quorum_timeout>60000</insert_quorum_timeout>
         </default>
     </profiles>
 </yandex>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
https://clickhouse-test-reports.s3.yandex.net/26959/888d096ede5e254ee8c059cc3146e3f84f920a35/stress_test_(address).html#fail1
```
2021.07.29 18:28:55.745472 [ 1964 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Debug> executeQuery: (from [::1]:33624) (comment: '/usr/share/clickhouse-test/queries/0_stateless/01509_check_many_parallel_quorum_inserts_long.sh') INSERT INTO r1 SELECT 7
2021.07.29 18:28:55.745783 [ 1964 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> ContextAccess (default): Access granted: INSERT(x) ON test_3.r1
2021.07.29 18:28:55.746593 [ 1964 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> ContextAccess (default): Access granted: SELECT(dummy) ON system.one
2021.07.29 18:28:55.746879 [ 1964 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
2021.07.29 18:28:55.750212 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Debug> DiskLocal: Reserving 1.00 MiB on disk `default`, having unreserved 1.17 TiB.
2021.07.29 18:28:56.006291 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Debug> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Wrote block with ID 'all_12738264881733641796_10975651605505476931', 1 rows
2021.07.29 18:28:56.046802 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Information> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Block with ID all_12738264881733641796_10975651605505476931 already exists locally as part all_58_58_0; ignoring it, but checking quorum.
2021.07.29 18:28:56.046879 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Waiting for quorum
2021.07.29 18:28:56.048038 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Quorum node /clickhouse/tables/01509_check_many_parallel_quorum_inserts_long_test_3/parallel_quorum_many/quorum/parallel/all_58_58_0 still exists, will wait for updates
2021.07.29 18:35:42.237835 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Quorum /clickhouse/tables/01509_check_many_parallel_quorum_inserts_long_test_3/parallel_quorum_many/quorum/parallel/all_58_58_0 updated, will check quorum node still exists
2021.07.29 18:35:42.238620 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Quorum node /clickhouse/tables/01509_check_many_parallel_quorum_inserts_long_test_3/parallel_quorum_many/quorum/parallel/all_58_58_0 still exists, will wait for updates
2021.07.29 18:35:42.354467 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Quorum /clickhouse/tables/01509_check_many_parallel_quorum_inserts_long_test_3/parallel_quorum_many/quorum/parallel/all_58_58_0 updated, will check quorum node still exists
2021.07.29 18:35:42.355245 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Quorum node /clickhouse/tables/01509_check_many_parallel_quorum_inserts_long_test_3/parallel_quorum_many/quorum/parallel/all_58_58_0 still exists, will wait for updates
2021.07.29 18:35:43.312499 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Quorum /clickhouse/tables/01509_check_many_parallel_quorum_inserts_long_test_3/parallel_quorum_many/quorum/parallel/all_58_58_0 updated, will check quorum node still exists
2021.07.29 18:35:43.314613 [ 3105 ] {5eb18756-5e5d-4ced-ac70-5af41293cb32} <Trace> test_3.r1 (0482e3c3-c874-41a4-8482-e3c3c87481a4) (Replicated OutputStream): Quorum node /clickhouse/tables/01509_check_many_parallel_quorum_inserts_long_test_3/parallel_quorum_many/quorum/parallel/all_58_58_0 still exists, will wait for updates
```
