### PR TITLE
Fix initialization of `StorageURLSource`

### DIFF
--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -119,7 +119,7 @@ namespace
                             std::make_unique<ReadWriteBufferFromHTTP>(
                                 request_uri,
                                 method,
-                                std::move(callback),
+                                callback,
                                 timeouts,
                                 context->getSettingsRef().max_http_get_redirects,
                                 Poco::Net::HTTPBasicCredentials{},

--- a/tests/integration/test_redirect_url_storage/test.py
+++ b/tests/integration/test_redirect_url_storage/test.py
@@ -54,7 +54,7 @@ def test_url_with_globs_and_failover(started_cluster):
 
     result = node1.query(
         "select * from url('http://hdfs1:50075/webhdfs/v1/simple_storage_{0|1|2|3}_{1..3}?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV', 'data String') as data order by data")
-    assert result == "1\n2\n3\n"
+    assert result == "1\n2\n3\n" or result == "4\n5\n6\n"
 
 
 def test_url_with_redirect_not_allowed(started_cluster):

--- a/tests/queries/0_stateless/02044_url_glob_parallel.sh
+++ b/tests/queries/0_stateless/02044_url_glob_parallel.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Tags: distributed
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Sometimes five seconds are not enough due to system overload.
+# But if it can run in less than five seconds at least sometimes - it is enough for the test.
+while true
+do
+    timeout 5s ${CLICKHOUSE_CLIENT} --max_threads 10 --query "SELECT * FROM url('http://127.0.0.{1..10}:${CLICKHOUSE_PORT_HTTP}/?query=SELECT+sleep(1)', TSV, 'x UInt8')" --format Null && break
+done


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make `url` table function to process multiple URLs in parallel. This closes #29670 and closes #29671.