### PR TITLE
Revert "Allow AppleClang builds"

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -18,6 +18,10 @@ if (COMPILER_GCC)
 elseif (COMPILER_CLANG)
     # Require minimum version of clang/apple-clang
     if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+        # If you are developer you can figure out what exact versions of AppleClang are Ok,
+        # simply remove the following line.
+        message (FATAL_ERROR "AppleClang is not supported, you should install clang from brew. See the instruction: https://clickhouse.com/docs/en/development/build-osx/")
+
         # AppleClang 10.0.1 (Xcode 10.2) corresponds to LLVM/Clang upstream version 7.0.0
         # AppleClang 11.0.0 (Xcode 11.0) corresponds to LLVM/Clang upstream version 8.0.0
         set (XCODE_MINIMUM_VERSION 10.2)


### PR DESCRIPTION
This reverts commit 1ddea6d7eed5cadce087cf19e51413440571a472.
This reverts #18488.

Changelog category (leave one):
- Documentation (changelog entry is not required)

AppleClang from XCode is de-facto unsupported. See https://github.com/ClickHouse/ClickHouse/issues/27593#issuecomment-950186500
We should direct people to use the recent `clang` compiler, otherwise it's too much burden.