### PR TITLE
Remove branchy code in filter operation with a better implementation …

### DIFF
--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -260,12 +260,13 @@ ColumnPtr ColumnFixedString::filter(const IColumn::Filter & filt, ssize_t result
         {
             size_t res_chars_size = res->chars.size();
             size_t pcnt = __builtin_popcount(mask);
-            for(size_t j = 0; j < pcnt; j++) {
+            for (size_t j = 0; j < pcnt; ++j)
+            {
                 size_t index = __builtin_ctz(mask);
                 res->chars.resize(res_chars_size + n);
-                memcpySmallAllowReadWriteOverflow15(&res->chars[res_chars_size], data_pos+index*n, n);
+                memcpySmallAllowReadWriteOverflow15(&res->chars[res_chars_size], data_pos + index * n, n);
                 res_chars_size += n;
-                mask = mask & (mask-1);
+                mask = mask & (mask - 1);
             }
         }
         data_pos += chars_per_simd_elements;

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -231,7 +231,7 @@ ColumnPtr ColumnFixedString::filter(const IColumn::Filter & filt, ssize_t result
     const UInt8 * filt_end = filt_pos + col_size;
     const UInt8 * data_pos = chars.data();
 
-#if defined(__SSE2__) && defined(__POPCNT__)
+#ifdef __SSE2__
     /** A slightly more optimized version.
         * Based on the assumption that often pieces of consecutive values
         *  completely pass or do not pass the filter.

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -248,19 +248,14 @@ ColumnPtr ColumnFixedString::filter(const IColumn::Filter & filt, ssize_t result
         UInt16 mask = _mm_movemask_epi8(_mm_cmpeq_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i *>(filt_pos)), zero16));
         mask = ~mask;
 
-        if (0 == mask)
-        {
-            /// Nothing is inserted.
-        }
-        else if (0xFFFF == mask)
+        if (0xFFFF == mask)
         {
             res->chars.insert(data_pos, data_pos + chars_per_simd_elements);
         }
         else
         {
             size_t res_chars_size = res->chars.size();
-            size_t pcnt = __builtin_popcount(mask);
-            for (size_t j = 0; j < pcnt; ++j)
+            while(mask)
             {
                 size_t index = __builtin_ctz(mask);
                 res->chars.resize(res_chars_size + n);

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -255,7 +255,7 @@ ColumnPtr ColumnFixedString::filter(const IColumn::Filter & filt, ssize_t result
         else
         {
             size_t res_chars_size = res->chars.size();
-            while(mask)
+            while (mask)
             {
                 size_t index = __builtin_ctz(mask);
                 res->chars.resize(res_chars_size + n);

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -311,7 +311,7 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
     const UInt8 * filt_end = filt_pos + size;
     const T * data_pos = data.data();
 
-#if defined(__SSE2__) && defined(__POPCNT__)
+#ifdef __SSE2__
     /** A slightly more optimized version.
     * Based on the assumption that often pieces of consecutive values
     *  completely pass or do not pass the filter.

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -327,18 +327,13 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
         UInt16 mask = _mm_movemask_epi8(_mm_cmpeq_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i *>(filt_pos)), zero16));
         mask = ~mask;
 
-        if (0 == mask)
-        {
-            /// Nothing is inserted.
-        }
-        else if (0xFFFF == mask)
+        if (0xFFFF == mask)
         {
             res_data.insert(data_pos, data_pos + SIMD_BYTES);
         }
         else
         {
-            size_t pcnt = __builtin_popcount(mask);
-            for (size_t j = 0; j < pcnt; ++j)
+            while(mask)
             {
                 size_t index = __builtin_ctz(mask);
                 res_data.push_back(data_pos[index]);

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -343,7 +343,7 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
                 size_t index = __builtin_ctz(mask);
                 res_data.push_back(data_pos[index]);
                 mask = mask & (mask - 1);
-            }         
+            }
         }
 
         filt_pos += SIMD_BYTES;

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -338,10 +338,11 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
         else
         {
             size_t pcnt = __builtin_popcount(mask);
-            for(size_t j = 0; j < pcnt; j++) {
+            for (size_t j = 0; j < pcnt; ++j)
+            {
                 size_t index = __builtin_ctz(mask);
                 res_data.push_back(data_pos[index]);
-                mask = mask & (mask-1);
+                mask = mask & (mask - 1);
             }         
         }
 

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -333,7 +333,7 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
         }
         else
         {
-            while(mask)
+            while (mask)
             {
                 size_t index = __builtin_ctz(mask);
                 res_data.push_back(data_pos[index]);

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -263,10 +263,11 @@ namespace
             else
             {
                 size_t pcnt = __builtin_popcount(mask);
-                for(size_t j = 0; j < pcnt; j++) {
+                for (size_t j = 0; j < pcnt; ++j)
+                {
                     size_t index = __builtin_ctz(mask);
                     copy_array(offsets_pos + index);
-                    mask = mask & (mask-1);
+                    mask = mask & (mask - 1);
                 }
             }
 

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -229,7 +229,7 @@ namespace
             memcpy(&res_elems[elems_size_old], &src_elems[arr_offset], arr_size * sizeof(T));
         };
 
-    #if defined(__SSE2__) && defined(__POPCNT__)
+    #ifdef __SSE2__
         const __m128i zero_vec = _mm_setzero_si128();
         static constexpr size_t SIMD_BYTES = 16;
         const auto * filt_end_aligned = filt_pos + size / SIMD_BYTES * SIMD_BYTES;

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -258,7 +258,7 @@ namespace
             }
             else
             {
-                while(mask)
+                while (mask)
                 {
                     size_t index = __builtin_ctz(mask);
                     copy_array(offsets_pos + index);

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -241,11 +241,7 @@ namespace
                 zero_vec));
             mask = ~mask;
 
-            if (mask == 0)
-            {
-                /// SIMD_BYTES consecutive rows do not pass the filter
-            }
-            else if (mask == 0xffff)
+            if (mask == 0xffff)
             {
                 /// SIMD_BYTES consecutive rows pass the filter
                 const auto first = offsets_pos == offsets_begin;
@@ -262,8 +258,7 @@ namespace
             }
             else
             {
-                size_t pcnt = __builtin_popcount(mask);
-                for (size_t j = 0; j < pcnt; ++j)
+                while(mask)
                 {
                     size_t index = __builtin_ctz(mask);
                     copy_array(offsets_pos + index);


### PR DESCRIPTION
Optimize-column-string-filter-perf

Co-authored-by: Zhu Jasper <jasper.zhu@intel.com>

Changelog category (leave one):
* Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Remove branchy code in filter operation with a better implementation with popcnt/ctz which have better performance

Detailed description / Documentation draft:

This optimization is to optimize filter operation in `ColumnFixedString`, `ColumnVector`, `ColumnCommon`, where we observed huge branch misprediction (as much as 10% on micro-benchmark) because the value in `filt_pos` is quite random. 
The optimized code removed the branch code by directly use of `ctz`, and we see much better performance on filtering
E.g. in `ColumnFixedString` with fixed buffer (n) size less than 32Bytes, it has more than 1.8X better on microbenchmark call filter only.
Larger fixed buffer size may have more bound on `memcpy` hence improvement by this optimization will be smaller

End to end test based on queries: 

Q1: `SELECT SearchPhrase FROM hits_100m_obfuscated WHERE SearchPhrase != '' ORDER BY EventTime, SearchPhrase LIMIT 10`

Q2: `SELECT SearchPhrase FROM hits_100m_obfuscated WHERE SearchPhrase != '' ORDER BY SearchPhrase LIMIT 10`

| Test      | Baseline   | optimized  | perf improvement |
| --------- | ---------- | ---------- | ---------------- |
|Q1         | 15.04ms    | 14.13ms    | 6.4%             |
|Q2         | 12.27ms    | 11.76ms    | 4.3%           |

Detailed Performance report 
[Performance report from CI](https://clickhouse-test-reports.s3.yandex.net/29881/3940382c2f4e84c17eb7b9ff8819eca1a1bc579d/performance_comparison/report.html)

update with DCO

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
