### PR TITLE
Use seq_cst semantic for MergeTreeBackgroundExecutor mertic.

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -36,12 +36,12 @@ struct TaskRuntimeData
         : task(std::move(task_))
         , metric(metric_)
     {
-        CurrentMetrics::values[metric].fetch_add(1, std::memory_order_release);
+        CurrentMetrics::values[metric].fetch_add(1);
     }
 
     ~TaskRuntimeData()
     {
-        CurrentMetrics::values[metric].fetch_sub(1, std::memory_order_release);
+        CurrentMetrics::values[metric].fetch_sub(1);
     }
 
     ExecutableTaskPtr task;

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -36,6 +36,10 @@ struct TaskRuntimeData
         : task(std::move(task_))
         , metric(metric_)
     {
+        /// Increment and decrement a metric with sequentially consistent memory order
+        /// This is needed, because in unit test this metric is read from another thread
+        /// and some invariant is checked. With relaxed memory order we could read stale value
+        /// for this metric, that's why test can be failed.
         CurrentMetrics::values[metric].fetch_add(1);
     }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Maybe it will help in case of unit test failure like in https://s3.amazonaws.com/clickhouse-test-reports/31673/1acbafdffe7461ca69cfb38e48665dfc8f1b8cfb/unit_tests__tsan__actions_/runlog.log
```
[ RUN      ] Executor.RemoveTasksStress
../src/Storages/MergeTree/tests/gtest_executor.cpp:150: Failure
Expected equality of these values:
  CurrentMetrics::values[CurrentMetrics::BackgroundMergesAndMutationsPoolTask]
    Which is: 0
  0
[  FAILED  ] Executor.RemoveTasksStress (960 ms)
```