### PR TITLE
perf: add missing DROP TABLE queries

### DIFF
--- a/tests/performance/sum_map.xml
+++ b/tests/performance/sum_map.xml
@@ -31,4 +31,6 @@
 
     <query>SELECT {func}(key, val) FROM sum_map_{scale} FORMAT Null</query>
     <query>SELECT {func}((key, val)) FROM sum_map_{scale} FORMAT Null</query>
+
+    <drop_query>DROP TABLE sum_map_{scale}</drop_query>
 </test>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Note: I've looked though other tests, using `gg -i 'CREATE TABLE' tests/performance/ | cut -d: -f1 | xargs -i sh -c 'fgrep -i -q "DROP TABLE" {} || echo {}'` and this was the only one test.