### PR TITLE
Allow reloading max_concurrent_queries without a server restart

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -859,6 +859,9 @@ if (ThreadFuzzer::instance().isEffective())
             if (config->has("max_partition_size_to_drop"))
                 global_context->setMaxPartitionSizeToDrop(config->getUInt64("max_partition_size_to_drop"));
 
+            if (config->has("max_concurrent_queries"))
+                global_context->getProcessList().setMaxSize(config->getInt("max_concurrent_queries", 0));
+
             if (!initial_loading)
             {
                 /// We do not load ZooKeeper configuration on the first config loading


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Apply config changes to `max_concurrent_queries` during runtime (no need to restart).


Detailed description / Documentation draft:

In some situations (incidents) it's useful to be able to temporarily modify `max_concurrent_queries` without needing to restart the server.