### PR TITLE
Rename window-view function to time window function

### DIFF
--- a/docs/en/sql-reference/functions/time-window-functions.md
+++ b/docs/en/sql-reference/functions/time-window-functions.md
@@ -1,13 +1,13 @@
 ---
 toc_priority: 68
-toc_title: Window View
+toc_title: Time Window
 ---
 
-# Window View Functions {#window-view-functions}
+# Time Window Functions {#time-window-functions}
 
-Window view functions return the inclusive lower and exclusive upper bound of the corresponding window. The functions for working with WindowView are listed below:
+Time window functions return the inclusive lower and exclusive upper bound of the corresponding window. The functions for working with WindowView are listed below:
 
-## tumble {#window-view-functions-tumble}
+## tumble {#time-window-functions-tumble}
 
 A tumbling time window assigns records to non-overlapping, continuous windows with a fixed duration (`interval`). 
 
@@ -42,7 +42,7 @@ Result:
 └───────────────────────────────────────────────┘
 ```
 
-## hop {#window-view-functions-hop}
+## hop {#time-window-functions-hop}
 
 A hopping time window has a fixed duration (`window_interval`) and hops by a specified hop interval (`hop_interval`). If the `hop_interval` is smaller than the `window_interval`, hopping windows are overlapping. Thus, records can be assigned to multiple windows. 
 
@@ -79,7 +79,7 @@ Result:
 └───────────────────────────────────────────────────────────┘
 ```
 
-## tumbleStart {#window-view-functions-tumblestart}
+## tumbleStart {#time-window-functions-tumblestart}
 
 Returns the inclusive lower bound of the corresponding tumbling window.
 
@@ -87,7 +87,7 @@ Returns the inclusive lower bound of the corresponding tumbling window.
 tumbleStart(time_attr, interval [, timezone]);
 ```
 
-## tumbleEnd {#window-view-functions-tumbleend}
+## tumbleEnd {#time-window-functions-tumbleend}
 
 Returns the exclusive upper bound of the corresponding tumbling window.
 
@@ -95,7 +95,7 @@ Returns the exclusive upper bound of the corresponding tumbling window.
 tumbleEnd(time_attr, interval [, timezone]);
 ```
 
-## hopStart {#window-view-functions-hopstart}
+## hopStart {#time-window-functions-hopstart}
 
 Returns the inclusive lower bound of the corresponding hopping window.
 
@@ -103,7 +103,7 @@ Returns the inclusive lower bound of the corresponding hopping window.
 hopStart(time_attr, hop_interval, window_interval [, timezone]);
 ```
 
-## hopEnd {#window-view-functions-hopend}
+## hopEnd {#time-window-functions-hopend}
 
 Returns the exclusive upper bound of the corresponding hopping window.
 

--- a/docs/en/sql-reference/statements/create/view.md
+++ b/docs/en/sql-reference/statements/create/view.md
@@ -251,22 +251,22 @@ Most common uses of live view tables include:
     Enable usage of window views and `WATCH` query using [allow_experimental_window_view](../../../operations/settings/settings.md#allow-experimental-window-view) setting. Input the command `set allow_experimental_window_view = 1`.
 
 ``` sql
-CREATE WINDOW VIEW [IF NOT EXISTS] [db.]table_name [TO [db.]table_name] [ENGINE = engine] [WATERMARK = strategy] [ALLOWED_LATENESS = interval_function] AS SELECT ... GROUP BY window_view_function
+CREATE WINDOW VIEW [IF NOT EXISTS] [db.]table_name [TO [db.]table_name] [ENGINE = engine] [WATERMARK = strategy] [ALLOWED_LATENESS = interval_function] AS SELECT ... GROUP BY time_window_function
 ```
 
 Window view can aggregate data by time window and output the results when the window is ready to fire. It stores the partial aggregation results in an inner(or specified) table to reduce latency and can push the processing result to a specified table or push notifications using the WATCH query.
 
 Creating a window view is similar to creating `MATERIALIZED VIEW`. Window view needs an inner storage engine to store intermediate data. The inner storage will use `AggregatingMergeTree` as the default engine.
 
-### Window View Functions {#window-view-windowviewfunctions}
+### Time Window Functions {#window-view-timewindowfunctions}
 
-[Window view functions](../../functions/window-view-functions.md) are used to get the lower and upper window bound of records. The window view needs to be used with a window view function.
+[Time window functions](../../functions/time-window-functions.md) are used to get the lower and upper window bound of records. The window view needs to be used with a time window function.
 
 ### TIME ATTRIBUTES {#window-view-timeattributes}
 
 Window view supports **processing time** and **event time** process.
 
-**Processing time** allows window view to produce results based on the local machine's time and is used by default. It is the most straightforward notion of time but does not provide determinism. The processing time attribute can be defined by setting the `time_attr` of the window view function to a table column or using the function `now()`. The following query creates a window view with processing time.
+**Processing time** allows window view to produce results based on the local machine's time and is used by default. It is the most straightforward notion of time but does not provide determinism. The processing time attribute can be defined by setting the `time_attr` of the time window function to a table column or using the function `now()`. The following query creates a window view with processing time.
 
 ``` sql
 CREATE WINDOW VIEW wv AS SELECT count(number), tumbleStart(w_id) as w_start from date GROUP BY tumble(now(), INTERVAL '5' SECOND) as w_id

--- a/docs/zh/sql-reference/functions/time-window-functions.md
+++ b/docs/zh/sql-reference/functions/time-window-functions.md
@@ -1,13 +1,13 @@
 ---
 toc_priority: 68
-toc_title: Window View
+toc_title: 时间窗口
 ---
 
-# Window View 函数 {#window-view-han-shu}
+# 时间窗口函数 {#time-window-han-shu}
 
-Window view函数用于获取窗口的起始(包含边界)和结束时间(不包含边界)。系统支持的window view函数如下：
+时间窗口函数用于获取窗口的起始(包含边界)和结束时间(不包含边界)。系统支持的时间窗口函数如下：
 
-## tumble {#window-view-functions-tumble}
+## tumble {#time-window-functions-tumble}
 
 tumble窗口是连续的、不重叠的固定大小(`interval`)时间窗口。
 
@@ -42,7 +42,7 @@ SELECT tumble(now(), toIntervalDay('1'))
 └───────────────────────────────────────────────┘
 ```
 
-## hop {#window-view-functions-hop}
+## hop {#time-window-functions-hop}
 
 hop窗口是一个固定大小(`window_interval`)的时间窗口，并按照一个固定的滑动间隔(`hop_interval`)滑动。当滑动间隔小于窗口大小时，滑动窗口间存在重叠，此时一个数据可能存在于多个窗口。
 
@@ -79,7 +79,7 @@ SELECT hop(now(), INTERVAL '1' SECOND, INTERVAL '2' SECOND)
 └───────────────────────────────────────────────────────────┘
 ```
 
-## tumbleStart {#window-view-functions-tumblestart}
+## tumbleStart {#time-window-functions-tumblestart}
 
 返回tumble窗口的开始时间(包含边界)。
 
@@ -87,7 +87,7 @@ SELECT hop(now(), INTERVAL '1' SECOND, INTERVAL '2' SECOND)
 tumbleStart(time_attr, interval [, timezone]);
 ```
 
-## tumbleEnd {#window-view-functions-tumbleend}
+## tumbleEnd {#time-window-functions-tumbleend}
 
 返回tumble窗口的结束时间(不包含边界)。
 
@@ -95,7 +95,7 @@ tumbleStart(time_attr, interval [, timezone]);
 tumbleEnd(time_attr, interval [, timezone]);
 ```
 
-## hopStart {#window-view-functions-hopstart}
+## hopStart {#time-window-functions-hopstart}
 
 返回hop窗口的开始时间(包含边界)。
 
@@ -103,7 +103,7 @@ tumbleEnd(time_attr, interval [, timezone]);
 hopStart(time_attr, hop_interval, window_interval [, timezone]);
 ```
 
-## hopEnd {#window-view-functions-hopend}
+## hopEnd {#time-window-functions-hopend}
 
 返回hop窗口的结束时间(不包含边界)。
 

--- a/docs/zh/sql-reference/statements/create/view.md
+++ b/docs/zh/sql-reference/statements/create/view.md
@@ -250,28 +250,28 @@ Code: 60. DB::Exception: Received from localhost:9000. DB::Exception: Table defa
     `set allow_experimental_window_view = 1`。
 
 ``` sql
-CREATE WINDOW VIEW [IF NOT EXISTS] [db.]table_name [TO [db.]table_name] [ENGINE = engine] [WATERMARK = strategy] [ALLOWED_LATENESS = interval_function] AS SELECT ... GROUP BY window_view_function
+CREATE WINDOW VIEW [IF NOT EXISTS] [db.]table_name [TO [db.]table_name] [ENGINE = engine] [WATERMARK = strategy] [ALLOWED_LATENESS = interval_function] AS SELECT ... GROUP BY time_window_function
 ```
 
 Window view可以通过时间窗口聚合数据，并在满足窗口触发条件时自动触发对应窗口计算。其通过将计算状态保存降低处理延迟，支持将处理结果输出至目标表或通过`WATCH`语句输出至终端。
 
 创建window view的方式和创建物化视图类似。Window view使用默认为`AggregatingMergeTree`的内部存储引擎存储计算中间状态。
 
-### Window View 函数 {#window-view-han-shu}
+### 时间窗口函数 {#window-view-shi-jian-chuang-kou-han-shu}
 
-[Window view函数](../../functions/window-view-functions.md)用于获取窗口的起始和结束时间。Window view需要和window view函数配合使用。
+[时间窗口函数](../../functions/time-window-functions.md)用于获取窗口的起始和结束时间。Window view需要和时间窗口函数配合使用。
 
 ### 时间属性 {#window-view-shi-jian-shu-xing}
 
 Window view 支持**处理时间**和**事件时间**两种时间类型。
 
-**处理时间**为默认时间类型，该模式下window view使用本地机器时间计算窗口数据。“处理时间”时间类型计算简单，但具有不确定性。该模式下时间可以为window view函数的第一个参数`time_attr`，或通过函数`now()`使用当前机器时间。下面的例子展示了使用“处理时间”创建的window view的例子。
+**处理时间**为默认时间类型，该模式下window view使用本地机器时间计算窗口数据。“处理时间”时间类型计算简单，但具有不确定性。该模式下时间可以为时间窗口函数的第一个参数`time_attr`，或通过函数`now()`使用当前机器时间。下面的例子展示了使用“处理时间”创建window view的例子。
 
 ``` sql
 CREATE WINDOW VIEW wv AS SELECT count(number), tumbleStart(w_id) as w_start from date GROUP BY tumble(now(), INTERVAL '5' SECOND) as w_id
 ```
 
-**事件时间** 是事件真实发生的时间，该时间往往在事件发生时便嵌入数据记录。事件时间处理提供较高的确定性，可以处理乱序数据以及迟到数据。Window view 通过水位线(`WATERMARK`)启用事件时间处理。
+**事件时间** 是事件真实发生的时间，该时间往往在事件发生时便嵌入数据记录。事件时间处理提供较高的确定性，可以处理乱序数据以及迟到数据。Window view通过水位线(`WATERMARK`)启用事件时间处理。
 
 Window view提供如下三种水位线策略：
 

--- a/src/Functions/FunctionsTimeWindow.cpp
+++ b/src/Functions/FunctionsTimeWindow.cpp
@@ -638,13 +638,13 @@ struct TimeWindowImpl<HOP_END>
     }
 };
 
-template <WindowFunctionName type>
+template <TimeWindowFunctionName type>
 DataTypePtr FunctionTimeWindow<type>::getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const
 {
     return TimeWindowImpl<type>::getReturnType(arguments, name);
 }
 
-template <WindowFunctionName type>
+template <TimeWindowFunctionName type>
 ColumnPtr FunctionTimeWindow<type>::executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const
 {
     return TimeWindowImpl<type>::dispatchForColumns(arguments, name);

--- a/src/Functions/FunctionsTimeWindow.cpp
+++ b/src/Functions/FunctionsTimeWindow.cpp
@@ -9,7 +9,7 @@
 #include <Functions/extractTimeZoneFromFunctionArguments.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
-#include <Functions/FunctionsWindow.h>
+#include <Functions/FunctionsTimeWindow.h>
 
 namespace DB
 {
@@ -114,7 +114,7 @@ namespace
 }
 
 template <>
-struct WindowImpl<TUMBLE>
+struct TimeWindowImpl<TUMBLE>
 {
     static constexpr auto name = "tumble";
 
@@ -211,7 +211,7 @@ struct WindowImpl<TUMBLE>
 };
 
 template <>
-struct WindowImpl<TUMBLE_START>
+struct TimeWindowImpl<TUMBLE_START>
 {
     static constexpr auto name = "tumbleStart";
 
@@ -231,7 +231,7 @@ struct WindowImpl<TUMBLE_START>
         }
         else
         {
-            return std::static_pointer_cast<const DataTypeTuple>(WindowImpl<TUMBLE>::getReturnType(arguments, function_name))
+            return std::static_pointer_cast<const DataTypeTuple>(TimeWindowImpl<TUMBLE>::getReturnType(arguments, function_name))
                 ->getElement(0);
         }
     }
@@ -249,19 +249,19 @@ struct WindowImpl<TUMBLE_START>
                 result_column = time_column.column;
         }
         else
-            result_column = WindowImpl<TUMBLE>::dispatchForColumns(arguments, function_name);
+            result_column = TimeWindowImpl<TUMBLE>::dispatchForColumns(arguments, function_name);
         return executeWindowBound(result_column, 0, function_name);
     }
 };
 
 template <>
-struct WindowImpl<TUMBLE_END>
+struct TimeWindowImpl<TUMBLE_END>
 {
     static constexpr auto name = "tumbleEnd";
 
     [[maybe_unused]] static DataTypePtr getReturnType(const ColumnsWithTypeAndName & arguments, const String & function_name)
     {
-        return WindowImpl<TUMBLE_START>::getReturnType(arguments, function_name);
+        return TimeWindowImpl<TUMBLE_START>::getReturnType(arguments, function_name);
     }
 
     [[maybe_unused]] static ColumnPtr dispatchForColumns(const ColumnsWithTypeAndName & arguments, const String& function_name)
@@ -277,13 +277,13 @@ struct WindowImpl<TUMBLE_END>
                 result_column = time_column.column;
         }
         else
-            result_column = WindowImpl<TUMBLE>::dispatchForColumns(arguments, function_name);
+            result_column = TimeWindowImpl<TUMBLE>::dispatchForColumns(arguments, function_name);
         return executeWindowBound(result_column, 1, function_name);
     }
 };
 
 template <>
-struct WindowImpl<HOP>
+struct TimeWindowImpl<HOP>
 {
     static constexpr auto name = "hop";
 
@@ -415,7 +415,7 @@ struct WindowImpl<HOP>
 };
 
 template <>
-struct WindowImpl<WINDOW_ID>
+struct TimeWindowImpl<WINDOW_ID>
 {
     static constexpr auto name = "windowID";
 
@@ -547,7 +547,7 @@ struct WindowImpl<WINDOW_ID>
     [[maybe_unused]] static ColumnPtr
     dispatchForTumbleColumns(const ColumnsWithTypeAndName & arguments, const String & function_name)
     {
-        ColumnPtr column = WindowImpl<TUMBLE>::dispatchForColumns(arguments, function_name);
+        ColumnPtr column = TimeWindowImpl<TUMBLE>::dispatchForColumns(arguments, function_name);
         return executeWindowBound(column, 1, function_name);
     }
 
@@ -567,7 +567,7 @@ struct WindowImpl<WINDOW_ID>
 };
 
 template <>
-struct WindowImpl<HOP_START>
+struct TimeWindowImpl<HOP_START>
 {
     static constexpr auto name = "hopStart";
 
@@ -587,7 +587,7 @@ struct WindowImpl<HOP_START>
         }
         else
         {
-            return std::static_pointer_cast<const DataTypeTuple>(WindowImpl<HOP>::getReturnType(arguments, function_name))->getElement(0);
+            return std::static_pointer_cast<const DataTypeTuple>(TimeWindowImpl<HOP>::getReturnType(arguments, function_name))->getElement(0);
         }
     }
 
@@ -604,19 +604,19 @@ struct WindowImpl<HOP_START>
                 result_column = time_column.column;
         }
         else
-            result_column = WindowImpl<HOP>::dispatchForColumns(arguments, function_name);
+            result_column = TimeWindowImpl<HOP>::dispatchForColumns(arguments, function_name);
         return executeWindowBound(result_column, 0, function_name);
     }
 };
 
 template <>
-struct WindowImpl<HOP_END>
+struct TimeWindowImpl<HOP_END>
 {
     static constexpr auto name = "hopEnd";
 
     [[maybe_unused]] static DataTypePtr getReturnType(const ColumnsWithTypeAndName & arguments, const String & function_name)
     {
-        return WindowImpl<HOP_START>::getReturnType(arguments, function_name);
+        return TimeWindowImpl<HOP_START>::getReturnType(arguments, function_name);
     }
 
     [[maybe_unused]] static ColumnPtr dispatchForColumns(const ColumnsWithTypeAndName & arguments, const String & function_name)
@@ -632,25 +632,25 @@ struct WindowImpl<HOP_END>
                 result_column = time_column.column;
         }
         else
-            result_column = WindowImpl<HOP>::dispatchForColumns(arguments, function_name);
+            result_column = TimeWindowImpl<HOP>::dispatchForColumns(arguments, function_name);
 
         return executeWindowBound(result_column, 1, function_name);
     }
 };
 
 template <WindowFunctionName type>
-DataTypePtr FunctionWindow<type>::getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const
+DataTypePtr FunctionTimeWindow<type>::getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const
 {
-    return WindowImpl<type>::getReturnType(arguments, name);
+    return TimeWindowImpl<type>::getReturnType(arguments, name);
 }
 
 template <WindowFunctionName type>
-ColumnPtr FunctionWindow<type>::executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const
+ColumnPtr FunctionTimeWindow<type>::executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const
 {
-    return WindowImpl<type>::dispatchForColumns(arguments, name);
+    return TimeWindowImpl<type>::dispatchForColumns(arguments, name);
 }
 
-void registerFunctionsWindow(FunctionFactory& factory)
+void registerFunctionsTimeWindow(FunctionFactory& factory)
 {
     factory.registerFunction<FunctionTumble>();
     factory.registerFunction<FunctionHop>();

--- a/src/Functions/FunctionsTimeWindow.h
+++ b/src/Functions/FunctionsTimeWindow.h
@@ -30,7 +30,7 @@ namespace DB
   * hopEnd(time_attr, hop_interval, window_interval [, timezone])
   *
   */
-enum WindowFunctionName
+enum TimeWindowFunctionName
 {
     TUMBLE,
     TUMBLE_START,
@@ -117,7 +117,7 @@ struct ToStartOfTransform;
     ADD_TIME(Second, 1)
 #undef ADD_TIME
 
-template <WindowFunctionName type>
+template <TimeWindowFunctionName type>
 struct TimeWindowImpl
 {
     static constexpr auto name = "UNKNOWN";
@@ -127,7 +127,7 @@ struct TimeWindowImpl
     static ColumnPtr dispatchForColumns(const ColumnsWithTypeAndName & arguments, const String & function_name);
 };
 
-template <WindowFunctionName type>
+template <TimeWindowFunctionName type>
 class FunctionTimeWindow : public IFunction
 {
 public:

--- a/src/Functions/FunctionsTimeWindow.h
+++ b/src/Functions/FunctionsTimeWindow.h
@@ -7,7 +7,7 @@
 namespace DB
 {
 
-/** Window functions:
+/** Time window functions:
   *
   * tumble(time_attr, interval [, timezone])
   *
@@ -118,7 +118,7 @@ struct ToStartOfTransform;
 #undef ADD_TIME
 
 template <WindowFunctionName type>
-struct WindowImpl
+struct TimeWindowImpl
 {
     static constexpr auto name = "UNKNOWN";
 
@@ -128,11 +128,11 @@ struct WindowImpl
 };
 
 template <WindowFunctionName type>
-class FunctionWindow : public IFunction
+class FunctionTimeWindow : public IFunction
 {
 public:
-    static constexpr auto name = WindowImpl<type>::name;
-    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionWindow>(); }
+    static constexpr auto name = TimeWindowImpl<type>::name;
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionTimeWindow>(); }
     String getName() const override { return name; }
     bool isVariadic() const override { return true; }
     size_t getNumberOfArguments() const override { return 0; }
@@ -145,11 +145,11 @@ public:
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const override;
 };
 
-using FunctionTumble = FunctionWindow<TUMBLE>;
-using FunctionTumbleStart = FunctionWindow<TUMBLE_START>;
-using FunctionTumbleEnd = FunctionWindow<TUMBLE_END>;
-using FunctionHop = FunctionWindow<HOP>;
-using FunctionWindowId = FunctionWindow<WINDOW_ID>;
-using FunctionHopStart = FunctionWindow<HOP_START>;
-using FunctionHopEnd = FunctionWindow<HOP_END>;
+using FunctionTumble = FunctionTimeWindow<TUMBLE>;
+using FunctionTumbleStart = FunctionTimeWindow<TUMBLE_START>;
+using FunctionTumbleEnd = FunctionTimeWindow<TUMBLE_END>;
+using FunctionHop = FunctionTimeWindow<HOP>;
+using FunctionWindowId = FunctionTimeWindow<WINDOW_ID>;
+using FunctionHopStart = FunctionTimeWindow<HOP_START>;
+using FunctionHopEnd = FunctionTimeWindow<HOP_END>;
 }

--- a/src/Functions/registerFunctions.cpp
+++ b/src/Functions/registerFunctions.cpp
@@ -54,7 +54,7 @@ void registerFunctionValidateNestedArraySizes(FunctionFactory & factory);
 void registerFunctionsSnowflake(FunctionFactory & factory);
 void registerFunctionTid(FunctionFactory & factory);
 void registerFunctionLogTrace(FunctionFactory & factory);
-void registerFunctionsWindow(FunctionFactory &);
+void registerFunctionsTimeWindow(FunctionFactory &);
 
 #if USE_SSL
 void registerFunctionEncrypt(FunctionFactory & factory);
@@ -115,7 +115,7 @@ void registerFunctions()
     registerFunctionsStringHash(factory);
     registerFunctionValidateNestedArraySizes(factory);
     registerFunctionsSnowflake(factory);
-    registerFunctionsWindow(factory);
+    registerFunctionsTimeWindow(factory);
 
 #if USE_SSL
     registerFunctionEncrypt(factory);

--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -4,7 +4,7 @@
 #include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionFactory.h>
-#include <Functions/FunctionsWindow.h>
+#include <Functions/FunctionsTimeWindow.h>
 #include <Interpreters/AddDefaultDatabaseVisitor.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/InDepthNodeVisitor.h>
@@ -93,7 +93,7 @@ namespace
                     temp_node->setAlias("");
                     if (startsWith(t->arguments->children[0]->getColumnName(), "toDateTime"))
                         throw Exception(
-                            "The first argument of window function should not be a constant value.",
+                            "The first argument of time window function should not be a constant value.",
                             ErrorCodes::QUERY_IS_NOT_SUPPORTED_IN_WINDOW_VIEW);
                     if (!data.window_function)
                     {
@@ -108,7 +108,7 @@ namespace
                     else
                     {
                         if (serializeAST(*temp_node) != data.serialized_window_function)
-                            throw Exception("WINDOW VIEW only support ONE WINDOW FUNCTION", ErrorCodes::QUERY_IS_NOT_SUPPORTED_IN_WINDOW_VIEW);
+                            throw Exception("WINDOW VIEW only support ONE TIME WINDOW FUNCTION", ErrorCodes::QUERY_IS_NOT_SUPPORTED_IN_WINDOW_VIEW);
                         t->name = "windowID";
                     }
                 }
@@ -1042,14 +1042,14 @@ ASTPtr StorageWindowView::innerQueryParser(const ASTSelectQuery & query)
 
     if (!query_info_data.is_tumble && !query_info_data.is_hop)
         throw Exception(ErrorCodes::INCORRECT_QUERY,
-                        "WINDOW FUNCTION is not specified for {}", getName());
+                        "TIME WINDOW FUNCTION is not specified for {}", getName());
 
     window_id_name = query_info_data.window_id_name;
     window_id_alias = query_info_data.window_id_alias;
     timestamp_column_name = query_info_data.timestamp_column_name;
     is_tumble = query_info_data.is_tumble;
 
-    // Parse window function
+    // Parse time window function
     ASTFunction & window_function = typeid_cast<ASTFunction &>(*query_info_data.window_function);
     const auto & arguments = window_function.arguments->children;
     extractWindowArgument(

--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -116,7 +116,7 @@ namespace
         }
     };
 
-    /// Replace windowID node name with either tumble or hop.
+    /// Replace windowID node name with either tumble or hop
     struct ReplaceWindowIdMatcher
     {
     public:


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

This PR renaming `window-view function` to `time window function` because window-view functions are used to aggregate data by time.  The naming away from the window view also means that the window-view function does not need to be used with the window view.

e.g. use tumble function in a table for batch processing (`SELECT * FROM * GROUP BY tumble()`. (But it is meaningless to use the hop function without the window view)