### PR TITLE
WIP: use cgroup memory limit in getMemoryAmountOrZero

### DIFF
--- a/base/base/getMemoryAmount.cpp
+++ b/base/base/getMemoryAmount.cpp
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <fstream>
 #include <base/getMemoryAmount.h>
 #include <base/getPageSize.h>
 
@@ -15,6 +16,17 @@
   */
 uint64_t getMemoryAmountOrZero()
 {
+#if defined(OS_LINUX)
+    // Try to lookup at the Cgroup limit
+    std::ifstream cgroup_limit("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+    if (cgroup_limit.is_open())
+    {
+        uint64 amount = 0; // in case of read error
+        cgroup_limit >> amount;
+        return amount;
+    }
+#endif
+
     int64_t num_pages = sysconf(_SC_PHYS_PAGES);
     if (num_pages <= 0)
         return 0;

--- a/base/base/getMemoryAmount.cpp
+++ b/base/base/getMemoryAmount.cpp
@@ -21,7 +21,7 @@ uint64_t getMemoryAmountOrZero()
     std::ifstream cgroup_limit("/sys/fs/cgroup/memory/memory.limit_in_bytes");
     if (cgroup_limit.is_open())
     {
-        uint64 amount = 0; // in case of read error
+        uint64_t amount = 0; // in case of read error
         cgroup_limit >> amount;
         return amount;
     }


### PR DESCRIPTION
Try to read the memory amount from `/sys/fs/cgroup/memory/memory.limit_in_bytes`

See issue #25662

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Get memory amount with Docker/cgroups limitations. See #25662.
