### PR TITLE
Skip max_partition_size_to_drop check in case of ATTACH PARTITION ... FROM

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3445,7 +3445,8 @@ Pipe MergeTreeData::alterPartition(
 
             case PartitionCommand::REPLACE_PARTITION:
             {
-                checkPartitionCanBeDropped(command.partition);
+                if (command->replace)
+                    checkPartitionCanBeDropped(command.partition);
                 String from_database = query_context->resolveDatabase(command.from_database);
                 auto from_storage = DatabaseCatalog::instance().getTable({from_database, command.from_table}, query_context);
                 replacePartitionFrom(from_storage, command.partition, command.replace, query_context);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3423,7 +3423,6 @@ Pipe MergeTreeData::alterPartition(
 
                     case PartitionCommand::MoveDestinationType::TABLE:
                     {
-                        checkPartitionCanBeDropped(command.partition);
                         String dest_database = query_context->resolveDatabase(command.to_database);
                         auto dest_storage = DatabaseCatalog::instance().getTable({dest_database, command.to_table}, query_context);
                         movePartitionToTable(dest_storage, command.partition, query_context);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3445,7 +3445,7 @@ Pipe MergeTreeData::alterPartition(
 
             case PartitionCommand::REPLACE_PARTITION:
             {
-                if (command->replace)
+                if (command.replace)
                     checkPartitionCanBeDropped(command.partition);
                 String from_database = query_context->resolveDatabase(command.from_database);
                 auto from_storage = DatabaseCatalog::instance().getTable({from_database, command.from_table}, query_context);

--- a/tests/integration/test_attach_partition_with_large_destination/configs/config.xml
+++ b/tests/integration/test_attach_partition_with_large_destination/configs/config.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <max_table_size_to_drop>1</max_table_size_to_drop>
+    <max_partition_size_to_drop>1</max_partition_size_to_drop>
+</clickhouse>

--- a/tests/integration/test_attach_partition_with_large_destination/test.py
+++ b/tests/integration/test_attach_partition_with_large_destination/test.py
@@ -35,3 +35,5 @@ def test_attach_partition_with_large_destination(started_cluster, engine):
     # Attach partition when destination partition is larger than max_partition_size_to_drop
     node.query("ALTER TABLE db.destination ATTACH PARTITION 0 FROM db.source_2")
     assert node.query("SELECT n FROM db.destination ORDER BY n") == "2\n4\n6\n8\n"
+
+    node.query("DROP DATABASE db")

--- a/tests/integration/test_attach_partition_with_large_destination/test.py
+++ b/tests/integration/test_attach_partition_with_large_destination/test.py
@@ -1,0 +1,37 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance('node', main_configs=["configs/config.xml"], with_zookeeper=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+@pytest.mark.parametrize("engine", ['Ordinary', 'Atomic'])
+def test_attach_partition_with_large_destination(started_cluster, engine):
+    # Initialize
+    node.query("CREATE DATABASE db ENGINE={}".format(engine))
+    node.query("CREATE TABLE db.destination (n UInt64) ENGINE=ReplicatedMergeTree('/test/destination', 'r1') ORDER BY n PARTITION BY n % 2")
+    node.query("CREATE TABLE db.source_1 (n UInt64) ENGINE=ReplicatedMergeTree('/test/source_1', 'r1') ORDER BY n PARTITION BY n % 2")
+    node.query("INSERT INTO db.source_1 VALUES (1), (2), (3), (4)")
+    node.query("CREATE TABLE db.source_2 (n UInt64) ENGINE=ReplicatedMergeTree('/test/source_2', 'r1') ORDER BY n PARTITION BY n % 2")
+    node.query("INSERT INTO db.source_2 VALUES (5), (6), (7), (8)")
+
+    # Attach partition when destination partition is empty
+    node.query("ALTER TABLE db.destination ATTACH PARTITION 0 FROM db.source_1")
+    assert node.query("SELECT n FROM db.destination ORDER BY n") == "2\n4\n"
+
+    # REPLACE PARTITION should still respect max_partition_size_to_drop
+    assert node.query_and_get_error("ALTER TABLE db.destination REPLACE PARTITION 0 FROM db.source_2")
+    assert node.query("SELECT n FROM db.destination ORDER BY n") == "2\n4\n"
+
+    # Attach partition when destination partition is larger than max_partition_size_to_drop
+    node.query("ALTER TABLE db.destination ATTACH PARTITION 0 FROM db.source_2")
+    assert node.query("SELECT n FROM db.destination ORDER BY n") == "2\n4\n6\n8\n"

--- a/tests/integration/test_attach_partition_with_large_destination/test.py
+++ b/tests/integration/test_attach_partition_with_large_destination/test.py
@@ -41,10 +41,10 @@ def test_attach_partition_with_large_destination(started_cluster, engine):
     assert node.query("SELECT n FROM db.destination ORDER BY n") == "2\n4\n6\n8\n"
 
     # Cleanup
-    create_force_drop_flag()
+    create_force_drop_flag(node)
     node.query("DROP TABLE db.source_1 SYNC")
-    create_force_drop_flag()
+    create_force_drop_flag(node)
     node.query("DROP TABLE db.source_2 SYNC")
-    create_force_drop_flag()
+    create_force_drop_flag(node)
     node.query("DROP TABLE db.destination SYNC")
     node.query("DROP DATABASE db")


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Skip max_partition_size_to_drop check in case of ATTACH PARTITION ... FROM and MOVE PARTITION
...


Detailed description / Documentation draft:
`ATTACH PARTITION ... FROM ...` fail when target partition size is larger than the `max_partition_size_to_drop` because `ATTACH PARTITION ... FROM ...` gets interpreted as `ASTAlterCommand::REPLACE_PARTITION` command with `replace` flag set to `false`. 
That's why it enters the code path for `REPLACE_PARTITION` which checks that partition can be dropped.
This check should be skipped in the case of `ATTACH PARTITION ... FROM ...` commands that were interpreted as `REPLACE_PARTITION` (i.e. if `command->replace` is `false`)

The same limit is skipped for MOVE PARTITION as well since the partition is dropped from source table after moving to destination, so no need to worry about data loss.

Fixes #30897