### PR TITLE
Do not allow create postgres storage with bad arguments

### DIFF
--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -73,6 +73,15 @@ StorageMaterializedPostgreSQL::StorageMaterializedPostgreSQL(
             is_attach,
             replication_settings->materialized_postgresql_max_block_size.value,
             /* allow_automatic_update */ false, /* is_materialized_postgresql_database */false);
+
+    if (!is_attach)
+    {
+        replication_handler->addStorage(remote_table_name, this);
+        /// Start synchronization preliminary setup immediately and throw in case of failure.
+        /// It should be guaranteed that if MaterializedPostgreSQL table was created successfully, then
+        /// its nested table was also created.
+        replication_handler->startSynchronization(/* throw_on_error */ true);
+    }
 }
 
 
@@ -201,23 +210,12 @@ StoragePtr StorageMaterializedPostgreSQL::prepare()
 void StorageMaterializedPostgreSQL::startup()
 {
     /// replication_handler != nullptr only in case of single table engine MaterializedPostgreSQL.
-    if (replication_handler)
+    if (replication_handler && is_attach)
     {
         replication_handler->addStorage(remote_table_name, this);
-
-        if (is_attach)
-        {
-            /// In case of attach table use background startup in a separate thread. First wait until connection is reachable,
-            /// then check for nested table -- it should already be created.
-            replication_handler->startup();
-        }
-        else
-        {
-            /// Start synchronization preliminary setup immediately and throw in case of failure.
-            /// It should be guaranteed that if MaterializedPostgreSQL table was created successfully, then
-            /// its nested table was also created.
-            replication_handler->startSynchronization(/* throw_on_error */ true);
-        }
+        /// In case of attach table use background startup in a separate thread. First wait until connection is reachable,
+        /// then check for nested table -- it should already be created.
+        replication_handler->startup();
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not allow creating StorageMaterializedPostgreSQL with bad arguments. Closes https://github.com/ClickHouse/ClickHouse/issues/28423.