### PR TITLE
fix rename of path for iostream_debug_helpers.h

### DIFF
--- a/base/base/CMakeLists.txt
+++ b/base/base/CMakeLists.txt
@@ -29,7 +29,7 @@ elseif (ENABLE_READLINE)
 endif ()
 
 if (USE_DEBUG_HELPERS)
-    set (INCLUDE_DEBUG_HELPERS "-include \"${ClickHouse_SOURCE_DIR}/base/common/iostream_debug_helpers.h\"")
+    set (INCLUDE_DEBUG_HELPERS "-include \"${ClickHouse_SOURCE_DIR}/base/base/iostream_debug_helpers.h\"")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${INCLUDE_DEBUG_HELPERS}")
 endif ()
 


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix an build error because of [Rename "common" to "base"](https://github.com/ClickHouse/ClickHouse/commit/fe6b7c77c7d6bd2a45a20f3b6bb4eb91da6177ff)


Detailed description / Documentation draft:
There was a problem when building:
```
[2/2223] Building CXX object base/base/CMakeFiles/common.dir/coverage.cpp.o
FAILED: base/base/CMakeFiles/common.dir/coverage.cpp.o 
/usr/bin/clang++-13  -DBOOST_ASIO_STANDALONE=1 -DPOCO_ENABLE_CPP11 -DPOCO_HAVE_FD_EPOLL -DPOCO_OS_FAMILY_UNIX -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUSE_REPLXX=1 -DWITH_COVERAGE=0 -DZ_TLS=__thread -Dcommon_EXPORTS -Iincludes/configs -I../base/base/.. -Ibase/base/.. -I../contrib/cityhash102/include -I../contrib/cctz/include -I../contrib/magic_enum/include -isystem ../contrib/libcxx/include -isystem ../contrib/libcxxabi/include -isystem ../contrib/libunwind/include -isystem ../contrib/boost -isystem ../contrib/poco/Net/include -isystem ../contrib/poco/Foundation/include -isystem ../contrib/poco/NetSSL_OpenSSL/include -isystem ../contrib/poco/Crypto/include -isystem ../contrib/boringssl/include -isystem ../contrib/poco/Util/include -isystem ../contrib/poco/JSON/include -isystem ../contrib/poco/XML/include -isystem ../contrib/replxx/include -isystem ../contrib/fmtlib-cmake/../fmtlib/include -isystem ../contrib/libc-headers/x86_64-linux-gnu -isystem ../contrib/libc-headers -fdiagnostics-color=always -Xclang -fuse-ctor-homing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -falign-functions=32   -Wall -Wno-unused-command-line-argument  -fdiagnostics-absolute-paths -fexperimental-new-pass-manager -Werror -Wextra -Wpedantic -Wno-vla-extension -Wno-zero-length-array -Wno-c11-extensions -Wcomma -Wconditional-uninitialized -Wcovered-switch-default -Wdeprecated -Wembedded-directive -Wempty-init-stmt -Wextra-semi-stmt -Wextra-semi -Wgnu-case-range -Winconsistent-missing-destructor-override -Wnewline-eof -Wold-style-cast -Wrange-loop-analysis -Wredundant-parens -Wreserved-id-macro -Wshadow-field -Wshadow-uncaptured-local -Wshadow -Wstring-plus-int -Wundef -Wunreachable-code-return -Wunreachable-code -Wunused-exception-parameter -Wunused-macros -Wunused-member-function -Wunneeded-internal-declaration -Wimplicit-int-float-conversion -Wanon-enum-enum-conversion -Wassign-enum -Wbitwise-op-parentheses -Wint-in-bool-context -Wsometimes-uninitialized -Wtautological-bitwise-compare -Wzero-as-null-pointer-constant -Weverything -Wno-c++98-compat-pedantic -Wno-c++98-compat -Wno-c99-extensions -Wno-conversion -Wno-ctad-maybe-unsupported -Wno-deprecated-dynamic-exception-spec -Wno-disabled-macro-expansion -Wno-documentation-unknown-command -Wno-double-promotion -Wno-exit-time-destructors -Wno-float-equal -Wno-global-constructors -Wno-missing-prototypes -Wno-missing-variable-declarations -Wno-nested-anon-types -Wno-packed -Wno-padded -Wno-shift-sign-overflow -Wno-sign-conversion -Wno-switch-enum -Wno-undefined-func-template -Wno-unused-template -Wno-vla -Wno-weak-template-vtables -Wno-weak-vtables -include "/home/semin-serg/ClickHouse/base/common/iostream_debug_helpers.h" -g -O0 -g3 -ggdb3 -fno-inline  -D_LIBCPP_DEBUG=0 -fPIC   -D OS_LINUX -nostdinc++ -std=gnu++2a -MD -MT base/base/CMakeFiles/common.dir/coverage.cpp.o -MF base/base/CMakeFiles/common.dir/coverage.cpp.o.d -o base/base/CMakeFiles/common.dir/coverage.cpp.o -c ../base/base/coverage.cpp
<built-in>:1:10: fatal error: '/home/semin-serg/ClickHouse/base/common/iostream_debug_helpers.h' file not found
#include "/home/semin-serg/ClickHouse/base/common/iostream_debug_helpers.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```

I have grepped this include and among results there was file I have changed in this PR:
```
semin-serg@semin-serg-ub:~/ClickHouse$ grep -r "iostream_debug_helpers.h" .
./base/base/CMakeLists.txt:    set (INCLUDE_DEBUG_HELPERS "-include \"${ClickHouse_SOURCE_DIR}/base/common/iostream_debug_helpers.h\"")
```

There is no file https://github.com/ClickHouse/ClickHouse/blob/master/base/common/iostream_debug_helpers.h
But file https://github.com/ClickHouse/ClickHouse/blob/master/base/base/iostream_debug_helpers.h exists.
So I changed ./base/base/CMakeLists.txt accordingly.