### PR TITLE
Better clickhouse-client multiline input

### DIFF
--- a/base/base/LineReader.h
+++ b/base/base/LineReader.h
@@ -53,7 +53,6 @@ protected:
 
     String input;
 
-private:
     bool multiline;
 
     Patterns extenders;

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -22,7 +22,14 @@ namespace
 /// Trim ending whitespace inplace
 void trim(String & s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
+}
+
+/// Check if string ends with given character after skipping whitespaces.
+bool ends_with(const std::string_view & s, const std::string_view & p)
+{
+    auto ss = std::string_view(s.data(), s.rend() - std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }));
+    return ss.ends_with(p);
 }
 
 /// Copied from replxx::src/util.cxx::now_ms_str() under the terms of 3-clause BSD license of Replxx.
@@ -178,8 +185,28 @@ ReplxxLineReader::ReplxxLineReader(
     rx.bind_key(Replxx::KEY::control('N'), [this](char32_t code) { return rx.invoke(Replxx::ACTION::HISTORY_NEXT, code); });
     rx.bind_key(Replxx::KEY::control('P'), [this](char32_t code) { return rx.invoke(Replxx::ACTION::HISTORY_PREVIOUS, code); });
 
+    auto commit_action = [this](char32_t code)
+    {
+        std::string_view str = rx.get_state().text();
+
+        /// Always commit line when we see extender at the end. It will start a new prompt.
+        for (const auto * extender : extenders)
+            if (ends_with(str, extender))
+                return rx.invoke(Replxx::ACTION::COMMIT_LINE, code);
+
+        /// If we see an delimiter at the end, commit right away.
+        for (const auto * delimiter : delimiters)
+            if (ends_with(str, delimiter))
+                return rx.invoke(Replxx::ACTION::COMMIT_LINE, code);
+
+        /// If we allow multiline and there is already something in the input, start a newline.
+        if (multiline && !input.empty())
+            return rx.invoke(Replxx::ACTION::NEW_LINE, code);
+        return rx.invoke(Replxx::ACTION::COMMIT_LINE, code);
+    };
     /// bind C-j to ENTER action.
-    rx.bind_key(Replxx::KEY::control('J'), [this](char32_t code) { return rx.invoke(Replxx::ACTION::COMMIT_LINE, code); });
+    rx.bind_key(Replxx::KEY::control('J'), commit_action);
+    rx.bind_key(Replxx::KEY::ENTER, commit_action);
 
     /// By default COMPLETE_NEXT/COMPLETE_PREV was binded to C-p/C-n, re-bind
     /// to M-P/M-N (that was used for HISTORY_COMMON_PREFIX_SEARCH before, but

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1354,11 +1354,8 @@ void ClientBase::runInteractive()
     LineReader lr(history_file, config().has("multiline"), query_extenders, query_delimiters);
 #endif
 
-    /// Enable bracketed-paste-mode only when multiquery is enabled and multiline is
-    ///  disabled, so that we are able to paste and execute multiline queries in a whole
-    ///  instead of erroring out, while be less intrusive.
-    if (config().has("multiquery") && !config().has("multiline"))
-        lr.enableBracketedPaste();
+    /// Enable bracketed-paste-mode so that we are able to paste multiline queries as a whole.
+    lr.enableBracketedPaste();
 
     do
     {

--- a/tests/queries/0_stateless/01526_client_start_and_exit.sh
+++ b/tests/queries/0_stateless/01526_client_start_and_exit.sh
@@ -10,8 +10,11 @@ ${CLICKHOUSE_CLIENT} -q "SELECT 'CREATE TABLE test_' || hex(randomPrintableASCII
 
 function stress()
 {
+    # 2004l is ignored because parallel running expect emulated terminal doesn't
+    # work well with bracketed paste enabling sequence, which is \e033?2004l
+    # (https://cirw.in/blog/bracketed-paste)
     while true; do
-        "${CURDIR}"/01526_client_start_and_exit.expect-not-a-test-case | grep -v -P 'ClickHouse client|Connecting|Connected|:\) Bye\.|new year|^\s*$|spawn bash|^0\s*$'
+        "${CURDIR}"/01526_client_start_and_exit.expect-not-a-test-case | grep -v -P 'ClickHouse client|Connecting|Connected|:\) Bye\.|new year|^\s*$|spawn bash|\?2004l|^0\s*$'
     done
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable multiline editing in clickhouse-client by default. This addresses https://github.com/ClickHouse/ClickHouse/issues/31121 .

Before https://github.com/ClickHouse/ClickHouse/pull/30143 , we didn't support native multline editing in clickhouse-client. Thus bracketed pasting is only enabled when `-n` is enabled and `-m` is disabled (see https://github.com/ClickHouse/ClickHouse/issues/7757) . Now we allow multiple sections of multiline inputs delimited by extender character: `\`.

Detailed description / Documentation draft:
.