### PR TITLE
00623_replicated_truncate_table_zookeeper_long: Wait for truncate in replicas

### DIFF
--- a/tests/queries/0_stateless/00623_replicated_truncate_table_zookeeper_long.sql
+++ b/tests/queries/0_stateless/00623_replicated_truncate_table_zookeeper_long.sql
@@ -16,7 +16,7 @@ SELECT * FROM replicated_truncate1 ORDER BY k;
 SELECT * FROM replicated_truncate2 ORDER BY k;
 
 SELECT '======After Truncate And Empty======';
-TRUNCATE TABLE replicated_truncate1;
+TRUNCATE TABLE replicated_truncate1 SETTINGS replication_alter_partitions_sync=2;
 
 SELECT * FROM replicated_truncate1 ORDER BY k;
 SELECT * FROM replicated_truncate2 ORDER BY k;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Attempt to fix https://github.com/ClickHouse/ClickHouse/issues/31655 by waiting for all replicas to apply the TRUNCATE before querying them.

Closes https://github.com/ClickHouse/ClickHouse/issues/31655
