### PR TITLE
Doc. ArgMax/Min are not supported anymore by SimpleAggregateFunction

### DIFF
--- a/docs/ru/sql-reference/data-types/simpleaggregatefunction.md
+++ b/docs/ru/sql-reference/data-types/simpleaggregatefunction.md
@@ -21,8 +21,6 @@
 -   [`sumMap`](../../sql-reference/aggregate-functions/reference/summap.md#agg_functions-summap)
 -   [`minMap`](../../sql-reference/aggregate-functions/reference/minmap.md#agg_functions-minmap)
 -   [`maxMap`](../../sql-reference/aggregate-functions/reference/maxmap.md#agg_functions-maxmap)
--   [`argMin`](../../sql-reference/aggregate-functions/reference/argmin.md)
--   [`argMax`](../../sql-reference/aggregate-functions/reference/argmax.md)
 
 !!! note "Примечание"
     Значения `SimpleAggregateFunction(func, Type)` отображаются и хранятся так же, как и `Type`, поэтому комбинаторы [-Merge](../../sql-reference/aggregate-functions/combinators.md#aggregate_functions_combinators-merge) и [-State](../../sql-reference/aggregate-functions/combinators.md#agg-functions-combinator-state) не требуются.


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)
