### PR TITLE
Fix graphite-bench build

### DIFF
--- a/utils/graphite-rollup/CMakeLists.txt
+++ b/utils/graphite-rollup/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(
 )
 target_include_directories(
     graphite-rollup-bench
-    PRIVATE
+    SYSTEM PRIVATE
     ${ClickHouse_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/src
     ${ClickHouse_SOURCE_DIR}/base ${ClickHouse_SOURCE_DIR}/base/pcg-random
     ${CMAKE_BINARY_DIR}/src/Core/include


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


Detailed description / Documentation draft:
```
In file included from /home/jakalletti/ClickHouse/ClickHouse/utils/graphite-rollup/graphite-rollup-bench.cpp:12:
In file included from /home/jakalletti/ClickHouse/ClickHouse/src/Processors/Merges/Algorithms/Graphite.h:4:
In file included from /home/jakalletti/ClickHouse/ClickHouse/src/Common/OptimizedRegularExpression.h:13:
In file included from /home/jakalletti/ClickHouse/build/contrib/re2_st/re2_st/re2.h:218:
/home/jakalletti/ClickHouse/build/contrib/re2_st/re2_st/stringpiece.h:59:15: error: zero as null pointer constant [-Werror,-Wzero-as-null-pointer-constant]
      : data_(NULL), size_(0) {}
              ^~~~
              nullptr
/usr/lib/llvm-13/lib/clang/13.0.1/include/stddef.h:84:18: note: expanded from macro 'NULL'
#    define NULL __null
                 ^
In file included from /home/jakalletti/ClickHouse/ClickHouse/utils/graphite-rollup/graphite-rollup-bench.cpp:12:
In file included from /home/jakalletti/ClickHouse/ClickHouse/src/Processors/Merges/Algorithms/Graphite.h:4:
In file included from /home/jakalletti/ClickHouse/ClickHouse/src/Common/OptimizedRegularExpression.h:13:
In file included from /home/jakalletti/ClickHouse/build/contrib/re2_st/re2_st/re2.h:218:
/home/jakalletti/ClickHouse/build/contrib/re2_st/re2_st/stringpiece.h:67:34: error: zero as null pointer constant [-Werror,-Wzero-as-null-pointer-constant]
      : data_(str), size_(str == NULL ? 0 : strlen(str)) {}
                                 ^~~~
                                 nullptr
/usr/lib/llvm-13/lib/clang/13.0.1/include/stddef.h:84:18: note: expanded from macro 'NULL'
#    define NULL __null
                 ^
In file included from /home/jakalletti/ClickHouse/ClickHouse/utils/graphite-rollup/graphite-rollup-bench.cpp:12:
In file included from /home/jakalletti/ClickHouse/ClickHouse/src/Processors/Merges/Algorithms/Graphite.h:4:
In file included from /home/jakalletti/ClickHouse/ClickHouse/src/Common/OptimizedRegularExpression.h:13:
In file included from /home/jakalletti/ClickHouse/build/contrib/re2_st/re2_st/re2.h:218:
/home/jakalletti/ClickHouse/build/contrib/re2_st/re2_st/stringpiece.h:98:20: error: zero as null pointer constant [-Werror,-Wzero-as-null-pointer-constant]
    size_ = str == NULL ? 0 : strlen(str);
                   ^~~~
                   nullptr
/usr/lib/llvm-13/lib/clang/13.0.1/include/stddef.h:84:18: note: expanded from macro 'NULL'
#    define NULL __null
                 ^
In file included from /home/jakalletti/ClickHouse/ClickHouse/utils/graphite-rollup/graphite-rollup-bench.cpp:12:
In file included from /home/jakalletti/ClickHouse/ClickHouse/src/Processors/Merges/Algorithms/Graphite.h:4:
In file included from /home/jakalletti/ClickHouse/ClickHouse/src/Common/OptimizedRegularExpression.h:13:
/home/jakalletti/ClickHouse/build/contrib/re2_st/re2_st/re2.h:881:17: error: zero as null pointer constant [-Werror,-Wzero-as-null-pointer-constant]
    if (dest == NULL) return true;
                ^~~~
                nullptr
/usr/lib/llvm-13/lib/clang/13.0.1/include/stddef.h:84:18: note: expanded from macro 'NULL'
#    define NULL __null
                 ^
4 errors generated.
```