### PR TITLE
Disable fsync_metadata on CI

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -48,6 +48,7 @@ ln -sf $SRC_PATH/users.d/opentelemetry.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/remote_queries.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/session_log_test.xml $DEST_SERVER_PATH/users.d/
 ln -sf $SRC_PATH/users.d/memory_profiler.xml $DEST_SERVER_PATH/users.d/
+ln -sf $SRC_PATH/users.d/no_fsync_metadata.xml $DEST_SERVER_PATH/users.d/
 
 # FIXME DataPartsExchange may hang for http_send_timeout seconds
 # when nobody is going to read from the other side of socket (due to "Fetching of part was cancelled"),

--- a/tests/config/users.d/no_fsync_metadata.xml
+++ b/tests/config/users.d/no_fsync_metadata.xml
@@ -1,0 +1,11 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- Sometimes we see that pretty simple queries like
+                 CREATE DATABASE can take > 30 seconds.
+                 Let's try to disable fsync.
+             -->
+            <fsync_metadata>false</fsync_metadata>
+        </default>
+    </profiles>
+</clickhouse>


### PR DESCRIPTION
Sometimes we see that pretty simple queries like CREATE DATABASE can
take > 30 seconds, let's try to disable fsync.

CI: https://clickhouse-test-reports.s3.yandex.net/30065/e5bc573250d3d6938937739b05d6f8cf618722db/functional_stateless_tests_(address).html#fail1
CI: https://clickhouse-test-reports.s3.yandex.net/30065/e5bc573250d3d6938937739b05d6f8cf618722db/functional_stateless_tests_(release).html#fail1

Changelog category (leave one):
- Not for changelog (changelog entry is not required)