### PR TITLE
Improve 00738_lock_for_inner_table stability

### DIFF
--- a/tests/queries/0_stateless/00738_lock_for_inner_table.sh
+++ b/tests/queries/0_stateless/00738_lock_for_inner_table.sh
@@ -14,7 +14,8 @@ DROP TABLE IF EXISTS mv SYNC;
 -- create table with fsync and 20 partitions for slower INSERT
 -- (since increasing number of records will make it significantly slower in debug build, but not in release)
 CREATE TABLE tab_00738(a Int) ENGINE = MergeTree() ORDER BY a PARTITION BY a%20 SETTINGS fsync_after_insert=1;
-CREATE MATERIALIZED VIEW mv UUID '$uuid' ENGINE = Log AS SELECT a FROM tab_00738;" | ${CLICKHOUSE_CLIENT} -n
+-- The matview will take at least 2 seconds to be finished (10000000 * 0.0000002)
+CREATE MATERIALIZED VIEW mv UUID '$uuid' ENGINE = Log AS SELECT sleepEachRow(0.0000002) FROM tab_00738;" | ${CLICKHOUSE_CLIENT} -n
 
 ${CLICKHOUSE_CLIENT} --query_id insert_$CLICKHOUSE_DATABASE --query "INSERT INTO tab_00738 SELECT number FROM numbers(10000000)" &
 

--- a/tests/queries/0_stateless/00738_lock_for_inner_table.sh
+++ b/tests/queries/0_stateless/00738_lock_for_inner_table.sh
@@ -11,9 +11,7 @@ uuid=$(${CLICKHOUSE_CLIENT} --query "SELECT reinterpretAsUUID(currentDatabase())
 
 echo "DROP TABLE IF EXISTS tab_00738 SYNC;
 DROP TABLE IF EXISTS mv SYNC;
--- create table with fsync and 20 partitions for slower INSERT
--- (since increasing number of records will make it significantly slower in debug build, but not in release)
-CREATE TABLE tab_00738(a Int) ENGINE = MergeTree() ORDER BY a PARTITION BY a%20 SETTINGS fsync_after_insert=1;
+CREATE TABLE tab_00738(a Int) ENGINE = MergeTree() ORDER BY a;
 -- The matview will take at least 2 seconds to be finished (10000000 * 0.0000002)
 CREATE MATERIALIZED VIEW mv UUID '$uuid' ENGINE = Log AS SELECT sleepEachRow(0.0000002) FROM tab_00738;" | ${CLICKHOUSE_CLIENT} -n
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

The test would fail with fast machines / drives:

```
00738_lock_for_inner_table:                                             [ FAIL ] - return code 2
, result:
```

The issue is that the test waited for 0.5 seconds to make sure that the MV had started (and locked the inner table) but that might be too long and the query could have ended by then. For example:

```
Row 2:
──────
type:                                  QueryFinish
event_date:                            2021-08-06
event_time:                            2021-08-06 16:10:49
event_time_microseconds:               2021-08-06 16:10:49.088122
query_start_time:                      2021-08-06 16:10:48
query_start_time_microseconds:         2021-08-06 16:10:48.542805
query_duration_ms:                     545
read_rows:                             10485450
read_bytes:                            83883600
written_rows:                          20000000
written_bytes:                         80000000
result_rows:                           0
result_bytes:                          0
memory_usage:                          23177710
current_database:                      test_phqo8f
query:                                 INSERT INTO tab_00738 SELECT number FROM numbers(10000000)
```

To avoid this, force the MV to take at least a couple of seconds.