### PR TITLE
MaterializedMySQL: Fix issue with table named 'table'

### DIFF
--- a/src/Databases/MySQL/MaterializedMySQLSyncThread.cpp
+++ b/src/Databases/MySQL/MaterializedMySQLSyncThread.cpp
@@ -309,7 +309,7 @@ getTableOutput(const String & database_name, const String & table_name, ContextM
 
 
     String comment = "Materialize MySQL step 1: execute dump data";
-    BlockIO res = tryToExecuteQuery("INSERT INTO " + backQuoteIfNeed(table_name) + "(" + insert_columns_str.str() + ")" + " VALUES",
+    BlockIO res = tryToExecuteQuery("INSERT INTO " + backQuote(table_name) + " (" + insert_columns_str.str() + ")" + " VALUES",
         query_context, database_name, comment);
 
     return std::move(res.pipeline);

--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -1035,3 +1035,19 @@ def materialized_mysql_large_transaction(clickhouse_node, mysql_node, service_na
 
     clickhouse_node.query("DROP DATABASE largetransaction")
     mysql_node.query("DROP DATABASE largetransaction")
+
+def table_table(clickhouse_node, mysql_node, service_name):
+    mysql_node.query("DROP DATABASE IF EXISTS table_test")
+    clickhouse_node.query("DROP DATABASE IF EXISTS table_test")
+    mysql_node.query("CREATE DATABASE table_test")
+
+    # Test that the table name 'table' work as expected
+    mysql_node.query("CREATE TABLE table_test.table (id INT UNSIGNED PRIMARY KEY)")
+    mysql_node.query("INSERT INTO table_test.table VALUES (0),(1),(2),(3),(4)")
+
+    clickhouse_node.query("CREATE DATABASE table_test ENGINE=MaterializeMySQL('{}:3306', 'table_test', 'root', 'clickhouse')".format(service_name))
+
+    check_query(clickhouse_node, "SELECT COUNT(*) FROM table_test.table", "5\n")
+
+    mysql_node.query("DROP DATABASE table_test")
+    clickhouse_node.query("DROP DATABASE table_test")

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -245,3 +245,7 @@ def test_mysql_settings(started_cluster, started_mysql_8_0, started_mysql_5_7, c
 def test_large_transaction(started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node):
     materialize_with_ddl.materialized_mysql_large_transaction(clickhouse_node, started_mysql_8_0, "mysql80")
     materialize_with_ddl.materialized_mysql_large_transaction(clickhouse_node, started_mysql_5_7, "mysql57")
+
+def test_table_table(started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node):
+    materialize_with_ddl.table_table(clickhouse_node, started_mysql_8_0, "mysql80")
+    materialize_with_ddl.table_table(clickhouse_node, started_mysql_5_7, "mysql57")


### PR DESCRIPTION
This fixes an issue if the database contained a table named 'table'.
We would previously generate a query that ClickHouse could not parse.

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
MaterializedMySQL: Fix issue with table named 'table'