### PR TITLE
Fix trivial mistake in DiskWebServer

### DIFF
--- a/src/Disks/DiskWebServer.cpp
+++ b/src/Disks/DiskWebServer.cpp
@@ -40,7 +40,7 @@ void DiskWebServer::initialize(const String & uri_path) const
                                             ReadWriteBufferFromHTTP::OutStreamCallback(),
                                             ConnectionTimeouts::getHTTPTimeouts(getContext()));
         String file_name;
-        FileData file_data;
+        FileData file_data{};
 
         String dir_name = fs::path(uri_path.substr(url.size())) / "";
         LOG_TRACE(&Poco::Logger::get("DiskWeb"), "Adding directory: {}", dir_name);

--- a/src/Disks/DiskWebServer.h
+++ b/src/Disks/DiskWebServer.h
@@ -186,7 +186,7 @@ private:
     struct FileData
     {
         FileType type;
-        size_t size;
+        size_t size = 0;
     };
 
     using Files = std::unordered_map<String, FileData>; /// file path -> file data

--- a/src/Disks/DiskWebServer.h
+++ b/src/Disks/DiskWebServer.h
@@ -185,7 +185,7 @@ private:
 
     struct FileData
     {
-        FileType type;
+        FileType type{};
         size_t size = 0;
     };
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #29333.

Field `size` was uninitialized for directories. It was only used for log message.