### PR TITLE
Fix base64Encode adding trailing bytes on small strings

### DIFF
--- a/src/Functions/base64Decode.cpp
+++ b/src/Functions/base64Decode.cpp
@@ -8,7 +8,7 @@ namespace DB
 {
 void registerFunctionBase64Decode(FunctionFactory & factory)
 {
-    tb64ini(0, 1);
+    tb64ini(0, 0);
     factory.registerFunction<FunctionBase64Conversion<Base64Decode>>();
 
     /// MysQL compatibility alias.

--- a/src/Functions/base64Encode.cpp
+++ b/src/Functions/base64Encode.cpp
@@ -12,7 +12,7 @@ namespace DB
 {
 void registerFunctionBase64Encode(FunctionFactory & factory)
 {
-    tb64ini(0, 1);
+    tb64ini(0, 0);
     factory.registerFunction<FunctionBase64Conversion<Base64Encode>>();
 
     /// MysQL compatibility alias.

--- a/tests/queries/0_stateless/02113_base64encode_trailing_bytes.reference
+++ b/tests/queries/0_stateless/02113_base64encode_trailing_bytes.reference
@@ -1,0 +1,2 @@
+SELECT * FROM tabl_1 SETTINGS log_comment = ?;
+SELECT * FROM tabl_2 SETTINGS log_comment = ?;

--- a/tests/queries/0_stateless/02113_base64encode_trailing_bytes.sql
+++ b/tests/queries/0_stateless/02113_base64encode_trailing_bytes.sql
@@ -1,0 +1,13 @@
+SET log_queries=1;
+
+CREATE TABLE tabl_1 (key String) ENGINE MergeTree ORDER BY key;
+CREATE TABLE tabl_2 (key String) ENGINE MergeTree ORDER BY key;
+SELECT * FROM tabl_1 SETTINGS log_comment = 'ad15a651';
+SELECT * FROM tabl_2 SETTINGS log_comment = 'ad15a651';
+SYSTEM FLUSH LOGS;
+
+SELECT base64Decode(base64Encode(normalizeQuery(query)))
+    FROM system.query_log
+    WHERE type='QueryFinish' AND log_comment = 'ad15a651'
+    GROUP BY normalizeQuery(query)
+    ORDER BY normalizeQuery(query);


### PR DESCRIPTION
**Changelog category:**
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

**Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):**
Fix base64Encode adding trailing bytes on small strings

Sometimes, base64Encode returns data that belongs to the next string in the buffer.
This test, when failing, shows something like that:

    -SELECT * FROM tabl_1 SETTINGS log_comment = ?;
    -SELECT * FROM tabl_2 SETTINGS log_comment = ?;
    +SELECT * FROM tabl_1 SETTINGS log_comment = ?;\0S
    +SELECT * FROM tabl_2 SETTINGS log_comment = ?;\0c

Where the S at the end of the first string is the first S of the next string in the buffer.

I don't know exactly why, but reading from `query_log` is how I manage to reliably trigger the bug.
The same code on literals, or even on a different table, did not trigger the bug, something related to alignment maybe.

I know it's encode and not decode because in my initial discovery the decoding part was outside of ClickHouse.

The "fast" mode of turbo base64 seem to go too fast on small strings, disabling the AVX2 optimisation for small string fixes the problem.


Disabling this optimisation might have visible performance impacts, maybe there is a better way to fix that.

Also, there is something about MSAN near this code, but I don't know anything about MSAN, no idea if it's related:
https://github.com/ClickHouse/ClickHouse/blob/b39c19399ff951a598dd35e575c715c5c4dfb5a2/src/Functions/FunctionBase64Conversion.h#L156-L158

