### PR TITLE
Support Nullable(String) type in arrayStringConcat

### DIFF
--- a/docs/en/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/en/sql-reference/functions/splitting-merging-functions.md
@@ -213,7 +213,7 @@ SELECT splitByNonAlpha('  1!  a,  b.  ');
 
 ## arrayStringConcat(arr\[, separator\]) {#arraystringconcatarr-separator}
 
-Concatenates the strings listed in the array with the separator.’separator’ is an optional parameter: a constant string, set to an empty string by default.
+Concatenates the strings (values of type String or Nullable(String)) listed in the array with the separator. ’separator’ is an optional parameter: a constant string, set to an empty string by default.
 Returns the string.
 
 ## alphaTokens(s) {#alphatokenss}

--- a/src/Functions/FunctionsStringArray.cpp
+++ b/src/Functions/FunctionsStringArray.cpp
@@ -1,9 +1,43 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsStringArray.h>
 
+namespace
+{
+bool isNullableStringOrNullableNothing(DB::DataTypePtr type)
+{
+    if (type->isNullable())
+    {
+        const auto & nested_type = assert_cast<const DB::DataTypeNullable &>(*type).getNestedType();
+        if (isString(nested_type) || isNothing(nested_type))
+            return true;
+    }
+    return false;
+}
+
+}
 
 namespace DB
 {
+DataTypePtr FunctionArrayStringConcat::getReturnTypeImpl(const DataTypes & arguments) const
+{
+    if (arguments.size() != 1 && arguments.size() != 2)
+        throw Exception(
+            "Number of arguments for function " + getName() + " doesn't match: passed " + toString(arguments.size())
+                + ", should be 1 or 2.",
+            ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+
+    const DataTypeArray * array_type = checkAndGetDataType<DataTypeArray>(arguments[0].get());
+    // An array consisting of only Null-s has type Array(Nullable(Nothing))
+    if (!array_type || !(isString(array_type->getNestedType()) || isNullableStringOrNullableNothing(array_type->getNestedType())))
+        throw Exception(
+            "First argument for function " + getName() + " must be an array of String-s or Nullable(String)-s.",
+            ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
+    if (arguments.size() == 2 && !isString(arguments[1]))
+        throw Exception("Second argument for function " + getName() + " must be constant string.", ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
+    return std::make_shared<DataTypeString>();
+}
 
 void registerFunctionsStringArray(FunctionFactory & factory)
 {

--- a/src/Functions/FunctionsStringArray.cpp
+++ b/src/Functions/FunctionsStringArray.cpp
@@ -18,6 +18,12 @@ bool isNullableStringOrNullableNothing(DB::DataTypePtr type)
 
 namespace DB
 {
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
 DataTypePtr FunctionArrayStringConcat::getReturnTypeImpl(const DataTypes & arguments) const
 {
     if (arguments.size() != 1 && arguments.size() != 2)

--- a/src/Functions/FunctionsStringArray.h
+++ b/src/Functions/FunctionsStringArray.h
@@ -24,7 +24,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int BAD_ARGUMENTS;
     extern const int ILLEGAL_COLUMN;
 }

--- a/tests/queries/0_stateless/00255_array_concat_string.reference
+++ b/tests/queries/0_stateless/00255_array_concat_string.reference
@@ -63,3 +63,6 @@ yandex google test 123  hello world goodbye xyz yandex google test 123  hello wo
 012
 
 0
+hello;world;xyz;def
+
+

--- a/tests/queries/0_stateless/00255_array_concat_string.reference
+++ b/tests/queries/0_stateless/00255_array_concat_string.reference
@@ -66,3 +66,6 @@ yandex google test 123  hello world goodbye xyz yandex google test 123  hello wo
 hello;world;xyz;def
 
 
+hello;world;xyz;def
+
+

--- a/tests/queries/0_stateless/00255_array_concat_string.sql
+++ b/tests/queries/0_stateless/00255_array_concat_string.sql
@@ -11,3 +11,6 @@ SELECT arrayStringConcat(arrayMap(x -> toString(x), range(number % 4))) FROM sys
 SELECT arrayStringConcat([Null, 'hello', Null, 'world', Null, 'xyz', 'def', Null], ';');
 SELECT arrayStringConcat([Null, Null], ';');
 SELECT arrayStringConcat([Null::Nullable(String), Null::Nullable(String)], ';');
+SELECT arrayStringConcat(materialize([Null, 'hello', Null, 'world', Null, 'xyz', 'def', Null]), ';');
+SELECT arrayStringConcat(materialize([Null, Null]), ';');
+SELECT arrayStringConcat(materialize([Null::Nullable(String), Null::Nullable(String)]), ';');

--- a/tests/queries/0_stateless/00255_array_concat_string.sql
+++ b/tests/queries/0_stateless/00255_array_concat_string.sql
@@ -8,3 +8,6 @@ SELECT arrayStringConcat(arrayMap(x -> toString(x), range(number)), '') FROM sys
 SELECT arrayStringConcat(arrayMap(x -> toString(x), range(number)), ',') FROM system.numbers LIMIT 10;
 SELECT arrayStringConcat(arrayMap(x -> transform(x, [0, 1, 2, 3, 4, 5, 6, 7, 8], ['yandex', 'google', 'test', '123', '', 'hello', 'world', 'goodbye', 'xyz'], ''), arrayMap(x -> x % 9, range(number))), ' ') FROM system.numbers LIMIT 20;
 SELECT arrayStringConcat(arrayMap(x -> toString(x), range(number % 4))) FROM system.numbers LIMIT 10;
+SELECT arrayStringConcat([Null, 'hello', Null, 'world', Null, 'xyz', 'def', Null], ';');
+SELECT arrayStringConcat([Null, Null], ';');
+SELECT arrayStringConcat([Null::Nullable(String), Null::Nullable(String)], ';');


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Arrays of `Nullable(String)`-s is now allowed. `Null` is treated as "no value at all" so that `arrayStringConcat(['x',Null], ';') == 'x'`.

Issue: #29967