### PR TITLE
MaterializedPostgreSQL fix

### DIFF
--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -66,7 +66,7 @@ void DatabaseMaterializedPostgreSQL::startSynchronization()
             *settings,
             /* is_materialized_postgresql_database = */ true);
 
-    NameSet tables_to_replicate;
+    std::set<String> tables_to_replicate;
     try
     {
         tables_to_replicate = replication_handler->fetchRequiredTables();

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -28,9 +28,9 @@ namespace ErrorCodes
 
 
 template<typename T>
-std::unordered_set<std::string> fetchPostgreSQLTablesList(T & tx, const String & postgres_schema)
+std::set<String> fetchPostgreSQLTablesList(T & tx, const String & postgres_schema)
 {
-    std::unordered_set<std::string> tables;
+    std::set<String> tables;
     std::string query = fmt::format("SELECT tablename FROM pg_catalog.pg_tables "
                                     "WHERE schemaname != 'pg_catalog' AND {}",
                                     postgres_schema.empty() ? "schemaname != 'information_schema'" : "schemaname = " + quoteString(postgres_schema));
@@ -272,7 +272,7 @@ PostgreSQLTableStructure fetchPostgreSQLTableStructure(pqxx::connection & connec
 }
 
 
-std::unordered_set<std::string> fetchPostgreSQLTablesList(pqxx::connection & connection, const String & postgres_schema)
+std::set<String> fetchPostgreSQLTablesList(pqxx::connection & connection, const String & postgres_schema)
 {
     pqxx::ReadTransaction tx(connection);
     auto result = fetchPostgreSQLTablesList(tx, postgres_schema);
@@ -297,13 +297,13 @@ PostgreSQLTableStructure fetchPostgreSQLTableStructure(
         bool with_primary_key, bool with_replica_identity_index);
 
 template
-std::unordered_set<std::string> fetchPostgreSQLTablesList(pqxx::work & tx, const String & postgres_schema);
+std::set<String> fetchPostgreSQLTablesList(pqxx::work & tx, const String & postgres_schema);
 
 template
-std::unordered_set<std::string> fetchPostgreSQLTablesList(pqxx::ReadTransaction & tx, const String & postgres_schema);
+std::set<String> fetchPostgreSQLTablesList(pqxx::ReadTransaction & tx, const String & postgres_schema);
 
 template
-std::unordered_set<std::string> fetchPostgreSQLTablesList(pqxx::nontransaction & tx, const String & postgres_schema);
+std::set<String> fetchPostgreSQLTablesList(pqxx::nontransaction & tx, const String & postgres_schema);
 
 }
 

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.h
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.h
@@ -21,7 +21,7 @@ struct PostgreSQLTableStructure
 
 using PostgreSQLTableStructurePtr = std::unique_ptr<PostgreSQLTableStructure>;
 
-std::unordered_set<std::string> fetchPostgreSQLTablesList(pqxx::connection & connection, const String & postgres_schema);
+std::set<String> fetchPostgreSQLTablesList(pqxx::connection & connection, const String & postgres_schema);
 
 PostgreSQLTableStructure fetchPostgreSQLTableStructure(
     pqxx::connection & connection, const String & postgres_table_name, bool use_nulls = true);
@@ -32,7 +32,7 @@ PostgreSQLTableStructure fetchPostgreSQLTableStructure(
     bool with_primary_key = false, bool with_replica_identity_index = false);
 
 template<typename T>
-std::unordered_set<std::string> fetchPostgreSQLTablesList(T & tx, const String & postgres_schema);
+std::set<String> fetchPostgreSQLTablesList(T & tx, const String & postgres_schema);
 
 }
 

--- a/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
@@ -169,7 +169,7 @@ void PostgreSQLReplicationHandler::startSynchronization(bool throw_on_error)
         initial_sync();
     }
     /// Always drop replication slot if it is CREATE query and not ATTACH.
-    else if (!is_attach || new_publication)
+    else if (!is_attach)
     {
         if (!user_managed_slot)
             dropReplicationSlot(tx);
@@ -362,7 +362,6 @@ void PostgreSQLReplicationHandler::createPublicationIfNeeded(pqxx::nontransactio
         {
             tx.exec(query_str);
             LOG_TRACE(log, "Created publication {} with tables list: {}", publication_name, tables_list);
-            new_publication = true;
         }
         catch (Exception & e)
         {
@@ -513,10 +512,10 @@ void PostgreSQLReplicationHandler::shutdownFinal()
 
 
 /// Used by MaterializedPostgreSQL database engine.
-NameSet PostgreSQLReplicationHandler::fetchRequiredTables()
+std::set<String> PostgreSQLReplicationHandler::fetchRequiredTables()
 {
     postgres::Connection connection(connection_info);
-    NameSet result_tables;
+    std::set<String> result_tables;
     bool publication_exists_before_startup;
 
     {
@@ -569,6 +568,7 @@ NameSet PostgreSQLReplicationHandler::fetchRequiredTables()
                 }
 
                 NameSet diff;
+                std::sort(expected_tables.begin(), expected_tables.end());
                 std::set_symmetric_difference(expected_tables.begin(), expected_tables.end(),
                                               result_tables.begin(), result_tables.end(),
                                               std::inserter(diff, diff.begin()));
@@ -581,12 +581,30 @@ NameSet PostgreSQLReplicationHandler::fetchRequiredTables()
                             diff_tables += ", ";
                         diff_tables += table_name;
                     }
+                    String publication_tables;
+                    for (const auto & table_name : result_tables)
+                    {
+                        if (!publication_tables.empty())
+                            publication_tables += ", ";
+                        publication_tables += table_name;
+                    }
+                    String listed_tables;
+                    for (const auto & table_name : expected_tables)
+                    {
+                        if (!listed_tables.empty())
+                            listed_tables += ", ";
+                        listed_tables += table_name;
+                    }
 
-                    LOG_WARNING(log,
-                                "Publication {} already exists, but specified tables list differs from publication tables list in tables: {}.",
-                                publication_name, diff_tables);
+                    LOG_ERROR(log,
+                              "Publication {} already exists, but specified tables list differs from publication tables list in tables: {}. ",
+                              "Will use tables list from setting. "
+                              "To avoid redundant work, you can try ALTER PUBLICATION query to remove redundant tables. "
+                              "Or you can you ALTER SETTING. "
+                              "\nPublication tables: {}.\nTables list: {}",
+                              publication_name, diff_tables, publication_tables, listed_tables);
 
-                    connection.execWithRetry([&](pqxx::nontransaction & tx_){ dropPublication(tx_); });
+                    return std::set(expected_tables.begin(), expected_tables.end());
                 }
             }
         }
@@ -596,7 +614,7 @@ NameSet PostgreSQLReplicationHandler::fetchRequiredTables()
     {
         if (!tables_list.empty())
         {
-            result_tables = NameSet(expected_tables.begin(), expected_tables.end());
+            result_tables = std::set(expected_tables.begin(), expected_tables.end());
         }
         else
         {
@@ -614,10 +632,10 @@ NameSet PostgreSQLReplicationHandler::fetchRequiredTables()
 }
 
 
-NameSet PostgreSQLReplicationHandler::fetchTablesFromPublication(pqxx::work & tx)
+std::set<String> PostgreSQLReplicationHandler::fetchTablesFromPublication(pqxx::work & tx)
 {
     std::string query = fmt::format("SELECT tablename FROM pg_publication_tables WHERE pubname = '{}'", publication_name);
-    std::unordered_set<std::string> tables;
+    std::set<String> tables;
 
     for (auto table_name : tx.stream<std::string>(query))
         tables.insert(std::get<0>(table_name));

--- a/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.h
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.h
@@ -39,7 +39,7 @@ public:
     void addStorage(const std::string & table_name, StorageMaterializedPostgreSQL * storage);
 
     /// Fetch list of tables which are going to be replicated. Used for database engine.
-    NameSet fetchRequiredTables();
+    std::set<String> fetchRequiredTables();
 
     /// Start replication setup immediately.
     void startSynchronization(bool throw_on_error);
@@ -61,7 +61,7 @@ private:
 
     void createPublicationIfNeeded(pqxx::nontransaction & tx);
 
-    NameSet fetchTablesFromPublication(pqxx::work & tx);
+    std::set<String> fetchTablesFromPublication(pqxx::work & tx);
 
     void dropPublication(pqxx::nontransaction & ntx);
 
@@ -94,9 +94,6 @@ private:
 
     /// If it is not attach, i.e. a create query, then if publication already exists - always drop it.
     bool is_attach;
-
-    /// If new publication is created at start up - always drop replication slot if it exists.
-    bool new_publication = false;
 
     const String remote_database_name, current_database_name;
 

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -143,7 +143,7 @@ StoragePtr StorageMaterializedPostgreSQL::createTemporary() const
     }
 
     auto new_context = Context::createCopy(context);
-    return StorageMaterializedPostgreSQL::create(tmp_table_id, new_context, "", table_id.table_name);
+    return StorageMaterializedPostgreSQL::create(tmp_table_id, new_context, "temporary", table_id.table_name);
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed incorrect behaviour of setting `materialized_postgresql_tables_list` at server restart. Found in https://github.com/ClickHouse/ClickHouse/issues/28529.