### PR TITLE
Fix build due to conflicts in serverConstants

### DIFF
--- a/src/Functions/serverConstants.cpp
+++ b/src/Functions/serverConstants.cpp
@@ -106,7 +106,7 @@ namespace
     {
     public:
         static constexpr auto name = "getOSKernelVersion";
-        explicit FunctionGetOSKernelVersion(ContextPtr context) : FunctionConstantBase(context, Poco::Environment::osName() + " " + Poco::Environment::osVersion()) {}
+        explicit FunctionGetOSKernelVersion(ContextPtr context) : FunctionConstantBase(Poco::Environment::osName() + " " + Poco::Environment::osVersion(), context->isDistributed()) {}
         static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionGetOSKernelVersion>(context); }
     };
 #endif


### PR DESCRIPTION
In #29913 signature of FunctionConstantBase had been changed, but #29755 hadn't been updated.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)