### PR TITLE
Adjust performance tests

### DIFF
--- a/tests/performance/parallel_mv.xml
+++ b/tests/performance/parallel_mv.xml
@@ -19,7 +19,7 @@
     <fill_query>SYSTEM STOP MERGES mt_3</fill_query>
     <fill_query>SYSTEM STOP MERGES mt_4</fill_query>
 
-    <query>insert into main_table select number from numbers(10000000)</query>
+    <query>insert into main_table select number from numbers(5e6)</query>
 
     <drop_query>drop table if exists main_table;</drop_query>
     <drop_query>drop table if exists mv_1;</drop_query>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- tests/performance: decrease number of rows to INSERT in parallel_mv (10e6 is too much, and usually it exceed `allowed_single_run_time` (=2s))