### PR TITLE
Fix invalid header in projection block calculation

### DIFF
--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -237,7 +237,7 @@ Block ProjectionDescription::calculate(const Block & block, ContextPtr context) 
     auto builder = InterpreterSelectQuery(
                        query_ast,
                        context,
-                       Pipe(std::make_shared<SourceFromSingleChunk>(block, Chunk(block.getColumns(), block.rows()))),
+                       Pipe(std::make_shared<SourceFromSingleChunk>(block)),
                        SelectQueryOptions{
                            type == ProjectionDescription::Type::Normal ? QueryProcessingStage::FetchColumns
                                                                        : QueryProcessingStage::WithMergeableState})

--- a/tests/queries/0_stateless/01710_aggregate_projection_with_hashing.sql
+++ b/tests/queries/0_stateless/01710_aggregate_projection_with_hashing.sql
@@ -1,0 +1,11 @@
+set allow_experimental_projection_optimization = 1, force_optimize_projection = 1;
+
+drop table if exists tp;
+
+create table tp (type Int32, device UUID, cnt UInt64) engine = MergeTree order by (type, device);
+insert into tp select number%3, generateUUIDv4(), 1 from numbers(300);
+
+alter table tp add projection uniq_city_proj ( select type, uniq(cityHash64(device)), sum(cnt) group by type );
+alter table tp materialize projection uniq_city_proj settings mutations_sync = 1;
+
+drop table tp;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash when projection with hashing function is materialized. This fixes https://github.com/ClickHouse/ClickHouse/issues/30861 . The issue is similar to https://github.com/ClickHouse/ClickHouse/pull/28560 which is a lack of proper understanding of the invariant of header's emptyness.


Detailed description / Documentation draft:
.