### PR TITLE
Debug rabbitmq tests

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2217,10 +2217,10 @@ def test_rabbitmq_random_detach(rabbitmq_cluster):
         time.sleep(random.uniform(0, 1))
         thread.start()
 
-    time.sleep(5)
-    kill_rabbitmq(rabbitmq_cluster.rabbitmq_docker_id)
-    instance.query("detach table test.rabbitmq")
-    revive_rabbitmq(rabbitmq_cluster.rabbitmq_docker_id)
+    #time.sleep(5)
+    #kill_rabbitmq(rabbitmq_cluster.rabbitmq_docker_id)
+    #instance.query("detach table test.rabbitmq")
+    #revive_rabbitmq(rabbitmq_cluster.rabbitmq_docker_id)
 
     for thread in threads:
         thread.join()


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Locally tests pass so may be the reason is in random order of tests, will check here.