### PR TITLE
Fix incorrect assertion during writing to StorageKafka

### DIFF
--- a/src/Storages/Kafka/WriteBufferToKafkaProducer.cpp
+++ b/src/Storages/Kafka/WriteBufferToKafkaProducer.cpp
@@ -48,7 +48,7 @@ WriteBufferToKafkaProducer::WriteBufferToKafkaProducer(
 
 WriteBufferToKafkaProducer::~WriteBufferToKafkaProducer()
 {
-    assert(rows == 0 && chunks.empty());
+    assert(rows == 0);
 }
 
 void WriteBufferToKafkaProducer::countRow(const Columns & columns, size_t current_row)

--- a/src/Storages/RabbitMQ/WriteBufferToRabbitMQProducer.cpp
+++ b/src/Storages/RabbitMQ/WriteBufferToRabbitMQProducer.cpp
@@ -101,7 +101,7 @@ WriteBufferToRabbitMQProducer::~WriteBufferToRabbitMQProducer()
         std::this_thread::sleep_for(std::chrono::milliseconds(CONNECT_SLEEP));
     }
 
-    assert(rows == 0 && chunks.empty());
+    assert(rows == 0);
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect assertion during writing to StorageKafka

Detailed description / Documentation draft:
The problem it does not triggered in CI always because buffers was not
destroyed by that time.

Fixes: #26547
Fixes: #27820
Introduced-in: #19886 
Cc: @filimonov 

*NOTE: should be marked as `do not backport` since assertion is only in debug builds*