### PR TITLE
Allow spaces in JSONPath.

### DIFF
--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
@@ -17,22 +17,17 @@ namespace DB
 bool ParserJSONPathMemberAccess::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     if (pos->type != TokenType::Dot)
-    {
         return false;
-    }
+
     ++pos;
 
-    if (pos->type != TokenType::BareWord)
-    {
+    if (pos->type != TokenType::BareWord && pos->type !=TokenType::QuotedIdentifier)
         return false;
-    }
 
     ParserIdentifier name_p;
     ASTPtr member_name;
     if (!name_p.parse(pos, member_name, expected))
-    {
         return false;
-    }
 
     auto member_access = std::make_shared<ASTJSONPathMemberAccess>();
     node = member_access;

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -9,6 +9,7 @@ null
 
 
 
+"bar"
 --JSON_QUERY--
 [{"hello":1}]
 [1]

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -11,6 +11,7 @@ SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello');
 SELECT JSON_VALUE('{"hello":{"world":"!"}}', '$.hello');
 SELECT JSON_VALUE('{hello:world}', '$.hello'); -- invalid json => default value (empty string)
 SELECT JSON_VALUE('', '$.hello');
+SELECT JSON_VALUE('{"foo foo":"bar"}', '$."foo foo"');
 
 SELECT '--JSON_QUERY--';
 SELECT JSON_QUERY('{"hello":1}', '$');


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix JSONValue/Query with quoted identifiers. This allows to have spaces in json path. Closes https://github.com/ClickHouse/ClickHouse/issues/30971.