### PR TITLE
More easy cross-compiling for FreeBSD

### DIFF
--- a/cmake/freebsd/toolchain-aarch64.cmake
+++ b/cmake/freebsd/toolchain-aarch64.cmake
@@ -3,7 +3,7 @@ set (CMAKE_SYSTEM_PROCESSOR "aarch64")
 set (CMAKE_C_COMPILER_TARGET "aarch64-unknown-freebsd12")
 set (CMAKE_CXX_COMPILER_TARGET "aarch64-unknown-freebsd12")
 set (CMAKE_ASM_COMPILER_TARGET "aarch64-unknown-freebsd12")
-set (CMAKE_SYSROOT "${CMAKE_CURRENT_LIST_DIR}/../toolchain/freebsd-aarch64")
+set (CMAKE_SYSROOT "${CMAKE_CURRENT_LIST_DIR}/../../contrib/sysroot/freebsd-aarch64")
 
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)  # disable linkage check - it doesn't work in CMake
 

--- a/cmake/freebsd/toolchain-x86_64.cmake
+++ b/cmake/freebsd/toolchain-x86_64.cmake
@@ -3,7 +3,7 @@ set (CMAKE_SYSTEM_PROCESSOR "x86_64")
 set (CMAKE_C_COMPILER_TARGET "x86_64-pc-freebsd11")
 set (CMAKE_CXX_COMPILER_TARGET "x86_64-pc-freebsd11")
 set (CMAKE_ASM_COMPILER_TARGET "x86_64-pc-freebsd11")
-set (CMAKE_SYSROOT "${CMAKE_CURRENT_LIST_DIR}/../toolchain/freebsd-x86_64")
+set (CMAKE_SYSROOT "${CMAKE_CURRENT_LIST_DIR}/../../contrib/sysroot/freebsd-x86_64")
 
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)  # disable linkage check - it doesn't work in CMake
 

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -93,9 +93,6 @@ RUN git clone https://github.com/tpoechtrager/cctools-port.git \
 # Download toolchain and SDK for Darwin
 RUN wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz
 
-# Download toolchain for FreeBSD 11.3
-RUN wget -nv https://clickhouse-datasets.s3.yandex.net/toolchains/toolchains/freebsd-11.3-toolchain.tar.xz
-
 # NOTE: Seems like gcc-11 is too new for ubuntu20 repository
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
     && apt-get update \

--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -6,9 +6,6 @@ mkdir -p build/cmake/toolchain/darwin-x86_64
 tar xJf MacOSX11.0.sdk.tar.xz -C build/cmake/toolchain/darwin-x86_64 --strip-components=1
 ln -sf darwin-x86_64 build/cmake/toolchain/darwin-aarch64
 
-mkdir -p build/cmake/toolchain/freebsd-x86_64
-tar xJf freebsd-11.3-toolchain.tar.xz -C build/cmake/toolchain/freebsd-x86_64 --strip-components=1
-
 # Uncomment to debug ccache. Don't put ccache log in /output right away, or it
 # will be confusingly packed into the "performance" package.
 # export CCACHE_LOGFILE=/build/ccache.log

--- a/src/Common/renameat2.cpp
+++ b/src/Common/renameat2.cpp
@@ -81,10 +81,10 @@ static bool renameat2(const std::string & old_path, const std::string & new_path
         return false;
 
     if (errno == EEXIST)
-        throwFromErrno(ErrorCodes::ATOMIC_RENAME_FAIL, "Cannot rename {} to {} because the second path already exists", old_path, new_path);
+        throwFromErrno(fmt::format("Cannot rename {} to {} because the second path already exists", old_path, new_path), ErrorCodes::ATOMIC_RENAME_FAIL);
     if (errno == ENOENT)
-        throwFromErrno(ErrorCodes::ATOMIC_RENAME_FAIL, "Paths cannot be exchanged because {} or {} does not exist", old_path, new_path);
-    throwFromErrnoWithPath("Cannot rename " + old_path + " to " + new_path, new_path, ErrorCodes::SYSTEM_ERROR);
+        throwFromErrno(fmt::format("Paths cannot be exchanged because {} or {} does not exist", old_path, new_path), ErrorCodes::ATOMIC_RENAME_FAIL);
+    throwFromErrnoWithPath(fmt::format("Cannot rename {} to {}", old_path, new_path), new_path, ErrorCodes::SYSTEM_ERROR);
 }
 
 bool supportsRenameat2()

--- a/src/Common/renameat2.cpp
+++ b/src/Common/renameat2.cpp
@@ -6,6 +6,20 @@
 
 namespace fs = std::filesystem;
 
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+    extern const int ATOMIC_RENAME_FAIL;
+    extern const int SYSTEM_ERROR;
+    extern const int UNSUPPORTED_METHOD;
+    extern const int FILE_ALREADY_EXISTS;
+}
+
+}
+
 
 #if defined(__linux__)
 
@@ -40,15 +54,6 @@ namespace fs = std::filesystem;
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-    extern const int ATOMIC_RENAME_FAIL;
-    extern const int SYSTEM_ERROR;
-    extern const int UNSUPPORTED_METHOD;
-    extern const int FILE_ALREADY_EXISTS;
-}
 
 static bool supportsRenameat2Impl()
 {

--- a/src/Common/renameat2.cpp
+++ b/src/Common/renameat2.cpp
@@ -4,6 +4,9 @@
 #include <Poco/Environment.h>
 #include <filesystem>
 
+namespace fs = std::filesystem;
+
+
 #if defined(__linux__)
 
 #include <unistd.h>
@@ -34,8 +37,6 @@
     #endif
 #endif
 
-
-namespace fs = std::filesystem;
 
 namespace DB
 {

--- a/src/IO/ThreadPoolReader.cpp
+++ b/src/IO/ThreadPoolReader.cpp
@@ -30,6 +30,8 @@
         #define SYS_preadv2 286
     #elif defined(__ppc64__)
         #define SYS_preadv2 380
+    #elif defined(__riscv)
+        #define SYS_preadv2 286
     #else
         #error "Unsupported architecture"
     #endif


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid downloading toolchain tarballs for cross-compiling for FreeBSD.