### PR TITLE
Fix handling of nullable arguments in JSONExtract

### DIFF
--- a/tests/queries/0_stateless/02023_json_extract_nullable_argument.reference
+++ b/tests/queries/0_stateless/02023_json_extract_nullable_argument.reference
@@ -1,0 +1,6 @@
+\N	Nullable(String)
+	String
+\N	Nullable(String)
+	Nullable(String)
+\N	Nullable(Nothing)
+\N	Nullable(Nothing)

--- a/tests/queries/0_stateless/02023_json_extract_nullable_argument.sql
+++ b/tests/queries/0_stateless/02023_json_extract_nullable_argument.sql
@@ -1,0 +1,6 @@
+SELECT JSONExtract('{"string_value":null}', 'string_value', 'Nullable(String)') as x, toTypeName(x);
+SELECT JSONExtract('{"string_value":null}', 'string_value', 'String') as x, toTypeName(x);
+SELECT JSONExtract(toNullable('{"string_value":null}'), 'string_value', 'Nullable(String)') as x, toTypeName(x);
+SELECT JSONExtract(toNullable('{"string_value":null}'), 'string_value', 'String') as x, toTypeName(x);
+SELECT JSONExtract(NULL, 'string_value', 'Nullable(String)') as x, toTypeName(x);
+SELECT JSONExtract(NULL, 'string_value', 'String') as x, toTypeName(x);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix handling of nullable arguments in JSONExtract, so
```
SELECT JSONExtract(toNullable('{"string_value":null}'), 'string_value', 'Nullable(String)') as x, toTypeName(x) as type
```
now returns 

```
┌─x────┬─type─────────────┐
│ ᴺᵁᴸᴸ │ Nullable(String) │
└──────┴──────────────────┘
```

This PR fixes https://github.com/ClickHouse/ClickHouse/issues/27930