### PR TITLE
Apply settings from CREATE AS SELECT queries

### DIFF
--- a/tests/queries/0_stateless/02028_create_select_settings.sql
+++ b/tests/queries/0_stateless/02028_create_select_settings.sql
@@ -1,0 +1,1 @@
+create table test_table engine MergeTree order by a as select a_table.a, b_table.b_arr from (select arrayJoin(range(10000)) as a) a_table cross join (select range(10000) as b_arr) b_table settings max_memory_usage = 1; -- { serverError MEMORY_LIMIT_EXCEEDED }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Apply settings from CREATE AS SELECT queries (fixes: #28810)