### PR TITLE
Fix KILL MUTATION for ReplicatedMergeTree on ALTER with mutation

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1534,7 +1534,11 @@ MutationCommands ReplicatedMergeTreeQueue::getMutationCommands(
     auto in_partition = mutations_by_partition.find(part->info.partition_id);
     if (in_partition == mutations_by_partition.end())
     {
-        LOG_WARNING(log, "There are no mutations for partition ID {} (trying to mutate part {} to {})", part->info.partition_id, part->name, toString(desired_mutation_version));
+        LOG_WARNING(log,
+            "There are no mutations for partition ID {} (trying to mutate part {} to {}). Mutation is likely killed.",
+            part->info.partition_id,
+            part->name,
+            toString(desired_mutation_version));
         return MutationCommands{};
     }
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1857,9 +1857,11 @@ bool StorageReplicatedMergeTree::tryExecutePartMutation(const StorageReplicatedM
 
     if (source_part->name != source_part_name)
     {
-        LOG_WARNING(log, "Part " + source_part_name + " is covered by " + source_part->name
-                    + " but should be mutated to " + entry.new_part_name + ". "
-                    + "Possibly the mutation of this part is not needed and will be skipped. This shouldn't happen often.");
+        LOG_WARNING(log,
+            "Part {} is covered by {} should be mutated to {}. "
+            "Possibly the mutation of this part is not needed and will be skipped. "
+            "This shouldn't happen often.",
+            source_part_name, source_part->name, entry.new_part_name);
         return false;
     }
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1884,6 +1884,11 @@ bool StorageReplicatedMergeTree::tryExecutePartMutation(const StorageReplicatedM
     MergeTreePartInfo new_part_info = MergeTreePartInfo::fromPartName(
         entry.new_part_name, format_version);
     MutationCommands commands = queue.getMutationCommands(source_part, new_part_info.mutation);
+    if (commands.empty())
+    {
+        /// Logging is done from the getMutationCommands()
+        return true;
+    }
 
     /// Once we mutate part, we must reserve space on the same disk, because mutations can possibly create hardlinks.
     /// Can throw an exception.

--- a/tests/integration/test_kill_mutation/test.py
+++ b/tests/integration/test_kill_mutation/test.py
@@ -1,0 +1,54 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=line-too-long
+
+import pytest
+import time
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance('node', with_zookeeper=True)
+
+@pytest.fixture(scope='module')
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_kill_mutation(started_cluster):
+    node.query("""
+    create table data (
+        key Int,
+        index key_idx key type minmax granularity 1
+    )
+    engine = ReplicatedMergeTree('/ch/{database}/', 'r1')
+    order by key
+    settings
+        min_bytes_for_wide_part=0;
+
+    insert into data values (1);
+    """)
+
+    # Remove data skipping index to trigger consistency error
+    node.exec_in_container(['bash', '-c', 'rm /var/lib/clickhouse/data/default/data/*/skp_*'])
+
+    with pytest.raises(QueryRuntimeException, match=".*skp_idx_key_idx.idx2 doesn't exist.*"):
+        node.query("""
+        alter table data materialize index key_idx;
+        """, settings={
+            'mutations_sync': '2',
+        })
+
+    node.query("kill mutation where database = 'default' and table = 'data'")
+
+    # If mutation will not be killed then FILE_DOESNT_EXIST will be triggered endlessly.
+    value_before = int(node.query("select value from system.errors where name = 'FILE_DOESNT_EXIST'"))
+    assert value_before > 0
+
+    time.sleep(5)
+    value_after = int(node.query("select value from system.errors where name = 'FILE_DOESNT_EXIST'"))
+
+    assert value_before == value_after


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `KILL MUTATION` (before this patch after `KILL MUTATION` it will be endlessly retried with zero mutation commands) for `ReplicatedMergeTree` on `ALTER` with mutation (i.e. `ALTER TABLE MATERIALIZE INDEX`)

Cc: @alesapin 