### PR TITLE
Doc build: remove single.md

### DIFF
--- a/docs/tools/build.py
+++ b/docs/tools/build.py
@@ -117,6 +117,9 @@ def build_for_lang(lang, args):
             )
         )
 
+        # Clean to be safe if last build finished abnormally
+        single_page.remove_temporary_files(lang, args)  
+
         raw_config['nav'] = nav.build_docs_nav(lang, args)
 
         cfg = config.load_config(**raw_config)

--- a/docs/tools/single_page.py
+++ b/docs/tools/single_page.py
@@ -12,6 +12,7 @@ import test
 import util
 import website
 
+TEMPORARY_FILE_NAME = 'single.md'
 
 def recursive_values(item):
     if isinstance(item, dict):
@@ -101,6 +102,14 @@ def concatenate(lang, docs_path, single_page_file, nav):
 
     single_page_file.flush()
 
+def get_temporary_file_name(lang, args):
+    return os.path.join(args.docs_dir, lang, TEMPORARY_FILE_NAME)
+
+def remove_temporary_files(lang, args):
+    single_md_path = get_temporary_file_name(lang, args)
+    if os.path.exists(single_md_path):
+        os.unlink(single_md_path)
+
 
 def build_single_page_version(lang, args, nav, cfg):
     logging.info(f'Building single page version for {lang}')
@@ -109,7 +118,7 @@ def build_single_page_version(lang, args, nav, cfg):
     extra['single_page'] = True
     extra['is_amp'] = False
 
-    single_md_path = os.path.join(args.docs_dir, lang, 'single.md')
+    single_md_path = get_temporary_file_name(lang, args)
     with open(single_md_path, 'w') as single_md:
         concatenate(lang, args.docs_dir, single_md, nav)
 
@@ -226,5 +235,4 @@ def build_single_page_version(lang, args, nav, cfg):
 
         logging.info(f'Finished building single page version for {lang}')
 
-        if os.path.exists(single_md_path):
-            os.unlink(single_md_path)
+        remove_temporary_files(lang, args)


### PR DESCRIPTION
Changelog category:

- Not for changelog

If building documentation finishes abnormally (for example Ctrl+C) then temporary `docs/*/single.md` files are left in doc source tree. Then next build finishes with warnings:
`WARNING:mkdocs.structure.pages:Documentation file 'single.md' contains a link to '../development/build.md' which is not found in the documentation files.`

Now `docs/*/single.md` are also removed at the beginning of a build process.