### PR TITLE
rocksdb: fix race condition during multiple DB opening

### DIFF
--- a/tests/integration/test_rocksdb_options/test.py
+++ b/tests/integration/test_rocksdb_options/test.py
@@ -73,3 +73,13 @@ def test_table_valid_column_family_options(start_cluster):
     CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB PRIMARY KEY(key);
     DROP TABLE test;
     """)
+
+def test_table_invalid_column_family_options(start_cluster):
+    node.exec_in_container(['bash', '-c', "sed -i 's/max_bytes_for_level_base/no_such_table_column_family_option/g' /etc/clickhouse-server/config.d/rocksdb.xml"])
+    node.restart_clickhouse()
+    with pytest.raises(QueryRuntimeException):
+        node.query("""
+        CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB PRIMARY KEY(key);
+        """)
+    node.exec_in_container(['bash', '-c', "sed -i 's/no_such_table_column_family_option/max_bytes_for_level_base/g' /etc/clickhouse-server/config.d/rocksdb.xml"])
+    node.restart_clickhouse()

--- a/tests/integration/test_rocksdb_options/test.py
+++ b/tests/integration/test_rocksdb_options/test.py
@@ -58,6 +58,16 @@ def test_valid_column_family_options(start_cluster):
     DROP TABLE test;
     """)
 
+def test_invalid_column_family_options(start_cluster):
+    node.exec_in_container(['bash', '-c', "sed -i 's/num_levels/no_such_column_family_option/g' /etc/clickhouse-server/config.d/rocksdb.xml"])
+    node.restart_clickhouse()
+    with pytest.raises(QueryRuntimeException):
+        node.query("""
+        CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB PRIMARY KEY(key);
+        """)
+    node.exec_in_container(['bash', '-c', "sed -i 's/no_such_column_family_option/num_levels/g' /etc/clickhouse-server/config.d/rocksdb.xml"])
+    node.restart_clickhouse()
+
 def test_table_valid_column_family_options(start_cluster):
     node.query("""
     CREATE TABLE test (key UInt64, value String) Engine=EmbeddedRocksDB PRIMARY KEY(key);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
rocksdb: fix race condition during multiple DB opening (and get back some tests that triggers the problem on CI)

Detailed description / Documentation draft:
This should fix the following SIGSEGV, that was found on CI [1]:

    <Fatal> BaseDaemon: Address: NULL pointer. Access: read. Unknown si_code.
    <Fatal> BaseDaemon: 4.4. inlined from ../contrib/rocksdb/utilities/object_registry.cc:19: rocksdb::ObjectLibrary::FindEntry() const
    ...
    <Fatal> BaseDaemon: 7.3. inlined from ../contrib/rocksdb/options/cf_options.cc:678: rocksdb::$_7::operator()()

  [1]: https://clickhouse-test-reports.s3.yandex.net/29341/2b2bec3679df7965af908ce3f1e8e17e39bd12fe/integration_tests_flaky_check_(asan).html#fail1

And also I checked manually with TSan binary, and here is a data race
reported by TSan:

    WARNING: ThreadSanitizer: data race (pid=3356)
      Read of size 8 at 0x7b0c0008cca8 by thread T40:
        2 rocksdb::ObjectLibrary::FindEntry() const obj-x86_64-linux-gnu/../contrib/rocksdb/utilities/object_registry.cc:18:27 (clickhouse-tsan+0x1b839a6c)
        ...
        6 rocksdb::$_7::operator()() const obj-x86_64-linux-gnu/../contrib/rocksdb/options/cf_options.cc:676:32 (clickhouse-tsan+0x1b6bfa63)
        ...
        28 rocksdb::GetColumnFamilyOptionsFromMap() obj-x86_64-linux-gnu/../contrib/rocksdb/options/options_helper.cc:727:10 (clickhouse-tsan+0x1b6fffd2)
        29 DB::StorageEmbeddedRocksDB::initDb() obj-x86_64-linux-gnu/../src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp:359:26 (clickhouse-tsan+0x14195e31)
        ...

      Previous write of size 8 at 0x7b0c0008cca8 by thread T41:
        ...
        9 rocksdb::ObjectLibrary::AddEntry() obj-x86_64-linux-gnu/../contrib/rocksdb/utilities/object_registry.cc:31:19 (clickhouse-tsan+0x1b8392fc)
        ...
        11 rocksdb::RegisterTableFactories()::$_0::operator()() const obj-x86_64-linux-gnu/../contrib/rocksdb/table/table_factory.cc:23:14 (clickhouse-tsan+0x1b7ea94c)
        ...
        43 rocksdb::GetColumnFamilyOptionsFromMap() obj-x86_64-linux-gnu/../contrib/rocksdb/options/options_helper.cc:727:10 (clickhouse-tsan+0x1b6fffd2)
        44 DB::StorageEmbeddedRocksDB::initDb() obj-x86_64-linux-gnu/../src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp:359:26 (clickhouse-tsan+0x14195e31)

Refs: https://github.com/ClickHouse-Extras/rocksdb/pull/13
Fixes: #29341

*NOTE: I marked it as `Bug fix` but I'm not sure that it is `Bug fix` in your terms*