### PR TITLE
Improve 01006_simpod_empty_part_single_column_write

### DIFF
--- a/tests/queries/0_stateless/01006_simpod_empty_part_single_column_write.sh
+++ b/tests/queries/0_stateless/01006_simpod_empty_part_single_column_write.sh
@@ -26,13 +26,7 @@ ${CLICKHOUSE_CLIENT} --query="INSERT INTO table_with_empty_part VALUES (1, 1)"
 
 ${CLICKHOUSE_CLIENT} --query="INSERT INTO table_with_empty_part VALUES (2, 2)"
 
-${CLICKHOUSE_CLIENT} --query="ALTER TABLE table_with_empty_part DELETE WHERE id % 2 == 0"
-
-sleep 0.5
-
-mutation_id=$(${CLICKHOUSE_CLIENT} --query="SELECT max(mutation_id) FROM system.mutations WHERE table='table_with_empty_part'")
-
-wait_for_mutation "table_with_empty_part" "$mutation_id"
+${CLICKHOUSE_CLIENT} --mutations_sync=2 --query="ALTER TABLE table_with_empty_part DELETE WHERE id % 2 == 0"
 
 ${CLICKHOUSE_CLIENT} --query="SELECT COUNT(DISTINCT value) FROM table_with_empty_part"
 

--- a/tests/queries/0_stateless/mergetree_mutations.lib
+++ b/tests/queries/0_stateless/mergetree_mutations.lib
@@ -10,7 +10,7 @@ function wait_for_mutation()
     for i in {1..100}
     do
         sleep 0.1
-        if [[ $(${CLICKHOUSE_CLIENT} --query="SELECT min(is_done) FROM system.mutations WHERE database='$database' AND table='$table' AND mutation_id='$mutation_id'") -eq 1 ]]; then
+        if [[ $(${CLICKHOUSE_CLIENT} --query="SELECT min(is_done) + (count() == 0) FROM system.mutations WHERE database='$database' AND table='$table' AND mutation_id='$mutation_id'") -eq 1 ]]; then
             break
         fi
 

--- a/tests/queries/0_stateless/mergetree_mutations.lib
+++ b/tests/queries/0_stateless/mergetree_mutations.lib
@@ -10,7 +10,7 @@ function wait_for_mutation()
     for i in {1..100}
     do
         sleep 0.1
-        if [[ $(${CLICKHOUSE_CLIENT} --query="SELECT min(is_done) + (count() == 0) FROM system.mutations WHERE database='$database' AND table='$table' AND mutation_id='$mutation_id'") -eq 1 ]]; then
+        if [[ $(${CLICKHOUSE_CLIENT} --query="SELECT min(is_done) FROM system.mutations WHERE database='$database' AND table='$table' AND mutation_id='$mutation_id'") -eq 1 ]]; then
             break
         fi
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Fixes flakiness of 01006_simpod_empty_part_single_column_write in my system. The mutation could be fully finished before `wait_for_mutation` was called, so it never returned and ended up timing out.