### PR TITLE
Speed up count over nullable columns

### DIFF
--- a/tests/performance/count.xml
+++ b/tests/performance/count.xml
@@ -4,8 +4,8 @@
     <fill_query>INSERT INTO data SELECT number, 1 from numbers(10000000)</fill_query>
 
     <query tag='count_10M' short='1'>SELECT count() FROM data</query>
-    <query>SELECT count(k) FROM data</query>
-    <query>SELECT count(toNullable(k)) FROM data</query>
+    <query>SELECT count(k) FROM (SELECT k FROM data, numbers(20) _a)</query>
+    <query>SELECT count(k) FROM (SELECT toNullable(k) as k FROM data, numbers(20) _a)</query>
 
     <drop_query>DROP TABLE IF EXISTS data</drop_query>
 </test>

--- a/tests/performance/count.xml
+++ b/tests/performance/count.xml
@@ -4,6 +4,8 @@
     <fill_query>INSERT INTO data SELECT number, 1 from numbers(10000000)</fill_query>
 
     <query tag='count_10M' short='1'>SELECT count() FROM data</query>
+    <query>SELECT count(k) FROM data</query>
+    <query>SELECT count(toNullable(k)) FROM data</query>
 
     <drop_query>DROP TABLE IF EXISTS data</drop_query>
 </test>

--- a/tests/performance/countIf.xml
+++ b/tests/performance/countIf.xml
@@ -1,3 +1,21 @@
 <test>
     <query>SELECT countIf(number % 2) FROM numbers(100000000)</query>
+
+    <query>
+        SELECT countIf(key IS NOT NULL)
+        FROM
+        (
+            SELECT materialize(toNullable(1)) AS key
+            FROM numbers(100000000)
+        )
+    </query>
+
+    <query>
+        SELECT countIf(key IS NOT NULL)
+        FROM
+        (
+            SELECT materialize(CAST(NULL, 'Nullable(Int8)')) AS key
+            FROM numbers(100000000)
+        )
+    </query>
 </test>


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up count over nullable columns


Detailed description / Documentation draft:

Implements AggregateFunctionCountNotNullUnary::addBatchSinglePlace so it doesn't fallback to the base class implementation which won't use countBytesInFilter / countBytesInFilterWithNull to check the flag and null arrays .


SQL:
```sql
SELECT count(n)
FROM
(
    SELECT toNullable(number) AS n
    FROM system.numbers
    LIMIT 10000000000
)
```

* Master: Elapsed: 2.385 sec. Processed 9.71 billion rows, 77.70 GB (4.07 billion rows/s., 32.57 GB/s.)
* PR: Elapsed: 1.825 sec. Processed 9.95 billion rows, 79.59 GB (5.45 billion rows/s., 43.61 GB/s.)

Closes https://github.com/ClickHouse/ClickHouse/issues/31627