### PR TITLE
Remove redundant from http buffer

### DIFF
--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -252,9 +252,6 @@ namespace detail
                     impl->position() = position();
             }
 
-            if (!working_buffer.empty())
-                impl->position() = position();
-
             if (!impl->next())
                 return false;
 

--- a/tests/integration/test_disk_over_web_server/configs/async_read.xml
+++ b/tests/integration/test_disk_over_web_server/configs/async_read.xml
@@ -1,0 +1,7 @@
+<yandex>
+    <profiles>
+        <default>
+            <remote_filesystem_read_method>read_threadpool</remote_filesystem_read_method>
+        </default>
+    </profiles>
+</yandex>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The same two lines are in use_external_buffer==false case above, so it is redundant because already done in any case except for disk web with async reads. In branch use_external_buffer=true it is not needed because working buffer is always empty there anyway so it will do nothing.