### PR TITLE
Improve how queries are output in the performance dashboard

### DIFF
--- a/docker/test/performance-comparison/report.py
+++ b/docker/test/performance-comparison/report.py
@@ -233,6 +233,10 @@ def tsvRows(n):
             for row in csv.reader(fd, delimiter="\t", quoting=csv.QUOTE_NONE):
                 new_row = []
                 for e in row:
+                    # The first one .encode('utf-8').decode('unicode-escape') decodes the escape characters from the strings.
+                    # The second one (encode('latin1').decode('utf-8')) fixes the changes with unicode vs utf-8 chars, so
+                    # 'Ð§ÐµÐ¼ Ð·Ð�Ð½Ð¸Ð¼Ð°ÐµÑ�Ð¬Ñ�Ñ�' is transformed back into 'Чем зАнимаешЬся'.
+
                     new_row.append(e.encode('utf-8').decode('unicode-escape').encode('latin1').decode('utf-8'))
                 result.append(new_row)
         return result

--- a/docker/test/performance-comparison/report.py
+++ b/docker/test/performance-comparison/report.py
@@ -227,10 +227,16 @@ def tableEnd():
     return '</table>'
 
 def tsvRows(n):
-    result = []
     try:
         with open(n, encoding='utf-8') as fd:
-            return [row for row in csv.reader(fd, delimiter="\t", quotechar='"')]
+            result = []
+            for row in csv.reader(fd, delimiter="\t", quoting=csv.QUOTE_NONE):
+                new_row = []
+                for e in row:
+                    new_row.append(e.encode('utf-8').decode('unicode-escape').encode('latin1').decode('utf-8'))
+                result.append(new_row)
+        return result
+
     except:
         report_errors.append(
             traceback.format_exception_only(


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

I'm not sure if all the cases are covered, but at least it improves it quite a bit by removing the \' and the \n from the queries.


Before:
![image](https://user-images.githubusercontent.com/664253/143424203-567e38f1-5e9a-4489-8b14-ad34fac4ec08.png)


After:
![image](https://user-images.githubusercontent.com/664253/143424078-32ca210c-15aa-4489-a82c-f8d5f4b9b43b.png)


Closes https://github.com/ClickHouse/ClickHouse/pull/31739