### PR TITLE
Enable using constants from with and select in aggregate function parameters (2)

### DIFF
--- a/src/Interpreters/QueryNormalizer.cpp
+++ b/src/Interpreters/QueryNormalizer.cpp
@@ -256,6 +256,9 @@ void QueryNormalizer::visit(ASTPtr & ast, Data & data)
         visit(*node_select, ast, data);
     else if (auto * node_param = ast->as<ASTQueryParameter>())
         throw Exception("Query parameter " + backQuote(node_param->name) + " was not set", ErrorCodes::UNKNOWN_QUERY_PARAMETER);
+    else if (auto * node_function = ast->as<ASTFunction>())
+        if (node_function->parameters)
+            visit(node_function->parameters, data);
 
     /// If we replace the root of the subtree, we will be called again for the new root, in case the alias is replaced by an alias.
     if (ast.get() != initial_ast.get())

--- a/src/Interpreters/RequiredSourceColumnsVisitor.cpp
+++ b/src/Interpreters/RequiredSourceColumnsVisitor.cpp
@@ -123,6 +123,17 @@ void RequiredSourceColumnsMatcher::visit(const ASTSelectQuery & select, const AS
             data.addColumnAliasIfAny(*node);
     }
 
+    if (auto & with = select.with())
+    {
+        for (auto & node : with->children)
+        {
+            if (const auto * identifier = node->as<ASTIdentifier>())
+                data.addColumnIdentifier(*identifier);
+            else
+                data.addColumnAliasIfAny(*node);
+        }
+    }
+
     std::vector<ASTPtr *> out;
     for (const auto & node : select.children)
     {
@@ -134,6 +145,8 @@ void RequiredSourceColumnsMatcher::visit(const ASTSelectQuery & select, const AS
 
     /// revisit select_expression_list (with children) when all the aliases are set
     Visitor(data).visit(select.select());
+    if (auto with = select.with())
+        Visitor(data).visit(with);
 }
 
 void RequiredSourceColumnsMatcher::visit(const ASTIdentifier & node, const ASTPtr &, Data & data)


### PR DESCRIPTION
Resubmit of #27531

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable using constants from with and select in aggregate function parameters. close  [#10945](https://github.com/ClickHouse/ClickHouse/issues/10945)

Detailed description / Documentation draft:
Enable using constants from with and select in aggregate function parameters.
detail is in [#10945](https://github.com/ClickHouse/ClickHouse/issues/10945)