### PR TITLE
Fix part name parsing in system.detached_parts

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -712,7 +712,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
     MergeTreeData::DataPart::Checksums & checksums,
     ThrottlerPtr throttler)
 {
-    static const String TMP_PREFIX = "tmp_fetch_";
+    static const String TMP_PREFIX = "tmp-fetch_";
     String tmp_prefix = tmp_prefix_.empty() ? TMP_PREFIX : tmp_prefix_;
 
     /// We will remove directory if it's already exists. Make precautions.
@@ -784,7 +784,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDiskRemoteMeta(
     LOG_DEBUG(log, "Downloading Part {} unique id {} metadata onto disk {}.",
         part_name, part_id, disk->getName());
 
-    static const String TMP_PREFIX = "tmp_fetch_";
+    static const String TMP_PREFIX = "tmp-fetch_";
     String tmp_prefix = tmp_prefix_.empty() ? TMP_PREFIX : tmp_prefix_;
 
     String part_relative_path = String(to_detached ? "detached/" : "") + tmp_prefix + part_name;

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1322,6 +1322,9 @@ String IMergeTreeDataPart::getRelativePathForDetachedPart(const String & prefix)
 {
     /// Do not allow underscores in the prefix because they are used as separators.
     assert(prefix.find_first_of('_') == String::npos);
+    assert(prefix.empty() || std::find(DetachedPartInfo::DETACH_REASONS.begin(),
+                                       DetachedPartInfo::DETACH_REASONS.end(),
+                                       prefix) != DetachedPartInfo::DETACH_REASONS.end());
     return "detached/" + getRelativePathForPrefix(prefix);
 }
 

--- a/src/Storages/MergeTree/MergeTreePartInfo.cpp
+++ b/src/Storages/MergeTree/MergeTreePartInfo.cpp
@@ -247,13 +247,39 @@ String MergeTreePartInfo::getPartNameV0(DayNum left_date, DayNum right_date) con
     return wb.str();
 }
 
+
+const std::vector<String> DetachedPartInfo::DETACH_REASONS =
+    {
+        "broken",
+        "unexpected",
+        "noquorum",
+        "ignored",
+        "broken-on-start",
+        "clone",
+        "attaching",
+        "deleting",
+        "tmp-fetch",
+    };
+
 bool DetachedPartInfo::tryParseDetachedPartName(const String & dir_name, DetachedPartInfo & part_info,
                                                 MergeTreeDataFormatVersion format_version)
 {
     part_info.dir_name = dir_name;
 
-    /// First, try to parse as <part_name>.
-    // TODO what if tryParsePartName will parse prefix as partition_id? It can happen if dir_name doesn't contain mutation number at the end
+    /// First, try to find known prefix and parse dir_name as <prefix>_<partname>.
+    /// Arbitrary strings are not allowed for partition_id, so known_prefix cannot be confused with partition_id.
+    for (const auto & known_prefix : DETACH_REASONS)
+    {
+        if (dir_name.starts_with(known_prefix) && known_prefix.size() < dir_name.size() && dir_name[known_prefix.size()] == '_')
+        {
+            part_info.prefix = known_prefix;
+            String part_name = dir_name.substr(known_prefix.size() + 1);
+            bool parsed = MergeTreePartInfo::tryParsePartName(part_name, &part_info, format_version);
+            return part_info.valid_name = parsed;
+        }
+    }
+
+    /// Next, try to parse dir_name as <part_name>.
     if (MergeTreePartInfo::tryParsePartName(dir_name, &part_info, format_version))
         return part_info.valid_name = true;
 
@@ -263,7 +289,6 @@ bool DetachedPartInfo::tryParseDetachedPartName(const String & dir_name, Detache
     if (first_separator == String::npos)
         return part_info.valid_name = false;
 
-    // TODO what if <prefix> contains '_'?
     const auto part_name = dir_name.substr(first_separator + 1,
                                            dir_name.size() - first_separator - 1);
     if (!MergeTreePartInfo::tryParsePartName(part_name, &part_info, format_version))

--- a/src/Storages/MergeTree/MergeTreePartInfo.h
+++ b/src/Storages/MergeTree/MergeTreePartInfo.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <tuple>
+#include <vector>
 #include <common/types.h>
 #include <common/DayNum.h>
 #include <Storages/MergeTree/MergeTreeDataFormatVersion.h>
@@ -115,6 +116,10 @@ struct DetachedPartInfo : public MergeTreePartInfo
     /// If false, MergeTreePartInfo is in invalid state (directory name was not successfully parsed).
     bool valid_name;
 
+    static const std::vector<String> DETACH_REASONS;
+
+    /// NOTE: It may parse part info incorrectly.
+    /// For example, if prefix contain '_' or if DETACH_REASONS doesn't contain prefix.
     static bool tryParseDetachedPartName(const String & dir_name, DetachedPartInfo & part_info, MergeTreeDataFormatVersion format_version);
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In rare cases `system.detached_parts` table might contain incorrect information for some parts, it's fixed. Fixes #27114
