### PR TITLE
Fix error code of clickhouse-test if server is dead.

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1162,6 +1162,9 @@ def main(args):
             total_tests_run += do_run_tests(
                 jobs, suite, suite_dir, suite_tmp_dir, all_tests, parallel_tests, sequential_tests, args.parallel)
 
+    if server_died.is_set():
+        exit_code.value = 1
+
     if args.hung_check:
 
         # Some queries may execute in background for some time after test was finished. This is normal.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Trying to fix OK in fast tests in case of server crash.
https://clickhouse-test-reports.s3.yandex.net/28582/aea1871755fcd3bfa31951e22fe00516cd427091/fast_test.html