### PR TITLE
Do not fail if HTTP port is not set and user tries to send request to TCP port

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -56,7 +56,8 @@ std::string formatHTTPErrorResponse(const Poco::Util::AbstractConfiguration& con
         "Port {} is for clickhouse-client program\r\n",
         config.getString("tcp_port"));
 
-    if (config.has("http_port")) {
+    if (config.has("http_port"))
+    {
         result += fmt::format(
             "You must use port {} for HTTP.\r\n",
             config.getString("http_port"));

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -32,6 +32,7 @@
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <Compression/CompressionFactory.h>
 #include <common/logger_useful.h>
+#include <fmt/format.h>
 
 #include <Processors/Executors/PullingAsyncPipelineExecutor.h>
 
@@ -45,6 +46,26 @@
 
 namespace DB
 {
+
+namespace
+{
+std::string formatHTTPErrorResponse(const Poco::Util::AbstractConfiguration& config)
+{
+    std::string result = fmt::format(
+        "HTTP/1.0 400 Bad Request\r\n\r\n"
+        "Port {} is for clickhouse-client program\r\n",
+        config.getString("tcp_port"));
+
+    if (config.has("http_port")) {
+        result += fmt::format(
+            "You must use port {} for HTTP.\r\n",
+            config.getString("http_port"));
+    }
+
+    return result;
+}
+}
+
 
 namespace ErrorCodes
 {
@@ -922,10 +943,8 @@ void TCPHandler::receiveHello()
           */
         if (packet_type == 'G' || packet_type == 'P')
         {
-            writeString("HTTP/1.0 400 Bad Request\r\n\r\n"
-                "Port " + server.config().getString("tcp_port") + " is for clickhouse-client program.\r\n"
-                "You must use port " + server.config().getString("http_port") + " for HTTP.\r\n",
-                *out);
+            writeString(formatHTTPErrorResponse(server.config()),
+                        *out);
 
             throw Exception("Client has connected to wrong port", ErrorCodes::CLIENT_HAS_CONNECTED_TO_WRONG_PORT);
         }

--- a/tests/integration/test_tcp_handler_http_responses/configs/config.d/http-port-31337.xml
+++ b/tests/integration/test_tcp_handler_http_responses/configs/config.d/http-port-31337.xml
@@ -1,0 +1,3 @@
+<yandex>
+  <http_port replace="replace">31337</http_port>
+</yandex>

--- a/tests/integration/test_tcp_handler_http_responses/configs/config.d/no-http-port.xml
+++ b/tests/integration/test_tcp_handler_http_responses/configs/config.d/no-http-port.xml
@@ -1,0 +1,3 @@
+<yandex>
+    <http_port remove="remove"></http_port>
+</yandex>

--- a/tests/integration/test_tcp_handler_http_responses/test_case.py
+++ b/tests/integration/test_tcp_handler_http_responses/test_case.py
@@ -1,0 +1,42 @@
+"""Test HTTP responses given by the TCP Handler."""
+from pathlib import Path
+import pytest
+from helpers.cluster import ClickHouseCluster
+import requests
+
+cluster = ClickHouseCluster(__file__)
+
+node_with_http = cluster.add_instance(
+    'node_with_http',
+    main_configs=["configs/config.d/http-port-31337.xml"]
+)
+HTTP_PORT = 31337
+
+node_without_http = cluster.add_instance(
+    'node_without_http',
+    main_configs=["configs/config.d/no-http-port.xml"]
+)
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+def test_request_to_http_full_instance(start_cluster):
+    response = requests.get(
+        f'http://{node_with_http.ip_address}:9000'
+    )
+    assert response.status_code == 400
+    assert str(HTTP_PORT) in response.text
+
+def test_request_to_http_less_instance(start_cluster):
+    response = requests.post(
+        f'http://{node_without_http.ip_address}:9000'
+    )
+    assert response.status_code == 400
+    assert str(HTTP_PORT) not in response.text
+    assert "8123"         not in response.text


### PR DESCRIPTION
Fixes #27171 

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Send response with error message if HTTP port is not set and user tries to send HTTP request to TCP port.


Detailed description / Documentation draft:
Users sometimes get the port wrong and send HTTP requests to the TCP port. There TCP server handling code
checks whether it's getting a HTTP request, and if so, will send back a HTTP 400 response telling the user about
their mistake, and recommending them to do the request against the HTTP port. That is, if the HTTP has been set.
The problem is that some users may not have a `http_port` set in their config. This change makes sure that the logic
does not fail in cases that the user does not have a `http_port`.

The change also adds integration test that provide coverage of the logic in both cases: when the user has the `http_port`
set and when they don't. I thought this was the most appropriate kind of test for this change, but let me know if you
want me to test it in some other way.

> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

I think this change doesn't need documentation? It's a cool feature but not something we would advertise to users right?
