### PR TITLE
less sys calls #2: make vdso work again

### DIFF
--- a/base/glibc-compatibility/musl/getauxval.c
+++ b/base/glibc-compatibility/musl/getauxval.c
@@ -49,10 +49,13 @@ static unsigned long  __auxv_init(unsigned long type)
     if (secure_idx != ((size_t) -1))
         __auxv_secure = __auxv[secure_idx];
 
+    // Now we've initialized __auxv, next time getauxval() will only call __get_auxval().
     a_cas_p(&getauxval_func, (void *)__auxv_init, (void *)__getauxval);
+
     return __getauxval(type);
 }
 
+// First time getauxval() will call __auxv_init().
 static void * volatile getauxval_func = (void *)__auxv_init;
 
 unsigned long getauxval(unsigned long type)

--- a/base/glibc-compatibility/musl/getauxval.c
+++ b/base/glibc-compatibility/musl/getauxval.c
@@ -39,8 +39,14 @@ static void * volatile getauxval_func;
 static unsigned long  __auxv_init(unsigned long type)
 {
     if (!__environ)
+    {
+        // __environ is not initialized yet so we can't initialize __auxv right now.
+        // This is normally occurred when getauxval() is called from some sanitizer's internal code.
+        errno = ENOENT;
         return 0;
+    }
 
+    // Initialize __auxv and __auxv_secure.
     size_t i;
     for (i = 0; __environ[i]; i++);
     __auxv = (unsigned long *) (__environ + i + 1);

--- a/base/glibc-compatibility/musl/getauxval.c
+++ b/base/glibc-compatibility/musl/getauxval.c
@@ -41,7 +41,7 @@ static unsigned long  __auxv_init(unsigned long type)
     if (!__environ)
     {
         // __environ is not initialized yet so we can't initialize __auxv right now.
-        // This is normally occurred when getauxval() is called from some sanitizer's internal code.
+        // That's normally occurred only when getauxval() is called from some sanitizer's internal code.
         errno = ENOENT;
         return 0;
     }

--- a/base/glibc-compatibility/musl/getauxval.c
+++ b/base/glibc-compatibility/musl/getauxval.c
@@ -17,7 +17,11 @@ static size_t __find_auxv(unsigned long type)
     return (size_t) -1;
 }
 
-__attribute__((constructor)) static void __auxv_init()
+/// __auxv_init should happen BEFORE the first use of getauxval.
+/// but getauxval can be used in other init sections (namely in musl/clock_gettime.c::cgt_init), 
+/// so constructor(0) is needed to prioritize that constructor
+/// see also: https://stackoverflow.com/questions/11106875/attribute-constructor-call-order-confusion/11198936
+__attribute__((constructor(0))) static void __auxv_init()
 {
     size_t i;
     for (i = 0; __environ[i]; i++);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Less number of `clock_gettime` syscalls that may lead to performance improvement for some types of fast queries.

Detailed description / Documentation draft:
`cgt_init` has used `getauxval` BEFORE `__auxv_init` was fired, and because of that vdso was not working for `clock_gettime` (and maybe some other API).

Again have very significant improvement locally, but let's see what performance tests will say.

```
laptop-5591 :) SELECT count() FROM zeros(100000000000);

SELECT count()
FROM zeros(100000000000)

Query id: 7d1018a8-50ad-4659-9f97-9fe8248d0248

Connecting to localhost:9000 as user default.
Connected to ClickHouse server version 21.9.1 revision 54449.

┌──────count()─┐
│ 100000000000 │
└──────────────┘

1 rows in set. Elapsed: 4.106 sec. Processed 100.00 billion rows, 100.00 GB (24.35 billion rows/s., 24.35 GB/s.)

laptop-5591 :) SELECT count() FROM zeros(100000000000);

SELECT count()
FROM zeros(100000000000)

Query id: 1f4f29db-f05f-44bc-b0c5-5446e7f12ee0

Connecting to localhost:9000 as user default.
Connected to ClickHouse server version 21.9.1 revision 54449.

┌──────count()─┐
│ 100000000000 │
└──────────────┘

1 rows in set. Elapsed: 2.448 sec. Processed 100.00 billion rows, 100.00 GB (40.86 billion rows/s., 40.86 GB/s.)

```