### PR TITLE
Rename setting value read_threadpool to threadpool

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -508,7 +508,7 @@ class IColumn;
     M(ShortCircuitFunctionEvaluation, short_circuit_function_evaluation, ShortCircuitFunctionEvaluation::ENABLE, "Setting for short-circuit function evaluation configuration. Possible values: 'enable' - use short-circuit function evaluation for functions that are suitable for it, 'disable' - disable short-circuit function evaluation, 'force_enable' - use short-circuit function evaluation for all functions.", 0) \
     \
     M(String, local_filesystem_read_method, "pread", "Method of reading data from local filesystem, one of: read, pread, mmap, pread_threadpool.", 0) \
-    M(String, remote_filesystem_read_method, "read", "Method of reading data from remote filesystem, one of: read, read_threadpool.", 0) \
+    M(String, remote_filesystem_read_method, "read", "Method of reading data from remote filesystem, one of: read, threadpool.", 0) \
     M(Bool, local_filesystem_read_prefetch, false, "Should use prefetching when reading data from local filesystem.", 0) \
     M(Bool, remote_filesystem_read_prefetch, true, "Should use prefetching when reading data from remote filesystem.", 0) \
     M(Int64, read_priority, 0, "Priority to read data from local filesystem. Only supported for 'pread_threadpool' method.", 0) \

--- a/src/Disks/DiskWebServer.cpp
+++ b/src/Disks/DiskWebServer.cpp
@@ -166,7 +166,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskWebServer::readFile(const String & p
     RemoteMetadata meta(path, remote_path);
     meta.remote_fs_objects.emplace_back(std::make_pair(remote_path, iter->second.size));
 
-    bool threadpool_read = read_settings.remote_fs_method == RemoteFSReadMethod::read_threadpool;
+    bool threadpool_read = read_settings.remote_fs_method == RemoteFSReadMethod::threadpool;
 
     auto web_impl = std::make_unique<ReadBufferFromWebServerGather>(path, url, meta, getContext(), threadpool_read, read_settings);
 

--- a/src/Disks/HDFS/DiskHDFS.cpp
+++ b/src/Disks/HDFS/DiskHDFS.cpp
@@ -77,7 +77,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskHDFS::readFile(const String & path, 
 
     auto hdfs_impl = std::make_unique<ReadBufferFromHDFSGather>(path, config, remote_fs_root_path, metadata, read_settings.remote_fs_buffer_size);
 
-    if (read_settings.remote_fs_method == RemoteFSReadMethod::read_threadpool)
+    if (read_settings.remote_fs_method == RemoteFSReadMethod::threadpool)
     {
         auto reader = getThreadPoolReader();
         return std::make_unique<AsynchronousReadIndirectBufferFromRemoteFS>(reader, read_settings, std::move(hdfs_impl));

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -230,7 +230,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskS3::readFile(const String & path, co
     LOG_TRACE(log, "Read from file by path: {}. Existing S3 objects: {}",
         backQuote(metadata_path + path), metadata.remote_fs_objects.size());
 
-    bool threadpool_read = read_settings.remote_fs_method == RemoteFSReadMethod::read_threadpool;
+    bool threadpool_read = read_settings.remote_fs_method == RemoteFSReadMethod::threadpool;
 
     auto s3_impl = std::make_unique<ReadBufferFromS3Gather>(
         path,

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -170,7 +170,7 @@ std::unique_ptr<ReadBuffer> ReadBufferFromS3::initialize()
     req.SetKey(key);
 
     /**
-     * If remote_filesystem_read_method = 'read_threadpool', then for MergeTree family tables
+     * If remote_filesystem_read_method = 'threadpool', then for MergeTree family tables
      * exact byte ranges to read are always passed here.
      */
     if (read_until_position)

--- a/src/IO/ReadSettings.h
+++ b/src/IO/ReadSettings.h
@@ -46,7 +46,7 @@ enum class LocalFSReadMethod
 enum class RemoteFSReadMethod
 {
     read,
-    read_threadpool,
+    threadpool,
 };
 
 class MMappedFileCache;

--- a/tests/integration/test_disk_over_web_server/configs/async_read.xml
+++ b/tests/integration/test_disk_over_web_server/configs/async_read.xml
@@ -1,7 +1,7 @@
 <yandex>
     <profiles>
         <default>
-            <remote_filesystem_read_method>read_threadpool</remote_filesystem_read_method>
+            <remote_filesystem_read_method>threadpool</remote_filesystem_read_method>
         </default>
     </profiles>
 </yandex>

--- a/tests/integration/test_merge_tree_s3/configs/config.d/async_read.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.d/async_read.xml
@@ -1,7 +1,7 @@
 <yandex>
     <profiles>
         <default>
-            <remote_filesystem_read_method>read_threadpool</remote_filesystem_read_method>
+            <remote_filesystem_read_method>threadpool</remote_filesystem_read_method>
         </default>
     </profiles>
 </yandex>


### PR DESCRIPTION
Changelog category (leave one):
- Imrovement (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Rename setting value `read_threadpool` to `threadpool` for setting `remote_filesystem_read_method`

