### PR TITLE
Add query to the exception message in case of error during processing INSERT block on client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -2033,8 +2033,21 @@ private:
         PullingAsyncPipelineExecutor executor(pipeline);
 
         Block block;
-        while (executor.pull(block))
+        while (true)
         {
+            try
+            {
+                if (!executor.pull(block))
+                {
+                    break;
+                }
+            }
+            catch (Exception & e)
+            {
+                e.addMessage(fmt::format("(in query: {})", full_query));
+                throw;
+            }
+
             /// Check if server send Log packet
             receiveLogs();
 

--- a/tests/queries/0_stateless/00900_long_parquet_load.reference
+++ b/tests/queries/0_stateless/00900_long_parquet_load.reference
@@ -89,7 +89,7 @@ idx10	['This','is','a','test']
 23
 24
 === Try load data from datapage_v2.snappy.parquet
-Code: 33. DB::ParsingEx---tion: Error while reading Parquet data: IOError: Not yet implemented: Unsupported encoding.: While executing ParquetBlockInputFormat: data for INSERT was parsed from stdin. (CANNOT_READ_ALL_DATA)
+Code: 33. DB::ParsingEx---tion: Error while reading Parquet data: IOError: Not yet implemented: Unsupported encoding.: While executing ParquetBlockInputFormat: (in query: INSERT INTO parquet_load FORMAT Parquet): data for INSERT was parsed from stdin. (CANNOT_READ_ALL_DATA)
 
 === Try load data from datatype-date32.parquet
 1925-01-01


### PR DESCRIPTION
Since client process the INSERT block itself, and only after, send it
to the client, for example:

    clickhouse-client --stacktrace --input_format_null_as_default=1 --query="INSERT INTO FUNCTION null('k Int, v Tuple(Int,Int)') VALUES ()"
    Code: 62. DB::Exception: Cannot parse expression of type Int32 here: ): While executing ValuesBlockInputFormat: (in query: INSERT INTO FUNCTION null('k Int, v Tuple(Int,Int)') VALUES ()): data for INSERT was parsed from query. (SYNTAX_ERROR), Stack trace (when copying this message, always include the lines below):

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #28827 
Cc: @kssenii 