### PR TITLE
Update documentation for distributed_push_down_limit

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1795,7 +1795,7 @@ This will allow to avoid:
 - sending extra rows over network,
 - processing rows behind the limit on the initiator.
 
-It is possible if one of next is true:
+It is possible if at least one of the following conditions met:
 
 - `distributed_group_by_no_merge` > 0
 - query **does not have `GROUP BY`/`DISTINCT`/`LIMIT BY`**, but it has `ORDER BY`/`LIMIT`.

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1788,15 +1788,31 @@ Default value: 0
 
 ## distributed_push_down_limit (#distributed-push-down-limit}
 
-LIMIT will be applied on each shard separatelly. Usually you don't need to use it, since this will be done automatically if it is possible, i.e. for simple query SELECT FROM LIMIT.
+LIMIT will be applied on each shard separatelly.
+
+This will allow to avoid:
+
+- sending extra rows over network,
+- processing rows behind the limit on the initiator.
+
+It is possible if one of next is true:
+
+- `distributed_group_by_no_merge` > 0
+- query **does not have `GROUP BY`/`DISTINCT`/`LIMIT BY`**, but it has `ORDER BY`/`LIMIT`.
+- query **has `GROUP BY`/`DISTINCT`/`LIMIT BY`** with `ORDER BY`/`LIMIT` and:
+  - `optimize_skip_unused_shards_limit` is enabled
+  - `optimize_distributed_group_by_sharding_key` is enabled
 
 Possible values:
 
 -  0 - Disabled
 -  1 - Enabled
 
-!!! note "Note"
-    That with this setting the result of the query may be inaccurate.
+See also:
+
+-   [distributed_group_by_no_merge](#distributed-group-by-no-merge)
+-   [optimize_skip_unused_shards](#optimize-skip-unused-shards)
+-   [optimize_distributed_group_by_sharding_key](#optimize-distributed-group-by-sharding-key)
 
 ## optimize_skip_unused_shards_limit {#optimize-skip-unused-shards-limit}
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update documentation for `distributed_push_down_limit`

After #26466 you cannot get inaccurate results anymore, since
distributed_push_down_limit changes query execution only if at least one of the conditions met:
- `distributed_group_by_no_merge` > 0
- query **does not have `GROUP BY`/`DISTINCT`/`LIMIT BY`**, but it has `ORDER BY`/`LIMIT`.
- query **has `GROUP BY`/`DISTINCT`/`LIMIT BY`** with `ORDER BY`/`LIMIT` and:
  - `optimize_skip_unused_shards_limit` is enabled
  - `optimize_distributed_group_by_sharding_key` is enabled

Cc: @alexey-milovidov 