### PR TITLE
tests/integration: pass through lock for iptables for proper --wait

### DIFF
--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -2,12 +2,10 @@
 #-*- coding: utf-8 -*-
 import subprocess
 import os
-import getpass
 import glob
 import argparse
 import logging
 import signal
-import subprocess
 import sys
 
 CUR_FILE_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -274,6 +274,7 @@ if __name__ == "__main__":
         --volume={library_bridge_bin}:/clickhouse-library-bridge --volume={bin}:/clickhouse \
         --volume={base_cfg}:/clickhouse-config --volume={cases_dir}:/ClickHouse/tests/integration \
         --volume={src_dir}/Server/grpc_protos:/ClickHouse/src/Server/grpc_protos \
+        --volume=/run/xtables.lock:/run/xtables.lock:ro \
         {dockerd_internal_volume} -e DOCKER_CLIENT_TIMEOUT=300 -e COMPOSE_HTTP_TIMEOUT=600 \
         {env_tags} {env_cleanup} -e PYTEST_OPTS='{parallel} {opts} {tests_list} -vvv' {img} {command}".format(
         net=net,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #25823
Cc: @qoega 