### PR TITLE
Try our best to log query_kind

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -262,7 +262,11 @@ static void onExceptionBeforeStart(const String & query_for_logging, ContextPtr 
     elem.query = query_for_logging;
     elem.normalized_query_hash = normalizedQueryHash<false>(query_for_logging);
 
-    // We don't calculate query_kind, databases, tables and columns when the query isn't able to start
+    // Try log query_kind if ast is valid
+    if (ast)
+        elem.query_kind = ast->getQueryKindString();
+
+    // We don't calculate databases, tables and columns when the query isn't able to start
 
     elem.exception_code = getCurrentExceptionCode();
     elem.exception = getCurrentExceptionMessage(false);

--- a/src/Parsers/ASTAlterQuery.h
+++ b/src/Parsers/ASTAlterQuery.h
@@ -225,6 +225,8 @@ public:
         return removeOnCluster<ASTAlterQuery>(clone(), new_database);
     }
 
+    const char * getQueryKindString() const override { return "Alter"; }
+
 protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -102,6 +102,8 @@ public:
 
     bool isView() const { return is_ordinary_view || is_materialized_view || is_live_view; }
 
+    const char * getQueryKindString() const override { return "Create"; }
+
 protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };

--- a/src/Parsers/ASTDropQuery.h
+++ b/src/Parsers/ASTDropQuery.h
@@ -45,6 +45,8 @@ public:
         return removeOnCluster<ASTDropQuery>(clone(), new_database);
     }
 
+    const char * getQueryKindString() const override { return "Drop"; }
+
 protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };

--- a/src/Parsers/ASTGrantQuery.h
+++ b/src/Parsers/ASTGrantQuery.h
@@ -34,5 +34,6 @@ public:
     void replaceEmptyDatabase(const String & current_database);
     void replaceCurrentUserTag(const String & current_user_name) const;
     ASTPtr getRewrittenASTWithoutOnCluster(const std::string &) const override { return removeOnCluster<ASTGrantQuery>(clone()); }
+    const char * getQueryKindString() const override { return is_revoke ? "Revoke" : "Grant"; }
 };
 }

--- a/src/Parsers/ASTInsertQuery.h
+++ b/src/Parsers/ASTInsertQuery.h
@@ -47,6 +47,8 @@ public:
         return res;
     }
 
+    const char * getQueryKindString() const override { return "Insert"; }
+
 protected:
     void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 };

--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -61,6 +61,8 @@ public:
         return query_ptr;
     }
 
+    const char * getQueryKindString() const override { return "Rename"; }
+
 protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override
     {

--- a/src/Parsers/ASTSelectQuery.h
+++ b/src/Parsers/ASTSelectQuery.h
@@ -95,6 +95,8 @@ public:
 
     void setFinal();
 
+    const char * getQueryKindString() const override { return "Select"; }
+
 protected:
     void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 

--- a/src/Parsers/ASTSelectWithUnionQuery.h
+++ b/src/Parsers/ASTSelectWithUnionQuery.h
@@ -16,6 +16,8 @@ public:
     ASTPtr clone() const override;
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
+    const char * getQueryKindString() const override { return "Select"; }
+
     enum class Mode
     {
         Unspecified,

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -86,6 +86,8 @@ public:
         return removeOnCluster<ASTSystemQuery>(clone(), new_database);
     }
 
+    const char * getQueryKindString() const override { return "System"; }
+
 protected:
 
     void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -231,6 +231,9 @@ public:
 
     void cloneChildren();
 
+    // Return query_kind string representation of this AST query.
+    virtual const char * getQueryKindString() const { return ""; }
+
 public:
     /// For syntax highlighting.
     static const char * hilite_keyword;

--- a/tests/queries/0_stateless/01600_log_queries_with_extensive_info.reference
+++ b/tests/queries/0_stateless/01600_log_queries_with_extensive_info.reference
@@ -6,6 +6,7 @@ create database test_log_queries	18329631544365042880	Create	['test_log_queries'
 create table test_log_queries.logtable(i int, j int, k int) engine MergeTree order by i	14473140110122260412	Create	['test_log_queries']	['test_log_queries.logtable']	[]
 insert into test_log_queries.logtable values 	10533878590475998223	Insert	['test_log_queries']	['test_log_queries.logtable']	[]
 select k from test_log_queries.logtable where i = 4	10551554599491277990	Select	['test_log_queries']	['test_log_queries.logtable']	['test_log_queries.logtable.i','test_log_queries.logtable.k']
+select k from test_log_queries.logtable where i > \'\'	10861140285495151963	Select	[]	[]	[]
 select k from test_log_queries.logtable where i = 1	10551554599491277990	Select	['test_log_queries']	['test_log_queries.logtable']	['test_log_queries.logtable.i','test_log_queries.logtable.k']
 select * from test_log_queries.logtable where i = 1	2790142879136771124	Select	['test_log_queries']	['test_log_queries.logtable']	['test_log_queries.logtable.i','test_log_queries.logtable.j','test_log_queries.logtable.k']
 create table test_log_queries.logtable2 as test_log_queries.logtable	16326833375045356331	Create	['test_log_queries']	['test_log_queries.logtable','test_log_queries.logtable2']	[]

--- a/tests/queries/0_stateless/01600_log_queries_with_extensive_info.sh
+++ b/tests/queries/0_stateless/01600_log_queries_with_extensive_info.sh
@@ -10,6 +10,10 @@ ${CLICKHOUSE_CLIENT} -q "create database test_log_queries" "--query_id=01600_log
 ${CLICKHOUSE_CLIENT} -q "create table test_log_queries.logtable(i int, j int, k int) engine MergeTree order by i" "--query_id=01600_log_queries_with_extensive_info_002"
 ${CLICKHOUSE_CLIENT} -q "insert into test_log_queries.logtable values (1,2,3), (4,5,6)" "--query_id=01600_log_queries_with_extensive_info_003"
 ${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i = 4" "--query_id=01600_log_queries_with_extensive_info_004"
+
+# exception query should also contain query_kind
+${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i > ''" "--query_id=01600_log_queries_with_extensive_info_004_err" 2> /dev/null || true
+
 ${CLICKHOUSE_CLIENT} -q "select k from test_log_queries.logtable where i = 1" "--query_id=01600_log_queries_with_extensive_info_005"
 ${CLICKHOUSE_CLIENT} -q "select * from test_log_queries.logtable where i = 1" "--query_id=01600_log_queries_with_extensive_info_006"
 ${CLICKHOUSE_CLIENT} -q "create table test_log_queries.logtable2 as test_log_queries.logtable" "--query_id=01600_log_queries_with_extensive_info_007"
@@ -26,4 +30,4 @@ ${CLICKHOUSE_CLIENT} -q "drop table if exists test_log_queries.logtable3" "--que
 ${CLICKHOUSE_CLIENT} -q "drop database if exists test_log_queries" "--query_id=01600_log_queries_with_extensive_info_018"
 
 ${CLICKHOUSE_CLIENT} -q "system flush logs"
-${CLICKHOUSE_CLIENT} -q "select columns(query, normalized_query_hash, query_kind, databases, tables, columns) apply (any) from system.query_log where current_database = currentDatabase() AND type = 'QueryFinish' and query_id like '01600_log_queries_with_extensive_info%' group by query_id order by query_id"
+${CLICKHOUSE_CLIENT} -q "select columns(query, normalized_query_hash, query_kind, databases, tables, columns) apply (any) from system.query_log where current_database = currentDatabase() AND type != 'QueryStart' and query_id like '01600_log_queries_with_extensive_info%' group by query_id order by query_id"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Try recording `query_kind` even when query fails to start.

Detailed description / Documentation draft:
.