### PR TITLE
Fixed test with dictGet without database name as column default value

### DIFF
--- a/tests/queries/0_stateless/02015_column_default_dict_get_identifier.sql
+++ b/tests/queries/0_stateless/02015_column_default_dict_get_identifier.sql
@@ -1,5 +1,10 @@
-DROP TABLE IF EXISTS test_table;
-CREATE TABLE test_table
+-- Tags: no-parallel
+
+DROP DATABASE IF EXISTS 02015_db;
+CREATE DATABASE 02015_db;
+
+DROP TABLE IF EXISTS 02015_db.test_table;
+CREATE TABLE 02015_db.test_table
 (
     key_column UInt64,
     data_column_1 UInt64,
@@ -8,10 +13,10 @@ CREATE TABLE test_table
 ENGINE = MergeTree
 ORDER BY key_column;
 
-INSERT INTO test_table VALUES (0, 0, 0);
+INSERT INTO 02015_db.test_table VALUES (0, 0, 0);
 
-DROP DICTIONARY IF EXISTS test_dictionary;
-CREATE DICTIONARY test_dictionary
+DROP DICTIONARY IF EXISTS 02015_db.test_dictionary;
+CREATE DICTIONARY 02015_db.test_dictionary
 (
     key_column UInt64 DEFAULT 0,
     data_column_1 UInt64 DEFAULT 1,
@@ -19,19 +24,21 @@ CREATE DICTIONARY test_dictionary
 )
 PRIMARY KEY key_column
 LAYOUT(DIRECT())
-SOURCE(CLICKHOUSE(TABLE 'test_table'));
+SOURCE(CLICKHOUSE(DB '02015_db' TABLE 'test_table'));
 
-DROP TABLE IF EXISTS test_table_default;
-CREATE TABLE test_table_default
+DROP TABLE IF EXISTS 02015_db.test_table_default;
+CREATE TABLE 02015_db.test_table_default
 (
-    data_1 DEFAULT dictGetUInt64('test_dictionary', 'data_column_1', toUInt64(0)),
-    data_2 DEFAULT dictGet(test_dictionary, 'data_column_2', toUInt64(0))
+    data_1 DEFAULT dictGetUInt64('02015_db.test_dictionary', 'data_column_1', toUInt64(0)),
+    data_2 DEFAULT dictGet(02015_db.test_dictionary, 'data_column_2', toUInt64(0))
 )
 ENGINE=TinyLog;
 
-INSERT INTO test_table_default(data_1) VALUES (5);
-SELECT * FROM test_table_default;
+INSERT INTO 02015_db.test_table_default(data_1) VALUES (5);
+SELECT * FROM 02015_db.test_table_default;
 
-DROP DICTIONARY test_dictionary;
-DROP TABLE test_table;
-DROP TABLE test_table_default;
+DROP DICTIONARY 02015_db.test_dictionary;
+DROP TABLE 02015_db.test_table;
+DROP TABLE 02015_db.test_table_default;
+
+DROP DATABASE 02015_db;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes #29559.