### PR TITLE
Fix Xcode 13 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,9 @@ if (COMPILER_CLANG)
     endif()
 endif ()
 
+# If compiler has support for -Wreserved-identifier. It is difficult to detect by clang version,
+# because there are two different branches of clang: clang and AppleClang.
+# (AppleClang is not supported by ClickHouse, but some developers have misfortune to use it).
 if (HAS_RESERVED_IDENTIFIER)
     add_compile_definitions (HAS_RESERVED_IDENTIFIER)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,10 @@ if (COMPILER_CLANG)
     endif()
 endif ()
 
+if (HAS_RESERVED_IDENTIFIER)
+    add_compile_definitions(HAS_RESERVED_IDENTIFIER)
+endif()
+
 # If turned `ON`, assumes the user has either the system GTest library or the bundled one.
 option(ENABLE_TESTS "Provide unit_test_dbms target with Google.Test unit tests" ON)
 option(ENABLE_EXAMPLES "Build all example programs in 'examples' subdirectories" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,8 +177,8 @@ if (COMPILER_CLANG)
 endif ()
 
 if (HAS_RESERVED_IDENTIFIER)
-    add_compile_definitions(HAS_RESERVED_IDENTIFIER)
-endif()
+    add_compile_definitions (HAS_RESERVED_IDENTIFIER)
+endif ()
 
 # If turned `ON`, assumes the user has either the system GTest library or the bundled one.
 option(ENABLE_TESTS "Provide unit_test_dbms target with Google.Test unit tests" ON)

--- a/base/base/LineReader.cpp
+++ b/base/base/LineReader.cpp
@@ -16,7 +16,7 @@ extern "C"
 }
 #endif
 
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/base/base/phdr_cache.cpp
+++ b/base/base/phdr_cache.cpp
@@ -1,4 +1,4 @@
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/base/base/unit.h
+++ b/base/base/unit.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstddef>
 
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -1,4 +1,4 @@
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/base/readpassphrase/readpassphrase.c
+++ b/base/readpassphrase/readpassphrase.c
@@ -27,7 +27,7 @@
 #define _PATH_TTY "/dev/tty"
 #endif
 
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/cmake/check_flags.cmake
+++ b/cmake/check_flags.cmake
@@ -1,6 +1,7 @@
 include (CheckCXXCompilerFlag)
 include (CheckCCompilerFlag)
 
+check_cxx_compiler_flag("-Wreserved-identifier" HAS_RESERVED_IDENTIFIER)
 check_cxx_compiler_flag("-Wsuggest-destructor-override" HAS_SUGGEST_DESTRUCTOR_OVERRIDE)
 check_cxx_compiler_flag("-Wshadow" HAS_SHADOW)
 check_cxx_compiler_flag("-Wsuggest-override" HAS_SUGGEST_OVERRIDE)

--- a/cmake/find/orc.cmake
+++ b/cmake/find/orc.cmake
@@ -2,7 +2,7 @@ option (ENABLE_ORC "Enable ORC" ${ENABLE_LIBRARIES})
 
 if(NOT ENABLE_ORC)
     if(USE_INTERNAL_ORC_LIBRARY)
-        message (${RECONFIGURE_MESSAGE_LEVEL} "Cannot use internal ORC library with ENABLE_ORD=OFF")
+        message (${RECONFIGURE_MESSAGE_LEVEL} "Cannot use internal ORC library with ENABLE_ORC=OFF")
     endif()
     return()
 endif()

--- a/src/Common/ThreadFuzzer.cpp
+++ b/src/Common/ThreadFuzzer.cpp
@@ -31,7 +31,7 @@
         M(int, pthread_mutex_unlock, pthread_mutex_t * arg)
 #endif
 
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/src/Common/examples/int_hashes_perf.cpp
+++ b/src/Common/examples/int_hashes_perf.cpp
@@ -1,4 +1,4 @@
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/src/Compression/CompressionCodecDoubleDelta.cpp
+++ b/src/Compression/CompressionCodecDoubleDelta.cpp
@@ -1,4 +1,4 @@
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/src/Compression/CompressionCodecGorilla.cpp
+++ b/src/Compression/CompressionCodecGorilla.cpp
@@ -1,4 +1,4 @@
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/src/Functions/FunctionsCodingIP.cpp
+++ b/src/Functions/FunctionsCodingIP.cpp
@@ -1,4 +1,4 @@
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/src/IO/ReadBufferFromFileDescriptor.cpp
+++ b/src/IO/ReadBufferFromFileDescriptor.cpp
@@ -11,7 +11,7 @@
 #include <sys/stat.h>
 
 
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/src/IO/tests/gtest_bit_io.cpp
+++ b/src/IO/tests/gtest_bit_io.cpp
@@ -1,4 +1,4 @@
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
@@ -1,4 +1,4 @@
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 

--- a/utils/memcpy-bench/memcpy-bench.cpp
+++ b/utils/memcpy-bench/memcpy-bench.cpp
@@ -1,4 +1,4 @@
-#if defined(__clang__) && __clang_major__ >= 13
+#ifdef HAS_RESERVED_IDENTIFIER
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 #endif
 


### PR DESCRIPTION
Changelog category:
- Not for changelog (changelog entry is not required)

Detailed description:
- Fix compilation under Xcode 13 and whatever version of Clang it is using.
- Parquet/Arrow/Orc have to be disabled though, with: `... -DENABLE_PARQUET=OFF -DUSE_INTERNAL_PARQUET_LIBRARY=OFF -DUSE_INTERNAL_ORC_LIBRARY=OFF ...`