### PR TITLE
Better exception message while reading column from Arrow-supported formats

### DIFF
--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -15,6 +15,7 @@
 
 #include <base/logger_useful.h>
 
+
 namespace DB
 {
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better exception message while reading column from Arrow-supported formats like `Arrow`, `ArrowStream`, `Parquet` and `ORC`. This closes #29926.


Notes: No tests will be provided for this change.