### PR TITLE
Fix WithMergeableStateAfterAggregationAndLimit with LIMIT BY and LIMIT OFFSET

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1327,15 +1327,20 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, const BlockInpu
             }
 
             bool apply_limit = options.to_stage != QueryProcessingStage::WithMergeableStateAfterAggregation;
+            bool apply_prelimit = apply_limit &&
+                                  query.limitLength() && !query.limit_with_ties &&
+                                  !hasWithTotalsInAnySubqueryInFromClause(query) &&
+                                  !query.arrayJoinExpressionList() &&
+                                  !query.distinct &&
+                                  !expressions.hasLimitBy() &&
+                                  !settings.extremes &&
+                                  !has_withfill;
             bool apply_offset = options.to_stage != QueryProcessingStage::WithMergeableStateAfterAggregationAndLimit;
-            bool has_prelimit = false;
-            if (apply_limit &&
-                query.limitLength() && !query.limit_with_ties && !hasWithTotalsInAnySubqueryInFromClause(query) &&
-                !query.arrayJoinExpressionList() && !query.distinct && !expressions.hasLimitBy() && !settings.extremes &&
-                !has_withfill)
+            bool limit_applied = false;
+            if (apply_prelimit)
             {
                 executePreLimit(query_plan, /* do_not_skip_offset= */!apply_offset);
-                has_prelimit = true;
+                limit_applied = true;
             }
 
             /** If there was more than one stream,
@@ -1354,10 +1359,10 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, const BlockInpu
 
             /// If we have 'WITH TIES', we need execute limit before projection,
             /// because in that case columns from 'ORDER BY' are used.
-            if (query.limit_with_ties)
+            if (query.limit_with_ties && apply_offset)
             {
                 executeLimit(query_plan);
-                has_prelimit = true;
+                limit_applied = true;
             }
 
             /// Projection not be done on the shards, since then initiator will not find column in blocks.
@@ -1372,7 +1377,12 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, const BlockInpu
             executeExtremes(query_plan);
 
             /// Limit is no longer needed if there is prelimit.
-            if (apply_limit && !has_prelimit)
+            ///
+            /// NOTE: that LIMIT cannot be applied of OFFSET should not be applied,
+            /// since LIMIT will apply OFFSET too.
+            /// This is the case for various optimizations for distributed queries,
+            /// and when LIMIT cannot be applied it will be applied on the initiator anyway.
+            if (apply_limit && !limit_applied && apply_offset)
                 executeLimit(query_plan);
 
             if (apply_offset)

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2429,7 +2429,10 @@ void InterpreterSelectQuery::executePreLimit(QueryPlan & query_plan, bool do_not
         }
 
         auto limit = std::make_unique<LimitStep>(query_plan.getCurrentDataStream(), limit_length, limit_offset);
-        limit->setStepDescription("preliminary LIMIT");
+        if (do_not_skip_offset)
+            limit->setStepDescription("preliminary LIMIT (with OFFSET)");
+        else
+            limit->setStepDescription("preliminary LIMIT (without OFFSET)");
         query_plan.addStep(std::move(limit));
     }
 }

--- a/tests/queries/0_stateless/01562_optimize_monotonous_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01562_optimize_monotonous_functions_in_order_by.reference
@@ -5,7 +5,7 @@ FROM test_order_by
 ORDER BY timestamp ASC
 LIMIT 10
 Expression (Projection)
-  Limit (preliminary LIMIT)
+  Limit (preliminary LIMIT (without OFFSET))
     MergingSorted (Merge sorted streams for ORDER BY)
       MergeSorting (Merge sorted blocks for ORDER BY)
         PartialSorting (Sort each block for ORDER BY)
@@ -19,7 +19,7 @@ FROM test_order_by
 ORDER BY toDate(timestamp) ASC
 LIMIT 10
 Expression (Projection)
-  Limit (preliminary LIMIT)
+  Limit (preliminary LIMIT (without OFFSET))
     FinishSorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
@@ -33,7 +33,7 @@ ORDER BY
     timestamp ASC
 LIMIT 10
 Expression (Projection)
-  Limit (preliminary LIMIT)
+  Limit (preliminary LIMIT (without OFFSET))
     FinishSorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)

--- a/tests/queries/0_stateless/01576_alias_column_rewrite.reference
+++ b/tests/queries/0_stateless/01576_alias_column_rewrite.reference
@@ -22,7 +22,7 @@ lambda
 1
 optimize_read_in_order
 Expression (Projection)
-  Limit (preliminary LIMIT)
+  Limit (preliminary LIMIT (without OFFSET))
     MergingSorted (Merge sorted streams for ORDER BY)
       MergeSorting (Merge sorted blocks for ORDER BY)
         PartialSorting (Sort each block for ORDER BY)
@@ -30,13 +30,13 @@ Expression (Projection)
             SettingQuotaAndLimits (Set limits and quota after reading from storage)
               ReadFromMergeTree
 Expression (Projection)
-  Limit (preliminary LIMIT)
+  Limit (preliminary LIMIT (without OFFSET))
     FinishSorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
           ReadFromMergeTree
 Expression (Projection)
-  Limit (preliminary LIMIT)
+  Limit (preliminary LIMIT (without OFFSET))
     FinishSorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)

--- a/tests/queries/0_stateless/02003_WithMergeableStateAfterAggregationAndLimit_LIMIT_BY_LIMIT_OFFSET.reference
+++ b/tests/queries/0_stateless/02003_WithMergeableStateAfterAggregationAndLimit_LIMIT_BY_LIMIT_OFFSET.reference
@@ -1,0 +1,36 @@
+-- { echo }
+SELECT *
+FROM remote('127.{1,2}', view(
+    SELECT *
+    FROM numbers(10)
+), number)
+GROUP BY number
+ORDER BY number ASC
+LIMIT 1 BY number
+LIMIT 5, 5
+SETTINGS
+    optimize_skip_unused_shards = 1,
+    optimize_distributed_group_by_sharding_key = 1,
+    distributed_push_down_limit=1;
+5
+6
+7
+8
+9
+SELECT *
+FROM remote('127.{1,2}', view(
+    SELECT *
+    FROM numbers(10)
+), number)
+GROUP BY number
+ORDER BY number ASC
+LIMIT 1 BY number
+LIMIT 5, 5
+SETTINGS
+    distributed_group_by_no_merge=2,
+    distributed_push_down_limit=1;
+5
+6
+7
+8
+9

--- a/tests/queries/0_stateless/02003_WithMergeableStateAfterAggregationAndLimit_LIMIT_BY_LIMIT_OFFSET.sql
+++ b/tests/queries/0_stateless/02003_WithMergeableStateAfterAggregationAndLimit_LIMIT_BY_LIMIT_OFFSET.sql
@@ -1,0 +1,26 @@
+-- { echo }
+SELECT *
+FROM remote('127.{1,2}', view(
+    SELECT *
+    FROM numbers(10)
+), number)
+GROUP BY number
+ORDER BY number ASC
+LIMIT 1 BY number
+LIMIT 5, 5
+SETTINGS
+    optimize_skip_unused_shards = 1,
+    optimize_distributed_group_by_sharding_key = 1,
+    distributed_push_down_limit=1;
+SELECT *
+FROM remote('127.{1,2}', view(
+    SELECT *
+    FROM numbers(10)
+), number)
+GROUP BY number
+ORDER BY number ASC
+LIMIT 1 BY number
+LIMIT 5, 5
+SETTINGS
+    distributed_group_by_no_merge=2,
+    distributed_push_down_limit=1;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `distributed_group_by_no_merge=2`+`distributed_push_down_limit=1` or `optimize_distributed_group_by_sharding_key=1` with `LIMIT BY` and `LIMIT OFFSET`

Detailed description / Documentation draft:
In case of LIMIT BY, pre LIMIT cannot be applied (that is done on the
shard before), and hence shard applies regular LIMIT, but it goes with
applying OFFSET, and also the initiator will do apply OFFSET too.