### PR TITLE
Split mutex into individual regexp construction.

### DIFF
--- a/src/Functions/Regexps.h
+++ b/src/Functions/Regexps.h
@@ -122,8 +122,6 @@ namespace MultiRegexps
 
         Regexps * operator()()
         {
-            if (regexp)
-                return &*regexp;
             std::unique_lock lock(mutex);
             if (regexp)
                 return &*regexp;

--- a/src/Functions/Regexps.h
+++ b/src/Functions/Regexps.h
@@ -113,12 +113,36 @@ namespace MultiRegexps
         ScratchPtr scratch;
     };
 
+    class RegexpsConstructor
+    {
+    public:
+        RegexpsConstructor() = default;
+
+        void setConstructor(std::function<Regexps()> constructor_) { constructor = std::move(constructor_); }
+
+        Regexps * operator()()
+        {
+            if (regexp)
+                return &*regexp;
+            std::unique_lock lock(mutex);
+            if (regexp)
+                return &*regexp;
+            regexp = constructor();
+            return &*regexp;
+        }
+
+    private:
+        std::function<Regexps()> constructor;
+        std::optional<Regexps> regexp;
+        std::mutex mutex;
+    };
+
     struct Pool
     {
         /// Mutex for finding in map.
         std::mutex mutex;
         /// Patterns + possible edit_distance to database and scratch.
-        std::map<std::pair<std::vector<String>, std::optional<UInt32>>, Regexps> storage;
+        std::map<std::pair<std::vector<String>, std::optional<UInt32>>, RegexpsConstructor> storage;
     };
 
     template <bool save_indices, bool CompileForEditDistance>
@@ -250,15 +274,19 @@ namespace MultiRegexps
 
         /// If not found, compile and let other threads wait.
         if (known_regexps.storage.end() == it)
+        {
             it = known_regexps.storage
-                     .emplace(
-                         std::pair{str_patterns, edit_distance},
-                         constructRegexps<save_indices, CompileForEditDistance>(str_patterns, edit_distance))
+                     .emplace(std::piecewise_construct, std::make_tuple(std::move(str_patterns), edit_distance), std::make_tuple())
                      .first;
-        /// If found, unlock and return the database.
-        lock.unlock();
+            it->second.setConstructor([&str_patterns = it->first.first, edit_distance]()
+            {
+                return constructRegexps<save_indices, CompileForEditDistance>(str_patterns, edit_distance);
+            });
+        }
 
-        return &it->second;
+        /// Unlock before possible construction.
+        lock.unlock();
+        return it->second();
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Split global mutex into individual regexp construction. This helps avoid huge regexp construction blocking other related threads. Not sure how to proper test the improvement.


Detailed description / Documentation draft:
.