### PR TITLE
Fix check in async buffer

### DIFF
--- a/src/Disks/IO/AsynchronousReadIndirectBufferFromRemoteFS.h
+++ b/src/Disks/IO/AsynchronousReadIndirectBufferFromRemoteFS.h
@@ -76,7 +76,7 @@ private:
 
     size_t bytes_to_ignore = 0;
 
-    std::optional<size_t> read_until_position = 0;
+    std::optional<size_t> read_until_position;
 
     bool must_read_until_position;
 };


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Broke it 3 days ago in https://github.com/ClickHouse/ClickHouse/pull/31112.
It broke case when async reads were turned on with non-MergeTree tables.
Later it will not get broken again because now async reads will be turn on in all tests after https://github.com/ClickHouse/ClickHouse/pull/31291.
Backporting it because fix #31112, which broke it, was also backported.