### PR TITLE
01950_kill_large_group_by_query: Increase timeout

### DIFF
--- a/tests/queries/0_stateless/01950_kill_large_group_by_query.sh
+++ b/tests/queries/0_stateless/01950_kill_large_group_by_query.sh
@@ -12,9 +12,11 @@ function wait_for_query_to_start()
 }
 
 
+MAX_TIMEOUT=30
+
 # TCP CLIENT
 
-$CLICKHOUSE_CLIENT --max_execution_time 10 --query_id "test_01948_tcp_$CLICKHOUSE_DATABASE" -q \
+$CLICKHOUSE_CLIENT --max_execution_time $MAX_TIMEOUT --query_id "test_01948_tcp_$CLICKHOUSE_DATABASE" -q \
     "SELECT * FROM
     (
         SELECT a.name as n
@@ -30,12 +32,12 @@ $CLICKHOUSE_CLIENT --max_execution_time 10 --query_id "test_01948_tcp_$CLICKHOUS
     LIMIT 20
     FORMAT Null" > /dev/null 2>&1 &
 wait_for_query_to_start "test_01948_tcp_$CLICKHOUSE_DATABASE"
-$CLICKHOUSE_CLIENT --max_execution_time 10 -q "KILL QUERY WHERE query_id = 'test_01948_tcp_$CLICKHOUSE_DATABASE' SYNC"
+$CLICKHOUSE_CLIENT --max_execution_time $MAX_TIMEOUT -q "KILL QUERY WHERE query_id = 'test_01948_tcp_$CLICKHOUSE_DATABASE' SYNC"
 
 
 # HTTP CLIENT
 
-${CLICKHOUSE_CURL_COMMAND} -q --max-time 10 -sS "$CLICKHOUSE_URL&query_id=test_01948_http_$CLICKHOUSE_DATABASE" -d \
+${CLICKHOUSE_CURL_COMMAND} -q --max-time $MAX_TIMEOUT -sS "$CLICKHOUSE_URL&query_id=test_01948_http_$CLICKHOUSE_DATABASE" -d \
     "SELECT * FROM
     (
         SELECT a.name as n
@@ -51,4 +53,4 @@ ${CLICKHOUSE_CURL_COMMAND} -q --max-time 10 -sS "$CLICKHOUSE_URL&query_id=test_0
     LIMIT 20
     FORMAT Null" > /dev/null 2>&1 &
 wait_for_query_to_start "test_01948_http_$CLICKHOUSE_DATABASE"
-$CLICKHOUSE_CURL --max-time 10 -sS "$CLICKHOUSE_URL" -d "KILL QUERY WHERE query_id = 'test_01948_http_$CLICKHOUSE_DATABASE' SYNC"
+$CLICKHOUSE_CURL --max-time $MAX_TIMEOUT -sS "$CLICKHOUSE_URL" -d "KILL QUERY WHERE query_id = 'test_01948_http_$CLICKHOUSE_DATABASE' SYNC"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

I saw a failure in debug build (https://s3.amazonaws.com/clickhouse-test-reports/0/ca5b6ce654203a1eb9bc6cb514f91be6fd83f59b/stateless_tests__debug__actions_.html) and since the query itself might take minutes in a release build it should be safe to increase timeouts and leave more time to the KILL query to work.