### PR TITLE
Remove thread_local std::string

### DIFF
--- a/src/Common/setThreadName.cpp
+++ b/src/Common/setThreadName.cpp
@@ -12,6 +12,8 @@
 #include <Common/Exception.h>
 #include <Common/setThreadName.h>
 
+#define THREAD_NAME_SIZE 16
+
 
 namespace DB
 {
@@ -23,13 +25,13 @@ namespace ErrorCodes
 
 
 /// Cache thread_name to avoid prctl(PR_GET_NAME) for query_log/text_log
-static thread_local std::string thread_name;
+static thread_local char thread_name[THREAD_NAME_SIZE]{};
 
 
 void setThreadName(const char * name)
 {
 #ifndef NDEBUG
-    if (strlen(name) > 15)
+    if (strlen(name) > THREAD_NAME_SIZE - 1)
         throw DB::Exception("Thread name cannot be longer than 15 bytes", DB::ErrorCodes::PTHREAD_ERROR);
 #endif
 
@@ -45,28 +47,25 @@ void setThreadName(const char * name)
 #endif
         DB::throwFromErrno("Cannot set thread name with prctl(PR_SET_NAME, ...)", DB::ErrorCodes::PTHREAD_ERROR);
 
-    thread_name = name;
+    strcpy(thread_name, name);
 }
 
-const std::string & getThreadName()
+const char * getThreadName()
 {
-    if (!thread_name.empty())
+    if (thread_name[0])
         return thread_name;
 
-    thread_name.resize(16);
-
 #if defined(__APPLE__) || defined(OS_SUNOS)
-    if (pthread_getname_np(pthread_self(), thread_name.data(), thread_name.size()))
+    if (pthread_getname_np(pthread_self(), thread_name, THREAD_NAME_SIZE))
         throw DB::Exception("Cannot get thread name with pthread_getname_np()", DB::ErrorCodes::PTHREAD_ERROR);
 #elif defined(__FreeBSD__)
 // TODO: make test. freebsd will have this function soon https://freshbsd.org/commit/freebsd/r337983
-//    if (pthread_get_name_np(pthread_self(), thread_name.data(), thread_name.size()))
+//    if (pthread_get_name_np(pthread_self(), thread_name, THREAD_NAME_SIZE))
 //        throw DB::Exception("Cannot get thread name with pthread_get_name_np()", DB::ErrorCodes::PTHREAD_ERROR);
 #else
-    if (0 != prctl(PR_GET_NAME, thread_name.data(), 0, 0, 0))
+    if (0 != prctl(PR_GET_NAME, thread_name, 0, 0, 0))
         DB::throwFromErrno("Cannot get thread name with prctl(PR_GET_NAME)", DB::ErrorCodes::PTHREAD_ERROR);
 #endif
 
-    thread_name.resize(std::strlen(thread_name.data()));
     return thread_name;
 }

--- a/src/Common/setThreadName.cpp
+++ b/src/Common/setThreadName.cpp
@@ -47,7 +47,7 @@ void setThreadName(const char * name)
 #endif
         DB::throwFromErrno("Cannot set thread name with prctl(PR_SET_NAME, ...)", DB::ErrorCodes::PTHREAD_ERROR);
 
-    strcpy(thread_name, name);
+    memcpy(thread_name, name, 1 + strlen(name));
 }
 
 const char * getThreadName()

--- a/src/Common/setThreadName.h
+++ b/src/Common/setThreadName.h
@@ -7,4 +7,4 @@
   */
 void setThreadName(const char * name);
 
-const std::string & getThreadName();
+const char * getThreadName();

--- a/src/Databases/MySQL/MaterializedMySQLSyncThread.cpp
+++ b/src/Databases/MySQL/MaterializedMySQLSyncThread.cpp
@@ -3,26 +3,27 @@
 #if USE_MYSQL
 
 #include <Databases/MySQL/MaterializedMySQLSyncThread.h>
-#    include <cstdlib>
-#    include <random>
-#    include <Columns/ColumnTuple.h>
-#    include <Columns/ColumnDecimal.h>
-#    include <QueryPipeline/QueryPipelineBuilder.h>
-#    include <Processors/Executors/PullingPipelineExecutor.h>
-#    include <Processors/Executors/CompletedPipelineExecutor.h>
-#    include <Processors/Sources/SourceFromSingleChunk.h>
-#    include <Processors/Transforms/CountingTransform.h>
-#    include <Databases/MySQL/DatabaseMaterializedMySQL.h>
-#    include <Databases/MySQL/MaterializeMetadata.h>
-#    include <Processors/Sources/MySQLSource.h>
-#    include <IO/ReadBufferFromString.h>
-#    include <Interpreters/Context.h>
-#    include <Interpreters/executeQuery.h>
-#    include <Storages/StorageMergeTree.h>
-#    include <Common/quoteString.h>
-#    include <Common/setThreadName.h>
-#    include <base/sleep.h>
-#    include <base/bit_cast.h>
+#include <cstdlib>
+#include <random>
+#include <string_view>
+#include <Columns/ColumnTuple.h>
+#include <Columns/ColumnDecimal.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
+#include <Processors/Executors/CompletedPipelineExecutor.h>
+#include <Processors/Sources/SourceFromSingleChunk.h>
+#include <Processors/Transforms/CountingTransform.h>
+#include <Databases/MySQL/DatabaseMaterializedMySQL.h>
+#include <Databases/MySQL/MaterializeMetadata.h>
+#include <Processors/Sources/MySQLSource.h>
+#include <IO/ReadBufferFromString.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/executeQuery.h>
+#include <Storages/StorageMergeTree.h>
+#include <Common/quoteString.h>
+#include <Common/setThreadName.h>
+#include <base/sleep.h>
+#include <base/bit_cast.h>
 
 namespace DB
 {
@@ -765,7 +766,7 @@ void MaterializedMySQLSyncThread::executeDDLAtomic(const QueryEvent & query_even
 
 bool MaterializedMySQLSyncThread::isMySQLSyncThread()
 {
-    return getThreadName() == MYSQL_BACKGROUND_THREAD_NAME;
+    return getThreadName() == std::string_view(MYSQL_BACKGROUND_THREAD_NAME);
 }
 
 void MaterializedMySQLSyncThread::setSynchronizationThreadException(const std::exception_ptr & exception)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This is bad. CC @azat 