### PR TITLE
Normalize hostname in stateless tests

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -27,6 +27,7 @@ except ImportError:
 import random
 import string
 import multiprocessing
+import socket
 from contextlib import closing
 
 USE_JINJA = True
@@ -266,6 +267,9 @@ def run_single_test(args, ext, server_logs_level, client_options, case_file, std
     if args.replicated_database:
         os.system("LC_ALL=C sed -i -e 's|/auto_{{shard}}||g' {file}".format(file=stdout_file))
         os.system("LC_ALL=C sed -i -e 's|auto_{{replica}}||g' {file}".format(file=stdout_file))
+
+    # Normalize hostname in stdout file.
+    os.system("LC_ALL=C sed -i -e 's/{hostname}/localhost/g' {file}".format(hostname=socket.gethostname(), file=stdout_file))
 
     stdout = open(stdout_file, 'rb').read() if os.path.exists(stdout_file) else b''
     stdout = str(stdout, errors='replace', encoding='utf-8')

--- a/tests/queries/0_stateless/02001_hostname_test.reference
+++ b/tests/queries/0_stateless/02001_hostname_test.reference
@@ -1,0 +1,2 @@
+localhost
+localhost	2

--- a/tests/queries/0_stateless/02001_hostname_test.sql
+++ b/tests/queries/0_stateless/02001_hostname_test.sql
@@ -1,0 +1,2 @@
+select hostname();
+select hostName() h, count() from cluster(test_cluster_two_shards, system.one) group by h;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Normalize hostname in stateless tests. Just in case we will test `hostName()` function.


Detailed description / Documentation draft:
.