### PR TITLE
test to check what happen with tests if allow_experimental_projection_optimization is enabled

### DIFF
--- a/programs/server/users.xml
+++ b/programs/server/users.xml
@@ -18,6 +18,7 @@
                  first_or_random - if first replica one has higher number of errors, pick a random one from replicas with minimum number of errors.
             -->
             <load_balancing>random</load_balancing>
+            <allow_experimental_projection_optimization>1</allow_experimental_projection_optimization>
         </default>
 
         <!-- Profile that allows only read queries. -->


### PR DESCRIPTION
Do not merge.

we observe that allow_experimental_projection_optimization impacts tables/queries without projections.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
