### PR TITLE
Use bytes instead of strings in the GRPC protocol.

### DIFF
--- a/src/Server/grpc_protos/clickhouse_grpc.proto
+++ b/src/Server/grpc_protos/clickhouse_grpc.proto
@@ -32,7 +32,7 @@ message ExternalTable {
    // Data to insert to the external table.
    // If a method with streaming input (i.e. ExecuteQueryWithStreamInput() or ExecuteQueryWithStreamIO()) is used,
    // then data for insertion to the same external table can be split between multiple QueryInfos.
-   string data = 3;
+   bytes data = 3;
 
    // Format of the data to insert to the external table.
    string format = 4;
@@ -53,10 +53,10 @@ message QueryInfo {
    string database = 4;
 
    // Input data, used both as data for INSERT query and as data for the input() function.
-   string input_data = 5;
+   bytes input_data = 5;
 
    // Delimiter for input_data, inserted between input_data from adjacent QueryInfos.
-   string input_data_delimiter = 6;
+   bytes input_data_delimiter = 6;
 
    // Default output format. If not specified, 'TabSeparated' is used.
    string output_format = 7;
@@ -128,9 +128,9 @@ message Exception {
 // Result of execution of a query which is sent back by the ClickHouse server to the client.
 message Result {
    // Output of the query, represented in the `output_format` or in a format specified in `query`.
-   string output = 1;
-   string totals = 2;
-   string extremes = 3;
+   bytes output = 1;
+   bytes totals = 2;
+   bytes extremes = 3;
 
    repeated LogEntry logs = 4;
    Progress progress = 5;

--- a/tests/integration/test_grpc_protocol/test.py
+++ b/tests/integration/test_grpc_protocol/test.py
@@ -6,7 +6,9 @@ import grpc
 from helpers.cluster import ClickHouseCluster, run_and_check
 from threading import Thread
 
+GRPC_PORT = 9100
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+DEFAULT_ENCODING = 'utf-8'
 
 
 # Use grpcio-tools to generate *pb2.py files from *.proto.
@@ -28,11 +30,10 @@ import clickhouse_grpc_pb2_grpc
 config_dir = os.path.join(SCRIPT_DIR, './configs')
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=['configs/grpc_config.xml'])
-grpc_port = 9100
 main_channel = None
 
 def create_channel():
-    node_ip_with_grpc_port = cluster.get_instance_ip('node') + ':' + str(grpc_port)
+    node_ip_with_grpc_port = cluster.get_instance_ip('node') + ':' + str(GRPC_PORT)
     channel = grpc.insecure_channel(node_ip_with_grpc_port)
     grpc.channel_ready_future(channel).result(timeout=10)
     global main_channel
@@ -42,20 +43,27 @@ def create_channel():
 
 def query_common(query_text, settings={}, input_data=[], input_data_delimiter='', output_format='TabSeparated', external_tables=[],
                  user_name='', password='', query_id='123', session_id='', stream_output=False, channel=None):
-    if type(input_data) == str:
+    if type(input_data) is not list:
         input_data = [input_data]
+    if type(input_data_delimiter) is str:
+        input_data_delimiter=input_data_delimiter.encode(DEFAULT_ENCODING)
     if not channel:
         channel = main_channel
     stub = clickhouse_grpc_pb2_grpc.ClickHouseStub(channel)
     def query_info():
-        input_data_part = input_data.pop(0) if input_data else ''
-        return clickhouse_grpc_pb2.QueryInfo(query=query_text, settings=settings, input_data=input_data_part, input_data_delimiter=input_data_delimiter,
-                                             output_format=output_format, external_tables=external_tables, user_name=user_name, password=password,
-                                             query_id=query_id, session_id=session_id, next_query_info=bool(input_data))
+        input_data_part = input_data.pop(0) if input_data else b''
+        if type(input_data_part) is str:
+            input_data_part = input_data_part.encode(DEFAULT_ENCODING)
+        return clickhouse_grpc_pb2.QueryInfo(query=query_text, settings=settings, input_data=input_data_part,
+                                             input_data_delimiter=input_data_delimiter, output_format=output_format,
+                                             external_tables=external_tables, user_name=user_name, password=password, query_id=query_id,
+                                             session_id=session_id, next_query_info=bool(input_data))
     def send_query_info():
         yield query_info()
         while input_data:
             input_data_part = input_data.pop(0)
+            if type(input_data_part) is str:
+                input_data_part = input_data_part.encode(DEFAULT_ENCODING)
             yield clickhouse_grpc_pb2.QueryInfo(input_data=input_data_part, next_query_info=bool(input_data))
     stream_input = len(input_data) > 1
     if stream_input and stream_output:
@@ -74,10 +82,10 @@ def query_no_errors(*args, **kwargs):
     return results
 
 def query(*args, **kwargs):
-    output = ""
+    output = b''
     for result in query_no_errors(*args, **kwargs):
         output += result.output
-    return output
+    return output.decode(DEFAULT_ENCODING)
 
 def query_and_get_error(*args, **kwargs):
     results = query_common(*args, **kwargs)
@@ -86,16 +94,16 @@ def query_and_get_error(*args, **kwargs):
     return results[-1].exception
 
 def query_and_get_totals(*args, **kwargs):
-    totals = ""
+    totals = b''
     for result in query_no_errors(*args, **kwargs):
         totals += result.totals
-    return totals
+    return totals.decode(DEFAULT_ENCODING)
 
 def query_and_get_extremes(*args, **kwargs):
-    extremes = ""
+    extremes = b''
     for result in query_no_errors(*args, **kwargs):
         extremes += result.extremes
-    return extremes
+    return extremes.decode(DEFAULT_ENCODING)
 
 def query_and_get_logs(*args, **kwargs):
     logs = ""
@@ -134,6 +142,7 @@ def start_cluster():
 def reset_after_test():
     yield
     node.query_with_retry("DROP TABLE IF EXISTS t")
+
 
 # Actual tests
 
@@ -270,18 +279,18 @@ def test_input_function():
 
 def test_external_table():
     columns = [clickhouse_grpc_pb2.NameAndType(name='UserID', type='UInt64'), clickhouse_grpc_pb2.NameAndType(name='UserName', type='String')]
-    ext1 = clickhouse_grpc_pb2.ExternalTable(name='ext1', columns=columns, data='1\tAlex\n2\tBen\n3\tCarl\n', format='TabSeparated')
+    ext1 = clickhouse_grpc_pb2.ExternalTable(name='ext1', columns=columns, data=b'1\tAlex\n2\tBen\n3\tCarl\n', format='TabSeparated')
     assert query("SELECT * FROM ext1 ORDER BY UserID", external_tables=[ext1]) == "1\tAlex\n"\
                                                                                   "2\tBen\n"\
                                                                                   "3\tCarl\n"
-    ext2 = clickhouse_grpc_pb2.ExternalTable(name='ext2', columns=columns, data='4,Daniel\n5,Ethan\n', format='CSV')
+    ext2 = clickhouse_grpc_pb2.ExternalTable(name='ext2', columns=columns, data=b'4,Daniel\n5,Ethan\n', format='CSV')
     assert query("SELECT * FROM (SELECT * FROM ext1 UNION ALL SELECT * FROM ext2) ORDER BY UserID", external_tables=[ext1, ext2]) == "1\tAlex\n"\
                                                                                                                                      "2\tBen\n"\
                                                                                                                                      "3\tCarl\n"\
                                                                                                                                      "4\tDaniel\n"\
                                                                                                                                      "5\tEthan\n"
     unnamed_columns = [clickhouse_grpc_pb2.NameAndType(type='UInt64'), clickhouse_grpc_pb2.NameAndType(type='String')]
-    unnamed_table = clickhouse_grpc_pb2.ExternalTable(columns=unnamed_columns, data='6\tGeorge\n7\tFred\n')
+    unnamed_table = clickhouse_grpc_pb2.ExternalTable(columns=unnamed_columns, data=b'6\tGeorge\n7\tFred\n')
     assert query("SELECT * FROM _data ORDER BY _2", external_tables=[unnamed_table]) == "7\tFred\n"\
                                                                                         "6\tGeorge\n"
 
@@ -289,16 +298,16 @@ def test_external_table_streaming():
     columns = [clickhouse_grpc_pb2.NameAndType(name='UserID', type='UInt64'), clickhouse_grpc_pb2.NameAndType(name='UserName', type='String')]
     def send_query_info():
         yield clickhouse_grpc_pb2.QueryInfo(query="SELECT * FROM exts ORDER BY UserID",
-                                            external_tables=[clickhouse_grpc_pb2.ExternalTable(name='exts', columns=columns, data='1\tAlex\n2\tBen\n3\tCarl\n')],
+                                            external_tables=[clickhouse_grpc_pb2.ExternalTable(name='exts', columns=columns, data=b'1\tAlex\n2\tBen\n3\tCarl\n')],
                                             next_query_info=True)
-        yield clickhouse_grpc_pb2.QueryInfo(external_tables=[clickhouse_grpc_pb2.ExternalTable(name='exts', data='4\tDaniel\n5\tEthan\n')])
+        yield clickhouse_grpc_pb2.QueryInfo(external_tables=[clickhouse_grpc_pb2.ExternalTable(name='exts', data=b'4\tDaniel\n5\tEthan\n')])
     stub = clickhouse_grpc_pb2_grpc.ClickHouseStub(main_channel)
     result = stub.ExecuteQueryWithStreamInput(send_query_info())
-    assert result.output == "1\tAlex\n"\
-                            "2\tBen\n"\
-                            "3\tCarl\n"\
-                            "4\tDaniel\n"\
-                            "5\tEthan\n"
+    assert result.output == b'1\tAlex\n'\
+                            b'2\tBen\n'\
+                            b'3\tCarl\n'\
+                            b'4\tDaniel\n'\
+                            b'5\tEthan\n'
 
 def test_simultaneous_queries_same_channel():
     threads=[]
@@ -325,8 +334,8 @@ def test_simultaneous_queries_multiple_channels():
 def test_cancel_while_processing_input():
     query("CREATE TABLE t (a UInt8) ENGINE = Memory")
     def send_query_info():
-        yield clickhouse_grpc_pb2.QueryInfo(query="INSERT INTO t FORMAT TabSeparated", input_data="1\n2\n3\n", next_query_info=True)
-        yield clickhouse_grpc_pb2.QueryInfo(input_data="4\n5\n6\n", next_query_info=True)
+        yield clickhouse_grpc_pb2.QueryInfo(query="INSERT INTO t FORMAT TabSeparated", input_data=b'1\n2\n3\n', next_query_info=True)
+        yield clickhouse_grpc_pb2.QueryInfo(input_data=b'4\n5\n6\n', next_query_info=True)
         yield clickhouse_grpc_pb2.QueryInfo(cancel=True)
     stub = clickhouse_grpc_pb2_grpc.ClickHouseStub(main_channel)
     result = stub.ExecuteQueryWithStreamInput(send_query_info())
@@ -343,7 +352,7 @@ def test_cancel_while_generating_output():
     results = list(stub.ExecuteQueryWithStreamIO(send_query_info()))
     assert len(results) >= 1
     assert results[-1].cancelled == True
-    output = ''
+    output = b''
     for result in results:
         output += result.output
-    assert output == '0\t0\n1\t0\n2\t0\n3\t0\n'
+    assert output == b'0\t0\n1\t0\n2\t0\n3\t0\n'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Improvement

Changelog entry:
Use bytes instead of strings for binary data in the GRPC protocol.