### PR TITLE
Fix link in docs

### DIFF
--- a/docs/ru/whats-new/index.md
+++ b/docs/ru/whats-new/index.md
@@ -5,4 +5,4 @@ toc_priority: 82
 
 # Что нового в ClickHouse?
 
-Планы развития вкратце изложены [здесь](extended-roadmap.md), а новости по предыдущим релизам подробно описаны в [журнале изменений](changelog/index.md).
+Планы развития вкратце изложены [здесь](https://github.com/ClickHouse/ClickHouse/issues/17623), а новости по предыдущим релизам подробно описаны в [журнале изменений](changelog/index.md).


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)
