### PR TITLE
Use `max_parse_depth` in fuzzers

### DIFF
--- a/src/Parsers/fuzzers/create_parser_fuzzer.cpp
+++ b/src/Parsers/fuzzers/create_parser_fuzzer.cpp
@@ -13,7 +13,7 @@ try
     std::string input = std::string(reinterpret_cast<const char*>(data), size);
 
     DB::ParserCreateQuery parser;
-    DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, 0);
+    DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, 1000);
 
     DB::WriteBufferFromOwnString wb;
     DB::formatAST(*ast, wb);

--- a/src/Parsers/fuzzers/select_parser_fuzzer.cpp
+++ b/src/Parsers/fuzzers/select_parser_fuzzer.cpp
@@ -12,7 +12,7 @@ try
     std::string input = std::string(reinterpret_cast<const char*>(data), size);
 
     DB::ParserQueryWithOutput parser(input.data() + input.size());
-    DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, 0);
+    DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, 1000);
 
     DB::WriteBufferFromOwnString wb;
     DB::formatAST(*ast, wb);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In ClickHouse itself we have `max_parse_depth` = 1000. 