### PR TITLE
enable modify table comment of rest table engine

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -1027,10 +1027,9 @@ void StorageBuffer::checkAlterIsPossible(const AlterCommands & commands, Context
     auto name_deps = getDependentViewsByColumn(local_context);
     for (const auto & command : commands)
     {
-        if (command.type != AlterCommand::Type::ADD_COLUMN
-            && command.type != AlterCommand::Type::MODIFY_COLUMN
-            && command.type != AlterCommand::Type::DROP_COLUMN
-            && command.type != AlterCommand::Type::COMMENT_COLUMN)
+        if (command.type != AlterCommand::Type::ADD_COLUMN && command.type != AlterCommand::Type::MODIFY_COLUMN
+            && command.type != AlterCommand::Type::DROP_COLUMN && command.type != AlterCommand::Type::COMMENT_COLUMN
+            && command.type != AlterCommand::Type::COMMENT_TABLE)
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Alter of type '{}' is not supported by storage {}",
                 command.type, getName());
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -762,11 +762,9 @@ void StorageDistributed::checkAlterIsPossible(const AlterCommands & commands, Co
     auto name_deps = getDependentViewsByColumn(local_context);
     for (const auto & command : commands)
     {
-        if (command.type != AlterCommand::Type::ADD_COLUMN
-            && command.type != AlterCommand::Type::MODIFY_COLUMN
-            && command.type != AlterCommand::Type::DROP_COLUMN
-            && command.type != AlterCommand::Type::COMMENT_COLUMN
-            && command.type != AlterCommand::Type::RENAME_COLUMN)
+        if (command.type != AlterCommand::Type::ADD_COLUMN && command.type != AlterCommand::Type::MODIFY_COLUMN
+            && command.type != AlterCommand::Type::DROP_COLUMN && command.type != AlterCommand::Type::COMMENT_COLUMN
+            && command.type != AlterCommand::Type::RENAME_COLUMN && command.type != AlterCommand::Type::COMMENT_TABLE)
 
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Alter of type '{}' is not supported by storage {}",
                 command.type, getName());

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -629,10 +629,9 @@ void StorageMerge::checkAlterIsPossible(const AlterCommands & commands, ContextP
     auto name_deps = getDependentViewsByColumn(local_context);
     for (const auto & command : commands)
     {
-        if (command.type != AlterCommand::Type::ADD_COLUMN
-            && command.type != AlterCommand::Type::MODIFY_COLUMN
-            && command.type != AlterCommand::Type::DROP_COLUMN
-            && command.type != AlterCommand::Type::COMMENT_COLUMN)
+        if (command.type != AlterCommand::Type::ADD_COLUMN && command.type != AlterCommand::Type::MODIFY_COLUMN
+            && command.type != AlterCommand::Type::DROP_COLUMN && command.type != AlterCommand::Type::COMMENT_COLUMN
+            && command.type != AlterCommand::Type::COMMENT_TABLE)
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Alter of type '{}' is not supported by storage {}",
                 command.type, getName());
 

--- a/tests/queries/0_stateless/02111_modify_table_comment.reference
+++ b/tests/queries/0_stateless/02111_modify_table_comment.reference
@@ -1,0 +1,4 @@
+CREATE TABLE `02111_modify_table_comment`.t\n(\n    `n` Int8\n)\nENGINE = MergeTree\nORDER BY n\nSETTINGS index_granularity = 8192\nCOMMENT \'this is a MergeTree table\'
+CREATE TABLE `02111_modify_table_comment`.t\n(\n    `n` Int8\n)\nENGINE = MergeTree\nORDER BY n\nSETTINGS index_granularity = 8192\nCOMMENT \'MergeTree Table\'
+CREATE TABLE `02111_modify_table_comment`.t_merge\n(\n    `n` Int8\n)\nENGINE = Merge(\'02111_modify_table_comment\', \'t\')\nCOMMENT \'this is a Merge table\'
+CREATE TABLE `02111_modify_table_comment`.t_merge\n(\n    `n` Int8\n)\nENGINE = Merge(\'02111_modify_table_comment\', \'t\')\nCOMMENT \'Merge Table\'

--- a/tests/queries/0_stateless/02111_modify_table_comment.sql
+++ b/tests/queries/0_stateless/02111_modify_table_comment.sql
@@ -1,0 +1,32 @@
+DROP DATABASE IF EXISTS 02111_modify_table_comment;
+CREATE DATABASE 02111_modify_table_comment;
+
+USE 02111_modify_table_comment;
+
+CREATE TABLE t
+(
+    `n` Int8
+)
+ENGINE = MergeTree
+ORDER BY n
+COMMENT 'this is a MergeTree table';
+
+SHOW CREATE t;
+
+ALTER TABLE t
+    MODIFY COMMENT 'MergeTree Table';
+
+SHOW CREATE t;
+
+CREATE TABLE t_merge AS t
+ENGINE = Merge('02111_modify_table_comment', 't')
+COMMENT 'this is a Merge table';
+
+SHOW CREATE t_merge;
+
+ALTER TABLE t_merge
+    MODIFY COMMENT 'Merge Table';
+
+SHOW CREATE t_merge;
+
+DROP DATABASE 02111_modify_table_comment;

--- a/tests/queries/0_stateless/02111_modify_table_comment.sql
+++ b/tests/queries/0_stateless/02111_modify_table_comment.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel
+
 DROP DATABASE IF EXISTS 02111_modify_table_comment;
 CREATE DATABASE 02111_modify_table_comment;
 


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Closes #30784.