### PR TITLE
Better detection of the default interface in replicated fetches tests

### DIFF
--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -241,18 +241,26 @@ class _NetworkManager:
 # Approximately mesure network I/O speed for interface
 class NetThroughput(object):
     def __init__(self, node):
-        try:
-            self.interface = subprocess.check_output("awk '{print $1}' /proc/net/route  | head -n 2 | tail -n 1", shell=True).strip().decode("utf-8")
-        except Exception as ex:
-            raise Exception("Cannot get default network interface" + str(ex)) from ex
-
         self.node = node
+        # trying to get default interface and check it in /proc/net/dev
+        self.interface = self.node.exec_in_container(["bash", "-c", "awk '{print $1 \" \" $2}' /proc/net/route | grep 00000000 | awk '{print $1}'"]).strip()
+        check = self.node.exec_in_container(["bash", "-c", f'grep "^ *{self.interface}:" /proc/net/dev']).strip()
+        if not check: # if check is not successful just try eth{1-10}
+            for i in range(10):
+                try:
+                    self.interface = self.node.exec_in_container(["bash", "-c", f"awk '{{print $1}}' /proc/net/route | grep 'eth{i}'"]).strip()
+                    break
+                except Exception as ex:
+                    print(f"No interface eth{i}")
+            else:
+                raise Exception("No interface eth{1-10} and default interface not specified in /proc/net/route, maybe some special network configuration")
+
         try:
-            check = subprocess.check_output(f'grep "^ *{self.interface}:" /proc/net/dev', shell=True)
+            check = self.node.exec_in_container(["bash", "-c", f'grep "^ *{self.interface}:" /proc/net/dev']).strip()
             if not check:
                 raise Exception(f"No such interface {self.interface} found in /proc/net/dev")
         except:
-            logging.error("All available interfaces %s", subprocess.check_output("cat /proc/net/dev", shell=True))
+            logging.error("All available interfaces %s", self.node.exec_in_container(["bash", "-c", "cat /proc/net/dev"]))
             raise Exception(f"No such interface {self.interface} found in /proc/net/dev")
 
         self.current_in = self._get_in_bytes()

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -240,8 +240,12 @@ class _NetworkManager:
 
 # Approximately mesure network I/O speed for interface
 class NetThroughput(object):
-    def __init__(self, node, interface="eth0"):
-        self.interface = interface
+    def __init__(self, node):
+        try:
+            self.interface = subprocess.check_output("route | grep '^default' | grep -o '[^ ]*$'", shell=True).strip().decode("utf-8")
+        except Exception as ex:
+            raise Exception("Cannot get default network interface" + str(ex)) from ex
+
         self.node = node
         try:
             check = subprocess.check_output(f'grep "^ *{self.interface}:" /proc/net/dev', shell=True)

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -242,7 +242,7 @@ class _NetworkManager:
 class NetThroughput(object):
     def __init__(self, node):
         try:
-            self.interface = subprocess.check_output("route | grep '^default' | awk '{print $NF}'", shell=True).strip().decode("utf-8")
+            self.interface = subprocess.check_output("awk '{ print $1 " " $2}' /proc/net/route | grep 00000000 | awk '{print $1}'", shell=True).strip().decode("utf-8")
         except Exception as ex:
             raise Exception("Cannot get default network interface" + str(ex)) from ex
 

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -242,7 +242,7 @@ class _NetworkManager:
 class NetThroughput(object):
     def __init__(self, node):
         try:
-            self.interface = subprocess.check_output("awk '{ print $1 " " $2}' /proc/net/route | grep 00000000 | awk '{print $1}'", shell=True).strip().decode("utf-8")
+            self.interface = subprocess.check_output("awk '{ print $1 " " $2}' /proc/net/route  | head -n 2 | tail -n 1 | awk '{print $1}'", shell=True).strip().decode("utf-8")
         except Exception as ex:
             raise Exception("Cannot get default network interface" + str(ex)) from ex
 

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -242,7 +242,7 @@ class _NetworkManager:
 class NetThroughput(object):
     def __init__(self, node):
         try:
-            self.interface = subprocess.check_output("route | grep '^default' | grep -o '[^ ]*$'", shell=True).strip().decode("utf-8")
+            self.interface = subprocess.check_output("route | grep '^default' | awk '{print $NF}'", shell=True).strip().decode("utf-8")
         except Exception as ex:
             raise Exception("Cannot get default network interface" + str(ex)) from ex
 

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -242,7 +242,7 @@ class _NetworkManager:
 class NetThroughput(object):
     def __init__(self, node):
         try:
-            self.interface = subprocess.check_output("awk '{ print $1 " " $2}' /proc/net/route  | head -n 2 | tail -n 1 | awk '{print $1}'", shell=True).strip().decode("utf-8")
+            self.interface = subprocess.check_output("awk '{print $1}' /proc/net/route  | head -n 2 | tail -n 1", shell=True).strip().decode("utf-8")
         except Exception as ex:
             raise Exception("Cannot get default network interface" + str(ex)) from ex
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
