### PR TITLE
Avoid nullptr dereference during processing of NULL messages in Kafka for some formats

### DIFF
--- a/src/Storages/Kafka/KafkaBlockInputStream.cpp
+++ b/src/Storages/Kafka/KafkaBlockInputStream.cpp
@@ -252,7 +252,11 @@ Block KafkaBlockInputStream::readImpl()
         }
         else
         {
-            LOG_WARNING(log, "Parsing of message (topic: {}, partition: {}, offset: {}) return no rows.", buffer->currentTopic(), buffer->currentPartition(), buffer->currentOffset());
+            // We came here in case of tombstone (or sometimes zero-length) messages, and it is not something abnormal
+            // TODO: it seems like in case of put_error_to_stream=true we may need to process those differently
+            // currently we just skip them with note in logs.
+            buffer->storeLastReadMessageOffset();
+            LOG_DEBUG(log, "Parsing of message (topic: {}, partition: {}, offset: {}) return no rows.", buffer->currentTopic(), buffer->currentPartition(), buffer->currentOffset());
         }
 
         if (!buffer->hasMorePolledMessages()

--- a/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
+++ b/src/Storages/Kafka/ReadBufferFromKafkaConsumer.cpp
@@ -472,12 +472,11 @@ bool ReadBufferFromKafkaConsumer::nextImpl()
     allowed = false;
     ++current;
 
-    // in some cases message can be NULL (tombstone records for example)
-    // parsers are not ready to get NULLs on input.
-    if (unlikely(message_data == nullptr))
+    /// If message is empty, return end of stream.
+    if (message_data == nullptr)
         return false;
 
-    // XXX: very fishy place with const casting.
+    /// const_cast is needed, because ReadBuffer works with non-const char *.
     auto * new_position = reinterpret_cast<char *>(const_cast<unsigned char *>(message_data));
     BufferBase::set(new_position, message_size, 0);
     return true;

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -283,6 +283,11 @@ def test_kafka_json_as_string(kafka_cluster):
     kafka_produce(kafka_cluster, 'kafka_json_as_string', ['{"t": 123, "e": {"x": "woof"} }', '', '{"t": 124, "e": {"x": "test"} }',
                                            '{"F1":"V1","F2":{"F21":"V21","F22":{},"F23":"V23","F24":"2019-12-24T16:28:04"},"F3":"V3"}'])
 
+    # 'tombstone' record (null value) = marker of deleted record
+    producer = KafkaProducer(bootstrap_servers="localhost:{}".format(cluster.kafka_port), value_serializer=producer_serializer, key_serializer=producer_serializer)
+    producer.send(topic='kafka_json_as_string', key='xxx')
+    producer.flush()
+
     instance.query('''
         CREATE TABLE test.kafka (field String)
             ENGINE = Kafka


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prevent crashes for some formats when NULL (tombstone) message was coming from Kafka. Closes #19255.

Detailed description / Documentation draft:
As not all the parsers are ready to get nulls, we just skip them now.

For some formats (LineAsString, JSONAsSring, RawBLOB) theoretically we can do better (pass the NULL through as DB  NULL)  if the target is Nullable(String). But it's not clear how to do it correctly and if it's really needed.