### PR TITLE
DictionariesLoader qualify name with database fix

### DIFF
--- a/src/Interpreters/ExternalDictionariesLoader.cpp
+++ b/src/Interpreters/ExternalDictionariesLoader.cpp
@@ -95,14 +95,16 @@ QualifiedTableName ExternalDictionariesLoader::qualifyDictionaryNameWithDatabase
         return qualified_dictionary_name;
     }
 
-    if (qualified_name->database.empty() && has(dictionary_name))
+    /// If dictionary was not qualified with database name, try to resolve dictionary as xml dictionary.
+    if (qualified_name->database.empty() && !has(qualified_name->table))
     {
-        /// This is xml dictionary
-        return *qualified_name;
-    }
+        auto current_database_name = query_context->getCurrentDatabase();
+        std::string resolved_name = resolveDictionaryNameFromDatabaseCatalog(dictionary_name, current_database_name);
 
-    if (qualified_name->database.empty())
-        qualified_name->database = query_context->getCurrentDatabase();
+        /// If after qualify dictionary_name with default_database_name we find it, add default_database to qualified name.
+        if (has(resolved_name))
+            qualified_name->database = query_context->getCurrentDatabase();
+    }
 
     return *qualified_name;
 }

--- a/src/Interpreters/ExternalDictionariesLoader.cpp
+++ b/src/Interpreters/ExternalDictionariesLoader.cpp
@@ -98,12 +98,12 @@ QualifiedTableName ExternalDictionariesLoader::qualifyDictionaryNameWithDatabase
     /// If dictionary was not qualified with database name, try to resolve dictionary as xml dictionary.
     if (qualified_name->database.empty() && !has(qualified_name->table))
     {
-        auto current_database_name = query_context->getCurrentDatabase();
+        std::string current_database_name = query_context->getCurrentDatabase();
         std::string resolved_name = resolveDictionaryNameFromDatabaseCatalog(dictionary_name, current_database_name);
 
         /// If after qualify dictionary_name with default_database_name we find it, add default_database to qualified name.
         if (has(resolved_name))
-            qualified_name->database = query_context->getCurrentDatabase();
+            qualified_name->database = std::move(current_database_name);
     }
 
     return *qualified_name;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
XML dictionaries identifiers, used in table create query, can be qualified to `default_database` during upgrade to newer version. Closes #31963.