### PR TITLE
Improvement for #28373

### DIFF
--- a/src/Databases/DDLDependencyVisitor.h
+++ b/src/Databases/DDLDependencyVisitor.h
@@ -8,6 +8,7 @@ namespace DB
 
 class ASTFunction;
 class ASTFunctionWithKeyValueArguments;
+class ASTStorage;
 
 /// Visits ASTCreateQuery and extracts names of table (or dictionary) dependencies
 /// from column default expressions (joinGet, dictGet, etc)
@@ -33,6 +34,7 @@ public:
 private:
     static void visit(const ASTFunction & function, Data & data);
     static void visit(const ASTFunctionWithKeyValueArguments & dict_source, Data & data);
+    static void visit(const ASTStorage & storage, Data & data);
 
     static void extractTableNameFromArgument(const ASTFunction & function, Data & data, size_t arg_idx);
 };

--- a/tests/integration/helpers/0_common_instance_config.xml
+++ b/tests/integration/helpers/0_common_instance_config.xml
@@ -9,7 +9,7 @@
     <users_config>users.xml</users_config>
 
   <logger>
-        <level>trace</level>
+        <level>test</level>
         <log>/var/log/clickhouse-server/clickhouse-server.log</log>
         <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
         <size>1000M</size>

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2357,17 +2357,20 @@ class ClickHouseInstance:
         dictionaries_dir = p.abspath(p.join(instance_config_dir, 'dictionaries'))
         os.mkdir(dictionaries_dir)
 
-        def write_embedded_config(name, dest_dir):
+        def write_embedded_config(name, dest_dir, fix_log_level=False):
             with open(p.join(HELPERS_DIR, name), 'r') as f:
                 data = f.read()
                 data = data.replace('yandex', self.config_root_name)
+                if fix_log_level:
+                    data = data.replace('<level>test</level>', '<level>trace</level>')
                 with open(p.join(dest_dir, name), 'w') as r:
                     r.write(data)
 
         logging.debug("Copy common configuration from helpers")
         # The file is named with 0_ prefix to be processed before other configuration overloads.
         if self.copy_common_configs:
-            write_embedded_config('0_common_instance_config.xml', self.config_d_dir)
+            need_fix_log_level = self.tag != 'latest'
+            write_embedded_config('0_common_instance_config.xml', self.config_d_dir, need_fix_log_level)
 
         write_embedded_config('0_common_instance_users.xml', users_d_dir)
 

--- a/tests/integration/test_dictionaries_dependency/test.py
+++ b/tests/integration/test_dictionaries_dependency/test.py
@@ -36,6 +36,8 @@ def cleanup_after_test():
         yield
     finally:
         for node in nodes:
+            for i in range(4):
+                node.query("DROP DICTIONARY IF EXISTS test.other_{}".format(i))
             node.query("DROP DICTIONARY IF EXISTS test.adict")
             node.query("DROP DICTIONARY IF EXISTS test.zdict")
             node.query("DROP DICTIONARY IF EXISTS atest.dict")

--- a/tests/integration/test_dictionaries_dependency/test.py
+++ b/tests/integration/test_dictionaries_dependency/test.py
@@ -106,8 +106,11 @@ def test_dependency_via_dictionary_database(node):
         for d_name in d_names:
             assert node.query("SELECT dictGet({}, 'y', toUInt64(5))".format(d_name)) == "6\n"
 
-    check()
+
+    for d_name in d_names:
+        assert node.query("SELECT dictGet({}, 'y', toUInt64(5))".format(d_name)) == "6\n"
 
     # Restart must not break anything.
     node.restart_clickhouse()
-    check()
+    for d_name in d_names:
+        assert node.query_with_retry("SELECT dictGet({}, 'y', toUInt64(5))".format(d_name)) == "6\n"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
Without this change test `test_dictionaries_dependency/test.py::test_dependency_via_explicit_table` is flaky.
"Not for changelog" because #28373 in not released yet.
