### PR TITLE
Fix Docs Check

### DIFF
--- a/docs/en/commercial/cloud.md
+++ b/docs/en/commercial/cloud.md
@@ -6,4 +6,4 @@ toc_title: Cloud
 # ClickHouse Cloud Service {#clickhouse-cloud-service}
 
 !!! info "Info"
-    Detailed public description for ClickHouse cloud services is not ready yet, please [contact us](/company/#contact) to learn more.
+    Detailed public description for ClickHouse cloud services is not ready yet, please [contact us](https://clickhouse.com/company/#contact) to learn more.

--- a/docs/en/commercial/support.md
+++ b/docs/en/commercial/support.md
@@ -6,4 +6,4 @@ toc_title: Support
 # ClickHouse Commercial Support Service  {#clickhouse-commercial-support-service}
 
 !!! info "Info"
-    Detailed public description for ClickHouse support services is not ready yet, please [contact us](/company/#contact) to learn more.
+    Detailed public description for ClickHouse support services is not ready yet, please [contact us](https://clickhouse.com/company/#contact) to learn more.

--- a/docs/ja/commercial/cloud.md
+++ b/docs/ja/commercial/cloud.md
@@ -8,4 +8,4 @@ toc_title: "\u30AF\u30E9\u30A6\u30C9"
 # ClickHouse Cloud Service {#clickhouse-cloud-service}
 
 !!! info "Info"
-    Detailed public description for ClickHouse cloud services is not ready yet, please [contact us](/company/#contact) to learn more.
+    Detailed public description for ClickHouse cloud services is not ready yet, please [contact us](https://clickhouse.com/company/#contact) to learn more.

--- a/docs/ru/commercial/cloud.md
+++ b/docs/ru/commercial/cloud.md
@@ -6,4 +6,4 @@ toc_title: "Поставщики облачных услуг ClickHouse"
 # Поставщики облачных услуг ClickHouse {#clickhouse-cloud-service-providers}
 
 !!! info "Info"
-    Detailed public description for ClickHouse cloud services is not ready yet, please [contact us](/company/#contact) to learn more.
+    Detailed public description for ClickHouse cloud services is not ready yet, please [contact us](https://clickhouse.com/company/#contact) to learn more.

--- a/docs/zh/commercial/cloud.md
+++ b/docs/zh/commercial/cloud.md
@@ -8,4 +8,4 @@ toc_title: 云
 # ClickHouse Cloud Service {#clickhouse-cloud-service}
 
 !!! info "Info"
-    Detailed public description for ClickHouse cloud services is not ready yet, please [contact us](/company/#contact) to learn more.
+    Detailed public description for ClickHouse cloud services is not ready yet, please [contact us](https://clickhouse.com/company/#contact) to learn more.

--- a/docs/zh/commercial/support.md
+++ b/docs/zh/commercial/support.md
@@ -6,4 +6,4 @@ toc_title: 支持
 # ClickHouse 商业支持服务提供商 {#clickhouse-commercial-support-service-providers}
 
 !!! info "Info"
-    Detailed public description for ClickHouse support services is not ready yet, please [contact us](/company/#contact) to learn more.
+    Detailed public description for ClickHouse support services is not ready yet, please [contact us](https://clickhouse.com/company/#contact) to learn more.


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

It argued about broken links. The links are in fact correct.
But better to replace to absolute links nevertheless, so the links will work from GitHub.