### PR TITLE
remove unnecessary assert in StorageFileLog

### DIFF
--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -470,7 +470,6 @@ void StorageFileLog::openFilesAndSetPos()
 
 void StorageFileLog::closeFilesAndStoreMeta(size_t start, size_t end)
 {
-    assert(start >= 0);
     assert(start < end);
     assert(end <= file_infos.file_names.size());
 
@@ -491,7 +490,6 @@ void StorageFileLog::closeFilesAndStoreMeta(size_t start, size_t end)
 
 void StorageFileLog::storeMetas(size_t start, size_t end)
 {
-    assert(start >= 0);
     assert(start < end);
     assert(end <= file_infos.file_names.size());
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

comparison of unsigned expression in ‘>= 0’ is always true

