### PR TITLE
Add ability to disable converting expressions to local filter for external queries

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -386,6 +386,7 @@ class IColumn;
     M(Bool, low_cardinality_allow_in_native_format, true, "Use LowCardinality type in Native format. Otherwise, convert LowCardinality columns to ordinary for select query, and convert ordinary columns to required LowCardinality for insert query.", 0) \
     M(Bool, cancel_http_readonly_queries_on_client_close, false, "Cancel HTTP readonly queries when a client closes the connection without waiting for response.", 0) \
     M(Bool, external_table_functions_use_nulls, true, "If it is set to true, external table functions will implicitly use Nullable type if needed. Otherwise NULLs will be substituted with default values. Currently supported only by 'mysql', 'postgresql' and 'odbc' table functions.", 0) \
+    M(Bool, external_table_strict_query, false, "If it is set to true, transforming expression to local filter is forbidden for queries to external tables.", 0) \
     \
     M(Bool, allow_hyperscan, true, "Allow functions that use Hyperscan library. Disable to avoid potentially long compilation times and excessive resource usage.", 0) \
     M(UInt64, max_hyperscan_regexp_length, 0, "Max length of regexp than can be used in hyperscan multi-match functions. Zero means unlimited.", 0) \

--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -220,17 +220,32 @@ TEST(TransformQueryForExternalDatabase, ForeignColumnInWhere)
           R"(SELECT "column", "apply_id" FROM "test"."table" WHERE ("column" > 2) AND ("apply_id" = 1))");
 }
 
-TEST(TransformQueryForExternalDatabase, Strict)
+TEST(TransformQueryForExternalDatabase, NoStrict)
 {
     const State & state = State::instance();
 
     check(state, 1,
           "SELECT field FROM table WHERE field IN (SELECT attr FROM table2)",
           R"(SELECT "field" FROM "test"."table")");
+}
 
+TEST(TransformQueryForExternalDatabase, Strict)
+{
+    const State & state = State::instance();
     state.context->setSetting("external_table_strict_query", true);
+
+    check(state, 1,
+          "SELECT field FROM table WHERE field = '1'",
+          R"(SELECT "field" FROM "test"."table" WHERE "field" = '1')");
+    check(state, 1,
+          "SELECT field FROM table WHERE field IN ('1', '2')",
+          R"(SELECT "field" FROM "test"."table" WHERE "field" IN ('1', '2'))");
+    check(state, 1,
+          "SELECT field FROM table WHERE field LIKE '%test%'",
+          R"(SELECT "field" FROM "test"."table" WHERE "field" LIKE '%test%')");
+
     /// removeUnknownSubexpressionsFromWhere() takes place
     EXPECT_THROW(check(state, 1, "SELECT field FROM table WHERE field IN (SELECT attr FROM table2)", ""), Exception);
-    /// isCompatible() takes place
+    /// !isCompatible() takes place
     EXPECT_THROW(check(state, 1, "SELECT column FROM test.table WHERE left(column, 10) = RIGHT(column, 10) AND SUBSTRING(column FROM 1 FOR 2) = 'Hello'", ""), Exception);
 }

--- a/src/Storages/transformQueryForExternalDatabase.h
+++ b/src/Storages/transformQueryForExternalDatabase.h
@@ -22,6 +22,9 @@ class IAST;
   * that contain only compatible expressions.
   *
   * Compatible expressions are comparisons of identifiers, constants, and logical operations on them.
+  *
+  * Throws INCORRECT_QUERY if external_table_strict_query (from context settings)
+  * is set and some expression from WHERE is not compatible.
   */
 String transformQueryForExternalDatabase(
     const SelectQueryInfo & query_info,


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add ability to disable converting expressions to local filter for external queries (`external_table_strict_query=true`)

Detailed description / Documentation draft:
Sometimes it is undesirable to remove any expressions from WHERE, since
this may lead to reading the whole table, and this is pretty heavy job
for MySQL and PostgreSQL (even if you read only one column).

So `external_table_strict_query` had been introduced to prohibit this and
fail the query instead.