### PR TITLE
Handle CREATE TABLE LIKE in MaterializedMySQL

### DIFF
--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -225,6 +225,31 @@ def drop_table_with_materialized_mysql_database(clickhouse_node, mysql_node, ser
     mysql_node.query("DROP DATABASE test_database_drop")
 
 
+def create_table_like_with_materialize_mysql_database(clickhouse_node, mysql_node, service_name):
+    mysql_node.query("DROP DATABASE IF EXISTS create_like")
+    mysql_node.query("DROP DATABASE IF EXISTS create_like2")
+    clickhouse_node.query("DROP DATABASE IF EXISTS create_like")
+
+    mysql_node.query("CREATE DATABASE create_like")
+    mysql_node.query("CREATE DATABASE create_like2")
+    mysql_node.query("CREATE TABLE create_like.t1 (id INT NOT NULL PRIMARY KEY)")
+    mysql_node.query("CREATE TABLE create_like2.t1 LIKE create_like.t1")
+
+    clickhouse_node.query(
+        f"CREATE DATABASE create_like ENGINE = MaterializeMySQL('{service_name}:3306', 'create_like', 'root', 'clickhouse')")
+    mysql_node.query("CREATE TABLE create_like.t2 LIKE create_like.t1")
+    mysql_node.query("USE create_like")
+    mysql_node.query("CREATE TABLE t3 LIKE create_like2.t1")
+    mysql_node.query("CREATE TABLE t4 LIKE t1")
+
+    check_query(clickhouse_node, "SHOW TABLES FROM create_like", "t1\nt2\nt4\n")
+    check_query(clickhouse_node, "SHOW DATABASES LIKE 'create_like%'", "create_like\n")
+
+    clickhouse_node.query("DROP DATABASE create_like")
+    mysql_node.query("DROP DATABASE create_like")
+    mysql_node.query("DROP DATABASE create_like2")
+
+
 def create_table_with_materialized_mysql_database(clickhouse_node, mysql_node, service_name):
     mysql_node.query("DROP DATABASE IF EXISTS test_database_create")
     clickhouse_node.query("DROP DATABASE IF EXISTS test_database_create")

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -117,6 +117,7 @@ def test_materialize_database_ddl_with_mysql_5_7(started_cluster, started_mysql_
     # materialize_with_ddl.alter_rename_column_with_materialized_mysql_database(clickhouse_node, started_mysql_5_7, "mysql57")
     materialize_with_ddl.alter_rename_table_with_materialized_mysql_database(clickhouse_node, started_mysql_5_7, "mysql57")
     materialize_with_ddl.alter_modify_column_with_materialized_mysql_database(clickhouse_node, started_mysql_5_7, "mysql57")
+    materialize_with_ddl.create_table_like_with_materialize_mysql_database(clickhouse_node, started_mysql_5_7, "mysql57")
 
 @pytest.mark.parametrize(('clickhouse_node'), [pytest.param(node_db_ordinary, id="ordinary"), pytest.param(node_db_atomic, id="atomic")])
 def test_materialize_database_ddl_with_mysql_8_0(started_cluster, started_mysql_8_0, clickhouse_node):
@@ -128,6 +129,7 @@ def test_materialize_database_ddl_with_mysql_8_0(started_cluster, started_mysql_
     materialize_with_ddl.alter_rename_table_with_materialized_mysql_database(clickhouse_node, started_mysql_8_0, "mysql80")
     materialize_with_ddl.alter_rename_column_with_materialized_mysql_database(clickhouse_node, started_mysql_8_0, "mysql80")
     materialize_with_ddl.alter_modify_column_with_materialized_mysql_database(clickhouse_node, started_mysql_8_0, "mysql80")
+    materialize_with_ddl.create_table_like_with_materialize_mysql_database(clickhouse_node, started_mysql_8_0, "mysql80")
 
 @pytest.mark.parametrize(('clickhouse_node'), [pytest.param(node_db_ordinary, id="ordinary"), pytest.param(node_db_atomic, id="atomic")])
 def test_materialize_database_ddl_with_empty_transaction_5_7(started_cluster, started_mysql_5_7, clickhouse_node):


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
MaterializedMySQL now handles `CREATE TABLE ... LIKE ...` DDL queries.


Detailed description / Documentation draft:
...


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
