### PR TITLE
Improve the experience of running stateless tests locally

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -650,6 +650,10 @@ def run_tests_array(all_tests_with_params):
                         status += " - having exception in stdout:\n{}\n".format(
                             '\n'.join(stdout.split('\n')[:100]))
                         status += 'Database: ' + testcase_args.testcase_database
+                    elif '@@SKIP@@' in stdout:
+                        skipped_total += 1
+                        skip_reason = stdout.replace('@@SKIP@@', '').rstrip("\n")
+                        status += MSG_SKIPPED + f" - {skip_reason}\n"
                     elif reference_file is None:
                         status += MSG_UNKNOWN
                         status += print_test_time(total_time)

--- a/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
+++ b/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
@@ -6,9 +6,14 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # If we run sanitized binary under qemu, it will try to slowly allocate 20 TiB until OOM.
 # Don't even try to do that. This test should be disabled for sanitizer builds.
-${CLICKHOUSE_LOCAL} --query "SELECT max(value LIKE '%sanitize%') FROM system.build_options" | grep -q '1' && echo 'Skip test for sanitizer build' && exit
+${CLICKHOUSE_LOCAL} --query "SELECT max(value LIKE '%sanitize%') FROM system.build_options" | grep -q '1' && echo '@@SKIP@@: Sanitizer build' && exit
 
 command=$(command -v ${CLICKHOUSE_LOCAL})
+
+if ! hash qemu-x86_64-static 2>/dev/null; then
+    echo "@@SKIP@@: No qemu-x86_64-static"
+    exit 0
+fi
 
 function run_with_cpu()
 {

--- a/tests/queries/0_stateless/01801_s3_cluster.sh
+++ b/tests/queries/0_stateless/01801_s3_cluster.sh
@@ -7,6 +7,15 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+if [[ -z $S3_ACCESS_KEY_ID ]]; then
+    echo "@@SKIP@@: Missing \$S3_ACCESS_KEY_ID"
+    exit 0
+fi
+
+if [[ -z $S3_SECRET_ACCESS ]]; then
+    echo "@@SKIP@@: Missing \$S3_SECRET_ACCESS"
+    exit 0
+fi
 
 ${CLICKHOUSE_CLIENT_BINARY} --send_logs_level="none" -q "SELECT *  FROM s3('https://s3.mds.yandex.net/clickhouse-test-reports/*/*/functional_stateless_tests_(ubsan)/test_results.tsv',  '$S3_ACCESS_KEY_ID', '$S3_SECRET_ACCESS', 'LineAsString', 'line String') limit 100 FORMAT Null;"
 ${CLICKHOUSE_CLIENT_BINARY} --send_logs_level="none" -q "SELECT *  FROM s3Cluster('test_cluster_two_shards', 'https://s3.mds.yandex.net/clickhouse-test-reports/*/*/functional_stateless_tests_(ubsan)/test_results.tsv',  '$S3_ACCESS_KEY_ID', '$S3_SECRET_ACCESS', 'LineAsString', 'line String') limit 100 FORMAT Null;"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

* 01103_check_cpu_instructions_at_startup.sh: Only do something if `qemu-x86_64-static` is available.
* 01801_s3_cluster.sh: Only check it if the s3 env variables are setup. This test requires an account with access to that specific s3 bucket.