### PR TITLE
Fix MaxOS build doc

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -58,7 +58,7 @@ cd ClickHouse
 rm -rf build
 mkdir build
 cd build
-cmake -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_JEMALLOC=0 ..
+cmake -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_JEMALLOC=OFF ..
 cmake --build . --config RelWithDebInfo
 cd ..
 ```

--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -58,7 +58,7 @@ cd ClickHouse
 rm -rf build
 mkdir build
 cd build
-cmake -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_JEMALLOC=0 ..
 cmake --build . --config RelWithDebInfo
 cd ..
 ```


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description / Documentation draft:
Jemalloc should be disabled when build on MacOS.

When jemalloc is enabled, build on MacOS is ok, but run by command `./clickhouse server --config-files=/path/to/config/file` fails with the following error:
```
<jemalloc>: ../contrib/jemalloc/include/jemalloc/internal/tsd_generic.h:145: Failed assertion: "tsd_booted"
```
