### PR TITLE
Fix signed integer overflow for nth_value() window function

### DIFF
--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1614,16 +1614,11 @@ struct WindowFunctionLagLeadInFrame final : public WindowFunction
             offset = (*current_block.input_columns[
                     workspace.argument_column_indices[1]])[
                         transform->current_row.row].get<Int64>();
-            if (offset < 0)
+
+            if (offset > INT64_MAX || offset < 0)
             {
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                    "The offset for function {} must be nonnegative, {} given",
-                    getName(), offset);
-            }
-            if (offset > INT64_MAX)
-            {
-                throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                    "The offset for function {} must be less than {}, {} given",
+                    "The offset for function {} must be in (0, {}], {} given",
                     getName(), INT64_MAX, offset);
             }
         }

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -423,7 +423,7 @@ void WindowTransform::advancePartitionEnd()
     assert(!partition_ended && partition_end == blocksEnd());
 }
 
-auto WindowTransform::moveRowNumberNoCheck(const RowNumber & _x, int offset) const
+auto WindowTransform::moveRowNumberNoCheck(const RowNumber & _x, int64_t offset) const
 {
     RowNumber x = _x;
 
@@ -461,9 +461,9 @@ auto WindowTransform::moveRowNumberNoCheck(const RowNumber & _x, int offset) con
             assertValid(x);
             assert(offset <= 0);
 
-            // abs(offset) is less than INT_MAX, as checked in the parser, so
+            // abs(offset) is less than INT64_MAX, as checked in the parser, so
             // this negation should always work.
-            assert(offset >= -INT_MAX);
+            assert(offset >= -INT64_MAX);
             if (x.row >= static_cast<uint64_t>(-offset))
             {
                 x.row -= -offset;
@@ -493,7 +493,7 @@ auto WindowTransform::moveRowNumberNoCheck(const RowNumber & _x, int offset) con
     return std::tuple{x, offset};
 }
 
-auto WindowTransform::moveRowNumber(const RowNumber & _x, int offset) const
+auto WindowTransform::moveRowNumber(const RowNumber & _x, int64_t offset) const
 {
     auto [x, o] = moveRowNumberNoCheck(_x, offset);
 
@@ -1620,11 +1620,11 @@ struct WindowFunctionLagLeadInFrame final : public WindowFunction
                     "The offset for function {} must be nonnegative, {} given",
                     getName(), offset);
             }
-            if (offset > INT_MAX)
+            if (offset > INT64_MAX)
             {
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,
                     "The offset for function {} must be less than {}, {} given",
-                    getName(), INT_MAX, offset);
+                    getName(), INT64_MAX, offset);
             }
         }
 
@@ -1698,11 +1698,11 @@ struct WindowFunctionNthValue final : public WindowFunction
                 workspace.argument_column_indices[1]])[
             transform->current_row.row].get<Int64>();
 
-        if (offset > INT_MAX || offset <= 0)
+        if (offset > INT64_MAX || offset <= 0)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "The offset for function {} must be in (0, {}], {} given",
-                getName(), INT_MAX, offset);
+                getName(), INT64_MAX, offset);
         }
 
         --offset;

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1696,22 +1696,16 @@ struct WindowFunctionNthValue final : public WindowFunction
 
         int64_t offset = (*current_block.input_columns[
                 workspace.argument_column_indices[1]])[
-            transform->current_row.row].get<Int64>() - 1;
+            transform->current_row.row].get<Int64>();
 
-        if (offset < 0)
+        if (offset > INT_MAX || offset <= 0)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "The offset for function {} must be non-negative, {} given",
-                getName(), offset);
-        }
-
-        if (offset > INT_MAX)
-        {
-            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "The offset for function {} must be less than {}, {} given",
+                "The offset for function {} must be in (0, {}], {} given",
                 getName(), INT_MAX, offset);
         }
 
+        --offset;
         const auto [target_row, offset_left] = transform->moveRowNumber(transform->frame_start, offset);
         if (offset_left != 0
             || target_row < transform->frame_start

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1615,7 +1615,8 @@ struct WindowFunctionLagLeadInFrame final : public WindowFunction
                     workspace.argument_column_indices[1]])[
                         transform->current_row.row].get<Int64>();
 
-            if (offset > INT64_MAX || offset < 0)
+            /// Either overflow or really negative value, both is not acceptable.
+            if (offset < 0)
             {
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,
                     "The offset for function {} must be in (0, {}], {} given",
@@ -1693,7 +1694,8 @@ struct WindowFunctionNthValue final : public WindowFunction
                 workspace.argument_column_indices[1]])[
             transform->current_row.row].get<Int64>();
 
-        if (offset > INT64_MAX || offset <= 0)
+        /// Either overflow or really negative value, both is not acceptable.
+        if (offset <= 0)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "The offset for function {} must be in (0, {}], {} given",

--- a/src/Processors/Transforms/WindowTransform.h
+++ b/src/Processors/Transforms/WindowTransform.h
@@ -218,8 +218,8 @@ public:
 #endif
     }
 
-    auto moveRowNumber(const RowNumber & _x, int offset) const;
-    auto moveRowNumberNoCheck(const RowNumber & _x, int offset) const;
+    auto moveRowNumber(const RowNumber & _x, int64_t offset) const;
+    auto moveRowNumberNoCheck(const RowNumber & _x, int64_t offset) const;
 
     void assertValid(const RowNumber & x) const
     {

--- a/tests/queries/0_stateless/01591_window_functions.reference
+++ b/tests/queries/0_stateless/01591_window_functions.reference
@@ -1150,6 +1150,14 @@ WINDOW w AS (ORDER BY number ASC)
 2	0	2
 3	0	2
 4	0	2
+-- UBsan
+SELECT nth_value(number, -9223372036854775808) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(number, 0) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(number, /* INT_MAX+1 */ 2147483648) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(number, /* INT_MAX */ 2147483647) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC);
+0
+SELECT nth_value(number, 1) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC);
+0
 -- In this case, we had a problem with PartialSortingTransform returning zero-row
 -- chunks for input chunks w/o columns.
 select count() over () from numbers(4) where number < 2;

--- a/tests/queries/0_stateless/01591_window_functions.reference
+++ b/tests/queries/0_stateless/01591_window_functions.reference
@@ -1150,13 +1150,31 @@ WINDOW w AS (ORDER BY number ASC)
 2	0	2
 3	0	2
 4	0	2
--- UBsan
-SELECT nth_value(number, -9223372036854775808) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
-SELECT nth_value(number, 0) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
-SELECT nth_value(number, /* INT_MAX+1 */ 2147483648) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
-SELECT nth_value(number, /* INT_MAX */ 2147483647) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC);
+-- nth_value UBsan
+SELECT nth_value(1, -1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(1, 0) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(1, /* INT64_MAX+1 */ 0x7fffffffffffffff+1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(1, /* INT64_MAX */ 0x7fffffffffffffff) OVER ();
 0
-SELECT nth_value(number, 1) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC);
+SELECT nth_value(1, 1) OVER ();
+1
+-- lagInFrame UBsan
+SELECT lagInFrame(1, -1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT lagInFrame(1, 0) OVER ();
+1
+SELECT lagInFrame(1, /* INT64_MAX+1 */ 0x7fffffffffffffff+1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT lagInFrame(1, /* INT64_MAX */ 0x7fffffffffffffff) OVER ();
+0
+SELECT lagInFrame(1, 1) OVER ();
+0
+-- leadInFrame UBsan
+SELECT leadInFrame(1, -1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT leadInFrame(1, 0) OVER ();
+1
+SELECT leadInFrame(1, /* INT64_MAX+1 */ 0x7fffffffffffffff+1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT leadInFrame(1, /* INT64_MAX */ 0x7fffffffffffffff) OVER ();
+0
+SELECT leadInFrame(1, 1) OVER ();
 0
 -- In this case, we had a problem with PartialSortingTransform returning zero-row
 -- chunks for input chunks w/o columns.

--- a/tests/queries/0_stateless/01591_window_functions.sql
+++ b/tests/queries/0_stateless/01591_window_functions.sql
@@ -435,12 +435,26 @@ FROM numbers(5)
 WINDOW w AS (ORDER BY number ASC)
 ;
 
--- UBsan
-SELECT nth_value(number, -9223372036854775808) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
-SELECT nth_value(number, 0) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
-SELECT nth_value(number, /* INT_MAX+1 */ 2147483648) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
-SELECT nth_value(number, /* INT_MAX */ 2147483647) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC);
-SELECT nth_value(number, 1) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC);
+-- nth_value UBsan
+SELECT nth_value(1, -1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(1, 0) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(1, /* INT64_MAX+1 */ 0x7fffffffffffffff+1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(1, /* INT64_MAX */ 0x7fffffffffffffff) OVER ();
+SELECT nth_value(1, 1) OVER ();
+
+-- lagInFrame UBsan
+SELECT lagInFrame(1, -1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT lagInFrame(1, 0) OVER ();
+SELECT lagInFrame(1, /* INT64_MAX+1 */ 0x7fffffffffffffff+1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT lagInFrame(1, /* INT64_MAX */ 0x7fffffffffffffff) OVER ();
+SELECT lagInFrame(1, 1) OVER ();
+
+-- leadInFrame UBsan
+SELECT leadInFrame(1, -1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT leadInFrame(1, 0) OVER ();
+SELECT leadInFrame(1, /* INT64_MAX+1 */ 0x7fffffffffffffff+1) OVER (); -- { serverError BAD_ARGUMENTS }
+SELECT leadInFrame(1, /* INT64_MAX */ 0x7fffffffffffffff) OVER ();
+SELECT leadInFrame(1, 1) OVER ();
 
 -- In this case, we had a problem with PartialSortingTransform returning zero-row
 -- chunks for input chunks w/o columns.

--- a/tests/queries/0_stateless/01591_window_functions.sql
+++ b/tests/queries/0_stateless/01591_window_functions.sql
@@ -434,7 +434,14 @@ SELECT
 FROM numbers(5)
 WINDOW w AS (ORDER BY number ASC)
 ;
-    
+
+-- UBsan
+SELECT nth_value(number, -9223372036854775808) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(number, 0) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(number, /* INT_MAX+1 */ 2147483648) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC); -- { serverError BAD_ARGUMENTS }
+SELECT nth_value(number, /* INT_MAX */ 2147483647) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC);
+SELECT nth_value(number, 1) OVER w AS v FROM numbers(1) WINDOW w AS (ORDER BY number DESC);
+
 -- In this case, we had a problem with PartialSortingTransform returning zero-row
 -- chunks for input chunks w/o columns.
 select count() over () from numbers(4) where number < 2;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix signed integer overflow for nth_value() window function

Detailed description / Documentation draft:
CI report [1]:

    ../src/Processors/Transforms/WindowTransform.cpp:1699:54: runtime error: signed integer overflow: -9223372036854775808 - 1 cannot be represented in type 'long' Received signal -3 Received signal Unknown signal (-3)

In query:

```sql

    SELECT
        number,
        nth_value(number, 2147483648) OVER w,
        anyOrNull(number) OVER (ORDER BY -2147483648 - intDiv(number, 1024) DESC NULLS FIRST, number DESC ROWS BETWEEN 65535 FOLLOWING AND UNBOUNDED FOLLOWING),
        nth_value(number, 65537) OVER w AS firstValue,
        nth_value(number, -9223372036854775808) OVER w AS secondValue,
        nth_value(number, 1048576) OVER w AS thirdValue
    FROM numbers(1)
    WINDOW w AS (ORDER BY number DESC)
    ORDER BY number DESC

```

  [1]: https://clickhouse-test-reports.s3.yandex.net/28532/7623af5513e12aa8dfa1bee963caffe00185c31a/fuzzer_ubsan/report.html#fail1

Cc: @akuzm 
Fixes: #28001