### PR TITLE
tests/ci/docker_images_check: add missing time import

### DIFF
--- a/tests/ci/docker_images_check.py
+++ b/tests/ci/docker_images_check.py
@@ -5,6 +5,7 @@ from report import create_test_html_report
 from s3_helper import S3Helper
 import json
 import os
+import time
 from pr_info import PRInfo
 from github import Github
 import shutil


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://github.com/ClickHouse/ClickHouse/runs/4018875334?check_suite_focus=true

```
Traceback (most recent call last):
  File "docker_images_check.py", line 204, in <module>
    images_processing_result += process_single_image(versions, full_path, image_name)
  File "docker_images_check.py", line 117, in process_single_image
    time.sleep(i * 5)
NameError: name 'time' is not defined
```

Cc: @alesapin 