### PR TITLE
Fix link to external MySQL dict

### DIFF
--- a/docs/ru/sql-reference/table-functions/mysql.md
+++ b/docs/ru/sql-reference/table-functions/mysql.md
@@ -107,5 +107,5 @@ SELECT * FROM mysql('localhost:3306', 'test', 'test', 'bayonet', '123');
 **Смотрите также**
 
 -   [Движок таблиц ‘MySQL’](../../sql-reference/table-functions/mysql.md)
--   [Использование MySQL как источника данных для внешнего словаря](../../sql-reference/table-functions/mysql.md#dicts-external_dicts_dict_sources-mysql)
+-   [Использование MySQL как источника данных для внешнего словаря](../../sql-reference/dictionaries/external-dictionaries/external-dicts-dict-sources.md##dicts-external_dicts_dict_sources-mysql)
 

--- a/docs/ru/sql-reference/table-functions/mysql.md
+++ b/docs/ru/sql-reference/table-functions/mysql.md
@@ -107,5 +107,5 @@ SELECT * FROM mysql('localhost:3306', 'test', 'test', 'bayonet', '123');
 **Смотрите также**
 
 -   [Движок таблиц ‘MySQL’](../../sql-reference/table-functions/mysql.md)
--   [Использование MySQL как источника данных для внешнего словаря](../../sql-reference/dictionaries/external-dictionaries/external-dicts-dict-sources.md##dicts-external_dicts_dict_sources-mysql)
+-   [Использование MySQL как источника данных для внешнего словаря](../../sql-reference/dictionaries/external-dictionaries/external-dicts-dict-sources.md#dicts-external_dicts_dict_sources-mysql)
 


### PR DESCRIPTION
Corrected link to external dictionary MySQL

Changelog category (leave one):

- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
