### PR TITLE
CompiledExpressionCache limit elements size

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -957,9 +957,14 @@ if (ThreadFuzzer::instance().isEffective())
         global_context->setMMappedFileCache(mmap_cache_size);
 
 #if USE_EMBEDDED_COMPILER
+    /// 128 MB
     constexpr size_t compiled_expression_cache_size_default = 1024 * 1024 * 128;
     size_t compiled_expression_cache_size = config().getUInt64("compiled_expression_cache_size", compiled_expression_cache_size_default);
-    CompiledExpressionCacheFactory::instance().init(compiled_expression_cache_size);
+
+    constexpr size_t compiled_expression_cache_elements_size_default = 10000;
+    size_t compiled_expression_cache_elements_size = config().getUInt64("compiled_expression_cache_elements_size", compiled_expression_cache_elements_size_default);
+
+    CompiledExpressionCacheFactory::instance().init(compiled_expression_cache_size, compiled_expression_cache_elements_size);
 #endif
 
     /// Set path for format schema files

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -351,8 +351,11 @@
       -->
     <mmap_cache_size>1000</mmap_cache_size>
 
-    <!-- Cache size for compiled expressions.-->
+    <!-- Cache size in bytes for compiled expressions.-->
     <compiled_expression_cache_size>134217728</compiled_expression_cache_size>
+
+    <!-- Cache size in elements for compiled expressions.-->
+    <compiled_expression_cache_elements_size>10000</compiled_expression_cache_elements_size>
 
     <!-- Path to data directory, with trailing slash. -->
     <path>/var/lib/clickhouse/</path>

--- a/programs/server/config.yaml.example
+++ b/programs/server/config.yaml.example
@@ -279,8 +279,11 @@ mark_cache_size: 5368709120
 # also it can be dropped manually by the SYSTEM DROP MMAP CACHE query.
 mmap_cache_size: 1000
 
-# Cache size for compiled expressions.
+# Cache size in bytes for compiled expressions.
 compiled_expression_cache_size: 134217728
+
+# Cache size in elements for compiled expressions.
+compiled_expression_cache_elements_size: 10000
 
 # Path to data directory, with trailing slash.
 path: /var/lib/clickhouse/

--- a/src/Common/LRUCache.h
+++ b/src/Common/LRUCache.h
@@ -36,6 +36,9 @@ public:
     using Mapped = TMapped;
     using MappedPtr = std::shared_ptr<Mapped>;
 
+    /** Initialize LRUCache with max_size and max_elements_size.
+      * max_elements_size == 0 means no elements size restrictions.
+      */
     LRUCache(size_t max_size_, size_t max_elements_size_ = 0)
         : max_size(std::max(static_cast<size_t>(1), max_size_))
         , max_elements_size(max_elements_size_)

--- a/src/Common/LRUCache.h
+++ b/src/Common/LRUCache.h
@@ -36,12 +36,10 @@ public:
     using Mapped = TMapped;
     using MappedPtr = std::shared_ptr<Mapped>;
 
-private:
-    using Clock = std::chrono::steady_clock;
-
-public:
-    LRUCache(size_t max_size_)
-        : max_size(std::max(static_cast<size_t>(1), max_size_)) {}
+    LRUCache(size_t max_size_, size_t max_elements_size_ = 0)
+        : max_size(std::max(static_cast<size_t>(1), max_size_))
+        , max_elements_size(max_elements_size_)
+        {}
 
     MappedPtr get(const Key & key)
     {
@@ -252,6 +250,7 @@ private:
     /// Total weight of values.
     size_t current_size = 0;
     const size_t max_size;
+    const size_t max_elements_size;
 
     std::atomic<size_t> hits {0};
     std::atomic<size_t> misses {0};
@@ -311,7 +310,8 @@ private:
     {
         size_t current_weight_lost = 0;
         size_t queue_size = cells.size();
-        while ((current_size > max_size) && (queue_size > 1))
+
+        while ((current_size > max_size || (max_elements_size != 0 && queue_size > max_elements_size)) && (queue_size > 1))
         {
             const Key & key = queue.front();
 

--- a/src/Interpreters/JIT/CompiledExpressionCache.cpp
+++ b/src/Interpreters/JIT/CompiledExpressionCache.cpp
@@ -16,12 +16,12 @@ CompiledExpressionCacheFactory & CompiledExpressionCacheFactory::instance()
     return factory;
 }
 
-void CompiledExpressionCacheFactory::init(size_t cache_size)
+void CompiledExpressionCacheFactory::init(size_t cache_size_in_bytes, size_t cache_size_in_elements)
 {
     if (cache)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "CompiledExpressionCache was already initialized");
 
-    cache = std::make_unique<CompiledExpressionCache>(cache_size);
+    cache = std::make_unique<CompiledExpressionCache>(cache_size_in_bytes, cache_size_in_elements);
 }
 
 CompiledExpressionCache * CompiledExpressionCacheFactory::tryGetCache()

--- a/src/Interpreters/JIT/CompiledExpressionCache.h
+++ b/src/Interpreters/JIT/CompiledExpressionCache.h
@@ -52,7 +52,7 @@ private:
 public:
     static CompiledExpressionCacheFactory & instance();
 
-    void init(size_t cache_size);
+    void init(size_t cache_size_in_bytes, size_t cache_size_in_elements);
     CompiledExpressionCache * tryGetCache();
 };
 


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
CompiledExpressionCache limit elements size using `compiled_expression_cache_elements_size` setting.
