### PR TITLE
apply cgroup memory limit to physical memory amount

### DIFF
--- a/base/base/getMemoryAmount.cpp
+++ b/base/base/getMemoryAmount.cpp
@@ -16,17 +16,6 @@
   */
 uint64_t getMemoryAmountOrZero()
 {
-#if defined(OS_LINUX)
-    // Try to lookup at the Cgroup limit
-    std::ifstream cgroup_limit("/sys/fs/cgroup/memory/memory.limit_in_bytes");
-    if (cgroup_limit.is_open())
-    {
-        uint64_t amount = 0; // in case of read error
-        cgroup_limit >> amount;
-        return amount;
-    }
-#endif
-
     int64_t num_pages = sysconf(_SC_PHYS_PAGES);
     if (num_pages <= 0)
         return 0;
@@ -35,7 +24,22 @@ uint64_t getMemoryAmountOrZero()
     if (page_size <= 0)
         return 0;
 
-    return num_pages * page_size;
+    uint64_t memory_amount = num_pages * page_size;
+
+#if defined(OS_LINUX)
+    // Try to lookup at the Cgroup limit
+    std::ifstream cgroup_limit("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+    if (cgroup_limit.is_open())
+    {
+        int64_t memory_limit = 0; // in case of read error
+        cgroup_limit >> memory_limit;
+        if (memory_limit > 0 && memory_limit < memory_amount)
+            memory_amount = memory_limit;
+    }
+#endif
+
+    return memory_amount;
+
 }
 
 

--- a/base/base/getMemoryAmount.cpp
+++ b/base/base/getMemoryAmount.cpp
@@ -31,7 +31,7 @@ uint64_t getMemoryAmountOrZero()
     std::ifstream cgroup_limit("/sys/fs/cgroup/memory/memory.limit_in_bytes");
     if (cgroup_limit.is_open())
     {
-        int64_t memory_limit = 0; // in case of read error
+        uint64_t memory_limit = 0; // in case of read error
         cgroup_limit >> memory_limit;
         if (memory_limit > 0 && memory_limit < memory_amount)
             memory_amount = memory_limit;


### PR DESCRIPTION
... after obtaining the memory amount, in order to return not greater
than the physical memory from `getMemoryAmount()`

Additionally reading the memory limit as a singned int64_t, since
there is no guarantie the setting file contains non-negative value.

See issue #25662

Improvement for  pull request #30574


Changelog category (leave one):
- Bug Fix

Changelog entry:
Memory amount was incorrectly estimated when ClickHouse is run in containers with cgroup limits.
