### PR TITLE
Smaller smoothing window in throttler.

### DIFF
--- a/src/Common/Throttler.cpp
+++ b/src/Common/Throttler.cpp
@@ -23,7 +23,7 @@ static constexpr auto NS = 1000000000UL;
 
 /// Tracking window. Actually the size is not really important. We just want to avoid
 /// throttles when there are no actions for a long period time.
-static const double window_ns = 7UL * NS;
+static const double window_ns = 1UL * NS;
 
 void Throttler::add(size_t amount)
 {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

01288_shard_max_network_bandwidth