### PR TITLE
Modify ConnectionPoolWithFailover get_priority ROUND_ROBIN comments

### DIFF
--- a/src/Client/ConnectionPoolWithFailover.cpp
+++ b/src/Client/ConnectionPoolWithFailover.cpp
@@ -73,8 +73,8 @@ IConnectionPool::Entry ConnectionPoolWithFailover::get(const ConnectionTimeouts 
         ++last_used;
         /* Consider nested_pools.size() equals to 5
          * last_used = 1 -> get_priority: 0 1 2 3 4
-         * last_used = 2 -> get_priority: 5 0 1 2 3
-         * last_used = 3 -> get_priority: 5 4 0 1 2
+         * last_used = 2 -> get_priority: 4 0 1 2 3
+         * last_used = 3 -> get_priority: 4 3 0 1 2
          * ...
          * */
         get_priority = [&](size_t i) { ++i; return i < last_used ? nested_pools.size() - i : i - last_used; };


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Modify comments.
