### PR TITLE
Reduce the files that depend on parser headers

### DIFF
--- a/programs/copier/ClusterCopier.cpp
+++ b/programs/copier/ClusterCopier.cpp
@@ -8,6 +8,7 @@
 #include <Common/setThreadName.h>
 #include <IO/ConnectionTimeoutsContext.h>
 #include <Interpreters/InterpreterInsertQuery.h>
+#include <Parsers/ASTFunction.h>
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <QueryPipeline/Chain.h>

--- a/programs/copier/Internals.cpp
+++ b/programs/copier/Internals.cpp
@@ -1,8 +1,9 @@
 #include "Internals.h"
-#include <Storages/MergeTree/MergeTreeData.h>
-#include <Storages/extractKeyExpressionList.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/Transforms/SquashingChunksTransform.h>
+#include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/extractKeyExpressionList.h>
 
 namespace DB
 {

--- a/programs/copier/Internals.cpp
+++ b/programs/copier/Internals.cpp
@@ -1,4 +1,5 @@
 #include "Internals.h"
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/Transforms/SquashingChunksTransform.h>

--- a/programs/copier/TaskTableAndShard.h
+++ b/programs/copier/TaskTableAndShard.h
@@ -5,6 +5,7 @@
 #include "ClusterPartition.h"
 
 #include <Core/Defines.h>
+#include <Parsers/ASTFunction.h>
 
 #include <base/map.h>
 #include <boost/algorithm/string/join.hpp>

--- a/src/Access/AccessEntityIO.cpp
+++ b/src/Access/AccessEntityIO.cpp
@@ -7,6 +7,7 @@
 #include <Access/SettingsProfile.h>
 #include <Access/User.h>
 #include <Core/Defines.h>
+#include <IO/WriteHelpers.h>
 #include <Interpreters/Access/InterpreterCreateQuotaQuery.h>
 #include <Interpreters/Access/InterpreterCreateRoleQuery.h>
 #include <Interpreters/Access/InterpreterCreateRowPolicyQuery.h>

--- a/src/AggregateFunctions/parseAggregateFunctionParameters.cpp
+++ b/src/AggregateFunctions/parseAggregateFunctionParameters.cpp
@@ -1,6 +1,6 @@
 #include <AggregateFunctions/parseAggregateFunctionParameters.h>
 
-#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/parseQuery.h>
 

--- a/src/AggregateFunctions/parseAggregateFunctionParameters.h
+++ b/src/AggregateFunctions/parseAggregateFunctionParameters.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTExpressionList.h>
 #include <Interpreters/Context_fwd.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/IAST_fwd.h>
 
 
 namespace DB

--- a/src/Backups/renameInCreateQuery.cpp
+++ b/src/Backups/renameInCreateQuery.cpp
@@ -1,12 +1,13 @@
-#include <Backups/renameInCreateQuery.h>
 #include <Backups/BackupRenamingConfig.h>
+#include <Backups/renameInCreateQuery.h>
+#include <Interpreters/InDepthNodeVisitor.h>
+#include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <TableFunctions/TableFunctionFactory.h>
-#include <Interpreters/InDepthNodeVisitor.h>
-#include <Interpreters/evaluateConstantExpression.h>
 
 
 namespace DB

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -40,7 +40,6 @@
 #include <Parsers/ASTDropQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTUseQuery.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTQueryWithOutput.h>
 #include <Parsers/ASTLiteral.h>

--- a/src/Compression/CompressionCodecEncrypted.cpp
+++ b/src/Compression/CompressionCodecEncrypted.cpp
@@ -7,11 +7,9 @@
 #include <Compression/CompressionCodecEncrypted.h>
 #include <Poco/Logger.h>
 #include <base/logger_useful.h>
-#include <Common/ErrorCodes.h>
 
 // This depends on BoringSSL-specific API, notably <openssl/aead.h>.
 #if USE_SSL && USE_INTERNAL_SSL_LIBRARY
-#include <Parsers/ASTLiteral.h>
 #include <openssl/digest.h>
 #include <openssl/err.h>
 #include <boost/algorithm/hex.hpp>

--- a/src/Compression/CompressionCodecGorilla.cpp
+++ b/src/Compression/CompressionCodecGorilla.cpp
@@ -7,7 +7,6 @@
 #include <Compression/CompressionFactory.h>
 #include <base/unaligned.h>
 #include <Parsers/IAST_fwd.h>
-#include <Parsers/ASTIdentifier.h>
 #include <IO/WriteHelpers.h>
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/BitHelpers.h>

--- a/src/Compression/CompressionCodecNone.cpp
+++ b/src/Compression/CompressionCodecNone.cpp
@@ -1,7 +1,6 @@
 #include <Compression/CompressionCodecNone.h>
 #include <Compression/CompressionInfo.h>
 #include <Compression/CompressionFactory.h>
-#include <Parsers/ASTIdentifier.h>
 
 
 namespace DB

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -5,7 +5,6 @@
 #include <base/unaligned.h>
 #include <Parsers/IAST.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTFunction.h>
 #include <IO/WriteHelpers.h>
 #include <Core/Types.h>

--- a/src/DataTypes/DataTypeAggregateFunction.cpp
+++ b/src/DataTypes/DataTypeAggregateFunction.cpp
@@ -15,8 +15,8 @@
 
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTIdentifier.h>
 
 
 namespace DB

--- a/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
+++ b/src/DataTypes/DataTypeCustomSimpleAggregateFunction.cpp
@@ -8,8 +8,9 @@
 
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 
 #include <boost/algorithm/string/join.hpp>
 

--- a/src/DataTypes/convertMySQLDataType.cpp
+++ b/src/DataTypes/convertMySQLDataType.cpp
@@ -5,7 +5,6 @@
 #include <Core/MultiEnum.h>
 #include <Core/SettingsEnums.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/IAST.h>
 #include "DataTypeDate.h"
 #include "DataTypeDateTime.h"

--- a/src/Databases/DDLDependencyVisitor.cpp
+++ b/src/Databases/DDLDependencyVisitor.cpp
@@ -1,10 +1,11 @@
 #include <Databases/DDLDependencyVisitor.h>
-#include <Parsers/ASTFunction.h>
-#include <Parsers/ASTCreateQuery.h>
-#include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Dictionaries/getDictionaryConfigurationFromAST.h>
 #include <Interpreters/Context.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Poco/String.h>
 
 namespace DB

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -11,9 +11,7 @@
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/formatAST.h>
 #include <Parsers/queryToString.h>
 #include <Storages/ExternalDataSourceConfiguration.h>
 #include <Common/Macros.h>

--- a/src/Databases/DatabaseMemory.cpp
+++ b/src/Databases/DatabaseMemory.cpp
@@ -5,6 +5,7 @@
 #include <Databases/DDLDependencyVisitor.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTFunction.h>
 #include <Storages/IStorage.h>
 #include <filesystem>
 

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -7,6 +7,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterCreateQuery.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/formatAST.h>
 #include <Parsers/parseQuery.h>

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -18,6 +18,7 @@
 #include <base/getFQDNOrHostName.h>
 #include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTDropQuery.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Interpreters/InterpreterCreateQuery.h>

--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -2,6 +2,7 @@
 #include <Interpreters/InterpreterCreateQuery.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/formatAST.h>
 #include <Storages/StorageDictionary.h>

--- a/src/Databases/DatabasesCommon.h
+++ b/src/Databases/DatabasesCommon.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <base/types.h>
-#include <Parsers/ASTFunction.h>
 #include <Parsers/IAST.h>
 #include <Storages/IStorage_fwd.h>
 #include <Databases/IDatabase.h>

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -1,5 +1,7 @@
 #include <Databases/PostgreSQL/DatabasePostgreSQL.h>
 
+#include <Parsers/ASTIdentifier.h>
+
 #if USE_LIBPQXX
 
 #include <DataTypes/DataTypeNullable.h>

--- a/src/Databases/SQLite/DatabaseSQLite.cpp
+++ b/src/Databases/SQLite/DatabaseSQLite.cpp
@@ -8,6 +8,7 @@
 #include <Databases/SQLite/fetchSQLiteTableStructure.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTColumnDeclaration.h>
+#include <Parsers/ASTFunction.h>
 #include <Interpreters/Context.h>
 #include <Storages/StorageSQLite.h>
 #include <Databases/SQLite/SQLiteUtils.h>

--- a/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -9,6 +9,7 @@
 #include <Parsers/queryToString.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
 #include <Core/Names.h>
 #include <Common/FieldVisitorToString.h>
 #include <Parsers/ASTFunctionWithKeyValueArguments.h>

--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
@@ -1,7 +1,7 @@
 #include <Functions/JSONPath/ASTs/ASTJSONPathMemberAccess.h>
 #include <Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.h>
 
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/Lexer.h>
 

--- a/src/Interpreters/AggregateFunctionOfGroupByKeysVisitor.h
+++ b/src/Interpreters/AggregateFunctionOfGroupByKeysVisitor.h
@@ -4,7 +4,6 @@
 #include <IO/WriteHelpers.h>
 #include <Interpreters/InDepthNodeVisitor.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>

--- a/src/Interpreters/AggregateFunctionOfGroupByKeysVisitor.h
+++ b/src/Interpreters/AggregateFunctionOfGroupByKeysVisitor.h
@@ -4,7 +4,6 @@
 #include <IO/WriteHelpers.h>
 #include <Interpreters/InDepthNodeVisitor.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/IAST.h>

--- a/src/Interpreters/ApplyWithSubqueryVisitor.cpp
+++ b/src/Interpreters/ApplyWithSubqueryVisitor.cpp
@@ -3,6 +3,7 @@
 #include <Interpreters/StorageID.h>
 #include <Interpreters/misc.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>

--- a/src/Interpreters/ApplyWithSubqueryVisitor.cpp
+++ b/src/Interpreters/ApplyWithSubqueryVisitor.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ASTWithElement.h>

--- a/src/Interpreters/CollectJoinOnKeysVisitor.cpp
+++ b/src/Interpreters/CollectJoinOnKeysVisitor.cpp
@@ -1,3 +1,4 @@
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/queryToString.h>
 
 #include <Interpreters/CollectJoinOnKeysVisitor.h>

--- a/src/Interpreters/ComparisonGraph.h
+++ b/src/Interpreters/ComparisonGraph.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Parsers/IAST_fwd.h>
-#include <Parsers/ASTLiteral.h>
 #include <Interpreters/TreeCNFConverter.h>
 #include <unordered_map>
 #include <map>

--- a/src/Interpreters/DuplicateOrderByVisitor.cpp
+++ b/src/Interpreters/DuplicateOrderByVisitor.cpp
@@ -1,9 +1,7 @@
 #include <Interpreters/DuplicateOrderByVisitor.h>
 #include <Functions/FunctionFactory.h>
 #include <AggregateFunctions/AggregateFunctionFactory.h>
-#include <IO/WriteHelpers.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>

--- a/src/Interpreters/ExtractExpressionInfoVisitor.cpp
+++ b/src/Interpreters/ExtractExpressionInfoVisitor.cpp
@@ -2,6 +2,8 @@
 #include <Functions/FunctionFactory.h>
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <Interpreters/IdentifierSemantic.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSubquery.h>
 
 

--- a/src/Interpreters/ExtractExpressionInfoVisitor.h
+++ b/src/Interpreters/ExtractExpressionInfoVisitor.h
@@ -3,12 +3,13 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/DatabaseAndTableWithAlias.h>
 #include <Interpreters/InDepthNodeVisitor.h>
-#include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/IAST_fwd.h>
 
 namespace DB
 {
+
+class ASTFunction;
+class ASTIdentifier;
 
 
 struct ExpressionInfoMatcher

--- a/src/Interpreters/FunctionNameNormalizer.cpp
+++ b/src/Interpreters/FunctionNameNormalizer.cpp
@@ -2,6 +2,7 @@
 
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTFunction.h>
 
 namespace DB
 {

--- a/src/Interpreters/FunctionNameNormalizer.h
+++ b/src/Interpreters/FunctionNameNormalizer.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <Parsers/IAST.h>
-#include <Parsers/ASTFunction.h>
+#include <Parsers/IAST_fwd.h>
 
 namespace DB
 {

--- a/src/Interpreters/GatherFunctionQuantileVisitor.cpp
+++ b/src/Interpreters/GatherFunctionQuantileVisitor.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <Interpreters/GatherFunctionQuantileVisitor.h>
+#include <Parsers/ASTFunction.h>
 #include <Common/Exception.h>
 #include <base/types.h>
 

--- a/src/Interpreters/GatherFunctionQuantileVisitor.h
+++ b/src/Interpreters/GatherFunctionQuantileVisitor.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <Parsers/ASTFunction.h>
-#include <Parsers/IAST.h>
-#include <Interpreters/InDepthNodeVisitor.h>
 #include <AggregateFunctions/AggregateFunctionQuantile.h>
+#include <Interpreters/InDepthNodeVisitor.h>
+#include <Parsers/IAST_fwd.h>
 
 namespace DB
 {
+
+class ASTFunction;
 
 /// Gather all the `quantile*` functions
 class GatherFunctionQuantileData

--- a/src/Interpreters/GlobalSubqueriesVisitor.h
+++ b/src/Interpreters/GlobalSubqueriesVisitor.h
@@ -10,7 +10,6 @@
 #include <Interpreters/interpretSubquery.h>
 #include <Interpreters/SubqueryForSet.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSubquery.h>

--- a/src/Interpreters/GroupByFunctionKeysVisitor.h
+++ b/src/Interpreters/GroupByFunctionKeysVisitor.h
@@ -4,7 +4,6 @@
 #include <IO/WriteHelpers.h>
 #include <Interpreters/InDepthNodeVisitor.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>

--- a/src/Interpreters/GroupByFunctionKeysVisitor.h
+++ b/src/Interpreters/GroupByFunctionKeysVisitor.h
@@ -4,7 +4,6 @@
 #include <IO/WriteHelpers.h>
 #include <Interpreters/InDepthNodeVisitor.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ASTIdentifier.h>

--- a/src/Interpreters/IdentifierSemantic.cpp
+++ b/src/Interpreters/IdentifierSemantic.cpp
@@ -7,6 +7,7 @@
 
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTSelectQuery.h>
 
 namespace DB
 {

--- a/src/Interpreters/IdentifierSemantic.cpp
+++ b/src/Interpreters/IdentifierSemantic.cpp
@@ -6,6 +6,7 @@
 #include <Interpreters/StorageID.h>
 
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 
 namespace DB
 {

--- a/src/Interpreters/IdentifierSemantic.h
+++ b/src/Interpreters/IdentifierSemantic.h
@@ -6,12 +6,12 @@
 #include <Interpreters/QueryAliasesVisitor.h>
 #include <Interpreters/getHeaderForProcessingStage.h>
 #include <Interpreters/getTableExpressions.h>
-#include <Parsers/ASTSelectQuery.h>
 
 namespace DB
 {
 
 class ASTIdentifier;
+class ASTSelectQuery;
 
 struct IdentifierSemanticImpl
 {

--- a/src/Interpreters/IdentifierSemantic.h
+++ b/src/Interpreters/IdentifierSemantic.h
@@ -6,11 +6,12 @@
 #include <Interpreters/QueryAliasesVisitor.h>
 #include <Interpreters/getHeaderForProcessingStage.h>
 #include <Interpreters/getTableExpressions.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSelectQuery.h>
 
 namespace DB
 {
+
+class ASTIdentifier;
 
 struct IdentifierSemanticImpl
 {

--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -11,6 +11,7 @@
 #include <Interpreters/executeDDLQueryOnCluster.h>
 #include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTAssignment.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Storages/AlterCommands.h>
 #include <Storages/IStorage.h>
 #include <Storages/LiveView/LiveViewCommands.h>

--- a/src/Interpreters/InterpreterCreateFunctionQuery.cpp
+++ b/src/Interpreters/InterpreterCreateFunctionQuery.cpp
@@ -1,15 +1,16 @@
 #include <Interpreters/InterpreterCreateFunctionQuery.h>
 
 #include <Access/ContextAccess.h>
-#include <Parsers/ASTCreateFunctionQuery.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/FunctionNameNormalizer.h>
-#include <Interpreters/UserDefinedSQLObjectsLoader.h>
 #include <Interpreters/UserDefinedSQLFunctionFactory.h>
+#include <Interpreters/UserDefinedSQLObjectsLoader.h>
 #include <Interpreters/executeDDLQueryOnCluster.h>
+#include <Parsers/ASTCreateFunctionQuery.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 
 
 namespace DB

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -12,6 +12,7 @@
 #include <Parsers/queryToString.h>
 #include <Parsers/ASTExplainQuery.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 
 #include <Storages/StorageView.h>
 #include <Processors/QueryPlan/QueryPlan.h>

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -297,7 +297,7 @@ BlockIO InterpreterInsertQuery::execute()
                 const auto & union_modes = select_query.list_of_modes;
 
                 /// ASTSelectWithUnionQuery is not normalized now, so it may pass some queries which can be Trivial select queries
-                const auto mode_is_all = [](const auto & mode) { return mode == ASTSelectWithUnionQuery::Mode::ALL; };
+                const auto mode_is_all = [](const auto & mode) { return mode == SelectUnionMode::ALL; };
 
                 is_trivial_insert_select =
                     std::all_of(union_modes.begin(), union_modes.end(), std::move(mode_is_all))

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -293,7 +293,7 @@ void InterpreterSelectWithUnionQuery::buildQueryPlan(QueryPlan & query_plan)
         query_plan.unitePlans(std::move(union_step), std::move(plans));
 
         const auto & query = query_ptr->as<ASTSelectWithUnionQuery &>();
-        if (query.union_mode == ASTSelectWithUnionQuery::Mode::DISTINCT)
+        if (query.union_mode == SelectUnionMode::DISTINCT)
         {
             /// Add distinct transform
             SizeLimits limits(settings.max_rows_in_distinct, settings.max_bytes_in_distinct, settings.distinct_overflow_mode);

--- a/src/Interpreters/MarkTableIdentifiersVisitor.cpp
+++ b/src/Interpreters/MarkTableIdentifiersVisitor.cpp
@@ -4,6 +4,7 @@
 #include <Interpreters/IdentifierSemantic.h>
 #include <Interpreters/misc.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 

--- a/src/Interpreters/MonotonicityCheckVisitor.h
+++ b/src/Interpreters/MonotonicityCheckVisitor.h
@@ -9,7 +9,6 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTOrderByElement.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/IAST.h>
 #include <Common/typeid_cast.h>

--- a/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.cpp
+++ b/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.cpp
@@ -1,6 +1,7 @@
 #include <Interpreters/NormalizeSelectWithUnionQueryVisitor.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTSelectIntersectExceptQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Common/typeid_cast.h>
 
 namespace DB
@@ -41,7 +42,7 @@ void NormalizeSelectWithUnionQueryMatcher::visit(ASTSelectWithUnionQuery & ast, 
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Got empty list of selects for ASTSelectWithUnionQuery");
 
     /// Since nodes are traversed from bottom to top, we can also collect union modes from children up to parents.
-    ASTSelectWithUnionQuery::UnionModesSet current_set_of_modes;
+    SelectUnionModesSet current_set_of_modes;
     bool distinct_found = false;
 
     int i;
@@ -58,22 +59,22 @@ void NormalizeSelectWithUnionQueryMatcher::visit(ASTSelectWithUnionQuery & ast, 
             continue;
 
         /// Rewrite UNION Mode
-        if (union_modes[i] == ASTSelectWithUnionQuery::Mode::Unspecified)
+        if (union_modes[i] == SelectUnionMode::Unspecified)
         {
             if (data.union_default_mode == UnionMode::ALL)
-                union_modes[i] = ASTSelectWithUnionQuery::Mode::ALL;
+                union_modes[i] = SelectUnionMode::ALL;
             else if (data.union_default_mode == UnionMode::DISTINCT)
-                union_modes[i] = ASTSelectWithUnionQuery::Mode::DISTINCT;
+                union_modes[i] = SelectUnionMode::DISTINCT;
             else
                 throw Exception(
                     "Expected ALL or DISTINCT in SelectWithUnion query, because setting (union_default_mode) is empty",
                     DB::ErrorCodes::EXPECTED_ALL_OR_DISTINCT);
         }
 
-        if (union_modes[i] == ASTSelectWithUnionQuery::Mode::ALL)
+        if (union_modes[i] == SelectUnionMode::ALL)
         {
             if (auto * inner_union = select_list[i + 1]->as<ASTSelectWithUnionQuery>();
-                inner_union && inner_union->union_mode == ASTSelectWithUnionQuery::Mode::ALL)
+                inner_union && inner_union->union_mode == SelectUnionMode::ALL)
             {
                 /// Inner_union is an UNION ALL list, just lift up
                 for (auto child = inner_union->list_of_selects->children.rbegin(); child != inner_union->list_of_selects->children.rend();
@@ -84,7 +85,7 @@ void NormalizeSelectWithUnionQueryMatcher::visit(ASTSelectWithUnionQuery & ast, 
                 selects.push_back(select_list[i + 1]);
         }
         /// flatten all left nodes and current node to a UNION DISTINCT list
-        else if (union_modes[i] == ASTSelectWithUnionQuery::Mode::DISTINCT)
+        else if (union_modes[i] == SelectUnionMode::DISTINCT)
         {
             auto distinct_list = std::make_shared<ASTSelectWithUnionQuery>();
             distinct_list->list_of_selects = std::make_shared<ASTExpressionList>();
@@ -95,7 +96,7 @@ void NormalizeSelectWithUnionQueryMatcher::visit(ASTSelectWithUnionQuery & ast, 
                 getSelectsFromUnionListNode(select_list[j], distinct_list->list_of_selects->children);
             }
 
-            distinct_list->union_mode = ASTSelectWithUnionQuery::Mode::DISTINCT;
+            distinct_list->union_mode = SelectUnionMode::DISTINCT;
             distinct_list->is_normalized = true;
             selects.push_back(std::move(distinct_list));
             distinct_found = true;
@@ -112,7 +113,7 @@ void NormalizeSelectWithUnionQueryMatcher::visit(ASTSelectWithUnionQuery & ast, 
     if (!distinct_found)
     {
         if (auto * inner_union = select_list[0]->as<ASTSelectWithUnionQuery>();
-            inner_union && inner_union->union_mode == ASTSelectWithUnionQuery::Mode::ALL)
+            inner_union && inner_union->union_mode == SelectUnionMode::ALL)
         {
             /// Inner_union is an UNION ALL list, just lift it up
             for (auto child = inner_union->list_of_selects->children.rbegin(); child != inner_union->list_of_selects->children.rend();
@@ -135,7 +136,7 @@ void NormalizeSelectWithUnionQueryMatcher::visit(ASTSelectWithUnionQuery & ast, 
     std::reverse(selects.begin(), selects.end());
 
     ast.is_normalized = true;
-    ast.union_mode = ASTSelectWithUnionQuery::Mode::ALL;
+    ast.union_mode = SelectUnionMode::ALL;
     ast.set_of_modes = std::move(current_set_of_modes);
 
     ast.list_of_selects->children = std::move(selects);

--- a/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.h
+++ b/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.h
@@ -2,16 +2,16 @@
 
 #include <unordered_set>
 
-#include <Parsers/IAST.h>
 #include <Interpreters/InDepthNodeVisitor.h>
+#include <Parsers/IAST_fwd.h>
 
 #include <Core/Settings.h>
-#include <Parsers/ASTSelectWithUnionQuery.h>
 
 namespace DB
 {
 
 class ASTFunction;
+class ASTSelectWithUnionQuery;
 
 class NormalizeSelectWithUnionQueryMatcher
 {

--- a/src/Interpreters/OptimizeIfChains.cpp
+++ b/src/Interpreters/OptimizeIfChains.cpp
@@ -1,5 +1,4 @@
 #include <Common/typeid_cast.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Interpreters/OptimizeIfChains.h>

--- a/src/Interpreters/PredicateExpressionsOptimizer.cpp
+++ b/src/Interpreters/PredicateExpressionsOptimizer.cpp
@@ -1,13 +1,14 @@
 #include <Interpreters/PredicateExpressionsOptimizer.h>
 
-#include <Parsers/IAST.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ExtractExpressionInfoVisitor.h>
+#include <Interpreters/PredicateRewriteVisitor.h>
+#include <Interpreters/getTableExpressions.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
-#include <Interpreters/Context.h>
-#include <Interpreters/getTableExpressions.h>
-#include <Interpreters/PredicateRewriteVisitor.h>
-#include <Interpreters/ExtractExpressionInfoVisitor.h>
+#include <Parsers/IAST.h>
 
 
 namespace DB

--- a/src/Interpreters/PredicateExpressionsOptimizer.h
+++ b/src/Interpreters/PredicateExpressionsOptimizer.h
@@ -2,11 +2,11 @@
 
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/DatabaseAndTableWithAlias.h>
-#include <Parsers/ASTSelectQuery.h>
 
 namespace DB
 {
 
+class ASTSelectQuery;
 struct Settings;
 
 /** Predicate optimization based on rewriting ast rules

--- a/src/Interpreters/PredicateRewriteVisitor.cpp
+++ b/src/Interpreters/PredicateRewriteVisitor.cpp
@@ -7,6 +7,7 @@
 #include <Parsers/ASTColumnsMatcher.h>
 #include <Parsers/ASTQualifiedAsterisk.h>
 #include <Parsers/ASTSelectIntersectExceptQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Interpreters/IdentifierSemantic.h>
 #include <Interpreters/getTableExpressions.h>
 #include <Interpreters/InterpreterSelectQuery.h>

--- a/src/Interpreters/PredicateRewriteVisitor.h
+++ b/src/Interpreters/PredicateRewriteVisitor.h
@@ -3,14 +3,14 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/DatabaseAndTableWithAlias.h>
 #include <Interpreters/InDepthNodeVisitor.h>
-#include <Parsers/ASTSelectQuery.h>
-#include <Parsers/ASTSelectWithUnionQuery.h>
-#include <Parsers/IAST.h>
+#include <Parsers/IAST_fwd.h>
 
 namespace DB
 {
 
 class ASTSelectIntersectExceptQuery;
+class ASTSelectQuery;
+class ASTSelectWithUnionQuery;
 
 class PredicateRewriteVisitorData : WithContext
 {

--- a/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
+++ b/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
@@ -2,13 +2,14 @@
 
 #include <Interpreters/InDepthNodeVisitor.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTOrderByElement.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTExpressionList.h>
 
 namespace DB
 {
+
+class ASTIdentifier;
 
 class RedundantFunctionsInOrderByMatcher
 {

--- a/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
+++ b/src/Interpreters/RedundantFunctionsInOrderByVisitor.h
@@ -3,7 +3,6 @@
 #include <Interpreters/InDepthNodeVisitor.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTOrderByElement.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTExpressionList.h>
 
 namespace DB

--- a/src/Interpreters/RenameColumnVisitor.cpp
+++ b/src/Interpreters/RenameColumnVisitor.cpp
@@ -1,5 +1,6 @@
-#include <Interpreters/RenameColumnVisitor.h>
 #include <Interpreters/IdentifierSemantic.h>
+#include <Interpreters/RenameColumnVisitor.h>
+#include <Parsers/ASTIdentifier.h>
 
 namespace DB
 {

--- a/src/Interpreters/RenameColumnVisitor.h
+++ b/src/Interpreters/RenameColumnVisitor.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <Interpreters/InDepthNodeVisitor.h>
-#include <Parsers/ASTIdentifier.h>
 
 namespace DB
 {
+
+class ASTIdentifier;
+
 /// Data for RenameColumnVisitor which traverse tree and rename all columns with
 /// name column_name to rename_to
 struct RenameColumnData

--- a/src/Interpreters/RewriteAnyFunctionVisitor.cpp
+++ b/src/Interpreters/RewriteAnyFunctionVisitor.cpp
@@ -1,11 +1,9 @@
 #include <Common/typeid_cast.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSubquery.h>
 #include <Interpreters/RewriteAnyFunctionVisitor.h>
 #include <AggregateFunctions/AggregateFunctionFactory.h>
-#include <IO/WriteHelpers.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 
 namespace DB

--- a/src/Interpreters/RewriteCountVariantsVisitor.cpp
+++ b/src/Interpreters/RewriteCountVariantsVisitor.cpp
@@ -1,6 +1,5 @@
 #include <Interpreters/RewriteCountVariantsVisitor.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>

--- a/src/Interpreters/RewriteFunctionToSubcolumnVisitor.cpp
+++ b/src/Interpreters/RewriteFunctionToSubcolumnVisitor.cpp
@@ -3,6 +3,7 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTFunction.h>
 
 namespace DB
 {

--- a/src/Interpreters/RewriteFunctionToSubcolumnVisitor.h
+++ b/src/Interpreters/RewriteFunctionToSubcolumnVisitor.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <Parsers/ASTFunction.h>
 #include <Interpreters/InDepthNodeVisitor.h>
 #include <Storages/StorageInMemoryMetadata.h>
 
 namespace DB
 {
+
+class ASTFunction;
 
 /// Rewrites functions to subcolumns, if possible, to reduce amount of read data.
 /// E.g. 'length(arr)' -> 'arr.size0', 'col IS NULL' -> 'col.null'

--- a/src/Interpreters/SelectIntersectExceptQueryVisitor.cpp
+++ b/src/Interpreters/SelectIntersectExceptQueryVisitor.cpp
@@ -1,5 +1,6 @@
 #include <Interpreters/SelectIntersectExceptQueryVisitor.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Common/typeid_cast.h>
 
 
@@ -43,16 +44,16 @@ void SelectIntersectExceptQueryMatcher::visit(ASTSelectWithUnionQuery & ast, Dat
 
     ASTs children = {selects.back()};
     selects.pop_back();
-    ASTSelectWithUnionQuery::UnionModes modes;
+    SelectUnionModes modes;
 
     for (const auto & mode : union_modes)
     {
         switch (mode)
         {
-            case ASTSelectWithUnionQuery::Mode::EXCEPT:
+            case SelectUnionMode::EXCEPT:
             {
                 auto left = std::make_shared<ASTSelectWithUnionQuery>();
-                left->union_mode = ASTSelectWithUnionQuery::Mode::ALL;
+                left->union_mode = SelectUnionMode::ALL;
 
                 left->list_of_selects = std::make_shared<ASTExpressionList>();
                 left->children.push_back(left->list_of_selects);
@@ -71,7 +72,7 @@ void SelectIntersectExceptQueryMatcher::visit(ASTSelectWithUnionQuery & ast, Dat
                 children = {except_node};
                 break;
             }
-            case ASTSelectWithUnionQuery::Mode::INTERSECT:
+            case SelectUnionMode::INTERSECT:
             {
                 bool from_except = false;
                 const auto * except_ast = typeid_cast<const ASTSelectIntersectExceptQuery *>(children.back().get());
@@ -121,7 +122,7 @@ void SelectIntersectExceptQueryMatcher::visit(ASTSelectWithUnionQuery & ast, Dat
         children.emplace_back(std::move(right));
     }
 
-    ast.union_mode = ASTSelectWithUnionQuery::Mode::Unspecified;
+    ast.union_mode = SelectUnionMode::Unspecified;
     ast.list_of_selects->children = std::move(children);
     ast.list_of_modes = std::move(modes);
 }

--- a/src/Interpreters/SelectIntersectExceptQueryVisitor.h
+++ b/src/Interpreters/SelectIntersectExceptQueryVisitor.h
@@ -6,13 +6,13 @@
 #include <Interpreters/InDepthNodeVisitor.h>
 
 #include <Parsers/ASTSelectIntersectExceptQuery.h>
-#include <Parsers/ASTSelectWithUnionQuery.h>
 
 
 namespace DB
 {
 
 class ASTFunction;
+class ASTSelectWithUnionQuery;
 
 class SelectIntersectExceptQueryMatcher
 {

--- a/src/Interpreters/TreeCNFConverter.h
+++ b/src/Interpreters/TreeCNFConverter.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <Parsers/IAST_fwd.h>
-#include <Parsers/ASTLiteral.h>
-#include <vector>
 #include <set>
 #include <unordered_map>
+#include <vector>
+#include <IO/Operators.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/IAST_fwd.h>
 
 namespace DB
 {

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -28,10 +28,11 @@
 
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/queryToString.h>
-#include <Parsers/ASTLiteral.h>
 
 #include <DataTypes/NestedUtils.h>
 #include <DataTypes/DataTypeNullable.h>

--- a/src/Interpreters/WhereConstraintsOptimizer.h
+++ b/src/Interpreters/WhereConstraintsOptimizer.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <Parsers/IAST_fwd.h>
-#include <Parsers/ASTSelectQuery.h>
 
 namespace DB
 {
 
+class ASTSelectQuery;
 struct StorageInMemoryMetadata;
 using StorageMetadataPtr = std::shared_ptr<const StorageInMemoryMetadata>;
 

--- a/src/Interpreters/evaluateConstantExpression.h
+++ b/src/Interpreters/evaluateConstantExpression.h
@@ -4,7 +4,6 @@
 #include <Core/Field.h>
 #include <Interpreters/Context_fwd.h>
 #include <Parsers/IAST.h>
-#include <Parsers/IParser.h>
 
 #include <memory>
 #include <optional>

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -6,6 +6,7 @@
 #include <Parsers/ASTQueryWithOutput.h>
 #include <Parsers/ASTQueryWithOnCluster.h>
 #include <Parsers/ASTAlterQuery.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/queryToString.h>
 #include <Access/Common/AccessRightsElement.h>
 #include <Access/ContextAccess.h>

--- a/src/Interpreters/getHeaderForProcessingStage.cpp
+++ b/src/Interpreters/getHeaderForProcessingStage.cpp
@@ -3,6 +3,7 @@
 #include <Interpreters/TreeRewriter.h>
 #include <Interpreters/IdentifierSemantic.h>
 #include <Storages/IStorage.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>

--- a/src/Interpreters/getHeaderForProcessingStage.cpp
+++ b/src/Interpreters/getHeaderForProcessingStage.cpp
@@ -3,6 +3,7 @@
 #include <Interpreters/TreeRewriter.h>
 #include <Interpreters/IdentifierSemantic.h>
 #include <Storages/IStorage.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -4,7 +4,6 @@
 #include <Parsers/ASTQueryWithOnCluster.h>
 #include <Parsers/ASTDictionary.h>
 #include <Parsers/ASTDictionaryAttributeDeclaration.h>
-#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Interpreters/StorageID.h>
 
 namespace DB
@@ -12,6 +11,7 @@ namespace DB
 
 class ASTFunction;
 class ASTSetQuery;
+class ASTSelectWithUnionQuery;
 
 class ASTStorage : public IAST
 {

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -4,7 +4,6 @@
 #include <Parsers/ASTQueryWithOnCluster.h>
 #include <Parsers/ASTDictionary.h>
 #include <Parsers/ASTDictionaryAttributeDeclaration.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Interpreters/StorageID.h>
 

--- a/src/Parsers/ASTDictionary.h
+++ b/src/Parsers/ASTDictionary.h
@@ -2,7 +2,6 @@
 
 #include <Parsers/IAST.h>
 #include <Parsers/ASTFunctionWithKeyValueArguments.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTExpressionList.h>
 
 #include <Parsers/ASTSetQuery.h>
@@ -11,6 +10,8 @@
 
 namespace DB
 {
+
+class ASTLiteral;
 
 /// AST for external dictionary lifetime:
 /// lifetime(min 10 max 100)

--- a/src/Parsers/ASTExternalDDLQuery.h
+++ b/src/Parsers/ASTExternalDDLQuery.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <Parsers/IAST.h>
+#include <IO/Operators.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/IAST.h>
 
 namespace DB
 {

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -6,13 +6,9 @@
 #include <Common/FieldVisitorToString.h>
 #include <Common/SipHash.h>
 #include <Common/typeid_cast.h>
-#include <DataTypes/IDataType.h>
-#include <DataTypes/NumberTraits.h>
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
-#include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTWithAlias.h>

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -10,6 +10,7 @@
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTWithAlias.h>
 #include <Parsers/queryToString.h>

--- a/src/Parsers/ASTFunction.h
+++ b/src/Parsers/ASTFunction.h
@@ -2,13 +2,13 @@
 
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTIdentifier_fwd.h>
-#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTWithAlias.h>
 
 
 namespace DB
 {
 
+class ASTSelectWithUnionQuery;
 
 /** AST for function application or operator.
   */

--- a/src/Parsers/ASTFunction.h
+++ b/src/Parsers/ASTFunction.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <Parsers/ASTWithAlias.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTWithAlias.h>
 
 
 namespace DB
 {
 
-class ASTIdentifier;
 
 /** AST for function application or operator.
   */

--- a/src/Parsers/ASTIdentifier.h
+++ b/src/Parsers/ASTIdentifier.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <Core/UUID.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTQueryParameter.h>
 #include <Parsers/ASTWithAlias.h>
-
-#include <optional>
 
 
 namespace DB
@@ -92,18 +91,5 @@ public:
 
     void updateTreeHashImpl(SipHash & hash_state) const override;
 };
-
-
-/// ASTIdentifier Helpers: hide casts and semantic.
-
-void setIdentifierSpecial(ASTPtr & ast);
-
-String getIdentifierName(const IAST * ast);
-std::optional<String> tryGetIdentifierName(const IAST * ast);
-bool tryGetIdentifierNameInto(const IAST * ast, String & name);
-
-inline String getIdentifierName(const ASTPtr & ast) { return getIdentifierName(ast.get()); }
-inline std::optional<String> tryGetIdentifierName(const ASTPtr & ast) { return tryGetIdentifierName(ast.get()); }
-inline bool tryGetIdentifierNameInto(const ASTPtr & ast, String & name) { return tryGetIdentifierNameInto(ast.get(), name); }
 
 }

--- a/src/Parsers/ASTIdentifier_fwd.h
+++ b/src/Parsers/ASTIdentifier_fwd.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Parsers/IAST_fwd.h>
+#include <base/types.h>
+
+#include <optional>
+#include <vector>
+
+namespace DB
+{
+
+class ASTIdentifier;
+class ASTTableIdentifier;
+
+/// ASTIdentifier Helpers: hide casts and semantic.
+
+void setIdentifierSpecial(ASTPtr & ast);
+
+String getIdentifierName(const IAST * ast);
+std::optional<String> tryGetIdentifierName(const IAST * ast);
+bool tryGetIdentifierNameInto(const IAST * ast, String & name);
+
+inline String getIdentifierName(const ASTPtr & ast)
+{
+    return getIdentifierName(ast.get());
+}
+inline std::optional<String> tryGetIdentifierName(const ASTPtr & ast)
+{
+    return tryGetIdentifierName(ast.get());
+}
+inline bool tryGetIdentifierNameInto(const ASTPtr & ast, String & name)
+{
+    return tryGetIdentifierNameInto(ast.get(), name);
+}
+
+}

--- a/src/Parsers/ASTProjectionDeclaration.cpp
+++ b/src/Parsers/ASTProjectionDeclaration.cpp
@@ -1,7 +1,6 @@
-#include <Parsers/ASTFunction.h>
+#include <IO/Operators.h>
 #include <Parsers/ASTProjectionDeclaration.h>
 #include <Common/quoteString.h>
-
 
 namespace DB
 {

--- a/src/Parsers/ASTProjectionDeclaration.cpp
+++ b/src/Parsers/ASTProjectionDeclaration.cpp
@@ -1,3 +1,4 @@
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTProjectionDeclaration.h>
 #include <Common/quoteString.h>
 

--- a/src/Parsers/ASTProjectionDeclaration.h
+++ b/src/Parsers/ASTProjectionDeclaration.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Parsers/ASTFunction.h>
 #include <Parsers/IAST.h>
 
 

--- a/src/Parsers/ASTProjectionSelectQuery.cpp
+++ b/src/Parsers/ASTProjectionSelectQuery.cpp
@@ -1,3 +1,4 @@
+#include <IO/Operators.h>
 #include <Interpreters/StorageID.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>

--- a/src/Parsers/ASTSelectWithUnionQuery.cpp
+++ b/src/Parsers/ASTSelectWithUnionQuery.cpp
@@ -32,13 +32,13 @@ void ASTSelectWithUnionQuery::formatQueryImpl(const FormatSettings & settings, F
 
     auto mode_to_str = [&](auto mode)
     {
-        if (mode == Mode::ALL)
+        if (mode == SelectUnionMode::ALL)
             return "UNION ALL";
-        else if (mode == Mode::DISTINCT)
+        else if (mode == SelectUnionMode::DISTINCT)
             return "UNION DISTINCT";
-        else if (mode == Mode::INTERSECT)
+        else if (mode == SelectUnionMode::INTERSECT)
             return "INTERSECT";
-        else if (mode == Mode::EXCEPT)
+        else if (mode == SelectUnionMode::EXCEPT)
             return "EXCEPT";
         return "";
     };
@@ -77,7 +77,8 @@ void ASTSelectWithUnionQuery::formatQueryImpl(const FormatSettings & settings, F
 
 bool ASTSelectWithUnionQuery::hasNonDefaultUnionMode() const
 {
-    return set_of_modes.contains(Mode::DISTINCT) || set_of_modes.contains(Mode::INTERSECT) || set_of_modes.contains(Mode::EXCEPT);
+    return set_of_modes.contains(SelectUnionMode::DISTINCT) || set_of_modes.contains(SelectUnionMode::INTERSECT)
+        || set_of_modes.contains(SelectUnionMode::EXCEPT);
 }
 
 }

--- a/src/Parsers/ASTSelectWithUnionQuery.cpp
+++ b/src/Parsers/ASTSelectWithUnionQuery.cpp
@@ -1,4 +1,3 @@
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Common/typeid_cast.h>

--- a/src/Parsers/ASTSelectWithUnionQuery.h
+++ b/src/Parsers/ASTSelectWithUnionQuery.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Parsers/ASTQueryWithOutput.h>
-
+#include <Parsers/SelectUnionMode.h>
 
 namespace DB
 {
@@ -19,27 +19,15 @@ public:
 
     const char * getQueryKindString() const override { return "Select"; }
 
-    enum class Mode
-    {
-        Unspecified,
-        ALL,
-        DISTINCT,
-        EXCEPT,
-        INTERSECT
-    };
+    SelectUnionMode union_mode;
 
-    using UnionModes = std::vector<Mode>;
-    using UnionModesSet = std::unordered_set<Mode>;
-
-    Mode union_mode;
-
-    UnionModes list_of_modes;
+    SelectUnionModes list_of_modes;
 
     bool is_normalized = false;
 
     ASTPtr list_of_selects;
 
-    UnionModesSet set_of_modes;
+    SelectUnionModesSet set_of_modes;
 
     /// Consider any mode other than ALL as non-default.
     bool hasNonDefaultUnionMode() const;

--- a/src/Parsers/Access/ASTUserNameWithHost.h
+++ b/src/Parsers/Access/ASTUserNameWithHost.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Parsers/IParser.h>
+#include <Parsers/IAST.h>
 
 
 namespace DB

--- a/src/Parsers/Access/ParserCreateQuotaQuery.cpp
+++ b/src/Parsers/Access/ParserCreateQuotaQuery.cpp
@@ -2,7 +2,7 @@
 #include <Parsers/Access/ASTCreateQuotaQuery.h>
 #include <Parsers/Access/ASTRolesOrUsersSet.h>
 #include <Parsers/Access/ParserRolesOrUsersSet.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -4,7 +4,6 @@
 #include <Parsers/Access/ASTRowPolicyName.h>
 #include <Parsers/Access/ParserRolesOrUsersSet.h>
 #include <Parsers/Access/ParserRowPolicyName.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/parseDatabaseAndTableName.h>

--- a/src/Parsers/Access/ParserGrantQuery.cpp
+++ b/src/Parsers/Access/ParserGrantQuery.cpp
@@ -1,9 +1,9 @@
-#include <Parsers/Access/ParserGrantQuery.h>
+#include <Parsers/ASTIdentifier_fwd.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/Access/ASTGrantQuery.h>
 #include <Parsers/Access/ASTRolesOrUsersSet.h>
+#include <Parsers/Access/ParserGrantQuery.h>
 #include <Parsers/Access/ParserRolesOrUsersSet.h>
-#include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/parseDatabaseAndTableName.h>

--- a/src/Parsers/Access/ParserSettingsProfileElement.cpp
+++ b/src/Parsers/Access/ParserSettingsProfileElement.cpp
@@ -1,10 +1,10 @@
-#include <Parsers/Access/ParserSettingsProfileElement.h>
-#include <Parsers/Access/ASTSettingsProfileElement.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/Access/ASTSettingsProfileElement.h>
+#include <Parsers/Access/ParserSettingsProfileElement.h>
 #include <Parsers/CommonParsers.h>
-#include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ExpressionListParsers.h>
 #include <Parsers/parseIdentifierOrStringLiteral.h>
 #include <boost/algorithm/string/predicate.hpp>
 

--- a/src/Parsers/Access/parseUserName.cpp
+++ b/src/Parsers/Access/parseUserName.cpp
@@ -1,4 +1,5 @@
 #include <Parsers/Access/parseUserName.h>
+
 #include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Parsers/Access/ParserUserNameWithHost.h>
 #include <Parsers/CommonParsers.h>

--- a/src/Parsers/Access/parseUserName.h
+++ b/src/Parsers/Access/parseUserName.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Types.h>
 #include <Parsers/IParser.h>
 
 

--- a/src/Parsers/CommonParsers.h
+++ b/src/Parsers/CommonParsers.h
@@ -2,6 +2,8 @@
 
 #include <Parsers/IParserBase.h>
 
+#include <cassert>
+
 namespace DB
 {
 

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -18,7 +18,6 @@
 #include <Parsers/ASTOrderByElement.h>
 #include <Parsers/ASTQualifiedAsterisk.h>
 #include <Parsers/ASTQueryParameter.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTTLElement.h>

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -9,6 +9,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ParserCreateQuery.h>
@@ -144,28 +145,28 @@ bool ParserUnionList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             // SELECT ... UNION ALL SELECT ...
             if (s_all_parser.check(pos, expected))
             {
-                union_modes.push_back(ASTSelectWithUnionQuery::Mode::ALL);
+                union_modes.push_back(SelectUnionMode::ALL);
             }
             // SELECT ... UNION DISTINCT SELECT ...
             else if (s_distinct_parser.check(pos, expected))
             {
-                union_modes.push_back(ASTSelectWithUnionQuery::Mode::DISTINCT);
+                union_modes.push_back(SelectUnionMode::DISTINCT);
             }
             // SELECT ... UNION SELECT ...
             else
             {
-                union_modes.push_back(ASTSelectWithUnionQuery::Mode::Unspecified);
+                union_modes.push_back(SelectUnionMode::Unspecified);
             }
             return true;
         }
         else if (s_except_parser.check(pos, expected))
         {
-            union_modes.push_back(ASTSelectWithUnionQuery::Mode::EXCEPT);
+            union_modes.push_back(SelectUnionMode::EXCEPT);
             return true;
         }
         else if (s_intersect_parser.check(pos, expected))
         {
-            union_modes.push_back(ASTSelectWithUnionQuery::Mode::INTERSECT);
+            union_modes.push_back(SelectUnionMode::INTERSECT);
             return true;
         }
         return false;

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -6,12 +6,13 @@
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTFunctionWithKeyValueArguments.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ParserCreateQuery.h>
-#include <Parsers/parseIntervalKind.h>
 #include <Parsers/ParserUnionQueryElement.h>
+#include <Parsers/parseIntervalKind.h>
 #include <Common/StringUtils/StringUtils.h>
 
 using namespace std::literals;

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -7,6 +7,7 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTFunctionWithKeyValueArguments.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>

--- a/src/Parsers/ExpressionListParsers.h
+++ b/src/Parsers/ExpressionListParsers.h
@@ -5,8 +5,8 @@
 #include <Parsers/IParserBase.h>
 #include <Parsers/CommonParsers.h>
 
-#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/SelectUnionMode.h>
 #include <Common/IntervalKind.h>
 
 namespace DB
@@ -108,7 +108,7 @@ protected:
     const char * getName() const override { return "list of union elements"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 private:
-    ASTSelectWithUnionQuery::UnionModes union_modes;
+    SelectUnionModes union_modes;
 };
 
 /** An expression with an infix binary left-associative operator.

--- a/src/Parsers/IParser.h
+++ b/src/Parsers/IParser.h
@@ -4,10 +4,10 @@
 #include <memory>
 
 #include <Core/Defines.h>
-#include <base/types.h>
-#include <IO/WriteHelpers.h>
-#include <Parsers/IAST.h>
+#include <Parsers/IAST_fwd.h>
 #include <Parsers/TokenIterator.h>
+#include <base/types.h>
+#include <Common/Exception.h>
 
 
 namespace DB
@@ -64,7 +64,9 @@ public:
         {
             ++depth;
             if (max_depth > 0 && depth > max_depth)
-                throw Exception("Maximum parse depth (" + toString(max_depth) + ") exceeded. Consider rising max_parser_depth parameter.", ErrorCodes::TOO_DEEP_RECURSION);
+                throw Exception(
+                    "Maximum parse depth (" + std::to_string(max_depth) + ") exceeded. Consider rising max_parser_depth parameter.",
+                    ErrorCodes::TOO_DEEP_RECURSION);
         }
 
         void decreaseDepth()

--- a/src/Parsers/MySQL/ASTDeclareColumn.cpp
+++ b/src/Parsers/MySQL/ASTDeclareColumn.cpp
@@ -1,12 +1,12 @@
 #include <Parsers/MySQL/ASTDeclareColumn.h>
 
-#include <Parsers/ASTIdentifier.h>
-#include <Parsers/ParserDataType.h>
-#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/MySQL/ASTDeclareConstraint.h>
 #include <Parsers/MySQL/ASTDeclareOption.h>
 #include <Parsers/MySQL/ASTDeclareReference.h>
-#include <Parsers/MySQL/ASTDeclareConstraint.h>
+#include <Parsers/ParserDataType.h>
 
 namespace DB
 {

--- a/src/Parsers/MySQL/ASTDeclarePartitionOptions.cpp
+++ b/src/Parsers/MySQL/ASTDeclarePartitionOptions.cpp
@@ -1,9 +1,10 @@
 #include <Parsers/MySQL/ASTDeclarePartitionOptions.h>
 
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/CommonParsers.h>
-#include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ExpressionListParsers.h>
 #include <Parsers/MySQL/ASTDeclarePartition.h>
 
 namespace DB

--- a/src/Parsers/MySQL/tests/gtest_alter_command_parser.cpp
+++ b/src/Parsers/MySQL/tests/gtest_alter_command_parser.cpp
@@ -2,7 +2,7 @@
 #include <Parsers/parseQuery.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/MySQL/ASTAlterCommand.h>
 #include <Parsers/MySQL/ASTDeclareOption.h>
 

--- a/src/Parsers/ParserBackupQuery.cpp
+++ b/src/Parsers/ParserBackupQuery.cpp
@@ -1,7 +1,6 @@
 #include <Parsers/ParserBackupQuery.h>
 #include <Parsers/ASTBackupQuery.h>
 #include <Parsers/ASTIdentifier_fwd.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ExpressionListParsers.h>

--- a/src/Parsers/ParserBackupQuery.cpp
+++ b/src/Parsers/ParserBackupQuery.cpp
@@ -1,6 +1,6 @@
 #include <Parsers/ParserBackupQuery.h>
 #include <Parsers/ASTBackupQuery.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>

--- a/src/Parsers/ParserCheckQuery.cpp
+++ b/src/Parsers/ParserCheckQuery.cpp
@@ -1,6 +1,5 @@
 #include <Parsers/ParserCheckQuery.h>
 #include <Parsers/CommonParsers.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ASTCheckQuery.h>
 #include <Parsers/ParserPartition.h>

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ASTProjectionDeclaration.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ExpressionListParsers.h>

--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -5,7 +5,7 @@
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ASTNameTypePair.h>
 #include <Parsers/ASTColumnDeclaration.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ParserDataType.h>

--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -6,7 +6,6 @@
 #include <Parsers/ASTNameTypePair.h>
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTIdentifier_fwd.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ParserDataType.h>
 #include <Poco/String.h>

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -1,7 +1,7 @@
 #include <Parsers/ParserDataType.h>
 
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ParserCreateQuery.h>

--- a/src/Parsers/ParserDictionary.cpp
+++ b/src/Parsers/ParserDictionary.cpp
@@ -1,12 +1,13 @@
 #include <Parsers/ParserDictionary.h>
 
-#include <Parsers/ExpressionListParsers.h>
-#include <Parsers/ExpressionElementParsers.h>
-#include <Parsers/ASTFunctionWithKeyValueArguments.h>
-#include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTDictionary.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTDictionary.h>
+#include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTFunctionWithKeyValueArguments.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ParserDictionaryAttributeDeclaration.h>
 
 #include <Poco/String.h>

--- a/src/Parsers/ParserDictionary.h
+++ b/src/Parsers/ParserDictionary.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Parsers/IParser.h>
 #include <Parsers/IParserBase.h>
 
 #include <Parsers/ParserSetQuery.h>

--- a/src/Parsers/ParserDictionaryAttributeDeclaration.cpp
+++ b/src/Parsers/ParserDictionaryAttributeDeclaration.cpp
@@ -1,5 +1,6 @@
 #include <Parsers/ParserDictionaryAttributeDeclaration.h>
 
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ParserDataType.h>

--- a/src/Parsers/ParserDictionaryAttributeDeclaration.h
+++ b/src/Parsers/ParserDictionaryAttributeDeclaration.h
@@ -4,7 +4,6 @@
 #include <Parsers/IAST_fwd.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ASTDictionaryAttributeDeclaration.h>
-#include <Parsers/ASTIdentifier.h>
 
 
 namespace DB

--- a/src/Parsers/ParserDropQuery.cpp
+++ b/src/Parsers/ParserDropQuery.cpp
@@ -1,4 +1,3 @@
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTDropQuery.h>
 
 #include <Parsers/CommonParsers.h>

--- a/src/Parsers/ParserExternalDDLQuery.cpp
+++ b/src/Parsers/ParserExternalDDLQuery.cpp
@@ -1,10 +1,11 @@
 #include "config_core.h"
 
 #include <Parsers/ASTExternalDDLQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
-#include <Parsers/ParserExternalDDLQuery.h>
 #include <Parsers/ParserDropQuery.h>
+#include <Parsers/ParserExternalDDLQuery.h>
 #include <Parsers/ParserRenameQuery.h>
 
 #if USE_MYSQL

--- a/src/Parsers/ParserInsertQuery.cpp
+++ b/src/Parsers/ParserInsertQuery.cpp
@@ -1,6 +1,6 @@
-#include <Parsers/ASTIdentifier.h>
-#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>

--- a/src/Parsers/ParserOptimizeQuery.cpp
+++ b/src/Parsers/ParserOptimizeQuery.cpp
@@ -3,7 +3,6 @@
 #include <Parsers/CommonParsers.h>
 
 #include <Parsers/ASTOptimizeQuery.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ExpressionListParsers.h>
 
 

--- a/src/Parsers/ParserRenameQuery.cpp
+++ b/src/Parsers/ParserRenameQuery.cpp
@@ -1,4 +1,4 @@
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTRenameQuery.h>
 
 #include <Parsers/CommonParsers.h>

--- a/src/Parsers/ParserSetQuery.cpp
+++ b/src/Parsers/ParserSetQuery.cpp
@@ -1,4 +1,4 @@
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSetQuery.h>
 

--- a/src/Parsers/ParserShowTablesQuery.cpp
+++ b/src/Parsers/ParserShowTablesQuery.cpp
@@ -1,5 +1,5 @@
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTShowTablesQuery.h>
 
 #include <Parsers/CommonParsers.h>

--- a/src/Parsers/ParserTablePropertiesQuery.cpp
+++ b/src/Parsers/ParserTablePropertiesQuery.cpp
@@ -1,4 +1,3 @@
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>
 
 #include <Parsers/CommonParsers.h>

--- a/src/Parsers/ParserUseQuery.cpp
+++ b/src/Parsers/ParserUseQuery.cpp
@@ -1,5 +1,5 @@
 #include <Parsers/ParserUseQuery.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ASTUseQuery.h>

--- a/src/Parsers/ParserWatchQuery.cpp
+++ b/src/Parsers/ParserWatchQuery.cpp
@@ -10,7 +10,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTWatchQuery.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ParserWatchQuery.h>

--- a/src/Parsers/ParserWatchQuery.cpp
+++ b/src/Parsers/ParserWatchQuery.cpp
@@ -9,7 +9,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTWatchQuery.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ParserWatchQuery.h>

--- a/src/Parsers/ParserWithElement.cpp
+++ b/src/Parsers/ParserWithElement.cpp
@@ -1,5 +1,5 @@
 #include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTWithElement.h>
 #include <Parsers/CommonParsers.h>

--- a/src/Parsers/SelectUnionMode.h
+++ b/src/Parsers/SelectUnionMode.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <unordered_set>
+#include <vector>
+
+namespace DB
+{
+enum class SelectUnionMode
+{
+    Unspecified,
+    ALL,
+    DISTINCT,
+    EXCEPT,
+    INTERSECT
+};
+
+using SelectUnionModes = std::vector<SelectUnionMode>;
+using SelectUnionModesSet = std::unordered_set<SelectUnionMode>;
+
+}

--- a/src/Parsers/parseDatabaseAndTableName.cpp
+++ b/src/Parsers/parseDatabaseAndTableName.cpp
@@ -1,7 +1,7 @@
 #include "parseDatabaseAndTableName.h"
-#include <Parsers/ExpressionElementParsers.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/CommonParsers.h>
+#include <Parsers/ExpressionElementParsers.h>
 
 
 namespace DB

--- a/src/Parsers/parseIdentifierOrStringLiteral.cpp
+++ b/src/Parsers/parseIdentifierOrStringLiteral.cpp
@@ -1,8 +1,8 @@
 #include "parseIdentifierOrStringLiteral.h"
 
-#include "ExpressionElementParsers.h"
-#include "ASTLiteral.h"
-#include "ASTIdentifier.h"
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Common/typeid_cast.h>

--- a/src/Parsers/parseIdentifierOrStringLiteral.h
+++ b/src/Parsers/parseIdentifierOrStringLiteral.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Types.h>
 #include <Parsers/IParser.h>
 
 namespace DB

--- a/src/Parsers/parseQuery.h
+++ b/src/Parsers/parseQuery.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <Parsers/IParser.h>
-
+#include <Parsers/IAST_fwd.h>
 
 namespace DB
 {
+
+class IParser;
 
 /// Parse query or set 'out_error_message'.
 ASTPtr tryParseQuery(

--- a/src/Parsers/tests/gtest_dictionary_parser.cpp
+++ b/src/Parsers/tests/gtest_dictionary_parser.cpp
@@ -1,15 +1,16 @@
-#include <base/types.h>
+#include <IO/WriteBufferFromString.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTDropQuery.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/DumpASTNode.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ParserDropQuery.h>
+#include <Parsers/ParserTablePropertiesQuery.h>
+#include <Parsers/TablePropertiesQueriesASTs.h>
 #include <Parsers/formatAST.h>
 #include <Parsers/parseQuery.h>
-#include <Parsers/DumpASTNode.h>
-#include <Parsers/TablePropertiesQueriesASTs.h>
-#include <Parsers/ParserTablePropertiesQuery.h>
-#include <IO/WriteBufferFromString.h>
+#include <base/types.h>
 
 #include <gtest/gtest.h>
 

--- a/src/Parsers/tests/gtest_dictionary_parser.cpp
+++ b/src/Parsers/tests/gtest_dictionary_parser.cpp
@@ -1,6 +1,7 @@
 #include <base/types.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTDropQuery.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ParserDropQuery.h>
 #include <Parsers/formatAST.h>

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1,3 +1,4 @@
+#include <Parsers/ASTFunction.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Processors/ConcatProcessor.h>

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1,4 +1,5 @@
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTSelectQuery.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Processors/ConcatProcessor.h>

--- a/src/Server/GRPCServer.cpp
+++ b/src/Server/GRPCServer.cpp
@@ -20,7 +20,7 @@
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <Parsers/parseQuery.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTQueryWithOutput.h>
 #include <Parsers/ParserQuery.h>

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -17,7 +17,6 @@
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTConstraintDeclaration.h>
 #include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIndexDeclaration.h>
 #include <Parsers/ASTProjectionDeclaration.h>

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -4,6 +4,7 @@
 #include <Storages/StorageDistributed.h>
 #include <Disks/StoragePolicy.h>
 
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/queryToString.h>

--- a/src/Storages/ExternalDataSourceConfiguration.cpp
+++ b/src/Storages/ExternalDataSourceConfiguration.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <IO/WriteBufferFromString.h>
 

--- a/src/Storages/ExternalDataSourceConfiguration.h
+++ b/src/Storages/ExternalDataSourceConfiguration.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Parsers/ASTIdentifier.h>
 #include <Interpreters/Context.h>
 #include <Poco/Util/AbstractConfiguration.h>
 

--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -4,8 +4,9 @@
 
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIndexDeclaration.h>
-#include <Parsers/formatAST.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/ParserCreateQuery.h>
+#include <Parsers/formatAST.h>
 #include <Parsers/parseQuery.h>
 #include <Storages/extractKeyExpressionList.h>
 

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -12,6 +12,7 @@
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTLiteral.h>
 #include <Processors/Executors/CompletedPipelineExecutor.h>

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -18,9 +18,10 @@
 #include <Interpreters/convertFieldToType.h>
 #include <Interpreters/Set.h>
 #include <Parsers/queryToString.h>
-#include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSubquery.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
 #include <Storages/KeyDescription.h>

--- a/src/Storages/MergeTree/KeyCondition.h
+++ b/src/Storages/MergeTree/KeyCondition.h
@@ -6,13 +6,13 @@
 #include <Core/SortDescription.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTSelectQuery.h>
-#include <Parsers/ASTFunction.h>
 #include <Storages/SelectQueryInfo.h>
 
 
 namespace DB
 {
 
+class ASTFunction;
 class Context;
 class IFunction;
 using FunctionBasePtr = std::shared_ptr<IFunctionBase>;

--- a/src/Storages/MergeTree/KeyCondition.h
+++ b/src/Storages/MergeTree/KeyCondition.h
@@ -5,7 +5,6 @@
 #include <Interpreters/Set.h>
 #include <Core/SortDescription.h>
 #include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Storages/SelectQueryInfo.h>
 
 

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -8,6 +8,7 @@
 #include <Storages/MergeTree/MergeTreeIndexConditionBloomFilter.h>
 #include <Columns/ColumnConst.h>
 #include <Interpreters/BloomFilterHash.h>
+#include <Parsers/ASTFunction.h>
 
 
 namespace DB

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -4,15 +4,9 @@
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <base/types.h>
 #include <base/bit_cast.h>
-#include <Parsers/ASTLiteral.h>
-#include <IO/ReadHelpers.h>
-#include <IO/WriteHelpers.h>
-#include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Storages/MergeTree/MergeTreeIndexConditionBloomFilter.h>
-#include <Parsers/queryToString.h>
 #include <Columns/ColumnConst.h>
-#include <Columns/ColumnLowCardinality.h>
 #include <Interpreters/BloomFilterHash.h>
 
 

--- a/src/Storages/MergeTree/MergeTreeIndexHypothesis.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexHypothesis.cpp
@@ -5,10 +5,6 @@
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 
-#include <Parsers/ASTFunction.h>
-#include <Parsers/ASTLiteral.h>
-
-
 namespace DB
 {
 namespace ErrorCodes

--- a/src/Storages/MergeTree/MergeTreeIndexHypothesis.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexHypothesis.cpp
@@ -5,7 +5,6 @@
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTLiteral.h>
 

--- a/src/Storages/MergeTree/MergeTreeIndexHypothesisMergedCondition.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexHypothesisMergedCondition.cpp
@@ -6,6 +6,7 @@
 #include <Parsers/IAST_fwd.h>
 #include <Parsers/IAST.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTSelectQuery.h>
 
 namespace DB
 {

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -4,6 +4,8 @@
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 
+#include <Parsers/ASTFunction.h>
+
 #include <Poco/Logger.h>
 #include <Common/FieldVisitorsAccurateComparison.h>
 

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -4,9 +4,10 @@
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectQuery.h>
 
 
 namespace DB

--- a/src/Storages/MutationCommands.cpp
+++ b/src/Storages/MutationCommands.cpp
@@ -2,20 +2,16 @@
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
 #include <Parsers/formatAST.h>
-#include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ParserAlterQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/ASTAssignment.h>
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
-#include <Parsers/ASTLiteral.h>
 #include <Common/typeid_cast.h>
 #include <Common/quoteString.h>
 #include <Core/Defines.h>
 #include <DataTypes/DataTypeFactory.h>
-#include <Parsers/queryToString.h>
-#include <base/logger_useful.h>
 
 
 namespace DB

--- a/src/Storages/PartitionCommands.cpp
+++ b/src/Storages/PartitionCommands.cpp
@@ -2,7 +2,6 @@
 #include <Storages/IStorage.h>
 #include <Storages/DataDestinationType.h>
 #include <Parsers/ASTAlterQuery.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Core/ColumnWithTypeAndName.h>
 #include <DataTypes/DataTypeString.h>
 #include <Processors/Chunk.h>

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -6,6 +6,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterInsertQuery.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Processors/Executors/CompletedPipelineExecutor.h>
 #include <Common/SettingsChanges.h>

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -1,7 +1,5 @@
 #include "StorageMaterializedPostgreSQL.h"
 
-#include <Parsers/ASTIdentifier.h>
-
 #if USE_LIBPQXX
 #include <base/logger_useful.h>
 #include <Common/Macros.h>
@@ -15,6 +13,8 @@
 #include <Formats/FormatFactory.h>
 #include <Formats/FormatSettings.h>
 #include <Processors/Transforms/FilterTransform.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <QueryPipeline/Pipe.h>
 #include <Interpreters/executeQuery.h>

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.cpp
@@ -1,5 +1,7 @@
 #include "StorageMaterializedPostgreSQL.h"
 
+#include <Parsers/ASTIdentifier.h>
+
 #if USE_LIBPQXX
 #include <base/logger_useful.h>
 #include <Common/Macros.h>

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.h
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.h
@@ -7,7 +7,6 @@
 #include "MaterializedPostgreSQLSettings.h"
 
 #include <Parsers/IAST.h>
-#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Interpreters/evaluateConstantExpression.h>

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.h
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.h
@@ -7,7 +7,6 @@
 #include "MaterializedPostgreSQLSettings.h"
 
 #include <Parsers/IAST.h>
-#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTColumnDeclaration.h>

--- a/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.h
+++ b/src/Storages/PostgreSQL/StorageMaterializedPostgreSQL.h
@@ -9,7 +9,6 @@
 #include <Parsers/IAST.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Interpreters/evaluateConstantExpression.h>

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -2,6 +2,7 @@
 #include <Interpreters/TreeRewriter.h>
 #include <Storages/ProjectionsDescription.h>
 
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTProjectionDeclaration.h>
 #include <Parsers/ASTProjectionSelectQuery.h>

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -2,15 +2,15 @@
 #include <Interpreters/TreeRewriter.h>
 #include <Storages/ProjectionsDescription.h>
 
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTProjectionDeclaration.h>
+#include <Parsers/ASTProjectionSelectQuery.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/queryToString.h>
 
 #include <Core/Defines.h>
 #include <Interpreters/InterpreterSelectQuery.h>
-#include <Parsers/ASTProjectionSelectQuery.h>
-#include <Parsers/ASTSubquery.h>
 #include <QueryPipeline/Pipe.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Processors/Transforms/SquashingChunksTransform.h>

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -1,15 +1,11 @@
 #include <amqpcpp.h>
-#include <DataTypes/DataTypeDateTime.h>
-#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterInsertQuery.h>
-#include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTInsertQuery.h>
-#include <Parsers/ASTLiteral.h>
 #include <Processors/Executors/CompletedPipelineExecutor.h>
 #include <Processors/Executors/PushingPipelineExecutor.h>
 #include <Processors/Transforms/ExpressionTransform.h>
@@ -21,17 +17,13 @@
 #include <Storages/ExternalDataSourceConfiguration.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/StorageMaterializedView.h>
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
-#include <Poco/Util/AbstractConfiguration.h>
 #include <Common/Exception.h>
 #include <Common/Macros.h>
-#include <Common/config_version.h>
 #include <Common/parseAddress.h>
 #include <Common/quoteString.h>
 #include <Common/setThreadName.h>
-#include <Common/typeid_cast.h>
 #include <base/logger_useful.h>
 
 namespace DB

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -31,6 +31,7 @@
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/ParserAlterQuery.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -26,6 +26,7 @@
 
 #include <Parsers/ASTDropQuery.h>
 #include <Parsers/ASTExpressionList.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTLiteral.h>

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -8,7 +8,6 @@
 #include <Common/SimpleIncrement.h>
 #include <Client/ConnectionPool.h>
 #include <Client/ConnectionPoolWithFailover.h>
-#include <Parsers/ASTFunction.h>
 #include <base/logger_useful.h>
 #include <Common/ActionBlocker.h>
 #include <Interpreters/Cluster.h>

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -5,9 +5,9 @@
 #include <Interpreters/evaluateConstantExpression.h>
 
 #include <Parsers/ASTCreateQuery.h>
-#include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ASTLiteral.h>
 
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadBufferFromFileDescriptor.h>

--- a/src/Storages/StorageJoin.cpp
+++ b/src/Storages/StorageJoin.cpp
@@ -5,7 +5,7 @@
 #include <Interpreters/HashJoin.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Core/ColumnNumbers.h>
 #include <DataTypes/NestedUtils.h>
 #include <Interpreters/joinDispatch.h>

--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -18,10 +18,7 @@
 
 #include <DataTypes/NestedUtils.h>
 
-#include <Columns/ColumnArray.h>
-
 #include <Interpreters/Context.h>
-#include <Parsers/ASTLiteral.h>
 #include "StorageLogSettings.h"
 #include <Processors/Sources/NullSource.h>
 #include <Processors/Sources/SourceWithProgress.h>

--- a/src/Storages/StorageMaterializedMySQL.cpp
+++ b/src/Storages/StorageMaterializedMySQL.cpp
@@ -4,17 +4,10 @@
 
 #include <Storages/StorageMaterializedMySQL.h>
 
-#include <Core/Settings.h>
-#include <Interpreters/Context.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 
-#include <Parsers/ASTFunction.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
-
-#include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTIdentifier.h>
 
 #include <QueryPipeline/Pipe.h>
 #include <Processors/Transforms/FilterTransform.h>

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -1,6 +1,5 @@
 #include <Storages/StorageMaterializedView.h>
 
-#include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTCreateQuery.h>
 

--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -3,7 +3,6 @@
 #include <base/shared_ptr_helper.h>
 
 #include <Parsers/IAST_fwd.h>
-#include <Parsers/ASTSelectWithUnionQuery.h>
 
 #include <Storages/IStorage.h>
 #include <Storages/StorageInMemoryMetadata.h>

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -13,6 +13,7 @@
 #include <Interpreters/getHeaderForProcessingStage.h>
 #include <Interpreters/addTypeConversionToAST.h>
 #include <Interpreters/replaceAliasColumnsInQuery.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTIdentifier.h>

--- a/src/Storages/StorageMongoDB.h
+++ b/src/Storages/StorageMongoDB.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <Poco/MongoDB/Connection.h>
+
 #include <base/shared_ptr_helper.h>
 
 #include <Storages/IStorage.h>
 #include <Storages/ExternalDataSourceConfiguration.h>
-
-#include <Poco/MongoDB/Connection.h>
 
 
 namespace DB

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -39,6 +39,7 @@
 
 #include <Parsers/formatAST.h>
 #include <Parsers/ASTDropQuery.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTOptimizeQuery.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/queryToString.h>

--- a/src/Storages/StorageSet.cpp
+++ b/src/Storages/StorageSet.cpp
@@ -14,7 +14,6 @@
 #include <Interpreters/Context.h>
 #include <Processors/Sinks/SinkToStorage.h>
 #include <Parsers/ASTCreateQuery.h>
-#include <Parsers/ASTLiteral.h>
 #include <filesystem>
 
 namespace fs = std::filesystem;

--- a/src/Storages/StorageView.cpp
+++ b/src/Storages/StorageView.cpp
@@ -4,9 +4,10 @@
 #include <DataTypes/DataTypeLowCardinality.h>
 
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTTablesInSelectQuery.h>
-#include <Parsers/ASTSelectWithUnionQuery.h>
 
 #include <Storages/StorageView.h>
 #include <Storages/StorageFactory.h>

--- a/src/Storages/StorageView.cpp
+++ b/src/Storages/StorageView.cpp
@@ -4,6 +4,7 @@
 #include <DataTypes/DataTypeLowCardinality.h>
 
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSubquery.h>

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -9,7 +9,6 @@
 #include <DataTypes/DataTypeDateTime64.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Parsers/queryToString.h>
-#include <Parsers/ASTSelectQuery.h>
 #include <Access/ContextAccess.h>
 #include <Databases/IDatabase.h>
 #include <Processors/Sources/NullSource.h>

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -1,5 +1,4 @@
 #include <Columns/ColumnString.h>
-#include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -10,6 +9,7 @@
 #include <Access/ContextAccess.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/queryToString.h>
 #include <Common/typeid_cast.h>
 #include <Common/StringUtils/StringUtils.h>

--- a/src/Storages/TTLDescription.cpp
+++ b/src/Storages/TTLDescription.cpp
@@ -6,16 +6,12 @@
 #include <Interpreters/TreeRewriter.h>
 #include <Interpreters/InDepthNodeVisitor.h>
 #include <Interpreters/addTypeConversionToAST.h>
-#include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTTTLElement.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTAssignment.h>
-#include <Parsers/ASTLiteral.h>
 #include <Storages/ColumnsDescription.h>
 #include <Interpreters/Context.h>
-
-#include <Parsers/queryToString.h>
 
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime.h>

--- a/src/TableFunctions/TableFunctionExecutable.cpp
+++ b/src/TableFunctions/TableFunctionExecutable.cpp
@@ -5,6 +5,7 @@
 #include <TableFunctions/parseColumnsListForTableFunction.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Storages/StorageExecutable.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <Interpreters/evaluateConstantExpression.h>

--- a/src/TableFunctions/TableFunctionMySQL.cpp
+++ b/src/TableFunctions/TableFunctionMySQL.cpp
@@ -1,17 +1,11 @@
 #include "config_core.h"
 
 #if USE_MYSQL
-#include <Core/Defines.h>
 #include <Databases/MySQL/FetchTablesColumnsList.h>
-#include <DataTypes/DataTypeString.h>
-#include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/convertMySQLDataType.h>
 #include <Processors/Sources/MySQLSource.h>
-#include <IO/Operators.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTLiteral.h>
 #include <Storages/StorageMySQL.h>
 #include <Storages/MySQL/MySQLSettings.h>
 #include <TableFunctions/ITableFunction.h>

--- a/src/TableFunctions/TableFunctionNumbers.cpp
+++ b/src/TableFunctions/TableFunctionNumbers.cpp
@@ -2,7 +2,6 @@
 #include <TableFunctions/TableFunctionNumbers.h>
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTLiteral.h>
 #include <Common/typeid_cast.h>
 #include <Common/FieldVisitorToString.h>
 #include <Storages/System/StorageSystemNumbers.h>

--- a/src/TableFunctions/TableFunctionPostgreSQL.cpp
+++ b/src/TableFunctions/TableFunctionPostgreSQL.cpp
@@ -6,13 +6,10 @@
 
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Parsers/ASTFunction.h>
-#include <Parsers/ASTLiteral.h>
 #include <TableFunctions/ITableFunction.h>
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Common/Exception.h>
-#include <Common/parseAddress.h>
 #include "registerTableFunctions.h"
-#include <Common/quoteString.h>
 #include <Common/parseRemoteDescription.h>
 
 

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -2,7 +2,7 @@
 
 #include <Storages/getStructureOfRemoteTable.h>
 #include <Storages/StorageDistributed.h>
-#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTExpressionList.h>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

I've started looking into the parser and doing changes there is quite painful since they require rebuilding lots of files so I've spend some time removing unnecessary headers, introducing forward declarations (+ adding the header in the src files that needed them) and so on. 

* ASTIdentifier: 483 -> 163 files need to be rebuilt after a change
* AstLiteral: 590 -> 546
* AstFunction: 481 -> 230
* AstSelectQuery: 243 -> 152
* AstSelectQueryWithUnion: 521 -> 77

There are more affected files (indirectly) and many things that could be done, but it's a start. I don't expect any behaviour or performance change except faster builder times (specially when editing parser files).