### PR TITLE
Allow http multipart response

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -249,6 +249,7 @@ class IColumn;
     M(UInt64, http_max_fields, 1000000, "Maximum number of fields in HTTP header", 0) \
     M(UInt64, http_max_field_name_size, 1048576, "Maximum length of field name in HTTP header", 0) \
     M(UInt64, http_max_field_value_size, 1048576, "Maximum length of field value in HTTP header", 0) \
+    M(Bool, http_multipart_response, false, "If setting is enabled, the response to a HTTP request will be a multipart containing *data* and *logs* (based on send_logs_level).", 0) \
     M(Bool, optimize_throw_if_noop, false, "If setting is enabled and OPTIMIZE query didn't actually assign a merge then an explanatory exception is thrown", 0) \
     M(Bool, use_index_for_in_with_subqueries, true, "Try using an index if there is a subquery or a table expression on the right side of the IN operator.", 0) \
     M(Bool, joined_subquery_requires_alias, true, "Force joined subqueries and table functions to have aliases for correct name qualification.", 0) \

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -472,29 +472,29 @@ void HTTPHandler::Output::multipart_setup(HTTPServerResponse & response)
     response.setContentType("multipart/form-data; boundary=\"" + boundary + "\"");
 }
 
-void HTTPHandler::Output::multipart_add_form_boundary()
+void HTTPHandler::Output::multipart_add_form_boundary() const
 {
     std::string boundary_str = "\r\n--" + boundary + "\r\n";
-    writeString(boundary_str, *out_maybe_delayed_and_compressed);
+    DB::writeString(boundary_str, *out_maybe_delayed_and_compressed);
 }
 
-void HTTPHandler::Output::multipart_add_form_closing_boundary()
+void HTTPHandler::Output::multipart_add_form_closing_boundary() const
 {
     std::string boundary_str = "\r\n--" + boundary + "--\r\n";
-    writeString(boundary_str, *out_maybe_delayed_and_compressed);
+    DB::writeString(boundary_str, *out_maybe_delayed_and_compressed);
 }
 
-void HTTPHandler::Output::multipart_add_data_headers(const std::string & content_type)
+void HTTPHandler::Output::multipart_add_data_headers(const std::string & content_type) const
 {
     multipart_add_form_boundary();
     std::string form_content_name = "Content-Disposition: form-data; name=\"data\"\r\n";
     std::string form_content_type = "Content-Type: " + content_type + "\r\n\r\n";
 
-    writeString(form_content_name, *out_maybe_delayed_and_compressed);
-    writeString(form_content_type, *out_maybe_delayed_and_compressed);
+    DB::writeString(form_content_name, *out_maybe_delayed_and_compressed);
+    DB::writeString(form_content_type, *out_maybe_delayed_and_compressed);
 }
 
-void HTTPHandler::Output::multipart_add_logs()
+void HTTPHandler::Output::multipart_add_logs() const
 {
     if (multipart && logs_queue && !logs_queue->empty())
     {
@@ -557,7 +557,7 @@ void HTTPHandler::Output::multipart_add_logs()
     }
 }
 
-void HTTPHandler::Output::multipart_add_error(const std::string & s)
+void HTTPHandler::Output::multipart_add_error(const std::string & s) const
 {
     auto & wb = *out_maybe_delayed_and_compressed;
 

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -61,12 +61,23 @@ private:
         std::shared_ptr<WriteBuffer> out_maybe_delayed_and_compressed;
 
         /// A queue with internal logs that will be passed to client
-        InternalTextLogsQueuePtr logs_queue;
+        InternalTextLogsQueuePtr logs_queue = nullptr;
+        /// Using multipart
+        bool multipart = false;
+        /// Multipart boundary
+        String boundary = "";
 
         inline bool hasDelayed() const
         {
             return out_maybe_delayed_and_compressed != out_maybe_compressed;
         }
+
+        void multipart_setup(HTTPServerResponse & response);
+        void multipart_add_form_boundary();
+        void multipart_add_form_closing_boundary();
+        void multipart_add_data_headers(const std::string & content_type);
+        void multipart_add_logs();
+        void multipart_add_error(const std::string & s);
     };
 
     IServer & server;

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/Names.h>
+#include <Interpreters/InternalTextLogsQueue.h>
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/HTTPRequestHandler.h>
 #include <Common/CurrentMetrics.h>
@@ -58,6 +59,9 @@ private:
         std::shared_ptr<WriteBuffer> out_maybe_compressed;
         /// Points to 'out' or to CompressedWriteBuffer(*out) or to CascadeWriteBuffer.
         std::shared_ptr<WriteBuffer> out_maybe_delayed_and_compressed;
+
+        /// A queue with internal logs that will be passed to client
+        InternalTextLogsQueuePtr logs_queue;
 
         inline bool hasDelayed() const
         {

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -73,11 +73,11 @@ private:
         }
 
         void multipart_setup(HTTPServerResponse & response);
-        void multipart_add_form_boundary();
-        void multipart_add_form_closing_boundary();
-        void multipart_add_data_headers(const std::string & content_type);
-        void multipart_add_logs();
-        void multipart_add_error(const std::string & s);
+        void multipart_add_form_boundary() const;
+        void multipart_add_form_closing_boundary() const;
+        void multipart_add_data_headers(const std::string & content_type) const;
+        void multipart_add_logs() const;
+        void multipart_add_error(const std::string & s) const;
     };
 
     IServer & server;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add http_multipart_response setting, which allows the HTTP Handler to return data, server logs and errors separately.


Detailed description / Documentation draft:

Background at https://github.com/ClickHouse/ClickHouse/issues/28144 and https://github.com/ClickHouse/ClickHouse/issues/21136

The idea is to showcase that it is possible to return both data, logs and errors via the same http.1 connection. I've only checked that you can extract all the information in other server languages like python and node. The browsers can't read it as is and might require some massaging in the front-end (I can give it a try).

Set as a draft for now, but reviews and comentaries are more than welcome.

Pending:
* **Decide if it's worth it or there is a better solution to the problem. **
* Integration tests
* Documentation.


Example doing a request and parsing it in python (uses requests_toolbelt to parse the forms):
```python
import cgi
import requests
from requests_toolbelt.multipart import decoder

def decode_multipart(r):
    lst = []
    partn = 0
    for part in decoder.MultipartDecoder.from_response(r).parts:
        name = 'unknown_' + str(partn)
        type = 'text/plain'
        charset = 'utf-8'
        partn += 1
        if b'Content-Disposition' in part.headers:
            _, params = cgi.parse_header(part.headers[b'Content-Disposition'].decode('ascii'))
            if 'name' in params:
                name = params['name']

        if b'Content-Type' in part.headers:
            value, params = cgi.parse_header(part.headers[b'Content-Type'].decode('ascii'))
            type = value
            if 'charset' in params:
                charset = params['charset']
        content = part.content.decode(charset)
        lst.append({'name': name, "type": type, "content": content, "charset": charset})
    return lst

r = requests.post(
    'http://localhost:8123/?wait_end_of_query=1&http_multipart_response=1&send_logs_level=trace',
    "Select * from system.numbers limit 10 FORMAT JSON"
    )
print(decode_multipart(r))


#r = requests.post(
    #'http://localhost:8123/?wait_end_of_query=0&http_multipart_response=1&send_logs_level=debug&enable_http_compression=1&query=SELECT%20toString(cityHash64(number))%20FROM%20%20numbers(10000000000)%20%20%20%20where%20intDiv(1,number-200000)%3E-1000000000000000'
    #)
#print(decode_multipart(r))

#r = requests.post(
    #'http://localhost:8123/?wait_end_of_query=0&http_multipart_response=1&send_logs_level=debug&enable_http_compression=0&query=SELECT%20toString(cityHash64(number))%20FROM%20%20numbers(10000000000)%20%20%20%20where%20intDiv(1,number-200000)%3E-1000000000000000'
    #)
#print(decode_multipart(r))
```

Sample output (ok query):

```
[{'name': 'data', 'type': 'application/json', 'content': '{\n\t"meta":\n\t[\n\t\t{\n\t\t\t"name": "number",\n\t\t\t"type": "UInt64"\n\t\t}\n\t],\n\n\t"data":\n\t[\n\t\t{\n\t\t\t"number": "0"\n\t\t},\n\t\t{\n\t\t\t"number": "1"\n\t\t},\n\t\t{\n\t\t\t"number": "2"\n\t\t},\n\t\t{\n\t\t\t"number": "3"\n\t\t},\n\t\t{\n\t\t\t"number": "4"\n\t\t},\n\t\t{\n\t\t\t"number": "5"\n\t\t},\n\t\t{\n\t\t\t"number": "6"\n\t\t},\n\t\t{\n\t\t\t"number": "7"\n\t\t},\n\t\t{\n\t\t\t"number": "8"\n\t\t},\n\t\t{\n\t\t\t"number": "9"\n\t\t}\n\t],\n\n\t"rows": 10,\n\n\t"rows_before_limit_at_least": 10,\n\n\t"statistics":\n\t{\n\t\t"elapsed": 0.00006663,\n\t\t"rows_read": 10,\n\t\t"bytes_read": 80\n\t}\n}\n', 'charset': 'UTF-8'}, {'name': 'logs', 'type': 'text/plain', 'content': '2021.08.26 18:30:22.014659 [ 334751 ] {5d3e9bef-d353-4f90-9e24-1556a4f10674} <Information> executeQuery: Read 10 rows, 80.00 B in 0.000396297 sec., 25233 rows/sec., 197.14 KiB/sec.\n', 'charset': 'UTF-8'}]
```

Or in nodeJS (uses multiparty to parse the forms):
```js
const multiparty = require('multiparty')
const http = require('http')

var options2 = {
  host: '127.0.0.1',
  port: 8123,
//   path: 'http://localhost:8123/?wait_end_of_query=0&http_multipart_response=1&send_logs_level=debug&query=Select%20count(distinct%20repository)%20from%20github_events%20FORMAT%20CSV%20SETTINGS%20send_logs_level=%27debug%27',

   path: 'http://localhost:8123/?wait_end_of_query=0&http_multipart_response=1&send_logs_level=debug&enable_http_compression=0&query=SELECT%20toString(cityHash64(number))%20FROM%20%20numbers(10000000000)%20%20%20%20where%20intDiv(1,number-200000)%3E-1000000000000000',
  method: 'POST'
};

const req2 = http.request(options2, function(res) {
    var form = new multiparty.Form({'maxFieldsSize': 100 * 1024 * 1024});
    form.parse(res, function(err, fields, files) {
        console.log(fields);
    });
});
req2.end();
```

Output example of the node run, which is a query that failed after it had already started returning data:

```
{
  data: [
    '4761183170873013810\n' +
      '10577349846663553072\n' +
      '18198135717204167749\n' +
      '9624464864560415994\n' +
      '7766709361750702608\n' +
      '15228578409069794350\n' +
      '12742043333840853032\n' +
      '13365811232860260488\n' +
--- CUT HERE ---
     '2932317051899664345\n' +
      '4513747946220550376\n' +
      '2548036246277231731\n'
  ],
  logs: [
    "2021.08.26 18:28:31.151130 [ 334750 ] {5a411a58-0429-45d1-8a7d-109f426f63fa} <Error> executeQuery: Code: 153. DB::Exception: Division by zero: while executing 'FUNCTION intDiv(1 :: 1, minus(number, 200000) :: 4) -> intDiv(1, minus(number, 200000)) Int8 : 2'. (ILLEGAL_DIVISION) (version 21.10.1.1) (from 127.0.0.1:58690) (in query: SELECT toString(cityHash64(number)) FROM numbers(10000000000) where intDiv(1,number-200000)>-1000000000000000 ), Stack trace (when copying this message, always include the lines below):\n" +
      '\n' +
      '0. /mnt/ch/ClickHouse/contrib/poco/Foundation/src/Exception.cpp:28: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x11733a in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Foundation/lib_poco_foundation.so\n' +
      '1. /mnt/ch/ClickHouse/src/Common/Exception.cpp:59: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x118e2e in /mnt/ch/ClickHouse/build/src/libclickhouse_common_io.so\n' +
      '2. /mnt/ch/ClickHouse/src/Functions/DivisionUtils.h:0: void DB::throwIfDivisionLeadsToFPE<signed char, long>(signed char, long) @ 0x3093b21 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '3. /mnt/ch/ClickHouse/src/Functions/DivisionUtils.h:64: void DB::impl_::BinaryOperation<char8_t, long, DB::DivideIntegralImpl<char8_t, long>, signed char>::process<(DB::impl_::OpCase)1>(char8_t const*, long const*, signed char*, unsigned long) @ 0x3893fdf in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '4. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:0: COW<DB::IColumn>::immutable_ptr<DB::IColumn> DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeNumeric<DB::DataTypeNumber<char8_t>, DB::DataTypeNumber<long> >(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, DB::DataTypeNumber<char8_t> const&, DB::DataTypeNumber<long> const&) const @ 0x3893df8 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      "5. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:1299: bool DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::castType<auto bool DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::castBothTypes<DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const::'lambda'(auto const&, auto const&)>(DB::IDataType const*, DB::IDataType const*, auto&&)::'lambda'(auto const&)::operator()<DB::DataTypeNumber<char8_t> >(auto const&) const::'lambda'(auto const&)>(DB::IDataType const*, auto&&) @ 0x388ed29 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n" +
      "6. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:580: bool DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::castType<bool DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::castBothTypes<DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const::'lambda'(auto const&, auto const&)>(DB::IDataType const*, DB::IDataType const*, auto&&)::'lambda'(auto const&)>(DB::IDataType const*, auto&&) @ 0x388e1d7 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n" +
      '7. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:0: DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x388db67 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '8. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:0: DB::FunctionBinaryArithmeticWithConstants<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x388ca12 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '9. /mnt/ch/ClickHouse/src/Functions/IFunctionAdaptors.h:21: DB::FunctionToExecutableFunctionAdaptor::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x1c97833 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '10. /mnt/ch/ClickHouse/src/Functions/IFunction.cpp:0: DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x4a9f2f in /mnt/ch/ClickHouse/build/src/libdbms.so\n' +
      '11. /mnt/ch/ClickHouse/contrib/boost/boost/smart_ptr/intrusive_ptr.hpp:115: DB::IExecutableFunction::execute(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x4aa47e in /mnt/ch/ClickHouse/build/src/libdbms.so\n' +
      '12. /mnt/ch/ClickHouse/src/Interpreters/ExpressionActions.cpp:0: DB::ExpressionActions::execute(DB::Block&, unsigned long&, bool) const @ 0x9983a7 in /mnt/ch/ClickHouse/build/src/libclickhouse_interpreters.so\n' +
      '13. /mnt/ch/ClickHouse/src/Processors/Transforms/FilterTransform.cpp:0: DB::FilterTransform::transform(DB::Chunk&) @ 0xde941 in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_transforms.so\n' +
      '14. /mnt/ch/ClickHouse/contrib/libcxx/include/type_traits:3933: DB::ISimpleTransform::transform(DB::Chunk&, DB::Chunk&) @ 0x2c0953 in /mnt/ch/ClickHouse/build/src/Dictionaries/libclickhouse_dictionaries.so\n' +
      '15. /mnt/ch/ClickHouse/src/Processors/ISimpleTransform.cpp:99: DB::ISimpleTransform::work() @ 0x5b587 in /mnt/ch/ClickHouse/build/src/libclickhouse_processors.so\n' +
      '16. /mnt/ch/ClickHouse/src/Processors/Executors/PipelineExecutor.cpp:108: void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::PipelineExecutor::addJob(DB::ExecutingGraph::Node*)::$_0, void ()> >(std::__1::__function::__policy_storage const*) @ 0x3cc4c in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_executors.so\n' +
      '17. /mnt/ch/ClickHouse/src/Processors/Executors/PipelineExecutor.cpp:604: DB::PipelineExecutor::executeStepImpl(unsigned long, unsigned long, std::__1::atomic<bool>*) @ 0x3b0a7 in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_executors.so\n' +
      '18. /mnt/ch/ClickHouse/src/Processors/Executors/PipelineExecutor.cpp:0: DB::PipelineExecutor::executeImpl(unsigned long) @ 0x39a8d in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_executors.so\n' +
      '19. /mnt/ch/ClickHouse/contrib/libcxx/include/memory:1627: DB::PipelineExecutor::execute(unsigned long) @ 0x395aa in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_executors.so\n' +
      '20. /mnt/ch/ClickHouse/contrib/libcxx/include/memory:3211: DB::executeQuery(DB::ReadBuffer&, DB::WriteBuffer&, bool, std::__1::shared_ptr<DB::Context>, std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>, std::__1::optional<DB::FormatSettings> const&, std::__1::function<void ()>) @ 0xe3cec7 in /mnt/ch/ClickHouse/build/src/libclickhouse_interpreters.so\n' +
      '21. /mnt/ch/ClickHouse/src/Server/HTTPHandler.cpp:894: DB::HTTPHandler::processQuery(DB::HTTPServerRequest&, DB::HTMLForm&, DB::HTTPServerResponse&, DB::HTTPHandler::Output&, std::__1::optional<DB::CurrentThread::QueryScope>&) @ 0xd4f31 in /mnt/ch/ClickHouse/build/src/libclickhouse_server.so\n' +
      '22. /mnt/ch/ClickHouse/src/Server/HTTPHandler.cpp:1051: DB::HTTPHandler::handleRequest(DB::HTTPServerRequest&, DB::HTTPServerResponse&) @ 0xd7de6 in /mnt/ch/ClickHouse/build/src/libclickhouse_server.so\n' +
      '23. /mnt/ch/ClickHouse/contrib/poco/Foundation/include/Poco/AutoPtr.h:215: DB::HTTPServerConnection::run() @ 0x32593 in /mnt/ch/ClickHouse/build/src/libclickhouse_server_http.so\n' +
      '24. /mnt/ch/ClickHouse/contrib/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x12c62c in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Net/lib_poco_net.so\n' +
      '25. /mnt/ch/ClickHouse/contrib/libcxx/include/memory:1397: Poco::Net::TCPServerDispatcher::run() @ 0x12caee in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Net/lib_poco_net.so\n' +
      '26. /mnt/ch/ClickHouse/contrib/poco/Foundation/src/ThreadPool.cpp:213: Poco::PooledThread::run() @ 0x199398 in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Foundation/lib_poco_foundation.so\n' +
      '27. /mnt/ch/ClickHouse/contrib/poco/Foundation/include/Poco/SharedPtr.h:156: Poco::ThreadImpl::runnableEntry(void*) @ 0x1968df in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Foundation/lib_poco_foundation.so\n' +
      '28. start_thread @ 0x9259 in /usr/lib/libpthread-2.33.so\n' +
      '29. __clone @ 0xfe5e3 in /usr/lib/libc-2.33.so\n' +
      '\n' +
      "2021.08.26 18:28:31.153055 [ 334750 ] {5a411a58-0429-45d1-8a7d-109f426f63fa} <Error> DynamicQueryHandler: Code: 153. DB::Exception: Division by zero: while executing 'FUNCTION intDiv(1 :: 1, minus(number, 200000) :: 4) -> intDiv(1, minus(number, 200000)) Int8 : 2'. (ILLEGAL_DIVISION), Stack trace (when copying this message, always include the lines below):\n" +
      '\n' +
      '0. /mnt/ch/ClickHouse/contrib/poco/Foundation/src/Exception.cpp:28: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x11733a in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Foundation/lib_poco_foundation.so\n' +
      '1. /mnt/ch/ClickHouse/src/Common/Exception.cpp:59: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x118e2e in /mnt/ch/ClickHouse/build/src/libclickhouse_common_io.so\n' +
      '2. /mnt/ch/ClickHouse/src/Functions/DivisionUtils.h:0: void DB::throwIfDivisionLeadsToFPE<signed char, long>(signed char, long) @ 0x3093b21 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '3. /mnt/ch/ClickHouse/src/Functions/DivisionUtils.h:64: void DB::impl_::BinaryOperation<char8_t, long, DB::DivideIntegralImpl<char8_t, long>, signed char>::process<(DB::impl_::OpCase)1>(char8_t const*, long const*, signed char*, unsigned long) @ 0x3893fdf in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '4. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:0: COW<DB::IColumn>::immutable_ptr<DB::IColumn> DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeNumeric<DB::DataTypeNumber<char8_t>, DB::DataTypeNumber<long> >(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, DB::DataTypeNumber<char8_t> const&, DB::DataTypeNumber<long> const&) const @ 0x3893df8 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      "5. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:1299: bool DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::castType<auto bool DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::castBothTypes<DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const::'lambda'(auto const&, auto const&)>(DB::IDataType const*, DB::IDataType const*, auto&&)::'lambda'(auto const&)::operator()<DB::DataTypeNumber<char8_t> >(auto const&) const::'lambda'(auto const&)>(DB::IDataType const*, auto&&) @ 0x388ed29 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n" +
      "6. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:580: bool DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::castType<bool DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::castBothTypes<DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const::'lambda'(auto const&, auto const&)>(DB::IDataType const*, DB::IDataType const*, auto&&)::'lambda'(auto const&)>(DB::IDataType const*, auto&&) @ 0x388e1d7 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n" +
      '7. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:0: DB::FunctionBinaryArithmetic<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x388db67 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '8. /mnt/ch/ClickHouse/src/Functions/FunctionBinaryArithmetic.h:0: DB::FunctionBinaryArithmeticWithConstants<DB::DivideIntegralImpl, DB::NameIntDiv, false, true>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x388ca12 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '9. /mnt/ch/ClickHouse/src/Functions/IFunctionAdaptors.h:21: DB::FunctionToExecutableFunctionAdaptor::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const @ 0x1c97833 in /mnt/ch/ClickHouse/build/src/Functions/libclickhouse_functions.so\n' +
      '10. /mnt/ch/ClickHouse/src/Functions/IFunction.cpp:0: DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x4a9f2f in /mnt/ch/ClickHouse/build/src/libdbms.so\n' +
      '11. /mnt/ch/ClickHouse/contrib/boost/boost/smart_ptr/intrusive_ptr.hpp:115: DB::IExecutableFunction::execute(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> > const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const @ 0x4aa47e in /mnt/ch/ClickHouse/build/src/libdbms.so\n' +
      '12. /mnt/ch/ClickHouse/src/Interpreters/ExpressionActions.cpp:0: DB::ExpressionActions::execute(DB::Block&, unsigned long&, bool) const @ 0x9983a7 in /mnt/ch/ClickHouse/build/src/libclickhouse_interpreters.so\n' +
      '13. /mnt/ch/ClickHouse/src/Processors/Transforms/FilterTransform.cpp:0: DB::FilterTransform::transform(DB::Chunk&) @ 0xde941 in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_transforms.so\n' +
      '14. /mnt/ch/ClickHouse/contrib/libcxx/include/type_traits:3933: DB::ISimpleTransform::transform(DB::Chunk&, DB::Chunk&) @ 0x2c0953 in /mnt/ch/ClickHouse/build/src/Dictionaries/libclickhouse_dictionaries.so\n' +
      '15. /mnt/ch/ClickHouse/src/Processors/ISimpleTransform.cpp:99: DB::ISimpleTransform::work() @ 0x5b587 in /mnt/ch/ClickHouse/build/src/libclickhouse_processors.so\n' +
      '16. /mnt/ch/ClickHouse/src/Processors/Executors/PipelineExecutor.cpp:108: void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::PipelineExecutor::addJob(DB::ExecutingGraph::Node*)::$_0, void ()> >(std::__1::__function::__policy_storage const*) @ 0x3cc4c in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_executors.so\n' +
      '17. /mnt/ch/ClickHouse/src/Processors/Executors/PipelineExecutor.cpp:604: DB::PipelineExecutor::executeStepImpl(unsigned long, unsigned long, std::__1::atomic<bool>*) @ 0x3b0a7 in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_executors.so\n' +
      '18. /mnt/ch/ClickHouse/src/Processors/Executors/PipelineExecutor.cpp:0: DB::PipelineExecutor::executeImpl(unsigned long) @ 0x39a8d in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_executors.so\n' +
      '19. /mnt/ch/ClickHouse/contrib/libcxx/include/memory:1627: DB::PipelineExecutor::execute(unsigned long) @ 0x395aa in /mnt/ch/ClickHouse/build/src/libclickhouse_processors_executors.so\n' +
      '20. /mnt/ch/ClickHouse/contrib/libcxx/include/memory:3211: DB::executeQuery(DB::ReadBuffer&, DB::WriteBuffer&, bool, std::__1::shared_ptr<DB::Context>, std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>, std::__1::optional<DB::FormatSettings> const&, std::__1::function<void ()>) @ 0xe3cec7 in /mnt/ch/ClickHouse/build/src/libclickhouse_interpreters.so\n' +
      '21. /mnt/ch/ClickHouse/src/Server/HTTPHandler.cpp:894: DB::HTTPHandler::processQuery(DB::HTTPServerRequest&, DB::HTMLForm&, DB::HTTPServerResponse&, DB::HTTPHandler::Output&, std::__1::optional<DB::CurrentThread::QueryScope>&) @ 0xd4f31 in /mnt/ch/ClickHouse/build/src/libclickhouse_server.so\n' +
      '22. /mnt/ch/ClickHouse/src/Server/HTTPHandler.cpp:1051: DB::HTTPHandler::handleRequest(DB::HTTPServerRequest&, DB::HTTPServerResponse&) @ 0xd7de6 in /mnt/ch/ClickHouse/build/src/libclickhouse_server.so\n' +
      '23. /mnt/ch/ClickHouse/contrib/poco/Foundation/include/Poco/AutoPtr.h:215: DB::HTTPServerConnection::run() @ 0x32593 in /mnt/ch/ClickHouse/build/src/libclickhouse_server_http.so\n' +
      '24. /mnt/ch/ClickHouse/contrib/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x12c62c in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Net/lib_poco_net.so\n' +
      '25. /mnt/ch/ClickHouse/contrib/libcxx/include/memory:1397: Poco::Net::TCPServerDispatcher::run() @ 0x12caee in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Net/lib_poco_net.so\n' +
      '26. /mnt/ch/ClickHouse/contrib/poco/Foundation/src/ThreadPool.cpp:213: Poco::PooledThread::run() @ 0x199398 in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Foundation/lib_poco_foundation.so\n' +
      '27. /mnt/ch/ClickHouse/contrib/poco/Foundation/include/Poco/SharedPtr.h:156: Poco::ThreadImpl::runnableEntry(void*) @ 0x1968df in /mnt/ch/ClickHouse/build/contrib/poco-cmake/Foundation/lib_poco_foundation.so\n' +
      '28. start_thread @ 0x9259 in /usr/lib/libpthread-2.33.so\n' +
      '29. __clone @ 0xfe5e3 in /usr/lib/libc-2.33.so\n' +
      ' (version 21.10.1.1)\n'
  ],
  error: [
    "Code: 153. DB::Exception: Division by zero: while executing 'FUNCTION intDiv(1 :: 1, minus(number, 200000) :: 4) -> intDiv(1, minus(number, 200000)) Int8 : 2'. (ILLEGAL_DIVISION) (version 21.10.1.1)"
  ]
}
```

Or curl:
```
$ curl -vvv 'http://localhost:8123/?wait_end_of_query=1&http_multipart_response=1&send_logs_level=debug' -d "Select count(distinct repository) from github_events FORMAT CSV SETTINGS send_logs_level='debug'"
*   Trying 127.0.0.1:8123...
* Connected to localhost (127.0.0.1) port 8123 (#0)
> POST /?wait_end_of_query=1&http_multipart_response=1&send_logs_level=debug HTTP/1.1
> Host: localhost:8123
> User-Agent: curl/7.78.0
> Accept: */*
> Content-Length: 96
> Content-Type: application/x-www-form-urlencoded
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Thu, 26 Aug 2021 16:31:02 GMT
< Connection: Keep-Alive
< Content-Type: multipart/form-data; boundary="dIp5YzQNoWOqF7qCmaXtggDXVTONa1KMbyJNGnAL1vffmlR5VrOWNu5x9s2q"
< X-ClickHouse-Server-Display-Name: Mordor.localdomain
< Transfer-Encoding: chunked
< MIME-Version: 1.0
< X-ClickHouse-Query-Id: 1e167428-d272-4dde-9284-bfe5c072e96e
< X-ClickHouse-Format: CSV
< X-ClickHouse-Timezone: Europe/Madrid
< Keep-Alive: timeout=3
< X-ClickHouse-Summary: {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"0"}
< 

--dIp5YzQNoWOqF7qCmaXtggDXVTONa1KMbyJNGnAL1vffmlR5VrOWNu5x9s2q
Content-Disposition: form-data; name="data"
Content-Type: text/csv; charset=UTF-8; header=absent

9384072

--dIp5YzQNoWOqF7qCmaXtggDXVTONa1KMbyJNGnAL1vffmlR5VrOWNu5x9s2q
Content-Disposition: form-data; name="logs"
Content-Type: text/plain; charset=UTF-8

2021.08.26 18:31:02.874008 [ 334979 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> MemoryTracker: Current memory usage (for query): 1.02 GiB.
2021.08.26 18:31:03.112574 [ 334973 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> MemoryTracker: Current memory usage (for query): 2.02 GiB.
2021.08.26 18:31:03.165678 [ 334911 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 9008668 to 1 rows (from 289.24 MiB) in 0.721626187 sec. (12483842.968 rows/sec., 400.81 MiB/sec.)
2021.08.26 18:31:03.165884 [ 334902 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 6380239 to 1 rows (from 204.81 MiB) in 0.721865555 sec. (8838541.964 rows/sec., 283.72 MiB/sec.)
2021.08.26 18:31:03.166270 [ 334931 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 7317994 to 1 rows (from 235.32 MiB) in 0.722255772 sec. (10132136.403 rows/sec., 325.81 MiB/sec.)
2021.08.26 18:31:03.166296 [ 334932 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 6153632 to 1 rows (from 198.64 MiB) in 0.722272171 sec. (8519824.309 rows/sec., 275.03 MiB/sec.)
2021.08.26 18:31:03.166494 [ 334935 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 9074416 to 1 rows (from 292.87 MiB) in 0.72245915 sec. (12560455.494 rows/sec., 405.37 MiB/sec.)
2021.08.26 18:31:03.166768 [ 334967 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 7157590 to 1 rows (from 230.52 MiB) in 0.722748748 sec. (9903289.379 rows/sec., 318.94 MiB/sec.)
2021.08.26 18:31:03.167837 [ 334968 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 6118894 to 1 rows (from 197.48 MiB) in 0.723839129 sec. (8453389.372 rows/sec., 272.83 MiB/sec.)
2021.08.26 18:31:03.167968 [ 334979 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 8214725 to 1 rows (from 263.47 MiB) in 0.723949837 sec. (11347091.442 rows/sec., 363.93 MiB/sec.)
2021.08.26 18:31:03.168303 [ 334927 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 5858420 to 1 rows (from 188.15 MiB) in 0.724295245 sec. (8088441.889 rows/sec., 259.77 MiB/sec.)
2021.08.26 18:31:03.168422 [ 334755 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 7282271 to 1 rows (from 234.55 MiB) in 0.724396784 sec. (10052875.939 rows/sec., 323.79 MiB/sec.)
2021.08.26 18:31:03.168444 [ 334920 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 7987884 to 1 rows (from 256.49 MiB) in 0.724435703 sec. (11026353.294 rows/sec., 354.06 MiB/sec.)
2021.08.26 18:31:03.169951 [ 334915 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 6924774 to 1 rows (from 221.86 MiB) in 0.72591242 sec. (9539406.971 rows/sec., 305.63 MiB/sec.)
2021.08.26 18:31:03.171905 [ 334958 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 6807401 to 1 rows (from 219.74 MiB) in 0.727881564 sec. (9352347.053 rows/sec., 301.89 MiB/sec.)
2021.08.26 18:31:03.173278 [ 334948 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 7228444 to 1 rows (from 231.94 MiB) in 0.729250632 sec. (9912153.220 rows/sec., 318.05 MiB/sec.)
2021.08.26 18:31:03.175278 [ 334973 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 5831412 to 1 rows (from 188.28 MiB) in 0.731261985 sec. (7974449.814 rows/sec., 257.47 MiB/sec.)
2021.08.26 18:31:03.185107 [ 334961 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Debug> AggregatingTransform: Aggregated. 5740956 to 1 rows (from 185.22 MiB) in 0.741111362 sec. (7746414.769 rows/sec., 249.92 MiB/sec.)
2021.08.26 18:31:04.065228 [ 334750 ] {1e167428-d272-4dde-9284-bfe5c072e96e} <Information> executeQuery: Read 113087720 rows, 3.55 GiB in 1.62299796 sec., 69678288 rows/sec., 2.19 GiB/sec.

--dIp5YzQNoWOqF7qCmaXtggDXVTONa1KMbyJNGnAL1vffmlR5VrOWNu5x9s2q--
* Connection #0 to host localhost left intact
```
