### PR TITLE
Fix MySQLWire format (this will also fix performance tests)

### DIFF
--- a/tests/queries/0_stateless/02123_MySQLWire_regression.sql
+++ b/tests/queries/0_stateless/02123_MySQLWire_regression.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS table_MySQLWire;
+CREATE TABLE table_MySQLWire (x UInt64) ENGINE = File(MySQLWire);
+INSERT INTO table_MySQLWire SELECT number FROM numbers(10);
+-- regression for not initializing serializations
+INSERT INTO table_MySQLWire SELECT number FROM numbers(10);
+DROP TABLE table_MySQLWire;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix MySQLWire format (in case of multiple writes)

Detailed description / Documentation draft:
In case of multiple writes File() engine will set doNotWritePrefix(),
and this will avoid serializations initilization, move this to do this
always.

**Note, that this will also fix performance tests [in master](https://clickhouse-test-reports.s3.yandex.net/0/fc9ef14a736d62f121d27d3a23490ef7198190be/performance_comparison/report.html#fail1) (in PRs not all tests will be run, so most of the time they will be ok)**

Fixes: #31004 (cc @Avogar )

*NOTE: Marked as `Not for changelog` since original PR has not been included into any stable release yet*