### PR TITLE
Compress keeper snapshots with default ZSTD codec

### DIFF
--- a/src/Coordination/CoordinationSettings.h
+++ b/src/Coordination/CoordinationSettings.h
@@ -16,6 +16,7 @@ struct Settings;
   * and should not be changed by the user without a reason.
   */
 
+
 #define LIST_OF_COORDINATION_SETTINGS(M) \
     M(Milliseconds, session_timeout_ms, Coordination::DEFAULT_SESSION_TIMEOUT_MS, "Default client session timeout", 0) \
     M(Milliseconds, operation_timeout_ms, Coordination::DEFAULT_OPERATION_TIMEOUT_MS, "Default client operation timeout", 0) \
@@ -36,7 +37,8 @@ struct Settings;
     M(UInt64, max_requests_batch_size, 100, "Max size of batch in requests count before it will be sent to RAFT", 0) \
     M(Bool, quorum_reads, false, "Execute read requests as writes through whole RAFT consesus with similar speed", 0) \
     M(Bool, force_sync, true, "Call fsync on each change in RAFT changelog", 0) \
-    M(Bool, compress_logs, true, "Write compressed coordination logs in ZSTD format", 0)
+    M(Bool, compress_logs, true, "Write compressed coordination logs in ZSTD format", 0) \
+    M(Bool, compress_snapshots_with_zstd_format, true, "Write compressed snapshots in ZSTD format (instead of custom LZ4)", 0)
 
 DECLARE_SETTINGS_TRAITS(CoordinationSettingsTraits, LIST_OF_COORDINATION_SETTINGS)
 

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -435,10 +435,10 @@ nuraft::ptr<nuraft::buffer> KeeperSnapshotManager::deserializeSnapshotBufferFrom
     return writer.getBuffer();
 }
 
-nuraft::ptr<nuraft::buffer> KeeperSnapshotManager::serializeSnapshotToBuffer(const KeeperStorageSnapshot & snapshot)
+nuraft::ptr<nuraft::buffer> KeeperSnapshotManager::serializeSnapshotToBuffer(const KeeperStorageSnapshot & snapshot) const
 {
     std::unique_ptr<WriteBufferFromNuraftBuffer> writer = std::make_unique<WriteBufferFromNuraftBuffer>();
-    auto buffer_raw_ptr = writer.get();
+    auto * buffer_raw_ptr = writer.get();
     std::unique_ptr<WriteBuffer> compressed_writer;
     if (compress_snapshots_zstd)
         compressed_writer = wrapWriteBufferWithCompressionMethod(std::move(writer), CompressionMethod::Zstd, 3);
@@ -451,7 +451,7 @@ nuraft::ptr<nuraft::buffer> KeeperSnapshotManager::serializeSnapshotToBuffer(con
 }
 
 
-bool KeeperSnapshotManager::isZstdCompressed(nuraft::ptr<nuraft::buffer> buffer) const
+bool KeeperSnapshotManager::isZstdCompressed(nuraft::ptr<nuraft::buffer> buffer)
 {
     static constexpr uint32_t ZSTD_COMPRESSED_MAGIC = 0xFD2FB528;
     ReadBufferFromNuraftBuffer reader(buffer);

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -10,6 +10,7 @@
 #include <IO/ReadBufferFromFile.h>
 #include <IO/copyData.h>
 #include <filesystem>
+#include <memory>
 
 namespace DB
 {
@@ -32,9 +33,12 @@ namespace
         return parse<uint64_t>(name_parts[1]);
     }
 
-    std::string getSnapshotFileName(uint64_t up_to_log_idx)
+    std::string getSnapshotFileName(uint64_t up_to_log_idx, bool compress_zstd)
     {
-        return std::string{"snapshot_"} + std::to_string(up_to_log_idx) + ".bin";
+        auto base = std::string{"snapshot_"} + std::to_string(up_to_log_idx) + ".bin";
+        if (compress_zstd)
+            base += ".zstd";
+        return base;
     }
 
     std::string getBaseName(const String & path)
@@ -218,6 +222,7 @@ SnapshotMetadataPtr KeeperStorageSnapshot::deserialize(KeeperStorage & storage, 
     storage.zxid = result->get_last_log_idx();
     storage.session_id_counter = session_id;
 
+    /// Before V1 we serialized ACL without acl_map
     if (current_version >= SnapshotVersion::V1)
     {
         size_t acls_map_size;
@@ -338,9 +343,13 @@ KeeperStorageSnapshot::~KeeperStorageSnapshot()
     storage->disableSnapshotMode();
 }
 
-KeeperSnapshotManager::KeeperSnapshotManager(const std::string & snapshots_path_, size_t snapshots_to_keep_, const std::string & superdigest_, size_t storage_tick_time_)
+KeeperSnapshotManager::KeeperSnapshotManager(
+    const std::string & snapshots_path_, size_t snapshots_to_keep_,
+    bool compress_snapshots_zstd_,
+    const std::string & superdigest_, size_t storage_tick_time_)
     : snapshots_path(snapshots_path_)
     , snapshots_to_keep(snapshots_to_keep_)
+    , compress_snapshots_zstd(compress_snapshots_zstd_)
     , superdigest(superdigest_)
     , storage_tick_time(storage_tick_time_)
 {
@@ -380,7 +389,7 @@ std::string KeeperSnapshotManager::serializeSnapshotBufferToDisk(nuraft::buffer 
 {
     ReadBufferFromNuraftBuffer reader(buffer);
 
-    auto snapshot_file_name = getSnapshotFileName(up_to_log_idx);
+    auto snapshot_file_name = getSnapshotFileName(up_to_log_idx, compress_snapshots_zstd);
     auto tmp_snapshot_file_name = "tmp_" + snapshot_file_name;
     std::string tmp_snapshot_path = std::filesystem::path{snapshots_path} / tmp_snapshot_file_name;
     std::string new_snapshot_path = std::filesystem::path{snapshots_path} / snapshot_file_name;
@@ -428,20 +437,44 @@ nuraft::ptr<nuraft::buffer> KeeperSnapshotManager::deserializeSnapshotBufferFrom
 
 nuraft::ptr<nuraft::buffer> KeeperSnapshotManager::serializeSnapshotToBuffer(const KeeperStorageSnapshot & snapshot)
 {
-    WriteBufferFromNuraftBuffer writer;
-    CompressedWriteBuffer compressed_writer(writer);
+    std::unique_ptr<WriteBufferFromNuraftBuffer> writer = std::make_unique<WriteBufferFromNuraftBuffer>();
+    auto buffer_raw_ptr = writer.get();
+    std::unique_ptr<WriteBuffer> compressed_writer;
+    if (compress_snapshots_zstd)
+        compressed_writer = wrapWriteBufferWithCompressionMethod(std::move(writer), CompressionMethod::Zstd, 3);
+    else
+        compressed_writer = std::make_unique<CompressedWriteBuffer>(*writer);
 
-    KeeperStorageSnapshot::serialize(snapshot, compressed_writer);
-    compressed_writer.finalize();
-    return writer.getBuffer();
+    KeeperStorageSnapshot::serialize(snapshot, *compressed_writer);
+    compressed_writer->finalize();
+    return buffer_raw_ptr->getBuffer();
+}
+
+
+bool KeeperSnapshotManager::isZstdCompressed(nuraft::ptr<nuraft::buffer> buffer) const
+{
+    static constexpr uint32_t ZSTD_COMPRESSED_MAGIC = 0xFD2FB528;
+    ReadBufferFromNuraftBuffer reader(buffer);
+    uint32_t magic_from_buffer;
+    reader.readStrict(reinterpret_cast<char *>(&magic_from_buffer), sizeof(magic_from_buffer));
+    buffer->pos(0);
+    return magic_from_buffer == ZSTD_COMPRESSED_MAGIC;
 }
 
 SnapshotMetaAndStorage KeeperSnapshotManager::deserializeSnapshotFromBuffer(nuraft::ptr<nuraft::buffer> buffer) const
 {
-    ReadBufferFromNuraftBuffer reader(buffer);
-    CompressedReadBuffer compressed_reader(reader);
+    bool is_zstd_compressed = isZstdCompressed(buffer);
+
+    std::unique_ptr<ReadBufferFromNuraftBuffer> reader = std::make_unique<ReadBufferFromNuraftBuffer>(buffer);
+    std::unique_ptr<ReadBuffer> compressed_reader;
+
+    if (is_zstd_compressed)
+        compressed_reader = wrapReadBufferWithCompressionMethod(std::move(reader), CompressionMethod::Zstd);
+    else
+        compressed_reader = std::make_unique<CompressedReadBuffer>(*reader);
+
     auto storage = std::make_unique<KeeperStorage>(storage_tick_time, superdigest);
-    auto snapshot_metadata = KeeperStorageSnapshot::deserialize(*storage, compressed_reader);
+    auto snapshot_metadata = KeeperStorageSnapshot::deserialize(*storage, *compressed_reader);
     return std::make_pair(snapshot_metadata, std::move(storage));
 }
 

--- a/src/Coordination/KeeperSnapshotManager.h
+++ b/src/Coordination/KeeperSnapshotManager.h
@@ -79,7 +79,7 @@ public:
     SnapshotMetaAndStorage restoreFromLatestSnapshot();
 
     /// Compress snapshot and serialize it to buffer
-    nuraft::ptr<nuraft::buffer> serializeSnapshotToBuffer(const KeeperStorageSnapshot & snapshot);
+    nuraft::ptr<nuraft::buffer> serializeSnapshotToBuffer(const KeeperStorageSnapshot & snapshot) const;
 
     /// Serialize already compressed snapshot to disk (return path)
     std::string serializeSnapshotBufferToDisk(nuraft::buffer & buffer, uint64_t up_to_log_idx);
@@ -114,7 +114,7 @@ private:
 
     /// Checks first 4 buffer bytes to became sure that snapshot compressed with
     /// ZSTD codec.
-    bool isZstdCompressed(nuraft::ptr<nuraft::buffer> buffer) const;
+    static bool isZstdCompressed(nuraft::ptr<nuraft::buffer> buffer);
 
     const std::string snapshots_path;
     /// How many snapshots to keep before remove

--- a/src/Coordination/KeeperSnapshotManager.h
+++ b/src/Coordination/KeeperSnapshotManager.h
@@ -15,10 +15,19 @@ enum SnapshotVersion : uint8_t
     V0 = 0,
     V1 = 1, /// with ACL map
     V2 = 2, /// with 64 bit buffer header
+    V3 = 3, /// compress snapshots with ZSTD codec
 };
 
-static constexpr auto CURRENT_SNAPSHOT_VERSION = SnapshotVersion::V2;
+static constexpr auto CURRENT_SNAPSHOT_VERSION = SnapshotVersion::V3;
 
+/// In memory keeper snapshot. Keeper Storage based on a hash map which can be
+/// turned into snapshot mode. This operation is fast and KeeperStorageSnapshot
+/// class do it in constructor. It also copies iterators from storage hash table
+/// up to some log index with lock. In destructor this class turn off snapshot
+/// mode for KeeperStorage.
+///
+/// This representation of snapshot have to be serialized into NuRaft
+/// buffer and send over network or saved to file.
 struct KeeperStorageSnapshot
 {
 public:
@@ -34,12 +43,20 @@ public:
     KeeperStorage * storage;
 
     SnapshotVersion version = CURRENT_SNAPSHOT_VERSION;
+    /// Snapshot metadata
     SnapshotMetadataPtr snapshot_meta;
+    /// Max session id
     int64_t session_id;
+    /// Size of snapshot container in amount of nodes after begin iterator
+    /// so we have for loop for (i = 0; i < snapshot_container_size; ++i) { doSmth(begin + i); }
     size_t snapshot_container_size;
+    /// Iterator to the start of the storage
     KeeperStorage::Container::const_iterator begin;
+    /// Active sessions and their timeouts
     SessionAndTimeout session_and_timeout;
+    /// Sessions credentials
     KeeperStorage::SessionAndAuth session_and_auth;
+    /// ACLs cache for better performance. Without we cannot deserialize storage.
     std::unordered_map<uint64_t, Coordination::ACLs> acl_map;
 };
 
@@ -49,28 +66,42 @@ using CreateSnapshotCallback = std::function<void(KeeperStorageSnapshotPtr &&)>;
 
 using SnapshotMetaAndStorage = std::pair<SnapshotMetadataPtr, KeeperStoragePtr>;
 
+/// Class responsible for snapshots serialization and deserialization. Each snapshot
+/// has it's path on disk and log index.
 class KeeperSnapshotManager
 {
 public:
-    KeeperSnapshotManager(const std::string & snapshots_path_, size_t snapshots_to_keep_, const std::string & superdigest_ = "", size_t storage_tick_time_ = 500);
+    KeeperSnapshotManager(
+        const std::string & snapshots_path_, size_t snapshots_to_keep_,
+        bool compress_snapshots_zstd_ = true, const std::string & superdigest_ = "", size_t storage_tick_time_ = 500);
 
+    /// Restore storage from latest available snapshot
     SnapshotMetaAndStorage restoreFromLatestSnapshot();
 
-    static nuraft::ptr<nuraft::buffer> serializeSnapshotToBuffer(const KeeperStorageSnapshot & snapshot);
+    /// Compress snapshot and serialize it to buffer
+    nuraft::ptr<nuraft::buffer> serializeSnapshotToBuffer(const KeeperStorageSnapshot & snapshot);
+
+    /// Serialize already compressed snapshot to disk (return path)
     std::string serializeSnapshotBufferToDisk(nuraft::buffer & buffer, uint64_t up_to_log_idx);
 
     SnapshotMetaAndStorage deserializeSnapshotFromBuffer(nuraft::ptr<nuraft::buffer> buffer) const;
 
+    /// Deserialize snapshot with log index up_to_log_idx from disk into compressed nuraft buffer.
     nuraft::ptr<nuraft::buffer> deserializeSnapshotBufferFromDisk(uint64_t up_to_log_idx) const;
+
+    /// Deserialize latest snapshot from disk into compressed nuraft buffer.
     nuraft::ptr<nuraft::buffer> deserializeLatestSnapshotBufferFromDisk();
 
+    /// Remove snapshot  with this log_index
     void removeSnapshot(uint64_t log_idx);
 
+    /// Total amount of snapshots
     size_t totalSnapshots() const
     {
         return existing_snapshots.size();
     }
 
+    /// The most fresh snapshot log index we have
     size_t getLatestSnapshotIndex() const
     {
         if (!existing_snapshots.empty())
@@ -80,13 +111,28 @@ public:
 
 private:
     void removeOutdatedSnapshotsIfNeeded();
+
+    /// Checks first 4 buffer bytes to became sure that snapshot compressed with
+    /// ZSTD codec.
+    bool isZstdCompressed(nuraft::ptr<nuraft::buffer> buffer) const;
+
     const std::string snapshots_path;
+    /// How many snapshots to keep before remove
     const size_t snapshots_to_keep;
+    /// All existing snapshots in our path (log_index -> path)
     std::map<uint64_t, std::string> existing_snapshots;
+    /// Compress snapshots in common ZSTD format instead of custom ClickHouse block LZ4 format
+    const bool compress_snapshots_zstd;
+    /// Superdigest for deserialization of storage
     const std::string superdigest;
+    /// Storage sessions timeout check interval (also for deserializatopn)
     size_t storage_tick_time;
 };
 
+/// Keeper create snapshots in background thread. KeeperStateMachine just create
+/// in-memory snapshot from storage and push task for it serialization into
+/// special tasks queue. Background thread check this queue and after snapshot
+/// successfully serialized notify state machine.
 struct CreateSnapshotTask
 {
     KeeperStorageSnapshotPtr snapshot;

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -46,7 +46,10 @@ KeeperStateMachine::KeeperStateMachine(
         const CoordinationSettingsPtr & coordination_settings_,
         const std::string & superdigest_)
     : coordination_settings(coordination_settings_)
-    , snapshot_manager(snapshots_path_, coordination_settings->snapshots_to_keep, superdigest_, coordination_settings->dead_session_check_period_ms.totalMicroseconds())
+    , snapshot_manager(
+        snapshots_path_, coordination_settings->snapshots_to_keep,
+        coordination_settings->compress_snapshots_with_zstd_format, superdigest_,
+        coordination_settings->dead_session_check_period_ms.totalMicroseconds())
     , responses_queue(responses_queue_)
     , snapshots_queue(snapshots_queue_)
     , last_committed_idx(0)

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -1469,7 +1469,7 @@ TEST_P(CoordinationTest, TestCompressedLogsMultipleRewrite)
 
 }
 
-TEST_P(CoordinationTest, TestStorageSnapshotDifferenCompressions)
+TEST_P(CoordinationTest, TestStorageSnapshotDifferentCompressions)
 {
     auto params = GetParam();
 

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -1469,14 +1469,12 @@ TEST_P(CoordinationTest, TestCompressedLogsMultipleRewrite)
 
 }
 
-TEST_P(CoordinationTest, TestStorageSnapshotDifferenVersions)
+TEST_P(CoordinationTest, TestStorageSnapshotDifferenCompressions)
 {
     auto params = GetParam();
-    if (!params.enable_compression)
-        return;
 
     ChangelogDirTest test("./snapshots");
-    DB::KeeperSnapshotManager manager("./snapshots", 3, false);
+    DB::KeeperSnapshotManager manager("./snapshots", 3, params.enable_compression);
 
     DB::KeeperStorage storage(500, "");
     addNode(storage, "/hello", "world", 1);
@@ -1492,9 +1490,9 @@ TEST_P(CoordinationTest, TestStorageSnapshotDifferenVersions)
 
     auto buf = manager.serializeSnapshotToBuffer(snapshot);
     manager.serializeSnapshotBufferToDisk(*buf, 2);
-    EXPECT_TRUE(fs::exists("./snapshots/snapshot_2.bin"));
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_2.bin" + params.extension));
 
-    DB::KeeperSnapshotManager new_manager("./snapshots", 3, true);
+    DB::KeeperSnapshotManager new_manager("./snapshots", 3, !params.enable_compression);
 
     auto debuf = new_manager.deserializeSnapshotBufferFromDisk(2);
 

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -934,8 +934,9 @@ void addNode(DB::KeeperStorage & storage, const std::string & path, const std::s
 
 TEST_P(CoordinationTest, TestStorageSnapshotSimple)
 {
+    auto params = GetParam();
     ChangelogDirTest test("./snapshots");
-    DB::KeeperSnapshotManager manager("./snapshots", 3);
+    DB::KeeperSnapshotManager manager("./snapshots", 3, params.enable_compression);
 
     DB::KeeperStorage storage(500, "");
     addNode(storage, "/hello", "world", 1);
@@ -956,7 +957,7 @@ TEST_P(CoordinationTest, TestStorageSnapshotSimple)
 
     auto buf = manager.serializeSnapshotToBuffer(snapshot);
     manager.serializeSnapshotBufferToDisk(*buf, 2);
-    EXPECT_TRUE(fs::exists("./snapshots/snapshot_2.bin"));
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_2.bin" + params.extension));
 
 
     auto debuf = manager.deserializeSnapshotBufferFromDisk(2);
@@ -981,8 +982,9 @@ TEST_P(CoordinationTest, TestStorageSnapshotSimple)
 
 TEST_P(CoordinationTest, TestStorageSnapshotMoreWrites)
 {
+    auto params = GetParam();
     ChangelogDirTest test("./snapshots");
-    DB::KeeperSnapshotManager manager("./snapshots", 3);
+    DB::KeeperSnapshotManager manager("./snapshots", 3, params.enable_compression);
 
     DB::KeeperStorage storage(500, "");
     storage.getSessionID(130);
@@ -1005,7 +1007,7 @@ TEST_P(CoordinationTest, TestStorageSnapshotMoreWrites)
 
     auto buf = manager.serializeSnapshotToBuffer(snapshot);
     manager.serializeSnapshotBufferToDisk(*buf, 50);
-    EXPECT_TRUE(fs::exists("./snapshots/snapshot_50.bin"));
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_50.bin" + params.extension));
 
 
     auto debuf = manager.deserializeSnapshotBufferFromDisk(50);
@@ -1021,8 +1023,9 @@ TEST_P(CoordinationTest, TestStorageSnapshotMoreWrites)
 
 TEST_P(CoordinationTest, TestStorageSnapshotManySnapshots)
 {
+    auto params = GetParam();
     ChangelogDirTest test("./snapshots");
-    DB::KeeperSnapshotManager manager("./snapshots", 3);
+    DB::KeeperSnapshotManager manager("./snapshots", 3, params.enable_compression);
 
     DB::KeeperStorage storage(500, "");
     storage.getSessionID(130);
@@ -1037,14 +1040,14 @@ TEST_P(CoordinationTest, TestStorageSnapshotManySnapshots)
         DB::KeeperStorageSnapshot snapshot(&storage, j * 50);
         auto buf = manager.serializeSnapshotToBuffer(snapshot);
         manager.serializeSnapshotBufferToDisk(*buf, j * 50);
-        EXPECT_TRUE(fs::exists(std::string{"./snapshots/snapshot_"} + std::to_string(j * 50) + ".bin"));
+        EXPECT_TRUE(fs::exists(std::string{"./snapshots/snapshot_"} + std::to_string(j * 50) + ".bin" + params.extension));
     }
 
-    EXPECT_FALSE(fs::exists("./snapshots/snapshot_50.bin"));
-    EXPECT_FALSE(fs::exists("./snapshots/snapshot_100.bin"));
-    EXPECT_TRUE(fs::exists("./snapshots/snapshot_150.bin"));
-    EXPECT_TRUE(fs::exists("./snapshots/snapshot_200.bin"));
-    EXPECT_TRUE(fs::exists("./snapshots/snapshot_250.bin"));
+    EXPECT_FALSE(fs::exists("./snapshots/snapshot_50.bin" + params.extension));
+    EXPECT_FALSE(fs::exists("./snapshots/snapshot_100.bin" + params.extension));
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_150.bin" + params.extension));
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_200.bin" + params.extension));
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_250.bin" + params.extension));
 
 
     auto [meta, restored_storage] = manager.restoreFromLatestSnapshot();
@@ -1059,8 +1062,9 @@ TEST_P(CoordinationTest, TestStorageSnapshotManySnapshots)
 
 TEST_P(CoordinationTest, TestStorageSnapshotMode)
 {
+    auto params = GetParam();
     ChangelogDirTest test("./snapshots");
-    DB::KeeperSnapshotManager manager("./snapshots", 3);
+    DB::KeeperSnapshotManager manager("./snapshots", 3, params.enable_compression);
     DB::KeeperStorage storage(500, "");
     for (size_t i = 0; i < 50; ++i)
     {
@@ -1087,7 +1091,7 @@ TEST_P(CoordinationTest, TestStorageSnapshotMode)
         auto buf = manager.serializeSnapshotToBuffer(snapshot);
         manager.serializeSnapshotBufferToDisk(*buf, 50);
     }
-    EXPECT_TRUE(fs::exists("./snapshots/snapshot_50.bin"));
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_50.bin" + params.extension));
     EXPECT_EQ(storage.container.size(), 26);
     storage.clearGarbageAfterSnapshot();
     EXPECT_EQ(storage.container.snapshotSize(), 26);
@@ -1110,8 +1114,9 @@ TEST_P(CoordinationTest, TestStorageSnapshotMode)
 
 TEST_P(CoordinationTest, TestStorageSnapshotBroken)
 {
+    auto params = GetParam();
     ChangelogDirTest test("./snapshots");
-    DB::KeeperSnapshotManager manager("./snapshots", 3);
+    DB::KeeperSnapshotManager manager("./snapshots", 3, params.enable_compression);
     DB::KeeperStorage storage(500, "");
     for (size_t i = 0; i < 50; ++i)
     {
@@ -1122,10 +1127,10 @@ TEST_P(CoordinationTest, TestStorageSnapshotBroken)
         auto buf = manager.serializeSnapshotToBuffer(snapshot);
         manager.serializeSnapshotBufferToDisk(*buf, 50);
     }
-    EXPECT_TRUE(fs::exists("./snapshots/snapshot_50.bin"));
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_50.bin" + params.extension));
 
     /// Let's corrupt file
-    DB::WriteBufferFromFile plain_buf("./snapshots/snapshot_50.bin", DBMS_DEFAULT_BUFFER_SIZE, O_APPEND | O_CREAT | O_WRONLY);
+    DB::WriteBufferFromFile plain_buf("./snapshots/snapshot_50.bin" + params.extension, DBMS_DEFAULT_BUFFER_SIZE, O_APPEND | O_CREAT | O_WRONLY);
     plain_buf.truncate(34);
     plain_buf.sync();
 
@@ -1463,6 +1468,54 @@ TEST_P(CoordinationTest, TestCompressedLogsMultipleRewrite)
     }
 
 }
+
+TEST_P(CoordinationTest, TestStorageSnapshotDifferenVersions)
+{
+    auto params = GetParam();
+    if (!params.enable_compression)
+        return;
+
+    ChangelogDirTest test("./snapshots");
+    DB::KeeperSnapshotManager manager("./snapshots", 3, false);
+
+    DB::KeeperStorage storage(500, "");
+    addNode(storage, "/hello", "world", 1);
+    addNode(storage, "/hello/somepath", "somedata", 3);
+    storage.session_id_counter = 5;
+    storage.zxid = 2;
+    storage.ephemerals[3] = {"/hello"};
+    storage.ephemerals[1] = {"/hello/somepath"};
+    storage.getSessionID(130);
+    storage.getSessionID(130);
+
+    DB::KeeperStorageSnapshot snapshot(&storage, 2);
+
+    auto buf = manager.serializeSnapshotToBuffer(snapshot);
+    manager.serializeSnapshotBufferToDisk(*buf, 2);
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_2.bin"));
+
+    DB::KeeperSnapshotManager new_manager("./snapshots", 3, true);
+
+    auto debuf = new_manager.deserializeSnapshotBufferFromDisk(2);
+
+    auto [snapshot_meta, restored_storage] = new_manager.deserializeSnapshotFromBuffer(debuf);
+
+    EXPECT_EQ(restored_storage->container.size(), 3);
+    EXPECT_EQ(restored_storage->container.getValue("/").children.size(), 1);
+    EXPECT_EQ(restored_storage->container.getValue("/hello").children.size(), 1);
+    EXPECT_EQ(restored_storage->container.getValue("/hello/somepath").children.size(), 0);
+
+    EXPECT_EQ(restored_storage->container.getValue("/").data, "");
+    EXPECT_EQ(restored_storage->container.getValue("/hello").data, "world");
+    EXPECT_EQ(restored_storage->container.getValue("/hello/somepath").data, "somedata");
+    EXPECT_EQ(restored_storage->session_id_counter, 7);
+    EXPECT_EQ(restored_storage->zxid, 2);
+    EXPECT_EQ(restored_storage->ephemerals.size(), 2);
+    EXPECT_EQ(restored_storage->ephemerals[3].size(), 1);
+    EXPECT_EQ(restored_storage->ephemerals[1].size(), 1);
+    EXPECT_EQ(restored_storage->session_and_timeout.size(), 2);
+}
+
 
 INSTANTIATE_TEST_SUITE_P(CoordinationTestSuite,
     CoordinationTest,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now ClickHouse Keeper snapshots compressed with `ZSTD` codec by default instead of custom ClickHouse LZ4 block compression. This behavior can be turned off with `compress_snapshots_with_zstd_format` coordination setting (must be equal on all quorum replicas). Backward incompatibility is quite rare and may happen only when new node will send snapshot (happens in case of recovery) to the old node which is unable to read snapshots in ZSTD format. 