### PR TITLE
Fix insert_quorum_timeout in zookeeper_mutations_and_insert_quorum_long

### DIFF
--- a/tests/queries/0_stateless/01090_zookeeper_mutations_and_insert_quorum_long.sql
+++ b/tests/queries/0_stateless/01090_zookeeper_mutations_and_insert_quorum_long.sql
@@ -4,7 +4,8 @@ DROP TABLE IF EXISTS mutations_and_quorum2;
 CREATE TABLE mutations_and_quorum1 (`server_date` Date, `something` String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test_01090/mutations_and_quorum', '1') PARTITION BY toYYYYMM(server_date) ORDER BY (server_date, something);
 CREATE TABLE mutations_and_quorum2 (`server_date` Date, `something` String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test_01090/mutations_and_quorum', '2') PARTITION BY toYYYYMM(server_date) ORDER BY (server_date, something);
 
-SET insert_quorum=2, insert_quorum_parallel=0, insert_quorum_timeout=3000000;
+-- Should not be larger then 600e6 (default timeout in clickhouse-test)
+SET insert_quorum=2, insert_quorum_parallel=0, insert_quorum_timeout=300e3;
 
 INSERT INTO mutations_and_quorum1 VALUES ('2019-01-01', 'test1'), ('2019-02-01', 'test2'), ('2019-03-01', 'test3'), ('2019-04-01', 'test4'), ('2019-05-01', 'test1'), ('2019-06-01', 'test2'), ('2019-07-01', 'test3'), ('2019-08-01', 'test4'), ('2019-09-01', 'test1'), ('2019-10-01', 'test2'), ('2019-11-01', 'test3'), ('2019-12-01', 'test4');
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)