### PR TITLE
Fix bug "Replica already exists" in creating table as replicated merge tree

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -768,7 +768,11 @@ void InterpreterCreateQuery::setEngine(ASTCreateQuery & create) const
                 ErrorCodes::INCORRECT_QUERY);
 
         if (as_create.storage)
+        {
             create.set(create.storage, as_create.storage->ptr());
+            if (create.storage->engine->name.starts_with("Replicated"))
+                create.storage->engine->arguments.reset();
+        }
         else if (as_create.as_table_function)
             create.as_table_function = as_create.as_table_function->clone();
         else


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug "Replica already exists" in creating table as replicated merge tree.


Detailed description / Documentation draft:
When creating a table as ReplicatedXxxMergeTree, the engine arguments is copied to the new table. So the replica path is the same as the existing table, and an error "Replica ... already exists" is reported. The solution is, reset the engine arguments, then fall back to use the default replica path.

Reproduce steps:
1. config.xml: 
```
<default_replica_path>/clickhouse/tables/{database}/{table}/{shard}</default_replica_path>
<default_replica_name>{replica}</default_replica_name>
```
2. create two replicated tables:
```
CREATE TABLE default.demo
(
    `name` String,
    `id` UInt32,
    `dt` String
)
ENGINE = ReplicatedMergeTree()
PARTITION BY dt
ORDER BY name;

CREATE TABLE demo2 as demo;  // this will failed with "Replica ... already exists"
```
