### PR TITLE
Fix segfault in MaterializedMySQL

### DIFF
--- a/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
@@ -137,7 +137,9 @@ StoragePtr DatabaseMaterializedMySQL::tryGetTable(const String & name, ContextPt
     StoragePtr nested_storage = DatabaseAtomic::tryGetTable(name, context_);
     if (context_->isInternalQuery())
         return nested_storage;
-    return std::make_shared<StorageMaterializedMySQL>(std::move(nested_storage), this);
+    if (nested_storage)
+        return std::make_shared<StorageMaterializedMySQL>(std::move(nested_storage), this);
+    return nullptr;
 }
 
 DatabaseTablesIteratorPtr


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
Not for changelog because it's not released yet. Introduced in #31292.
https://s3.amazonaws.com/clickhouse-test-reports/0/888200087cefa6f3a1dbd6b226b5fc54c9c1b668/integration_tests__release__actions_/integration_run_parallel7_0.log
