### PR TITLE
Fix active replicas count in quorum inserts

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -76,18 +76,24 @@ void ReplicatedMergeTreeSink::checkQuorumPrecondition(zkutil::ZooKeeperPtr & zoo
 {
     quorum_info.status_path = storage.zookeeper_path + "/quorum/status";
 
+    Strings replicas = zookeeper->getChildren(fs::path(storage.zookeeper_path) / "replicas");
+    std::vector<std::future<Coordination::ExistsResponse>> replicas_status_futures;
+    replicas_status_futures.reserve(replicas.size());
+    for (const auto & replica : replicas)
+        if (replica != storage.replica_name)
+            replicas_status_futures.emplace_back(zookeeper->asyncExists(fs::path(storage.zookeeper_path) / "replicas" / replica));
+
     std::future<Coordination::GetResponse> is_active_future = zookeeper->asyncTryGet(storage.replica_path + "/is_active");
     std::future<Coordination::GetResponse> host_future = zookeeper->asyncTryGet(storage.replica_path + "/host");
 
-    /// List of live replicas. All of them register an ephemeral node for leader_election.
+    size_t active_replicas = 1;     /// Assume current replica is active (will check below)
+    for (auto & status : replicas_status_futures)
+        if (status.get().error == Coordination::Error::ZOK)
+            ++active_replicas;
 
-    Coordination::Stat leader_election_stat;
-    zookeeper->get(storage.zookeeper_path + "/leader_election", &leader_election_stat);
-
-    if (leader_election_stat.numChildren < static_cast<int32_t>(quorum))
-        throw Exception("Number of alive replicas ("
-            + toString(leader_election_stat.numChildren) + ") is less than requested quorum (" + toString(quorum) + ").",
-            ErrorCodes::TOO_FEW_LIVE_REPLICAS);
+    if (active_replicas < quorum)
+        throw Exception(ErrorCodes::TOO_FEW_LIVE_REPLICAS, "Number of alive replicas ({}) is less than requested quorum ({}).",
+                        active_replicas, quorum);
 
     /** Is there a quorum for the last part for which a quorum is needed?
         * Write of all the parts with the included quorum is linearly ordered.

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -81,7 +81,7 @@ void ReplicatedMergeTreeSink::checkQuorumPrecondition(zkutil::ZooKeeperPtr & zoo
     replicas_status_futures.reserve(replicas.size());
     for (const auto & replica : replicas)
         if (replica != storage.replica_name)
-            replicas_status_futures.emplace_back(zookeeper->asyncExists(fs::path(storage.zookeeper_path) / "replicas" / replica));
+            replicas_status_futures.emplace_back(zookeeper->asyncExists(fs::path(storage.zookeeper_path) / "replicas" / replica / "is_active"));
 
     std::future<Coordination::GetResponse> is_active_future = zookeeper->asyncTryGet(storage.replica_path + "/is_active");
     std::future<Coordination::GetResponse> host_future = zookeeper->asyncTryGet(storage.replica_path + "/host");


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Number of active replicas might be determined incorrectly when inserting with quorum if setting `replicated_can_become_leader` is disabled on some replicas. It's fixed.
