### PR TITLE
clickhouse-test: Retry DROP DATABASE in case of concurrent DROP/CREATE TABLE

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -592,7 +592,15 @@ class TestCase:
                 client = make_clickhouse_client(args)
                 client.connection.force_connect()
                 with client.connection.timeout_setter(seconds_left):
-                    client.execute("DROP DATABASE " + database)
+                    # Retry in case of "New table appeared in database being dropped or detached" error.
+                    while True:
+                        try:
+                            client.execute("DROP DATABASE " + database)
+                            break
+                        except clickhouse_driver.errors.ServerException as e:
+                            if e.code == error_codes.DATABASE_NOT_EMPTY:
+                                pass
+                            raise
             except (TimeoutError, clickhouse_driver.errors.SocketTimeoutError):
                 total_time = (datetime.now() - start_time).total_seconds()
                 return None, "", f"Timeout dropping database {database} after test", total_time


### PR DESCRIPTION
CI [1]:

    2021-10-10 09:28:55 01103_optimize_drop_race_zookeeper:                                     [ UNKNOWN ] 0.00 sec. - Test internal error: ServerException
    2021-10-10 09:28:55 Code: 219.
    2021-10-10 09:28:55 DB::Exception: New table appeared in database being dropped or detached. Try again.. Stack trace:

<details>

    2021-10-10 09:28:55
    2021-10-10 09:28:55 0. ./obj-x86_64-linux-gnu/../contrib/libcxx/include/exception:133: std::exception::capture() @ 0x14e44ba2 in /usr/bin/clickhouse
    2021-10-10 09:28:55 1. ./obj-x86_64-linux-gnu/../contrib/libcxx/include/exception:111: std::exception::exception() @ 0x14e44b70 in /usr/bin/clickhouse
    2021-10-10 09:28:55 2. ./obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Exception.cpp:27: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x26e107c0 in /usr/bin/clickhouse
    2021-10-10 09:28:55 3. ./obj-x86_64-linux-gnu/../src/Common/Exception.cpp:57: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x14e2662e in /usr/bin/clickhouse
    2021-10-10 09:28:55 4. ./obj-x86_64-linux-gnu/../src/Interpreters/DatabaseCatalog.cpp:351: DB::DatabaseCatalog::detachDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, bool) @ 0x211590f4 in /usr/bin/clickhouse
    2021-10-10 09:28:55 5. ./obj-x86_64-linux-gnu/../src/Interpreters/InterpreterDropQuery.cpp:372: DB::InterpreterDropQuery::executeToDatabaseImpl(DB::ASTDropQuery const&, std::__1::shared_ptr<DB::IDatabase>&, std::__1::vector<StrongTypedef<wide::integer<128ul, unsigned int>, DB::UUIDTag>, std::__1::allocator<StrongTypedef<wide::integer<128ul, unsigned int>, DB::UUIDTag> > >&) @ 0x216348ee in /usr/bin/clickhouse
    2021-10-10 09:28:55 6. ./obj-x86_64-linux-gnu/../src/Interpreters/InterpreterDropQuery.cpp:280: DB::InterpreterDropQuery::executeToDatabase(DB::ASTDropQuery const&) @ 0x21630cb9 in /usr/bin/clickhouse
    2021-10-10 09:28:55 7. ./obj-x86_64-linux-gnu/../src/Interpreters/InterpreterDropQuery.cpp:64: DB::InterpreterDropQuery::execute() @ 0x216306fa in /usr/bin/clickhouse
    2021-10-10 09:28:55 8. ./obj-x86_64-linux-gnu/../src/Interpreters/executeQuery.cpp:635: DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x21cf057b in /usr/bin/clickhouse
    2021-10-10 09:28:55 9. ./obj-x86_64-linux-gnu/../src/Interpreters/executeQuery.cpp:950: DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum) @ 0x21cee144 in /usr/bin/clickhouse
    2021-10-10 09:28:55 10. ./obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:302: DB::TCPHandler::runImpl() @ 0x228f8627 in /usr/bin/clickhouse
    2021-10-10 09:28:55 11. ./obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:1653: DB::TCPHandler::run() @ 0x22905f65 in /usr/bin/clickhouse
    2021-10-10 09:28:55 12. ./obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerConnection.cpp:43: Poco::Net::TCPServerConnection::start() @ 0x26d4a0f9 in /usr/bin/clickhouse
    2021-10-10 09:28:55 13. ./obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerDispatcher.cpp:115: Poco::Net::TCPServerDispatcher::run() @ 0x26d4a908 in /usr/bin/clickhouse
    2021-10-10 09:28:55 14. ./obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:199: Poco::PooledThread::run() @ 0x26e98834 in /usr/bin/clickhouse
    2021-10-10 09:28:55 15. ./obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:56: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x26e9531a in /usr/bin/clickhouse
    2021-10-10 09:28:55 16. ./obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread_POSIX.cpp:345: Poco::ThreadImpl::runnableEntry(void*) @ 0x26e940fc in /usr/bin/clickhouse
    2021-10-10 09:28:55 17. start_thread @ 0x9609 in /usr/lib/x86_64-linux-gnu/libpthread-2.31.so
    2021-10-10 09:28:55 18. __clone @ 0x122293 in /usr/lib/x86_64-linux-gnu/libc-2.31.so
    2021-10-10 09:28:55
    2021-10-10 09:28:55   File "/usr/bin/clickhouse-test", line 638, in run
    2021-10-10 09:28:55     proc, stdout, stderr, total_time = self.run_single_test(server_logs_level, client_options)
    2021-10-10 09:28:55
    2021-10-10 09:28:55   File "/usr/bin/clickhouse-test", line 595, in run_single_test
    2021-10-10 09:28:55     client.execute("DROP DATABASE " + database)
    2021-10-10 09:28:55
    2021-10-10 09:28:55   File "/usr/local/lib/python3.8/dist-packages/clickhouse_driver/client.py", line 286, in execute
    2021-10-10 09:28:55     rv = self.process_ordinary_query(
    2021-10-10 09:28:55
    2021-10-10 09:28:55   File "/usr/local/lib/python3.8/dist-packages/clickhouse_driver/client.py", line 479, in process_ordinary_query
    2021-10-10 09:28:55     return self.receive_result(with_column_types=with_column_types,
    2021-10-10 09:28:55
    2021-10-10 09:28:55   File "/usr/local/lib/python3.8/dist-packages/clickhouse_driver/client.py", line 136, in receive_result
    2021-10-10 09:28:55     return result.get_result()
    2021-10-10 09:28:55
    2021-10-10 09:28:55   File "/usr/local/lib/python3.8/dist-packages/clickhouse_driver/result.py", line 50, in get_result
    2021-10-10 09:28:55     for packet in self.packet_generator:
    2021-10-10 09:28:55
    2021-10-10 09:28:55   File "/usr/local/lib/python3.8/dist-packages/clickhouse_driver/client.py", line 152, in packet_generator
    2021-10-10 09:28:55     packet = self.receive_packet()
    2021-10-10 09:28:55
    2021-10-10 09:28:55   File "/usr/local/lib/python3.8/dist-packages/clickhouse_driver/client.py", line 169, in receive_packet
    2021-10-10 09:28:55     raise packet.exception

</details>

  [1]: https://clickhouse-test-reports.s3.yandex.net/0/2c3b866ab16b9b6ab315928aba1b2b3b19c60789/functional_stateless_tests_(debug).html#fail1

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #29856