### PR TITLE
Adjust packages buckets

### DIFF
--- a/tests/ci/ast_fuzzer_check.py
+++ b/tests/ci/ast_fuzzer_check.py
@@ -3,14 +3,13 @@
 import logging
 import subprocess
 import os
-import json
 import sys
 
 from github import Github
 
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from build_download_helper import get_build_name_for_check, get_build_urls
 from docker_pull_helper import get_image_with_version
 from commit_status_helper import post_commit_status
@@ -44,10 +43,7 @@ if __name__ == "__main__":
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
 
     gh = Github(get_best_robot_token())
 

--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -8,7 +8,7 @@ import sys
 import time
 from github import Github
 from s3_helper import S3Helper
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from get_robot_token import get_best_robot_token
 from version_helper import get_version_from_repo, update_version_local
 from ccache_utils import get_ccache_if_not_exists, upload_ccache
@@ -99,10 +99,7 @@ if __name__ == "__main__":
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
 
     logging.info("Repo copy path %s", repo_path)
 

--- a/tests/ci/build_report_check.py
+++ b/tests/ci/build_report_check.py
@@ -8,7 +8,7 @@ from github import Github
 from report import create_build_html_report
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from commit_status_helper import  get_commit
 
 class BuildResult():
@@ -105,10 +105,8 @@ if __name__ == "__main__":
 
     gh = Github(get_best_robot_token())
     s3_helper = S3Helper('https://s3.amazonaws.com')
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r') as event_file:
-        event = json.load(event_file)
 
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
 
     branch_url = f"{os.getenv('GITHUB_SERVER_URL')}/{os.getenv('GITHUB_REPOSITORY')}/commits/master"
     branch_name = "master"

--- a/tests/ci/compatibility_check.py
+++ b/tests/ci/compatibility_check.py
@@ -3,14 +3,13 @@
 from distutils.version import StrictVersion
 import logging
 import os
-import json
 import subprocess
 
 from github import Github
 
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from build_download_helper import download_builds_filter
 from upload_result_helper import upload_results
 from docker_pull_helper import get_images_with_versions
@@ -106,10 +105,7 @@ if __name__ == "__main__":
     repo_path = os.getenv("REPO_COPY", os.path.abspath("../../"))
     reports_path = os.getenv("REPORTS_PATH", "./reports")
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
 
     gh = Github(get_best_robot_token())
 

--- a/tests/ci/docker_images_check.py
+++ b/tests/ci/docker_images_check.py
@@ -7,7 +7,7 @@ import time
 import shutil
 from github import Github
 from s3_helper import S3Helper
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from get_robot_token import get_best_robot_token, get_parameter_from_ssm
 from upload_result_helper import upload_results
 from commit_status_helper import get_commit
@@ -167,10 +167,7 @@ if __name__ == "__main__":
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event, False, True)
+    pr_info = PRInfo(get_event(), need_changed_files=True)
     changed_images, dockerhub_repo_name = get_changed_docker_images(pr_info, repo_path, "docker/images.json")
     logging.info("Has changed images %s", ', '.join([str(image[0]) for image in changed_images]))
     pr_commit_version = str(pr_info.number) + '-' + pr_info.sha

--- a/tests/ci/docs_check.py
+++ b/tests/ci/docs_check.py
@@ -2,11 +2,10 @@
 import logging
 import subprocess
 import os
-import json
 import sys
 from github import Github
 from s3_helper import S3Helper
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from get_robot_token import get_best_robot_token
 from upload_result_helper import upload_results
 from docker_pull_helper import get_image_with_version
@@ -25,10 +24,7 @@ if __name__ == "__main__":
     temp_path = os.path.join(os.getenv("TEMP_PATH"))
     repo_path = os.path.join(os.getenv("REPO_COPY"))
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event, need_changed_files=True)
+    pr_info = PRInfo(get_event(), need_changed_files=True)
 
     gh = Github(get_best_robot_token())
     if not pr_info.has_changes_in_documentation():

--- a/tests/ci/docs_release.py
+++ b/tests/ci/docs_release.py
@@ -2,13 +2,12 @@
 import logging
 import subprocess
 import os
-import json
 import sys
 
 from github import Github
 
 from s3_helper import S3Helper
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from get_robot_token import get_best_robot_token
 from ssh import SSHKey
 from upload_result_helper import upload_results
@@ -23,10 +22,7 @@ if __name__ == "__main__":
     temp_path = os.path.join(os.getenv("TEMP_PATH"))
     repo_path = os.path.join(os.getenv("REPO_COPY"))
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event, need_changed_files=True)
+    pr_info = PRInfo(get_event(), need_changed_files=True)
 
     gh = Github(get_best_robot_token())
     if not pr_info.has_changes_in_documentation():

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -3,12 +3,11 @@
 import logging
 import subprocess
 import os
-import json
 import csv
 import sys
 
 from github import Github
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
 from upload_result_helper import upload_results
@@ -64,10 +63,7 @@ if __name__ == "__main__":
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
 
     gh = Github(get_best_robot_token())
 

--- a/tests/ci/finish_check.py
+++ b/tests/ci/finish_check.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 import logging
-import json
 import os
 from github import Github
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from get_robot_token import get_best_robot_token
 from commit_status_helper import get_commit
 
@@ -26,10 +25,8 @@ def filter_statuses(statuses):
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r') as event_file:
-        event = json.load(event_file)
 
-    pr_info = PRInfo(event, need_orgs=True)
+    pr_info = PRInfo(get_event(), need_orgs=True)
     gh = Github(get_best_robot_token())
     commit = get_commit(gh, pr_info.sha)
 

--- a/tests/ci/functional_test_check.py
+++ b/tests/ci/functional_test_check.py
@@ -4,14 +4,13 @@ import csv
 import logging
 import subprocess
 import os
-import json
 import sys
 
 from github import Github
 
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from build_download_helper import download_all_deb_packages
 from upload_result_helper import upload_results
 from docker_pull_helper import get_image_with_version
@@ -112,11 +111,8 @@ if __name__ == "__main__":
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as event_file:
-        event = json.load(event_file)
-
     gh = Github(get_best_robot_token())
-    pr_info = PRInfo(event, need_changed_files=flaky_check)
+    pr_info = PRInfo(get_event(), need_changed_files=flaky_check)
     tests_to_run = []
     if flaky_check:
         tests_to_run = get_tests_to_run(pr_info)

--- a/tests/ci/integration_test_check.py
+++ b/tests/ci/integration_test_check.py
@@ -11,7 +11,7 @@ from github import Github
 
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from build_download_helper import download_all_deb_packages
 from upload_result_helper import upload_results
 from docker_pull_helper import get_images_with_versions
@@ -108,11 +108,8 @@ if __name__ == "__main__":
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as event_file:
-        event = json.load(event_file)
-
     is_flaky_check = 'flaky' in check_name
-    pr_info = PRInfo(event, need_changed_files=is_flaky_check)
+    pr_info = PRInfo(get_event(), need_changed_files=is_flaky_check)
 
     gh = Github(get_best_robot_token())
 

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import json
 import os
 import urllib
 
@@ -27,6 +28,12 @@ def get_pr_for_commit(sha, ref):
     except Exception as ex:
         print("Cannot fetch PR info from commit", ex)
     return None
+
+
+def get_event():
+    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as ef:
+        return json.load(ef)
+
 
 class PRInfo:
     def __init__(self, github_event, need_orgs=False, need_changed_files=False):

--- a/tests/ci/pvs_check.py
+++ b/tests/ci/pvs_check.py
@@ -9,7 +9,7 @@ import logging
 import sys
 from github import Github
 from s3_helper import S3Helper
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from get_robot_token import get_best_robot_token, get_parameter_from_ssm
 from upload_result_helper import upload_results
 from commit_status_helper import get_commit
@@ -44,9 +44,7 @@ if __name__ == "__main__":
     repo_path = os.path.join(os.getenv("REPO_COPY", os.path.abspath("../../")))
     temp_path = os.path.join(os.getenv("TEMP_PATH"))
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r') as event_file:
-        event = json.load(event_file)
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
     # this check modify repository so copy it to the temp directory
     logging.info("Repo copy path %s", repo_path)
 

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 import os
-import json
 import sys
 import logging
 from github import Github
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from get_robot_token import get_best_robot_token
 from commit_status_helper import get_commit
 
@@ -105,10 +104,8 @@ def should_run_checks_for_pr(pr_info):
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r') as event_file:
-        event = json.load(event_file)
 
-    pr_info = PRInfo(event, need_orgs=True)
+    pr_info = PRInfo(get_event(), need_orgs=True)
     can_run, description = should_run_checks_for_pr(pr_info)
     gh = Github(get_best_robot_token())
     commit = get_commit(gh, pr_info.sha)

--- a/tests/ci/split_build_smoke_check.py
+++ b/tests/ci/split_build_smoke_check.py
@@ -2,14 +2,13 @@
 
 import os
 import logging
-import json
 import subprocess
 
 from github import Github
 
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from build_download_helper import download_shared_build
 from upload_result_helper import upload_results
 from docker_pull_helper import get_image_with_version
@@ -63,10 +62,7 @@ if __name__ == "__main__":
     repo_path = os.getenv("REPO_COPY", os.path.abspath("../../"))
     reports_path = os.getenv("REPORTS_PATH", "./reports")
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
 
     gh = Github(get_best_robot_token())
 

--- a/tests/ci/stress_check.py
+++ b/tests/ci/stress_check.py
@@ -4,14 +4,13 @@ import csv
 import logging
 import subprocess
 import os
-import json
 import sys
 
 from github import Github
 
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from build_download_helper import download_all_deb_packages
 from upload_result_helper import upload_results
 from docker_pull_helper import get_image_with_version
@@ -77,10 +76,7 @@ if __name__ == "__main__":
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
 
     gh = Github(get_best_robot_token())
 

--- a/tests/ci/style_check.py
+++ b/tests/ci/style_check.py
@@ -3,10 +3,9 @@ import logging
 import subprocess
 import os
 import csv
-import json
 from github import Github
 from s3_helper import S3Helper
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from get_robot_token import get_best_robot_token
 from upload_result_helper import upload_results
 from docker_pull_helper import get_image_with_version
@@ -46,6 +45,7 @@ def process_result(result_folder):
             state, description = "error", "Failed to read test_results.tsv"
         return state, description, test_results, additional_files
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
@@ -54,9 +54,7 @@ if __name__ == "__main__":
     repo_path = os.path.join(os.getenv("GITHUB_WORKSPACE", os.path.abspath("../../")))
     temp_path = os.path.join(os.getenv("RUNNER_TEMP", os.path.abspath("./temp")), 'style_check')
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r') as event_file:
-        event = json.load(event_file)
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
 
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)

--- a/tests/ci/unit_tests_check.py
+++ b/tests/ci/unit_tests_check.py
@@ -4,13 +4,12 @@ import logging
 import os
 import sys
 import subprocess
-import json
 
 from github import Github
 
 from s3_helper import S3Helper
 from get_robot_token import get_best_robot_token
-from pr_info import PRInfo
+from pr_info import PRInfo, get_event
 from build_download_helper import download_unit_tests
 from upload_result_helper import upload_results
 from docker_pull_helper import get_image_with_version
@@ -102,10 +101,7 @@ if __name__ == "__main__":
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)
 
-    with open(os.getenv('GITHUB_EVENT_PATH'), 'r', encoding='utf-8') as event_file:
-        event = json.load(event_file)
-
-    pr_info = PRInfo(event)
+    pr_info = PRInfo(get_event())
 
     gh = Github(get_best_robot_token())
 


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Adjust artifactory pusher to a new bucket paths
- Use only version or pull request number in bucket, no `0`
- Create a function to read github event data

Relates to: #31851 