### PR TITLE
Fix "Not found column ... in block" error, when join on alias column

### DIFF
--- a/src/Interpreters/ColumnAliasesVisitor.cpp
+++ b/src/Interpreters/ColumnAliasesVisitor.cpp
@@ -25,7 +25,8 @@ bool ColumnAliasesMatcher::needChildVisit(const ASTPtr & node, const ASTPtr &)
 
     return !(node->as<ASTTableExpression>()
             || node->as<ASTSubquery>()
-            || node->as<ASTArrayJoin>());
+            || node->as<ASTArrayJoin>()
+            || node->as<ASTTableJoin>());
 }
 
 void ColumnAliasesMatcher::visit(ASTPtr & ast, Data & data)

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -962,11 +962,6 @@ TreeRewriterResultPtr TreeRewriter::analyzeSelect(
     if (const auto * join_ast = select_query->join(); join_ast && tables_with_columns.size() >= 2)
     {
         auto & table_join_ast = join_ast->table_join->as<ASTTableJoin &>();
-        if (table_join_ast.using_expression_list && result.metadata_snapshot)
-            replaceAliasColumnsInQuery(table_join_ast.using_expression_list, result.metadata_snapshot->getColumns(), result.array_join_result_to_source, getContext());
-        if (table_join_ast.on_expression && result.metadata_snapshot)
-            replaceAliasColumnsInQuery(table_join_ast.on_expression, result.metadata_snapshot->getColumns(), result.array_join_result_to_source, getContext());
-
         collectJoinedColumns(*result.analyzed_join, table_join_ast, tables_with_columns, result.aliases);
     }
 

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -532,10 +532,10 @@ void collectJoinedColumns(TableJoin & analyzed_join, const ASTTableJoin & table_
 
         CollectJoinOnKeysVisitor::Data data{analyzed_join, tables[0], tables[1], aliases, is_asof};
         CollectJoinOnKeysVisitor(data).visit(table_join.on_expression);
-        if (analyzed_join.keyNamesLeft().empty())
+        if (analyzed_join.keyNamesLeft().empty() || analyzed_join.keyNamesRight().empty())
         {
-            throw Exception("Cannot get JOIN keys from JOIN ON section: " + queryToString(table_join.on_expression),
-                            ErrorCodes::INVALID_JOIN_ON_EXPRESSION);
+            throw Exception(ErrorCodes::INVALID_JOIN_ON_EXPRESSION, "Cannot get JOIN keys from JOIN ON section: '{}'",
+                            queryToString(table_join.on_expression));
         }
 
         if (is_asof)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

* Fix "Not found column ... in block" error, when join on alias column, close https://github.com/ClickHouse/ClickHouse/issues/26980

Follow up https://github.com/ClickHouse/ClickHouse/pull/25634