### PR TITLE
Fix test 02022

### DIFF
--- a/src/Storages/FileLog/FileLogSettings.h
+++ b/src/Storages/FileLog/FileLogSettings.h
@@ -14,7 +14,7 @@ class ASTStorage;
     M(Milliseconds, poll_timeout_ms, 0, "Timeout for single poll from StorageFileLog.", 0) \
     M(UInt64, poll_max_batch_size, 0, "Maximum amount of messages to be polled in a single StorageFileLog poll.", 0) \
     M(UInt64, max_block_size, 0, "Number of row collected by poll(s) for flushing data from StorageFileLog.", 0) \
-    M(UInt64, max_threads, 8, "Number of max threads to parse files, default is 8", 0) \
+    M(UInt64, max_threads, 0, "Number of max threads to parse files, default is 0, which means the number will be max(1, physical_cpu_cores / 4)", 0) \
     M(Milliseconds, poll_directory_watch_events_backoff_init, 500, "The initial sleep value for watch directory thread.", 0) \
     M(Milliseconds, poll_directory_watch_events_backoff_max, 32000, "The max sleep value for watch directory thread.", 0) \
     M(UInt64, poll_directory_watch_events_backoff_factor, 2, "The speed of backoff, exponential by default", 0)

--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -753,6 +753,7 @@ void registerStorageFileLog(StorageFactory & factory)
         if (!num_threads) /// Default
         {
             num_threads = std::max(unsigned(1), physical_cpu_cores / 4);
+            filelog_settings->set("max_threads", num_threads);
         }
         else if (num_threads > physical_cpu_cores)
         {

--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -750,7 +750,11 @@ void registerStorageFileLog(StorageFactory & factory)
         auto physical_cpu_cores = getNumberOfPhysicalCPUCores();
         auto num_threads = filelog_settings->max_threads.value;
 
-        if (num_threads > physical_cpu_cores)
+        if (!num_threads) /// Default
+        {
+            num_threads = std::max(unsigned(1), physical_cpu_cores / 4);
+        }
+        else if (num_threads > physical_cpu_cores)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Number of threads to parse files can not be bigger than {}", physical_cpu_cores);
         }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes test:
```
2021-10-27 09:13:29 02022_storage_filelog_one_file:                                         [ FAIL ] 2.30 sec. - return code: 36
2021-10-27 09:13:29 [ea3367ff8fe3] 2021.10.27 09:13:29.206014 [ 72853 ] {a3f1753d-b679-469c-9385-1bce6c61973d} <Error> executeQuery: Code: 36. 
DB::Exception: Number of threads to parse files can not be bigger than 4. 
```
https://s3.amazonaws.com/clickhouse-test-reports/30729/c3007e8aae0e6ef0324fe8956fcec47374890163/fasttest.html