### PR TITLE
Fix flaky test 01158_zookeeper_log_long

### DIFF
--- a/tests/queries/0_stateless/01158_zookeeper_log_long.sql
+++ b/tests/queries/0_stateless/01158_zookeeper_log_long.sql
@@ -4,7 +4,7 @@
 drop table if exists rmt;
 -- cleanup code will perform extra Exists
 -- (so the .reference will not match)
-create table rmt (n int) engine=ReplicatedMergeTree('/test/01158/{database}/rmt', '1') order by n settings cleanup_delay_period=86400;
+create table rmt (n int) engine=ReplicatedMergeTree('/test/01158/{database}/rmt', '1') order by n settings cleanup_delay_period=86400, replicated_can_become_leader=0;
 system sync replica rmt;
 insert into rmt values (1);
 insert into rmt values (1);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
```
2021-09-25 00:59:35 01158_zookeeper_log_long:                                               [ FAIL ] 5.32 sec. - result differs with reference: 
2021-09-25 00:59:35 --- /usr/share/clickhouse-test/queries/0_stateless/01158_zookeeper_log_long.reference	2021-09-25 00:07:35.000000000 +0000
2021-09-25 00:59:35 +++ /tmp/clickhouse-test/0_stateless/01158_zookeeper_log_long.stdout	2021-09-25 00:59:35.376867585 +0000
2021-09-25 00:59:35 @@ -38,3 +38,5 @@
2021-09-25 00:59:35  Response	0	Error	/test/01158/default/rmt/temp/abandonable_lock-	1	1	\N	0	3	ZRUNTIMEINCONSISTENCY	\N	\N		0	0	0	0
2021-09-25 00:59:35  Request	0	Get	/test/01158/default/rmt/blocks/all_6308706741995381342_2495791770474910886	0	0	\N	0	0	\N	\N	\N		0	0	0	0
2021-09-25 00:59:35  Response	0	Get	/test/01158/default/rmt/blocks/all_6308706741995381342_2495791770474910886	0	0	\N	0	0	ZOK	\N	\N		0	0	9	0
2021-09-25 00:59:35 +Request	0	Exists	/test/01158/default/rmt/blocks/all_6308706741995381342_2495791770474910886	0	0	\N	0	0	\N	\N	\N		0	0	0	0
2021-09-25 00:59:35 +Response	0	Exists	/test/01158/default/rmt/blocks/all_6308706741995381342_2495791770474910886	0	0	\N	0	0	ZOK	\N	\N		0	0	9	0
```
