### PR TITLE
Update documentation for TSVWithNames parsing

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -164,8 +164,7 @@ This format is also available under the name `TSVRaw`.
 ## TabSeparatedWithNames {#tabseparatedwithnames}
 
 Differs from the `TabSeparated` format in that the column names are written in the first row.
-During parsing, the first row is completely ignored. You can’t use column names to determine their position or to check their correctness.
-(Support for parsing the header row may be added in the future.)
+During parsing, the first row is expected to contain the column names. You can use column names to determine their position and to check their correctness.
 
 This format is also available under the name `TSVWithNames`.
 


### PR DESCRIPTION
The documentation of the format `TabSeparatedWithNames` states that during parsing the first row (header) is ignored. It is not true anymore, the header is parsed, and the column position is determined from the header:

```
$ clickhouse-client -q "CREATE TABLE test(col1 String, col2 UInt8) ENGINE MergeTree() ORDER BY col1"
$ echo -e 'col2\tcol1\n1\tone\n2\ttwo' | clickhouse-client -q "INSERT INTO test FORMAT TabSeparatedWithNames"
$ clickhouse-client -q "SELECT * FROM test FORMAT TabSeparatedWithNames"
col1    col2
one     1
two     2
$ clickhouse-client --version
ClickHouse client version 21.7.9.7 (official build).
```

Changelog category (leave one):
- Documentation (changelog entry is not required)