### PR TITLE
Allow to reset memory tracker limit to 0

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -360,7 +360,7 @@ void MemoryTracker::setOrRaiseHardLimit(Int64 value)
 {
     /// This is just atomic set to maximum.
     Int64 old_value = hard_limit.load(std::memory_order_relaxed);
-    while (old_value < value && !hard_limit.compare_exchange_weak(old_value, value))
+    while ((value == 0 || old_value < value) && !hard_limit.compare_exchange_weak(old_value, value))
         ;
 }
 
@@ -368,6 +368,6 @@ void MemoryTracker::setOrRaiseHardLimit(Int64 value)
 void MemoryTracker::setOrRaiseProfilerLimit(Int64 value)
 {
     Int64 old_value = profiler_limit.load(std::memory_order_relaxed);
-    while (old_value < value && !profiler_limit.compare_exchange_weak(old_value, value))
+    while ((value == 0 || old_value < value) && !profiler_limit.compare_exchange_weak(old_value, value))
         ;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
After setting `max_memory_usage*` to non-zero value it was not possible to reset it back to 0 (unlimited). It's fixed.
