### PR TITLE
Fix data-race in WriteIndirectBuffer (used in DiskMemory)

### DIFF
--- a/src/Disks/DiskMemory.cpp
+++ b/src/Disks/DiskMemory.cpp
@@ -103,6 +103,8 @@ public:
         /// str() finalizes buffer.
         String value = impl.str();
 
+        std::lock_guard lock(disk->mutex);
+
         auto iter = disk->files.find(path);
 
         if (iter == disk->files.end())


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix data-race in `WriteIndirectBuffer` (used in `StripeLog`)

CI founds [1]:

<details>

```
WARNING: ThreadSanitizer: data race (pid=497)
  Write of size 8 at 0x7b30000260b8 by thread T381 (mutexes: write M546759850860896464):
    ...
    3 DB::DiskMemory::writeFile() obj-x86_64-linux-gnu/../src/Disks/DiskMemory.cpp:339:15 (clickhouse+0x14a1849f)
    4 DB::FileChecker::save() const obj-x86_64-linux-gnu/../src/Common/FileChecker.cpp:111:50 (clickhouse+0x15bbe19f)
    5 DB::TinyLogSink::TinyLogSink() obj-x86_64-linux-gnu/../src/Storages/StorageTinyLog.cpp:214:34 (clickhouse+0x15bca215)

  Previous read of size 8 at 0x7b30000260b8 by thread T460:
    ...
    2 DB::WriteIndirectBuffer::finalize() obj-x86_64-linux-gnu/../src/Disks/DiskMemory.cpp:106:33 (clickhouse+0x14a1e044)
    9 DB::StripeLogSink::onFinish() obj-x86_64-linux-gnu/../src/Storages/StorageStripeLog.cpp:227:30 (clickhouse+0x15bd241a)
```

</details>

  [1]: https://clickhouse-test-reports.s3.yandex.net/29680/d0fc26f91a0141b56a0550741219c3dc43630e03/stress_test_(thread)/stderr.log