### PR TITLE
Try fix attaching gdb in tests

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -123,7 +123,7 @@ thread apply all backtrace
 continue
 " > script.gdb
 
-    gdb -batch -command script.gdb -p "$server_pid" &
+    sudo gdb -batch -command script.gdb -p "$server_pid" &
 }
 
 function clone_root

--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -123,7 +123,7 @@ thread apply all backtrace
 continue
 " > script.gdb
 
-    sudo gdb -batch -command script.gdb -p "$server_pid" &
+    gdb -batch -command script.gdb -p "$server_pid" &
 }
 
 function clone_root

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -165,7 +165,7 @@ thread apply all backtrace
 continue
 " > script.gdb
 
-    gdb -batch -command script.gdb -p $server_pid &
+    sudo gdb -batch -command script.gdb -p $server_pid &
 
     # Check connectivity after we attach gdb, because it might cause the server
     # to freeze and the fuzzer will fail.

--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -291,7 +291,7 @@ function get_profiles_watchdog
 
     for pid in $(pgrep -f clickhouse)
     do
-        gdb -p "$pid" --batch --ex "info proc all" --ex "thread apply all bt" --ex quit &> "$pid.gdb.log" &
+        sudo gdb -p "$pid" --batch --ex "info proc all" --ex "thread apply all bt" --ex quit &> "$pid.gdb.log" &
     done
     wait
 

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -142,7 +142,7 @@ quit
     # FIXME Hung check may work incorrectly because of attached gdb
     # 1. False positives are possible
     # 2. We cannot attach another gdb to get stacktraces if some queries hung
-    gdb -batch -command script.gdb -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" >> /test_output/gdb.log &
+    sudo gdb -batch -command script.gdb -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" >> /test_output/gdb.log &
 }
 
 configure

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC2094
 # shellcheck disable=SC2086
+# shellcheck disable=SC2024
 
 set -x
 

--- a/tests/ci/ast_fuzzer_check.py
+++ b/tests/ci/ast_fuzzer_check.py
@@ -21,7 +21,7 @@ IMAGE_NAME = 'clickhouse/fuzzer'
 
 def get_run_command(pr_number, sha, download_url, workspace_path, image):
     return f'docker run --network=host --volume={workspace_path}:/workspace ' \
-          '--cap-add syslog --cap-add sys_admin ' \
+          '--cap-add syslog --cap-add sys_admin --cap-add=SYS_PTRACE ' \
           f'-e PR_TO_TEST={pr_number} -e SHA_TO_TEST={sha} -e BINARY_URL_TO_DOWNLOAD="{download_url}" '\
           f'{image}'
 

--- a/tests/ci/stress_check.py
+++ b/tests/ci/stress_check.py
@@ -22,7 +22,7 @@ from tee_popen import TeePopen
 
 
 def get_run_command(build_path, result_folder, server_log_folder, image):
-    cmd = "docker run -e S3_URL='https://clickhouse-datasets.s3.amazonaws.com' " + \
+    cmd = "docker run --cap-add=SYS_PTRACE -e S3_URL='https://clickhouse-datasets.s3.amazonaws.com' " + \
           f"--volume={build_path}:/package_folder "  \
           f"--volume={result_folder}:/test_output " \
           f"--volume={server_log_folder}:/var/log/clickhouse-server {image}"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
https://s3.amazonaws.com/clickhouse-test-reports/0/30963dcbc2e97b831677415314bccd5275702884/stress_test__thread__actions_/runlog.log
```
+ gdb -batch -command script.gdb -p 203
Could not attach to process.  If your uid matches the uid of the target
process, check the setting of /proc/sys/kernel/yama/ptrace_scope, or try
again as the root user.  For more details, see /etc/sysctl.d/10-ptrace.conf
ptrace: Operation not permitted.
script.gdb:7: Error in sourced command file:
The program is not being run.

...

+ zgrep -Fa ' <Fatal> ' /var/log/clickhouse-server/clickhouse-server.log /var/log/clickhouse-server/clickhouse-server.log.1 /var/log/clickhouse-server/clickhouse-server.log.2
/var/log/clickhouse-server/clickhouse-server.log.2:2021.12.08 13:55:02.838357 [ 503 ] {} <Fatal> Application: Child process was terminated by signal 11.
```
