### PR TITLE
support compile in arm machine with parameter "-DENABLE_TESTS=OFF"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,7 +624,7 @@ macro (add_executable target)
     # invoke built-in add_executable
     # explicitly acquire and interpose malloc symbols by clickhouse_malloc
     # if GLIBC_COMPATIBILITY is ON and ENABLE_THINLTO is on than provide memcpy symbol explicitly to neutrialize thinlto's libcall generation.
-    if (GLIBC_COMPATIBILITY AND ENABLE_THINLTO)
+    if (ARCH_AMD64 AND GLIBC_COMPATIBILITY AND ENABLE_THINLTO)
         _add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc> $<TARGET_OBJECTS:memcpy>)
     else ()
         _add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc>)


### PR DESCRIPTION
Changelog category (leave one):
- Build

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

support compile in arm machine with parameter "-DENABLE_TESTS=OFF"

compile error is:
CMake Error at CMakeLists.txt:601 (_add_executable):
Error evaluating generator expression:
  $<TARGET_OBJECTS:memcpy>
Objects of target "memcpy" referenced but no such target exists.
Call Stack (most recent call first):
  programs/CMakeLists.txt:334 (add_executable)

