### PR TITLE
Fix waiting of the editor during interactive query editing

### DIFF
--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -25,6 +25,16 @@ void trim(String & s)
     s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
 }
 
+std::string get_editor()
+{
+    const char * editor = std::getenv("EDITOR");
+
+    if (!editor || !*editor)
+        editor = "vim";
+
+    return editor;
+}
+
 /// Copied from replxx::src/util.cxx::now_ms_str() under the terms of 3-clause BSD license of Replxx.
 /// Copyright (c) 2017-2018, Marcin Konarski (amok at codestation.org)
 /// Copyright (c) 2010, Salvatore Sanfilippo (antirez at gmail dot com)
@@ -123,6 +133,7 @@ ReplxxLineReader::ReplxxLineReader(
     Patterns delimiters_,
     replxx::Replxx::highlighter_callback_t highlighter_)
     : LineReader(history_file_path_, multiline_, std::move(extenders_), std::move(delimiters_)), highlighter(std::move(highlighter_))
+    , editor(get_editor())
 {
     using namespace std::placeholders;
     using Replxx = replxx::Replxx;
@@ -236,14 +247,11 @@ void ReplxxLineReader::addToHistory(const String & line)
         rx.print("Unlock of history file failed: %s\n", errnoToString(errno).c_str());
 }
 
-int ReplxxLineReader::execute(const std::string & command)
+int ReplxxLineReader::executeEditor(const std::string & path)
 {
-    std::vector<char> argv0("sh", &("sh"[3]));
-    std::vector<char> argv1("-c", &("-c"[3]));
-    std::vector<char> argv2(command.data(), command.data() + command.size() + 1);
-
-    const char * filename = "/bin/sh";
-    char * const argv[] = {argv0.data(), argv1.data(), argv2.data(), nullptr};
+    std::vector<char> argv0(editor.data(), editor.data() + editor.size() + 1);
+    std::vector<char> argv1(path.data(), path.data() + path.size() + 1);
+    char * const argv[] = {argv0.data(), argv1.data(), nullptr};
 
     static void * real_vfork = dlsym(RTLD_DEFAULT, "vfork");
     if (!real_vfork)
@@ -267,7 +275,8 @@ int ReplxxLineReader::execute(const std::string & command)
         sigprocmask(0, nullptr, &mask);
         sigprocmask(SIG_UNBLOCK, &mask, nullptr);
 
-        execv(filename, argv);
+        execvp(editor.c_str(), argv);
+        rx.print("Cannot execute %s: %s\n", editor.c_str(), errnoToString(errno).c_str());
         _exit(-1);
     }
 
@@ -289,10 +298,6 @@ void ReplxxLineReader::openEditor()
         rx.print("Cannot create temporary file to edit query: %s\n", errnoToString(errno).c_str());
         return;
     }
-
-    const char * editor = std::getenv("EDITOR");
-    if (!editor || !*editor)
-        editor = "vim";
 
     replxx::Replxx::State state(rx.get_state());
 
@@ -316,7 +321,7 @@ void ReplxxLineReader::openEditor()
         return;
     }
 
-    if (0 == execute(fmt::format("{} {}", editor, filename)))
+    if (0 == executeEditor(filename))
     {
         try
         {

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -281,11 +281,19 @@ int ReplxxLineReader::executeEditor(const std::string & path)
     }
 
     int status = 0;
-    if (-1 == waitpid(pid, &status, 0))
-    {
-        rx.print("Cannot waitpid: %s\n", errnoToString(errno).c_str());
-        return -1;
-    }
+    do {
+        int exited_pid = waitpid(pid, &status, 0);
+        if (exited_pid == -1)
+        {
+            if (errno == EINTR)
+                continue;
+
+            rx.print("Cannot waitpid: %s\n", errnoToString(errno).c_str());
+            return -1;
+        }
+        else
+            break;
+    } while (true);
     return status;
 }
 

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -247,6 +247,8 @@ void ReplxxLineReader::addToHistory(const String & line)
         rx.print("Unlock of history file failed: %s\n", errnoToString(errno).c_str());
 }
 
+/// See comments in ShellCommand::executeImpl()
+/// (for the vfork via dlsym())
 int ReplxxLineReader::executeEditor(const std::string & path)
 {
     std::vector<char> argv0(editor.data(), editor.data() + editor.size() + 1);
@@ -268,6 +270,7 @@ int ReplxxLineReader::executeEditor(const std::string & path)
         return -1;
     }
 
+    /// Child
     if (0 == pid)
     {
         sigset_t mask;

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -25,7 +25,7 @@ void trim(String & s)
     s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
 }
 
-std::string get_editor()
+std::string getEditor()
 {
     const char * editor = std::getenv("EDITOR");
 
@@ -133,7 +133,7 @@ ReplxxLineReader::ReplxxLineReader(
     Patterns delimiters_,
     replxx::Replxx::highlighter_callback_t highlighter_)
     : LineReader(history_file_path_, multiline_, std::move(extenders_), std::move(delimiters_)), highlighter(std::move(highlighter_))
-    , editor(get_editor())
+    , editor(getEditor())
 {
     using namespace std::placeholders;
     using Replxx = replxx::Replxx;
@@ -284,7 +284,8 @@ int ReplxxLineReader::executeEditor(const std::string & path)
     }
 
     int status = 0;
-    do {
+    do
+    {
         int exited_pid = waitpid(pid, &status, 0);
         if (exited_pid == -1)
         {

--- a/base/base/ReplxxLineReader.h
+++ b/base/base/ReplxxLineReader.h
@@ -22,7 +22,7 @@ public:
 private:
     InputStatus readOneLine(const String & prompt) override;
     void addToHistory(const String & line) override;
-    int execute(const std::string & command);
+    int executeEditor(const std::string & path);
     void openEditor();
 
     replxx::Replxx rx;
@@ -31,4 +31,6 @@ private:
     // used to call flock() to synchronize multiple clients using same history file
     int history_file_fd = -1;
     bool bracketed_paste_enabled = false;
+
+    std::string editor;
 };

--- a/tests/queries/0_stateless/01610_client_spawn_editor.sh
+++ b/tests/queries/0_stateless/01610_client_spawn_editor.sh
@@ -7,7 +7,7 @@ match_max 100000
 
 if ![info exists env(CLICKHOUSE_PORT_TCP)] {set env(CLICKHOUSE_PORT_TCP) 9000}
 
-set env(EDITOR) [file dirname [file normalize [info script]]]"/01610_client_spawn_editor_open.editor"
+set env(EDITOR) [file dirname [file normalize [info script]]]/01610_client_spawn_editor_open.editor
 
 spawn clickhouse-client --disable_suggestion
 expect ":) "


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix waiting of the editor during interactive query edition (`waitpid()` returns -1 on `SIGWINCH` and `EDITOR` and `clickhouse-local`/`clickhouse-client` works concurrently)

Follow-up for: #17665 (cc @amosbird )