### PR TITLE
Send UNKNOWN_DATABASE to the client (via TCP)

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -115,6 +115,20 @@ void TCPHandler::runImpl()
     try
     {
         receiveHello();
+        sendHello();
+
+        if (!is_interserver_mode) /// In interserver mode queries are executed without a session context.
+        {
+            session->makeSessionContext();
+
+            /// If session created, then settings in session context has been updated.
+            /// So it's better to update the connection settings for flexibility.
+            extractConnectionSettingsFromContext(session->sessionContext());
+
+            /// When connecting, the default database could be specified.
+            if (!default_database.empty())
+                session->sessionContext()->setCurrentDatabase(default_database);
+        }
     }
     catch (const Exception & e) /// Typical for an incorrect username, password, or address.
     {
@@ -138,21 +152,6 @@ void TCPHandler::runImpl()
         catch (...) {}
 
         throw;
-    }
-
-    sendHello();
-
-    if (!is_interserver_mode) /// In interserver mode queries are executed without a session context.
-    {
-        session->makeSessionContext();
-
-        /// If session created, then settings in session context has been updated.
-        /// So it's better to update the connection settings for flexibility.
-        extractConnectionSettingsFromContext(session->sessionContext());
-
-        /// When connecting, the default database could be specified.
-        if (!default_database.empty())
-            session->sessionContext()->setCurrentDatabase(default_database);
     }
 
     while (true)

--- a/tests/queries/0_stateless/02030_client_unknown_database.sh
+++ b/tests/queries/0_stateless/02030_client_unknown_database.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+CLICKHOUSE_DATABASE=no_such_database_could_exist
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "SELECT 1" |& grep -q UNKNOWN_DATABASE


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Send normal `Database doesn't exist error` (`UNKNOWN_DATABASE`) to the client (via TCP) instead of `Attempt to read after eof` (`ATTEMPT_TO_READ_AFTER_EOF`)

Detailed description / Documentation draft:
Before this patch:

    $ clickhouse-client --database foo -q 'select 1'
    Code: 32. DB::Exception: Attempt to read after eof: while receiving packet from localhost:9000. (ATTEMPT_TO_READ_AFTER_EOF)

After:

    $ clickhouse-client --database foo -q 'select 1'
    Received exception from server (version 21.11.1):
    Code: 81. DB::Exception: Received from localhost:9000. DB::Exception: Database foo doesn't exist. (UNKNOWN_DATABASE)
    (query: select 1)

Fixes: #26864 (cc @vitlibar)