### PR TITLE
Proper buffer flush while handling HTTP queries (avoids std::terminate)

### DIFF
--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -179,6 +179,8 @@ void WriteBufferFromHTTPServerResponse::finalize()
         if (out)
             out->finalize();
         out.reset();
+        /// Catch write-after-finalize bugs.
+        set(nullptr, 0);
     }
     catch (...)
     {

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.cpp
@@ -87,8 +87,13 @@ void WriteBufferFromHTTPServerResponse::finishSendHeaders()
 
 void WriteBufferFromHTTPServerResponse::nextImpl()
 {
+    if (!initialized)
     {
         std::lock_guard lock(mutex);
+
+        /// Initialize as early as possible since if the code throws,
+        /// next() should not be called anymore.
+        initialized = true;
 
         startSendHeaders();
 

--- a/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
+++ b/src/Server/HTTP/WriteBufferFromHTTPServerResponse.h
@@ -46,6 +46,7 @@ private:
     std::shared_ptr<std::ostream> response_header_ostr;
 
     std::unique_ptr<WriteBuffer> out;
+    bool initialized = false;
 
     bool headers_started_sending = false;
     bool headers_finished_sending = false;    /// If true, you could not add any headers.

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -815,17 +815,31 @@ try
         writeChar('\n', *used_output.out_maybe_compressed);
 
         used_output.out_maybe_compressed->next();
-        used_output.out->finalize();
     }
     else
     {
         assert(false);
         __builtin_unreachable();
     }
+
+    if (used_output.out)
+        used_output.out->finalize();
 }
 catch (...)
 {
     tryLogCurrentException(log, "Cannot send exception to client");
+
+    if (used_output.out)
+    {
+        try
+        {
+            used_output.out->finalize();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(log, "Cannot flush data to client (after sending exception)");
+        }
+    }
 }
 
 

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -3,6 +3,7 @@
 #include <Core/Names.h>
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/HTTPRequestHandler.h>
+#include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/CurrentThread.h>
 
@@ -62,6 +63,16 @@ private:
         inline bool hasDelayed() const
         {
             return out_maybe_delayed_and_compressed != out_maybe_compressed;
+        }
+
+        inline void finalize() const
+        {
+            if (out_maybe_delayed_and_compressed)
+                out_maybe_delayed_and_compressed->finalize();
+            if (out_maybe_compressed)
+                out_maybe_compressed->finalize();
+            if (out)
+                out->finalize();
         }
     };
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Proper buffer flush while handling HTTP queries (avoids std::terminate and avoids calling finalize() multiple times). Fixes #26829

Detailed description:
This will avoid possible std::terminate, like in [1]:

  [1]: https://github.com/ClickHouse/ClickHouse/pull/24023#issuecomment-842979875

Cc: @amosbird

*NOTE: the first patch just reduce the scope for the trySendExceptionToClient*