### PR TITLE
[github] we're switching to CLA based on Apache CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
-
 Changelog category (leave one):
 - New Feature
 - Improvement


### PR DESCRIPTION
CLA signing is automated with CLA Assistant.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
