### PR TITLE
Apply max_untracked_memory/memory_profiler_step/memory_profiler_sample_probability during mutate/merge

### DIFF
--- a/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
@@ -185,7 +185,13 @@ std::pair<bool, ReplicatedMergeMutateTaskBase::PartLogWriter> MergeFromLogEntryT
     auto table_id = storage.getStorageID();
 
     /// Add merge to list
-    merge_mutate_entry = storage.getContext()->getMergeList().insert(storage.getStorageID(), future_merged_part);
+    const Settings & settings = storage.getContext()->getSettingsRef();
+    merge_mutate_entry = storage.getContext()->getMergeList().insert(
+        storage.getStorageID(),
+        future_merged_part,
+        settings.memory_profiler_step,
+        settings.memory_profiler_sample_probability,
+        settings.max_untracked_memory);
 
     transaction_ptr = std::make_unique<MergeTreeData::Transaction>(storage);
     stopwatch_ptr = std::make_unique<Stopwatch>();

--- a/src/Storages/MergeTree/MergeList.cpp
+++ b/src/Storages/MergeTree/MergeList.cpp
@@ -10,7 +10,7 @@ namespace DB
 {
 
 
-MemoryTrackerThreadSwitcher::MemoryTrackerThreadSwitcher(MemoryTracker * memory_tracker_ptr)
+MemoryTrackerThreadSwitcher::MemoryTrackerThreadSwitcher(MemoryTracker * memory_tracker_ptr, UInt64 untracked_memory_limit)
 {
     // Each merge is executed into separate background processing pool thread
     background_thread_memory_tracker = CurrentThread::getMemoryTracker();
@@ -31,6 +31,9 @@ MemoryTrackerThreadSwitcher::MemoryTrackerThreadSwitcher(MemoryTracker * memory_
         background_thread_memory_tracker_prev_parent = background_thread_memory_tracker->getParent();
         background_thread_memory_tracker->setParent(memory_tracker_ptr);
     }
+
+    prev_untracked_memory_limit = current_thread->untracked_memory_limit;
+    current_thread->untracked_memory_limit = untracked_memory_limit;
 }
 
 
@@ -40,15 +43,23 @@ MemoryTrackerThreadSwitcher::~MemoryTrackerThreadSwitcher()
 
     if (background_thread_memory_tracker)
         background_thread_memory_tracker->setParent(background_thread_memory_tracker_prev_parent);
+
+    current_thread->untracked_memory_limit = prev_untracked_memory_limit;
 }
 
-MergeListElement::MergeListElement(const StorageID & table_id_, FutureMergedMutatedPartPtr future_part)
+MergeListElement::MergeListElement(
+    const StorageID & table_id_,
+    FutureMergedMutatedPartPtr future_part,
+    UInt64 memory_profiler_step,
+    UInt64 memory_profiler_sample_probability,
+    UInt64 max_untracked_memory_)
     : table_id{table_id_}
     , partition_id{future_part->part_info.partition_id}
     , result_part_name{future_part->name}
     , result_part_path{future_part->path}
     , result_part_info{future_part->part_info}
     , num_parts{future_part->parts.size()}
+    , max_untracked_memory(max_untracked_memory_)
     , thread_id{getThreadId()}
     , merge_type{future_part->merge_type}
     , merge_algorithm{MergeAlgorithm::Undecided}
@@ -68,6 +79,11 @@ MergeListElement::MergeListElement(const StorageID & table_id_, FutureMergedMuta
         source_data_version = future_part->parts[0]->info.getDataVersion();
         is_mutation = (result_part_info.getDataVersion() != source_data_version);
     }
+
+    memory_tracker.setDescription("Mutate/Merge");
+    memory_tracker.setProfilerStep(memory_profiler_step);
+    memory_tracker.setOrRaiseProfilerLimit(memory_profiler_step);
+    memory_tracker.setSampleProbability(memory_profiler_sample_probability);
 }
 
 MergeInfo MergeListElement::getInfo() const

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -30,7 +30,7 @@ bool MergePlainMergeTreeTask::executeStep()
     /// Make out memory tracker a parent of current thread memory tracker
     MemoryTrackerThreadSwitcherPtr switcher;
     if (merge_list_entry)
-        switcher = std::make_unique<MemoryTrackerThreadSwitcher>(&(*merge_list_entry)->memory_tracker);
+        switcher = std::make_unique<MemoryTrackerThreadSwitcher>(&(*merge_list_entry)->memory_tracker, (*merge_list_entry)->max_untracked_memory);
 
     switch (state)
     {
@@ -77,7 +77,13 @@ void MergePlainMergeTreeTask::prepare()
     future_part = merge_mutate_entry->future_part;
     stopwatch_ptr = std::make_unique<Stopwatch>();
 
-    merge_list_entry = storage.getContext()->getMergeList().insert(storage.getStorageID(), future_part);
+    const Settings & settings = storage.getContext()->getSettingsRef();
+    merge_list_entry = storage.getContext()->getMergeList().insert(
+        storage.getStorageID(),
+        future_part,
+        settings.memory_profiler_step,
+        settings.memory_profiler_sample_probability,
+        settings.max_untracked_memory);
 
     write_part_log = [this] (const ExecutionStatus & execution_status)
     {

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -535,11 +535,18 @@ bool MergeTask::MergeProjectionsStage::mergeMinMaxIndexAndPrepareProjections() c
         if (projection.type == ProjectionDescription::Type::Aggregate)
             projection_merging_params.mode = MergeTreeData::MergingParams::Aggregating;
 
+        const Settings & settings = global_ctx->context->getSettingsRef();
+
         ctx->tasks_for_projections.emplace_back(std::make_shared<MergeTask>(
             projection_future_part,
             projection.metadata,
             global_ctx->merge_entry,
-            std::make_unique<MergeListElement>((*global_ctx->merge_entry)->table_id, projection_future_part),
+            std::make_unique<MergeListElement>(
+                (*global_ctx->merge_entry)->table_id,
+                projection_future_part,
+                settings.memory_profiler_step,
+                settings.memory_profiler_sample_probability,
+                settings.max_untracked_memory),
             global_ctx->time_of_merge,
             global_ctx->context,
             global_ctx->space_reservation,

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -71,7 +71,13 @@ std::pair<bool, ReplicatedMergeMutateTaskBase::PartLogWriter> MutateFromLogEntry
     future_mutated_part->updatePath(storage, reserved_space.get());
     future_mutated_part->type = source_part->getType();
 
-    merge_mutate_entry = storage.getContext()->getMergeList().insert(storage.getStorageID(), future_mutated_part);
+    const Settings & settings = storage.getContext()->getSettingsRef();
+    merge_mutate_entry = storage.getContext()->getMergeList().insert(
+        storage.getStorageID(),
+        future_mutated_part,
+        settings.memory_profiler_step,
+        settings.memory_profiler_sample_probability,
+        settings.max_untracked_memory);
 
     stopwatch_ptr = std::make_unique<Stopwatch>();
 

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -628,12 +628,19 @@ public:
             if (projection.type == ProjectionDescription::Type::Aggregate)
                 projection_merging_params.mode = MergeTreeData::MergingParams::Aggregating;
 
+            const Settings & settings = ctx->context->getSettingsRef();
+
             LOG_DEBUG(log, "Merged {} parts in level {} to {}", selected_parts.size(), current_level, projection_future_part->name);
             auto tmp_part_merge_task = ctx->mutator->mergePartsToTemporaryPart(
                 projection_future_part,
                 projection.metadata,
                 ctx->mutate_entry,
-                std::make_unique<MergeListElement>((*ctx->mutate_entry)->table_id, projection_future_part),
+                std::make_unique<MergeListElement>(
+                    (*ctx->mutate_entry)->table_id,
+                    projection_future_part,
+                    settings.memory_profiler_step,
+                    settings.memory_profiler_sample_probability,
+                    settings.max_untracked_memory),
                 *ctx->holder,
                 ctx->time_of_mutation,
                 ctx->context,

--- a/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp
@@ -122,7 +122,7 @@ bool ReplicatedMergeMutateTaskBase::executeImpl()
 {
     MemoryTrackerThreadSwitcherPtr switcher;
     if (merge_mutate_entry)
-        switcher = std::make_unique<MemoryTrackerThreadSwitcher>(&(*merge_mutate_entry)->memory_tracker);
+        switcher = std::make_unique<MemoryTrackerThreadSwitcher>(&(*merge_mutate_entry)->memory_tracker, (*merge_mutate_entry)->max_untracked_memory);
 
     auto remove_processed_entry = [&] () -> bool
     {

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -966,7 +966,12 @@ bool StorageMergeTree::mutateSelectedPart(const StorageMetadataPtr & metadata_sn
 {
     auto & future_part = merge_mutate_entry.future_part;
 
-    auto merge_list_entry = getContext()->getMergeList().insert(getStorageID(), future_part);
+    const Settings & settings = getContext()->getSettingsRef();
+    auto merge_list_entry = getContext()->getMergeList().insert(
+        getStorageID(), future_part,
+        settings.memory_profiler_step,
+        settings.memory_profiler_sample_probability,
+        settings.max_untracked_memory);
     Stopwatch stopwatch;
     MutableDataPartPtr new_part;
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Apply `max_untracked_memory`/`memory_profiler_step`/`memory_profiler_sample_probability` during mutate/merge