### PR TITLE
Fix system tables recreation check (fails to detect changes in enum values)

### DIFF
--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -527,7 +527,7 @@ void SystemLog<LogElement>::prepareTable()
         auto alias_columns = LogElement::getNamesAndAliases();
         auto current_query = InterpreterCreateQuery::formatColumns(ordinary_columns, alias_columns);
 
-        if (old_query->getTreeHash() != current_query->getTreeHash())
+        if (serializeAST(*old_query) != serializeAST(*current_query))
         {
             /// Rename the existing table.
             int suffix = 0;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix system tables recreation check (fails to detect changes in enum values)

`getTreeHash()` does takes all possible values of enum into account, and so if someone will extend some Enum type then the table will not be recreated.

Fixes: #23934 (cc @kitaisreal)

*NOTE: although seems that the definition of tables hadn't been changed in that way that `getTreeHash` cannot detect the change, so I guess no need to backport*