### PR TITLE
Save information about used functions/tables/... into query_log on error

### DIFF
--- a/src/Storages/StorageFactory.cpp
+++ b/src/Storages/StorageFactory.cpp
@@ -222,7 +222,7 @@ StoragePtr StorageFactory::get(
         storage_def->engine->arguments->children = empty_engine_args;
     }
 
-    if (local_context->hasQueryContext() && context->getSettingsRef().log_queries)
+    if (local_context->hasQueryContext() && local_context->getSettingsRef().log_queries)
         local_context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Storage, name);
 
     return res;

--- a/tests/queries/0_stateless/01656_test_query_log_factories_info.reference
+++ b/tests/queries/0_stateless/01656_test_query_log_factories_info.reference
@@ -13,6 +13,9 @@ arraySort(used_table_functions)
 arraySort(used_functions)
 ['CAST','CRC32','addDays','array','arrayFlatten','modulo','plus','pow','round','substring','tanh','toDate','toDayOfYear','toTypeName','toWeek']
 
+used_functions
+['repeat']
+
 arraySort(used_data_type_families)
 ['Array','Int32','Nullable','String']
 

--- a/tests/queries/0_stateless/01656_test_query_log_factories_info.sql
+++ b/tests/queries/0_stateless/01656_test_query_log_factories_info.sql
@@ -1,4 +1,5 @@
 SET database_atomic_wait_for_drop_and_detach_synchronously=1;
+SET log_queries=1;
 
 SELECT uniqArray([1, 1, 2]),
        SUBSTRING('Hello, world', 7, 5),
@@ -13,9 +14,16 @@ SELECT uniqArray([1, 1, 2]),
        countIf(toDate('2000-12-05') + number as d,
        toDayOfYear(d) % 2)
 FROM numbers(100);
+
+SELECT repeat('a', number)
+FROM numbers(10e3)
+SETTINGS max_memory_usage=4e6, max_block_size=100
+FORMAT Null; -- { serverError 241 }
+
 SELECT '';
 
 SYSTEM FLUSH LOGS;
+
 SELECT arraySort(used_aggregate_functions)
 FROM system.query_log WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND (query LIKE '%toDate(\'2000-12-05\')%')
 ORDER BY query_start_time DESC LIMIT 1 FORMAT TabSeparatedWithNames;
@@ -33,6 +41,11 @@ SELECT '';
 
 SELECT arraySort(used_functions)
 FROM system.query_log WHERE current_database = currentDatabase() AND type = 'QueryFinish' AND (query LIKE '%toDate(\'2000-12-05\')%')
+ORDER BY query_start_time DESC LIMIT 1 FORMAT TabSeparatedWithNames;
+SELECT '';
+
+SELECT used_functions
+FROM system.query_log WHERE current_database = currentDatabase() AND type != 'QueryStart' AND (query LIKE '%repeat%')
 ORDER BY query_start_time DESC LIMIT 1 FORMAT TabSeparatedWithNames;
 SELECT '';
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Save information about used functions/tables/... into query_log on error

Cc: @kssenii 
Follow-up for: #19371