### PR TITLE
Accept error code by error name in client test hints

### DIFF
--- a/programs/client/CMakeLists.txt
+++ b/programs/client/CMakeLists.txt
@@ -3,6 +3,7 @@ set (CLICKHOUSE_CLIENT_SOURCES
     ConnectionParameters.cpp
     QueryFuzzer.cpp
     Suggest.cpp
+    TestHint.cpp
 )
 
 set (CLICKHOUSE_CLIENT_LINK

--- a/programs/client/TestHint.cpp
+++ b/programs/client/TestHint.cpp
@@ -8,6 +8,33 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int CANNOT_PARSE_TEXT;
+}
+
+}
+
+namespace
+{
+
+int parseErrorCode(std::stringstream & ss) // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+{
+    using namespace DB;
+
+    int code;
+    ss >> code;
+    if (ss.fail())
+        throw Exception(ErrorCodes::CANNOT_PARSE_TEXT,
+            "Expected integer value for test hint, got: '{}'", ss.str());
+    return code;
+}
+
+}
+
+namespace DB
+{
+
 TestHint::TestHint(bool enabled_, const String & query_)
     : query(query_)
 {
@@ -63,9 +90,9 @@ void TestHint::parse(const String & hint, bool is_leading_hint)
         if (!is_leading_hint)
         {
             if (item == "serverError")
-                ss >> server_error;
+                server_error = parseErrorCode(ss);
             else if (item == "clientError")
-                ss >> client_error;
+                client_error = parseErrorCode(ss);
         }
 
         if (item == "echo")

--- a/programs/client/TestHint.cpp
+++ b/programs/client/TestHint.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <iostream>
 #include <Common/Exception.h>
+#include <Common/ErrorCodes.h>
 #include <Parsers/Lexer.h>
 
 namespace DB
@@ -23,10 +24,18 @@ int parseErrorCode(std::stringstream & ss) // STYLE_CHECK_ALLOW_STD_STRING_STREA
     using namespace DB;
 
     int code;
+    String code_name;
+
     ss >> code;
     if (ss.fail())
-        throw Exception(ErrorCodes::CANNOT_PARSE_TEXT,
-            "Expected integer value for test hint, got: '{}'", ss.str());
+    {
+        ss.clear();
+        ss >> code_name;
+        if (ss.fail())
+            throw Exception(ErrorCodes::CANNOT_PARSE_TEXT,
+                "Cannot parse test hint '{}'", ss.str());
+        return ErrorCodes::getErrorCodeByName(code_name);
+    }
     return code;
 }
 

--- a/programs/client/TestHint.cpp
+++ b/programs/client/TestHint.cpp
@@ -1,0 +1,80 @@
+#include "TestHint.h"
+
+#include <sstream>
+#include <iostream>
+#include <Common/Exception.h>
+#include <Parsers/Lexer.h>
+
+namespace DB
+{
+
+TestHint::TestHint(bool enabled_, const String & query_)
+    : query(query_)
+{
+    if (!enabled_)
+        return;
+
+    // Don't parse error hints in leading comments, because it feels weird.
+    // Leading 'echo' hint is OK.
+    bool is_leading_hint = true;
+
+    Lexer lexer(query.data(), query.data() + query.size());
+
+    for (Token token = lexer.nextToken(); !token.isEnd(); token = lexer.nextToken())
+    {
+        if (token.type != TokenType::Comment
+            && token.type != TokenType::Whitespace)
+        {
+            is_leading_hint = false;
+        }
+        else if (token.type == TokenType::Comment)
+        {
+            String comment(token.begin, token.begin + token.size());
+
+            if (!comment.empty())
+            {
+                size_t pos_start = comment.find('{', 0);
+                if (pos_start != String::npos)
+                {
+                    size_t pos_end = comment.find('}', pos_start);
+                    if (pos_end != String::npos)
+                    {
+                        String hint(comment.begin() + pos_start + 1, comment.begin() + pos_end);
+                        parse(hint, is_leading_hint);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void TestHint::parse(const String & hint, bool is_leading_hint)
+{
+    std::stringstream ss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    ss << hint;
+    String item;
+
+    while (!ss.eof())
+    {
+        ss >> item;
+        if (ss.eof())
+            break;
+
+        if (!is_leading_hint)
+        {
+            if (item == "serverError")
+                ss >> server_error;
+            else if (item == "clientError")
+                ss >> client_error;
+        }
+
+        if (item == "echo")
+            echo.emplace(true);
+        if (item == "echoOn")
+            echo.emplace(true);
+        if (item == "echoOff")
+            echo.emplace(false);
+    }
+}
+
+}

--- a/programs/client/TestHint.h
+++ b/programs/client/TestHint.h
@@ -15,6 +15,10 @@ namespace DB
 ///
 /// - "-- { clientError 20 }" -- in case of you are expecting client error.
 ///
+/// - "-- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }" -- by error name.
+///
+/// - "-- { clientError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }" -- by error name.
+///
 ///   Remember that the client parse the query first (not the server), so for
 ///   example if you are expecting syntax error, then you should use
 ///   clientError not serverError.

--- a/programs/client/TestHint.h
+++ b/programs/client/TestHint.h
@@ -1,11 +1,7 @@
 #pragma once
 
-#include <memory>
-#include <sstream>
-#include <iostream>
+#include <optional>
 #include <Core/Types.h>
-#include <Common/Exception.h>
-#include <Parsers/Lexer.h>
 
 
 namespace DB
@@ -43,45 +39,7 @@ namespace DB
 class TestHint
 {
 public:
-    TestHint(bool enabled_, const String & query_) :
-        query(query_)
-    {
-        if (!enabled_)
-            return;
-
-        // Don't parse error hints in leading comments, because it feels weird.
-        // Leading 'echo' hint is OK.
-        bool is_leading_hint = true;
-
-        Lexer lexer(query.data(), query.data() + query.size());
-
-        for (Token token = lexer.nextToken(); !token.isEnd(); token = lexer.nextToken())
-        {
-            if (token.type != TokenType::Comment
-                && token.type != TokenType::Whitespace)
-            {
-                is_leading_hint = false;
-            }
-            else if (token.type == TokenType::Comment)
-            {
-                String comment(token.begin, token.begin + token.size());
-
-                if (!comment.empty())
-                {
-                    size_t pos_start = comment.find('{', 0);
-                    if (pos_start != String::npos)
-                    {
-                        size_t pos_end = comment.find('}', pos_start);
-                        if (pos_end != String::npos)
-                        {
-                            String hint(comment.begin() + pos_start + 1, comment.begin() + pos_end);
-                            parse(hint, is_leading_hint);
-                        }
-                    }
-                }
-            }
-        }
-    }
+    TestHint(bool enabled_, const String & query_);
 
     int serverError() const { return server_error; }
     int clientError() const { return client_error; }
@@ -93,34 +51,7 @@ private:
     int client_error = 0;
     std::optional<bool> echo;
 
-    void parse(const String & hint, bool is_leading_hint)
-    {
-        std::stringstream ss;       // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-        ss << hint;
-        String item;
-
-        while (!ss.eof())
-        {
-            ss >> item;
-            if (ss.eof())
-                break;
-
-            if (!is_leading_hint)
-            {
-                if (item == "serverError")
-                    ss >> server_error;
-                else if (item == "clientError")
-                    ss >> client_error;
-            }
-
-            if (item == "echo")
-                echo.emplace(true);
-            if (item == "echoOn")
-                echo.emplace(true);
-            if (item == "echoOff")
-                echo.emplace(false);
-        }
-    }
+    void parse(const String & hint, bool is_leading_hint);
 
     bool allErrorsExpected(int actual_server_error, int actual_client_error) const
     {

--- a/src/Common/ErrorCodes.cpp
+++ b/src/Common/ErrorCodes.cpp
@@ -1,4 +1,5 @@
 #include <Common/ErrorCodes.h>
+#include <Common/Exception.h>
 #include <chrono>
 
 /** Previously, these constants were located in one enum.
@@ -564,6 +565,7 @@
     M(594, BZIP2_STREAM_DECODER_FAILED) \
     M(595, BZIP2_STREAM_ENCODER_FAILED) \
     M(596, INTERSECT_OR_EXCEPT_RESULT_STRUCTURES_MISMATCH) \
+    M(597, NO_SUCH_ERROR_CODE) \
     \
     M(998, POSTGRESQL_CONNECTION_FAILURE) \
     M(999, KEEPER_EXCEPTION) \
@@ -600,6 +602,21 @@ namespace ErrorCodes
         if (error_code < 0 || error_code >= END)
             return std::string_view();
         return error_codes_names.names[error_code];
+    }
+
+    ErrorCode getErrorCodeByName(std::string_view error_name)
+    {
+        for (size_t i = 0, end = ErrorCodes::end(); i < end; ++i)
+        {
+            std::string_view name = ErrorCodes::getName(i);
+
+            if (name.empty())
+                continue;
+
+            if (name == error_name)
+                return i;
+        }
+        throw Exception(NO_SUCH_ERROR_CODE, "No error code with name: '{}'", error_name);
     }
 
     ErrorCode end() { return END + 1; }

--- a/src/Common/ErrorCodes.h
+++ b/src/Common/ErrorCodes.h
@@ -25,6 +25,12 @@ namespace ErrorCodes
     /// Get name of error_code by identifier.
     /// Returns statically allocated string.
     std::string_view getName(ErrorCode error_code);
+    /// Get error code value by name.
+    ///
+    /// It has O(N) complexity, but this is not major, since it is used only
+    /// for test hints, and it does not worth to keep another structure for
+    /// this.
+    ErrorCode getErrorCodeByName(std::string_view error_name);
 
     struct Error
     {

--- a/tests/queries/0_stateless/02006_client_test_hint_error_name.sql
+++ b/tests/queries/0_stateless/02006_client_test_hint_error_name.sql
@@ -1,0 +1,1 @@
+select throwIf(1); -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }

--- a/tests/queries/0_stateless/02006_client_test_hint_no_such_error_name.reference
+++ b/tests/queries/0_stateless/02006_client_test_hint_no_such_error_name.reference
@@ -1,0 +1,1 @@
+No error code with name: 'FOOBAR'. (NO_SUCH_ERROR_CODE)

--- a/tests/queries/0_stateless/02006_client_test_hint_no_such_error_name.sh
+++ b/tests/queries/0_stateless/02006_client_test_hint_no_such_error_name.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --testmode -n -q 'select 1 -- { clientError FOOBAR }' |& grep -o 'No error code with name:.*'


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Accept error code by error name in client test hints