### PR TITLE
Fix replication queue accumulation caused by the entries that has bee…

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -612,7 +612,9 @@ class IColumn;
     \
     M(Bool, cross_to_inner_join_rewrite, true, "Use inner join instead of comma/cross join if possible", 0) \
     \
-    M(Bool, output_format_arrow_low_cardinality_as_dictionary, false, "Enable output LowCardinality type as Dictionary Arrow type", 0) \
+    M(Bool, output_format_arrow_low_cardinality_as_dictionary, false, "Enable output LowCardinality type as Dictionary Arrow type", 0)                                \
+                                   \
+    M(UInt64, max_log_entry_num_tries, 1000, "Maximum number of retries for entry in the replication queue", 0) \
 
 // End of FORMAT_FACTORY_SETTINGS
 // Please add settings non-related to formats into the COMMON_SETTINGS above.

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1443,6 +1443,13 @@ bool ReplicatedMergeTreeQueue::processEntry(
 
     if (saved_exception)
     {
+        /// Avoid entries that have been failing, causing queues to accumulate
+        if (entry->num_tries > storage.getContext()->getSettingsRef().max_log_entry_num_tries)
+        {
+            removeProcessedEntry(get_zookeeper(), entry);
+            return false;
+        }
+
         std::lock_guard lock(state_mutex);
         entry->exception = saved_exception;
         return false;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

replication queue accumulation caused by the entries that has been failing.
```
database:               growth
table:                  aily_report_for_clickhouse_pages_local
replica_name:           03
position:               289
node_name:              queue-0000156831
type:                   REPLACE_RANGE
create_time:            2021-08-23 02:25:00
required_quorum:        0
source_replica:         04
new_part_name:
parts_to_merge:         []
is_detach:              0
is_currently_executing: 0
num_tries:              2638
last_exception:         Code: 234, e.displayText() = DB::Exception: Not found part 4a2e094c228d15c6c534804cdb411458_7_7_0 (or part covering it) neither source table neither remote replicas (version 102.1.1)
last_attempt_time:      2021-09-17 01:35:15
num_postponed:          8895
postpone_reason:
last_postpone_time:     2021-09-17 11:12:21

SELECT
    table,
    count(*)
FROM replication_queue
GROUP BY table

┌─table─────────────────────────────────────────────────────┬─count()─┐
│ daily_report_for_clickhouse_pages_local                   │     682 │
└───────────────────────────────────────────────────────────┴─────────┘
```
This failed entries cannot be successful no matter how many retries, I think it should be removed.
