### PR TITLE
Fix --hung-check in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -109,7 +109,10 @@ def clickhouse_execute_json(base_args, query, timeout=30, settings=None):
     data = clickhouse_execute_http(base_args, query, timeout, settings, 'JSONEachRow')
     if not data:
         return None
-    return json.loads(data)
+    rows = []
+    for row in data.strip().split(b'\n'):
+        rows.append(json.loads(row))
+    return rows
 
 
 class Terminated(KeyboardInterrupt):

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1395,7 +1395,6 @@ if __name__ == '__main__':
     http_port = os.getenv("CLICKHOUSE_PORT_HTTP")
     if http_port is not None:
         args.http_port = int(http_port)
-        args.client += f" --port={http_port}"
     else:
         args.http_port = 8123
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -110,7 +110,7 @@ def clickhouse_execute_json(base_args, query, timeout=30, settings=None):
     if not data:
         return None
     rows = []
-    for row in data.strip().split(b'\n'):
+    for row in data.strip().splitlines():
         rows.append(json.loads(row))
     return rows
 
@@ -478,19 +478,19 @@ class TestCase:
 
                 if os.path.isfile(self.stdout_file):
                     description += ", result:\n\n"
-                    description += '\n'.join(open(self.stdout_file).read().split('\n')[:100])
+                    description += '\n'.join(open(self.stdout_file).read().splitlines()[:100])
                     description += '\n'
 
                 description += "\nstdout:\n{}\n".format(stdout)
                 return TestResult(self.name, TestStatus.FAIL, reason, total_time, description)
 
         if stderr:
-            description += "\n{}\n".format('\n'.join(stderr.split('\n')[:100]))
+            description += "\n{}\n".format('\n'.join(stderr.splitlines()[:100]))
             description += "\nstdout:\n{}\n".format(stdout)
             return TestResult(self.name, TestStatus.FAIL, FailureReason.STDERR, total_time, description)
 
         if 'Exception' in stdout:
-            description += "\n{}\n".format('\n'.join(stdout.split('\n')[:100]))
+            description += "\n{}\n".format('\n'.join(stdout.splitlines()[:100]))
             return TestResult(self.name, TestStatus.FAIL, FailureReason.EXCEPTION, total_time, description)
 
         if '@@SKIP@@' in stdout:


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

JSONEachRow cannot be parsed with a simple json.loads(), instead it
should be passed to json.loads() line by line.

CI: https://clickhouse-test-reports.s3.yandex.net/30189/a063097fdffc7ca9e9a4bad859dbddc5fa926220/stress_test_(address)/test_run.txt.out.log

Fixes: #30065