### PR TITLE
Fix flaky integration test for MaterializedMySQL CREATE TABLE LIKE

### DIFF
--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -238,6 +238,8 @@ def create_table_like_with_materialize_mysql_database(clickhouse_node, mysql_nod
     clickhouse_node.query(
         f"CREATE DATABASE create_like ENGINE = MaterializeMySQL('{service_name}:3306', 'create_like', 'root', 'clickhouse')")
     mysql_node.query("CREATE TABLE create_like.t2 LIKE create_like.t1")
+    check_query(clickhouse_node, "SHOW TABLES FROM create_like", "t1\nt2\n")
+
     mysql_node.query("USE create_like")
     mysql_node.query("CREATE TABLE t3 LIKE create_like2.t1")
     mysql_node.query("CREATE TABLE t4 LIKE t1")


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
