### PR TITLE
Speed up sumIf/countIf

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionIf.cpp
+++ b/src/AggregateFunctions/AggregateFunctionIf.cpp
@@ -49,7 +49,7 @@ public:
  *  When the buffer is all zeros, this is slightly faster than doing a memcmp since doesn't require allocating memory
  *  When the buffer has values, this is much faster since it avoids visiting all memory (and the allocation and function calls)
  */
-bool ALWAYS_INLINE is_all_zeros(const UInt8 * flags, size_t size)
+static bool ALWAYS_INLINE inline is_all_zeros(const UInt8 * flags, size_t size)
 {
     size_t unroll_size = size - size % 8;
     size_t i = 0;

--- a/src/AggregateFunctions/AggregateFunctionIf.cpp
+++ b/src/AggregateFunctions/AggregateFunctionIf.cpp
@@ -156,7 +156,7 @@ public:
         const auto * filter_flags = assert_cast<const ColumnUInt8 *>(filter_column)->getData().data();
         auto final_nulls = std::make_unique<UInt8[]>(batch_size);
         for (size_t i = 0; i < batch_size; ++i)
-            final_nulls[i] = null_map[i] | !filter_flags[i];
+            final_nulls[i] = (!!null_map[i]) | (!filter_flags[i]);
 
         this->nested_function->addBatchSinglePlaceNotNull(
             batch_size, this->nestedPlace(place), columns_param, final_nulls.get(), arena, -1);

--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -96,8 +96,9 @@ struct AggregateFunctionSumData
         Impl::add(sum, local_sum);
     }
 
-    template <typename Value>
-    void NO_SANITIZE_UNDEFINED NO_INLINE addManyNotNull(const Value * __restrict ptr, const UInt8 * __restrict null_map, size_t count)
+    template <typename Value, bool add_if_zero>
+    void NO_SANITIZE_UNDEFINED NO_INLINE
+    addManyConditional_internal(const Value * __restrict ptr, const UInt8 * __restrict condition_map, size_t count)
     {
         const auto * end = ptr + count;
 
@@ -110,10 +111,10 @@ struct AggregateFunctionSumData
             T local_sum{};
             while (ptr < end)
             {
-                T multiplier = !*null_map;
+                T multiplier = !*condition_map == add_if_zero;
                 Impl::add(local_sum, *ptr * multiplier);
                 ++ptr;
-                ++null_map;
+                ++condition_map;
             }
             Impl::add(sum, local_sum);
             return;
@@ -130,13 +131,13 @@ struct AggregateFunctionSumData
             {
                 for (size_t i = 0; i < unroll_count; ++i)
                 {
-                    if (!null_map[i])
+                    if (!condition_map[i] == add_if_zero)
                     {
                         Impl::add(partial_sums[i], ptr[i]);
                     }
                 }
                 ptr += unroll_count;
-                null_map += unroll_count;
+                condition_map += unroll_count;
             }
 
             for (size_t i = 0; i < unroll_count; ++i)
@@ -146,12 +147,24 @@ struct AggregateFunctionSumData
         T local_sum{};
         while (ptr < end)
         {
-            if (!*null_map)
+            if (!*condition_map == add_if_zero)
                 Impl::add(local_sum, *ptr);
             ++ptr;
-            ++null_map;
+            ++condition_map;
         }
         Impl::add(sum, local_sum);
+    }
+
+    template <typename Value>
+    void ALWAYS_INLINE addManyNotNull(const Value * __restrict ptr, const UInt8 * __restrict null_map, size_t count)
+    {
+        return addManyConditional_internal<Value, true>(ptr, null_map, count);
+    }
+
+    template <typename Value>
+    void ALWAYS_INLINE addManyConditional(const Value * __restrict ptr, const UInt8 * __restrict cond_map, size_t count)
+    {
+        return addManyConditional_internal<Value, false>(ptr, cond_map, count);
     }
 
     void NO_SANITIZE_UNDEFINED merge(const AggregateFunctionSumData & rhs)
@@ -229,8 +242,8 @@ struct AggregateFunctionSumKahanData
         }
     }
 
-    template <typename Value>
-    void NO_INLINE addManyNotNull(const Value * __restrict ptr, const UInt8 * __restrict null_map, size_t count)
+    template <typename Value, bool add_if_zero>
+    void NO_INLINE addManyConditional_internal(const Value * __restrict ptr, const UInt8 * __restrict condition_map, size_t count)
     {
         constexpr size_t unroll_count = 4;
         T partial_sums[unroll_count]{};
@@ -242,10 +255,10 @@ struct AggregateFunctionSumKahanData
         while (ptr < unrolled_end)
         {
             for (size_t i = 0; i < unroll_count; ++i)
-                if (!null_map[i])
+                if ((!condition_map[i]) == add_if_zero)
                     addImpl(ptr[i], partial_sums[i], partial_compensations[i]);
             ptr += unroll_count;
-            null_map += unroll_count;
+            condition_map += unroll_count;
         }
 
         for (size_t i = 0; i < unroll_count; ++i)
@@ -253,11 +266,23 @@ struct AggregateFunctionSumKahanData
 
         while (ptr < end)
         {
-            if (!*null_map)
+            if ((!*condition_map) == add_if_zero)
                 addImpl(*ptr, sum, compensation);
             ++ptr;
-            ++null_map;
+            ++condition_map;
         }
+    }
+
+    template <typename Value>
+    void ALWAYS_INLINE addManyNotNull(const Value * __restrict ptr, const UInt8 * __restrict null_map, size_t count)
+    {
+        return addManyConditional_internal<Value, true>(ptr, null_map, count);
+    }
+
+    template <typename Value>
+    void ALWAYS_INLINE addManyConditional(const Value * __restrict ptr, const UInt8 * __restrict cond_map, size_t count)
+    {
+        return addManyConditional_internal<Value, false>(ptr, cond_map, count);
     }
 
     void ALWAYS_INLINE mergeImpl(T & to_sum, T & to_compensation, T from_sum, T from_compensation)
@@ -352,22 +377,17 @@ public:
             this->data(place).add(column.getData()[row_num]);
     }
 
-    /// Vectorized version when there is no GROUP BY keys.
     void addBatchSinglePlace(
-        size_t batch_size, AggregateDataPtr place, const IColumn ** columns, Arena * arena, ssize_t if_argument_pos) const override
+        size_t batch_size, AggregateDataPtr place, const IColumn ** columns, Arena *, ssize_t if_argument_pos) const override
     {
+        const auto & column = assert_cast<const ColVecType &>(*columns[0]);
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = 0; i < batch_size; ++i)
-            {
-                if (flags[i])
-                    add(place, columns, i, arena);
-            }
+            this->data(place).addManyConditional(column.getData().data(), flags.data(), batch_size);
         }
         else
         {
-            const auto & column = assert_cast<const ColVecType &>(*columns[0]);
             this->data(place).addMany(column.getData().data(), batch_size);
         }
     }

--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -404,7 +404,7 @@ public:
             const auto * if_flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData().data();
             auto final_flags = std::make_unique<UInt8[]>(batch_size);
             for (size_t i = 0; i < batch_size; ++i)
-                final_flags[i] = !null_map[i] && if_flags[i];
+                final_flags[i] = (!null_map[i]) & if_flags[i];
 
             this->data(place).addManyConditional(column.getData().data(), final_flags.get(), batch_size);
         }

--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -190,6 +190,7 @@ public:
         size_t batch_size, AggregateDataPtr place, const IColumn ** columns, Arena * arena, ssize_t if_argument_pos = -1) const = 0;
 
     /** The same for single place when need to aggregate only filtered data.
+      * Instead of using an if-column, the condition is combined inside the null_map
       */
     virtual void addBatchSinglePlaceNotNull(
         size_t batch_size,

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -85,7 +85,7 @@ size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * nu
         /// TODO Add duff device for tail?
 #endif
 
-    for (; pos < end; ++pos)
+    for (; pos < end; ++pos, ++pos2)
         count += (*pos & ~*pos2) != 0;
 
     return count;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up sumIf and countIf aggregation functions

Detailed description / Documentation draft:

As https://github.com/ClickHouse/ClickHouse/pull/26248 showed, with certain types (integers) you can do some tricks to transform a flag check into a multiplication. Checking for null or checking for a different flag is exactly the same procedure (except null is 1 when you want to discard it, and -If is 1 when you want to keep it) so we can apply the same trick to sumIf.

Comparing the performance of a simple query:

```sql
SELECT sumIf(number, (number % 10) = 0)
FROM numbers(1000000000)
```

```
clickhouse-benchmark --max_threads 1 --query "Select sumIf(number, number % 10 == 0) from numbers(1000000000)"
```

* MASTER: localhost:9000, queries 22, QPS: 1.046, RPS: 1046078712.498, MiB/s: 7980.947, result RPS: 1.046, result MiB/s: 0.000.
* CHANGES: localhost:9000, queries 22, QPS: 1.139, RPS: 1138836403.326, MiB/s: 8688.632, result RPS: 1.139, result MiB/s: 0.000.
* IMPROVEMENT: **1.09x as fast**


Once you have this in place, you can use the same trick when you have a sumIf of a nullable type, except that this time you don't have 1 flag but 2, but combining them is trivial. 

```sql
SELECT sumIf(number, (number % 10) = 0)
FROM
(
    SELECT toNullable(number) AS number
    FROM numbers(1000000000)
)
```

```
clickhouse-benchmark --max_threads 1 --query "Select sumIf(number, number % 10 == 0) FROM (Select toNullable(number) as number from numbers(1000000000))"
```

* MASTER: localhost:9000, queries 11, QPS: 0.366, RPS: 366413296.245, MiB/s: 2795.512, result RPS: 0.366, result MiB/s: 0.000.
* CHANGES: localhost:9000, queries 12, QPS: 0.728, RPS: 727744569.722, MiB/s: 5552.250, result RPS: 0.728, result MiB/s: 0.000.
* IMPROVEMENT:  **1.99x as fast**


To be able to reach this point, it was necessary to specialize AggregateFunctionIfNullUnary::addBatchSinglePlace to call the nested function addBatchSinglePlaceNotNull with the appropiate data, so accidentally it also improves other functions like countIf:

```sql
SELECT countIf((number % 10) = 0)
FROM
(
    SELECT toNullable(number) AS number
    FROM numbers(1000000000)
)

```

```
clickhouse-benchmark --max_threads 1 --query "Select countIf(number % 10 == 0) FROM (Select toNullable(number) as number from numbers(1000000000))"
```

* MASTER: localhost:9000, queries 29, QPS: 0.355, RPS: 355401345.478, MiB/s: 2711.497, result RPS: 0.355, result MiB/s: 0.000.
* CHANGES: localhost:9000, queries 22, QPS: 1.106, RPS: 1105876088.463, MiB/s: 8437.165, result RPS: 1.106, result MiB/s: 0.000.
* IMPROVEMENT: **3.11x as fast**


I haven't looked at whether the performance tests are checking these functions (sumIf, sumIf with nullable, countIf with nullable) so I might need to add them or even break the PR into 2, one for each improvement. Let's see what the CI thinks about it first.
