### PR TITLE
get Build ID via Section headers first

### DIFF
--- a/src/Common/Elf.cpp
+++ b/src/Common/Elf.cpp
@@ -119,6 +119,24 @@ std::optional<Elf::Section> Elf::findSectionByName(const char * name) const
 
 String Elf::getBuildID() const
 {
+    /// Section headers are the first choice for a not loaded file
+    if (String build_id; iterateSections([&build_id](const Section & section, size_t)
+    {
+        if (section.header.sh_type == SHT_NOTE)
+        {
+            build_id = Elf::getBuildID(section.begin(), section.size());
+            if (!build_id.empty())
+            {
+                return true;
+            }
+        }
+        return false;
+    }))
+    {
+        return build_id;
+    }
+
+    /// fallback to PHDR
     for (size_t idx = 0; idx < header->e_phnum; ++idx)
     {
         const ElfPhdr & phdr = program_headers[idx];
@@ -126,6 +144,7 @@ String Elf::getBuildID() const
         if (phdr.p_type == PT_NOTE)
             return getBuildID(mapped + phdr.p_offset, phdr.p_filesz);
     }
+
     return {};
 }
 

--- a/src/Common/Elf.cpp
+++ b/src/Common/Elf.cpp
@@ -119,7 +119,7 @@ std::optional<Elf::Section> Elf::findSectionByName(const char * name) const
 
 String Elf::getBuildID() const
 {
-    /// Section headers are the first choice for a not loaded file
+    /// Section headers are the first choice for a debuginfo file
     if (String build_id; iterateSections([&build_id](const Section & section, size_t)
     {
         if (section.header.sh_type == SHT_NOTE)

--- a/src/Common/Elf.h
+++ b/src/Common/Elf.h
@@ -54,7 +54,8 @@ public:
     const char * end() const { return mapped + elf_size; }
     size_t size() const { return elf_size; }
 
-    /// Obtain build id from PT_NOTES section of program headers. Return empty string if does not exist.
+    /// Obtain build id from SHT_NOTE of section headers (fallback to PT_NOTES section of program headers).
+    /// Return empty string if does not exist.
     /// The string is returned in binary. Note that "readelf -n ./clickhouse-server" prints it in hex.
     String getBuildID() const;
     static String getBuildID(const char * nhdr_pos, size_t size);


### PR DESCRIPTION
elf Program headers in debuginfo files are not reliable, it is better to use Section headers

Changelog category (leave one):

- Not for changelog (changelog entry is not required)

