### PR TITLE
output_format_avro_rows_in_file

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -572,8 +572,8 @@ class IColumn;
     M(Bool, input_format_values_accurate_types_of_literals, true, "For Values format: when parsing and interpreting expressions using template, check actual type of literal to avoid possible overflow and precision issues.", 0) \
     M(Bool, input_format_avro_allow_missing_fields, false, "For Avro/AvroConfluent format: when field is not found in schema use default value instead of error", 0) \
     M(URI, format_avro_schema_registry_url, "", "For AvroConfluent format: Confluent Schema Registry URL.", 0) \
-    M(Bool, output_format_json_quote_64bit_integers, true, "Controls quoting of 64-bit integers in JSON output format.", 0) \
     \
+    M(Bool, output_format_json_quote_64bit_integers, true, "Controls quoting of 64-bit integers in JSON output format.", 0) \
     M(Bool, output_format_json_quote_denormals, false, "Enables '+nan', '-nan', '+inf', '-inf' outputs in JSON output format.", 0) \
     \
     M(Bool, output_format_json_escape_forward_slashes, true, "Controls escaping forward slashes for string outputs in JSON output format. This is intended for compatibility with JavaScript. Don't confuse with backslashes that are always escaped.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -572,8 +572,6 @@ class IColumn;
     M(Bool, input_format_values_accurate_types_of_literals, true, "For Values format: when parsing and interpreting expressions using template, check actual type of literal to avoid possible overflow and precision issues.", 0) \
     M(Bool, input_format_avro_allow_missing_fields, false, "For Avro/AvroConfluent format: when field is not found in schema use default value instead of error", 0) \
     M(URI, format_avro_schema_registry_url, "", "For AvroConfluent format: Confluent Schema Registry URL.", 0) \
-    M(String, output_format_avro_string_column_pattern, "", "For Avro format: regexp of String columns to select as AVRO string.", 0) \
-    \
     M(Bool, output_format_json_quote_64bit_integers, true, "Controls quoting of 64-bit integers in JSON output format.", 0) \
     \
     M(Bool, output_format_json_quote_denormals, false, "Enables '+nan', '-nan', '+inf', '-inf' outputs in JSON output format.", 0) \
@@ -590,6 +588,8 @@ class IColumn;
     M(UInt64, output_format_parquet_row_group_size, 1000000, "Row group size in rows.", 0) \
     M(String, output_format_avro_codec, "", "Compression codec used for output. Possible values: 'null', 'deflate', 'snappy'.", 0) \
     M(UInt64, output_format_avro_sync_interval, 16 * 1024, "Sync interval in bytes.", 0) \
+    M(String, output_format_avro_string_column_pattern, "", "For Avro format: regexp of String columns to select as AVRO string.", 0) \
+    M(UInt64, output_format_avro_rows_in_file, 1000000, "Max rows in a file (if permitted by storage)", 0) \
     M(Bool, output_format_tsv_crlf_end_of_line, false, "If it is set true, end of line in TSV format will be \\r\\n instead of \\n.", 0) \
     M(String, output_format_csv_null_representation, "\\N", "Custom NULL representation in CSV format", 0) \
     M(String, output_format_tsv_null_representation, "\\N", "Custom NULL representation in TSV format", 0) \

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -53,6 +53,7 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.avro.output_sync_interval = settings.output_format_avro_sync_interval;
     format_settings.avro.schema_registry_url = settings.format_avro_schema_registry_url.toString();
     format_settings.avro.string_column_pattern = settings.output_format_avro_string_column_pattern.toString();
+    format_settings.avro.output_rows_in_file = settings.output_format_avro_rows_in_file;
     format_settings.csv.allow_double_quotes = settings.format_csv_allow_double_quotes;
     format_settings.csv.allow_single_quotes = settings.format_csv_allow_single_quotes;
     format_settings.csv.crlf_end_of_line = settings.output_format_csv_crlf_end_of_line;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -64,7 +64,7 @@ struct FormatSettings
         UInt64 output_sync_interval = 16 * 1024;
         bool allow_missing_fields = false;
         String string_column_pattern;
-        UInt64 output_rows_in_file = 1000000;
+        UInt64 output_rows_in_file = 1;
     } avro;
 
     struct CSV

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -64,6 +64,7 @@ struct FormatSettings
         UInt64 output_sync_interval = 16 * 1024;
         bool allow_missing_fields = false;
         String string_column_pattern;
+        UInt64 output_rows_in_file = 1000000;
     } avro;
 
     struct CSV

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -64,7 +64,7 @@ struct FormatSettings
         UInt64 output_sync_interval = 16 * 1024;
         bool allow_missing_fields = false;
         String string_column_pattern;
-        UInt64 output_rows_in_file = 1;
+        UInt64 output_rows_in_file = 1000000;
     } avro;
 
     struct CSV

--- a/src/Processors/Formats/IRowOutputFormat.h
+++ b/src/Processors/Formats/IRowOutputFormat.h
@@ -23,18 +23,24 @@ class WriteBuffer;
   */
 class IRowOutputFormat : public IOutputFormat
 {
+public:
+    using Params = RowOutputFormatParams;
+
+private:
+    bool prefix_written = false;
+    bool suffix_written = false;
+
 protected:
     DataTypes types;
     Serializations serializations;
+    Params params;
+
     bool first_row = true;
 
     void consume(Chunk chunk) override;
     void consumeTotals(Chunk chunk) override;
     void consumeExtremes(Chunk chunk) override;
     void finalize() override;
-
-    bool prefix_written = false;
-    bool suffix_written = false;
 
     void writePrefixIfNot()
     {
@@ -53,8 +59,6 @@ protected:
     }
 
 public:
-    using Params = RowOutputFormatParams;
-
     IRowOutputFormat(const Block & header, WriteBuffer & out_, const Params & params_);
 
     /** Write a row.
@@ -81,9 +85,6 @@ public:
     virtual void writeBeforeExtremes() {}
     virtual void writeAfterExtremes() {}
     virtual void writeLastSuffix() {}  /// Write something after resultset, totals end extremes.
-
-private:
-    Params params;
 
 };
 

--- a/src/Processors/Formats/IRowOutputFormat.h
+++ b/src/Processors/Formats/IRowOutputFormat.h
@@ -33,6 +33,25 @@ protected:
     void consumeExtremes(Chunk chunk) override;
     void finalize() override;
 
+    bool prefix_written = false;
+    bool suffix_written = false;
+
+    void writePrefixIfNot()
+    {
+        if (!prefix_written)
+            writePrefix();
+
+        prefix_written = true;
+    }
+
+    void writeSuffixIfNot()
+    {
+        if (!suffix_written)
+            writeSuffix();
+
+        suffix_written = true;
+    }
+
 public:
     using Params = RowOutputFormatParams;
 
@@ -64,26 +83,7 @@ public:
     virtual void writeLastSuffix() {}  /// Write something after resultset, totals end extremes.
 
 private:
-    bool prefix_written = false;
-    bool suffix_written = false;
-
     Params params;
-
-    void writePrefixIfNot()
-    {
-        if (!prefix_written)
-            writePrefix();
-
-        prefix_written = true;
-    }
-
-    void writeSuffixIfNot()
-    {
-        if (!suffix_written)
-            writeSuffix();
-
-        suffix_written = true;
-    }
 
 };
 

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -443,6 +443,10 @@ void AvroRowOutputFormat::consumeImplWithCallback(DB::Chunk chunk)
 
     for (size_t row = 0; row < num_rows;)
     {
+        size_t current_row = row;
+        /// used by WriteBufferToKafkaProducer to obtain auxiliary data
+        ///   from the starting row of a file
+
         writePrefix();
         for (size_t row_in_file = 0;
              row_in_file < settings.avro.output_rows_in_file && row < num_rows;
@@ -451,11 +455,10 @@ void AvroRowOutputFormat::consumeImplWithCallback(DB::Chunk chunk)
             write(columns, row);
         }
 
-
         file_writer_ptr->flush();
         writeSuffix();
 
-        params.callback(columns, num_rows);
+        params.callback(columns, current_row);
     }
 }
 

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -385,7 +385,6 @@ AvroRowOutputFormat::AvroRowOutputFormat(
     WriteBuffer & out_, const Block & header_, const RowOutputFormatParams & params_, const FormatSettings & settings_)
     : IRowOutputFormat(header_, out_, params_)
     , settings(settings_)
-    , params(params_)
     , serializer(header_.getColumnsWithTypeAndName(), std::make_unique<AvroSerializerTraits>(settings))
 {
 }
@@ -433,7 +432,6 @@ void AvroRowOutputFormat::consumeImpl(DB::Chunk chunk)
     for (size_t row = 0; row < num_rows; ++row)
     {
         write(columns, row);
-        first_row = false;
     }
 
 }
@@ -458,7 +456,6 @@ void AvroRowOutputFormat::consumeImplWithCallback(DB::Chunk chunk)
         writeSuffix();
 
         params.callback(columns, num_rows);
-        first_row = false;
     }
 }
 

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.h
@@ -58,7 +58,6 @@ public:
 
 private:
     FormatSettings settings;
-    Params params;
     AvroSerializer serializer;
     std::unique_ptr<avro::DataFileWriterBase> file_writer_ptr;
 

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.h
@@ -49,6 +49,7 @@ public:
     AvroRowOutputFormat(WriteBuffer & out_, const Block & header_, const RowOutputFormatParams & params_, const FormatSettings & settings_);
     virtual ~AvroRowOutputFormat() override;
 
+    void consume(Chunk) override;
     String getName() const override { return "AvroRowOutputFormat"; }
     void write(const Columns & columns, size_t row_num) override;
     void writeField(const IColumn &, const ISerialization &, size_t) override {}
@@ -57,8 +58,13 @@ public:
 
 private:
     FormatSettings settings;
+    Params params;
     AvroSerializer serializer;
-    avro::DataFileWriterBase file_writer;
+    std::unique_ptr<avro::DataFileWriterBase> file_writer_ptr;
+
+    void consumeImpl(Chunk);
+    void consumeImplCallback(Chunk);
+
 };
 
 }

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.h
@@ -63,7 +63,7 @@ private:
     std::unique_ptr<avro::DataFileWriterBase> file_writer_ptr;
 
     void consumeImpl(Chunk);
-    void consumeImplCallback(Chunk);
+    void consumeImplWithCallback(Chunk);
 
 };
 

--- a/src/Storages/Kafka/WriteBufferToKafkaProducer.cpp
+++ b/src/Storages/Kafka/WriteBufferToKafkaProducer.cpp
@@ -3,8 +3,6 @@
 #include "Columns/ColumnString.h"
 #include "Columns/ColumnsNumber.h"
 
-#include <base/logger_useful.h>
-
 namespace DB
 {
 WriteBufferToKafkaProducer::WriteBufferToKafkaProducer(
@@ -55,8 +53,6 @@ WriteBufferToKafkaProducer::~WriteBufferToKafkaProducer()
 
 void WriteBufferToKafkaProducer::countRow(const Columns & columns, size_t current_row)
 {
-
-    LOG_TRACE(&Poco::Logger::get("WriteBufferToKafkaProducer"), "top of countRow");
     if (++rows % max_rows == 0)
     {
         const std::string & last_chunk = chunks.back();
@@ -78,8 +74,6 @@ void WriteBufferToKafkaProducer::countRow(const Columns & columns, size_t curren
 
         cppkafka::MessageBuilder builder(topic);
         builder.payload(payload);
-
-        LOG_TRACE(&Poco::Logger::get("WriteBufferToKafkaProducer"), "payload size {}", payload.size());
 
         // Note: if it will be few rows per message - it will take the value from last row of block
         if (key_column_index)
@@ -121,7 +115,6 @@ void WriteBufferToKafkaProducer::countRow(const Columns & columns, size_t curren
 
 void WriteBufferToKafkaProducer::flush()
 {
-    LOG_TRACE(&Poco::Logger::get("WriteBufferToKafkaProducer"), "flush");
     // For unknown reason we may hit some internal timeout when inserting for the first time.
     while (true)
     {
@@ -142,13 +135,11 @@ void WriteBufferToKafkaProducer::flush()
 
 void WriteBufferToKafkaProducer::nextImpl()
 {
-    LOG_TRACE(&Poco::Logger::get("WriteBufferToKafkaProducer"), "nextImpl");
     addChunk();
 }
 
 void WriteBufferToKafkaProducer::addChunk()
 {
-    LOG_TRACE(&Poco::Logger::get("WriteBufferToKafkaProducer"), "addChunk");
     chunks.push_back(std::string());
     chunks.back().resize(chunk_size);
     set(chunks.back().data(), chunk_size);
@@ -156,7 +147,6 @@ void WriteBufferToKafkaProducer::addChunk()
 
 void WriteBufferToKafkaProducer::reinitializeChunks()
 {
-    LOG_TRACE(&Poco::Logger::get("WriteBufferToKafkaProducer"), "reinitializeChunks");
     rows = 0;
     chunks.clear();
     /// We cannot leave the buffer in the undefined state (i.e. without any

--- a/src/Storages/RabbitMQ/WriteBufferToRabbitMQProducer.cpp
+++ b/src/Storages/RabbitMQ/WriteBufferToRabbitMQProducer.cpp
@@ -88,7 +88,7 @@ void WriteBufferToRabbitMQProducer::countRow()
         const std::string & last_chunk = chunks.back();
         size_t last_chunk_size = offset();
 
-        if (delim && last_chunk[last_chunk_size - 1] == delim)
+        if (last_chunk_size && delim && last_chunk[last_chunk_size - 1] == delim)
             --last_chunk_size;
 
         std::string payload;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avro format works against Kafka.
Setting `output_format_avro_rows_in_file` added.

> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
