### PR TITLE
Rewrite clickhouse-test to use python clickhouse_driver

### DIFF
--- a/docker/test/fasttest/Dockerfile
+++ b/docker/test/fasttest/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update \
         unixodbc \
        --yes --no-install-recommends
 
-RUN pip3 install numpy scipy pandas Jinja2
+RUN pip3 install numpy scipy pandas Jinja2 pandas clickhouse_driver
 
 # This symlink required by gcc to find lld compiler
 RUN ln -s /usr/bin/lld-${LLVM_VERSION} /usr/bin/ld.lld

--- a/docker/test/fuzzer/Dockerfile
+++ b/docker/test/fuzzer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install Jinja2
+RUN pip3 install Jinja2 pandas clickhouse_driver
 
 COPY * /
 

--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update -y \
             postgresql-client \
             sqlite3
 
-RUN pip3 install numpy scipy pandas Jinja2
+RUN pip3 install numpy scipy pandas Jinja2 clickhouse_driver
 
 RUN mkdir -p /tmp/clickhouse-odbc-tmp \
    && wget -nv -O - ${odbc_driver_url} | tar --strip-components=1 -xz -C /tmp/clickhouse-odbc-tmp \

--- a/docker/test/style/Dockerfile
+++ b/docker/test/style/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
     python3-pip \
     pylint \
     yamllint \
-    && pip3 install codespell
+    && pip3 install codespell pandas clickhouse_driver
 
 COPY run.sh /
 COPY process_style_check_result.py /

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -87,8 +87,11 @@ class Client(clickhouse_driver.Client):
         return data
 
 # Helpers
-def make_clickhouse_client(base_args, *args, **kwargs):
+def make_clickhouse_client(base_args):
     return Client(host=base_args.tcp_host, port=base_args.tcp_port,
+        # hung check in stress tests may remove the database,
+        # hence we should use 'system'.
+        database='system',
         settings=get_additional_client_options_dict(base_args))
 def clickhouse_execute_one(base_args, *args, **kwargs):
     return make_clickhouse_client(base_args).execute_one(*args, **kwargs)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
 
 # pylint: disable=too-many-return-statements
-# pylint: disable=consider-using-f-string
 # pylint: disable=global-variable-not-assigned
-# pylint: disable=consider-using-with
-# pylint: disable=unspecified-encoding
-# pylint: disable=consider-using-min-builtin
 
 import enum
 import shutil

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -86,6 +86,17 @@ class Client(clickhouse_driver.Client):
         data = pandas.DataFrame(data=rows, columns=header)
         return data
 
+# Helpers
+def make_clickhouse_client(base_args, *args, **kwargs):
+    return Client(host=base_args.tcp_host, port=base_args.tcp_port,
+        settings=get_additional_client_options_dict(base_args))
+def clickhouse_execute_one(base_args, *args, **kwargs):
+    return make_clickhouse_client(base_args).execute_one(*args, **kwargs)
+def clickhouse_execute(base_args, *args, **kwargs):
+    return make_clickhouse_client(base_args).execute(*args, **kwargs)
+def clickhouse_execute_pandas(base_args, *args, **kwargs):
+    return make_clickhouse_client(base_args).execute_pandas(*args, **kwargs)
+
 
 class Terminated(KeyboardInterrupt):
     pass
@@ -128,16 +139,14 @@ def get_db_engine(args, database_name):
 
 
 def get_zookeeper_session_uptime(args):
-    global clickhouse_client
-
     try:
         if args.replicated_database:
-            return int(clickhouse_client.execute_one("""
+            return int(clickhouse_execute_one(args, """
             SELECT min(materialize(zookeeperSessionUptime()))
             FROM clusterAllReplicas('test_cluster_database_replicated', system.one)
             """))
         else:
-            return int(clickhouse_client.execute_one('SELECT zookeeperSessionUptime()'))
+            return int(clickhouse_execute_one(args, 'SELECT zookeeperSessionUptime()'))
     except:
         return None
 
@@ -167,15 +176,14 @@ def need_retry_error(args, error, total_time):
 
 
 def get_processlist(args):
-    global clickhouse_client
     if args.replicated_database:
-        return clickhouse_client.execute_pandas("""
+        return clickhouse_execute_pandas(args, """
         SELECT materialize((hostName(), tcpPort())) as host, *
         FROM clusterAllReplicas('test_cluster_database_replicated', system.processes)
         WHERE query NOT LIKE '%system.processes%'
         """)
     else:
-        return clickhouse_client.execute_pandas('SHOW PROCESSLIST')
+        return clickhouse_execute_pandas(args, 'SHOW PROCESSLIST')
 
 
 # collect server stacktraces using gdb
@@ -342,7 +350,6 @@ class TestCase:
 
     @staticmethod
     def configure_testcase_args(args, case_file, suite_tmp_dir):
-        global clickhouse_client
         testcase_args = copy.deepcopy(args)
 
         testcase_args.testcase_start_time = datetime.now()
@@ -363,7 +370,7 @@ class TestCase:
             database = 'test_{suffix}'.format(suffix=random_str())
 
             try:
-                clickhouse_client.execute("CREATE DATABASE " + database + get_db_engine(testcase_args, database), settings={'log_comment': testcase_basename})
+                clickhouse_execute(args, "CREATE DATABASE " + database + get_db_engine(testcase_args, database), settings={'log_comment': testcase_basename})
             except (TimeoutError, clickhouse_driver.errors.SocketTimeoutError):
                 total_time = (datetime.now() - testcase_args.testcase_start_time).total_seconds()
                 return None, "", f"Timeout creating database {database} before test", total_time
@@ -536,12 +543,10 @@ class TestCase:
 
     @staticmethod
     def send_test_name_failed(suite: str, case: str) -> bool:
-        global clickhouse_client
         pid = os.getpid()
-        clickhouse_client.execute(f"SELECT 'Running test {suite}/{case} from pid={pid}'")
+        clickhouse_execute(args, f"SELECT 'Running test {suite}/{case} from pid={pid}'")
 
     def run_single_test(self, server_logs_level, client_options):
-        global clickhouse_client
         args = self.testcase_args
         client = args.testcase_client
         start_time = args.testcase_start_time
@@ -585,8 +590,10 @@ class TestCase:
         if need_drop_database:
             seconds_left = max(args.timeout - (datetime.now() - start_time).total_seconds(), 20)
             try:
-                with clickhouse_client.connection.timeout_setter(seconds_left):
-                    clickhouse_client.execute("DROP DATABASE " + database)
+                client = make_clickhouse_client(args)
+                client.connection.force_connect()
+                with client.connection.timeout_setter(seconds_left):
+                    client.execute("DROP DATABASE " + database)
             except (TimeoutError, clickhouse_driver.errors.SocketTimeoutError):
                 total_time = (datetime.now() - start_time).total_seconds()
                 return None, "", f"Timeout dropping database {database} after test", total_time
@@ -793,8 +800,7 @@ class TestSuite:
     @staticmethod
     def readTestSuite(args, suite_dir_name: str):
         def is_data_present():
-            global clickhouse_client
-            return int(clickhouse_client.execute_one('EXISTS TABLE test.hits'))
+            return int(clickhouse_execute_one(args, 'EXISTS TABLE test.hits'))
 
         base_dir = os.path.abspath(args.queries)
         tmp_dir = os.path.abspath(args.tmp)
@@ -827,7 +833,6 @@ class TestSuite:
 
 
 stop_time = None
-clickhouse_client = None
 exit_code = None
 server_died = None
 stop_tests_triggered_lock = None
@@ -957,14 +962,14 @@ def run_tests_array(all_tests_with_params):
 server_logs_level = "warning"
 
 
-def check_server_started(retry_count):
-    global clickhouse_client
+def check_server_started(args):
     print("Connecting to ClickHouse server...", end='')
 
     sys.stdout.flush()
+    retry_count = args.server_check_retries
     while retry_count > 0:
         try:
-            clickhouse_client.execute('SELECT 1')
+            clickhouse_execute(args, 'SELECT 1')
             print(" OK")
             sys.stdout.flush()
             return True
@@ -992,12 +997,10 @@ class BuildFlags():
     POLYMORPHIC_PARTS = 'polymorphic-parts'
 
 
-def collect_build_flags():
-    global clickhouse_client
-
+def collect_build_flags(args):
     result = []
 
-    value = clickhouse_client.execute_one("SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'")
+    value = clickhouse_execute_one(args, "SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'")
     if '-fsanitize=thread' in value:
         result.append(BuildFlags.THREAD)
     elif '-fsanitize=address' in value:
@@ -1007,21 +1010,21 @@ def collect_build_flags():
     elif '-fsanitize=memory' in value:
         result.append(BuildFlags.MEMORY)
 
-    value = clickhouse_client.execute_one("SELECT value FROM system.build_options WHERE name = 'BUILD_TYPE'")
+    value = clickhouse_execute_one(args, "SELECT value FROM system.build_options WHERE name = 'BUILD_TYPE'")
     if 'Debug' in value:
         result.append(BuildFlags.DEBUG)
     elif 'RelWithDebInfo' in value or 'Release' in value:
         result.append(BuildFlags.RELEASE)
 
-    value = clickhouse_client.execute_one("SELECT value FROM system.build_options WHERE name = 'UNBUNDLED'")
+    value = clickhouse_execute_one(args, "SELECT value FROM system.build_options WHERE name = 'UNBUNDLED'")
     if value in ('ON', '1'):
         result.append(BuildFlags.UNBUNDLED)
 
-    value = clickhouse_client.execute_one("SELECT value FROM system.settings WHERE name = 'default_database_engine'")
+    value = clickhouse_execute_one(args, "SELECT value FROM system.settings WHERE name = 'default_database_engine'")
     if value == 'Ordinary':
         result.append(BuildFlags.ORDINARY_DATABASE)
 
-    value = int(clickhouse_client.execute_one("SELECT value FROM system.merge_tree_settings WHERE name = 'min_bytes_for_wide_part'"))
+    value = int(clickhouse_execute_one(args, "SELECT value FROM system.merge_tree_settings WHERE name = 'min_bytes_for_wide_part'"))
     if value == 0:
         result.append(BuildFlags.POLYMORPHIC_PARTS)
 
@@ -1118,9 +1121,8 @@ def main(args):
     global exit_code
     global server_logs_level
     global restarted_tests
-    global clickhouse_client
 
-    if not check_server_started(args.server_check_retries):
+    if not check_server_started(args):
         msg = "Server is not responding. Cannot execute 'SELECT 1' query. \
             If you are using split build, you have to specify -c option."
         if args.hung_check:
@@ -1130,7 +1132,7 @@ def main(args):
             print_stacktraces()
         raise Exception(msg)
 
-    args.build_flags = collect_build_flags()
+    args.build_flags = collect_build_flags(args)
 
     if args.skip:
         args.skip = set(args.skip)
@@ -1167,7 +1169,7 @@ def main(args):
         while create_database_retries < MAX_RETRIES:
             start_time = datetime.now()
             try:
-                clickhouse_client.execute("CREATE DATABASE IF NOT EXISTS " + db_name + get_db_engine(args, db_name))
+                clickhouse_execute(args, "CREATE DATABASE IF NOT EXISTS " + db_name + get_db_engine(args, db_name))
             except Exception as e:
                 total_time = (datetime.now() - start_time).total_seconds()
                 if not need_retry_error(args, e, total_time):
@@ -1384,9 +1386,10 @@ if __name__ == '__main__':
 
         tcp_host = os.getenv("CLICKHOUSE_HOST")
         if tcp_host is not None:
+            args.tcp_host = tcp_host
             args.client += f' --host={tcp_host}'
         else:
-            tcp_host = 'localhost'
+            args.tcp_host = 'localhost'
 
         tcp_port = os.getenv("CLICKHOUSE_PORT_TCP")
         if tcp_port is not None:
@@ -1398,8 +1401,9 @@ if __name__ == '__main__':
         client_database = os.getenv("CLICKHOUSE_DATABASE")
         if client_database is not None:
             args.client += f' --database={client_database}'
+            args.client_database = client_database
         else:
-            client_database = 'default'
+            args.client_database = 'default'
 
     if args.client_option:
         # Set options for client
@@ -1430,10 +1434,5 @@ if __name__ == '__main__':
     # configure pandas to make it more like Vertical format
     pandas.options.display.max_columns = None
     pandas.options.display.width = None
-
-    clickhouse_client = Client(host=tcp_host,
-        port=args.tcp_port,
-        database=client_database,
-        settings=get_additional_client_options_dict(args))
 
     main(args)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 
 # pylint: disable=too-many-return-statements
+# pylint: disable=consider-using-f-string
+# pylint: disable=global-variable-not-assigned
+# pylint: disable=consider-using-with
+# pylint: disable=unspecified-encoding
+# pylint: disable=consider-using-min-builtin
+
 import enum
 import shutil
 import sys

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -19,13 +19,10 @@ import traceback
 import math
 
 from argparse import ArgumentParser
-from typing import Tuple, Union, Optional, TextIO, Dict, Set, List
-import shlex
+from typing import Tuple, Union, Optional, Dict, Set, List
 import subprocess
 from subprocess import Popen
 from subprocess import PIPE
-from subprocess import CalledProcessError
-from subprocess import TimeoutExpired
 from datetime import datetime
 from time import time, sleep
 from errno import ESRCH
@@ -41,6 +38,9 @@ import multiprocessing
 import socket
 from contextlib import closing
 
+import clickhouse_driver
+import pandas
+
 USE_JINJA = True
 try:
     import jinja2
@@ -48,19 +48,44 @@ except ImportError:
     USE_JINJA = False
     print('WARNING: jinja2 not installed! Template tests will be skipped.')
 
-DISTRIBUTED_DDL_TIMEOUT_MSG = "is executing longer than distributed_ddl_task_timeout"
-
 MESSAGES_TO_RETRY = [
     "ConnectionPoolWithFailover: Connection failed at try",
     "DB::Exception: New table appeared in database being dropped or detached. Try again",
     "is already started to be removing by another replica right now",
     "DB::Exception: Cannot enqueue query",
-    DISTRIBUTED_DDL_TIMEOUT_MSG  # FIXME
+    "is executing longer than distributed_ddl_task_timeout" # FIXME
+]
+error_codes = clickhouse_driver.errors.ErrorCodes
+error_codes.NOT_A_LEADER = 529
+ERROR_CODES_TO_RETRY = [
+    error_codes.ALL_CONNECTION_TRIES_FAILED,
+    error_codes.DATABASE_NOT_EMPTY,
+    error_codes.NOT_A_LEADER,
+    error_codes.UNFINISHED,
 ]
 
 MAX_RETRIES = 3
 
 TEST_FILE_EXTENSIONS = ['.sql', '.sql.j2', '.sh', '.py', '.expect']
+
+class Client(clickhouse_driver.Client):
+    # return first column of the first row
+    def execute_one(self, *args, **kwargs):
+        return super().execute(*args, **kwargs)[0][0]
+
+    # return pandas.DataFrame
+    def execute_pandas(self, *args, **kwargs):
+        data = super().execute(*args, **kwargs, with_column_types=True)
+        return Client.__combine(data)
+
+    @staticmethod
+    def __combine(data):
+        cols = data[1]
+        rows = data[0]
+        header = [ i[0] for i in cols ]
+        data = pandas.DataFrame(data=rows, columns=header)
+        return data
+
 
 class Terminated(KeyboardInterrupt):
     pass
@@ -103,18 +128,16 @@ def get_db_engine(args, database_name):
 
 
 def get_zookeeper_session_uptime(args):
+    global clickhouse_client
+
     try:
-        query = b"SELECT zookeeperSessionUptime()"
-
         if args.replicated_database:
-            query = b"SELECT min(materialize(zookeeperSessionUptime())) " \
-                    b"FROM clusterAllReplicas('test_cluster_database_replicated', system.one) "
-
-        clickhouse_proc = open_client_process(args.client)
-
-        (stdout, _) = clickhouse_proc.communicate((query), timeout=20)
-
-        return int(stdout.decode('utf-8').strip())
+            return int(clickhouse_client.execute_one("""
+            SELECT min(materialize(zookeeperSessionUptime()))
+            FROM clusterAllReplicas('test_cluster_database_replicated', system.one)
+            """))
+        else:
+            return int(clickhouse_client.execute_one('SELECT zookeeperSessionUptime()'))
     except:
         return None
 
@@ -128,24 +151,31 @@ def need_retry(args, stdout, stderr, total_time):
         return True
     return any(msg in stdout for msg in MESSAGES_TO_RETRY) or any(msg in stderr for msg in MESSAGES_TO_RETRY)
 
+def need_retry_error(args, error, total_time):
+    # Sometimes we may get unexpected exception like "Replica is readonly" or "Shutdown is called for table"
+    # instead of "Session expired" or "Connection loss"
+    # Retry if session was expired during test execution
+    session_uptime = get_zookeeper_session_uptime(args)
+    if session_uptime is not None and session_uptime < math.ceil(total_time):
+        return True
+    if isinstance(error, clickhouse_driver.errors.Error):
+        if error.code in ERROR_CODES_TO_RETRY:
+            return True
+        if any(msg in error.message for msg in MESSAGES_TO_RETRY):
+            return True
+    return False
+
 
 def get_processlist(args):
-    try:
-        query = b"SHOW PROCESSLIST FORMAT Vertical"
-
-        if args.replicated_database:
-            query = b"SELECT materialize((hostName(), tcpPort())) as host, * " \
-                    b"FROM clusterAllReplicas('test_cluster_database_replicated', system.processes) " \
-                    b"WHERE query NOT LIKE '%system.processes%' FORMAT Vertical"
-
-        clickhouse_proc = open_client_process(args.client)
-
-        (stdout, _) = clickhouse_proc.communicate((query), timeout=20)
-
-        return False, stdout.decode('utf-8')
-    except Exception as ex:
-        print("Exception", ex)
-        return True, ""
+    global clickhouse_client
+    if args.replicated_database:
+        return clickhouse_client.execute_pandas("""
+        SELECT materialize((hostName(), tcpPort())) as host, *
+        FROM clusterAllReplicas('test_cluster_database_replicated', system.processes)
+        WHERE query NOT LIKE '%system.processes%'
+        """)
+    else:
+        return clickhouse_client.execute_pandas('SHOW PROCESSLIST')
 
 
 # collect server stacktraces using gdb
@@ -311,7 +341,8 @@ class TestCase:
         return None
 
     @staticmethod
-    def configure_testcase_args(args, case_file, suite_tmp_dir, stderr_file):
+    def configure_testcase_args(args, case_file, suite_tmp_dir):
+        global clickhouse_client
         testcase_args = copy.deepcopy(args)
 
         testcase_args.testcase_start_time = datetime.now()
@@ -331,23 +362,11 @@ class TestCase:
 
             database = 'test_{suffix}'.format(suffix=random_str())
 
-            with open(stderr_file, 'w') as stderr:
-                client_cmd = testcase_args.testcase_client + " " \
-                             + get_additional_client_options(args)
-
-                clickhouse_proc_create = open_client_process(
-                    universal_newlines=True,
-                    client_args=client_cmd,
-                    stderr_file=stderr)
-
-                try:
-                    clickhouse_proc_create.communicate(
-                        ("CREATE DATABASE " + database + get_db_engine(testcase_args, database)),
-                        timeout=testcase_args.timeout)
-                except TimeoutExpired:
-                    total_time = (datetime.now() - testcase_args.testcase_start_time).total_seconds()
-                    return clickhouse_proc_create, "", "Timeout creating database {} before test".format(
-                        database), total_time
+            try:
+                clickhouse_client.execute("CREATE DATABASE " + database + get_db_engine(testcase_args, database), settings={'log_comment': testcase_basename})
+            except (TimeoutError, clickhouse_driver.errors.SocketTimeoutError):
+                total_time = (datetime.now() - testcase_args.testcase_start_time).total_seconds()
+                return None, "", f"Timeout creating database {database} before test", total_time
 
             os.environ["CLICKHOUSE_DATABASE"] = database
             # Set temporary directory to match the randomly generated database,
@@ -418,41 +437,42 @@ class TestCase:
     def process_result_impl(self, proc, stdout: str, stderr: str, total_time: float):
         description = ""
 
-        if proc.returncode is None:
-            try:
-                proc.kill()
-            except OSError as e:
-                if e.errno != ESRCH:
-                    raise
+        if proc:
+            if proc.returncode is None:
+                try:
+                    proc.kill()
+                except OSError as e:
+                    if e.errno != ESRCH:
+                        raise
 
-            if stderr:
-                description += stderr
-            return TestResult(self.name, TestStatus.FAIL, FailureReason.TIMEOUT, total_time, description)
+                if stderr:
+                    description += stderr
+                return TestResult(self.name, TestStatus.FAIL, FailureReason.TIMEOUT, total_time, description)
 
-        if proc.returncode != 0:
-            reason = FailureReason.EXIT_CODE
-            description += str(proc.returncode)
+            if proc.returncode != 0:
+                reason = FailureReason.EXIT_CODE
+                description += str(proc.returncode)
 
-            if stderr:
-                description += "\n"
-                description += stderr
+                if stderr:
+                    description += "\n"
+                    description += stderr
 
-            # Stop on fatal errors like segmentation fault. They are sent to client via logs.
-            if ' <Fatal> ' in stderr:
-                reason = FailureReason.SERVER_DIED
+                # Stop on fatal errors like segmentation fault. They are sent to client via logs.
+                if ' <Fatal> ' in stderr:
+                    reason = FailureReason.SERVER_DIED
 
-            if self.testcase_args.stop \
-                    and ('Connection refused' in stderr or 'Attempt to read after eof' in stderr) \
-                    and 'Received exception from server' not in stderr:
-                reason = FailureReason.SERVER_DIED
+                if self.testcase_args.stop \
+                        and ('Connection refused' in stderr or 'Attempt to read after eof' in stderr) \
+                        and 'Received exception from server' not in stderr:
+                    reason = FailureReason.SERVER_DIED
 
-            if os.path.isfile(self.stdout_file):
-                description += ", result:\n\n"
-                description += '\n'.join(open(self.stdout_file).read().split('\n')[:100])
-                description += '\n'
+                if os.path.isfile(self.stdout_file):
+                    description += ", result:\n\n"
+                    description += '\n'.join(open(self.stdout_file).read().split('\n')[:100])
+                    description += '\n'
 
-            description += "\nstdout:\n{}\n".format(stdout)
-            return TestResult(self.name, TestStatus.FAIL, reason, total_time, description)
+                description += "\nstdout:\n{}\n".format(stdout)
+                return TestResult(self.name, TestStatus.FAIL, reason, total_time, description)
 
         if stderr:
             description += "\n{}\n".format('\n'.join(stderr.split('\n')[:100]))
@@ -516,21 +536,12 @@ class TestCase:
 
     @staticmethod
     def send_test_name_failed(suite: str, case: str) -> bool:
-        clickhouse_proc = open_client_process(args.client, universal_newlines=True)
-
-        failed_to_check = False
-
+        global clickhouse_client
         pid = os.getpid()
-        query = f"SELECT 'Running test {suite}/{case} from pid={pid}';"
-
-        try:
-            clickhouse_proc.communicate((query), timeout=20)
-        except:
-            failed_to_check = True
-
-        return failed_to_check or clickhouse_proc.returncode != 0
+        clickhouse_client.execute(f"SELECT 'Running test {suite}/{case} from pid={pid}'")
 
     def run_single_test(self, server_logs_level, client_options):
+        global clickhouse_client
         args = self.testcase_args
         client = args.testcase_client
         start_time = args.testcase_start_time
@@ -572,28 +583,13 @@ class TestCase:
             need_drop_database = not maybe_passed
 
         if need_drop_database:
-            with open(self.stderr_file, 'a') as stderr:
-                clickhouse_proc_create = open_client_process(client, universal_newlines=True, stderr_file=stderr)
-
             seconds_left = max(args.timeout - (datetime.now() - start_time).total_seconds(), 20)
-
             try:
-                drop_database_query = "DROP DATABASE " + database
-                if args.replicated_database:
-                    drop_database_query += " ON CLUSTER test_cluster_database_replicated"
-                clickhouse_proc_create.communicate((drop_database_query), timeout=seconds_left)
-            except TimeoutExpired:
-                # kill test process because it can also hung
-                if proc.returncode is None:
-                    try:
-                        proc.kill()
-                    except OSError as e:
-                        if e.errno != ESRCH:
-                            raise
-
+                with clickhouse_client.connection.timeout_setter(seconds_left):
+                    clickhouse_client.execute("DROP DATABASE " + database)
+            except (TimeoutError, clickhouse_driver.errors.SocketTimeoutError):
                 total_time = (datetime.now() - start_time).total_seconds()
-                return clickhouse_proc_create, "", f"Timeout dropping database {database} after test", total_time
-
+                return None, "", f"Timeout dropping database {database} after test", total_time
             shutil.rmtree(args.test_tmp_dir)
 
         total_time = (datetime.now() - start_time).total_seconds()
@@ -624,12 +620,15 @@ class TestCase:
             if skip_reason is not None:
                 return TestResult(self.name, TestStatus.SKIPPED, skip_reason, 0., "")
 
-            if args.testname and self.send_test_name_failed(suite.suite, self.case):
-                description = "\nServer does not respond to health check\n"
-                return TestResult(self.name, TestStatus.FAIL, FailureReason.SERVER_DIED, 0., description)
+            if args.testname:
+                try:
+                    self.send_test_name_failed(suite.suite, self.case)
+                except:
+                    return TestResult(self.name, TestStatus.FAIL, FailureReason.SERVER_DIED, 0.,
+                        "\nServer does not respond to health check\n")
 
             self.runs_count += 1
-            self.testcase_args = self.configure_testcase_args(args, self.case_file, suite.suite_tmp_path, self.stderr_file)
+            self.testcase_args = self.configure_testcase_args(args, self.case_file, suite.suite_tmp_path)
             proc, stdout, stderr, total_time = self.run_single_test(server_logs_level, client_options)
 
             result = self.process_result_impl(proc, stdout, stderr, total_time)
@@ -794,12 +793,8 @@ class TestSuite:
     @staticmethod
     def readTestSuite(args, suite_dir_name: str):
         def is_data_present():
-            clickhouse_proc = open_client_process(args.client)
-            (stdout, stderr) = clickhouse_proc.communicate(b"EXISTS TABLE test.hits")
-            if clickhouse_proc.returncode != 0:
-                raise CalledProcessError(clickhouse_proc.returncode, args.client, stderr)
-
-            return stdout.startswith(b'1')
+            global clickhouse_client
+            return int(clickhouse_client.execute_one('EXISTS TABLE test.hits'))
 
         base_dir = os.path.abspath(args.queries)
         tmp_dir = os.path.abspath(args.tmp)
@@ -832,6 +827,7 @@ class TestSuite:
 
 
 stop_time = None
+clickhouse_client = None
 exit_code = None
 server_died = None
 stop_tests_triggered_lock = None
@@ -961,42 +957,26 @@ def run_tests_array(all_tests_with_params):
 server_logs_level = "warning"
 
 
-def check_server_started(client, retry_count):
+def check_server_started(retry_count):
+    global clickhouse_client
     print("Connecting to ClickHouse server...", end='')
 
     sys.stdout.flush()
-
     while retry_count > 0:
-        clickhouse_proc = open_client_process(client)
-        (stdout, stderr) = clickhouse_proc.communicate(b"SELECT 1")
-
-        if clickhouse_proc.returncode == 0 and stdout.startswith(b"1"):
+        try:
+            clickhouse_client.execute('SELECT 1')
             print(" OK")
             sys.stdout.flush()
             return True
-
-        if clickhouse_proc.returncode == 210:
-            # Connection refused, retry
+        except (ConnectionRefusedError, ConnectionResetError, clickhouse_driver.errors.NetworkError):
             print('.', end='')
             sys.stdout.flush()
             retry_count -= 1
             sleep(0.5)
             continue
 
-        code: int = clickhouse_proc.returncode
-
-        print(f"\nClient invocation failed with code {code}:\n\
-            stdout: {stdout}\n\
-            stderr: {stderr}\n\
-            args: {''.join(clickhouse_proc.args)}\n")
-
-        sys.stdout.flush()
-
-        return False
-
     print('\nAll connection tries failed')
     sys.stdout.flush()
-
     return False
 
 
@@ -1012,60 +992,38 @@ class BuildFlags():
     POLYMORPHIC_PARTS = 'polymorphic-parts'
 
 
-def collect_build_flags(client):
-    clickhouse_proc = open_client_process(client)
-    (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'")
+def collect_build_flags():
+    global clickhouse_client
+
     result = []
 
-    if clickhouse_proc.returncode == 0:
-        if b'-fsanitize=thread' in stdout:
-            result.append(BuildFlags.THREAD)
-        elif b'-fsanitize=address' in stdout:
-            result.append(BuildFlags.ADDRESS)
-        elif b'-fsanitize=undefined' in stdout:
-            result.append(BuildFlags.UNDEFINED)
-        elif b'-fsanitize=memory' in stdout:
-            result.append(BuildFlags.MEMORY)
-    else:
-        raise Exception("Cannot get information about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
+    value = clickhouse_client.execute_one("SELECT value FROM system.build_options WHERE name = 'CXX_FLAGS'")
+    if '-fsanitize=thread' in value:
+        result.append(BuildFlags.THREAD)
+    elif '-fsanitize=address' in value:
+        result.append(BuildFlags.ADDRESS)
+    elif '-fsanitize=undefined' in value:
+        result.append(BuildFlags.UNDEFINED)
+    elif '-fsanitize=memory' in value:
+        result.append(BuildFlags.MEMORY)
 
-    clickhouse_proc = open_client_process(client)
-    (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.build_options WHERE name = 'BUILD_TYPE'")
+    value = clickhouse_client.execute_one("SELECT value FROM system.build_options WHERE name = 'BUILD_TYPE'")
+    if 'Debug' in value:
+        result.append(BuildFlags.DEBUG)
+    elif 'RelWithDebInfo' in value or 'Release' in value:
+        result.append(BuildFlags.RELEASE)
 
-    if clickhouse_proc.returncode == 0:
-        if b'Debug' in stdout:
-            result.append(BuildFlags.DEBUG)
-        elif b'RelWithDebInfo' in stdout or b'Release' in stdout:
-            result.append(BuildFlags.RELEASE)
-    else:
-        raise Exception("Cannot get information about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
+    value = clickhouse_client.execute_one("SELECT value FROM system.build_options WHERE name = 'UNBUNDLED'")
+    if value in ('ON', '1'):
+        result.append(BuildFlags.UNBUNDLED)
 
-    clickhouse_proc = open_client_process(client)
-    (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.build_options WHERE name = 'UNBUNDLED'")
+    value = clickhouse_client.execute_one("SELECT value FROM system.settings WHERE name = 'default_database_engine'")
+    if value == 'Ordinary':
+        result.append(BuildFlags.ORDINARY_DATABASE)
 
-    if clickhouse_proc.returncode == 0:
-        if b'ON' in stdout or b'1' in stdout:
-            result.append(BuildFlags.UNBUNDLED)
-    else:
-        raise Exception("Cannot get information about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
-
-    clickhouse_proc = open_client_process(client)
-    (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.settings WHERE name = 'default_database_engine'")
-
-    if clickhouse_proc.returncode == 0:
-        if b'Ordinary' in stdout:
-            result.append(BuildFlags.ORDINARY_DATABASE)
-    else:
-        raise Exception("Cannot get information about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
-
-    clickhouse_proc = open_client_process(client)
-    (stdout, stderr) = clickhouse_proc.communicate(b"SELECT value FROM system.merge_tree_settings WHERE name = 'min_bytes_for_wide_part'")
-
-    if clickhouse_proc.returncode == 0:
-        if stdout == b'0\n':
-            result.append(BuildFlags.POLYMORPHIC_PARTS)
-    else:
-        raise Exception("Cannot get inforamtion about build from server errorcode {}, stderr {}".format(clickhouse_proc.returncode, stderr))
+    value = int(clickhouse_client.execute_one("SELECT value FROM system.merge_tree_settings WHERE name = 'min_bytes_for_wide_part'"))
+    if value == 0:
+        result.append(BuildFlags.POLYMORPHIC_PARTS)
 
     return result
 
@@ -1090,16 +1048,6 @@ def extract_key(key: str) -> str:
         args.extract_from_config +
         " --try --config " +
         args.configserver + key)[1]
-
-
-def open_client_process(
-    client_args: str,
-    universal_newlines: bool = False,
-    stderr_file: Optional[TextIO] = None):
-    return Popen(
-        shlex.split(client_args), stdin=PIPE, stdout=PIPE,
-        stderr=stderr_file if stderr_file is not None else PIPE,
-        universal_newlines=True if universal_newlines else None)
 
 
 def do_run_tests(jobs, test_suite: TestSuite, parallel):
@@ -1170,8 +1118,9 @@ def main(args):
     global exit_code
     global server_logs_level
     global restarted_tests
+    global clickhouse_client
 
-    if not check_server_started(args.client, args.server_check_retries):
+    if not check_server_started(args.server_check_retries):
         msg = "Server is not responding. Cannot execute 'SELECT 1' query. \
             If you are using split build, you have to specify -c option."
         if args.hung_check:
@@ -1181,13 +1130,12 @@ def main(args):
             print_stacktraces()
         raise Exception(msg)
 
-    args.build_flags = collect_build_flags(args.client)
+    args.build_flags = collect_build_flags()
 
     if args.skip:
         args.skip = set(args.skip)
 
     base_dir = os.path.abspath(args.queries)
-    tmp_dir = os.path.abspath(args.tmp)
 
     # Keep same default values as in queries/shell_config.sh
     os.environ.setdefault("CLICKHOUSE_BINARY", args.binary)
@@ -1218,17 +1166,12 @@ def main(args):
         create_database_retries = 0
         while create_database_retries < MAX_RETRIES:
             start_time = datetime.now()
-
-            client_cmd = args.client + " " + get_additional_client_options(args)
-
-            clickhouse_proc_create = open_client_process(client_cmd, universal_newlines=True)
-
-            (stdout, stderr) = clickhouse_proc_create.communicate(("CREATE DATABASE IF NOT EXISTS " + db_name + get_db_engine(args, db_name)))
-
-            total_time = (datetime.now() - start_time).total_seconds()
-
-            if not need_retry(args, stdout, stderr, total_time):
-                break
+            try:
+                clickhouse_client.execute("CREATE DATABASE IF NOT EXISTS " + db_name + get_db_engine(args, db_name))
+            except Exception as e:
+                total_time = (datetime.now() - start_time).total_seconds()
+                if not need_retry_error(args, e, total_time):
+                    break
             create_database_retries += 1
 
     if args.database and args.database != "test":
@@ -1255,18 +1198,14 @@ def main(args):
 
         # Some queries may execute in background for some time after test was finished. This is normal.
         for _ in range(1, 60):
-            timeout, processlist = get_processlist(args)
-            if timeout or not processlist:
+            processlist = get_processlist(args)
+            if processlist.empty:
                 break
             sleep(1)
 
-        if timeout or processlist:
-            if processlist:
-                print(colored("\nFound hung queries in processlist:", args, "red", attrs=["bold"]))
-                print(processlist)
-            else:
-                print(colored("Seems like server hung and cannot respond to queries", args, "red", attrs=["bold"]))
-
+        if not processlist.empty:
+            print(colored("\nFound hung queries in processlist:", args, "red", attrs=["bold"]))
+            print(processlist)
 
             print_stacktraces()
             exit_code.value = 1
@@ -1311,15 +1250,19 @@ def find_binary(name):
 def get_additional_client_options(args):
     if args.client_option:
         return ' '.join('--' + option for option in args.client_option)
-
     return ''
-
 
 def get_additional_client_options_url(args):
     if args.client_option:
         return '&'.join(args.client_option)
-
     return ''
+
+def get_additional_client_options_dict(args):
+    settings = {}
+    if args.client_option:
+        for key, value in map(lambda x: x.split('='), args.client_option):
+            settings[key] = value
+    return settings
 
 
 if __name__ == '__main__':
@@ -1439,14 +1382,24 @@ if __name__ == '__main__':
         if args.configclient:
             args.client += ' --config-file=' + args.configclient
 
-        if os.getenv("CLICKHOUSE_HOST"):
-            args.client += ' --host=' + os.getenv("CLICKHOUSE_HOST")
+        tcp_host = os.getenv("CLICKHOUSE_HOST")
+        if tcp_host is not None:
+            args.client += f' --host={tcp_host}'
+        else:
+            tcp_host = 'localhost'
 
-        args.tcp_port = int(os.getenv("CLICKHOUSE_PORT_TCP", "9000"))
-        args.client += f" --port={args.tcp_port}"
+        tcp_port = os.getenv("CLICKHOUSE_PORT_TCP")
+        if tcp_port is not None:
+            args.tcp_port = int(tcp_port)
+            args.client += f" --port={tcp_port}"
+        else:
+            args.tcp_port = 9000
 
-        if os.getenv("CLICKHOUSE_DATABASE"):
-            args.client += ' --database=' + os.getenv("CLICKHOUSE_DATABASE")
+        client_database = os.getenv("CLICKHOUSE_DATABASE")
+        if client_database is not None:
+            args.client += f' --database={client_database}'
+        else:
+            client_database = 'default'
 
     if args.client_option:
         # Set options for client
@@ -1473,5 +1426,14 @@ if __name__ == '__main__':
 
     if args.jobs is None:
         args.jobs = multiprocessing.cpu_count()
+
+    # configure pandas to make it more like Vertical format
+    pandas.options.display.max_columns = None
+    pandas.options.display.width = None
+
+    clickhouse_client = Client(host=tcp_host,
+        port=args.tcp_port,
+        database=client_database,
+        settings=get_additional_client_options_dict(args))
 
     main(args)


### PR DESCRIPTION
Pros:
- Using native protocol over executing binaries is always better
- `clickhouse-client` in debug build takes almost a second to execute simple `SELECT 1`
  and `clickhouse-test` requires ~5 queries at start (determine some
  flags, zk, alive, create database)

Notes:
- `FORMAT Vertical` had been replaced with printing of `pandas.DataFrame`

And after this patch tiny tests work with the speed of the test, and
does not requires +-5 seconds of bootstrapping.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)