### PR TITLE
Fix 01961_roaring_memory_tracking for split builds

### DIFF
--- a/contrib/croaring-cmake/CMakeLists.txt
+++ b/contrib/croaring-cmake/CMakeLists.txt
@@ -26,17 +26,14 @@ target_include_directories(roaring SYSTEM BEFORE PUBLIC "${LIBRARY_DIR}/include"
 target_include_directories(roaring SYSTEM BEFORE PUBLIC "${LIBRARY_DIR}/cpp")
 
 # We redirect malloc/free family of functions to different functions that will track memory in ClickHouse.
-# It will make this library depend on linking to 'clickhouse_common_io' library that is not done explicitly via 'target_link_libraries'.
-# And we check that all libraries dependencies are satisfied and all symbols are resolved if we do build with shared libraries.
-# That's why we enable it only in static build.
 # Also note that we exploit implicit function declarations.
 
-if (USE_STATIC_LIBRARIES)
-    target_compile_definitions(roaring PRIVATE
+target_compile_definitions(roaring PRIVATE
         -Dmalloc=clickhouse_malloc
         -Dcalloc=clickhouse_calloc
         -Drealloc=clickhouse_realloc
         -Dreallocarray=clickhouse_reallocarray
         -Dfree=clickhouse_free
         -Dposix_memalign=clickhouse_posix_memalign)
-endif ()
+
+target_link_libraries(roaring PUBLIC clickhouse_common_io)

--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -155,6 +155,10 @@ Normally ClickHouse is statically linked into a single static `clickhouse` binar
 -DUSE_STATIC_LIBRARIES=0 -DSPLIT_SHARED_LIBRARIES=1 -DCLICKHOUSE_SPLIT_BINARY=1
 ```
 
-Note that in this configuration there is no single `clickhouse` binary, and you have to run `clickhouse-server`, `clickhouse-client` etc.
+Note that the split build has several drawbacks:
+* There is no single `clickhouse` binary, and you have to run `clickhouse-server`, `clickhouse-client`, etc.
+* Risk of segfault if you run any of the programs while rebuilding the project.
+* You cannot run the integration tests since they only work a single complete binary.
+* You can't easily copy the binaries elsewhere. Instead of moving a single binary you'll need to copy all binaries and libraries.
 
 [Original article](https://clickhouse.tech/docs/en/development/build/) <!--hide-->

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -299,10 +299,11 @@ target_link_libraries(clickhouse_common_io
             ${ZLIB_LIBRARIES}
             pcg_random
             Poco::Foundation
-            roaring
 )
 
-
+# Make dbms depend on roaring instead of clickhouse_common_io so that roaring itself can depend on clickhouse_common_io
+# That way we we can redirect malloc/free functions avoiding circular dependencies
+dbms_target_link_libraries(PUBLIC roaring)
 
 if (USE_RDKAFKA)
     dbms_target_link_libraries(PRIVATE ${CPPKAFKA_LIBRARY} ${RDKAFKA_LIBRARY})


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Background: https://github.com/ClickHouse/ClickHouse/pull/27252

Add an explicit dependency from libroaring to clickhouse_common_io. Since this would create a circular dependency, remove the dependency on roaring from `clickhouse_common_io` and add it to `dbms`.

Another option would have been to detect the split build environment and avoid running the test, but that wouldn't fix the underlying issue (tracking libroaring memory use). I've tested with split build and release mode (single binary by default) and it works under both setups. Feel free to suggest better approaches (if any).

I'm also adding a list of drawbacks to the split build documentation based on comments from @alexey-milovidov 