### PR TITLE
Fix tests that relies on checking stack size under TSan

### DIFF
--- a/src/Common/checkStackSize.cpp
+++ b/src/Common/checkStackSize.cpp
@@ -1,6 +1,7 @@
 #include <Common/checkStackSize.h>
 #include <Common/Exception.h>
 #include <base/scope_guard.h>
+#include <base/defines.h> /// THREAD_SANITIZER
 #include <pthread.h>
 #include <cstdint>
 
@@ -86,15 +87,24 @@ __attribute__((__weak__)) void checkStackSize()
     uintptr_t int_frame_address = reinterpret_cast<uintptr_t>(frame_address);
     uintptr_t int_stack_address = reinterpret_cast<uintptr_t>(stack_address);
 
+#if !defined(THREAD_SANITIZER)
+    /// It's overkill to use more then half of stack.
+    static constexpr double STACK_SIZE_FREE_RATIO = 0.5;
+#else
+    /// Under TSan recursion eats too much RAM, so half of stack is too much.
+    /// So under TSan only 5% of a stack is allowed (this is ~400K)
+    static constexpr double STACK_SIZE_FREE_RATIO = 0.05;
+#endif
+
     /// We assume that stack grows towards lower addresses. And that it starts to grow from the end of a chunk of memory of max_stack_size.
     if (int_frame_address > int_stack_address + max_stack_size)
         throw Exception("Logical error: frame address is greater than stack begin address", ErrorCodes::LOGICAL_ERROR);
 
     size_t stack_size = int_stack_address + max_stack_size - int_frame_address;
+    size_t max_stack_size_allowed = max_stack_size * STACK_SIZE_FREE_RATIO;
 
-    /// Just check if we have already eat more than a half of stack size. It's a bit overkill (a half of stack size is wasted).
-    /// It's safe to assume that overflow in multiplying by two cannot occur.
-    if (stack_size * 2 > max_stack_size)
+    /// Just check if we have eat more than a STACK_SIZE_FREE_RATIO of stack size already.
+    if (stack_size > max_stack_size_allowed)
     {
         throw Exception(ErrorCodes::TOO_DEEP_RECURSION,
                         "Stack size too large. Stack address: {}, frame address: {}, stack size: {}, maximum stack size: {}",


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Under TSan using too much stack requires too much RSS for shadow memory,
and neither of this TSAN_OPTIONS helps:
- `history_size=2`
- `flush_memory_ms=2000`
- `memory_limit_mb=50000`

So instead, change allowed limit of the stack size in checkStackSize(),
to address exessive memory usage for the server compiled with TSan.

Note, that before this patch 01763_max_distributed_depth test can
increase RSS of the server to 70GiB.

Supersedes #30009 

*NOTE: marked as draft for now, since I want to check logs of TSan server, but it should be OK with this patch*