### PR TITLE
Fix CAST from Nullable with cast_keep_nullable

### DIFF
--- a/tests/queries/0_stateless/02128_cast_nullable.reference
+++ b/tests/queries/0_stateless/02128_cast_nullable.reference
@@ -1,0 +1,9 @@
+-- { echo }
+SELECT toUInt32OrDefault(toNullable(toUInt32(1))) SETTINGS cast_keep_nullable=1;
+1
+SELECT toUInt32OrDefault(toNullable(toUInt32(1)), toNullable(toUInt32(2))) SETTINGS cast_keep_nullable=1;
+1
+SELECT toUInt32OrDefault(toUInt32(1)) SETTINGS cast_keep_nullable=1;
+1
+SELECT toUInt32OrDefault(toUInt32(1), toUInt32(2)) SETTINGS cast_keep_nullable=1;
+1

--- a/tests/queries/0_stateless/02128_cast_nullable.sql
+++ b/tests/queries/0_stateless/02128_cast_nullable.sql
@@ -1,0 +1,5 @@
+-- { echo }
+SELECT toUInt32OrDefault(toNullable(toUInt32(1))) SETTINGS cast_keep_nullable=1;
+SELECT toUInt32OrDefault(toNullable(toUInt32(1)), toNullable(toUInt32(2))) SETTINGS cast_keep_nullable=1;
+SELECT toUInt32OrDefault(toUInt32(1)) SETTINGS cast_keep_nullable=1;
+SELECT toUInt32OrDefault(toUInt32(1), toUInt32(2)) SETTINGS cast_keep_nullable=1;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `CAST` from `Nullable` with `cast_keep_nullable` (`PARAMETER_OUT_OF_BOUND` error before for i.e. `toUInt32OrDefault(toNullable(toUInt32(1)))`)

Detailed description:
UBsan report [1]:

    SELECT toUInt32OrDefault(toNullable(0)) SETTINGS cast_keep_nullable = 1

    ../src/Common/assert_cast.h:50:12: runtime error: downcast of address 0x000029461170 which does not point to an object of type 'const DB::ColumnNullable'
    0x000029461170: note: object is of type 'DB::ColumnVector<unsigned int>'
     00 00 00 00  a0 51 3d 09 00 00 00 00  01 00 00 00 00 00 00 00  a0 3f 4e 29 00 00 00 00  a4 3f 4e 29
                  ^~~~~~~~~~~~~~~~~~~~~~~
                  vptr for 'DB::ColumnVector<unsigned int>'
        0 0x1e3e279d in DB::ColumnNullable const& assert_cast<DB::ColumnNullable const&, DB::IColumn const&>(DB::IColumn const&) obj-x86_64-linux-gnu/../src/Common/assert_cast.h:50:12
        1 0x1e3e279d in DB::ColumnNullable::insertRangeFrom(DB::IColumn const&, unsigned long, unsigned long) obj-x86_64-linux-gnu/../src/Columns/ColumnNullable.cpp:167:43
        2 0x12db4507 in DB::FunctionCastOrDefault::executeImpl() const (/src/ch/tmp/32019/clickhouse-ubsan+0x12db4507)

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/32019/9e1222a50b1805f696f4205e451365f8acdbc8a5/fuzzer_astfuzzerubsan,actions//report.html

And w/o -fsanitize=undefined:

    SELECT toUInt32OrDefault(toNullable(1), toNullable(toUInt32(1))) SETTINGS cast_keep_nullable = 1

    Received exception:
    Code: 12. DB::Exception: Parameters start = 0, length = 1 are out of bound in ColumnVector<T>::insertRangeFrom method (data.size() = 0).: While processing toUInt32OrDefault(toNullable(1), toNullable(toUInt32(1))). (PARAMETER_OUT_OF_BOUND)
