### PR TITLE
Refactor arrayJoin check on partition expressions

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3207,16 +3207,6 @@ Pipe MergeTreeData::alterPartition(
     return {};
 }
 
-void checkPartitionExpressionFunction(const ASTPtr & ast)
-{
-    if (const auto * func = ast->as<ASTFunction>())
-        if (func->name == "arrayJoin")
-            throw Exception("The partition expression cannot contain array joins", ErrorCodes::INVALID_PARTITION_VALUE);
-    for (const auto & child : ast->children)
-        checkPartitionExpressionFunction(child);
-}
-
-
 String MergeTreeData::getPartitionIDFromQuery(const ASTPtr & ast, ContextPtr local_context) const
 {
     const auto & partition_ast = ast->as<ASTPartition &>();
@@ -3226,9 +3216,6 @@ String MergeTreeData::getPartitionIDFromQuery(const ASTPtr & ast, ContextPtr loc
         MergeTreePartInfo::validatePartitionID(partition_ast.id, format_version);
         return partition_ast.id;
     }
-
-    if (partition_ast.value->as<ASTFunction>())
-        checkPartitionExpressionFunction(ast);
 
     if (format_version < MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING)
     {
@@ -3251,6 +3238,16 @@ String MergeTreeData::getPartitionIDFromQuery(const ASTPtr & ast, ContextPtr loc
             "Wrong number of fields in the partition expression: " + toString(partition_ast.fields_count) +
             ", must be: " + toString(fields_count),
             ErrorCodes::INVALID_PARTITION_VALUE);
+
+    if (partition_ast.value->as<ASTFunction>())
+    {
+        ASTPtr query = partition_ast.value->clone();
+        auto syntax_analyzer_result = TreeRewriter(local_context)
+                  .analyze(query, metadata_snapshot->getPartitionKey().sample_block.getNamesAndTypesList(), {}, {}, false, false);
+        auto actions = ExpressionAnalyzer(query, syntax_analyzer_result, local_context).getActions(true);
+        if (actions->hasArrayJoin())
+            throw Exception("The partition expression cannot contain array joins", ErrorCodes::INVALID_PARTITION_VALUE);
+    }
 
     const FormatSettings format_settings;
     Row partition_row(fields_count);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3242,7 +3242,7 @@ String MergeTreeData::getPartitionIDFromQuery(const ASTPtr & ast, ContextPtr loc
     if (auto * f = partition_ast.value->as<ASTFunction>())
     {
         assert(f->name == "tuple");
-        if (f->arguments && f->arguments->as<ASTExpressionList>()->children.size())
+        if (f->arguments && !f->arguments->as<ASTExpressionList>()->children.empty())
         {
             ASTPtr query = partition_ast.value->clone();
             auto syntax_analyzer_result

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3239,14 +3239,19 @@ String MergeTreeData::getPartitionIDFromQuery(const ASTPtr & ast, ContextPtr loc
             ", must be: " + toString(fields_count),
             ErrorCodes::INVALID_PARTITION_VALUE);
 
-    if (partition_ast.value->as<ASTFunction>())
+    if (auto * f = partition_ast.value->as<ASTFunction>())
     {
-        ASTPtr query = partition_ast.value->clone();
-        auto syntax_analyzer_result = TreeRewriter(local_context)
-                  .analyze(query, metadata_snapshot->getPartitionKey().sample_block.getNamesAndTypesList(), {}, {}, false, false);
-        auto actions = ExpressionAnalyzer(query, syntax_analyzer_result, local_context).getActions(true);
-        if (actions->hasArrayJoin())
-            throw Exception("The partition expression cannot contain array joins", ErrorCodes::INVALID_PARTITION_VALUE);
+        assert(f->name == "tuple");
+        if (f->arguments && f->arguments->as<ASTExpressionList>()->children.size())
+        {
+            ASTPtr query = partition_ast.value->clone();
+            auto syntax_analyzer_result
+                = TreeRewriter(local_context)
+                      .analyze(query, metadata_snapshot->getPartitionKey().sample_block.getNamesAndTypesList(), {}, {}, false, false);
+            auto actions = ExpressionAnalyzer(query, syntax_analyzer_result, local_context).getActions(true);
+            if (actions->hasArrayJoin())
+                throw Exception("The partition expression cannot contain array joins", ErrorCodes::INVALID_PARTITION_VALUE);
+        }
     }
 
     const FormatSettings format_settings;

--- a/tests/queries/skip_list.json
+++ b/tests/queries/skip_list.json
@@ -160,6 +160,7 @@
         "01781_merge_tree_deduplication",
         "00980_zookeeper_merge_tree_alter_settings",
         "00980_merge_alter_settings",
+        "02009_array_join_partition",
         /// Old syntax is not allowed
         "01062_alter_on_mutataion_zookeeper",
         "00925_zookeeper_empty_replicated_merge_tree_optimize_final",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Use ExpressionActions instead iterating the AST to look for ArrayJoin calls in the partition expression.
It also disables the test under replicated databases as that will trigger a `Unsupported type of ALTER query` error.

Refactor for https://github.com/ClickHouse/ClickHouse/pull/27648