### PR TITLE
Add support for IS NULL/IS NOT NULL for external dbs (i.e. MySQL)

### DIFF
--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -249,3 +249,22 @@ TEST(TransformQueryForExternalDatabase, Strict)
     /// !isCompatible() takes place
     EXPECT_THROW(check(state, 1, "SELECT column FROM test.table WHERE left(column, 10) = RIGHT(column, 10) AND SUBSTRING(column FROM 1 FOR 2) = 'Hello'", ""), Exception);
 }
+
+TEST(TransformQueryForExternalDatabase, Null)
+{
+    const State & state = State::instance();
+
+    check(state, 1,
+          "SELECT field FROM table WHERE field IS NULL",
+          R"(SELECT "field" FROM "test"."table" WHERE "field" IS NULL)");
+    check(state, 1,
+          "SELECT field FROM table WHERE field IS NOT NULL",
+          R"(SELECT "field" FROM "test"."table" WHERE "field" IS NOT NULL)");
+
+    check(state, 1,
+          "SELECT field FROM table WHERE isNull(field)",
+          R"(SELECT "field" FROM "test"."table" WHERE "field" IS NULL)");
+    check(state, 1,
+          "SELECT field FROM table WHERE isNotNull(field)",
+          R"(SELECT "field" FROM "test"."table" WHERE "field" IS NOT NULL)");
+}

--- a/src/Storages/transformQueryForExternalDatabase.cpp
+++ b/src/Storages/transformQueryForExternalDatabase.cpp
@@ -132,6 +132,8 @@ bool isCompatible(IAST & node)
             || name == "notLike"
             || name == "in"
             || name == "notIn"
+            || name == "isNull"
+            || name == "isNotNull"
             || name == "tuple"))
             return false;
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for `IS NULL`/`IS NOT NULL` for external dbs (i.e. MySQL)