### PR TITLE
Fix  crash of sample by tuple()

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -132,10 +132,14 @@ namespace ErrorCodes
     extern const int ALTER_OF_COLUMN_IS_FORBIDDEN;
     extern const int SUPPORT_IS_DISABLED;
     extern const int TOO_MANY_SIMULTANEOUS_QUERIES;
+    extern const int INCORRECT_QUERY;
 }
 
 static void checkSampleExpression(const StorageInMemoryMetadata & metadata, bool allow_sampling_expression_not_in_primary_key, bool check_sample_column_is_correct)
 {
+    if (metadata.sampling_key.column_names.empty())
+        throw Exception("There are no columns in sampling expression", ErrorCodes::INCORRECT_QUERY);
+
     const auto & pk_sample_block = metadata.getPrimaryKey().sample_block;
     if (!pk_sample_block.has(metadata.sampling_key.column_names[0]) && !allow_sampling_expression_not_in_primary_key)
         throw Exception("Sampling expression must be present in the primary key", ErrorCodes::BAD_ARGUMENTS);

--- a/tests/queries/0_stateless/02096_sample_by_tuple.sql
+++ b/tests/queries/0_stateless/02096_sample_by_tuple.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS t;
+
+CREATE TABLE t (n UInt8) ENGINE=MergeTree ORDER BY n SAMPLE BY tuple(); -- { serverError 80 }
+
+CREATE TABLE t (n UInt8) ENGINE=MergeTree ORDER BY tuple();
+
+ALTER TABLE t MODIFY SAMPLE BY tuple(); -- { serverError 80 }


### PR DESCRIPTION
add tests

Changelog category (leave one):

- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash of sample by `tuple()`, closes #30004.

