### PR TITLE
Fix parallel formatting and progress flicker in clickhouse-client

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -342,7 +342,6 @@ void ClientBase::initBlockOutputStream(const Block & block, ASTPtr parsed_query)
         select_into_file = false;
 
         /// The query can specify output format or output file.
-        /// FIXME: try to prettify this cast using `as<>()`
         if (const auto * query_with_output = dynamic_cast<const ASTQueryWithOutput *>(parsed_query.get()))
         {
             if (query_with_output->out_file)

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -155,6 +155,7 @@ protected:
     ConnectionParameters connection_parameters;
 
     String format; /// Query results output format.
+    bool select_into_file = false; /// If writing result INTO OUTFILE. It affects progress rendering.
     bool is_default_format = true; /// false, if format is set in the config or command line.
     size_t format_max_block_size = 0; /// Max block size for console output.
     String insert_format; /// Format of INSERT data that is read from stdin in batch mode.


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Queries with `INTO OUTFILE` in `clickhouse-client` will use multiple threads. Fix the issue with flickering progress-bar when using `INTO OUTFILE`. This closes #30873. This closes #30872.

After:
```
milovidov@milovidov-desktop:~/work/ClickHouse/tests/queries/0_stateless$ clickhouse-client 
ClickHouse client version 21.11.1.1.
Connecting to localhost:9000 as user default.
Connected to ClickHouse server version 21.11.1 revision 54450.

milovidov-desktop :) SELECT * FROM test.hits INTO OUTFILE 'hits.csv' FORMAT CSV

SELECT *
FROM test.hits
INTO OUTFILE 'hits.csv'
FORMAT CSV

Query id: d9b4b2d2-2d29-4ed9-aa87-35994af1ad37


8873898 rows in set. Elapsed: 8.522 sec. Processed 8.87 million rows, 8.46 GB (1.04 million rows/s., 992.84 MB/s.)

milovidov-desktop :) Bye.
```

Before:
```
milovidov@milovidov-desktop:~/work/ClickHouse/tests/queries/0_stateless$ ../../../programs/server/clickhouse-21.10 client
ClickHouse client version 21.10.3.38 (official build).
Connecting to localhost:9000 as user default.
Connected to ClickHouse server version 21.11.1 revision 54450.

ClickHouse client version is older than ClickHouse server. It may lack support for new features.

milovidov-desktop :) SELECT * FROM test.hits INTO OUTFILE 'hits.csv' FORMAT CSV

SELECT *
FROM test.hits
INTO OUTFILE 'hits.csv'
FORMAT CSV

Query id: 24aef9c5-f156-4a26-a221-2d5526bfb842


8873898 rows in set. Elapsed: 33.057 sec. Processed 8.87 million rows, 8.46 GB (268.44 thousand rows/s., 255.94 MB/s.)

milovidov-desktop :) Bye.
```