### PR TITLE
Add missed keeper jepsen config

### DIFF
--- a/tests/ci/ci_config.json
+++ b/tests/ci/ci_config.json
@@ -704,6 +704,18 @@
                 "clang-tidy": "disable",
                 "with_coverage": false
             }
+        },
+        "ClickHouse Keeper Jepsen": {
+            "required_build_properties": {
+                "compiler": "clang-13",
+                "package_type": "binary",
+                "build_type": "relwithdebuginfo",
+                "sanitizer": "none",
+                "bundled": "bundled",
+                "splitted": "unsplitted",
+                "clang-tidy": "disable",
+                "with_coverage": false
+            }
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Not for changelog (changelog entry is not required)

