### PR TITLE
Optimize the performance of function bitmapAnd 

### DIFF
--- a/src/Functions/FunctionsBitmap.h
+++ b/src/Functions/FunctionsBitmap.h
@@ -1176,10 +1176,14 @@ private:
             const AggregateDataPtr data_ptr_0 = is_column_const[0] ? container0[0] : container0[i];
             const AggregateDataPtr data_ptr_1 = is_column_const[1] ? container1[0] : container1[i];
 
-            col_to->insertFrom(data_ptr_0);
+            auto && bm_1 = reinterpret_cast<AggregateFunctionGroupBitmapData<T> *>(data_ptr_0);
+            auto && bm_2 = reinterpret_cast<AggregateFunctionGroupBitmapData<T> *>(data_ptr_1);
+
+            auto need_exchange = (name == NameBitmapAnd::name) && bm_1->rbs.isLarge() && bm_2->rbs.isSmall();
+            col_to->insertFrom(need_exchange ? data_ptr_1 : data_ptr_0);
             AggregateFunctionGroupBitmapData<T> & bitmap_data_1 = *reinterpret_cast<AggregateFunctionGroupBitmapData<T> *>(col_to->getData()[i]);
             const AggregateFunctionGroupBitmapData<T> & bitmap_data_2
-                = *reinterpret_cast<const AggregateFunctionGroupBitmapData<T> *>(data_ptr_1);
+            = *reinterpret_cast<const AggregateFunctionGroupBitmapData<T> *>(need_exchange ? data_ptr_0 : data_ptr_1);
             Impl<T>::apply(bitmap_data_1, bitmap_data_2);
         }
         return col_to;

--- a/src/Functions/FunctionsBitmap.h
+++ b/src/Functions/FunctionsBitmap.h
@@ -1077,6 +1077,11 @@ struct BitmapAndnotImpl
     }
 };
 
+struct NameBitmapAnd
+{
+    static constexpr auto name = "bitmapAnd";
+};
+
 template <template <typename> class Impl, typename Name>
 class FunctionBitmap : public IFunction
 {
@@ -1176,14 +1181,16 @@ private:
             const AggregateDataPtr data_ptr_0 = is_column_const[0] ? container0[0] : container0[i];
             const AggregateDataPtr data_ptr_1 = is_column_const[1] ? container1[0] : container1[i];
 
-            auto && bm_1 = reinterpret_cast<AggregateFunctionGroupBitmapData<T> *>(data_ptr_0);
-            auto && bm_2 = reinterpret_cast<AggregateFunctionGroupBitmapData<T> *>(data_ptr_1);
+            // bitmapAnd(RoaringBitMap, SmallSet) is slower than bitmapAnd(SmallSet, RoaringBitMap), so we can exchange the position of two arguments for the speed
+            auto * bm_1 = reinterpret_cast<AggregateFunctionGroupBitmapData<T> *>(data_ptr_0);
+            auto * bm_2 = reinterpret_cast<AggregateFunctionGroupBitmapData<T> *>(data_ptr_1);
 
+            // check the name of operation (bitmapAnd) and check if it is the situation mentioned above
             auto need_exchange = (name == NameBitmapAnd::name) && bm_1->rbs.isLarge() && bm_2->rbs.isSmall();
             col_to->insertFrom(need_exchange ? data_ptr_1 : data_ptr_0);
             AggregateFunctionGroupBitmapData<T> & bitmap_data_1 = *reinterpret_cast<AggregateFunctionGroupBitmapData<T> *>(col_to->getData()[i]);
             const AggregateFunctionGroupBitmapData<T> & bitmap_data_2
-            = *reinterpret_cast<const AggregateFunctionGroupBitmapData<T> *>(need_exchange ? data_ptr_0 : data_ptr_1);
+                = *reinterpret_cast<const AggregateFunctionGroupBitmapData<T> *>(need_exchange ? data_ptr_0 : data_ptr_1);
             Impl<T>::apply(bitmap_data_1, bitmap_data_2);
         }
         return col_to;
@@ -1241,10 +1248,6 @@ using FunctionBitmapAndnotCardinality = FunctionBitmapCardinality<BitmapAndnotCa
 using FunctionBitmapHasAll = FunctionBitmapCardinality<BitmapHasAllImpl, NameBitmapHasAll, UInt8>;
 using FunctionBitmapHasAny = FunctionBitmapCardinality<BitmapHasAnyImpl, NameBitmapHasAny, UInt8>;
 
-struct NameBitmapAnd
-{
-    static constexpr auto name = "bitmapAnd";
-};
 struct NameBitmapOr
 {
     static constexpr auto name = "bitmapOr";


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up bitmapAnd function

I found that when I use the function ```bitmapAnd(bt1, bt2)```, if the bt1 is type ```RoaringBitmap``` and bt2 has a small number of values which are saved in the ```SmallSet```, the speed is slower than the ```bitmapAnd(bt2, bt1)```

Comparing the performance of a simple query:
```
with (select bt1 from bitmap_local where event_id='2') as big_bitmap select bitmapCardinality(bitmapAnd(big_bitmap, bt1)) from bitmap_local where event_id>'2';

with (select bt1 from bitmap_local where event_id='2') as big_bitmap select bitmapCardinality(bitmapAnd(bt1, big_bitmap)) from bitmap_local where event_id>'2';
```

- the first query Elapsed: 0.037 sec. Processed 1.00 thousand rows, 540.13 KB (27.16 thousand rows/s., 14.64 MB/s.) 
- the second query Elapsed: 1.878 sec. Processed 1.00 thousand rows, 540.13 KB (533.42 rows/s., 287.54 KB/s.)

So I try to exchange the position of two args in this case. With the same query the final results are similar, both are about 0.035 sec.

IMPROVEMENT: **60x as fast**

