### PR TITLE
Give some love to macOS platform

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,10 @@
 [submodule "contrib/cctz"]
 	path = contrib/cctz
 	url = https://github.com/ClickHouse-Extras/cctz.git
+[submodule "contrib/zlib-ng"]
+	path = contrib/zlib-ng
+	url = https://github.com/ClickHouse-Extras/zlib-ng.git
+	branch = clickhouse-2.0.x
 [submodule "contrib/googletest"]
 	path = contrib/googletest
 	url = https://github.com/google/googletest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,10 +14,6 @@
 [submodule "contrib/cctz"]
 	path = contrib/cctz
 	url = https://github.com/ClickHouse-Extras/cctz.git
-[submodule "contrib/zlib-ng"]
-	path = contrib/zlib-ng
-	url = https://github.com/ClickHouse-Extras/zlib-ng.git
-	branch = clickhouse-new
 [submodule "contrib/googletest"]
 	path = contrib/googletest
 	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ if (OS_DARWIN)
     # from a _specific_ library, which is what we need.
     set(WHOLE_ARCHIVE -force_load)
     # The `-noall_load` flag is the default and now obsolete.
-    set(NO_WHOLE_ARCHIVE "")
+    set(NO_WHOLE_ARCHIVE "-undefined,error") # Effectively, a no-op. Here to avoid empty "-Wl, " sequence to be generated in the command line.
 else ()
     set(WHOLE_ARCHIVE --whole-archive)
     set(NO_WHOLE_ARCHIVE --no-whole-archive)

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -18,9 +18,10 @@ if (COMPILER_GCC)
 elseif (COMPILER_CLANG)
     # Require minimum version of clang/apple-clang
     if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-        # If you are developer you can figure out what exact versions of AppleClang are Ok,
-        # simply remove the following line.
-        message (FATAL_ERROR "AppleClang is not supported, you should install clang from brew. See the instruction: https://clickhouse.com/docs/en/development/build-osx/")
+        # (Experimental!) Specify "-DALLOW_APPLECLANG=ON" when running CMake configuration step, if you want to experiment with using it.
+        if (NOT ALLOW_APPLECLANG AND NOT DEFINED ENV{ALLOW_APPLECLANG})
+            message (FATAL_ERROR "AppleClang is not supported, you should install clang from brew. See the instruction: https://clickhouse.com/docs/en/development/build-osx/")
+        endif ()
 
         # AppleClang 10.0.1 (Xcode 10.2) corresponds to LLVM/Clang upstream version 7.0.0
         # AppleClang 11.0.0 (Xcode 11.0) corresponds to LLVM/Clang upstream version 8.0.0

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -301,9 +301,10 @@ endif()
 # instead of controlling it via CMAKE_FOLDER.
 
 function (ensure_target_rooted_in _target _folder)
-    # Skip INTERFACE library targets, since FOLDER property is not available for them.
+    # Skip aliases and INTERFACE library targets, since FOLDER property is not available/writable for them.
+    get_target_property (_target_aliased "${_target}" ALIASED_TARGET)
     get_target_property (_target_type "${_target}" TYPE)
-    if (_target_type STREQUAL "INTERFACE_LIBRARY")
+    if (_target_aliased OR _target_type STREQUAL "INTERFACE_LIBRARY")
         return ()
     endif ()
 

--- a/contrib/libcxx-cmake/CMakeLists.txt
+++ b/contrib/libcxx-cmake/CMakeLists.txt
@@ -73,6 +73,11 @@ target_compile_options(cxx PRIVATE -w)
 
 target_link_libraries(cxx PUBLIC cxxabi)
 
+# For __udivmodti4, __divmodti4.
+if (OS_DARWIN AND COMPILER_GCC)
+    target_link_libraries(cxx PRIVATE gcc)
+endif ()
+
 install(
     TARGETS cxx
     EXPORT global

--- a/contrib/sentry-native-cmake/CMakeLists.txt
+++ b/contrib/sentry-native-cmake/CMakeLists.txt
@@ -28,10 +28,15 @@ set (SRCS
     ${SRC_DIR}/src/sentry_unix_pageallocator.c
     ${SRC_DIR}/src/path/sentry_path_unix.c
     ${SRC_DIR}/src/symbolizer/sentry_symbolizer_unix.c
-    ${SRC_DIR}/src/modulefinder/sentry_modulefinder_linux.c
     ${SRC_DIR}/src/transports/sentry_transport_curl.c
     ${SRC_DIR}/src/backends/sentry_backend_none.c
 )
+
+if(APPLE)
+    list(APPEND SRCS ${SRC_DIR}/src/modulefinder/sentry_modulefinder_apple.c)
+else()
+    list(APPEND SRCS ${SRC_DIR}/src/modulefinder/sentry_modulefinder_linux.c)
+endif()
 
 add_library(sentry ${SRCS})
 add_library(sentry::sentry ALIAS sentry)

--- a/contrib/simdjson-cmake/CMakeLists.txt
+++ b/contrib/simdjson-cmake/CMakeLists.txt
@@ -6,4 +6,6 @@ add_library(simdjson ${SIMDJSON_SRC})
 target_include_directories(simdjson SYSTEM PUBLIC "${SIMDJSON_INCLUDE_DIR}" PRIVATE "${SIMDJSON_SRC_DIR}")
 
 # simdjson is using its own CPU dispatching and get confused if we enable AVX/AVX2 flags.
-target_compile_options(simdjson PRIVATE -mno-avx -mno-avx2)
+if(ARCH_AMD64)
+    target_compile_options(simdjson PRIVATE -mno-avx -mno-avx2)
+endif()

--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -3,15 +3,14 @@ toc_priority: 65
 toc_title: Build on Mac OS X
 ---
 
-# You don't have to build ClickHouse
-
-You can install ClickHouse as follows: https://clickhouse.com/#quick-start
-Choose Mac x86 or M1.
-
 # How to Build ClickHouse on Mac OS X {#how-to-build-clickhouse-on-mac-os-x}
 
-Build should work on x86_64 (Intel) and arm64 (Apple Silicon) based macOS 10.15 (Catalina) and higher with Homebrew's vanilla Clang.
-It is always recommended to use `clang` compiler. It is possible to use XCode's `AppleClang` or `gcc` but it's strongly discouraged.
+!!! info "You don't have to build ClickHouse yourself!"
+    You can install pre-built ClickHouse as described in [Quick Start](https://clickhouse.com/#quick-start).
+    Follow `macOS (Intel)` or `macOS (Apple silicon)` installation instructions.
+
+Build should work on x86_64 (Intel) and arm64 (Apple silicon) based macOS 10.15 (Catalina) and higher with Homebrew's vanilla Clang.
+It is always recommended to use vanilla `clang` compiler. It is possible to use XCode's `apple-clang` or `gcc` but it's strongly discouraged.
 
 ## Install Homebrew {#install-homebrew}
 
@@ -33,8 +32,6 @@ sudo rm -rf /Library/Developer/CommandLineTools
 sudo xcode-select --install
 ```
 
-Reboot.
-
 ## Install Required Compilers, Tools, and Libraries {#install-required-compilers-tools-and-libraries}
 
 ``` bash
@@ -51,40 +48,41 @@ git clone --recursive git@github.com:ClickHouse/ClickHouse.git
 
 ## Build ClickHouse {#build-clickhouse}
 
-To build using Homebrew's vanilla Clang compiler:
+To build using Homebrew's vanilla Clang compiler (the only **recommended** way):
 
 ``` bash
 cd ClickHouse
 rm -rf build
 mkdir build
 cd build
-cmake -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_AR=$(brew --prefix llvm)/bin/llvm-ar -DCMAKE_RANLIB=$(brew --prefix llvm)/bin/llvm-ranlib -DOBJCOPY_PATH=$(brew --prefix llvm)/bin/llvm-objcopy -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 cmake --build . --config RelWithDebInfo
-cd ..
+# The resulting binary will be created at: ./programs/clickhouse
 ```
 
-To build using Xcode's native AppleClang compiler (this option is strongly not recommended; use the option above):
+To build using Xcode's native AppleClang compiler in Xcode IDE (this option is only for development builds and workflows, and is **not recommended** unless you know what you are doing):
 
 ``` bash
 cd ClickHouse
 rm -rf build
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-cmake --build . --config RelWithDebInfo
-cd ..
+XCODE_IDE=1 ALLOW_APPLECLANG=1 cmake -G Xcode -DCMAKE_BUILD_TYPE=Debug -DENABLE_JEMALLOC=OFF ..
+cmake --open .
+# ...then, in Xcode IDE select ALL_BUILD scheme and start the building process.
+# The resulting binary will be created at: ./programs/Debug/clickhouse
 ```
 
-To build using Homebrew's vanilla GCC compiler (this option is absolutely not recommended, I'm wondering why do we ever have it):
+To build using Homebrew's vanilla GCC compiler (this option is only for development experiments, and is **absolutely not recommended** unless you really know what you are doing):
 
 ``` bash
 cd ClickHouse
 rm -rf build
 mkdir build
 cd build
-cmake -DCMAKE_C_COMPILER=$(brew --prefix gcc)/bin/gcc-11 -DCMAKE_CXX_COMPILER=$(brew --prefix gcc)/bin/g++-11 -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake -DCMAKE_C_COMPILER=$(brew --prefix gcc)/bin/gcc-11 -DCMAKE_CXX_COMPILER=$(brew --prefix gcc)/bin/g++-11 -DCMAKE_AR=$(brew --prefix gcc)/bin/gcc-ar-11 -DCMAKE_RANLIB=$(brew --prefix gcc)/bin/gcc-ranlib-11 -DOBJCOPY_PATH=$(brew --prefix binutils)/bin/objcopy -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 cmake --build . --config RelWithDebInfo
-cd ..
+# The resulting binary will be created at: ./programs/clickhouse
 ```
 
 ## Caveats {#caveats}
@@ -140,9 +138,9 @@ sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
 
 To check if it’s working, use the `ulimit -n` or `launchctl limit maxfiles` commands.
 
-## Run ClickHouse server:
+## Running ClickHouse server
 
-```
+``` bash
 cd ClickHouse
 ./build/programs/clickhouse-server --config-file ./programs/server/config.xml
 ```

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -492,8 +492,9 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                 /// Override the default paths.
 
                 /// Data paths.
+                const std::string data_file = config_d / "data-paths.xml";
+                if (!fs::exists(data_file))
                 {
-                    std::string data_file = config_d / "data-paths.xml";
                     WriteBufferFromFile out(data_file);
                     out << "<clickhouse>\n"
                     "    <path>" << data_path.string() << "</path>\n"
@@ -503,12 +504,14 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                     "</clickhouse>\n";
                     out.sync();
                     out.finalize();
+                    fs::permissions(data_file, fs::perms::owner_read, fs::perm_options::replace);
                     fmt::print("Data path configuration override is saved to file {}.\n", data_file);
                 }
 
                 /// Logger.
+                const std::string logger_file = config_d / "logger.xml";
+                if (!fs::exists(logger_file))
                 {
-                    std::string logger_file = config_d / "logger.xml";
                     WriteBufferFromFile out(logger_file);
                     out << "<clickhouse>\n"
                     "    <logger>\n"
@@ -518,12 +521,14 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                     "</clickhouse>\n";
                     out.sync();
                     out.finalize();
+                    fs::permissions(logger_file, fs::perms::owner_read, fs::perm_options::replace);
                     fmt::print("Log path configuration override is saved to file {}.\n", logger_file);
                 }
 
                 /// User directories.
+                const std::string user_directories_file = config_d / "user-directories.xml";
+                if (!fs::exists(user_directories_file))
                 {
-                    std::string user_directories_file = config_d / "user-directories.xml";
                     WriteBufferFromFile out(user_directories_file);
                     out << "<clickhouse>\n"
                     "    <user_directories>\n"
@@ -534,12 +539,14 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                     "</clickhouse>\n";
                     out.sync();
                     out.finalize();
+                    fs::permissions(user_directories_file, fs::perms::owner_read, fs::perm_options::replace);
                     fmt::print("User directory path configuration override is saved to file {}.\n", user_directories_file);
                 }
 
                 /// OpenSSL.
+                const std::string openssl_file = config_d / "openssl.xml";
+                if (!fs::exists(openssl_file))
                 {
-                    std::string openssl_file = config_d / "openssl.xml";
                     WriteBufferFromFile out(openssl_file);
                     out << "<clickhouse>\n"
                     "    <openSSL>\n"
@@ -552,6 +559,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                     "</clickhouse>\n";
                     out.sync();
                     out.finalize();
+                    fs::permissions(openssl_file, fs::perms::owner_read, fs::perm_options::replace);
                     fmt::print("OpenSSL path configuration override is saved to file {}.\n", openssl_file);
                 }
             }

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -328,7 +328,11 @@ struct Checker
     {
         checkRequiredInstructions();
     }
-} checker __attribute__((init_priority(101)));  /// Run before other static initializers.
+} checker
+#ifndef __APPLE__
+    __attribute__((init_priority(101)))    /// Run before other static initializers.
+#endif
+;
 
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -548,10 +548,5 @@ if (ENABLE_TESTS AND USE_GTEST)
         clickhouse_common_zookeeper
         string_utils)
 
-    # For __udivmodti4 referenced in Core/tests/gtest_DecimalFunctions.cpp
-    if (OS_DARWIN AND COMPILER_GCC)
-        target_link_libraries(unit_tests_dbms PRIVATE gcc)
-    endif ()
-
     add_check(unit_tests_dbms)
 endif ()

--- a/website/templates/index/quickstart.html
+++ b/website/templates/index/quickstart.html
@@ -20,10 +20,10 @@
                     <a class="nav-link" id="arm-tab" data-toggle="tab" href="#arm" role="tab" aria-controls="arm" aria-selected="false" title="ARM packages">Linux (ARM)</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" id="mac-x86-tab" data-toggle="tab" href="#mac-x86" role="tab" aria-controls="mac-x86" aria-selected="false" title="Mac x86 packages">macOS (Intel)</a>
+                    <a class="nav-link" id="mac-x86-tab" data-toggle="tab" href="#mac-x86" role="tab" aria-controls="mac-x86" aria-selected="false" title="macOS x86_64 packages">macOS (Intel)</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" id="mac-arm-tab" data-toggle="tab" href="#mac-arm" role="tab" aria-controls="mac-arm" aria-selected="false" title="Mac ARM packages">Mac (Apple Silicon)</a>
+                    <a class="nav-link" id="mac-arm-tab" data-toggle="tab" href="#mac-arm" role="tab" aria-controls="mac-arm" aria-selected="false" title="macOS arm64 packages">macOS (Apple silicon)</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" id="freebsd-tab" data-toggle="tab" href="#freebsd" role="tab" aria-controls="freebsd" aria-selected="false" title="FreeBSD packages">FreeBSD (x86_64)</a>


### PR DESCRIPTION
Changelog category:
- Not for changelog (changelog entry is not required)

Detailed description:
- fix compilation for M1 macOS for AppleClange (still needs to be enabled manually, for development only)
- when reassigning "folders" for IDEs, do not manipulate `ALIASED_TARGET`s in CMake
- make macOS build docs more useful and correct
- fix naming
- set permissions on some of config override files during `clickhouse install`