### PR TITLE
Fix index analysis for set index

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -451,9 +451,9 @@ bool MergeTreeIndexConditionSet::checkASTUseless(const ASTPtr & node, bool atomi
         const ASTs & args = func->arguments->children;
 
         if (func->name == "and" || func->name == "indexHint")
-            return checkASTUseless(args[0], atomic) && checkASTUseless(args[1], atomic);
+            return std::all_of(args.begin(), args.end(), [this, atomic](const auto & arg) { return checkASTUseless(arg, atomic); });
         else if (func->name == "or")
-            return checkASTUseless(args[0], atomic) || checkASTUseless(args[1], atomic);
+            return std::any_of(args.begin(), args.end(), [this, atomic](const auto & arg) { return checkASTUseless(arg, atomic); });
         else if (func->name == "not")
             return checkASTUseless(args[0], atomic);
         else

--- a/tests/queries/0_stateless/02112_skip_index_set_and_or.sql
+++ b/tests/queries/0_stateless/02112_skip_index_set_and_or.sql
@@ -1,0 +1,6 @@
+drop table if exists set_index;
+
+create table set_index (a Int32, b Int32, INDEX b_set b type set(0) granularity 1) engine MergeTree order by tuple();
+insert into set_index values (1, 2);
+
+select b from set_index where a = 1 and a = 1 and b = 1 settings force_data_skipping_indices = 'b_set', optimize_move_to_prewhere=0;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix set index not used in AND/OR expressions when there are more than two operands. This fixes https://github.com/ClickHouse/ClickHouse/issues/30416 .


Detailed description / Documentation draft:
.