### PR TITLE
Add missing parenthesis for isNotNull/isNull rewrites to IS [NOT] NULL

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -294,8 +294,12 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
                     continue;
                 }
 
+                if (frame.need_parens)
+                    settings.ostr << '(';
                 arguments->formatImpl(settings, state, nested_need_parens);
                 settings.ostr << (settings.hilite ? hilite_operator : "") << func[1] << (settings.hilite ? hilite_none : "");
+                if (frame.need_parens)
+                    settings.ostr << ')';
 
                 written = true;
 

--- a/tests/queries/0_stateless/00826_cross_to_inner_join.reference
+++ b/tests/queries/0_stateless/00826_cross_to_inner_join.reference
@@ -146,7 +146,7 @@ SELECT
     t2_00826.b
 FROM t1_00826
 ALL INNER JOIN t2_00826 ON b = t2_00826.a
-WHERE (b = t2_00826.a) AND (t2_00826.b IS NULL OR (t2_00826.b > t2_00826.a))
+WHERE (b = t2_00826.a) AND ((t2_00826.b IS NULL) OR (t2_00826.b > t2_00826.a))
 --- do not rewrite alias ---
 SELECT a AS b
 FROM t1_00826
@@ -178,4 +178,4 @@ SELECT
     t2_00826.b
 FROM t1_00826
 ALL INNER JOIN t2_00826 ON a = t2_00826.a
-WHERE (a = t2_00826.a) AND (t2_00826.b IS NULL OR (t2_00826.b < 2))
+WHERE (a = t2_00826.a) AND ((t2_00826.b IS NULL) OR (t2_00826.b < 2))

--- a/tests/queries/0_stateless/02035_isNull_isNotNull_format.reference
+++ b/tests/queries/0_stateless/02035_isNull_isNotNull_format.reference
@@ -7,3 +7,8 @@ explain syntax select isNull(null);
 SELECT NULL IS NULL
 explain syntax select isNotNull(null);
 SELECT NULL IS NOT NULL
+explain syntax select isNotNull(1)+isNotNull(2) from remote('127.2', system.one);
+SELECT (1 IS NOT NULL) + (2 IS NOT NULL)
+FROM remote(\'127.2\', \'system.one\')
+select isNotNull(1)+isNotNull(2) from remote('127.2', system.one);
+2

--- a/tests/queries/0_stateless/02035_isNull_isNotNull_format.sql
+++ b/tests/queries/0_stateless/02035_isNull_isNotNull_format.sql
@@ -3,3 +3,5 @@ explain syntax select null is null;
 explain syntax select null is not null;
 explain syntax select isNull(null);
 explain syntax select isNotNull(null);
+explain syntax select isNotNull(1)+isNotNull(2) from remote('127.2', system.one);
+select isNotNull(1)+isNotNull(2) from remote('127.2', system.one);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add missing parenthesis for `isNotNull`/`isNull` rewrites to `IS [NOT] NULL` (fixes queries that has something like `isNotNull(1)+isNotNull(2)`)

Detailed description / Documentation draft:
After #29446 the following query was "broken":

    select isNotNull(1)+isNotNull(2) from remote('127.2', system.one)

This was also a problem for queries to external storages (i.e. mysql),
since it also uses query rewrite, like non-local distributed queries.

Fixes: #29446 (cc @alexey-milovidov )

*NOTE: this should be marked as `do-not-backport`, since original PR has not been included into any release yet*