### PR TITLE
MV: Improve text logs when doing parallel processing

### DIFF
--- a/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -342,19 +342,7 @@ void PushingToViewsBlockOutputStream::writeSuffix()
 
                 runViewStage(view, stage_step, [&] { process_suffix(view); });
                 if (view.exception)
-                {
                     exception_count.fetch_add(1, std::memory_order_relaxed);
-                }
-                else
-                {
-                    LOG_TRACE(
-                        log,
-                        "Pushing (parallel {}) from {} to {} took {} ms.",
-                        max_threads,
-                        storage->getStorageID().getNameForLogs(),
-                        view.table_id.getNameForLogs(),
-                        view.runtime_stats.elapsed_ms);
-                }
             });
         }
         pool.wait();
@@ -371,20 +359,22 @@ void PushingToViewsBlockOutputStream::writeSuffix()
             }
             runViewStage(view, stage_step, [&] { process_suffix(view); });
             if (view.exception)
-            {
                 exception_happened = true;
-            }
-            else
-            {
-                LOG_TRACE(
-                    log,
-                    "Pushing (sequentially) from {} to {} took {} ms.",
-                    storage->getStorageID().getNameForLogs(),
-                    view.table_id.getNameForLogs(),
-                    view.runtime_stats.elapsed_ms);
-            }
         }
     }
+
+    for (auto & view : views)
+    {
+        if (!view.exception)
+            LOG_TRACE(
+                log,
+                "Pushing ({}) from {} to {} took {} ms.",
+                max_threads <= 1 ? "sequentially" : ("parallel " + std::to_string(max_threads)),
+                storage->getStorageID().getNameForLogs(),
+                view.table_id.getNameForLogs(),
+                view.runtime_stats.elapsed_ms);
+    }
+
     if (exception_happened)
         checkExceptionsInViews();
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Make sure text logs during parallel processing of materialization views include the query_id by running them under the appropiate context/thread.

Example before:
```
2021.08.13 12:39:42.218389 [ 161507 ] {} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner_5 took 0 ms.
2021.08.13 12:39:42.218389 [ 161534 ] {} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner_4 took 2000 ms.
2021.08.13 12:39:42.218406 [ 161535 ] {} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner_2 took 0 ms.
2021.08.13 12:39:42.218406 [ 161366 ] {} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner took 0 ms.
2021.08.13 12:39:42.218407 [ 161512 ] {} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner_3 took 2000 ms.
2021.08.13 12:39:42.218496 [ 161546 ] {d1d60a37-81da-400a-a797-5bd7deeb8f0e} <Debug> PushingToViewsBlockOutputStream: Pushing from default.table_b to 5 views took 2004 ms.
2021.08.13 12:39:42.218588 [ 161546 ] {} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 2) from default.table_a to default.matview_a took 2001 ms.
2021.08.13 12:39:42.218629 [ 161517 ] {d1d60a37-81da-400a-a797-5bd7deeb8f0e} <Debug> PushingToViewsBlockOutputStream: Pushing from default.table_a to 2 views took 2004 ms.
```

Example after:
```
2021.08.13 13:42:51.457627 [ 214794 ] {e2a0ea5e-6709-4a55-af72-d735e1148e2b} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner took 0 ms.
2021.08.13 13:42:51.457661 [ 214794 ] {e2a0ea5e-6709-4a55-af72-d735e1148e2b} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner_2 took 0 ms.
2021.08.13 13:42:51.457669 [ 214794 ] {e2a0ea5e-6709-4a55-af72-d735e1148e2b} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner_3 took 2000 ms.
2021.08.13 13:42:51.457678 [ 214794 ] {e2a0ea5e-6709-4a55-af72-d735e1148e2b} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner_4 took 2000 ms.
2021.08.13 13:42:51.457685 [ 214794 ] {e2a0ea5e-6709-4a55-af72-d735e1148e2b} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 5) from default.table_b to default.matview_inner_5 took 0 ms.
2021.08.13 13:42:51.457693 [ 214794 ] {e2a0ea5e-6709-4a55-af72-d735e1148e2b} <Debug> PushingToViewsBlockOutputStream: Pushing from default.table_b to 5 views took 2004 ms.
2021.08.13 13:42:51.457877 [ 214788 ] {e2a0ea5e-6709-4a55-af72-d735e1148e2b} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 2) from default.table_a to default.matview_a took 2001 ms.
2021.08.13 13:42:51.457911 [ 214788 ] {e2a0ea5e-6709-4a55-af72-d735e1148e2b} <Trace> PushingToViewsBlockOutputStream: Pushing (parallel 2) from default.table_a to default.table_a_live_min took 0 ms.
2021.08.13 13:42:51.457921 [ 214788 ] {e2a0ea5e-6709-4a55-af72-d735e1148e2b} <Debug> PushingToViewsBlockOutputStream: Pushing from default.table_a to 2 views took 2005 ms.
```

I broke it in a recent PR :disappointed: 