### PR TITLE
Change default http timeout from 1800 to 180

### DIFF
--- a/src/Core/Defines.h
+++ b/src/Core/Defines.h
@@ -44,7 +44,7 @@
 /// The boundary on which the blocks for asynchronous file operations should be aligned.
 #define DEFAULT_AIO_FILE_BLOCK_SIZE 4096
 
-#define DEFAULT_HTTP_READ_BUFFER_TIMEOUT 1800
+#define DEFAULT_HTTP_READ_BUFFER_TIMEOUT 180
 #define DEFAULT_HTTP_READ_BUFFER_CONNECTION_TIMEOUT 1
 /// Maximum number of http-connections between two endpoints
 /// the number is unmotivated


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Default value of `http_send_timeout` and `http_receive_timeout` settings changed from 1800 (30 minutes) to 180 (3 minutes)

Detailed description / Documentation draft:
https://github.com/ClickHouse/ClickHouse/pull/31410#issuecomment-970165905
