### PR TITLE
Fix race in MergeTreeBackgroundExecutor

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include <common/logger_useful.h>
 #include <Common/setThreadName.h>
 #include <Storages/MergeTree/BackgroundJobsAssignee.h>
 
@@ -125,20 +126,25 @@ void MergeTreeBackgroundExecutor::routine(TaskRuntimeDataPtr item)
         std::lock_guard guard(mutex);
         erase_from_active();
         has_tasks.notify_one();
-    }
 
-    try
-    {
-        ALLOW_ALLOCATIONS_IN_SCOPE;
-        /// In a situation of a lack of memory this method can throw an exception,
-        /// because it may interact somehow with BackgroundSchedulePool, which may allocate memory
-        /// But it is rather safe, because we have try...catch block here, and another one in ThreadPool.
-        item->task->onCompleted();
-        item->task.reset();
-    }
-    catch (...)
-    {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        /// We have to call reset() under a lock, otherwise a race is possible.
+        /// Imagine, that task is finally completed (last execution returned false),
+        /// we removed the task from both queues, but still have pointer.
+        /// The thread that shutdowns storage will scan queues in order to find some tasks to wait for, but will find nothing.
+        /// So, the destructor of a task and the destructor of a storage will be executed concurrently.
+        try
+        {
+            ALLOW_ALLOCATIONS_IN_SCOPE;
+            /// In a situation of a lack of memory this method can throw an exception,
+            /// because it may interact somehow with BackgroundSchedulePool, which may allocate memory
+            /// But it is rather safe, because we have try...catch block here, and another one in ThreadPool.
+            item->task->onCompleted();
+            item->task.reset();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


Detailed description / Documentation draft:
Example of ASAN failure https://clickhouse-test-reports.s3.yandex.net/28325/9416c5e74d24af764101caae4e82746347ad3e36/stress_test_(address)/stderr.log

CC @alesapin 
