### PR TITLE
Proper progress for numbers_mt

### DIFF
--- a/src/Storages/System/StorageSystemNumbers.cpp
+++ b/src/Storages/System/StorageSystemNumbers.cpp
@@ -149,7 +149,14 @@ Pipe StorageSystemNumbers::read(
         UInt64 max_counter = offset + *limit;
 
         for (size_t i = 0; i < num_streams; ++i)
-            pipe.addSource(std::make_shared<NumbersMultiThreadedSource>(state, max_block_size, max_counter));
+        {
+            auto source = std::make_shared<NumbersMultiThreadedSource>(state, max_block_size, max_counter);
+
+            if (i == 0)
+                source->addTotalRowsApprox(*limit);
+
+            pipe.addSource(std::move(source));
+        }
 
         return pipe;
     }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Previously progress was shown only for `numbers` table function, not for `numbers_mt`. Now for `numbers_mt` it is also shown.