### PR TITLE
correct disk space calculations

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -206,8 +206,8 @@ static void getNoSpaceLeftInfoMessage(std::filesystem::path path, String & msg)
 
     fmt::format_to(std::back_inserter(msg),
         "\nTotal space: {}\nAvailable space: {}\nTotal inodes: {}\nAvailable inodes: {}\nMount point: {}",
-        ReadableSize(fs.f_blocks * fs.f_bsize),
-        ReadableSize(fs.f_bavail * fs.f_bsize),
+        ReadableSize(fs.f_blocks * fs.f_frsize),
+        ReadableSize(fs.f_bavail * fs.f_frsize),
         formatReadableQuantity(fs.f_files),
         formatReadableQuantity(fs.f_favail),
         mount_point);

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -172,7 +172,7 @@ UInt64 DiskLocal::getTotalSpace() const
         fs = getStatVFS((fs::path(disk_path) / "data/").string());
     else
         fs = getStatVFS(disk_path);
-    UInt64 total_size = fs.f_blocks * fs.f_bsize;
+    UInt64 total_size = fs.f_blocks * fs.f_frsize;
     if (total_size < keep_free_space_bytes)
         return 0;
     return total_size - keep_free_space_bytes;
@@ -187,7 +187,7 @@ UInt64 DiskLocal::getAvailableSpace() const
         fs = getStatVFS((fs::path(disk_path) / "data/").string());
     else
         fs = getStatVFS(disk_path);
-    UInt64 total_size = fs.f_bavail * fs.f_bsize;
+    UInt64 total_size = fs.f_bavail * fs.f_frsize;
     if (total_size < keep_free_space_bytes)
         return 0;
     return total_size - keep_free_space_bytes;

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1222,9 +1222,9 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
     {
         auto stat = getStatVFS(getContext()->getPath());
 
-        new_values["FilesystemMainPathTotalBytes"] = stat.f_blocks * stat.f_bsize;
-        new_values["FilesystemMainPathAvailableBytes"] = stat.f_bavail * stat.f_bsize;
-        new_values["FilesystemMainPathUsedBytes"] = (stat.f_blocks - stat.f_bavail) * stat.f_bsize;
+        new_values["FilesystemMainPathTotalBytes"] = stat.f_blocks * stat.f_frsize;
+        new_values["FilesystemMainPathAvailableBytes"] = stat.f_bavail * stat.f_frsize;
+        new_values["FilesystemMainPathUsedBytes"] = (stat.f_blocks - stat.f_bavail) * stat.f_frsize;
         new_values["FilesystemMainPathTotalINodes"] = stat.f_files;
         new_values["FilesystemMainPathAvailableINodes"] = stat.f_favail;
         new_values["FilesystemMainPathUsedINodes"] = stat.f_files - stat.f_favail;
@@ -1234,9 +1234,9 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
         /// Current working directory of the server is the directory with logs.
         auto stat = getStatVFS(".");
 
-        new_values["FilesystemLogsPathTotalBytes"] = stat.f_blocks * stat.f_bsize;
-        new_values["FilesystemLogsPathAvailableBytes"] = stat.f_bavail * stat.f_bsize;
-        new_values["FilesystemLogsPathUsedBytes"] = (stat.f_blocks - stat.f_bavail) * stat.f_bsize;
+        new_values["FilesystemLogsPathTotalBytes"] = stat.f_blocks * stat.f_frsize;
+        new_values["FilesystemLogsPathAvailableBytes"] = stat.f_bavail * stat.f_frsize;
+        new_values["FilesystemLogsPathUsedBytes"] = (stat.f_blocks - stat.f_bavail) * stat.f_frsize;
         new_values["FilesystemLogsPathTotalINodes"] = stat.f_files;
         new_values["FilesystemLogsPathAvailableINodes"] = stat.f_favail;
         new_values["FilesystemLogsPathUsedINodes"] = stat.f_files - stat.f_favail;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
Long story short: clickhouse thinks that I have a lot of space on my disks:
```
snar@elephantti:~>tail -f /var/log/clickhouse/clickhouse-server.log | grep -i reserve
2021.11.07 20:10:41.448788 [ 101179 ] {} <Debug> DiskLocal: Reserving 1.00 MiB on disk `default`, having unreserved 215.70 TiB.
2021.11.07 20:10:42.037239 [ 101181 ] {} <Debug> DiskLocal: Reserving 11.79 MiB on disk `default`, having unreserved 215.70 TiB.
```
but this is clearly not true, because I have only 2Tb here (and only 1Tb free):
```
snar@elephantti:~>df -H /var/db/clickhouse 
Filesystem            Size    Used   Avail Capacity  Mounted on
zroot/ROOT/default    1.9T    978G    926G    51%    /
```
Environment: FreeBSD 11 (the same behaviour on FreeBSD 13), filesystem: ZFS (tested with UFS too).

Root cause: clickhouse uses statvfs f_bsize as block size instead of f_frsize.
[FreeBSD documentation](https://www.freebsd.org/cgi/man.cgi?query=statvfs&apropos=0&sektion=0&manpath=FreeBSD+13.0-RELEASE&arch=default&format=html) clearly says that:

f_bsize is The preferred length of I/O requests for files on this file system.
(Corresponds to the f_iosize member of struct statfs.)

f_frsize The size in bytes of the minimum unit of allocation on this file system.	 (This corresponds to the f_bsize member of struct statfs.)

[Linux documentation](https://man7.org/linux/man-pages/man3/statvfs.3.html) is not verbose on this topic and it is not clear what is block and what is fragment here.
However, [first google result](https://stackoverflow.com/questions/54823541/what-do-f-bsize-and-f-frsize-in-struct-statvfs-stand-for) suggests that f_frsize shall be used on Linux to be compatible with space calculations on macOS.

