### PR TITLE
Fix --stage for clickhouse-local

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1116,8 +1116,6 @@ void Client::processOptions(const OptionsDescription & options_description,
     if (options.count("config-file") && options.count("config"))
         throw Exception("Two or more configuration files referenced in arguments", ErrorCodes::BAD_ARGUMENTS);
 
-    query_processing_stage = QueryProcessingStage::fromString(options["stage"].as<std::string>());
-
     if (options.count("config"))
         config().setString("config-file", options["config"].as<std::string>());
     if (options.count("host") && !options["host"].defaulted())

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1577,6 +1577,8 @@ void ClientBase::init(int argc, char ** argv)
     if (options.count("log-level"))
         Poco::Logger::root().setLevel(options["log-level"].as<std::string>());
 
+    query_processing_stage = QueryProcessingStage::fromString(options["stage"].as<std::string>());
+
     processOptions(options_description, options, external_tables_arguments);
     argsToConfig(common_arguments, config(), 100);
     clearPasswordFromCommandLine(argc, argv);


### PR DESCRIPTION
This also fixes UBsan error, since query_processing_stage was not
initialized before for clikchouse-local.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @kssenii 
Follow-up for: #26231 