### PR TITLE
typo in PostgreSQL

### DIFF
--- a/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-sources.md
+++ b/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-sources.md
@@ -746,7 +746,7 @@ Setting fields:
 !!! info "Note"
     The `column_family` or `where` fields cannot be used together with the `query` field. And either one of the `column_family` or `query` fields must be declared.
 
-### PosgreSQL {#dicts-external_dicts_dict_sources-postgresql}
+### PostgreSQL {#dicts-external_dicts_dict_sources-postgresql}
 
 Example of settings:
 


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Detailed description / Documentation draft:
typo in documentation

