### PR TITLE
Parse backslash letter

### DIFF
--- a/src/Parsers/Lexer.cpp
+++ b/src/Parsers/Lexer.cpp
@@ -187,6 +187,8 @@ Token Lexer::nextTokenImpl()
             return Token(TokenType::Comma, token_begin, ++pos);
         case ';':
             return Token(TokenType::Semicolon, token_begin, ++pos);
+        case '\\':
+            return Token(TokenType::Backslash, token_begin, ++pos);
 
         case '.':   /// qualifier, tuple access operator or start of floating point number
         {

--- a/src/Parsers/Lexer.h
+++ b/src/Parsers/Lexer.h
@@ -28,6 +28,7 @@ namespace DB
     \
     M(Comma) \
     M(Semicolon) \
+    M(Backslash) \
     M(Dot)                    /** Compound identifiers, like a.b or tuple access operator a.1, (x, y).2. */ \
                               /** Need to be distinguished from floating point number with omitted integer part: .1 */ \
     \

--- a/src/Parsers/ParserBackslashLetter.cpp
+++ b/src/Parsers/ParserBackslashLetter.cpp
@@ -1,0 +1,56 @@
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTShowTablesQuery.h>
+#include <Parsers/ASTUseQuery.h>
+
+#include <Parsers/CommonParsers.h>
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ParserBackslashLetter.h>
+
+
+namespace DB
+{
+
+bool ParserBackslashLetter::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserToken t_backslash(TokenType::Backslash);
+
+    if (!t_backslash.ignore(pos, expected))
+        return false;
+
+    const char letter = *pos->begin;
+    ++pos;
+
+    switch (letter)
+    {
+    case 'd':
+        {
+            node = std::make_shared<ASTShowTablesQuery>();
+            return true;
+        }
+    case 'l':
+        {
+            auto query = std::make_shared<ASTShowTablesQuery>();
+            query->databases = true;
+            node = query;
+            return true;
+        }
+    case 'c':
+        {
+            ParserIdentifier name_p;
+            ASTPtr database;
+
+            if (!name_p.parse(pos, database, expected))
+                return false;
+
+            auto query = std::make_shared<ASTUseQuery>();
+            tryGetIdentifierNameInto(database, query->database);
+            node = query;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+}

--- a/src/Parsers/ParserBackslashLetter.h
+++ b/src/Parsers/ParserBackslashLetter.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Parsers/IParserBase.h>
+
+
+namespace DB
+{
+
+/** Query like this:
+  * \l or \d
+  * or \c db_name
+  */
+class ParserBackslashLetter final : public IParserBase
+{
+protected:
+    const char * getName() const override { return "\\l|d|c 'name'"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
+}

--- a/src/Parsers/ParserQuery.cpp
+++ b/src/Parsers/ParserQuery.cpp
@@ -1,6 +1,7 @@
 #include <Parsers/ParserAlterQuery.h>
 #include <Parsers/ParserCreateFunctionQuery.h>
 #include <Parsers/ParserBackupQuery.h>
+#include <Parsers/ParserBackslashLetter.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ParserCreateQuotaQuery.h>
 #include <Parsers/ParserCreateRoleQuery.h>
@@ -46,6 +47,7 @@ bool ParserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserSetRoleQuery set_role_p;
     ParserExternalDDLQuery external_ddl_p;
     ParserBackupQuery backup_p;
+    ParserBackslashLetter backslash_letter_p;
 
     bool res = query_with_output_p.parse(pos, node, expected)
         || insert_p.parse(pos, node, expected)
@@ -63,7 +65,8 @@ bool ParserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         || drop_access_entity_p.parse(pos, node, expected)
         || grant_p.parse(pos, node, expected)
         || external_ddl_p.parse(pos, node, expected)
-        || backup_p.parse(pos, node, expected);
+        || backup_p.parse(pos, node, expected)
+        || backslash_letter_p.parse(pos, node, expected);
 
     return res;
 }

--- a/tests/queries/0_stateless/02105_backslash_letter_commands.reference
+++ b/tests/queries/0_stateless/02105_backslash_letter_commands.reference
@@ -1,0 +1,11 @@
+-- DATABASES --
+INFORMATION_SCHEMA
+default
+information_schema
+system
+test
+default
+zbackslash_letter_commands
+-- TABLES --
+A
+B

--- a/tests/queries/0_stateless/02105_backslash_letter_commands.sql
+++ b/tests/queries/0_stateless/02105_backslash_letter_commands.sql
@@ -1,0 +1,20 @@
+-- Tags: no-parallel
+
+DROP DATABASE IF EXISTS zbackslash_letter_commands;
+CREATE DATABASE zbackslash_letter_commands;
+CREATE TABLE zbackslash_letter_commands.A (A UInt8) ENGINE = TinyLog;
+CREATE TABLE zbackslash_letter_commands.B (A UInt8) ENGINE = TinyLog;
+
+-- SHOW DATABASES;
+-- USE zbackslash_letter_commands;
+-- SHOW TABLES;
+
+SELECT trim('-- DATABASES --');
+\l ;
+
+SELECT trim('-- TABLES --');
+\c zbackslash_letter_commands;
+\d;
+
+
+DROP DATABASE zbackslash_letter_commands;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
+ added `\l`, `\d`, `\c` commands as in MySQL

Detailed description / Documentation draft:

The following `\<letter>` commands are available:
  * `\d` as alias for `SHOW TABLES`
  * `\l` as alias for `SHOW DATABASES`
  * `\c db_name` as alias for `USE db_name`


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
