### PR TITLE
(Manual) Backport #29544 to 21.8: Avoid deadlocks on JOIN Engine tables

### DIFF
--- a/src/Functions/FunctionJoinGet.cpp
+++ b/src/Functions/FunctionJoinGet.cpp
@@ -25,14 +25,14 @@ ColumnPtr ExecutableFunctionJoinGet<or_null>::executeImpl(const ColumnsWithTypeA
         auto key = arguments[i];
         keys.emplace_back(std::move(key));
     }
-    return storage_join->joinGet(keys, result_columns).column;
+    return storage_join->joinGet(keys, result_columns, getContext()).column;
 }
 
 template <bool or_null>
 ExecutableFunctionPtr FunctionJoinGet<or_null>::prepare(const ColumnsWithTypeAndName &) const
 {
     Block result_columns {{return_type->createColumn(), return_type, attr_name}};
-    return std::make_unique<ExecutableFunctionJoinGet<or_null>>(table_lock, storage_join, result_columns);
+    return std::make_unique<ExecutableFunctionJoinGet<or_null>>(getContext(), table_lock, storage_join, result_columns);
 }
 
 static std::pair<std::shared_ptr<StorageJoin>, String>
@@ -94,7 +94,7 @@ FunctionBasePtr JoinGetOverloadResolver<or_null>::buildImpl(const ColumnsWithTyp
         data_types[i - 2] = arguments[i].type;
     auto return_type = storage_join->joinGetCheckAndGetReturnType(data_types, attr_name, or_null);
     auto table_lock = storage_join->lockForShare(getContext()->getInitialQueryId(), getContext()->getSettingsRef().lock_acquire_timeout);
-    return std::make_unique<FunctionJoinGet<or_null>>(table_lock, storage_join, attr_name, data_types, return_type);
+    return std::make_unique<FunctionJoinGet<or_null>>(getContext(), table_lock, storage_join, attr_name, data_types, return_type);
 }
 
 void registerFunctionJoinGet(FunctionFactory & factory)

--- a/src/Functions/FunctionJoinGet.h
+++ b/src/Functions/FunctionJoinGet.h
@@ -14,13 +14,15 @@ class StorageJoin;
 using StorageJoinPtr = std::shared_ptr<StorageJoin>;
 
 template <bool or_null>
-class ExecutableFunctionJoinGet final : public IExecutableFunction
+class ExecutableFunctionJoinGet final : public IExecutableFunction, WithContext
 {
 public:
-    ExecutableFunctionJoinGet(TableLockHolder table_lock_,
+    ExecutableFunctionJoinGet(ContextPtr context_,
+                              TableLockHolder table_lock_,
                               StorageJoinPtr storage_join_,
                               const DB::Block & result_columns_)
-        : table_lock(std::move(table_lock_))
+        : WithContext(context_)
+        , table_lock(std::move(table_lock_))
         , storage_join(std::move(storage_join_))
         , result_columns(result_columns_)
     {}
@@ -42,15 +44,17 @@ private:
 };
 
 template <bool or_null>
-class FunctionJoinGet final : public IFunctionBase
+class FunctionJoinGet final : public IFunctionBase, WithContext
 {
 public:
     static constexpr auto name = or_null ? "joinGetOrNull" : "joinGet";
 
-    FunctionJoinGet(TableLockHolder table_lock_,
+    FunctionJoinGet(ContextPtr context_,
+                    TableLockHolder table_lock_,
                     StorageJoinPtr storage_join_, String attr_name_,
                     DataTypes argument_types_, DataTypePtr return_type_)
-        : table_lock(std::move(table_lock_))
+        : WithContext(context_)
+        , table_lock(std::move(table_lock_))
         , storage_join(storage_join_)
         , attr_name(std::move(attr_name_))
         , argument_types(std::move(argument_types_))

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -818,11 +818,11 @@ JoinPtr SelectQueryExpressionAnalyzer::appendJoin(ExpressionActionsChain & chain
     return table_join;
 }
 
-static JoinPtr tryGetStorageJoin(std::shared_ptr<TableJoin> analyzed_join)
+static JoinPtr tryGetStorageJoin(ContextPtr context, std::shared_ptr<TableJoin> analyzed_join)
 {
     if (auto * table = analyzed_join->joined_storage.get())
         if (auto * storage_join = dynamic_cast<StorageJoin *>(table))
-            return storage_join->getJoinLocked(analyzed_join);
+            return storage_join->getJoinLocked(analyzed_join, context);
     return {};
 }
 
@@ -887,7 +887,7 @@ JoinPtr SelectQueryExpressionAnalyzer::makeTableJoin(
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Table join was already created for query");
 
     /// Use StorageJoin if any.
-    JoinPtr join = tryGetStorageJoin(syntax->analyzed_join);
+    JoinPtr join = tryGetStorageJoin(getContext(), syntax->analyzed_join);
 
     if (!join)
     {

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -633,7 +633,7 @@ bool HashJoin::addJoinedBlock(const Block & source_block, bool check_limits)
     size_t total_bytes = 0;
 
     {
-        if (storage_join_lock.mutex())
+        if (storage_join_lock)
             throw DB::Exception("addJoinedBlock called when HashJoin locked to prevent updates",
                                 ErrorCodes::LOGICAL_ERROR);
 

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -15,6 +15,7 @@
 #include <Common/ColumnsHashing.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/HashTable/FixedHashMap.h>
+#include <Common/RWLock.h>
 
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnFixedString.h>
@@ -322,9 +323,9 @@ public:
 
     /// We keep correspondence between used_flags and hash table internal buffer.
     /// Hash table cannot be modified during HashJoin lifetime and must be protected with lock.
-    void setLock(std::shared_mutex & rwlock)
+    void setLock(RWLockImpl::LockHolder rwlock_holder)
     {
-        storage_join_lock = std::shared_lock<std::shared_mutex>(rwlock);
+        storage_join_lock = rwlock_holder;
     }
 
     void reuseJoinedData(const HashJoin & join);
@@ -383,7 +384,7 @@ private:
 
     /// Should be set via setLock to protect hash table from modification from StorageJoin
     /// If set HashJoin instance is not available for modification (addJoinedBlock)
-    std::shared_lock<std::shared_mutex> storage_join_lock;
+    RWLockImpl::LockHolder storage_join_lock = nullptr;
 
     void init(Type type_);
 

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -200,6 +200,7 @@ private:
     /// without locks.
     MultiVersionStorageMetadataPtr metadata;
 
+protected:
     RWLockImpl::LockHolder tryLockTimed(
         const RWLock & rwlock, RWLockImpl::Type type, const String & query_id, const std::chrono::milliseconds & acquire_timeout) const;
 

--- a/src/Storages/StorageJoin.h
+++ b/src/Storages/StorageJoin.h
@@ -2,7 +2,9 @@
 
 #include <common/shared_ptr_helper.h>
 
+#include <Common/RWLock.h>
 #include <Storages/StorageSet.h>
+#include <Storages/TableLockHolder.h>
 #include <Storages/JoinSettings.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 
@@ -35,7 +37,7 @@ public:
 
     /// Return instance of HashJoin holding lock that protects from insertions to StorageJoin.
     /// HashJoin relies on structure of hash table that's why we need to return it with locked mutex.
-    HashJoinPtr getJoinLocked(std::shared_ptr<TableJoin> analyzed_join) const;
+    HashJoinPtr getJoinLocked(std::shared_ptr<TableJoin> analyzed_join, ContextPtr context) const;
 
     /// Get result type for function "joinGet(OrNull)"
     DataTypePtr joinGetCheckAndGetReturnType(const DataTypes & data_types, const String & column_name, bool or_null) const;
@@ -43,7 +45,7 @@ public:
     /// Execute function "joinGet(OrNull)" on data block.
     /// Takes rwlock for read to prevent parallel StorageJoin updates during processing data block
     /// (but not during processing whole query, it's safe for joinGet that doesn't involve `used_flags` from HashJoin)
-    ColumnWithTypeAndName joinGet(const Block & block, const Block & block_with_columns_to_add) const;
+    ColumnWithTypeAndName joinGet(const Block & block, const Block & block_with_columns_to_add, ContextPtr context) const;
 
     BlockOutputStreamPtr write(const ASTPtr & query, const StorageMetadataPtr & metadata_snapshot, ContextPtr context) override;
 
@@ -73,12 +75,13 @@ private:
 
     /// Protect state for concurrent use in insertFromBlock and joinBlock.
     /// Lock is stored in HashJoin instance during query and blocks concurrent insertions.
-    mutable std::shared_mutex rwlock;
+    mutable RWLock rwlock = RWLockImpl::create();
     mutable std::mutex mutate_mutex;
 
-    void insertBlock(const Block & block) override;
+    void insertBlock(const Block & block, ContextPtr context) override;
     void finishInsert() override {}
-    size_t getSize() const override;
+    size_t getSize(ContextPtr context) const override;
+    RWLockImpl::LockHolder tryLockTimedWithContext(const RWLock & lock, RWLockImpl::Type type, ContextPtr context) const;
 
 protected:
     StorageJoin(

--- a/src/Storages/StorageSet.h
+++ b/src/Storages/StorageSet.h
@@ -51,10 +51,10 @@ private:
     void restoreFromFile(const String & file_path);
 
     /// Insert the block into the state.
-    virtual void insertBlock(const Block & block) = 0;
+    virtual void insertBlock(const Block & block, ContextPtr context) = 0;
     /// Call after all blocks were inserted.
     virtual void finishInsert() = 0;
-    virtual size_t getSize() const = 0;
+    virtual size_t getSize(ContextPtr context) const = 0;
 };
 
 
@@ -81,9 +81,9 @@ public:
 private:
     SetPtr set;
 
-    void insertBlock(const Block & block) override;
+    void insertBlock(const Block & block, ContextPtr) override;
     void finishInsert() override;
-    size_t getSize() const override;
+    size_t getSize(ContextPtr) const override;
 
 protected:
     StorageSet(

--- a/tests/queries/0_stateless/02033_join_engine_deadlock_long.sh
+++ b/tests/queries/0_stateless/02033_join_engine_deadlock_long.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Tags: long, deadlock
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+create_table () {
+    $CLICKHOUSE_CLIENT --query "
+            CREATE TABLE join_block_test
+            (
+                id String,
+                num Int64
+            )
+            ENGINE = Join(ANY, LEFT, id)
+        "
+}
+
+drop_table () {
+    # Force a sync drop to free the memory before ending the test
+    # Otherwise things get interesting if you run the test many times before the database is finally dropped
+    $CLICKHOUSE_CLIENT --query "
+            DROP TABLE join_block_test SYNC
+        "
+}
+
+populate_table_bg () {
+    (
+        $CLICKHOUSE_CLIENT --query "
+            INSERT INTO join_block_test
+            SELECT toString(number) as id, number * number as num
+            FROM system.numbers LIMIT 3000000
+        " >/dev/null
+    ) &
+}
+
+read_table_bg () {
+    (
+        $CLICKHOUSE_CLIENT --query "
+            SELECT *
+            FROM
+            (
+                SELECT toString(number) AS user_id
+                FROM system.numbers LIMIT 10000 OFFSET 20000
+            ) AS t1
+            LEFT JOIN
+            (
+                SELECT
+                    *
+                FROM join_block_test AS i1
+                ANY LEFT JOIN
+                (
+                    SELECT *
+                    FROM join_block_test
+                ) AS i2 ON i1.id = toString(i2.num)
+            ) AS t2 ON t1.user_id = t2.id
+        " >/dev/null
+    ) &
+}
+
+create_table
+for _ in {1..5};
+do
+    populate_table_bg
+    sleep 0.05
+    read_table_bg
+    sleep 0.05
+done
+
+wait
+drop_table


### PR DESCRIPTION
Backport of #29544

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid deadlocks when reading and writting on JOIN Engine tables at the same time

Detailed description / Documentation draft:

Manual backport of #29544 to 21.8 since there were some conflicts and automatic backport didn't work.

Tested by adding the test (`./tests/clickhouse-test 02033_join_engine_deadlock_long`) and running it before the changes (blocks and doesn't finish) and after (finishes normally).

It's a backport, but tagging it as a bug fix since the CI asks for a description.