### PR TITLE
Add cast to `MATERIALIZE COLUMN`

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -569,7 +569,10 @@ ASTPtr MutationsInterpreter::prepare(bool dry_run)
                 stages.emplace_back(context);
 
             const auto & column = columns_desc.get(command.column_name);
-            stages.back().column_to_updated.emplace(column.name, column.default_desc.expression->clone());
+            auto materialized_column = makeASTFunction(
+                "_CAST", column.default_desc.expression->clone(), std::make_shared<ASTLiteral>(column.type->getName()));
+
+            stages.back().column_to_updated.emplace(column.name, materialized_column);
         }
         else if (command.type == MutationCommand::MATERIALIZE_INDEX)
         {

--- a/tests/queries/0_stateless/02131_materialize_column_cast.reference
+++ b/tests/queries/0_stateless/02131_materialize_column_cast.reference
@@ -1,0 +1,14 @@
+1_1_1_0_2	i	Int32
+1_1_1_0_2	s	LowCardinality(String)
+===========
+1_1_1_0_2	i	Int32
+1_1_1_0_2	s	LowCardinality(String)
+2_3_3_0	i	Int32
+2_3_3_0	s	LowCardinality(String)
+===========
+1_1_1_0_4	i	Int32
+1_1_1_0_4	s	LowCardinality(String)
+2_3_3_0_4	i	Int32
+2_3_3_0_4	s	LowCardinality(String)
+1	1
+2	2

--- a/tests/queries/0_stateless/02131_materialize_column_cast.sql
+++ b/tests/queries/0_stateless/02131_materialize_column_cast.sql
@@ -1,0 +1,35 @@
+DROP TABLE IF EXISTS t_materialize_column;
+
+CREATE TABLE t_materialize_column (i Int32)
+ENGINE = MergeTree ORDER BY i PARTITION BY i
+SETTINGS min_bytes_for_wide_part = 0;
+
+INSERT INTO t_materialize_column VALUES (1);
+
+ALTER TABLE t_materialize_column ADD COLUMN s LowCardinality(String) DEFAULT toString(i);
+ALTER TABLE t_materialize_column MATERIALIZE COLUMN s SETTINGS mutations_sync = 2;
+
+SELECT name, column, type FROM system.parts_columns
+WHERE table = 't_materialize_column' AND database = currentDatabase() AND active
+ORDER BY name, column;
+
+SELECT '===========';
+
+INSERT INTO t_materialize_column (i) VALUES (2);
+
+SELECT name, column, type FROM system.parts_columns
+WHERE table = 't_materialize_column' AND database = currentDatabase() AND active
+ORDER BY name, column;
+
+SELECT '===========';
+
+ALTER TABLE t_materialize_column ADD INDEX s_bf (s) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE t_materialize_column MATERIALIZE INDEX s_bf SETTINGS mutations_sync = 2;
+
+SELECT name, column, type FROM system.parts_columns
+WHERE table = 't_materialize_column' AND database = currentDatabase() AND active
+ORDER BY name, column;
+
+SELECT * FROM t_materialize_column ORDER BY i;
+
+DROP TABLE t_materialize_column;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `ALTER ... MATERIALIZE COLUMN ...` queries in case when data type of default expression is not equal to the data type of column.

Fixes #29702.