### PR TITLE
Add NULL value of param serialization for a parameterized query into Client

### DIFF
--- a/src/DataTypes/Serializations/SerializationNullable.cpp
+++ b/src/DataTypes/Serializations/SerializationNullable.cpp
@@ -228,7 +228,9 @@ ReturnType SerializationNullable::deserializeTextEscapedImpl(IColumn & column, R
     {
         /// This is not null, surely.
         return safeDeserialize<ReturnType>(column, *nested,
-            [] { return false; },
+            [&istr] {
+                return checkStringByFirstCharacterAndAssertTheRestCaseInsensitive("NULL", istr);
+            },
             [&nested, &istr, &settings] (IColumn & nested_column) { nested->deserializeTextEscaped(nested_column, istr, settings); });
     }
     else

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1185,7 +1185,7 @@ def main(args):
 
     # Keep same default values as in queries/shell_config.sh
     os.environ.setdefault("CLICKHOUSE_BINARY", args.binary)
-    # os.environ.setdefault("CLICKHOUSE_CLIENT", args.client)
+    os.environ.setdefault("CLICKHOUSE_CLIENT", args.client)
     os.environ.setdefault("CLICKHOUSE_CONFIG", args.configserver)
 
     if args.configclient:

--- a/tests/queries/0_stateless/00954_client_prepared_statements.reference
+++ b/tests/queries/0_stateless/00954_client_prepared_statements.reference
@@ -9,3 +9,4 @@ Hello, world
 Hello, world
 0
 0
+\N

--- a/tests/queries/0_stateless/00954_client_prepared_statements.sh
+++ b/tests/queries/0_stateless/00954_client_prepared_statements.sh
@@ -33,3 +33,5 @@ $CLICKHOUSE_CLIENT --param_test='Hello, world' --query 'SELECT {test:String}'
 
 $CLICKHOUSE_CLIENT --param_test '' --query 'SELECT length({test:String})'
 $CLICKHOUSE_CLIENT --param_test='' --query 'SELECT length({test:String})'
+
+$CLICKHOUSE_CLIENT --param_test='Null' --query 'SELECT {test:Nullable(Nothing)}'


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fixed the exception in case of sending NULL param's value for a parameterized query into Client

Detailed description / Documentation draft:
- Fix bug for sending NULL param's value for a parameterized query in Client

Example:
>  clickhouse-client --param_x=Null --query='SELECT {x:Nullable(Nothing)}'
> \N
