### PR TITLE
Destroy `main_config_reloader` before shared context.

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1083,6 +1083,9 @@ if (ThreadFuzzer::instance().isEffective())
         /// Wait server pool to avoid use-after-free of destroyed context in the handlers
         server_pool.joinAll();
 
+        // Uses a raw pointer to global context for getting ZooKeeper.
+        main_config_reloader.reset();
+
         /** Explicitly destroy Context. It is more convenient than in destructor of Server, because logger is still available.
           * At this moment, no one could own shared part of Context.
           */
@@ -1514,7 +1517,6 @@ if (ThreadFuzzer::instance().isEffective())
                 LOG_INFO(log, "Closed connections.");
 
             dns_cache_updater.reset();
-            main_config_reloader.reset();
 
             if (current_connections)
             {


### PR DESCRIPTION
This tries to fix crash reported in a comment
https://github.com/ClickHouse/ClickHouse/pull/24404#issuecomment-847012002.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix extremely rare segfaults on shutdown due to incorrect order of context/config reloader shutdown.
