### PR TITLE
Fix coredump in creating distributed table

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1332,7 +1332,12 @@ void registerStorageDistributed(StorageFactory & factory)
         String remote_table = engine_args[2]->as<ASTLiteral &>().value.safeGet<String>();
 
         const auto & sharding_key = engine_args.size() >= 4 ? engine_args[3] : nullptr;
-        const auto & storage_policy = engine_args.size() >= 5 ? engine_args[4]->as<ASTLiteral &>().value.safeGet<String>() : "default";
+        String storage_policy = "default";
+        if (engine_args.size() >= 5)
+        {
+            engine_args[4] = evaluateConstantExpressionOrIdentifierAsLiteral(engine_args[4], local_context);
+            storage_policy = engine_args[4]->as<ASTLiteral &>().value.safeGet<String>();
+        }
 
         /// Check that sharding_key exists in the table and has numeric type.
         if (sharding_key)

--- a/tests/queries/0_stateless/02017_create_distributed_table_coredump.sql
+++ b/tests/queries/0_stateless/02017_create_distributed_table_coredump.sql
@@ -1,0 +1,12 @@
+drop table if exists t;
+drop table if exists td1;
+drop table if exists td2;
+drop table if exists td3;
+create table t (val UInt32) engine = MergeTree order by val;
+create table td1 engine = Distributed(test_shard_localhost, currentDatabase(), 't') as t;
+create table td2 engine = Distributed(test_shard_localhost, currentDatabase(), 't', xxHash32(val), default) as t;
+create table td3 engine = Distributed(test_shard_localhost, currentDatabase(), 't', xxHash32(val), 'default') as t;
+drop table if exists t;
+drop table if exists td1; 
+drop table if exists td2; 
+drop table if exists td3; 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the coredump in the creation of distributed tables, when the parameters passed in are wrong


Detailed description / Documentation draft:

sql like this：
`create table td1 engine = Distributed(test_shard_localhost, currentDatabase(), 't', xxHash32(val), default) as t;`
If the fifth parameter `default` is not wrapped in quotation marks, a coredump will be generated.

It's okay to write like this:
`create table td1 engine = Distributed(cluster_2shards_2replicas, currentDatabase(), 't', xxHash32(val), 'default') as t;`

