### PR TITLE
clickhouse-local: fix CREATE DATABASE with Atomic engine

### DIFF
--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -43,6 +43,7 @@ DatabaseAtomic::DatabaseAtomic(String name_, String metadata_path_, UUID uuid, c
     , db_uuid(uuid)
 {
     assert(db_uuid != UUIDHelpers::Nil);
+    fs::create_directories(fs::path(getContext()->getPath()) / "metadata");
     fs::create_directories(path_to_table_symlinks);
     tryCreateMetadataSymlink();
 }

--- a/tests/queries/0_stateless/02135_local_create_db.sh
+++ b/tests/queries/0_stateless/02135_local_create_db.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+for Engine in Atomic Ordinary; do
+    $CLICKHOUSE_LOCAL --query """
+    CREATE DATABASE foo_$Engine Engine=$Engine;
+    DROP DATABASE foo_$Engine;
+    """
+done


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
clickhouse-local: fix CREATE DATABASE with Atomic engine

Detailed description / Documentation draft:
Before it fails to create due to "metadata" directory had not been
created, since metadata_path is different for Atomic database, see
InterpreterCreateQuery.cpp.