### PR TITLE
Perf fixes

### DIFF
--- a/tests/performance/parallel_mv.xml
+++ b/tests/performance/parallel_mv.xml
@@ -13,6 +13,12 @@
     <create_query>create materialized view mv_4 engine = MergeTree order by tuple() as
         select number, toString(number) from main_table where number % 13 != 4;</create_query>
 
+    <fill_query>SYSTEM STOP MERGES main_table</fill_query>
+    <fill_query>SYSTEM STOP MERGES mt_1</fill_query>
+    <fill_query>SYSTEM STOP MERGES mt_2</fill_query>
+    <fill_query>SYSTEM STOP MERGES mt_3</fill_query>
+    <fill_query>SYSTEM STOP MERGES mt_4</fill_query>
+
     <query>insert into main_table select number from numbers(10000000)</query>
 
     <drop_query>drop table if exists main_table;</drop_query>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://clickhouse-test-reports.s3.yandex.net/29513/769bfbe71f22c392458eced655080a0bbd442e02/performance_comparison/report.html#fail1

@alesapin also I've noticed that perf tests that runs successfully has [better CPU - `Gold 6230 CPU @ 2.10GHz`](https://clickhouse-test-reports.s3.yandex.net/29364/fb584715e175fef3a4c4373d1bbcebecab1db6d8/performance_comparison/report.html#unstable-queries.select_format.6) than the one that [fails - `E5-2660 v4 @ 2.00GHz`](https://clickhouse-test-reports.s3.yandex.net/29513/769bfbe71f22c392458eced655080a0bbd442e02/performance_comparison/report.html#fail1), maybe it is pretty easy to stick perf tests to Xeon Gold (at least as a temporary workaround)?