### PR TITLE
Ignore "file changed as we read it" error for integration tests artifacts

### DIFF
--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -257,7 +257,7 @@ class ClickhouseIntegrationTestsRunner:
         return None, None
 
     def _compress_logs(self, dir, relpaths, result_path):
-        subprocess.check_call("tar czf {} -C {} {}".format(result_path, dir, ' '.join(relpaths)), shell=True)  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
+        subprocess.check_call("tar --warning=no-file-changed -czf {} -C {} {}".format(result_path, dir, ' '.join(relpaths)), shell=True)  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
 
     def _get_all_tests(self, repo_path):
         image_cmd = self._get_runner_image_cmd(repo_path)


### PR DESCRIPTION
CI reported failure [1]:

    ...
    tar: test_mysql_database_engine/_instances_0/node1/database/store/a9e/a9e3fd27-b61c-4239-a9e3-fd27b61c2239: file changed as we read it

  [1]: https://clickhouse-test-reports.s3.yandex.net/28213/91621cfcd2bf83e71931697ae1de9a1b3abdfa14/integration_tests_(release).html#fail1

And we cannot be sure that there are no clickhouse-service alive since
restart/cleanup of old containers will happens only after the test group
will run.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)