### PR TITLE
02050: Use CLICKHOUSE_TMP and delete files when finished

### DIFF
--- a/tests/queries/0_stateless/02050_clickhouse_client_local_exception.sh
+++ b/tests/queries/0_stateless/02050_clickhouse_client_local_exception.sh
@@ -4,5 +4,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-touch test_exception
-$CLICKHOUSE_LOCAL --query="SELECT 1 INTO OUTFILE 'test_exception' FORMAT Native" 2>&1 | grep -q "Code: 76. DB::ErrnoException:" && echo 'OK' || echo 'FAIL' ||:
+touch "${CLICKHOUSE_TMP}/test_exception"
+function cleanup()
+{
+    rm "${CLICKHOUSE_TMP}/test_exception"
+}
+trap cleanup EXIT
+$CLICKHOUSE_LOCAL --query="SELECT 1 INTO OUTFILE '${CLICKHOUSE_TMP}/test_exception' FORMAT Native" 2>&1 | grep -q "Code: 76. DB::ErrnoException:" && echo 'OK' || echo 'FAIL' ||:


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

02050_clickhouse_client_local_exception is leaving behind a file called `test_exception`. Instead create it in the TMP folder and clean them up at the end.