### PR TITLE
Allow optimize_arithmetic_operations_in_aggregate_functions when alias is used

### DIFF
--- a/src/Interpreters/ArithmeticOperationsInAgrFuncOptimize.cpp
+++ b/src/Interpreters/ArithmeticOperationsInAgrFuncOptimize.cpp
@@ -107,10 +107,7 @@ ASTPtr tryExchangeFunctions(const ASTFunction & func)
         || !supported.find(lower_name)->second.count(child_func->name))
         return {};
 
-    /// Cannot rewrite function with alias cause alias could become undefined
-    if (!func.tryGetAlias().empty() || !child_func->tryGetAlias().empty())
-        return {};
-
+    auto original_alias = func.tryGetAlias();
     const auto & child_func_args = child_func->arguments->children;
     const auto * first_literal = child_func_args[0]->as<ASTLiteral>();
     const auto * second_literal = child_func_args[1]->as<ASTLiteral>();
@@ -132,7 +129,12 @@ ASTPtr tryExchangeFunctions(const ASTFunction & func)
         optimized_ast = exchangeExtractSecondArgument(new_name, *child_func);
     }
 
-    return optimized_ast;
+    if (optimized_ast)
+    {
+        optimized_ast->setAlias(original_alias);
+        return optimized_ast;
+    }
+    return {};
 }
 
 }

--- a/src/Interpreters/TreeOptimizer.cpp
+++ b/src/Interpreters/TreeOptimizer.cpp
@@ -14,7 +14,6 @@
 #include <Interpreters/RewriteCountVariantsVisitor.h>
 #include <Interpreters/MonotonicityCheckVisitor.h>
 #include <Interpreters/ConvertStringsToEnumVisitor.h>
-#include <Interpreters/PredicateExpressionsOptimizer.h>
 #include <Interpreters/RewriteFunctionToSubcolumnVisitor.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExternalDictionariesLoader.h>
@@ -709,9 +708,6 @@ void TreeOptimizer::apply(ASTPtr & query, TreeRewriterResult & result,
     /// Move arithmetic operations out of aggregation functions
     if (settings.optimize_arithmetic_operations_in_aggregate_functions)
         optimizeAggregationFunctions(query);
-
-    /// Push the predicate expression down to the subqueries.
-    result.rewrite_subqueries = PredicateExpressionsOptimizer(context, tables_with_columns, settings).optimize(*select_query);
 
     /// GROUP BY injective function elimination.
     optimizeGroupBy(select_query, result.source_columns_set, context);

--- a/tests/queries/0_stateless/01271_optimize_arithmetic_operations_in_aggr_func_with_alias.reference
+++ b/tests/queries/0_stateless/01271_optimize_arithmetic_operations_in_aggr_func_with_alias.reference
@@ -1,0 +1,10 @@
+SELECT min(n AS a) + (1 AS b) AS c
+FROM
+(
+    SELECT number AS n
+    FROM numbers(10)
+    WHERE (1 > 0) AND (n > 0)
+)
+WHERE (a > 0) AND (b > 0)
+HAVING c > 0
+2

--- a/tests/queries/0_stateless/01271_optimize_arithmetic_operations_in_aggr_func_with_alias.sql
+++ b/tests/queries/0_stateless/01271_optimize_arithmetic_operations_in_aggr_func_with_alias.sql
@@ -1,0 +1,4 @@
+set optimize_arithmetic_operations_in_aggregate_functions = 1;
+
+explain syntax select min((n as a) + (1 as b)) c from (select number n from numbers(10)) where a > 0 and b > 0 having c > 0;
+select min((n as a) + (1 as b)) c from (select number n from numbers(10)) where a > 0 and b > 0 having c > 0;

--- a/tests/queries/0_stateless/01470_columns_transformers.reference
+++ b/tests/queries/0_stateless/01470_columns_transformers.reference
@@ -54,8 +54,8 @@ SELECT
     sum(k)
 FROM columns_transformers
 SELECT
-    avg(i + 1 AS i),
-    avg(j + 2 AS j),
+    avg(i) + 1,
+    avg(j) + 2,
     avg(k)
 FROM columns_transformers
 SELECT


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow optimization :  `optimize_arithmetic_operations_in_aggregate_functions = 1` when alias is used. I cannot figure out why it was disabled. We set aliases in all other TreeOptimizers, except this one. Maybe I'm missing something important) @4ertus2 could you give a bad example?

The motivation is to enable this for projections, since projection query analysis ignores aliases and this brings inconsistency.

Detailed description / Documentation draft:
.