### PR TITLE
DOCSUP-16363: Document the getOSKernelVersion function

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -2427,3 +2427,39 @@ Type: [UInt32](../../sql-reference/data-types/int-uint.md).
 **See Also**
 
 - [shardNum()](#shard-num) function example also contains `shardCount()` function call.
+
+## getOSKernelVersion {#getoskernelversion}
+
+Returns string with the current OS kernel version.
+
+**Syntax**
+
+``` sql
+getOSKernelVersion()
+```
+
+**Arguments**
+
+-   None.
+
+**Returned value**
+
+-   The current OS kernel version.
+
+Type: [String](../../sql-reference/data-types/string.md).
+
+**Example**
+
+Query:
+
+``` sql
+SELECT getOSKernelVersion();
+```
+
+Result:
+
+``` text
+┌─getOSKernelVersion()────┐
+│ Linux 4.15.0-55-generic │
+└─────────────────────────┘
+```

--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -2430,7 +2430,7 @@ Type: [UInt32](../../sql-reference/data-types/int-uint.md).
 
 ## getOSKernelVersion {#getoskernelversion}
 
-Returns string with the current OS kernel version.
+Returns a string with the current OS kernel version.
 
 **Syntax**
 

--- a/docs/ru/sql-reference/functions/other-functions.md
+++ b/docs/ru/sql-reference/functions/other-functions.md
@@ -2375,3 +2375,39 @@ shardCount()
 **См. также**
 
 - Пример использования функции [shardNum()](#shard-num) также содержит вызов `shardCount()`.
+
+## getOSKernelVersion {#getoskernelversion}
+
+Возвращает строку с текущей версией ядра ОС.
+
+**Синтаксис**
+
+``` sql
+getOSKernelVersion()
+```
+
+**Аргументы**
+
+-   Нет.
+
+**Возвращаемое значение**
+
+-   Текущая версия ядра ОС.
+
+Тип: [String](../../sql-reference/data-types/string.md).
+
+**Пример**
+
+Запрос:
+
+``` sql
+SELECT getOSKernelVersion();
+```
+
+Результат:
+
+``` text
+┌─getOSKernelVersion()────┐
+│ Linux 4.15.0-55-generic │
+└─────────────────────────┘
+```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:

- Documentation for #29755