### PR TITLE
Add test for clickhouse-client history navigation

### DIFF
--- a/tests/queries/0_stateless/02132_client_history_navigation.expect
+++ b/tests/queries/0_stateless/02132_client_history_navigation.expect
@@ -1,0 +1,33 @@
+#!/usr/bin/expect -f
+# Tags: no-fasttest
+
+log_user 0
+set timeout 3
+match_max 100000
+# A default timeout action is to do nothing, change it to fail
+expect_after {
+    timeout {
+        exit 1
+    }
+}
+
+# useful debugging configuration
+# exp_internal 1
+
+set basedir [file dirname $argv0]
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion --highlight 0"
+expect ":) "
+
+# Make a query
+send -- "SELECT 1\r"
+expect "1"
+expect ":) "
+send -- "SELECT 2"
+send -- "\033\[A"
+expect "SELECT 1"
+send -- "\033\[B"
+expect "SELECT 2"
+send -- "\r"
+expect "2"
+send -- "exit\r"
+expect eof


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add test for clickhouse-client history navigation. This closes https://github.com/ClickHouse/ClickHouse/issues/30686


Detailed description / Documentation draft:
.