### PR TITLE
Optimize `mapContains` to reading of subcolumn

### DIFF
--- a/tests/queries/0_stateless/02115_map_contains.reference
+++ b/tests/queries/0_stateless/02115_map_contains.reference
@@ -1,0 +1,4 @@
+SELECT has(`m.keys`, \'a\')
+FROM t_map_contains
+1
+0

--- a/tests/queries/0_stateless/02115_map_contains.sql
+++ b/tests/queries/0_stateless/02115_map_contains.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS t_map_contains;
+
+CREATE TABLE t_map_contains (m Map(String, UInt32)) ENGINE = Memory;
+
+INSERT INTO t_map_contains VALUES (map('a', 1, 'b', 2)), (map('c', 3, 'd', 4));
+
+SET optimize_functions_to_subcolumns = 1;
+
+EXPLAIN SYNTAX SELECT mapContains(m, 'a') FROM t_map_contains;
+SELECT mapContains(m, 'a') FROM t_map_contains;
+
+DROP TABLE t_map_contains;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize function `mapContains` to reading of subcolumn `key` with enabled settings `optimize_functions_to_subcolumns`.
