### PR TITLE
Fix excessive DESC TABLE for remote() over identifier

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1026,7 +1026,6 @@ void Context::addQueryFactoriesInfo(QueryLogFactories factory_type, const String
 
 StoragePtr Context::executeTableFunction(const ASTPtr & table_expression)
 {
-    /// Slightly suboptimal.
     auto hash = table_expression->getTreeHash();
     String key = toString(hash.first) + '_' + toString(hash.second);
 
@@ -1035,9 +1034,20 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression)
     if (!res)
     {
         TableFunctionPtr table_function_ptr = TableFunctionFactory::instance().get(table_expression, shared_from_this());
-
-        /// Run it and remember the result
         res = table_function_ptr->execute(table_expression, shared_from_this(), table_function_ptr->getName());
+
+        /// Since ITableFunction::parseArguments() may change table_expression, i.e.:
+        ///
+        ///     remote('127.1', system.one) -> remote('127.1', 'system.one'),
+        ///
+        auto new_hash = table_expression->getTreeHash();
+        if (hash != new_hash)
+        {
+            key = toString(new_hash.first) + '_' + toString(new_hash.second);
+            table_function_results[key] = res;
+        }
+
+        return res;
     }
 
     return res;

--- a/tests/integration/test_distributed_respect_user_timeouts/test.py
+++ b/tests/integration/test_distributed_respect_user_timeouts/test.py
@@ -127,11 +127,11 @@ def _check_timeout_and_exception(node, user, query_base, query):
 
     extra_repeats = 1
     # Table function remote() are executed two times.
-    # It tries to get table stucture from remote shards.
-    # On 'node'2 it will firsty try to get structure from 'node1' (which is not available),
-    # so so threre are two extra conection attempts for 'node2' and 'remote'
+    # It tries to get table structure from remote shards.
+    # On 'node2' it will firstly try to get structure from 'node1' (which is not available),
+    # so there are 1 extra connection attempts for 'node2' and 'remote'
     if node.name == 'node2' and query_base == 'remote':
-        extra_repeats = 3
+        extra_repeats = 2
 
     expected_timeout = EXPECTED_BEHAVIOR[user]['timeout'] * repeats * extra_repeats
 

--- a/tests/queries/0_stateless/01455_opentelemetry_distributed.reference
+++ b/tests/queries/0_stateless/01455_opentelemetry_distributed.reference
@@ -1,13 +1,11 @@
 ===http===
 {"query":"select 1 from remote('127.0.0.2', system, one) format Null\n","status":"QueryFinish","tracestate":"some custom state","sorted_by_start_time":1}
 {"query":"DESC TABLE system.one","status":"QueryFinish","tracestate":"some custom state","sorted_by_start_time":1}
-{"query":"DESC TABLE system.one","status":"QueryFinish","tracestate":"some custom state","sorted_by_start_time":1}
 {"query":"SELECT 1 FROM system.one","status":"QueryFinish","tracestate":"some custom state","sorted_by_start_time":1}
-{"query":"DESC TABLE system.one","query_status":"QueryFinish","tracestate":"some custom state","sorted_by_finish_time":1}
 {"query":"DESC TABLE system.one","query_status":"QueryFinish","tracestate":"some custom state","sorted_by_finish_time":1}
 {"query":"SELECT 1 FROM system.one","query_status":"QueryFinish","tracestate":"some custom state","sorted_by_finish_time":1}
 {"query":"select 1 from remote('127.0.0.2', system, one) format Null\n","query_status":"QueryFinish","tracestate":"some custom state","sorted_by_finish_time":1}
-{"total spans":"4","unique spans":"4","unique non-zero parent spans":"3"}
+{"total spans":"3","unique spans":"3","unique non-zero parent spans":"3"}
 {"initial query spans with proper parent":"1"}
 {"unique non-empty tracestate values":"1"}
 ===native===

--- a/tests/queries/0_stateless/02126_dist_desc.reference
+++ b/tests/queries/0_stateless/02126_dist_desc.reference
@@ -1,0 +1,81 @@
+-- { echo }
+select * from remote('127.1', 'system.one') settings log_queries=1, log_comment='127.1 db.name literal' format Null;
+system flush logs;
+select count() from system.query_log where
+    type = 'QueryFinish' and
+    not is_initial_query and
+    startsWith(query, 'DESC') and
+    initial_query_id = (
+        select distinct query_id from system.query_log where log_comment = '127.1 db.name literal' and current_database = currentDatabase()
+    );
+0
+select * from remote('127.1', 'system', 'one') settings log_queries=1, log_comment='127.1 db,name literal' format Null;
+system flush logs;
+select count() from system.query_log where
+    type = 'QueryFinish' and
+    not is_initial_query and
+    startsWith(query, 'DESC') and
+    initial_query_id = (
+        select distinct query_id from system.query_log where log_comment = '127.1 db,name literal' and current_database = currentDatabase()
+    );
+0
+select * from remote('127.1', system.one) settings log_queries=1, log_comment='127.1 db.name identifier' format Null;
+system flush logs;
+select count() from system.query_log where
+    type = 'QueryFinish' and
+    not is_initial_query and
+    startsWith(query, 'DESC') and
+    initial_query_id = (
+        select distinct query_id from system.query_log where log_comment = '127.1 db.name identifier' and current_database = currentDatabase()
+    );
+0
+select * from remote('127.1', system, one) settings log_queries=1, log_comment='127.1 db,name identifier' format Null;
+system flush logs;
+select count() from system.query_log where
+    type = 'QueryFinish' and
+    not is_initial_query and
+    startsWith(query, 'DESC') and
+    initial_query_id = (
+        select distinct query_id from system.query_log where log_comment = '127.1 db,name identifier' and current_database = currentDatabase()
+    );
+0
+select * from remote('127.2', 'system.one') settings log_queries=1, log_comment='127.2 db.name literal' format Null;
+system flush logs;
+select count() from system.query_log where
+    type = 'QueryFinish' and
+    not is_initial_query and
+    startsWith(query, 'DESC') and
+    initial_query_id = (
+        select distinct query_id from system.query_log where log_comment = '127.2 db.name literal' and current_database = currentDatabase()
+    );
+1
+select * from remote('127.2', 'system', 'one') settings log_queries=1, log_comment='127.2 db,name literal' format Null;
+system flush logs;
+select count() from system.query_log where
+    type = 'QueryFinish' and
+    not is_initial_query and
+    startsWith(query, 'DESC') and
+    initial_query_id = (
+        select distinct query_id from system.query_log where log_comment = '127.2 db,name literal' and current_database = currentDatabase()
+    );
+1
+select * from remote('127.2', system.one) settings log_queries=1, log_comment='127.2 db.name identifier' format Null;
+system flush logs;
+select count() from system.query_log where
+    type = 'QueryFinish' and
+    not is_initial_query and
+    startsWith(query, 'DESC') and
+    initial_query_id = (
+        select distinct query_id from system.query_log where log_comment = '127.2 db.name identifier' and current_database = currentDatabase()
+    );
+1
+select * from remote('127.2', system, one) settings log_queries=1, log_comment='127.2 db,name identifier' format Null;
+system flush logs;
+select count() from system.query_log where
+    type = 'QueryFinish' and
+    not is_initial_query and
+    startsWith(query, 'DESC') and
+    initial_query_id = (
+        select distinct query_id from system.query_log where log_comment = '127.2 db,name identifier' and current_database = currentDatabase()
+    );
+1

--- a/tests/queries/0_stateless/02126_dist_desc.sql.j2
+++ b/tests/queries/0_stateless/02126_dist_desc.sql.j2
@@ -1,0 +1,19 @@
+-- { echo }
+{% for host in ['127.1', '127.2'] -%}
+{% for args, comment in [
+    ("'system.one'",    host + ' db.name literal'),
+    ("'system', 'one'", host + ' db,name literal'),
+    ("system.one",      host + ' db.name identifier'),
+    ("system, one",     host + ' db,name identifier'),
+] -%}
+select * from remote('{{host}}', {{args}}) settings log_queries=1, log_comment='{{comment}}' format Null;
+system flush logs;
+select count() from system.query_log where
+    type = 'QueryFinish' and
+    not is_initial_query and
+    startsWith(query, 'DESC') and
+    initial_query_id = (
+        select distinct query_id from system.query_log where log_comment = '{{comment}}' and current_database = currentDatabase()
+    );
+{% endfor -%}
+{% endfor -%}


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove excessive `DESC TABLE` requests for `remote()` (in case of `remote('127.1', system.one)` (i.e. identifier as the db.table instead of string) there was excessive `DESC TABLE` request)

Fixes: #14228