### PR TITLE
Fixed `--disable-net-host` in `runner`

### DIFF
--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -150,8 +150,7 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--network",
-        default='host',
-        help="Set network driver for runnner container")
+        help="Set network driver for runnner container (defaults to `host`)")
 
     parser.add_argument(
         "--docker-image-version",


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `--disable-net-host` in `runner`.
