### PR TITLE
Revert "Drop unused headers"

### DIFF
--- a/src/Client/HedgedConnections.h
+++ b/src/Client/HedgedConnections.h
@@ -8,7 +8,8 @@
 #include <Client/HedgedConnectionsFactory.h>
 #include <Client/IConnections.h>
 #include <Client/PacketReceiver.h>
-
+#include <Common/FiberStack.h>
+#include <Common/Fiber.h>
 
 namespace DB
 {

--- a/src/Common/Fiber.h
+++ b/src/Common/Fiber.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <common/defines.h>
 #include <boost/context/fiber.hpp>
 
 using Fiber = boost::context::fiber;

--- a/src/DataStreams/RemoteQueryExecutor.cpp
+++ b/src/DataStreams/RemoteQueryExecutor.cpp
@@ -13,15 +13,15 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/InternalTextLogsQueue.h>
 #include <IO/ConnectionTimeoutsContext.h>
+#include <Common/FiberStack.h>
 #include <Client/MultiplexedConnections.h>
 #include <Client/HedgedConnections.h>
 #include <Storages/MergeTree/MergeTreeDataPartUUID.h>
 
-
 namespace CurrentMetrics
 {
-    extern const Metric SyncDrainedConnections;
-    extern const Metric ActiveSyncDrainedConnections;
+extern const Metric SyncDrainedConnections;
+extern const Metric ActiveSyncDrainedConnections;
 }
 
 namespace DB

--- a/src/DataStreams/RemoteQueryExecutor.h
+++ b/src/DataStreams/RemoteQueryExecutor.h
@@ -6,9 +6,9 @@
 #include <Storages/IStorage_fwd.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/StorageID.h>
+#include <Common/FiberStack.h>
 #include <Common/TimerDescriptor.h>
 #include <variant>
-
 
 namespace DB
 {

--- a/src/IO/SeekAvoidingReadBuffer.cpp
+++ b/src/IO/SeekAvoidingReadBuffer.cpp
@@ -7,9 +7,7 @@ namespace DB
 SeekAvoidingReadBuffer::SeekAvoidingReadBuffer(std::unique_ptr<ReadBufferFromFileBase> impl_, UInt64 min_bytes_for_seek_)
     : ReadBufferFromFileDecorator(std::move(impl_))
     , min_bytes_for_seek(min_bytes_for_seek_)
-{
-}
-
+{ }
 
 off_t SeekAvoidingReadBuffer::seek(off_t off, int whence)
 {


### PR DESCRIPTION
This reverts commit 19445ac096a5c5a20ae91df1de8998296d4b8a47.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
