### PR TITLE
Another attempt to fix unit test Executor::RemoveTasksStress

### DIFF
--- a/src/Storages/MergeTree/tests/gtest_executor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_executor.cpp
@@ -147,7 +147,7 @@ TEST(Executor, RemoveTasksStress)
     for (size_t j = 0; j < tasks_kinds; ++j)
         executor->removeTasksCorrespondingToStorage({"test", std::to_string(j)});
 
-    ASSERT_EQ(CurrentMetrics::values[CurrentMetrics::BackgroundMergesAndMutationsPoolTask], 0);
-
     executor->wait();
+
+    ASSERT_EQ(CurrentMetrics::values[CurrentMetrics::BackgroundMergesAndMutationsPoolTask], 0);
 }


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
