### PR TITLE
Add metadata for *_log into tests artifacts

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -139,11 +139,16 @@ mv /var/log/clickhouse-server/stderr.log /test_output/ ||:
 if [[ -n "$WITH_COVERAGE" ]] && [[ "$WITH_COVERAGE" -eq 1 ]]; then
     tar -chf /test_output/clickhouse_coverage.tar.gz /profraw ||:
 fi
-tar -chf /test_output/text_log_dump.tar /var/lib/clickhouse/data/system/text_log ||:
-tar -chf /test_output/query_log_dump.tar /var/lib/clickhouse/data/system/query_log ||:
-tar -chf /test_output/zookeeper_log_dump.tar /var/lib/clickhouse/data/system/zookeeper_log ||:
-tar -chf /test_output/trace_log_dump.tar /var/lib/clickhouse/data/system/trace_log ||:
+
 tar -chf /test_output/coordination.tar /var/lib/clickhouse/coordination ||:
+
+# Replace the engine with Ordinary to avoid extra symlinks stuff in artifacts.
+# (so that clickhouse-local --path can read it w/o extra care).
+sed -i -e "s/ATTACH DATABASE _ UUID '[^']*'/ATTACH DATABASE system/" -e "s/Atomic/Ordinary/" /var/lib/clickhouse/metadata/system.sql
+for table in text_log query_log zookeeper_log trace_log; do
+    sed -i "s/ATTACH TABLE _ UUID '[^']*'/ATTACH TABLE $table/" /var/lib/clickhouse/metadata/system/${table}.sql
+    tar -chf /test_output/${table}_dump.tar /var/lib/clickhouse/metadata/system.sql /var/lib/clickhouse/metadata/system/${table}.sql /var/lib/clickhouse/data/system/${table} ||:
+done
 
 if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then
     grep -Fa "Fatal" /var/log/clickhouse-server/clickhouse-server1.log ||:

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -183,8 +183,14 @@ done
 
 tar -chf /test_output/coordination.tar /var/lib/clickhouse/coordination ||:
 mv /var/log/clickhouse-server/stderr.log /test_output/
-tar -chf /test_output/query_log_dump.tar /var/lib/clickhouse/data/system/query_log ||:
-tar -chf /test_output/trace_log_dump.tar /var/lib/clickhouse/data/system/trace_log ||:
+
+# Replace the engine with Ordinary to avoid extra symlinks stuff in artifacts.
+# (so that clickhouse-local --path can read it w/o extra care).
+sed -i -e "s/ATTACH DATABASE _ UUID '[^']*'/ATTACH DATABASE system/" -e "s/Atomic/Ordinary/" /var/lib/clickhouse/metadata/system.sql
+for table in query_log trace_log; do
+    sed -i "s/ATTACH TABLE _ UUID '[^']*'/ATTACH TABLE $table/" /var/lib/clickhouse/metadata/system/${table}.sql
+    tar -chf /test_output/${table}_dump.tar /var/lib/clickhouse/metadata/system.sql /var/lib/clickhouse/metadata/system/${table}.sql /var/lib/clickhouse/data/system/${table} ||:
+done
 
 # Write check result into check_status.tsv
 clickhouse-local --structure "test String, res String" -q "SELECT 'failure', test FROM table WHERE res != 'OK' order by (lower(test) like '%hung%') LIMIT 1" < /test_output/test_results.tsv > /test_output/check_status.tsv


### PR DESCRIPTION
This will allow to use artifacts as-is, i.e.:

    clickhouse-local --path /path/to/log/artifact

Changelog category (leave one):
- Not for changelog (changelog entry is not required)