### PR TITLE
Ignore parallel removing warning in 00992_system_parts_race_condition_zookeeper_long

### DIFF
--- a/tests/queries/0_stateless/00992_system_parts_race_condition_zookeeper_long.sh
+++ b/tests/queries/0_stateless/00992_system_parts_race_condition_zookeeper_long.sh
@@ -79,7 +79,7 @@ timeout $TIMEOUT bash -c thread5 2> /dev/null &
 wait
 check_replication_consistency "alter_table" "count(), sum(a), sum(b), round(sum(c))"
 
-$CLICKHOUSE_CLIENT -n -q "DROP TABLE alter_table0;" &
-$CLICKHOUSE_CLIENT -n -q "DROP TABLE alter_table1;" &
+$CLICKHOUSE_CLIENT -n -q "DROP TABLE alter_table0;" 2> >(grep -F -v 'is already started to be removing by another replica right now') &
+$CLICKHOUSE_CLIENT -n -q "DROP TABLE alter_table1;" 2> >(grep -F -v 'is already started to be removing by another replica right now') &
 
 wait


### PR DESCRIPTION
CI: https://clickhouse-test-reports.s3.yandex.net/0/6c7fbf0b888db9c1272478189f0ff40212a3e7c9/functional_stateless_tests_(release,_databaseordinary)/test_run.txt.out.log

Changelog category (leave one):
- Not for changelog (changelog entry is not required)