### PR TITLE
Lower compiled_expression_cache_size to 128MB

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -962,7 +962,7 @@ if (ThreadFuzzer::instance().isEffective())
         global_context->setMMappedFileCache(mmap_cache_size);
 
 #if USE_EMBEDDED_COMPILER
-    constexpr size_t compiled_expression_cache_size_default = 1024 * 1024 * 1024;
+    constexpr size_t compiled_expression_cache_size_default = 1024 * 1024 * 128;
     size_t compiled_expression_cache_size = config().getUInt64("compiled_expression_cache_size", compiled_expression_cache_size_default);
     CompiledExpressionCacheFactory::instance().init(compiled_expression_cache_size);
 #endif

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -331,7 +331,7 @@
     <mmap_cache_size>1000</mmap_cache_size>
 
     <!-- Cache size for compiled expressions.-->
-    <compiled_expression_cache_size>1073741824</compiled_expression_cache_size>
+    <compiled_expression_cache_size>134217728</compiled_expression_cache_size>
 
     <!-- Path to data directory, with trailing slash. -->
     <path>/var/lib/clickhouse/</path>

--- a/programs/server/config.yaml.example
+++ b/programs/server/config.yaml.example
@@ -280,7 +280,7 @@ mark_cache_size: 5368709120
 mmap_cache_size: 1000
 
 # Cache size for compiled expressions.
-compiled_expression_cache_size: 1073741824
+compiled_expression_cache_size: 134217728
 
 # Path to data directory, with trailing slash.
 path: /var/lib/clickhouse/


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
