### PR TITLE
Fix clang-tidy warnings in FunctionsJSON code

### DIFF
--- a/src/Functions/FunctionsJSON.h
+++ b/src/Functions/FunctionsJSON.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <type_traits>
+
+namespace DB
+{
+
+namespace FunctionJSONHelpersDetails
+{
+    template <class T, class = void>
+    struct has_index_operator : std::false_type {};
+
+    template <class T>
+    struct has_index_operator<T, std::void_t<decltype(std::declval<T>()[0])>> : std::true_type {};
+}
+
+}


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #30145 (cc @kitaisreal )