### PR TITLE
Generalize code in IColumn::permute

### DIFF
--- a/src/Columns/ColumnAggregateFunction.cpp
+++ b/src/Columns/ColumnAggregateFunction.cpp
@@ -316,23 +316,7 @@ void ColumnAggregateFunction::expand(const Filter & mask, bool inverted)
 
 ColumnPtr ColumnAggregateFunction::permute(const Permutation & perm, size_t limit) const
 {
-    size_t size = data.size();
-
-    if (limit == 0)
-        limit = size;
-    else
-        limit = std::min(size, limit);
-
-    if (perm.size() < limit)
-        throw Exception("Size of permutation is less than required.", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
-
-    auto res = createView();
-
-    res->data.resize(limit);
-    for (size_t i = 0; i < limit; ++i)
-        res->data[i] = data[perm[i]];
-
-    return res;
+    return permuteImpl(*this, perm, limit);
 }
 
 ColumnPtr ColumnAggregateFunction::index(const IColumn & indexes, size_t limit) const
@@ -343,6 +327,7 @@ ColumnPtr ColumnAggregateFunction::index(const IColumn & indexes, size_t limit) 
 template <typename Type>
 ColumnPtr ColumnAggregateFunction::indexImpl(const PaddedPODArray<Type> & indexes, size_t limit) const
 {
+    assert(limit <= indexes.size());
     auto res = createView();
 
     res->data.resize(limit);

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -762,39 +762,7 @@ ColumnPtr ColumnArray::filterTuple(const Filter & filt, ssize_t result_size_hint
 
 ColumnPtr ColumnArray::permute(const Permutation & perm, size_t limit) const
 {
-    size_t size = getOffsets().size();
-
-    if (limit == 0)
-        limit = size;
-    else
-        limit = std::min(size, limit);
-
-    if (perm.size() < limit)
-        throw Exception("Size of permutation is less than required.", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
-
-    if (limit == 0)
-        return ColumnArray::create(data);
-
-    Permutation nested_perm(getOffsets().back());
-
-    auto res = ColumnArray::create(data->cloneEmpty());
-
-    Offsets & res_offsets = res->getOffsets();
-    res_offsets.resize(limit);
-    size_t current_offset = 0;
-
-    for (size_t i = 0; i < limit; ++i)
-    {
-        for (size_t j = 0; j < sizeAt(perm[i]); ++j)
-            nested_perm[current_offset + j] = offsetAt(perm[i]) + j;
-        current_offset += sizeAt(perm[i]);
-        res_offsets[i] = current_offset;
-    }
-
-    if (current_offset != 0)
-        res->data = data->permute(nested_perm, current_offset);
-
-    return res;
+    return permuteImpl(*this, perm, limit);
 }
 
 ColumnPtr ColumnArray::index(const IColumn & indexes, size_t limit) const
@@ -805,8 +773,9 @@ ColumnPtr ColumnArray::index(const IColumn & indexes, size_t limit) const
 template <typename T>
 ColumnPtr ColumnArray::indexImpl(const PaddedPODArray<T> & indexes, size_t limit) const
 {
+    assert(limit <= indexes.size());
     if (limit == 0)
-        return ColumnArray::create(data);
+        return ColumnArray::create(data->cloneEmpty());
 
     /// Convert indexes to UInt64 in case of overflow.
     auto nested_indexes_column = ColumnUInt64::create();

--- a/src/Columns/ColumnConst.cpp
+++ b/src/Columns/ColumnConst.cpp
@@ -93,7 +93,7 @@ ColumnPtr ColumnConst::replicate(const Offsets & offsets) const
 
 ColumnPtr ColumnConst::permute(const Permutation & perm, size_t limit) const
 {
-    limit = getLimitForPermutation(*this, perm, limit);
+    limit = getLimitForPermutation(size(), perm.size(), limit);
     return ColumnConst::create(data, limit);
 }
 

--- a/src/Columns/ColumnConst.cpp
+++ b/src/Columns/ColumnConst.cpp
@@ -93,15 +93,7 @@ ColumnPtr ColumnConst::replicate(const Offsets & offsets) const
 
 ColumnPtr ColumnConst::permute(const Permutation & perm, size_t limit) const
 {
-    if (limit == 0)
-        limit = s;
-    else
-        limit = std::min(s, limit);
-
-    if (perm.size() < limit)
-        throw Exception("Size of permutation (" + toString(perm.size()) + ") is less than required (" + toString(limit) + ")",
-            ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
-
+    limit = getLimitForPermutation(*this, perm, limit);
     return ColumnConst::create(data, limit);
 }
 

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -231,17 +231,7 @@ void ColumnDecimal<T>::updatePermutation(bool reverse, size_t limit, int, IColum
 template <is_decimal T>
 ColumnPtr ColumnDecimal<T>::permute(const IColumn::Permutation & perm, size_t limit) const
 {
-    size_t size = limit ? std::min(data.size(), limit) : data.size();
-    if (perm.size() < size)
-        throw Exception("Size of permutation is less than required.", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
-
-    auto res = this->create(size, scale);
-    typename Self::Container & res_data = res->getData();
-
-    for (size_t i = 0; i < size; ++i)
-        res_data[i] = data[perm[i]];
-
-    return res;
+    return permuteImpl(*this, perm, limit);
 }
 
 template <is_decimal T>

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -219,12 +219,7 @@ template <is_decimal T>
 template <typename Type>
 ColumnPtr ColumnDecimal<T>::indexImpl(const PaddedPODArray<Type> & indexes, size_t limit) const
 {
-    size_t size = indexes.size();
-
-    if (limit == 0)
-        limit = size;
-    else
-        limit = std::min(size, limit);
+    assert(limit <= indexes.size());
 
     auto res = this->create(limit, scale);
     typename Self::Container & res_data = res->getData();

--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -93,7 +93,7 @@ void ColumnFunction::expand(const Filter & mask, bool inverted)
 
 ColumnPtr ColumnFunction::permute(const Permutation & perm, size_t limit) const
 {
-    limit = getLimitForPermutation(*this, perm, limit);
+    limit = getLimitForPermutation(size(), perm.size(), limit);
 
     ColumnsWithTypeAndName capture = captured_columns;
     for (auto & column : capture)

--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -93,14 +93,7 @@ void ColumnFunction::expand(const Filter & mask, bool inverted)
 
 ColumnPtr ColumnFunction::permute(const Permutation & perm, size_t limit) const
 {
-    if (limit == 0)
-        limit = size_;
-    else
-        limit = std::min(size_, limit);
-
-    if (perm.size() < limit)
-        throw Exception("Size of permutation (" + toString(perm.size()) + ") is less than required ("
-                        + toString(limit) + ")", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
+    limit = getLimitForPermutation(*this, perm, limit);
 
     ColumnsWithTypeAndName capture = captured_columns;
     for (auto & column : capture)

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -208,51 +208,7 @@ void ColumnString::expand(const IColumn::Filter & mask, bool inverted)
 
 ColumnPtr ColumnString::permute(const Permutation & perm, size_t limit) const
 {
-    size_t size = offsets.size();
-
-    if (limit == 0)
-        limit = size;
-    else
-        limit = std::min(size, limit);
-
-    if (perm.size() < limit)
-        throw Exception("Size of permutation is less than required.", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
-
-    if (limit == 0)
-        return ColumnString::create();
-
-    auto res = ColumnString::create();
-
-    Chars & res_chars = res->chars;
-    Offsets & res_offsets = res->offsets;
-
-    if (limit == size)
-        res_chars.resize(chars.size());
-    else
-    {
-        size_t new_chars_size = 0;
-        for (size_t i = 0; i < limit; ++i)
-            new_chars_size += sizeAt(perm[i]);
-        res_chars.resize(new_chars_size);
-    }
-
-    res_offsets.resize(limit);
-
-    Offset current_new_offset = 0;
-
-    for (size_t i = 0; i < limit; ++i)
-    {
-        size_t j = perm[i];
-        size_t string_offset = offsets[j - 1];
-        size_t string_size = offsets[j] - string_offset;
-
-        memcpySmallAllowReadWriteOverflow15(&res_chars[current_new_offset], &chars[string_offset], string_size);
-
-        current_new_offset += string_size;
-        res_offsets[i] = current_new_offset;
-    }
-
-    return res;
+    return permuteImpl(*this, perm, limit);
 }
 
 
@@ -300,6 +256,7 @@ ColumnPtr ColumnString::index(const IColumn & indexes, size_t limit) const
 template <typename Type>
 ColumnPtr ColumnString::indexImpl(const PaddedPODArray<Type> & indexes, size_t limit) const
 {
+    assert(limit <= indexes.size());
     if (limit == 0)
         return ColumnString::create();
 

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -443,22 +443,7 @@ void ColumnVector<T>::applyZeroMap(const IColumn::Filter & filt, bool inverted)
 template <typename T>
 ColumnPtr ColumnVector<T>::permute(const IColumn::Permutation & perm, size_t limit) const
 {
-    size_t size = data.size();
-
-    if (limit == 0)
-        limit = size;
-    else
-        limit = std::min(size, limit);
-
-    if (perm.size() < limit)
-        throw Exception("Size of permutation is less than required.", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
-
-    auto res = this->create(limit);
-    typename Self::Container & res_data = res->getData();
-    for (size_t i = 0; i < limit; ++i)
-        res_data[i] = data[perm[i]];
-
-    return res;
+    return permuteImpl(*this, perm, limit);
 }
 
 template <typename T>

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -360,12 +360,7 @@ template <typename T>
 template <typename Type>
 ColumnPtr ColumnVector<T>::indexImpl(const PaddedPODArray<Type> & indexes, size_t limit) const
 {
-    size_t size = indexes.size();
-
-    if (limit == 0)
-        limit = size;
-    else
-        limit = std::min(size, limit);
+    assert(limit <= indexes.size());
 
     auto res = this->create(limit);
     typename Self::Container & res_data = res->getData();

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -345,4 +345,19 @@ namespace detail
     template const PaddedPODArray<UInt64> * getIndexesData<UInt64>(const IColumn & indexes);
 }
 
+size_t getLimitForPermutation(size_t column_size, size_t perm_size, size_t limit)
+{
+    if (limit == 0)
+        limit = column_size;
+    else
+        limit = std::min(column_size, limit);
+
+    if (perm_size < limit)
+        throw Exception(ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH,
+            "Size of permutation ({}) is less than required ({})", perm_size, limit);
+
+    return limit;
+}
+
+
 }

--- a/src/Columns/ColumnsCommon.h
+++ b/src/Columns/ColumnsCommon.h
@@ -72,19 +72,7 @@ ColumnPtr selectIndexImpl(const Column & column, const IColumn & indexes, size_t
                         ErrorCodes::LOGICAL_ERROR);
 }
 
-size_t getLimitForPermutation(size_t column_size, size_t perm_size, size_t limit)
-{
-    if (limit == 0)
-        limit = column_size;
-    else
-        limit = std::min(column_size, limit);
-
-    if (perm_size < limit)
-        throw Exception(ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH,
-            "Size of permutation ({}) is less than required ({})", perm_size, limit);
-
-    return limit;
-}
+size_t getLimitForPermutation(size_t column_size, size_t perm_size, size_t limit);
 
 template <typename Column>
 ColumnPtr permuteImpl(const Column & column, const IColumn::Permutation & perm, size_t limit)

--- a/src/Columns/ColumnsCommon.h
+++ b/src/Columns/ColumnsCommon.h
@@ -72,17 +72,16 @@ ColumnPtr selectIndexImpl(const Column & column, const IColumn & indexes, size_t
                         ErrorCodes::LOGICAL_ERROR);
 }
 
-template <typename Column>
-size_t getLimitForPermutation(const Column & column, const IColumn::Permutation & perm, size_t limit)
+size_t getLimitForPermutation(size_t column_size, size_t perm_size, size_t limit)
 {
     if (limit == 0)
-        limit = column.size();
+        limit = column_size;
     else
-        limit = std::min(column.size(), limit);
+        limit = std::min(column_size, limit);
 
-    if (perm.size() < limit)
+    if (perm_size < limit)
         throw Exception(ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH,
-            "Size of permutation ({}) is less than required ({})", perm.size(), limit);
+            "Size of permutation ({}) is less than required ({})", perm_size, limit);
 
     return limit;
 }
@@ -90,7 +89,7 @@ size_t getLimitForPermutation(const Column & column, const IColumn::Permutation 
 template <typename Column>
 ColumnPtr permuteImpl(const Column & column, const IColumn::Permutation & perm, size_t limit)
 {
-    limit = getLimitForPermutation(column, perm, limit);
+    limit = getLimitForPermutation(column.size(), perm.size(), limit);
     return column.indexImpl(perm, limit);
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`IColumn::permute` is actually a special case of `IColumn::index` and it had almost identic implemetation with `IColumn::index` for all columns.