### PR TITLE
Fix polling of /sys/block

### DIFF
--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -77,6 +77,7 @@ AsynchronousMetrics::AsynchronousMetrics(
     , update_period(update_period_seconds)
     , servers_to_start_before_tables(servers_to_start_before_tables_)
     , servers(servers_)
+    , log(&Poco::Logger::get("AsynchronousMetrics"))
 {
 #if defined(OS_LINUX)
     openFileIfExists("/proc/meminfo", meminfo);
@@ -174,25 +175,38 @@ AsynchronousMetrics::AsynchronousMetrics(
             edac.back().second = openFileIfExists(edac_uncorrectable_file);
     }
 
-    if (std::filesystem::exists("/sys/block"))
-    {
-        for (const auto & device_dir : std::filesystem::directory_iterator("/sys/block"))
-        {
-            String device_name = device_dir.path().filename();
-
-            /// We are not interested in loopback devices.
-            if (device_name.starts_with("loop"))
-                continue;
-
-            std::unique_ptr<ReadBufferFromFilePRead> file = openFileIfExists(device_dir.path() / "stat");
-            if (!file)
-                continue;
-
-            block_devs[device_name] = std::move(file);
-        }
-    }
+    openBlockDevices();
 #endif
 }
+
+#if defined(OS_LINUX)
+void AsynchronousMetrics::openBlockDevices()
+{
+    LOG_TRACE(log, "Scanning /sys/block");
+
+    if (!std::filesystem::exists("/sys/block"))
+        return;
+
+    block_devices_rescan_delay.restart();
+
+    block_devs.clear();
+
+    for (const auto & device_dir : std::filesystem::directory_iterator("/sys/block"))
+    {
+        String device_name = device_dir.path().filename();
+
+        /// We are not interested in loopback devices.
+        if (device_name.starts_with("loop"))
+            continue;
+
+        std::unique_ptr<ReadBufferFromFilePRead> file = openFileIfExists(device_dir.path() / "stat");
+        if (!file)
+            continue;
+
+        block_devs[device_name] = std::move(file);
+    }
+}
+#endif
 
 void AsynchronousMetrics::start()
 {
@@ -550,7 +564,7 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
 
             /// Log only if difference is high. This is for convenience. The threshold is arbitrary.
             if (difference >= 1048576 || difference <= -1048576)
-                LOG_TRACE(&Poco::Logger::get("AsynchronousMetrics"),
+                LOG_TRACE(log,
                     "MemoryTracking: was {}, peak {}, will set to {} (RSS), difference: {}",
                     ReadableSize(amount),
                     ReadableSize(peak),
@@ -877,6 +891,11 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
         }
     }
 
+    /// Update list of block devices periodically
+    /// (i.e. someone may add new disk to RAID array)
+    if (block_devices_rescan_delay.elapsedSeconds() >= 300)
+        openBlockDevices();
+
     for (auto & [name, device] : block_devs)
     {
         try
@@ -930,6 +949,16 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
         }
         catch (...)
         {
+            /// Try to reopen block devices in case of error
+            /// (i.e. ENOENT means that some disk had been replaced, and it may apperas with a new name)
+            try
+            {
+                openBlockDevices();
+            }
+            catch (...)
+            {
+                tryLogCurrentException(__PRETTY_FUNCTION__);
+            }
             tryLogCurrentException(__PRETTY_FUNCTION__);
         }
     }
@@ -1303,9 +1332,9 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
     new_values["AsynchronousMetricsCalculationTimeSpent"] = watch.elapsedSeconds();
 
     /// Log the new metrics.
-    if (auto log = getContext()->getAsynchronousMetricLog())
+    if (auto asynchronous_metric_log = getContext()->getAsynchronousMetricLog())
     {
-        log->addValues(new_values);
+        asynchronous_metric_log->addValues(new_values);
     }
 
     first_run = false;

--- a/src/Interpreters/AsynchronousMetrics.h
+++ b/src/Interpreters/AsynchronousMetrics.h
@@ -3,6 +3,7 @@
 #include <Interpreters/Context_fwd.h>
 #include <Common/MemoryStatisticsOS.h>
 #include <Common/ThreadPool.h>
+#include <Common/Stopwatch.h>
 #include <IO/ReadBufferFromFile.h>
 
 #include <condition_variable>
@@ -14,6 +15,11 @@
 #include <optional>
 #include <unordered_map>
 
+
+namespace Poco
+{
+class Logger;
+}
 
 namespace DB
 {
@@ -175,12 +181,17 @@ private:
 
     std::unordered_map<String /* device name */, NetworkInterfaceStatValues> network_interface_stats;
 
+    Stopwatch block_devices_rescan_delay;
+
+    void openBlockDevices();
 #endif
 
     std::unique_ptr<ThreadFromGlobalPool> thread;
 
     void run();
     void update(std::chrono::system_clock::time_point update_time);
+
+    Poco::Logger * log;
 };
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix polling of /sys/block (on errors and by timer)

Detailed description / Documentation draft:
- rescan /sys/block on errors (disk had been replaced and you will got
  ENOENT)
- rescan /sys/block periodically (each 5m), for newly added devices
  (i.e. new disk to RAID array can be added)

Cc: @alexey-milovidov 