### PR TITLE
Stateless tests: Keep an DNS error free log

### DIFF
--- a/tests/queries/0_stateless/00965_shard_unresolvable_addresses.sql
+++ b/tests/queries/0_stateless/00965_shard_unresolvable_addresses.sql
@@ -1,2 +1,5 @@
 SELECT count() FROM remote('127.0.0.1,localhos', system.one); -- { serverError 198 }
 SELECT count() FROM remote('127.0.0.1|localhos', system.one);
+
+-- Clear cache to avoid future errors in the logs
+SYSTEM DROP DNS CACHE

--- a/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
+++ b/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
@@ -68,3 +68,6 @@ INSERT INTO buffer VALUES (1);
 --                                                     |                              |-> file (1)
 --                                                     |-> remote(127.0.0.2) --> ...
 SELECT sum(n) from rich_syntax;
+
+-- Clear cache to avoid future errors in the logs
+SYSTEM DROP DNS CACHE

--- a/tests/queries/0_stateless/01372_remote_table_function_empty_table.sql
+++ b/tests/queries/0_stateless/01372_remote_table_function_empty_table.sql
@@ -1,1 +1,4 @@
 SELECT * FROM remote('127..2', 'a.'); -- { serverError 36 }
+
+-- Clear cache to avoid future errors in the logs
+SYSTEM DROP DNS CACHE


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Keep an DNS error free log. These 3 tests would "pollute" the DNS with invalid addresses which means hundreds of errors during a run.