### PR TITLE
BloomFilter indexes map data type support fix unsafe identifier cast

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionBloomFilter.cpp
@@ -390,7 +390,11 @@ bool MergeTreeIndexConditionBloomFilter::traverseASTIn(
             if (set_contain_default_value)
                 return false;
 
-            const auto & col_name = assert_cast<ASTIdentifier *>(function->arguments.get()->children[0].get())->name();
+            const auto * column_ast_identifier = function->arguments.get()->children[0].get()->as<ASTIdentifier>();
+            if (!column_ast_identifier)
+                return false;
+
+            const auto & col_name = column_ast_identifier->name();
             auto map_keys_index_column_name = fmt::format("mapKeys({})", col_name);
             auto map_values_index_column_name = fmt::format("mapValues({})", col_name);
 
@@ -578,7 +582,11 @@ bool MergeTreeIndexConditionBloomFilter::traverseASTEquals(
 
     if (function_name == "mapContains" || function_name == "has")
     {
-        const auto & col_name = assert_cast<ASTIdentifier *>(key_ast.get())->name();
+        const auto * key_ast_identifier = key_ast.get()->as<const ASTIdentifier>();
+        if (!key_ast_identifier)
+            return false;
+
+        const auto & col_name = key_ast_identifier->name();
         auto map_keys_index_column_name = fmt::format("mapKeys({})", col_name);
 
         if (!header.has(map_keys_index_column_name))
@@ -633,7 +641,11 @@ bool MergeTreeIndexConditionBloomFilter::traverseASTEquals(
             if (value_field == value_type->getDefault())
                 return false;
 
-            const auto & col_name = assert_cast<ASTIdentifier *>(function->arguments.get()->children[0].get())->name();
+            const auto * column_ast_identifier = function->arguments.get()->children[0].get()->as<ASTIdentifier>();
+            if (!column_ast_identifier)
+                return false;
+
+            const auto & col_name = column_ast_identifier->name();
 
             auto map_keys_index_column_name = fmt::format("mapKeys({})", col_name);
             auto map_values_index_column_name = fmt::format("mapValues({})", col_name);

--- a/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -477,7 +477,11 @@ bool MergeTreeConditionFullText::traverseASTEquals(
             if (value_field == value_type->getDefault())
                 return false;
 
-            const auto & map_column_name = assert_cast<ASTIdentifier *>(function->arguments.get()->children[0].get())->name();
+            const auto * column_ast_identifier = function->arguments.get()->children[0].get()->as<ASTIdentifier>();
+            if (!column_ast_identifier)
+                return false;
+
+            const auto & map_column_name = column_ast_identifier->name();
 
             size_t map_keys_key_column_num = 0;
             auto map_keys_index_column_name = fmt::format("mapKeys({})", map_column_name);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)