### PR TITLE
Add setting to log formatted query into system.query_log

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -169,6 +169,7 @@ class IColumn;
     M(Int64, os_thread_priority, 0, "If non zero - set corresponding 'nice' value for query processing threads. Can be used to adjust query priority for OS scheduler.", 0) \
     \
     M(Bool, log_queries, 1, "Log requests and write the log to the system table.", 0) \
+    M(Bool, log_formatted_queries, 0, "Log formatted queries and write the log to the system table.", 0) \
     M(LogQueriesType, log_queries_min_type, QueryLogElementType::QUERY_START, "Minimal type in query_log to log, possible values (from low to high): QUERY_START, QUERY_FINISH, EXCEPTION_BEFORE_START, EXCEPTION_WHILE_PROCESSING.", 0) \
     M(Milliseconds, log_queries_min_query_duration_ms, 0, "Minimal time for the query to run, to get to the query_log/query_thread_log.", 0) \
     M(UInt64, log_queries_cut_to_length, 100000, "If query length is greater than specified threshold (in bytes), then cut query when writing to query log. Also limit length of printed query in ordinary text log.", 0) \

--- a/src/Interpreters/QueryLog.cpp
+++ b/src/Interpreters/QueryLog.cpp
@@ -57,6 +57,7 @@ NamesAndTypesList QueryLogElement::getNamesAndTypes()
 
         {"current_database", std::make_shared<DataTypeString>()},
         {"query", std::make_shared<DataTypeString>()},
+        {"formatted_query", std::make_shared<DataTypeString>()},
         {"normalized_query_hash", std::make_shared<DataTypeUInt64>()},
         {"query_kind", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
         {"databases", std::make_shared<DataTypeArray>(
@@ -151,6 +152,7 @@ void QueryLogElement::appendToBlock(MutableColumns & columns) const
 
     columns[i++]->insertData(current_database.data(), current_database.size());
     columns[i++]->insertData(query.data(), query.size());
+    columns[i++]->insertData(formatted_query.data(), formatted_query.size());
     columns[i++]->insert(normalized_query_hash);
     columns[i++]->insertData(query_kind.data(), query_kind.size());
 

--- a/src/Interpreters/QueryLog.h
+++ b/src/Interpreters/QueryLog.h
@@ -51,6 +51,7 @@ struct QueryLogElement
 
     String current_database;
     String query;
+    String formatted_query;
     UInt64 normalized_query_hash{};
 
     String query_kind;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -265,7 +265,11 @@ static void onExceptionBeforeStart(const String & query_for_logging, ContextPtr 
 
     // Try log query_kind if ast is valid
     if (ast)
+    {
         elem.query_kind = ast->getQueryKindString();
+        if (settings.log_formatted_queries)
+            elem.formatted_query = queryToString(ast);
+    }
 
     // We don't calculate databases, tables and columns when the query isn't able to start
 
@@ -641,6 +645,8 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 
             elem.current_database = context->getCurrentDatabase();
             elem.query = query_for_logging;
+            if (settings.log_formatted_queries)
+                elem.formatted_query = queryToString(ast);
             elem.normalized_query_hash = normalizedQueryHash<false>(query_for_logging);
 
             elem.client_info = client_info;

--- a/tests/queries/0_stateless/02005_log_formatted_queries.reference
+++ b/tests/queries/0_stateless/02005_log_formatted_queries.reference
@@ -1,0 +1,3 @@
+02005_log_formatted_queries.sql
+select \'02005_log_formatted_queries.sql\' from system.one;	SELECT \'02005_log_formatted_queries.sql\' FROM system.one
+select \'02005_log_formatted_queries.sql\' from system.one;	SELECT \'02005_log_formatted_queries.sql\' FROM system.one

--- a/tests/queries/0_stateless/02005_log_formatted_queries.sql
+++ b/tests/queries/0_stateless/02005_log_formatted_queries.sql
@@ -1,0 +1,5 @@
+set log_formatted_queries = 1;
+
+select '02005_log_formatted_queries.sql' from system.one;
+system flush logs;
+select query, formatted_query from system.query_log where current_database = currentDatabase() and query = 'select \'02005_log_formatted_queries.sql\' from system.one;' and event_date >= yesterday() and event_time > now() - interval 5 minute;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add setting `log_formatted_queries` to log additional formatted query into `system.query_log`. It's useful for normalized query analysis because functions like `normalizeQuery` and `normalizeQueryKeepNames` don't parse/format queries in order to achieve better performance. 

https://github.com/ClickHouse/ClickHouse/issues/27229
https://github.com/ClickHouse/ClickHouse/issues/26877

Detailed description / Documentation draft:
.