### PR TITLE
Fix stress tests

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -55,9 +55,41 @@ function configure()
     echo "<clickhouse><asynchronous_metrics_update_period_s>1</asynchronous_metrics_update_period_s></clickhouse>" \
         > /etc/clickhouse-server/config.d/asynchronous_metrics_update_period_s.xml
 
+    local total_mem
+    total_mem=$(awk '/MemTotal/ { print $(NF-1) }' /proc/meminfo) # KiB
+    total_mem=$(( total_mem*1024 )) # bytes
     # Set maximum memory usage as half of total memory (less chance of OOM).
-    echo "<clickhouse><max_server_memory_usage_to_ram_ratio>0.5</max_server_memory_usage_to_ram_ratio></clickhouse>" \
-        > /etc/clickhouse-server/config.d/max_server_memory_usage_to_ram_ratio.xml
+    #
+    # But not via max_server_memory_usage but via max_memory_usage_for_user,
+    # so that we can override this setting and execute service queries, like:
+    # - hung check
+    # - show/drop database
+    # - ...
+    #
+    # So max_memory_usage_for_user will be a soft limit, and
+    # max_server_memory_usage will be hard limit, and queries that should be
+    # executed regardless memory limits will use max_memory_usage_for_user=0,
+    # instead of relying on max_untracked_memory
+    local max_server_mem
+    max_server_mem=$((total_mem*75/100)) # 75%
+    echo "Setting max_server_memory_usage=$max_server_mem"
+    cat > /etc/clickhouse-server/config.d/max_server_memory_usage.xml <<EOL
+<clickhouse>
+    <max_server_memory_usage>${max_server_mem}</max_server_memory_usage>
+</clickhouse>
+EOL
+    local max_users_mem
+    max_users_mem=$((total_mem*50/100)) # 50%
+    echo "Setting max_memory_usage_for_user=$max_users_mem"
+    cat > /etc/clickhouse-server/users.d/max_memory_usage_for_user.xml <<EOL
+<clickhouse>
+    <profiles>
+        <default>
+            <max_memory_usage_for_user>${max_users_mem}</max_memory_usage_for_user>
+        </default>
+    </profiles>
+</clickhouse>
+EOL
 }
 
 function stop()

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -139,9 +139,15 @@ def prepare_for_hung_check(drop_databases):
 
 
     # Wait for last queries to finish if any, not longer than 300 seconds
-    call("""clickhouse client -q "select sleepEachRow((
-            select maxOrDefault(300 - elapsed) + 1 from system.processes where query not like '%from system.processes%' and elapsed < 300
-            ) / 300) from numbers(300) format Null" """, shell=True, stderr=STDOUT, timeout=330)
+    call(make_query_command("""
+    select sleepEachRow((
+        select maxOrDefault(300 - elapsed) + 1
+        from system.processes
+        where query not like '%from system.processes%' and elapsed < 300
+    ) / 300)
+    from numbers(300)
+    format Null
+    """), shell=True, stderr=STDOUT, timeout=330)
 
     # Even if all clickhouse-test processes are finished, there are probably some sh scripts,
     # which still run some new queries. Let's ignore them.

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -188,7 +188,13 @@ if __name__ == "__main__":
     if args.hung_check:
         have_long_running_queries = prepare_for_hung_check(args.drop_databases)
         logging.info("Checking if some queries hung")
-        cmd = "{} {} {}".format(args.test_cmd, "--hung-check", "00001_select_1")
+        cmd = ' '.join([args.test_cmd,
+            # Do not track memory allocations up to 100MiB,
+            # this will allow to ignore server memory limit (max_server_memory_usage) for this query.
+            "--client-option", "max_untracked_memory=100Mi",
+            "--hung-check",
+            "00001_select_1"
+        ])
         res = call(cmd, shell=True, stderr=STDOUT)
         hung_check_status = "No queries hung\tOK\n"
         if res != 0 and have_long_running_queries:

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -75,6 +75,9 @@ def call_with_retry(query, timeout=30, retry_count=5):
         else:
             break
 
+def make_query_command(query):
+    return f"""clickhouse client -q "{query}" --max_untracked_memory=1Gi --memory_profiler_step=1Gi"""
+
 
 def prepare_for_hung_check(drop_databases):
     # FIXME this function should not exist, but...
@@ -95,23 +98,23 @@ def prepare_for_hung_check(drop_databases):
     # Some tests execute SYSTEM STOP MERGES or similar queries.
     # It may cause some ALTERs to hang.
     # Possibly we should fix tests and forbid to use such queries without specifying table.
-    call_with_retry("clickhouse client -q 'SYSTEM START MERGES'")
-    call_with_retry("clickhouse client -q 'SYSTEM START DISTRIBUTED SENDS'")
-    call_with_retry("clickhouse client -q 'SYSTEM START TTL MERGES'")
-    call_with_retry("clickhouse client -q 'SYSTEM START MOVES'")
-    call_with_retry("clickhouse client -q 'SYSTEM START FETCHES'")
-    call_with_retry("clickhouse client -q 'SYSTEM START REPLICATED SENDS'")
-    call_with_retry("clickhouse client -q 'SYSTEM START REPLICATION QUEUES'")
-    call_with_retry("clickhouse client -q 'SYSTEM DROP MARK CACHE'")
+    call_with_retry(make_query_command('SYSTEM START MERGES'))
+    call_with_retry(make_query_command('SYSTEM START DISTRIBUTED SENDS'))
+    call_with_retry(make_query_command('SYSTEM START TTL MERGES'))
+    call_with_retry(make_query_command('SYSTEM START MOVES'))
+    call_with_retry(make_query_command('SYSTEM START FETCHES'))
+    call_with_retry(make_query_command('SYSTEM START REPLICATED SENDS'))
+    call_with_retry(make_query_command('SYSTEM START REPLICATION QUEUES'))
+    call_with_retry(make_query_command('SYSTEM DROP MARK CACHE'))
 
     # Issue #21004, live views are experimental, so let's just suppress it
-    call_with_retry("""clickhouse client -q "KILL QUERY WHERE upper(query) LIKE 'WATCH %'" """)
+    call_with_retry(make_query_command("KILL QUERY WHERE upper(query) LIKE 'WATCH %'"))
 
     # Kill other queries which known to be slow
     # It's query from 01232_preparing_sets_race_condition_long, it may take up to 1000 seconds in slow builds
-    call_with_retry("""clickhouse client -q "KILL QUERY WHERE query LIKE 'insert into tableB select %'" """)
+    call_with_retry(make_query_command("KILL QUERY WHERE query LIKE 'insert into tableB select %'"))
     # Long query from 00084_external_agregation
-    call_with_retry("""clickhouse client -q "KILL QUERY WHERE query LIKE 'SELECT URL, uniq(SearchPhrase) AS u FROM test.hits GROUP BY URL ORDER BY u %'" """)
+    call_with_retry(make_query_command("KILL QUERY WHERE query LIKE 'SELECT URL, uniq(SearchPhrase) AS u FROM test.hits GROUP BY URL ORDER BY u %'"))
 
     if drop_databases:
         for i in range(5):
@@ -120,12 +123,11 @@ def prepare_for_hung_check(drop_databases):
                 # Otherwise we will get rid of queries which wait for background pool. It can take a long time on slow builds (more than 900 seconds).
                 #
                 # Also specify max_untracked_memory to allow 1GiB of memory to overcommit.
-                databases = check_output('clickhouse client -q "SHOW DATABASES" --max_untracked_memory=1Gi --memory_profiler_step=1Gi',
-                    shell=True, timeout=30).decode('utf-8').strip().split()
+                databases = check_output(make_query_command('SHOW DATABASES'), shell=True, timeout=30).decode('utf-8').strip().split()
                 for db in databases:
                     if db == "system":
                         continue
-                    command = f'clickhouse client -q "DROP DATABASE {db}" --max_untracked_memory=1Gi --memory_profiler_step=1Gi'
+                    command = make_query_command(f'DROP DATABASE {db}')
                     # we don't wait for drop
                     Popen(command, shell=True)
                 break

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -76,7 +76,7 @@ def call_with_retry(query, timeout=30, retry_count=5):
             break
 
 def make_query_command(query):
-    return f"""clickhouse client -q "{query}" --max_untracked_memory=1Gi --memory_profiler_step=1Gi"""
+    return f"""clickhouse client -q "{query}" --max_untracked_memory=1Gi --memory_profiler_step=1Gi --max_memory_usage_for_user=0"""
 
 
 def prepare_for_hung_check(drop_databases):
@@ -211,6 +211,7 @@ if __name__ == "__main__":
             # Aggregator code.
             # But right now it should work, since neither hung check, nor 00001_select_1 has GROUP BY.
             "--client-option", "max_untracked_memory=1Gi",
+            "--client-option", "max_memory_usage_for_user=0",
             "--client-option", "memory_profiler_step=1Gi",
             "--hung-check",
             "00001_select_1"

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -118,13 +118,13 @@ def prepare_for_hung_check(drop_databases):
                 # Here we try to drop all databases in async mode. If some queries really hung, than drop will hung too.
                 # Otherwise we will get rid of queries which wait for background pool. It can take a long time on slow builds (more than 900 seconds).
                 #
-                # Also specify max_untracked_memory to allow 100MiB of memory to overcommit.
-                databases = check_output('clickhouse client -q "SHOW DATABASES" --max_untracked_memory=100Mi',
+                # Also specify max_untracked_memory to allow 1GiB of memory to overcommit.
+                databases = check_output('clickhouse client -q "SHOW DATABASES" --max_untracked_memory=1Gi --memory_profiler_step=1Gi',
                     shell=True, timeout=30).decode('utf-8').strip().split()
                 for db in databases:
                     if db == "system":
                         continue
-                    command = f'clickhouse client -q "DROP DATABASE {db}" --max_untracked_memory=100Mi'
+                    command = f'clickhouse client -q "DROP DATABASE {db}" --max_untracked_memory=1Gi --memory_profiler_step=1Gi'
                     # we don't wait for drop
                     Popen(command, shell=True)
                 break
@@ -192,9 +192,19 @@ if __name__ == "__main__":
         have_long_running_queries = prepare_for_hung_check(args.drop_databases)
         logging.info("Checking if some queries hung")
         cmd = ' '.join([args.test_cmd,
-            # Do not track memory allocations up to 100MiB,
+            # Do not track memory allocations up to 1Gi,
             # this will allow to ignore server memory limit (max_server_memory_usage) for this query.
-            "--client-option", "max_untracked_memory=100Mi",
+            #
+            # NOTE: memory_profiler_step should be also adjusted, because:
+            #
+            #     untracked_memory_limit = min(settings.max_untracked_memory, settings.memory_profiler_step)
+            #
+            # NOTE: that if there will be queries with GROUP BY, this trick
+            # will not work due to CurrentMemoryTracker::check() from
+            # Aggregator code.
+            # But right now it should work, since neither hung check, nor 00001_select_1 has GROUP BY.
+            "--client-option", "max_untracked_memory=1Gi",
+            "--client-option", "memory_profiler_step=1Gi",
             "--hung-check",
             "00001_select_1"
         ])

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -91,9 +91,7 @@ def prepare_for_hung_check(drop_databases):
     logging.info("Will terminate gdb (if any)")
     call_with_retry("kill -TERM $(pidof gdb)")
 
-    # Some tests set too low memory limit for default user and forget to reset in back.
-    # It may cause SYSTEM queries to fail, let's disable memory limit.
-    call_with_retry("clickhouse client --max_memory_usage_for_user=0 -q 'SELECT 1 FORMAT Null'")
+    call_with_retry(make_query_command('SELECT 1 FORMAT Null'))
 
     # Some tests execute SYSTEM STOP MERGES or similar queries.
     # It may cause some ALTERs to hang.

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -102,6 +102,7 @@ def prepare_for_hung_check(drop_databases):
     call_with_retry("clickhouse client -q 'SYSTEM START FETCHES'")
     call_with_retry("clickhouse client -q 'SYSTEM START REPLICATED SENDS'")
     call_with_retry("clickhouse client -q 'SYSTEM START REPLICATION QUEUES'")
+    call_with_retry("clickhouse client -q 'SYSTEM DROP MARK CACHE'")
 
     # Issue #21004, live views are experimental, so let's just suppress it
     call_with_retry("""clickhouse client -q "KILL QUERY WHERE upper(query) LIKE 'WATCH %'" """)

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -117,11 +117,14 @@ def prepare_for_hung_check(drop_databases):
             try:
                 # Here we try to drop all databases in async mode. If some queries really hung, than drop will hung too.
                 # Otherwise we will get rid of queries which wait for background pool. It can take a long time on slow builds (more than 900 seconds).
-                databases = check_output('clickhouse client -q "SHOW DATABASES"', shell=True, timeout=30).decode('utf-8').strip().split()
+                #
+                # Also specify max_untracked_memory to allow 100MiB of memory to overcommit.
+                databases = check_output('clickhouse client -q "SHOW DATABASES" --max_untracked_memory=100Mi',
+                    shell=True, timeout=30).decode('utf-8').strip().split()
                 for db in databases:
                     if db == "system":
                         continue
-                    command = f'clickhouse client -q "DROP DATABASE {db}"'
+                    command = f'clickhouse client -q "DROP DATABASE {db}" --max_untracked_memory=100Mi'
                     # we don't wait for drop
                     Popen(command, shell=True)
                 break

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -205,26 +205,31 @@ def get_stacktraces_from_gdb(server_pid):
 
 # collect server stacktraces from system.stack_trace table
 # it does not work in Sandbox
-def get_stacktraces_from_clickhouse(client, replicated_database=False):
+def get_stacktraces_from_clickhouse(args):
+    settings_str = ' '.join([
+        get_additional_client_options(args),
+        '--allow_introspection_functions=1',
+        '--skip_unavailable_shards=1',
+    ])
     replicated_msg = \
-        "{} --allow_introspection_functions=1 --skip_unavailable_shards=1 --query \
+        "{} {} --query \
         \"SELECT materialize((hostName(), tcpPort())) as host, thread_id, \
         arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), \
         arrayMap(x -> addressToLine(x), trace), \
         arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace \
         FROM clusterAllReplicas('test_cluster_database_replicated', 'system.stack_trace') \
-        ORDER BY host, thread_id FORMAT Vertical\"".format(client)
+        ORDER BY host, thread_id FORMAT Vertical\"".format(args.client, settings_str)
 
     msg = \
-        "{} --allow_introspection_functions=1 --query \
+        "{} {} --query \
         \"SELECT arrayStringConcat(arrayMap(x, y -> concat(x, ': ', y), \
         arrayMap(x -> addressToLine(x), trace), \
         arrayMap(x -> demangle(addressToSymbol(x)), trace)), '\n') as trace \
-        FROM system.stack_trace FORMAT Vertical\"".format(client)
+        FROM system.stack_trace FORMAT Vertical\"".format(args.client, settings_str)
 
     try:
         return subprocess.check_output(
-            replicated_msg if replicated_database else msg,
+            replicated_msg if args.replicated_database else msg,
             shell=True, stderr=subprocess.STDOUT).decode('utf-8')
     except Exception as e:
         print(f"Error occurred while receiving stack traces from client: {e}")
@@ -250,8 +255,7 @@ def print_stacktraces() -> None:
     if bt is None:
         print("\nCollecting stacktraces from system.stacktraces table:")
 
-        bt = get_stacktraces_from_clickhouse(
-            args.client, args.replicated_database)
+        bt = get_stacktraces_from_clickhouse(args)
 
     if bt is not None:
         print(bt)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Right now stress tests almost always fails because service queries (hung check, DROP DATABASE, ...) cannot be executed when total memory limit exceeded.

To avoid this:
- `max_server_memory_usage` had been replaced with `max_memory_usage_for_user` (`max_memory_usage_for_user` is used as a soft limit, and `max_server_memory_usage` as a hard, so queries can allow memory overcommit, using `max_memory_usage_for_user=0` instead of relying on `max_untracked_memory` hack)
- add `SYSTEM DROP MARK CACHE` (just in case, since some of runs uses static database and some tables may left)
- apply `--client-option` in `clickhouse-test` for various service queries (so that it will apply new settings correctly)
- adds memory overcommit via `max_untracked_memory` (this was done just in case)