### PR TITLE
[RFC] Do not allow ThreadFromGlobalPool::join() from the spawned/occupated thread

### DIFF
--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -8,6 +8,7 @@
 #include <queue>
 #include <list>
 #include <optional>
+#include <atomic>
 
 #include <Poco/Event.h>
 #include <Common/ThreadStatus.h>
@@ -156,20 +157,24 @@ public:
 class ThreadFromGlobalPool
 {
 public:
-    ThreadFromGlobalPool() {}
+    ThreadFromGlobalPool() = default;
 
     template <typename Function, typename... Args>
     explicit ThreadFromGlobalPool(Function && func, Args &&... args)
         : state(std::make_shared<Poco::Event>())
+        , thread_id(std::make_shared<std::thread::id>())
     {
         /// NOTE: If this will throw an exception, the destructor won't be called.
         GlobalThreadPool::instance().scheduleOrThrow([
+            thread_id = thread_id,
             state = state,
             func = std::forward<Function>(func),
             args = std::make_tuple(std::forward<Args>(args)...)]() mutable /// mutable is needed to destroy capture
         {
             auto event = std::move(state);
             SCOPE_EXIT(event->set());
+
+            thread_id = std::make_shared<std::thread::id>(std::this_thread::get_id());
 
             /// This moves are needed to destroy function and arguments before exit.
             /// It will guarantee that after ThreadFromGlobalPool::join all captured params are destroyed.
@@ -193,6 +198,7 @@ public:
         if (joinable())
             abort();
         state = std::move(rhs.state);
+        thread_id = std::move(rhs.thread_id);
         return *this;
     }
 
@@ -220,12 +226,18 @@ public:
 
     bool joinable() const
     {
-        return state != nullptr;
+        if (!state)
+            return false;
+        /// Thread cannot join itself.
+        if (*thread_id == std::this_thread::get_id())
+            return false;
+        return true;
     }
 
 private:
     /// The state used in this object and inside the thread job.
     std::shared_ptr<Poco::Event> state;
+    std::shared_ptr<std::thread::id> thread_id;
 };
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not allow ThreadFromGlobalPool::join() from the spawned/occupated thread

Detailed description:
I found one issue with MaterializedMySQL (MaterializeMySQLSyncThread), in the error code path, that cause server hung instead of terminate.