### PR TITLE
Log queries to external databases (since they may be rewritten)

### DIFF
--- a/base/mysqlxx/Query.cpp
+++ b/base/mysqlxx/Query.cpp
@@ -77,9 +77,7 @@ void Query::executeImpl()
         case CR_SERVER_LOST:
             throw ConnectionLost(errorMessage(mysql_driver), err_no);
         default:
-            /// Add query to the exception message, since it may differs from the user input query.
-            /// (also you can use this and create query with an error to see what query ClickHouse created)
-            throw BadQuery(errorMessage(mysql_driver) + " (query: " + query_string + ")", err_no);
+            throw BadQuery(errorMessage(mysql_driver), err_no);
         }
     }
 }

--- a/src/Storages/StorageMySQL.cpp
+++ b/src/Storages/StorageMySQL.cpp
@@ -21,6 +21,7 @@
 #include <Processors/Sinks/SinkToStorage.h>
 #include <Processors/Pipe.h>
 #include <Common/parseRemoteDescription.h>
+#include <common/logger_useful.h>
 
 
 namespace DB
@@ -62,6 +63,7 @@ StorageMySQL::StorageMySQL(
     , on_duplicate_clause{on_duplicate_clause_}
     , mysql_settings(mysql_settings_)
     , pool(std::make_shared<mysqlxx::PoolWithFailover>(pool_))
+    , log(&Poco::Logger::get("StorageMySQL (" + table_id_.table_name + ")"))
 {
     StorageInMemoryMetadata storage_metadata;
     storage_metadata.setColumns(columns_);
@@ -88,6 +90,7 @@ Pipe StorageMySQL::read(
         remote_database_name,
         remote_table_name,
         context_);
+    LOG_TRACE(log, "Query: {}", query);
 
     Block sample_block;
     for (const String & column_name : column_names_)

--- a/src/Storages/StorageMySQL.h
+++ b/src/Storages/StorageMySQL.h
@@ -13,6 +13,10 @@
 #include <Storages/ExternalDataSourceConfiguration.h>
 #include <mysqlxx/PoolWithFailover.h>
 
+namespace Poco
+{
+class Logger;
+}
 
 namespace DB
 {
@@ -64,6 +68,8 @@ private:
     MySQLSettings mysql_settings;
 
     mysqlxx::PoolWithFailoverPtr pool;
+
+    Poco::Logger * log;
 };
 
 }

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -7,6 +7,7 @@
 #include <Common/assert_cast.h>
 #include <Common/parseRemoteDescription.h>
 #include <Core/Settings.h>
+#include <common/logger_useful.h>
 
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeArray.h>
@@ -64,6 +65,7 @@ StoragePostgreSQL::StoragePostgreSQL(
     , remote_table_schema(remote_table_schema_)
     , on_conflict(on_conflict_)
     , pool(std::move(pool_))
+    , log(&Poco::Logger::get("StoragePostgreSQL (" + table_id_.table_name + ")"))
 {
     StorageInMemoryMetadata storage_metadata;
     storage_metadata.setColumns(columns_);
@@ -89,6 +91,7 @@ Pipe StoragePostgreSQL::read(
     String query = transformQueryForExternalDatabase(
         query_info_, metadata_snapshot->getColumns().getOrdinary(),
         IdentifierQuotingStyle::DoubleQuotes, remote_table_schema, remote_table_name, context_);
+    LOG_TRACE(log, "Query: {}", query);
 
     Block sample_block;
     for (const String & column_name : column_names_)

--- a/src/Storages/StoragePostgreSQL.h
+++ b/src/Storages/StoragePostgreSQL.h
@@ -12,6 +12,10 @@
 #include <Core/PostgreSQL/PoolWithFailover.h>
 #include <Storages/ExternalDataSourceConfiguration.h>
 
+namespace Poco
+{
+class Logger;
+}
 
 namespace DB
 {
@@ -52,6 +56,8 @@ private:
     String remote_table_schema;
     String on_conflict;
     postgres::PoolWithFailoverPtr pool;
+
+    Poco::Logger * log;
 };
 
 }

--- a/src/Storages/StorageSQLite.cpp
+++ b/src/Storages/StorageSQLite.cpp
@@ -2,6 +2,7 @@
 
 #if USE_SQLITE
 #include <common/range.h>
+#include <common/logger_useful.h>
 #include <DataStreams/SQLiteSource.h>
 #include <Databases/SQLite/SQLiteUtils.h>
 #include <DataTypes/DataTypeString.h>
@@ -41,6 +42,7 @@ StorageSQLite::StorageSQLite(
     , database_path(database_path_)
     , global_context(context_)
     , sqlite_db(sqlite_db_)
+    , log(&Poco::Logger::get("StorageSQLite (" + table_id_.table_name + ")"))
 {
     StorageInMemoryMetadata storage_metadata;
     storage_metadata.setColumns(columns_);
@@ -70,6 +72,7 @@ Pipe StorageSQLite::read(
         "",
         remote_table_name,
         context_);
+    LOG_TRACE(log, "Query: {}", query);
 
     Block sample_block;
     for (const String & column_name : column_names)

--- a/src/Storages/StorageSQLite.h
+++ b/src/Storages/StorageSQLite.h
@@ -10,6 +10,10 @@
 
 #include <sqlite3.h> // Y_IGNORE
 
+namespace Poco
+{
+class Logger;
+}
 
 namespace DB
 {
@@ -48,6 +52,7 @@ private:
     String database_path;
     ContextPtr global_context;
     SQLitePtr sqlite_db;
+    Poco::Logger * log;
 };
 
 }

--- a/src/Storages/StorageXDBC.cpp
+++ b/src/Storages/StorageXDBC.cpp
@@ -46,8 +46,8 @@ StorageXDBC::StorageXDBC(
     , bridge_helper(bridge_helper_)
     , remote_database_name(remote_database_name_)
     , remote_table_name(remote_table_name_)
+    , log(&Poco::Logger::get("Storage" + bridge_helper->getName()))
 {
-    log = &Poco::Logger::get("Storage" + bridge_helper->getName());
     uri = bridge_helper->getMainURI();
 }
 
@@ -81,6 +81,7 @@ std::function<void(std::ostream &)> StorageXDBC::getReadPOSTDataCallback(
         remote_database_name,
         remote_table_name,
         local_context);
+    LOG_TRACE(log, "Query: {}", query);
 
     NamesAndTypesList cols;
     for (const String & name : column_names)

--- a/src/Storages/StorageXDBC.h
+++ b/src/Storages/StorageXDBC.h
@@ -3,6 +3,10 @@
 #include <Storages/StorageURL.h>
 #include <Bridge/XDBCBridgeHelper.h>
 
+namespace Poco
+{
+class Logger;
+}
 
 namespace DB
 {


### PR DESCRIPTION
By rewritten means that some expression from WHERE can be removed, yes
there is external_table_strict_query, but sometimes it is too strict.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)