### PR TITLE
Fix detach/attach for ReplicatedVersionedCollapsingMergeTree after alter

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
@@ -49,7 +49,7 @@ ReplicatedMergeTreeTableMetadata::ReplicatedMergeTreeTableMetadata(const MergeTr
     {
         /// We don't use preparsed AST `sorting_key.expression_list_ast` because
         /// it contain version column for VersionedCollapsingMergeTree, which
-        /// shouldn't be defined as a part of key definition AST. So the best
+        /// is not stored in ZooKeeper for compatibility reasons. So the best
         /// compatible way is just to convert definition_ast to list and
         /// serialize it. In all other places key.expression_list_ast should be
         /// used.

--- a/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
@@ -46,7 +46,15 @@ ReplicatedMergeTreeTableMetadata::ReplicatedMergeTreeTableMetadata(const MergeTr
 
     primary_key = formattedAST(metadata_snapshot->getPrimaryKey().expression_list_ast);
     if (metadata_snapshot->isPrimaryKeyDefined())
-        sorting_key = formattedAST(metadata_snapshot->getSortingKey().expression_list_ast);
+    {
+        /// We don't use preparsed AST `sorting_key.expression_list_ast` because
+        /// it contain version column for VersionedCollapsingMergeTree, which
+        /// shouldn't be defined as a part of key definition AST. So the best
+        /// compatible way is just to convert definition_ast to list and
+        /// serialize it. In all other places key.expression_list_ast should be
+        /// used.
+        sorting_key = formattedAST(extractKeyExpressionList(metadata_snapshot->getSortingKey().definition_ast));
+    }
 
     data_format_version = data.format_version;
 

--- a/tests/queries/0_stateless/01526_alter_add_and_modify_order_zookeeper.reference
+++ b/tests/queries/0_stateless/01526_alter_add_and_modify_order_zookeeper.reference
@@ -1,6 +1,6 @@
 2019-10-01	a	1	aa	1	1	1
 2019-10-01	a	1	aa	1	1	1	0
-CREATE TABLE default.table_for_alter\n(\n    `d` Date,\n    `a` String,\n    `b` UInt8,\n    `x` String,\n    `y` Int8,\n    `version` UInt64,\n    `sign` Int8 DEFAULT 1,\n    `order` UInt32\n)\nENGINE = ReplicatedVersionedCollapsingMergeTree(\'/clickhouse/tables/01526_alter_add/t1\', \'1\', sign, version)\nPARTITION BY y\nPRIMARY KEY d\nORDER BY (d, order)\nSETTINGS index_granularity = 8192
+CREATE TABLE default.table_for_alter\n(\n    `d` Date,\n    `a` String,\n    `b` UInt8,\n    `x` String,\n    `y` Int8,\n    `version` UInt64,\n    `sign` Int8 DEFAULT 1,\n    `order` UInt32\n)\nENGINE = ReplicatedVersionedCollapsingMergeTree(\'/clickhouse/tables/default/01526_alter_add/t1\', \'1\', sign, version)\nPARTITION BY y\nPRIMARY KEY d\nORDER BY (d, order)\nSETTINGS index_granularity = 8192
 2019-10-01	a	1	aa	1	1	1	0	0
 2019-10-02	b	2	bb	2	2	2	1	2
-CREATE TABLE default.table_for_alter\n(\n    `d` Date,\n    `a` String,\n    `b` UInt8,\n    `x` String,\n    `y` Int8,\n    `version` UInt64,\n    `sign` Int8 DEFAULT 1,\n    `order` UInt32,\n    `datum` UInt32\n)\nENGINE = ReplicatedVersionedCollapsingMergeTree(\'/clickhouse/tables/01526_alter_add/t1\', \'1\', sign, version)\nPARTITION BY y\nPRIMARY KEY d\nORDER BY (d, order, datum)\nSETTINGS index_granularity = 8192
+CREATE TABLE default.table_for_alter\n(\n    `d` Date,\n    `a` String,\n    `b` UInt8,\n    `x` String,\n    `y` Int8,\n    `version` UInt64,\n    `sign` Int8 DEFAULT 1,\n    `order` UInt32,\n    `datum` UInt32\n)\nENGINE = ReplicatedVersionedCollapsingMergeTree(\'/clickhouse/tables/default/01526_alter_add/t1\', \'1\', sign, version)\nPARTITION BY y\nPRIMARY KEY d\nORDER BY (d, order, datum)\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/01526_alter_add_and_modify_order_zookeeper.sql
+++ b/tests/queries/0_stateless/01526_alter_add_and_modify_order_zookeeper.sql
@@ -19,9 +19,19 @@ SETTINGS index_granularity = 8192;
 
 INSERT INTO table_for_alter VALUES(toDate('2019-10-01'), 'a', 1, 'aa', 1, 1, 1);
 
+DETACH TABLE table_for_alter;
+
+ATTACH TABLE table_for_alter;
+
+
 SELECT * FROM table_for_alter;
 
 ALTER TABLE table_for_alter ADD COLUMN order UInt32, MODIFY ORDER BY (d, order);
+
+
+DETACH TABLE table_for_alter;
+
+ATTACH TABLE table_for_alter;
 
 SELECT * FROM table_for_alter;
 
@@ -34,5 +44,9 @@ INSERT INTO table_for_alter VALUES(toDate('2019-10-02'), 'b', 2, 'bb', 2, 2, 2, 
 SELECT * FROM table_for_alter ORDER BY d;
 
 SHOW CREATE TABLE table_for_alter;
+
+DETACH TABLE table_for_alter;
+
+ATTACH TABLE table_for_alter;
 
 DROP TABLE IF EXISTS table_for_alter;

--- a/tests/queries/0_stateless/01526_alter_add_and_modify_order_zookeeper.sql
+++ b/tests/queries/0_stateless/01526_alter_add_and_modify_order_zookeeper.sql
@@ -12,7 +12,7 @@ CREATE TABLE table_for_alter
     `version` UInt64,
     `sign` Int8 DEFAULT 1
 )
-ENGINE = ReplicatedVersionedCollapsingMergeTree('/clickhouse/tables/01526_alter_add/t1', '1', sign, version)
+ENGINE = ReplicatedVersionedCollapsingMergeTree('/clickhouse/tables/{database}/01526_alter_add/t1', '1', sign, version)
 PARTITION BY y
 ORDER BY d
 SETTINGS index_granularity = 8192;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug which can lead to error `Existing table metadata in ZooKeeper differs in sorting key expression.` after alter of `ReplicatedVersionedCollapsingMergeTree`. Fixes #28515.