### PR TITLE
Add test for #32186

### DIFF
--- a/tests/queries/0_stateless/02128_wait_end_of_query_fix.sh
+++ b/tests/queries/0_stateless/02128_wait_end_of_query_fix.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# https://github.com/ClickHouse/ClickHouse/issues/32186
+
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}/?&query=SELECT+cluster%2C+host_address%2C+port+FROM+system.clusters+FORMAT+JSON&max_result_bytes=104857600&log_queries=1&optimize_throw_if_noop=1&output_format_json_quote_64bit_integers=0&lock_acquire_timeout=10&max_execution_time=10&wait_end_of_query=1" >/dev/null


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Adds test for https://github.com/ClickHouse/ClickHouse/issues/32186 which should be fixed in 21.11 with https://github.com/ClickHouse/ClickHouse/pull/32202. It didn't affect master so no code changes required
