### PR TITLE
Transform isNull/isNotNull to IS NULL/IS NOT NULL (for external dbs)

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -217,16 +217,19 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
         settings.ostr << nl_or_nothing << indent_str << ")";
         return;
     }
+
     /// Should this function to be written as operator?
     bool written = false;
+
     if (arguments && !parameters)
     {
+        /// Unary prefix operators.
         if (arguments->children.size() == 1)
         {
             const char * operators[] =
             {
-                "negate", "-",
-                "not", "NOT ",
+                "negate",      "-",
+                "not",         "NOT ",
                 nullptr
             };
 
@@ -265,6 +268,32 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
 
                 if (need_parens)
                     settings.ostr << ')';
+
+                break;
+            }
+        }
+
+        /// Unary postfix operators.
+        if (!written && arguments->children.size() == 1)
+        {
+            const char * operators[] =
+            {
+                "isNull",          " IS NULL",
+                "isNotNull",       " IS NOT NULL",
+                nullptr
+            };
+
+            for (const char ** func = operators; *func; func += 2)
+            {
+                if (strcasecmp(name.c_str(), func[0]) != 0)
+                {
+                    continue;
+                }
+
+                arguments->formatImpl(settings, state, nested_need_parens);
+                settings.ostr << (settings.hilite ? hilite_operator : "") << func[1] << (settings.hilite ? hilite_none : "");
+
+                written = true;
 
                 break;
             }

--- a/tests/queries/0_stateless/00826_cross_to_inner_join.reference
+++ b/tests/queries/0_stateless/00826_cross_to_inner_join.reference
@@ -146,7 +146,7 @@ SELECT
     t2_00826.b
 FROM t1_00826
 ALL INNER JOIN t2_00826 ON b = t2_00826.a
-WHERE (b = t2_00826.a) AND (isNull(t2_00826.b) OR (t2_00826.b > t2_00826.a))
+WHERE (b = t2_00826.a) AND (t2_00826.b IS NULL OR (t2_00826.b > t2_00826.a))
 --- do not rewrite alias ---
 SELECT a AS b
 FROM t1_00826
@@ -178,4 +178,4 @@ SELECT
     t2_00826.b
 FROM t1_00826
 ALL INNER JOIN t2_00826 ON a = t2_00826.a
-WHERE (a = t2_00826.a) AND (isNull(t2_00826.b) OR (t2_00826.b < 2))
+WHERE (a = t2_00826.a) AND (t2_00826.b IS NULL OR (t2_00826.b < 2))

--- a/tests/queries/0_stateless/01872_functions_to_subcolumns.reference
+++ b/tests/queries/0_stateless/01872_functions_to_subcolumns.reference
@@ -1,7 +1,7 @@
 0	0	1
 0	1	0
 SELECT
-    isNull(id),
+    id IS NULL,
     `n.null`,
     NOT `n.null`
 FROM t_func_to_subcolumns
@@ -31,7 +31,7 @@ FROM t_func_to_subcolumns
 SELECT
     id,
     `n.null`,
-    isNull(right.n)
+    right.n IS NULL
 FROM t_func_to_subcolumns AS left
 ALL FULL OUTER JOIN
 (

--- a/tests/queries/0_stateless/02035_isNull_isNotNull_format.reference
+++ b/tests/queries/0_stateless/02035_isNull_isNotNull_format.reference
@@ -1,0 +1,9 @@
+-- { echo }
+explain syntax select null is null;
+SELECT NULL IS NULL
+explain syntax select null is not null;
+SELECT NULL IS NOT NULL
+explain syntax select isNull(null);
+SELECT NULL IS NULL
+explain syntax select isNotNull(null);
+SELECT NULL IS NOT NULL

--- a/tests/queries/0_stateless/02035_isNull_isNotNull_format.sql
+++ b/tests/queries/0_stateless/02035_isNull_isNotNull_format.sql
@@ -1,0 +1,5 @@
+-- { echo }
+explain syntax select null is null;
+explain syntax select null is not null;
+explain syntax select isNull(null);
+explain syntax select isNotNull(null);


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Transform `isNull`/`isNotNull` to `IS NULL`/`IS NOT NULL` (for external dbs, i.e. MySQL)

Detailed description / Documentation draft:
This is required to support queries (like `foo IS NULL`/`foo IS NOT NULL`) to external databases (i.e. MySQL).

This patch had been submitted separately, due to:
- avoid mixing patches
- run CI (and update tests references)

*NOTE: that it may introduce backward compatibility, but none of users should rely on this anyway (hopefully)*