### PR TITLE
Fix uncaught exception in DatabaseLazy

### DIFF
--- a/src/Databases/DatabaseLazy.cpp
+++ b/src/Databases/DatabaseLazy.cpp
@@ -269,6 +269,7 @@ StoragePtr DatabaseLazy::loadTable(const String & table_name) const
 }
 
 void DatabaseLazy::clearExpiredTables() const
+try
 {
     std::lock_guard lock(mutex);
     auto time_now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
@@ -302,6 +303,10 @@ void DatabaseLazy::clearExpiredTables() const
     }
 
     cache_expiration_queue.splice(cache_expiration_queue.begin(), busy_tables, busy_tables.begin(), busy_tables.end());
+}
+catch (...)
+{
+    tryLogCurrentException(log, __PRETTY_FUNCTION__);
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
Fixes  #31689 (however, I didn't understand why it happened)