### PR TITLE
Disable memory tracking for roaring bitmaps on Mac OS

### DIFF
--- a/contrib/croaring-cmake/CMakeLists.txt
+++ b/contrib/croaring-cmake/CMakeLists.txt
@@ -27,8 +27,10 @@ target_include_directories(roaring SYSTEM BEFORE PUBLIC "${LIBRARY_DIR}/cpp")
 
 # We redirect malloc/free family of functions to different functions that will track memory in ClickHouse.
 # Also note that we exploit implicit function declarations.
+# Also it is disabled on Mac OS because it fails).
 
-target_compile_definitions(roaring PRIVATE
+if (NOT OS_DARWIN)
+    target_compile_definitions(roaring PRIVATE
         -Dmalloc=clickhouse_malloc
         -Dcalloc=clickhouse_calloc
         -Drealloc=clickhouse_realloc
@@ -36,4 +38,5 @@ target_compile_definitions(roaring PRIVATE
         -Dfree=clickhouse_free
         -Dposix_memalign=clickhouse_posix_memalign)
 
-target_link_libraries(roaring PUBLIC clickhouse_common_io)
+    target_link_libraries(roaring PUBLIC clickhouse_common_io)
+endif ()


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #27568.