### PR TITLE
MaterializedMySQL: Fix corruption of DECIMAL data

### DIFF
--- a/src/Core/MySQL/MySQLReplication.cpp
+++ b/src/Core/MySQL/MySQLReplication.cpp
@@ -501,6 +501,9 @@ namespace MySQLReplication
                             UInt32 mask = 0;
                             DecimalType res(0);
 
+                            if (payload.eof())
+                                throw Exception("Attempt to read after EOF.", ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF);
+
                             if ((*payload.position() & 0x80) == 0)
                                 mask = UInt32(-1);
 


### PR DESCRIPTION
If the first byte of a DECIMAL value happened to be just after we
had reached the end of the ReadBuffer, the value could get
corrupted because we would get the "is negative" bit from a byte
after the current end of the buffer.

Closes #29468, #29917, #25896, #19597, #16265

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
MaterializedMySQL: Fix rare corruption of DECIMAL data
