### PR TITLE
New setting: output_format_csv_null_representation 

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -2833,6 +2833,43 @@ Possible values:
 
 Default value: `1`.
 
+## output_format_csv_null_representation {#output_format_csv_null_representation}
+
+Defines the representation of `NULL` for [CSV](../../interfaces/formats.md#csv) output format. User can set any string as a value, for example, `My NULL`.
+
+Default value: `\N`.
+
+**Examples**
+
+Query
+
+```sql
+SELECT * from csv_custom_null FORMAT CSV;
+```
+
+Result
+
+```text
+788
+\N
+\N
+```
+
+Query
+
+```sql
+SET output_format_csv_null_representation = 'My NULL';
+SELECT * FROM csv_custom_null FORMAT CSV;
+```
+
+Result
+
+```text
+788
+My NULL
+My NULL
+```
+
 ## output_format_tsv_null_representation {#output_format_tsv_null_representation}
 
 Defines the representation of `NULL` for [TSV](../../interfaces/formats.md#tabseparated) output format. User can set any string as a value, for example, `My NULL`.

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -574,6 +574,7 @@ class IColumn;
     M(String, output_format_avro_codec, "", "Compression codec used for output. Possible values: 'null', 'deflate', 'snappy'.", 0) \
     M(UInt64, output_format_avro_sync_interval, 16 * 1024, "Sync interval in bytes.", 0) \
     M(Bool, output_format_tsv_crlf_end_of_line, false, "If it is set true, end of line in TSV format will be \\r\\n instead of \\n.", 0) \
+    M(String, output_format_csv_null_representation, "\\N", "Custom NULL representation in CSV format", 0) \
     M(String, output_format_tsv_null_representation, "\\N", "Custom NULL representation in TSV format", 0) \
     M(Bool, output_format_decimal_trailing_zeros, false, "Output trailing zeros when printing Decimal values. E.g. 1.230000 instead of 1.23.", 0) \
     \

--- a/src/DataTypes/Serializations/SerializationNullable.cpp
+++ b/src/DataTypes/Serializations/SerializationNullable.cpp
@@ -327,7 +327,7 @@ void SerializationNullable::serializeTextCSV(const IColumn & column, size_t row_
     const ColumnNullable & col = assert_cast<const ColumnNullable &>(column);
 
     if (col.isNullAt(row_num))
-        writeCString("\\N", ostr);
+        writeString(settings.csv.null_representation, ostr);
     else
         nested->serializeTextCSV(col.getNestedColumn(), row_num, ostr, settings);
 }

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -60,6 +60,7 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.csv.delimiter = settings.format_csv_delimiter;
     format_settings.csv.empty_as_default = settings.input_format_defaults_for_omitted_fields;
     format_settings.csv.input_format_enum_as_number = settings.input_format_csv_enum_as_number;
+    format_settings.csv.null_representation = settings.output_format_csv_null_representation;
     format_settings.csv.unquoted_null_literal_as_null = settings.input_format_csv_unquoted_null_literal_as_null;
     format_settings.csv.input_format_arrays_as_nested_csv = settings.input_format_csv_arrays_as_nested_csv;
     format_settings.custom.escaping_rule = settings.format_custom_escaping_rule;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -76,6 +76,7 @@ struct FormatSettings
         bool crlf_end_of_line = false;
         bool input_format_enum_as_number = false;
         bool input_format_arrays_as_nested_csv = false;
+        String null_representation = "\\N";
     } csv;
 
     struct Custom

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -433,7 +433,7 @@ void MaterializedPostgreSQLConsumer::processReplicationMessage(const char * repl
 
                 if (new_relation_definition)
                 {
-                    current_schema_data.column_identifiers.emplace_back(std::make_tuple(data_type_id, type_modifier));
+                    current_schema_data.column_identifiers.emplace_back(std::make_pair(data_type_id, type_modifier));
                 }
                 else
                 {

--- a/tests/queries/0_stateless/02029_output_csv_null_representation.reference
+++ b/tests/queries/0_stateless/02029_output_csv_null_representation.reference
@@ -1,0 +1,4 @@
+# output_format_csv_null_representation should initially be \\N
+"val1",\N,"val3"
+# Changing output_format_csv_null_representation
+"val1",∅,"val3"

--- a/tests/queries/0_stateless/02029_output_csv_null_representation.sql
+++ b/tests/queries/0_stateless/02029_output_csv_null_representation.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS test_data;
+CREATE TABLE test_data (
+    col1 Nullable(String),
+    col2 Nullable(String),
+    col3 Nullable(String)
+) ENGINE = Memory;
+
+INSERT INTO test_data VALUES ('val1', NULL, 'val3');
+
+SELECT '# output_format_csv_null_representation should initially be \\N';
+SELECT * FROM test_data FORMAT CSV;
+
+SELECT '# Changing output_format_csv_null_representation';
+SET output_format_csv_null_representation = '∅';
+SELECT * FROM test_data FORMAT CSV;
+SET output_format_csv_null_representation = '\\N';


### PR DESCRIPTION
**Changelog category (leave one):**
- New Feature

**Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):**
Added a setting `output_format_csv_null_representation`: This is the same as `output_format_tsv_null_representation` but is for CSV output.

**Detailed description / Documentation draft:**
Included in the commit.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
