### PR TITLE
fix build error in keeper data dumper

### DIFF
--- a/utils/keeper-data-dumper/main.cpp
+++ b/utils/keeper-data-dumper/main.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
 
     LOG_INFO(logger, "Last committed index: {}", last_commited_index);
 
-    DB::KeeperLogStore changelog(argv[2], 10000000, true);
+    DB::KeeperLogStore changelog(argv[2], 10000000, true, settings->compress_logs);
     changelog.init(last_commited_index, 10000000000UL); /// collect all logs
     if (changelog.size() == 0)
         LOG_INFO(logger, "Changelog empty");


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
N/A
Detailed description / Documentation draft:

https://github.com/ClickHouse/ClickHouse/pull/29223 add a parameter with no default value to the constructor of KeeperLogStore. see https://github.com/ClickHouse/ClickHouse/issues/29366 for details


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
