### PR TITLE
add aliases for `\<letter>` interactive client commands

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1366,12 +1366,19 @@ void ClientBase::runInteractive()
 
         for (const auto& [alias, command] : backslash_aliases)
         {
-            if (input.starts_with(alias))
+            auto it = std::search(input.begin(), input.end(), alias.begin(), alias.end());
+            if (it != input.end() && std::all_of(input.begin(), it, isWhitespaceASCII))
             {
-                // append the rest of input to the command
-                // for parameters support, e.g. \c db_name -> USE db_name
-                input = command + input.substr(alias.size());
-                break;
+                it += alias.size();
+                if (it == input.end() || isWhitespaceASCII(*it))
+                {
+                    String new_input = command;
+                    // append the rest of input to the command
+                    // for parameters support, e.g. \c db_name -> USE db_name
+                    new_input.append(it, input.end());
+                    input = std::move(new_input);
+                    break;
+                }
             }
         }
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -61,6 +61,14 @@ namespace DB
 
 static const NameSet exit_strings{"exit", "quit", "logout", "учше", "йгше", "дщпщге", "exit;", "quit;", "logout;", "учшеж", "йгшеж", "дщпщгеж", "q", "й", "\\q", "\\Q", "\\й", "\\Й", ":q", "Жй"};
 
+static const std::initializer_list<std::pair<String, String>> backslash_aliases
+{
+    { "\\l", "SHOW DATABASES" },
+    { "\\d", "SHOW TABLES" },
+    { "\\c", "USE" },
+};
+
+
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
@@ -1354,6 +1362,17 @@ void ClientBase::runInteractive()
         {
             input.resize(input.size() - 2);
             has_vertical_output_suffix = true;
+        }
+
+        for (const auto& [alias, command] : backslash_aliases)
+        {
+            if (input.starts_with(alias))
+            {
+                // append the rest of input to the command
+                // for parameters support, e.g. \c db_name -> USE db_name
+                input = command + input.substr(alias.size());
+                break;
+            }
         }
 
         try

--- a/tests/queries/0_stateless/02105_backslash_letter_commands.expect
+++ b/tests/queries/0_stateless/02105_backslash_letter_commands.expect
@@ -1,0 +1,47 @@
+#!/usr/bin/expect -f
+# Tags: no-fasttest
+
+log_user 0
+set timeout 02
+match_max 100000
+# A default timeout action is to do nothing, change it to fail
+expect_after {
+    timeout {
+        exit 1
+    }
+}
+
+set basedir [file dirname $argv0]
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion"
+expect ":) "
+
+# Send a command
+send -- "\\ld;\r"
+expect "Syntax error: *"
+expect ":) "
+
+send -- "\\c;\r"
+expect "Syntax error: *"
+expect ":) "
+
+send -- "  \\l ;  \\d;  \r"
+expect "Syntax error (Multi-statements are not allowed): *"
+expect ":) "
+
+send -- "  \\l  ;\r"
+expect "SHOW DATABASES"
+expect "system"
+expect ":) "
+
+send -- "\\c system;\r"
+#expect "USE system"
+expect ":) "
+
+send -- "  \\d like 'one'\\G\r"
+expect "SHOW TABLES"
+expect "Row 1:"
+expect "name: one"
+expect ":) "
+
+send -- "\4"
+expect eof


### PR DESCRIPTION
This is another way to support `\<letter>` commands like:
  * `\d` aka `SHOW TABLES`
  * `\l` aka `SHOW DATABASES`
  * `\c` aka `USE`

It has been implemented as `input` string prefix replacement with an aliased command
inside of the loop of `ClientBase::runInteractive()` in order to allow
command parameters, like `\c db_name`.

Additionally this  allow us to use all the command parameters:

> :) \l like 'system'\G
>
> SHOW DATABASES LIKE 'system'
>
> Query id: 26edd1f6-1695-4be2-baac-9fa30f7d820d
>
> Row 1:
> ──────
> name: system


Automated testing seems not easy to do, since the aliases work only in interactive client mode.

See issue #9339


Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
added \l, \d, \c aliases like in MySQL


Detailed description / Documentation draft:
The following \<letter> commands are available:

  - `\d` as alias for `SHOW TABLES`
  - `\l` as alias for `SHOW DATABASES`
  - `\c` as alias for `USE db_name`
 

> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
