### PR TITLE
Fix race in ParallelFormattingOutputFormat constructor

### DIFF
--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
@@ -74,18 +74,23 @@ public:
         , pool(params.max_threads_for_parallel_formatting)
 
     {
-        /// Just heuristic. We need one thread for collecting, one thread for receiving chunks
-        /// and n threads for formatting.
-        processing_units.resize(params.max_threads_for_parallel_formatting + 2);
-        collector_thread = ThreadFromGlobalPool([thread_group = CurrentThread::getGroup(), this]
-        {
-            collectorThreadFunction(thread_group);
-        });
+        LOG_TRACE(&Poco::Logger::get("ParallelFormattingOutputFormat"), "Parallel formatting is being used");
 
         NullWriteBuffer buf;
         save_totals_and_extremes_in_statistics = internal_formatter_creator(buf)->areTotalsAndExtremesUsedInFinalize();
 
-        LOG_TRACE(&Poco::Logger::get("ParallelFormattingOutputFormat"), "Parallel formatting is being used");
+        /// Just heuristic. We need one thread for collecting, one thread for receiving chunks
+        /// and n threads for formatting.
+        processing_units.resize(params.max_threads_for_parallel_formatting + 2);
+
+        /// Do not put any code that could throw an exception under this line.
+        /// Because otherwise the destructor of this class won't be called and this thread won't be joined.
+        /// Also some race condition is possible, because collector_thread runs in parallel with
+        /// the destruction of the objects already created in this scope.
+        collector_thread = ThreadFromGlobalPool([thread_group = CurrentThread::getGroup(), this]
+        {
+            collectorThreadFunction(thread_group);
+        });
     }
 
     ~ParallelFormattingOutputFormat() override

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
@@ -74,7 +74,7 @@ public:
         , pool(params.max_threads_for_parallel_formatting)
 
     {
-        LOG_TRACE(&Poco::Logger::get("ParallelFormattingOutputFormat"), "Parallel formatting is being used");
+        LOG_TEST(&Poco::Logger::get("ParallelFormattingOutputFormat"), "Parallel formatting is being used");
 
         NullWriteBuffer buf;
         save_totals_and_extremes_in_statistics = internal_formatter_creator(buf)->areTotalsAndExtremesUsedInFinalize();


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
How I think the race was triggered by some exception like std::bad_alloc from logger.  Closes #31958