### PR TITLE
Fix keeper zookeeper converter test

### DIFF
--- a/tests/integration/test_keeper_zookeeper_converter/configs/keeper_config.xml
+++ b/tests/integration/test_keeper_zookeeper_converter/configs/keeper_config.xml
@@ -6,8 +6,8 @@
         <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
 
         <coordination_settings>
-            <operation_timeout_ms>5000</operation_timeout_ms>
-            <session_timeout_ms>10000</session_timeout_ms>
+            <operation_timeout_ms>30000</operation_timeout_ms>
+            <session_timeout_ms>600000</session_timeout_ms>
             <raft_logs_level>trace</raft_logs_level>
             <snapshot_distance>75</snapshot_distance>
         </coordination_settings>

--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -60,12 +60,12 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
-def get_fake_zk(timeout=30.0):
+def get_fake_zk(timeout=60.0):
     _fake_zk_instance = KazooClient(hosts=cluster.get_instance_ip('node') + ":9181", timeout=timeout)
     _fake_zk_instance.start()
     return _fake_zk_instance
 
-def get_genuine_zk(timeout=30.0):
+def get_genuine_zk(timeout=60.0):
     _genuine_zk_instance = KazooClient(hosts=cluster.get_instance_ip('node') + ":2181", timeout=timeout)
     _genuine_zk_instance.start()
     return _genuine_zk_instance


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix failure like this: https://clickhouse-test-reports.s3.yandex.net/30493/82749eef31a5290db9c5dc8e2afbca7e199f2aef/integration_tests_(thread)/integration_run_parallel5_0.log
In this test Keeper is just too fast in disconnecting session and deleting ephemeral nodes. So for original zookeeper we have:
`numChildren=10` and `cversion=10`, but for Keeper `numChildren=0` and `cversion=20` which means that all ephemeral children were deleted.