### PR TITLE
Fix 01300_client_save_history_when_terminated_long

### DIFF
--- a/tests/queries/0_stateless/01300_client_save_history_when_terminated_long.expect
+++ b/tests/queries/0_stateless/01300_client_save_history_when_terminated_long.expect
@@ -27,7 +27,7 @@ close
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT"
 expect ":) "
 send -- "\[A"
-expect "SELECT 'for the history'"
+expect "for the history"
 
 # Will check that Ctrl+C clears current line.
 send -- "\3"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

It was broken because of colored output

Original code:
```
# Run client one more time and press "up" to see the last recorded query
spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT"
expect ":) "
send -- "\[A"
expect "SELECT 'for the history'"
```


The error was like this:
```
expect: does "\u001b[23GSELECT \u001b[0;22;36m'for the history'\u001b[0m\u001b[J\u001b[47G" (spawn_id exp7) match glob pattern "SELECT 'for the history'"? no
```

So the problem was that it wasn't playing nicely with colored output in the client.