### PR TITLE
Disable fuzzer builds in CI

### DIFF
--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -81,11 +81,11 @@ then
 fi
 
 # Also build fuzzers if any sanitizer specified
-if [ -n "$SANITIZER" ]
-then
-  # Currently we are in build/build_docker directory
-  ../docker/packager/other/fuzzer.sh
-fi
+# if [ -n "$SANITIZER" ]
+# then
+#   # Currently we are in build/build_docker directory
+#   ../docker/packager/other/fuzzer.sh
+# fi
 
 ccache --show-config ||:
 ccache --show-stats ||:

--- a/docker/packager/deb/build.sh
+++ b/docker/packager/deb/build.sh
@@ -31,15 +31,15 @@ then
 fi
 
 # Also build fuzzers if any sanitizer specified
-if [ -n "$SANITIZER" ]
-then
-  # Script is supposed that we are in build directory.
-  mkdir -p build/build_docker
-  cd build/build_docker
-  # Launching build script
-  ../docker/packager/other/fuzzer.sh
-  cd
-fi
+# if [ -n "$SANITIZER" ]
+# then
+#   # Script is supposed that we are in build directory.
+#   mkdir -p build/build_docker
+#   cd build/build_docker
+#   # Launching build script
+#   ../docker/packager/other/fuzzer.sh
+#   cd
+# fi
 
 ccache --show-config ||:
 ccache --show-stats ||:


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Because it flushes the ccache