### PR TITLE
fix snappy build error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,7 +76,8 @@
 	url = https://github.com/ClickHouse-Extras/libcxxabi.git
 [submodule "contrib/snappy"]
 	path = contrib/snappy
-	url = https://github.com/google/snappy
+	url = https://github.com/taiyang-li/snappy.git
+	branch = fix_snappy_build_error
 [submodule "contrib/cppkafka"]
 	path = contrib/cppkafka
 	url = https://github.com/mfontanini/cppkafka.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -76,8 +76,7 @@
 	url = https://github.com/ClickHouse-Extras/libcxxabi.git
 [submodule "contrib/snappy"]
 	path = contrib/snappy
-	url = https://github.com/taiyang-li/snappy.git
-	branch = fix_snappy_build_error
+	url = https://github.com/ClickHouse-Extras/snappy.git
 [submodule "contrib/cppkafka"]
 	path = contrib/cppkafka
 	url = https://github.com/mfontanini/cppkafka.git


### PR DESCRIPTION

Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix build snappy error in https://github.com/ClickHouse/ClickHouse/issues/30790
Update of contrib/snappy is in https://github.com/google/snappy/pull/145/files