### PR TITLE
fix clickhouse local create table with projection exception

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -291,6 +291,8 @@ try
         fs::create_directories(fs::path(path) / "metadata/");
         loadMetadataSystem(global_context);
         attachSystemTables(global_context);
+        /// We load temporary database first, because projections need it.
+        DatabaseCatalog::instance().initializeAndLoadTemporaryDatabase();
         loadMetadata(global_context);
         DatabaseCatalog::instance().loadDatabases();
         LOG_DEBUG(log, "Loaded metadata.");


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

fix "Database _temporary_and_external_tables doesn't exist exception" when creating MergeTree Table with projection feature using clickhouse-local.


Detailed description / Documentation draft:
This PR related to issue: https://github.com/ClickHouse/ClickHouse/issues/27124