### PR TITLE
Fix gtest_disk_encrypted (for new readFile/createReadBufferFromFileBase() interfaces)

### DIFF
--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -57,7 +57,7 @@ protected:
 
     String getFileContents(const String & file_name)
     {
-        auto buf = encrypted_disk->readFile(file_name, {}, 0);
+        auto buf = encrypted_disk->readFile(file_name, /* settings= */ {}, /* size= */ {});
         String str;
         readStringUntilEOF(str, *buf);
         return str;

--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -65,7 +65,7 @@ protected:
 
     static String getBinaryRepresentation(const String & abs_path)
     {
-        auto buf = createReadBufferFromFileBase(abs_path, {}, 0);
+        auto buf = createReadBufferFromFileBase(abs_path, /* settings= */ {});
         String str;
         readStringUntilEOF(str, *buf);
         return str;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #30611 
Follow-up for: #30494 (cc @vitlibar )