### PR TITLE
cmake generator: unlink before creating a link

### DIFF
--- a/docs/tools/cmake_in_clickhouse_generator.py
+++ b/docs/tools/cmake_in_clickhouse_generator.py
@@ -160,7 +160,10 @@ def generate_cmake_flags_files() -> None:
                            "docs/ru/development/cmake-in-clickhouse.md"]
 
         for lang in other_languages:
-            os.symlink(output_file_name, os.path.join(root_path, lang))
+            other_file_name = os.path.join(root_path, lang)
+            if os.path.exists(other_file_name):
+                os.unlink(other_file_name)    
+            os.symlink(output_file_name, other_file_name)
 
 if __name__ == '__main__':
     generate_cmake_flags_files()


### PR DESCRIPTION
Changelog category:

- Not for changelog

Detailed description:
Links to cmake-in-clickhouse.md are removed before creating them.
Otherwise building the doc fails if links already exist.