### PR TITLE
Fix typo and update NuRaft

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1914,12 +1914,12 @@ void Context::initializeKeeperDispatcher([[maybe_unused]] bool start_async) cons
         if (start_async)
         {
             assert(!is_standalone_app);
-            LOG_INFO(shared->log, "Connected to ZooKeeper (or Keeper) before internal Keeper start or we don't depend on our Keeper cluster"
-                     ", will wait for Keeper asynchronously");
+            LOG_INFO(shared->log, "Connected to ZooKeeper (or Keeper) before internal Keeper start or we don't depend on our Keeper cluster, "
+                     "will wait for Keeper asynchronously");
         }
         else
         {
-            LOG_INFO(shared->log, "Cannot connect to ZooKeeper (or Keeper) before internal Keeper start,"
+            LOG_INFO(shared->log, "Cannot connect to ZooKeeper (or Keeper) before internal Keeper start, "
                      "will wait for Keeper synchronously");
         }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Trying to fix very strange `"Address already in use"` error like this: https://clickhouse-test-reports.s3.yandex.net/0/feeb572219a4af37f70ea99017bf0712526aacc2/functional_stateless_tests_(release,_wide_parts_enabled).html#fail1 or https://clickhouse-test-reports.s3.yandex.net/0/d3df1c02bca5483eca30df3d9d362607139e3ce5/functional_stateless_tests_(debug).html#fail1