### PR TITLE
Implemented creating databases with comments

### DIFF
--- a/src/Databases/DatabaseDictionary.cpp
+++ b/src/Databases/DatabaseDictionary.cpp
@@ -126,6 +126,8 @@ ASTPtr DatabaseDictionary::getCreateDatabaseQuery() const
     {
         WriteBufferFromString buffer(query);
         buffer << "CREATE DATABASE " << backQuoteIfNeed(getDatabaseName()) << " ENGINE = Dictionary";
+        if (const auto comment_value = getDatabaseComment(); !comment_value.empty())
+            buffer << " COMMENT " << backQuote(comment_value);
     }
     auto settings = getContext()->getSettingsRef();
     ParserCreateQuery parser;

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -78,8 +78,11 @@ DatabasePtr DatabaseFactory::get(const ASTCreateQuery & create, const String & m
         if (impl && context->hasQueryContext() && context->getSettingsRef().log_queries)
             context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Database, impl->getEngineName());
 
-        return impl;
+        // Attach database metadata
+        if (impl && create.storage && create.storage->comment)
+            impl->setDatabaseComment(create.storage->comment->as<ASTLiteral>()->value.safeGet<String>());
 
+        return impl;
     }
     catch (...)
     {

--- a/src/Databases/DatabaseMemory.cpp
+++ b/src/Databases/DatabaseMemory.cpp
@@ -69,6 +69,10 @@ ASTPtr DatabaseMemory::getCreateDatabaseQuery() const
     create_query->database = getDatabaseName();
     create_query->set(create_query->storage, std::make_shared<ASTStorage>());
     create_query->storage->set(create_query->storage->engine, makeASTFunction(getEngineName()));
+
+    if (const auto comment_value = getDatabaseComment(); !comment_value.empty())
+        create_query->storage->set(create_query->storage->comment, std::make_shared<ASTLiteral>(comment_value));
+
     return create_query;
 }
 

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -259,6 +259,17 @@ public:
     /// Get the CREATE DATABASE query for current database.
     virtual ASTPtr getCreateDatabaseQuery() const = 0;
 
+    String getDatabaseComment() const
+    {
+        std::lock_guard lock{mutex};
+        return comment;
+    }
+    void setDatabaseComment(String new_comment)
+    {
+        std::lock_guard lock{mutex};
+        comment = std::move(new_comment);
+    }
+
     /// Get name of database.
     String getDatabaseName() const
     {
@@ -324,6 +335,7 @@ protected:
 
     mutable std::mutex mutex;
     String database_name;
+    String comment;
 };
 
 using DatabasePtr = std::shared_ptr<IDatabase>;

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -196,6 +196,10 @@ ASTPtr DatabaseMySQL::getCreateDatabaseQuery() const
     const auto & create_query = std::make_shared<ASTCreateQuery>();
     create_query->database = getDatabaseName();
     create_query->set(create_query->storage, database_engine_define);
+
+    if (const auto comment_value = getDatabaseComment(); !comment_value.empty())
+        create_query->storage->set(create_query->storage->comment, std::make_shared<ASTLiteral>(comment_value));
+
     return create_query;
 }
 

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -347,6 +347,10 @@ ASTPtr DatabasePostgreSQL::getCreateDatabaseQuery() const
     const auto & create_query = std::make_shared<ASTCreateQuery>();
     create_query->database = getDatabaseName();
     create_query->set(create_query->storage, database_engine_define);
+
+    if (const auto comment_value = getDatabaseComment(); !comment_value.empty())
+        create_query->storage->set(create_query->storage->comment, std::make_shared<ASTLiteral>(comment_value));
+
     return create_query;
 }
 

--- a/src/Databases/SQLite/DatabaseSQLite.cpp
+++ b/src/Databases/SQLite/DatabaseSQLite.cpp
@@ -162,6 +162,10 @@ ASTPtr DatabaseSQLite::getCreateDatabaseQuery() const
     const auto & create_query = std::make_shared<ASTCreateQuery>();
     create_query->database = getDatabaseName();
     create_query->set(create_query->storage, database_engine_define);
+
+    if (const auto comment_value = getDatabaseComment(); !comment_value.empty())
+        create_query->storage->set(create_query->storage->comment, std::make_shared<ASTLiteral>(comment_value));
+
     return create_query;
 }
 

--- a/src/Storages/System/StorageSystemDatabases.cpp
+++ b/src/Storages/System/StorageSystemDatabases.cpp
@@ -17,6 +17,7 @@ NamesAndTypesList StorageSystemDatabases::getNamesAndTypes()
         {"data_path", std::make_shared<DataTypeString>()},
         {"metadata_path", std::make_shared<DataTypeString>()},
         {"uuid", std::make_shared<DataTypeUUID>()},
+        {"comment", std::make_shared<DataTypeString>()}
     };
 }
 
@@ -39,6 +40,7 @@ void StorageSystemDatabases::fillData(MutableColumns & res_columns, ContextPtr c
         res_columns[2]->insert(context->getPath() + database->getDataPath());
         res_columns[3]->insert(database->getMetadataPath());
         res_columns[4]->insert(database->getUUID());
+        res_columns[5]->insert(database->getDatabaseComment());
    }
 }
 

--- a/tests/queries/0_stateless/02021_create_database_with_comment.reference
+++ b/tests/queries/0_stateless/02021_create_database_with_comment.reference
@@ -1,0 +1,16 @@
+engine : Atomic
+CREATE DATABASE default\nENGINE = Atomic\nCOMMENT \'Test DB with comment\'
+comment=	Test DB with comment
+
+engine : Ordinary
+CREATE DATABASE default\nENGINE = Ordinary\nCOMMENT \'Test DB with comment\'
+comment=	Test DB with comment
+
+engine : Lazy(1)
+CREATE DATABASE default\nENGINE = Lazy(1)\nCOMMENT \'Test DB with comment\'
+comment=	Test DB with comment
+
+engine : Memory
+CREATE DATABASE default\nENGINE = Memory()\nCOMMENT \'Test DB with comment\'
+comment=	Test DB with comment
+

--- a/tests/queries/0_stateless/02021_create_database_with_comment.sh
+++ b/tests/queries/0_stateless/02021_create_database_with_comment.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+DB_NAME="${CLICKHOUSE_DATABASE}"
+
+function get_db_comment_info()
+{
+    $CLICKHOUSE_CLIENT --query="SHOW CREATE DATABASE ${DB_NAME};"
+    $CLICKHOUSE_CLIENT --query="SELECT 'comment=', comment FROM system.databases WHERE name='${DB_NAME}'"
+    echo # just a newline
+}
+
+function test_db_comments()
+{
+    local ENGINE_NAME="$1"
+    echo "engine : ${ENGINE_NAME}"
+
+    $CLICKHOUSE_CLIENT -nm <<EOF
+DROP DATABASE IF EXISTS ${DB_NAME};
+CREATE DATABASE ${DB_NAME} ENGINE = ${ENGINE_NAME} COMMENT 'Test DB with comment';
+EOF
+
+    get_db_comment_info
+}
+
+# For some reason order seems important, putting Atomic after Memory makes test fail every time
+#  due to DB metadata SQL file still being present after "DROP DATABASE"
+test_db_comments "Atomic"
+test_db_comments "Ordinary"
+test_db_comments "Lazy(1)"
+test_db_comments "Memory"
+# test_db_comments "MySQL('127.0.0.1:9004', 'default', 'default', '')" # fails due to CH internal reasons
+# test_db_comments "SQLite('dummy_sqlitedb')"
+## needs to be explicitly enabled with `SET allow_experimental_database_replicated=1`
+# test_db_comments "Replicated('/clickhouse/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX', '1') ORDER BY k"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Users now can set comments to database in `CREATE DATABASE` statement
...


Detailed description / Documentation draft:
...