### PR TITLE
Fix disabling query profiler

### DIFF
--- a/src/Common/QueryProfiler.h
+++ b/src/Common/QueryProfiler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <base/types.h>
 #include <signal.h>
 #include <time.h>
@@ -40,14 +41,14 @@ private:
 
 #if USE_UNWIND
     /// Timer id from timer_create(2)
-    timer_t timer_id = nullptr;
+    std::optional<timer_t> timer_id;
 #endif
 
     /// Pause signal to interrupt threads to get traces
     int pause_signal;
 
     /// Previous signal handler to restore after query profiler exits
-    struct sigaction * previous_handler = nullptr;
+    std::optional<struct sigaction> previous_handler;
 };
 
 /// Query profiler with timer based on real clock


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix disabling query profiler (In case of `query_profiler_real_time_period_ns>0`/`query_profiler_cpu_time_period_ns>0` query profiler can stayed enabled even after query finished)

Detailed description / Documentation draft:
Before there was two incorrect checks:
- timer_id != nullptr, but first timer is 0x0 and the comparison does
  not work
- previous_handler should also be reseted regardless it was nullptr or
  not, plus it also incorrectly uses 'sigaction * previous_handler'
  before.

Which leads to permanent query profiler enabled for particular thread,
this is especially visible if you have query profiler disabled and you
are running some query with profiler enabled, i.e.:

  select 1 settings query_profiler_real_time_period_ns=1

After, QueryPipelineEx will eat lots of CPU due because of profiler.