### PR TITLE
Support nullable arguments in function `initializeAggregation`

### DIFF
--- a/src/Functions/initializeAggregation.cpp
+++ b/src/Functions/initializeAggregation.cpp
@@ -40,6 +40,7 @@ public:
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
     bool useDefaultImplementationForConstants() const override { return true; }
+    bool useDefaultImplementationForNulls() const override { return false; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {0}; }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override;

--- a/tests/queries/0_stateless/02097_initializeAggregationNullable.reference
+++ b/tests/queries/0_stateless/02097_initializeAggregationNullable.reference
@@ -1,0 +1,6 @@
+1
+AggregateFunction(uniqExact, Nullable(String))
+1
+AggregateFunction(uniqExact, Nullable(UInt8))
+1
+1

--- a/tests/queries/0_stateless/02097_initializeAggregationNullable.sql
+++ b/tests/queries/0_stateless/02097_initializeAggregationNullable.sql
@@ -1,0 +1,8 @@
+SELECT finalizeAggregation(initializeAggregation('uniqExactState', toNullable('foo')));
+SELECT toTypeName(initializeAggregation('uniqExactState', toNullable('foo')));
+
+SELECT finalizeAggregation(initializeAggregation('uniqExactState', toNullable(123)));
+SELECT toTypeName(initializeAggregation('uniqExactState', toNullable(123)));
+
+SELECT initializeAggregation('uniqExactState', toNullable('foo')) = arrayReduce('uniqExactState', [toNullable('foo')]);
+SELECT initializeAggregation('uniqExactState', toNullable(123)) = arrayReduce('uniqExactState', [toNullable(123)]);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support nullable arguments in function `initializeAggregation`.

Fixes #30175.
