### PR TITLE
Fix test_merge_tree_s3_failover with debug build

### DIFF
--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -68,17 +68,19 @@ def drop_table(cluster):
 # S3 request will be failed for an appropriate part file write.
 FILES_PER_PART_BASE = 5  # partition.dat, default_compression_codec.txt, count.txt, columns.txt, checksums.txt
 FILES_PER_PART_WIDE = FILES_PER_PART_BASE + 1 + 1 + 3 * 2  # Primary index, MinMax, Mark and data file for column(s)
+FILES_PER_PART_WIDE_DEBUG = 2  # Additional requests to S3 in debug build
 FILES_PER_PART_COMPACT = FILES_PER_PART_BASE + 1 + 1 + 2
+FILES_PER_PART_COMPACT_DEBUG = 0
 
 
 @pytest.mark.parametrize(
-    "min_bytes_for_wide_part,request_count",
+    "min_bytes_for_wide_part,request_count,debug_request_count",
     [
-        (0, FILES_PER_PART_WIDE),
-        (1024 * 1024, FILES_PER_PART_COMPACT)
+        (0, FILES_PER_PART_WIDE, FILES_PER_PART_WIDE_DEBUG),
+        (1024 * 1024, FILES_PER_PART_COMPACT, FILES_PER_PART_COMPACT_DEBUG)
     ]
 )
-def test_write_failover(cluster, min_bytes_for_wide_part, request_count):
+def test_write_failover(cluster, min_bytes_for_wide_part, request_count, debug_request_count):
     node = cluster.instances["node"]
 
     node.query(
@@ -95,17 +97,24 @@ def test_write_failover(cluster, min_bytes_for_wide_part, request_count):
         .format(min_bytes_for_wide_part)
     )
 
-    for request in range(request_count + 1):
+    is_debug_mode = False
+    success_count = 0
+
+    for request in range(request_count + debug_request_count + 1):
         # Fail N-th request to S3.
         fail_request(cluster, request + 1)
 
         data = "('2020-03-01',0,'data'),('2020-03-01',1,'data')"
-        positive = request == request_count
+        positive = request >= (request_count + debug_request_count if is_debug_mode else request_count)
         try:
             node.query("INSERT INTO s3_failover_test VALUES {}".format(data))
-
             assert positive, "Insert query should be failed, request {}".format(request)
+            success_count += 1
         except QueryRuntimeException as e:
+            if not is_debug_mode and positive:
+                is_debug_mode = True
+                positive = False
+
             assert not positive, "Insert query shouldn't be failed, request {}".format(request)
             assert str(e).find("Expected Error") != -1, "Unexpected error {}".format(str(e))
 
@@ -114,7 +123,9 @@ def test_write_failover(cluster, min_bytes_for_wide_part, request_count):
             fail_request(cluster, 0)
 
             assert node.query("CHECK TABLE s3_failover_test") == '1\n'
-            assert node.query("SELECT * FROM s3_failover_test FORMAT Values") == data
+            assert success_count > 1 or node.query("SELECT * FROM s3_failover_test FORMAT Values") == data
+
+    assert success_count == (1 if is_debug_mode else debug_request_count + 1), "Insert query should be successful at least once"
 
 
 # Check that second data part move is ended successfully if first attempt was failed.

--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -68,7 +68,10 @@ def drop_table(cluster):
 # S3 request will be failed for an appropriate part file write.
 FILES_PER_PART_BASE = 5  # partition.dat, default_compression_codec.txt, count.txt, columns.txt, checksums.txt
 FILES_PER_PART_WIDE = FILES_PER_PART_BASE + 1 + 1 + 3 * 2  # Primary index, MinMax, Mark and data file for column(s)
+
+# In debug build there are additional requests (from MergeTreeDataPartWriterWide.cpp:554 due to additional validation).
 FILES_PER_PART_WIDE_DEBUG = 2  # Additional requests to S3 in debug build
+
 FILES_PER_PART_COMPACT = FILES_PER_PART_BASE + 1 + 1 + 2
 FILES_PER_PART_COMPACT_DEBUG = 0
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix test_merge_tree_s3_failover with debug build

Detailed description / Documentation draft:
Test test_merge_tree_s3_failover relies on specific number of requests to S3 storage. In debug build there are additional request (from https://github.com/ClickHouse/ClickHouse/blob/master/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp#L554) and test was broken.
