### PR TITLE
Fix on-disk format breakage for secondary indices over Nullable column

### DIFF
--- a/tests/integration/test_backward_compatibility/test_data_skipping_indices.py
+++ b/tests/integration/test_backward_compatibility/test_data_skipping_indices.py
@@ -1,0 +1,44 @@
+# pylint: disable=line-too-long
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance('node', image='yandex/clickhouse-server', tag='21.6', stay_alive=True, with_installed_binary=True)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+# TODO: cover other types too, but for this we need to add something like
+# restart_with_tagged_version(), since right now it is not possible to
+# switch to old tagged clickhouse version.
+def test_index(start_cluster):
+    node.query("""
+    CREATE TABLE data
+    (
+        key Int,
+        value Nullable(Int),
+        INDEX value_index value TYPE minmax GRANULARITY 1
+    )
+    ENGINE = MergeTree
+    ORDER BY key;
+
+    INSERT INTO data SELECT number, number FROM numbers(10000);
+
+    SELECT * FROM data WHERE value = 20000 SETTINGS force_data_skipping_indices = 'value_index' SETTINGS force_data_skipping_indices = 'value_index', max_rows_to_read=1;
+    """)
+    node.restart_with_latest_version()
+    node.query("""
+    SELECT * FROM data WHERE value = 20000 SETTINGS force_data_skipping_indices = 'value_index' SETTINGS force_data_skipping_indices = 'value_index', max_rows_to_read=1;
+    DROP TABLE data;
+    """)

--- a/tests/queries/0_stateless/01410_nullable_key_and_index.sql
+++ b/tests/queries/0_stateless/01410_nullable_key_and_index.sql
@@ -49,11 +49,15 @@ SET force_primary_key = 0;
 SELECT * FROM nullable_minmax_index ORDER BY k;
 SET max_rows_to_read = 6;
 SELECT * FROM nullable_minmax_index WHERE v IS NULL;
-SET max_rows_to_read = 8;
+-- NOTE: granuals with Null values cannot be filtred in data skipping indexes,
+-- due to backward compatibility
+SET max_rows_to_read = 0;
 SELECT * FROM nullable_minmax_index WHERE v IS NOT NULL;
 SET max_rows_to_read = 6;
 SELECT * FROM nullable_minmax_index WHERE v > 2;
-SET max_rows_to_read = 4;
+-- NOTE: granuals with Null values cannot be filtred in data skipping indexes,
+-- due to backward compatibility
+SET max_rows_to_read = 0;
 SELECT * FROM nullable_minmax_index WHERE v <= 2;
 
 DROP TABLE nullable_key;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix on-disk format breakage for secondary indices over Nullable column (no stable release had been affected)

Detailed description / Documentation draft:
[1] breaks on disk format.

  [1]: https://github.com/ClickHouse/ClickHouse/pull/12455#discussion_r682830812

I checked this patchset for compatibility after
reverting this patch [2] (use case: I've applied it manually, then
revert it, and data skipping indexes over Nullable column had been
broken)

  [2]: https://github.com/ClickHouse/ClickHouse/pull/12455#issuecomment-823423772

But this patchset actually breaks compatibility with older versions of
clickhouse for Nullable data skipping indexes after simple upgrade:

<details>

Here is a simple reproducer:

    --
    -- run this with 21.6 or similar (i.e. w/o this patch)
    --

    CREATE TABLE data
    (
        `key` Int,
        `value` Nullable(Int),
        INDEX value_index value TYPE minmax GRANULARITY 1
    )
    ENGINE = MergeTree
    ORDER BY key;

    INSERT INTO data SELECT
        number,
        number
    FROM numbers(10000);

    SELECT * FROM data WHERE value = 20000 SETTINGS force_data_skipping_indices = 'value_index' SETTINGS force_data_skipping_indices = 'value_index', max_rows_to_read=1;

Now upgrade and run the query again:

    SELECT * FROM data WHERE value = 20000 SETTINGS force_data_skipping_indices = 'value_index' SETTINGS force_data_skipping_indices = 'value_index', max_rows_to_read=1;

And it will fail because of on disk format changes:

    $ ll --time-style=+ data/*/data/all_1_1_0/skp*.idx
    -rw-r----- 1 azat azat 36  data/with_nullable_patch/data/all_1_1_0/skp_idx_value_index.idx
    -rw-r----- 1 azat azat 37  data/without_nullable_patch/data/all_1_1_0/skp_idx_value_index.idx

    $ md5sum data/*/data/all_1_1_0/skp*.idx
    a19c95c4a14506c65665a1e30ab404bf  data/with_nullable_patch/data/all_1_1_0/skp_idx_value_index.idx
    e50e2fcfa873b232196623d56ab26105  data/without_nullable_patch/data/all_1_1_0/skp_idx_value_index.idx

</details>

**Note, that there is no stable release with this patch included yet, so
no need to backport.**

Also note that you may create data skipping indexes over Nullable
column even before [3].

  [3]: https://github.com/ClickHouse/ClickHouse/pull/12455


Changelog:

<details>

- v2: break cases when granulas has Null in values due to backward compatibility

</details>

Cc: @alexey-milovidov (please add no-backport label)
Cc: @amosbird (please take a look)