### PR TITLE
Improve kafka integration test error messages

### DIFF
--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -277,7 +277,7 @@ if __name__ == "__main__":
         --volume={base_cfg}:/clickhouse-config --volume={cases_dir}:/ClickHouse/tests/integration \
         --volume={src_dir}/Server/grpc_protos:/ClickHouse/src/Server/grpc_protos \
         {dockerd_internal_volume} -e DOCKER_CLIENT_TIMEOUT=300 -e COMPOSE_HTTP_TIMEOUT=600 \
-        {env_tags} {env_cleanup} -e PYTEST_OPTS='{parallel} {opts} {tests_list}' {img} {command}".format(
+        {env_tags} {env_cleanup} -e PYTEST_OPTS='{parallel} {opts} {tests_list} -vvv' {img} {command}".format(
         net=net,
         tty=tty,
         bin=args.binary,

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -2,7 +2,6 @@ import json
 import os.path as p
 import random
 import socket
-import subprocess
 import threading
 import time
 import logging
@@ -181,32 +180,6 @@ def avro_confluent_message(schema_registry_client, value):
     })
     return serializer.encode_record_with_schema('test_subject', schema, value)
 
-# Since everything is async and shaky when receiving messages from Kafka,
-# we may want to try and check results multiple times in a loop.
-def kafka_check_result(result, check=False, ref_file='test_kafka_json.reference'):
-    fpath = p.join(p.dirname(__file__), ref_file)
-    with open(fpath) as reference:
-        if check:
-            assert TSV(result) == TSV(reference)
-        else:
-            return TSV(result) == TSV(reference)
-
-def describe_consumer_group(kafka_cluster, name):
-    admin_client = KafkaAdminClient(bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port))
-    consumer_groups = admin_client.describe_consumer_groups([name])
-    res = []
-    for member in consumer_groups[0].members:
-        member_info = {}
-        member_info['member_id'] = member.member_id
-        member_info['client_id'] = member.client_id
-        member_info['client_host'] = member.client_host
-        member_topics_assignment = []
-        for (topic, partitions) in member.member_assignment.assignment:
-            member_topics_assignment.append({'topic': topic, 'partitions': partitions})
-        member_info['assignment'] = member_topics_assignment
-        res.append(member_info)
-    return res
-
 # Fixtures
 
 @pytest.fixture(scope="module")
@@ -262,7 +235,7 @@ kafka_topic_old	old
 
     kafka_check_result(result, True)
 
-    members = describe_consumer_group('old')
+    members = describe_consumer_group(kafka_cluster, 'old')
     assert members[0]['client_id'] == 'ClickHouse-instance-test-kafka'
     # text_desc = kafka_cluster.exec_in_container(kafka_cluster.get_container_id('kafka1'),"kafka-consumer-groups --bootstrap-server localhost:9092 --describe --members --group old --verbose"))
 
@@ -302,7 +275,7 @@ def test_kafka_settings_new_syntax(kafka_cluster):
 
     kafka_check_result(result, True)
 
-    members = describe_consumer_group('new')
+    members = describe_consumer_group(kafka_cluster, 'new')
     assert members[0]['client_id'] == 'instance test 1234'
 
 
@@ -734,82 +707,6 @@ def kafka_setup_teardown():
 
 
 # Tests
-
-def test_kafka_settings_old_syntax(kafka_cluster):
-    assert TSV(instance.query("SELECT * FROM system.macros WHERE macro like 'kafka%' ORDER BY macro",
-                              ignore_error=True)) == TSV('''kafka_broker	kafka1
-kafka_client_id	instance
-kafka_format_json_each_row	JSONEachRow
-kafka_group_name_new	new
-kafka_group_name_old	old
-kafka_topic_new	new
-kafka_topic_old	old
-''')
-
-    instance.query('''
-        CREATE TABLE test.kafka (key UInt64, value UInt64)
-            ENGINE = Kafka('{kafka_broker}:19092', '{kafka_topic_old}', '{kafka_group_name_old}', '{kafka_format_json_each_row}', '\\n');
-        ''')
-
-    # Don't insert malformed messages since old settings syntax
-    # doesn't support skipping of broken messages.
-    messages = []
-    for i in range(50):
-        messages.append(json.dumps({'key': i, 'value': i}))
-    kafka_produce(kafka_cluster, 'old', messages)
-
-    result = ''
-    while True:
-        result += instance.query('SELECT * FROM test.kafka', ignore_error=True)
-        if kafka_check_result(result):
-            break
-
-    kafka_check_result(result, True)
-
-    members = describe_consumer_group(kafka_cluster, 'old')
-    assert members[0]['client_id'] == 'ClickHouse-instance-test-kafka'
-    # text_desc = kafka_cluster.exec_in_container(kafka_cluster.get_container_id('kafka1'),"kafka-consumer-groups --bootstrap-server localhost:{} --describe --members --group old --verbose".format(cluster.kafka_port)))
-
-
-def test_kafka_settings_new_syntax(kafka_cluster):
-    instance.query('''
-        CREATE TABLE test.kafka (key UInt64, value UInt64)
-            ENGINE = Kafka
-            SETTINGS kafka_broker_list = '{kafka_broker}:19092',
-                     kafka_topic_list = '{kafka_topic_new}',
-                     kafka_group_name = '{kafka_group_name_new}',
-                     kafka_format = '{kafka_format_json_each_row}',
-                     kafka_row_delimiter = '\\n',
-                     kafka_client_id = '{kafka_client_id} test 1234',
-                     kafka_skip_broken_messages = 1;
-        ''')
-
-    messages = []
-    for i in range(25):
-        messages.append(json.dumps({'key': i, 'value': i}))
-    kafka_produce(kafka_cluster, 'new', messages)
-
-    # Insert couple of malformed messages.
-    kafka_produce(kafka_cluster, 'new', ['}{very_broken_message,'])
-    kafka_produce(kafka_cluster, 'new', ['}another{very_broken_message,'])
-
-    messages = []
-    for i in range(25, 50):
-        messages.append(json.dumps({'key': i, 'value': i}))
-    kafka_produce(kafka_cluster, 'new', messages)
-
-    result = ''
-    while True:
-        result += instance.query('SELECT * FROM test.kafka', ignore_error=True)
-        if kafka_check_result(result):
-            break
-
-    kafka_check_result(result, True)
-
-    members = describe_consumer_group(kafka_cluster, 'new')
-    assert members[0]['client_id'] == 'instance test 1234'
-
-
 def test_kafka_issue11308(kafka_cluster):
     # Check that matview does respect Kafka SETTINGS
     kafka_produce(kafka_cluster, 'issue11308', ['{"t": 123, "e": {"x": "woof"} }', '{"t": 123, "e": {"x": "woof"} }',


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

I ocasionally see errors in these 2 tests:
* test_kafka_consumer_hang2
* test_kafka_virtual_columns_with_materialized_view

I don't think this is going to fix anything by itself but having clearer code and errors should help debug the issues in the future:
* Add -vvv to pytest so it doesn't cut short error messages (like the ones in assert)
* Removes duplicated functions (kafka_check_result, describe_consumer_group). Some minor differences in the 2 implementations of describe_consumer_group
* Removes duplicated tests (test_kafka_settings_old_syntax and test_kafka_settings_new_syntax). Both were found twice with the same exact code.
* In test_kafka_virtual_columns_with_materialized_view, set a max amount of requests (instead of repeating the same for 1800s) and show a proper error if the result is different from the expected. Also, enforce the order the output: it should be the same, but better to be safe.