### PR TITLE
Add more maxfiles plist file details for OS X

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -114,15 +114,25 @@ To do so, create the `/Library/LaunchDaemons/limit.maxfiles.plist` file with the
 </plist>
 ```
 
-Execute the following command:
+Give the file correct permissions:
 
 ``` bash
 sudo chown root:wheel /Library/LaunchDaemons/limit.maxfiles.plist
 ```
 
-Reboot.
+Validate that the file is correct:
 
-To check if it’s working, you can use `ulimit -n` command.
+``` bash
+plutil /Library/LaunchDaemons/limit.maxfiles.plist
+```
+
+Load the file (or reboot):
+
+``` bash
+sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
+```
+
+To check if it’s working, use the `ulimit -n` or `launchctl limit maxfiles` commands.
 
 ## Run ClickHouse server:
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description / Documentation draft:
Update instructions for `maxfiles` plist file use with modern launchd-related commands.