### PR TITLE
Make test_MemoryTracking::test_http not flaky

### DIFF
--- a/tests/integration/test_MemoryTracking/test.py
+++ b/tests/integration/test_MemoryTracking/test.py
@@ -57,6 +57,8 @@ def get_MemoryTracking():
     return int(http_query("SELECT value FROM system.metrics WHERE metric = 'MemoryTracking'"))
 
 def check_memory(memory):
+    # bytes -> megabytes
+    memory = [*map(lambda x: int(int(x)/1024/1024), memory)]
     # 3 changes to MemoryTracking is minimum, since:
     # - this is not that high to not detect inacuracy
     # - memory can go like X/X+N due to some background allocations

--- a/tests/integration/test_MemoryTracking/test.py
+++ b/tests/integration/test_MemoryTracking/test.py
@@ -2,6 +2,17 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=line-too-long
 
+# This test verifies that memory tracking does not have significant drift,
+# in other words, every allocation should be taken into account at the global
+# memory tracker.
+#
+# So we are running some queries with GROUP BY to make some allocations,
+# and after we are checking MemoryTracking metric from system.metrics,
+# and check that it does not changes too frequently.
+#
+# Also note, that syncing MemoryTracking with RSS had been disabled in
+# asynchronous_metrics_update_period_s.xml.
+
 import logging
 import pytest
 from helpers.cluster import ClickHouseCluster


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

By comparing only megabytes in the memory changes, instead of bytes as
before, since it may be tricky at least due to max_untracked_memory and
how thread pool handle it.

It should be safe, since originally it was written in #16121 which fixes
issue #15932, which has ~4MB consumption of memory per request.