### PR TITLE
Fix expressions compilation with short circuit evaluation

### DIFF
--- a/src/Interpreters/ExpressionJIT.cpp
+++ b/src/Interpreters/ExpressionJIT.cpp
@@ -380,25 +380,25 @@ static CompileDAG getCompilableDAG(
 
         if (!is_compilable_function || is_compilable_constant)
         {
-           CompileDAG::Node compile_node;
-           compile_node.function = node->function_base;
-           compile_node.result_type = node->result_type;
+            CompileDAG::Node compile_node;
+            compile_node.function = node->function_base;
+            compile_node.result_type = node->result_type;
 
-           if (is_compilable_constant)
-           {
-               compile_node.type = CompileDAG::CompileType::CONSTANT;
-               compile_node.column = node->column;
-           }
-           else
-           {
+            if (is_compilable_constant)
+            {
+                compile_node.type = CompileDAG::CompileType::CONSTANT;
+                compile_node.column = node->column;
+            }
+            else
+            {
                 compile_node.type = CompileDAG::CompileType::INPUT;
                 children.emplace_back(node);
-           }
+            }
 
-           visited_node_to_compile_dag_position[node] = dag.getNodesCount();
-           dag.addNode(std::move(compile_node));
-           stack.pop();
-           continue;
+            visited_node_to_compile_dag_position[node] = dag.getNodesCount();
+            dag.addNode(std::move(compile_node));
+            stack.pop();
+            continue;
         }
 
         while (frame.next_child_to_visit < node->children.size())

--- a/src/Interpreters/ExpressionJIT.cpp
+++ b/src/Interpreters/ExpressionJIT.cpp
@@ -353,7 +353,8 @@ static bool isCompilableFunction(const ActionsDAG::Node & node, const std::unord
 
 static CompileDAG getCompilableDAG(
     const ActionsDAG::Node * root,
-    ActionsDAG::NodeRawConstPtrs & children)
+    ActionsDAG::NodeRawConstPtrs & children,
+    const std::unordered_set<const ActionsDAG::Node *> & lazy_executed_nodes)
 {
     /// Extract CompileDAG from root actions dag node.
 
@@ -376,7 +377,7 @@ static CompileDAG getCompilableDAG(
         const auto * node = frame.node;
 
         bool is_compilable_constant = isCompilableConstant(*node);
-        bool is_compilable_function = isCompilableFunction(*node, {});
+        bool is_compilable_function = isCompilableFunction(*node, lazy_executed_nodes);
 
         if (!is_compilable_function || is_compilable_constant)
         {
@@ -568,7 +569,7 @@ void ActionsDAG::compileFunctions(size_t min_count_to_compile_expression, const 
     for (auto & node : nodes_to_compile)
     {
         NodeRawConstPtrs new_children;
-        auto dag = getCompilableDAG(node, new_children);
+        auto dag = getCompilableDAG(node, new_children, lazy_executed_nodes);
 
         if (dag.getInputNodesCount() == 0)
             continue;

--- a/tests/queries/0_stateless/02024_compile_expressions_with_short_circuit_evaluation.reference
+++ b/tests/queries/0_stateless/02024_compile_expressions_with_short_circuit_evaluation.reference
@@ -1,0 +1,3 @@
+-- { echo }
+select 1+number+multiIf(number == 1, cityHash64(number), number) from numbers(1) settings compile_expressions=1, min_count_to_compile_expression=0;
+1

--- a/tests/queries/0_stateless/02024_compile_expressions_with_short_circuit_evaluation.sql
+++ b/tests/queries/0_stateless/02024_compile_expressions_with_short_circuit_evaluation.sql
@@ -1,0 +1,2 @@
+-- { echo }
+select 1+number+multiIf(number == 1, cityHash64(number), number) from numbers(1) settings compile_expressions=1, min_count_to_compile_expression=0;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix expressions compilation with short circuit evaluation

Detailed description / Documentation draft:
Before this patch, you may get the following error:

    Column Function is not a contiguous block of memory

Refs: #23367
Cc: @Avogar 
Cc: @kitaisreal 

*P.S. formatting change is in a separate patch, last patch is a real fix and contains only 4 lines of code changes*