### PR TITLE
Less clock_gettime calls

### DIFF
--- a/src/DataStreams/ExecutionSpeedLimits.h
+++ b/src/DataStreams/ExecutionSpeedLimits.h
@@ -3,6 +3,7 @@
 #include <Poco/Timespan.h>
 #include <common/types.h>
 #include <DataStreams/SizeLimits.h>
+#include <Common/Stopwatch.h>
 
 namespace DB
 {
@@ -25,7 +26,7 @@ public:
     /// Pause execution in case if speed limits were exceeded.
     void throttle(size_t read_rows, size_t read_bytes, size_t total_rows_to_read, UInt64 total_elapsed_microseconds) const;
 
-    bool checkTimeLimit(UInt64 elapsed_ns, OverflowMode overflow_mode) const;
+    bool checkTimeLimit(const Stopwatch & stopwatch, OverflowMode overflow_mode) const;
 };
 
 }

--- a/src/DataStreams/IBlockInputStream.cpp
+++ b/src/DataStreams/IBlockInputStream.cpp
@@ -201,7 +201,7 @@ void IBlockInputStream::updateExtremes(Block & block)
 
 bool IBlockInputStream::checkTimeLimit() const
 {
-    return limits.speed_limits.checkTimeLimit(info.total_stopwatch.elapsed(), limits.timeout_overflow_mode);
+    return limits.speed_limits.checkTimeLimit(info.total_stopwatch, limits.timeout_overflow_mode);
 }
 
 

--- a/src/Processors/Sources/SourceWithProgress.cpp
+++ b/src/Processors/Sources/SourceWithProgress.cpp
@@ -49,7 +49,7 @@ void SourceWithProgress::setProcessListElement(QueryStatus * elem)
 
 void SourceWithProgress::work()
 {
-    if (!limits.speed_limits.checkTimeLimit(total_stopwatch.elapsed(), limits.timeout_overflow_mode))
+    if (!limits.speed_limits.checkTimeLimit(total_stopwatch, limits.timeout_overflow_mode))
     {
         cancel();
     }

--- a/src/Processors/Transforms/LimitsCheckingTransform.cpp
+++ b/src/Processors/Transforms/LimitsCheckingTransform.cpp
@@ -32,7 +32,7 @@ void LimitsCheckingTransform::transform(Chunk & chunk)
         info.started = true;
     }
 
-    if (!limits.speed_limits.checkTimeLimit(info.total_stopwatch.elapsed(), limits.timeout_overflow_mode))
+    if (!limits.speed_limits.checkTimeLimit(info.total_stopwatch, limits.timeout_overflow_mode))
     {
         stopReading();
         return;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve the performance of fast queries when `max_execution_time=0` by reducing the number of `clock_gettime` system calls.

Detailed description / Documentation draft:

```
-- before 
SELECT count() FROM zeros(100000000000)

┌──────count()─┐
│ 100000000000 │
└──────────────┘

1 rows in set. Elapsed: 4.933 sec. Processed 100.00 billion rows, 100.00 GB (20.27 billion rows/s., 20.27 GB/s.)

-- after 
select count() from zeros(100000000000);

┌──────count()─┐
│ 100000000000 │
└──────────────┘

1 rows in set. Elapsed: 3.964 sec. Processed 100.00 billion rows, 100.00 GB (25.23 billion rows/s., 25.23 GB/s.)

```