### PR TITLE
Remove fallback to failed O_DIRECT case on open

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -44,7 +44,6 @@
     M(MarkCacheMisses, "") \
     M(CreatedReadBufferOrdinary, "") \
     M(CreatedReadBufferDirectIO, "") \
-    M(CreatedReadBufferDirectIOFailed, "") \
     M(CreatedReadBufferMMap, "") \
     M(CreatedReadBufferMMapFailed, "") \
     M(DiskReadElapsedMicroseconds, "Total time spent waiting for read syscall. This include reads from page cache.") \

--- a/src/IO/createReadBufferFromFileBase.cpp
+++ b/src/IO/createReadBufferFromFileBase.cpp
@@ -89,17 +89,26 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
     if (settings.direct_io_threshold && estimated_size >= settings.direct_io_threshold)
     {
         /** O_DIRECT
-          * The O_DIRECT flag may impose alignment restrictions on the length and address of user-space buffers and the file offset of I/Os.
-          * In Linux alignment restrictions vary by filesystem and kernel version and might be absent entirely.
-          * However there is currently no filesystem-independent interface for an application to discover these restrictions
-          * for a given file or filesystem. Some filesystems provide their own interfaces for doing so, for example the
-          * XFS_IOC_DIOINFO operation in xfsctl(3).
           *
-          * Under Linux 2.4, transfer sizes, and the alignment of the user buffer and the file offset must all be
-          * multiples of the logical block size of the filesystem. Since Linux 2.6.0, alignment to the logical block size
-          * of the underlying storage (typically 512 bytes) suffices.
+          * The O_DIRECT flag may impose alignment restrictions on the length
+          * and address of user-space buffers and the file offset of I/Os.
           *
-          * - man 2 open
+          * In Linux alignment restrictions vary by filesystem and kernel
+          * version and might be absent entirely, but usually aligment is
+          * st_blksize (stat(2)) / BLKSSZGET (ioctl(2)).
+          *
+          * But there is precise filesystem-independent method for an
+          * application to discover these restrictions for a given file or
+          * filesystem. Some filesystems provide their own interfaces for doing
+          * so, for example the XFS_IOC_DIOINFO operation in xfsctl(3).
+          *
+          * From open(2):
+          *
+          *     Under Linux 2.4, transfer sizes, and the alignment of the user
+          *     buffer and the file offset must all be multiples of the logical
+          *     block size of the filesystem. Since Linux 2.6.0, alignment to the
+          *     logical block size of the underlying storage (typically 512 bytes)
+          *     suffices.
           */
         constexpr size_t min_alignment = DEFAULT_AIO_FILE_BLOCK_SIZE;
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove fallback to failed O_DIRECT case on open

Detailed description / Documentation draft:
open() for O_DIRECT will fail only if it is not supported by the
filesystem, and I don't know any widely used filesystem that does not
support O_DIRECT completely (and if the filesystem is not widely used I
don't think that it should be used to store data, but if you want to
test something you can always disable O_DIRECT in ClickHouse completelly
using settings/merge tree settings).

O_DIRECT may fail on read(), if the aligment restrictions had been not
satisfied, but createReadBufferFromFileBase() does not checks this
anyway.

But, almost always 4K (buffer size for O_DIRECT) is enough.

And also remove CreatedReadBufferDirectIOFailed profile event.

Follow-up for: #26003 (cc @alexey-milovidov )