### PR TITLE
keeper-converter add the last logfile that is less than the zxid.

### DIFF
--- a/src/Coordination/ZooKeeperDataReader.cpp
+++ b/src/Coordination/ZooKeeperDataReader.cpp
@@ -572,12 +572,24 @@ void deserializeLogsAndApplyToStorage(KeeperStorage & storage, const std::string
 
     LOG_INFO(log, "Totally have {} logs", existing_logs.size());
 
-    for (auto [zxid, log_path] : existing_logs)
+    std::vector<std::string> stored_files;
+    for (auto it = existing_logs.rbegin(); it != existing_logs.rend(); ++it)
     {
-        if (zxid > storage.zxid)
-            deserializeLogAndApplyToStorage(storage, log_path, log);
-        else
-            LOG_INFO(log, "Skipping log {}, it's ZXID {} is smaller than storages ZXID {}", log_path, zxid, storage.zxid);
+        if (it->first >= storage.zxid)
+        {
+            stored_files.emplace_back(it->second);
+        }
+        else if (it->first < storage.zxid)
+        {
+            /// add the last logfile that is less than the zxid
+            stored_files.emplace_back(it->second);
+            break;
+        }
+    }
+
+    for (auto & log_path : stored_files)
+    {
+        deserializeLogAndApplyToStorage(storage, log_path, log);
     }
 }
 

--- a/src/Coordination/ZooKeeperDataReader.cpp
+++ b/src/Coordination/ZooKeeperDataReader.cpp
@@ -587,9 +587,9 @@ void deserializeLogsAndApplyToStorage(KeeperStorage & storage, const std::string
         }
     }
 
-    for (auto & log_path : stored_files)
+    for (auto it = stored_files.rbegin(); it != stored_files.rend(); ++it)
     {
-        deserializeLogAndApplyToStorage(storage, log_path, log);
+        deserializeLogAndApplyToStorage(storage, *it, log);
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug in `clickhouse-keeper-converter` which can lead to some data loss while restoring from ZooKeeper logs (not snapshot).
