### PR TITLE
JOIN key type inference respects low cardinality and nullability

### DIFF
--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -371,7 +371,7 @@ bool TableJoin::inferJoinKeyCommonType(const NamesAndTypesList & left, const Nam
             return false;
         }
 
-        if (JoinCommon::typesEqualUpToNullability(ltype->second, rtype->second))
+        if (ltype->second->equals(*rtype->second))
             continue;
 
         DataTypePtr supertype;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
JOIN key type inference respects low cardinality and nullability. Close #27691
