### PR TITLE
StorageKafka: Use post kafka 0.9 auto.offset.reset value.

### DIFF
--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -411,7 +411,7 @@ ConsumerBufferPtr StorageKafka::createReadBuffer(const size_t consumer_number)
     }
     conf.set("client.software.name", VERSION_NAME);
     conf.set("client.software.version", VERSION_DESCRIBE);
-    conf.set("auto.offset.reset", "smallest");     // If no offset stored for this group, read all messages from the start
+    conf.set("auto.offset.reset", "earliest");     // If no offset stored for this group, read all messages from the start
 
     // that allows to prevent fast draining of the librdkafka queue
     // during building of single insert block. Improves performance


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Change `auto.offset.reset` from `smallest` to `earliest` to conform to the standard naming used in newer Kafka versions.


Detailed description / Documentation draft:

Currently clickhouse uses "smallest" value by default for auto.offset.reset in
order to read earliest messages. This is outdated value of pre 0.9 kafka
protocol look here:
https://kafka.apache.org/082/documentation.html - 0.82 version from 2015
uses "smallest"/ "largest"
https://kafka.apache.org/090/documentation.html - 0.9 version uses
"earliest"/ "latest".

This patch changes the offset default value to adopt "modern" kafka
protocol values.


<s>The issue is that some  modern kafka implementations (for example red
panda) does not implement the "smallest"/"largest" as it is too old
protocol.</s>

<s>This issue might be related to: https://github.com/ClickHouse/ClickHouse/issues/2251</s>