### PR TITLE
Do not clean iptables rules in session-scope fixture

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,8 +7,10 @@ from helpers.network import _NetworkManager
 
 @pytest.fixture(autouse=True, scope="session")
 def cleanup_environment():
-    _NetworkManager.clean_all_user_iptables_rules()
     try:
+        if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS")) == 1:
+            logging.debug(f"Cleaning all iptables rules")
+            _NetworkManager.clean_all_user_iptables_rules()
         result = run_and_check(['docker ps | wc -l'], shell=True)
         if int(result) > 1:
             if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS")) != 1:


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
Looks like pytest may execute session scope fixture multiple times if tests are running in parallel. And we already have iptables cleanup here: https://github.com/ClickHouse/ClickHouse/blob/e42607834427114204c667c32a0c1ee4375b5d33/tests/integration/ci-runner.py#L124
AFAIK `PYTEST_CLEANUP_CONTAINERS` is not set in CI
