### PR TITLE
Attempt to fix flaky 00705_drop_create_merge_tree

### DIFF
--- a/tests/queries/0_stateless/00705_drop_create_merge_tree.sh
+++ b/tests/queries/0_stateless/00705_drop_create_merge_tree.sh
@@ -7,10 +7,20 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 function stress()
 {
-    while true; do
+    # We set up a signal handler to make sure to wait for all queries to be finished before ending
+    CONTINUE=true
+    handle_interruption()
+    {
+        CONTINUE=false
+    }
+    trap handle_interruption INT
+
+    while $CONTINUE; do
         ${CLICKHOUSE_CLIENT} --query "CREATE TABLE IF NOT EXISTS table (x UInt8) ENGINE = MergeTree ORDER BY tuple()" 2>/dev/null
         ${CLICKHOUSE_CLIENT} --query "DROP TABLE table" 2>/dev/null
     done
+
+    trap - INT
 }
 
 # https://stackoverflow.com/questions/9954794/execute-a-shell-function-with-timeout
@@ -18,7 +28,7 @@ export -f stress
 
 for _ in {1..5}; do
     # Ten seconds are just barely enough to reproduce the issue in most of runs.
-    timeout 10 bash -c stress &
+    timeout -s INT 10 bash -c stress &
 done
 
 wait


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Comes from https://github.com/ClickHouse/ClickHouse/pull/26978#issuecomment-889833554

I couldn't reproduce the flakiness locally no matter how many runs, parallel or sequential, I do, but it looks like it would be safer to wait for the subworker iteration to finish instead of sending a TERM signal which might kill the client but won't wait for table creation.