### PR TITLE
clickhouse-test: fix long tag check for flaky check (--test-runs > 1)

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -465,7 +465,7 @@ class TestCase:
             description += "\n{}\n".format(diff)
             return TestResult(self.name, TestStatus.FAIL, FailureReason.RESULT_DIFF, total_time, description)
 
-        if self.testcase_args.test_runs > 1 and total_time > 60 and 'long' not in self.name:
+        if self.testcase_args.test_runs > 1 and total_time > 60 and 'long' not in self.tags:
             # We're in Flaky Check mode, check the run time as well while we're at it.
             return TestResult(self.name, TestStatus.FAIL, FailureReason.TOO_LONG, total_time, description)
 


### PR DESCRIPTION
Otherwise it will mark the test as failed, like in [1].

  [1]: https://clickhouse-test-reports.s3.yandex.net/29369/2320be204397bbb9f9a673cf093b7967fd37a107/functional_stateless_tests_flaky_check_(address).html#fail1

Follow-up for: #28909 (Cc: @vitlibar)

Changelog category (leave one):
- Not for changelog (changelog entry is not required)