### PR TITLE
Support optional client/serverError? in test hints

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -231,13 +231,13 @@ bool Client::executeMultiQuery(const String & all_queries_text)
                 {
                     if (test_hint.serverError())
                     {
-                        if (!server_exception)
+                        if (!server_exception && test_hint.errorRequired())
                         {
                             error_matches_hint = false;
                             fmt::print(stderr, "Expected server error code '{}' but got no server error (query: {}).\n",
                                        test_hint.serverError(), full_query);
                         }
-                        else if (server_exception->code() != test_hint.serverError())
+                        else if (server_exception && server_exception->code() != test_hint.serverError() && test_hint.serverError() >= 0)
                         {
                             error_matches_hint = false;
                             fmt::print(stderr, "Expected server error code: {} but got: {} (query: {}).\n",
@@ -246,20 +246,21 @@ bool Client::executeMultiQuery(const String & all_queries_text)
                     }
                     if (test_hint.clientError())
                     {
-                        if (!client_exception)
+                        if (!client_exception && test_hint.errorRequired())
                         {
                             error_matches_hint = false;
                             fmt::print(stderr, "Expected client error code '{}' but got no client error (query: {}).\n",
                                        test_hint.clientError(), full_query);
                         }
-                        else if (client_exception->code() != test_hint.clientError())
+                        else if (client_exception && client_exception->code() != test_hint.clientError() && test_hint.clientError() >= 0)
                         {
                             error_matches_hint = false;
                             fmt::print(stderr, "Expected client error code '{}' but got '{}' (query: {}).\n",
                                        test_hint.clientError(), client_exception->code(), full_query);
                         }
                     }
-                    if (!test_hint.clientError() && !test_hint.serverError())
+                    if ((client_exception && !test_hint.clientError()) ||
+                        (server_exception && !test_hint.serverError()))
                     {
                         // No error was expected but it still occurred. This is the
                         // default case w/o test hint, doesn't need additional
@@ -269,13 +270,13 @@ bool Client::executeMultiQuery(const String & all_queries_text)
                 }
                 else
                 {
-                    if (test_hint.clientError())
+                    if (test_hint.clientError() && test_hint.errorRequired())
                     {
                         fmt::print(stderr, "The query succeeded but the client error '{}' was expected (query: {}).\n",
                                    test_hint.clientError(), full_query);
                         error_matches_hint = false;
                     }
-                    if (test_hint.serverError())
+                    if (test_hint.serverError() && test_hint.errorRequired())
                     {
                         fmt::print(stderr, "The query succeeded but the server error '{}' was expected (query: {}).\n",
                                    test_hint.serverError(), full_query);

--- a/src/Client/TestHint.cpp
+++ b/src/Client/TestHint.cpp
@@ -24,6 +24,10 @@ int parseErrorCode(DB::ReadBufferFromString & in)
 
     /// Try parse as string
     readStringUntilWhitespace(code_name, in);
+    if (code_name.empty())
+    {
+        return code;
+    }
     return DB::ErrorCodes::getErrorCodeByName(code_name);
 }
 
@@ -88,9 +92,13 @@ void TestHint::parse(const String & hint, bool is_leading_hint)
         if (!is_leading_hint)
         {
             if (item == "serverError")
-                server_error = parseErrorCode(in);
+                expected_error = ExpectedError::makeServer(parseErrorCode(in));
             else if (item == "clientError")
-                client_error = parseErrorCode(in);
+                expected_error = ExpectedError::makeClient(parseErrorCode(in));
+            else if (item == "serverError?")
+                expected_error = ExpectedError::makeServer(parseErrorCode(in), false);
+            else if (item == "clientError?")
+                expected_error = ExpectedError::makeClient(parseErrorCode(in), false);
         }
 
         if (item == "echo")

--- a/tests/queries/0_stateless/00002_system_numbers.sql
+++ b/tests/queries/0_stateless/00002_system_numbers.sql
@@ -6,7 +6,7 @@ SELECT number FROM system.numbers WHERE number >= 5 LIMIT 2;
 SELECT * FROM system.numbers WHERE number == 7 LIMIT 1;
 SELECT number AS n FROM system.numbers WHERE number IN(8, 9) LIMIT 2;
 select number from system.numbers limit 0;
-select x from system.numbers limit 1; -- { clientError 0 serverError 47 }
+select x from system.numbers limit 1; -- { serverError 47 }
 SELECT x, number FROM system.numbers LIMIT 1; -- { serverError 47 }
 SELECT * FROM system.number LIMIT 1; -- { serverError 60 }
 SELECT * FROM system LIMIT 1; -- { serverError 60 }

--- a/tests/queries/0_stateless/02029_optional_error.sql
+++ b/tests/queries/0_stateless/02029_optional_error.sql
@@ -1,0 +1,22 @@
+DROP TABLE IF EXISTS t;
+
+CREATE TABLE t ( a Int32 ) ENGINE = Memory;
+
+INSERT INTO t VALUES (abs(functionThatDoesNotExists(42))); -- { clientError? UNKNOWN_FUNCTION }
+INSERT INTO t VALUES (abs(functionThatDoesNotExists(42))); -- { clientError? }
+INSERT INTO t VALUES (abs(functionThatDoesNotExists(42))); -- { clientError }
+INSERT INTO t VALUES (1, 2); -- { clientError? SYNTAX_ERROR }
+INSERT INTO t VALUES (1, 2); -- { clientError? }
+INSERT INTO t VALUES (1, 2); -- { clientError }
+INSERT INTO t VALUES (1); -- { clientError? UNKNOWN_FUNCTION }
+INSERT INTO t VALUES (1); -- { clientError? SYNTAX_ERROR }
+INSERT INTO t VALUES (1); -- { clientError? }
+
+SELECT throwIf(0) FORMAT Null; -- { serverError? NOT_IMPLEMENTED }
+SELECT throwIf(0) FORMAT Null; -- { serverError? }
+SELECT throwIf(0) FORMAT Null; -- { serverError? FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+SELECT throwIf(1) FORMAT Null; -- { serverError? FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+SELECT throwIf(1) FORMAT Null; -- { serverError? }
+SELECT throwIf(1) FORMAT Null; -- { serverError }
+
+DROP TABLE IF EXISTS t;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* `clickhouse client --testmode`: Add test hints for optional errors: `clientError?` / `serverError?`
* `clickhouse client --testmode`:  Allow not to specify exact error code in test hint 

