### PR TITLE
Drop libc-headers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -135,9 +135,6 @@
 [submodule "contrib/flatbuffers"]
 	path = contrib/flatbuffers
 	url = https://github.com/ClickHouse-Extras/flatbuffers.git
-[submodule "contrib/libc-headers"]
-	path = contrib/libc-headers
-	url = https://github.com/ClickHouse-Extras/libc-headers.git
 [submodule "contrib/replxx"]
 	path = contrib/replxx
 	url = https://github.com/ClickHouse-Extras/replxx.git

--- a/cmake/linux/default_libs.cmake
+++ b/cmake/linux/default_libs.cmake
@@ -29,14 +29,6 @@ message(STATUS "Default libraries: ${DEFAULT_LIBS}")
 set(CMAKE_CXX_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 set(CMAKE_C_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 
-# glibc-compatibility library relies on constant version of libc headers
-# (because minor changes in function attributes between different glibc versions will introduce incompatibilities)
-# This is for x86_64. For other architectures we have separate toolchains.
-if (ARCH_AMD64 AND NOT CMAKE_CROSSCOMPILING AND GLIBC_COMPATIBILITY)
-    set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${ClickHouse_SOURCE_DIR}/contrib/libc-headers/x86_64-linux-gnu ${ClickHouse_SOURCE_DIR}/contrib/libc-headers)
-    set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${ClickHouse_SOURCE_DIR}/contrib/libc-headers/x86_64-linux-gnu ${ClickHouse_SOURCE_DIR}/contrib/libc-headers)
-endif ()
-
 # Unfortunately '-pthread' doesn't work with '-nodefaultlibs'.
 # Just make sure we have pthreads at all.
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/cmake/linux/default_libs.cmake
+++ b/cmake/linux/default_libs.cmake
@@ -29,10 +29,10 @@ message(STATUS "Default libraries: ${DEFAULT_LIBS}")
 set(CMAKE_CXX_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 set(CMAKE_C_STANDARD_LIBRARIES ${DEFAULT_LIBS})
 
-# glibc-compatibility library relies to constant version of libc headers
+# glibc-compatibility library relies on constant version of libc headers
 # (because minor changes in function attributes between different glibc versions will introduce incompatibilities)
 # This is for x86_64. For other architectures we have separate toolchains.
-if (ARCH_AMD64 AND NOT CMAKE_CROSSCOMPILING)
+if (ARCH_AMD64 AND NOT CMAKE_CROSSCOMPILING AND GLIBC_COMPATIBILITY)
     set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${ClickHouse_SOURCE_DIR}/contrib/libc-headers/x86_64-linux-gnu ${ClickHouse_SOURCE_DIR}/contrib/libc-headers)
     set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${ClickHouse_SOURCE_DIR}/contrib/libc-headers/x86_64-linux-gnu ${ClickHouse_SOURCE_DIR}/contrib/libc-headers)
 endif ()

--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -174,7 +174,6 @@ function clone_submodules
             contrib/double-conversion
             contrib/libcxx
             contrib/libcxxabi
-            contrib/libc-headers
             contrib/lz4
             contrib/zstd
             contrib/fastops


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

`contrib/libc-headers` are no longer necessary since they are superseeded by hermetic builds (#30011)