### PR TITLE
Add HTTP string parsing test

### DIFF
--- a/tests/queries/0_stateless/02011_http_parsing.reference
+++ b/tests/queries/0_stateless/02011_http_parsing.reference
@@ -1,0 +1,6 @@
+One
+Two
+Three
+Four
+Five
+Six

--- a/tests/queries/0_stateless/02011_http_parsing.sh
+++ b/tests/queries/0_stateless/02011_http_parsing.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo -ne 'One\nTwo\n'  | ${CLICKHOUSE_CURL} -sSF 'metrics_list=@-;' "${CLICKHOUSE_URL}/?metrics_list_format=TSV&metrics_list_structure=Path+String&query=SELECT+*+FROM+metrics_list";
+echo -ne 'Three\nFour' | ${CLICKHOUSE_CURL} -sSF 'metrics_list=@-;' "${CLICKHOUSE_URL}/?metrics_list_format=TSV&metrics_list_structure=Path+String&query=SELECT+*+FROM+metrics_list";
+echo -ne 'Five\n'      | ${CLICKHOUSE_CURL} -sSF 'metrics_list=@-;' "${CLICKHOUSE_URL}/?metrics_list_format=TSV&metrics_list_structure=Path+String&query=SELECT+*+FROM+metrics_list";
+echo -ne 'Six'         | ${CLICKHOUSE_CURL} -sSF 'metrics_list=@-;' "${CLICKHOUSE_URL}/?metrics_list_format=TSV&metrics_list_structure=Path+String&query=SELECT+*+FROM+metrics_list";


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Test of HTTP POST multipart/form-data string parsing. This closes #23648.
