### PR TITLE
Remove OpenCL completely

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -85,9 +85,6 @@
 #if !defined(ARCADIA_BUILD)
 #   include "config_core.h"
 #   include "Common/config_version.h"
-#   if USE_OPENCL
-#       include "Common/BitonicSort.h"
-#   endif
 #endif
 
 #if defined(OS_LINUX)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`USE_OPENCL` define and `src/Common/BitonicSort.h` were removed in #15023
Cleaning this unavailable code up.