### PR TITLE
Make use of untuple alias for untupled columns names prefix

### DIFF
--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -693,6 +693,7 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
 
     ASTs columns;
     size_t tid = 0;
+    auto func_alias = function->tryGetAlias();
     for (const auto & name [[maybe_unused]] : tuple_type->getElementNames())
     {
         auto tuple_ast = function->arguments->children[0];
@@ -703,7 +704,8 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
         visit(*literal, literal, data);
 
         auto func = makeASTFunction("tupleElement", tuple_ast, literal);
-
+        if (!func_alias.empty())
+            func->setAlias(func_alias + toString(tid));
         auto function_builder = FunctionFactory::instance().get(func->name, data.getContext());
         data.addFunction(function_builder, {tuple_name_type->name, literal->getColumnName()}, func->getColumnName());
 

--- a/src/Interpreters/ActionsVisitor.cpp
+++ b/src/Interpreters/ActionsVisitor.cpp
@@ -705,7 +705,7 @@ ASTs ActionsMatcher::doUntuple(const ASTFunction * function, ActionsMatcher::Dat
 
         auto func = makeASTFunction("tupleElement", tuple_ast, literal);
         if (!func_alias.empty())
-            func->setAlias(func_alias + toString(tid));
+            func->setAlias(func_alias + "." + toString(tid));
         auto function_builder = FunctionFactory::instance().get(func->name, data.getContext());
         data.addFunction(function_builder, {tuple_name_type->name, literal->getColumnName()}, func->getColumnName());
 

--- a/tests/queries/0_stateless/02113_untuple_func_alias.reference
+++ b/tests/queries/0_stateless/02113_untuple_func_alias.reference
@@ -1,0 +1,2 @@
+ut1	ut2	ut3	ut4	ut21	ut22	ut23	ut24
+1	2	3	\N	\N	3	2	1

--- a/tests/queries/0_stateless/02113_untuple_func_alias.reference
+++ b/tests/queries/0_stateless/02113_untuple_func_alias.reference
@@ -1,2 +1,2 @@
-ut1	ut2	ut3	ut4	ut21	ut22	ut23	ut24
+ut.1	ut.2	ut.3	ut.4	ut2.1	ut2.2	ut2.3	ut2.4
 1	2	3	\N	\N	3	2	1

--- a/tests/queries/0_stateless/02113_untuple_func_alias.sql
+++ b/tests/queries/0_stateless/02113_untuple_func_alias.sql
@@ -1,0 +1,2 @@
+SELECT untuple((1, 2, 3, b)) AS `ut`, untuple((NULL, 3, 2, a)) AS `ut2`
+FROM (SELECT 1 AS a, NULL AS b) FORMAT TSVWithNames;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Detailed description / Documentation draft:

Passing alias of `untuple` to internal function `tupleElement`,  making subcolumns easier to use , 
since #26179 breaks column names of untupled columns of previous implementation.