### PR TITLE
Fix DROP DICTIONARY for Cached dictionaries under high memory pressure

### DIFF
--- a/src/Dictionaries/CacheDictionaryUpdateQueue.cpp
+++ b/src/Dictionaries/CacheDictionaryUpdateQueue.cpp
@@ -3,6 +3,7 @@
 #include <Dictionaries/CacheDictionaryUpdateQueue.h>
 
 #include <Common/setThreadName.h>
+#include <Common/MemoryTracker.h>
 
 namespace DB
 {
@@ -35,13 +36,16 @@ CacheDictionaryUpdateQueue<dictionary_key_type>::CacheDictionaryUpdateQueue(
 template <DictionaryKeyType dictionary_key_type>
 CacheDictionaryUpdateQueue<dictionary_key_type>::~CacheDictionaryUpdateQueue()
 {
-    try {
+    MemoryTracker::BlockerInThread untrack_lock(VariableContext::Global);
+
+    try
+    {
         if (!finished)
             stopAndWait();
     }
     catch (...)
     {
-        /// TODO: Write log
+        tryLogCurrentException(__PRETTY_FUNCTION__);
     }
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix DROP DICTIONARY for Cached dictionaries under high memory pressure

Detailed description / Documentation draft:
In case of memory pressure CacheDictionaryUpdateQueue can fail to insert
elements to queue that should terminate the worker thread, and so it
will wait undefinitelly.

And I believe this is exactly what happend on CI [1]:

<details>

Hung check reports:

    elapsed:              1500.595811519
    query:                DROP DICTIONARY IF EXISTS db_dict.cache_hits;
    thread_ids:           [12462]

gdb reports:

    Thread 751 (Thread 0x7f8688683700 (LWP 12462)):
    3  0x00000000193383d8 in Poco::EventImpl::waitImpl (this=0x7b2000f22798) at ../contrib/poco/Foundation/src/Event_POSIX.cpp:106
    4  0x000000000978cb01 in Poco::Event::wait (this=0x7b2000f22798) at ../contrib/poco/Foundation/include/Poco/Event.h:97
    5  ThreadFromGlobalPool::join (this=0x7b0c00f52db0) at ../src/Common/ThreadPool.h:217
    6  ThreadPoolImpl<ThreadFromGlobalPool>::finalize (this=this@entry=0x7b6802d1a198) at ../src/Common/ThreadPool.cpp:215
    7  0x000000000978c805 in ThreadPoolImpl<ThreadFromGlobalPool>::~ThreadPoolImpl (this=0x7b6802d1a198) at ../src/Common/ThreadPool.cpp:201
    8  0x00000000120a4e56 in DB::CacheDictionaryUpdateQueue<(DB::DictionaryKeyType)0>::~CacheDictionaryUpdateQueue (this=0x7b6802d1a020) at ../src/Dictionaries/CacheDictionaryUpdateQueue.cpp:46

    Thread 616 (Thread 0x7f8747cab700 (LWP 5005)):
    4  0x00000000120a5ec1 in Poco::Semaphore::wait (this=<optimized out>) at ../contrib/poco/Foundation/include/Poco/Semaphore.h:117
    5  ConcurrentBoundedQueue<std::__1::shared_ptr<DB::CacheDictionaryUpdateUnit<(DB::DictionaryKeyType)0> > >::pop (this=<optimized out>, x=...) at ../src/Common/ConcurrentBoundedQueue.h:89
    6  DB::CacheDictionaryUpdateQueue<(DB::DictionaryKeyType)0>::updateThreadFunction (this=<optimized out>) at ../src/Dictionaries/CacheDictionaryUpdateQueue.cpp:131
    7  0x00000000120a8282 in DB::CacheDictionaryUpdateQueue<(DB::DictionaryKeyType)0>::CacheDictionaryUpdateQueue(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, DB::CacheDictionaryUpdateQueueConfiguration, std::__1::function<void (std::__1::shared_ptr<DB::CacheDictionaryUpdateUnit<(DB::DictionaryKeyType)0> >)>&&)::{lambda()#1}::operator()() const (this=0x7f8747c64238) at ../src/Dictionaries/CacheDictionaryUpdateQueue.cpp:32

And server has MEMORY_LIMIT_EXCEEED errors on adding messages to the
log, in the stderr, so it is under high memory pressure.

And as you can see 12462 does not wait thread pool from
stopAndWait(), instead it waits from dtor, and this means that some
exception had been throw there.

</details>

  [1]: https://clickhouse-test-reports.s3.yandex.net/29060/c087fc0ed5fbea133eb3dc3a64b8db93a81d0ece/stress_test_(thread).html#fail1

Cc: @kitaisreal 