### PR TITLE
Fix client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -403,36 +403,6 @@ void Client::initialize(Poco::Util::Application & self)
 }
 
 
-void Client::prepareForInteractive()
-{
-    clearTerminal();
-    showClientVersion();
-
-    if (delayed_interactive)
-        std::cout << std::endl;
-
-    /// Load Warnings at the beginning of connection
-    if (!config().has("no-warnings"))
-    {
-        try
-        {
-            std::vector<String> messages = loadWarningMessages();
-            if (!messages.empty())
-            {
-                std::cout << "Warnings:" << std::endl;
-                for (const auto & message : messages)
-                    std::cout << " * " << message << std::endl;
-                std::cout << std::endl;
-            }
-        }
-        catch (...)
-        {
-            /// Ignore exception
-        }
-    }
-}
-
-
 int Client::main(const std::vector<std::string> & /*args*/)
 try
 {
@@ -459,11 +429,37 @@ try
 
     processConfig();
 
+    /// Includes delayed_interactive.
+    if (is_interactive)
+    {
+        clearTerminal();
+        showClientVersion();
+    }
+
     connect();
+
+    /// Load Warnings at the beginning of connection
+    if (is_interactive && !config().has("no-warnings"))
+    {
+        try
+        {
+            std::vector<String> messages = loadWarningMessages();
+            if (!messages.empty())
+            {
+                std::cout << "Warnings:" << std::endl;
+                for (const auto & message : messages)
+                    std::cout << " * " << message << std::endl;
+                std::cout << std::endl;
+            }
+        }
+        catch (...)
+        {
+            /// Ignore exception
+        }
+    }
 
     if (is_interactive && !delayed_interactive)
     {
-        prepareForInteractive();
         runInteractive();
     }
     else
@@ -489,10 +485,7 @@ try
         }
 
         if (delayed_interactive)
-        {
-            prepareForInteractive();
             runInteractive();
-        }
     }
 
     return 0;
@@ -566,9 +559,7 @@ void Client::connect()
     if (is_interactive)
     {
         std::cout << "Connected to " << server_name << " server version " << server_version << " revision " << server_revision << "."
-                    << std::endl;
-        if (!delayed_interactive)
-            std::cout << std::endl;
+                    << std::endl << std::endl;
 
         auto client_version_tuple = std::make_tuple(VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
         auto server_version_tuple = std::make_tuple(server_version_major, server_version_minor, server_version_patch);

--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -20,7 +20,6 @@ protected:
     bool processWithFuzzing(const String & full_query) override;
 
     void connect() override;
-    void prepareForInteractive() override;
     void processError(const String & query) const override;
     String getName() const override { return "client"; }
 

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -396,14 +396,6 @@ void LocalServer::connect()
 }
 
 
-void LocalServer::prepareForInteractive()
-{
-    clearTerminal();
-    showClientVersion();
-    std::cerr << std::endl;
-}
-
-
 int LocalServer::main(const std::vector<std::string> & /*args*/)
 try
 {
@@ -436,11 +428,18 @@ try
 
     processConfig();
     applyCmdSettings(global_context);
+
+    if (is_interactive)
+    {
+        clearTerminal();
+        showClientVersion();
+        std::cerr << std::endl;
+    }
+
     connect();
 
     if (is_interactive && !delayed_interactive)
     {
-        prepareForInteractive();
         runInteractive();
     }
     else
@@ -448,10 +447,7 @@ try
         runNonInteractive();
 
         if (delayed_interactive)
-        {
-            prepareForInteractive();
             runInteractive();
-        }
     }
 
     cleanup();

--- a/programs/local/LocalServer.h
+++ b/programs/local/LocalServer.h
@@ -34,7 +34,6 @@ protected:
     bool executeMultiQuery(const String & all_queries_text) override;
 
     void connect() override;
-    void prepareForInteractive() override;
     void processError(const String & query) const override;
     String getName() const override { return "local"; }
 

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -59,7 +59,6 @@ protected:
 
     virtual bool executeMultiQuery(const String & all_queries_text) = 0;
     virtual void connect() = 0;
-    virtual void prepareForInteractive() = 0;
     virtual void processError(const String & query) const = 0;
     virtual String getName() const = 0;
 

--- a/tests/queries/0_stateless/02116_interactive_hello.expect
+++ b/tests/queries/0_stateless/02116_interactive_hello.expect
@@ -1,0 +1,24 @@
+#!/usr/bin/expect -f
+# Tags: no-fasttest
+
+log_user 0
+set timeout 60
+match_max 100000
+
+# A default timeout action is to do nothing, change it to fail
+expect_after {
+    timeout {
+        exit 1
+    }
+}
+
+set basedir [file dirname $argv0]
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion"
+
+expect -re "ClickHouse client version \[\\d\]{2}.\[\\d\]{1,2}.\[\\d\]{1,2}.\[\\d\]{1,2}.\r"
+expect -re "Connecting to database .* at localhost:9000 as user default.\r"
+expect -re "Connected to ClickHouse server version \[\\d\]{2}.\[\\d\]{1,2}.\[\\d\]{1,2} revision .*\r"
+expect ":) "
+
+send -- ""
+expect eof


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Broken after https://github.com/ClickHouse/ClickHouse/pull/30851, only in 21.12, so no backport needed.