### PR TITLE
Try to fix possible data race in RemoteQueryExecutorReadContext

### DIFF
--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -172,10 +172,10 @@ bool RemoteQueryExecutorReadContext::resumeRoutine()
             return false;
 
         fiber = std::move(fiber).resume();
-    }
 
-    if (exception)
-        std::rethrow_exception(std::move(exception));
+        if (exception)
+            std::rethrow_exception(std::move(exception));
+    }
 
     return true;
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Try to fix possible data race in RemoteQueryExecutorReadContext.

Detailed description / Documentation draft:
Data race on `exception`: https://clickhouse-test-reports.s3.yandex.net/30599/200913a5a575ffb03a0307c68da4162c9844acbb/stress_test_(thread)/stderr.log

read in `resumeRoutine()`: https://github.com/ClickHouse/ClickHouse/blob/2bef313f75e4cacc6ea2ef2133e8849ecf0385ec/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp#L177

write in routine (routine could be called from `cancel()`):
https://github.com/ClickHouse/ClickHouse/blob/2bef313f75e4cacc6ea2ef2133e8849ecf0385ec/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp#L59

It could happen because we read `exception` after unlocking `fiber_lock`: we can resume routine in `cancel()` after unlocking and before reading `exception`. So, move reading `exception` under lock.
 