### PR TITLE
Use metadata snapshot in getSourceFromASTInsertQuery

### DIFF
--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -428,7 +428,7 @@ BlockIO InterpreterInsertQuery::execute()
         if (query.hasInlinedData() && !async_insert)
         {
             /// can execute without additional data
-            auto pipe = getSourceFromASTInsertQuery(query_ptr, true, query_sample_block, getContext(), nullptr);
+            auto pipe = getSourceFromASTInsertQuery(query_ptr, true, metadata_snapshot, getContext(), nullptr);
             res.pipeline.complete(std::move(pipe));
         }
     }

--- a/src/Processors/Transforms/getSourceFromASTInsertQuery.cpp
+++ b/src/Processors/Transforms/getSourceFromASTInsertQuery.cpp
@@ -68,18 +68,16 @@ InputFormatPtr getInputFormatFromASTInsertQuery(
 Pipe getSourceFromASTInsertQuery(
     const ASTPtr & ast,
     bool with_buffers,
-    const Block & header,
+    const StorageMetadataPtr & metadata_snapshot,
     ContextPtr context,
     const ASTPtr & input_function)
 {
-    auto source = getInputFormatFromASTInsertQuery(ast, with_buffers, header, context, input_function);
+    auto source = getInputFormatFromASTInsertQuery(ast, with_buffers, metadata_snapshot->getSampleBlock(), context, input_function);
     Pipe pipe(source);
 
     const auto * ast_insert_query = ast->as<ASTInsertQuery>();
     if (context->getSettingsRef().input_format_defaults_for_omitted_fields && ast_insert_query->table_id && !input_function)
     {
-        StoragePtr storage = DatabaseCatalog::instance().getTable(ast_insert_query->table_id, context);
-        auto metadata_snapshot = storage->getInMemoryMetadataPtr();
         const auto & columns = metadata_snapshot->getColumns();
         if (columns.hasDefaults())
         {

--- a/src/Processors/Transforms/getSourceFromASTInsertQuery.h
+++ b/src/Processors/Transforms/getSourceFromASTInsertQuery.h
@@ -3,6 +3,7 @@
 #include <Parsers/IAST.h>
 #include <Interpreters/Context_fwd.h>
 #include <Processors/Formats/IInputFormat.h>
+#include <Storages/StorageInMemoryMetadata.h>
 #include <cstddef>
 #include <memory>
 
@@ -24,7 +25,7 @@ InputFormatPtr getInputFormatFromASTInsertQuery(
 Pipe getSourceFromASTInsertQuery(
         const ASTPtr & ast,
         bool with_buffers,
-        const Block & header,
+        const StorageMetadataPtr & metadata_snapshot,
         ContextPtr context,
         const ASTPtr & input_function);
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use metadata snapshot in getSourceFromASTInsertQuery

Detailed description / Documentation draft:
This will avoid possibility of getting different set of columns with
concurrent ALTER.