### PR TITLE
use DiskPtr instead of OS's file system API in class IDiskRemote

### DIFF
--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -106,11 +106,11 @@ private:
 };
 
 
-class DiskLocalDirectoryIterator : public IDiskDirectoryIterator
+class DiskLocalDirectoryIterator final : public IDiskDirectoryIterator
 {
 public:
-    DiskLocalDirectoryIterator() {}
-    explicit DiskLocalDirectoryIterator(const String & disk_path_, const String & dir_path_)
+    DiskLocalDirectoryIterator() { }
+    DiskLocalDirectoryIterator(const String & disk_path_, const String & dir_path_)
         : dir_path(dir_path_), entry(fs::path(disk_path_) / dir_path_)
     {
     }

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -109,7 +109,7 @@ private:
 class DiskLocalDirectoryIterator final : public IDiskDirectoryIterator
 {
 public:
-    DiskLocalDirectoryIterator() { }
+    DiskLocalDirectoryIterator() = default;
     DiskLocalDirectoryIterator(const String & disk_path_, const String & dir_path_)
         : dir_path(dir_path_), entry(fs::path(disk_path_) / dir_path_)
     {

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -109,6 +109,7 @@ private:
 class DiskLocalDirectoryIterator : public IDiskDirectoryIterator
 {
 public:
+    DiskLocalDirectoryIterator() {}
     explicit DiskLocalDirectoryIterator(const String & disk_path_, const String & dir_path_)
         : dir_path(dir_path_), entry(fs::path(disk_path_) / dir_path_)
     {
@@ -244,7 +245,11 @@ void DiskLocal::moveDirectory(const String & from_path, const String & to_path)
 
 DiskDirectoryIteratorPtr DiskLocal::iterateDirectory(const String & path)
 {
-    return std::make_unique<DiskLocalDirectoryIterator>(disk_path, path);
+    fs::path meta_path = fs::path(disk_path) / path;
+    if (fs::exists(meta_path) && fs::is_directory(meta_path))
+        return std::make_unique<DiskLocalDirectoryIterator>(disk_path, path);
+    else
+        return std::make_unique<DiskLocalDirectoryIterator>();
 }
 
 void DiskLocal::moveFile(const String & from_path, const String & to_path)

--- a/src/Disks/HDFS/DiskHDFS.cpp
+++ b/src/Disks/HDFS/DiskHDFS.cpp
@@ -1,4 +1,5 @@
 #include <Disks/HDFS/DiskHDFS.h>
+#include <Disks/DiskLocal.h>
 
 #include <IO/SeekAvoidingReadBuffer.h>
 #include <Storages/HDFS/WriteBufferFromHDFS.h>
@@ -56,9 +57,9 @@ DiskHDFS::DiskHDFS(
     const String & disk_name_,
     const String & hdfs_root_path_,
     SettingsPtr settings_,
-    const String & metadata_path_,
+    DiskPtr metadata_disk_,
     const Poco::Util::AbstractConfiguration & config_)
-    : IDiskRemote(disk_name_, hdfs_root_path_, metadata_path_, "DiskHDFS", settings_->thread_pool_size)
+    : IDiskRemote(disk_name_, hdfs_root_path_, metadata_disk_, "DiskHDFS", settings_->thread_pool_size)
     , config(config_)
     , hdfs_builder(createHDFSBuilder(hdfs_root_path_, config))
     , hdfs_fs(createHDFSFS(hdfs_builder.get()))
@@ -73,7 +74,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskHDFS::readFile(const String & path, 
 
     LOG_TRACE(log,
         "Read from file by path: {}. Existing HDFS objects: {}",
-        backQuote(metadata_path + path), metadata.remote_fs_objects.size());
+        backQuote(metadata_disk->getPath() + path), metadata.remote_fs_objects.size());
 
     auto hdfs_impl = std::make_unique<ReadBufferFromHDFSGather>(path, config, remote_fs_root_path, metadata, read_settings.remote_fs_buffer_size);
 
@@ -99,7 +100,7 @@ std::unique_ptr<WriteBufferFromFileBase> DiskHDFS::writeFile(const String & path
     auto hdfs_path = remote_fs_root_path + file_name;
 
     LOG_TRACE(log, "{} to file by path: {}. HDFS path: {}", mode == WriteMode::Rewrite ? "Write" : "Append",
-              backQuote(metadata_path + path), hdfs_path);
+              backQuote(metadata_disk->getPath() + path), hdfs_path);
 
     /// Single O_WRONLY in libhdfs adds O_TRUNC
     auto hdfs_buffer = std::make_unique<WriteBufferFromHDFS>(hdfs_path,
@@ -174,11 +175,12 @@ void registerDiskHDFS(DiskFactory & factory)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "HDFS path must ends with '/', but '{}' doesn't.", uri);
 
         String metadata_path = context_->getPath() + "disks/" + name + "/";
+        auto metadata_disk = std::make_shared<DiskLocal>(name + "-metadata", metadata_path, 0);
 
         return std::make_shared<DiskHDFS>(
             name, uri,
             getSettings(config, config_prefix),
-            metadata_path, config);
+            metadata_disk, config);
     };
 
     factory.registerDiskType("hdfs", creator);

--- a/src/Disks/HDFS/DiskHDFS.h
+++ b/src/Disks/HDFS/DiskHDFS.h
@@ -39,7 +39,7 @@ public:
         const String & disk_name_,
         const String & hdfs_root_path_,
         SettingsPtr settings_,
-        const String & metadata_path_,
+        DiskPtr metadata_disk_,
         const Poco::Util::AbstractConfiguration & config_);
 
     DiskType getType() const override { return DiskType::HDFS; }

--- a/src/Disks/IDiskRemote.cpp
+++ b/src/Disks/IDiskRemote.cpp
@@ -31,11 +31,11 @@ namespace ErrorCodes
 /// Load metadata by path or create empty if `create` flag is set.
 IDiskRemote::Metadata::Metadata(
         const String & remote_fs_root_path_,
-        const String & disk_path_,
+        DiskPtr metadata_disk_,
         const String & metadata_file_path_,
         bool create)
     : RemoteMetadata(remote_fs_root_path_, metadata_file_path_)
-    , disk_path(disk_path_)
+    , metadata_disk(metadata_disk_)
     , total_size(0), ref_count(0)
 {
     if (create)
@@ -43,53 +43,54 @@ IDiskRemote::Metadata::Metadata(
 
     try
     {
-        ReadBufferFromFile buf(disk_path + metadata_file_path, 1024); /* reasonable buffer size for small file */
+        const ReadSettings read_settings;
+        auto buf = metadata_disk->readFile(metadata_file_path, read_settings, 1024);  /* reasonable buffer size for small file */
 
         UInt32 version;
-        readIntText(version, buf);
+        readIntText(version, *buf);
 
         if (version < VERSION_ABSOLUTE_PATHS || version > VERSION_READ_ONLY_FLAG)
             throw Exception(
                 ErrorCodes::UNKNOWN_FORMAT,
                 "Unknown metadata file version. Path: {}. Version: {}. Maximum expected version: {}",
-                disk_path + metadata_file_path, toString(version), toString(VERSION_READ_ONLY_FLAG));
+                metadata_disk->getPath() + metadata_file_path, toString(version), toString(VERSION_READ_ONLY_FLAG));
 
-        assertChar('\n', buf);
+        assertChar('\n', *buf);
 
         UInt32 remote_fs_objects_count;
-        readIntText(remote_fs_objects_count, buf);
-        assertChar('\t', buf);
-        readIntText(total_size, buf);
-        assertChar('\n', buf);
+        readIntText(remote_fs_objects_count, *buf);
+        assertChar('\t', *buf);
+        readIntText(total_size, *buf);
+        assertChar('\n', *buf);
         remote_fs_objects.resize(remote_fs_objects_count);
 
         for (size_t i = 0; i < remote_fs_objects_count; ++i)
         {
             String remote_fs_object_path;
             size_t remote_fs_object_size;
-            readIntText(remote_fs_object_size, buf);
-            assertChar('\t', buf);
-            readEscapedString(remote_fs_object_path, buf);
+            readIntText(remote_fs_object_size, *buf);
+            assertChar('\t', *buf);
+            readEscapedString(remote_fs_object_path, *buf);
             if (version == VERSION_ABSOLUTE_PATHS)
             {
                 if (!remote_fs_object_path.starts_with(remote_fs_root_path))
                     throw Exception(ErrorCodes::UNKNOWN_FORMAT,
                         "Path in metadata does not correspond to root path. Path: {}, root path: {}, disk path: {}",
-                        remote_fs_object_path, remote_fs_root_path, disk_path_);
+                        remote_fs_object_path, remote_fs_root_path, metadata_disk->getPath());
 
                 remote_fs_object_path = remote_fs_object_path.substr(remote_fs_root_path.size());
             }
-            assertChar('\n', buf);
+            assertChar('\n', *buf);
             remote_fs_objects[i] = {remote_fs_object_path, remote_fs_object_size};
         }
 
-        readIntText(ref_count, buf);
-        assertChar('\n', buf);
+        readIntText(ref_count, *buf);
+        assertChar('\n', *buf);
 
         if (version >= VERSION_READ_ONLY_FLAG)
         {
-            readBoolText(read_only, buf);
-            assertChar('\n', buf);
+            readBoolText(read_only, *buf);
+            assertChar('\n', *buf);
         }
     }
     catch (Exception & e)
@@ -110,33 +111,33 @@ void IDiskRemote::Metadata::addObject(const String & path, size_t size)
 /// Fsync metadata file if 'sync' flag is set.
 void IDiskRemote::Metadata::save(bool sync)
 {
-    WriteBufferFromFile buf(disk_path + metadata_file_path, 1024);
+    auto buf = metadata_disk->writeFile(metadata_file_path, 1024);
 
-    writeIntText(VERSION_RELATIVE_PATHS, buf);
-    writeChar('\n', buf);
+    writeIntText(VERSION_RELATIVE_PATHS, *buf);
+    writeChar('\n', *buf);
 
-    writeIntText(remote_fs_objects.size(), buf);
-    writeChar('\t', buf);
-    writeIntText(total_size, buf);
-    writeChar('\n', buf);
+    writeIntText(remote_fs_objects.size(), *buf);
+    writeChar('\t', *buf);
+    writeIntText(total_size, *buf);
+    writeChar('\n', *buf);
 
     for (const auto & [remote_fs_object_path, remote_fs_object_size] : remote_fs_objects)
     {
-        writeIntText(remote_fs_object_size, buf);
-        writeChar('\t', buf);
-        writeEscapedString(remote_fs_object_path, buf);
-        writeChar('\n', buf);
+        writeIntText(remote_fs_object_size, *buf);
+        writeChar('\t', *buf);
+        writeEscapedString(remote_fs_object_path, *buf);
+        writeChar('\n', *buf);
     }
 
-    writeIntText(ref_count, buf);
-    writeChar('\n', buf);
+    writeIntText(ref_count, *buf);
+    writeChar('\n', *buf);
 
-    writeBoolText(read_only, buf);
-    writeChar('\n', buf);
+    writeBoolText(read_only, *buf);
+    writeChar('\n', *buf);
 
-    buf.finalize();
+    buf->finalize();
     if (sync)
-        buf.sync();
+        buf->sync();
 }
 
 IDiskRemote::Metadata IDiskRemote::readOrCreateMetaForWriting(const String & path, WriteMode mode)
@@ -164,23 +165,21 @@ IDiskRemote::Metadata IDiskRemote::readOrCreateMetaForWriting(const String & pat
 
 IDiskRemote::Metadata IDiskRemote::readMeta(const String & path) const
 {
-    return Metadata(remote_fs_root_path, metadata_path, path);
+    return Metadata(remote_fs_root_path, metadata_disk, path);
 }
 
 
 IDiskRemote::Metadata IDiskRemote::createMeta(const String & path) const
 {
-    return Metadata(remote_fs_root_path, metadata_path, path, true);
+    return Metadata(remote_fs_root_path, metadata_disk, path, true);
 }
 
 
 void IDiskRemote::removeMeta(const String & path, RemoteFSPathKeeperPtr fs_paths_keeper)
 {
-    LOG_DEBUG(log, "Remove file by path: {}", backQuote(metadata_path + path));
+    LOG_DEBUG(log, "Remove file by path: {}", backQuote(metadata_disk->getPath() + path));
 
-    fs::path file(metadata_path + path);
-
-    if (!fs::is_regular_file(file))
+    if (!metadata_disk->isFile(path))
         throw Exception(ErrorCodes::CANNOT_DELETE_DIRECTORY, "Path '{}' is a directory", path);
 
     try
@@ -190,7 +189,7 @@ void IDiskRemote::removeMeta(const String & path, RemoteFSPathKeeperPtr fs_paths
         /// If there is no references - delete content from remote FS.
         if (metadata.ref_count == 0)
         {
-            fs::remove(file);
+            metadata_disk->removeFile(path);
             for (const auto & [remote_fs_object_path, _] : metadata.remote_fs_objects)
                 fs_paths_keeper->addPath(remote_fs_root_path + remote_fs_object_path);
         }
@@ -198,7 +197,7 @@ void IDiskRemote::removeMeta(const String & path, RemoteFSPathKeeperPtr fs_paths
         {
             --metadata.ref_count;
             metadata.save();
-            fs::remove(file);
+            metadata_disk->removeFile(path);
         }
     }
     catch (const Exception & e)
@@ -209,7 +208,7 @@ void IDiskRemote::removeMeta(const String & path, RemoteFSPathKeeperPtr fs_paths
             LOG_WARNING(log,
                 "Metadata file {} can't be read by reason: {}. Removing it forcibly.",
                 backQuote(path), e.nested() ? e.nested()->message() : e.message());
-            fs::remove(file);
+            metadata_disk->removeFile(path);
         }
         else
             throw;
@@ -221,8 +220,7 @@ void IDiskRemote::removeMetaRecursive(const String & path, RemoteFSPathKeeperPtr
 {
     checkStackSize(); /// This is needed to prevent stack overflow in case of cyclic symlinks.
 
-    fs::path file = fs::path(metadata_path) / path;
-    if (fs::is_regular_file(file))
+    if (metadata_disk->isFile(path))
     {
         removeMeta(path, fs_paths_keeper);
     }
@@ -230,7 +228,7 @@ void IDiskRemote::removeMetaRecursive(const String & path, RemoteFSPathKeeperPtr
     {
         for (auto it{iterateDirectory(path)}; it->isValid(); it->next())
             removeMetaRecursive(it->path(), fs_paths_keeper);
-        fs::remove(file);
+        metadata_disk->removeDirectory(path);
     }
 }
 
@@ -281,27 +279,27 @@ DiskRemoteReservation::~DiskRemoteReservation()
 IDiskRemote::IDiskRemote(
     const String & name_,
     const String & remote_fs_root_path_,
-    const String & metadata_path_,
+    DiskPtr metadata_disk_,
     const String & log_name_,
     size_t thread_pool_size)
     : IDisk(std::make_unique<AsyncExecutor>(log_name_, thread_pool_size))
     , log(&Poco::Logger::get(log_name_))
     , name(name_)
     , remote_fs_root_path(remote_fs_root_path_)
-    , metadata_path(metadata_path_)
+    , metadata_disk(metadata_disk_)
 {
 }
 
 
 bool IDiskRemote::exists(const String & path) const
 {
-    return fs::exists(fs::path(metadata_path) / path);
+    return metadata_disk->exists(path);
 }
 
 
 bool IDiskRemote::isFile(const String & path) const
 {
-    return fs::is_regular_file(fs::path(metadata_path) / path);
+    return metadata_disk->isFile(path);
 }
 
 
@@ -325,7 +323,7 @@ void IDiskRemote::moveFile(const String & from_path, const String & to_path)
     if (exists(to_path))
         throw Exception("File already exists: " + to_path, ErrorCodes::FILE_ALREADY_EXISTS);
 
-    fs::rename(fs::path(metadata_path) / from_path, fs::path(metadata_path) / to_path);
+    metadata_disk->moveFile(from_path, to_path);
 }
 
 
@@ -355,7 +353,7 @@ void IDiskRemote::removeSharedFile(const String & path, bool keep_in_remote_fs)
 void IDiskRemote::removeSharedFileIfExists(const String & path, bool keep_in_remote_fs)
 {
     RemoteFSPathKeeperPtr fs_paths_keeper = createFSPathKeeper();
-    if (fs::exists(fs::path(metadata_path) / path))
+    if (metadata_disk->exists(path))
     {
         removeMeta(path, fs_paths_keeper);
         if (!keep_in_remote_fs)
@@ -385,19 +383,19 @@ void IDiskRemote::setReadOnly(const String & path)
 
 bool IDiskRemote::isDirectory(const String & path) const
 {
-    return fs::is_directory(fs::path(metadata_path) / path);
+    return metadata_disk->isDirectory(path);
 }
 
 
 void IDiskRemote::createDirectory(const String & path)
 {
-    fs::create_directory(fs::path(metadata_path) / path);
+    metadata_disk->createDirectory(path);
 }
 
 
 void IDiskRemote::createDirectories(const String & path)
 {
-    fs::create_directories(fs::path(metadata_path) / path);
+    metadata_disk->createDirectories(path);
 }
 
 
@@ -411,17 +409,13 @@ void IDiskRemote::clearDirectory(const String & path)
 
 void IDiskRemote::removeDirectory(const String & path)
 {
-    fs::remove(fs::path(metadata_path) / path);
+    metadata_disk->removeDirectory(path);
 }
 
 
 DiskDirectoryIteratorPtr IDiskRemote::iterateDirectory(const String & path)
 {
-    fs::path meta_path = fs::path(metadata_path) / path;
-    if (fs::exists(meta_path) && fs::is_directory(meta_path))
-        return std::make_unique<RemoteDiskDirectoryIterator>(meta_path, path);
-    else
-        return std::make_unique<RemoteDiskDirectoryIterator>();
+    return metadata_disk->iterateDirectory(path);
 }
 
 
@@ -434,13 +428,13 @@ void IDiskRemote::listFiles(const String & path, std::vector<String> & file_name
 
 void IDiskRemote::setLastModified(const String & path, const Poco::Timestamp & timestamp)
 {
-    FS::setModificationTime(fs::path(metadata_path) / path, timestamp.epochTime());
+    metadata_disk->setLastModified(path, timestamp);
 }
 
 
 Poco::Timestamp IDiskRemote::getLastModified(const String & path)
 {
-    return FS::getModificationTimestamp(fs::path(metadata_path) / path);
+    return metadata_disk->getLastModified(path);
 }
 
 
@@ -452,7 +446,7 @@ void IDiskRemote::createHardLink(const String & src_path, const String & dst_pat
     src.save();
 
     /// Create FS hardlink to metadata file.
-    DB::createHardLink(metadata_path + src_path, metadata_path + dst_path);
+    metadata_disk->createHardLink(src_path, dst_path);
 }
 
 
@@ -490,7 +484,7 @@ bool IDiskRemote::tryReserve(UInt64 bytes)
 
 String IDiskRemote::getUniqueId(const String & path) const
 {
-    Metadata metadata(remote_fs_root_path, metadata_path, path);
+    Metadata metadata(remote_fs_root_path, metadata_disk, path);
     String id;
     if (!metadata.remote_fs_objects.empty())
         id = metadata.remote_fs_root_path + metadata.remote_fs_objects[0].first;

--- a/src/Disks/IDiskRemote.h
+++ b/src/Disks/IDiskRemote.h
@@ -47,7 +47,7 @@ public:
     IDiskRemote(
         const String & name_,
         const String & remote_fs_root_path_,
-        const String & metadata_path_,
+        DiskPtr metadata_disk_,
         const String & log_name_,
         size_t thread_pool_size);
 
@@ -55,7 +55,7 @@ public:
 
     const String & getName() const final override { return name; }
 
-    const String & getPath() const final override { return metadata_path; }
+    const String & getPath() const final override { return metadata_disk->getPath(); }
 
     Metadata readMeta(const String & path) const;
 
@@ -136,7 +136,7 @@ protected:
     const String name;
     const String remote_fs_root_path;
 
-    const String metadata_path;
+    DiskPtr metadata_disk;
 
 private:
     void removeMeta(const String & path, RemoteFSPathKeeperPtr fs_paths_keeper);
@@ -182,8 +182,7 @@ struct IDiskRemote::Metadata : RemoteMetadata
     static constexpr UInt32 VERSION_RELATIVE_PATHS = 2;
     static constexpr UInt32 VERSION_READ_ONLY_FLAG = 3;
 
-    /// Disk path.
-    const String & disk_path;
+    DiskPtr metadata_disk;
 
     /// Total size of all remote FS (S3, HDFS) objects.
     size_t total_size = 0;
@@ -196,7 +195,7 @@ struct IDiskRemote::Metadata : RemoteMetadata
 
     /// Load metadata by path or create empty if `create` flag is set.
     Metadata(const String & remote_fs_root_path_,
-            const String & disk_path_,
+            DiskPtr metadata_disk_,
             const String & metadata_file_path_,
             bool create = false);
 
@@ -206,33 +205,6 @@ struct IDiskRemote::Metadata : RemoteMetadata
     void save(bool sync = false);
 
 };
-
-
-class RemoteDiskDirectoryIterator final : public IDiskDirectoryIterator
-{
-public:
-    RemoteDiskDirectoryIterator() {}
-    RemoteDiskDirectoryIterator(const String & full_path, const String & folder_path_) : iter(full_path), folder_path(folder_path_) {}
-
-    void next() override { ++iter; }
-
-    bool isValid() const override { return iter != fs::directory_iterator(); }
-
-    String path() const override
-    {
-        if (fs::is_directory(iter->path()))
-            return folder_path / iter->path().filename().string() / "";
-        else
-            return folder_path / iter->path().filename().string();
-    }
-
-    String name() const override { return iter->path().filename(); }
-
-private:
-    fs::directory_iterator iter;
-    fs::path folder_path;
-};
-
 
 class DiskRemoteReservation final : public IReservation
 {

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -1003,7 +1003,6 @@ void DiskS3::restoreFileOperations(const RestoreInformation & restore_informatio
                 to_path /= from_path.filename();
 
             metadata_disk->moveDirectory(from_path, to_path);
-            metadata_disk->createDirectory(from_path);
         }
     }
 

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -158,11 +158,11 @@ DiskS3::DiskS3(
     String name_,
     String bucket_,
     String s3_root_path_,
-    String metadata_path_,
+    DiskPtr metadata_disk_,
     ContextPtr context_,
     SettingsPtr settings_,
     GetDiskSettings settings_getter_)
-    : IDiskRemote(name_, s3_root_path_, metadata_path_, "DiskS3", settings_->thread_pool_size)
+    : IDiskRemote(name_, s3_root_path_, metadata_disk_, "DiskS3", settings_->thread_pool_size)
     , bucket(std::move(bucket_))
     , current_settings(std::move(settings_))
     , settings_getter(settings_getter_)
@@ -218,8 +218,7 @@ void DiskS3::moveFile(const String & from_path, const String & to_path, bool sen
         };
         createFileOperationObject("rename", revision, object_metadata);
     }
-
-    fs::rename(fs::path(metadata_path) / from_path, fs::path(metadata_path) / to_path);
+    metadata_disk->moveFile(from_path, to_path);
 }
 
 std::unique_ptr<ReadBufferFromFileBase> DiskS3::readFile(const String & path, const ReadSettings & read_settings, std::optional<size_t>) const
@@ -228,7 +227,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskS3::readFile(const String & path, co
     auto metadata = readMeta(path);
 
     LOG_TRACE(log, "Read from file by path: {}. Existing S3 objects: {}",
-        backQuote(metadata_path + path), metadata.remote_fs_objects.size());
+        backQuote(metadata_disk->getPath() + path), metadata.remote_fs_objects.size());
 
     bool threadpool_read = read_settings.remote_fs_method == RemoteFSReadMethod::read_threadpool;
 
@@ -268,7 +267,7 @@ std::unique_ptr<WriteBufferFromFileBase> DiskS3::writeFile(const String & path, 
     }
 
     LOG_TRACE(log, "{} to file by path: {}. S3 path: {}",
-              mode == WriteMode::Rewrite ? "Write" : "Append", backQuote(metadata_path + path), remote_fs_root_path + s3_path);
+              mode == WriteMode::Rewrite ? "Write" : "Append", backQuote(metadata_disk->getPath() + path), remote_fs_root_path + s3_path);
 
     auto s3_buffer = std::make_unique<WriteBufferFromS3>(
         settings->client,
@@ -307,7 +306,7 @@ void DiskS3::createHardLink(const String & src_path, const String & dst_path, bo
     src.save();
 
     /// Create FS hardlink to metadata file.
-    DB::createHardLink(metadata_path + src_path, metadata_path + dst_path);
+    metadata_disk->createHardLink(src_path, dst_path);
 }
 
 void DiskS3::shutdown()
@@ -421,7 +420,7 @@ void DiskS3::updateObjectMetadata(const String & key, const ObjectMetadata & met
 
 void DiskS3::migrateFileToRestorableSchema(const String & path)
 {
-    LOG_TRACE(log, "Migrate file {} to restorable schema", metadata_path + path);
+    LOG_TRACE(log, "Migrate file {} to restorable schema", metadata_disk->getPath() + path);
 
     auto meta = readMeta(path);
 
@@ -438,7 +437,7 @@ void DiskS3::migrateToRestorableSchemaRecursive(const String & path, Futures & r
 {
     checkStackSize(); /// This is needed to prevent stack overflow in case of cyclic symlinks.
 
-    LOG_TRACE(log, "Migrate directory {} to restorable schema", metadata_path + path);
+    LOG_TRACE(log, "Migrate directory {} to restorable schema", metadata_disk->getPath() + path);
 
     bool dir_contains_only_files = true;
     for (auto it = iterateDirectory(path); it->isValid(); it->next())
@@ -702,18 +701,19 @@ struct DiskS3::RestoreInformation
 
 void DiskS3::readRestoreInformation(DiskS3::RestoreInformation & restore_information)
 {
-    ReadBufferFromFile buffer(metadata_path + RESTORE_FILE_NAME, 512);
-    buffer.next();
+    const ReadSettings read_settings;
+    auto buffer = metadata_disk->readFile(RESTORE_FILE_NAME, read_settings, 512);
+    buffer->next();
 
     try
     {
         std::map<String, String> properties;
 
-        while (buffer.hasPendingData())
+        while (buffer->hasPendingData())
         {
             String property;
-            readText(property, buffer);
-            assertChar('\n', buffer);
+            readText(property, *buffer);
+            assertChar('\n', *buffer);
 
             auto pos = property.find('=');
             if (pos == String::npos || pos == 0 || pos == property.length())
@@ -797,8 +797,7 @@ void DiskS3::restore()
         restoreFiles(information);
         restoreFileOperations(information);
 
-        fs::path restore_file = fs::path(metadata_path) / RESTORE_FILE_NAME;
-        fs::remove(restore_file);
+        metadata_disk->removeFile(RESTORE_FILE_NAME);
 
         saveSchemaVersion(RESTORABLE_SCHEMA_VERSION);
 
@@ -996,15 +995,15 @@ void DiskS3::restoreFileOperations(const RestoreInformation & restore_informatio
 
             LOG_TRACE(log, "Move directory to 'detached' {} -> {}", path, detached_path);
 
-            fs::path from_path = fs::path(metadata_path) / path;
-            fs::path to_path = fs::path(metadata_path) / detached_path;
+            fs::path from_path = fs::path(path);
+            fs::path to_path = fs::path(detached_path);
             if (path.ends_with('/'))
                 to_path /= from_path.parent_path().filename();
             else
                 to_path /= from_path.filename();
-            fs::create_directories(to_path);
-            fs::copy(from_path, to_path, fs::copy_options::recursive | fs::copy_options::overwrite_existing);
-            fs::remove_all(from_path);
+
+            metadata_disk->moveDirectory(from_path, to_path);
+            metadata_disk->createDirectory(from_path);
         }
     }
 
@@ -1044,9 +1043,9 @@ String DiskS3::pathToDetached(const String & source_path)
 void DiskS3::onFreeze(const String & path)
 {
     createDirectories(path);
-    WriteBufferFromFile revision_file_buf(metadata_path + path + "revision.txt", 32);
-    writeIntText(revision_counter.load(), revision_file_buf);
-    revision_file_buf.finalize();
+    auto revision_file_buf = metadata_disk->writeFile(path + "revision.txt", 32);
+    writeIntText(revision_counter.load(), *revision_file_buf);
+    revision_file_buf->finalize();
 }
 
 void DiskS3::applyNewSettings(const Poco::Util::AbstractConfiguration & config, ContextPtr context_, const String &, const DisksMap &)

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -1002,6 +1002,10 @@ void DiskS3::restoreFileOperations(const RestoreInformation & restore_informatio
             else
                 to_path /= from_path.filename();
 
+            /// to_path may exist and non-empty in case for example abrupt restart, so remove it before rename
+            if (metadata_disk->exists(to_path))
+                metadata_disk->removeRecursive(to_path);
+
             metadata_disk->moveDirectory(from_path, to_path);
         }
     }

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -68,7 +68,7 @@ public:
         String name_,
         String bucket_,
         String s3_root_path_,
-        String metadata_path_,
+        DiskPtr metadata_disk_,
         ContextPtr context_,
         SettingsPtr settings_,
         GetDiskSettings settings_getter_);

--- a/src/Disks/S3/registerDiskS3.cpp
+++ b/src/Disks/S3/registerDiskS3.cpp
@@ -17,7 +17,7 @@
 #include "ProxyListConfiguration.h"
 #include "ProxyResolverConfiguration.h"
 #include "Disks/DiskRestartProxy.h"
-
+#include "Disks/DiskLocal.h"
 
 namespace DB
 {
@@ -178,12 +178,13 @@ void registerDiskS3(DiskFactory & factory)
 
         String metadata_path = config.getString(config_prefix + ".metadata_path", context->getPath() + "disks/" + name + "/");
         fs::create_directories(metadata_path);
+        auto metadata_disk = std::make_shared<DiskLocal>(name + "-metadata", metadata_path, 0);
 
         std::shared_ptr<IDisk> s3disk = std::make_shared<DiskS3>(
             name,
             uri.bucket,
             uri.key,
-            metadata_path,
+            metadata_disk,
             context,
             getSettings(config, config_prefix, context),
             getSettings);


### PR DESCRIPTION
Changelog category (leave one):
- Improvement  

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use DiskPtr instead of OS's file system API in class IDiskRemote in order to get more extendiability. Closes #31117