### PR TITLE
Change link in nav from community -> learn

### DIFF
--- a/website/templates/global/nav.html
+++ b/website/templates/global/nav.html
@@ -42,7 +42,7 @@
                     <a class="nav-link" href="/docs/en/">Documentation</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/#community">Community</a>
+                    <a class="nav-link" href="/learn/">Learn</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="/company/">Company</a>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
This updates the community link in the global nav to point to the learn page.

Preview:
![image](https://user-images.githubusercontent.com/310973/138309168-926d911e-7e77-4078-bf97-f604b41b4fea.png)
