### PR TITLE
Fix shutdown of NamedSessionStorage.

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -53,7 +53,6 @@
 #include <Interpreters/ExternalLoaderXMLConfigRepository.h>
 #include <Interpreters/InterserverCredentials.h>
 #include <Interpreters/JIT/CompiledExpressionCache.h>
-#include <Interpreters/Session.h>
 #include <Access/AccessControlManager.h>
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Storages/System/attachSystemTables.h>
@@ -1429,7 +1428,6 @@ if (ThreadFuzzer::instance().isEffective())
 
         /// Must be done after initialization of `servers`, because async_metrics will access `servers` variable from its thread.
         async_metrics.start();
-        Session::startupNamedSessions();
 
         {
             String level_str = config().getString("text_log.level", "");

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -59,6 +59,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/DDLWorker.h>
 #include <Interpreters/DDLTask.h>
+#include <Interpreters/Session.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/UncompressedCache.h>
 #include <IO/MMappedFileCache.h>
@@ -272,6 +273,8 @@ struct ContextSharedPart
         if (shutdown_called)
             return;
         shutdown_called = true;
+
+        Session::shutdownNamedSessions();
 
         /**  After system_logs have been shut down it is guaranteed that no system table gets created or written to.
           *  Note that part changes at shutdown won't be logged to part log.

--- a/src/Interpreters/Session.h
+++ b/src/Interpreters/Session.h
@@ -82,8 +82,6 @@ private:
     String session_id;
     std::shared_ptr<NamedSessionData> named_session;
     bool named_session_created = false;
-
-    static std::optional<NamedSessionsStorage> named_sessions;
 };
 
 }

--- a/src/Interpreters/Session.h
+++ b/src/Interpreters/Session.h
@@ -28,9 +28,8 @@ using UserPtr = std::shared_ptr<const User>;
 class Session
 {
 public:
-    /// Allow to use named sessions. The thread will be run to cleanup sessions after timeout has expired.
-    /// The method must be called at the server startup.
-    static void startupNamedSessions();
+    /// Stops using named sessions. The method must be called at the server shutdown.
+    static void shutdownNamedSessions();
 
     Session(const ContextPtr & global_context_, ClientInfo::Interface interface_);
     Session(Session &&);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:
- Bug Fix

Changelog entry:
After https://github.com/ClickHouse/ClickHouse/pull/26864. Fix shutdown of `NamedSessionStorage`: session contexts stored in `NamedSessionStorage` are now destroyed before destroying the global context.