### PR TITLE
Fix ReplicatedAccessStorage shutdown without startup

### DIFF
--- a/src/Access/ReplicatedAccessStorage.cpp
+++ b/src/Access/ReplicatedAccessStorage.cpp
@@ -63,9 +63,12 @@ void ReplicatedAccessStorage::shutdown()
     bool prev_stop_flag = stop_flag.exchange(true);
     if (!prev_stop_flag)
     {
-        /// Notify the worker thread to stop waiting for new queue items
-        refresh_queue.push(UUIDHelpers::Nil);
-        worker_thread.join();
+        if (worker_thread.joinable())
+        {
+            /// Notify the worker thread to stop waiting for new queue items
+            refresh_queue.push(UUIDHelpers::Nil);
+            worker_thread.join();
+        }
     }
 }
 

--- a/src/Access/tests/gtest_replicated_access_storage.cpp
+++ b/src/Access/tests/gtest_replicated_access_storage.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <Access/ReplicatedAccessStorage.h>
+
+using namespace DB;
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int NO_ZOOKEEPER;
+}
+}
+
+
+TEST(ReplicatedAccessStorage, ShutdownWithoutStartup)
+{
+    auto get_zk = []()
+    {
+        return std::shared_ptr<zkutil::ZooKeeper>();
+    };
+
+    auto storage = ReplicatedAccessStorage("replicated", "/clickhouse/access", get_zk);
+    storage.shutdown();
+}
+
+
+TEST(ReplicatedAccessStorage, ShutdownWithFailedStartup)
+{
+    auto get_zk = []()
+    {
+        return std::shared_ptr<zkutil::ZooKeeper>();
+    };
+
+    auto storage = ReplicatedAccessStorage("replicated", "/clickhouse/access", get_zk);
+    try
+    {
+        storage.startup();
+    }
+    catch (Exception & e)
+    {
+        if (e.code() != ErrorCodes::NO_ZOOKEEPER)
+            throw;
+    }
+    storage.shutdown();
+}
+


### PR DESCRIPTION
If ReplicatedAccessStorage startup was not executed or if it failed before completing (for instance when ZooKeeper was not configured), its destructor would call shutdown and try to join a missing thread.

**Changelog category (leave one):**
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

**Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):**
Fix replicated access storage not shutting down cleanly when misconfigured

---
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
