### PR TITLE
Allow symlinks to library dictionary path

### DIFF
--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -27,6 +27,7 @@ namespace ErrorCodes
     extern const int CANNOT_STATVFS;
     extern const int PATH_ACCESS_DENIED;
     extern const int CANNOT_CREATE_FILE;
+    extern const int BAD_ARGUMENTS;
 }
 
 
@@ -122,6 +123,17 @@ bool pathStartsWith(const std::filesystem::path & path, const std::filesystem::p
     return path_starts_with_prefix_path;
 }
 
+bool symlinkStartsWith(const std::filesystem::path & path, const std::filesystem::path & prefix_path)
+{
+    auto absolute_path = std::filesystem::absolute(path);
+    auto absolute_prefix_path = std::filesystem::weakly_canonical(prefix_path);
+
+    auto [_, prefix_path_mismatch_it] = std::mismatch(absolute_path.begin(), absolute_path.end(), absolute_prefix_path.begin(), absolute_prefix_path.end());
+
+    bool path_starts_with_prefix_path = (prefix_path_mismatch_it == absolute_prefix_path.end());
+    return path_starts_with_prefix_path;
+}
+
 bool pathStartsWith(const String & path, const String & prefix_path)
 {
     auto filesystem_path = std::filesystem::path(path);
@@ -130,6 +142,13 @@ bool pathStartsWith(const String & path, const String & prefix_path)
     return pathStartsWith(filesystem_path, filesystem_prefix_path);
 }
 
+bool symlinkStartsWith(const String & path, const String & prefix_path)
+{
+    auto filesystem_path = std::filesystem::path(path);
+    auto filesystem_prefix_path = std::filesystem::path(prefix_path);
+
+    return symlinkStartsWith(filesystem_path, filesystem_prefix_path);
+}
 }
 
 

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -132,7 +132,7 @@ bool symlinkStartsWith(const std::filesystem::path & path, const std::filesystem
     auto absolute_path = std::filesystem::absolute(path);
     absolute_path = absolute_path.lexically_normal(); /// Normalize path.
     auto absolute_prefix_path = std::filesystem::absolute(prefix_path);
-    absolute_pefix_path = absolute_prefix_path.lexically_normal(); /// Normalize path.
+    absolute_prefix_path = absolute_prefix_path.lexically_normal(); /// Normalize path.
 
     auto [_, prefix_path_mismatch_it] = std::mismatch(absolute_path.begin(), absolute_path.end(), absolute_prefix_path.begin(), absolute_prefix_path.end());
 

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -27,7 +27,6 @@ namespace ErrorCodes
     extern const int CANNOT_STATVFS;
     extern const int PATH_ACCESS_DENIED;
     extern const int CANNOT_CREATE_FILE;
-    extern const int BAD_ARGUMENTS;
 }
 
 

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -126,6 +126,7 @@ bool pathStartsWith(const std::filesystem::path & path, const std::filesystem::p
 bool symlinkStartsWith(const std::filesystem::path & path, const std::filesystem::path & prefix_path)
 {
     auto absolute_path = std::filesystem::absolute(path);
+    absolute_path = absolute_path.lexically_normal();
     auto absolute_prefix_path = std::filesystem::weakly_canonical(prefix_path);
 
     auto [_, prefix_path_mismatch_it] = std::mismatch(absolute_path.begin(), absolute_path.end(), absolute_prefix_path.begin(), absolute_prefix_path.end());

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -131,7 +131,8 @@ bool symlinkStartsWith(const std::filesystem::path & path, const std::filesystem
 
     auto absolute_path = std::filesystem::absolute(path);
     absolute_path = absolute_path.lexically_normal(); /// Normalize path.
-    auto absolute_prefix_path = std::filesystem::weakly_canonical(prefix_path);
+    auto absolute_prefix_path = std::filesystem::absolute(prefix_path);
+    absolute_pefix_path = absolute_prefix_path.lexically_normal(); /// Normalize path.
 
     auto [_, prefix_path_mismatch_it] = std::mismatch(absolute_path.begin(), absolute_path.end(), absolute_prefix_path.begin(), absolute_prefix_path.end());
 

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -124,8 +124,13 @@ bool pathStartsWith(const std::filesystem::path & path, const std::filesystem::p
 
 bool symlinkStartsWith(const std::filesystem::path & path, const std::filesystem::path & prefix_path)
 {
+    /// Differs from pathStartsWith in how `path` is normalized before comparison.
+    /// Make `path` absolute if it was relative and put it into normalized form: remove
+    /// `.` and `..` and extra `/`. Path is not canonized because otherwise path will
+    /// not be a path of a symlink itself.
+
     auto absolute_path = std::filesystem::absolute(path);
-    absolute_path = absolute_path.lexically_normal();
+    absolute_path = absolute_path.lexically_normal(); /// Normalize path.
     auto absolute_prefix_path = std::filesystem::weakly_canonical(prefix_path);
 
     auto [_, prefix_path_mismatch_it] = std::mismatch(absolute_path.begin(), absolute_path.end(), absolute_prefix_path.begin(), absolute_prefix_path.end());

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -35,6 +35,8 @@ bool pathStartsWith(const std::filesystem::path & path, const std::filesystem::p
 /// Returns true if path starts with prefix path
 bool pathStartsWith(const String & path, const String & prefix_path);
 
+bool symlinkStartsWith(const String & path, const String & prefix_path);
+
 }
 
 namespace FS

--- a/src/Dictionaries/LibraryDictionarySource.cpp
+++ b/src/Dictionaries/LibraryDictionarySource.cpp
@@ -41,10 +41,13 @@ LibraryDictionarySource::LibraryDictionarySource(
     , sample_block{sample_block_}
     , context(Context::createCopy(context_))
 {
-    if (fs::path(path).is_relative())
-        path = fs::canonical(path);
+    bool path_checked = false;
+    if (fs::is_symlink(path))
+        path_checked = symlinkStartsWith(path, context->getDictionariesLibPath());
+    else
+        path_checked = pathStartsWith(path, context->getDictionariesLibPath());
 
-    if (created_from_ddl && !pathStartsWith(path, context->getDictionariesLibPath()))
+    if (created_from_ddl && !path_checked)
         throw Exception(ErrorCodes::PATH_ACCESS_DENIED, "File path {} is not inside {}", path, context->getDictionariesLibPath());
 
     if (!fs::exists(path))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow symlinks for library dictionaty path.