### PR TITLE
Parser number binary literal

### DIFF
--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1525,6 +1525,26 @@ bool ParserNull::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 }
 
 
+static bool parseNumber(char * buffer, size_t size, bool negative, int base, Field & res)
+{
+    errno = 0;    /// Functions strto* don't clear errno.
+
+    char * pos_integer = buffer;
+    UInt64 uint_value = std::strtoull(buffer, &pos_integer, base);
+
+    if (pos_integer == buffer + size && errno != ERANGE && (!negative || uint_value <= (1ULL << 63)))
+    {
+        if (negative)
+            res = static_cast<Int64>(-uint_value);
+        else
+            res = uint_value;
+
+        return true;
+    }
+
+    return false;
+}
+
 bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     Pos literal_begin = pos;
@@ -1564,6 +1584,22 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     Float64 float_value = std::strtod(buf, &pos_double);
     if (pos_double != buf + pos->size() || errno == ERANGE)
     {
+        /// Try to parse number as binary literal representation. Example: 0b0001.
+        if (pos->size() > 2 && buf[0] == '0' && buf[1] == 'b')
+        {
+            char * buf_skip_prefix = buf + 2;
+
+            if (parseNumber(buf_skip_prefix, pos->size() - 2, negative, 2, res))
+            {
+                auto literal = std::make_shared<ASTLiteral>(res);
+                literal->begin = literal_begin;
+                literal->end = ++pos;
+                node = literal;
+
+                return true;
+            }
+        }
+
         expected.add(pos, "number");
         return false;
     }
@@ -1578,22 +1614,16 @@ bool ParserNumber::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     /// try to use more exact type: UInt64
 
-    char * pos_integer = buf;
-
-    errno = 0;
-    UInt64 uint_value = std::strtoull(buf, &pos_integer, 0);
-    if (pos_integer == pos_double && errno != ERANGE && (!negative || uint_value <= (1ULL << 63)))
+    if (parseNumber(buf, pos->size(), negative, 0, res))
     {
-        if (negative)
-            res = static_cast<Int64>(-uint_value);
-        else
-            res = uint_value;
+        auto literal = std::make_shared<ASTLiteral>(res);
+        literal->begin = literal_begin;
+        literal->end = ++pos;
+        node = literal;
+
+        return true;
     }
 
-    auto literal = std::make_shared<ASTLiteral>(res);
-    literal->begin = literal_begin;
-    literal->end = ++pos;
-    node = literal;
     return true;
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to write number in query as binary literal. Example `SELECT 0b001;`