### PR TITLE
Stateless flaky tests fixes

### DIFF
--- a/tests/queries/0_stateless/00984_parser_stack_overflow.sh
+++ b/tests/queries/0_stateless/00984_parser_stack_overflow.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-CLICKHOUSE_CURL_TIMEOUT=30
+# Such a huge timeout mostly for debug build.
+CLICKHOUSE_CURL_TIMEOUT=60
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01085_max_distributed_connections.sh
+++ b/tests/queries/0_stateless/01085_max_distributed_connections.sh
@@ -10,13 +10,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 while true
 do
     opts=(
-        --max_distributed_connections 9
+        --max_distributed_connections 20
         --max_threads 1
-        --query "SELECT sleepEachRow(1) FROM remote('127.{2..10}', system.one)"
+        --query "SELECT sleepEachRow(1) FROM remote('127.{2..21}', system.one)"
         --format Null
     )
-    # 5 less then 9 seconds (9 streams), but long enough to cover possible load peaks
+    # 10 less then 20 seconds (20 streams), but long enough to cover possible load peaks
     # "$@" left to pass manual options (like --experimental_use_processors 0) during manual testing
 
-    timeout 5s ${CLICKHOUSE_CLIENT} "${opts[@]}" "$@" && break
+    timeout 10s ${CLICKHOUSE_CLIENT} "${opts[@]}" "$@" && break
 done


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Make `00984_parser_stack_overflow` less flaky (increased timeout, but verified in trace_log, unwind really takes too much time)
- Make `01085_max_distributed_connections` less flaky