### PR TITLE
Forward profile events to client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <string>
 #include "Client.h"
+#include "Core/Protocol.h"
 
 #include <base/argsToConfig.h>
 #include <base/find_symbols.h>
@@ -376,6 +377,9 @@ std::vector<String> Client::loadWarningMessages()
 
             case Protocol::Server::EndOfStream:
                 return messages;
+
+            case Protocol::Server::ProfileEvents:
+                continue;
 
             default:
                 throw Exception(ErrorCodes::UNKNOWN_PACKET_FROM_SERVER, "Unknown packet {} from server {}",

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -671,6 +671,7 @@ void ClientBase::onProfileEvents(Block & block)
         return;
     const auto & array_thread_id = typeid_cast<const ColumnUInt64 &>(*block.getByName("thread_id").column).getData();
     const auto & names = typeid_cast<const ColumnString &>(*block.getByName("name").column);
+    const auto & host_names = typeid_cast<const ColumnString &>(*block.getByName("host_name").column);
     const auto & array_values = typeid_cast<const ColumnUInt64 &>(*block.getByName("value").column).getData();
 
     auto const * user_time_name = ProfileEvents::getName(ProfileEvents::UserTimeMicroseconds);
@@ -679,16 +680,18 @@ void ClientBase::onProfileEvents(Block & block)
     for (size_t i = 0; i < block.rows(); ++i)
     {
         auto thread_id = array_thread_id[i];
-        progress_indication.addThreadIdToList(thread_id);
+        auto host_name = host_names.getDataAt(i).toString();
+        if (thread_id != 0)
+            progress_indication.addThreadIdToList(host_name, thread_id);
         auto event_name = names.getDataAt(i);
         auto value = array_values[i];
         if (event_name == user_time_name)
         {
-            progress_indication.updateThreadUserTime(thread_id, value);
+            progress_indication.updateThreadUserTime(host_name, thread_id, value);
         }
         else if (event_name == system_time_name)
         {
-            progress_indication.updateThreadSystemTime(thread_id, value);
+            progress_indication.updateThreadSystemTime(host_name, thread_id, value);
         }
     }
 }

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -694,8 +694,12 @@ void ClientBase::onProfileEvents(Block & block)
         {
             thread_times[host_name][thread_id].system_ms = value;
         }
+        else if (event_name == MemoryTracker::USAGE_EVENT_NAME)
+        {
+            thread_times[host_name][thread_id].memory_usage = value;
+        }
     }
-    progress_indication.updateThreadTimes(thread_times);
+    progress_indication.updateThreadEventData(thread_times);
 }
 
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -667,18 +667,19 @@ void ClientBase::onEndOfStream()
 
 void ClientBase::onProfileEvents(Block & block)
 {
-    if (block.rows() == 0)
+    const auto rows = block.rows();
+    if (rows == 0)
         return;
     const auto & array_thread_id = typeid_cast<const ColumnUInt64 &>(*block.getByName("thread_id").column).getData();
     const auto & names = typeid_cast<const ColumnString &>(*block.getByName("name").column);
     const auto & host_names = typeid_cast<const ColumnString &>(*block.getByName("host_name").column);
     const auto & array_values = typeid_cast<const ColumnUInt64 &>(*block.getByName("value").column).getData();
 
-    auto const * user_time_name = ProfileEvents::getName(ProfileEvents::UserTimeMicroseconds);
-    auto const * system_time_name = ProfileEvents::getName(ProfileEvents::SystemTimeMicroseconds);
+    const auto * user_time_name = ProfileEvents::getName(ProfileEvents::UserTimeMicroseconds);
+    const auto * system_time_name = ProfileEvents::getName(ProfileEvents::SystemTimeMicroseconds);
 
     HostToThreadTimesMap thread_times;
-    for (size_t i = 0; i < block.rows(); ++i)
+    for (size_t i = 0; i < rows; ++i)
     {
         auto thread_id = array_thread_id[i];
         auto host_name = host_names.getDataAt(i).toString();

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -9,6 +9,7 @@
 #include <base/LocalDate.h>
 #include <base/LineReader.h>
 #include <base/scope_guard_safe.h>
+#include "Core/Protocol.h"
 
 #if !defined(ARCADIA_BUILD)
 #    include <Common/config_version.h>
@@ -611,6 +612,10 @@ bool ClientBase::receiveAndProcessPacket(ASTPtr parsed_query, bool cancelled)
             onEndOfStream();
             return false;
 
+        case Protocol::Server::ProfileEvents:
+            onProfileEvents();
+            return true;
+
         default:
             throw Exception(
                 ErrorCodes::UNKNOWN_PACKET_FROM_SERVER, "Unknown packet {} from server {}", packet.type, connection->getDescription());
@@ -649,6 +654,10 @@ void ClientBase::onEndOfStream()
         std::cout << "Ok." << std::endl;
     }
 }
+
+
+void ClientBase::onProfileEvents()
+{}
 
 
 /// Flush all buffers.

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -677,6 +677,7 @@ void ClientBase::onProfileEvents(Block & block)
     auto const * user_time_name = ProfileEvents::getName(ProfileEvents::UserTimeMicroseconds);
     auto const * system_time_name = ProfileEvents::getName(ProfileEvents::SystemTimeMicroseconds);
 
+    HostToThreadTimesMap thread_times;
     for (size_t i = 0; i < block.rows(); ++i)
     {
         auto thread_id = array_thread_id[i];
@@ -687,13 +688,14 @@ void ClientBase::onProfileEvents(Block & block)
         auto value = array_values[i];
         if (event_name == user_time_name)
         {
-            progress_indication.updateThreadUserTime(host_name, thread_id, value);
+            thread_times[host_name][thread_id].user_ms = value;
         }
         else if (event_name == system_time_name)
         {
-            progress_indication.updateThreadSystemTime(host_name, thread_id, value);
+            thread_times[host_name][thread_id].system_ms = value;
         }
     }
+    progress_indication.updateThreadTimes(thread_times);
 }
 
 

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -114,7 +114,7 @@ private:
     void onReceiveExceptionFromServer(std::unique_ptr<Exception> && e);
     void onProfileInfo(const BlockStreamProfileInfo & profile_info);
     void onEndOfStream();
-    void onProfileEvents();
+    void onProfileEvents(Block & block);
 
     void sendData(Block & sample, const ColumnsDescription & columns_description, ASTPtr parsed_query);
     void sendDataFrom(ReadBuffer & buf, Block & sample,

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -114,6 +114,7 @@ private:
     void onReceiveExceptionFromServer(std::unique_ptr<Exception> && e);
     void onProfileInfo(const BlockStreamProfileInfo & profile_info);
     void onEndOfStream();
+    void onProfileEvents();
 
     void sendData(Block & sample, const ColumnsDescription & columns_description, ASTPtr parsed_query);
     void sendDataFrom(ReadBuffer & buf, Block & sample,

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -22,6 +22,7 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/OpenSSLHelpers.h>
 #include <Common/randomSeed.h>
+#include "Core/Block.h"
 #include <Interpreters/ClientInfo.h>
 #include <Compression/CompressionFactory.h>
 #include <Processors/Pipe.h>
@@ -872,6 +873,7 @@ Packet Connection::receivePacket()
                 return res;
 
             case Protocol::Server::ProfileEvents:
+                LOG_DEBUG(log_wrapper.get(), "Connection received ProfileEvents");
                 res.block = receiveProfileEvents();
                 return res;
 

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -873,7 +873,6 @@ Packet Connection::receivePacket()
                 return res;
 
             case Protocol::Server::ProfileEvents:
-                LOG_DEBUG(log_wrapper.get(), "Connection received ProfileEvents");
                 res.block = receiveProfileEvents();
                 return res;
 

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -537,6 +537,7 @@ void Connection::sendQuery(
     maybe_compressed_out.reset();
     block_in.reset();
     block_logs_in.reset();
+    block_profile_events_in.reset();
     block_out.reset();
 
     /// Send empty block which means end of data.

--- a/src/Client/Connection.h
+++ b/src/Client/Connection.h
@@ -206,6 +206,7 @@ private:
     std::shared_ptr<ReadBuffer> maybe_compressed_in;
     std::unique_ptr<NativeReader> block_in;
     std::unique_ptr<NativeReader> block_logs_in;
+    std::unique_ptr<NativeReader> block_profile_events_in;
 
     /// Where to write data for INSERT.
     std::shared_ptr<WriteBuffer> maybe_compressed_out;
@@ -249,6 +250,7 @@ private:
     Block receiveData();
     Block receiveLogData();
     Block receiveDataImpl(NativeReader & reader);
+    Block receiveProfileEvents();
 
     std::vector<String> receiveMultistringMessage(UInt64 msg_type) const;
     std::unique_ptr<Exception> receiveException() const;
@@ -258,6 +260,7 @@ private:
     void initInputBuffers();
     void initBlockInput();
     void initBlockLogsInput();
+    void initBlockProfileEventsInput();
 
     [[noreturn]] void throwUnexpectedPacket(UInt64 packet_type, const char * expected) const;
 };

--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -1,3 +1,4 @@
+#include "Core/Protocol.h"
 #if defined(OS_LINUX)
 
 #include <Client/HedgedConnections.h>
@@ -412,6 +413,7 @@ Packet HedgedConnections::receivePacketFromReplica(const ReplicaLocation & repli
         case Protocol::Server::Totals:
         case Protocol::Server::Extremes:
         case Protocol::Server::Log:
+        case Protocol::Server::ProfileEvents:
             replica_with_last_received_packet = replica_location;
             break;
 

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -5,6 +5,7 @@
 #include <Processors/Executors/PushingPipelineExecutor.h>
 #include <Processors/Executors/PushingAsyncPipelineExecutor.h>
 #include <Storages/IStorage.h>
+#include "Core/Protocol.h"
 
 
 namespace DB
@@ -328,6 +329,7 @@ Packet LocalConnection::receivePacket()
         case Protocol::Server::Extremes: [[fallthrough]];
         case Protocol::Server::Log: [[fallthrough]];
         case Protocol::Server::Data:
+        case Protocol::Server::ProfileEvents:
         {
             if (state->block && state->block.value())
             {

--- a/src/Client/MultiplexedConnections.cpp
+++ b/src/Client/MultiplexedConnections.cpp
@@ -2,6 +2,7 @@
 #include <IO/ConnectionTimeouts.h>
 #include <IO/Operators.h>
 #include <Common/thread_local_rng.h>
+#include "Core/Protocol.h"
 
 
 namespace DB
@@ -320,6 +321,7 @@ Packet MultiplexedConnections::receivePacketUnlocked(AsyncCallback async_callbac
         case Protocol::Server::Totals:
         case Protocol::Server::Extremes:
         case Protocol::Server::Log:
+        case Protocol::Server::ProfileEvents:
             break;
 
         case Protocol::Server::EndOfStream:

--- a/src/Client/Suggest.cpp
+++ b/src/Client/Suggest.cpp
@@ -6,6 +6,7 @@
 #include <Columns/ColumnString.h>
 #include <Common/typeid_cast.h>
 #include <Common/Macros.h>
+#include "Core/Protocol.h"
 #include <IO/Operators.h>
 #include <Functions/FunctionFactory.h>
 #include <TableFunctions/TableFunctionFactory.h>
@@ -161,6 +162,8 @@ void Suggest::fetch(IServerConnection & connection, const ConnectionTimeouts & t
             case Protocol::Server::Extremes:
                 continue;
             case Protocol::Server::Log:
+                continue;
+            case Protocol::Server::ProfileEvents:
                 continue;
 
             case Protocol::Server::Exception:

--- a/src/Common/CurrentMetrics.h
+++ b/src/Common/CurrentMetrics.h
@@ -41,6 +41,12 @@ namespace CurrentMetrics
         values[metric].store(value, std::memory_order_relaxed);
     }
 
+    /// Get value of specified metric.
+    inline Value get(Metric metric)
+    {
+        return values[metric].load(std::memory_order_relaxed);
+    }
+
     /// Add value for specified metric. You must subtract value later; or see class Increment below.
     inline void add(Metric metric, Value value = 1)
     {

--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -91,6 +91,24 @@ std::shared_ptr<InternalTextLogsQueue> CurrentThread::getInternalTextLogsQueue()
     return current_thread->getInternalTextLogsQueue();
 }
 
+void CurrentThread::attachInternalProfileEventsQueue(const InternalProfileEventsQueuePtr & queue)
+{
+    if (unlikely(!current_thread))
+        return;
+    current_thread->attachInternalProfileEventsQueue(queue);
+}
+
+InternalProfileEventsQueuePtr CurrentThread::getInternalProfileEventsQueue()
+{
+    if (unlikely(!current_thread))
+        return nullptr;
+
+    if (current_thread->getCurrentState() == ThreadStatus::ThreadState::Died)
+        return nullptr;
+
+    return current_thread->getInternalProfileEventsQueue();
+}
+
 ThreadGroupStatusPtr CurrentThread::getGroup()
 {
     if (unlikely(!current_thread))

--- a/src/Common/CurrentThread.h
+++ b/src/Common/CurrentThread.h
@@ -46,6 +46,9 @@ public:
                                             LogsLevel client_logs_level);
     static std::shared_ptr<InternalTextLogsQueue> getInternalTextLogsQueue();
 
+    static void attachInternalProfileEventsQueue(const InternalProfileEventsQueuePtr & queue);
+    static InternalProfileEventsQueuePtr getInternalProfileEventsQueue();
+
     static void setFatalErrorCallback(std::function<void()> callback);
 
     /// Makes system calls to update ProfileEvents that contain info from rusage and taskstats

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -143,6 +143,11 @@ public:
         metric.store(metric_, std::memory_order_relaxed);
     }
 
+    CurrentMetrics::Metric getMetric()
+    {
+        return metric.load(std::memory_order_relaxed);
+    }
+
     void setDescription(const char * description)
     {
         description_ptr.store(description, std::memory_order_relaxed);

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -64,6 +64,9 @@ private:
     void setOrRaiseProfilerLimit(Int64 value);
 
 public:
+
+    static constexpr auto USAGE_EVENT_NAME = "MemoryTrackerUsage";
+
     explicit MemoryTracker(VariableContext level_ = VariableContext::Thread);
     explicit MemoryTracker(MemoryTracker * parent_, VariableContext level_ = VariableContext::Thread);
 

--- a/src/Common/ProgressIndication.cpp
+++ b/src/Common/ProgressIndication.cpp
@@ -29,6 +29,7 @@ void ProgressIndication::resetProgress()
     show_progress_bar = false;
     written_progress_chars = 0;
     write_progress_on_update = false;
+    thread_ids.clear();
 }
 
 void ProgressIndication::setFileProgressCallback(ContextMutablePtr context, bool write_progress_on_update_)
@@ -41,6 +42,11 @@ void ProgressIndication::setFileProgressCallback(ContextMutablePtr context, bool
         if (write_progress_on_update)
             writeProgress();
     });
+}
+
+void ProgressIndication::addThreadIdToList(UInt64 thread_id)
+{
+    thread_ids.insert(thread_id);
 }
 
 void ProgressIndication::writeFinalProgress()
@@ -57,6 +63,9 @@ void ProgressIndication::writeFinalProgress()
                     << formatReadableSizeWithDecimalSuffix(progress.read_bytes * 1000000000.0 / elapsed_ns) << "/s.)";
     else
         std::cout << ". ";
+    size_t used_threads = getUsedThreadsCount();
+    if (used_threads != 0)
+        std::cout << "\nUsed threads to process: " << used_threads << ".";
 }
 
 void ProgressIndication::writeProgress()

--- a/src/Common/ProgressIndication.cpp
+++ b/src/Common/ProgressIndication.cpp
@@ -237,7 +237,7 @@ void ProgressIndication::writeProgress()
     {
         // Calculated cores number may be not accurate
         // so it's better to print min(threads, cores).
-        auto threads_number = getUsedThreadsCount();
+        UInt64 threads_number = getUsedThreadsCount();
         message << " Running " << threads_number << " threads on "
             << std::min(cores_number, threads_number) << " cores";
 

--- a/src/Common/ProgressIndication.h
+++ b/src/Common/ProgressIndication.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <unordered_map>
 #include <unordered_set>
 #include <IO/Progress.h>
 #include <Interpreters/Context.h>
@@ -43,17 +44,17 @@ public:
     /// How much seconds passed since query execution start.
     double elapsedSeconds() const { return watch.elapsedSeconds(); }
 
-    void addThreadIdToList(UInt64 thread_id);
+    void addThreadIdToList(String const & host, UInt64 thread_id);
 
-    void updateThreadUserTime(UInt64 thread_id, UInt64 value);
+    void updateThreadUserTime(String const & host, UInt64 thread_id, UInt64 value);
 
-    void updateThreadSystemTime(UInt64 thread_id, UInt64 value);
+    void updateThreadSystemTime(String const & host, UInt64 thread_id, UInt64 value);
 
 private:
 
-    size_t getUsedThreadsCount() const { return thread_times.size(); }
+    size_t getUsedThreadsCount() const;
 
-    UInt64 getAccumulatedThreadTime() const;
+    UInt64 getApproximateCoresNumber() const;
 
     /// This flag controls whether to show the progress bar. We start showing it after
     /// the query has been executing for 0.5 seconds, and is still less than half complete.
@@ -78,7 +79,10 @@ private:
         UInt64 system_ms = 0;
     };
 
-    std::unordered_map<UInt64, ThreadTime> thread_times;
+    using ThreadIdToTimeMap = std::unordered_map<UInt64, ThreadTime>;
+    using HostToThreadTimesMap = std::unordered_map<String, ThreadIdToTimeMap>;
+
+    HostToThreadTimesMap thread_times;
 };
 
 }

--- a/src/Common/ProgressIndication.h
+++ b/src/Common/ProgressIndication.h
@@ -45,9 +45,16 @@ public:
 
     void addThreadIdToList(UInt64 thread_id);
 
-    size_t getUsedThreadsCount() const { return thread_ids.size(); }
+    void updateThreadUserTime(UInt64 thread_id, UInt64 value);
+
+    void updateThreadSystemTime(UInt64 thread_id, UInt64 value);
 
 private:
+
+    size_t getUsedThreadsCount() const { return thread_times.size(); }
+
+    UInt64 getAccumulatedThreadTime() const;
+
     /// This flag controls whether to show the progress bar. We start showing it after
     /// the query has been executing for 0.5 seconds, and is still less than half complete.
     bool show_progress_bar = false;
@@ -65,7 +72,13 @@ private:
 
     bool write_progress_on_update = false;
 
-    std::unordered_set<UInt64> thread_ids;
+    struct ThreadTime
+    {
+        UInt64 user_ms   = 0;
+        UInt64 system_ms = 0;
+    };
+
+    std::unordered_map<UInt64, ThreadTime> thread_times;
 };
 
 }

--- a/src/Common/ProgressIndication.h
+++ b/src/Common/ProgressIndication.h
@@ -14,6 +14,17 @@
 namespace DB
 {
 
+struct ThreadTime
+{
+    UInt64 time() const noexcept { return user_ms + system_ms; }
+
+    UInt64 user_ms   = 0;
+    UInt64 system_ms = 0;
+};
+
+using ThreadIdToTimeMap = std::unordered_map<UInt64, ThreadTime>;
+using HostToThreadTimesMap = std::unordered_map<String, ThreadIdToTimeMap>;
+
 class ProgressIndication
 {
 public:
@@ -46,9 +57,7 @@ public:
 
     void addThreadIdToList(String const & host, UInt64 thread_id);
 
-    void updateThreadUserTime(String const & host, UInt64 thread_id, UInt64 value);
-
-    void updateThreadSystemTime(String const & host, UInt64 thread_id, UInt64 value);
+    void updateThreadTimes(HostToThreadTimesMap & new_thread_times);
 
 private:
 
@@ -73,15 +82,7 @@ private:
 
     bool write_progress_on_update = false;
 
-    struct ThreadTime
-    {
-        UInt64 user_ms   = 0;
-        UInt64 system_ms = 0;
-    };
-
-    using ThreadIdToTimeMap = std::unordered_map<UInt64, ThreadTime>;
-    using HostToThreadTimesMap = std::unordered_map<String, ThreadIdToTimeMap>;
-
+    std::unordered_map<String, UInt64> host_active_cores;
     HostToThreadTimesMap thread_times;
 };
 

--- a/src/Common/ProgressIndication.h
+++ b/src/Common/ProgressIndication.h
@@ -14,15 +14,16 @@
 namespace DB
 {
 
-struct ThreadTime
+struct ThreadEventData
 {
     UInt64 time() const noexcept { return user_ms + system_ms; }
 
-    UInt64 user_ms   = 0;
-    UInt64 system_ms = 0;
+    UInt64 user_ms      = 0;
+    UInt64 system_ms    = 0;
+    UInt64 memory_usage = 0;
 };
 
-using ThreadIdToTimeMap = std::unordered_map<UInt64, ThreadTime>;
+using ThreadIdToTimeMap = std::unordered_map<UInt64, ThreadEventData>;
 using HostToThreadTimesMap = std::unordered_map<String, ThreadIdToTimeMap>;
 
 class ProgressIndication
@@ -57,13 +58,15 @@ public:
 
     void addThreadIdToList(String const & host, UInt64 thread_id);
 
-    void updateThreadTimes(HostToThreadTimesMap & new_thread_times);
+    void updateThreadEventData(HostToThreadTimesMap & new_thread_data);
 
 private:
 
     size_t getUsedThreadsCount() const;
 
     UInt64 getApproximateCoresNumber() const;
+
+    UInt64 getMemoryUsage() const;
 
     /// This flag controls whether to show the progress bar. We start showing it after
     /// the query has been executing for 0.5 seconds, and is still less than half complete.
@@ -83,7 +86,7 @@ private:
     bool write_progress_on_update = false;
 
     std::unordered_map<String, UInt64> host_active_cores;
-    HostToThreadTimesMap thread_times;
+    HostToThreadTimesMap thread_data;
 };
 
 }

--- a/src/Common/ProgressIndication.h
+++ b/src/Common/ProgressIndication.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <unordered_set>
 #include <IO/Progress.h>
 #include <Interpreters/Context.h>
+#include <base/types.h>
 #include <Common/Stopwatch.h>
 
 
@@ -41,6 +43,10 @@ public:
     /// How much seconds passed since query execution start.
     double elapsedSeconds() const { return watch.elapsedSeconds(); }
 
+    void addThreadIdToList(UInt64 thread_id);
+
+    size_t getUsedThreadsCount() const { return thread_ids.size(); }
+
 private:
     /// This flag controls whether to show the progress bar. We start showing it after
     /// the query has been executing for 0.5 seconds, and is still less than half complete.
@@ -58,6 +64,8 @@ private:
     Stopwatch watch;
 
     bool write_progress_on_update = false;
+
+    std::unordered_set<UInt64> thread_ids;
 };
 
 }

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -142,6 +142,12 @@ ThreadStatus::~ThreadStatus()
         /// We've already allocated a little bit more than the limit and cannot track it in the thread memory tracker or its parent.
     }
 
+    if (thread_group)
+    {
+        std::lock_guard guard(thread_group->mutex);
+        thread_group->threads.erase(this);
+    }
+
 #if !defined(ARCADIA_BUILD)
     /// It may cause segfault if query_context was destroyed, but was not detached
     auto query_context_ptr = query_context.lock();

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -10,6 +10,7 @@
 #include <base/getPageSize.h>
 
 #include <csignal>
+#include <mutex>
 
 
 namespace DB
@@ -195,6 +196,17 @@ void ThreadStatus::attachInternalTextLogsQueue(const InternalTextLogsQueuePtr & 
     std::lock_guard lock(thread_group->mutex);
     thread_group->logs_queue_ptr = logs_queue;
     thread_group->client_logs_level = client_logs_level;
+}
+
+void ThreadStatus::attachInternalProfileEventsQueue(const InternalProfileEventsQueuePtr & profile_queue)
+{
+    profile_queue_ptr = profile_queue;
+
+    if (!thread_group)
+        return;
+
+    std::lock_guard lock(thread_group->mutex);
+    thread_group->profile_queue_ptr = profile_queue;
 }
 
 void ThreadStatus::setFatalErrorCallback(std::function<void()> callback)

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <unordered_set>
 
 
 namespace Poco
@@ -41,7 +42,7 @@ struct ViewRuntimeData;
 class QueryViewsLog;
 using InternalTextLogsQueuePtr = std::shared_ptr<InternalTextLogsQueue>;
 using InternalTextLogsQueueWeakPtr = std::weak_ptr<InternalTextLogsQueue>;
-
+using ThreadStatusPtr = ThreadStatus *;
 
 /** Thread group is a collection of threads dedicated to single task
   * (query or other process like background merge).
@@ -66,6 +67,7 @@ public:
     std::function<void()> fatal_error_callback;
 
     std::vector<UInt64> thread_ids;
+    std::unordered_set<ThreadStatusPtr> threads;
 
     /// The first thread created this thread group
     UInt64 master_thread_id = 0;

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -7,6 +7,7 @@
 #include <Common/OpenTelemetryTraceContext.h>
 #include <Common/ProfileEvents.h>
 #include <base/StringRef.h>
+#include <Common/ConcurrentBoundedQueue.h>
 
 #include <boost/noncopyable.hpp>
 
@@ -42,6 +43,10 @@ struct ViewRuntimeData;
 class QueryViewsLog;
 using InternalTextLogsQueuePtr = std::shared_ptr<InternalTextLogsQueue>;
 using InternalTextLogsQueueWeakPtr = std::weak_ptr<InternalTextLogsQueue>;
+
+using InternalProfileEventsQueue = ConcurrentBoundedQueue<Block>;
+using InternalProfileEventsQueuePtr = std::shared_ptr<InternalProfileEventsQueue>;
+using InternalProfileEventsQueueWeakPtr = std::weak_ptr<InternalProfileEventsQueue>;
 using ThreadStatusPtr = ThreadStatus *;
 
 /** Thread group is a collection of threads dedicated to single task
@@ -64,6 +69,7 @@ public:
     ContextWeakPtr global_context;
 
     InternalTextLogsQueueWeakPtr logs_queue_ptr;
+    InternalProfileEventsQueueWeakPtr profile_queue_ptr;
     std::function<void()> fatal_error_callback;
 
     std::vector<UInt64> thread_ids;
@@ -133,6 +139,8 @@ protected:
 
     /// A logs queue used by TCPHandler to pass logs to a client
     InternalTextLogsQueueWeakPtr logs_queue_ptr;
+
+    InternalProfileEventsQueueWeakPtr profile_queue_ptr;
 
     bool performance_counters_finalized = false;
     UInt64 query_start_time_nanoseconds = 0;
@@ -207,6 +215,13 @@ public:
 
     void attachInternalTextLogsQueue(const InternalTextLogsQueuePtr & logs_queue,
                                      LogsLevel client_logs_level);
+
+    InternalProfileEventsQueuePtr getInternalProfileEventsQueue() const
+    {
+        return thread_state == Died ? nullptr : profile_queue_ptr.lock();
+    }
+
+    void attachInternalProfileEventsQueue(const InternalProfileEventsQueuePtr & profile_queue);
 
     /// Callback that is used to trigger sending fatal error messages to client.
     void setFatalErrorCallback(std::function<void()> callback);

--- a/src/Core/Protocol.h
+++ b/src/Core/Protocol.h
@@ -80,7 +80,8 @@ namespace Protocol
             ReadTaskRequest = 13,     /// String (UUID) describes a request for which next task is needed
                                       /// This is such an inverted logic, where server sends requests
                                       /// And client returns back response
-            MAX = ReadTaskRequest,
+            ProfileEvents = 14,
+            MAX = ProfileEvents,
         };
 
         /// NOTE: If the type of packet argument would be Enum, the comparison packet >= 0 && packet < 10

--- a/src/Core/Protocol.h
+++ b/src/Core/Protocol.h
@@ -80,7 +80,7 @@ namespace Protocol
             ReadTaskRequest = 13,     /// String (UUID) describes a request for which next task is needed
                                       /// This is such an inverted logic, where server sends requests
                                       /// And client returns back response
-            ProfileEvents = 14,
+            ProfileEvents = 14,       /// Packet with profile events from server.
             MAX = ProfileEvents,
         };
 

--- a/src/Core/Protocol.h
+++ b/src/Core/Protocol.h
@@ -104,7 +104,8 @@ namespace Protocol
                 "Log",
                 "TableColumns",
                 "PartUUIDs",
-                "ReadTaskRequest"
+                "ReadTaskRequest",
+                "ProfileEvents",
             };
             return packet <= MAX
                 ? data[packet]

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -36,6 +36,8 @@
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_DISTRIBUTED_DEPTH 54448
 
+#define DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS 54450
+
 /// Version of ClickHouse TCP protocol.
 ///
 /// Should be incremented manually on protocol changes.
@@ -43,6 +45,6 @@
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-#define DBMS_TCP_PROTOCOL_VERSION 54449
+#define DBMS_TCP_PROTOCOL_VERSION 54450
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME 54449

--- a/src/DataStreams/ConnectionCollector.cpp
+++ b/src/DataStreams/ConnectionCollector.cpp
@@ -3,6 +3,7 @@
 #include <Core/BackgroundSchedulePool.h>
 #include <Interpreters/Context.h>
 #include <Common/Exception.h>
+#include "Core/Protocol.h"
 #include <base/logger_useful.h>
 
 namespace CurrentMetrics
@@ -81,6 +82,7 @@ void ConnectionCollector::drainConnections(IConnections & connections) noexcept
         {
             case Protocol::Server::EndOfStream:
             case Protocol::Server::Log:
+            case Protocol::Server::ProfileEvents:
                 break;
 
             case Protocol::Server::Exception:

--- a/src/DataStreams/RemoteQueryExecutor.cpp
+++ b/src/DataStreams/RemoteQueryExecutor.cpp
@@ -395,11 +395,9 @@ std::optional<Block> RemoteQueryExecutor::processPacket(Packet packet)
 
         case Protocol::Server::ProfileEvents:
             /// Pass profile events from remote server to client
-            {
-                auto profile_queue = CurrentThread::getInternalProfileEventsQueue();
+            if (auto profile_queue = CurrentThread::getInternalProfileEventsQueue())
                 profile_queue->emplace(std::move(packet.block));
-                break;
-            }
+            break;
 
         default:
             got_unknown_packet_from_replica = true;

--- a/src/DataStreams/RemoteQueryExecutor.cpp
+++ b/src/DataStreams/RemoteQueryExecutor.cpp
@@ -4,6 +4,7 @@
 
 #include <Columns/ColumnConst.h>
 #include <Common/CurrentThread.h>
+#include "Core/Protocol.h"
 #include <Processors/Pipe.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Storages/IStorage.h>
@@ -388,6 +389,9 @@ std::optional<Block> RemoteQueryExecutor::processPacket(Packet packet)
             /// Pass logs from remote server to client
             if (auto log_queue = CurrentThread::getInternalTextLogsQueue())
                 log_queue->pushBlock(std::move(packet.block));
+            break;
+
+        case Protocol::Server::ProfileEvents:
             break;
 
         default:

--- a/src/DataStreams/RemoteQueryExecutor.cpp
+++ b/src/DataStreams/RemoteQueryExecutor.cpp
@@ -1,3 +1,5 @@
+#include <Common/ConcurrentBoundedQueue.h>
+
 #include <DataStreams/ConnectionCollector.h>
 #include <DataStreams/RemoteQueryExecutor.h>
 #include <DataStreams/RemoteQueryExecutorReadContext.h>
@@ -393,7 +395,12 @@ std::optional<Block> RemoteQueryExecutor::processPacket(Packet packet)
 
         case Protocol::Server::ProfileEvents:
             /// Pass profile events from remote server to client
-            break;
+            {
+                LOG_DEBUG(log, "RemoteQueryExecutor received ProfileEvents");
+                auto profile_queue = CurrentThread::getInternalProfileEventsQueue();
+                profile_queue->emplace(std::move(packet.block));
+                break;
+            }
 
         default:
             got_unknown_packet_from_replica = true;

--- a/src/DataStreams/RemoteQueryExecutor.cpp
+++ b/src/DataStreams/RemoteQueryExecutor.cpp
@@ -392,6 +392,7 @@ std::optional<Block> RemoteQueryExecutor::processPacket(Packet packet)
             break;
 
         case Protocol::Server::ProfileEvents:
+            /// Pass profile events from remote server to client
             break;
 
         default:

--- a/src/DataStreams/RemoteQueryExecutor.cpp
+++ b/src/DataStreams/RemoteQueryExecutor.cpp
@@ -396,7 +396,6 @@ std::optional<Block> RemoteQueryExecutor::processPacket(Packet packet)
         case Protocol::Server::ProfileEvents:
             /// Pass profile events from remote server to client
             {
-                LOG_DEBUG(log, "RemoteQueryExecutor received ProfileEvents");
                 auto profile_queue = CurrentThread::getInternalProfileEventsQueue();
                 profile_queue->emplace(std::move(packet.block));
                 break;

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -129,6 +129,7 @@ void ThreadStatus::setupState(const ThreadGroupStatusPtr & thread_group_)
         logs_queue_ptr = thread_group->logs_queue_ptr;
         fatal_error_callback = thread_group->fatal_error_callback;
         query_context = thread_group->query_context;
+        profile_queue_ptr = thread_group->profile_queue_ptr;
 
         if (global_context.expired())
             global_context = thread_group->global_context;

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -123,6 +123,7 @@ void ThreadStatus::setupState(const ThreadGroupStatusPtr & thread_group_)
 
         /// NOTE: thread may be attached multiple times if it is reused from a thread pool.
         thread_group->thread_ids.emplace_back(thread_id);
+        thread_group->threads.insert(this);
 
         logs_queue_ptr = thread_group->logs_queue_ptr;
         fatal_error_callback = thread_group->fatal_error_callback;

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -1,3 +1,4 @@
+#include <mutex>
 #include <Common/ThreadStatus.h>
 
 #include <Processors/Transforms/buildPushingToViewsChain.h>
@@ -398,6 +399,10 @@ void ThreadStatus::detachQuery(bool exit_if_already_detached, bool thread_exits)
     finalizePerformanceCounters();
 
     /// Detach from thread group
+    {
+        std::lock_guard guard(thread_group->mutex);
+        thread_group->threads.erase(this);
+    }
     performance_counters.setParent(&ProfileEvents::global_counters);
     memory_tracker.reset();
 

--- a/src/Server/GRPCServer.cpp
+++ b/src/Server/GRPCServer.cpp
@@ -596,6 +596,7 @@ namespace
         void addExtremesToResult(const Block & extremes);
         void addProfileInfoToResult(const BlockStreamProfileInfo & info);
         void addLogsToResult();
+        void addProfileEventsToResult();
         void sendResult();
         void throwIfFailedToSendResult();
         void sendException(const Exception & exception);
@@ -1123,6 +1124,7 @@ namespace
                 if (after_send_progress.elapsedMicroseconds() >= interactive_delay)
                 {
                     addProgressToResult();
+                    addProfileEventsToResult();
                     after_send_progress.restart();
                 }
 
@@ -1174,6 +1176,7 @@ namespace
         finalize = true;
         io.onFinish();
         addProgressToResult();
+        addProfileEventsToResult();
         query_scope->logPeakMemoryUsage();
         addLogsToResult();
         sendResult();
@@ -1435,6 +1438,11 @@ namespace
                 log_entry.set_text(text.data, text.size);
             }
         }
+    }
+
+    void Call::addProfileEventsToResult()
+    {
+
     }
 
     void Call::sendResult()

--- a/src/Server/GRPCServer.cpp
+++ b/src/Server/GRPCServer.cpp
@@ -1,4 +1,6 @@
 #include "GRPCServer.h"
+#include <limits>
+#include <memory>
 #if USE_GRPC
 
 #include <Columns/ColumnString.h>
@@ -622,6 +624,7 @@ namespace
         BlockIO io;
         Progress progress;
         InternalTextLogsQueuePtr logs_queue;
+        InternalProfileEventsQueuePtr profile_queue;
 
         GRPCQueryInfo query_info; /// We reuse the same messages multiple times.
         GRPCResult result;
@@ -773,6 +776,8 @@ namespace
             CurrentThread::attachInternalTextLogsQueue(logs_queue, client_logs_level);
             CurrentThread::setFatalErrorCallback([this]{ onFatalError(); });
         }
+        profile_queue = std::make_shared<InternalProfileEventsQueue>(std::numeric_limits<int>::max());
+        CurrentThread::attachInternalProfileEventsQueue(profile_queue);
 
         /// Set the current database if specified.
         if (!query_info.database().empty())

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -666,6 +666,7 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
                 /// Some time passed and there is a progress.
                 after_send_progress.restart();
                 sendProgress();
+                sendProfileEvents();
             }
 
             sendLogs();
@@ -691,6 +692,7 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
             sendProfileInfo(executor.getProfileInfo());
             sendProgress();
             sendLogs();
+            sendProfileEvents();
         }
 
         if (state.is_connection_closed)
@@ -867,12 +869,12 @@ namespace
         MemoryTracker * memoryTracker,
         MutableColumns & columns,
         String const & host_name,
-        time_t current_time,
         UInt64 thread_id)
     {
         auto metric = memoryTracker->getMetric();
         if (metric == CurrentMetrics::end())
             return;
+        time_t current_time = time(nullptr);
 
         size_t i = 0;
         columns[i++]->insertData(host_name.data(), host_name.size());
@@ -890,13 +892,6 @@ namespace
 
 void TCPHandler::sendProfileEvents()
 {
-    auto thread_group = CurrentThread::getGroup();
-    auto const counters_snapshot = CurrentThread::getProfileEvents().getPartiallyAtomicSnapshot();
-    auto current_time = time(nullptr);
-    auto * memory_tracker = CurrentThread::getMemoryTracker();
-
-    auto const thread_id = CurrentThread::get().thread_id;
-
     auto profile_event_type = std::make_shared<DataTypeEnum8>(
         DataTypeEnum8::Values
         {
@@ -920,9 +915,17 @@ void TCPHandler::sendProfileEvents()
     Block block(std::move(temp_columns));
 
     MutableColumns columns = block.mutateColumns();
-    dumpProfileEvents(counters_snapshot, columns, server_display_name, current_time, thread_id);
-    dumpMemoryTracker(memory_tracker, columns, server_display_name, current_time, thread_id);
+    auto thread_group = CurrentThread::getGroup();
+    for (auto * thread : thread_group->threads)
+    {
+        auto const counters_snapshot = thread->performance_counters.getPartiallyAtomicSnapshot();
+        auto current_time = time(nullptr);
+        auto * memory_tracker = &thread->memory_tracker;
+        auto const thread_id = CurrentThread::get().thread_id;
 
+        dumpProfileEvents(counters_snapshot, columns, server_display_name, current_time, thread_id);
+        dumpMemoryTracker(memory_tracker, columns, server_display_name, thread_id);
+    }
     block.setColumns(std::move(columns));
 
     initProfileEventsBlockOutput(block);

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -246,8 +246,11 @@ void TCPHandler::runImpl()
                     sendLogs();
                 });
             }
-            state.profile_queue = std::make_shared<InternalProfileEventsQueue>(std::numeric_limits<int>::max());
-            CurrentThread::attachInternalProfileEventsQueue(state.profile_queue);
+            if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS)
+            {
+                state.profile_queue = std::make_shared<InternalProfileEventsQueue>(std::numeric_limits<int>::max());
+                CurrentThread::attachInternalProfileEventsQueue(state.profile_queue);
+            }
 
             query_context->setExternalTablesInitializer([this] (ContextPtr context)
             {

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -918,6 +918,9 @@ namespace
 
 void TCPHandler::sendProfileEvents()
 {
+    if (client_tcp_protocol_version < DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS)
+        return;
+
     auto profile_event_type = std::make_shared<DataTypeEnum8>(
         DataTypeEnum8::Values
         {

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -675,10 +675,10 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
                 /// Some time passed and there is a progress.
                 after_send_progress.restart();
                 sendProgress();
+                sendProfileEvents();
             }
 
             sendLogs();
-            sendProfileEvents();
 
             if (block)
             {
@@ -701,7 +701,7 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
             sendProfileInfo(executor.getProfileInfo());
             sendProgress();
             sendLogs();
-            // sendProfileEvents();
+            sendProfileEvents();
         }
 
         if (state.is_connection_closed)

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -48,6 +48,8 @@ struct QueryState
     InternalTextLogsQueuePtr logs_queue;
     std::unique_ptr<NativeWriter> logs_block_out;
 
+    std::unique_ptr<NativeWriter> profile_events_block_out;
+
     /// From where to read data for INSERT.
     std::shared_ptr<ReadBuffer> maybe_compressed_in;
     std::unique_ptr<NativeReader> block_in;
@@ -228,11 +230,13 @@ private:
     void sendProfileInfo(const BlockStreamProfileInfo & info);
     void sendTotals(const Block & totals);
     void sendExtremes(const Block & extremes);
+    void sendProfileEvents();
 
     /// Creates state.block_in/block_out for blocks read/write, depending on whether compression is enabled.
     void initBlockInput();
     void initBlockOutput(const Block & block);
     void initLogsBlockOutput(const Block & block);
+    void initProfileEventsBlockOutput(const Block & block);
 
     bool isQueryCancelled();
 

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -48,6 +48,7 @@ struct QueryState
     InternalTextLogsQueuePtr logs_queue;
     std::unique_ptr<NativeWriter> logs_block_out;
 
+    InternalProfileEventsQueuePtr profile_queue;
     std::unique_ptr<NativeWriter> profile_events_block_out;
 
     /// From where to read data for INSERT.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Send profile events from server to client. New packet type `ProfileEvents` was introduced. Closes #26177.
