### PR TITLE
fix bitmap to array size error

### DIFF
--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -43,7 +43,6 @@ namespace ErrorCodes
   *  SELECT range(10000000)
   * will take less than 500ms on your machine.
   */
-static constexpr size_t max_array_size_as_field = 1000000;
 
 
 ColumnArray::ColumnArray(MutableColumnPtr && nested_column, MutableColumnPtr && offsets_column)

--- a/src/Columns/ColumnArray.h
+++ b/src/Columns/ColumnArray.h
@@ -10,7 +10,7 @@
 
 namespace DB
 {
-
+static constexpr size_t max_array_size_as_field = 1000000;
 /** A column of array values.
   * In memory, it is represented as one column of a nested type, whose size is equal to the sum of the sizes of all arrays,
   *  and as an array of offsets in it, which allows you to get each element.

--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -254,21 +254,24 @@ public:
     const IColumn & getDataColumn() const { return *data; }
     const ColumnPtr & getDataColumnPtr() const { return data; }
 
-    Field getField() const 
-    { 
-        auto & col = getDataColumn();
-        auto * array_col = typeid_cast<ColumnArray *>(const_cast<IColumn*>(&col));
-        //if it can successfully down-convert to ColumnArray 
+    Field getField() const
+    {
+        auto col = getDataColumnPtr();
+        Field field;
+        const auto * array_col = typeid_cast<const ColumnArray *>(col.get());
+        /// if it can successfully down-convert to ColumnArray
         if (array_col)
         {
             auto field_size = array_col->getOffsets()[0];
             if (field_size > max_array_size_as_field)
             {
-                Field zero = 0;
-                return zero;
+                /// make sure that in the function checkBlockStructure it gets two same field values
+                field = 0;
             }
         }
-        return col[0];
+        else
+            col->get(0, field);
+        return field;
     }
 
     /// The constant value. It is valid even if the size of the column is 0.

--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -269,8 +269,7 @@ public:
                 field = 0;
             }
         }
-        else
-            col->get(0, field);
+        col->get(0, field);
         return field;
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix an exception when bitmap is converted to array type

When we create the following table and use two different statements (same semantics) to insert, the statement with ```with...as``` will throw an exception, while the statement without ```with...as``` can be inserted successfully:

```
create table tb_crowd_idx_array_local(crowd_id String, idx_array Array(UInt64), log_date DateTime) engine=MergeTree() order by crowd_id;
```
- first statement : ```<Error> executeQuery: Code: 128, e.displayText() = DB::Exception: Array of size 2000000 is too large to be manipulated as single field, maximum size 1000000 (version 21.7.4.1)```
```
INSERT INTO tb_crowd_idx_array_local (crowd_id, idx_array, log_date) WITH 
    (
        SELECT bitmapBuild(n_array)
        FROM 
        (
            SELECT groupArray(number) AS n_array
            FROM 
            (
                SELECT number
                FROM system.numbers
                LIMIT 2000000
            )
        )
    ) AS A
SELECT
    '1' AS crowd_id,
    bitmapToArray(A) AS idx_array,
    '2021-08-30 00:00:00' AS log_date;
```

- second statement : insert successfully
```
INSERT INTO tb_crowd_idx_array_local (crowd_id, idx_array, log_date)
SELECT
    '1' AS crowd_id,
    bitmapToArray(bt) AS idx_array,
    '2021-08-30 00:00:00' AS log_date
from
(
    SELECT bitmapBuild(n_array) as bt
        FROM 
        (
            SELECT groupArray(number) AS n_array
            FROM 
            (
                SELECT number
                FROM system.numbers
                LIMIT 2000000
            )
        )
);
```

After modification, both statements can be successfully inserted
