### PR TITLE
Improved `runner` to use `pytest` keyword expressions

### DIFF
--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -178,6 +178,12 @@ if __name__ == "__main__":
         help="List of tests to run")
 
     parser.add_argument(
+        "-k", "--keyword_expression",
+        action="store",
+        dest="keyword_expression",
+        help="pytest keyword expression")
+
+    parser.add_argument(
         "--tmpfs",
         action='store_true',
         default=False,
@@ -262,6 +268,9 @@ if __name__ == "__main__":
     for old_log_path in glob.glob(args.cases_dir + "/pytest*.log"):
         os.remove(old_log_path)
 
+    if args.keyword_expression:
+        args.pytest_args += ['-k', args.keyword_expression]
+
     cmd = "docker run {net} {tty} --rm --name {name} --privileged \
         --volume={odbc_bridge_bin}:/clickhouse-odbc-bridge --volume={bin}:/clickhouse \
         --volume={library_bridge_bin}:/clickhouse-library-bridge --volume={bin}:/clickhouse \
@@ -280,7 +289,7 @@ if __name__ == "__main__":
         env_tags=env_tags,
         env_cleanup=env_cleanup,
         parallel=parallel_args,
-        opts=' '.join(args.pytest_args),
+        opts=' '.join(args.pytest_args).replace('\'', '\\\''),
         tests_list=' '.join(args.tests_list),
         dockerd_internal_volume=dockerd_internal_volume,
         img=DIND_INTEGRATION_TESTS_IMAGE_NAME + ":" + args.docker_image_version,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

Before:
```
./runner '-k test_mutations_with_merge_tree'
```

After:
```
./runner -k test_mutations_with_merge_tree
```