### PR TITLE
Provide clickhouse binary w/o debug symbols (stripped) in fasttest

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -234,6 +234,9 @@ function build
         time ninja clickhouse-bundle 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee "$FASTTEST_OUTPUT/build_log.txt"
         if [ "$COPY_CLICKHOUSE_BINARY_TO_OUTPUT" -eq "1" ]; then
             cp programs/clickhouse "$FASTTEST_OUTPUT/clickhouse"
+
+            strip programs/clickhouse -o "$FASTTEST_OUTPUT/clickhouse-stripped"
+            gzip "$FASTTEST_OUTPUT/clickhouse-stripped"
         fi
         ccache --show-stats ||:
     )


### PR DESCRIPTION
- regular: 1.8G
- stripped version: 343M, ~5x less.
- compressed stripped: 92M, ~20x less

This can be useful to check something fast.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alesapin 