### PR TITLE
Rename Mac architecture on Quick Start page

### DIFF
--- a/website/templates/index/quickstart.html
+++ b/website/templates/index/quickstart.html
@@ -20,10 +20,10 @@
                     <a class="nav-link" id="arm-tab" data-toggle="tab" href="#arm" role="tab" aria-controls="arm" aria-selected="false" title="ARM packages">Linux (ARM)</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" id="mac-x86-tab" data-toggle="tab" href="#mac-x86" role="tab" aria-controls="mac-x86" aria-selected="false" title="Mac x86 packages">Mac (x86)</a>
+                    <a class="nav-link" id="mac-x86-tab" data-toggle="tab" href="#mac-x86" role="tab" aria-controls="mac-x86" aria-selected="false" title="Mac x86 packages">Mac (Intel)</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" id="mac-arm-tab" data-toggle="tab" href="#mac-arm" role="tab" aria-controls="mac-arm" aria-selected="false" title="Mac ARM packages">Mac (ARM)</a>
+                    <a class="nav-link" id="mac-arm-tab" data-toggle="tab" href="#mac-arm" role="tab" aria-controls="mac-arm" aria-selected="false" title="Mac ARM packages">Mac (Apple Silicon)</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" id="freebsd-tab" data-toggle="tab" href="#freebsd" role="tab" aria-controls="freebsd" aria-selected="false" title="FreeBSD packages">FreeBSD</a>

--- a/website/templates/index/quickstart.html
+++ b/website/templates/index/quickstart.html
@@ -26,7 +26,7 @@
                     <a class="nav-link" id="mac-arm-tab" data-toggle="tab" href="#mac-arm" role="tab" aria-controls="mac-arm" aria-selected="false" title="Mac ARM packages">Mac (Apple Silicon)</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" id="freebsd-tab" data-toggle="tab" href="#freebsd" role="tab" aria-controls="freebsd" aria-selected="false" title="FreeBSD packages">FreeBSD</a>
+                    <a class="nav-link" id="freebsd-tab" data-toggle="tab" href="#freebsd" role="tab" aria-controls="freebsd" aria-selected="false" title="FreeBSD packages">FreeBSD (x86_64)</a>
                 </li>
             </ul>
 

--- a/website/templates/index/quickstart.html
+++ b/website/templates/index/quickstart.html
@@ -20,7 +20,7 @@
                     <a class="nav-link" id="arm-tab" data-toggle="tab" href="#arm" role="tab" aria-controls="arm" aria-selected="false" title="ARM packages">Linux (ARM)</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" id="mac-x86-tab" data-toggle="tab" href="#mac-x86" role="tab" aria-controls="mac-x86" aria-selected="false" title="Mac x86 packages">Mac (Intel)</a>
+                    <a class="nav-link" id="mac-x86-tab" data-toggle="tab" href="#mac-x86" role="tab" aria-controls="mac-x86" aria-selected="false" title="Mac x86 packages">macOS (Intel)</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" id="mac-arm-tab" data-toggle="tab" href="#mac-arm" role="tab" aria-controls="mac-arm" aria-selected="false" title="Mac ARM packages">Mac (Apple Silicon)</a>


### PR DESCRIPTION
Feature request by @traceon 

Changelog category (leave one):
- Documentation (changelog entry is not required)
