### PR TITLE
Add error for multiple keys without current_key_id

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -82,7 +82,7 @@ Load from config:
 ```xml
 <encryption_codecs>
     <aes_128_gcm_siv>
-        <key>12345567812345678</key>
+        <key>1234567812345678</key>
     </aes_128_gcm_siv>
 </encryption_codecs>
 ```

--- a/src/Compression/CompressionCodecEncrypted.cpp
+++ b/src/Compression/CompressionCodecEncrypted.cpp
@@ -319,6 +319,10 @@ void CompressionCodecEncrypted::Configuration::loadImpl(
     if (new_params->keys_storage[method].size() > 1 && !config.has(config_prefix + ".current_key_id"))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "There are multiple keys in config. current_key_id is required");
 
+    /// If there is only one key with non zero ID, curren_key_id should be defined.
+    if (new_params->keys_storage[method].size() == 1 && !new_params->keys_storage[method].contains(0) && !config.has(config_prefix + ".current_key_id"))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Config has one key with non zero id. сurrent_key_id is required");
+
     /// Try to find which key will be used for encryption. If there is no current_key and only one key without id
     /// or with zero id, first key will be used for encryption (its index equals to zero).
     new_params->current_key_id[method] = config.getUInt64(config_prefix + ".current_key_id", 0);

--- a/src/Compression/CompressionCodecEncrypted.cpp
+++ b/src/Compression/CompressionCodecEncrypted.cpp
@@ -315,13 +315,16 @@ void CompressionCodecEncrypted::Configuration::loadImpl(
     if (new_params->keys_storage[method].empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "No keys, an encryption needs keys to work");
 
-    /// In case of multiple keys, current_key_id is mandatory
-    if (new_params->keys_storage[method].size() > 1 && !config.has(config_prefix + ".current_key_id"))
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "There are multiple keys in config. current_key_id is required");
+    if (!config.has(config_prefix + ".current_key_id"))
+    {
+        /// In case of multiple keys, current_key_id is mandatory
+        if (new_params->keys_storage[method].size() > 1)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "There are multiple keys in config. current_key_id is required");
 
-    /// If there is only one key with non zero ID, curren_key_id should be defined.
-    if (new_params->keys_storage[method].size() == 1 && !new_params->keys_storage[method].contains(0) && !config.has(config_prefix + ".current_key_id"))
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Config has one key with non zero id. сurrent_key_id is required");
+        /// If there is only one key with non zero ID, curren_key_id should be defined.
+        if (new_params->keys_storage[method].size() == 1 && !new_params->keys_storage[method].contains(0))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Config has one key with non zero id. сurrent_key_id is required");
+    }
 
     /// Try to find which key will be used for encryption. If there is no current_key and only one key without id
     /// or with zero id, first key will be used for encryption (its index equals to zero).

--- a/src/Compression/CompressionCodecEncrypted.cpp
+++ b/src/Compression/CompressionCodecEncrypted.cpp
@@ -315,8 +315,12 @@ void CompressionCodecEncrypted::Configuration::loadImpl(
     if (new_params->keys_storage[method].empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "No keys, an encryption needs keys to work");
 
-    /// Try to find which key will be used for encryption. If there is no current_key,
-    /// first key will be used for encryption (its index equals to zero).
+    /// In case of multiple keys, current_key_id is mandatory
+    if (new_params->keys_storage[method].size() > 1 && !config.has(config_prefix + ".current_key_id"))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "There are multiple keys in config. current_key_id is required");
+
+    /// Try to find which key will be used for encryption. If there is no current_key and only one key without id
+    /// or with zero id, first key will be used for encryption (its index equals to zero).
     new_params->current_key_id[method] = config.getUInt64(config_prefix + ".current_key_id", 0);
 
     /// Check that we have current key. Otherwise config is incorrect.

--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -76,6 +76,10 @@ namespace
             if (res->keys.empty())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "No keys, an encrypted disk needs keys to work");
 
+            /// In case of multiple keys, current_key_id is mandatory
+            if (res->keys.size() > 1 && !config.has(config_prefix + ".current_key_id"))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "There are multiple keys in config. current_key_id is required");
+
             res->current_key_id = config.getUInt64(config_prefix + ".current_key_id", 0);
             if (!res->keys.contains(res->current_key_id))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Not found a key with the current ID {}", res->current_key_id);

--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -80,6 +80,10 @@ namespace
             if (res->keys.size() > 1 && !config.has(config_prefix + ".current_key_id"))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "There are multiple keys in config. current_key_id is required");
 
+            /// If there is only one key with non zero ID, curren_key_id should be defined.
+            if (res->keys.size() == 1 && !res->keys.contains(0) && !config.has(config_prefix + ".current_key_id"))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Config has one key with non zero id. сurrent_key_id is required");
+
             res->current_key_id = config.getUInt64(config_prefix + ".current_key_id", 0);
             if (!res->keys.contains(res->current_key_id))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Not found a key with the current ID {}", res->current_key_id);

--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -76,13 +76,16 @@ namespace
             if (res->keys.empty())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "No keys, an encrypted disk needs keys to work");
 
-            /// In case of multiple keys, current_key_id is mandatory
-            if (res->keys.size() > 1 && !config.has(config_prefix + ".current_key_id"))
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "There are multiple keys in config. current_key_id is required");
+            if (!config.has(config_prefix + ".current_key_id"))
+            {
+                /// In case of multiple keys, current_key_id is mandatory
+                if (res->keys.size() > 1)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "There are multiple keys in config. current_key_id is required");
 
-            /// If there is only one key with non zero ID, curren_key_id should be defined.
-            if (res->keys.size() == 1 && !res->keys.contains(0) && !config.has(config_prefix + ".current_key_id"))
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Config has one key with non zero id. сurrent_key_id is required");
+                /// If there is only one key with non zero ID, curren_key_id should be defined.
+                if (res->keys.size() == 1 && !res->keys.contains(0))
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Config has one key with non zero id. сurrent_key_id is required");
+            }
 
             res->current_key_id = config.getUInt64(config_prefix + ".current_key_id", 0);
             if (!res->keys.contains(res->current_key_id))


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adding exception, when multiple keys are used without current_key_id.


Detailed description / Documentation draft:
Also fix mistake in docs.