### PR TITLE
Do not allow zero-length reads

### DIFF
--- a/src/IO/ReadBufferFromEmptyFile.h
+++ b/src/IO/ReadBufferFromEmptyFile.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <IO/ReadBuffer.h>
+
+namespace DB
+{
+
+/// In case of empty file it does not make any sense to read it.
+///
+/// Plus regular readers from file has an assert that buffer is not empty, that will fail:
+/// - ReadBufferFromFileDescriptor
+/// - SynchronousReader
+/// - ThreadPoolReader
+class ReadBufferFromEmptyFile : public ReadBufferFromFileBase
+{
+private:
+    bool nextImpl() override { return false; }
+    std::string getFileName() const override { return "<empty>"; }
+    off_t seek(off_t /*off*/, int /*whence*/) override { return 0; }
+    off_t getPosition() override { return 0; }
+};
+
+}

--- a/src/IO/ReadBufferFromFileDescriptor.cpp
+++ b/src/IO/ReadBufferFromFileDescriptor.cpp
@@ -51,6 +51,9 @@ std::string ReadBufferFromFileDescriptor::getFileName() const
 
 bool ReadBufferFromFileDescriptor::nextImpl()
 {
+    /// If internal_buffer size is empty, then read() cannot be distinguished from EOF
+    assert(!internal_buffer.empty());
+
     size_t bytes_read = 0;
     while (!bytes_read)
     {

--- a/src/IO/SynchronousReader.cpp
+++ b/src/IO/SynchronousReader.cpp
@@ -37,6 +37,9 @@ namespace ErrorCodes
 
 std::future<IAsynchronousReader::Result> SynchronousReader::submit(Request request)
 {
+    /// If size is zero, then read() cannot be distinguished from EOF
+    assert(request.size);
+
     int fd = assert_cast<const LocalFileDescriptor &>(*request.descriptor).fd;
 
 #if defined(POSIX_FADV_WILLNEED)

--- a/src/IO/ThreadPoolReader.cpp
+++ b/src/IO/ThreadPoolReader.cpp
@@ -76,6 +76,9 @@ ThreadPoolReader::ThreadPoolReader(size_t pool_size, size_t queue_size_)
 
 std::future<IAsynchronousReader::Result> ThreadPoolReader::submit(Request request)
 {
+    /// If size is zero, then read() cannot be distinguished from EOF
+    assert(request.size);
+
     int fd = assert_cast<const LocalFileDescriptor &>(*request.descriptor).fd;
 
 #if defined(__linux__)

--- a/src/IO/createReadBufferFromFileBase.cpp
+++ b/src/IO/createReadBufferFromFileBase.cpp
@@ -1,4 +1,5 @@
 #include <IO/createReadBufferFromFileBase.h>
+#include <IO/ReadBufferFromEmptyFile.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/MMapReadBufferFromFileWithCache.h>
 #include <IO/AsynchronousReadBufferFromFile.h>
@@ -33,6 +34,8 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
     char * existing_memory,
     size_t alignment)
 {
+    if (size.has_value() && !*size)
+        return std::make_unique<ReadBufferFromEmptyFile>();
     size_t estimated_size = size.has_value() ? *size : 0;
 
     if (!existing_memory

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -71,6 +71,9 @@ MergeTreeReaderCompact::MergeTreeReaderCompact(
         if (buffer_size)
             settings.read_settings = settings.read_settings.adjustBufferSize(buffer_size);
 
+        if (!settings.read_settings.local_fs_buffer_size || !settings.read_settings.remote_fs_buffer_size)
+            throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Cannot read to empty buffer.");
+
         const String full_data_path = data_part->getFullRelativePath() + MergeTreeDataPartCompact::DATA_FILE_NAME_WITH_EXTENSION;
         if (uncompressed_cache)
         {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not allow zero-length reads (this may cause pretty odd issues, due to some code may not be ready for this, like MergeTree - #30192, and treat it as EOF)