### PR TITLE
Remove old dependencies from `debian/control`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,9 +8,6 @@ Build-Depends: debhelper (>= 9),
                clang-11,
                llvm-11,
                libc6-dev,
-               libicu-dev,
-               libreadline-dev,
-               gperf,
                tzdata
 Standards-Version: 3.9.8
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


We don't use `debuild` or any Debian infrastructure.
But we still have a list of "build dependencies" in `debian/control` for some reason.
It is outdated for years.