### PR TITLE
Do not try to fuzz `USE`/`SET` queries and print stacktrace

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -139,6 +139,7 @@ continue
     clickhouse-client \
         --receive_timeout=10 \
         --receive_data_timeout_ms=10000 \
+        --stacktrace \
         --query-fuzzer-runs=1000 \
         --queries-file $(ls -1 ch/tests/queries/0_stateless/*.sql | sort -R) \
         $NEW_TESTS_OPT \

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -711,6 +711,13 @@ bool Client::processWithFuzzing(const String & full_query)
             throw;
     }
 
+    // `USE db` should not be executed
+    // since this will break every query after `DROP db`
+    if (orig_ast->as<ASTUseQuery>())
+    {
+        return true;
+    }
+
     if (!orig_ast)
     {
         // Can't continue after a parsing error


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

*I've pushed this in one PR to avoid extra CI usage*