### PR TITLE
Make memory_profiler_step API cleaner

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1159,7 +1159,6 @@ if (ThreadFuzzer::instance().isEffective())
         UInt64 total_memory_profiler_step = config().getUInt64("total_memory_profiler_step", 0);
         if (total_memory_profiler_step)
         {
-            total_memory_tracker.setOrRaiseProfilerLimit(total_memory_profiler_step);
             total_memory_tracker.setProfilerStep(total_memory_profiler_step);
         }
 

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -61,6 +61,8 @@ private:
     void updatePeak(Int64 will_be, bool log_memory_usage);
     void logMemoryUsage(Int64 current) const;
 
+    void setOrRaiseProfilerLimit(Int64 value);
+
 public:
     explicit MemoryTracker(VariableContext level_ = VariableContext::Thread);
     explicit MemoryTracker(MemoryTracker * parent_, VariableContext level_ = VariableContext::Thread);
@@ -106,7 +108,6 @@ public:
       * Otherwise, set limit to new value, if new value is greater than previous limit.
       */
     void setOrRaiseHardLimit(Int64 value);
-    void setOrRaiseProfilerLimit(Int64 value);
 
     void setFaultProbability(double value)
     {
@@ -121,6 +122,7 @@ public:
     void setProfilerStep(Int64 value)
     {
         profiler_step = value;
+        setOrRaiseProfilerLimit(value);
     }
 
     /// next should be changed only once: from nullptr to some value.

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -203,7 +203,6 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
             if (query_context->hasTraceCollector())
             {
                 /// Set up memory profiling
-                thread_group->memory_tracker.setOrRaiseProfilerLimit(settings.memory_profiler_step);
                 thread_group->memory_tracker.setProfilerStep(settings.memory_profiler_step);
                 thread_group->memory_tracker.setSampleProbability(settings.memory_profiler_sample_probability);
             }

--- a/src/Storages/MergeTree/MergeList.cpp
+++ b/src/Storages/MergeTree/MergeList.cpp
@@ -82,7 +82,6 @@ MergeListElement::MergeListElement(
 
     memory_tracker.setDescription("Mutate/Merge");
     memory_tracker.setProfilerStep(memory_profiler_step);
-    memory_tracker.setOrRaiseProfilerLimit(memory_profiler_step);
     memory_tracker.setSampleProbability(memory_profiler_sample_probability);
 }
 


### PR DESCRIPTION
Right now to configure memory_profiler_step/total_memory_profiler_step
you need to call:

    MemoryTracker::setOrRaiseProfilerLimit()
    MemoryTracker::setProfilerStep()

But it is easy to forget about setOrRaiseProfilerLimit(), since there is
no even any comments about this.

So instead, make setOrRaiseProfilerLimit() private and call it from
setProfilerStep()

Changelog category (leave one):
- Not for changelog (changelog entry is not required)