### PR TITLE
Using formatted string literals in clickhouse-test, extracted sort key functions and stacktraces printer

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -11,6 +11,7 @@ import copy
 import traceback
 
 from argparse import ArgumentParser
+from typing import Tuple, Union, Optional, TextIO
 import shlex
 import subprocess
 from subprocess import Popen
@@ -20,10 +21,12 @@ from subprocess import TimeoutExpired
 from datetime import datetime
 from time import time, sleep
 from errno import ESRCH
+
 try:
     import termcolor
 except ImportError:
     termcolor = None
+
 import random
 import string
 import multiprocessing
@@ -81,7 +84,7 @@ def stop_tests():
 def json_minify(string):
     """
     Removes all js-style comments from json string. Allows to have comments in skip_list.json.
-    The code taken from https://github.com/getify/JSON.minify/tree/python under the MIT license.
+    The code was taken from https://github.com/getify/JSON.minify/tree/python under the MIT license.
     """
 
     tokenizer = re.compile(r'"|(/\*)|(\*/)|(//)|\n|\r')
@@ -148,12 +151,16 @@ def remove_control_characters(s):
     s = re.sub(r"[\x00-\x08\x0b\x0e-\x1f\x7f]", "", s)
     return s
 
+
 def get_db_engine(args, database_name):
     if args.replicated_database:
-        return " ON CLUSTER test_cluster_database_replicated ENGINE=Replicated('/test/clickhouse/db/{}', '{{shard}}', '{{replica}}')".format(database_name)
+        return f" ON CLUSTER test_cluster_database_replicated \
+            ENGINE=Replicated('/test/clickhouse/db/{database_name}', \
+            '{{shard}}', '{{replica}}')"
     if args.db_engine:
         return " ENGINE=" + args.db_engine
     return ""   # Will use default engine
+
 
 def configure_testcase_args(args, case_file, suite_tmp_dir, stderr_file):
     testcase_args = copy.deepcopy(args)
@@ -166,7 +173,6 @@ def configure_testcase_args(args, case_file, suite_tmp_dir, stderr_file):
         database = testcase_args.database
         os.environ.setdefault("CLICKHOUSE_DATABASE", database)
         os.environ.setdefault("CLICKHOUSE_TMP", suite_tmp_dir)
-
     else:
         # If --database is not specified, we will create temporary database with unique name
         # And we will recreate and drop it for each test
@@ -176,8 +182,14 @@ def configure_testcase_args(args, case_file, suite_tmp_dir, stderr_file):
         database = 'test_{suffix}'.format(suffix=random_str())
 
         with open(stderr_file, 'w') as stderr:
-            client_cmd = testcase_args.testcase_client + " " + get_additional_client_options(args)
-            clickhouse_proc_create = Popen(shlex.split(client_cmd), stdin=PIPE, stdout=PIPE, stderr=stderr, universal_newlines=True)
+            client_cmd = testcase_args.testcase_client + " " \
+                + get_additional_client_options(args)
+
+            clickhouse_proc_create = open_client_process(
+                universal_newlines=True,
+                client_args=client_cmd,
+                stderr_file=stderr)
+
             try:
                 clickhouse_proc_create.communicate(("CREATE DATABASE " + database + get_db_engine(testcase_args, database)), timeout=testcase_args.timeout)
             except TimeoutExpired:
@@ -237,8 +249,10 @@ def run_single_test(args, ext, server_logs_level, client_options, case_file, std
 
     if need_drop_database:
         with open(stderr_file, 'a') as stderr:
-            clickhouse_proc_create = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=stderr, universal_newlines=True)
+            clickhouse_proc_create = open_client_process(client, universal_newlines=True, stderr_file=stderr)
+
         seconds_left = max(args.timeout - (datetime.now() - start_time).total_seconds(), 20)
+
         try:
             drop_database_query = "DROP DATABASE " + database
             if args.replicated_database:
@@ -254,7 +268,7 @@ def run_single_test(args, ext, server_logs_level, client_options, case_file, std
                         raise
 
             total_time = (datetime.now() - start_time).total_seconds()
-            return clickhouse_proc_create, "", "Timeout dropping database {} after test".format(database), total_time
+            return clickhouse_proc_create, "", f"Timeout dropping database {database} after test", total_time
 
         shutil.rmtree(args.test_tmp_dir)
 
@@ -286,12 +300,16 @@ def need_retry(stdout, stderr):
 def get_processlist(args):
     try:
         query = b"SHOW PROCESSLIST FORMAT Vertical"
+
         if args.replicated_database:
             query = b"SELECT materialize((hostName(), tcpPort())) as host, * " \
                     b"FROM clusterAllReplicas('test_cluster_database_replicated', system.processes) " \
                     b"WHERE query NOT LIKE '%system.processes%' FORMAT Vertical"
-        clickhouse_proc = Popen(shlex.split(args.client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+
+        clickhouse_proc = open_client_process(args.client)
+
         (stdout, _) = clickhouse_proc.communicate((query), timeout=20)
+
         return False, stdout.decode('utf-8')
     except Exception as ex:
         print("Exception", ex)
@@ -301,47 +319,90 @@ def get_processlist(args):
 # collect server stacktraces using gdb
 def get_stacktraces_from_gdb(server_pid):
     try:
-        cmd = "gdb -batch -ex 'thread apply all backtrace' -p {}".format(server_pid)
+        cmd = f"gdb -batch -ex 'thread apply all backtrace' -p {server_pid}"
         return subprocess.check_output(cmd, shell=True).decode('utf-8')
-    except Exception as ex:
-        print("Error occured while receiving stack traces from gdb: {}".format(str(ex)))
+    except Exception as e:
+        print(f"Error occurred while receiving stack traces from gdb: {e}")
         return None
 
 
 # collect server stacktraces from system.stack_trace table
 # it does not work in Sandbox
 def get_stacktraces_from_clickhouse(client, replicated_database=False):
-    try:
-        if replicated_database:
-            return subprocess.check_output("{} --allow_introspection_functions=1 --skip_unavailable_shards=1 --query "
-                "\"SELECT materialize((hostName(), tcpPort())) as host, thread_id, "
-                "arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), arrayMap(x -> addressToLine(x), trace), "
-                "arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace "
-                "FROM clusterAllReplicas('test_cluster_database_replicated', 'system.stack_trace') "
-                "ORDER BY host, thread_id format Vertical\"".format(client), shell=True, stderr=subprocess.STDOUT).decode('utf-8')
+    replicated_msg = \
+        "{} --allow_introspection_functions=1 --skip_unavailable_shards=1 --query \
+        \"SELECT materialize((hostName(), tcpPort())) as host, thread_id, \
+        arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), \
+        arrayMap(x -> addressToLine(x), trace), \
+        arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace \
+        FROM clusterAllReplicas('test_cluster_database_replicated', 'system.stack_trace') \
+        ORDER BY host, thread_id FORMAT Vertical\"".format(client)
 
-        return subprocess.check_output("{} --allow_introspection_functions=1 --query "
-               "\"SELECT arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), arrayMap(x -> addressToLine(x), trace), "
-               "arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace "
-               "FROM system.stack_trace format Vertical\"".format(client), shell=True, stderr=subprocess.STDOUT).decode('utf-8')
-    except Exception as ex:
-        print("Error occured while receiving stack traces from client: {}".format(str(ex)))
+    msg = \
+        "{} --allow_introspection_functions=1 --query \
+        \"SELECT arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), \
+        arrayMap(x -> addressToLine(x), trace), \
+        arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace \
+        FROM system.stack_trace FORMAT Vertical\"".format(client)
+
+    try:
+        return subprocess.check_output(
+            replicated_msg if replicated_database else msg,
+            shell=True, stderr=subprocess.STDOUT).decode('utf-8')
+    except Exception as e:
+        print(f"Error occurred while receiving stack traces from client: {e}")
         return None
 
-def get_server_pid(server_tcp_port):
+
+def print_stacktraces() -> None:
+    server_pid = get_server_pid()
+
+    bt = None
+
+    if server_pid and not args.replicated_database:
+        print("")
+        print(f"Located ClickHouse server process {server_pid} listening at TCP port {args.tcp_port}")
+        print("Collecting stacktraces from all running threads with gdb:")
+
+        bt = get_stacktraces_from_gdb(server_pid)
+
+        if len(bt) < 1000:
+            print("Got suspiciously small stacktraces: ", bt)
+            bt = None
+
+    if bt is None:
+        print("\nCollecting stacktraces from system.stacktraces table:")
+
+        bt = get_stacktraces_from_clickhouse(
+            args.client, args.replicated_database)
+
+    if bt is not None:
+        print(bt)
+        return
+
+    print(colored(
+        f"\nUnable to locate ClickHouse server process listening at TCP port {args.tcp_port}. "
+         "It must have crashed or exited prematurely!",
+        args, "red", attrs=["bold"]))
+
+
+def get_server_pid():
     # lsof does not work in stress tests for some reason
-    cmd_lsof = "lsof -i tcp:{port} -s tcp:LISTEN -Fp | awk '/^p[0-9]+$/{{print substr($0, 2)}}'".format(port=server_tcp_port)
+    cmd_lsof = f"lsof -i tcp:{args.tcp_port} -s tcp:LISTEN -Fp | awk '/^p[0-9]+$/{{print substr($0, 2)}}'"
     cmd_pidof = "pidof -s clickhouse-server"
+
     commands = [cmd_lsof, cmd_pidof]
     output = None
+
     for cmd in commands:
         try:
             output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
             if output:
                 return int(output)
         except Exception as e:
-            print("Cannot get server pid with {}, got {}: {}".format(cmd, output, e))
-    return None # most likely server dead
+            print(f"Cannot get server pid with {cmd}, got {output}: {e}")
+
+    return None  # most likely server is dead
 
 
 def colored(text, args, color=None, on_color=None, attrs=None):
@@ -357,6 +418,14 @@ server_died = multiprocessing.Event()
 stop_tests_triggered_lock = multiprocessing.Lock()
 stop_tests_triggered = multiprocessing.Event()
 queue = multiprocessing.Queue(maxsize=1)
+
+
+def print_test_time(test_time) -> str:
+    if args.print_time:
+        return " {0:.2f} sec.".format(test_time)
+    else:
+        return ''
+
 restarted_tests = []  # (test, stderr)
 
 # def run_tests_array(all_tests, suite, suite_dir, suite_tmp_dir, run_total):
@@ -385,15 +454,10 @@ def run_tests_array(all_tests_with_params):
 
     client_options = get_additional_client_options(args)
 
-    def print_test_time(test_time):
-        if args.print_time:
-            return " {0:.2f} sec.".format(test_time)
-        else:
-            return ''
-
     if num_tests > 0:
         about = 'about ' if is_concurrent else ''
-        print(f"\nRunning {about}{num_tests} {suite} tests ({multiprocessing.current_process().name}).\n")
+        proc_name = multiprocessing.current_process().name
+        print(f"\nRunning {about}{num_tests} {suite} tests ({proc_name}).\n")
 
     while True:
         if is_concurrent:
@@ -459,7 +523,6 @@ def run_tests_array(all_tests_with_params):
                     message = open(disabled_file, 'r').read()
                     status += MSG_SKIPPED + " - " + message + "\n"
                 else:
-
                     if args.testname:
                         clickhouse_proc = Popen(shlex.split(args.client), stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
                         failed_to_check = False
@@ -599,7 +662,12 @@ def run_tests_array(all_tests_with_params):
         except:
             exc_type, exc_value, tb = sys.exc_info()
             failures += 1
-            print("{0} - Test internal error: {1}\n{2}\n{3}".format(MSG_FAIL, exc_type.__name__, exc_value, "\n".join(traceback.format_tb(tb, 10))))
+
+            exc_name = exc_type.__name__
+            traceback_str = "\n".join(traceback.format_tb(tb, 10))
+
+            print(f"{MSG_FAIL} - Test internal error: {exc_name}")
+            print(f"{exc_value}\n{traceback_str}")
 
         if failures_chain >= 20:
             stop_tests()
@@ -627,9 +695,11 @@ server_logs_level = "warning"
 
 def check_server_started(client, retry_count):
     print("Connecting to ClickHouse server...", end='')
+
     sys.stdout.flush()
+
     while retry_count > 0:
-        clickhouse_proc = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        clickhouse_proc = open_client_process(client)
         (stdout, stderr) = clickhouse_proc.communicate(b"SELECT 1")
 
         if clickhouse_proc.returncode == 0 and stdout.startswith(b"1"):
@@ -679,7 +749,7 @@ class BuildFlags():
 
 
 def collect_build_flags(client):
-    clickhouse_proc = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    clickhouse_proc = open_client_process(client)
     (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'")
     result = []
 
@@ -695,7 +765,7 @@ def collect_build_flags(client):
     else:
         raise Exception("Cannot get information about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
 
-    clickhouse_proc = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    clickhouse_proc = open_client_process(client)
     (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.build_options WHERE name = 'BUILD_TYPE'")
 
     if clickhouse_proc.returncode == 0:
@@ -706,7 +776,7 @@ def collect_build_flags(client):
     else:
         raise Exception("Cannot get information about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
 
-    clickhouse_proc = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    clickhouse_proc = open_client_process(client)
     (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.build_options WHERE name = 'UNBUNDLED'")
 
     if clickhouse_proc.returncode == 0:
@@ -715,7 +785,7 @@ def collect_build_flags(client):
     else:
         raise Exception("Cannot get information about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
 
-    clickhouse_proc = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    clickhouse_proc = open_client_process(client)
     (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.settings WHERE name = 'default_database_engine'")
 
     if clickhouse_proc.returncode == 0:
@@ -724,7 +794,7 @@ def collect_build_flags(client):
     else:
         raise Exception("Cannot get information about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
 
-    clickhouse_proc = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    clickhouse_proc = open_client_process(client)
     (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.merge_tree_settings WHERE name = 'min_bytes_for_wide_part'")
 
     if clickhouse_proc.returncode == 0:
@@ -734,6 +804,56 @@ def collect_build_flags(client):
         raise Exception("Cannot get inforamtion about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
 
     return result
+
+
+def suite_key_func(item: str) -> Union[int, Tuple[int, str]]:
+    if args.order == 'random':
+        return random.random()
+
+    if -1 == item.find('_'):
+        return 99998, ''
+
+    prefix, suffix = item.split('_', 1)
+
+    try:
+        return int(prefix), suffix
+    except ValueError:
+        return 99997, ''
+
+
+def tests_in_suite_key_func(item: str) -> int:
+    if args.order == 'random':
+        return random.random()
+
+    reverse = 1 if args.order == 'asc' else -1
+
+    if -1 == item.find('_'):
+        return 99998
+
+    prefix, _ = item.split('_', 1)
+
+    try:
+        return reverse * int(prefix)
+    except ValueError:
+        return 99997
+
+
+def extract_key(key: str) -> str:
+    return subprocess.getstatusoutput(
+        args.extract_from_config +
+        " --try --config " +
+        args.configserver + key)[1]
+
+
+def open_client_process(
+    client_args: str,
+    universal_newlines: bool = False,
+    stderr_file: Optional[TextIO] = None):
+    return Popen(
+        shlex.split(client_args), stdin=PIPE, stdout=PIPE,
+        stderr=stderr_file if stderr_file is not None else PIPE,
+        universal_newlines=True if universal_newlines else None)
+
 
 
 def do_run_tests(jobs, suite, suite_dir, suite_tmp_dir, all_tests, parallel_tests, sequential_tests, parallel):
@@ -790,7 +910,7 @@ def removesuffix(text, *suffixes):
     Added in python 3.9
     https://www.python.org/dev/peps/pep-0616/
 
-    This version can work with severtal possible suffixes
+    This version can work with several possible suffixes
     """
     for suffix in suffixes:
         if suffix and text.endswith(suffix):
@@ -875,7 +995,7 @@ def main(args):
     global server_logs_level
 
     def is_data_present():
-        clickhouse_proc = Popen(shlex.split(args.client), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        clickhouse_proc = open_client_process(args.client)
         (stdout, stderr) = clickhouse_proc.communicate(b"EXISTS TABLE test.hits")
         if clickhouse_proc.returncode != 0:
             raise CalledProcessError(clickhouse_proc.returncode, args.client, stderr)
@@ -885,9 +1005,10 @@ def main(args):
     if not check_server_started(args.client, args.server_check_retries):
         raise Exception(
             "Server is not responding. Cannot execute 'SELECT 1' query. \
-            Note: if you are using split build, you may have to specify -c option.")
+            If you are using split build, you have to specify -c option.")
 
     build_flags = collect_build_flags(args.client)
+
     if args.replicated_database:
         build_flags.append(BuildFlags.DATABASE_REPLICATED)
 
@@ -911,6 +1032,7 @@ def main(args):
     os.environ.setdefault("CLICKHOUSE_BINARY", args.binary)
     #os.environ.setdefault("CLICKHOUSE_CLIENT", args.client)
     os.environ.setdefault("CLICKHOUSE_CONFIG", args.configserver)
+
     if args.configclient:
         os.environ.setdefault("CLICKHOUSE_CONFIG_CLIENT", args.configclient)
 
@@ -923,52 +1045,35 @@ def main(args):
         stop_time = time() + args.global_time_limit
 
     if args.zookeeper is None:
-        _, out = subprocess.getstatusoutput(args.extract_from_config + " --try --config " + args.configserver + ' --key zookeeper | grep . | wc -l')
         try:
-            if int(out) > 0:
-                args.zookeeper = True
-            else:
-                args.zookeeper = False
+            args.zookeeper = int(extract_key(" --key zookeeper | grep . | wc -l")) > 0
         except ValueError:
             args.zookeeper = False
 
     if args.shard is None:
-        _, out = subprocess.getstatusoutput(args.extract_from_config + " --try --config " + args.configserver + ' --key listen_host | grep -E "127.0.0.2|::"')
-        if out:
-            args.shard = True
-        else:
-            args.shard = False
+        args.shard = bool(extract_key(' --key listen_host | grep -E "127.0.0.2|::"'))
 
     def create_common_database(args, db_name):
         create_database_retries = 0
         while create_database_retries < MAX_RETRIES:
             client_cmd = args.client + " " + get_additional_client_options(args)
-            clickhouse_proc_create = Popen(shlex.split(client_cmd), stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+
+            clickhouse_proc_create = open_client_process(client_cmd, universal_newlines=True)
+
             (stdout, stderr) = clickhouse_proc_create.communicate(("CREATE DATABASE IF NOT EXISTS " + db_name + get_db_engine(args, db_name)))
+
             if not need_retry(stdout, stderr):
                 break
             create_database_retries += 1
 
     if args.database and args.database != "test":
         create_common_database(args, args.database)
+
     create_common_database(args, "test")
 
-    def sute_key_func(item):
-        if args.order == 'random':
-            return random.random()
-
-        if -1 == item.find('_'):
-            return 99998, ''
-
-        prefix, suffix = item.split('_', 1)
-
-        try:
-            return int(prefix), suffix
-        except ValueError:
-            return 99997, ''
-
     total_tests_run = 0
-    for suite in sorted(os.listdir(base_dir), key=sute_key_func):
+
+    for suite in sorted(os.listdir(base_dir), key=suite_key_func):
         if server_died.is_set():
             break
 
@@ -982,8 +1087,8 @@ def main(args):
             os.makedirs(suite_tmp_dir)
 
         suite = suite_re_obj.group(1)
-        if os.path.isdir(suite_dir):
 
+        if os.path.isdir(suite_dir):
             if 'stateful' in suite and not args.no_stateful and not is_data_present():
                 print("Won't run stateful tests because test data wasn't loaded.")
                 continue
@@ -994,29 +1099,14 @@ def main(args):
                 print("Won't run stateful tests because they were manually disabled.")
                 continue
 
-            # Reverse sort order: we want run newest test first.
-            # And not reverse subtests
-            def key_func(item):
-                if args.order == 'random':
-                    return random.random()
-
-                reverse = 1 if args.order == 'asc' else -1
-
-                if -1 == item.find('_'):
-                    return 99998
-
-                prefix, _ = item.split('_', 1)
-
-                try:
-                    return reverse * int(prefix)
-                except ValueError:
-                    return 99997
-
-            all_tests = get_tests_list(suite_dir, args.test, args.test_runs, key_func)
+            all_tests = get_tests_list(
+                suite_dir, args.test, args.test_runs, tests_in_suite_key_func)
 
             jobs = args.jobs
+
             parallel_tests = []
             sequential_tests = []
+
             for test in all_tests:
                 if any(s in test for s in args.sequential):
                     sequential_tests.append(test)
@@ -1042,44 +1132,21 @@ def main(args):
             else:
                 print(colored("Seems like server hung and cannot respond to queries", args, "red", attrs=["bold"]))
 
-            clickhouse_tcp_port = os.getenv("CLICKHOUSE_PORT_TCP", '9000')
-            server_pid = get_server_pid(clickhouse_tcp_port)
-            bt = None
-            if server_pid and not args.replicated_database:
-                print("\nLocated ClickHouse server process {} listening at TCP port {}".format(server_pid, clickhouse_tcp_port))
-                print("\nCollecting stacktraces from all running threads with gdb:")
-                bt = get_stacktraces_from_gdb(server_pid)
-                if len(bt) < 1000:
-                    print("Got suspiciously small stacktraces: ", bt)
-                    bt = None
-            if bt is None:
-                print("\nCollecting stacktraces from system.stacktraces table:")
-                bt = get_stacktraces_from_clickhouse(args.client, args.replicated_database)
-            if bt is None:
-                print(
-                    colored(
-                        "\nUnable to locate ClickHouse server process listening at TCP port {}. "
-                        "It must have crashed or exited prematurely!".format(clickhouse_tcp_port),
-                        args, "red", attrs=["bold"]))
-            else:
-                print(bt)
 
+            print_stacktraces()
             exit_code.value = 1
         else:
             print(colored("\nNo queries hung.", args, "green", attrs=["bold"]))
 
     if len(restarted_tests) > 0:
         print("\nSome tests were restarted:\n")
+
         for (test_case, stderr) in restarted_tests:
-            print(test_case)
-            print(stderr)
-            print("\n")
+            print(test_case + "\n" + stderr + "\n")
 
     if total_tests_run == 0:
         print("No tests were run.")
         sys.exit(1)
-    else:
-        print("All tests have finished.")
 
     sys.exit(exit_code.value)
 
@@ -1196,9 +1263,11 @@ if __name__ == '__main__':
     parser.add_argument('--no-long', action='store_false', dest='no_long', help='Do not run long tests')
     parser.add_argument('--client-option', nargs='+', help='Specify additional client argument')
     parser.add_argument('--print-time', action='store_true', dest='print_time', help='Print test time')
+
     group=parser.add_mutually_exclusive_group(required=False)
     group.add_argument('--zookeeper', action='store_true', default=None, dest='zookeeper', help='Run zookeeper related tests')
     group.add_argument('--no-zookeeper', action='store_false', default=None, dest='zookeeper', help='Do not run zookeeper related tests')
+
     group=parser.add_mutually_exclusive_group(required=False)
     group.add_argument('--shard', action='store_true', default=None, dest='shard', help='Run sharding related tests (required to clickhouse-server listen 127.0.0.2 127.0.0.3)')
     group.add_argument('--no-shard', action='store_false', default=None, dest='shard', help='Do not run shard related tests')
@@ -1206,7 +1275,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.queries and not os.path.isdir(args.queries):
-        print("Cannot access the specified directory with queries (" + args.queries + ")", file=sys.stderr)
+        print(f"Cannot access the specified directory with queries ({args.queries})", file=sys.stderr)
         sys.exit(1)
 
     # Autodetect the directory with queries if not specified
@@ -1257,10 +1326,13 @@ if __name__ == '__main__':
 
         if args.configclient:
             args.client += ' --config-file=' + args.configclient
+
         if os.getenv("CLICKHOUSE_HOST"):
             args.client += ' --host=' + os.getenv("CLICKHOUSE_HOST")
-        if os.getenv("CLICKHOUSE_PORT_TCP"):
-            args.client += ' --port=' + os.getenv("CLICKHOUSE_PORT_TCP")
+
+        args.tcp_port = int(os.getenv("CLICKHOUSE_PORT_TCP", 9000))
+        args.client += f" --port={args.tcp_port}"
+
         if os.getenv("CLICKHOUSE_DATABASE"):
             args.client += ' --database=' + os.getenv("CLICKHOUSE_DATABASE")
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -54,7 +54,7 @@ MESSAGES_TO_RETRY = [
     "DB::Exception: New table appeared in database being dropped or detached. Try again",
     "is already started to be removing by another replica right now",
     "Shutdown is called for table", # It happens in SYSTEM SYNC REPLICA query if session with ZooKeeper is being reinitialized.
-    DISTRIBUTED_DDL_TIMEOUT_MSG # FIXME
+    DISTRIBUTED_DDL_TIMEOUT_MSG  # FIXME
 ]
 
 MAX_RETRIES = 3
@@ -426,6 +426,67 @@ def print_test_time(test_time) -> str:
     else:
         return ''
 
+
+def should_skip_test_by_name(name: str, test_ext: str) -> Tuple[bool, str]:
+    if args.skip and any(s in name for s in args.skip):
+        return True, "skip"
+
+    if not args.zookeeper and ('zookeeper' in name or 'replica' in name):
+        return True, "no zookeeper"
+
+    if not args.shard and \
+        ('shard' in name or 'distributed' in name or 'global' in name):
+        return True, "no shard"
+
+    # Tests for races and deadlocks usually are run in a loop for a significant
+    # amount of time
+    if args.no_long and \
+        ('long' in name or 'deadlock' in name or 'race' in name):
+        return True, "no long"
+
+    if not USE_JINJA and test_ext.endswith("j2"):
+        return True, "no jinja"
+
+    return False, ""
+
+
+def should_skip_disabled_test(name: str, suite_dir: str) -> Tuple[bool, str]:
+    disabled_file = os.path.join(suite_dir, name) + '.disabled'
+
+    if os.path.exists(disabled_file) and not args.disabled:
+        return True, open(disabled_file, 'r').read()
+
+    return False, ""
+
+
+# should skip test, should increment skipped_total, skip reason
+def should_skip_test(name: str, test_ext: str, suite_dir: str) -> Tuple[bool, bool, str]:
+    should_skip, skip_reason = should_skip_test_by_name(name, test_ext)
+
+    if should_skip:
+        return True, True, skip_reason
+
+    should_skip, skip_reason = should_skip_disabled_test(name, suite_dir)
+
+    return should_skip, False, skip_reason
+
+
+def send_test_name_failed(suite: str, case: str) -> bool:
+    clickhouse_proc = open_client_process(args.client, universal_newlines=True)
+
+    failed_to_check = False
+
+    pid = os.getpid()
+    query = f"SELECT 'Running test {suite}/{case} from pid={pid}';"
+
+    try:
+        clickhouse_proc.communicate((query), timeout=20)
+    except:
+        failed_to_check = True
+
+    return failed_to_check or clickhouse_proc.returncode != 0
+
+
 restarted_tests = []  # (test, stderr)
 
 # def run_tests_array(all_tests, suite, suite_dir, suite_tmp_dir, run_total):
@@ -494,161 +555,135 @@ def run_tests_array(all_tests_with_params):
             else:
                 status = "{0:72}".format(removesuffix(name, ".gen", ".sql") + ": ")
 
-            if args.skip and any(s in name for s in args.skip):
-                status += MSG_SKIPPED + " - skip\n"
-                skipped_total += 1
-            elif not args.zookeeper and ('zookeeper' in name
-                    or 'replica' in name):
-                status += MSG_SKIPPED + " - no zookeeper\n"
-                skipped_total += 1
-            elif not args.shard and ('shard' in name
-                    or 'distributed' in name
-                    or 'global' in name):
-                status += MSG_SKIPPED + " - no shard\n"
-                skipped_total += 1
-            elif not args.no_long and ('long' in name
-                    # Tests for races and deadlocks usually are runned in loop
-                    #  for significant amount of time
-                    or 'deadlock' in name
-                    or 'race' in name):
-                status += MSG_SKIPPED + " - no long\n"
-                skipped_total += 1
-            elif not USE_JINJA and ext.endswith("j2"):
-                status += MSG_SKIPPED + " - no jinja\n"
-                skipped_total += 1
+            skip_test, increment_skip_count, skip_reason = \
+                should_skip_test(name, ext, suite_dir)
+
+            if skip_test:
+                status += MSG_SKIPPED + f" - {skip_reason}\n"
+
+                if increment_skip_count:
+                    skipped_total += 1
             else:
-                disabled_file = os.path.join(suite_dir, name) + '.disabled'
+                if args.testname and send_test_name_failed(suite, case):
+                    failures += 1
+                    print("Server does not respond to health check")
+                    server_died.set()
+                    stop_tests()
+                    break
 
-                if os.path.exists(disabled_file) and not args.disabled:
-                    message = open(disabled_file, 'r').read()
-                    status += MSG_SKIPPED + " - " + message + "\n"
+                file_suffix = ('.' + str(os.getpid())) if is_concurrent and args.test_runs > 1 else ''
+                reference_file = get_reference_file(suite_dir, name)
+                stdout_file = os.path.join(suite_tmp_dir, name) + file_suffix + '.stdout'
+                stderr_file = os.path.join(suite_tmp_dir, name) + file_suffix + '.stderr'
+
+                testcase_args = configure_testcase_args(args, case_file, suite_tmp_dir, stderr_file)
+                proc, stdout, stderr, total_time = run_single_test(testcase_args, ext, server_logs_level, client_options, case_file, stdout_file, stderr_file)
+
+                if proc.returncode is None:
+                    try:
+                        proc.kill()
+                    except OSError as e:
+                        if e.errno != ESRCH:
+                            raise
+
+                    failures += 1
+                    status += MSG_FAIL
+                    status += print_test_time(total_time)
+                    status += " - Timeout!\n"
+                    if stderr:
+                        status += stderr
+                    status += 'Database: ' + testcase_args.testcase_database
                 else:
-                    if args.testname:
-                        clickhouse_proc = Popen(shlex.split(args.client), stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-                        failed_to_check = False
-                        try:
-                            clickhouse_proc.communicate(("SELECT 'Running test {suite}/{case} from pid={pid}';".format(pid = os.getpid(), case = case, suite = suite)), timeout=20)
-                        except:
-                            failed_to_check = True
-
-                        if failed_to_check or clickhouse_proc.returncode != 0:
-                            failures += 1
-                            print("Server does not respond to health check")
-                            server_died.set()
-                            stop_tests()
+                    counter = 1
+                    while need_retry(stdout, stderr):
+                        restarted_tests.append((case_file, stderr))
+                        testcase_args = configure_testcase_args(args, case_file, suite_tmp_dir, stderr_file)
+                        proc, stdout, stderr, total_time = run_single_test(testcase_args, ext, server_logs_level, client_options, case_file, stdout_file, stderr_file)
+                        sleep(2**counter)
+                        counter += 1
+                        if MAX_RETRIES < counter:
+                            if args.replicated_database:
+                                if DISTRIBUTED_DDL_TIMEOUT_MSG in stderr:
+                                    server_died.set()
                             break
 
-                    file_suffix = ('.' + str(os.getpid())) if is_concurrent and args.test_runs > 1 else ''
-                    reference_file = get_reference_file(suite_dir, name)
-                    stdout_file = os.path.join(suite_tmp_dir, name) + file_suffix + '.stdout'
-                    stderr_file = os.path.join(suite_tmp_dir, name) + file_suffix + '.stderr'
-
-                    testcase_args = configure_testcase_args(args, case_file, suite_tmp_dir, stderr_file)
-                    proc, stdout, stderr, total_time = run_single_test(testcase_args, ext, server_logs_level, client_options, case_file, stdout_file, stderr_file)
-
-                    if proc.returncode is None:
-                        try:
-                            proc.kill()
-                        except OSError as e:
-                            if e.errno != ESRCH:
-                                raise
-
+                    if proc.returncode != 0:
                         failures += 1
+                        failures_chain += 1
                         status += MSG_FAIL
                         status += print_test_time(total_time)
-                        status += " - Timeout!\n"
+                        status += ' - return code {}\n'.format(proc.returncode)
+
                         if stderr:
                             status += stderr
+
+                        # Stop on fatal errors like segmentation fault. They are sent to client via logs.
+                        if ' <Fatal> ' in stderr:
+                            server_died.set()
+
+                        if testcase_args.stop \
+                            and ('Connection refused' in stderr or 'Attempt to read after eof' in stderr) \
+                            and 'Received exception from server' not in stderr:
+                            server_died.set()
+
+                        if os.path.isfile(stdout_file):
+                            status += ", result:\n\n"
+                            status += '\n'.join(
+                                open(stdout_file).read().split('\n')[:100])
+                            status += '\n'
+
+                        status += 'Database: ' + testcase_args.testcase_database
+
+                    elif stderr:
+                        failures += 1
+                        failures_chain += 1
+                        status += MSG_FAIL
+                        status += print_test_time(total_time)
+                        status += " - having stderror:\n{}\n".format(
+                            '\n'.join(stderr.split('\n')[:100]))
+                        status += 'Database: ' + testcase_args.testcase_database
+                    elif 'Exception' in stdout:
+                        failures += 1
+                        failures_chain += 1
+                        status += MSG_FAIL
+                        status += print_test_time(total_time)
+                        status += " - having exception:\n{}\n".format(
+                            '\n'.join(stdout.split('\n')[:100]))
+                        status += 'Database: ' + testcase_args.testcase_database
+                    elif reference_file is None:
+                        status += MSG_UNKNOWN
+                        status += print_test_time(total_time)
+                        status += " - no reference file\n"
                         status += 'Database: ' + testcase_args.testcase_database
                     else:
-                        counter = 1
-                        while need_retry(stdout, stderr):
-                            restarted_tests.append((case_file, stderr))
-                            testcase_args = configure_testcase_args(args, case_file, suite_tmp_dir, stderr_file)
-                            proc, stdout, stderr, total_time = run_single_test(testcase_args, ext, server_logs_level, client_options, case_file, stdout_file, stderr_file)
-                            sleep(2**counter)
-                            counter += 1
-                            if MAX_RETRIES < counter:
-                                if args.replicated_database:
-                                    if DISTRIBUTED_DDL_TIMEOUT_MSG in stderr:
-                                        server_died.set()
-                                break
+                        result_is_different = subprocess.call(['diff', '-q', reference_file, stdout_file], stdout=PIPE)
 
-                        if proc.returncode != 0:
+                        if result_is_different:
+                            diff = Popen(['diff', '-U', str(testcase_args.unified), reference_file, stdout_file], stdout=PIPE, universal_newlines=True).communicate()[0]
                             failures += 1
-                            failures_chain += 1
                             status += MSG_FAIL
                             status += print_test_time(total_time)
-                            status += ' - return code {}\n'.format(proc.returncode)
-
-                            if stderr:
-                                status += stderr
-
-                            # Stop on fatal errors like segmentation fault. They are sent to client via logs.
-                            if ' <Fatal> ' in stderr:
-                                server_died.set()
-
-                            if testcase_args.stop and ('Connection refused' in stderr or 'Attempt to read after eof' in stderr) and not 'Received exception from server' in stderr:
-                                server_died.set()
-
-                            if os.path.isfile(stdout_file):
-                                status += ", result:\n\n"
-                                status += '\n'.join(
-                                    open(stdout_file).read().split('\n')[:100])
-                                status += '\n'
-
-                            status += 'Database: ' + testcase_args.testcase_database
-
-                        elif stderr:
-                            failures += 1
-                            failures_chain += 1
-                            status += MSG_FAIL
-                            status += print_test_time(total_time)
-                            status += " - having stderror:\n{}\n".format(
-                                '\n'.join(stderr.split('\n')[:100]))
-                            status += 'Database: ' + testcase_args.testcase_database
-                        elif 'Exception' in stdout:
-                            failures += 1
-                            failures_chain += 1
-                            status += MSG_FAIL
-                            status += print_test_time(total_time)
-                            status += " - having exception:\n{}\n".format(
-                                '\n'.join(stdout.split('\n')[:100]))
-                            status += 'Database: ' + testcase_args.testcase_database
-                        elif reference_file is None:
-                            status += MSG_UNKNOWN
-                            status += print_test_time(total_time)
-                            status += " - no reference file\n"
+                            status += " - result differs with reference:\n{}\n".format(diff)
                             status += 'Database: ' + testcase_args.testcase_database
                         else:
-                            result_is_different = subprocess.call(['diff', '-q', reference_file, stdout_file], stdout=PIPE)
-
-                            if result_is_different:
-                                diff = Popen(['diff', '-U', str(testcase_args.unified), reference_file, stdout_file], stdout=PIPE, universal_newlines=True).communicate()[0]
+                            if testcase_args.test_runs > 1 and total_time > 60 and 'long' not in name:
+                                # We're in Flaky Check mode, check the run time as well while we're at it.
                                 failures += 1
+                                failures_chain += 1
                                 status += MSG_FAIL
                                 status += print_test_time(total_time)
-                                status += " - result differs with reference:\n{}\n".format(diff)
+                                status += " - Test runs too long (> 60s). Make it faster.\n"
                                 status += 'Database: ' + testcase_args.testcase_database
                             else:
-                                if testcase_args.test_runs > 1 and total_time > 60 and 'long' not in name:
-                                    # We're in Flaky Check mode, check the run time as well while we're at it.
-                                    failures += 1
-                                    failures_chain += 1
-                                    status += MSG_FAIL
-                                    status += print_test_time(total_time)
-                                    status += " - Test runs too long (> 60s). Make it faster.\n"
-                                    status += 'Database: ' + testcase_args.testcase_database
-                                else:
-                                    passed_total += 1
-                                    failures_chain = 0
-                                    status += MSG_OK
-                                    status += print_test_time(total_time)
-                                    status += "\n"
-                                    if os.path.exists(stdout_file):
-                                        os.remove(stdout_file)
-                                    if os.path.exists(stderr_file):
-                                        os.remove(stderr_file)
+                                passed_total += 1
+                                failures_chain = 0
+                                status += MSG_OK
+                                status += print_test_time(total_time)
+                                status += "\n"
+                                if os.path.exists(stdout_file):
+                                    os.remove(stdout_file)
+                                if os.path.exists(stderr_file):
+                                    os.remove(stderr_file)
 
             if status and not status.endswith('\n'):
                 status += '\n'
@@ -709,27 +744,30 @@ def check_server_started(client, retry_count):
 
         if clickhouse_proc.returncode == 210:
             # Connection refused, retry
-            print('.', end = '')
+            print('.', end='')
             sys.stdout.flush()
             retry_count -= 1
             sleep(0.5)
             continue
 
-        # Other kind of error, fail.
-        print('')
-        print("Client invocation failed with code ", clickhouse_proc.returncode, ": ")
+        # FIXME Some old comment, maybe now CH supports Python3 ?
         # We can't print this, because for some reason this is python 2,
         # and args appeared in 3.3. To hell with it.
         # print(''.join(clickhouse_proc.args))
-        print("stdout: ")
-        print(stdout)
-        print("stderr: ")
-        print(stderr)
+
+        # Other kind of error, fail.
+
+        code: int = clickhouse_proc.returncode
+
+        print(f"\nClient invocation failed with code {code}:\n\
+            stdout: {stdout}\n\
+            stderr: {stderr}")
+
         sys.stdout.flush()
+
         return False
 
-    print('')
-    print('All connection tries failed')
+    print('\nAll connection tries failed')
     sys.stdout.flush()
 
     return False
@@ -928,7 +966,7 @@ def render_test_template(j2env, suite_dir, test_name):
 
     test_base_name = removesuffix(test_name, ".sql.j2", ".sql")
 
-    reference_file_name = test_base_name  + ".reference.j2"
+    reference_file_name = test_base_name + ".reference.j2"
     reference_file_path = os.path.join(suite_dir, reference_file_name)
     if os.path.isfile(reference_file_path):
         tpl = j2env.get_template(reference_file_name)
@@ -1015,7 +1053,7 @@ def main(args):
     if args.use_skip_list:
         tests_to_skip_from_list = collect_tests_to_skip(args.skip_list_path, build_flags)
     else:
-        tests_to_skip_from_list = set([])
+        tests_to_skip_from_list = set()
 
     if args.skip:
         args.skip = set(args.skip) | tests_to_skip_from_list
@@ -1030,7 +1068,7 @@ def main(args):
 
     # Keep same default values as in queries/shell_config.sh
     os.environ.setdefault("CLICKHOUSE_BINARY", args.binary)
-    #os.environ.setdefault("CLICKHOUSE_CLIENT", args.client)
+    # os.environ.setdefault("CLICKHOUSE_CLIENT", args.client)
     os.environ.setdefault("CLICKHOUSE_CONFIG", args.configserver)
 
     if args.configclient:
@@ -1079,7 +1117,7 @@ def main(args):
 
         suite_dir = os.path.join(base_dir, suite)
         suite_re_obj = re.search('^[0-9]+_(.*)$', suite)
-        if not suite_re_obj: #skip .gitignore and so on
+        if not suite_re_obj:  # skip .gitignore and so on
             continue
 
         suite_tmp_dir = os.path.join(tmp_dir, suite)
@@ -1147,6 +1185,8 @@ def main(args):
     if total_tests_run == 0:
         print("No tests were run.")
         sys.exit(1)
+    else:
+        print("All tests have finished.")
 
     sys.exit(exit_code.value)
 
@@ -1183,18 +1223,23 @@ def get_additional_client_options_url(args):
 
 def collect_tests_to_skip(skip_list_path, build_flags):
     result = set([])
+
     if not os.path.exists(skip_list_path):
         return result
 
     with open(skip_list_path, 'r') as skip_list_file:
         content = skip_list_file.read()
+
         # allows to have comments in skip_list.json
         skip_dict = json.loads(json_minify(content))
+
         for build_flag in build_flags:
             result |= set(skip_dict[build_flag])
 
-    if len(result) > 0:
-        print("Found file with skip-list {}, {} test will be skipped".format(skip_list_path, len(result)))
+    count = len(result)
+
+    if count > 0:
+        print(f"Found file with skip-list {skip_list_path}, {count} test will be skipped")
 
     return result
 
@@ -1221,7 +1266,7 @@ if __name__ == '__main__':
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGHUP, signal_handler)
 
-    parser=ArgumentParser(description='ClickHouse functional tests')
+    parser = ArgumentParser(description='ClickHouse functional tests')
     parser.add_argument('-q', '--queries', help='Path to queries dir')
     parser.add_argument('--tmp', help='Path to tmp dir')
 
@@ -1233,7 +1278,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--extract_from_config', help='extract-from-config program')
     parser.add_argument('--configclient', help='Client config (if you use not default ports)')
-    parser.add_argument('--configserver', default= '/etc/clickhouse-server/config.xml', help='Preprocessed server config')
+    parser.add_argument('--configserver', default='/etc/clickhouse-server/config.xml', help='Preprocessed server config')
     parser.add_argument('-o', '--output', help='Output xUnit compliant test report directory')
     parser.add_argument('-t', '--timeout', type=int, default=600, help='Timeout for each test case in seconds')
     parser.add_argument('--global_time_limit', type=int, help='Stop if executing more than specified time (after current test finished)')
@@ -1260,15 +1305,15 @@ if __name__ == '__main__':
     parser.add_argument('--no-stateful', action='store_true', help='Disable all stateful tests')
     parser.add_argument('--skip', nargs='+', help="Skip these tests")
     parser.add_argument('--sequential', nargs='+', help="Run these tests sequentially even if --parallel specified")
-    parser.add_argument('--no-long', action='store_false', dest='no_long', help='Do not run long tests')
+    parser.add_argument('--no-long', action='store_true', dest='no_long', help='Do not run long tests')
     parser.add_argument('--client-option', nargs='+', help='Specify additional client argument')
     parser.add_argument('--print-time', action='store_true', dest='print_time', help='Print test time')
 
-    group=parser.add_mutually_exclusive_group(required=False)
+    group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument('--zookeeper', action='store_true', default=None, dest='zookeeper', help='Run zookeeper related tests')
     group.add_argument('--no-zookeeper', action='store_false', default=None, dest='zookeeper', help='Do not run zookeeper related tests')
 
-    group=parser.add_mutually_exclusive_group(required=False)
+    group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument('--shard', action='store_true', default=None, dest='shard', help='Run sharding related tests (required to clickhouse-server listen 127.0.0.2 127.0.0.3)')
     group.add_argument('--no-shard', action='store_false', default=None, dest='shard', help='Do not run shard related tests')
 
@@ -1284,7 +1329,7 @@ if __name__ == '__main__':
 
     if not os.path.isdir(args.queries):
         # If we're running from the repo
-        args.queries = os.path.join(os.path.dirname(os.path.abspath( __file__ )), 'queries')
+        args.queries = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'queries')
 
     if not os.path.isdir(args.queries):
         # Next we're going to try some system directories, don't write 'stdout' files into them.
@@ -1330,7 +1375,7 @@ if __name__ == '__main__':
         if os.getenv("CLICKHOUSE_HOST"):
             args.client += ' --host=' + os.getenv("CLICKHOUSE_HOST")
 
-        args.tcp_port = int(os.getenv("CLICKHOUSE_PORT_TCP", 9000))
+        args.tcp_port = int(os.getenv("CLICKHOUSE_PORT_TCP", "9000"))
         args.client += f" --port={args.tcp_port}"
 
         if os.getenv("CLICKHOUSE_DATABASE"):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
Not for changelog (changelog entry is not required)

- Lowering down pylint warnings (260 -> 180, only "line too long" or "statement too complex" left).
- Multiple typos.
- Using (multi line) formatted string literals instead of `.format()`.
- Extracted subprocess opening calls to a separate function.
- Extracted stack traces printing function.
- Extracted test skipping functions (bonus: -1 nest level).
- Extracted test suites and tests inside a suite sorting key functions.
- Setting ClickHouse default TCP port in main function.
- Added spaces where necessary.