### PR TITLE
Send incremental profile events to client

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -700,7 +700,7 @@ void ClientBase::onProfileEvents(Block & block)
         const auto & array_thread_id = typeid_cast<const ColumnUInt64 &>(*block.getByName("thread_id").column).getData();
         const auto & names = typeid_cast<const ColumnString &>(*block.getByName("name").column);
         const auto & host_names = typeid_cast<const ColumnString &>(*block.getByName("host_name").column);
-        const auto & array_values = typeid_cast<const ColumnUInt64 &>(*block.getByName("value").column).getData();
+        const auto & array_values = typeid_cast<const ColumnInt64 &>(*block.getByName("value").column).getData();
 
         const auto * user_time_name = ProfileEvents::getName(ProfileEvents::UserTimeMicroseconds);
         const auto * system_time_name = ProfileEvents::getName(ProfileEvents::SystemTimeMicroseconds);
@@ -727,7 +727,8 @@ void ClientBase::onProfileEvents(Block & block)
                 thread_times[host_name][thread_id].memory_usage = value;
             }
         }
-        progress_indication.updateThreadEventData(thread_times);
+        auto elapsed_time = profile_events.watch.elapsedMicroseconds();
+        progress_indication.updateThreadEventData(thread_times, elapsed_time);
     }
 
     if (profile_events.print)
@@ -739,7 +740,6 @@ void ClientBase::onProfileEvents(Block & block)
             logs_out_stream->writeProfileEvents(block);
             logs_out_stream->flush();
 
-            profile_events.watch.restart();
             profile_events.last_block = {};
         }
         else
@@ -747,6 +747,7 @@ void ClientBase::onProfileEvents(Block & block)
             profile_events.last_block = block;
         }
     }
+    profile_events.watch.restart();
 }
 
 

--- a/src/Client/InternalTextLogs.cpp
+++ b/src/Client/InternalTextLogs.cpp
@@ -105,7 +105,7 @@ void InternalTextLogs::writeProfileEvents(const Block & block)
     const auto & array_thread_id = typeid_cast<const ColumnUInt64 &>(*block.getByName("thread_id").column).getData();
     const auto & array_type = typeid_cast<const ColumnInt8 &>(*block.getByName("type").column).getData();
     const auto & column_name = typeid_cast<const ColumnString &>(*block.getByName("name").column);
-    const auto & array_value = typeid_cast<const ColumnUInt64 &>(*block.getByName("value").column).getData();
+    const auto & array_value = typeid_cast<const ColumnInt64 &>(*block.getByName("value").column).getData();
 
     for (size_t row_num = 0; row_num < block.rows(); ++row_num)
     {
@@ -146,7 +146,7 @@ void InternalTextLogs::writeProfileEvents(const Block & block)
         writeCString(": ", wb);
 
         /// value
-        UInt64 value = array_value[row_num];
+        Int64 value = array_value[row_num];
         writeIntText(value, wb);
 
         //// type

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -358,10 +358,6 @@ void increment(Event event, Count amount)
     DB::CurrentThread::getProfileEvents().increment(event, amount);
 }
 
-CountersIncrement::CountersIncrement() noexcept
-    : increment_holder()
-{}
-
 CountersIncrement::CountersIncrement(Counters::Snapshot const & snapshot)
 {
     init();

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -317,6 +317,20 @@ Counters::Snapshot::Snapshot()
     : counters_holder(new Count[num_counters] {})
 {}
 
+Counters::Snapshot::Snapshot(Counters::Snapshot const & other)
+    : Counters::Snapshot()
+{
+    std::memcpy(other.counters_holder.get(), counters_holder.get(), num_counters * sizeof(Count));
+}
+
+Counters::Snapshot operator-(Counters::Snapshot const & lhs, Counters::Snapshot const & rhs)
+{
+    Counters::Snapshot result;
+    for (Event i = 0; i < Counters::num_counters; ++i)
+        result.counters_holder[i] = lhs[i] - rhs[i];
+    return result;
+}
+
 Counters::Snapshot Counters::getPartiallyAtomicSnapshot() const
 {
     Snapshot res;

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/VariableContext.h>
+#include "base/types.h"
 #include <atomic>
 #include <memory>
 #include <stddef.h>
@@ -15,6 +16,7 @@ namespace ProfileEvents
     /// Event identifier (index in array).
     using Event = size_t;
     using Count = size_t;
+    using Increment = Int64;
     using Counter = std::atomic<Count>;
     class Counters;
 
@@ -62,22 +64,19 @@ namespace ProfileEvents
         struct Snapshot
         {
             Snapshot();
-            Snapshot(Snapshot const & other);
             Snapshot(Snapshot &&) = default;
 
-            const Count & operator[] (Event event) const
+            Count operator[] (Event event) const noexcept
             {
                 return counters_holder[event];
             }
 
             Snapshot & operator=(Snapshot &&) = default;
-
-            friend Snapshot operator-(Snapshot const & lhs, Snapshot const & rhs);
-
         private:
             std::unique_ptr<Count[]> counters_holder;
 
             friend class Counters;
+            friend struct CountersIncrement;
         };
 
         /// Every single value is fetched atomically, but not all values as a whole.
@@ -115,4 +114,25 @@ namespace ProfileEvents
 
     /// Get index just after last event identifier.
     Event end();
+
+    struct CountersIncrement
+    {
+        CountersIncrement() noexcept;
+        explicit CountersIncrement(Counters::Snapshot const & snapshot);
+        CountersIncrement(Counters::Snapshot const & after, Counters::Snapshot const & before);
+
+        CountersIncrement(CountersIncrement &&) = default;
+        CountersIncrement & operator=(CountersIncrement &&) = default;
+
+        Increment operator[](Event event) const noexcept
+        {
+            return increment_holder[event];
+        }
+    private:
+        void init();
+
+        static_assert(sizeof(Count) == sizeof(Increment), "Sizes of counter and increment differ");
+
+        std::unique_ptr<Increment[]> increment_holder;
+    };
 }

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -62,11 +62,17 @@ namespace ProfileEvents
         struct Snapshot
         {
             Snapshot();
+            Snapshot(Snapshot const & other);
+            Snapshot(Snapshot &&) = default;
 
             const Count & operator[] (Event event) const
             {
                 return counters_holder[event];
             }
+
+            Snapshot & operator=(Snapshot &&) = default;
+
+            friend Snapshot operator-(Snapshot const & lhs, Snapshot const & rhs);
 
         private:
             std::unique_ptr<Count[]> counters_holder;

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -117,7 +117,7 @@ namespace ProfileEvents
 
     struct CountersIncrement
     {
-        CountersIncrement() noexcept;
+        CountersIncrement() noexcept = default;
         explicit CountersIncrement(Counters::Snapshot const & snapshot);
         CountersIncrement(Counters::Snapshot const & after, Counters::Snapshot const & before);
 

--- a/src/Common/ProgressIndication.h
+++ b/src/Common/ProgressIndication.h
@@ -16,11 +16,11 @@ namespace DB
 
 struct ThreadEventData
 {
-    UInt64 time() const noexcept { return user_ms + system_ms; }
+    Int64 time() const noexcept { return user_ms + system_ms; }
 
-    UInt64 user_ms      = 0;
-    UInt64 system_ms    = 0;
-    UInt64 memory_usage = 0;
+    Int64 user_ms      = 0;
+    Int64 system_ms    = 0;
+    Int64 memory_usage = 0;
 };
 
 using ThreadIdToTimeMap = std::unordered_map<UInt64, ThreadEventData>;
@@ -58,7 +58,7 @@ public:
 
     void addThreadIdToList(String const & host, UInt64 thread_id);
 
-    void updateThreadEventData(HostToThreadTimesMap & new_thread_data);
+    void updateThreadEventData(HostToThreadTimesMap & new_thread_data, UInt64 elapsed_time);
 
     bool print_hardware_utilization = false;
 

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -38,7 +38,7 @@
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_DISTRIBUTED_DEPTH 54448
 
-#define DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS 54450
+#define DBMS_MIN_PROTOCOL_VERSION_WITH_INCREMENTAL_PROFILE_EVENTS 54451
 
 /// Version of ClickHouse TCP protocol.
 ///
@@ -47,6 +47,6 @@
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-#define DBMS_TCP_PROTOCOL_VERSION 54450
+#define DBMS_TCP_PROTOCOL_VERSION 54451
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME 54449

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -249,7 +249,7 @@ void TCPHandler::runImpl()
                     sendLogs();
                 });
             }
-            if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS)
+            if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_INCREMENTAL_PROFILE_EVENTS)
             {
                 state.profile_queue = std::make_shared<InternalProfileEventsQueue>(std::numeric_limits<int>::max());
                 CurrentThread::attachInternalProfileEventsQueue(state.profile_queue);
@@ -901,7 +901,7 @@ namespace
 
 void TCPHandler::sendProfileEvents()
 {
-    if (client_tcp_protocol_version < DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS)
+    if (client_tcp_protocol_version < DBMS_MIN_PROTOCOL_VERSION_WITH_INCREMENTAL_PROFILE_EVENTS)
         return;
 
     NamesAndTypesList column_names_and_types = {

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -3,6 +3,7 @@
 #include <Poco/Net/TCPServerConnection.h>
 
 #include <base/getFQDNOrHostName.h>
+#include "Common/ProfileEvents.h"
 #include <Common/CurrentMetrics.h>
 #include <Common/Stopwatch.h>
 #include <Core/Protocol.h>
@@ -15,6 +16,7 @@
 #include <Formats/NativeReader.h>
 
 #include "IServer.h"
+#include "base/types.h"
 
 
 namespace CurrentMetrics
@@ -181,6 +183,10 @@ private:
     LastBlockInputParameters last_block_in;
 
     CurrentMetrics::Increment metric_increment{CurrentMetrics::TCPConnection};
+
+    using ThreadIdToCountersSnapshot = std::unordered_map<UInt64, ProfileEvents::Counters::Snapshot>;
+
+    ThreadIdToCountersSnapshot last_sent_snapshots;
 
     /// It is the name of the server that will be sent to the client.
     String server_display_name;


### PR DESCRIPTION
Changelog category (leave one):

- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Now every replica will send to client only incremental information about profile events counters.