### PR TITLE
Fix shared build with ENABLE_EMBEDDED_COMPILER

### DIFF
--- a/cmake/find/llvm.cmake
+++ b/cmake/find/llvm.cmake
@@ -1,8 +1,10 @@
 if (APPLE OR SPLIT_SHARED_LIBRARIES OR NOT ARCH_AMD64 OR SANITIZE STREQUAL "undefined")
-    set (ENABLE_EMBEDDED_COMPILER OFF CACHE INTERNAL "")
+    set (ENABLE_EMBEDDED_COMPILER_DEFAULT OFF)
+else()
+    set (ENABLE_EMBEDDED_COMPILER_DEFAULT ON)
 endif()
 
-option (ENABLE_EMBEDDED_COMPILER "Enable support for 'compile_expressions' option for query execution" ON)
+option (ENABLE_EMBEDDED_COMPILER "Enable support for 'compile_expressions' option for query execution" ${ENABLE_EMBEDDED_COMPILER_DEFAULT})
 
 if (NOT ENABLE_EMBEDDED_COMPILER)
     set (USE_EMBEDDED_COMPILER 0)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -206,7 +206,7 @@ elseif(GTEST_SRC_DIR)
     target_compile_definitions(gtest INTERFACE GTEST_HAS_POSIX_RE=0)
 endif()
 
-if (USE_EMBEDDED_COMPILER)
+function(add_llvm)
     # ld: unknown option: --color-diagnostics
     if (APPLE)
         set (LINKER_SUPPORTS_COLOR_DIAGNOSTICS 0 CACHE INTERNAL "")
@@ -219,13 +219,12 @@ if (USE_EMBEDDED_COMPILER)
 
     # Need to use C++17 since the compilation is not possible with C++20 currently, due to ambiguous operator != etc.
     # LLVM project will set its default value for the -std=... but our global setting from CMake will override it.
-    set (CMAKE_CXX_STANDARD_bak ${CMAKE_CXX_STANDARD})
     set (CMAKE_CXX_STANDARD 17)
 
     add_subdirectory (llvm/llvm)
-
-    set (CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD_bak})
-    unset (CMAKE_CXX_STANDARD_bak)
+endfunction()
+if (USE_EMBEDDED_COMPILER)
+    add_llvm()
 endif ()
 
 if (USE_INTERNAL_LIBGSASL_LIBRARY)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -212,6 +212,8 @@ function(add_llvm)
         set (LINKER_SUPPORTS_COLOR_DIAGNOSTICS 0 CACHE INTERNAL "")
     endif ()
 
+    # Do not adjust RPATH in llvm, since then it will not be able to find libcxx/libcxxabi/libunwind
+    set (CMAKE_INSTALL_RPATH "ON")
     set (LLVM_ENABLE_EH 1 CACHE INTERNAL "")
     set (LLVM_ENABLE_RTTI 1 CACHE INTERNAL "")
     set (LLVM_ENABLE_PIC 0 CACHE INTERNAL "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -261,7 +261,7 @@ dbms_target_include_directories (PUBLIC "${ClickHouse_SOURCE_DIR}/src" "${ClickH
 target_include_directories (clickhouse_common_io PUBLIC "${ClickHouse_SOURCE_DIR}/src" "${ClickHouse_BINARY_DIR}/src")
 
 if (USE_EMBEDDED_COMPILER)
-    dbms_target_link_libraries (PRIVATE ${REQUIRED_LLVM_LIBRARIES})
+    dbms_target_link_libraries (PUBLIC ${REQUIRED_LLVM_LIBRARIES})
     dbms_target_include_directories (SYSTEM BEFORE PUBLIC ${LLVM_INCLUDE_DIRS})
 endif ()
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)