### PR TITLE
Fix bad cast in ParserCreateQuery

### DIFF
--- a/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
+++ b/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
@@ -120,7 +120,7 @@ static NamesAndTypesList getColumnsList(const ASTExpressionList * columns_defini
                     auto * literal = child->as<ASTLiteral>();
 
                     new_child->arguments = std::make_shared<ASTExpressionList>();
-                    new_child->arguments->children.push_back(std::make_shared<ASTLiteral>(literal->value.get<String>()));
+                    new_child->arguments->children.push_back(std::make_shared<ASTLiteral>(literal->value.safeGet<String>()));
                     new_child->arguments->children.push_back(std::make_shared<ASTLiteral>(Int16(++i)));
                     child = new_child;
                 }

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -481,7 +481,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
 
     if (attach && s_from.ignore(pos, expected))
     {
-        ParserLiteral from_path_p;
+        ParserStringLiteral from_path_p;
         if (!from_path_p.parse(pos, from_path, expected))
             return false;
     }

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -896,7 +896,7 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     if (ParserKeyword{"TO INNER UUID"}.ignore(pos, expected))
     {
-        ParserLiteral literal_p;
+        ParserStringLiteral literal_p;
         if (!literal_p.parse(pos, to_inner_uuid, expected))
             return false;
     }

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -461,7 +461,7 @@ bool MergeTreeIndexConditionSet::checkASTUseless(const ASTPtr & node, bool atomi
                 [this](const auto & arg) { return checkASTUseless(arg, true); });
     }
     else if (const auto * literal = node->as<ASTLiteral>())
-        return !atomic && literal->value.get<bool>();
+        return !atomic && literal->value.safeGet<bool>();
     else if (const auto * identifier = node->as<ASTIdentifier>())
         return key_columns.find(identifier->getColumnName()) == std::end(key_columns);
     else

--- a/tests/queries/0_stateless/01188_attach_table_from_path.sql
+++ b/tests/queries/0_stateless/01188_attach_table_from_path.sql
@@ -7,6 +7,7 @@ drop table if exists mt;
 attach table test from 'some/path' (n UInt8) engine=Memory; -- { serverError 48 }
 attach table test from '/etc/passwd' (s String) engine=File(TSVRaw); -- { serverError 481 }
 attach table test from '../../../../../../../../../etc/passwd' (s String) engine=File(TSVRaw); -- { serverError 481 }
+attach table test from 42 (s String) engine=File(TSVRaw); -- { clientError 62 }
 
 insert into table function file('01188_attach/file/data.TSV', 'TSV', 's String, n UInt8') values ('file', 42);
 attach table file from '01188_attach/file' (s String, n UInt8) engine=File(TSV);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bad cast in `ATTACH TABLE ... FROM 'path'` query when non-string literal is used instead of path. It may lead to reading of uninitialized memory.

- [x] check other places;
- [x] add a test.