### PR TITLE
Guard UDF container with a lock

### DIFF
--- a/src/Interpreters/UserDefinedFunctionFactory.cpp
+++ b/src/Interpreters/UserDefinedFunctionFactory.cpp
@@ -27,6 +27,8 @@ void UserDefinedFunctionFactory::registerFunction(const String & function_name, 
     if (AggregateFunctionFactory::instance().hasNameOrAlias(function_name))
         throw Exception(ErrorCodes::FUNCTION_ALREADY_EXISTS, "The aggregate function '{}' already exists", function_name);
 
+    std::lock_guard lock(mutex);
+
     auto [_, inserted] = function_name_to_create_query.emplace(function_name, std::move(create_function_query));
     if (!inserted)
         throw Exception(ErrorCodes::FUNCTION_ALREADY_EXISTS,
@@ -40,6 +42,8 @@ void UserDefinedFunctionFactory::unregisterFunction(const String & function_name
         AggregateFunctionFactory::instance().hasNameOrAlias(function_name))
         throw Exception(ErrorCodes::CANNOT_DROP_SYSTEM_FUNCTION, "Cannot drop system function '{}'", function_name);
 
+    std::lock_guard lock(mutex);
+
     auto it = function_name_to_create_query.find(function_name);
     if (it == function_name_to_create_query.end())
         throw Exception(ErrorCodes::UNKNOWN_FUNCTION,
@@ -51,6 +55,8 @@ void UserDefinedFunctionFactory::unregisterFunction(const String & function_name
 
 ASTPtr UserDefinedFunctionFactory::get(const String & function_name) const
 {
+    std::lock_guard lock(mutex);
+
     auto it = function_name_to_create_query.find(function_name);
     if (it == function_name_to_create_query.end())
         throw Exception(ErrorCodes::UNKNOWN_FUNCTION,
@@ -62,6 +68,8 @@ ASTPtr UserDefinedFunctionFactory::get(const String & function_name) const
 
 ASTPtr UserDefinedFunctionFactory::tryGet(const std::string & function_name) const
 {
+    std::lock_guard lock(mutex);
+
     auto it = function_name_to_create_query.find(function_name);
     if (it == function_name_to_create_query.end())
         return nullptr;
@@ -73,6 +81,8 @@ std::vector<std::string> UserDefinedFunctionFactory::getAllRegisteredNames() con
 {
     std::vector<std::string> registered_names;
     registered_names.reserve(function_name_to_create_query.size());
+
+    std::lock_guard lock(mutex);
 
     for (const auto & [name, _] : function_name_to_create_query)
         registered_names.emplace_back(name);

--- a/src/Interpreters/UserDefinedFunctionFactory.h
+++ b/src/Interpreters/UserDefinedFunctionFactory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <mutex>
 
 #include <Common/NamePrompter.h>
 
@@ -25,8 +26,8 @@ public:
     std::vector<String> getAllRegisteredNames() const override;
 
 private:
-
     std::unordered_map<String, ASTPtr> function_name_to_create_query;
+    mutable std::mutex mutex;
 };
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Guard UDF container with a lock

Detailed description / Documentation draft:
Fixes TSAN report [1]:

    WARNING: ThreadSanitizer: data race (pid=436)
      Write of size 8 at 0x7b040076e450 by thread T240:
        ...
        3 DB::UserDefinedFunctionFactory::registerFunction() obj-x86_64-linux-gnu/../src/Interpreters/UserDefinedFunctionFactory.cpp:30:56 (clickhouse+0x1500727f)
        4 DB::InterpreterCreateFunctionQuery::execute() obj-x86_64-linux-gnu/../src/Interpreters/InterpreterCreateFunctionQuery.cpp:37:44 (clickhouse+0x14b1224a)
        5 DB::executeQueryImpl() obj-x86_64-linux-gnu/../src/Interpreters/executeQuery.cpp:573:32 (clickhouse+0x15039241)
        6 DB::executeQuery() obj-x86_64-linux-gnu/../src/Interpreters/executeQuery.cpp:934:30 (clickhouse+0x150376fa)
        7 DB::TCPHandler::runImpl() obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:291:24 (clickhouse+0x15a7af2a)

      Previous read of size 8 at 0x7b040076e450 by thread T1370:
        ...
        2 DB::UserDefinedFunctionFactory::tryGet() const obj-x86_64-linux-gnu/../src/Interpreters/UserDefinedFunctionFactory.cpp:65:45 (clickhouse+0x150078a4)
        3 DB::UserDefinedFunctionsMatcher::tryToReplaceFunction() obj-x86_64-linux-gnu/../src/Interpreters/UserDefinedFunctionsVisitor.cpp:39:73 (clickhouse+0x15007cd0)
        4 DB::UserDefinedFunctionsMatcher::visit() obj-x86_64-linux-gnu/../src/Interpreters/UserDefinedFunctionsVisitor.cpp:27:19 (clickhouse+0x15007ba8)
        5 DB::InDepthNodeVisitor<>::visit() obj-x86_64-linux-gnu/../src/Interpreters/InDepthNodeVisitor.h:34:13 (clickhouse+0x14fbcba4)
        ..
        24 DB::executeQueryImpl() obj-x86_64-linux-gnu/../src/Interpreters/executeQuery.cpp:543:28 (clickhouse+0x15038f3b)

  [1]: https://clickhouse-test-reports.s3.yandex.net/0/df1fe27791f82c2a917390faa30716effbd32b8f/stress_test_(thread).html#fail1

*NOTE: marked as `Not for changelog` since UDF is not included to any release yet*

Refs: #27796
Cc: @kitaisreal 