### PR TITLE
Disable check for ZooKeeper session uptime by default

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -264,7 +264,7 @@ function run_tests
 
     set +e
     time clickhouse-test --hung-check -j 8 --order=random \
-            --fast-tests-only --no-long --testname --shard --zookeeper \
+            --fast-tests-only --no-long --testname --shard --zookeeper --check-zookeeper-session \
             -- "$FASTTEST_FOCUS" 2>&1 \
         | ts '%Y-%m-%d %H:%M:%S' \
         | tee "$FASTTEST_OUTPUT/test_result.txt"

--- a/docker/test/stateful/run.sh
+++ b/docker/test/stateful/run.sh
@@ -109,7 +109,7 @@ function run_tests()
     fi
 
     set +e
-    clickhouse-test --testname --shard --zookeeper --no-stateless --hung-check --print-time "${ADDITIONAL_OPTIONS[@]}" \
+    clickhouse-test --testname --shard --zookeeper --check-zookeeper-session --no-stateless --hung-check --print-time "${ADDITIONAL_OPTIONS[@]}" \
         "$SKIP_TESTS_OPTION" 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee test_output/test_result.txt
     set -e
 }

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -97,7 +97,7 @@ function run_tests()
     fi
 
     set +e
-    clickhouse-test --testname --shard --zookeeper --hung-check --print-time \
+    clickhouse-test --testname --shard --zookeeper --check-zookeeper-session --hung-check --print-time \
             --test-runs "$NUM_TRIES" "${ADDITIONAL_OPTIONS[@]}" 2>&1 \
         | ts '%Y-%m-%d %H:%M:%S' \
         | tee -a test_output/test_result.txt

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -170,12 +170,15 @@ def get_zookeeper_session_uptime(args):
 
 
 def need_retry(args, stdout, stderr, total_time):
-    # Sometimes we may get unexpected exception like "Replica is readonly" or "Shutdown is called for table"
-    # instead of "Session expired" or "Connection loss"
-    # Retry if session was expired during test execution
-    session_uptime = get_zookeeper_session_uptime(args)
-    if session_uptime is not None and session_uptime < math.ceil(total_time):
-        return True
+    if args.check_zookeeper_session:
+        # Sometimes we may get unexpected exception like "Replica is readonly" or "Shutdown is called for table"
+        # instead of "Session expired" or "Connection loss"
+        # Retry if session was expired during test execution.
+        # If ZooKeeper is configured, then it's more reliable than checking stderr,
+        # but the following condition is always true if ZooKeeper is not configured.
+        session_uptime = get_zookeeper_session_uptime(args)
+        if session_uptime is not None and session_uptime < math.ceil(total_time):
+            return True
     return any(msg in stdout for msg in MESSAGES_TO_RETRY) or any(msg in stderr for msg in MESSAGES_TO_RETRY)
 
 
@@ -1320,6 +1323,7 @@ if __name__ == '__main__':
     parser.add_argument('--no-long', action='store_true', dest='no_long', help='Do not run long tests')
     parser.add_argument('--client-option', nargs='+', help='Specify additional client argument')
     parser.add_argument('--print-time', action='store_true', dest='print_time', help='Print test time')
+    parser.add_argument('--check-zookeeper-session', action='store_true', help='Check ZooKeeper session uptime to determine if failed test should be retried')
 
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument('--zookeeper', action='store_true', default=None, dest='zookeeper', help='Run zookeeper related tests')


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
Fixes #30802
