### PR TITLE
Update 01083_expressions_in_engine_arguments.sql

### DIFF
--- a/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
+++ b/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
@@ -84,3 +84,14 @@ SELECT sum(n) from rich_syntax;
 
 -- Clear cache to avoid future errors in the logs
 SYSTEM DROP DNS CACHE
+
+DROP TABLE IF EXISTS file;
+DROP TABLE IF EXISTS url;
+DROP TABLE IF EXISTS view;
+DROP TABLE IF EXISTS buffer;
+DROP TABLE IF EXISTS merge;
+DROP TABLE IF EXISTS merge_tf;
+DROP TABLE IF EXISTS distributed;
+DROP TABLE IF EXISTS distributed_tf;
+DROP TABLE IF EXISTS rich_syntax;
+DROP DICTIONARY IF EXISTS dict;

--- a/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
+++ b/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
@@ -8,6 +8,7 @@ DROP TABLE IF EXISTS merge;
 DROP TABLE IF EXISTS merge_tf;
 DROP TABLE IF EXISTS distributed;
 DROP TABLE IF EXISTS distributed_tf;
+DROP TABLE IF EXISTS rich_syntax;
 DROP DICTIONARY IF EXISTS dict;
 
 CREATE TABLE file (n Int8) ENGINE = File(upper('tsv') || 'WithNames' || 'AndTypes');

--- a/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
+++ b/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
@@ -1,5 +1,15 @@
 -- Tags: no-parallel, no-fasttest
 
+DROP TABLE IF EXISTS file;
+DROP TABLE IF EXISTS url;
+DROP TABLE IF EXISTS view;
+DROP TABLE IF EXISTS buffer;
+DROP TABLE IF EXISTS merge;
+DROP TABLE IF EXISTS merge_tf;
+DROP TABLE IF EXISTS distributed;
+DROP TABLE IF EXISTS distributed_tf;
+DROP DICTIONARY IF EXISTS dict;
+
 CREATE TABLE file (n Int8) ENGINE = File(upper('tsv') || 'WithNames' || 'AndTypes');
 CREATE TABLE buffer (n Int8) ENGINE = Buffer(currentDatabase(), file, 16, 10, 200, 10000, 1000000, 10000000, 1000000000);
 CREATE TABLE merge (n Int8) ENGINE = Merge('', lower('DISTRIBUTED'));

--- a/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
+++ b/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
@@ -83,7 +83,7 @@ INSERT INTO buffer VALUES (1);
 SELECT sum(n) from rich_syntax;
 
 -- Clear cache to avoid future errors in the logs
-SYSTEM DROP DNS CACHE
+SYSTEM DROP DNS CACHE;
 
 DROP TABLE file;
 DROP TABLE url;

--- a/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
+++ b/tests/queries/0_stateless/01083_expressions_in_engine_arguments.sql
@@ -85,13 +85,13 @@ SELECT sum(n) from rich_syntax;
 -- Clear cache to avoid future errors in the logs
 SYSTEM DROP DNS CACHE
 
-DROP TABLE IF EXISTS file;
-DROP TABLE IF EXISTS url;
-DROP TABLE IF EXISTS view;
-DROP TABLE IF EXISTS buffer;
-DROP TABLE IF EXISTS merge;
-DROP TABLE IF EXISTS merge_tf;
-DROP TABLE IF EXISTS distributed;
-DROP TABLE IF EXISTS distributed_tf;
-DROP TABLE IF EXISTS rich_syntax;
-DROP DICTIONARY IF EXISTS dict;
+DROP TABLE file;
+DROP TABLE url;
+DROP TABLE view;
+DROP TABLE buffer;
+DROP TABLE merge;
+DROP TABLE merge_tf;
+DROP TABLE distributed;
+DROP TABLE distributed_tf;
+DROP TABLE rich_syntax;
+DROP DICTIONARY dict;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Tables are not dropped after this test is ended, so running it locally more than once results in table already exists errors.