### PR TITLE
Fix decrypt nullable

### DIFF
--- a/src/Functions/FunctionsAES.cpp
+++ b/src/Functions/FunctionsAES.cpp
@@ -21,8 +21,11 @@ namespace OpenSSLDetails
 {
 void onError(std::string error_message)
 {
-    error_message += ". OpenSSL error code: " + std::to_string(ERR_get_error());
-    throw DB::Exception(error_message, DB::ErrorCodes::OPENSSL_ERROR);
+    const auto error = ERR_get_error();
+    if (const auto reason = ERR_reason_error_string(error))
+        throw DB::Exception(DB::ErrorCodes::OPENSSL_ERROR, "{}, OpenSSL error {} ({})", error_message, reason, error);
+    else
+        throw DB::Exception(DB::ErrorCodes::OPENSSL_ERROR, "{}, OpenSSL error {}", error_message, error);
 }
 
 StringRef foldEncryptionKeyInMySQLCompatitableMode(size_t cipher_key_size, const StringRef & key, std::array<char, EVP_MAX_KEY_LENGTH> & folded_key)

--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -450,6 +450,8 @@ private:
             },
             optional_args
         );
+        if (arguments[1].column->isNullable())
+            return std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>());
 
         return std::make_shared<DataTypeString>();
     }
@@ -566,11 +568,8 @@ private:
 
                 if constexpr (mode == CipherMode::RFC5116_AEAD_AES_GCM)
                 {
-                    if (string_size < tag_size)
-                        throw Exception("Encrypted data is smaller than the size of additional data for AEAD mode, cannot decrypt.",
-                            ErrorCodes::BAD_ARGUMENTS);
-
-                    resulting_size -= tag_size;
+                    if (string_size)
+                        resulting_size -= tag_size;
                 }
             }
 

--- a/tests/queries/0_stateless/2021_encrypt_decrypt_nullable.reference
+++ b/tests/queries/0_stateless/2021_encrypt_decrypt_nullable.reference
@@ -1,0 +1,16 @@
+aes_encrypt_mysql
+\N
+D1B43643E1D0E9390E39BA4EAE150851
+aes_decrypt_mysql
+\N
+48656C6C6F20576F726C6421
+encrypt
+aes-256-ecb	\N
+aes-256-gcm	\N
+aes-256-ecb	D1B43643E1D0E9390E39BA4EAE150851
+aes-256-gcm	219E6478A1A3BB5B686DA4BAD70323F192EFEDCCBBD6F49E78A7E2F6
+decrypt
+aes-256-ecb	\N
+aes-256-gcm	\N
+aes-256-ecb	Hello World!
+aes-256-gcm	Hello World!

--- a/tests/queries/0_stateless/2021_encrypt_decrypt_nullable.sql
+++ b/tests/queries/0_stateless/2021_encrypt_decrypt_nullable.sql
@@ -1,33 +1,57 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: Depends on OpenSSL
+
 -------------------------------------------------------------------------------
 -- Validate that encrypt/decrypt (and mysql versions) work against Nullable(String).
 -- null gets encrypted/decrypted as null, non-null encrypted/decrypted as usual.
 -------------------------------------------------------------------------------
 -- using nullIf since that is the easiest way to produce `Nullable(String)` with a `null` value
 
-SELECT aes_encrypt_mysql('aes-256-ecb', nullIf('Hello World!', 'Hello World!'), 'test_key________________________') FORMAT Null;
-SELECT aes_encrypt_mysql('aes-256-ecb', toNullable('Hello World!'), 'test_key________________________') FORMAT Null;
+-----------------------------------------------------------------------------------------------------------------------------------
+-- MySQL compatibility
+SELECT 'aes_encrypt_mysql';
 
-WITH unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext
-SELECT aes_decrypt_mysql('aes-256-ecb', nullIf(ciphertext, ciphertext), 'test_key________________________') FORMAT Null;
+SELECT aes_encrypt_mysql('aes-256-ecb', CAST(null as Nullable(String)), 'test_key________________________');
 
-WITH unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext
-SELECT aes_encrypt_mysql('aes-256-ecb', toNullable(ciphertext), 'test_key________________________') FORMAT Null;
+WITH 'aes-256-ecb' as mode, 'Hello World!' as plaintext, 'test_key________________________' as key
+SELECT hex(aes_encrypt_mysql(mode, toNullable(plaintext), key));
 
+SELECT 'aes_decrypt_mysql';
 
-SELECT encrypt('aes-256-ecb', nullIf('Hello World!', 'Hello World!'), 'test_key________________________') FORMAT Null;
-SELECT encrypt('aes-256-gcm', nullIf('Hello World!', 'Hello World!'), 'test_key________________________', 'test_iv_____') FORMAT Null;
-SELECT encrypt('aes-256-ecb', toNullable('Hello World!'), 'test_key________________________') FORMAT Null;
-SELECT encrypt('aes-256-gcm', toNullable('Hello World!'), 'test_key________________________', 'test_iv_____') FORMAT Null;
+SELECT aes_decrypt_mysql('aes-256-ecb', CAST(null as Nullable(String)), 'test_key________________________');
 
+WITH 'aes-256-ecb' as mode, unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext, 'test_key________________________' as key
+SELECT hex(aes_decrypt_mysql(mode, toNullable(ciphertext), key));
 
-WITH unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext
-SELECT decrypt('aes-256-ecb', nullIf(ciphertext, ciphertext), 'test_key________________________') FORMAT Null;
+-----------------------------------------------------------------------------------------------------------------------------------
+-- encrypt both non-null and null values of Nullable(String)
+SELECT 'encrypt';
 
-WITH unhex('219E6478A1A3BB5B686DA4BAD70323F192EFEDCCBBD6F49E78A7E2F6') as ciphertext
-SELECT decrypt('aes-256-gcm', nullIf(ciphertext, ciphertext), 'test_key________________________', 'test_iv_____') FORMAT Null;
+WITH 'aes-256-ecb' as mode, 'test_key________________________' as key
+SELECT mode, encrypt(mode, CAST(null as Nullable(String)), key);
 
-WITH unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext
-SELECT decrypt('aes-256-ecb', toNullable(ciphertext), 'test_key________________________') FORMAT Null;
+WITH 'aes-256-gcm' as mode, 'test_key________________________' as key, 'test_iv_____' as iv
+SELECT mode, encrypt(mode, CAST(null as Nullable(String)), key, iv);
 
-WITH unhex('219E6478A1A3BB5B686DA4BAD70323F192EFEDCCBBD6F49E78A7E2F6') as ciphertext
-SELECT decrypt('aes-256-gcm', toNullable(ciphertext), 'test_key________________________', 'test_iv_____') FORMAT Null;
+WITH 'aes-256-ecb' as mode, 'test_key________________________' as key
+SELECT mode, hex(encrypt(mode, toNullable('Hello World!'), key));
+
+WITH 'aes-256-gcm' as mode, 'test_key________________________' as key, 'test_iv_____' as iv
+SELECT mode, hex(encrypt(mode, toNullable('Hello World!'), key, iv));
+
+-----------------------------------------------------------------------------------------------------------------------------------
+-- decrypt both non-null and null values of Nullable(String)
+
+SELECT 'decrypt';
+
+WITH 'aes-256-ecb' as mode, 'test_key________________________' as key
+SELECT mode, decrypt(mode, CAST(null as Nullable(String)), key);
+
+WITH 'aes-256-gcm' as mode, 'test_key________________________' as key, 'test_iv_____' as iv
+SELECT mode, decrypt(mode, CAST(null as Nullable(String)), key, iv);
+
+WITH 'aes-256-ecb' as mode, unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext, 'test_key________________________' as key
+SELECT mode, decrypt(mode, toNullable(ciphertext), key);
+
+WITH 'aes-256-gcm' as mode, unhex('219E6478A1A3BB5B686DA4BAD70323F192EFEDCCBBD6F49E78A7E2F6') as ciphertext, 'test_key________________________' as key, 'test_iv_____' as iv
+SELECT mode, decrypt(mode, toNullable(ciphertext), key, iv);

--- a/tests/queries/0_stateless/2021_encrypt_decrypt_nullable.sql
+++ b/tests/queries/0_stateless/2021_encrypt_decrypt_nullable.sql
@@ -1,0 +1,33 @@
+-------------------------------------------------------------------------------
+-- Validate that encrypt/decrypt (and mysql versions) work against Nullable(String).
+-- null gets encrypted/decrypted as null, non-null encrypted/decrypted as usual.
+-------------------------------------------------------------------------------
+-- using nullIf since that is the easiest way to produce `Nullable(String)` with a `null` value
+
+SELECT aes_encrypt_mysql('aes-256-ecb', nullIf('Hello World!', 'Hello World!'), 'test_key________________________') FORMAT Null;
+SELECT aes_encrypt_mysql('aes-256-ecb', toNullable('Hello World!'), 'test_key________________________') FORMAT Null;
+
+WITH unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext
+SELECT aes_decrypt_mysql('aes-256-ecb', nullIf(ciphertext, ciphertext), 'test_key________________________') FORMAT Null;
+
+WITH unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext
+SELECT aes_encrypt_mysql('aes-256-ecb', toNullable(ciphertext), 'test_key________________________') FORMAT Null;
+
+
+SELECT encrypt('aes-256-ecb', nullIf('Hello World!', 'Hello World!'), 'test_key________________________') FORMAT Null;
+SELECT encrypt('aes-256-gcm', nullIf('Hello World!', 'Hello World!'), 'test_key________________________', 'test_iv_____') FORMAT Null;
+SELECT encrypt('aes-256-ecb', toNullable('Hello World!'), 'test_key________________________') FORMAT Null;
+SELECT encrypt('aes-256-gcm', toNullable('Hello World!'), 'test_key________________________', 'test_iv_____') FORMAT Null;
+
+
+WITH unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext
+SELECT decrypt('aes-256-ecb', nullIf(ciphertext, ciphertext), 'test_key________________________') FORMAT Null;
+
+WITH unhex('219E6478A1A3BB5B686DA4BAD70323F192EFEDCCBBD6F49E78A7E2F6') as ciphertext
+SELECT decrypt('aes-256-gcm', nullIf(ciphertext, ciphertext), 'test_key________________________', 'test_iv_____') FORMAT Null;
+
+WITH unhex('D1B43643E1D0E9390E39BA4EAE150851') as ciphertext
+SELECT decrypt('aes-256-ecb', toNullable(ciphertext), 'test_key________________________') FORMAT Null;
+
+WITH unhex('219E6478A1A3BB5B686DA4BAD70323F192EFEDCCBBD6F49E78A7E2F6') as ciphertext
+SELECT decrypt('aes-256-gcm', toNullable(ciphertext), 'test_key________________________', 'test_iv_____') FORMAT Null;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed error on decrypting `null`-value with either `decrypt` or `aes_decrypt_mysql` funtions.
...


Detailed description / Documentation draft:
...
Closes: #31426