### PR TITLE
Fix ZK watch leak in DDLWorker.

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -213,7 +213,13 @@ void DDLWorker::shutdown()
     bool prev_stop_flag = stop_flag.exchange(true);
     if (!prev_stop_flag)
     {
-        queue_updated_event->set();
+        /// notify main thread
+        {
+            std::unique_lock<std::mutex> cv_lock(cv_mutex);
+            queue_updated = true;
+        }
+        cv.notify_all();
+
         cleanup_event->set();
         main_thread.join();
         cleanup_thread.join();
@@ -378,7 +384,16 @@ void DDLWorker::scheduleTasks(bool reinitialized)
         }
     }
 
-    Strings queue_nodes = zookeeper->getChildren(queue_dir, &queue_node_stat, queue_updated_event);
+    auto watch_queue_update = [this](const Coordination::WatchResponse &)
+    {
+        {
+            std::unique_lock<std::mutex> cv_lock(cv_mutex);
+            queue_updated = true;
+        }
+        cv.notify_all();
+    };
+
+    Strings queue_nodes = zookeeper->getChildrenWatch(queue_dir, &queue_node_stat, watch_queue_update);
     size_t size_before_filtering = queue_nodes.size();
     filterAndSortQueueNodes(queue_nodes);
     /// The following message is too verbose, but it can be useful too debug mysterious test failures in CI
@@ -1154,28 +1169,11 @@ void DDLWorker::runMainThread()
 
             LOG_DEBUG(log, "Waiting for queue updates (stat: {}, {}, {}, {})",
                       queue_node_stat.version, queue_node_stat.cversion, queue_node_stat.numChildren, queue_node_stat.pzxid);
-            /// FIXME It may hang for unknown reason. Timeout is just a hotfix.
-            constexpr int queue_wait_timeout_ms = 10000;
-            bool updated = queue_updated_event->tryWait(queue_wait_timeout_ms);
-            if (!updated)
+
             {
-                Coordination::Stat new_stat;
-                tryGetZooKeeper()->get(queue_dir, &new_stat);
-                bool queue_changed = memcmp(&queue_node_stat, &new_stat, sizeof(Coordination::Stat)) != 0;
-                bool watch_triggered = queue_updated_event->tryWait(0);
-                if (queue_changed && !watch_triggered)
-                {
-                    /// It should never happen.
-                    /// Maybe log message, abort() and system.zookeeper_log will help to debug it and remove timeout (#26036).
-                    LOG_TRACE(
-                        log,
-                        "Queue was not updated (stat: {}, {}, {}, {})",
-                        new_stat.version,
-                        new_stat.cversion,
-                        new_stat.numChildren,
-                        new_stat.pzxid);
-                    context->getZooKeeperLog()->flush();
-                }
+                std::unique_lock<std::mutex> cv_lock(cv_mutex);
+                cv.wait(cv_lock, [this]{ return queue_updated; });
+                queue_updated = false;
             }
         }
         catch (const Coordination::Exception & e)

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -127,7 +127,7 @@ protected:
     std::list<DDLTaskPtr> current_tasks;
 
     Coordination::Stat queue_node_stat;
-    std::shared_ptr<Poco::Event> queue_updated_event = std::make_shared<Poco::Event>();
+
     std::shared_ptr<Poco::Event> cleanup_event = std::make_shared<Poco::Event>();
     std::atomic<bool> initialized = false;
     std::atomic<bool> stop_flag = false;
@@ -149,6 +149,12 @@ protected:
     std::atomic<UInt64> max_id = 0;
     const CurrentMetrics::Metric * max_entry_metric;
     const CurrentMetrics::Metric * max_pushed_entry_metric;
+
+    /// Prevent zookeeper watch from being triggered in advance
+    std::mutex cv_mutex;
+    std::condition_variable cv;
+    bool queue_updated = false;
+
 };
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

When we registered watch with zookeeper. It avoids that the watch has been triggered before ```queue_updated_event->wait()```. For example, before executing ```queue_updated_event->wait()```, ```cleanup_thread``` or other server has removed the znode and triggered the watch.
This closes https://github.com/ClickHouse/ClickHouse/issues/26036