### PR TITLE
Update docs to stop referencing insert_sample_with_metadata

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -704,7 +704,7 @@ CREATE TABLE IF NOT EXISTS example_table
 -   If `input_format_defaults_for_omitted_fields = 1`, then the default value for `x` equals `0`, but the default value of `a` equals `x * 2`.
 
 !!! note "Warning"
-    When inserting data with `insert_sample_with_metadata = 1`, ClickHouse consumes more computational resources, compared to insertion with `insert_sample_with_metadata = 0`.
+    When inserting data with `input_format_defaults_for_omitted_fields = 1`, ClickHouse consumes more computational resources, compared to insertion with `input_format_defaults_for_omitted_fields = 0`.
 
 ### Selecting Data {#selecting-data}
 

--- a/docs/ja/interfaces/formats.md
+++ b/docs/ja/interfaces/formats.md
@@ -559,7 +559,7 @@ CREATE TABLE IF NOT EXISTS example_table
 -   もし `input_format_defaults_for_omitted_fields = 1` のデフォルト値 `x` 等しい `0` しかし、デフォルト値は `a` 等しい `x * 2`.
 
 !!! note "警告"
-    データを挿入するとき `insert_sample_with_metadata = 1`,ClickHouseは、挿入と比較して、より多くの計算リソースを消費します `insert_sample_with_metadata = 0`.
+    データを挿入するとき `input_format_defaults_for_omitted_fields = 1`,ClickHouseは、挿入と比較して、より多くの計算リソースを消費します `input_format_defaults_for_omitted_fields = 0`.
 
 ### データの選択 {#selecting-data}
 

--- a/docs/zh/interfaces/formats.md
+++ b/docs/zh/interfaces/formats.md
@@ -685,7 +685,7 @@ CREATE TABLE IF NOT EXISTS example_table
 -   如果`input_format_defaults_for_omitted_fields = 1`, 那么`x`的默认值为`0`，但`a`的默认值为`x * 2`。
 
 !!! note "注意"
-当使用`insert_sample_with_metadata = 1`插入数据时，与使用`insert_sample_with_metadata = 0`相比，ClickHouse消耗更多的计算资源。
+当使用`input_format_defaults_for_omitted_fields = 1`插入数据时，与使用`input_format_defaults_for_omitted_fields = 0`相比，ClickHouse消耗更多的计算资源。
 
 ### Selecting Data {#selecting-data}
 


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Update docs to stop referencing insert_sample_with_metadata and mention input_format_defaults_for_omitted_fields instead

Detailed description / Documentation draft:

The setting was renamed a long time ago (https://github.com/ClickHouse/ClickHouse/pull/4771 19.5)
