### PR TITLE
Less Stopwatch.h

### DIFF
--- a/programs/client/QueryFuzzer.h
+++ b/programs/client/QueryFuzzer.h
@@ -7,7 +7,6 @@
 #include <pcg-random/pcg_random.hpp>
 
 #include <Common/randomSeed.h>
-#include <Common/Stopwatch.h>
 #include <Core/Field.h>
 #include <Parsers/IAST.h>
 

--- a/src/Coordination/KeeperStorageDispatcher.cpp
+++ b/src/Coordination/KeeperStorageDispatcher.cpp
@@ -1,6 +1,5 @@
 #include <Coordination/KeeperStorageDispatcher.h>
 #include <Common/setThreadName.h>
-#include <Common/Stopwatch.h>
 #include <Common/ZooKeeper/KeeperException.h>
 #include <future>
 #include <chrono>

--- a/src/DataStreams/ExecutionSpeedLimits.h
+++ b/src/DataStreams/ExecutionSpeedLimits.h
@@ -3,7 +3,8 @@
 #include <Poco/Timespan.h>
 #include <common/types.h>
 #include <DataStreams/SizeLimits.h>
-#include <Common/Stopwatch.h>
+
+class Stopwatch;
 
 namespace DB
 {

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -8,7 +8,6 @@
 #include <Interpreters/executeQuery.h>
 #include <Parsers/queryToString.h>
 #include <Common/Exception.h>
-#include <Common/Stopwatch.h>
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/ZooKeeper/Types.h>
 #include <Common/ZooKeeper/ZooKeeper.h>

--- a/src/Dictionaries/SSDCacheDictionaryStorage.h
+++ b/src/Dictionaries/SSDCacheDictionaryStorage.h
@@ -12,7 +12,6 @@
 #include <absl/container/flat_hash_set.h>
 
 #include <common/unaligned.h>
-#include <Common/Stopwatch.h>
 #include <Common/randomSeed.h>
 #include <Common/Arena.h>
 #include <Common/ArenaWithFreeLists.h>

--- a/src/IO/Progress.h
+++ b/src/IO/Progress.h
@@ -6,8 +6,6 @@
 #include <common/types.h>
 
 #include <Core/Defines.h>
-#include <Common/Stopwatch.h>
-
 
 namespace DB
 {

--- a/src/Interpreters/CrashLog.cpp
+++ b/src/Interpreters/CrashLog.cpp
@@ -6,6 +6,7 @@
 #include <DataTypes/DataTypeDateTime.h>
 #include <Common/ClickHouseRevision.h>
 #include <Common/SymbolIndex.h>
+#include <Common/Stopwatch.h>
 
 #if !defined(ARCADIA_BUILD)
 #   include <Common/config_version.h>

--- a/src/Interpreters/DNSCacheUpdater.h
+++ b/src/Interpreters/DNSCacheUpdater.h
@@ -2,8 +2,6 @@
 
 #include <Core/BackgroundSchedulePool.h>
 #include <Interpreters/Context_fwd.h>
-#include <Common/Stopwatch.h>
-
 
 namespace DB
 {

--- a/src/Interpreters/QueryPriorities.h
+++ b/src/Interpreters/QueryPriorities.h
@@ -6,8 +6,6 @@
 #include <memory>
 #include <chrono>
 #include <Common/CurrentMetrics.h>
-#include <Common/Stopwatch.h>
-
 
 namespace CurrentMetrics
 {

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -12,7 +12,6 @@
 #include <common/types.h>
 #include <Core/Defines.h>
 #include <Storages/IStorage.h>
-#include <Common/Stopwatch.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/ParserCreateQuery.h>

--- a/src/Processors/Formats/IRowInputFormat.h
+++ b/src/Processors/Formats/IRowInputFormat.h
@@ -5,8 +5,8 @@
 #include <Processors/Formats/IInputFormat.h>
 #include <DataStreams/SizeLimits.h>
 #include <Poco/Timespan.h>
-#include <Common/Stopwatch.h>
 
+class Stopwatch;
 
 namespace DB
 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove unneeded `include <Common/Stopwatch.h>` / replace is with forward declarations when possible

Detailed description / Documentation draft:
https://github.com/ClickHouse/ClickHouse/pull/27325#discussion_r684408815