### PR TITLE
Fix remote query cancelation (in case of remote server abnormaly terminated)

### DIFF
--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -74,16 +74,23 @@ void TimerDescriptor::drain() const
     }
 }
 
-void TimerDescriptor::setRelative(Poco::Timespan timespan) const
+void TimerDescriptor::setRelative(uint64_t usec) const
 {
+    static constexpr uint32_t TIMER_PRECISION = 1e6;
+
     itimerspec spec;
     spec.it_interval.tv_nsec = 0;
     spec.it_interval.tv_sec = 0;
-    spec.it_value.tv_sec = timespan.totalSeconds();
-    spec.it_value.tv_nsec = timespan.useconds() * 1000;
+    spec.it_value.tv_sec = usec / TIMER_PRECISION;
+    spec.it_value.tv_nsec = (usec % TIMER_PRECISION) * 1'000;
 
     if (-1 == timerfd_settime(timer_fd, 0 /*relative timer */, &spec, nullptr))
         throwFromErrno("Cannot set time for timer_fd", ErrorCodes::CANNOT_SET_TIMER_PERIOD);
+}
+
+void TimerDescriptor::setRelative(Poco::Timespan timespan) const
+{
+    setRelative(timespan.totalMicroseconds());
 }
 
 }

--- a/src/Common/TimerDescriptor.h
+++ b/src/Common/TimerDescriptor.h
@@ -24,6 +24,7 @@ public:
 
     void reset() const;
     void drain() const;
+    void setRelative(uint64_t usec) const;
     void setRelative(Poco::Timespan timespan) const;
 };
 

--- a/src/DataStreams/RemoteQueryExecutorReadContext.cpp
+++ b/src/DataStreams/RemoteQueryExecutorReadContext.cpp
@@ -100,7 +100,7 @@ void RemoteQueryExecutorReadContext::setConnectionFD(int fd, Poco::Timespan time
     connection_fd = fd;
     epoll.add(connection_fd);
 
-    receive_timeout = timeout;
+    receive_timeout_usec = timeout.totalMicroseconds();
     connection_fd_description = fd_description;
 }
 
@@ -157,8 +157,8 @@ void RemoteQueryExecutorReadContext::setTimer() const
     /// Did not get packet yet. Init timeout for the next async reading.
     timer.reset();
 
-    if (receive_timeout.totalMicroseconds())
-        timer.setRelative(receive_timeout);
+    if (receive_timeout_usec)
+        timer.setRelative(receive_timeout_usec);
 }
 
 bool RemoteQueryExecutorReadContext::resumeRoutine()

--- a/src/DataStreams/RemoteQueryExecutorReadContext.h
+++ b/src/DataStreams/RemoteQueryExecutorReadContext.h
@@ -34,7 +34,8 @@ public:
     /// This mutex for fiber is needed because fiber could be destroyed in cancel method from another thread.
     std::mutex fiber_lock;
 
-    Poco::Timespan receive_timeout;
+    /// atomic is required due to data-race between setConnectionFD() and setTimer() from the cancellation path.
+    std::atomic<uint64_t> receive_timeout_usec = 0;
     IConnections & connections;
     Poco::Net::Socket * last_used_socket = nullptr;
 

--- a/src/DataStreams/RemoteQueryExecutorReadContext.h
+++ b/src/DataStreams/RemoteQueryExecutorReadContext.h
@@ -75,6 +75,7 @@ class RemoteQueryExecutorReadContext
 {
 public:
     void cancel() {}
+    void setTimer() {}
 };
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve remote query cancelation (in case of remote server abnormaly terminated).

Detailed description / Documentation draft:
In case the remote server abnormally terminated, neither FIN nor RST
packet will be sent, and the initiator will not know that the connection
died (unless tcp_keep_alive_timeout > 0).

Fix this, using default timeouts.