### PR TITLE
fix keep_alive_timeout default value (10s) in docs

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -390,12 +390,12 @@ This section contains the following parameters:
 
 ## keep_alive_timeout {#keep-alive-timeout}
 
-The number of seconds that ClickHouse waits for incoming requests before closing the connection. Defaults to 3 seconds.
+The number of seconds that ClickHouse waits for incoming requests before closing the connection. Defaults to 10 seconds.
 
 **Example**
 
 ``` xml
-<keep_alive_timeout>3</keep_alive_timeout>
+<keep_alive_timeout>10</keep_alive_timeout>
 ```
 
 ## listen_host {#server_configuration_parameters-listen_host}

--- a/docs/ja/operations/server-configuration-parameters/settings.md
+++ b/docs/ja/operations/server-configuration-parameters/settings.md
@@ -284,12 +284,12 @@ ClickHouseサーバー間でデータを交換するポート。
 
 ## keep_alive_timeout {#keep-alive-timeout}
 
-ClickHouseが接続を閉じる前に受信要求を待機する秒数。 既定値は3秒です。
+ClickHouseが接続を閉じる前に受信要求を待機する秒数。 既定値は10秒です。
 
 **例**
 
 ``` xml
-<keep_alive_timeout>3</keep_alive_timeout>
+<keep_alive_timeout>10</keep_alive_timeout>
 ```
 
 ## listen_host {#server_configuration_parameters-listen_host}

--- a/docs/ru/operations/server-configuration-parameters/settings.md
+++ b/docs/ru/operations/server-configuration-parameters/settings.md
@@ -371,12 +371,12 @@ ClickHouse проверяет условия для `min_part_size` и `min_part
 
 ## keep_alive_timeout {#keep-alive-timeout}
 
-Время в секундах, в течение которого ClickHouse ожидает входящих запросов прежде, чем закрыть соединение.
+Время в секундах, в течение которого ClickHouse ожидает входящих запросов прежде, чем 10акрыть соединение.
 
 **Пример**
 
 ``` xml
-<keep_alive_timeout>3</keep_alive_timeout>
+<keep_alive_timeout>10</keep_alive_timeout>
 ```
 
 ## listen_host {#server_configuration_parameters-listen_host}

--- a/docs/zh/operations/server-configuration-parameters/settings.md
+++ b/docs/zh/operations/server-configuration-parameters/settings.md
@@ -282,12 +282,12 @@ ClickHouse每x秒重新加载内置字典。 这使得编辑字典 “on the fly
 
 ## keep_alive_timeout {#keep-alive-timeout}
 
-ClickHouse在关闭连接之前等待传入请求的秒数。 默认为3秒。
+ClickHouse在关闭连接之前等待传入请求的秒数。默认为10秒。
 
 **示例**
 
 ``` xml
-<keep_alive_timeout>3</keep_alive_timeout>
+<keep_alive_timeout>10</keep_alive_timeout>
 ```
 
 ## listen_host {#server_configuration_parameters-listen_host}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)
