### PR TITLE
Allow non-replicated ALTER TABLE FETCH/ATTACH in Replicated databases

### DIFF
--- a/docs/en/engines/database-engines/replicated.md
+++ b/docs/en/engines/database-engines/replicated.md
@@ -35,7 +35,7 @@ The [system.clusters](../../operations/system-tables/clusters.md) system table c
 
 When creating a new replica of the database, this replica creates tables by itself. If the replica has been unavailable for a long time and has lagged behind the replication log — it checks its local metadata with the current metadata in ZooKeeper, moves the extra tables with data to a separate non-replicated database (so as not to accidentally delete anything superfluous), creates the missing tables, updates the table names if they have been renamed. The data is replicated at the `ReplicatedMergeTree` level, i.e. if the table is not replicated, the data will not be replicated (the database is responsible only for metadata).
 
-[`ALTER TABLE FETCH`](../../sql-reference/statements/alter/partition.md) and [`ALTER TABLE ATTACH`](../../sql-reference/statements/alter/partition.md) queries are allowed but not replicated. The database engine will only add the partition/part to the current replica. However, if the table itself uses a Replicated table engine, then the data will be replicated after using `ATTACH`.
+[`ALTER TABLE ATTACH|FETCH|DROP|DROP DETACHED|DETACH PARTITION|PART`](../../sql-reference/statements/alter/partition.md) queries are allowed but not replicated. The database engine will only add/fetch/remove the partition/part to the current replica. However, if the table itself uses a Replicated table engine, then the data will be replicated after using `ATTACH`.
 
 ## Usage Example {#usage-example}
 

--- a/docs/en/engines/database-engines/replicated.md
+++ b/docs/en/engines/database-engines/replicated.md
@@ -35,6 +35,8 @@ The [system.clusters](../../operations/system-tables/clusters.md) system table c
 
 When creating a new replica of the database, this replica creates tables by itself. If the replica has been unavailable for a long time and has lagged behind the replication log — it checks its local metadata with the current metadata in ZooKeeper, moves the extra tables with data to a separate non-replicated database (so as not to accidentally delete anything superfluous), creates the missing tables, updates the table names if they have been renamed. The data is replicated at the `ReplicatedMergeTree` level, i.e. if the table is not replicated, the data will not be replicated (the database is responsible only for metadata).
 
+[`ALTER TABLE FETCH`](../../sql-reference/statements/alter/partition.md) and [`ALTER TABLE ATTACH`](../../sql-reference/statements/alter/partition.md) queries are allowed but not replicated. The database engine will only add the partition/part to the current replica. However, if the table itself uses a Replicated table engine, then the data will be replicated after using `ATTACH`.
+
 ## Usage Example {#usage-example}
 
 Creating a cluster with three hosts:

--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -57,7 +57,8 @@ BlockIO InterpreterAlterQuery::execute()
     if (typeid_cast<DatabaseReplicated *>(database.get())
         && !getContext()->getClientInfo().is_replicated_database_internal
         && !alter.isAttachAlter()
-        && !alter.isFetchAlter())
+        && !alter.isFetchAlter()
+        && !alter.isDropPartitionAlter())
     {
         auto guard = DatabaseCatalog::instance().getDDLGuard(table_id.database_name, table_id.table_name);
         guard->releaseTableLock();

--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -55,7 +55,9 @@ BlockIO InterpreterAlterQuery::execute()
 
     DatabasePtr database = DatabaseCatalog::instance().getDatabase(table_id.database_name);
     if (typeid_cast<DatabaseReplicated *>(database.get())
-        && !getContext()->getClientInfo().is_replicated_database_internal)
+        && !getContext()->getClientInfo().is_replicated_database_internal
+        && !alter.isAttachAlter()
+        && !alter.isFetchAlter())
     {
         auto guard = DatabaseCatalog::instance().getDDLGuard(table_id.database_name, table_id.table_name);
         guard->releaseTableLock();

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -460,6 +460,11 @@ bool ASTAlterQuery::isFetchAlter() const
     return isOneCommandTypeOnly(ASTAlterCommand::FETCH_PARTITION);
 }
 
+bool ASTAlterQuery::isDropPartitionAlter() const
+{
+    return isOneCommandTypeOnly(ASTAlterCommand::DROP_PARTITION) || isOneCommandTypeOnly(ASTAlterCommand::DROP_DETACHED_PARTITION);
+}
+
 
 /** Get the text that identifies this element. */
 String ASTAlterQuery::getID(char delim) const

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -450,6 +450,17 @@ bool ASTAlterQuery::isFreezeAlter() const
         || isOneCommandTypeOnly(ASTAlterCommand::UNFREEZE_PARTITION) || isOneCommandTypeOnly(ASTAlterCommand::UNFREEZE_ALL);
 }
 
+bool ASTAlterQuery::isAttachAlter() const
+{
+    return isOneCommandTypeOnly(ASTAlterCommand::ATTACH_PARTITION);
+}
+
+bool ASTAlterQuery::isFetchAlter() const
+{
+    return isOneCommandTypeOnly(ASTAlterCommand::FETCH_PARTITION);
+}
+
+
 /** Get the text that identifies this element. */
 String ASTAlterQuery::getID(char delim) const
 {

--- a/src/Parsers/ASTAlterQuery.h
+++ b/src/Parsers/ASTAlterQuery.h
@@ -222,6 +222,8 @@ public:
 
     bool isFetchAlter() const;
 
+    bool isDropPartitionAlter() const;
+
     String getID(char) const override;
 
     ASTPtr clone() const override;

--- a/src/Parsers/ASTAlterQuery.h
+++ b/src/Parsers/ASTAlterQuery.h
@@ -218,6 +218,10 @@ public:
 
     bool isFreezeAlter() const;
 
+    bool isAttachAlter() const;
+
+    bool isFetchAlter() const;
+
     String getID(char) const override;
 
     ASTPtr clone() const override;

--- a/tests/integration/test_replicated_database/configs/settings.xml
+++ b/tests/integration/test_replicated_database/configs/settings.xml
@@ -1,6 +1,7 @@
 <yandex>
     <profiles>
         <default>
+            <allow_drop_detached>1</allow_drop_detached>
             <allow_experimental_database_replicated>1</allow_experimental_database_replicated>
             <allow_experimental_alter_materialized_view_structure>1</allow_experimental_alter_materialized_view_structure>
         </default>

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import time
 import re
 import pytest
@@ -16,7 +18,7 @@ snapshot_recovering_node = cluster.add_instance('snapshot_recovering_node', main
 
 all_nodes = [main_node, dummy_node, competing_node, snapshotting_node, snapshot_recovering_node]
 
-uuid_regex = re.compile("[0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12}")
+uuid_regex = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 def assert_create_query(nodes, table_name, expected):
     replace_uuid = lambda x: re.sub(uuid_regex, "uuid", x)
     query = "show create table {}".format(table_name)
@@ -98,6 +100,51 @@ def test_simple_alter_table(started_cluster, engine):
                "SETTINGS index_granularity = 8192".format(name, full_engine)
 
     assert_create_query([main_node, dummy_node, competing_node], name, expected)
+
+
+def get_table_uuid(database, name):
+    return main_node.query(f"SELECT uuid FROM system.tables WHERE database = '{database}' and name = '{name}'").strip()
+
+
+@pytest.fixture(scope="module", name="attachable_part")
+def fixture_attachable_part(started_cluster):
+    main_node.query(f"CREATE DATABASE testdb_attach_atomic ENGINE = Atomic")
+    main_node.query(f"CREATE TABLE testdb_attach_atomic.test (CounterID UInt32) ENGINE = MergeTree ORDER BY (CounterID)")
+    main_node.query(f"INSERT INTO testdb_attach_atomic.test VALUES (123)")
+    main_node.query(f"ALTER TABLE testdb_attach_atomic.test FREEZE WITH NAME 'test_attach'")
+    table_uuid = get_table_uuid("testdb_attach_atomic", "test")
+    return os.path.join(main_node.path, f"database/shadow/test_attach/store/{table_uuid[:3]}/{table_uuid}/all_1_1_0")
+
+
+
+@pytest.mark.parametrize("engine", ["MergeTree", "ReplicatedMergeTree"])
+def test_alter_attach(started_cluster, attachable_part, engine):
+    name  = "alter_attach_test_{}".format(engine)
+    main_node.query(f"CREATE TABLE testdb.{name} (CounterID UInt32) ENGINE = {engine} ORDER BY (CounterID)")
+    table_uuid = get_table_uuid("testdb", name)
+    # Provide and attach a part to the main node
+    shutil.copytree(
+        attachable_part, os.path.join(main_node.path, f"database/store/{table_uuid[:3]}/{table_uuid}/detached/all_1_1_0")
+    )
+    main_node.query(f"ALTER TABLE testdb.{name} ATTACH PART 'all_1_1_0'")
+    # On the main node, data is attached
+    assert main_node.query(f"SELECT CounterID FROM testdb.{name}") == "123\n"
+    # On the other node, data is replicated only if using a Replicated table engine
+    if engine == "ReplicatedMergeTree":
+        assert dummy_node.query(f"SELECT CounterID FROM testdb.{name}") == "123\n"
+    else:
+        assert dummy_node.query(f"SELECT CounterID FROM testdb.{name}") == ""
+
+
+def test_alter_fetch(started_cluster):
+    main_node.query("CREATE TABLE testdb.fetch_source (CounterID UInt32) ENGINE = ReplicatedMergeTree ORDER BY (CounterID)")
+    main_node.query("CREATE TABLE testdb.fetch_target (CounterID UInt32) ENGINE = ReplicatedMergeTree ORDER BY (CounterID)")
+    main_node.query("INSERT INTO testdb.fetch_source VALUES (123)")
+    table_uuid = get_table_uuid("testdb", "fetch_source")
+    main_node.query(f"ALTER TABLE testdb.fetch_target FETCH PART 'all_0_0_0' FROM '/clickhouse/tables/{table_uuid}/{{shard}}' ")
+    detached_parts_query = "SELECT name FROM system.detached_parts WHERE database='testdb' AND table='fetch_target'"
+    assert main_node.query(detached_parts_query) == "all_0_0_0\n"
+    assert dummy_node.query(detached_parts_query) == ""
 
 
 def test_alters_from_different_replicas(started_cluster):

--- a/tests/queries/0_stateless/00626_replace_partition_from_table.sql
+++ b/tests/queries/0_stateless/00626_replace_partition_from_table.sql
@@ -1,5 +1,4 @@
--- Tags: no-replicated-database, no-parallel
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tags: no-parallel
 
 DROP TABLE IF EXISTS src;
 DROP TABLE IF EXISTS dst;

--- a/tests/queries/0_stateless/00626_replace_partition_from_table_zookeeper.sh
+++ b/tests/queries/0_stateless/00626_replace_partition_from_table_zookeeper.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-replicated-database, no-parallel
-# Tag no-replicated-database: Unsupported type of ALTER query
+# Tags: zookeeper, no-parallel
 
 # Because REPLACE PARTITION does not forces immediate removal of replaced data parts from local filesystem
 # (it tries to do it as quick as possible, but it still performed in separate thread asynchronously)

--- a/tests/queries/0_stateless/00753_alter_attach.sql
+++ b/tests/queries/0_stateless/00753_alter_attach.sql
@@ -1,5 +1,4 @@
--- Tags: no-replicated-database, no-parallel
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tags: no-parallel
 
 DROP TABLE IF EXISTS alter_attach;
 CREATE TABLE alter_attach (x UInt64, p UInt8) ENGINE = MergeTree ORDER BY tuple() PARTITION BY p;

--- a/tests/queries/0_stateless/00955_test_final_mark.sql
+++ b/tests/queries/0_stateless/00955_test_final_mark.sql
@@ -1,5 +1,4 @@
--- Tags: no-replicated-database, no-parallel
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tags: no-parallel
 
 SET send_logs_level = 'fatal';
 

--- a/tests/queries/0_stateless/00955_test_final_mark_use.sh
+++ b/tests/queries/0_stateless/00955_test_final_mark_use.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-replicated-database, no-parallel
-# Tag no-replicated-database: Unsupported type of ALTER query
+# Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01015_attach_part.sql
+++ b/tests/queries/0_stateless/01015_attach_part.sql
@@ -1,5 +1,4 @@
--- Tags: no-replicated-database, no-parallel
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tags: no-parallel
 
 DROP TABLE IF EXISTS table_01;
 

--- a/tests/queries/0_stateless/01021_only_tuple_columns.sql
+++ b/tests/queries/0_stateless/01021_only_tuple_columns.sql
@@ -1,5 +1,4 @@
--- Tags: no-replicated-database, no-parallel
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tags: no-parallel
 
 CREATE TABLE test
 (

--- a/tests/queries/0_stateless/01060_shutdown_table_after_detach.sql
+++ b/tests/queries/0_stateless/01060_shutdown_table_after_detach.sql
@@ -1,5 +1,4 @@
--- Tags: no-replicated-database, no-parallel
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tags: no-parallel
 
 DROP TABLE IF EXISTS test;
 CREATE TABLE test Engine = MergeTree ORDER BY number AS SELECT number, toString(rand()) x from numbers(10000000);

--- a/tests/queries/0_stateless/01130_in_memory_parts_partitons.sql
+++ b/tests/queries/0_stateless/01130_in_memory_parts_partitons.sql
@@ -1,5 +1,4 @@
--- Tags: no-replicated-database, no-parallel
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tags: no-parallel
 
 DROP TABLE IF EXISTS t2;
 

--- a/tests/queries/0_stateless/01417_freeze_partition_verbose_zookeeper.sh
+++ b/tests/queries/0_stateless/01417_freeze_partition_verbose_zookeeper.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tags: zookeeper, no-replicated-database, no-parallel
-# Tag no-replicated-database: Unsupported type of ALTER query
+# Tag no-replicated-database: Fails due to additional replicas or shards
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01451_detach_drop_part.sql
+++ b/tests/queries/0_stateless/01451_detach_drop_part.sql
@@ -1,6 +1,3 @@
--- Tags: no-replicated-database
--- Tag no-replicated-database: Unsupported type of ALTER query
-
 DROP TABLE IF EXISTS mt_01451;
 
 CREATE TABLE mt_01451 (v UInt8) ENGINE = MergeTree() order by tuple();

--- a/tests/queries/0_stateless/01451_replicated_detach_drop_part_long.sql
+++ b/tests/queries/0_stateless/01451_replicated_detach_drop_part_long.sql
@@ -1,5 +1,5 @@
 -- Tags: long, replica, no-replicated-database
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tag no-replicated-database: Fails due to additional replicas or shards
 
 SET replication_alter_partitions_sync = 2;
 

--- a/tests/queries/0_stateless/01650_fetch_patition_with_macro_in_zk_path_long.sql
+++ b/tests/queries/0_stateless/01650_fetch_patition_with_macro_in_zk_path_long.sql
@@ -1,5 +1,4 @@
--- Tags: long, no-replicated-database
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tags: long
 
 DROP TABLE IF EXISTS test_01640;
 DROP TABLE IF EXISTS restore_01640;

--- a/tests/queries/0_stateless/02009_array_join_partition.sql
+++ b/tests/queries/0_stateless/02009_array_join_partition.sql
@@ -1,6 +1,3 @@
--- Tags: no-replicated-database
--- Tag no-replicated-database: Unsupported type of ALTER query
-
 CREATE TABLE table_2009_part (`i` Int64, `d` Date, `s` String) ENGINE = MergeTree PARTITION BY toYYYYMM(d) ORDER BY i;
 
 ALTER TABLE table_2009_part ATTACH PARTITION tuple(arrayJoin([0, 1])); -- {serverError 248}

--- a/tests/queries/0_stateless/02012_changed_enum_type_non_replicated.sql
+++ b/tests/queries/0_stateless/02012_changed_enum_type_non_replicated.sql
@@ -1,5 +1,4 @@
--- Tags: replica, no-replicated-database
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tags: replica
 
 create table enum_alter_issue (a Enum8('one' = 1, 'two' = 2)) engine = MergeTree() ORDER BY a;
 insert into enum_alter_issue values ('one'), ('two');

--- a/tests/queries/0_stateless/02012_zookeeper_changed_enum_type.sql
+++ b/tests/queries/0_stateless/02012_zookeeper_changed_enum_type.sql
@@ -1,5 +1,5 @@
 -- Tags: zookeeper, no-replicated-database
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tag no-replicated-database: Fails due to additional replicas or shards
 
 create table enum_alter_issue (a Enum8('one' = 1, 'two' = 2), b Int)
 engine = ReplicatedMergeTree('/clickhouse/tables/{database}/test_02012/enum_alter_issue', 'r1')

--- a/tests/queries/0_stateless/02012_zookeeper_changed_enum_type_incompatible.sql
+++ b/tests/queries/0_stateless/02012_zookeeper_changed_enum_type_incompatible.sql
@@ -1,5 +1,5 @@
 -- Tags: zookeeper, no-replicated-database
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tag no-replicated-database: Fails due to additional replicas or shards
 
 drop table if exists enum_alter_issue;
 create table enum_alter_issue (a Enum16('one' = 1, 'two' = 2), b Int)

--- a/tests/queries/1_stateful/00054_merge_tree_partitions.sql
+++ b/tests/queries/1_stateful/00054_merge_tree_partitions.sql
@@ -1,6 +1,3 @@
--- Tags: no-replicated-database
--- Tag no-replicated-database: Unsupported type of ALTER query
-
 DROP TABLE IF EXISTS test.partitions;
 CREATE TABLE test.partitions (EventDate Date, CounterID UInt32) ENGINE = MergeTree(EventDate, CounterID, 8192);
 INSERT INTO test.partitions SELECT EventDate + UserID % 365 AS EventDate, CounterID FROM test.hits WHERE CounterID = 1704509;

--- a/tests/queries/1_stateful/00152_insert_different_granularity.sql
+++ b/tests/queries/1_stateful/00152_insert_different_granularity.sql
@@ -1,5 +1,5 @@
 -- Tags: no-tsan, no-replicated-database
--- Tag no-replicated-database: Unsupported type of ALTER query
+-- Tag no-replicated-database: Fails due to additional replicas or shards
 
 DROP TABLE IF EXISTS fixed_granularity_table;
 


### PR DESCRIPTION
`ALTER TABLE ... FETCH` and `ALTER TABLE ... ATTACH` queries were disabled in the Replicated database engine, because it could cause accidental duplication of data.

This enables these queries but without replicating them.

In the case of `FETCH`, the part will only be fetched on the server where the query is issued.

Similarly, in the case of `ATTACH`, the attached part only needs to be available on the server where the query is issued.

If the table itself is using one of the Replicated MergeTree engines, the attached data is then replicated by the table engine itself, without intervention of the database engine.

This change is meant to help with live backup/restore when using the Replicated database engine, using FREEZE for backup and ATTACH for restore.

**Changelog category (leave one):**
- New Feature


**Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):**
Allow non-replicated ALTER TABLE FETCH and ATTACH in Replicated databases


**Detailed description / Documentation draft:**
Included in the commit


---
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```