### PR TITLE
Fix test_storage_s3/test_put_get_with_globs (cleanup after test)

### DIFF
--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -326,6 +326,10 @@ def test_put_get_with_globs(started_cluster):
     assert run_query(instance, query).splitlines() == [
         "450\t450\t900\t0.csv\t{bucket}/{max_path}".format(bucket=bucket, max_path=max_path)]
 
+    minio = started_cluster.minio_client
+    for obj in list(minio.list_objects(started_cluster.minio_bucket, prefix='{}/'.format(unique_prefix), recursive=True)):
+        minio.remove_object(started_cluster.minio_bucket, obj.object_name)
+
 
 # Test multipart put.
 @pytest.mark.parametrize("maybe_auth,positive", [


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix flapping test for S3


Detailed description / Documentation draft:
Remove test objects in MinIO after test. This objects may be cause of test flapps when test starts several times.