### PR TITLE
Try print stacktraces if server does not respond to `select 1`

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -998,9 +998,14 @@ def main(args):
         return stdout.startswith(b'1')
 
     if not check_server_started(args.client, args.server_check_retries):
-        raise Exception(
-            "Server is not responding. Cannot execute 'SELECT 1' query. \
-            If you are using split build, you have to specify -c option.")
+        msg = "Server is not responding. Cannot execute 'SELECT 1' query. \
+            If you are using split build, you have to specify -c option."
+        if args.hung_check:
+            print(msg)
+            pid = get_server_pid()
+            print("Got server pid", pid)
+            print_stacktraces()
+        raise Exception(msg)
 
     args.build_flags = collect_build_flags(args.client)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
Hopefully it will help to debug failures like this https://clickhouse-test-reports.s3.yandex.net/29061/3bca88617427ca5f686c8550a64c737ce6586d8c/functional_stateless_tests_(memory).html#fail1
