### PR TITLE
Add time dependency for clickhouse-server unit (systemd and sysvinit init)

### DIFF
--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -3,7 +3,7 @@
 # Provides:          clickhouse-server
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Required-Start:    $network
+# Required-Start:    $time $network
 # Required-Stop:     $network
 # Short-Description: Yandex clickhouse-server daemon
 ### END INIT INFO

--- a/debian/clickhouse-server.init
+++ b/debian/clickhouse-server.init
@@ -3,10 +3,17 @@
 # Provides:          clickhouse-server
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Required-Start:    $time $network
-# Required-Stop:     $network
+# Should-Start:      $time $network
+# Should-Stop:       $network
 # Short-Description: Yandex clickhouse-server daemon
 ### END INIT INFO
+#
+# NOTES:
+# - Should-* -- script can start if the listed facilities are missing, unlike Required-*
+#
+# For the documentation [1]:
+#
+#   [1]: https://wiki.debian.org/LSBInitScripts
 
 CLICKHOUSE_USER=clickhouse
 CLICKHOUSE_GROUP=${CLICKHOUSE_USER}

--- a/debian/clickhouse-server.service
+++ b/debian/clickhouse-server.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=ClickHouse Server (analytic DBMS for big data)
 Requires=network-online.target
-After=network-online.target
+After=time-sync.target network-online.target
+Wants=time-sync.target
 
 [Service]
 Type=simple

--- a/debian/clickhouse-server.service
+++ b/debian/clickhouse-server.service
@@ -1,6 +1,10 @@
 [Unit]
 Description=ClickHouse Server (analytic DBMS for big data)
 Requires=network-online.target
+# NOTE: that After/Wants=time-sync.target is not enough, you need to ensure
+# that the time was adjusted already, if you use systemd-timesyncd you are
+# safe, but if you use ntp or some other daemon, you should configure it
+# additionaly.
 After=time-sync.target network-online.target
 Wants=time-sync.target
 
@@ -17,4 +21,5 @@ LimitNOFILE=500000
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_IPC_LOCK CAP_SYS_NICE
 
 [Install]
+# ClickHouse should not start from the rescue shell (rescue.target).
 WantedBy=multi-user.target


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add time dependency for clickhouse-server unit (systemd and sysvinit init)

Detailed description / Documentation draft:
Running clickhouse w/ not synced time may lead to:
- unexpected results (i.e. any date function will return incorrect result)
- bugs like #28760 fixes (which will lead to parts corruption at the next server restart)

So service files should have `$time`/`time-sync.target` to ensure the time is adjusted (if any).

But note, that this is not enough, you also need to use `systemd-timesyncd`/`ntp` (and property configure it, since just started `ntp` is not enough to make sure that the time had been already adjusted, so for example for systemd you need to put `/run/systemd/timesync/synchronized` according to this [article](https://blog.debiania.in.ua/posts/2020-11-27-howto-delay-a-systemd-service-until-the-clock-is-synchronized.html))

Also one of things that you should take into consideration, that after replacing hardware on the server the time can go out of sync.