### PR TITLE
Improve the performance of SUM of nullable floating point numbers

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -128,7 +128,7 @@ struct AggregateFunctionSumData
             /// We reinterpret the floating point number as an unsigned integer of the same size
             /// This was tested with clang12. gcc11 would need to be tricked into vectorizing by iterating over the integer representation
             static_assert(sizeof(Value) == 4 || sizeof(Value) == 8);
-            typedef typename std::conditional<sizeof(Value) == 4, uint32_t, uint64_t>::type equivalent_integer;
+            typedef typename std::conditional<sizeof(Value) == 4, UInt32, UInt64>::type equivalent_integer;
 
 #if defined(__clang__)
             /// Without these instructions clang will prefer using a jump as it knows that the number might be zero, and that's

--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -70,7 +70,6 @@ struct AggregateFunctionSumData
         {
 #if defined(__clang__)
 /// With clang we can tell the compiler to vectorize and it should work with all types when possible, including floating types
-/// TODO: Test how this affects non floating point types
 /// Something around the number of SSE registers * the number of elements fit in register.
 /// Recommend half of those for each vectorization
 #pragma clang loop vectorize(enable) vectorize_width(64 / sizeof(T)) unroll_count(128 / sizeof(T))
@@ -139,23 +138,24 @@ struct AggregateFunctionSumData
             /// For floating point we use a similar trick as above, except that now we use a mask instead (0 to discard, 0xFF..FF to keep)
             /// We reinterpret the floating point number as an unsigned integer of the same size
             /// This was tested with clang12. gcc11 would need to be tricked into vectorizing by iterating over the integer representation
-            static_assert(sizeof(T) == 4 || sizeof(T) == 8);
-            typedef typename std::conditional<sizeof(T) == 4, uint32_t, uint64_t>::type equivalent_integer;
+            static_assert(sizeof(Value) == 4 || sizeof(Value) == 8);
+            typedef typename std::conditional<sizeof(Value) == 4, uint32_t, uint64_t>::type equivalent_integer;
 
 #if defined(__clang__)
             /// Without these instructions clang will prefer using a jump as it knows that the number might be zero, and that's
             /// ~10x slower than doing the bitwise operator and the add under SSE4
-#pragma clang loop vectorize(enable) vectorize_width(64/sizeof(T)) unroll_count(128 / sizeof(T))
+#pragma clang loop vectorize(enable) vectorize_width(64/sizeof(Value)) unroll_count(128 / sizeof(Value))
 #endif
             for (size_t i = 0; i < count; i++)
             {
                 equivalent_integer value;
-                std::memcpy(&value, &ptr[i], sizeof(T)); // Will be optimized by the compiler when strict aliasing isn't necessary
-                value &= (!*condition_map != add_if_zero) - 1; // When we want to add it this will &= -1 (no-op)
-                T d;
-                std::memcpy(&d, &value, sizeof(T)); // Same as above
+                std::memcpy(&value, &ptr[i], sizeof(Value)); // Will be optimized by the compiler when strict aliasing isn't necessary
+                value &= (!condition_map[i] != add_if_zero) - 1; // When we want to add it this will &= -1 (no-op)
+                Value d;
+                std::memcpy(&d, &value, sizeof(Value)); // Same as above
                 Impl::add(sum, d);
             }
+
             return;
         }
 

--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -68,17 +68,6 @@ struct AggregateFunctionSumData
 
         if constexpr (std::is_floating_point_v<T>)
         {
-#if defined(__clang__)
-/// With clang we can tell the compiler to vectorize and it should work with all types when possible, including floating types
-/// Something around the number of SSE registers * the number of elements fit in register.
-/// Recommend half of those for each vectorization
-#pragma clang loop vectorize(enable) vectorize_width(64 / sizeof(T)) unroll_count(128 / sizeof(T))
-            for (size_t i = 0; i < count; i++)
-            {
-                Impl::add(sum, ptr[i]);
-            }
-            return;
-#endif
             /// Compiler cannot unroll this loop, do it manually.
             /// (at least for floats, most likely due to the lack of -fassociative-math)
 

--- a/tests/performance/sum.xml
+++ b/tests/performance/sum.xml
@@ -16,4 +16,15 @@
     <query>SELECT sum(toNullable(toFloat64(number))) FROM numbers(100000000)</query>
     <query>SELECT sumKahan(toNullable(toFloat32(number))) FROM numbers(100000000)</query>
     <query>SELECT sumKahan(toNullable(toFloat64(number))) FROM numbers(100000000)</query>
+
+    <!-- Create a table with ~20% null values. Make it random so the branch predictor doesn't do all the work -->
+    <create_query>CREATE TABLE nullfloat32 (x Nullable(Float32)) ENGINE = Memory</create_query>
+    <fill_query>INSERT INTO nullfloat32
+                SELECT IF(rand() % 5 == 0, NULL::Nullable(Float32), toFloat32(number)) as x
+                FROM numbers_mt(200000000)
+                SETTINGS max_threads = 8
+    </fill_query>
+    <query>SELECT sum(x) FROM nullfloat32</query>
+    <query>SELECT sum(x::Nullable(Float64)) FROM nullfloat32</query>
+    <drop_query>DROP TABLE IF EXISTS nullfloat32</drop_query>
 </test>


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve the performance of SUM of nullable floating point numbers

Detailed description / Documentation draft:

Similarly to what I did in https://github.com/ClickHouse/ClickHouse/pull/26248 you can avoid using a branch when adding Nullable floating point numbers by replacing it with bit operations.

For float32:
- Reinterpret the bits as UInt32. This is done via memcpy to avoid undefined behaviour but the compiler will remove it completely under x86-64 (not sure about other architectures, I'm guessing anywhere that doesn't enforce strict aliasing would do the same). The C equivalent would be something like `equivalent_integer value = ((equivalent_integer *)ptr)[i];`.
- Based on the condition, generate a mask for the number without branches. The mask will be 0 if we want to drop the number, or -1 (0xFFFFFFFF) if we want to keep it.
- Apply the mask to the UInt32. If it marked as NULL the result will be 0x00000000 (0 as Uint32 and as Float32), otherwise it will remain unchanged.
- Reinterpret the result into Float32.
- Do a normal (branchless) addition.

For Float64 you do the same but use Uint64 instead.

As clang is too clever by half, it knows that if you do `number & 0` you get zero, and that adding 0 to the result is a no-op so it can remove it. Knowing that when the mask is zero it doesn't need to do any work, clang reintroduces the branch and we are back to square one. To avoid that I had to add several indications via pragma to force it to unroll and vectorize the loop which keeps the branchless path (I guess based on some compiler heuristic) and makes everything much faster (~10x vs no pragmas).
This same trick could also be used in the not-null function and simplify the code there with the same performance, but since I didn't find an equivalent way to do it in GCC I decided to keep it as it was. GCC still vectorizes the loop, but it's not as good as the manual unroll (or clang unrolling with the directives).

The previously existing performance tests aren't likely to show much of a difference in performance because they are testing without NULLs in the data, so the branch predictor is 100% correct making the branch almost free. To better test the improvement, I added a test that has 20% of NULLs randomly across the data. 

In this test (20% random nulls), the query performance is around 1.8x as fast as master in my machine, both for Nullable(Float32) and for Nullable(Float64)). I've only tested the integration with Clickhouse with clang 12.0.1. External tests also showed an improvement with GCC (but smaller).