### PR TITLE
Fix LimitStep header after limit push down optimization.

### DIFF
--- a/src/Processors/QueryPlan/LimitStep.cpp
+++ b/src/Processors/QueryPlan/LimitStep.cpp
@@ -40,7 +40,7 @@ void LimitStep::updateInputStream(DataStream input_stream)
 {
     input_streams.clear();
     input_streams.emplace_back(std::move(input_stream));
-    output_stream = createOutputStream(input_streams.front(), output_stream->header, getDataStreamTraits());
+    output_stream = createOutputStream(input_streams.front(), input_streams.front().header, getDataStreamTraits());
 }
 
 void LimitStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)

--- a/tests/queries/0_stateless/02100_limit_push_down_bug.sql
+++ b/tests/queries/0_stateless/02100_limit_push_down_bug.sql
@@ -1,0 +1,21 @@
+drop table if exists tbl_repr;
+
+CREATE TABLE tbl_repr(
+ts DateTime,
+x  String)
+ENGINE=MergeTree ORDER BY ts;
+
+
+SELECT *
+FROM
+(
+    SELECT
+        x,
+        length(x)
+    FROM tbl_repr
+    WHERE ts > now()
+    LIMIT 1
+)
+WHERE x != '';
+
+drop table if exists tbl_repr;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Limit push down optimization could cause a error `Cannot find column`. Fixes #30438