### PR TITLE
Fix CURR_DATABASE empty for 01034_move_partition_from_table_zookeeper.sh

### DIFF
--- a/tests/queries/0_stateless/01034_move_partition_from_table_zookeeper.sh
+++ b/tests/queries/0_stateless/01034_move_partition_from_table_zookeeper.sh
@@ -75,8 +75,8 @@ $CLICKHOUSE_CLIENT --query="DROP TABLE dst;"
 
 $CLICKHOUSE_CLIENT --query="SELECT 'MOVE incompatible schema different order by';"
 
-$CLICKHOUSE_CLIENT --query="CREATE TABLE src (p UInt64, k String, d UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/$CURR_DATABASE/src3', '1') PARTITION BY p ORDER BY (p, k, d);"
-$CLICKHOUSE_CLIENT --query="CREATE TABLE dst (p UInt64, k String, d UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/$CURR_DATABASE/dst3', '1') PARTITION BY p ORDER BY (d, k, p);"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE src (p UInt64, k String, d UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/src3', '1') PARTITION BY p ORDER BY (p, k, d);"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE dst (p UInt64, k String, d UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/dst3', '1') PARTITION BY p ORDER BY (d, k, p);"
 
 
 $CLICKHOUSE_CLIENT --query="INSERT INTO src VALUES (0, '0', 1);"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

- Not for changelog (changelog entry is not required)

https://github.com/ClickHouse/ClickHouse/pull/27125 Through this pr test case, it is found that the ‘/clickhouse//src3’ zk path was used when creating the table. It shows that the CURR_DATABASE variable is empty.