### PR TITLE
Rename columns in SessionLog

### DIFF
--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -244,7 +244,7 @@ void Session::shutdownNamedSessions()
 }
 
 Session::Session(const ContextPtr & global_context_, ClientInfo::Interface interface_)
-    : session_id(UUIDHelpers::generateV4()),
+    : auth_id(UUIDHelpers::generateV4()),
       global_context(global_context_),
       log(&Poco::Logger::get(String{magic_enum::enum_name(interface_)} + "-Session"))
 {
@@ -255,7 +255,7 @@ Session::Session(const ContextPtr & global_context_, ClientInfo::Interface inter
 Session::~Session()
 {
     LOG_DEBUG(log, "{} Destroying {} of user {}",
-        toString(session_id),
+        toString(auth_id),
         (named_session ? "named session '" + named_session->key.second + "'" : "unnamed session"),
         (user_id ? toString(*user_id) : "<EMPTY>")
     );
@@ -267,7 +267,7 @@ Session::~Session()
     if (notified_session_log_about_login)
     {
         if (auto session_log = getSessionLog(); session_log && user)
-            session_log->addLogOut(session_id, user->getName(), getClientInfo());
+            session_log->addLogOut(auth_id, user->getName(), getClientInfo());
     }
 }
 
@@ -285,7 +285,7 @@ Authentication::Type Session::getAuthenticationTypeOrLogInFailure(const String &
     catch (const Exception & e)
     {
         if (auto session_log = getSessionLog())
-            session_log->addLoginFailure(session_id, getClientInfo(), user_name, e);
+            session_log->addLoginFailure(auth_id, getClientInfo(), user_name, e);
 
         throw;
     }
@@ -306,19 +306,19 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
         address = Poco::Net::SocketAddress{"127.0.0.1", 0};
 
     LOG_DEBUG(log, "{} Authenticating user '{}' from {}",
-            toString(session_id), credentials_.getUserName(), address.toString());
+            toString(auth_id), credentials_.getUserName(), address.toString());
 
     try
     {
         user_id = global_context->getAccessControlManager().login(credentials_, address.host());
         LOG_DEBUG(log, "{} Authenticated with global context as user {}",
-                toString(session_id), user_id ? toString(*user_id) : "<EMPTY>");
+                toString(auth_id), user_id ? toString(*user_id) : "<EMPTY>");
     }
     catch (const Exception & e)
     {
-        LOG_DEBUG(log, "{} Authentication failed with error: {}", toString(session_id), e.what());
+        LOG_DEBUG(log, "{} Authentication failed with error: {}", toString(auth_id), e.what());
         if (auto session_log = getSessionLog())
-            session_log->addLoginFailure(session_id, *prepared_client_info, credentials_.getUserName(), e);
+            session_log->addLoginFailure(auth_id, *prepared_client_info, credentials_.getUserName(), e);
         throw;
     }
 
@@ -350,7 +350,7 @@ ContextMutablePtr Session::makeSessionContext()
         throw Exception("Session context must be created before any query context", ErrorCodes::LOGICAL_ERROR);
 
     LOG_DEBUG(log, "{} Creating session context with user_id: {}",
-            toString(session_id), user_id ? toString(*user_id) : "<EMPTY>");
+            toString(auth_id), user_id ? toString(*user_id) : "<EMPTY>");
     /// Make a new session context.
     ContextMutablePtr new_session_context;
     new_session_context = Context::createCopy(global_context);
@@ -380,7 +380,7 @@ ContextMutablePtr Session::makeSessionContext(const String & session_name_, std:
         throw Exception("Session context must be created before any query context", ErrorCodes::LOGICAL_ERROR);
 
     LOG_DEBUG(log, "{} Creating named session context with name: {}, user_id: {}",
-              toString(session_id), session_name_, user_id ? toString(*user_id) : "<EMPTY>");
+              toString(auth_id), session_name_, user_id ? toString(*user_id) : "<EMPTY>");
 
     /// Make a new session context OR
     /// if the `session_id` and `user_id` were used before then just get a previously created session context.
@@ -439,7 +439,7 @@ ContextMutablePtr Session::makeQueryContextImpl(const ClientInfo * client_info_t
     query_context->makeQueryContext();
 
     LOG_DEBUG(log, "{} Creating query context from {} context, user_id: {}, parent context user: {}",
-              toString(session_id),
+              toString(auth_id),
               from_session_context ? "session" : "global",
               user_id ? toString(*user_id) : "<EMPTY>",
               query_context->getUser() ? query_context->getUser()->getName() : "<NOT SET>");
@@ -487,7 +487,7 @@ ContextMutablePtr Session::makeQueryContextImpl(const ClientInfo * client_info_t
         if (auto session_log = getSessionLog(); user && user_id && session_log)
         {
             session_log->addLoginSuccess(
-                    session_id,
+                    auth_id,
                     named_session ? std::optional<std::string>(named_session->key.second) : std::nullopt,
                     *query_context);
 

--- a/src/Interpreters/Session.h
+++ b/src/Interpreters/Session.h
@@ -77,7 +77,7 @@ private:
     ContextMutablePtr makeQueryContextImpl(const ClientInfo * client_info_to_copy, ClientInfo * client_info_to_move) const;
 
     mutable bool notified_session_log_about_login = false;
-    const UUID session_id;
+    const UUID auth_id;
     const ContextPtr global_context;
 
     /// ClientInfo that will be copied to a session context when it's created.

--- a/src/Interpreters/SessionLog.h
+++ b/src/Interpreters/SessionLog.h
@@ -27,17 +27,17 @@ struct SessionLogElement
     using Type = SessionLogElementType;
 
     SessionLogElement() = default;
-    SessionLogElement(const UUID & session_id_, Type type_);
+    SessionLogElement(const UUID & auth_id_, Type type_);
     SessionLogElement(const SessionLogElement &) = default;
     SessionLogElement & operator=(const SessionLogElement &) = default;
     SessionLogElement(SessionLogElement &&) = default;
     SessionLogElement & operator=(SessionLogElement &&) = default;
 
-    UUID session_id;
+    UUID auth_id;
 
     Type type = SESSION_LOGIN_FAILURE;
 
-    String session_name;
+    String session_id;
     time_t event_time{};
     Decimal64 event_time_microseconds{};
 
@@ -66,9 +66,9 @@ class SessionLog : public SystemLog<SessionLogElement>
     using SystemLog<SessionLogElement>::SystemLog;
 
 public:
-    void addLoginSuccess(const UUID & session_id, std::optional<String> session_name, const Context & login_context);
-    void addLoginFailure(const UUID & session_id, const ClientInfo & info, const String & user, const Exception & reason);
-    void addLogOut(const UUID & session_id, const String & user, const ClientInfo & client_info);
+    void addLoginSuccess(const UUID & auth_id, std::optional<String> session_id, const Context & login_context);
+    void addLoginFailure(const UUID & auth_id, const ClientInfo & info, const String & user, const Exception & reason);
+    void addLogOut(const UUID & auth_id, const String & user, const ClientInfo & client_info);
 };
 
 }

--- a/src/Interpreters/SessionLog.h
+++ b/src/Interpreters/SessionLog.h
@@ -46,7 +46,7 @@ struct SessionLogElement
     String external_auth_server;
     Strings roles;
     Strings profiles;
-    std::vector<std::pair<String, String>> changed_settings;
+    std::vector<std::pair<String, String>> settings;
 
     ClientInfo client_info;
     String auth_failure_reason;


### PR DESCRIPTION
Changelog category:
- Improvement

Changelog entry:
Rename the columns of SessionLog:
`session_id` -> `auth_id`,
`session_name` -> `session_id`,
`changed_settings` -> `settings`.
