### PR TITLE
Set force_restore_data in stress tests

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -30,6 +30,10 @@ function configure()
     # Set maximum memory usage as half of total memory (less chance of OOM).
     echo "<yandex><max_server_memory_usage_to_ram_ratio>0.5</max_server_memory_usage_to_ram_ratio></yandex>" \
         > /etc/clickhouse-server/config.d/max_server_memory_usage_to_ram_ratio.xml
+
+    # Avoid "The local set of parts of table" and similar errors.
+    # (this is possible if the previous run was terminated in the middle of some test)
+    touch /var/lib/clickhouse/flags/force_restore_data
 }
 
 function stop()


### PR DESCRIPTION
CI reports]:
- 1: https://clickhouse-test-reports.s3.yandex.net/27881/e8d87053c04e8e30bb35fa46298abb521818731f/stress_test_(undefined).html#fail1
- 2: https://clickhouse-test-reports.s3.yandex.net/27554/b67740c7439ca96c9654cf7aab13e9fc02c1d46c/stress_test_(memory).html#fail1
- 3: https://clickhouse-test-reports.s3.yandex.net/28533/37cff8120559bef6d07046261f5709337459cfdd/stress_test_(memory).html#fail1

<details>

### 1

```
    $ pigz -cd clickhouse-server.log.gz | fgrep 'Application: DB::Exception:' -m1
2021.08.25 11:34:10.208309 [ 9275 ] {} <Error> Application: DB::Exception: The local set of parts of table test_96v1zj.dst_10 doesn't look like the set of parts in ZooKeeper: 4.00 rows of 4.00 total rows in filesystem are suspicious. There are 1 unexpected parts with 4 rows (0 of them is not just-written with 0 rows), 0 missing parts (with 0 blocks).: Cannot attach table `test_96v1zj`.`dst_10` from metadata file /var/lib/clickhouse/metadata/test_96v1zj/dst_10.sql from query ATTACH TABLE test_96v1zj.dst_10 (`p` UInt64, `k` UInt64, `v` UInt64) ENGINE = ReplicatedMergeTree('/test/01154_move_partition_long_test_96v1zj/dst', '10') PARTITION BY p % 10 ORDER BY k SETTINGS index_granularity = 8192: while loading database `test_96v1zj` from path /var/lib/clickhouse/metadata/test_96v1zj
```

### 2

```
2021.08.12 03:26:24.345469 [ 11280 ] {} <Error> Application: DB::Exception: The local set of parts of table test_1.ttl_table2 doesn't look like the set of parts in ZooKeeper: 15.00 rows of 15.00 total rows in filesystem are suspicious. There are 4 unexpected parts with 15 rows (1 of them is not just-written with 0 rows), 0 missing parts (with 0 blocks).: Cannot attach table `test_1`.`ttl_table2` from metadata file /var/lib/clickhouse/metadata/test_1/ttl_table2.sql from query ATTACH TABLE test_1.ttl_table2 (`key` DateTime) ENGINE = ReplicatedMergeTree('/test/01921_concurrent_ttl_and_normal_merges/01921_concurrent_ttl_and_normal_merges_zookeeper_long_test_1/ttl_table', '2') ORDER BY tuple() TTL key + toIntervalSecond(1) SETTINGS merge_with_ttl_timeout = 1, max_replicated_merges_with_ttl_in_queue = 100, max_number_of_merges_with_ttl_in_pool = 100, cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, index_granularity = 8192: while loading database `test_1` from path /var/lib/clickhouse/metadata/test_1
```

</details>

Changelog category (leave one):
- Not for changelog (changelog entry is not required)