### PR TITLE
Temporary disable ConnectionsCollector by default.

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -547,7 +547,7 @@ if (ThreadFuzzer::instance().isEffective())
     // ignore `max_thread_pool_size` in configs we fetch from ZK, but oh well.
     GlobalThreadPool::initialize(config().getUInt("max_thread_pool_size", 10000));
 
-    ConnectionCollector::init(global_context, config().getUInt("max_threads_for_connection_collector", 10));
+    ConnectionCollector::init(global_context, config().getUInt("max_threads_for_connection_collector", 0));
 
     bool has_zookeeper = config().has("zookeeper");
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

To check if distributed_stress feel better without it