### PR TITLE
Reset GlobalThreadPool before the application exit

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -329,6 +329,8 @@ int Keeper::main(const std::vector<std::string> & /*args*/)
     const Settings & settings = global_context->getSettingsRef();
 
     GlobalThreadPool::initialize(config().getUInt("max_thread_pool_size", 100));
+    // Reset the thread pool at exit to ensure thread destructors are called while the subsystems (logging) are still alive
+    SCOPE_EXIT({ GlobalThreadPool::reset(); });
 
     static ServerErrorHandler error_handler;
     Poco::ErrorHandler::set(&error_handler);

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -547,6 +547,8 @@ if (ThreadFuzzer::instance().isEffective())
     // nodes (`from_zk`), because ZooKeeper interface uses the pool. We will
     // ignore `max_thread_pool_size` in configs we fetch from ZK, but oh well.
     GlobalThreadPool::initialize(config().getUInt("max_thread_pool_size", 10000));
+    // Reset the thread pool at exit to ensure thread destructors are called while the subsystems (logging) are still alive
+    SCOPE_EXIT({ GlobalThreadPool::reset(); });
 
     ConnectionCollector::init(global_context, config().getUInt("max_threads_for_connection_collector", 10));
 

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -338,6 +338,11 @@ void GlobalThreadPool::initialize(size_t max_threads)
         false /*shutdown_on_exception*/));
 }
 
+void GlobalThreadPool::reset()
+{
+    the_instance.reset();
+}
+
 GlobalThreadPool & GlobalThreadPool::instance()
 {
     if (!the_instance)

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -146,6 +146,7 @@ class GlobalThreadPool : public FreeThreadPool, private boost::noncopyable
 
 public:
     static void initialize(size_t max_threads = 10000);
+    static void reset();
     static GlobalThreadPool & instance();
 };
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

The GlobalThreadPool destructor might log exceptions (if there weren't before) which requires the logging subsystem (and its static variables) to be alive. Instead of waiting until the program/binary shutdown, where the order of static object destructor depends on it's creation and that is tricky, force the reset before control is returned to the Application.

Fixes #27812