### PR TITLE
Fix typo in an error message

### DIFF
--- a/src/Storages/StorageView.cpp
+++ b/src/Storages/StorageView.cpp
@@ -158,8 +158,8 @@ void StorageView::read(
     {
         throw DB::Exception(ErrorCodes::INCORRECT_QUERY,
                             "Query from view {} returned Nullable column having not Nullable type in structure. "
-                            "If query from view has JOIN, it may be cause by different values of 'json_use_nulls' setting. "
-                            "You may explicitly specify 'json_use_nulls' in 'CREATE VIEW' query to avoid this error",
+                            "If query from view has JOIN, it may be cause by different values of 'join_use_nulls' setting. "
+                            "You may explicitly specify 'join_use_nulls' in 'CREATE VIEW' query to avoid this error",
                             getStorageID().getFullTableName());
     }
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/20551

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
join_use_nulls message typo fix.
