### PR TITLE
Fix 01150_ddl_guard_rwr test

### DIFF
--- a/tests/queries/0_stateless/01150_ddl_guard_rwr.sh
+++ b/tests/queries/0_stateless/01150_ddl_guard_rwr.sh
@@ -15,9 +15,9 @@ $CLICKHOUSE_CLIENT --query "CREATE TABLE test_01150.t2 (x UInt64, s Array(Nullab
 
 function thread_detach_attach {
     while true; do
-        $CLICKHOUSE_CLIENT --query "DETACH DATABASE test_01150" 2>&1 | grep -v -F -e 'Received exception from server' -e 'Code: (219)' -e '(query: '
+        $CLICKHOUSE_CLIENT --query "DETACH DATABASE test_01150" 2>&1 | grep -v -F -e 'Received exception from server' -e 'Code: 219' -e '(query: '
         sleep 0.0$RANDOM
-        $CLICKHOUSE_CLIENT --query "ATTACH DATABASE test_01150" 2>&1 | grep -v -F -e 'Received exception from server' -e 'Code: (219)' -e '(query: '
+        $CLICKHOUSE_CLIENT --query "ATTACH DATABASE test_01150" 2>&1 | grep -v -F -e 'Received exception from server' -e 'Code: 82' -e '(query: '
         sleep 0.0$RANDOM
     done
 }


### PR DESCRIPTION
CI report [1]:

    2021-09-13 09:55:27 Code: 219. DB::Exception: Received from localhost:9000. DB::Exception: New table appeared in database being dropped or detached. Try again.. (DATABASE_NOT_EMPTY)
    2021-09-13 09:55:27 Code: 82. DB::Exception: Received from localhost:9000. DB::Exception: Database test_01150 already exists.. (DATABASE_ALREADY_EXISTS)

  [1]: https://clickhouse-test-reports.s3.yandex.net/0/abe314feecd1647d7c2b952a25da7abf5c19f352/functional_stateless_tests_(release,_databaseordinary)/test_run.txt.out.log

Changelog category (leave one):
- Not for changelog (changelog entry is not required)