### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,17 +13,24 @@ The following versions of ClickHouse server are currently being supported with s
 | 18.x   | :x:                |
 | 19.x   | :x:                |
 | 20.1   | :x: |
-| 20.3   | :white_check_mark: |
+| 20.3   | :x: |
 | 20.4   | :x: |
 | 20.5   | :x: |
 | 20.6   | :x: |
 | 20.7   | :x: |
-| 20.8   | :white_check_mark: |
+| 20.8   | :x: |
 | 20.9   | :x: |
 | 20.10  | :x: |
-| 20.11  | :white_check_mark: |
-| 20.12  | :white_check_mark: |
-| 21.1   | :white_check_mark: |
+| 20.11  | :x: |
+| 20.12  | :x: |
+| 21.1   | :x: |
+| 21.2   | :x: |
+| 21.3   | ✅ |
+| 21.4   | :x: |
+| 21.5   | :x: |
+| 21.6   | ✅ |
+| 21.7   | ✅ |
+| 21.8   | ✅ |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,11 @@
 # Security Policy
 
-## Supported Versions
+## Security Announcements
+Security fixes will be announced by posting them in the [security changelog](https://clickhouse.tech/docs/en/whats-new/security-changelog/)
 
-The following versions of ClickHouse server are
-currently being supported with security updates:
+## Scope and Supported Versions
+
+The following versions of ClickHouse server are currently being supported with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -25,4 +27,29 @@ currently being supported with security updates:
 
 ## Reporting a Vulnerability
 
+We're extremely grateful for security researchers and users that report vulnerabilities to the Kubernetes Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
+
 To report a potential vulnerability in ClickHouse please send the details about it to [clickhouse-feedback@yandex-team.com](mailto:clickhouse-feedback@yandex-team.com).
+
+### When Should I Report a Vulnerability?
+
+- You think you discovered a potential security vulnerability in Clickhouse
+- You are unsure how a vulnerability affects Clickhouse
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help tuning Clickhouse components for security
+- You need help applying security related updates
+- Your issue is not security related
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by Clickhouse maintainers within 3 working days.
+
+As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
+
+## Public Disclosure Timing
+
+A public disclosure date is negotiated by the Clickhouse maintainers and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. 
+
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,29 +34,28 @@ The following versions of ClickHouse server are currently being supported with s
 
 ## Reporting a Vulnerability
 
-We're extremely grateful for security researchers and users that report vulnerabilities to the Kubernetes Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
+We're extremely grateful for security researchers and users that report vulnerabilities to the ClickHouse Open Source Community. All reports are thoroughly investigated by developers.
 
 To report a potential vulnerability in ClickHouse please send the details about it to [clickhouse-feedback@yandex-team.com](mailto:clickhouse-feedback@yandex-team.com).
 
 ### When Should I Report a Vulnerability?
 
-- You think you discovered a potential security vulnerability in Clickhouse
-- You are unsure how a vulnerability affects Clickhouse
+- You think you discovered a potential security vulnerability in ClickHouse
+- You are unsure how a vulnerability affects ClickHouse
 
 ### When Should I NOT Report a Vulnerability?
 
-- You need help tuning Clickhouse components for security
+- You need help tuning ClickHouse components for security
 - You need help applying security related updates
 - Your issue is not security related
 
 ## Security Vulnerability Response
 
-Each report is acknowledged and analyzed by Clickhouse maintainers within 3 working days.
-
+Each report is acknowledged and analyzed by ClickHouse maintainers within 5 working days.
 As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
 
 ## Public Disclosure Timing
 
-A public disclosure date is negotiated by the Clickhouse maintainers and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. 
+A public disclosure date is negotiated by the ClickHouse maintainers and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to 90 days. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. 
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add a proposal for a more robust VDP as described in issue #27896
