### PR TITLE
Increase operation_timeout_ms for database_replicated tests

### DIFF
--- a/tests/config/config.d/database_replicated.xml
+++ b/tests/config/config.d/database_replicated.xml
@@ -12,6 +12,7 @@
             <host>localhost</host>
             <port>29181</port>
         </node>
+        <operation_timeout_ms>20000</operation_timeout_ms>
     </zookeeper>
 
     <keeper_server>
@@ -19,7 +20,7 @@
         <server_id>1</server_id>
 
         <coordination_settings>
-            <operation_timeout_ms>10000</operation_timeout_ms>
+            <operation_timeout_ms>20000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
             <heart_beat_interval_ms>1000</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>4000</election_timeout_lower_bound_ms>


### PR DESCRIPTION
CI reports [1]:

<details>
    2021.09.28 09:49:37.205294 [ 640 ] {} <Test> KeeperStateMachine: Commit request for session 5 with type Remove, log id 770498, path /test/01154_move_partition_long_test_kue21q/s1/src/replicas/r2_1264626517/queue/queue-0000000321
    2021.09.28 09:49:37.267731 [ 586 ] {} <Trace> KeeperTCPHandler: Received heartbeat for session #2
    2021.09.28 09:49:39.610989 [ 667 ] {} <Trace> SystemLog (system.asynchronous_metric_log): Flushing system log, 5796 entries to flush up to offset 3494292
    2021.09.28 09:49:43.081774 [ 591 ] {} <Trace> KeeperTCPHandler: Received heartbeat for session #4
    2021.09.28 09:49:43.580865 [ 658 ] {} <Trace> SystemLog (system.query_thread_log): Flushing system log, 1 entries to flush up to offset 22082
    2021.09.28 09:49:43.681288 [ 654 ] {} <Trace> SystemLog (system.query_log): Flushing system log, 1 entries to flush up to offset 43707
    2021.09.28 09:49:44.034109 [ 919 ] {} <Debug> system.asynchronous_metric_log (bb13afbb-543d-4730-bb13-afbb543d9730) (MergerMutator): Selected 5 parts from 202109_596_596_0 to 202109_600_600_0
    2021.09.28 09:49:48.835504 [ 586 ] {} <Information> KeeperTCPHandler: Got exception processing session #2: Code: 210. DB::NetException: I/O error: Broken pipe, while writing to socket ([::1]:55544). (NETWORK_ERROR), Stack trace (...)

    0. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x94fe394 in /usr/lib/debug/.build-id/69/a5fe716478bb310e86532ade0d971b828da8f9.debug
    1. DB::WriteBufferFromPocoSocket::nextImpl() @ 0x10e0a77c in /usr/lib/debug/.build-id/69/a5fe716478bb310e86532ade0d971b828da8f9.debug
    2. Coordination::ZooKeeperResponse::write(DB::WriteBuffer&) const @ 0x12316383 in /usr/lib/debug/.build-id/69/a5fe716478bb310e86532ade0d971b828da8f9.debug
    3. DB::KeeperTCPHandler::runImpl() @ 0x11ef877d in /usr/lib/debug/.build-id/69/a5fe716478bb310e86532ade0d971b828da8f9.debug
    4. Poco::Net::TCPServerConnection::start() @ 0x14b5aa2f in /usr/lib/debug/.build-id/69/a5fe716478bb310e86532ade0d971b828da8f9.debug
    5. Poco::Net::TCPServerDispatcher::run() @ 0x14b5ce21 in /usr/lib/debug/.build-id/69/a5fe716478bb310e86532ade0d971b828da8f9.debug
    6. Poco::PooledThread::run() @ 0x14c715c9 in /usr/lib/debug/.build-id/69/a5fe716478bb310e86532ade0d971b828da8f9.debug
    7. Poco::ThreadImpl::runnableEntry(void*) @ 0x14c6ed00 in /usr/lib/debug/.build-id/69/a5fe716478bb310e86532ade0d971b828da8f9.debug
    8. start_thread @ 0x9609 in /usr/lib/x86_64-linux-gnu/libpthread-2.31.so
    9. __clone @ 0x122293 in /usr/lib/x86_64-linux-gnu/libc-2.31.so
</details>

  [1]: https://clickhouse-test-reports.s3.yandex.net/28760/20bdda60084621a2589cc45303d0fb2de0f33f5a/functional_stateless_tests_(release,_databasereplicated).html#fail1

And according to logs seems that it requires a little bit higher timeout
in this case (I tried to look at trace_log, but keeper threads are not
traceable).

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @tavplubix 