### PR TITLE
(manual backport) Avoid crashes from parallel_view_processing 

### DIFF
--- a/src/DataStreams/SquashingTransform.cpp
+++ b/src/DataStreams/SquashingTransform.cpp
@@ -115,7 +115,10 @@ bool SquashingTransform::isEnoughSize(const Block & block)
 
     for (const auto & [column, type, name] : block)
     {
-        if (!rows)
+        if (!column)
+            throw Exception("Column " + name + " in block is nullptr, in method isEnoughSize."
+                            , ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
+        else if (!rows)
             rows = column->size();
         else if (rows != column->size())
             throw Exception("Sizes of columns doesn't match", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);

--- a/src/DataStreams/SquashingTransform.cpp
+++ b/src/DataStreams/SquashingTransform.cpp
@@ -115,10 +115,9 @@ bool SquashingTransform::isEnoughSize(const Block & block)
 
     for (const auto & [column, type, name] : block)
     {
-        if (!column)
-            throw Exception("Column " + name + " in block is nullptr, in method isEnoughSize."
-                            , ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);
-        else if (!rows)
+        assert(column && "Invalid column in block");
+
+        if (!rows)
             rows = column->size();
         else if (rows != column->size())
             throw Exception("Sizes of columns doesn't match", ErrorCodes::SIZES_OF_COLUMNS_DOESNT_MATCH);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix exception handling in `parallel_view_processing`. That resolves issues / prevents crashes in some rare corner cases, when that feature is enabled and exception (like "Memory limit exceeded ...")  happened in the middle of materialized view processing.

Detailed description / Documentation draft:
Exceptions from `parallel_view_processing` were silently ignored between blocks, leaving the dirty state of internal objects.
It's for <=21.10. Newer version - may be no fix will be needed after #28582 (cc @KochetovNicolai)

For the reference - example of the segfault:
```
2021.10.20 14:07:37.089149 [ 13128 ] {} <Fatal> BaseDaemon: ########################################
2021.10.20 14:07:37.089324 [ 13128 ] {} <Fatal> BaseDaemon: (version 21.8.9.13 (official build), build id: 80B715B072608D5DD3A2BCED0DFC8DD6F101218A) (from thread 13050) (query_id: 2809155b-d9ed-46b5-addf-b831067a2126) Received signal Segmentation fault (11)
2021.10.20 14:07:37.089349 [ 13128 ] {} <Fatal> BaseDaemon: Address: NULL pointer. Access: read. Address not mapped to object.
2021.10.20 14:07:37.089374 [ 13128 ] {} <Fatal> BaseDaemon: Stack trace: 0xfdf3a2e 0xfdf3750 0x103dcb39 0x100e401e 0x103d3873 0x9018638 0x901a1df 0x901591f 0x9019203 0x7f28a4f41609 0x7f28a4e57293
2021.10.20 14:07:37.089426 [ 13128 ] {} <Fatal> BaseDaemon: 1. DB::SquashingTransform::isEnoughSize(DB::Block const&) @ 0xfdf3a2e in /usr/lib/debug/.build-id/80/b715b072608d5dd3a2bced0dfc8dd6f101218a.debug
2021.10.20 14:07:37.089470 [ 13128 ] {} <Fatal> BaseDaemon: 2. DB::Block DB::SquashingTransform::addImpl<DB::Block const&>(DB::Block const&) @ 0xfdf3750 in /usr/lib/debug/.build-id/80/b715b072608d5dd3a2bced0dfc8dd6f101218a.debug
2021.10.20 14:07:37.089488 [ 13128 ] {} <Fatal> BaseDaemon: 3. DB::SquashingBlockOutputStream::write(DB::Block const&) @ 0x103dcb39 in /usr/lib/debug/.build-id/80/b715b072608d5dd3a2bced0dfc8dd6f101218a.debug
2021.10.20 14:07:37.089510 [ 13128 ] {} <Fatal> BaseDaemon: 4. DB::CountingBlockOutputStream::write(DB::Block const&) @ 0x100e401e in /usr/lib/debug/.build-id/80/b715b072608d5dd3a2bced0dfc8dd6f101218a.debug
2021.10.20 14:07:37.089531 [ 13128 ] {} <Fatal> BaseDaemon: 5. DB::PushingToViewsBlockOutputStream::process(DB::Block const&, DB::PushingToViewsBlockOutputStream::ViewInfo&) @ 0x103d3873 in /usr/lib/debug/.build-id/80/b715b072608d5dd3a2bced0dfc8dd6f101218a.debug
2021.10.20 14:07:37.089564 [ 13128 ] {} <Fatal> BaseDaemon: 6. ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::__1::__list_iterator<ThreadFromGlobalPool, void*>) @ 0x9018638 in /usr/lib/debug/.build-id/80/b715b072608d5dd3a2bced0dfc8dd6f101218a.debug
2021.10.20 14:07:37.089600 [ 13128 ] {} <Fatal> BaseDaemon: 7. ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(void&&, void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...)::'lambda'()::operator()() @ 0x901a1df in /usr/lib/debug/.build-id/80/b715b072608d5dd3a2bced0dfc8dd6f101218a.debug
2021.10.20 14:07:37.089620 [ 13128 ] {} <Fatal> BaseDaemon: 8. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x901591f in /usr/lib/debug/.build-id/80/b715b072608d5dd3a2bced0dfc8dd6f101218a.debug
2021.10.20 14:07:37.089648 [ 13128 ] {} <Fatal> BaseDaemon: 9. void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()> >(void*) @ 0x9019203 in /usr/lib/debug/.build-id/80/b715b072608d5dd3a2bced0dfc8dd6f101218a.debug
2021.10.20 14:07:37.089671 [ 13128 ] {} <Fatal> BaseDaemon: 10. start_thread @ 0x9609 in /usr/lib/x86_64-linux-gnu/libpthread-2.31.so
2021.10.20 14:07:37.089696 [ 13128 ] {} <Fatal> BaseDaemon: 11. __clone @ 0x122293 in /usr/lib/x86_64-linux-gnu/libc-2.31.so
2021.10.20 14:07:37.194564 [ 13128 ] {} <Fatal> BaseDaemon: Checksum of the binary: 9F7189789EFE80560B107FF89512BEC7, integrity check passed.
2021.10.20 14:07:57.644477 [ 12894 ] {} <Fatal> Application: Child process was terminated by signal 11.
```

The issue was caused by "Memory limit exceeded ..." in the middle of 
https://github.com/ClickHouse/ClickHouse/blob/4273d46e037556cb17906e6f10f8c31d1ae9aa53/src/DataStreams/SquashingTransform.cpp#L104
and `accumulated_block` there had some dirty state (one of the columns was nullptr, some - processed already and having more rows, some - not and having less rows). That exception was catched in PushingToViewsBlockOutputStream and on next `write` the same `SquashingTransform` was reused. 