### PR TITLE
rename/exchange database/table/dictionary support IF EXISTS syntax

### DIFF
--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -84,15 +84,12 @@ BlockIO InterpreterRenameQuery::executeToTables(const ASTRenameQuery & rename, c
         {
             if (rename.exchange)
             {
-                ignore = rename.dictionary ? (!database_catalog.isDictionaryExist(StorageID(elem.to_database_name, elem.to_table_name)) ||
-                    !database_catalog.isDictionaryExist(StorageID(elem.from_database_name, elem.from_table_name))) :
-                    (!database_catalog.isTableExist(StorageID(elem.to_database_name, elem.to_table_name), getContext()) ||
-                    !database_catalog.isTableExist(StorageID(elem.from_database_name, elem.from_table_name), getContext()));
+                ignore = !database_catalog.isTableExist(StorageID(elem.to_database_name, elem.to_table_name), getContext()) ||
+                    !database_catalog.isTableExist(StorageID(elem.from_database_name, elem.from_table_name), getContext());
             }
             else
             {
-                ignore = rename.dictionary ? (!database_catalog.isDictionaryExist(StorageID(elem.from_database_name, elem.from_table_name))) :
-                    (!database_catalog.isTableExist(StorageID(elem.from_database_name, elem.from_table_name), getContext()));
+                ignore = !database_catalog.isTableExist(StorageID(elem.from_database_name, elem.from_table_name), getContext());
             }
         }
 

--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -91,8 +91,8 @@ BlockIO InterpreterRenameQuery::executeToTables(const ASTRenameQuery & rename, c
             }
             else
             {
-                ignore = rename.dictionary ? (!database_catalog.isDictionaryExist(StorageID(elem.to_database_name, elem.to_table_name))) :
-                    (!database_catalog.isTableExist(StorageID(elem.to_database_name, elem.to_table_name), getContext()));
+                ignore = rename.dictionary ? (!database_catalog.isDictionaryExist(StorageID(elem.from_database_name, elem.from_table_name))) :
+                    (!database_catalog.isTableExist(StorageID(elem.from_database_name, elem.from_table_name), getContext()));
             }
         }
 

--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -155,7 +155,8 @@ BlockIO InterpreterRenameQuery::executeToDatabase(const ASTRenameQuery &, const 
 
     auto db = descriptions.front().if_exists ? catalog.tryGetDatabase(old_name) : catalog.getDatabase(old_name);
 
-    if (db) {
+    if (db)
+    {
         catalog.assertDatabaseDoesntExist(new_name);
         db->renameDatabase(new_name);
     }

--- a/src/Interpreters/InterpreterRenameQuery.h
+++ b/src/Interpreters/InterpreterRenameQuery.h
@@ -31,7 +31,8 @@ struct RenameDescription
             from_database_name(elem.from.database.empty() ? current_database : elem.from.database),
             from_table_name(elem.from.table),
             to_database_name(elem.to.database.empty() ? current_database : elem.to.database),
-            to_table_name(elem.to.table)
+            to_table_name(elem.to.table),
+            if_exists(elem.if_exists)
     {}
 
     String from_database_name;
@@ -39,6 +40,7 @@ struct RenameDescription
 
     String to_database_name;
     String to_table_name;
+    bool if_exists;
 };
 
 using RenameDescriptions = std::vector<RenameDescription>;

--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -73,6 +73,10 @@ protected:
         if (database)
         {
             settings.ostr << (settings.hilite ? hilite_keyword : "") << "RENAME DATABASE " << (settings.hilite ? hilite_none : "");
+
+            if (elements.at(0).if_exists)
+                settings.ostr << "IF EXISTS ";
+
             settings.ostr << backQuoteIfNeed(elements.at(0).from.database);
             settings.ostr << (settings.hilite ? hilite_keyword : "") << " TO " << (settings.hilite ? hilite_none : "");
             settings.ostr << backQuoteIfNeed(elements.at(0).to.database);
@@ -97,6 +101,8 @@ protected:
             if (it != elements.cbegin())
                 settings.ostr << ", ";
 
+            if (it->if_exists)
+                settings.ostr << "IF EXISTS ";
             settings.ostr << (!it->from.database.empty() ? backQuoteIfNeed(it->from.database) + "." : "") << backQuoteIfNeed(it->from.table)
                 << (settings.hilite ? hilite_keyword : "") << (exchange ? " AND " : " TO ") << (settings.hilite ? hilite_none : "")
                 << (!it->to.database.empty() ? backQuoteIfNeed(it->to.database) + "." : "") << backQuoteIfNeed(it->to.table);

--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -25,6 +25,7 @@ public:
     {
         Table from;
         Table to;
+        bool if_exists{false};   /// If this directive is used, one will not get an error if the table/database/dictionary to be renamed/exchanged doesn't exist.
     };
 
     using Elements = std::vector<Element>;

--- a/src/Parsers/ParserRenameQuery.cpp
+++ b/src/Parsers/ParserRenameQuery.cpp
@@ -108,7 +108,7 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         ASTRenameQuery::Element& ref = elements.emplace_back();
 
         if (!exchange)
-            ref.if_exists = s_if_exists.ignore( pos, expected);
+            ref.if_exists = s_if_exists.ignore(pos, expected);
 
         if (!parseDatabaseAndTable(ref.from, pos, expected)
             || !ignore_delim()

--- a/src/Parsers/ParserRenameQuery.cpp
+++ b/src/Parsers/ParserRenameQuery.cpp
@@ -44,6 +44,7 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ParserKeyword s_rename_dictionary("RENAME DICTIONARY");
     ParserKeyword s_exchange_dictionaries("EXCHANGE DICTIONARIES");
     ParserKeyword s_rename_database("RENAME DATABASE");
+    ParserKeyword s_if_exists("IF EXISTS");
     ParserKeyword s_to("TO");
     ParserKeyword s_and("AND");
     ParserToken s_comma(TokenType::Comma);
@@ -67,6 +68,7 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         ASTPtr from_db;
         ASTPtr to_db;
         ParserIdentifier db_name_p;
+        bool if_exists = s_if_exists.ignore(pos, expected);
         if (!db_name_p.parse(pos, from_db, expected))
             return false;
         if (!s_to.ignore(pos, expected))
@@ -84,6 +86,7 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         auto query = std::make_shared<ASTRenameQuery>();
         query->database = true;
         query->elements.emplace({});
+        query->elements.front().if_exists = if_exists;
         tryGetIdentifierNameInto(from_db, query->elements.front().from.database);
         tryGetIdentifierNameInto(to_db, query->elements.front().to.database);
         query->cluster = cluster_str;
@@ -103,6 +106,7 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             break;
 
         ASTRenameQuery::Element& ref = elements.emplace_back();
+        ref.if_exists = s_if_exists.ignore( pos, expected);
 
         if (!parseDatabaseAndTable(ref.from, pos, expected)
             || !ignore_delim()

--- a/src/Parsers/ParserRenameQuery.cpp
+++ b/src/Parsers/ParserRenameQuery.cpp
@@ -106,7 +106,9 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             break;
 
         ASTRenameQuery::Element& ref = elements.emplace_back();
-        ref.if_exists = s_if_exists.ignore( pos, expected);
+
+        if (!exchange)
+            ref.if_exists = s_if_exists.ignore( pos, expected);
 
         if (!parseDatabaseAndTable(ref.from, pos, expected)
             || !ignore_delim()

--- a/tests/queries/0_stateless/01109_exchange_tables.reference
+++ b/tests/queries/0_stateless/01109_exchange_tables.reference
@@ -16,3 +16,5 @@
 3	world
 0	exchange
 1	tables
+0
+1

--- a/tests/queries/0_stateless/01109_exchange_tables.sql
+++ b/tests/queries/0_stateless/01109_exchange_tables.sql
@@ -13,23 +13,17 @@ CREATE TABLE t2 ENGINE=MergeTree() ORDER BY tuple() AS SELECT rowNumberInAllBloc
 EXCHANGE TABLES t1 AND t3; -- { serverError 60 }
 EXCHANGE TABLES t4 AND t2; -- { serverError 60 }
 RENAME TABLE t0 TO t1; -- { serverError 57 }
-
-RENAME DATABASE IF EXISTS test_non_exists TO test_non_exists_renamed;
-EXCHANGE TABLES IF EXISTS t1 AND t3;
-EXCHANGE TABLES IF EXISTS t4 AND t2;
-RENAME TABLE IF EXISTS t3 TO t4;
-
-DROP TABLE IF EXISTS t1;
-RENAME TABLE IF EXISTS t0 TO t1;
+DROP TABLE t1;
+RENAME TABLE t0 TO t1;
 SELECT * FROM t1;
 SELECT * FROM t2;
 
-EXCHANGE TABLES IF EXISTS t1 AND t2;
+EXCHANGE TABLES t1 AND t2;
 SELECT * FROM t1;
 SELECT * FROM t2;
 
-RENAME TABLE IF EXISTS t1 TO t1tmp, t2 TO t2tmp;
-RENAME TABLE IF EXISTS t1tmp TO t2, t2tmp TO t1;
+RENAME TABLE t1 TO t1tmp, t2 TO t2tmp;
+RENAME TABLE t1tmp TO t2, t2tmp TO t1;
 SELECT * FROM t1;
 SELECT * FROM t2;
 
@@ -50,13 +44,26 @@ EXCHANGE TABLES test_01109_other_atomic.t3 AND test_01109_ordinary.t4; -- { serv
 EXCHANGE TABLES test_01109_ordinary.t4 AND test_01109_other_atomic.t3; -- { serverError 48 }
 EXCHANGE TABLES test_01109_ordinary.t4 AND test_01109_ordinary.t4; -- { serverError 48 }
 
-EXCHANGE TABLES IF EXISTS t1 AND test_01109_other_atomic.t3;
-EXCHANGE TABLES IF EXISTS t2 AND t2;
+EXCHANGE TABLES t1 AND test_01109_other_atomic.t3;
+EXCHANGE TABLES t2 AND t2;
 SELECT * FROM t1;
 SELECT * FROM t2;
 SELECT * FROM test_01109_other_atomic.t3;
 SELECT * FROM test_01109_ordinary.t4;
 
+DROP DATABASE IF EXISTS test_01109_rename_exists;
+CREATE DATABASE test_01109_rename_exists ENGINE=Atomic;
+USE test_01109_rename_exists;
+CREATE TABLE t0 ENGINE=Log() AS SELECT * FROM system.numbers limit 2;
+RENAME TABLE t0_tmp TO t1; -- { serverError 60 }
+RENAME TABLE if exists t0_tmp TO t1;
+RENAME TABLE if exists t0 TO t1;
+SELECT * FROM t1;
+
 DROP DATABASE test_01109;
 DROP DATABASE test_01109_other_atomic;
 DROP DATABASE test_01109_ordinary;
+DROP DATABASE test_01109_rename_exists;
+
+
+

--- a/tests/queries/0_stateless/01109_exchange_tables.sql
+++ b/tests/queries/0_stateless/01109_exchange_tables.sql
@@ -13,17 +13,23 @@ CREATE TABLE t2 ENGINE=MergeTree() ORDER BY tuple() AS SELECT rowNumberInAllBloc
 EXCHANGE TABLES t1 AND t3; -- { serverError 60 }
 EXCHANGE TABLES t4 AND t2; -- { serverError 60 }
 RENAME TABLE t0 TO t1; -- { serverError 57 }
-DROP TABLE t1;
-RENAME TABLE t0 TO t1;
+
+RENAME DATABASE IF EXISTS test_non_exists TO test_non_exists_renamed;
+EXCHANGE TABLES IF EXISTS t1 AND t3;
+EXCHANGE TABLES IF EXISTS t4 AND t2;
+RENAME TABLE IF EXISTS t3 TO t4;
+
+DROP TABLE IF EXISTS t1;
+RENAME TABLE IF EXISTS t0 TO t1;
 SELECT * FROM t1;
 SELECT * FROM t2;
 
-EXCHANGE TABLES t1 AND t2;
+EXCHANGE TABLES IF EXISTS t1 AND t2;
 SELECT * FROM t1;
 SELECT * FROM t2;
 
-RENAME TABLE t1 TO t1tmp, t2 TO t2tmp;
-RENAME TABLE t1tmp TO t2, t2tmp TO t1;
+RENAME TABLE IF EXISTS t1 TO t1tmp, t2 TO t2tmp;
+RENAME TABLE IF EXISTS t1tmp TO t2, t2tmp TO t1;
 SELECT * FROM t1;
 SELECT * FROM t2;
 
@@ -44,8 +50,8 @@ EXCHANGE TABLES test_01109_other_atomic.t3 AND test_01109_ordinary.t4; -- { serv
 EXCHANGE TABLES test_01109_ordinary.t4 AND test_01109_other_atomic.t3; -- { serverError 48 }
 EXCHANGE TABLES test_01109_ordinary.t4 AND test_01109_ordinary.t4; -- { serverError 48 }
 
-EXCHANGE TABLES t1 AND test_01109_other_atomic.t3;
-EXCHANGE TABLES t2 AND t2;
+EXCHANGE TABLES IF EXISTS t1 AND test_01109_other_atomic.t3;
+EXCHANGE TABLES IF EXISTS t2 AND t2;
 SELECT * FROM t1;
 SELECT * FROM t2;
 SELECT * FROM test_01109_other_atomic.t3;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support `IF EXISTS` modifier for `RENAME DATABASE`/`TABLE`/`DICTIONARY` query, If this directive is used, one will not get an error if the DATABASE/TABLE/DICTIONARY to be renamed doesn't exist.