### PR TITLE
Revert "Mark tests for `DatabaseReplicated` as green"

### DIFF
--- a/docker/test/stateless/process_functional_tests_result.py
+++ b/docker/test/stateless/process_functional_tests_result.py
@@ -105,10 +105,6 @@ def process_result(result_path):
             description += ", skipped: {}".format(skipped)
         if unknown != 0:
             description += ", unknown: {}".format(unknown)
-
-        # Temporary green for tests with DatabaseReplicated:
-        if 1 == int(os.environ.get('USE_DATABASE_REPLICATED', 0)):
-            state = "success"
     else:
         state = "failure"
         description = "Output log doesn't exist"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

 - Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:

Reverts ClickHouse/ClickHouse#27688

Tests are stable enough. Failure in #27682 is caused by real bug in Keeper (or in our ZooKeeper client, it's hard to tell), see #26036 and https://github.com/ClickHouse/ClickHouse/pull/27033#issuecomment-891313959 for details. Since we have some logs to debug the issue we can remove `abort()` from `DDLWorker` that was needed to catch the bug in CI and record as many logs as possible. Tests with Replicated database were disabled for only two days, but we already have merged PR which breaks them (#27648). Please, create an issue or mention me next time you will see suspicious failure which seems to be related to Replicated database.