### PR TITLE
Fix cannot use non-ordinary table names in materialized postgresql

### DIFF
--- a/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
@@ -212,7 +212,7 @@ StoragePtr PostgreSQLReplicationHandler::loadFromSnapshot(String & snapshot_name
 
     /// Load from snapshot, which will show table state before creation of replication slot.
     /// Already connected to needed database, no need to add it to query.
-    query_str = fmt::format("SELECT * FROM {}", table_name);
+    query_str = fmt::format("SELECT * FROM {}", doubleQuoteString(table_name));
 
     materialized_storage->createNestedIfNeeded(fetchTableStructure(*tx, table_name));
     auto nested_storage = materialized_storage->getNested();
@@ -321,7 +321,7 @@ void PostgreSQLReplicationHandler::createPublicationIfNeeded(pqxx::work & tx)
             {
                 if (!tables_list.empty())
                     tables_list += ", ";
-                tables_list += storage_data.first;
+                tables_list += doubleQuoteString(storage_data.first);
             }
         }
 

--- a/tests/integration/test_postgresql_replica_database_engine/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine/test.py
@@ -19,15 +19,15 @@ instance = cluster.add_instance('instance',
         with_postgres=True, stay_alive=True)
 
 postgres_table_template = """
-    CREATE TABLE IF NOT EXISTS {} (
+    CREATE TABLE IF NOT EXISTS "{}" (
     key Integer NOT NULL, value Integer, PRIMARY KEY(key))
     """
 postgres_table_template_2 = """
-    CREATE TABLE IF NOT EXISTS {} (
+    CREATE TABLE IF NOT EXISTS "{}" (
     key Integer NOT NULL, value1 Integer, value2 Integer, value3 Integer, PRIMARY KEY(key))
     """
 postgres_table_template_3 = """
-    CREATE TABLE IF NOT EXISTS {} (
+    CREATE TABLE IF NOT EXISTS "{}" (
     key1 Integer NOT NULL, value1 Integer, key2 Integer NOT NULL, value2 Integer NOT NULL)
     """
 
@@ -76,8 +76,11 @@ def drop_materialized_db(materialized_database='test_database'):
     instance.query('DROP DATABASE IF EXISTS {}'.format(materialized_database))
     assert materialized_database not in instance.query('SHOW DATABASES')
 
+def drop_postgres_table(cursor, table_name):
+    cursor.execute("""DROP DATABASE IF EXISTS "{}" """.format(table_name))
+
 def create_postgres_table(cursor, table_name, replica_identity_full=False, template=postgres_table_template):
-    cursor.execute("DROP TABLE IF EXISTS {}".format(table_name))
+    drop_postgres_table(cursor, table_name)
     cursor.execute(template.format(table_name))
     if replica_identity_full:
         cursor.execute('ALTER TABLE {} REPLICA IDENTITY FULL;'.format(table_name))
@@ -921,6 +924,21 @@ def test_abrupt_server_restart_while_heavy_replication(started_cluster):
     drop_materialized_db()
     for i in range(NUM_TABLES):
         cursor.execute('drop table if exists postgresql_replica_{};'.format(i))
+
+
+def test_quoting(started_cluster):
+    drop_materialized_db()
+    conn = get_postgres_conn(ip=started_cluster.postgres_ip,
+                             port=started_cluster.postgres_port,
+                             database=True)
+    cursor = conn.cursor()
+    table_name = 'user'
+    create_postgres_table(cursor, table_name);
+    instance.query("INSERT INTO postgres_database.{} SELECT number, number from numbers(50)".format(table_name))
+    create_materialized_db(ip=started_cluster.postgres_ip, port=started_cluster.postgres_port)
+    check_tables_are_synchronized(table_name);
+    drop_postgres_table(cursor, table_name)
+    drop_materialized_db()
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_postgresql_replica_database_engine/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine/test.py
@@ -77,7 +77,7 @@ def drop_materialized_db(materialized_database='test_database'):
     assert materialized_database not in instance.query('SHOW DATABASES')
 
 def drop_postgres_table(cursor, table_name):
-    cursor.execute("""DROP DATABASE IF EXISTS "{}" """.format(table_name))
+    cursor.execute("""DROP TABLE IF EXISTS "{}" """.format(table_name))
 
 def create_postgres_table(cursor, table_name, replica_identity_full=False, template=postgres_table_template):
     drop_postgres_table(cursor, table_name)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix lack of quotes for table names in MaterializedPostgreSQL engine. Closes https://github.com/ClickHouse/ClickHouse/issues/28316.