### PR TITLE
Fix possible data-race in case of query cancellation with async_socket_for_remote

### DIFF
--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -296,6 +296,12 @@ std::variant<Block, int> RemoteQueryExecutor::read(std::unique_ptr<ReadContext> 
         }
         else
         {
+            /// We need to check that query was not cancelled again,
+            /// to avoid the race between cancel() thread and read() thread.
+            /// (since cancel() thread will steal the fiber and may update the packet).
+            if (was_cancelled)
+                return Block();
+
             if (auto data = processPacket(std::move(read_context->packet)))
                 return std::move(*data);
             else if (got_duplicated_part_uuids)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible data-race in case of query cancellation with async_socket_for_remote

Detailed description / Documentation draft:
RemoteQueryExecutor::cancel() (that is called in another thread), steal
the fiber, and process any pending packets, to leave the connection in
the correct state (so that it can be reused for further queries).

However this requires processing pending packets, and this will update
the RemoteQueryExecutorReadContext::packet field, which can be read in
another thread by the RemoteQueryExecutor::read().

This was pretty tricky due to fibers, but AFAICS I understand this
correctly and this should fix the race.

Note, that if you will look at the logs from the #28854, you will see,
that all those data races was triggered after query cancellation.

Fixes: #28854 (cc @tavplubix )
Refs: #18715 (cc @KochetovNicolai )