### PR TITLE
Fix null deference for GROUP BY WITH TOTALS HAVING (when the column from HAVING wasn't selected)

### DIFF
--- a/src/Processors/Transforms/TotalsHavingTransform.cpp
+++ b/src/Processors/Transforms/TotalsHavingTransform.cpp
@@ -3,6 +3,7 @@
 
 #include <Columns/ColumnAggregateFunction.h>
 #include <Columns/FilterDescription.h>
+#include <Columns/ColumnsCommon.h>
 
 #include <Common/typeid_cast.h>
 #include <DataStreams/finalizeBlock.h>
@@ -224,7 +225,7 @@ void TotalsHavingTransform::transform(Chunk & chunk)
             }
         }
 
-        num_rows = columns.front()->size();
+        num_rows = columns.empty() ? countBytesInFilter(*filter_description.data) : columns.front()->size();
         chunk.setColumns(std::move(columns), num_rows);
     }
 

--- a/tests/queries/0_stateless/02039_group_by_with_totals_having.reference
+++ b/tests/queries/0_stateless/02039_group_by_with_totals_having.reference
@@ -1,0 +1,8 @@
+-- { echo }
+SELECT '' FROM numbers(1) GROUP BY number WITH TOTALS HAVING count(number)>0;
+
+
+
+SELECT '' FROM numbers(1) GROUP BY number WITH TOTALS HAVING count(number)<0;
+
+

--- a/tests/queries/0_stateless/02039_group_by_with_totals_having.reference
+++ b/tests/queries/0_stateless/02039_group_by_with_totals_having.reference
@@ -1,8 +1,9 @@
 -- { echo }
-SELECT '' FROM numbers(1) GROUP BY number WITH TOTALS HAVING count(number)>0;
+SELECT 'x' FROM numbers(2) GROUP BY number WITH TOTALS HAVING count(number)>0;
+x
+x
 
+x
+SELECT 'x' FROM numbers(2) GROUP BY number WITH TOTALS HAVING count(number)<0;
 
-
-SELECT '' FROM numbers(1) GROUP BY number WITH TOTALS HAVING count(number)<0;
-
-
+x

--- a/tests/queries/0_stateless/02039_group_by_with_totals_having.sql
+++ b/tests/queries/0_stateless/02039_group_by_with_totals_having.sql
@@ -1,0 +1,3 @@
+-- { echo }
+SELECT '' FROM numbers(1) GROUP BY number WITH TOTALS HAVING count(number)>0;
+SELECT '' FROM numbers(1) GROUP BY number WITH TOTALS HAVING count(number)<0;

--- a/tests/queries/0_stateless/02039_group_by_with_totals_having.sql
+++ b/tests/queries/0_stateless/02039_group_by_with_totals_having.sql
@@ -1,3 +1,3 @@
 -- { echo }
-SELECT '' FROM numbers(1) GROUP BY number WITH TOTALS HAVING count(number)>0;
-SELECT '' FROM numbers(1) GROUP BY number WITH TOTALS HAVING count(number)<0;
+SELECT 'x' FROM numbers(2) GROUP BY number WITH TOTALS HAVING count(number)>0;
+SELECT 'x' FROM numbers(2) GROUP BY number WITH TOTALS HAVING count(number)<0;


### PR DESCRIPTION
Found by UBsan fuzzer [1].

  [1]: https://clickhouse-test-reports.s3.yandex.net/29503/a4f2663b8209e0e75021d8b84f932bc162c81857/fuzzer_ubsan/report.html#fail1

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix null deference for `GROUP BY WITH TOTALS HAVING` (when the column from `HAVING` wasn't selected)

Detailed description / Documentation draft:

Fixes: #29475 (cc @KochetovNicolai )
Fixes: #29687

*NOTE: marked as `Not for changelog` since original PR is not included into any release yet*
*UPD: have to mark it as `Bug fix` since orignial PR was a `Bug fix`*