### PR TITLE
Backquote default database in CREATE USER

### DIFF
--- a/src/Parsers/ASTDatabaseOrNone.cpp
+++ b/src/Parsers/ASTDatabaseOrNone.cpp
@@ -1,4 +1,5 @@
 #include <Parsers/ASTDatabaseOrNone.h>
+#include <Common/quoteString.h>
 #include <IO/Operators.h>
 
 namespace DB
@@ -10,7 +11,7 @@ void ASTDatabaseOrNone::formatImpl(const FormatSettings & settings, FormatState 
         settings.ostr << (settings.hilite ? IAST::hilite_keyword : "") << "NONE" << (settings.hilite ? IAST::hilite_none : "");
         return;
     }
-    settings.ostr << database_name;
+    settings.ostr << backQuoteIfNeed(database_name);
 }
 
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
After https://github.com/ClickHouse/ClickHouse/pull/25687. Add backquotes for the default database shown in CREATE USER.
