### PR TITLE
Fix 02050_client_profile_events flakiness

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -4,6 +4,8 @@
 #include <iomanip>
 #include <string_view>
 #include <filesystem>
+#include <map>
+#include <unordered_map>
 
 #include <base/argsToConfig.h>
 #include <base/DateLUT.h>
@@ -52,6 +54,7 @@
 #include <Processors/Executors/PullingAsyncPipelineExecutor.h>
 #include <Processors/Transforms/AddingDefaultsTransform.h>
 #include <Interpreters/ReplaceQueryParameterVisitor.h>
+#include <Interpreters/ProfileEventsExt.h>
 #include <IO/WriteBufferFromOStream.h>
 #include <IO/CompressionMethod.h>
 #include <Client/InternalTextLogs.h>
@@ -104,6 +107,99 @@ namespace ProfileEvents
 
 namespace DB
 {
+
+static void incrementProfileEventsBlock(Block & dst, const Block & src)
+{
+    if (!dst)
+    {
+        dst = src;
+        return;
+    }
+
+    assertBlocksHaveEqualStructure(src, dst, "ProfileEvents");
+
+    std::unordered_map<String, size_t> name_pos;
+    for (size_t i = 0; i < dst.columns(); ++i)
+        name_pos[dst.getByPosition(i).name] = i;
+
+    size_t dst_rows = dst.rows();
+    MutableColumns mutable_columns = dst.mutateColumns();
+
+    auto & dst_column_host_name = typeid_cast<ColumnString &>(*mutable_columns[name_pos["host_name"]]);
+    auto & dst_array_current_time = typeid_cast<ColumnUInt32 &>(*mutable_columns[name_pos["current_time"]]).getData();
+    auto & dst_array_thread_id = typeid_cast<ColumnUInt64 &>(*mutable_columns[name_pos["thread_id"]]).getData();
+    auto & dst_array_type = typeid_cast<ColumnInt8 &>(*mutable_columns[name_pos["type"]]).getData();
+    auto & dst_column_name = typeid_cast<ColumnString &>(*mutable_columns[name_pos["name"]]);
+    auto & dst_array_value = typeid_cast<ColumnInt64 &>(*mutable_columns[name_pos["value"]]).getData();
+
+    const auto & src_column_host_name = typeid_cast<const ColumnString &>(*src.getByName("host_name").column);
+    const auto & src_array_current_time = typeid_cast<const ColumnUInt32 &>(*src.getByName("current_time").column).getData();
+    const auto & src_array_thread_id = typeid_cast<const ColumnUInt64 &>(*src.getByName("thread_id").column).getData();
+    const auto & src_column_name = typeid_cast<const ColumnString &>(*src.getByName("name").column);
+    const auto & src_array_value = typeid_cast<const ColumnInt64 &>(*src.getByName("value").column).getData();
+
+    struct Id
+    {
+        StringRef name;
+        StringRef host_name;
+        UInt64 thread_id;
+
+        bool operator<(const Id & rhs) const
+        {
+            return std::tie(name, host_name, thread_id)
+                 < std::tie(rhs.name, rhs.host_name, rhs.thread_id);
+        }
+    };
+    std::map<Id, UInt64> rows_by_name;
+    for (size_t src_row = 0; src_row < src.rows(); ++src_row)
+    {
+        Id id{
+            src_column_name.getDataAt(src_row),
+            src_column_host_name.getDataAt(src_row),
+            src_array_thread_id[src_row],
+        };
+        rows_by_name[id] = src_row;
+    }
+
+    /// Merge src into dst.
+    for (size_t dst_row = 0; dst_row < dst_rows; ++dst_row)
+    {
+        Id id{
+            dst_column_name.getDataAt(dst_row),
+            dst_column_host_name.getDataAt(dst_row),
+            dst_array_thread_id[dst_row],
+        };
+
+        if (auto it = rows_by_name.find(id); it != rows_by_name.end())
+        {
+            size_t src_row = it->second;
+            dst_array_current_time[dst_row] = src_array_current_time[src_row];
+
+            switch (dst_array_type[dst_row])
+            {
+                case ProfileEvents::Type::INCREMENT:
+                    dst_array_value[dst_row] += src_array_value[src_row];
+                    break;
+                case ProfileEvents::Type::GAUGE:
+                    dst_array_value[dst_row] = src_array_value[src_row];
+                    break;
+            }
+
+            rows_by_name.erase(it);
+        }
+    }
+
+    /// Copy rows from src that dst does not contains.
+    for (const auto & [id, pos] : rows_by_name)
+    {
+        for (size_t col = 0; col < src.columns(); ++col)
+        {
+            mutable_columns[col]->insert((*src.getByPosition(col).column)[pos]);
+        }
+    }
+
+    dst.setColumns(std::move(mutable_columns));
+}
 
 
 std::atomic_flag exit_on_signal = ATOMIC_FLAG_INIT;
@@ -753,7 +849,7 @@ void ClientBase::onProfileEvents(Block & block)
         }
         else
         {
-            profile_events.last_block = block;
+            incrementProfileEventsBlock(profile_events.last_block, block);
         }
     }
     profile_events.watch.restart();

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -72,6 +72,24 @@ static thread_local bool has_alt_stack = false;
 #endif
 
 
+std::vector<ThreadGroupStatus::ProfileEventsCountersAndMemory> ThreadGroupStatus::getProfileEventsCountersAndMemoryForThreads()
+{
+    std::lock_guard guard(mutex);
+
+    /// It is OK to move it, since it is enough to report statistics for the thread at least once.
+    auto stats = std::move(finished_threads_counters_memory);
+    for (auto * thread : threads)
+    {
+        stats.emplace_back(ProfileEventsCountersAndMemory{
+            thread->performance_counters.getPartiallyAtomicSnapshot(),
+            thread->memory_tracker.get(),
+            thread->thread_id,
+        });
+    }
+
+    return stats;
+}
+
 ThreadStatus::ThreadStatus()
     : thread_id{getThreadId()}
 {
@@ -145,6 +163,11 @@ ThreadStatus::~ThreadStatus()
     if (thread_group)
     {
         std::lock_guard guard(thread_group->mutex);
+        thread_group->finished_threads_counters_memory.emplace_back(ThreadGroupStatus::ProfileEventsCountersAndMemory{
+            performance_counters.getPartiallyAtomicSnapshot(),
+            memory_tracker.get(),
+            thread_id,
+        });
         thread_group->threads.erase(this);
     }
 

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -139,6 +139,7 @@ ThreadStatus::~ThreadStatus()
     {
         /// It's a minor tracked memory leak here (not the memory itself but it's counter).
         /// We've already allocated a little bit more than the limit and cannot track it in the thread memory tracker or its parent.
+        tryLogCurrentException(log);
     }
 
     if (thread_group)

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -61,6 +61,13 @@ using ThreadStatusPtr = ThreadStatus *;
 class ThreadGroupStatus
 {
 public:
+    struct ProfileEventsCountersAndMemory
+    {
+        ProfileEvents::Counters::Snapshot counters;
+        Int64 memory_usage;
+        UInt64 thread_id;
+    };
+
     mutable std::mutex mutex;
 
     ProfileEvents::Counters performance_counters{VariableContext::Process};
@@ -83,6 +90,10 @@ public:
 
     String query;
     UInt64 normalized_query_hash = 0;
+
+    std::vector<ProfileEventsCountersAndMemory> finished_threads_counters_memory;
+
+    std::vector<ProfileEventsCountersAndMemory> getProfileEventsCountersAndMemoryForThreads();
 };
 
 using ThreadGroupStatusPtr = std::shared_ptr<ThreadGroupStatus>;

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -947,28 +947,27 @@ void TCPHandler::sendProfileEvents()
     ThreadIdToCountersSnapshot new_snapshots;
     ProfileEventsSnapshot group_snapshot;
     {
-        std::lock_guard guard(thread_group->mutex);
-        snapshots.reserve(thread_group->threads.size());
-        for (auto * thread : thread_group->threads)
+        auto stats = thread_group->getProfileEventsCountersAndMemoryForThreads();
+        snapshots.reserve(stats.size());
+
+        for (auto & stat : stats)
         {
-            auto const thread_id = thread->thread_id;
+            auto const thread_id = stat.thread_id;
             if (thread_id == current_thread_id)
                 continue;
             auto current_time = time(nullptr);
-            auto counters = thread->performance_counters.getPartiallyAtomicSnapshot();
-            auto memory_usage = thread->memory_tracker.get();
             auto previous_snapshot = last_sent_snapshots.find(thread_id);
             auto increment =
                 previous_snapshot != last_sent_snapshots.end()
-                ? CountersIncrement(counters, previous_snapshot->second)
-                : CountersIncrement(counters);
+                ? CountersIncrement(stat.counters, previous_snapshot->second)
+                : CountersIncrement(stat.counters);
             snapshots.push_back(ProfileEventsSnapshot{
                 thread_id,
                 std::move(increment),
-                memory_usage,
+                stat.memory_usage,
                 current_time
             });
-            new_snapshots[thread_id] = std::move(counters);
+            new_snapshots[thread_id] = std::move(stat.counters);
         }
 
         group_snapshot.thread_id    = 0;

--- a/tests/queries/0_stateless/02050_client_profile_events.reference
+++ b/tests/queries/0_stateless/02050_client_profile_events.reference
@@ -1,4 +1,5 @@
 0
+100000
 SelectedRows: 131010 (increment)
 OK
 OK

--- a/tests/queries/0_stateless/02050_client_profile_events.reference
+++ b/tests/queries/0_stateless/02050_client_profile_events.reference
@@ -1,5 +1,5 @@
 0
 100000
-SelectedRows: 131010 (increment)
+[ 0 ] SelectedRows: 131010 (increment)
 OK
 OK

--- a/tests/queries/0_stateless/02050_client_profile_events.sh
+++ b/tests/queries/0_stateless/02050_client_profile_events.sh
@@ -6,8 +6,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # do not print any ProfileEvents packets
 $CLICKHOUSE_CLIENT -q 'select * from numbers(1e5) format Null' |& grep -c 'SelectedRows'
-# print only last
-$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -q 'select * from numbers(1e5) format Null' |& grep -o 'SelectedRows: .*$'
+# print only last (and also number of rows to provide more info in case of failures)
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -q 'select * from numbers(1e5)' 2> >(grep -o -e 'SelectedRows: .*$' -e Exception) 1> >(wc -l)
 # print everything
 profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
 test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"

--- a/tests/queries/0_stateless/02050_client_profile_events.sh
+++ b/tests/queries/0_stateless/02050_client_profile_events.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: long
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -10,6 +9,8 @@ $CLICKHOUSE_CLIENT -q 'select * from numbers(1e5) format Null' |& grep -c 'Selec
 # print only last
 $CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -q 'select * from numbers(1e5) format Null' |& grep -o 'SelectedRows: .*$'
 # print everything
-test "$($CLICKHOUSE_CLIENT --print-profile-events -q 'select * from numbers(1e9) format Null' |& grep -c 'SelectedRows')" -gt 1 && echo OK || echo FAIL
+profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
+test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"
 # print each 100 ms
-test "$($CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=100 -q 'select * from numbers(1e9) format Null' |& grep -c 'SelectedRows')" -gt 1 && echo OK || echo FAIL
+profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events --profile-events-delay-ms=100 -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
+test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"

--- a/tests/queries/0_stateless/02050_client_profile_events.sh
+++ b/tests/queries/0_stateless/02050_client_profile_events.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # do not print any ProfileEvents packets
 $CLICKHOUSE_CLIENT -q 'select * from numbers(1e5) format Null' |& grep -c 'SelectedRows'
 # print only last (and also number of rows to provide more info in case of failures)
-$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -q 'select * from numbers(1e5)' 2> >(grep -o -e 'SelectedRows: .*$' -e Exception) 1> >(wc -l)
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -q 'select * from numbers(1e5)' 2> >(grep -o -e '\[ 0 \] SelectedRows: .*$' -e Exception) 1> >(wc -l)
 # print everything
 profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
 test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"


### PR DESCRIPTION
Changelog:
- Do not loose ProfileEvents in case of thread destroyed before
- Merge ProfileEvents in case they were not printed

CI: https://s3.amazonaws.com/clickhouse-test-reports/32303/24751e7d45d94541be854c86ce46d65c2e0f66da/stateless_tests__thread__actions_.html

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @novikd 