### PR TITLE
RFC: save memory and improve mark cache hit rate by compressing marks in memory

### DIFF
--- a/src/Formats/MarkInCompressedFile.h
+++ b/src/Formats/MarkInCompressedFile.h
@@ -1,14 +1,23 @@
 #pragma once
 
 #include <tuple>
+#include <mutex>
 
 #include <base/types.h>
 #include <IO/WriteHelpers.h>
 #include <Common/PODArray.h>
-
+#include <common/logger_useful.h>
+#include <zstd.h>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_DECOMPRESS;
+    extern const int CANNOT_COMPRESS;
+    extern const int CANNOT_READ_COMPRESSED_CHUNK;
+}
 
 /** Mark is the position in the compressed file. The compressed file consists of adjacent compressed blocks.
   * Mark is a tuple - the offset in the file to the start of the compressed block, the offset in the decompressed block to the start of the data.
@@ -40,14 +49,106 @@ struct MarkInCompressedFile
 
 };
 
-class MarksInCompressedFile : public PODArray<MarkInCompressedFile>
+size_t const BLOCK_SIZE = 128;
+
+struct MarksIndex
 {
+  std::string data;
+  std::vector<size_t> index;
+  size_t current_block;
+  bool current_block_initialized;
+  char compression_buf[2 * BLOCK_SIZE * sizeof(MarkInCompressedFile)];
+  size_t uncompressed_size;
+  std::mutex mutex;
+
+  MarksIndex(size_t n)
+  {
+    data.reserve((n * sizeof(MarkInCompressedFile)) / 5);
+    index.reserve(n / BLOCK_SIZE + 1);
+    uncompressed_size = 0;
+    current_block_initialized = false;
+  }
+
+  MarkInCompressedFile get(size_t i)
+  {
+    std::lock_guard lock(mutex);
+
+    size_t const block = i / BLOCK_SIZE;
+    assert(block < index.size());
+    //LOG_TRACE(&Poco::Logger::get("MarksInCompressedFile"),"get {} block {}", i, block);
+    if (!current_block_initialized || current_block != block)
+    {
+      size_t const block_start = index[block];
+      size_t const block_end = block + 1 == index.size() ? data.size() : index[block+1];
+      LOG_TRACE(&Poco::Logger::get("MarksInCompressedFile"),"get {} block {} block_start {} block_end {} index.size {} data.size {}", i, block, block_start, block_end, index.size(), data.size());
+      assert(block_start < block_end);
+      uncompressed_size = ZSTD_decompress(&compression_buf,sizeof(compression_buf),&data[block_start],block_end - block_start);
+      if (ZSTD_isError(uncompressed_size)) {
+        current_block_initialized = false;
+        throw Exception(ErrorCodes::CANNOT_DECOMPRESS,"MarksIndex");
+      }
+      current_block_initialized = true;
+      current_block = block;
+    }
+    if (((i % BLOCK_SIZE) + 1) * sizeof(MarkInCompressedFile) > uncompressed_size)
+      throw Exception(ErrorCodes::CANNOT_READ_COMPRESSED_CHUNK,"MarksIndex");
+    return *(reinterpret_cast<MarkInCompressedFile*>(compression_buf) + (i % BLOCK_SIZE));
+  }
+
+  size_t size_in_bytes() const { return data.capacity() + index.capacity() * sizeof(size_t) + sizeof(MarksIndex); }
+};
+
+class MarksInCompressedFile
+{
+private:
+    std::unique_ptr<PODArray<MarkInCompressedFile>> marks_;
+    std::unique_ptr<MarksIndex> indexed_;
 public:
-    MarksInCompressedFile(size_t n) : PODArray(n) {}
+    MarksInCompressedFile(size_t n) { marks_.reset(new PODArray<MarkInCompressedFile>(n)); }
 
     void read(ReadBuffer & buffer, size_t from, size_t count)
     {
-        buffer.readStrict(reinterpret_cast<char *>(data() + from), count * sizeof(MarkInCompressedFile));
+        buffer.readStrict(reinterpret_cast<char *>(marks_->data() + from), count * sizeof(MarkInCompressedFile));
+    }
+
+    MarkInCompressedFile get(size_t i)
+    {
+      if (indexed_)
+        return indexed_->get(i);
+
+      return (*marks_)[i];
+    }
+
+    MarkInCompressedFile* data() { return marks_->data(); }
+
+    size_t size_in_bytes() const { return (marks_ ? marks_->size() * sizeof(MarkInCompressedFile) : indexed_->size_in_bytes()); }
+
+    void finish()
+    {
+      auto const& marks = *marks_;
+
+      if (marks.size() < BLOCK_SIZE * 5) return;
+
+      LOG_TRACE(&Poco::Logger::get("MarksInCompressedFile"),"indexing {} marks", marks.size());
+
+      indexed_.reset(new MarksIndex(marks.size()));
+      size_t start = 0;
+      while (start < marks.size())
+      {
+        size_t const next = (start + BLOCK_SIZE < marks.size() ? start + BLOCK_SIZE : marks.size());
+        size_t const compressed_size = ZSTD_compress(&indexed_->compression_buf, sizeof(indexed_->compression_buf), &marks[start], (next - start) * sizeof(MarkInCompressedFile), 1);
+        if (ZSTD_isError(compressed_size))
+          throw Exception(ErrorCodes::CANNOT_COMPRESS,"MarksIndex");
+        indexed_->index.push_back(indexed_->data.size());
+        indexed_->data.append(indexed_->compression_buf, compressed_size);
+        start = next;
+      }
+
+      LOG_TRACE(&Poco::Logger::get("MarksInCompressedFile"),"indexed {} bytes ({} marks) into {} bytes", marks.size() * sizeof(MarkInCompressedFile), marks.size(), indexed_->size_in_bytes());
+      indexed_->data.shrink_to_fit();
+      indexed_->index.shrink_to_fit();
+      LOG_TRACE(&Poco::Logger::get("MarksInCompressedFile"),"indexed and shrinked {} bytes ({} marks) into {} bytes", marks.size() * sizeof(MarkInCompressedFile), marks.size(), indexed_->size_in_bytes());
+      marks_.reset();
     }
 };
 

--- a/src/Storages/MarkCache.h
+++ b/src/Storages/MarkCache.h
@@ -26,7 +26,7 @@ struct MarksWeightFunction
 
     size_t operator()(const MarksInCompressedFile & marks) const
     {
-        return marks.size() * sizeof(MarkInCompressedFile) + MARK_CACHE_OVERHEAD;
+        return marks.size_in_bytes() + MARK_CACHE_OVERHEAD;
     }
 };
 

--- a/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
+++ b/src/Storages/MergeTree/MergeTreeMarksLoader.cpp
@@ -30,7 +30,7 @@ MergeTreeMarksLoader::MergeTreeMarksLoader(
     , save_marks_in_cache(save_marks_in_cache_)
     , columns_in_mark(columns_in_mark_) {}
 
-const MarkInCompressedFile & MergeTreeMarksLoader::getMark(size_t row_index, size_t column_index)
+MarkInCompressedFile MergeTreeMarksLoader::getMark(size_t row_index, size_t column_index)
 {
     if (!marks)
         loadMarks();
@@ -41,7 +41,7 @@ const MarkInCompressedFile & MergeTreeMarksLoader::getMark(size_t row_index, siz
             + " is out of range [0, " + toString(columns_in_mark) + ")", ErrorCodes::LOGICAL_ERROR);
 #endif
 
-    return (*marks)[row_index * columns_in_mark + column_index];
+    return marks->get(row_index * columns_in_mark + column_index);
 }
 
 MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksImpl()
@@ -84,7 +84,8 @@ MarkCache::MappedPtr MergeTreeMarksLoader::loadMarksImpl()
         if (i * mark_size != file_size)
             throw Exception("Cannot read all marks from file " + mrk_path, ErrorCodes::CANNOT_READ_ALL_DATA);
     }
-    res->protect();
+    res->finish();
+    //res->protect();
     return res;
 }
 

--- a/src/Storages/MergeTree/MergeTreeMarksLoader.h
+++ b/src/Storages/MergeTree/MergeTreeMarksLoader.h
@@ -21,7 +21,7 @@ public:
         bool save_marks_in_cache_,
         size_t columns_in_mark_ = 1);
 
-    const MarkInCompressedFile & getMark(size_t row_index, size_t column_index = 0);
+    MarkInCompressedFile getMark(size_t row_index, size_t column_index = 0);
 
     bool initialized() const { return marks != nullptr; }
 


### PR DESCRIPTION
When using tables with hundreds of billions of rows and 10s of columns, storing all marks in memory can easily use several hundreds of gigabytes. Although mark cache is officially a cache, running queries with high miss rate has a sizeable performance impact. One solution would be to increase granularity, but this sacrifices performances of small queries. 
But actually, marks data representation is very wasteful. Offset in compressed block is usually 0, so it takes 8 bytes to store zeros, and offset field is monotonic. Data can easily be compressed in memory, which allows to keep all marks in ram when using servers with good ram/disks space ratio.
This is a rough implementation of such idea, we have been running it on production for more than a year, and it has had only beneficial effects.

That being said, the implementation is pretty basic. It split marks into blocks, and compress each blocks with ZSTD, with a cache buffer for one decompressed space. It uses a mutex, which is not optimal, but does not seem to affect perf too much. A proper implemenation would probably use Delta coding codec instead of zstd, and it should probably be an opt-in feature, but submitting this in the current form to know if there is interest in such a feature. 