### PR TITLE
Update outdated ya.make files

### DIFF
--- a/src/Databases/ya.make
+++ b/src/Databases/ya.make
@@ -9,6 +9,7 @@ PEERDIR(
 
 
 SRCS(
+    DDLDependencyVisitor.cpp
     DatabaseAtomic.cpp
     DatabaseDictionary.cpp
     DatabaseFactory.cpp
@@ -30,6 +31,7 @@ SRCS(
     SQLite/DatabaseSQLite.cpp
     SQLite/SQLiteUtils.cpp
     SQLite/fetchSQLiteTableStructure.cpp
+    TablesLoader.cpp
 
 )
 

--- a/src/Functions/ya.make
+++ b/src/Functions/ya.make
@@ -304,6 +304,7 @@ SRCS(
     h3IndexesAreNeighbors.cpp
     h3IsValid.cpp
     h3ToChildren.cpp
+    h3ToGeoBoundary.cpp
     h3ToParent.cpp
     h3ToString.cpp
     h3kRing.cpp

--- a/src/Interpreters/ya.make
+++ b/src/Interpreters/ya.make
@@ -28,6 +28,7 @@ SRCS(
     ApplyWithSubqueryVisitor.cpp
     ArithmeticOperationsInAgrFuncOptimize.cpp
     ArrayJoinAction.cpp
+    AsynchronousInsertQueue.cpp
     AsynchronousMetricLog.cpp
     AsynchronousMetrics.cpp
     BloomFilter.cpp

--- a/src/Processors/ya.make
+++ b/src/Processors/ya.make
@@ -28,6 +28,7 @@ SRCS(
     Executors/PollingQueue.cpp
     Executors/PullingAsyncPipelineExecutor.cpp
     Executors/PullingPipelineExecutor.cpp
+    Executors/StreamingFormatExecutor.cpp
     ForkProcessor.cpp
     Formats/IInputFormat.cpp
     Formats/IOutputFormat.cpp
@@ -58,12 +59,8 @@ SRCS(
     Formats/Impl/MySQLOutputFormat.cpp
     Formats/Impl/NullFormat.cpp
     Formats/Impl/ODBCDriver2BlockOutputFormat.cpp
-    Formats/Impl/ORCBlockInputFormat.cpp
-    Formats/Impl/ORCBlockOutputFormat.cpp
     Formats/Impl/ParallelFormattingOutputFormat.cpp
     Formats/Impl/ParallelParsingInputFormat.cpp
-    Formats/Impl/ParquetBlockInputFormat.cpp
-    Formats/Impl/ParquetBlockOutputFormat.cpp
     Formats/Impl/PostgreSQLOutputFormat.cpp
     Formats/Impl/PrettyBlockOutputFormat.cpp
     Formats/Impl/PrettyCompactBlockOutputFormat.cpp

--- a/src/Storages/ya.make
+++ b/src/Storages/ya.make
@@ -164,6 +164,7 @@ SRCS(
     StorageView.cpp
     StorageXDBC.cpp
     System/StorageSystemAggregateFunctionCombinators.cpp
+    System/StorageSystemAsynchronousInserts.cpp
     System/StorageSystemAsynchronousMetrics.cpp
     System/StorageSystemBuildOptions.cpp
     System/StorageSystemClusters.cpp


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


Detailed description / Documentation draft:

This runs the `utils/generate-ya-make/generate-ya-make.sh` script to
update the ya.make files that are not updated.

I wonder why they were not updated and how it was missed.