### PR TITLE
move InputCreatorFunc to InputCreator

### DIFF
--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -68,13 +68,11 @@ public:
         size_t row)>;
 
 private:
-    using InputCreatorFunc = InputFormatPtr(
-        ReadBuffer & buf,
-        const Block & header,
-        const RowInputFormatParams & params,
-        const FormatSettings & settings);
-
-    using InputCreator = std::function<InputCreatorFunc>;
+    using InputCreator = std::function<InputFormatPtr(
+            ReadBuffer & buf,
+            const Block & header,
+            const RowInputFormatParams & params,
+            const FormatSettings & settings)>;
 
     using OutputCreator = std::function<OutputFormatPtr(
             WriteBuffer & buf,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
In src/Formats/FormatFactory.h, the code of InputCreator and OutputCreator have some difference, we first get InputCreatorFunc, then get InputCreator, but we directly get OutputCreator. I think it might be confusing for beginners looking at the code for the first time, so I wanted to make it uniform.


