### PR TITLE
Fix LOGICAL_ERROR for INSERT with concurrent ALTER

### DIFF
--- a/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -348,7 +348,7 @@ Chain buildPushingToViewsChain(
     /// Do not push to destination table if the flag is set
     else if (!no_destination)
     {
-        auto sink = storage->write(query_ptr, storage->getInMemoryMetadataPtr(), context);
+        auto sink = storage->write(query_ptr, metadata_snapshot, context);
         metadata_snapshot->check(sink->getHeader().getColumnsWithTypeAndName());
         sink->setRuntimeData(thread_status, elapsed_counter_ms);
         result_chain.addSource(std::move(sink));


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `LOGICAL_ERROR` for `INSERT` with concurrent `ALTER`

Detailed description / Documentation draft:
In #28582 the problem was introduced due to it obtains new metadata
snapshot and so it may fail when it will check that headers does not
differs, like in [1]:

<details>

    {7b1256b1-09dc-4cc3-93d9-e9f6e26b0b99} <Fatal> : Logical error: 'Block structure mismatch in  function connect between ConvertingTransform and ReplicatedMergeTreeSink stream: different number of columns:
    a UInt8 UInt8(size = 0), b Int16 Int16(size = 0), c Float32 Float32(size = 0), d String String(size = 0), e Array(UInt8) Array(size = 0, UInt64(size = 0), UInt8(size = 0)), f Nullable(UUID) Nullable(size = 0, UUID(size = 0), UInt8(size = 0)), g Tuple(UInt8, UInt16) Tuple(size = 0, UInt8(size = 0), UInt16(size = 0)), h UInt64 UInt64(size = 0)
    a UInt8 UInt8(size = 0), b Int16 Int16(size = 0), c Float32 Float32(size = 0), d String String(size = 0), e Array(UInt8) Array(size = 0, UInt64(size = 0), UInt8(size = 0)), f Nullable(UUID) Nullable(size = 0, UUID(size = 0), UInt8(size = 0)), g Tuple(UInt8, UInt16) Tuple(size = 0, UInt8(size = 0), UInt16(size = 0))'.
    {7b1256b1-09dc-4cc3-93d9-e9f6e26b0b99} <Fatal> : Logical error: 'Block structure mismatch in  function connect between ConvertingTransform and ReplicatedMergeTreeSink stream: different number of columns:
    {} <Fatal> BaseDaemon: ########################################
    {} <Fatal> BaseDaemon: (version 21.11.1.8227, build id: E012027D3A9E94FD61655974C45C15F58215605B) (from thread 2180) (query_id: 7b1256b1-09dc-4cc3-93d9-e9f6e26b0b99) Received signal Aborted (6)
    {} <Fatal> BaseDaemon:
    {} <Fatal> BaseDaemon: Stack trace: 0x7f5661a3b18b 0x7f5661a1a859 0x1333bcb8 0x1333bdc2 0x1d9f04d1 0x1d9eec3c 0x1d9eeeca 0x1f7cc44c 0x1f79b992 0x1e52123f 0x1e522b8e 0x1eb7e27b 0x1eb7be44 0x1f751e26 0x1f75f0e5 0x23ba1179 0x23ba1988 0x23cef8b4 0x23cec39a 0x23ceb17c 0x7f5661c01609 0x7f5661b17293
    {} <Fatal> BaseDaemon: 4. raise @ 0x4618b in /usr/lib/x86_64-linux-gnu/libc-2.31.so
    {} <Fatal> BaseDaemon: 5. abort @ 0x25859 in /usr/lib/x86_64-linux-gnu/libc-2.31.so
    {} <Fatal> BaseDaemon: 6. ./obj-x86_64-linux-gnu/../src/Common/Exception.cpp:53: DB::handle_error_code(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool, std::__1::vector<void*, std::__1::allocator<void*> > const&) @ 0x1333bcb8 in /usr/bin/clickhouse
    {} <Fatal> BaseDaemon: 7. ./obj-x86_64-linux-gnu/../src/Common/Exception.cpp:60: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x1333bdc2 in /usr/bin/clickhouse
    {} <Fatal> BaseDaemon: 8. ./obj-x86_64-linux-gnu/../src/Core/Block.cpp:32: void DB::onError<void>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x1d9f04d1 in /usr/bin/clickhouse
    {} <Fatal> BaseDaemon: 9. ./obj-x86_64-linux-gnu/../src/Core/Block.cpp:86: void DB::checkBlockStructure<void>(DB::Block const&, DB::Block const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) @ 0x1d9eec3c in /usr/bin/clickhouse
    {} <Fatal> BaseDaemon: 10. ./obj-x86_64-linux-gnu/../src/Core/Block.cpp:607: DB::assertCompatibleHeader(DB::Block const&, DB::Block const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x1d9eeeca in /usr/bin/clickhouse
    {} <Fatal> BaseDaemon: 11. ./obj-x86_64-linux-gnu/../src/Processors/Port.cpp:19: DB::connect(DB::OutputPort&, DB::InputPort&) @ 0x1f7cc44c in /usr/bin/clickhouse
    {} <Fatal> BaseDaemon: 12. ./obj-x86_64-linux-gnu/../src/Processors/Chain.cpp:81: DB::Chain::addSource(std::__1::shared_ptr<DB::IProcessor>) @ 0x1f79b992 in /usr/bin/clickhouse
    {} <Fatal> BaseDaemon: 13. ./obj-x86_64-linux-gnu/../src/Interpreters/InterpreterInsertQuery.cpp:222: DB::InterpreterInsertQuery::buildChainImpl(std::__1::shared_ptr<DB::IStorage> const&, std::__1::shared_ptr<DB::StorageInMemoryMetadata const> const&, DB::Block const&, DB::ThreadStatus*, std::__1::atomic<unsigned long>*) @ 0x1e52123f in /usr/bin/clickhouse
    {} <Fatal> BaseDaemon: 14. ./obj-x86_64-linux-gnu/../src/Interpreters/InterpreterInsertQuery.cpp:368: DB::InterpreterInsertQuery::execute() @ 0x1e522b8e in /usr/bin/clickhouse

</details>

  [1]: https://clickhouse-test-reports.s3.yandex.net/29461/d6cd057e2c0c8b04d8a712a7b2a83526507ef512/functional_stateless_tests_(debug).html#fail1

Fixes: #28582 (cc: @KochetovNicolai)

*NOTE: marked as `Not for changelog` since original PR hadn't been included to any release yet*