### PR TITLE
Fix style-check for ProfileEvents checking

### DIFF
--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -75,6 +75,7 @@ EXTERN_TYPES_EXCLUDES=(
     ProfileEvents::TypeEnum
     ProfileEvents::dumpToMapColumn
     ProfileEvents::LOCAL_NAME
+    ProfileEvents::CountersIncrement
 
     CurrentMetrics::add
     CurrentMetrics::sub


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes the following error:

```
ProfileEvents::CountersIncrement is used in file /ClickHouse/src/Server/TCPHandler.cpp but not defined
```