### PR TITLE
Enable memory profiler on CI

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -46,6 +46,7 @@ ln -sf $SRC_PATH/users.d/database_atomic_drop_detach_sync.xml $DEST_SERVER_PATH/
 ln -sf $SRC_PATH/users.d/opentelemetry.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/remote_queries.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/session_log_test.xml $DEST_SERVER_PATH/users.d/
+ln -sf $SRC_PATH/users.d/memory_profiler.xml $DEST_SERVER_PATH/users.d/
 
 # FIXME DataPartsExchange may hang for http_send_timeout seconds
 # when nobody is going to read from the other side of socket (due to "Fetching of part was cancelled"),

--- a/tests/config/users.d/memory_profiler.xml
+++ b/tests/config/users.d/memory_profiler.xml
@@ -1,0 +1,8 @@
+<yandex>
+    <profiles>
+        <default>
+            <max_untracked_memory>1Mi</max_untracked_memory>
+            <memory_profiler_step>1Mi</memory_profiler_step>
+        </default>
+    </profiles>
+</yandex>

--- a/tests/queries/0_stateless/01293_show_settings.reference
+++ b/tests/queries/0_stateless/01293_show_settings.reference
@@ -3,3 +3,5 @@ connect_timeout	Seconds	10
 connect_timeout_with_failover_ms	Milliseconds	2000
 connect_timeout_with_failover_secure_ms	Milliseconds	3000
 max_memory_usage	UInt64	10000000000
+max_untracked_memory	UInt64	1048576
+memory_profiler_step	UInt64	1048576

--- a/tests/queries/0_stateless/01656_test_query_log_factories_info.sql
+++ b/tests/queries/0_stateless/01656_test_query_log_factories_info.sql
@@ -17,7 +17,7 @@ SELECT uniqArray([1, 1, 2]),
        toDayOfYear(d) % 2)
 FROM numbers(100);
 
-SELECT repeat('a', number)
+SELECT repeat('aa', number)
 FROM numbers(10e3)
 SETTINGS max_memory_usage=4e6, max_block_size=100
 FORMAT Null; -- { serverError 241 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This maybe useful to debug various issues with tests that depends on memory tracking.