### PR TITLE
fix getNumberOfArguments() for s2Rect functions

### DIFF
--- a/src/Functions/s2RectAdd.cpp
+++ b/src/Functions/s2RectAdd.cpp
@@ -41,7 +41,7 @@ public:
         return name;
     }
 
-    size_t getNumberOfArguments() const override { return 4; }
+    size_t getNumberOfArguments() const override { return 3; }
 
     bool useDefaultImplementationForConstants() const override { return true; }
 

--- a/src/Functions/s2RectContains.cpp
+++ b/src/Functions/s2RectContains.cpp
@@ -41,7 +41,7 @@ public:
         return name;
     }
 
-    size_t getNumberOfArguments() const override { return 4; }
+    size_t getNumberOfArguments() const override { return 3; }
 
     bool useDefaultImplementationForConstants() const override { return true; }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix the number of arguments required by s2RectAdd and s2RectContains functions.


Detailed description / Documentation draft:

This fixes the value returned by the `getNumberOfArguments()` by the
`s2RectAdd` and the `s2RectContains` functions. Only `3` arguments are
used by these functions and not `4`:

- low s2Point of rectangle
- high s2Point of rectangle
- given s2Point

The given s2Point is used to groow the size of the bounding rectangle to
include the given S2Point in case of the `s2RectAdd` function. In case
of `s2RectContains`, the function determines if the bounded rectangle
contains the given point.

PS: I wonder if it's more apt to call `rectAdd` as `rectGrow` since
it's used to grow the size of a given rectangle.