### PR TITLE
print out git status information at configure stage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ include (cmake/arch.cmake)
 include (cmake/target.cmake)
 include (cmake/tools.cmake)
 include (cmake/analysis.cmake)
+include (cmake/git_status.cmake)
 
 # Ignore export() since we don't use it,
 # but it gets broken with a global targets via link_libraries()

--- a/cmake/git_status.cmake
+++ b/cmake/git_status.cmake
@@ -1,0 +1,17 @@
+# Print the status of the git repository (if git is available).
+# This is useful for troubleshooting build failure reports
+find_package(Git)
+
+if (Git_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_ID
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  message(STATUS "HEAD's commit hash ${GIT_COMMIT_ID}")
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} status
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+else()
+  message(STATUS "The git program could not be found.")
+endif()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md)
Print out git status information at CMake configure stage.


Detailed description / Documentation draft:
Having git status information logged in the CMake logs will make triaging build failure reports easier.

This PR fixes #24373. Having the git status information available in the
CMake logs will make it easier to troubleshoot build failure reports.

Excerpt from my CMake logs after implementing the change:

```
-- Using custom linker by name: /usr/bin/ld.lld-12
-- HEAD's commit hash 08b21339ec3c53e2c738df81899c79746e35b21b
On branch build/add-git-status
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        .venv/

nothing added to commit but untracked files present (use "git add" to track)
-- CMAKE_BUILD_TYPE is not set, set to default = RelWithDebInfo
-- CMAKE_BUILD_TYPE: RelWithDebInfo
-- Using objcopy: /usr/bin/llvm-objcopy-12
-- Using llvm-ar: /usr/bin/llvm-ar-12.
```


