### PR TITLE
clickhouse-test: do not use random generator with shared state

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -371,9 +371,10 @@ class TestCase:
         else:
             # If --database is not specified, we will create temporary database with unique name
             # And we will recreate and drop it for each test
-            def random_str(length=8):
+            def random_str(length=6):
                 alphabet = string.ascii_lowercase + string.digits
-                return ''.join(random.choice(alphabet) for _ in range(length))
+                # NOTE: it is important not to use default random generator, since it shares state.
+                return ''.join(random.SystemRandom().choice(alphabet) for _ in range(length))
 
             database = 'test_{suffix}'.format(suffix=random_str())
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Recently (#32094) test database had been overlapped, and random prefix
for database had been increased from 6 to 8.

But actually 6 bytes for random prefix should be enough (with existing
alphabet (0-9a-z) it is 36**6=2'176'782'336), and the real reason of
this overlap is that random generator by default uses shared state [1]:

    The functions supplied by this module are actually bound methods of
    a hidden instance of the random.Random class. You can instantiate your
    own instances of Random to get generators that don’t share state.

  [1]: https://docs.python.org/3/library/random.html

I've played a little bit with random in python, and using default random
generator it generates non-unique strings pretty fast, just in a few
runs, but using SystemRandom (that uses /dev/urandom) it takes ~1 minute.

<details>

Test:

```sh
    $ while /tmp/test.py | LANG=c sort -S5G | LANG=c uniq -d | tee /dev/stderr | wc -l | fgrep -q -x -c 0; do :; done
```

```python
    #!/usr/bin/env python3

    import multiprocessing
    import string
    import random

    def random_str(length=6):
        alphabet = string.ascii_lowercase + string.digits
        return ''.join(random.SystemRandom().choice(alphabet) for _ in range(length))

    def worker(_):
        print(random_str())

    with multiprocessing.Pool(processes=2) as pool:
        pool.map(worker, range(0, int(10e3)))
```

So let's switch to SystemRandom and use 6-byte prefix.

</details>