### PR TITLE
make looping in H3 funcs uniform

### DIFF
--- a/src/Functions/geoToH3.cpp
+++ b/src/Functions/geoToH3.cpp
@@ -76,7 +76,7 @@ public:
         auto & dst_data = dst->getData();
         dst_data.resize(input_rows_count);
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const double lon = col_lon->getFloat64(row);
             const double lat = col_lat->getFloat64(row);

--- a/src/Functions/h3EdgeAngle.cpp
+++ b/src/Functions/h3EdgeAngle.cpp
@@ -58,7 +58,7 @@ public:
         auto & dst_data = dst->getData();
         dst_data.resize(input_rows_count);
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const int resolution = col_hindex->getUInt(row);
             if (resolution > MAX_H3_RES)

--- a/src/Functions/h3EdgeLengthM.cpp
+++ b/src/Functions/h3EdgeLengthM.cpp
@@ -63,7 +63,7 @@ public:
         auto & dst_data = dst->getData();
         dst_data.resize(input_rows_count);
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const UInt64 resolution = col_hindex->getUInt(row);
             if (resolution > MAX_H3_RES)

--- a/src/Functions/h3GetBaseCell.cpp
+++ b/src/Functions/h3GetBaseCell.cpp
@@ -55,7 +55,7 @@ public:
         auto & dst_data = dst->getData();
         dst_data.resize(input_rows_count);
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const UInt64 hindex = col_hindex->getUInt(row);
 

--- a/src/Functions/h3GetResolution.cpp
+++ b/src/Functions/h3GetResolution.cpp
@@ -55,7 +55,7 @@ public:
         auto & dst_data = dst->getData();
         dst_data.resize(input_rows_count);
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const UInt64 hindex = col_hindex->getUInt(row);
 

--- a/src/Functions/h3HexAreaM2.cpp
+++ b/src/Functions/h3HexAreaM2.cpp
@@ -58,7 +58,7 @@ public:
         auto & dst_data = dst->getData();
         dst_data.resize(input_rows_count);
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const UInt64 resolution = col_hindex->getUInt(row);
             if (resolution > MAX_H3_RES)

--- a/src/Functions/h3IndexesAreNeighbors.cpp
+++ b/src/Functions/h3IndexesAreNeighbors.cpp
@@ -63,7 +63,7 @@ public:
         auto & dst_data = dst->getData();
         dst_data.resize(input_rows_count);
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const UInt64 hindex_origin = col_hindex_origin->getUInt(row);
             const UInt64 hindex_dest = col_hindex_dest->getUInt(row);

--- a/src/Functions/h3IsValid.cpp
+++ b/src/Functions/h3IsValid.cpp
@@ -55,7 +55,7 @@ public:
         auto & dst_data = dst->getData();
         dst_data.resize(input_rows_count);
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const UInt64 hindex = col_hindex->getUInt(row);
 

--- a/src/Functions/h3ToChildren.cpp
+++ b/src/Functions/h3ToChildren.cpp
@@ -76,7 +76,7 @@ public:
 
         std::vector<H3Index> hindex_vec;
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const UInt64 parent_hindex = col_hindex->getUInt(row);
             const UInt8 child_resolution = col_resolution->getUInt(row);

--- a/src/Functions/h3ToParent.cpp
+++ b/src/Functions/h3ToParent.cpp
@@ -66,7 +66,7 @@ public:
         auto & dst_data = dst->getData();
         dst_data.resize(input_rows_count);
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const UInt64 hindex = col_hindex->getUInt(row);
             const UInt8 resolution = col_resolution->getUInt(row);

--- a/src/Functions/h3kRing.cpp
+++ b/src/Functions/h3kRing.cpp
@@ -73,7 +73,7 @@ public:
 
         std::vector<H3Index> hindex_vec;
 
-        for (const auto row : collections::range(0, input_rows_count))
+        for (size_t row = 0; row < input_rows_count; row++)
         {
             const H3Index origin_hindex = col_hindex->getUInt(row);
             const int k = col_k->getInt(row);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:

Some of the H3 funcs use `collections::range(0, input_rows_count)`
and some just use simple for loop for iterating over the rows.

In my recent PRs, I've been requested to use for loop in favor of
collections in the H3 functions and have been wanting to make the switch
for other functions too to make it uniform

This PR replaces `collections::range` with a simple for loop for this
kind of iteration in the remaining H3 funcs.