### PR TITLE
Increase length of random database in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -371,7 +371,7 @@ class TestCase:
         else:
             # If --database is not specified, we will create temporary database with unique name
             # And we will recreate and drop it for each test
-            def random_str(length=6):
+            def random_str(length=8):
                 alphabet = string.ascii_lowercase + string.digits
                 return ''.join(random.choice(alphabet) for _ in range(length))
 


### PR DESCRIPTION
In [1] there was one overlap with 6-byte prefix:

    $ pigz -cd clickhouse-server2.log.gz | fgrep  test_8a50uz | fgrep 'CREATE DATABASE' | fgrep comment | cut -d' ' -f7-
    <Debug> executeQuery: (from 0.0.0.0:0, user: ) (comment: 01018_insert_multiple_blocks_with_defaults.sh) /* ddl_entry=query-0000001951 */ CREATE DATABASE test_8a50uz UUID 'bb71f2ea-5ed3-466d-bb71-f2ea5ed3266d' ENGINE = Replicated('/test/clickhouse/db/test_8a50uz', '{shard}', '{replica}')
    <Debug> executeQuery: (from 0.0.0.0:0, user: ) (comment: 00098_k_union_all.sql) /* ddl_entry=query-0000003157 */ CREATE DATABASE test_8a50uz UUID '09cc030b-a4c1-4192-89cc-030ba4c1e192' ENGINE = Replicated('/test/clickhouse/db/test_8a50uz', '{shard}', '{replica}')
    <Error> executeQuery: Code: 82. DB::Exception: Database test_8a50uz already exists. (DATABASE_ALREADY_EXISTS) (version 21.12.1.8932) (from 0.0.0.0:0) (comment: 00098_k_union_all.sql) (in query: /* ddl_entry=query-0000003157 */ CREATE DATABASE test_8a50uz UUID '09cc030b-a4c1-4192-89cc-030ba4c1e192' ENGINE = Replicated('/test/clickhouse/db/test_8a50uz', '{shard}', '{replica}')), Stack trace (when copying this message, always include the lines below):

  [1]: https://clickhouse-test-reports.s3.yandex.net/32019/927b9cb1c6470b6d7cd86b4c3fd2078ff43b57df/functional_stateless_tests_(release,_databasereplicated).html#fail1

Changelog category (leave one):
- Not for changelog (changelog entry is not required)