### PR TITLE
Fix possible hang in PushingAsyncPipelineExecutor.

### DIFF
--- a/src/Processors/Executors/PushingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PushingAsyncPipelineExecutor.cpp
@@ -41,6 +41,7 @@ public:
 
     void finish()
     {
+        std::unique_lock lock(mutex);
         is_finished = true;
         condvar.notify_all();
     }
@@ -64,7 +65,7 @@ protected:
 private:
     Chunk data;
     bool has_data = false;
-    std::atomic_bool is_finished = false;
+    bool is_finished = false;
     std::mutex mutex;
     std::condition_variable condvar;
 };


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://clickhouse-test-reports.s3.yandex.net/0/8eaff1a02d473d16b8941af5191a7f0ebe6210fd/functional_stateless_tests_(release,_wide_parts_enabled).html#fail1