### PR TITLE
Fix issue: clickhouse-format --obfuscate cannot process queries with embedded dictionaries

### DIFF
--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -110,10 +110,6 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
                 hash_func.update(options["seed"].as<std::string>());
             }
 
-            SharedContextHolder shared_context = Context::createShared();
-            auto context = Context::createGlobal(shared_context.get());
-            context->makeGlobalContext();
-
             registerFunctions();
             registerAggregateFunctions();
             registerTableFunctions();
@@ -131,7 +127,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             {
                 std::string what(name);
 
-                return FunctionFactory::instance().tryGet(what, context) != nullptr
+                return FunctionFactory::instance().has(what)
                     || AggregateFunctionFactory::instance().isAggregateFunctionName(what)
                     || TableFunctionFactory::instance().isTableFunctionName(what)
                     || additional_names.count(what);

--- a/src/Functions/FunctionFactory.cpp
+++ b/src/Functions/FunctionFactory.cpp
@@ -87,6 +87,15 @@ FunctionOverloadResolverPtr FunctionFactory::get(
     return getImpl(name, context);
 }
 
+bool FunctionFactory::has(const std::string & name) const
+{
+    String canonical_name = getAliasToOrName(name);
+    if (functions.contains(canonical_name))
+        return true;
+    canonical_name = Poco::toLower(canonical_name);
+    return case_insensitive_functions.contains(canonical_name);
+}
+
 FunctionOverloadResolverPtr FunctionFactory::tryGetImpl(
     const std::string & name_param,
     ContextPtr context) const

--- a/src/Functions/FunctionFactory.h
+++ b/src/Functions/FunctionFactory.h
@@ -43,6 +43,8 @@ public:
     /// This function is used by YQL - internal Yandex product that depends on ClickHouse by source code.
     std::vector<std::string> getAllNames() const;
 
+    bool has(const std::string & name) const;
+
     /// Throws an exception if not found.
     FunctionOverloadResolverPtr get(const std::string & name, ContextPtr context) const;
 

--- a/tests/queries/0_stateless/02043_query_obfuscator_embedded_dictionaries.reference
+++ b/tests/queries/0_stateless/02043_query_obfuscator_embedded_dictionaries.reference
@@ -1,0 +1,1 @@
+SELECT regionToName(203), regionToCountry(203)

--- a/tests/queries/0_stateless/02043_query_obfuscator_embedded_dictionaries.sh
+++ b/tests/queries/0_stateless/02043_query_obfuscator_embedded_dictionaries.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_FORMAT --seed Hello --obfuscate <<< "SELECT regionToName(213), regionToCountry(213)"


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the issue: `clickhouse-format --obfuscate` cannot process queries with embedded dictionaries (functions `regionTo...`).