### PR TITLE
Better exception messages for some String-related functions

### DIFF
--- a/src/Functions/CountSubstringsImpl.h
+++ b/src/Functions/CountSubstringsImpl.h
@@ -19,11 +19,12 @@ namespace ErrorCodes
 /// NOTE: Intersecting substrings in haystack accounted only once, i.e.:
 ///
 ///     countSubstrings('aaaa', 'aa') == 2
-template <typename Impl>
+template <typename Name, typename Impl>
 struct CountSubstringsImpl
 {
     static constexpr bool use_default_implementation_for_constants = false;
     static constexpr bool supports_start_pos = true;
+    static constexpr auto name = Name::name;
 
     using ResultType = UInt64;
 
@@ -225,7 +226,7 @@ struct CountSubstringsImpl
     template <typename... Args>
     static void vectorFixedConstant(Args &&...)
     {
-        throw Exception("Functions 'position' don't support FixedString haystack argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support FixedString haystack argument", name);
     }
 };
 

--- a/src/Functions/FunctionsMultiStringFuzzySearch.h
+++ b/src/Functions/FunctionsMultiStringFuzzySearch.h
@@ -28,13 +28,13 @@ namespace ErrorCodes
 }
 
 
-template <typename Impl, typename Name, size_t LimitArgs>
+template <typename Impl, size_t LimitArgs>
 class FunctionsMultiStringFuzzySearch : public IFunction
 {
     static_assert(LimitArgs > 0);
 
 public:
-    static constexpr auto name = Name::name;
+    static constexpr auto name = Impl::name;
     static FunctionPtr create(ContextPtr context)
     {
         if (Impl::is_using_hyperscan && !context->getSettingsRef().allow_hyperscan)

--- a/src/Functions/FunctionsMultiStringSearch.h
+++ b/src/Functions/FunctionsMultiStringSearch.h
@@ -41,13 +41,13 @@ namespace ErrorCodes
 
 /// The argument limiting raises from Volnitsky searcher -- it is performance crucial to save only one byte for pattern number.
 /// But some other searchers use this function, for example, multiMatchAny -- hyperscan does not have such restrictions
-template <typename Impl, typename Name, size_t LimitArgs = std::numeric_limits<UInt8>::max()>
+template <typename Impl, size_t LimitArgs = std::numeric_limits<UInt8>::max()>
 class FunctionsMultiStringSearch : public IFunction
 {
     static_assert(LimitArgs > 0);
 
 public:
-    static constexpr auto name = Name::name;
+    static constexpr auto name = Impl::name;
     static FunctionPtr create(ContextPtr context)
     {
         if (Impl::is_using_hyperscan && !context->getSettingsRef().allow_hyperscan)

--- a/src/Functions/FunctionsStringSearch.h
+++ b/src/Functions/FunctionsStringSearch.h
@@ -46,11 +46,11 @@ namespace ErrorCodes
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 }
 
-template <typename Impl, typename Name>
+template <typename Impl>
 class FunctionsStringSearch : public IFunction
 {
 public:
-    static constexpr auto name = Name::name;
+    static constexpr auto name = Impl::name;
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionsStringSearch>(); }
 
     String getName() const override { return name; }
@@ -80,7 +80,7 @@ public:
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
         if (arguments.size() < 2 || 3 < arguments.size())
-            throw Exception("Number of arguments for function " + String(Name::name) + " doesn't match: passed "
+            throw Exception("Number of arguments for function " + getName() + " doesn't match: passed "
                 + toString(arguments.size()) + ", should be 2 or 3.",
                 ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 

--- a/src/Functions/FunctionsVisitParam.h
+++ b/src/Functions/FunctionsVisitParam.h
@@ -74,13 +74,14 @@ struct ExtractNumericType
  * If a field was not found or an incorrect value is associated with the field,
  * then the default value used - 0.
  */
-template <typename ParamExtractor>
+template <typename Name, typename ParamExtractor>
 struct ExtractParamImpl
 {
     using ResultType = typename ParamExtractor::ResultType;
 
     static constexpr bool use_default_implementation_for_constants = true;
     static constexpr bool supports_start_pos = false;
+    static constexpr auto name = Name::name;
 
     /// It is assumed that `res` is the correct size and initialized with zeros.
     static void vectorConstant(
@@ -91,7 +92,7 @@ struct ExtractParamImpl
         PaddedPODArray<ResultType> & res)
     {
         if (start_pos != nullptr)
-            throw Exception("Functions 'visitParamHas' and 'visitParamExtract*' doesn't support start_pos argument", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function '{}' doesn't support start_pos argument", name);
 
         /// We are looking for a parameter simply as a substring of the form "name"
         needle = "\"" + needle + "\":";
@@ -131,18 +132,18 @@ struct ExtractParamImpl
 
     template <typename... Args> static void vectorVector(Args &&...)
     {
-        throw Exception("Functions 'visitParamHas' and 'visitParamExtract*' doesn't support non-constant needle argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support non-constant needle argument", name);
     }
 
     template <typename... Args> static void constantVector(Args &&...)
     {
-        throw Exception("Functions 'visitParamHas' and 'visitParamExtract*' doesn't support non-constant needle argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support non-constant needle argument", name);
     }
 
     template <typename... Args>
     static void vectorFixedConstant(Args &&...)
     {
-        throw Exception("Functions 'visitParamHas' don't support FixedString haystack argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support FixedString haystack argument", name);
     }
 };
 

--- a/src/Functions/HasTokenImpl.h
+++ b/src/Functions/HasTokenImpl.h
@@ -14,13 +14,14 @@ namespace ErrorCodes
 
 /** Token search the string, means that needle must be surrounded by some separator chars, like whitespace or puctuation.
   */
-template <typename TokenSearcher, bool negate_result = false>
+template <typename Name, typename TokenSearcher, bool negate_result = false>
 struct HasTokenImpl
 {
     using ResultType = UInt8;
 
     static constexpr bool use_default_implementation_for_constants = true;
     static constexpr bool supports_start_pos = false;
+    static constexpr auto name = Name::name;
 
     static void vectorConstant(
         const ColumnString::Chars & data,
@@ -30,7 +31,7 @@ struct HasTokenImpl
         PaddedPODArray<UInt8> & res)
     {
         if (start_pos != nullptr)
-            throw Exception("Function 'hasToken' does not support start_pos argument", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function '{}' does not support start_pos argument", name);
 
         if (offsets.empty())
             return;
@@ -72,20 +73,20 @@ struct HasTokenImpl
     template <typename... Args>
     static void vectorVector(Args &&...)
     {
-        throw Exception("Function 'hasToken' does not support non-constant needle argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support non-constant needle argument", name);
     }
 
     /// Search different needles in single haystack.
     template <typename... Args>
     static void constantVector(Args &&...)
     {
-        throw Exception("Function 'hasToken' does not support non-constant needle argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support non-constant needle argument", name);
     }
 
     template <typename... Args>
     static void vectorFixedConstant(Args &&...)
     {
-        throw Exception("Functions 'hasToken' don't support FixedString haystack argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support FixedString haystack argument", name);
     }
 };
 

--- a/src/Functions/MatchImpl.h
+++ b/src/Functions/MatchImpl.h
@@ -73,11 +73,12 @@ static inline bool likePatternIsStrstr(const String & pattern, String & res)
   * NOTE: We want to run regexp search for whole columns by one call (as implemented in function 'position')
   *  but for that, regexp engine must support \0 bytes and their interpretation as string boundaries.
   */
-template <bool like, bool revert = false, bool case_insensitive = false>
+template <typename Name, bool like, bool revert = false, bool case_insensitive = false>
 struct MatchImpl
 {
     static constexpr bool use_default_implementation_for_constants = true;
     static constexpr bool supports_start_pos = false;
+    static constexpr auto name = Name::name;
 
     using ResultType = UInt8;
 
@@ -93,7 +94,8 @@ struct MatchImpl
         PaddedPODArray<UInt8> & res)
     {
         if (start_pos != nullptr)
-            throw Exception("Functions 'like' and 'match' don't support start_pos argument", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                    "Function '{}' doesn't support start_pos argument", name);
 
         if (offsets.empty())
             return;
@@ -406,14 +408,14 @@ struct MatchImpl
     template <typename... Args>
     static void vectorVector(Args &&...)
     {
-        throw Exception("Functions 'like' and 'match' don't support non-constant needle argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support non-constant needle argument", name);
     }
 
     /// Search different needles in single haystack.
     template <typename... Args>
     static void constantVector(Args &&...)
     {
-        throw Exception("Functions 'like' and 'match' don't support non-constant needle argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support non-constant needle argument", name);
     }
 };
 

--- a/src/Functions/MultiMatchAllIndicesImpl.h
+++ b/src/Functions/MultiMatchAllIndicesImpl.h
@@ -29,7 +29,7 @@ namespace ErrorCodes
 }
 
 
-template <typename Type, bool MultiSearchDistance>
+template <typename Name, typename Type, bool MultiSearchDistance>
 struct MultiMatchAllIndicesImpl
 {
     using ResultType = Type;
@@ -37,6 +37,8 @@ struct MultiMatchAllIndicesImpl
     /// Variable for understanding, if we used offsets for the output, most
     /// likely to determine whether the function returns ColumnVector of ColumnArray.
     static constexpr bool is_column_array = true;
+    static constexpr auto name = Name::name;
+
     static auto getReturnType()
     {
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());

--- a/src/Functions/MultiMatchAnyImpl.h
+++ b/src/Functions/MultiMatchAnyImpl.h
@@ -29,7 +29,7 @@ namespace ErrorCodes
 }
 
 
-template <typename Type, bool FindAny, bool FindAnyIndex, bool MultiSearchDistance>
+template <typename Name, typename Type, bool FindAny, bool FindAnyIndex, bool MultiSearchDistance>
 struct MultiMatchAnyImpl
 {
     static_assert(static_cast<int>(FindAny) + static_cast<int>(FindAnyIndex) == 1);
@@ -38,6 +38,8 @@ struct MultiMatchAnyImpl
     /// Variable for understanding, if we used offsets for the output, most
     /// likely to determine whether the function returns ColumnVector of ColumnArray.
     static constexpr bool is_column_array = false;
+    static constexpr auto name = Name::name;
+
     static auto getReturnType()
     {
         return std::make_shared<DataTypeNumber<ResultType>>();
@@ -120,7 +122,7 @@ struct MultiMatchAnyImpl
         memset(accum.data(), 0, accum.size());
         for (size_t j = 0; j < needles.size(); ++j)
         {
-            MatchImpl<false, false>::vectorConstant(haystack_data, haystack_offsets, needles[j].toString(), nullptr, accum);
+            MatchImpl<Name, false, false>::vectorConstant(haystack_data, haystack_offsets, needles[j].toString(), nullptr, accum);
             for (size_t i = 0; i < res.size(); ++i)
             {
                 if constexpr (FindAny)

--- a/src/Functions/MultiSearchFirstIndexImpl.h
+++ b/src/Functions/MultiSearchFirstIndexImpl.h
@@ -7,7 +7,7 @@
 namespace DB
 {
 
-template <typename Impl>
+template <typename Name, typename Impl>
 struct MultiSearchFirstIndexImpl
 {
     using ResultType = UInt64;
@@ -15,6 +15,8 @@ struct MultiSearchFirstIndexImpl
     /// Variable for understanding, if we used offsets for the output, most
     /// likely to determine whether the function returns ColumnVector of ColumnArray.
     static constexpr bool is_column_array = false;
+    static constexpr auto name = Name::name;
+
     static auto getReturnType() { return std::make_shared<DataTypeNumber<ResultType>>(); }
 
     static void vectorConstant(

--- a/src/Functions/MultiSearchFirstPositionImpl.h
+++ b/src/Functions/MultiSearchFirstPositionImpl.h
@@ -7,7 +7,7 @@
 namespace DB
 {
 
-template <typename Impl>
+template <typename Name, typename Impl>
 struct MultiSearchFirstPositionImpl
 {
     using ResultType = UInt64;
@@ -15,6 +15,8 @@ struct MultiSearchFirstPositionImpl
     /// Variable for understanding, if we used offsets for the output, most
     /// likely to determine whether the function returns ColumnVector of ColumnArray.
     static constexpr bool is_column_array = false;
+    static constexpr auto name = Name::name;
+
     static auto getReturnType() { return std::make_shared<DataTypeNumber<ResultType>>(); }
 
     static void vectorConstant(

--- a/src/Functions/MultiSearchImpl.h
+++ b/src/Functions/MultiSearchImpl.h
@@ -7,7 +7,7 @@
 namespace DB
 {
 
-template <typename Impl>
+template <typename Name, typename Impl>
 struct MultiSearchImpl
 {
     using ResultType = UInt8;
@@ -15,6 +15,8 @@ struct MultiSearchImpl
     /// Variable for understanding, if we used offsets for the output, most
     /// likely to determine whether the function returns ColumnVector of ColumnArray.
     static constexpr bool is_column_array = false;
+    static constexpr auto name = Name::name;
+
     static auto getReturnType() { return std::make_shared<DataTypeNumber<ResultType>>(); }
 
     static void vectorConstant(

--- a/src/Functions/PositionImpl.h
+++ b/src/Functions/PositionImpl.h
@@ -175,11 +175,12 @@ struct PositionCaseInsensitiveUTF8
 };
 
 
-template <typename Impl>
+template <typename Name, typename Impl>
 struct PositionImpl
 {
     static constexpr bool use_default_implementation_for_constants = false;
     static constexpr bool supports_start_pos = true;
+    static constexpr auto name = Name::name;
 
     using ResultType = UInt64;
 
@@ -408,7 +409,7 @@ struct PositionImpl
     template <typename... Args>
     static void vectorFixedConstant(Args &&...)
     {
-        throw Exception("Functions 'position' don't support FixedString haystack argument", ErrorCodes::ILLEGAL_COLUMN);
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Function '{}' doesn't support FixedString haystack argument", name);
     }
 };
 

--- a/src/Functions/countSubstrings.cpp
+++ b/src/Functions/countSubstrings.cpp
@@ -13,7 +13,7 @@ struct NameCountSubstrings
     static constexpr auto name = "countSubstrings";
 };
 
-using FunctionCountSubstrings = FunctionsStringSearch<CountSubstringsImpl<PositionCaseSensitiveASCII>, NameCountSubstrings>;
+using FunctionCountSubstrings = FunctionsStringSearch<CountSubstringsImpl<NameCountSubstrings, PositionCaseSensitiveASCII>>;
 
 }
 

--- a/src/Functions/countSubstringsCaseInsensitive.cpp
+++ b/src/Functions/countSubstringsCaseInsensitive.cpp
@@ -13,7 +13,7 @@ struct NameCountSubstringsCaseInsensitive
     static constexpr auto name = "countSubstringsCaseInsensitive";
 };
 
-using FunctionCountSubstringsCaseInsensitive = FunctionsStringSearch<CountSubstringsImpl<PositionCaseInsensitiveASCII>, NameCountSubstringsCaseInsensitive>;
+using FunctionCountSubstringsCaseInsensitive = FunctionsStringSearch<CountSubstringsImpl<NameCountSubstringsCaseInsensitive, PositionCaseInsensitiveASCII>>;
 
 }
 

--- a/src/Functions/countSubstringsCaseInsensitiveUTF8.cpp
+++ b/src/Functions/countSubstringsCaseInsensitiveUTF8.cpp
@@ -13,7 +13,8 @@ struct NameCountSubstringsCaseInsensitiveUTF8
     static constexpr auto name = "countSubstringsCaseInsensitiveUTF8";
 };
 
-using FunctionCountSubstringsCaseInsensitiveUTF8 = FunctionsStringSearch<CountSubstringsImpl<PositionCaseInsensitiveUTF8>, NameCountSubstringsCaseInsensitiveUTF8>;
+using FunctionCountSubstringsCaseInsensitiveUTF8 = FunctionsStringSearch<
+        CountSubstringsImpl<NameCountSubstringsCaseInsensitiveUTF8, PositionCaseInsensitiveUTF8>>;
 
 }
 

--- a/src/Functions/hasToken.cpp
+++ b/src/Functions/hasToken.cpp
@@ -14,7 +14,7 @@ struct NameHasToken
     static constexpr auto name = "hasToken";
 };
 
-using FunctionHasToken = FunctionsStringSearch<HasTokenImpl<VolnitskyCaseSensitiveToken, false>, NameHasToken>;
+using FunctionHasToken = FunctionsStringSearch<HasTokenImpl<NameHasToken, VolnitskyCaseSensitiveToken, false>>;
 
 }
 

--- a/src/Functions/hasTokenCaseInsensitive.cpp
+++ b/src/Functions/hasTokenCaseInsensitive.cpp
@@ -15,7 +15,7 @@ struct NameHasTokenCaseInsensitive
 };
 
 using FunctionHasTokenCaseInsensitive
-    = FunctionsStringSearch<HasTokenImpl<VolnitskyCaseInsensitiveToken, false>, NameHasTokenCaseInsensitive>;
+    = FunctionsStringSearch<HasTokenImpl<NameHasTokenCaseInsensitive, VolnitskyCaseInsensitiveToken, false>>;
 
 }
 

--- a/src/Functions/ilike.cpp
+++ b/src/Functions/ilike.cpp
@@ -12,8 +12,8 @@ struct NameILike
     static constexpr auto name = "ilike";
 };
 
-using ILikeImpl = MatchImpl<true, false, /*case-insensitive*/true>;
-using FunctionILike = FunctionsStringSearch<ILikeImpl, NameILike>;
+using ILikeImpl = MatchImpl<NameILike, true, false, /*case-insensitive*/true>;
+using FunctionILike = FunctionsStringSearch<ILikeImpl>;
 
 }
 

--- a/src/Functions/like.cpp
+++ b/src/Functions/like.cpp
@@ -13,8 +13,8 @@ struct NameLike
     static constexpr auto name = "like";
 };
 
-using LikeImpl = MatchImpl</*SQL LIKE */ true, /*revert*/false>;
-using FunctionLike = FunctionsStringSearch<LikeImpl, NameLike>;
+using LikeImpl = MatchImpl<NameLike, /*SQL LIKE */ true, /*revert*/false>;
+using FunctionLike = FunctionsStringSearch<LikeImpl>;
 
 }
 

--- a/src/Functions/match.cpp
+++ b/src/Functions/match.cpp
@@ -13,7 +13,7 @@ struct NameMatch
     static constexpr auto name = "match";
 };
 
-using FunctionMatch = FunctionsStringSearch<MatchImpl<false>, NameMatch>;
+using FunctionMatch = FunctionsStringSearch<MatchImpl<NameMatch, false>>;
 
 }
 

--- a/src/Functions/multiFuzzyMatchAllIndices.cpp
+++ b/src/Functions/multiFuzzyMatchAllIndices.cpp
@@ -14,8 +14,7 @@ struct NameMultiFuzzyMatchAllIndices
 };
 
 using FunctionMultiFuzzyMatchAllIndices = FunctionsMultiStringFuzzySearch<
-    MultiMatchAllIndicesImpl<UInt64, true>,
-    NameMultiFuzzyMatchAllIndices,
+    MultiMatchAllIndicesImpl<NameMultiFuzzyMatchAllIndices, UInt64, true>,
     std::numeric_limits<UInt32>::max()>;
 
 }

--- a/src/Functions/multiFuzzyMatchAny.cpp
+++ b/src/Functions/multiFuzzyMatchAny.cpp
@@ -14,8 +14,7 @@ struct NameMultiFuzzyMatchAny
 };
 
 using FunctionMultiFuzzyMatchAny = FunctionsMultiStringFuzzySearch<
-    MultiMatchAnyImpl<UInt8, true, false, true>,
-    NameMultiFuzzyMatchAny,
+    MultiMatchAnyImpl<NameMultiFuzzyMatchAny, UInt8, true, false, true>,
     std::numeric_limits<UInt32>::max()>;
 
 }

--- a/src/Functions/multiFuzzyMatchAnyIndex.cpp
+++ b/src/Functions/multiFuzzyMatchAnyIndex.cpp
@@ -14,8 +14,7 @@ struct NameMultiFuzzyMatchAnyIndex
 };
 
 using FunctionMultiFuzzyMatchAnyIndex = FunctionsMultiStringFuzzySearch<
-    MultiMatchAnyImpl<UInt64, false, true, true>,
-    NameMultiFuzzyMatchAnyIndex,
+    MultiMatchAnyImpl<NameMultiFuzzyMatchAnyIndex, UInt64, false, true, true>,
     std::numeric_limits<UInt32>::max()>;
 
 }

--- a/src/Functions/multiMatchAllIndices.cpp
+++ b/src/Functions/multiMatchAllIndices.cpp
@@ -14,8 +14,7 @@ struct NameMultiMatchAllIndices
 };
 
 using FunctionMultiMatchAllIndices = FunctionsMultiStringSearch<
-    MultiMatchAllIndicesImpl<UInt64, false>,
-    NameMultiMatchAllIndices,
+    MultiMatchAllIndicesImpl<NameMultiMatchAllIndices, UInt64, false>,
     std::numeric_limits<UInt32>::max()>;
 
 }

--- a/src/Functions/multiMatchAny.cpp
+++ b/src/Functions/multiMatchAny.cpp
@@ -14,8 +14,7 @@ struct NameMultiMatchAny
 };
 
 using FunctionMultiMatchAny = FunctionsMultiStringSearch<
-    MultiMatchAnyImpl<UInt8, true, false, false>,
-    NameMultiMatchAny,
+    MultiMatchAnyImpl<NameMultiMatchAny, UInt8, true, false, false>,
     std::numeric_limits<UInt32>::max()>;
 
 }

--- a/src/Functions/multiMatchAnyIndex.cpp
+++ b/src/Functions/multiMatchAnyIndex.cpp
@@ -14,8 +14,7 @@ struct NameMultiMatchAnyIndex
 };
 
 using FunctionMultiMatchAnyIndex = FunctionsMultiStringSearch<
-    MultiMatchAnyImpl<UInt64, false, true, false>,
-    NameMultiMatchAnyIndex,
+    MultiMatchAnyImpl<NameMultiMatchAnyIndex, UInt64, false, true, false>,
     std::numeric_limits<UInt32>::max()>;
 
 }

--- a/src/Functions/multiSearchAny.cpp
+++ b/src/Functions/multiSearchAny.cpp
@@ -14,7 +14,7 @@ struct NameMultiSearchAny
     static constexpr auto name = "multiSearchAny";
 };
 
-using FunctionMultiSearch = FunctionsMultiStringSearch<MultiSearchImpl<PositionCaseSensitiveASCII>, NameMultiSearchAny>;
+using FunctionMultiSearch = FunctionsMultiStringSearch<MultiSearchImpl<NameMultiSearchAny, PositionCaseSensitiveASCII>>;
 
 }
 

--- a/src/Functions/multiSearchAnyCaseInsensitive.cpp
+++ b/src/Functions/multiSearchAnyCaseInsensitive.cpp
@@ -14,7 +14,7 @@ struct NameMultiSearchAnyCaseInsensitive
     static constexpr auto name = "multiSearchAnyCaseInsensitive";
 };
 using FunctionMultiSearchCaseInsensitive
-    = FunctionsMultiStringSearch<MultiSearchImpl<PositionCaseInsensitiveASCII>, NameMultiSearchAnyCaseInsensitive>;
+    = FunctionsMultiStringSearch<MultiSearchImpl<NameMultiSearchAnyCaseInsensitive, PositionCaseInsensitiveASCII>>;
 
 }
 

--- a/src/Functions/multiSearchAnyCaseInsensitiveUTF8.cpp
+++ b/src/Functions/multiSearchAnyCaseInsensitiveUTF8.cpp
@@ -15,7 +15,7 @@ struct NameMultiSearchAnyCaseInsensitiveUTF8
 };
 
 using FunctionMultiSearchCaseInsensitiveUTF8
-    = FunctionsMultiStringSearch<MultiSearchImpl<PositionCaseInsensitiveUTF8>, NameMultiSearchAnyCaseInsensitiveUTF8>;
+    = FunctionsMultiStringSearch<MultiSearchImpl<NameMultiSearchAnyCaseInsensitiveUTF8, PositionCaseInsensitiveUTF8>>;
 
 }
 

--- a/src/Functions/multiSearchAnyUTF8.cpp
+++ b/src/Functions/multiSearchAnyUTF8.cpp
@@ -13,7 +13,7 @@ struct NameMultiSearchAnyUTF8
 {
     static constexpr auto name = "multiSearchAnyUTF8";
 };
-using FunctionMultiSearchUTF8 = FunctionsMultiStringSearch<MultiSearchImpl<PositionCaseSensitiveUTF8>, NameMultiSearchAnyUTF8>;
+using FunctionMultiSearchUTF8 = FunctionsMultiStringSearch<MultiSearchImpl<NameMultiSearchAnyUTF8, PositionCaseSensitiveUTF8>>;
 
 }
 

--- a/src/Functions/multiSearchFirstIndex.cpp
+++ b/src/Functions/multiSearchFirstIndex.cpp
@@ -15,7 +15,7 @@ struct NameMultiSearchFirstIndex
 };
 
 using FunctionMultiSearchFirstIndex
-    = FunctionsMultiStringSearch<MultiSearchFirstIndexImpl<PositionCaseSensitiveASCII>, NameMultiSearchFirstIndex>;
+    = FunctionsMultiStringSearch<MultiSearchFirstIndexImpl<NameMultiSearchFirstIndex, PositionCaseSensitiveASCII>>;
 
 }
 

--- a/src/Functions/multiSearchFirstIndexCaseInsensitive.cpp
+++ b/src/Functions/multiSearchFirstIndexCaseInsensitive.cpp
@@ -15,7 +15,7 @@ struct NameMultiSearchFirstIndexCaseInsensitive
 };
 
 using FunctionMultiSearchFirstIndexCaseInsensitive
-    = FunctionsMultiStringSearch<MultiSearchFirstIndexImpl<PositionCaseInsensitiveASCII>, NameMultiSearchFirstIndexCaseInsensitive>;
+    = FunctionsMultiStringSearch<MultiSearchFirstIndexImpl<NameMultiSearchFirstIndexCaseInsensitive, PositionCaseInsensitiveASCII>>;
 
 }
 

--- a/src/Functions/multiSearchFirstIndexCaseInsensitiveUTF8.cpp
+++ b/src/Functions/multiSearchFirstIndexCaseInsensitiveUTF8.cpp
@@ -15,7 +15,7 @@ struct NameMultiSearchFirstIndexCaseInsensitiveUTF8
 };
 
 using FunctionMultiSearchFirstIndexCaseInsensitiveUTF8
-    = FunctionsMultiStringSearch<MultiSearchFirstIndexImpl<PositionCaseInsensitiveUTF8>, NameMultiSearchFirstIndexCaseInsensitiveUTF8>;
+    = FunctionsMultiStringSearch<MultiSearchFirstIndexImpl<NameMultiSearchFirstIndexCaseInsensitiveUTF8, PositionCaseInsensitiveUTF8>>;
 
 }
 

--- a/src/Functions/multiSearchFirstIndexUTF8.cpp
+++ b/src/Functions/multiSearchFirstIndexUTF8.cpp
@@ -15,7 +15,7 @@ struct NameMultiSearchFirstIndexUTF8
 };
 
 using FunctionMultiSearchFirstIndexUTF8
-    = FunctionsMultiStringSearch<MultiSearchFirstIndexImpl<PositionCaseSensitiveUTF8>, NameMultiSearchFirstIndexUTF8>;
+    = FunctionsMultiStringSearch<MultiSearchFirstIndexImpl<NameMultiSearchFirstIndexUTF8, PositionCaseSensitiveUTF8>>;
 
 }
 

--- a/src/Functions/multiSearchFirstPosition.cpp
+++ b/src/Functions/multiSearchFirstPosition.cpp
@@ -15,7 +15,7 @@ struct NameMultiSearchFirstPosition
 };
 
 using FunctionMultiSearchFirstPosition
-    = FunctionsMultiStringSearch<MultiSearchFirstPositionImpl<PositionCaseSensitiveASCII>, NameMultiSearchFirstPosition>;
+    = FunctionsMultiStringSearch<MultiSearchFirstPositionImpl<NameMultiSearchFirstPosition, PositionCaseSensitiveASCII>>;
 
 }
 

--- a/src/Functions/multiSearchFirstPositionCaseInsensitive.cpp
+++ b/src/Functions/multiSearchFirstPositionCaseInsensitive.cpp
@@ -15,7 +15,7 @@ struct NameMultiSearchFirstPositionCaseInsensitive
 };
 
 using FunctionMultiSearchFirstPositionCaseInsensitive
-    = FunctionsMultiStringSearch<MultiSearchFirstPositionImpl<PositionCaseInsensitiveASCII>, NameMultiSearchFirstPositionCaseInsensitive>;
+    = FunctionsMultiStringSearch<MultiSearchFirstPositionImpl<NameMultiSearchFirstPositionCaseInsensitive, PositionCaseInsensitiveASCII>>;
 
 }
 

--- a/src/Functions/multiSearchFirstPositionCaseInsensitiveUTF8.cpp
+++ b/src/Functions/multiSearchFirstPositionCaseInsensitiveUTF8.cpp
@@ -15,8 +15,7 @@ struct NameMultiSearchFirstPositionCaseInsensitiveUTF8
 };
 
 using FunctionMultiSearchFirstPositionCaseInsensitiveUTF8 = FunctionsMultiStringSearch<
-    MultiSearchFirstPositionImpl<PositionCaseInsensitiveUTF8>,
-    NameMultiSearchFirstPositionCaseInsensitiveUTF8>;
+    MultiSearchFirstPositionImpl<NameMultiSearchFirstPositionCaseInsensitiveUTF8, PositionCaseInsensitiveUTF8>>;
 
 }
 

--- a/src/Functions/multiSearchFirstPositionUTF8.cpp
+++ b/src/Functions/multiSearchFirstPositionUTF8.cpp
@@ -15,7 +15,7 @@ struct NameMultiSearchFirstPositionUTF8
 };
 
 using FunctionMultiSearchFirstPositionUTF8
-    = FunctionsMultiStringSearch<MultiSearchFirstPositionImpl<PositionCaseSensitiveUTF8>, NameMultiSearchFirstPositionUTF8>;
+    = FunctionsMultiStringSearch<MultiSearchFirstPositionImpl<NameMultiSearchFirstPositionUTF8, PositionCaseSensitiveUTF8>>;
 
 }
 

--- a/src/Functions/notILike.cpp
+++ b/src/Functions/notILike.cpp
@@ -12,8 +12,8 @@ struct NameNotILike
     static constexpr auto name = "notILike";
 };
 
-using NotILikeImpl = MatchImpl<true, true, /*case-insensitive*/true>;
-using FunctionNotILike = FunctionsStringSearch<NotILikeImpl, NameNotILike>;
+using NotILikeImpl = MatchImpl<NameNotILike, true, true, /*case-insensitive*/true>;
+using FunctionNotILike = FunctionsStringSearch<NotILikeImpl>;
 
 }
 

--- a/src/Functions/notLike.cpp
+++ b/src/Functions/notLike.cpp
@@ -12,7 +12,7 @@ struct NameNotLike
     static constexpr auto name = "notLike";
 };
 
-using FunctionNotLike = FunctionsStringSearch<MatchImpl<true, true>, NameNotLike>;
+using FunctionNotLike = FunctionsStringSearch<MatchImpl<NameNotLike, true, true>>;
 
 }
 

--- a/src/Functions/position.cpp
+++ b/src/Functions/position.cpp
@@ -13,7 +13,7 @@ struct NamePosition
     static constexpr auto name = "position";
 };
 
-using FunctionPosition = FunctionsStringSearch<PositionImpl<PositionCaseSensitiveASCII>, NamePosition>;
+using FunctionPosition = FunctionsStringSearch<PositionImpl<NamePosition, PositionCaseSensitiveASCII>>;
 
 }
 

--- a/src/Functions/positionCaseInsensitive.cpp
+++ b/src/Functions/positionCaseInsensitive.cpp
@@ -13,7 +13,7 @@ struct NamePositionCaseInsensitive
     static constexpr auto name = "positionCaseInsensitive";
 };
 
-using FunctionPositionCaseInsensitive = FunctionsStringSearch<PositionImpl<PositionCaseInsensitiveASCII>, NamePositionCaseInsensitive>;
+using FunctionPositionCaseInsensitive = FunctionsStringSearch<PositionImpl<NamePositionCaseInsensitive, PositionCaseInsensitiveASCII>>;
 
 }
 

--- a/src/Functions/positionCaseInsensitiveUTF8.cpp
+++ b/src/Functions/positionCaseInsensitiveUTF8.cpp
@@ -14,7 +14,7 @@ struct NamePositionCaseInsensitiveUTF8
 };
 
 using FunctionPositionCaseInsensitiveUTF8
-    = FunctionsStringSearch<PositionImpl<PositionCaseInsensitiveUTF8>, NamePositionCaseInsensitiveUTF8>;
+    = FunctionsStringSearch<PositionImpl<NamePositionCaseInsensitiveUTF8, PositionCaseInsensitiveUTF8>>;
 
 }
 

--- a/src/Functions/positionUTF8.cpp
+++ b/src/Functions/positionUTF8.cpp
@@ -13,7 +13,7 @@ struct NamePositionUTF8
     static constexpr auto name = "positionUTF8";
 };
 
-using FunctionPositionUTF8 = FunctionsStringSearch<PositionImpl<PositionCaseSensitiveUTF8>, NamePositionUTF8>;
+using FunctionPositionUTF8 = FunctionsStringSearch<PositionImpl<NamePositionUTF8, PositionCaseSensitiveUTF8>>;
 
 }
 

--- a/src/Functions/visitParamExtractBool.cpp
+++ b/src/Functions/visitParamExtractBool.cpp
@@ -17,10 +17,10 @@ struct ExtractBool
 };
 
 struct NameVisitParamExtractBool   { static constexpr auto name = "visitParamExtractBool"; };
-using FunctionVisitParamExtractBool = FunctionsStringSearch<ExtractParamImpl<ExtractBool>, NameVisitParamExtractBool>;
+using FunctionVisitParamExtractBool = FunctionsStringSearch<ExtractParamImpl<NameVisitParamExtractBool, ExtractBool>>;
 
 struct NameSimpleJSONExtractBool   { static constexpr auto name = "simpleJSONExtractBool"; };
-using FunctionSimpleJSONExtractBool = FunctionsStringSearch<ExtractParamImpl<ExtractBool>, NameSimpleJSONExtractBool>;
+using FunctionSimpleJSONExtractBool = FunctionsStringSearch<ExtractParamImpl<NameSimpleJSONExtractBool, ExtractBool>>;
 
 void registerFunctionVisitParamExtractBool(FunctionFactory & factory)
 {

--- a/src/Functions/visitParamExtractFloat.cpp
+++ b/src/Functions/visitParamExtractFloat.cpp
@@ -7,10 +7,10 @@ namespace DB
 {
 
 struct NameVisitParamExtractFloat  { static constexpr auto name = "visitParamExtractFloat"; };
-using FunctionVisitParamExtractFloat = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Float64>>, NameVisitParamExtractFloat>;
+using FunctionVisitParamExtractFloat = FunctionsStringSearch<ExtractParamImpl<NameVisitParamExtractFloat, ExtractNumericType<Float64>>>;
 
 struct NameSimpleJSONExtractFloat  { static constexpr auto name = "simpleJSONExtractFloat"; };
-using FunctionSimpleJSONExtractFloat = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Float64>>, NameSimpleJSONExtractFloat>;
+using FunctionSimpleJSONExtractFloat = FunctionsStringSearch<ExtractParamImpl<NameSimpleJSONExtractFloat, ExtractNumericType<Float64>>>;
 
 void registerFunctionVisitParamExtractFloat(FunctionFactory & factory)
 {

--- a/src/Functions/visitParamExtractInt.cpp
+++ b/src/Functions/visitParamExtractInt.cpp
@@ -7,10 +7,10 @@ namespace DB
 {
 
 struct NameVisitParamExtractInt    { static constexpr auto name = "visitParamExtractInt"; };
-using FunctionVisitParamExtractInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Int64>>, NameVisitParamExtractInt>;
+using FunctionVisitParamExtractInt = FunctionsStringSearch<ExtractParamImpl<NameVisitParamExtractInt, ExtractNumericType<Int64>>>;
 
 struct NameSimpleJSONExtractInt    { static constexpr auto name = "simpleJSONExtractInt"; };
-using FunctionSimpleJSONExtractInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<Int64>>, NameSimpleJSONExtractInt>;
+using FunctionSimpleJSONExtractInt = FunctionsStringSearch<ExtractParamImpl<NameSimpleJSONExtractInt, ExtractNumericType<Int64>>>;
 
 void registerFunctionVisitParamExtractInt(FunctionFactory & factory)
 {

--- a/src/Functions/visitParamExtractUInt.cpp
+++ b/src/Functions/visitParamExtractUInt.cpp
@@ -7,10 +7,10 @@ namespace DB
 {
 
 struct NameVisitParamExtractUInt   { static constexpr auto name = "visitParamExtractUInt"; };
-using FunctionVisitParamExtractUInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<UInt64>>, NameVisitParamExtractUInt>;
+using FunctionVisitParamExtractUInt = FunctionsStringSearch<ExtractParamImpl<NameVisitParamExtractUInt, ExtractNumericType<UInt64>>>;
 
 struct NameSimpleJSONExtractUInt   { static constexpr auto name = "simpleJSONExtractUInt"; };
-using FunctionSimpleJSONExtractUInt = FunctionsStringSearch<ExtractParamImpl<ExtractNumericType<UInt64>>, NameSimpleJSONExtractUInt>;
+using FunctionSimpleJSONExtractUInt = FunctionsStringSearch<ExtractParamImpl<NameSimpleJSONExtractUInt, ExtractNumericType<UInt64>>>;
 
 
 void registerFunctionVisitParamExtractUInt(FunctionFactory & factory)

--- a/src/Functions/visitParamHas.cpp
+++ b/src/Functions/visitParamHas.cpp
@@ -17,10 +17,10 @@ struct HasParam
 };
 
 struct NameVisitParamHas           { static constexpr auto name = "visitParamHas"; };
-using FunctionVisitParamHas = FunctionsStringSearch<ExtractParamImpl<HasParam>, NameVisitParamHas>;
+using FunctionVisitParamHas = FunctionsStringSearch<ExtractParamImpl<NameVisitParamHas, HasParam>>;
 
 struct NameSimpleJSONHas           { static constexpr auto name = "simpleJSONHas"; };
-using FunctionSimpleJSONHas = FunctionsStringSearch<ExtractParamImpl<HasParam>, NameSimpleJSONHas>;
+using FunctionSimpleJSONHas = FunctionsStringSearch<ExtractParamImpl<NameSimpleJSONHas, HasParam>>;
 
 void registerFunctionVisitParamHas(FunctionFactory & factory)
 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
Using exact function name in exception message for some of the String-related functions, e.g. `hasToken`, `like`, `ilike`, etc.
...