### PR TITLE
Add support for build with `clang-13`

### DIFF
--- a/base/glibc-compatibility/CMakeLists.txt
+++ b/base/glibc-compatibility/CMakeLists.txt
@@ -9,10 +9,6 @@ if (GLIBC_COMPATIBILITY)
 
     check_include_file("sys/random.h" HAVE_SYS_RANDOM_H)
 
-    if(COMPILER_CLANG)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-builtin-requires-header")
-    endif()
-
     add_headers_and_sources(glibc_compatibility .)
     add_headers_and_sources(glibc_compatibility musl)
     if (ARCH_AARCH64)
@@ -35,11 +31,9 @@ if (GLIBC_COMPATIBILITY)
 
     add_library(glibc-compatibility STATIC ${glibc_compatibility_sources})
 
-    if (COMPILER_CLANG)
-        target_compile_options(glibc-compatibility PRIVATE -Wno-unused-command-line-argument)
-    elseif (COMPILER_GCC)
-        target_compile_options(glibc-compatibility PRIVATE -Wno-unused-but-set-variable)
-    endif ()
+    target_no_warning(glibc-compatibility unused-command-line-argument)
+    target_no_warning(glibc-compatibility unused-but-set-variable)
+    target_no_warning(glibc-compatibility builtin-requires-header)
 
     target_include_directories(glibc-compatibility PRIVATE libcxxabi ${musl_arch_include_dir})
 

--- a/cmake/add_warning.cmake
+++ b/cmake/add_warning.cmake
@@ -27,3 +27,22 @@ endmacro ()
 macro (no_warning flag)
     add_warning(no-${flag})
 endmacro ()
+
+
+# The same but only for specified target.
+macro (target_add_warning target flag)
+    string (REPLACE "-" "_" underscored_flag ${flag})
+    string (REPLACE "+" "x" underscored_flag ${underscored_flag})
+
+    check_cxx_compiler_flag("-W${flag}" SUPPORTS_CXXFLAG_${underscored_flag})
+
+    if (SUPPORTS_CXXFLAG_${underscored_flag})
+        target_compile_options (${target} PRIVATE "-W${flag}")
+    else ()
+        message (WARNING "Flag -W${flag} is unsupported")
+    endif ()
+endmacro ()
+
+macro (target_no_warning target flag)
+    target_add_warning(${target} no-${flag})
+endmacro ()


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for build with `clang-13`. This closes #27705.
