### PR TITLE
Kill container in integration tests if it's already running

### DIFF
--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -255,7 +255,6 @@ if __name__ == "__main__":
             subprocess.check_call('docker volume create {name}_volume'.format(name=CONTAINER_NAME), shell=True)
         except Exception as ex:
             print("Volume creationg failed, probably it already exists, exception", ex)
-
         dockerd_internal_volume = "--volume={}_volume:/var/lib/docker".format(CONTAINER_NAME)
 
     # If enabled we kill and remove containers before pytest session run.
@@ -301,6 +300,13 @@ if __name__ == "__main__":
         name=CONTAINER_NAME,
         command=args.command
     )
+
+    try:
+        print("Trying to kill container", CONTAINER_NAME, "if it's already running")
+        subprocess.check_call(f'docker kill $(docker ps -a -q --filter name={CONTAINER_NAME} --format="{{{{.ID}}}}")', shell=True)
+        print("Container killed")
+    except:
+        print("Nothing to kill")
 
     print(("Running pytest container as: '" + cmd + "'."))
     subprocess.check_call(cmd, shell=True)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)