### PR TITLE
Fix parallel_view_processing

### DIFF
--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -398,18 +398,22 @@ BlockIO InterpreterInsertQuery::execute()
             return std::make_shared<ExpressionTransform>(in_header, actions);
         });
 
-        auto num_select_threads = pipeline.getNumThreads();
-
+        size_t num_select_threads = pipeline.getNumThreads();
+        size_t num_insert_threads = std::max_element(out_chains.begin(), out_chains.end(), [&](const auto &a, const auto &b)
+        {
+            return a.getNumThreads() < b.getNumThreads();
+        })->getNumThreads();
         pipeline.addChains(std::move(out_chains));
+
+        pipeline.setMaxThreads(num_insert_threads);
+        /// Don't use more threads for insert then for select to reduce memory consumption.
+        if (!settings.parallel_view_processing && pipeline.getNumThreads() > num_select_threads)
+            pipeline.setMaxThreads(num_select_threads);
 
         pipeline.setSinks([&](const Block & cur_header, QueryPipelineBuilder::StreamType) -> ProcessorPtr
         {
             return std::make_shared<EmptySink>(cur_header);
         });
-
-        /// Don't use more threads for insert then for select to reduce memory consumption.
-        if (!settings.parallel_view_processing && pipeline.getNumThreads() > num_select_threads)
-            pipeline.setMaxThreads(num_select_threads);
 
         if (!allow_materialized)
         {

--- a/src/Processors/QueryPipelineBuilder.cpp
+++ b/src/Processors/QueryPipelineBuilder.cpp
@@ -139,6 +139,7 @@ void QueryPipelineBuilder::addChains(std::vector<Chain> chains)
 {
     checkInitializedAndNotCompleted();
     pipe.addChains(std::move(chains));
+    setMaxThreads(pipe.maxParallelStreams());
 }
 
 void QueryPipelineBuilder::addChain(Chain chain)
@@ -148,6 +149,7 @@ void QueryPipelineBuilder::addChain(Chain chain)
     chains.emplace_back(std::move(chain));
     pipe.resize(1);
     pipe.addChains(std::move(chains));
+    setMaxThreads(pipe.maxParallelStreams());
 }
 
 void QueryPipelineBuilder::transform(const Transformer & transformer)

--- a/src/Processors/QueryPipelineBuilder.cpp
+++ b/src/Processors/QueryPipelineBuilder.cpp
@@ -139,7 +139,6 @@ void QueryPipelineBuilder::addChains(std::vector<Chain> chains)
 {
     checkInitializedAndNotCompleted();
     pipe.addChains(std::move(chains));
-    setMaxThreads(pipe.maxParallelStreams());
 }
 
 void QueryPipelineBuilder::addChain(Chain chain)
@@ -149,7 +148,6 @@ void QueryPipelineBuilder::addChain(Chain chain)
     chains.emplace_back(std::move(chain));
     pipe.resize(1);
     pipe.addChains(std::move(chains));
-    setMaxThreads(pipe.maxParallelStreams());
 }
 
 void QueryPipelineBuilder::transform(const Transformer & transformer)

--- a/tests/queries/0_stateless/01275_parallel_mv.reference
+++ b/tests/queries/0_stateless/01275_parallel_mv.reference
@@ -1,4 +1,27 @@
+-- { echoOn }
+set parallel_view_processing=1;
+insert into testX select number from numbers(10) settings log_queries=1; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+system flush logs;
+select length(thread_ids) from system.query_log where current_database = currentDatabase() and type != 'QueryStart' and query like '%insert into testX %' and Settings['parallel_view_processing'] = '1';
+8
+select count() from testX;
 10
+select count() from testXA;
 10
+select count() from testXB;
 0
+select count() from testXC;
 10
+set parallel_view_processing=0;
+insert into testX select number from numbers(10) settings log_queries=1; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+system flush logs;
+select length(thread_ids) from system.query_log where current_database = currentDatabase() and type != 'QueryStart' and query like '%insert into testX %' and Settings['parallel_view_processing'] = '0';
+5
+select count() from testX;
+20
+select count() from testXA;
+20
+select count() from testXB;
+0
+select count() from testXC;
+20

--- a/tests/queries/0_stateless/01275_parallel_mv.sql
+++ b/tests/queries/0_stateless/01275_parallel_mv.sql
@@ -9,13 +9,27 @@ create materialized view testXA engine=MergeTree order by tuple() as select slee
 create materialized view testXB engine=MergeTree order by tuple() as select sleep(2), throwIf(A=1) from testX;
 create materialized view testXC engine=MergeTree order by tuple() as select sleep(1) from testX;
 
+-- { echoOn }
 set parallel_view_processing=1;
-insert into testX select number from numbers(10); -- {serverError 395}
+insert into testX select number from numbers(10) settings log_queries=1; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+system flush logs;
+select length(thread_ids) from system.query_log where current_database = currentDatabase() and type != 'QueryStart' and query like '%insert into testX %' and Settings['parallel_view_processing'] = '1';
 
 select count() from testX;
 select count() from testXA;
 select count() from testXB;
 select count() from testXC;
+
+set parallel_view_processing=0;
+insert into testX select number from numbers(10) settings log_queries=1; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+system flush logs;
+select length(thread_ids) from system.query_log where current_database = currentDatabase() and type != 'QueryStart' and query like '%insert into testX %' and Settings['parallel_view_processing'] = '0';
+
+select count() from testX;
+select count() from testXA;
+select count() from testXB;
+select count() from testXC;
+-- { echoOff }
 
 drop table testX;
 drop view testXA;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `parallel_view_processing`

Fixes: #28582 (cc @KochetovNicolai )
Fixes: #29621
Closes: #29760

*NOTE: marked as not for changelog, since the original PR has not been included to any release yet*