### PR TITLE
Disable fuzzers build with clang-tidy

### DIFF
--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -173,9 +173,6 @@ def parse_env_variables(build_type, compiler, sanitizer, package_type, image_typ
         cmake_flags.append('-DUSE_GTEST=1')
         cmake_flags.append('-DENABLE_TESTS=1')
         cmake_flags.append('-DENABLE_EXAMPLES=1')
-        cmake_flags.append('-DENABLE_FUZZING=1')
-        # For fuzzing needs
-        cmake_flags.append('-DUSE_YAML_CPP=1')
         # Don't stop on first error to find more clang-tidy errors in one run.
         result.append('NINJA_FLAGS=-k0')
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
