### PR TITLE
Сheck cluster name before creating Distributed

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1821,8 +1821,8 @@ std::shared_ptr<Cluster> Context::getCluster(const std::string & cluster_name) c
     auto res = getClusters()->getCluster(cluster_name);
     if (res)
         return res;
-
-    res = tryGetReplicatedDatabaseCluster(cluster_name);
+    if (!cluster_name.empty())
+        res = tryGetReplicatedDatabaseCluster(cluster_name);
     if (res)
         return res;
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -327,11 +327,13 @@ StorageDistributed::StorageDistributed(
     const String & relative_data_path_,
     const DistributedSettings & distributed_settings_,
     bool attach_,
-    ClusterPtr owned_cluster_)
+    ClusterPtr owned_cluster_,
+    ASTPtr remote_table_function_ptr_)
     : IStorage(id_)
     , WithContext(context_->getGlobalContext())
     , remote_database(remote_database_)
     , remote_table(remote_table_)
+    , remote_table_function_ptr(remote_table_function_ptr_)
     , log(&Poco::Logger::get("StorageDistributed (" + id_.table_name + ")"))
     , owned_cluster(std::move(owned_cluster_))
     , cluster_name(getContext()->getMacros()->expand(cluster_name_))
@@ -402,9 +404,9 @@ StorageDistributed::StorageDistributed(
         relative_data_path_,
         distributed_settings_,
         attach,
-        std::move(owned_cluster_))
+        std::move(owned_cluster_),
+        remote_table_function_ptr_)
 {
-    remote_table_function_ptr = std::move(remote_table_function_ptr_);
 }
 
 QueryProcessingStage::Enum StorageDistributed::getQueryProcessingStage(

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -136,7 +136,8 @@ private:
         const String & relative_data_path_,
         const DistributedSettings & distributed_settings_,
         bool attach_,
-        ClusterPtr owned_cluster_ = {});
+        ClusterPtr owned_cluster_ = {},
+        ASTPtr remote_table_function_ptr_ = {});
 
     StorageDistributed(
         const StorageID & id_,

--- a/tests/queries/0_stateless/00987_distributed_stack_overflow.sql
+++ b/tests/queries/0_stateless/00987_distributed_stack_overflow.sql
@@ -4,8 +4,7 @@ DROP TABLE IF EXISTS distr2;
 
 CREATE TABLE distr (x UInt8) ENGINE = Distributed(test_shard_localhost, currentDatabase(), distr); -- { serverError 269 }
 
-CREATE TABLE distr0 (x UInt8) ENGINE = Distributed(test_shard_localhost, '', distr0);
-SELECT * FROM distr0; -- { serverError 581 }
+CREATE TABLE distr0 (x UInt8) ENGINE = Distributed(test_shard_localhost, '', distr0); -- { serverError 269 }
 
 CREATE TABLE distr1 (x UInt8) ENGINE = Distributed(test_shard_localhost, currentDatabase(), distr2);
 CREATE TABLE distr2 (x UInt8) ENGINE = Distributed(test_shard_localhost, currentDatabase(), distr1);
@@ -13,6 +12,5 @@ CREATE TABLE distr2 (x UInt8) ENGINE = Distributed(test_shard_localhost, current
 SELECT * FROM distr1; -- { serverError 581 }
 SELECT * FROM distr2; -- { serverError 581 }
 
-DROP TABLE distr0;
 DROP TABLE distr1;
 DROP TABLE distr2;

--- a/tests/queries/0_stateless/01763_max_distributed_depth.sql
+++ b/tests/queries/0_stateless/01763_max_distributed_depth.sql
@@ -9,7 +9,9 @@ CREATE TABLE tt6
 	`status` String
 
 )
-ENGINE = Distributed('test_shard_localhost', '', 'tt6', rand());
+ENGINE = Distributed('test_shard_localhost', '', 'tt7', rand());
+
+CREATE TABLE tt7 as tt6 ENGINE = Distributed('test_shard_localhost', '', 'tt6', rand());
 
 INSERT INTO tt6 VALUES (1, 1, 1, 1, 'ok'); -- { serverError 581 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check cluster name before creating Distributed table, do not allow to create a table with incorrect cluster name. Fixes #27832


