### PR TITLE
Expose all GlobalThreadPool config params

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -763,6 +763,42 @@ Default value: 10000.
 <max_thread_pool_size>12000</max_thread_pool_size>
 ```
 
+## max_thread_pool_free_size {#max-thread-pool-free-size}
+
+The number of threads that are free in the Global Thread pool.
+
+Default value: 1000.
+
+**Example**
+
+``` xml
+<max_thread_pool_free_size>1200</max_thread_pool_free_size>
+```
+
+## thread_pool_queue_size {#thread-pool-queue-size}
+
+The limit to the number of jobs that can be scheduled on the Global Thread pool.
+
+Default value: 10000.
+
+**Example**
+
+``` xml
+<thread_pool_queue_size>12000</thread_pool_queue_size>
+```
+
+## thread_pool_shutdown_on_exception {#thread-pool-shutdown-on-exception}
+
+The flag deciding if the thread pool should shutdown on exception.
+
+Default value: false.
+
+**Example**
+
+``` xml
+<thread_pool_shutdown_on_exception>true</thread_pool_shutdown_on_exception>
+```
+
 ## merge_tree {#server_configuration_parameters-merge_tree}
 
 Fine tuning for tables in the [MergeTree](../../engines/table-engines/mergetree-family/mergetree.md).

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -765,7 +765,7 @@ Default value: 10000.
 
 ## max_thread_pool_free_size {#max-thread-pool-free-size}
 
-The number of threads that are free in the Global Thread pool.
+The number of threads that are always held in the Global Thread pool.
 
 Default value: 1000.
 
@@ -777,7 +777,7 @@ Default value: 1000.
 
 ## thread_pool_queue_size {#thread-pool-queue-size}
 
-The limit to the number of jobs that can be scheduled on the Global Thread pool.
+The limit to the number of jobs that can be scheduled on the Global Thread pool. Increasing queue size leads to larger memory usage. It is recommended to keep this value equal to the `max_thread_pool_size`.
 
 Default value: 10000.
 
@@ -785,18 +785,6 @@ Default value: 10000.
 
 ``` xml
 <thread_pool_queue_size>12000</thread_pool_queue_size>
-```
-
-## thread_pool_shutdown_on_exception {#thread-pool-shutdown-on-exception}
-
-The flag deciding if the thread pool should shutdown on exception.
-
-Default value: false.
-
-**Example**
-
-``` xml
-<thread_pool_shutdown_on_exception>true</thread_pool_shutdown_on_exception>
 ```
 
 ## merge_tree {#server_configuration_parameters-merge_tree}

--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -334,7 +334,12 @@ int Keeper::main(const std::vector<std::string> & /*args*/)
 
     std::string include_from_path = config().getString("include_from", "/etc/metrika.xml");
 
-    GlobalThreadPool::initialize(config().getUInt("max_thread_pool_size", 100));
+    GlobalThreadPool::initialize(
+        config().getUInt("max_thread_pool_size", 100),
+        config().getUInt("max_thread_pool_free_size", 1000),
+        config().getUInt("thread_pool_queue_size", 10000),
+        config().getBool("thread_pool_shutdown_on_exception", false)
+    );
 
     static ServerErrorHandler error_handler;
     Poco::ErrorHandler::set(&error_handler);

--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -337,8 +337,7 @@ int Keeper::main(const std::vector<std::string> & /*args*/)
     GlobalThreadPool::initialize(
         config().getUInt("max_thread_pool_size", 100),
         config().getUInt("max_thread_pool_free_size", 1000),
-        config().getUInt("thread_pool_queue_size", 10000),
-        config().getBool("thread_pool_shutdown_on_exception", false)
+        config().getUInt("thread_pool_queue_size", 10000)
     );
 
     static ServerErrorHandler error_handler;

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -513,7 +513,12 @@ if (ThreadFuzzer::instance().isEffective())
     // Initialize global thread pool. Do it before we fetch configs from zookeeper
     // nodes (`from_zk`), because ZooKeeper interface uses the pool. We will
     // ignore `max_thread_pool_size` in configs we fetch from ZK, but oh well.
-    GlobalThreadPool::initialize(config().getUInt("max_thread_pool_size", 10000));
+    GlobalThreadPool::initialize(
+        config().getUInt("max_thread_pool_size", 10000),
+        config().getUInt("max_thread_pool_free_size", 1000),
+        config().getUInt("thread_pool_queue_size", 10000),
+        config().getBool("thread_pool_shutdown_on_exception", false)
+    );
 
     ConnectionCollector::init(global_context, config().getUInt("max_threads_for_connection_collector", 10));
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -516,8 +516,7 @@ if (ThreadFuzzer::instance().isEffective())
     GlobalThreadPool::initialize(
         config().getUInt("max_thread_pool_size", 10000),
         config().getUInt("max_thread_pool_free_size", 1000),
-        config().getUInt("thread_pool_queue_size", 10000),
-        config().getBool("thread_pool_shutdown_on_exception", false)
+        config().getUInt("thread_pool_queue_size", 10000)
     );
 
     ConnectionCollector::init(global_context, config().getUInt("max_threads_for_connection_collector", 10));

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -320,7 +320,7 @@ template class ThreadPoolImpl<ThreadFromGlobalPool>;
 
 std::unique_ptr<GlobalThreadPool> GlobalThreadPool::the_instance;
 
-void GlobalThreadPool::initialize(size_t max_threads, size_t max_free_threads, size_t queue_size, bool shutdown_on_exception)
+void GlobalThreadPool::initialize(size_t max_threads, size_t max_free_threads, size_t queue_size)
 {
     if (the_instance)
     {
@@ -328,7 +328,7 @@ void GlobalThreadPool::initialize(size_t max_threads, size_t max_free_threads, s
             "The global thread pool is initialized twice");
     }
 
-    the_instance.reset(new GlobalThreadPool(max_threads, max_free_threads, queue_size, shutdown_on_exception));
+    the_instance.reset(new GlobalThreadPool(max_threads, max_free_threads, queue_size, false /*shutdown_on_exception*/));
 }
 
 GlobalThreadPool & GlobalThreadPool::instance()

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -320,7 +320,7 @@ template class ThreadPoolImpl<ThreadFromGlobalPool>;
 
 std::unique_ptr<GlobalThreadPool> GlobalThreadPool::the_instance;
 
-void GlobalThreadPool::initialize(size_t max_threads)
+void GlobalThreadPool::initialize(size_t max_threads, size_t max_free_threads, size_t queue_size, bool shutdown_on_exception)
 {
     if (the_instance)
     {
@@ -328,9 +328,7 @@ void GlobalThreadPool::initialize(size_t max_threads)
             "The global thread pool is initialized twice");
     }
 
-    the_instance.reset(new GlobalThreadPool(max_threads,
-        1000 /*max_free_threads*/, 10000 /*max_queue_size*/,
-        false /*shutdown_on_exception*/));
+    the_instance.reset(new GlobalThreadPool(max_threads, max_free_threads, queue_size, shutdown_on_exception));
 }
 
 GlobalThreadPool & GlobalThreadPool::instance()

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -147,7 +147,7 @@ class GlobalThreadPool : public FreeThreadPool, private boost::noncopyable
     {}
 
 public:
-    static void initialize(size_t max_threads = 10000);
+    static void initialize(size_t max_threads = 10000, size_t max_free_threads = 1000, size_t queue_size = 10000);
     static GlobalThreadPool & instance();
 };
 


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Exposes all GlobalThreadPool configurations to the configuration files.


Detailed description / Documentation draft:

### Adds three new configuration options
**max_thread_pool_free_size**: The max number of threads that are free in the Global Thread pool.
**thread_pool_queue_size**: The limit to the number of jobs that can be scheduled on the Global Thread pool.
**thread_pool_shutdown_on_exception**: The flag deciding if the thread pool should shutdown on exception.

Fixes this issue: https://github.com/ClickHouse/ClickHouse/issues/31256 