### PR TITLE
Add table alias to system.tables and database alias to system.databases

### DIFF
--- a/src/Storages/System/StorageSystemDatabases.cpp
+++ b/src/Storages/System/StorageSystemDatabases.cpp
@@ -21,6 +21,13 @@ NamesAndTypesList StorageSystemDatabases::getNamesAndTypes()
     };
 }
 
+NamesAndAliases StorageSystemDatabases::getNamesAndAliases()
+{
+    return {
+        {"database", std::make_shared<DataTypeString>(), "name"}
+    };
+}
+
 void StorageSystemDatabases::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo &) const
 {
     const auto access = context->getAccess();

--- a/src/Storages/System/StorageSystemDatabases.h
+++ b/src/Storages/System/StorageSystemDatabases.h
@@ -23,6 +23,8 @@ public:
 
     static NamesAndTypesList getNamesAndTypes();
 
+    static NamesAndAliases getNamesAndAliases();
+
 protected:
     using IStorageSystemOneBlock::IStorageSystemOneBlock;
 

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -59,6 +59,8 @@ StorageSystemTables::StorageSystemTables(const StorageID & table_id_)
         {"lifetime_bytes", std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>())},
         {"comment", std::make_shared<DataTypeString>()},
         {"has_own_data", std::make_shared<DataTypeUInt8>()},
+    }, {
+        {"table", std::make_shared<DataTypeString>(), "name"}
     }));
     setInMemoryMetadata(storage_metadata);
 }

--- a/tests/queries/0_stateless/02047_alias_for_table_and_database_name.reference
+++ b/tests/queries/0_stateless/02047_alias_for_table_and_database_name.reference
@@ -1,0 +1,2 @@
+numbers	numbers
+default	default

--- a/tests/queries/0_stateless/02047_alias_for_table_and_database_name.sql
+++ b/tests/queries/0_stateless/02047_alias_for_table_and_database_name.sql
@@ -1,0 +1,2 @@
+SELECT name,table from system.tables where database = 'system' and name = 'numbers';
+SELECt name,database from system.databases where name = 'default';


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `table` alias to system.tables and `database` alias to system.databases
https://github.com/ClickHouse/ClickHouse/issues/29677

Detailed description / Documentation draft:


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
