### PR TITLE
Improve CompressedReadBuffer

### DIFF
--- a/src/Compression/CompressedReadBufferBase.cpp
+++ b/src/Compression/CompressedReadBufferBase.cpp
@@ -72,9 +72,9 @@ static void validateChecksum(char * data, size_t size, const Checksum expected_c
     if (size < (1ULL << 20))
     {
         /// We need to copy data from ReadBuffer to flip bits as ReadBuffer should be immutable
-        BufferWithOwnMemory<WriteBuffer> tmp_buffer(size);
-        tmp_buffer.write(data, size);
-        char * tmp_data = tmp_buffer.buffer().begin();
+        PODArray<char> tmp_buffer(data, data + size);
+        char * tmp_data = tmp_buffer.data();
+
         /// Check if the difference caused by single bit flip in data.
         for (size_t bit_pos = 0; bit_pos < size * 8; ++bit_pos)
         {

--- a/src/Compression/CompressedReadBufferBase.cpp
+++ b/src/Compression/CompressedReadBufferBase.cpp
@@ -71,12 +71,16 @@ static void validateChecksum(char * data, size_t size, const Checksum expected_c
     /// And anyway this is pretty heavy, so avoid burning too much CPU here.
     if (size < (1ULL << 20))
     {
+        /// We need to copy data from ReadBuffer to flip bits as ReadBuffer should be immutable
+        BufferWithOwnMemory<WriteBuffer> tmp_buffer(size);
+        tmp_buffer.write(data, size);
+        char * tmp_data = tmp_buffer.buffer().begin();
         /// Check if the difference caused by single bit flip in data.
         for (size_t bit_pos = 0; bit_pos < size * 8; ++bit_pos)
         {
-            flip_bit(data, bit_pos);
+            flip_bit(tmp_data, bit_pos);
 
-            auto checksum_of_data_with_flipped_bit = CityHash_v1_0_2::CityHash128(data, size);
+            auto checksum_of_data_with_flipped_bit = CityHash_v1_0_2::CityHash128(tmp_data, size);
             if (expected_checksum == checksum_of_data_with_flipped_bit)
             {
                 message << ". The mismatch is caused by single bit flip in data block at byte " << (bit_pos / 8) << ", bit " << (bit_pos % 8) << ". "
@@ -84,7 +88,7 @@ static void validateChecksum(char * data, size_t size, const Checksum expected_c
                 throw Exception(message.str(), ErrorCodes::CHECKSUM_DOESNT_MATCH);
             }
 
-            flip_bit(data, bit_pos);    /// Restore
+            flip_bit(tmp_data, bit_pos);    /// Restore
         }
     }
 

--- a/src/Compression/ICompressionCodec.cpp
+++ b/src/Compression/ICompressionCodec.cpp
@@ -113,13 +113,19 @@ UInt32 ICompressionCodec::decompress(const char * source, UInt32 source_size, ch
 
 UInt32 ICompressionCodec::readCompressedBlockSize(const char * source)
 {
-    return unalignedLoad<UInt32>(&source[1]);
+    UInt32 compressed_block_size = unalignedLoad<UInt32>(&source[1]);
+    if (compressed_block_size == 0)
+        throw Exception(ErrorCodes::CORRUPTED_DATA, "Can't decompress data: header is corrupt with compressed block size 0");
+    return compressed_block_size;
 }
 
 
 UInt32 ICompressionCodec::readDecompressedBlockSize(const char * source)
 {
-    return unalignedLoad<UInt32>(&source[5]);
+    UInt32 decompressed_block_size = unalignedLoad<UInt32>(&source[5]);
+    if (decompressed_block_size == 0)
+        throw Exception(ErrorCodes::CORRUPTED_DATA, "Can't decompress data: header is corrupt with decompressed block size 0");
+    return decompressed_block_size;
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:
We can get corrupted header with 0 lengths of compressed/uncompressed data.
Bit flips check changes ReadBuffer and it should be immutable - fixes fuzzer warning https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37713


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
