### PR TITLE
reduce debug build binary size by clang optimazition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,13 @@ if (COMPILER_CLANG)
     if (NOT CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE")
         set(COMPILER_FLAGS "${COMPILER_FLAGS} -gdwarf-aranges")
     endif ()
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0)
+		if (CMAKE_BUILD_TYPE_UC STREQUAL "DEBUG" OR CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO")
+            set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fuse-ctor-homing")
+            set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Xclang -fuse-ctor-homing")
+        endif()
+    endif()
 endif ()
 
 # If turned `ON`, assumes the user has either the system GTest library or the bundled one.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Build/Testing/Packaging Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reduce Debug build binary size by clang optimization.

Detailed description / Documentation draft:
With [`constructor type homing` ](https://blog.llvm.org/posts/2021-04-05-constructor-homing-for-debug-info/) optimization from clang >= 12.0, the binary size of Debug build can reduce from 2.6G to 2.4G.

Before:
```
-rwxrwxr-x 1  2.6G Sep  8 15:05 programs/clickhouse
```
Now:
```
-rwxr-xr-x 1  2.4G Sep  8 19:47 programs/clickhouse
```