### PR TITLE
Fix strange mistake in documentation release process.

### DIFF
--- a/docs/tools/release.sh
+++ b/docs/tools/release.sh
@@ -41,7 +41,7 @@ then
     then
         sleep 1m
         # https://api.cloudflare.com/#zone-purge-files-by-cache-tags,-host-or-prefix
-        POST_DATA='{"hosts":["content.clickhouse.com"]}'
+        POST_DATA='{"hosts":["clickhouse.com"]}'
         curl -X POST "https://api.cloudflare.com/client/v4/zones/4fc6fb1d46e87851605aa7fa69ca6fe0/purge_cache" -H "Authorization: Bearer ${CLOUDFLARE_TOKEN}" -H "Content-Type:application/json" --data "${POST_DATA}"
     fi
 fi


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Our website infrastructure is completely undocumented :(, and I have to reverse-engineer it.

![Screenshot_20211031_204358](https://user-images.githubusercontent.com/18581488/139595524-30c4cbae-bfa5-477b-a526-85e225c2757a.png)

`content.clickhouse.com` was created most likely to provide a direct view to `clickhouse.github.io`
The script was dropping cache for `content.clickhouse.com` instead of `clickhouse.com`.
Most likely it was a mistake.