### PR TITLE
Fix test_MemoryTracking integration test flakiness

### DIFF
--- a/tests/integration/test_MemoryTracking/configs/no_system_log.xml
+++ b/tests/integration/test_MemoryTracking/configs/no_system_log.xml
@@ -1,7 +1,17 @@
 <yandex>
-    <metric_log remove="remove"/>
     <query_masking_rules remove="remove"/>
+
     <query_thread_log remove="remove"/>
+    <query_log remove="remove" />
+    <query_views_log remove="remove" />
+    <metric_log remove="remove"/>
     <text_log remove="remove"/>
     <trace_log remove="remove"/>
+    <asynchronous_metric_log remove="remove" />
+    <session_log remove="remove" />
+    <part_log remove="remove" />
+    <crash_log remove="remove" />
+    <opentelemetry_span_log remove="remove" />
+    <!-- just in case it will be enabled by default -->
+    <zookeeper_log remove="remove" />
 </yandex>

--- a/tests/integration/test_MemoryTracking/configs/users.d/overrides.xml
+++ b/tests/integration/test_MemoryTracking/configs/users.d/overrides.xml
@@ -1,0 +1,8 @@
+<yandex>
+    <profiles>
+        <default>
+            <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>
+            <query_profiler_cpu_time_period_ns>0</query_profiler_cpu_time_period_ns>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/integration/test_MemoryTracking/test.py
+++ b/tests/integration/test_MemoryTracking/test.py
@@ -12,7 +12,7 @@ node = cluster.add_instance('node', main_configs=[
     'configs/no_system_log.xml',
     'configs/asynchronous_metrics_update_period_s.xml',
 ], user_configs=[
-    'conifgs/users.d/overrides.xml',
+    'configs/users.d/overrides.xml',
 ])
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/integration/test_MemoryTracking/test.py
+++ b/tests/integration/test_MemoryTracking/test.py
@@ -11,6 +11,8 @@ cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=[
     'configs/no_system_log.xml',
     'configs/asynchronous_metrics_update_period_s.xml',
+], user_configs=[
+    'conifgs/users.d/overrides.xml',
 ])
 
 @pytest.fixture(scope='module', autouse=True)
@@ -23,8 +25,6 @@ def start_cluster():
 
 query_settings = {
     'max_threads': 1,
-    'query_profiler_real_time_period_ns': 0,
-    'query_profiler_cpu_time_period_ns': 0,
     'log_queries': 0,
 }
 sample_query = "SELECT groupArray(repeat('a', 1000)) FROM numbers(10000) GROUP BY number%10 FORMAT JSON"


### PR DESCRIPTION
CI reports faliures [1].

  [1]: https://clickhouse-test-reports.s3.yandex.net/28604/9911b3ea368a7745934517747e62db3217cddb00/integration_tests_(release).html#fail1

Since the test had been introduced some changes had been made that affects memory tracking:
- `asynchronous_metric_log` had not been disabled in the test (`asynchronous_metrics_update_period_s` was set to 1 in #24416, but it does not affect the test, since the test set `asynchronous_metrics_update_period_s` to 1day)
- `session_log` had been added

Changelog category (leave one):
- Not for changelog (changelog entry is not required)