### PR TITLE
Remove metric_log/part_log overrides in tests (enabled by default)

### DIFF
--- a/programs/server/config.d/metric_log.xml
+++ b/programs/server/config.d/metric_log.xml
@@ -1,1 +1,0 @@
-../../../tests/config/config.d/metric_log.xml

--- a/programs/server/config.d/part_log.xml
+++ b/programs/server/config.d/part_log.xml
@@ -1,1 +1,0 @@
-../../../tests/config/config.d/part_log.xml

--- a/tests/config/config.d/metric_log.xml
+++ b/tests/config/config.d/metric_log.xml
@@ -1,8 +1,0 @@
-<clickhouse>
-    <metric_log>
-        <database>system</database>
-        <table>metric_log</table>
-        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
-        <collect_interval_milliseconds>1000</collect_interval_milliseconds>
-    </metric_log>
-</clickhouse>

--- a/tests/config/config.d/part_log.xml
+++ b/tests/config/config.d/part_log.xml
@@ -1,8 +1,0 @@
-<clickhouse>
-    <part_log>
-        <database>system</database>
-        <table>part_log</table>
-
-        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
-    </part_log>
-</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -17,9 +17,7 @@ mkdir -p $DEST_CLIENT_PATH
 
 ln -sf $SRC_PATH/config.d/zookeeper.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/listen.xml $DEST_SERVER_PATH/config.d/
-ln -sf $SRC_PATH/config.d/part_log.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/text_log.xml $DEST_SERVER_PATH/config.d/
-ln -sf $SRC_PATH/config.d/metric_log.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/custom_settings_prefixes.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/macros.xml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/disks.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)