### PR TITLE
Use only SSE2 in "unbundled" build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,9 +395,10 @@ endif ()
 # Turns on all external libs like s3, kafka, ODBC, ...
 option(ENABLE_LIBRARIES "Enable all external libraries by default" ON)
 
-# We recommend avoiding this mode for production builds because we can't guarantee all needed libraries exist in your
-# system.
+# We recommend avoiding this mode for production builds because we can't guarantee
+# all needed libraries exist in your system.
 # This mode exists for enthusiastic developers who are searching for trouble.
+# The whole idea of using unknown version of libraries from the OS distribution is deeply flawed.
 # Useful for maintainers of OS packages.
 option (UNBUNDLED "Use system libraries instead of ones in contrib/" OFF)
 

--- a/contrib/libmetrohash/CMakeLists.txt
+++ b/contrib/libmetrohash/CMakeLists.txt
@@ -2,9 +2,5 @@ set (SRCS
     src/metrohash64.cpp
     src/metrohash128.cpp
 )
-if (HAVE_SSE42) # Not used. Pretty easy to port.
-    list (APPEND SRCS src/metrohash128crc.cpp)
-endif ()
-
 add_library(metrohash ${SRCS})
 target_include_directories(metrohash PUBLIC src)

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -151,8 +151,14 @@ def parse_env_variables(build_type, compiler, sanitizer, package_type, image_typ
         cmake_flags.append('-DENABLE_TESTS=1')
         cmake_flags.append('-DUSE_GTEST=1')
 
+    # "Unbundled" build is not suitable for any production usage.
+    # But it is occasionally used by some developers.
+    # The whole idea of using unknown version of libraries from the OS distribution is deeply flawed.
+    # We wish these developers good luck.
     if unbundled:
-        cmake_flags.append('-DUNBUNDLED=1 -DUSE_INTERNAL_RDKAFKA_LIBRARY=1 -DENABLE_ARROW=0 -DENABLE_AVRO=0 -DENABLE_ORC=0 -DENABLE_PARQUET=0')
+        # We also disable all CPU features except basic x86_64.
+        # It is only slightly related to "unbundled" build, but it is a good place to test if code compiled without these instruction sets.
+        cmake_flags.append('-DUNBUNDLED=1 -DUSE_INTERNAL_RDKAFKA_LIBRARY=1 -DENABLE_ARROW=0 -DENABLE_AVRO=0 -DENABLE_ORC=0 -DENABLE_PARQUET=0 -DENABLE_SSSE3=0 -DENABLE_SSE41=0 -DENABLE_SSE42=0 -DENABLE_PCLMULQDQ=0 -DENABLE_POPCNT=0 -DENABLE_AVX=0 -DENABLE_AVX2=0')
 
     if split_binary:
         cmake_flags.append('-DUSE_STATIC_LIBRARIES=0 -DSPLIT_SHARED_LIBRARIES=1 -DCLICKHOUSE_SPLIT_BINARY=1')

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -157,7 +157,7 @@ def parse_env_variables(build_type, compiler, sanitizer, package_type, image_typ
     # We wish these developers good luck.
     if unbundled:
         # We also disable all CPU features except basic x86_64.
-        # It is only slightly related to "unbundled" build, but it is a good place to test if code compiled without these instruction sets.
+        # It is only slightly related to "unbundled" build, but it is a good place to test if code compiles without these instruction sets.
         cmake_flags.append('-DUNBUNDLED=1 -DUSE_INTERNAL_RDKAFKA_LIBRARY=1 -DENABLE_ARROW=0 -DENABLE_AVRO=0 -DENABLE_ORC=0 -DENABLE_PARQUET=0 -DENABLE_SSSE3=0 -DENABLE_SSE41=0 -DENABLE_SSE42=0 -DENABLE_PCLMULQDQ=0 -DENABLE_POPCNT=0 -DENABLE_AVX=0 -DENABLE_AVX2=0')
 
     if split_binary:

--- a/release
+++ b/release
@@ -71,9 +71,6 @@ then
     export DEB_CC=${DEB_CC=clang-10}
     export DEB_CXX=${DEB_CXX=clang++-10}
     EXTRAPACKAGES="$EXTRAPACKAGES clang-10 lld-10"
-elif [[ $BUILD_TYPE == 'valgrind' ]]; then
-    MALLOC_OPTS="-DENABLE_TCMALLOC=0 -DENABLE_JEMALLOC=0"
-    VERSION_POSTFIX+="+valgrind"
 elif [[ $BUILD_TYPE == 'debug' ]]; then
     CMAKE_BUILD_TYPE=Debug
     VERSION_POSTFIX+="+debug"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This closes #17469.