### PR TITLE
clickhouse-local: fix block lost in interactive mode

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -285,13 +285,6 @@ bool LocalConnection::poll(size_t)
         return true;
     }
 
-    if (send_progress && !state->sent_progress)
-    {
-        state->sent_progress = true;
-        next_packet_type = Protocol::Server::Progress;
-        return true;
-    }
-
     if (state->block && state->block.value())
     {
         next_packet_type = Protocol::Server::Data;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix block lost in interactive mode of `clickhouse-local`

Detailed description / Documentation draft:
In case only one block in the query execution, LocalConnection can
return Progress packet instead of the block itself, after it will call
poll() again and the block will got lost.

Fix this by processing block before Progress packet.

And actually AFAICS Progress can be removed after pollImpl(), since
there is Progress handling before.

Fixes: #30282 (cc @kssenii)

*NOTE: should be marked as `not-for-backport` since original PR has not been included into any release yet*