### PR TITLE
Lower compiled_expression_cache_size (to avoid hitting vm.max_map_count)

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -330,7 +330,7 @@
     <mmap_cache_size>1000</mmap_cache_size>
 
     <!-- Cache size for compiled expressions.-->
-    <compiled_expression_cache_size>1073741824</compiled_expression_cache_size>
+    <compiled_expression_cache_size>4096</compiled_expression_cache_size>
 
     <!-- Path to data directory, with trailing slash. -->
     <path>/var/lib/clickhouse/</path>


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Lower compiled_expression_cache_size (to avoid hitting vm.max_map_count)

Detailed description:
Each compiled function variant (i.e. function with it's own set of
constant arguments) requires one VMA (see JITModuleMemoryManager)

And this means that it is pretty easy to hit vm.max_map_count limit.

Limit size of compiled_expression_cache_size to vm.max_map_count/2,
since ClickHouse itself needs VMA's too for allocations.

*NOTE: Marked as `Bug fix` by intention, to backport the change*

Cc: @kitaisreal 