### PR TITLE
Add TABLE OVERRIDE feature for MaterializedMySQL databases

### DIFF
--- a/docs/en/engines/database-engines/materialized-mysql.md
+++ b/docs/en/engines/database-engines/materialized-mysql.md
@@ -17,6 +17,7 @@ ClickHouse server works as MySQL replica. It reads binlog and performs DDL and D
 ``` sql
 CREATE DATABASE [IF NOT EXISTS] db_name [ON CLUSTER cluster]
 ENGINE = MaterializedMySQL('host:port', ['database' | database], 'user', 'password') [SETTINGS ...]
+[TABLE OVERRIDE table1 (...), TABLE OVERRIDE table2 (...)]
 ```
 
 **Engine Parameters**
@@ -109,15 +110,19 @@ MySQL DDL queries are converted into the corresponding ClickHouse DDL queries ([
 
 - MySQL `DELETE` query is converted into `INSERT` with `_sign=-1`.
 
-- MySQL `UPDATE` query is converted into `INSERT` with `_sign=-1` and `INSERT` with `_sign=1`.
+- MySQL `UPDATE` query is converted into `INSERT` with `_sign=-1` and `INSERT` with `_sign=1` if the primary key has been changed, or
+  `INSERT` with `_sign=1` if not.
 
 ### Selecting from MaterializedMySQL Tables {#select}
 
 `SELECT` query from `MaterializedMySQL` tables has some specifics:
 
-- If `_version` is not specified in the `SELECT` query, [FINAL](../../sql-reference/statements/select/from.md#select-from-final) modifier is used. So only rows with `MAX(_version)` are selected.
+- If `_version` is not specified in the `SELECT` query, the
+  [FINAL](../../sql-reference/statements/select/from.md#select-from-final) modifier is used, so only rows with
+  `MAX(_version)` are returned for each primary key value.
 
-- If `_sign` is not specified in the `SELECT` query, `WHERE _sign=1` is used by default. So the deleted rows are not included into the result set.
+- If `_sign` is not specified in the `SELECT` query, `WHERE _sign=1` is used by default. So the deleted rows are not
+  included into the result set.
 
 - The result includes columns comments in case they exist in MySQL database tables.
 
@@ -125,15 +130,69 @@ MySQL DDL queries are converted into the corresponding ClickHouse DDL queries ([
 
 MySQL `PRIMARY KEY` and `INDEX` clauses are converted into `ORDER BY` tuples in ClickHouse tables.
 
-ClickHouse has only one physical order, which is determined by `ORDER BY` clause. To create a new physical order, use [materialized views](../../sql-reference/statements/create/view.md#materialized).
+ClickHouse has only one physical order, which is determined by `ORDER BY` clause. To create a new physical order, use
+[materialized views](../../sql-reference/statements/create/view.md#materialized).
 
 **Notes**
 
 - Rows with `_sign=-1` are not deleted physically from the tables.
-- Cascade `UPDATE/DELETE` queries are not supported by the `MaterializedMySQL` engine.
+- Cascade `UPDATE/DELETE` queries are not supported by the `MaterializedMySQL` engine, as they are not visible in the
+  MySQL binlog.
 - Replication can be easily broken.
 - Manual operations on database and tables are forbidden.
-- `MaterializedMySQL` is influenced by [optimize_on_insert](../../operations/settings/settings.md#optimize-on-insert) setting. The data is merged in the corresponding table in the `MaterializedMySQL` database when a table in the MySQL server changes.
+- `MaterializedMySQL` is affected by the [optimize_on_insert](../../operations/settings/settings.md#optimize-on-insert)
+  setting. Data is merged in the corresponding table in the `MaterializedMySQL` database when a table in the MySQL
+  server changes.
+
+### Table Overrides {#table-overrides}
+
+Table overrides can be used to customize the ClickHouse DDL queries, allowing you to make schema optimizations for your
+application. This is especially useful for controlling partitioning, which is important for the overall performance of
+MaterializedMySQL.
+
+```sql
+CREATE DATABASE db_name ENGINE = MaterializedMySQL(...)
+[SETTINGS ...]
+[TABLE OVERRIDE table_name (
+    [COLUMNS (
+        [name1 [type1] [DEFAULT|MATERIALIZED|ALIAS expr1] [TTL expr1], ...]
+        [INDEX index_name1 expr1 TYPE type1(...) GRANULARITY value1, ...]
+        [PROJECTION projection_name_1 (SELECT <COLUMN LIST EXPR> [GROUP BY] [ORDER BY]), ...]
+	)]
+	[ORDER BY expr]
+	[PRIMARY KEY expr]
+	[PARTITION BY expr]
+	[SAMPLE BY expr]
+	[TTL expr]
+), ...]
+```
+
+Example:
+
+```sql
+CREATE DATABASE db_name ENGINE = MaterializedMySQL(...)
+TABLE OVERRIDE table1 (
+    COLUMNS (
+	    userid UUID,
+	    category LowCardinality(String),
+		timestamp DateTime CODEC(Delta, Default)
+    )
+    PARTITION BY toYear(timestamp)
+),
+TABLE OVERRIDE table2 (
+    COLUMNS (
+	    ip_hash UInt32 MATERIALIZED xxHash32(client_ip),
+		client_ip String TTL created + INTERVAL 72 HOUR
+	)
+	SAMPLE BY ip_hash
+)
+```
+
+The `COLUMNS` list is sparse; it contains only modified or extra (MATERIALIZED or ALIAS) columns. Modified columns with
+a different type must be assignable from the original type. There is currently no validation of this or similar issues
+when the `CREATE DATABASE` query executes, so extra care needs to be taken.
+
+You may specify overrides for tables that do not exist yet.
 
 ## Examples of Use {#examples-of-use}
 

--- a/docs/en/engines/database-engines/materialized-mysql.md
+++ b/docs/en/engines/database-engines/materialized-mysql.md
@@ -194,6 +194,14 @@ when the `CREATE DATABASE` query executes, so extra care needs to be taken.
 
 You may specify overrides for tables that do not exist yet.
 
+!!! note "Warning"
+    It is easy to break replication with TABLE OVERRIDEs if not used with care. For example:
+    
+    * If a column is added with a table override, but then later added to the source MySQL table, the converted ALTER TABLE
+      query in ClickHouse will fail because the column already exists.
+    * It is currently possible to add overrides that reference nullable columns where not-nullable are required, such as in
+      `ORDER BY` or `PARTITION BY`.
+
 ## Examples of Use {#examples-of-use}
 
 Queries in MySQL:

--- a/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
@@ -9,7 +9,6 @@
 #    include <Databases/MySQL/MaterializedMySQLSyncThread.h>
 #    include <Parsers/ASTCreateQuery.h>
 #    include <Storages/StorageMaterializedMySQL.h>
-#    include <Poco/Logger.h>
 #    include <Common/setThreadName.h>
 #    include <filesystem>
 

--- a/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
+++ b/src/Interpreters/MySQL/InterpretersMySQLDDLQuery.cpp
@@ -435,6 +435,22 @@ void InterpreterCreateImpl::validate(const InterpreterCreateImpl::TQuery & creat
     }
 }
 
+static ASTPtr tryGetTableOverride(const String & mapped_database, const String & table)
+{
+    if (auto database_ptr = DatabaseCatalog::instance().tryGetDatabase(mapped_database))
+    {
+        auto create_query = database_ptr->getCreateDatabaseQuery();
+        if (auto create_database_query = create_query->as<ASTCreateQuery>())
+        {
+            if (create_database_query->table_overrides)
+            {
+                return create_database_query->table_overrides->tryGetTableOverride(table);
+            }
+        }
+    }
+    return nullptr;
+}
+
 ASTs InterpreterCreateImpl::getRewrittenQueries(
     const TQuery & create_query, ContextPtr context, const String & mapped_to_database, const String & mysql_database)
 {
@@ -518,6 +534,12 @@ ASTs InterpreterCreateImpl::getRewrittenQueries(
     rewritten_query->if_not_exists = create_query.if_not_exists;
     rewritten_query->set(rewritten_query->storage, storage);
     rewritten_query->set(rewritten_query->columns_list, columns);
+
+    if (auto table_override = tryGetTableOverride(mapped_to_database, create_query.table))
+    {
+        auto override = table_override->as<ASTTableOverride>();
+        override->applyToCreateTableQuery(rewritten_query.get());
+    }
 
     return ASTs{rewritten_query};
 }

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -200,6 +200,8 @@ ASTPtr ASTCreateQuery::clone() const
         res->set(res->select, select->clone());
     if (tables)
         res->set(res->tables, tables->clone());
+    if (table_overrides)
+        res->set(res->table_overrides, table_overrides->clone());
 
     if (dictionary)
     {
@@ -239,6 +241,12 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
 
         if (storage)
             storage->formatImpl(settings, state, frame);
+
+        if (table_overrides)
+        {
+            settings.ostr << settings.nl_or_ws;
+            table_overrides->formatImpl(settings, state, frame);
+        }
 
         if (comment)
         {

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -4,6 +4,7 @@
 #include <Parsers/ASTQueryWithOnCluster.h>
 #include <Parsers/ASTDictionary.h>
 #include <Parsers/ASTDictionaryAttributeDeclaration.h>
+#include <Parsers/ASTTableOverrides.h>
 #include <Interpreters/StorageID.h>
 
 namespace DB
@@ -78,6 +79,8 @@ public:
     ASTPtr as_table_function;
     ASTSelectWithUnionQuery * select = nullptr;
     IAST * comment = nullptr;
+
+    ASTTableOverrideList * table_overrides = nullptr; /// For CREATE DATABASE with engines that automatically create tables
 
     bool is_dictionary{false}; /// CREATE DICTIONARY
     ASTExpressionList * dictionary_attributes_list = nullptr; /// attributes of

--- a/src/Parsers/ASTTableOverrides.cpp
+++ b/src/Parsers/ASTTableOverrides.cpp
@@ -1,0 +1,242 @@
+#include <IO/Operators.h>
+#include <Parsers/ASTColumnDeclaration.h>
+#include <Parsers/ASTConstraintDeclaration.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTIndexDeclaration.h>
+#include <Parsers/ASTProjectionDeclaration.h>
+#include <Parsers/ASTTableOverrides.h>
+
+namespace DB
+{
+
+ASTPtr ASTTableOverride::clone() const
+{
+    auto res = std::make_shared<ASTTableOverride>(*this);
+    res->children.clear();
+    res->table_name = table_name;
+    if (columns)
+        res->set(res->columns, columns->clone());
+    if (storage)
+        res->set(res->storage, storage->clone());
+    return res;
+}
+
+void ASTTableOverride::formatImpl(const FormatSettings & settings_, FormatState & state, FormatStateStacked frame) const
+{
+    FormatSettings settings = settings_;
+    settings.always_quote_identifiers = true;
+    String nl_or_nothing = settings.one_line ? "" : "\n";
+    String nl_or_ws = settings.one_line ? " " : "\n";
+    String hl_keyword = settings.hilite ? hilite_keyword : "";
+    String hl_none = settings.hilite ? hilite_none : "";
+
+    settings.ostr << hl_keyword << "TABLE OVERRIDE " << hl_none;
+    ASTIdentifier(table_name).formatImpl(settings, state, frame);
+    if (!columns && (!storage || storage->children.empty()))
+        return;
+    auto override_frame = frame;
+    ++override_frame.indent;
+    settings.ostr << nl_or_ws << '(' << nl_or_nothing;
+    String indent_str = settings.one_line ? "" : String(4 * override_frame.indent, ' ');
+    size_t override_elems = 0;
+    if (columns)
+    {
+        FormatStateStacked columns_frame = override_frame;
+        columns_frame.expression_list_always_start_on_new_line = true;
+        settings.ostr << indent_str << hl_keyword << "COLUMNS" << hl_none << nl_or_ws << indent_str << "(";
+        columns->formatImpl(settings, state, columns_frame);
+        settings.ostr << nl_or_nothing << indent_str << ")";
+        ++override_elems;
+    }
+    if (storage)
+    {
+        const auto & format_storage_elem = [&](IAST * elem, const String & elem_name)
+        {
+            if (elem)
+            {
+                settings.ostr << (override_elems++ ? nl_or_ws : "")
+                              << indent_str
+                              << hl_keyword << elem_name << hl_none << ' ';
+                elem->formatImpl(settings, state, override_frame);
+            }
+        };
+        format_storage_elem(storage->partition_by, "PARTITION BY");
+        format_storage_elem(storage->primary_key, "PRIMARY KEY");
+        format_storage_elem(storage->order_by, "ORDER BY");
+        format_storage_elem(storage->sample_by, "SAMPLE BY");
+        format_storage_elem(storage->ttl_table, "TTL");
+    }
+
+    settings.ostr << nl_or_nothing << ')';
+}
+
+void ASTTableOverride::applyToCreateTableQuery(ASTCreateQuery * create_query) const
+{
+    if (columns)
+    {
+        if (!create_query->columns_list)
+            create_query->set(create_query->columns_list, std::make_shared<ASTColumns>());
+        if (columns->columns)
+        {
+            for (const auto & override_column_ast : columns->columns->children)
+            {
+                auto * override_column = override_column_ast->as<ASTColumnDeclaration>();
+                if (!override_column)
+                    continue;
+                if (!create_query->columns_list->columns)
+                    create_query->columns_list->set(create_query->columns_list->columns, std::make_shared<ASTExpressionList>());
+                auto & dest_children = create_query->columns_list->columns->children;
+                auto exists = std::find_if(dest_children.begin(), dest_children.end(), [&](ASTPtr node) -> bool
+                {
+                    return node->as<ASTColumnDeclaration>()->name == override_column->name;
+                });
+                if (exists == dest_children.end())
+                    dest_children.emplace_back(override_column_ast);
+                else
+                    dest_children[exists - dest_children.begin()] = override_column_ast;
+            }
+        }
+        if (columns->indices)
+        {
+            for (const auto & override_index_ast : columns->indices->children)
+            {
+                auto * override_index = override_index_ast->as<ASTIndexDeclaration>();
+                if (!override_index)
+                    continue;
+                if (!create_query->columns_list->indices)
+                    create_query->columns_list->set(create_query->columns_list->indices, std::make_shared<ASTExpressionList>());
+                auto & dest_children = create_query->columns_list->indices->children;
+                auto exists = std::find_if(dest_children.begin(), dest_children.end(), [&](ASTPtr node) -> bool
+                {
+                    return node->as<ASTIndexDeclaration>()->name == override_index->name;
+                });
+                if (exists == dest_children.end())
+                    dest_children.emplace_back(override_index_ast);
+                else
+                    dest_children[exists - dest_children.begin()] = override_index_ast;
+            }
+        }
+        if (columns->constraints)
+        {
+            for (const auto & override_constraint_ast : columns->constraints->children)
+            {
+                auto * override_constraint = override_constraint_ast->as<ASTConstraintDeclaration>();
+                if (!override_constraint)
+                    continue;
+                if (!create_query->columns_list->constraints)
+                    create_query->columns_list->set(create_query->columns_list->constraints, std::make_shared<ASTExpressionList>());
+                auto & dest_children = create_query->columns_list->constraints->children;
+                auto exists = std::find_if(dest_children.begin(), dest_children.end(), [&](ASTPtr node) -> bool
+                {
+                    return node->as<ASTConstraintDeclaration>()->name == override_constraint->name;
+                });
+                if (exists == dest_children.end())
+                    dest_children.emplace_back(override_constraint_ast);
+                else
+                    dest_children[exists - dest_children.begin()] = override_constraint_ast;
+            }
+        }
+        if (columns->projections)
+        {
+            for (const auto & override_projection_ast : columns->projections->children)
+            {
+                auto * override_projection = override_projection_ast->as<ASTProjectionDeclaration>();
+                if (!override_projection)
+                    continue;
+                if (!create_query->columns_list->projections)
+                    create_query->columns_list->set(create_query->columns_list->projections, std::make_shared<ASTExpressionList>());
+                auto & dest_children = create_query->columns_list->projections->children;
+                auto exists = std::find_if(dest_children.begin(), dest_children.end(), [&](ASTPtr node) -> bool
+                {
+                    return node->as<ASTProjectionDeclaration>()->name == override_projection->name;
+                });
+                if (exists == dest_children.end())
+                    dest_children.emplace_back(override_projection_ast);
+                else
+                    dest_children[exists - dest_children.begin()] = override_projection_ast;
+            }
+        }
+    }
+    if (storage)
+    {
+        if (!create_query->storage)
+            create_query->set(create_query->storage, std::make_shared<ASTStorage>());
+        if (storage->partition_by)
+            create_query->storage->set(create_query->storage->partition_by, storage->partition_by->clone());
+        if (storage->primary_key)
+            create_query->storage->set(create_query->storage->primary_key, storage->primary_key->clone());
+        if (storage->order_by)
+            create_query->storage->set(create_query->storage->order_by, storage->order_by->clone());
+        if (storage->sample_by)
+            create_query->storage->set(create_query->storage->sample_by, storage->sample_by->clone());
+        if (storage->ttl_table)
+            create_query->storage->set(create_query->storage->ttl_table, storage->ttl_table->clone());
+        // not supporting overriding ENGINE
+    }
+}
+
+ASTPtr ASTTableOverrideList::clone() const
+{
+    auto res = std::make_shared<ASTTableOverrideList>(*this);
+    res->cloneChildren();
+    return res;
+}
+
+ASTPtr ASTTableOverrideList::tryGetTableOverride(const String & name) const
+{
+    auto it = positions.find(name);
+    if (it == positions.end())
+        return nullptr;
+    return children[it->second];
+}
+
+void ASTTableOverrideList::setTableOverride(const String & name, const ASTPtr ast)
+{
+    auto it = positions.find(name);
+    if (it == positions.end())
+    {
+        positions[name] = children.size();
+        children.emplace_back(ast);
+    }
+    else
+    {
+        children[it->second] = ast;
+    }
+}
+
+void ASTTableOverrideList::removeTableOverride(const String & name)
+{
+    if (hasOverride(name))
+    {
+        size_t pos = positions[name];
+        children.erase(children.begin() + pos);
+        positions.erase(name);
+        for (auto & pr : positions)
+            if (pr.second > pos)
+                --pr.second;
+    }
+}
+
+bool ASTTableOverrideList::hasOverride(const String & name) const
+{
+    return positions.count(name);
+}
+
+void ASTTableOverrideList::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
+{
+    if (frame.expression_list_prepend_whitespace)
+        settings.ostr << ' ';
+
+    for (ASTs::const_iterator it = children.begin(); it != children.end(); ++it)
+    {
+        if (it != children.begin())
+        {
+            settings.ostr << (settings.one_line ? ", " : ",\n");
+        }
+
+        (*it)->formatImpl(settings, state, frame);
+    }
+}
+
+}

--- a/src/Parsers/ASTTableOverrides.h
+++ b/src/Parsers/ASTTableOverrides.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Parsers/IAST.h>
+
+#include <map>
+
+
+namespace DB
+{
+
+class ASTColumns;
+class ASTCreateQuery;
+class ASTIdentifier;
+class ASTStorage;
+
+/// Storage and column overrides for a single table, for example:
+///
+///   TABLE OVERRIDE `foo` PARTITION BY toYYYYMM(`createtime`)
+///
+class ASTTableOverride : public IAST
+{
+public:
+    String table_name;
+    ASTColumns * columns = nullptr;
+    ASTStorage * storage = nullptr;
+    String getID(char) const override { return "TableOverride " + table_name; }
+    ASTPtr clone() const override;
+    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void applyToCreateTableQuery(ASTCreateQuery * create_query) const;
+};
+
+/// List of table overrides, for example:
+///
+///   TABLE OVERRIDE `foo` (PARTITION BY toYYYYMM(`createtime`)),
+///   TABLE OVERRIDE `bar` (SAMPLE BY `id`)
+///
+class ASTTableOverrideList : public IAST
+{
+public:
+    String getID(char) const override { return "TableOverrideList"; }
+    ASTPtr clone() const override;
+    void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+    void setTableOverride(const String & name, ASTPtr override);
+    void removeTableOverride(const String & name);
+    ASTPtr tryGetTableOverride(const String & name) const;
+    bool hasOverride(const String & name) const;
+
+private:
+    std::map<String, size_t> positions;
+};
+
+}

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1,22 +1,23 @@
-#include <Common/typeid_cast.h>
+#include <IO/ReadHelpers.h>
+#include <Parsers/ASTConstraintDeclaration.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIndexDeclaration.h>
-#include <Parsers/ASTProjectionDeclaration.h>
-#include <Parsers/ASTExpressionList.h>
-#include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTSetQuery.h>
+#include <Parsers/ASTProjectionDeclaration.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTSetQuery.h>
+#include <Parsers/ASTTableOverrides.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ParserCreateQuery.h>
-#include <Parsers/ParserSelectWithUnionQuery.h>
-#include <Parsers/ParserSetQuery.h>
-#include <Parsers/ASTConstraintDeclaration.h>
 #include <Parsers/ParserDictionary.h>
 #include <Parsers/ParserDictionaryAttributeDeclaration.h>
 #include <Parsers/ParserProjectionSelectQuery.h>
-#include <IO/ReadHelpers.h>
+#include <Parsers/ParserSelectWithUnionQuery.h>
+#include <Parsers/ParserSetQuery.h>
+#include <Common/typeid_cast.h>
 
 
 namespace DB
@@ -932,6 +933,141 @@ bool ParserCreateWindowViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
     return true;
 }
 
+bool ParserTableOverrideDeclaration::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserKeyword s_table_override("TABLE OVERRIDE");
+    ParserIdentifier table_name_p;
+    ParserToken lparen_p(TokenType::OpeningRoundBracket);
+    ParserToken rparen_p(TokenType::ClosingRoundBracket);
+    ParserTablePropertiesDeclarationList table_properties_p;
+    ParserExpression expression_p;
+    ParserTTLExpressionList parser_ttl_list;
+    ParserKeyword s_columns("COLUMNS");
+    ParserKeyword s_partition_by("PARTITION BY");
+    ParserKeyword s_primary_key("PRIMARY KEY");
+    ParserKeyword s_order_by("ORDER BY");
+    ParserKeyword s_sample_by("SAMPLE BY");
+    ParserKeyword s_ttl("TTL");
+    ASTPtr table_name;
+    ASTPtr columns;
+    ASTPtr partition_by;
+    ASTPtr primary_key;
+    ASTPtr order_by;
+    ASTPtr sample_by;
+    ASTPtr ttl_table;
+
+    if (!s_table_override.ignore(pos, expected))
+        return false;
+
+    if (!table_name_p.parse(pos, table_name, expected))
+        return false;
+
+    if (!lparen_p.ignore(pos, expected))
+        return false;
+
+    while (true)
+    {
+        if (!columns && s_columns.ignore(pos, expected))
+        {
+            if (!lparen_p.ignore(pos, expected))
+                return false;
+            if (!table_properties_p.parse(pos, columns, expected))
+                return false;
+            if (!rparen_p.ignore(pos, expected))
+                return false;
+        }
+
+
+        if (!partition_by && s_partition_by.ignore(pos, expected))
+        {
+            if (expression_p.parse(pos, partition_by, expected))
+                continue;
+            else
+                return false;
+        }
+
+        if (!primary_key && s_primary_key.ignore(pos, expected))
+        {
+            if (expression_p.parse(pos, primary_key, expected))
+                continue;
+            else
+                return false;
+        }
+
+        if (!order_by && s_order_by.ignore(pos, expected))
+        {
+            if (expression_p.parse(pos, order_by, expected))
+                continue;
+            else
+                return false;
+        }
+
+        if (!sample_by && s_sample_by.ignore(pos, expected))
+        {
+            if (expression_p.parse(pos, sample_by, expected))
+                continue;
+            else
+                return false;
+        }
+
+        if (!ttl_table && s_ttl.ignore(pos, expected))
+        {
+            if (parser_ttl_list.parse(pos, ttl_table, expected))
+                continue;
+            else
+                return false;
+        }
+
+        break;
+    }
+
+    if (!rparen_p.ignore(pos, expected))
+        return false;
+
+    auto storage = std::make_shared<ASTStorage>();
+    storage->set(storage->partition_by, partition_by);
+    storage->set(storage->primary_key, primary_key);
+    storage->set(storage->order_by, order_by);
+    storage->set(storage->sample_by, sample_by);
+    storage->set(storage->ttl_table, ttl_table);
+
+    auto res = std::make_shared<ASTTableOverride>();
+    res->table_name = table_name->as<ASTIdentifier>()->name();
+    res->set(res->storage, storage);
+    if (columns)
+        res->set(res->columns, columns);
+
+    node = res;
+
+    return true;
+}
+
+bool ParserTableOverridesDeclarationList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserTableOverrideDeclaration table_override_p;
+    ParserToken s_comma(TokenType::Comma);
+    auto res = std::make_shared<ASTTableOverrideList>();
+    auto parse_element = [&]
+    {
+        ASTPtr element;
+        if (!table_override_p.parse(pos, element, expected))
+            return false;
+        auto * table_override = element->as<ASTTableOverride>();
+        if (!table_override)
+            return false;
+        res->setTableOverride(table_override->table_name, element);
+        return true;
+    };
+
+    if (!ParserList::parseUtil(pos, expected, parse_element, s_comma, true))
+        return false;
+
+    if (!res->children.empty())
+        node = res;
+
+    return true;
+}
+
 bool ParserCreateDatabaseQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     ParserKeyword s_create("CREATE");
@@ -940,9 +1076,11 @@ bool ParserCreateDatabaseQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & e
     ParserKeyword s_if_not_exists("IF NOT EXISTS");
     ParserStorage storage_p;
     ParserIdentifier name_p(true);
+    ParserTableOverridesDeclarationList table_overrides_p;
 
     ASTPtr database;
     ASTPtr storage;
+    ASTPtr table_overrides;
     UUID uuid = UUIDHelpers::Nil;
 
     String cluster_str;
@@ -984,6 +1122,9 @@ bool ParserCreateDatabaseQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & e
     storage_p.parse(pos, storage, expected);
     auto comment = parseComment(pos, expected);
 
+    if (!table_overrides_p.parse(pos, table_overrides, expected))
+        return false;
+
     auto query = std::make_shared<ASTCreateQuery>();
     node = query;
 
@@ -1000,6 +1141,8 @@ bool ParserCreateDatabaseQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & e
     query->set(query->storage, storage);
     if (comment)
         query->set(query->comment, comment);
+    if (table_overrides && !table_overrides->children.empty())
+        query->set(query->table_overrides, table_overrides);
 
     return true;
 }

--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -385,6 +385,20 @@ protected:
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
+class ParserTableOverrideDeclaration : public IParserBase
+{
+protected:
+    const char * getName() const override { return "table override declaration"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
+class ParserTableOverridesDeclarationList : public IParserBase
+{
+protected:
+    const char * getName() const override { return "table overrides declaration list"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
 /// CREATE|ATTACH DATABASE db [ENGINE = engine]
 class ParserCreateDatabaseQuery : public IParserBase
 {

--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -1,11 +1,13 @@
-#include <Parsers/ParserOptimizeQuery.h>
+#include <IO/WriteBufferFromOStream.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ParserAlterQuery.h>
 #include <Parsers/ParserCreateQuery.h>
-
+#include <Parsers/ParserOptimizeQuery.h>
 #include <Parsers/ParserQueryWithOutput.h>
-#include <Parsers/parseQuery.h>
 #include <Parsers/formatAST.h>
-#include <IO/WriteBufferFromOStream.h>
+#include <Parsers/parseQuery.h>
 
 #include <string_view>
 
@@ -25,7 +27,7 @@ struct ParserTestCase
 
 std::ostream & operator<<(std::ostream & ostr, const std::shared_ptr<IParser> parser)
 {
-    return ostr << "Praser: " << parser->getName();
+    return ostr << "Parser: " << parser->getName();
 }
 
 std::ostream & operator<<(std::ostream & ostr, const ParserTestCase & test_case)
@@ -55,6 +57,45 @@ TEST_P(ParserTest, parseQuery)
     }
 }
 
+struct TableOverrideTestCase
+{
+    DB::String create_database_query;
+    DB::String create_table_query;
+    DB::String expected_create_table_query;
+};
+
+std::ostream & operator<<(std::ostream & ostr, const TableOverrideTestCase & test_case)
+{
+    return ostr << "database: " << test_case.create_database_query << ", table: " << test_case.create_table_query
+                << ", expected: " << test_case.expected_create_table_query;
+}
+
+class TableOverrideTest : public ::testing::TestWithParam<TableOverrideTestCase>
+{};
+
+TEST_P(TableOverrideTest, applyOverrides)
+{
+    const auto & [database_query, table_query, expected_query] = GetParam();
+    ParserCreateQuery parser;
+    ASTPtr database_ast;
+    ASSERT_NO_THROW(database_ast = parseQuery(parser, database_query, 0, 0));
+    auto * database = database_ast->as<ASTCreateQuery>();
+    ASSERT_NE(nullptr, database);
+    ASTPtr table_ast;
+    ASSERT_NO_THROW(table_ast = parseQuery(parser, table_query, 0, 0));
+    auto table = table_ast->as<ASTCreateQuery>();
+    ASSERT_NE(nullptr, table);
+    auto table_name = table->table->as<ASTIdentifier>()->name();
+    if (database->table_overrides)
+    {
+        auto override_ast = database->table_overrides->tryGetTableOverride(table_name);
+        ASSERT_NE(nullptr, override_ast);
+        auto override = override_ast->as<ASTTableOverride>();
+        ASSERT_NE(nullptr, override);
+        override->applyToCreateTableQuery(table);
+    }
+    EXPECT_EQ(expected_query, serializeAST(*table));
+}
 
 INSTANTIATE_TEST_SUITE_P(ParserOptimizeQuery, ParserTest,
     ::testing::Combine(
@@ -144,7 +185,7 @@ INSTANTIATE_TEST_SUITE_P(ParserAlterCommand_MODIFY_COMMENT, ParserTest,
 
 INSTANTIATE_TEST_SUITE_P(ParserCreateQuery_DICTIONARY_WITH_COMMENT, ParserTest,
     ::testing::Combine(
-        ::testing::Values(std::make_shared<ParserAlterCommand>()),
+        ::testing::Values(std::make_shared<ParserCreateQuery>()),
         ::testing::ValuesIn(std::initializer_list<ParserTestCase>{
         {
             R"sql(CREATE DICTIONARY 2024_dictionary_with_comment
@@ -170,3 +211,91 @@ LAYOUT(FLAT())
 COMMENT 'Test dictionary with comment')sql"
     }}
 )));
+
+INSTANTIATE_TEST_SUITE_P(ParserCreateDatabaseQuery, ParserTest,
+    ::testing::Combine(
+        ::testing::Values(std::make_shared<ParserCreateQuery>()),
+        ::testing::ValuesIn(std::initializer_list<ParserTestCase>{
+        {
+            "CREATE DATABASE db ENGINE=MaterializeMySQL('addr:port', 'db', 'user', 'pw')",
+            "CREATE DATABASE db\nENGINE = MaterializeMySQL('addr:port', 'db', 'user', 'pw')"
+        },
+        {
+            "CREATE DATABASE db ENGINE=MaterializeMySQL('addr:port', 'db', 'user', 'pw') TABLE OVERRIDE `tbl`\n(PARTITION BY toYYYYMM(created))",
+            "CREATE DATABASE db\nENGINE = MaterializeMySQL('addr:port', 'db', 'user', 'pw')\nTABLE OVERRIDE `tbl`\n(\n    PARTITION BY toYYYYMM(`created`)\n)"
+        },
+        {
+            "CREATE DATABASE db ENGINE=Foo TABLE OVERRIDE `tbl` (), TABLE OVERRIDE a (COLUMNS (_created DateTime MATERIALIZED now())), TABLE OVERRIDE b (PARTITION BY rand())",
+            "CREATE DATABASE db\nENGINE = Foo\nTABLE OVERRIDE `tbl`,\nTABLE OVERRIDE `a`\n(\n    COLUMNS\n    (\n        `_created` DateTime MATERIALIZED now()\n    )\n),\nTABLE OVERRIDE `b`\n(\n    PARTITION BY rand()\n)"
+        },
+        {
+            "CREATE DATABASE db ENGINE=MaterializeMySQL('addr:port', 'db', 'user', 'pw') TABLE OVERRIDE tbl (COLUMNS (id UUID) PARTITION BY toYYYYMM(created))",
+            "CREATE DATABASE db\nENGINE = MaterializeMySQL('addr:port', 'db', 'user', 'pw')\nTABLE OVERRIDE `tbl`\n(\n    COLUMNS\n    (\n        `id` UUID\n    )\n    PARTITION BY toYYYYMM(`created`)\n)"
+        },
+        {
+            "CREATE DATABASE db TABLE OVERRIDE tbl (COLUMNS (INDEX foo foo TYPE minmax GRANULARITY 1) PARTITION BY if(_staged = 1, 'staging', toYYYYMM(created)))",
+            "CREATE DATABASE db\nTABLE OVERRIDE `tbl`\n(\n    COLUMNS\n    (\n        INDEX foo `foo` TYPE minmax GRANULARITY 1\n    )\n    PARTITION BY if(`_staged` = 1, 'staging', toYYYYMM(`created`))\n)"
+        },
+        {
+            "CREATE DATABASE db TABLE OVERRIDE t1 (TTL inserted + INTERVAL 1 MONTH DELETE), TABLE OVERRIDE t2 (TTL `inserted` + INTERVAL 2 MONTH DELETE)",
+            "CREATE DATABASE db\nTABLE OVERRIDE `t1`\n(\n    TTL `inserted` + toIntervalMonth(1)\n),\nTABLE OVERRIDE `t2`\n(\n    TTL `inserted` + toIntervalMonth(2)\n)"
+        },
+        {
+            "CREATE DATABASE db ENGINE = MaterializeMySQL('127.0.0.1:3306', 'db', 'root', 'pw') SETTINGS allows_query_when_mysql_lost = 1 TABLE OVERRIDE tab3 (COLUMNS (_staged UInt8 MATERIALIZED 1) PARTITION BY (c3) TTL c3 + INTERVAL 10 minute), TABLE OVERRIDE tab5 (PARTITION BY (c3) TTL c3 + INTERVAL 10 minute)",
+            "CREATE DATABASE db\nENGINE = MaterializeMySQL('127.0.0.1:3306', 'db', 'root', 'pw')\nSETTINGS allows_query_when_mysql_lost = 1\nTABLE OVERRIDE `tab3`\n(\n    COLUMNS\n    (\n        `_staged` UInt8 MATERIALIZED 1\n    )\n    PARTITION BY `c3`\n    TTL `c3` + toIntervalMinute(10)\n),\nTABLE OVERRIDE `tab5`\n(\n    PARTITION BY `c3`\n    TTL `c3` + toIntervalMinute(10)\n)"
+        },
+        {
+            "CREATE DATABASE db TABLE OVERRIDE tbl (PARTITION BY toYYYYMM(created) COLUMNS (created DateTime CODEC(Delta)))",
+            "CREATE DATABASE db\nTABLE OVERRIDE `tbl`\n(\n    COLUMNS\n    (\n        `created` DateTime CODEC(Delta)\n    )\n    PARTITION BY toYYYYMM(`created`)\n)"
+        },
+        {
+            "CREATE DATABASE db ENGINE = Foo() SETTINGS a = 1",
+            "CREATE DATABASE db\nENGINE = Foo\nSETTINGS a = 1"
+        },
+        {
+            "CREATE DATABASE db ENGINE = Foo() SETTINGS a = 1, b = 2",
+            "CREATE DATABASE db\nENGINE = Foo\nSETTINGS a = 1, b = 2"
+        },
+        {
+            "CREATE DATABASE db ENGINE = Foo() SETTINGS a = 1, b = 2 TABLE OVERRIDE a (ORDER BY (id, version))",
+            "CREATE DATABASE db\nENGINE = Foo\nSETTINGS a = 1, b = 2\nTABLE OVERRIDE `a`\n(\n    ORDER BY (`id`, `version`)\n)"
+        },
+        {
+            "CREATE DATABASE db ENGINE = Foo() SETTINGS a = 1, b = 2 COMMENT 'db comment' TABLE OVERRIDE a (ORDER BY (id, version))",
+            "CREATE DATABASE db\nENGINE = Foo\nSETTINGS a = 1, b = 2\nTABLE OVERRIDE `a`\n(\n    ORDER BY (`id`, `version`)\n)\nCOMMENT 'db comment'"
+        }
+})));
+
+INSTANTIATE_TEST_SUITE_P(ApplyTableOverrides, TableOverrideTest,
+    ::testing::ValuesIn(std::initializer_list<TableOverrideTestCase>{
+    {
+        "CREATE DATABASE db",
+        "CREATE TABLE db.t (id Int64) ENGINE=Log",
+        "CREATE TABLE db.t (`id` Int64) ENGINE = Log"
+    },
+    {
+        "CREATE DATABASE db TABLE OVERRIDE t (PARTITION BY tuple())",
+        "CREATE TABLE db.t (id Int64) ENGINE=MergeTree",
+        "CREATE TABLE db.t (`id` Int64) ENGINE = MergeTree PARTITION BY tuple()"
+    },
+    {
+        "CREATE DATABASE db TABLE OVERRIDE t (COLUMNS (id UInt64, shard UInt8 MATERIALIZED modulo(id, 16)) PARTITION BY shard)",
+        "CREATE TABLE db.t (id Int64) ENGINE=MergeTree",
+        "CREATE TABLE db.t (`id` UInt64, `shard` UInt8 MATERIALIZED id % 16) ENGINE = MergeTree PARTITION BY shard"
+    },
+    {
+        "CREATE DATABASE db TABLE OVERRIDE a (PARTITION BY modulo(id, 3)), TABLE OVERRIDE b (PARTITION BY modulo(id, 5))",
+        "CREATE TABLE db.a (id Int64) ENGINE=MergeTree",
+        "CREATE TABLE db.a (`id` Int64) ENGINE = MergeTree PARTITION BY id % 3"
+    },
+    {
+        "CREATE DATABASE db TABLE OVERRIDE a (PARTITION BY modulo(id, 3)), TABLE OVERRIDE b (PARTITION BY modulo(id, 5))",
+        "CREATE TABLE db.b (id Int64) ENGINE=MergeTree",
+        "CREATE TABLE db.b (`id` Int64) ENGINE = MergeTree PARTITION BY id % 5"
+    },
+    {
+        "CREATE DATABASE db ENGINE=MaterializeMySQL('addr:port', 'db', 'user', 'pw') TABLE OVERRIDE `tbl` (PARTITION BY toYYYYMM(created))",
+        "CREATE TABLE db.tbl (id Int64, created DateTime) ENGINE=Foo",
+        "CREATE TABLE db.tbl (`id` Int64, `created` DateTime) ENGINE = Foo PARTITION BY toYYYYMM(created)",
+    }
+}));

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -249,3 +249,7 @@ def test_large_transaction(started_cluster, started_mysql_8_0, started_mysql_5_7
 def test_table_table(started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node):
     materialize_with_ddl.table_table(clickhouse_node, started_mysql_8_0, "mysql80")
     materialize_with_ddl.table_table(clickhouse_node, started_mysql_5_7, "mysql57")
+
+def test_table_overrides(started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node):
+    materialize_with_ddl.table_overrides(clickhouse_node, started_mysql_5_7, "mysql57")
+    materialize_with_ddl.table_overrides(clickhouse_node, started_mysql_8_0, "mysql80")


### PR DESCRIPTION
Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Add "TABLE OVERRIDE" feature for customizing MaterializedMySQL table schemas


Detailed description / Documentation draft:

[Design document here](https://github.com/ClickHouse/ClickHouse/issues/31480)

