### PR TITLE
Manual backport of #31766 into 21.11

### DIFF
--- a/src/IO/CascadeWriteBuffer.cpp
+++ b/src/IO/CascadeWriteBuffer.cpp
@@ -28,6 +28,9 @@ CascadeWriteBuffer::CascadeWriteBuffer(WriteBufferPtrs && prepared_sources_, Wri
 
 void CascadeWriteBuffer::nextImpl()
 {
+    if (!curr_buffer)
+        return;
+
     try
     {
         curr_buffer->position() = position();

--- a/tests/queries/0_stateless/02128_wait_end_of_query_fix.sh
+++ b/tests/queries/0_stateless/02128_wait_end_of_query_fix.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# https://github.com/ClickHouse/ClickHouse/issues/32186
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}/?&query=SELECT+cluster%2C+host_address%2C+port+FROM+system.clusters+FORMAT+JSON&max_result_bytes=104857600&log_queries=1&optimize_throw_if_noop=1&output_format_json_quote_64bit_integers=0&lock_acquire_timeout=10&max_execution_time=10&wait_end_of_query=1" >/dev/null


### PR DESCRIPTION
Backports https://github.com/ClickHouse/ClickHouse/pull/31766 to 21.11 to fix a crasher introduced while backporting https://github.com/ClickHouse/ClickHouse/pull/31673 in https://github.com/ClickHouse/ClickHouse/pull/31715

Fixes https://github.com/ClickHouse/ClickHouse/issues/32186

cc @kssenii @alexey-milovidov 

Will add the test to master in another PR too just in case.