### PR TITLE
Fixed null pointer exception in `MATERIALIZE COLUMN`

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -569,6 +569,11 @@ ASTPtr MutationsInterpreter::prepare(bool dry_run)
                 stages.emplace_back(context);
 
             const auto & column = columns_desc.get(command.column_name);
+            if (column.default_desc.kind != ColumnDefaultKind::Materialized)
+            {
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Column {} could not be materialized", column.name);
+            }
+
             stages.back().column_to_updated.emplace(column.name, column.default_desc.expression->clone());
         }
         else if (command.type == MutationCommand::MATERIALIZE_INDEX)


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed null pointer exception in `MATERIALIZE COLUMN`.

Detailed description / Documentation draft:
Fixed wrong error message when materializing columns which could not be materialized.

Fixes #31538 