### PR TITLE
Fix test_kafka_insert_avro by pinning avro version

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -60,7 +60,7 @@ RUN dockerd --version; docker --version
 RUN python3 -m pip install \
     PyMySQL \
     aerospike==4.0.0 \
-    avro \
+    avro==1.10.2 \
     cassandra-driver \
     confluent-kafka==1.5.0 \
     dict2xml \


### PR DESCRIPTION
New avro version has a code that does not allow to use BytesIO [1].

  [1]: https://github.com/apache/avro/commit/e8c61ba4f0#diff-ca721cc66db80ff81dcd7b8ad1bb0e83b2e5c2de80c207ebec79f5495d38db98R318-R319

Changelog category (leave one):
- Not for changelog (changelog entry is not required)