### PR TITLE
Increase timeout in 2010_lc_native

### DIFF
--- a/tests/queries/0_stateless/2010_lc_native.python
+++ b/tests/queries/0_stateless/2010_lc_native.python
@@ -193,7 +193,7 @@ def readException(s):
 
 def insertValidLowCardinalityRow():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(10)
+        s.settimeout(30)
         s.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
         sendHello(s)
         receiveHello(s)
@@ -229,7 +229,7 @@ def insertValidLowCardinalityRow():
 
 def insertLowCardinalityRowWithIndexOverflow():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(10)
+        s.settimeout(30)
         s.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
         sendHello(s)
         receiveHello(s)
@@ -262,7 +262,7 @@ def insertLowCardinalityRowWithIndexOverflow():
 
 def insertLowCardinalityRowWithIncorrectDictType():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(10)
+        s.settimeout(30)
         s.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
         sendHello(s)
         receiveHello(s)


### PR DESCRIPTION
10 seconds it not enough [1]:

    2010_lc_native:                                                         [ FAIL ] 15.53 sec. - having stderror:
    Traceback (most recent call last):
      File "/usr/share/clickhouse-test/queries/0_stateless/2010_lc_native.python", line 302, in <module>
        main()
      File "/usr/share/clickhouse-test/queries/0_stateless/2010_lc_native.python", line 298, in main
        insertLowCardinalityRowWithIndexOverflow()
      File "/usr/share/clickhouse-test/queries/0_stateless/2010_lc_native.python", line 259, in insertLowCardinalityRowWithIndexOverflow
        readException(s)
      File "/usr/share/clickhouse-test/queries/0_stateless/2010_lc_native.python", line 185, in readException
        assert(readVarUInt(s) == 2)
      File "/usr/share/clickhouse-test/queries/0_stateless/2010_lc_native.python", line 65, in readVarUInt
        byte = readStrict(s)[0]
      File "/usr/share/clickhouse-test/queries/0_stateless/2010_lc_native.python", line 34, in readStrict
        cur = s.recv(size)
    socket.timeout: timed out

  [1]: https://clickhouse-test-reports.s3.yandex.net/29060/7f1160c466a968c680d1bc73e0ad5e9419d0b6d0/functional_stateless_tests_(debug).html#fail1

Server log:

    2021.09.17 21:02:53.734388 [ 682 ] {123456} <Trace> ContextAccess (default): Access granted: INSERT(x) ON test_0tmdh4.tab
    2021.09.17 21:03:04.835044 [ 682 ] {123456} <Error> executeQuery: Code: 117. DB::Exception: Index for LowCardinality is out of range. Dictionary size is 1, but found index with value 72057594037927936. (INCORRECT_DATA) (version 21.11.1.8109) (from [::ffff:127.0.0.1]:59512) (in query: insert into test_0tmdh4.tab format TSV settings input_format_defaults_for_omitted_fields=0), Stack trace (when copying this message, always include the lines below):

And according to trace_log the problem is slow unwind:

    2021-09-17 21:02:55.103893 libunwind::LocalAddressSpace::get32
    2021-09-17 21:02:56.151960 libunwind::LocalAddressSpace::get8
    2021-09-17 21:03:03.168447 libunwind::LocalAddressSpace::getULEB128

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @KochetovNicolai 