### PR TITLE
Add ability to drain connections synchronously

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -293,6 +293,10 @@
 
     <max_thread_pool_size>10000</max_thread_pool_size>
 
+    <!-- Number of workers to recycle connections in background (see also drain_timeout).
+         If the pool is full, connection will be drained synchronously. -->
+    <!-- <max_threads_for_connection_collector>10</max_threads_for_connection_collector> -->
+
     <!-- On memory constrained environments you may have to set this to value larger than 1.
       -->
     <max_server_memory_usage_to_ram_ratio>0.9</max_server_memory_usage_to_ram_ratio>

--- a/src/Client/IConnections.cpp
+++ b/src/Client/IConnections.cpp
@@ -25,7 +25,12 @@ struct PocoSocketWrapper : public Poco::Net::SocketImpl
 void IConnections::DrainCallback::operator()(int fd, Poco::Timespan, const std::string fd_description) const
 {
     if (!PocoSocketWrapper(fd).poll(drain_timeout, Poco::Net::Socket::SELECT_READ))
-        throw Exception(ErrorCodes::SOCKET_TIMEOUT, "Read timeout while draining from {}", fd_description);
+    {
+        throw Exception(ErrorCodes::SOCKET_TIMEOUT,
+            "Read timeout ({} ms) while draining from {}",
+            drain_timeout.totalMilliseconds(),
+            fd_description);
+    }
 }
 
 }

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -55,7 +55,7 @@ class IColumn;
     M(Milliseconds, connect_timeout_with_failover_secure_ms, 100, "Connection timeout for selecting first healthy replica (for secure connections).", 0) \
     M(Seconds, receive_timeout, DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, "", 0) \
     M(Seconds, send_timeout, DBMS_DEFAULT_SEND_TIMEOUT_SEC, "", 0) \
-    M(Seconds, drain_timeout, 3, "", 0) \
+    M(Seconds, drain_timeout, 3, "Timeout for draining remote connections, -1 means synchronous drain w/o ignoring errors", 0) \
     M(Seconds, tcp_keep_alive_timeout, 290 /* less than DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC */, "The time in seconds the connection needs to remain idle before TCP starts sending keepalive probes", 0) \
     M(Milliseconds, hedged_connection_timeout_ms, 100, "Connection timeout for establishing connection with replica for Hedged requests", 0) \
     M(Milliseconds, receive_data_timeout_ms, 2000, "Connection timeout for receiving first packet of data or packet with positive progress from replica", 0) \

--- a/src/QueryPipeline/ConnectionCollector.cpp
+++ b/src/QueryPipeline/ConnectionCollector.cpp
@@ -90,6 +90,9 @@ void ConnectionCollector::drainConnections(IConnections & connections) noexcept
                 break;
 
             default:
+                /// Connection should be closed in case of unknown packet,
+                /// since this means that the connection in some bad state.
+                is_drained = false;
                 throw Exception(
                     ErrorCodes::UNKNOWN_PACKET_FROM_SERVER,
                     "Unknown packet {} from one of the following replicas: {}",

--- a/src/QueryPipeline/ConnectionCollector.cpp
+++ b/src/QueryPipeline/ConnectionCollector.cpp
@@ -46,7 +46,7 @@ struct AsyncDrainTask
     std::shared_ptr<IConnections> shared_connections;
     void operator()() const
     {
-        ConnectionCollector::drainConnections(*shared_connections);
+        ConnectionCollector::drainConnections(*shared_connections, /* throw_error= */ false);
     }
 
     // We don't have std::unique_function yet. Wrap it in shared_ptr to make the functor copyable.
@@ -71,7 +71,7 @@ std::shared_ptr<IConnections> ConnectionCollector::enqueueConnectionCleanup(
     return connections;
 }
 
-void ConnectionCollector::drainConnections(IConnections & connections) noexcept
+void ConnectionCollector::drainConnections(IConnections & connections, bool throw_error)
 {
     bool is_drained = false;
     try
@@ -114,6 +114,9 @@ void ConnectionCollector::drainConnections(IConnections & connections) noexcept
                 tryLogCurrentException(&Poco::Logger::get("ConnectionCollector"), __PRETTY_FUNCTION__);
             }
         }
+
+        if (throw_error)
+            throw;
     }
 }
 

--- a/src/QueryPipeline/ConnectionCollector.h
+++ b/src/QueryPipeline/ConnectionCollector.h
@@ -17,7 +17,7 @@ public:
     static ConnectionCollector & init(ContextMutablePtr global_context_, size_t max_threads);
     static std::shared_ptr<IConnections>
     enqueueConnectionCleanup(const ConnectionPoolWithFailoverPtr & pool, std::shared_ptr<IConnections> connections) noexcept;
-    static void drainConnections(IConnections & connections) noexcept;
+    static void drainConnections(IConnections & connections, bool throw_error);
 
 private:
     explicit ConnectionCollector(ContextMutablePtr global_context_, size_t max_threads);

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -495,14 +495,26 @@ void RemoteQueryExecutor::finish(std::unique_ptr<ReadContext> * read_context)
 
     /// Send the request to abort the execution of the request, if not already sent.
     tryCancel("Cancelling query because enough data has been read", read_context);
-    /// Try to drain connections asynchronously.
-    if (auto conn = ConnectionCollector::enqueueConnectionCleanup(pool, connections))
+
+    if (context->getSettingsRef().drain_timeout != Poco::Timespan(-1000000))
     {
-        /// Drain connections synchronously.
+        auto connections_left = ConnectionCollector::enqueueConnectionCleanup(pool, connections);
+        if (connections_left)
+        {
+            /// Drain connections synchronously and suppress errors.
+            CurrentMetrics::Increment metric_increment(CurrentMetrics::ActiveSyncDrainedConnections);
+            ConnectionCollector::drainConnections(*connections_left, /* throw_error= */ false);
+            CurrentMetrics::add(CurrentMetrics::SyncDrainedConnections, 1);
+        }
+    }
+    else
+    {
+        /// Drain connections synchronously w/o suppressing errors.
         CurrentMetrics::Increment metric_increment(CurrentMetrics::ActiveSyncDrainedConnections);
-        ConnectionCollector::drainConnections(*conn);
+        ConnectionCollector::drainConnections(*connections, /* throw_error= */ true);
         CurrentMetrics::add(CurrentMetrics::SyncDrainedConnections, 1);
     }
+
     finished = true;
 }
 

--- a/tests/queries/0_stateless/02127_connection_drain.reference
+++ b/tests/queries/0_stateless/02127_connection_drain.reference
@@ -1,0 +1,2 @@
+OK: sync drain
+OK: async drain

--- a/tests/queries/0_stateless/02127_connection_drain.sh
+++ b/tests/queries/0_stateless/02127_connection_drain.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-parallel
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02127_connection_drain.sh
+++ b/tests/queries/0_stateless/02127_connection_drain.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# sync drain
+for _ in {1..100}; do
+    prev=$(curl -d@- -sS "${CLICKHOUSE_URL}" <<<"select value from system.metrics where metric = 'SyncDrainedConnections'")
+    curl -d@- -sS "${CLICKHOUSE_URL}" <<<"select * from remote('127.{2,3}', view(select * from numbers(1e6))) limit 100 settings drain_timeout=-1 format Null"
+    now=$(curl -d@- -sS "${CLICKHOUSE_URL}" <<<"select value from system.metrics where metric = 'SyncDrainedConnections'")
+    if [[ "$prev" != $(( now-2 )) ]]; then
+        continue
+    fi
+    echo "OK: sync drain"
+    break
+done
+
+# async drain
+for _ in {1..100}; do
+    prev=$(curl -d@- -sS "${CLICKHOUSE_URL}" <<<"select value from system.metrics where metric = 'AsyncDrainedConnections'")
+    curl -d@- -sS "${CLICKHOUSE_URL}" <<<"select * from remote('127.{2,3}', view(select * from numbers(1e6))) limit 100 settings drain_timeout=10 format Null"
+    now=$(curl -d@- -sS "${CLICKHOUSE_URL}" <<<"select value from system.metrics where metric = 'AsyncDrainedConnections'")
+    if [[ "$prev" != $(( now-2 )) ]]; then
+        continue
+    fi
+    echo "OK: async drain"
+    break
+done


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add ability to drain connections synchronously (under `drain_timeout=-1`)
- Add timeout into some error messages
- Disconnect connection on unknown packet.

Cc: @amosbird 

*NOTE: initially I was investigating pretty tricky issue and asynchronous drain does not allow to see the error on the client*