### PR TITLE
Bump cmake minimum required version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.14)
 
 foreach(policy
         CMP0023


### PR DESCRIPTION
`libxz` (at least) uses `if(DEFINED CACHE{})` which has been added only in `3.14`,
and in previous version this syntax was simply treated as variable and detects that it is not defined.

```
-- Performing Test TUKLIB_CPUCORES_SCHED_GETAFFINITY
-- Performing Test TUKLIB_CPUCORES_SCHED_GETAFFINITY - Success
# it successfully determine that sced_getaffinity() is available, but fails later:
CMake Warning at contrib/xz/cmake/tuklib_cpucores.cmake:166 (message):
  No method to detect the number of CPU cores was found
Call Stack (most recent call first):
  contrib/xz/CMakeLists.txt:350 (tuklib_cpucores)
```

Changelog category (leave one):
- Not for changelog (changelog entry is not required)