### PR TITLE
Backport 21.6 cache dictionaries configuration parse fix

### DIFF
--- a/src/Dictionaries/registerCacheDictionaries.cpp
+++ b/src/Dictionaries/registerCacheDictionaries.cpp
@@ -154,8 +154,8 @@ DictionaryPtr createCacheDictionaryLayout(
     const Poco::Util::AbstractConfiguration & config,
     const std::string & config_prefix,
     DictionarySourcePtr source_ptr,
-    ContextPtr context,
-    bool created_from_ddl)
+    ContextPtr context [[maybe_unused]],
+    bool created_from_ddl [[maybe_unused]])
 {
     static_assert(dictionary_key_type != DictionaryKeyType::range, "Range key type is not supported by CacheDictionary");
 

--- a/src/Dictionaries/registerCacheDictionaries.cpp
+++ b/src/Dictionaries/registerCacheDictionaries.cpp
@@ -17,27 +17,26 @@ namespace ErrorCodes
 }
 
 CacheDictionaryStorageConfiguration parseCacheStorageConfiguration(
-    const String & full_name,
     const Poco::Util::AbstractConfiguration & config,
-    const String & layout_prefix,
-    const DictionaryLifetime & dict_lifetime,
-    DictionaryKeyType dictionary_key_type)
+    const String & full_name,
+    const String & layout_type,
+    const String & dictionary_layout_prefix,
+    const DictionaryLifetime & dict_lifetime)
 {
-    String dictionary_type_prefix = (dictionary_key_type == DictionaryKeyType::complex) ? ".complex_key_cache." : ".cache.";
-    String dictionary_configuration_prefix = layout_prefix + dictionary_type_prefix;
-
-    const size_t size = config.getUInt64(dictionary_configuration_prefix + "size_in_cells");
+    size_t size = config.getUInt64(dictionary_layout_prefix + ".size_in_cells");
     if (size == 0)
-        throw Exception(ErrorCodes::TOO_SMALL_BUFFER_SIZE,
-            "{}: cache dictionary cannot have 0 cells",
-            full_name);
+        throw Exception(ErrorCodes::TOO_SMALL_BUFFER_SIZE, "{}: dictionary of layout '{}' setting 'size_in_cells' must be greater than 0", full_name, layout_type);
 
     size_t dict_lifetime_seconds = static_cast<size_t>(dict_lifetime.max_sec);
-    const size_t strict_max_lifetime_seconds = config.getUInt64(dictionary_configuration_prefix + "strict_max_lifetime_seconds", dict_lifetime_seconds);
-
+    size_t strict_max_lifetime_seconds = config.getUInt64(dictionary_layout_prefix + ".strict_max_lifetime_seconds", dict_lifetime_seconds);
     size_t rounded_size = roundUpToPowerOfTwoOrZero(size);
 
-    CacheDictionaryStorageConfiguration storage_configuration{rounded_size, strict_max_lifetime_seconds, dict_lifetime};
+    CacheDictionaryStorageConfiguration storage_configuration
+    {
+        .max_size_in_cells = rounded_size,
+        .strict_max_lifetime_seconds = strict_max_lifetime_seconds,
+        .lifetime = dict_lifetime
+    };
 
     return storage_configuration;
 }
@@ -45,17 +44,13 @@ CacheDictionaryStorageConfiguration parseCacheStorageConfiguration(
 #if defined(OS_LINUX) || defined(__FreeBSD__)
 
 SSDCacheDictionaryStorageConfiguration parseSSDCacheStorageConfiguration(
-    const String & full_name,
     const Poco::Util::AbstractConfiguration & config,
-    const String & layout_prefix,
-    const DictionaryLifetime & dict_lifetime,
-    DictionaryKeyType dictionary_key_type)
+    const String & full_name,
+    const String & layout_type,
+    const String & dictionary_layout_prefix,
+    const DictionaryLifetime & dict_lifetime)
 {
-    String dictionary_type_prefix = dictionary_key_type == DictionaryKeyType::complex ? ".complex_key_ssd_cache." : ".ssd_cache.";
-    String dictionary_configuration_prefix = layout_prefix + dictionary_type_prefix;
-
-    const size_t strict_max_lifetime_seconds
-        = config.getUInt64(dictionary_configuration_prefix + "strict_max_lifetime_seconds", static_cast<size_t>(dict_lifetime.max_sec));
+    size_t strict_max_lifetime_seconds = config.getUInt64(dictionary_layout_prefix + ".strict_max_lifetime_seconds", static_cast<size_t>(dict_lifetime.max_sec));
 
     static constexpr size_t DEFAULT_SSD_BLOCK_SIZE_BYTES = DEFAULT_AIO_FILE_BLOCK_SIZE;
     static constexpr size_t DEFAULT_FILE_SIZE_BYTES = 4 * 1024 * 1024 * 1024ULL;
@@ -64,44 +59,48 @@ SSDCacheDictionaryStorageConfiguration parseSSDCacheStorageConfiguration(
 
     static constexpr size_t DEFAULT_PARTITIONS_COUNT = 16;
 
-    const size_t max_partitions_count
-        = config.getInt64(dictionary_configuration_prefix + "ssd_cache.max_partitions_count", DEFAULT_PARTITIONS_COUNT);
+    size_t max_partitions_count = config.getInt64(dictionary_layout_prefix + ".max_partitions_count", DEFAULT_PARTITIONS_COUNT);
 
-    const size_t block_size = config.getInt64(dictionary_configuration_prefix + "block_size", DEFAULT_SSD_BLOCK_SIZE_BYTES);
-    const size_t file_size = config.getInt64(dictionary_configuration_prefix + "file_size", DEFAULT_FILE_SIZE_BYTES);
+    size_t block_size = config.getInt64(dictionary_layout_prefix + ".block_size", DEFAULT_SSD_BLOCK_SIZE_BYTES);
+    size_t file_size = config.getInt64(dictionary_layout_prefix + ".file_size", DEFAULT_FILE_SIZE_BYTES);
     if (file_size % block_size != 0)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: file_size must be a multiple of block_size",
-            full_name);
+            "{}: dictionary of layout '{}' setting 'file_size' must be a multiple of block_size",
+            full_name,
+            layout_type);
 
-    const size_t read_buffer_size = config.getInt64(dictionary_configuration_prefix + "read_buffer_size", DEFAULT_READ_BUFFER_SIZE_BYTES);
+    size_t read_buffer_size = config.getInt64(dictionary_layout_prefix + ".read_buffer_size", DEFAULT_READ_BUFFER_SIZE_BYTES);
     if (read_buffer_size % block_size != 0)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: read_buffer_size must be a multiple of block_size",
-            full_name);
+            "{}: dictionary of layout '{}' setting 'read_buffer_size' must be a multiple of block_size",
+            full_name,
+            layout_type);
 
-    const size_t write_buffer_size
-        = config.getInt64(dictionary_configuration_prefix + "write_buffer_size", DEFAULT_WRITE_BUFFER_SIZE_BYTES);
+    size_t write_buffer_size = config.getInt64(dictionary_layout_prefix + ".write_buffer_size", DEFAULT_WRITE_BUFFER_SIZE_BYTES);
     if (write_buffer_size % block_size != 0)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: write_buffer_size must be a multiple of block_size",
-            full_name);
+            "{}: dictionary of layout '{}' setting 'write_buffer_size' must be a multiple of block_size",
+            full_name,
+            layout_type);
 
-    auto file_path = config.getString(dictionary_configuration_prefix + "path");
+    auto file_path = config.getString(dictionary_layout_prefix + ".path");
     if (file_path.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: ssd cache dictionary cannot have empty path",
-            full_name);
+            "{}: dictionary of layout '{}' setting 'path' must be specified",
+            full_name,
+            layout_type);
 
-    SSDCacheDictionaryStorageConfiguration configuration{
-        strict_max_lifetime_seconds,
-        dict_lifetime,
-        file_path,
-        max_partitions_count,
-        block_size,
-        file_size / block_size,
-        read_buffer_size / block_size,
-        write_buffer_size / block_size};
+    SSDCacheDictionaryStorageConfiguration configuration
+    {
+        .strict_max_lifetime_seconds = strict_max_lifetime_seconds,
+        .lifetime = dict_lifetime,
+        .file_path = file_path,
+        .max_partitions_count = max_partitions_count,
+        .block_size = block_size,
+        .file_blocks_size = file_size / block_size,
+        .read_buffer_blocks_size = read_buffer_size / block_size,
+        .write_buffer_blocks_size = write_buffer_size / block_size
+    };
 
     return configuration;
 }
@@ -109,98 +108,47 @@ SSDCacheDictionaryStorageConfiguration parseSSDCacheStorageConfiguration(
 #endif
 
 CacheDictionaryUpdateQueueConfiguration parseCacheDictionaryUpdateQueueConfiguration(
-    const String & full_name,
     const Poco::Util::AbstractConfiguration & config,
-    const String & layout_prefix,
-    DictionaryKeyType key_type)
+    const String & full_name,
+    const String & layout_type,
+    const String & dictionary_layout_prefix)
 {
-    String layout_type = key_type == DictionaryKeyType::complex ? "complex_key_cache" : "cache";
-
-    const size_t max_update_queue_size = config.getUInt64(layout_prefix + ".cache.max_update_queue_size", 100000);
+    size_t max_update_queue_size = config.getUInt64(dictionary_layout_prefix + ".max_update_queue_size", 100000);
     if (max_update_queue_size == 0)
         throw Exception(ErrorCodes::TOO_SMALL_BUFFER_SIZE,
-            "{}: dictionary of layout '{}' cannot have empty update queue of size 0",
+            "{}: dictionary of layout '{}' setting 'max_update_queue_size' must be greater than 0",
             full_name,
             layout_type);
 
-    const size_t update_queue_push_timeout_milliseconds
-        = config.getUInt64(layout_prefix + ".cache.update_queue_push_timeout_milliseconds", 10);
+    size_t update_queue_push_timeout_milliseconds = config.getUInt64(dictionary_layout_prefix + ".update_queue_push_timeout_milliseconds", 10);
     if (update_queue_push_timeout_milliseconds < 10)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: dictionary of layout '{}' have too little update_queue_push_timeout",
+            "{}: dictionary of layout '{}' setting 'update_queue_push_timeout_milliseconds' must be greater or equal than 10",
             full_name,
             layout_type);
 
-    const size_t query_wait_timeout_milliseconds = config.getUInt64(layout_prefix + ".cache.query_wait_timeout_milliseconds", 60000);
+    size_t query_wait_timeout_milliseconds = config.getUInt64(dictionary_layout_prefix + ".query_wait_timeout_milliseconds", 60000);
 
-    const size_t max_threads_for_updates = config.getUInt64(layout_prefix + ".max_threads_for_updates", 4);
+    size_t max_threads_for_updates = config.getUInt64(dictionary_layout_prefix + ".max_threads_for_updates", 4);
     if (max_threads_for_updates == 0)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: dictionary of layout) '{}' cannot have zero threads for updates",
+            "{}: dictionary of layout '{}' setting 'max_threads_for_updates' must be greater than 0",
             full_name,
             layout_type);
 
-    CacheDictionaryUpdateQueueConfiguration update_queue_configuration{
-        max_update_queue_size, max_threads_for_updates, update_queue_push_timeout_milliseconds, query_wait_timeout_milliseconds};
+    CacheDictionaryUpdateQueueConfiguration update_queue_configuration
+    {
+        .max_update_queue_size = max_update_queue_size,
+        .max_threads_for_updates = max_threads_for_updates,
+        .update_queue_push_timeout_milliseconds = update_queue_push_timeout_milliseconds,
+        .query_wait_timeout_milliseconds = query_wait_timeout_milliseconds
+    };
 
     return update_queue_configuration;
 }
 
-template <DictionaryKeyType dictionary_key_type>
+template <DictionaryKeyType dictionary_key_type, bool ssd>
 DictionaryPtr createCacheDictionaryLayout(
-    const String & full_name,
-    const DictionaryStructure & dict_struct,
-    const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix,
-    DictionarySourcePtr source_ptr)
-{
-    static_assert(dictionary_key_type != DictionaryKeyType::range, "Range key type is not supported by CacheDictionary");
-
-    if constexpr (dictionary_key_type == DictionaryKeyType::simple)
-    {
-        if (dict_struct.key)
-            throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "'key' is not supported for dictionary of layout 'cache'");
-    }
-    else if constexpr (dictionary_key_type == DictionaryKeyType::complex)
-    {
-        if (dict_struct.id)
-            throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "'id' is not supported for dictionary of layout 'complex_key_cache'");
-    }
-
-    if (dict_struct.range_min || dict_struct.range_max)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: elements .structure.range_min and .structure.range_max should be defined only "
-            "for a dictionary of layout 'range_hashed'",
-            full_name);
-
-    const bool require_nonempty = config.getBool(config_prefix + ".require_nonempty", false);
-    if (require_nonempty)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: cache dictionary of layout cannot have 'require_nonempty' attribute set",
-            full_name);
-
-    const auto & layout_prefix = config_prefix + ".layout";
-
-    const auto dict_id = StorageID::fromDictionaryConfig(config, config_prefix);
-
-    const DictionaryLifetime dict_lifetime{config, config_prefix + ".lifetime"};
-
-    const bool allow_read_expired_keys = config.getBool(layout_prefix + ".cache.allow_read_expired_keys", false);
-
-    auto storage_configuration = parseCacheStorageConfiguration(full_name, config, layout_prefix, dict_lifetime, dictionary_key_type);
-
-    std::shared_ptr<ICacheDictionaryStorage> storage = std::make_shared<CacheDictionaryStorage<dictionary_key_type>>(dict_struct, storage_configuration);
-
-    auto update_queue_configuration = parseCacheDictionaryUpdateQueueConfiguration(full_name, config, layout_prefix, dictionary_key_type);
-
-    return std::make_unique<CacheDictionary<dictionary_key_type>>(
-        dict_id, dict_struct, std::move(source_ptr), storage, update_queue_configuration, dict_lifetime, allow_read_expired_keys);
-}
-
-#if defined(OS_LINUX) || defined(__FreeBSD__)
-
-template <DictionaryKeyType dictionary_key_type>
-DictionaryPtr createSSDCacheDictionaryLayout(
     const String & full_name,
     const DictionaryStructure & dict_struct,
     const Poco::Util::AbstractConfiguration & config,
@@ -211,52 +159,79 @@ DictionaryPtr createSSDCacheDictionaryLayout(
 {
     static_assert(dictionary_key_type != DictionaryKeyType::range, "Range key type is not supported by CacheDictionary");
 
+    String layout_type;
+    if constexpr (dictionary_key_type == DictionaryKeyType::simple && !ssd)
+        layout_type = "cache";
+    else if constexpr (dictionary_key_type == DictionaryKeyType::simple && ssd)
+        layout_type = "ssd_cache";
+    else if constexpr (dictionary_key_type == DictionaryKeyType::complex && !ssd)
+        layout_type = "complex_key_cache";
+    else if constexpr (dictionary_key_type == DictionaryKeyType::complex && ssd)
+        layout_type = "complex_key_ssd_cache";
+
     if constexpr (dictionary_key_type == DictionaryKeyType::simple)
     {
         if (dict_struct.key)
-            throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "'key' is not supported for dictionary of layout 'ssd_cache'");
+            throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "{}: dictionary of layout '{}' 'key' is not supported", full_name, layout_type);
     }
     else if constexpr (dictionary_key_type == DictionaryKeyType::complex)
     {
         if (dict_struct.id)
-            throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "'id' is not supported for dictionary of layout 'complex_key_ssd_cache'");
+            throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "{}: dictionary of layout '{}' 'id' is not supported", full_name, layout_type);
     }
 
     if (dict_struct.range_min || dict_struct.range_max)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: elements .structure.range_min and .structure.range_max should be defined only "
+            "{}: dictionary of layout '{}' elements .structure.range_min and .structure.range_max must be defined only "
             "for a dictionary of layout 'range_hashed'",
-            full_name);
+            full_name,
+            layout_type);
 
     const bool require_nonempty = config.getBool(config_prefix + ".require_nonempty", false);
     if (require_nonempty)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "{}: cache dictionary of layout cannot have 'require_nonempty' attribute set",
-            full_name);
+            "{}: cache dictionary of layout '{}' cannot have 'require_nonempty' attribute set",
+            full_name,
+            layout_type);
 
-    const auto & layout_prefix = config_prefix + ".layout";
-
-    const auto dict_id = StorageID::fromDictionaryConfig(config, config_prefix);
-
+    const auto dictionary_identifier = StorageID::fromDictionaryConfig(config, config_prefix);
     const DictionaryLifetime dict_lifetime{config, config_prefix + ".lifetime"};
 
-    const bool allow_read_expired_keys = config.getBool(layout_prefix + ".cache.allow_read_expired_keys", false);
+    const auto & layout_prefix = config_prefix + ".layout";
+    const auto & dictionary_layout_prefix = layout_prefix + '.' + layout_type;
+    const bool allow_read_expired_keys = config.getBool(dictionary_layout_prefix + ".allow_read_expired_keys", false);
 
-    auto storage_configuration = parseSSDCacheStorageConfiguration(full_name, config, layout_prefix, dict_lifetime, dictionary_key_type);
+    auto update_queue_configuration = parseCacheDictionaryUpdateQueueConfiguration(config, full_name, layout_type, dictionary_layout_prefix);
 
-    if (created_from_ddl && !pathStartsWith(storage_configuration.file_path, context->getUserFilesPath()))
-        throw Exception(ErrorCodes::PATH_ACCESS_DENIED, "File path {} is not inside {}", storage_configuration.file_path, context->getUserFilesPath());
+    std::shared_ptr<ICacheDictionaryStorage> storage;
 
+    if constexpr (!ssd)
+    {
+        auto storage_configuration = parseCacheStorageConfiguration(config, full_name, layout_type, dictionary_layout_prefix, dict_lifetime);
+        storage = std::make_shared<CacheDictionaryStorage<dictionary_key_type>>(dict_struct, storage_configuration);
+    }
+#if defined(OS_LINUX) || defined(__FreeBSD__)
+    else
+    {
+        auto storage_configuration = parseSSDCacheStorageConfiguration(config, full_name, layout_type, dictionary_layout_prefix, dict_lifetime);
+        if (created_from_ddl && !pathStartsWith(storage_configuration.file_path, context->getUserFilesPath()))
+            throw Exception(ErrorCodes::PATH_ACCESS_DENIED, "File path {} is not inside {}", storage_configuration.file_path, context->getUserFilesPath());
 
-    auto storage = std::make_shared<SSDCacheDictionaryStorage<dictionary_key_type>>(storage_configuration);
-
-    auto update_queue_configuration = parseCacheDictionaryUpdateQueueConfiguration(full_name, config, layout_prefix, dictionary_key_type);
-
-    return std::make_unique<CacheDictionary<dictionary_key_type>>(
-        dict_id, dict_struct, std::move(source_ptr), storage, update_queue_configuration, dict_lifetime, allow_read_expired_keys);
-}
-
+        storage = std::make_shared<SSDCacheDictionaryStorage<dictionary_key_type>>(storage_configuration);
+    }
 #endif
+
+    auto dictionary = std::make_unique<CacheDictionary<dictionary_key_type>>(
+        dictionary_identifier,
+        dict_struct,
+        std::move(source_ptr),
+        std::move(storage),
+        update_queue_configuration,
+        dict_lifetime,
+        allow_read_expired_keys);
+
+    return dictionary;
+}
 
 void registerDictionaryCache(DictionaryFactory & factory)
 {
@@ -265,10 +240,10 @@ void registerDictionaryCache(DictionaryFactory & factory)
                                           const Poco::Util::AbstractConfiguration & config,
                                           const std::string & config_prefix,
                                           DictionarySourcePtr source_ptr,
-                                          ContextPtr /* context */,
-                                          bool /* created_from_ddl */) -> DictionaryPtr
+                                          ContextPtr context,
+                                          bool created_from_ddl) -> DictionaryPtr
     {
-        return createCacheDictionaryLayout<DictionaryKeyType::simple>(full_name, dict_struct, config, config_prefix, std::move(source_ptr));
+        return createCacheDictionaryLayout<DictionaryKeyType::simple, false/* ssd */>(full_name, dict_struct, config, config_prefix, std::move(source_ptr), std::move(context), created_from_ddl);
     };
 
     factory.registerLayout("cache", create_simple_cache_layout, false);
@@ -278,10 +253,10 @@ void registerDictionaryCache(DictionaryFactory & factory)
                                                const Poco::Util::AbstractConfiguration & config,
                                                const std::string & config_prefix,
                                                DictionarySourcePtr source_ptr,
-                                               ContextPtr /* context */,
-                                               bool /* created_from_ddl */) -> DictionaryPtr
+                                               ContextPtr context,
+                                               bool created_from_ddl) -> DictionaryPtr
     {
-        return createCacheDictionaryLayout<DictionaryKeyType::complex>(full_name, dict_struct, config, config_prefix, std::move(source_ptr));
+        return createCacheDictionaryLayout<DictionaryKeyType::complex, false /* ssd */>(full_name, dict_struct, config, config_prefix, std::move(source_ptr), std::move(context), created_from_ddl);
     };
 
     factory.registerLayout("complex_key_cache", create_complex_key_cache_layout, true);
@@ -296,7 +271,7 @@ void registerDictionaryCache(DictionaryFactory & factory)
                                               ContextPtr context,
                                               bool created_from_ddl) -> DictionaryPtr
     {
-        return createSSDCacheDictionaryLayout<DictionaryKeyType::simple>(full_name, dict_struct, config, config_prefix, std::move(source_ptr), context, created_from_ddl);
+        return createCacheDictionaryLayout<DictionaryKeyType::simple, true /* ssd */>(full_name, dict_struct, config, config_prefix, std::move(source_ptr), std::move(context), created_from_ddl);
     };
 
     factory.registerLayout("ssd_cache", create_simple_ssd_cache_layout, false);
@@ -308,11 +283,13 @@ void registerDictionaryCache(DictionaryFactory & factory)
                                                    DictionarySourcePtr source_ptr,
                                                    ContextPtr context,
                                                    bool created_from_ddl) -> DictionaryPtr {
-        return createSSDCacheDictionaryLayout<DictionaryKeyType::complex>(full_name, dict_struct, config, config_prefix, std::move(source_ptr), context, created_from_ddl);
+        return createCacheDictionaryLayout<DictionaryKeyType::complex, true /* ssd */>(full_name, dict_struct, config, config_prefix, std::move(source_ptr), std::move(context), created_from_ddl);
     };
 
     factory.registerLayout("complex_key_ssd_cache", create_complex_key_ssd_cache_layout, true);
+
 #endif
+
 }
 
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
Original pull-request #27032.

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `cache`, `complex_key_cache`, `ssd_cache`, `complex_key_ssd_cache` configuration parsing. Options `allow_read_expired_keys`, `max_update_queue_size`, `update_queue_push_timeout_milliseconds`, `query_wait_timeout_milliseconds` were not parsed for dictionaries with non `cache` type.
