### PR TITLE
fix build error on QueryProfiler

### DIFF
--- a/src/Common/QueryProfiler.cpp
+++ b/src/Common/QueryProfiler.cpp
@@ -31,6 +31,8 @@ namespace
     /// And so to overcome this flag is exists,
     /// to ignore delivered signals after timer_delete().
     thread_local bool signal_handler_disarmed = true;
+#else
+    thread_local bool signal_handler_disarmed = false;
 #endif
 
     void writeTraceInfo(TraceType trace_type, int /* sig */, siginfo_t * info, void * context)


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
n/a

Detailed description / Documentation draft:
fix build error: https://github.com/ClickHouse/ClickHouse/issues/32210


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
