### PR TITLE
Check left join strictness in tryInitDictJoin

### DIFF
--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -1095,7 +1095,7 @@ IColumn::Filter dictionaryJoinRightColumns(const TableJoin & table_join, AddedCo
                 std::move(key_getter), nullptr, added_columns, null_map, flags);
     }
 
-    throw Exception("Logical error: wrong JOIN combination", ErrorCodes::LOGICAL_ERROR);
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong JOIN combination: {} {}", STRICTNESS, KIND);
 }
 
 } /// nameless
@@ -1414,13 +1414,13 @@ void HashJoin::joinBlock(Block & block, ExtraBlockPtr & not_processed)
                     joinBlockImpl<Kind::Left, Strictness::Anti>(block, key_names_left, sample_block_with_columns_to_add, map);
                     break;
                 default:
-                    throw Exception("Logical error: wrong JOIN combination", ErrorCodes::LOGICAL_ERROR);
+                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong JOIN combination: dictionary + {} {}", strictness, kind);
             }
         }
         else if (kind == Kind::Inner && strictness == Strictness::All)
             joinBlockImpl<Kind::Left, Strictness::Semi>(block, key_names_left, sample_block_with_columns_to_add, map);
         else
-            throw Exception("Logical error: wrong JOIN combination", ErrorCodes::LOGICAL_ERROR);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong JOIN combination: dictionary + {} {}", strictness, kind);
     }
     else if (joinDispatch(kind, strictness, data->maps, [&](auto kind_, auto strictness_, auto & map)
         {
@@ -1432,7 +1432,7 @@ void HashJoin::joinBlock(Block & block, ExtraBlockPtr & not_processed)
     else if (kind == ASTTableJoin::Kind::Cross)
         joinBlockImplCross(block, not_processed);
     else
-        throw Exception("Logical error: unknown combination of JOIN", ErrorCodes::LOGICAL_ERROR);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Wrong JOIN combination: {} {}", strictness, kind);
 }
 
 template <typename Mapped>
@@ -1494,7 +1494,7 @@ public:
         };
 
         if (!joinDispatch(parent.kind, parent.strictness, parent.data->maps, fill_callback))
-            throw Exception("Logical error: unknown JOIN strictness (must be on of: ANY, ALL, ASOF)", ErrorCodes::LOGICAL_ERROR);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown JOIN strictness '{}' (must be on of: ANY, ALL, ASOF)", parent.strictness);
 
         fillNullsFromBlocks(columns_right, rows_added);
         return rows_added;

--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -339,8 +339,16 @@ static std::optional<String> getDictKeyName(const String & dict_name , ContextPt
 
 bool TableJoin::tryInitDictJoin(const Block & sample_block, ContextPtr context)
 {
+    using Strictness = ASTTableJoin::Strictness;
+
+    bool allowed_inner = isInner(kind()) && strictness() == Strictness::All;
+    bool allowed_left = isLeft(kind()) && (strictness() == Strictness::Any ||
+                                           strictness() == Strictness::All ||
+                                           strictness() == Strictness::Semi ||
+                                           strictness() == Strictness::Anti);
+
     /// Support ALL INNER, [ANY | ALL | SEMI | ANTI] LEFT
-    if (!isLeft(kind()) && !(isInner(kind()) && strictness() == ASTTableJoin::Strictness::All))
+    if (!allowed_inner && !allowed_left)
         return false;
 
     const Names & right_keys = keyNamesRight();

--- a/src/Parsers/ASTTablesInSelectQuery.h
+++ b/src/Parsers/ASTTablesInSelectQuery.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Parsers/IAST.h>
+#include <common/EnumReflection.h>
 
 
 namespace DB

--- a/tests/queries/0_stateless/01115_join_with_dictionary.reference
+++ b/tests/queries/0_stateless/01115_join_with_dictionary.reference
@@ -16,6 +16,12 @@ flat: any left
 2	2	2	2
 3	3	3	3
 4	0		0
+flat: any left + any_join_distinct_right_table_keys
+0	0	0	0
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	0		0
 flat: semi left
 0	0	0	0
 1	1	1	1

--- a/tests/queries/0_stateless/01115_join_with_dictionary.sql
+++ b/tests/queries/0_stateless/01115_join_with_dictionary.sql
@@ -33,6 +33,8 @@ SELECT 'flat: left';
 SELECT * FROM (SELECT number AS key FROM numbers(5)) s1 LEFT JOIN dict_flat d USING(key) ORDER BY key;
 SELECT 'flat: any left';
 SELECT * FROM (SELECT number AS key FROM numbers(5)) s1 ANY LEFT JOIN dict_flat d USING(key) ORDER BY key;
+SELECT 'flat: any left + any_join_distinct_right_table_keys'; -- falls back to regular join
+SELECT * FROM (SELECT number AS key FROM numbers(5)) s1 ANY LEFT JOIN dict_flat d USING(key) ORDER BY key SETTINGS any_join_distinct_right_table_keys = '1';
 SELECT 'flat: semi left';
 SELECT * FROM (SELECT number AS key FROM numbers(5)) s1 SEMI JOIN dict_flat d USING(key) ORDER BY key;
 SELECT 'flat: anti left';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Handle `any_join_distinct_right_table_keys` when join with dictionary, close #29007
