### PR TITLE
Check time limit sending data for global in.

### DIFF
--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -9,6 +9,7 @@
 #include "Core/Protocol.h"
 #include <QueryPipeline/Pipe.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
+#include <Processors/Transforms/LimitsCheckingTransform.h>
 #include <Storages/IStorage.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Interpreters/castColumn.h>
@@ -494,6 +495,12 @@ void RemoteQueryExecutor::sendExternalTables()
         external_tables_data.clear();
         external_tables_data.reserve(count);
 
+        StreamLocalLimits limits;
+        const auto & settings = context->getSettingsRef();
+        limits.mode = LimitsMode::LIMITS_TOTAL;
+        limits.speed_limits.max_execution_time = settings.max_execution_time;
+        limits.timeout_overflow_mode = settings.timeout_overflow_mode;
+
         for (size_t i = 0; i < count; ++i)
         {
             ExternalTablesData res;
@@ -503,7 +510,7 @@ void RemoteQueryExecutor::sendExternalTables()
 
                 auto data = std::make_unique<ExternalTableData>();
                 data->table_name = table.first;
-                data->creating_pipe_callback = [cur, context = this->context]()
+                data->creating_pipe_callback = [cur, limits, context = this->context]()
                 {
                     SelectQueryInfo query_info;
                     auto metadata_snapshot = cur->getInMemoryMetadataPtr();
@@ -518,6 +525,8 @@ void RemoteQueryExecutor::sendExternalTables()
                     if (pipe.empty())
                         return std::make_unique<Pipe>(
                             std::make_shared<SourceFromSingleChunk>(metadata_snapshot->getSampleBlock(), Chunk()));
+
+                    pipe.addTransform(std::make_shared<LimitsCheckingTransform>(pipe.getHeader(), limits));
 
                     return std::make_unique<Pipe>(std::move(pipe));
                 };

--- a/tests/queries/0_stateless/02116_global_in_time_limit.sh
+++ b/tests/queries/0_stateless/02116_global_in_time_limit.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# This test is pretty depend on query execution time
+# In release, it works about 14 seconds with no timeout.
+
+function run
+{
+  ${CLICKHOUSE_CLIENT} -q "select number from remote('127.0.0.2', numbers(10)) where number global in (select number + 9 from numbers(400000000)) settings max_execution_time=3" 2>&1 | echo > /dev/null
+}
+
+export -f run
+timeout 6 bash -c run


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Query with `GLOBAL IN` could be executing longer than `max_execution_time`.  Added time limit check in case of slowly sending data for `GLOBAL IN`. Maybe fixes #31349
