### PR TITLE
Improve fuzzer report in case of fuzzer killed

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -256,6 +256,12 @@ continue
         task_exit_code=0
         echo "success" > status.txt
         echo "OK" > description.txt
+    elif [ "$fuzzer_exit_code" == "137" ]
+    then
+        # Killed.
+        task_exit_code=$fuzzer_exit_code
+        echo "failure" > status.txt
+        echo "Killed" > description.txt
     else
         # The server was alive, but the fuzzer returned some error. This might
         # be some client-side error detected by fuzzing, or a problem in the


### PR DESCRIPTION
This will avoid Exception from fuzzer in description like in [1], that
someone may think that is related to the failure, which is obviously
don't in case it was KILLed.

  [1]: https://clickhouse-test-reports.s3.yandex.net/31259/a49e10c78860a451ff9cc39df6049c88234d507a/fuzzer_ubsan/report.html#fail1

Changelog category (leave one):
- Not for changelog (changelog entry is not required)