### PR TITLE
Make 01114_database_atomic more stable in debug builds

### DIFF
--- a/tests/queries/0_stateless/01114_database_atomic.sh
+++ b/tests/queries/0_stateless/01114_database_atomic.sh
@@ -6,10 +6,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 
-$CLICKHOUSE_CLIENT -q "DROP DATABASE IF EXISTS test_01114_1"
-$CLICKHOUSE_CLIENT -q "DROP DATABASE IF EXISTS test_01114_2"
-$CLICKHOUSE_CLIENT -q "DROP DATABASE IF EXISTS test_01114_3"
-
+$CLICKHOUSE_CLIENT -nm -q "
+DROP DATABASE IF EXISTS test_01114_1;
+DROP DATABASE IF EXISTS test_01114_2;
+DROP DATABASE IF EXISTS test_01114_3;
+"
 
 $CLICKHOUSE_CLIENT -q "CREATE DATABASE test_01114_1 ENGINE=Atomic"
 $CLICKHOUSE_CLIENT --default_database_engine=Atomic -q "CREATE DATABASE test_01114_2"
@@ -27,17 +28,19 @@ $CLICKHOUSE_CLIENT -q "SELECT name,
                               splitByChar('/', metadata_path)[-2] as uuid_path, ((splitByChar('/', metadata_path)[-3] as metadata) = substr(uuid_path, 1, 3)) OR metadata='metadata'
                               FROM system.databases WHERE name LIKE 'test_01114_%'" | sed "s/$uuid_db_1/00001114-1000-4000-8000-000000000001/g" | sed "s/$uuid_db_2/00001114-1000-4000-8000-000000000002/g"
 
-$CLICKHOUSE_CLIENT -q "CREATE TABLE test_01114_1.mt_tmp (n UInt64) ENGINE=MergeTree() ORDER BY tuple()"
-$CLICKHOUSE_CLIENT -q "INSERT INTO test_01114_1.mt_tmp SELECT * FROM numbers(100)"
-$CLICKHOUSE_CLIENT -q "CREATE TABLE test_01114_3.mt (n UInt64) ENGINE=MergeTree() ORDER BY tuple() PARTITION BY (n % 5)"
-$CLICKHOUSE_CLIENT -q "INSERT INTO test_01114_3.mt SELECT * FROM numbers(20)"
+$CLICKHOUSE_CLIENT -nm -q "
+CREATE TABLE test_01114_1.mt_tmp (n UInt64) ENGINE=MergeTree() ORDER BY tuple();
+INSERT INTO test_01114_1.mt_tmp SELECT * FROM numbers(100);
+CREATE TABLE test_01114_3.mt (n UInt64) ENGINE=MergeTree() ORDER BY tuple() PARTITION BY (n % 5);
+INSERT INTO test_01114_3.mt SELECT * FROM numbers(20);
 
-$CLICKHOUSE_CLIENT -q "RENAME TABLE test_01114_1.mt_tmp TO test_01114_3.mt_tmp"   # move from Atomic to Ordinary
-$CLICKHOUSE_CLIENT -q "RENAME TABLE test_01114_3.mt TO test_01114_1.mt"           # move from Ordinary to Atomic
-$CLICKHOUSE_CLIENT -q "SELECT count() FROM test_01114_1.mt"
-$CLICKHOUSE_CLIENT -q "SELECT count() FROM test_01114_3.mt_tmp"
+RENAME TABLE test_01114_1.mt_tmp TO test_01114_3.mt_tmp; /* move from Atomic to Ordinary */
+RENAME TABLE test_01114_3.mt TO test_01114_1.mt;         /* move from Ordinary to Atomic */
+SELECT count() FROM test_01114_1.mt;
+SELECT count() FROM test_01114_3.mt_tmp;
 
-$CLICKHOUSE_CLIENT -q "DROP DATABASE test_01114_3"
+DROP DATABASE test_01114_3;
+"
 
 explicit_uuid=$($CLICKHOUSE_CLIENT -q "SELECT generateUUIDv4()")
 $CLICKHOUSE_CLIENT -q "CREATE TABLE test_01114_2.mt UUID '$explicit_uuid' (n UInt64) ENGINE=MergeTree() ORDER BY tuple() PARTITION BY (n % 5)"
@@ -49,11 +52,13 @@ $CLICKHOUSE_CLIENT -q "SELECT count(col), sum(col) FROM (SELECT n + sleepEachRow
 $CLICKHOUSE_CLIENT -q "INSERT INTO test_01114_2.mt SELECT number + sleepEachRow(1.5) FROM numbers(30)" &                  # 45s
 sleep 1   # SELECT and INSERT should start before the following RENAMEs
 
-$CLICKHOUSE_CLIENT -q "RENAME TABLE test_01114_1.mt TO test_01114_1.mt_tmp"
-$CLICKHOUSE_CLIENT -q "RENAME TABLE test_01114_1.mt_tmp TO test_01114_2.mt_tmp"
-$CLICKHOUSE_CLIENT -q "EXCHANGE TABLES test_01114_2.mt AND test_01114_2.mt_tmp"
-$CLICKHOUSE_CLIENT -q "RENAME TABLE test_01114_2.mt_tmp TO test_01114_1.mt"
-$CLICKHOUSE_CLIENT -q "EXCHANGE TABLES test_01114_1.mt AND test_01114_2.mt"
+$CLICKHOUSE_CLIENT -nm -q "
+RENAME TABLE test_01114_1.mt TO test_01114_1.mt_tmp;
+RENAME TABLE test_01114_1.mt_tmp TO test_01114_2.mt_tmp;
+EXCHANGE TABLES test_01114_2.mt AND test_01114_2.mt_tmp;
+RENAME TABLE test_01114_2.mt_tmp TO test_01114_1.mt;
+EXCHANGE TABLES test_01114_1.mt AND test_01114_2.mt;
+"
 
 # Check that nothing changed
 $CLICKHOUSE_CLIENT -q "SELECT count() FROM test_01114_1.mt"
@@ -61,16 +66,18 @@ uuid_mt1=$($CLICKHOUSE_CLIENT -q "SELECT uuid FROM system.tables WHERE database=
 $CLICKHOUSE_CLIENT --show_table_uuid_in_table_create_query_if_not_nil=1 -q "SHOW CREATE TABLE test_01114_1.mt" | sed "s/$uuid_mt1/00001114-0000-4000-8000-000000000001/g"
 $CLICKHOUSE_CLIENT --show_table_uuid_in_table_create_query_if_not_nil=1 -q "SHOW CREATE TABLE test_01114_2.mt" | sed "s/$explicit_uuid/00001114-0000-4000-8000-000000000002/g"
 
-$CLICKHOUSE_CLIENT -q "DROP TABLE test_01114_1.mt" --database_atomic_wait_for_drop_and_detach_synchronously=0
-$CLICKHOUSE_CLIENT -q "CREATE TABLE test_01114_1.mt (s String) ENGINE=Log()"
-$CLICKHOUSE_CLIENT -q "INSERT INTO test_01114_1.mt SELECT 's' || toString(number) FROM numbers(5)"
-$CLICKHOUSE_CLIENT -q "SELECT count() FROM test_01114_1.mt"   # result: 5
+$CLICKHOUSE_CLIENT -nm -q "
+DROP TABLE test_01114_1.mt SETTINGS database_atomic_wait_for_drop_and_detach_synchronously=0;
+CREATE TABLE test_01114_1.mt (s String) ENGINE=Log();
+INSERT INTO test_01114_1.mt SELECT 's' || toString(number) FROM numbers(5);
+SELECT count() FROM test_01114_1.mt
+" # result: 5
 
 $CLICKHOUSE_CLIENT -q "SELECT tuple(s, sleepEachRow(3)) FROM test_01114_1.mt" > /dev/null &    # 15s
 sleep 1
 $CLICKHOUSE_CLIENT -q "DROP DATABASE test_01114_1" --database_atomic_wait_for_drop_and_detach_synchronously=0 && echo "dropped"
 
-wait # for INSERT
+wait # for INSERT and SELECT
 
 $CLICKHOUSE_CLIENT -q "SELECT count(n), sum(n) FROM test_01114_2.mt"    # result: 30, 435
 $CLICKHOUSE_CLIENT -q "DROP DATABASE test_01114_2" --database_atomic_wait_for_drop_and_detach_synchronously=0


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

By reducing number of clickhouse-client invocation, since it is pretty
heavy in debug builds.

Cc: @tavplubix 