### PR TITLE
Fix typo in USE_MYSQL check

### DIFF
--- a/src/Interpreters/InterpreterExternalDDLQuery.cpp
+++ b/src/Interpreters/InterpreterExternalDDLQuery.cpp
@@ -9,7 +9,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTExternalDDLQuery.h>
 
-#ifdef USE_MYSQL
+#if USE_MYSQL
 #    include <Interpreters/MySQL/InterpretersMySQLDDLQuery.h>
 #    include <Parsers/MySQL/ASTAlterQuery.h>
 #    include <Parsers/MySQL/ASTCreateQuery.h>
@@ -38,7 +38,7 @@ BlockIO InterpreterExternalDDLQuery::execute()
 
     if (external_ddl_query.from->name == "MySQL")
     {
-#ifdef USE_MYSQL
+#if USE_MYSQL
         const ASTs & arguments = external_ddl_query.from->arguments->children;
 
         if (arguments.size() != 2 || !arguments[0]->as<ASTIdentifier>() || !arguments[1]->as<ASTIdentifier>())

--- a/src/Parsers/ParserExternalDDLQuery.cpp
+++ b/src/Parsers/ParserExternalDDLQuery.cpp
@@ -7,7 +7,7 @@
 #include <Parsers/ParserDropQuery.h>
 #include <Parsers/ParserRenameQuery.h>
 
-#ifdef USE_MYSQL
+#if USE_MYSQL
 #    include <Parsers/MySQL/ASTAlterQuery.h>
 #    include <Parsers/MySQL/ASTCreateQuery.h>
 #endif
@@ -15,7 +15,7 @@
 namespace DB
 {
 
-#ifdef USE_MYSQL
+#if USE_MYSQL
 namespace ErrorCodes
 {
     extern const int MYSQL_SYNTAX_ERROR;
@@ -41,7 +41,7 @@ bool ParserExternalDDLQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expect
     bool res = false;
     if (external_ddl_query->from->name == "MySQL")
     {
-#ifdef USE_MYSQL
+#if USE_MYSQL
         ParserDropQuery p_drop_query;
         ParserRenameQuery p_rename_query;
         MySQLParser::ParserAlterQuery p_alter_query;


### PR DESCRIPTION
USE_MYSQL is always defined and set to either 0 or 1 via cmake pregenerated `config_core.h`.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)