### PR TITLE
insert_deduplication_token setting for INSERT statement

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -532,7 +532,7 @@ class IColumn;
     /** Experimental functions */ \
     M(Bool, allow_experimental_funnel_functions, false, "Enable experimental functions for funnel analysis.", 0) \
     M(Bool, allow_experimental_nlp_functions, false, "Enable experimental functions for natural language processing.", 0) \
-
+    M(String, insert_deduplication_token, "", "Used for deduplication detection instead of digest of data", 0) \
 // End of COMMON_SETTINGS
 // Please add settings related to formats into the FORMAT_FACTORY_SETTINGS and move obsolete settings to OBSOLETE_SETTINGS.
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1561,13 +1561,20 @@ String IMergeTreeDataPart::getUniqueId() const
 }
 
 
-String IMergeTreeDataPart::getZeroLevelPartBlockID() const
+String IMergeTreeDataPart::getZeroLevelPartBlockID(const String& token) const
 {
     if (info.level != 0)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to get block id for non zero level part {}", name);
 
     SipHash hash;
-    checksums.computeTotalChecksumDataOnly(hash);
+    if (token.empty())
+    {
+        checksums.computeTotalChecksumDataOnly(hash);
+    }
+    else
+    {
+        hash.update(token);
+    }
     union
     {
         char bytes[16];

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -170,7 +170,8 @@ public:
     bool isEmpty() const { return rows_count == 0; }
 
     /// Compute part block id for zero level part. Otherwise throws an exception.
-    String getZeroLevelPartBlockID() const;
+    /// If token is not empty, block id is calculated based on it instead of block data
+    String getZeroLevelPartBlockID(const String & token = String()) const;
 
     const MergeTreeData & storage;
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -154,7 +154,7 @@ void ReplicatedMergeTreeSink::consume(Chunk chunk)
         {
             /// We add the hash from the data and partition identifier to deduplication ID.
             /// That is, do not insert the same data to the same partition twice.
-            block_id = part->getZeroLevelPartBlockID();
+            block_id = part->getZeroLevelPartBlockID(context->getSettingsRef().insert_deduplication_token);
 
             LOG_DEBUG(log, "Wrote block with ID '{}', {} rows", block_id, current_block.block.rows());
         }

--- a/tests/queries/0_stateless/02115_insert_deduplication_token.reference
+++ b/tests/queries/0_stateless/02115_insert_deduplication_token.reference
@@ -1,0 +1,4 @@
+1	1001
+insert dupblicate by providing deduplication token
+1	1001
+1	1001

--- a/tests/queries/0_stateless/02115_insert_deduplication_token.sql
+++ b/tests/queries/0_stateless/02115_insert_deduplication_token.sql
@@ -1,0 +1,20 @@
+-- insert data duplicates by providing deduplication token on insert
+
+DROP TABLE IF EXISTS replicated_with_duplicates SYNC;
+
+CREATE TABLE IF NOT EXISTS replicated_with_duplicates (
+    id Int32, val UInt32
+) ENGINE=ReplicatedMergeTree('/clickhouse/tables/{database}/test_02115/replicated_with_duplicates', '{replica}') ORDER BY id;
+
+-- only one row will be inserted
+INSERT INTO replicated_with_duplicates VALUES(1, 1001);
+INSERT INTO replicated_with_duplicates VALUES(1, 1001);
+
+SELECT * FROM replicated_with_duplicates;
+
+select 'insert duplicate by providing deduplication token';
+set insert_deduplication_token = '1';
+INSERT INTO replicated_with_duplicates VALUES(1, 1001);
+
+OPTIMIZE TABLE replicated_with_duplicates;
+SELECT * FROM replicated_with_duplicates;


### PR DESCRIPTION
The setting allows a user to provide own deduplication semantic in Replicated*MergeTree
If provided, it's used instead of data digest to generate block ID
So, for example, by providing a unique value for the setting in each INSERT statement,
user can avoid the same inserted data being deduplicated

Issue: #7461

Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
insert_deduplication_token setting for INSERT statement (only for Replicated*MergeTree tables)
The setting allows a user to provide own deduplication semantic in Replicated*MergeTree
So, for example, by providing a unique value for the setting in each INSERT statement,
user can avoid the same inserted data being deduplicated

Detailed description / Documentation draft:
...


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
