### PR TITLE
Remove `printf` function usage.

### DIFF
--- a/src/Client/QueryFuzzer.cpp
+++ b/src/Client/QueryFuzzer.cpp
@@ -144,7 +144,7 @@ Field QueryFuzzer::fuzzField(Field field)
         {
             size_t pos = fuzz_rand() % arr.size();
             arr.erase(arr.begin() + pos);
-            fprintf(stderr, "erased\n");
+            std::cerr << "erased\n";
         }
 
         if (fuzz_rand() % 5 == 0)
@@ -153,12 +153,12 @@ Field QueryFuzzer::fuzzField(Field field)
             {
                 size_t pos = fuzz_rand() % arr.size();
                 arr.insert(arr.begin() + pos, fuzzField(arr[pos]));
-                fprintf(stderr, "inserted (pos %zd)\n", pos);
+                std::cerr << fmt::format("inserted (pos {})\n", pos);
             }
             else
             {
                 arr.insert(arr.begin(), getRandomField(0));
-                fprintf(stderr, "inserted (0)\n");
+                std::cerr << "inserted (0)\n";
             }
 
         }
@@ -278,7 +278,7 @@ void QueryFuzzer::fuzzOrderByList(IAST * ast)
         }
         else
         {
-            fprintf(stderr, "no random col!\n");
+            std::cerr << "No random column.\n";
         }
     }
 
@@ -312,13 +312,9 @@ void QueryFuzzer::fuzzColumnLikeExpressionList(IAST * ast)
                 : impl->children.begin() + fuzz_rand() % impl->children.size();
         auto col = getRandomColumnLike();
         if (col)
-        {
             impl->children.insert(pos, col);
-        }
         else
-        {
-            fprintf(stderr, "no random col!\n");
-        }
+            std::cerr << "No random column.\n";
     }
 
     // We don't have to recurse here to fuzz the children, this is handled by


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It's dangerous. See #29933.