### PR TITLE
configable LIBHDFS3_CONF, refers to #8159

### DIFF
--- a/docs/en/engines/table-engines/integrations/hdfs.md
+++ b/docs/en/engines/table-engines/integrations/hdfs.md
@@ -184,9 +184,10 @@ Similar to GraphiteMergeTree, the HDFS engine supports extended configuration us
 |hadoop\_kerberos\_keytab                               | ""                      |
 |hadoop\_kerberos\_principal                            | ""                      |
 |hadoop\_kerberos\_kinit\_command                       | kinit                   |
+|libhdfs3\_conf                                         | ""                      |
 
 ### Limitations {#limitations}
-  * hadoop\_security\_kerberos\_ticket\_cache\_path can be global only, not user specific
+  * hadoop\_security\_kerberos\_ticket\_cache\_path and libhdfs3\_conf can be global only, not user specific
 
 ## Kerberos support {#kerberos-support}
 
@@ -197,6 +198,22 @@ datanode communications are not secured by SASL (HADOOP\_SECURE\_DN\_USER is a r
 security approach). Use tests/integration/test\_storage\_kerberized\_hdfs/hdfs_configs/bootstrap.sh for reference.
 
 If hadoop\_kerberos\_keytab, hadoop\_kerberos\_principal or hadoop\_kerberos\_kinit\_command is specified, kinit will be invoked. hadoop\_kerberos\_keytab and hadoop\_kerberos\_principal are mandatory in this case. kinit tool and krb5 configuration files are required.
+
+## HDFS Namenode HA support{#namenode-ha}
+
+libhdfs3 support HDFS namenode HA.
+
+- Copy `hdfs-site.xml` from an HDFS node to `/etc/clickhouse-server/`.
+- Add following piece to ClickHouse config file:
+
+``` xml
+  <hdfs>
+    <libhdfs3_conf>/etc/clickhouse-server/hdfs-site.xml</libhdfs3_conf>
+  </hdfs>
+```
+
+- Then use `dfs.nameservices` tag value of `hdfs-site.xml` as the namenode address in the HDFS URI. For example, replace `hdfs://appadmin@192.168.101.11:8020/abc/` with `hdfs://appadmin@my_nameservice/abc/`.
+
 
 ## Virtual Columns {#virtual-columns}
 

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -123,6 +123,12 @@ HDFSBuilderWrapper createHDFSBuilder(const String & uri_str, const Poco::Util::A
     if (host.empty())
         throw Exception("Illegal HDFS URI: " + uri.toString(), ErrorCodes::BAD_ARGUMENTS);
 
+    // Shall set env LIBHDFS3_CONF *before* HDFSBuilderWrapper construction.
+    const String & libhdfs3_conf = config.getString(HDFSBuilderWrapper::CONFIG_PREFIX + ".libhdfs3_conf", "");
+    if (!libhdfs3_conf.empty())
+    {
+        setenv("LIBHDFS3_CONF", libhdfs3_conf.c_str(), 1);
+    }
     HDFSBuilderWrapper builder;
     if (builder.get() == nullptr)
         throw Exception("Unable to create builder to connect to HDFS: " +


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added libhdfs3_conf in server config instead of export env LIBHDFS3_CONF in clickhouse-server.service. 