### PR TITLE
Fix flaky integration tests (test_backup_restore/test_input_format_parallel_parsing_memory_tracking)

### DIFF
--- a/tests/integration/test_backup_restore/test.py
+++ b/tests/integration/test_backup_restore/test.py
@@ -39,12 +39,10 @@ def get_last_backup_path(instance, database, table):
     return os.path.join(path_to_data, 'shadow', increment, 'data', database, table)
 
 def copy_backup_to_detached(instance, database, src_table, dst_table):
-    fp_increment = os.path.join(path_to_data, 'shadow/increment.txt')
-    increment = instance.exec_in_container(['cat',  fp_increment]).strip()
-    fp_backup = os.path.join(path_to_data, 'shadow', increment, 'data', database, src_table)
+    fp_backup = os.path.join(path_to_data, 'shadow', '*', 'data', database, src_table)
     fp_detached = os.path.join(path_to_data, 'data', database, dst_table, 'detached')
-    logging.debug(f'copy from {fp_backup} to {fp_detached}. increment {fp_increment}')
-    instance.exec_in_container(['cp', '-r', f'{fp_backup}', '-T' , f'{fp_detached}'])
+    logging.debug(f'copy from {fp_backup} to {fp_detached}')
+    instance.exec_in_container(['bash', '-c', f'cp -r {fp_backup} -T {fp_detached}'])
 
 def test_restore(started_cluster):
     instance.query("CREATE TABLE test.tbl1 AS test.tbl")

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
@@ -30,7 +30,7 @@ def test_memory_tracking_total():
         CREATE TABLE null (row String) ENGINE=Null;
     ''')
     instance.exec_in_container(['bash', '-c',
-                                'clickhouse client -q "SELECT arrayStringConcat(arrayMap(x->toString(cityHash64(x)), range(1000)), \' \') from numbers(10000)" > data.json'])
+                                'clickhouse local -q "SELECT arrayStringConcat(arrayMap(x->toString(cityHash64(x)), range(1000)), \' \') from numbers(10000)" > data.json'])
     for it in range(0, 20):
         # the problem can be triggered only via HTTP,
         # since clickhouse-client parses the data by itself.


### PR DESCRIPTION
Checklist:
- [x] Fixes `test_backup_restore` after #29649 (Cc: @CurtizJ)
- [x] Fixes `test_input_format_parallel_parsing_memory_tracking/test.py::test_memory_tracking_total`

Changelog category (leave one):
- Not for changelog (changelog entry is not required)