### PR TITLE
Initial user's roles are used now to find row policies

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -6,11 +6,13 @@
 #include <Access/DiskAccessStorage.h>
 #include <Access/LDAPAccessStorage.h>
 #include <Access/ContextAccess.h>
+#include <Access/EnabledRolesInfo.h>
 #include <Access/RoleCache.h>
 #include <Access/RowPolicyCache.h>
 #include <Access/QuotaCache.h>
 #include <Access/QuotaUsage.h>
 #include <Access/SettingsProfilesCache.h>
+#include <Access/User.h>
 #include <Access/ExternalAuthenticators.h>
 #include <Core/Settings.h>
 #include <base/find_symbols.h>
@@ -481,6 +483,16 @@ std::shared_ptr<const EnabledRoles> AccessControl::getEnabledRoles(
 std::shared_ptr<const EnabledRowPolicies> AccessControl::getEnabledRowPolicies(const UUID & user_id, const boost::container::flat_set<UUID> & enabled_roles) const
 {
     return row_policy_cache->getEnabledRowPolicies(user_id, enabled_roles);
+}
+
+
+std::shared_ptr<const EnabledRowPolicies> AccessControl::tryGetDefaultRowPolicies(const UUID & user_id) const
+{
+    auto user = tryRead<User>(user_id);
+    if (!user)
+        return nullptr;
+    auto default_roles = getEnabledRoles(user->granted_roles.findGranted(user->default_roles), {})->getRolesInfo()->enabled_roles;
+    return getEnabledRowPolicies(user_id, default_roles);
 }
 
 

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -133,6 +133,8 @@ public:
         const UUID & user_id,
         const boost::container::flat_set<UUID> & enabled_roles) const;
 
+    std::shared_ptr<const EnabledRowPolicies> tryGetDefaultRowPolicies(const UUID & user_id) const;
+
     std::shared_ptr<const EnabledQuota> getEnabledQuota(
         const UUID & user_id,
         const String & user_name,

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -782,7 +782,7 @@ void Context::setInitialRowPolicy()
     auto initial_user_id = getAccessControl().find<User>(client_info.initial_user);
     if (!initial_user_id)
         return;
-    initial_row_policy = getAccessControl().getEnabledRowPolicies(*initial_user_id, {});
+    initial_row_policy = getAccessControl().tryGetDefaultRowPolicies(*initial_user_id);
 }
 
 

--- a/tests/integration/test_row_policy/test.py
+++ b/tests/integration/test_row_policy/test.py
@@ -437,3 +437,23 @@ def test_miscellaneous_engines():
     node.query("CREATE TABLE mydb.other_table (a UInt8, b UInt8) ENGINE Distributed('test_local_cluster', mydb, local)")
     assert node.query("SELECT * FROM mydb.other_table", user="another") == TSV([[1, 0], [1, 1], [1, 0], [1, 1]])
     assert node.query("SELECT sum(a), b FROM mydb.other_table GROUP BY b ORDER BY b", user="another") == TSV([[2, 0], [2, 1]])
+
+
+def test_policy_on_distributed_table_via_role():
+    node.query("DROP TABLE IF EXISTS local_tbl")
+    node.query("DROP TABLE IF EXISTS dist_tbl")
+
+    node.query("CREATE TABLE local_tbl engine=MergeTree ORDER BY tuple() as select * FROM numbers(10)")
+    node.query("CREATE TABLE dist_tbl ENGINE=Distributed( 'test_cluster_two_shards_localhost', default, local_tbl) AS local_tbl")
+
+    node.query("CREATE ROLE OR REPLACE 'role1'")
+    node.query("CREATE USER OR REPLACE 'user1' DEFAULT ROLE 'role1'")
+
+    node.query("GRANT SELECT ON dist_tbl TO 'role1'")
+    node.query("GRANT SELECT ON local_tbl TO 'role1'")
+
+    node.query("CREATE ROW POLICY OR REPLACE 'all_data' ON dist_tbl, local_tbl USING 1 TO ALL EXCEPT 'role1'")
+    node.query("CREATE ROW POLICY OR REPLACE 'role1_data' ON dist_tbl, local_tbl USING number % 2 = 0 TO 'role1'")
+
+    assert node.query("SELECT * FROM local_tbl SETTINGS prefer_localhost_replica=0", user="user1") == TSV([[0], [2], [4], [6], [8]])
+    assert node.query("SELECT * FROM dist_tbl SETTINGS prefer_localhost_replica=0", user="user1") == TSV([[0], [2], [4], [6], [8], [0], [2], [4], [6], [8]])


### PR DESCRIPTION
Changelog category:
- Improvement

Changelog entry:
Initial user's roles are used now to find row policies, see https://github.com/ClickHouse/ClickHouse/issues/31080

**Details:**

There are two modes: 1. when the interserver secret is not defined in the cluster's definition and 2. when it's defined.

1) When the interserver secret is not defined then while we're executing a distributed query on a shard we use row policies from both the initial user and the current user (the current user is defined in cluster's definition). And the row policy can be assigned to an user itself or to one of its roles.

|                     | row policy assigned to user | row policy assigned to user's role                                     |
|------------------|-------------------------------------|----------------------------------------------------------------------------|
| current user | filter applied                        | filter applied                                                                       |
| initial user    | filter applied                        | filter not applied (before this PR) / applied (after this PR) |

2) When the interserver secret is defined the initial user is used instead of the current user, and the current user is not used at all.

|                  | row policy assigned to user | row policy assigned to user's role |
|---------------|--------------------------------------|----------------------------------------------|
| initial user | filter applied                         | filter applied                                   |
