### PR TITLE
Increase number of iterations in test_distributed_load_balancing (fixes flakiness)

### DIFF
--- a/tests/integration/test_distributed_load_balancing/test.py
+++ b/tests/integration/test_distributed_load_balancing/test.py
@@ -43,21 +43,21 @@ def bootstrap():
             replicas_cluster,
             currentDatabase(),
             data)
-        """.format())
+        """)
         n.query("""
         CREATE TABLE dist_priority AS data
         Engine=Distributed(
             replicas_priority_cluster,
             currentDatabase(),
             data)
-        """.format())
+        """)
         n.query("""
         CREATE TABLE dist_priority_negative AS data
         Engine=Distributed(
             replicas_priority_negative_cluster,
             currentDatabase(),
             data)
-        """.format())
+        """)
 
 
 def make_uuid():

--- a/tests/integration/test_distributed_load_balancing/test.py
+++ b/tests/integration/test_distributed_load_balancing/test.py
@@ -14,7 +14,7 @@ n2 = cluster.add_instance('n2', main_configs=['configs/remote_servers.xml'])
 n3 = cluster.add_instance('n3', main_configs=['configs/remote_servers.xml'])
 
 nodes = len(cluster.instances)
-queries = nodes * 5
+queries = nodes * 10
 
 
 def bootstrap():


### PR DESCRIPTION
Before there was some flakiness, because for 15 iterations it does
generate all unique values (3 unique nodes) [1].

  [1]: https://clickhouse-test-reports.s3.yandex.net/28604/9911b3ea368a7745934517747e62db3217cddb00/integration_tests_(thread).html#fail1

<details>

```
$ grep 'FROM dist$' -A10 test_distributed_load_balancing/_instances_0/n1/logs/clickhouse-server.log  | fgrep Sent -m15
2021.09.08 03:09:51.541965 [ 170 ] {9689f9ea8adc4ee7b18d8c0db0ce85b1} <Debug> Connection (n2:9000): Sent data for 2 scalars, total 2 rows in 0.000318745 sec., 6201 rows/sec., 66.00 B (199.75 KiB/sec.), compressed 0.4520547945205479 times to 146.00 B (441.73 KiB/sec.)
2021.09.08 03:09:54.282724 [ 166 ] {e91901cef6dc477faa1c7ca101557643} <Debug> Connection (n2:9000): Sent data for 2 scalars, total 2 rows in 0.000328662 sec., 5959 rows/sec., 66.00 B (191.96 KiB/sec.), compressed 0.4520547945205479 times to 146.00 B (424.52 KiB/sec.)
2021.09.08 03:09:56.970290 [ 162 ] {91a2865b8f0c410b833347114d33c592} <Debug> Connection (n2:9000): Sent data for 2 scalars, total 2 rows in 0.000300908 sec., 6393 rows/sec., 66.00 B (205.98 KiB/sec.), compressed 0.4520547945205479 times to 146.00 B (455.51 KiB/sec.)
2021.09.08 03:10:02.363994 [ 164 ] {36b5558d0444481ba831b97bea02726e} <Debug> Connection (n1:9000): Sent data for 2 scalars, total 2 rows in 0.00014302 sec., 13271 rows/sec., 786.00 B (4.97 MiB/sec.), no compression.
2021.09.08 03:10:05.046983 [ 169 ] {371fa3ecc4d04677bc68ba3d31bc272f} <Debug> Connection (n1:9000): Sent data for 2 scalars, total 2 rows in 0.000149959 sec., 12778 rows/sec., 1.14 KiB (7.11 MiB/sec.), no compression.
2021.09.08 03:10:07.781185 [ 163 ] {30c2d61310d94f27a8d5a85d9cf8f45d} <Debug> Connection (n2:9000): Sent data for 2 scalars, total 2 rows in 0.000295519 sec., 6602 rows/sec., 66.00 B (212.63 KiB/sec.), compressed 0.4520547945205479 times to 146.00 B (470.22 KiB/sec.)
2021.09.08 03:10:10.541925 [ 170 ] {b5d557f2b8fd429a9bf9578abc7a34d2} <Debug> Connection (n2:9000): Sent data for 2 scalars, total 2 rows in 0.000296583 sec., 6609 rows/sec., 66.00 B (212.88 KiB/sec.), compressed 0.4520547945205479 times to 146.00 B (470.74 KiB/sec.)
2021.09.08 03:10:13.294139 [ 170 ] {811b0324bd154ee3bba157b452abfaf1} <Debug> Connection (n1:9000): Sent data for 2 scalars, total 2 rows in 0.000127005 sec., 14938 rows/sec., 1.51 KiB (11.03 MiB/sec.), no compression.
2021.09.08 03:10:15.989945 [ 164 ] {7158c0d8806243d19da9a47baed25a60} <Debug> Connection (n2:9000): Sent data for 2 scalars, total 2 rows in 0.000317462 sec., 6161 rows/sec., 66.00 B (198.40 KiB/sec.), compressed 0.4520547945205479 times to 146.00 B (438.74 KiB/sec.)
2021.09.08 03:10:18.687913 [ 169 ] {30d00f03bc5048c182aa7b7d3e8478dd} <Debug> Connection (n2:9000): Sent data for 2 scalars, total 2 rows in 0.000305144 sec., 6414 rows/sec., 66.00 B (206.64 KiB/sec.), compressed 0.4520547945205479 times to 146.00 B (456.89 KiB/sec.)
2021.09.08 03:10:21.372283 [ 171 ] {7d5dff8051a94c52bd320bdddfa9a447} <Debug> Connection (n1:9000): Sent data for 2 scalars, total 2 rows in 0.000135819 sec., 14137 rows/sec., 1.89 KiB (13.01 MiB/sec.), no compression.
2021.09.08 03:10:24.127647 [ 163 ] {7b4347c3b6f94aa4b4a690e5720cf2ab} <Debug> Connection (n1:9000): Sent data for 2 scalars, total 2 rows in 0.000132365 sec., 14363 rows/sec., 2.26 KiB (15.83 MiB/sec.), no compression.
2021.09.08 03:10:26.885911 [ 163 ] {49109f2ee96442b1858cb9a66307dac3} <Debug> Connection (n2:9000): Sent data for 2 scalars, total 2 rows in 0.000348723 sec., 5616 rows/sec., 66.00 B (180.92 KiB/sec.), compressed 0.4520547945205479 times to 146.00 B (400.04 KiB/sec.)
2021.09.08 03:10:29.582474 [ 164 ] {7d8c53d6cd24428ea5181e4620c029da} <Debug> Connection (n2:9000): Sent data for 2 scalars, total 2 rows in 0.000313289 sec., 6263 rows/sec., 66.00 B (201.73 KiB/sec.), compressed 0.4520547945205479 times to 146.00 B (445.30 KiB/sec.)
2021.09.08 03:10:32.413582 [ 169 ] {97ca9f0870bc410da98a0770acc92c96} <Debug> Connection (n1:9000): Sent data for 2 scalars, total 2 rows in 0.000129043 sec., 14822 rows/sec., 2.64 KiB (19.10 MiB/sec.), no compression.
```

</details>

I've tried other techincs (cap random value to the maximum number of
nodes, other RNG, but these does not solve it either).

Changelog category (leave one):
- Not for changelog (changelog entry is not required)