### PR TITLE
Fix bad cast in arrayIndex

### DIFF
--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -115,6 +115,13 @@ private:
         [[maybe_unused]] const NullMap * const null_map_data,
         [[maybe_unused]] const NullMap * const null_map_item)
     {
+        if constexpr (std::is_same_v<Data, IColumn> && std::is_same_v<Target, IColumn>)
+        {
+            /// Generic variant is using IColumn::compare function that only allows to compare columns of identical types.
+            if (typeid(data) != typeid(target))
+                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Columns {} and {} cannot be compared", data.getName(), target.getName());
+        }
+
         const size_t size = offsets.size();
 
         result.resize(size);

--- a/tests/queries/0_stateless/02010_array_index_bad_cast.sql
+++ b/tests/queries/0_stateless/02010_array_index_bad_cast.sql
@@ -1,0 +1,2 @@
+-- This query throws exception about uncomparable data types (but at least it does not introduce bad cast in code).
+SELECT has(materialize(CAST(['2021-07-14'] AS Array(LowCardinality(Nullable(DateTime))))), materialize('2021-07-14'::DateTime64(7))); -- { serverError 44 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bad type cast when functions like `arrayHas` are applied to arrays of LowCardinality of Nullable of different non-numeric types like `DateTime` and `DateTime64`. In previous versions bad cast occurs. In new version it will lead to exception. This closes #26330.


Detailed description / Documentation draft:
Tech debt after #12550