### PR TITLE
Fix stress test in `~CompressedWriteBuffer`

### DIFF
--- a/src/Compression/CompressedWriteBuffer.cpp
+++ b/src/Compression/CompressedWriteBuffer.cpp
@@ -30,10 +30,6 @@ void CompressedWriteBuffer::nextImpl()
     compressed_buffer.resize(compressed_reserve_size);
     UInt32 compressed_size = codec->compress(working_buffer.begin(), decompressed_size, compressed_buffer.data());
 
-    // FIXME remove this after fixing msan report in lz4.
-    // Almost always reproduces on stateless tests, the exact test unknown.
-    __msan_unpoison(compressed_buffer.data(), compressed_size);
-
     CityHash_v1_0_2::uint128 checksum = CityHash_v1_0_2::CityHash128(compressed_buffer.data(), compressed_size);
     out.write(reinterpret_cast<const char *>(&checksum), CHECKSUM_SIZE);
     out.write(compressed_buffer.data(), compressed_size);

--- a/src/Compression/CompressedWriteBuffer.cpp
+++ b/src/Compression/CompressedWriteBuffer.cpp
@@ -36,6 +36,12 @@ void CompressedWriteBuffer::nextImpl()
 }
 
 
+void CompressedWriteBuffer::finalize()
+{
+    next();
+}
+
+
 CompressedWriteBuffer::CompressedWriteBuffer(
     WriteBuffer & out_,
     CompressionCodecPtr codec_,
@@ -43,6 +49,7 @@ CompressedWriteBuffer::CompressedWriteBuffer(
     : BufferWithOwnMemory<WriteBuffer>(buf_size), out(out_), codec(std::move(codec_))
 {
 }
+
 
 CompressedWriteBuffer::~CompressedWriteBuffer()
 {

--- a/src/Compression/CompressedWriteBuffer.h
+++ b/src/Compression/CompressedWriteBuffer.h
@@ -22,6 +22,7 @@ private:
     PODArray<char> compressed_buffer;
 
     void nextImpl() override;
+    void finalize() override;
 
 public:
     CompressedWriteBuffer(

--- a/src/Compression/CompressedWriteBuffer.h
+++ b/src/Compression/CompressedWriteBuffer.h
@@ -22,13 +22,14 @@ private:
     PODArray<char> compressed_buffer;
 
     void nextImpl() override;
-    void finalize() override;
 
 public:
     CompressedWriteBuffer(
         WriteBuffer & out_,
         CompressionCodecPtr codec_ = CompressionCodecFactory::instance().getDefaultCodec(),
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE);
+
+    void finalize() override;
 
     /// The amount of compressed data
     size_t getCompressedBytes()


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See #27681.
This closes #26964.