### PR TITLE
Fix ugly typo

### DIFF
--- a/docker/test/coverage/s3downloader
+++ b/docker/test/coverage/s3downloader
@@ -92,7 +92,7 @@ if __name__ == "__main__":
             logging.info("Some exception occured %s", str(ex))
             raise
         finally:
-            logging.info("Will remove dowloaded file %s from filesystem if it exists", temp_archive_path)
+            logging.info("Will remove downloaded file %s from filesystem if it exists", temp_archive_path)
             if os.path.exists(temp_archive_path):
                 os.remove(temp_archive_path)
         logging.info("Processing of %s finished", dataset)

--- a/docker/test/stateful/s3downloader
+++ b/docker/test/stateful/s3downloader
@@ -92,7 +92,7 @@ if __name__ == "__main__":
             logging.info("Some exception occured %s", str(ex))
             raise
         finally:
-            logging.info("Will remove dowloaded file %s from filesystem if it exists", temp_archive_path)
+            logging.info("Will remove downloaded file %s from filesystem if it exists", temp_archive_path)
             if os.path.exists(temp_archive_path):
                 os.remove(temp_archive_path)
         logging.info("Processing of %s finished", dataset)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#29368

```
INFO:root:Will remove dowloaded file /tmp/kpihf2g0 from filesystem if it exists
```
\- here is that ugly typo.

```
INFO:root:Processing of visits finished
INFO:root:Fetch finished, enjoy your tables!
```
\- I was ready to enjoy, but noticed that annoying typo.

```
+ chmod 777 -R /var/lib/clickhouse
chmod: cannot access '/var/lib/clickhouse/store/949/9493b2ff-69ba-46de-9493-b2ff69baa6de/tmp_insert_202109_7_7_0': No such file or directory
```
\- no wonder that the whole infrastructure does not work properly.