### PR TITLE
Fix compilation with glibc 2.34 (MINSIGSTKSZ defined as sysconf(_SC_SIGSTKSZ))

### DIFF
--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -44,7 +44,7 @@ namespace
 struct ThreadStack
 {
     ThreadStack()
-        : data(aligned_alloc(getPageSize(), size))
+        : data(aligned_alloc(getPageSize(), getSize()))
     {
         /// Add a guard page
         /// (and since the stack grows downward, we need to protect the first page).
@@ -56,12 +56,11 @@ struct ThreadStack
         free(data);
     }
 
-    static size_t getSize() { return size; }
+    static size_t getSize() { return std::max<size_t>(16 << 10, MINSIGSTKSZ); }
     void * getData() const { return data; }
 
 private:
     /// 16 KiB - not too big but enough to handle error.
-    static constexpr size_t size = std::max<size_t>(16 << 10, MINSIGSTKSZ);
     void * data;
 };
 


### PR DESCRIPTION
Since glibc 2.34 `MINSIGSTKSZ` had been defined to `sysconf(_SC_SIGSTKSZ)` [1].

  [1]: https://sourceware.org/git/?p=glibc.git;a=commit;h=6c57d320484988e87e446e2e60ce42816bf51d53

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #29797