### PR TITLE
Fix missing condition in pushed down predicate.

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -1554,11 +1554,37 @@ ConjunctionNodes getConjunctionNodes(ActionsDAG::Node * predicate, std::unordere
     std::unordered_set<const ActionsDAG::Node *> allowed;
     std::unordered_set<const ActionsDAG::Node *> rejected;
 
+    /// Parts of predicate in case predicate is conjunction (or just predicate itself).
+    std::unordered_set<const ActionsDAG::Node *> predicates;
+    {
+        std::stack<const ActionsDAG::Node *> stack;
+        std::unordered_set<const ActionsDAG::Node *> visited_nodes;
+        stack.push(predicate);
+        visited_nodes.insert(predicate);
+        while (!stack.empty())
+        {
+            const auto * node = stack.top();
+            stack.pop();
+            bool is_conjunction = node->type == ActionsDAG::ActionType::FUNCTION && node->function_base->getName() == "and";
+            if (is_conjunction)
+            {
+                for (const auto & child : node->children)
+                {
+                    if (visited_nodes.count(child) == 0)
+                    {
+                        visited_nodes.insert(child);
+                        stack.push(child);
+                    }
+                }
+            }
+            else
+                predicates.insert(node);
+        }
+    }
+
     struct Frame
     {
         const ActionsDAG::Node * node = nullptr;
-        /// Node is a part of predicate (predicate itself, or some part of AND)
-        bool is_predicate = false;
         size_t next_child_to_visit = 0;
         size_t num_allowed_children = 0;
     };
@@ -1566,14 +1592,11 @@ ConjunctionNodes getConjunctionNodes(ActionsDAG::Node * predicate, std::unordere
     std::stack<Frame> stack;
     std::unordered_set<const ActionsDAG::Node *> visited_nodes;
 
-    stack.push(Frame{.node = predicate, .is_predicate = true});
+    stack.push(Frame{.node = predicate});
     visited_nodes.insert(predicate);
     while (!stack.empty())
     {
         auto & cur = stack.top();
-        bool is_conjunction = cur.is_predicate
-                                && cur.node->type == ActionsDAG::ActionType::FUNCTION
-                                && cur.node->function_base->getName() == "and";
 
         /// At first, visit all children.
         while (cur.next_child_to_visit < cur.node->children.size())
@@ -1583,7 +1606,7 @@ ConjunctionNodes getConjunctionNodes(ActionsDAG::Node * predicate, std::unordere
             if (visited_nodes.count(child) == 0)
             {
                 visited_nodes.insert(child);
-                stack.push({.node = child, .is_predicate = is_conjunction});
+                stack.push({.node = child});
                 break;
             }
 
@@ -1600,8 +1623,7 @@ ConjunctionNodes getConjunctionNodes(ActionsDAG::Node * predicate, std::unordere
                     allowed_nodes.emplace(cur.node);
             }
 
-            /// Add parts of AND to result. Do not add function AND.
-            if (cur.is_predicate && ! is_conjunction)
+            if (predicates.count(cur.node))
             {
                 if (allowed_nodes.count(cur.node))
                 {
@@ -1619,6 +1641,13 @@ ConjunctionNodes getConjunctionNodes(ActionsDAG::Node * predicate, std::unordere
             stack.pop();
         }
     }
+
+    // std::cerr << "Allowed " << conjunction.allowed.size() << std::endl;
+    // for (const auto & node : conjunction.allowed)
+    //     std::cerr << node->result_name << std::endl;
+    // std::cerr << "Rejected " << conjunction.rejected.size() << std::endl;
+    // for (const auto & node : conjunction.rejected)
+    //     std::cerr << node->result_name << std::endl;
 
     return conjunction;
 }

--- a/tests/queries/0_stateless/01763_filter_push_down_bugs.reference
+++ b/tests/queries/0_stateless/01763_filter_push_down_bugs.reference
@@ -4,3 +4,4 @@
 [[1]]	2
 String1_0	String2_0	String3_0	String4_0	1
 String1_0	String2_0	String3_0	String4_0	1
+1	[0,1,2]

--- a/tests/queries/0_stateless/01763_filter_push_down_bugs.sql
+++ b/tests/queries/0_stateless/01763_filter_push_down_bugs.sql
@@ -9,7 +9,7 @@ CREATE TABLE Test
 ENGINE = MergeTree()
 PRIMARY KEY (String1,String2)
 ORDER BY (String1,String2)
-AS 
+AS
 SELECT
    'String1_' || toString(number) as String1,
    'String2_' || toString(number) as String2,
@@ -35,3 +35,5 @@ FROM
 WHERE  String4 ='String4_0';
 
 DROP TABLE IF EXISTS Test;
+
+select x, y from (select [0, 1, 2] as y, 1 as a, 2 as b) array join y as x where a = 1 and b = 2 and (x = 1 or x != 1) and x = 1;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Condition in filter predicate could be lost after push-down optimisation.

In added query, last condition `x = 1` could be lost, cause it was traversed as a part of `(x = 1 or x != 1)` before.