### PR TITLE
Executable added option send_chunk_header

### DIFF
--- a/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -196,7 +196,7 @@ void registerDictionarySourceExecutable(DictionarySourceFactory & factory)
             .update_field = config.getString(settings_config_prefix + ".update_field", ""),
             .update_lag = config.getUInt64(settings_config_prefix + ".update_lag", 1),
             .implicit_key = config.getBool(settings_config_prefix + ".implicit_key", false),
-            .send_chunk_header = config.getBool(settings_config_prefix + ".implicit_key", false)
+            .send_chunk_header = config.getBool(settings_config_prefix + ".send_chunk_header", false)
         };
 
         return std::make_unique<ExecutableDictionarySource>(dict_struct, configuration, sample_block, context);

--- a/src/Dictionaries/ExecutableDictionarySource.h
+++ b/src/Dictionaries/ExecutableDictionarySource.h
@@ -19,13 +19,15 @@ public:
 
     struct Configuration
     {
-        const std::string command;
-        const std::string format;
-        const std::string update_field;
-        const UInt64 update_lag;
+        std::string command;
+        std::string format;
+        std::string update_field;
+        UInt64 update_lag;
         /// Implicit key means that the source script will return only values,
         /// and the correspondence to the requested keys is determined implicitly - by the order of rows in the result.
-        const bool implicit_key;
+        bool implicit_key;
+        /// Send number_of_rows\n before sending chunk to process
+        bool send_chunk_header;
     };
 
     ExecutableDictionarySource(

--- a/src/Dictionaries/ExecutablePoolDictionarySource.cpp
+++ b/src/Dictionaries/ExecutablePoolDictionarySource.cpp
@@ -100,7 +100,7 @@ Pipe ExecutablePoolDictionarySource::getStreamForBlock(const Block & block)
         config.terminate_in_destructor_strategy = ShellCommand::DestructorStrategy{ true /*terminate_in_destructor*/, configuration.command_termination_timeout };
         auto shell_command = ShellCommand::execute(config);
         return shell_command;
-    }, configuration.max_command_execution_time * 10000);
+    }, configuration.max_command_execution_time * 1000);
 
     if (!result)
         throw Exception(ErrorCodes::TIMEOUT_EXCEEDED,
@@ -112,6 +112,13 @@ Pipe ExecutablePoolDictionarySource::getStreamForBlock(const Block & block)
     ShellCommandSource::SendDataTask task = [process_in, block, this]() mutable
     {
         auto & out = *process_in;
+
+        if (configuration.send_chunk_header)
+        {
+            writeText(block.rows(), out);
+            writeChar('\n', out);
+        }
+
         auto output_stream = context->getOutputStream(configuration.format, out, block.cloneEmpty());
         formatBlock(output_stream, block);
     };
@@ -190,6 +197,7 @@ void registerDictionarySourceExecutablePool(DictionarySourceFactory & factory)
             .command_termination_timeout = config.getUInt64(settings_config_prefix + ".command_termination_timeout", 10),
             .max_command_execution_time = max_command_execution_time,
             .implicit_key = config.getBool(settings_config_prefix + ".implicit_key", false),
+            .send_chunk_header = config.getBool(settings_config_prefix + ".send_chunk_header", false)
         };
 
         return std::make_unique<ExecutablePoolDictionarySource>(dict_struct, configuration, sample_block, context);

--- a/src/Dictionaries/ExecutablePoolDictionarySource.h
+++ b/src/Dictionaries/ExecutablePoolDictionarySource.h
@@ -27,14 +27,16 @@ class ExecutablePoolDictionarySource final : public IDictionarySource
 public:
     struct Configuration
     {
-        const String command;
-        const String format;
-        const size_t pool_size;
-        const size_t command_termination_timeout;
-        const size_t max_command_execution_time;
+        String command;
+        String format;
+        size_t pool_size;
+        size_t command_termination_timeout;
+        size_t max_command_execution_time;
         /// Implicit key means that the source script will return only values,
         /// and the correspondence to the requested keys is determined implicitly - by the order of rows in the result.
-        const bool implicit_key;
+        bool implicit_key;
+        /// Send number_of_rows\n before sending chunk to process
+        bool send_chunk_header;
     };
 
     ExecutablePoolDictionarySource(

--- a/src/Storages/ExecutableSettings.cpp
+++ b/src/Storages/ExecutableSettings.cpp
@@ -1,4 +1,4 @@
-#include "ExecutablePoolSettings.h"
+#include "ExecutableSettings.h"
 
 #include <Common/Exception.h>
 
@@ -14,9 +14,9 @@ namespace ErrorCodes
     extern const int UNKNOWN_SETTING;
 }
 
-IMPLEMENT_SETTINGS_TRAITS(ExecutablePoolSettingsTraits, LIST_OF_EXECUTABLE_POOL_SETTINGS);
+IMPLEMENT_SETTINGS_TRAITS(ExecutableSettingsTraits, LIST_OF_EXECUTABLE_SETTINGS);
 
-void ExecutablePoolSettings::loadFromQuery(ASTStorage & storage_def)
+void ExecutableSettings::loadFromQuery(ASTStorage & storage_def)
 {
     if (storage_def.settings)
     {

--- a/src/Storages/ExecutableSettings.h
+++ b/src/Storages/ExecutableSettings.h
@@ -8,15 +8,16 @@ namespace DB
 
 class ASTStorage;
 
-#define LIST_OF_EXECUTABLE_POOL_SETTINGS(M) \
+#define LIST_OF_EXECUTABLE_SETTINGS(M) \
+    M(UInt64, send_chunk_header, false, "Send number_of_rows\n before sending chunk to process", 0) \
     M(UInt64, pool_size, 16, "Processes pool size. If size == 0, then there is no size restrictions", 0) \
     M(UInt64, max_command_execution_time, 10, "Max command execution time in seconds.", 0) \
     M(UInt64, command_termination_timeout, 10, "Command termination timeout in seconds.", 0) \
 
-DECLARE_SETTINGS_TRAITS(ExecutablePoolSettingsTraits, LIST_OF_EXECUTABLE_POOL_SETTINGS)
+DECLARE_SETTINGS_TRAITS(ExecutableSettingsTraits, LIST_OF_EXECUTABLE_SETTINGS)
 
 /// Settings for ExecutablePool engine.
-struct ExecutablePoolSettings : public BaseSettings<ExecutablePoolSettingsTraits>
+struct ExecutableSettings : public BaseSettings<ExecutableSettingsTraits>
 {
     void loadFromQuery(ASTStorage & storage_def);
 };

--- a/src/Storages/StorageExecutable.cpp
+++ b/src/Storages/StorageExecutable.cpp
@@ -56,7 +56,7 @@ StorageExecutable::StorageExecutable(
     const std::vector<String> & arguments_,
     const String & format_,
     const std::vector<ASTPtr> & input_queries_,
-    const ExecutablePoolSettings & pool_settings_,
+    const ExecutableSettings & settings_,
     const ColumnsDescription & columns,
     const ConstraintsDescription & constraints)
     : IStorage(table_id_)
@@ -64,9 +64,9 @@ StorageExecutable::StorageExecutable(
     , arguments(arguments_)
     , format(format_)
     , input_queries(input_queries_)
-    , pool_settings(pool_settings_)
+    , settings(settings_)
     /// If pool size == 0 then there is no size restrictions. Poco max size of semaphore is integer type.
-    , process_pool(std::make_shared<ProcessPool>(pool_settings.pool_size == 0 ? std::numeric_limits<int>::max() : pool_settings.pool_size))
+    , process_pool(std::make_shared<ProcessPool>(settings.pool_size == 0 ? std::numeric_limits<int>::max() : settings.pool_size))
     , log(&Poco::Logger::get("StorageExecutablePool"))
 {
     StorageInMemoryMetadata storage_metadata;
@@ -114,15 +114,15 @@ Pipe StorageExecutable::read(
     {
         bool result = process_pool->tryBorrowObject(process, [&config, this]()
         {
-            config.terminate_in_destructor_strategy = ShellCommand::DestructorStrategy{ true /*terminate_in_destructor*/, pool_settings.command_termination_timeout };
+            config.terminate_in_destructor_strategy = ShellCommand::DestructorStrategy{ true /*terminate_in_destructor*/, settings.command_termination_timeout };
             auto shell_command = ShellCommand::execute(config);
             return shell_command;
-        }, pool_settings.max_command_execution_time * 10000);
+        }, settings.max_command_execution_time * 1000);
 
         if (!result)
             throw Exception(ErrorCodes::TIMEOUT_EXCEEDED,
                 "Could not get process from pool, max command execution timeout exceeded {} seconds",
-                pool_settings.max_command_execution_time);
+                settings.max_command_execution_time);
     }
     else
     {
@@ -136,6 +136,8 @@ Pipe StorageExecutable::read(
     {
         BlockInputStreamPtr input_stream = inputs[i];
         WriteBufferFromFile * write_buffer = nullptr;
+
+        bool send_chunk_header = settings.send_chunk_header;
 
         if (i == 0)
         {
@@ -151,14 +153,22 @@ Pipe StorageExecutable::read(
             write_buffer = &it->second;
         }
 
-        ShellCommandSource::SendDataTask task = [input_stream, write_buffer, context, is_executable_pool, this]()
+        ShellCommandSource::SendDataTask task = [input_stream, write_buffer, context, is_executable_pool, send_chunk_header, this]()
         {
             auto output_stream = context->getOutputStream(format, *write_buffer, input_stream->getHeader().cloneEmpty());
             input_stream->readPrefix();
             output_stream->writePrefix();
 
             while (auto block = input_stream->read())
+            {
+                if (send_chunk_header)
+                {
+                    writeText(block.rows(), *write_buffer);
+                    writeChar('\n', *write_buffer);
+                }
+
                 output_stream->write(block);
+            }
 
             input_stream->readSuffix();
             output_stream->writeSuffix();
@@ -232,7 +242,7 @@ void registerStorageExecutable(StorageFactory & factory)
             if (max_execution_time_seconds != 0 && max_command_execution_time > max_execution_time_seconds)
                 max_command_execution_time = max_execution_time_seconds;
 
-            ExecutablePoolSettings pool_settings;
+            ExecutableSettings pool_settings;
             pool_settings.max_command_execution_time = max_command_execution_time;
             if (args.storage_def->settings)
                 pool_settings.loadFromQuery(*args.storage_def);

--- a/src/Storages/StorageExecutable.h
+++ b/src/Storages/StorageExecutable.h
@@ -4,7 +4,7 @@
 #include <common/shared_ptr_helper.h>
 #include <Storages/IStorage.h>
 #include <DataStreams/ShellCommandSource.h>
-#include <Storages/ExecutablePoolSettings.h>
+#include <Storages/ExecutableSettings.h>
 
 
 namespace DB
@@ -55,7 +55,7 @@ protected:
         const std::vector<String> & arguments_,
         const String & format_,
         const std::vector<ASTPtr> & input_queries_,
-        const ExecutablePoolSettings & pool_settings_,
+        const ExecutableSettings & settings_,
         const ColumnsDescription & columns,
         const ConstraintsDescription & constraints);
 
@@ -64,7 +64,7 @@ private:
     std::vector<String> arguments;
     String format;
     std::vector<ASTPtr> input_queries;
-    ExecutablePoolSettings pool_settings;
+    ExecutableSettings settings;
     std::shared_ptr<ProcessPool> process_pool;
     Poco::Logger * log;
 };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`Executable`, `ExecutablePool` added option `send_chunk_header`. If this option is true then chunk rows_count with line break will be sent to client before chunk.
