### PR TITLE
use application/x-ndjson for streaming JSON

### DIFF
--- a/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/JSONEachRowRowOutputFormat.h
@@ -27,7 +27,7 @@ public:
     /// Content-Type to set when sending HTTP response.
     String getContentType() const override
     {
-        return settings.json.array_of_rows ? "application/json; charset=UTF-8" : IRowOutputFormat::getContentType();
+        return settings.json.array_of_rows ? "application/json; charset=UTF-8" : "application/x-ndjson; charset=UTF-8" ;
     }
 
 protected:


### PR DESCRIPTION
Same as EllasticSearch and Spring also switched to it recently from "application/stream+json". See https://github.com/spring-projects/spring-framework/issues/21283

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use `Content-Type: application/x-ndjson` (http://ndjson.org/) for output format `JSONEachRow`

