### PR TITLE
Fix projections with JOIN alias columns

### DIFF
--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -890,9 +890,10 @@ static std::unique_ptr<QueryPlan> buildJoinedPlan(
         * - in the addExternalStorage function, the JOIN (SELECT ...) subquery is replaced with JOIN _data1,
         *   in the subquery_for_set object this subquery is exposed as source and the temporary table _data1 as the `table`.
         * - this function shows the expression JOIN _data1.
+        * - JOIN tables will need aliases to correctly resolve USING clause.
         */
     auto interpreter = interpretSubquery(
-        join_element.table_expression, context, original_right_columns, query_options.copy().setWithAllColumns());
+        join_element.table_expression, context, original_right_columns, query_options.copy().setWithAllColumns().ignoreAlias(false));
     auto joined_plan = std::make_unique<QueryPlan>();
     interpreter->buildQueryPlan(*joined_plan);
     {

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -272,6 +272,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
 
     query_info.ignore_projections = options.ignore_projections;
     query_info.is_projection_query = options.is_projection_query;
+    query_info.original_query = query_ptr->clone();
 
     initSettings();
     const Settings & settings = context->getSettingsRef();

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4531,7 +4531,7 @@ bool MergeTreeData::getQueryProcessingStageWithAggregateProjection(
     if (!settings.allow_experimental_projection_optimization || query_info.ignore_projections || query_info.is_projection_query)
         return false;
 
-    const auto & query_ptr = query_info.query;
+    const auto & query_ptr = query_info.original_query;
 
     if (auto * select = query_ptr->as<ASTSelectQuery>(); select)
     {

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -133,6 +133,7 @@ struct SelectQueryInfo
 {
     ASTPtr query;
     ASTPtr view_query; /// Optimized VIEW query
+    ASTPtr original_query; /// Unmodified query for projection analysis
 
     /// Cluster for the query.
     ClusterPtr cluster;

--- a/tests/queries/0_stateless/01710_projection_with_joins.sql
+++ b/tests/queries/0_stateless/01710_projection_with_joins.sql
@@ -1,0 +1,6 @@
+drop table if exists t;
+
+create table t (s UInt16, l UInt16, projection p (select s, l  order by l)) engine MergeTree order by s;
+
+set allow_experimental_projection_optimization=1;
+select s from t join (select toUInt16(1) as s) x using (s);

--- a/tests/queries/0_stateless/01710_projection_with_joins.sql
+++ b/tests/queries/0_stateless/01710_projection_with_joins.sql
@@ -2,5 +2,7 @@ drop table if exists t;
 
 create table t (s UInt16, l UInt16, projection p (select s, l  order by l)) engine MergeTree order by s;
 
-set allow_experimental_projection_optimization=1;
-select s from t join (select toUInt16(1) as s) x using (s);
+select s from t join (select toUInt16(1) as s) x using (s) settings allow_experimental_projection_optimization = 1;
+select s from t join (select toUInt16(1) as s) x using (s) settings allow_experimental_projection_optimization = 0;
+
+drop table t;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix column alias resolution of JOIN queries when projection is enabled. This fixes https://github.com/ClickHouse/ClickHouse/issues/30146


Detailed description / Documentation draft:
.