### PR TITLE
#32039 Make HDFS replication configurable in WriteBufferFromHDFSImpl#WriteBu…

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -75,6 +75,7 @@ class IColumn;
     M(UInt64, s3_max_single_read_retries, 4, "The maximum number of retries during single S3 read.", 0) \
     M(UInt64, s3_max_redirects, 10, "Max number of S3 redirects hops allowed.", 0) \
     M(UInt64, s3_max_connections, 1024, "The maximum number of connections per server.", 0) \
+    M(UInt64, hdfs_replication, 3, "The actual number of replications can be specified when the hdfs file is created.", 0) \
     M(UInt64, hsts_max_age, 0, "Expired time for hsts. 0 means disable HSTS.", 0) \
     M(Bool, extremes, false, "Calculate minimums and maximums of the result columns. They can be output in JSON-formats.", IMPORTANT) \
     M(Bool, use_uncompressed_cache, false, "Whether to use the cache of uncompressed blocks.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -75,7 +75,7 @@ class IColumn;
     M(UInt64, s3_max_single_read_retries, 4, "The maximum number of retries during single S3 read.", 0) \
     M(UInt64, s3_max_redirects, 10, "Max number of S3 redirects hops allowed.", 0) \
     M(UInt64, s3_max_connections, 1024, "The maximum number of connections per server.", 0) \
-    M(UInt64, hdfs_replication, 3, "The actual number of replications can be specified when the hdfs file is created.", 0) \
+    M(UInt64, hdfs_replication, 0, "The actual number of replications can be specified when the hdfs file is created.", 0) \
     M(UInt64, hsts_max_age, 0, "Expired time for hsts. 0 means disable HSTS.", 0) \
     M(Bool, extremes, false, "Calculate minimums and maximums of the result columns. They can be output in JSON-formats.", IMPORTANT) \
     M(Bool, use_uncompressed_cache, false, "Whether to use the cache of uncompressed blocks.", 0) \

--- a/src/Disks/HDFS/DiskHDFS.cpp
+++ b/src/Disks/HDFS/DiskHDFS.cpp
@@ -97,7 +97,7 @@ std::unique_ptr<WriteBufferFromFileBase> DiskHDFS::writeFile(const String & path
 
     /// Single O_WRONLY in libhdfs adds O_TRUNC
     auto hdfs_buffer = std::make_unique<WriteBufferFromHDFS>(hdfs_path,
-                                                             config, buf_size,
+                                                             config, settings->replication, buf_size,
                                                              mode == WriteMode::Rewrite ? O_WRONLY :  O_WRONLY | O_APPEND);
 
     return std::make_unique<WriteIndirectBufferFromRemoteFS<WriteBufferFromHDFS>>(std::move(hdfs_buffer),
@@ -147,7 +147,8 @@ std::unique_ptr<DiskHDFSSettings> getSettings(const Poco::Util::AbstractConfigur
     return std::make_unique<DiskHDFSSettings>(
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),
         config.getInt(config_prefix + ".thread_pool_size", 16),
-        config.getInt(config_prefix + ".objects_chunk_size_to_delete", 1000));
+        config.getInt(config_prefix + ".objects_chunk_size_to_delete", 1000),
+        config.getInt(config_prefix + ".dfs.replication", 3));
 }
 }
 

--- a/src/Disks/HDFS/DiskHDFS.cpp
+++ b/src/Disks/HDFS/DiskHDFS.cpp
@@ -60,11 +60,9 @@ DiskHDFS::DiskHDFS(
     const String & hdfs_root_path_,
     SettingsPtr settings_,
     DiskPtr metadata_disk_,
-    const Poco::Util::AbstractConfiguration & config_,
-    const Settings & contextSettings_)
+    const Poco::Util::AbstractConfiguration & config_)
     : IDiskRemote(disk_name_, hdfs_root_path_, metadata_disk_, "DiskHDFS", settings_->thread_pool_size)
     , config(config_)
-    , contextSettings(contextSettings_)
     , hdfs_builder(createHDFSBuilder(hdfs_root_path_, config))
     , hdfs_fs(createHDFSFS(hdfs_builder.get()))
     , settings(std::move(settings_))
@@ -99,7 +97,7 @@ std::unique_ptr<WriteBufferFromFileBase> DiskHDFS::writeFile(const String & path
 
     /// Single O_WRONLY in libhdfs adds O_TRUNC
     auto hdfs_buffer = std::make_unique<WriteBufferFromHDFS>(hdfs_path,
-                                                             config, contextSettings, buf_size,
+                                                             config, settings->replication, buf_size,
                                                              mode == WriteMode::Rewrite ? O_WRONLY :  O_WRONLY | O_APPEND);
 
     return std::make_unique<WriteIndirectBufferFromRemoteFS<WriteBufferFromHDFS>>(std::move(hdfs_buffer),
@@ -144,12 +142,13 @@ bool DiskHDFS::checkUniqueId(const String & hdfs_uri) const
 
 namespace
 {
-std::unique_ptr<DiskHDFSSettings> getSettings(const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
+std::unique_ptr<DiskHDFSSettings> getSettings(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, const Settings & setttings)
 {
     return std::make_unique<DiskHDFSSettings>(
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),
         config.getInt(config_prefix + ".thread_pool_size", 16),
-        config.getInt(config_prefix + ".objects_chunk_size_to_delete", 1000));
+        config.getInt(config_prefix + ".objects_chunk_size_to_delete", 1000),
+        setttings.hdfs_replication);
 }
 }
 

--- a/src/Disks/HDFS/DiskHDFS.cpp
+++ b/src/Disks/HDFS/DiskHDFS.cpp
@@ -174,7 +174,7 @@ void registerDiskHDFS(DiskFactory & factory)
 
         return std::make_shared<DiskHDFS>(
             name, uri,
-            getSettings(config, config_prefix, context_.getSettingsRef()),
+            getSettings(config, config_prefix, context_->getSettingsRef()),
             metadata_disk, config);
     };
 

--- a/src/Disks/HDFS/DiskHDFS.cpp
+++ b/src/Disks/HDFS/DiskHDFS.cpp
@@ -148,7 +148,7 @@ std::unique_ptr<DiskHDFSSettings> getSettings(const Poco::Util::AbstractConfigur
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),
         config.getInt(config_prefix + ".thread_pool_size", 16),
         config.getInt(config_prefix + ".objects_chunk_size_to_delete", 1000),
-        config.getInt(config_prefix + ".dfs.replication", 3));
+        config.getInt(config_prefix + ".replication", 3));
 }
 }
 

--- a/src/Disks/HDFS/DiskHDFS.cpp
+++ b/src/Disks/HDFS/DiskHDFS.cpp
@@ -142,13 +142,13 @@ bool DiskHDFS::checkUniqueId(const String & hdfs_uri) const
 
 namespace
 {
-std::unique_ptr<DiskHDFSSettings> getSettings(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, const Settings & setttings)
+std::unique_ptr<DiskHDFSSettings> getSettings(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, const Settings & settings)
 {
     return std::make_unique<DiskHDFSSettings>(
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),
         config.getInt(config_prefix + ".thread_pool_size", 16),
         config.getInt(config_prefix + ".objects_chunk_size_to_delete", 1000),
-        setttings.hdfs_replication);
+        settings.hdfs_replication);
 }
 }
 
@@ -174,8 +174,8 @@ void registerDiskHDFS(DiskFactory & factory)
 
         return std::make_shared<DiskHDFS>(
             name, uri,
-            getSettings(config, config_prefix),
-            metadata_disk, config, context.getSettingsRef());
+            getSettings(config, config_prefix, context_.getSettingsRef()),
+            metadata_disk, config);
     };
 
     factory.registerDiskType("hdfs", creator);

--- a/src/Disks/HDFS/DiskHDFS.h
+++ b/src/Disks/HDFS/DiskHDFS.h
@@ -14,14 +14,17 @@ struct DiskHDFSSettings
     size_t min_bytes_for_seek;
     int thread_pool_size;
     int objects_chunk_size_to_delete;
+    int replication;
 
     DiskHDFSSettings(
             int min_bytes_for_seek_,
             int thread_pool_size_,
-            int objects_chunk_size_to_delete_)
+            int objects_chunk_size_to_delete_,
+            int replication_)
         : min_bytes_for_seek(min_bytes_for_seek_)
         , thread_pool_size(thread_pool_size_)
-        , objects_chunk_size_to_delete(objects_chunk_size_to_delete_) {}
+        , objects_chunk_size_to_delete(objects_chunk_size_to_delete_)
+        , replication(replication_) {}
 };
 
 

--- a/src/Disks/HDFS/DiskHDFS.h
+++ b/src/Disks/HDFS/DiskHDFS.h
@@ -14,17 +14,14 @@ struct DiskHDFSSettings
     size_t min_bytes_for_seek;
     int thread_pool_size;
     int objects_chunk_size_to_delete;
-    int replication;
 
     DiskHDFSSettings(
             int min_bytes_for_seek_,
             int thread_pool_size_,
-            int objects_chunk_size_to_delete_,
-            int replication_)
+            int objects_chunk_size_to_delete_)
         : min_bytes_for_seek(min_bytes_for_seek_)
         , thread_pool_size(thread_pool_size_)
-        , objects_chunk_size_to_delete(objects_chunk_size_to_delete_)
-        , replication(replication_) {}
+        , objects_chunk_size_to_delete(objects_chunk_size_to_delete_) {}
 };
 
 
@@ -43,7 +40,8 @@ public:
         const String & hdfs_root_path_,
         SettingsPtr settings_,
         DiskPtr metadata_disk_,
-        const Poco::Util::AbstractConfiguration & config_);
+        const Poco::Util::AbstractConfiguration & config_,
+        const Settings & contextSettings_);
 
     DiskType getType() const override { return DiskType::HDFS; }
     bool isRemote() const override { return true; }
@@ -70,6 +68,7 @@ private:
     String getRandomName() { return toString(UUIDHelpers::generateV4()); }
 
     const Poco::Util::AbstractConfiguration & config;
+    const Settings & contextSettings;
 
     HDFSBuilderWrapper hdfs_builder;
     HDFSFSPtr hdfs_fs;

--- a/src/Disks/HDFS/DiskHDFS.h
+++ b/src/Disks/HDFS/DiskHDFS.h
@@ -14,14 +14,17 @@ struct DiskHDFSSettings
     size_t min_bytes_for_seek;
     int thread_pool_size;
     int objects_chunk_size_to_delete;
+    int replication;
 
     DiskHDFSSettings(
             int min_bytes_for_seek_,
             int thread_pool_size_,
-            int objects_chunk_size_to_delete_)
+            int objects_chunk_size_to_delete_,
+            int replication_)
         : min_bytes_for_seek(min_bytes_for_seek_)
         , thread_pool_size(thread_pool_size_)
-        , objects_chunk_size_to_delete(objects_chunk_size_to_delete_) {}
+        , objects_chunk_size_to_delete(objects_chunk_size_to_delete_)
+        , replication(replication_) {}
 };
 
 
@@ -40,8 +43,7 @@ public:
         const String & hdfs_root_path_,
         SettingsPtr settings_,
         DiskPtr metadata_disk_,
-        const Poco::Util::AbstractConfiguration & config_,
-        const Settings & contextSettings_);
+        const Poco::Util::AbstractConfiguration & config_);
 
     DiskType getType() const override { return DiskType::HDFS; }
     bool isRemote() const override { return true; }
@@ -68,7 +70,6 @@ private:
     String getRandomName() { return toString(UUIDHelpers::generateV4()); }
 
     const Poco::Util::AbstractConfiguration & config;
-    const Settings & contextSettings;
 
     HDFSBuilderWrapper hdfs_builder;
     HDFSFSPtr hdfs_fs;

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -203,7 +203,7 @@ public:
         const CompressionMethod compression_method)
         : SinkToStorage(sample_block)
     {
-        write_buf = wrapWriteBufferWithCompressionMethod(std::make_unique<WriteBufferFromHDFS>(uri, context->getGlobalContext()->getConfigRef(), context.getSettingsRef().hdfs_replication), compression_method, 3);
+        write_buf = wrapWriteBufferWithCompressionMethod(std::make_unique<WriteBufferFromHDFS>(uri, context->getGlobalContext()->getConfigRef(), context->getSettingsRef().hdfs_replication), compression_method, 3);
         writer = FormatFactory::instance().getOutputFormatParallelIfPossible(format, *write_buf, sample_block, context);
     }
 

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -203,7 +203,7 @@ public:
         const CompressionMethod compression_method)
         : SinkToStorage(sample_block)
     {
-        write_buf = wrapWriteBufferWithCompressionMethod(std::make_unique<WriteBufferFromHDFS>(uri, context->getGlobalContext()->getConfigRef()), compression_method, 3);
+        write_buf = wrapWriteBufferWithCompressionMethod(std::make_unique<WriteBufferFromHDFS>(uri, context->getGlobalContext()->getConfigRef(), 0), compression_method, 3);
         writer = FormatFactory::instance().getOutputFormatParallelIfPossible(format, *write_buf, sample_block, context);
     }
 

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -203,7 +203,7 @@ public:
         const CompressionMethod compression_method)
         : SinkToStorage(sample_block)
     {
-        write_buf = wrapWriteBufferWithCompressionMethod(std::make_unique<WriteBufferFromHDFS>(uri, context->getGlobalContext()->getConfigRef(), 0), compression_method, 3);
+        write_buf = wrapWriteBufferWithCompressionMethod(std::make_unique<WriteBufferFromHDFS>(uri, context->getGlobalContext()->getConfigRef(), context.getSettingsRef()), compression_method, 3);
         writer = FormatFactory::instance().getOutputFormatParallelIfPossible(format, *write_buf, sample_block, context);
     }
 

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -203,7 +203,7 @@ public:
         const CompressionMethod compression_method)
         : SinkToStorage(sample_block)
     {
-        write_buf = wrapWriteBufferWithCompressionMethod(std::make_unique<WriteBufferFromHDFS>(uri, context->getGlobalContext()->getConfigRef(), context.getSettingsRef()), compression_method, 3);
+        write_buf = wrapWriteBufferWithCompressionMethod(std::make_unique<WriteBufferFromHDFS>(uri, context->getGlobalContext()->getConfigRef(), context.getSettingsRef().hdfs_replication), compression_method, 3);
         writer = FormatFactory::instance().getOutputFormatParallelIfPossible(format, *write_buf, sample_block, context);
     }
 

--- a/src/Storages/HDFS/WriteBufferFromHDFS.cpp
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.cpp
@@ -29,6 +29,7 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
     explicit WriteBufferFromHDFSImpl(
             const std::string & hdfs_uri_,
             const Poco::Util::AbstractConfiguration & config_,
+            int replication_,
             int flags)
         : hdfs_uri(hdfs_uri_)
         , builder(createHDFSBuilder(hdfs_uri, config_))
@@ -43,7 +44,7 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
         if (!hdfsExists(fs.get(), path.c_str()))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "File {} already exists", path);
 
-        fout = hdfsOpenFile(fs.get(), path.c_str(), flags, 0, 0, 0);     /// O_WRONLY meaning create or overwrite i.e., implies O_TRUNCAT here
+        fout = hdfsOpenFile(fs.get(), path.c_str(), flags, 0, replication_, 0);     /// O_WRONLY meaning create or overwrite i.e., implies O_TRUNCAT here
 
         if (fout == nullptr)
         {
@@ -82,10 +83,11 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
 WriteBufferFromHDFS::WriteBufferFromHDFS(
         const std::string & hdfs_name_,
         const Poco::Util::AbstractConfiguration & config_,
+        int replication_,
         size_t buf_size_,
         int flags_)
     : BufferWithOwnMemory<WriteBuffer>(buf_size_)
-    , impl(std::make_unique<WriteBufferFromHDFSImpl>(hdfs_name_, config_, flags_))
+    , impl(std::make_unique<WriteBufferFromHDFSImpl>(hdfs_name_, config_, replication_, flags_))
 {
 }
 

--- a/src/Storages/HDFS/WriteBufferFromHDFS.cpp
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.cpp
@@ -29,7 +29,7 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
     explicit WriteBufferFromHDFSImpl(
             const std::string & hdfs_uri_,
             const Poco::Util::AbstractConfiguration & config_,
-            int replication_,
+            const Settings & settings_,
             int flags)
         : hdfs_uri(hdfs_uri_)
         , builder(createHDFSBuilder(hdfs_uri, config_))
@@ -44,7 +44,7 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
         if (!hdfsExists(fs.get(), path.c_str()))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "File {} already exists", path);
 
-        fout = hdfsOpenFile(fs.get(), path.c_str(), flags, 0, replication_, 0);     /// O_WRONLY meaning create or overwrite i.e., implies O_TRUNCAT here
+        fout = hdfsOpenFile(fs.get(), path.c_str(), flags, 0, settings_.hdfs_replication, 0);     /// O_WRONLY meaning create or overwrite i.e., implies O_TRUNCAT here
 
         if (fout == nullptr)
         {
@@ -83,11 +83,11 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
 WriteBufferFromHDFS::WriteBufferFromHDFS(
         const std::string & hdfs_name_,
         const Poco::Util::AbstractConfiguration & config_,
-        int replication_,
+        const Settings & settings_,
         size_t buf_size_,
         int flags_)
     : BufferWithOwnMemory<WriteBuffer>(buf_size_)
-    , impl(std::make_unique<WriteBufferFromHDFSImpl>(hdfs_name_, config_, replication_, flags_))
+    , impl(std::make_unique<WriteBufferFromHDFSImpl>(hdfs_name_, config_, settings_, flags_))
 {
 }
 

--- a/src/Storages/HDFS/WriteBufferFromHDFS.cpp
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.cpp
@@ -29,7 +29,7 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
     explicit WriteBufferFromHDFSImpl(
             const std::string & hdfs_uri_,
             const Poco::Util::AbstractConfiguration & config_,
-            const Settings & settings_,
+            int replication_,
             int flags)
         : hdfs_uri(hdfs_uri_)
         , builder(createHDFSBuilder(hdfs_uri, config_))
@@ -44,7 +44,7 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
         if (!hdfsExists(fs.get(), path.c_str()))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "File {} already exists", path);
 
-        fout = hdfsOpenFile(fs.get(), path.c_str(), flags, 0, settings_.hdfs_replication, 0);     /// O_WRONLY meaning create or overwrite i.e., implies O_TRUNCAT here
+        fout = hdfsOpenFile(fs.get(), path.c_str(), flags, 0, replication_, 0);     /// O_WRONLY meaning create or overwrite i.e., implies O_TRUNCAT here
 
         if (fout == nullptr)
         {
@@ -83,11 +83,11 @@ struct WriteBufferFromHDFS::WriteBufferFromHDFSImpl
 WriteBufferFromHDFS::WriteBufferFromHDFS(
         const std::string & hdfs_name_,
         const Poco::Util::AbstractConfiguration & config_,
-        const Settings & settings_,
+        int replication_,
         size_t buf_size_,
         int flags_)
     : BufferWithOwnMemory<WriteBuffer>(buf_size_)
-    , impl(std::make_unique<WriteBufferFromHDFSImpl>(hdfs_name_, config_, settings_, flags_))
+    , impl(std::make_unique<WriteBufferFromHDFSImpl>(hdfs_name_, config_, replication_, flags_))
 {
 }
 

--- a/src/Storages/HDFS/WriteBufferFromHDFS.h
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.h
@@ -23,6 +23,7 @@ public:
     WriteBufferFromHDFS(
         const String & hdfs_name_,
         const Poco::Util::AbstractConfiguration & config_,
+        int replication_,
         size_t buf_size_ = DBMS_DEFAULT_BUFFER_SIZE,
         int flags = O_WRONLY);
 

--- a/src/Storages/HDFS/WriteBufferFromHDFS.h
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.h
@@ -7,7 +7,6 @@
 #include <IO/BufferWithOwnMemory.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <fcntl.h>
-#include <Core/Settings.h>
 #include <string>
 #include <memory>
 

--- a/src/Storages/HDFS/WriteBufferFromHDFS.h
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.h
@@ -7,6 +7,7 @@
 #include <IO/BufferWithOwnMemory.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <fcntl.h>
+#include <Core/Settings.h>
 #include <string>
 #include <memory>
 
@@ -23,7 +24,7 @@ public:
     WriteBufferFromHDFS(
         const String & hdfs_name_,
         const Poco::Util::AbstractConfiguration & config_,
-        int replication_,
+        const Settings & settings_,
         size_t buf_size_ = DBMS_DEFAULT_BUFFER_SIZE,
         int flags = O_WRONLY);
 

--- a/src/Storages/HDFS/WriteBufferFromHDFS.h
+++ b/src/Storages/HDFS/WriteBufferFromHDFS.h
@@ -24,7 +24,7 @@ public:
     WriteBufferFromHDFS(
         const String & hdfs_name_,
         const Poco::Util::AbstractConfiguration & config_,
-        const Settings & settings_,
+        int replication_,
         size_t buf_size_ = DBMS_DEFAULT_BUFFER_SIZE,
         int flags = O_WRONLY);
 


### PR DESCRIPTION
Signed-off-by:  leosunli <lisheng.sun08@gmail.com>

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow a user configured `hdfs_replication` parameter for DiskHdfs and StorageHdfs. Closes https://github.com/ClickHouse/ClickHouse/issues/32039.