### PR TITLE
Format prometheus metric name

### DIFF
--- a/src/Server/PrometheusMetricsWriter.cpp
+++ b/src/Server/PrometheusMetricsWriter.cpp
@@ -149,7 +149,6 @@ void PrometheusMetricsWriter::write(WriteBuffer & wb) const
     }
 }
 
-/// Prometheus metrics name should meet constraint "[a-zA-Z_:][a-zA-Z0-9_:]*"
 void PrometheusMetricsWriter::toPrometheusMetricName(String & name)
 {
     if (likely(!name.empty()))

--- a/src/Server/PrometheusMetricsWriter.h
+++ b/src/Server/PrometheusMetricsWriter.h
@@ -29,9 +29,8 @@ private:
     const bool send_asynchronous_metrics;
     const bool send_status_info;
 
-    /// Prometheus metrics name should meet constraint "[a-zA-Z_:][a-zA-Z0-9_:]*"
-    /// @name is the suffix of a metric name
-    static void toPrometheusMetricName(String & name);
+    /// /// Prometheus metrics name should meet constraint "[a-zA-Z_:][a-zA-Z0-9_:]*"
+    static inline void toPrometheusMetricName(String & name);
 
     static inline constexpr auto profile_events_prefix = "ClickHouseProfileEvents_";
     static inline constexpr auto current_metrics_prefix = "ClickHouseMetrics_";

--- a/src/Server/PrometheusMetricsWriter.h
+++ b/src/Server/PrometheusMetricsWriter.h
@@ -29,7 +29,7 @@ private:
     const bool send_asynchronous_metrics;
     const bool send_status_info;
 
-    /// /// Prometheus metrics name should meet constraint "[a-zA-Z_:][a-zA-Z0-9_:]*"
+    /// Prometheus metrics name should meet constraint "[a-zA-Z_:][a-zA-Z0-9_:]*"
     static inline void toPrometheusMetricName(String & name);
 
     static inline constexpr auto profile_events_prefix = "ClickHouseProfileEvents_";

--- a/src/Server/PrometheusMetricsWriter.h
+++ b/src/Server/PrometheusMetricsWriter.h
@@ -29,6 +29,10 @@ private:
     const bool send_asynchronous_metrics;
     const bool send_status_info;
 
+    /// Prometheus metrics name should meet constraint "[a-zA-Z_:][a-zA-Z0-9_:]*"
+    /// @name is the suffix of a metric name
+    static void toPrometheusMetricName(String & name);
+
     static inline constexpr auto profile_events_prefix = "ClickHouseProfileEvents_";
     static inline constexpr auto current_metrics_prefix = "ClickHouseMetrics_";
     static inline constexpr auto asynchronous_metrics_prefix = "ClickHouseAsyncMetrics_";


### PR DESCRIPTION
Changelog category (leave one):

- Improvement

Prometheus metric name should meet constraint `\[a-zA-Z_:\]\[a-zA-Z0-9_:\]\*` 
Detailed in https://prometheus.io/docs/practices/naming/

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Format prometheus metric name in `PrometheusMetricsWriter` before sending.

This pr will close #31863 