### PR TITLE
Fix segfault on REPLACE PARTITION if session expired

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -5995,12 +5995,12 @@ void StorageReplicatedMergeTree::replacePartitionFrom(
     MutableDataPartsVector dst_parts;
     Strings block_id_paths;
     Strings part_checksums;
+    auto zookeeper = getZooKeeper();
     std::vector<EphemeralLockInZooKeeper> ephemeral_locks;
 
     LOG_DEBUG(log, "Cloning {} parts", src_all_parts.size());
 
     static const String TMP_PREFIX = "tmp_replace_from_";
-    auto zookeeper = getZooKeeper();
 
     String alter_partition_version_path = zookeeper_path + "/alter_partition_version";
     Coordination::Stat alter_partition_version_stat;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed segfault which might happen if session expired during execution of REPLACE PARTITION

Detailed description / Documentation draft:
https://clickhouse-test-reports.s3.yandex.net/0/68b29dfe3bbc61910a46d77f048aa15be75e5497/stress_test_(debug).html#fail1

https://gist.github.com/tavplubix/1f98640fa8aa0c3289ccb1679e35b378

