### PR TITLE
Fix broken non-x86 builds

### DIFF
--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -247,7 +247,7 @@ ColumnPtr ColumnDecimal<T>::filter(const IColumn::Filter & filt, ssize_t result_
 
     while (filt_pos < filt_end_aligned)
     {
-        UInt64 mask = Bytes64MaskToBits64Mask(filt_pos);
+        UInt64 mask = bytes64MaskToBits64Mask(filt_pos);
 
         if (0xffffffffffffffff == mask)
         {

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -242,7 +242,7 @@ ColumnPtr ColumnFixedString::filter(const IColumn::Filter & filt, ssize_t result
 
     while (filt_pos < filt_end_aligned)
     {
-        uint64_t mask = Bytes64MaskToBits64Mask(filt_pos);
+        uint64_t mask = bytes64MaskToBits64Mask(filt_pos);
 
         if (0xffffffffffffffff == mask)
         {

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -321,7 +321,7 @@ ColumnPtr ColumnVector<T>::filter(const IColumn::Filter & filt, ssize_t result_s
 
     while (filt_pos < filt_end_aligned)
     {
-        UInt64 mask = Bytes64MaskToBits64Mask(filt_pos);
+        UInt64 mask = bytes64MaskToBits64Mask(filt_pos);
 
         if (0xffffffffffffffff == mask)
         {

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -235,7 +235,7 @@ namespace
 
         while (filt_pos < filt_end_aligned)
         {
-            uint64_t mask = Bytes64MaskToBits64Mask(filt_pos);
+            uint64_t mask = bytes64MaskToBits64Mask(filt_pos);
 
             if (0xffffffffffffffff == mask)
             {

--- a/src/Columns/ColumnsCommon.h
+++ b/src/Columns/ColumnsCommon.h
@@ -21,7 +21,7 @@ namespace ErrorCodes
 }
 
 /// Transform 64-byte mask to 64-bit mask
-inline UInt64 Bytes64MaskToBits64Mask(const UInt8 * bytes64)
+inline UInt64 bytes64MaskToBits64Mask(const UInt8 * bytes64)
 {
 #if defined(__AVX512F__) && defined(__AVX512BW__)
     static const __m512i zero64 = _mm512_setzero_epi32();
@@ -46,10 +46,8 @@ inline UInt64 Bytes64MaskToBits64Mask(const UInt8 * bytes64)
         _mm_loadu_si128(reinterpret_cast<const __m128i *>(bytes64 + 48)), zero16))) << 48) & 0xffff000000000000);
 #else
     UInt64 res = 0;
-    const UInt8 * pos = bytes64;
-    const UInt8 * end = pos + 64;
-    for (; pos < end; ++pos)
-        res |= ((*pos == 0)<<(pos-bytes64));
+    for (size_t i = 0; i < 64; ++i)
+        res |= static_cast<UInt64>(0 == bytes64[i]) << i;
 #endif
     return ~res;
 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
All non-x86 builds were broken, because we don't have tests for them. This closes #31417. This closes #31524.
