### PR TITLE
Disable jemalloc under OSX

### DIFF
--- a/contrib/croaring-cmake/CMakeLists.txt
+++ b/contrib/croaring-cmake/CMakeLists.txt
@@ -27,16 +27,12 @@ target_include_directories(roaring SYSTEM BEFORE PUBLIC "${LIBRARY_DIR}/cpp")
 
 # We redirect malloc/free family of functions to different functions that will track memory in ClickHouse.
 # Also note that we exploit implicit function declarations.
-# Also it is disabled on Mac OS because it fails).
+target_compile_definitions(roaring PRIVATE
+    -Dmalloc=clickhouse_malloc
+    -Dcalloc=clickhouse_calloc
+    -Drealloc=clickhouse_realloc
+    -Dreallocarray=clickhouse_reallocarray
+    -Dfree=clickhouse_free
+    -Dposix_memalign=clickhouse_posix_memalign)
 
-if (NOT OS_DARWIN)
-    target_compile_definitions(roaring PRIVATE
-        -Dmalloc=clickhouse_malloc
-        -Dcalloc=clickhouse_calloc
-        -Drealloc=clickhouse_realloc
-        -Dreallocarray=clickhouse_reallocarray
-        -Dfree=clickhouse_free
-        -Dposix_memalign=clickhouse_posix_memalign)
-
-    target_link_libraries(roaring PUBLIC clickhouse_common_io)
-endif ()
+target_link_libraries(roaring PUBLIC clickhouse_common_io)

--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -1,10 +1,9 @@
+# Disabled under OSX until https://github.com/ClickHouse/ClickHouse/issues/27568 is fixed
 if (SANITIZE OR NOT (
-    ((OS_LINUX OR OS_FREEBSD) AND (ARCH_AMD64 OR ARCH_ARM OR ARCH_PPC64LE)) OR
-    (OS_DARWIN AND (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug"))
-))
+    ((OS_LINUX OR OS_FREEBSD) AND (ARCH_AMD64 OR ARCH_ARM OR ARCH_PPC64LE))))
     if (ENABLE_JEMALLOC)
         message (${RECONFIGURE_MESSAGE_LEVEL}
-                 "jemalloc is disabled implicitly: it doesn't work with sanitizers and can only be used with x86_64, aarch64, or ppc64le Linux or FreeBSD builds and RelWithDebInfo macOS builds.")
+                 "jemalloc is disabled implicitly: it doesn't work with sanitizers and can only be used with x86_64, aarch64, or ppc64le Linux or FreeBSD builds")
     endif ()
     set (ENABLE_JEMALLOC OFF)
 else ()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

Detailed description / Documentation draft:

Disable jemalloc under OSX until https://github.com/ClickHouse/ClickHouse/issues/27568 is fixed. Otherwise it's completely unusable.