### PR TITLE
Update featured image for 21.11 release blog post

### DIFF
--- a/website/blog/en/2021/clickhouse-v21.11-released.md
+++ b/website/blog/en/2021/clickhouse-v21.11-released.md
@@ -1,6 +1,6 @@
 ---
 title: 'ClickHouse v21.11 Released'
-image: 'https://blog-images.clickhouse.com/en/2021/clickhouse-v21-11/featured.jpg'
+image: 'https://blog-images.clickhouse.com/en/2021/clickhouse-v21-11/featured-dog.jpg'
 date: '2021-11-11'
 author: '[Rich Raposa](https://github.com/rfraposa), [Alexey Milovidov](https://github.com/alexey-milovidov)'
 tags: ['company', 'community']


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
This PR updates the featured image for the 21.11 release blog post. The new image is in this PR: https://github.com/ClickHouse/clickhouse-blog-images/pull/29