### PR TITLE
Clean up MySQL authentication.

### DIFF
--- a/src/Access/Authentication.cpp
+++ b/src/Access/Authentication.cpp
@@ -5,6 +5,7 @@
 #include <Access/GSSAcceptor.h>
 #include <Common/Exception.h>
 #include <Poco/SHA1Engine.h>
+#include <Common/typeid_cast.h>
 
 
 namespace DB
@@ -12,41 +13,57 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
-    extern const int LOGICAL_ERROR;
 }
 
-
-Authentication::Digest Authentication::getPasswordDoubleSHA1() const
+namespace
 {
-    switch (type)
+    using Digest = Authentication::Digest;
+    using Util = Authentication::Util;
+
+    bool checkPasswordPlainText(const String & password, const Digest & password_plaintext)
     {
-        case NO_PASSWORD:
-        {
-            Poco::SHA1Engine engine;
-            return engine.digest();
-        }
-
-        case PLAINTEXT_PASSWORD:
-        {
-            Poco::SHA1Engine engine;
-            engine.update(getPassword());
-            const Digest & first_sha1 = engine.digest();
-            engine.update(first_sha1.data(), first_sha1.size());
-            return engine.digest();
-        }
-
-        case DOUBLE_SHA1_PASSWORD:
-            return password_hash;
-
-        case SHA256_PASSWORD:
-        case LDAP:
-        case KERBEROS:
-            throw Exception("Cannot get password double SHA1 hash for authentication type " + toString(type), ErrorCodes::LOGICAL_ERROR);
-
-        case MAX_TYPE:
-            break;
+        return (Util::encodePlainText(password) == password_plaintext);
     }
-    throw Exception("getPasswordDoubleSHA1(): authentication type " + toString(type) + " not supported", ErrorCodes::NOT_IMPLEMENTED);
+
+    bool checkPasswordDoubleSHA1(const std::string_view & password, const Digest & password_double_sha1)
+    {
+        return (Util::encodeDoubleSHA1(password) == password_double_sha1);
+    }
+
+    bool checkPasswordSHA256(const std::string_view & password, const Digest & password_sha256)
+    {
+        return Util::encodeSHA256(password) == password_sha256;
+    }
+
+    bool checkPasswordDoubleSHA1MySQL(const std::string_view & scramble, const std::string_view & scrambled_password, const Digest & password_double_sha1)
+    {
+        /// scrambled_password = SHA1(password) XOR SHA1(scramble <concat> SHA1(SHA1(password)))
+
+        constexpr size_t scramble_length = 20;
+        constexpr size_t sha1_size = Poco::SHA1Engine::DIGEST_SIZE;
+
+        if ((scramble.size() < scramble_length) || (scramble.size() > scramble_length + 1)
+            || ((scramble.size() == scramble_length + 1) && (scramble[scramble_length] != 0))
+            || (scrambled_password.size() != sha1_size) || (password_double_sha1.size() != sha1_size))
+            return false;
+
+        Poco::SHA1Engine engine;
+        engine.update(scramble.data(), scramble_length);
+        engine.update(password_double_sha1.data(), sha1_size);
+        const Poco::SHA1Engine::Digest & digest = engine.digest();
+
+        Poco::SHA1Engine::Digest calculated_password_sha1(sha1_size);
+        for (size_t i = 0; i < sha1_size; i++)
+            calculated_password_sha1[i] = scrambled_password[i] ^ digest[i];
+
+        auto calculated_password_double_sha1 = Util::encodeSHA1(calculated_password_sha1);
+        return calculated_password_double_sha1 == password_double_sha1;
+    }
+
+    bool checkPasswordPlainTextMySQL(const std::string_view & scramble, const std::string_view & scrambled_password, const Digest & password_plaintext)
+    {
+        return checkPasswordDoubleSHA1MySQL(scramble, scrambled_password, Util::encodeDoubleSHA1(password_plaintext));
+    }
 }
 
 
@@ -55,7 +72,7 @@ bool Authentication::areCredentialsValid(const Credentials & credentials, const 
     if (!credentials.isReady())
         return false;
 
-    if (const auto * gss_acceptor_context = dynamic_cast<const GSSAcceptorContext *>(&credentials))
+    if (const auto * gss_acceptor_context = typeid_cast<const GSSAcceptorContext *>(&credentials))
     {
         switch (type)
         {
@@ -74,7 +91,7 @@ bool Authentication::areCredentialsValid(const Credentials & credentials, const 
         }
     }
 
-    if (const auto * basic_credentials = dynamic_cast<const BasicCredentials *>(&credentials))
+    if (const auto * mysql_credentials = typeid_cast<const MySQLNative41Credentials *>(&credentials))
     {
         switch (type)
         {
@@ -82,28 +99,36 @@ bool Authentication::areCredentialsValid(const Credentials & credentials, const 
                 return true; // N.B. even if the password is not empty!
 
             case PLAINTEXT_PASSWORD:
-            {
-                if (basic_credentials->getPassword() == std::string_view{reinterpret_cast<const char *>(password_hash.data()), password_hash.size()})
-                    return true;
-
-                // For compatibility with MySQL clients which support only native authentication plugin, SHA1 can be passed instead of password.
-                const auto password_sha1 = encodeSHA1(password_hash);
-                return basic_credentials->getPassword() == std::string_view{reinterpret_cast<const char *>(password_sha1.data()), password_sha1.size()};
-            }
-
-            case SHA256_PASSWORD:
-                return encodeSHA256(basic_credentials->getPassword()) == password_hash;
+                return checkPasswordPlainTextMySQL(mysql_credentials->getScramble(), mysql_credentials->getScrambledPassword(), password_hash);
 
             case DOUBLE_SHA1_PASSWORD:
-            {
-                const auto first_sha1 = encodeSHA1(basic_credentials->getPassword());
+                return checkPasswordDoubleSHA1MySQL(mysql_credentials->getScramble(), mysql_credentials->getScrambledPassword(), password_hash);
 
-                /// If it was MySQL compatibility server, then first_sha1 already contains double SHA1.
-                if (first_sha1 == password_hash)
-                    return true;
+            case SHA256_PASSWORD:
+            case LDAP:
+            case KERBEROS:
+                throw Require<BasicCredentials>("ClickHouse Basic Authentication");
 
-                return encodeSHA1(first_sha1) == password_hash;
-            }
+            case MAX_TYPE:
+                break;
+        }
+    }
+
+    if (const auto * basic_credentials = typeid_cast<const BasicCredentials *>(&credentials))
+    {
+        switch (type)
+        {
+            case NO_PASSWORD:
+                return true; // N.B. even if the password is not empty!
+
+            case PLAINTEXT_PASSWORD:
+                return checkPasswordPlainText(basic_credentials->getPassword(), password_hash);
+
+            case SHA256_PASSWORD:
+                return checkPasswordSHA256(basic_credentials->getPassword(), password_hash);
+
+            case DOUBLE_SHA1_PASSWORD:
+                return checkPasswordDoubleSHA1(basic_credentials->getPassword(), password_hash);
 
             case LDAP:
                 return external_authenticators.checkLDAPCredentials(ldap_server_name, *basic_credentials);
@@ -116,7 +141,7 @@ bool Authentication::areCredentialsValid(const Credentials & credentials, const 
         }
     }
 
-    if ([[maybe_unused]] const auto * always_allow_credentials = dynamic_cast<const AlwaysAllowCredentials *>(&credentials))
+    if ([[maybe_unused]] const auto * always_allow_credentials = typeid_cast<const AlwaysAllowCredentials *>(&credentials))
         return true;
 
     throw Exception("areCredentialsValid(): authentication type " + toString(type) + " not supported", ErrorCodes::NOT_IMPLEMENTED);

--- a/src/Access/Authentication.h
+++ b/src/Access/Authentication.h
@@ -86,17 +86,11 @@ public:
 
     /// Sets the password as a string of hexadecimal digits.
     void setPasswordHashHex(const String & hash);
-
     String getPasswordHashHex() const;
 
     /// Sets the password in binary form.
     void setPasswordHashBinary(const Digest & hash);
-
     const Digest & getPasswordHashBinary() const { return password_hash; }
-
-    /// Returns SHA1(SHA1(password)) used by MySQL compatibility server for authentication.
-    /// Allowed to use for Type::NO_PASSWORD, Type::PLAINTEXT_PASSWORD, Type::DOUBLE_SHA1_PASSWORD.
-    Digest getPasswordDoubleSHA1() const;
 
     /// Sets the server name for authentication type LDAP.
     const String & getLDAPServerName() const;
@@ -112,13 +106,17 @@ public:
     friend bool operator ==(const Authentication & lhs, const Authentication & rhs) { return (lhs.type == rhs.type) && (lhs.password_hash == rhs.password_hash); }
     friend bool operator !=(const Authentication & lhs, const Authentication & rhs) { return !(lhs == rhs); }
 
-private:
-    static Digest encodePlainText(const std::string_view & text) { return Digest(text.data(), text.data() + text.size()); }
-    static Digest encodeSHA256(const std::string_view & text);
-    static Digest encodeSHA1(const std::string_view & text);
-    static Digest encodeSHA1(const Digest & text) { return encodeSHA1(std::string_view{reinterpret_cast<const char *>(text.data()), text.size()}); }
-    static Digest encodeDoubleSHA1(const std::string_view & text) { return encodeSHA1(encodeSHA1(text)); }
+    struct Util
+    {
+        static Digest encodePlainText(const std::string_view & text) { return Digest(text.data(), text.data() + text.size()); }
+        static Digest encodeSHA256(const std::string_view & text);
+        static Digest encodeSHA1(const std::string_view & text);
+        static Digest encodeSHA1(const Digest & text) { return encodeSHA1(std::string_view{reinterpret_cast<const char *>(text.data()), text.size()}); }
+        static Digest encodeDoubleSHA1(const std::string_view & text) { return encodeSHA1(encodeSHA1(text)); }
+        static Digest encodeDoubleSHA1(const Digest & text) { return encodeSHA1(encodeSHA1(text)); }
+    };
 
+private:
     Type type = Type::NO_PASSWORD;
     Digest password_hash;
     String ldap_server_name;
@@ -192,7 +190,7 @@ inline String toString(Authentication::Type type_)
 }
 
 
-inline Authentication::Digest Authentication::encodeSHA256(const std::string_view & text [[maybe_unused]])
+inline Authentication::Digest Authentication::Util::encodeSHA256(const std::string_view & text [[maybe_unused]])
 {
 #if USE_SSL
     Digest hash;
@@ -206,7 +204,7 @@ inline Authentication::Digest Authentication::encodeSHA256(const std::string_vie
 #endif
 }
 
-inline Authentication::Digest Authentication::encodeSHA1(const std::string_view & text)
+inline Authentication::Digest Authentication::Util::encodeSHA1(const std::string_view & text)
 {
     Poco::SHA1Engine engine;
     engine.update(text.data(), text.size());
@@ -219,13 +217,13 @@ inline void Authentication::setPassword(const String & password_)
     switch (type)
     {
         case PLAINTEXT_PASSWORD:
-            return setPasswordHashBinary(encodePlainText(password_));
+            return setPasswordHashBinary(Util::encodePlainText(password_));
 
         case SHA256_PASSWORD:
-            return setPasswordHashBinary(encodeSHA256(password_));
+            return setPasswordHashBinary(Util::encodeSHA256(password_));
 
         case DOUBLE_SHA1_PASSWORD:
-            return setPasswordHashBinary(encodeDoubleSHA1(password_));
+            return setPasswordHashBinary(Util::encodeDoubleSHA1(password_));
 
         case NO_PASSWORD:
         case LDAP:

--- a/src/Access/Credentials.h
+++ b/src/Access/Credentials.h
@@ -54,4 +54,26 @@ private:
     String password;
 };
 
+class CredentialsWithScramble : public Credentials
+{
+public:
+    explicit CredentialsWithScramble(const String & user_name_, const String & scramble_, const String & scrambled_password_)
+        : Credentials(user_name_), scramble(scramble_), scrambled_password(scrambled_password_)
+    {
+        is_ready = true;
+    }
+
+    const String & getScramble() const { return scramble; }
+    const String & getScrambledPassword() const { return scrambled_password; }
+
+private:
+    String scramble;
+    String scrambled_password;
+};
+
+class MySQLNative41Credentials : public CredentialsWithScramble
+{
+    using CredentialsWithScramble::CredentialsWithScramble;
+};
+
 }

--- a/src/Core/MySQL/Authentication.cpp
+++ b/src/Core/MySQL/Authentication.cpp
@@ -3,6 +3,7 @@
 #include <Poco/RandomStream.h>
 #include <Poco/SHA1Engine.h>
 #include <Interpreters/Session.h>
+#include <Access/Credentials.h>
 
 #include <common/logger_useful.h>
 #include <Common/OpenSSLHelpers.h>
@@ -29,15 +30,16 @@ namespace Authentication
 
 static const size_t SCRAMBLE_LENGTH = 20;
 
-Native41::Native41()
+/** Generate a random string using ASCII characters but avoid separator character,
+  * produce pseudo random numbers between with about 7 bit worth of entropty between 1-127.
+  * https://github.com/mysql/mysql-server/blob/8.0/mysys/crypt_genhash_impl.cc#L427
+  */
+static String generateScramble()
 {
+    String scramble;
     scramble.resize(SCRAMBLE_LENGTH + 1, 0);
     Poco::RandomInputStream generator;
 
-    /** Generate a random string using ASCII characters but avoid separator character,
-      * produce pseudo random numbers between with about 7 bit worth of entropty between 1-127.
-      * https://github.com/mysql/mysql-server/blob/8.0/mysys/crypt_genhash_impl.cc#L427
-      */
     for (size_t i = 0; i < SCRAMBLE_LENGTH; ++i)
     {
         generator >> scramble[i];
@@ -45,14 +47,18 @@ Native41::Native41()
         if (scramble[i] == '\0' || scramble[i] == '$')
             scramble[i] = scramble[i] + 1;
     }
+
+    return scramble;
 }
 
-Native41::Native41(const String & password, const String & auth_plugin_data)
+Native41::Native41() : scramble(generateScramble()) { }
+
+Native41::Native41(const String & password_, const String & scramble_)
 {
     /// https://dev.mysql.com/doc/internals/en/secure-password-authentication.html
     /// SHA1( password ) XOR SHA1( "20-bytes random data from server" <concat> SHA1( SHA1( password ) ) )
     Poco::SHA1Engine engine1;
-    engine1.update(password);
+    engine1.update(password_);
     const Poco::SHA1Engine::Digest & password_sha1 = engine1.digest();
 
     Poco::SHA1Engine engine2;
@@ -60,15 +66,13 @@ Native41::Native41(const String & password, const String & auth_plugin_data)
     const Poco::SHA1Engine::Digest & password_double_sha1 = engine2.digest();
 
     Poco::SHA1Engine engine3;
-    engine3.update(auth_plugin_data.data(), auth_plugin_data.size());
+    engine3.update(scramble_.data(), scramble_.size());
     engine3.update(password_double_sha1.data(), password_double_sha1.size());
     const Poco::SHA1Engine::Digest & digest = engine3.digest();
 
     scramble.resize(SCRAMBLE_LENGTH);
     for (size_t i = 0; i < SCRAMBLE_LENGTH; i++)
-    {
         scramble[i] = static_cast<unsigned char>(password_sha1[i] ^ digest[i]);
-    }
 }
 
 void Native41::authenticate(
@@ -95,20 +99,7 @@ void Native41::authenticate(
                 + " bytes, received: " + std::to_string(auth_response->size()) + " bytes.",
             ErrorCodes::UNKNOWN_EXCEPTION);
 
-    Poco::SHA1Engine::Digest double_sha1_value = session.getPasswordDoubleSHA1(user_name);
-    assert(double_sha1_value.size() == Poco::SHA1Engine::DIGEST_SIZE);
-
-    Poco::SHA1Engine engine;
-    engine.update(scramble.data(), SCRAMBLE_LENGTH);
-    engine.update(double_sha1_value.data(), double_sha1_value.size());
-
-    String password_sha1(Poco::SHA1Engine::DIGEST_SIZE, 0x0);
-    const Poco::SHA1Engine::Digest & digest = engine.digest();
-    for (size_t i = 0; i < password_sha1.size(); i++)
-    {
-        password_sha1[i] = digest[i] ^ static_cast<unsigned char>((*auth_response)[i]);
-    }
-    session.authenticate(user_name, password_sha1, address);
+    session.authenticate(MySQLNative41Credentials{user_name, scramble, *auth_response}, address);
 }
 
 #if USE_SSL
@@ -120,16 +111,7 @@ Sha256Password::Sha256Password(RSA & public_key_, RSA & private_key_, Poco::Logg
      *  This plugin must do the same to stay consistent with historical behavior if it is set to operate as a default plugin. [1]
      *  https://github.com/mysql/mysql-server/blob/8.0/sql/auth/sql_authentication.cc#L3994
      */
-    scramble.resize(SCRAMBLE_LENGTH + 1, 0);
-    Poco::RandomInputStream generator;
-
-    for (size_t i = 0; i < SCRAMBLE_LENGTH; ++i)
-    {
-        generator >> scramble[i];
-        scramble[i] &= 0x7f;
-        if (scramble[i] == '\0' || scramble[i] == '$')
-            scramble[i] = scramble[i] + 1;
-    }
+    scramble = generateScramble();
 }
 
 void Sha256Password::authenticate(
@@ -211,7 +193,7 @@ void Sha256Password::authenticate(
         password.resize(plaintext_size);
         for (int i = 0; i < plaintext_size; i++)
         {
-            password[i] = plaintext[i] ^ static_cast<unsigned char>(scramble[i % scramble.size()]);
+            password[i] = plaintext[i] ^ static_cast<unsigned char>(scramble[i % SCRAMBLE_LENGTH]);
         }
     }
     else if (is_secure_connection)

--- a/src/Core/MySQL/Authentication.h
+++ b/src/Core/MySQL/Authentication.h
@@ -43,7 +43,7 @@ class Native41 : public IPlugin
 public:
     Native41();
 
-    Native41(const String & password, const String & auth_plugin_data);
+    Native41(const String & password_, const String & scramble_);
 
     String getName() override { return "mysql_native_password"; }
 

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -286,11 +286,6 @@ Authentication::Type Session::getAuthenticationTypeOrLogInFailure(const String &
     }
 }
 
-Authentication::Digest Session::getPasswordDoubleSHA1(const String & user_name) const
-{
-    return global_context->getAccessControlManager().read<User>(user_name)->authentication.getPasswordDoubleSHA1();
-}
-
 void Session::authenticate(const String & user_name, const String & password, const Poco::Net::SocketAddress & address)
 {
     authenticate(BasicCredentials{user_name, password}, address);

--- a/src/Interpreters/Session.h
+++ b/src/Interpreters/Session.h
@@ -41,7 +41,7 @@ public:
 
     /// Provides information about the authentication type of a specified user.
     Authentication::Type getAuthenticationType(const String & user_name) const;
-    Authentication::Digest getPasswordDoubleSHA1(const String & user_name) const;
+
     /// Same as getAuthenticationType, but adds LoginFailure event in case of error.
     Authentication::Type getAuthenticationTypeOrLogInFailure(const String & user_name) const;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog

This PR is code cleanup: it moves all password checking to one place - the `Authentication` class, and it removes the function `Authentication::getPasswordDoubleSHA1()` which was used before for password checking in `MySQLHandler`.
