### PR TITLE
perf: fix waiting of the server after running tests

### DIFF
--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -1409,7 +1409,7 @@ case "$stage" in
     while env kill -- -$watchdog_pid ; do sleep 1; done
 
     # Stop the servers to free memory for the subsequent query analysis.
-    while killall clickhouse; do echo . ; sleep 1 ; done
+    while killall clickhouse-server; do echo . ; sleep 1 ; done
     echo Servers stopped.
     ;&
 "analyze_queries")

--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -61,7 +61,7 @@ function configure
     cp -rv right/config left ||:
 
     # Start a temporary server to rename the tables
-    while killall clickhouse-server; do echo . ; sleep 1 ; done
+    while pkill clickhouse-serv; do echo . ; sleep 1 ; done
     echo all killed
 
     set -m # Spawn temporary in its own process groups
@@ -88,7 +88,7 @@ function configure
     clickhouse-client --port $LEFT_SERVER_PORT --query "create database test" ||:
     clickhouse-client --port $LEFT_SERVER_PORT --query "rename table datasets.hits_v1 to test.hits" ||:
 
-    while killall clickhouse-server; do echo . ; sleep 1 ; done
+    while pkill clickhouse-serv; do echo . ; sleep 1 ; done
     echo all killed
 
     # Make copies of the original db for both servers. Use hardlinks instead
@@ -106,7 +106,7 @@ function configure
 
 function restart
 {
-    while killall clickhouse-server; do echo . ; sleep 1 ; done
+    while pkill clickhouse-serv; do echo . ; sleep 1 ; done
     echo all killed
 
     # Change the jemalloc settings here.
@@ -1409,7 +1409,7 @@ case "$stage" in
     while env kill -- -$watchdog_pid ; do sleep 1; done
 
     # Stop the servers to free memory for the subsequent query analysis.
-    while killall clickhouse-server; do echo . ; sleep 1 ; done
+    while pkill clickhouse-serv; do echo . ; sleep 1 ; done
     echo Servers stopped.
     ;&
 "analyze_queries")


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Use `pkill` over `killall`, since `killall` has some magic (see `-e` option), and in this particular case it requires `clickhouse-server` instead of `clickhouse`:

    2021-12-03 05:24:56      + env kill -- -21700
    2021-12-03 05:24:56      kill: (-21700): No such process
    2021-12-03 05:24:56      + killall clickhouse
    2021-12-03 05:24:56      clickhouse: no process found
    2021-12-03 05:24:56      + echo Servers stopped.
    2021-12-03 05:24:56      Servers stopped.
    2021-12-03 05:24:56      + analyze_queries

    $ tail -n1 *-server-log.log
    ==> left-server-log.log <==
    2021.12.03 05:26:59.530647 [ 450 ] {} <Trace> SystemLog (system.asynchronous_metric_log): Flushed system log up to offset 1668052

    ==> right-server-log.log <==
    2021.12.03 05:27:20.873136 [ 466 ] {} <Trace> SystemLog (system.metric_log): Flushed system log up to offset 9605

    ==> setup-server-log.log <==
    2021.12.03 02:47:14.844395 [ 96 ] {} <Information> Application: Child process exited normally with code 0.

As you can see `killall` instantly fails with no such process, while this
cannot be true since it was there, and also according to logs there were
messages after running `analyze_queries()` from `compare.sh`

This should fix problems like in [1].

  [1]: https://clickhouse-test-reports.s3.yandex.net/32080/344298f4037f88b114b8e798bb30036b24be8f16/performance_comparison/report.html#fail1