### PR TITLE
Handle const column in JoinCommon::removeColumnNullability

### DIFF
--- a/src/Interpreters/join_common.cpp
+++ b/src/Interpreters/join_common.cpp
@@ -225,7 +225,13 @@ void removeColumnNullability(ColumnWithTypeAndName & column)
 
         if (column.column && column.column->isNullable())
         {
+            column.column = column.column->convertToFullColumnIfConst();
             const auto * nullable_col = checkAndGetColumn<ColumnNullable>(*column.column);
+            if (!nullable_col)
+            {
+                throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "Column '{}' is expected to be nullable", column.dumpStructure());
+            }
+
             MutableColumnPtr mutable_column = nullable_col->getNestedColumn().cloneEmpty();
             insertFromNullableOrDefault(mutable_column, nullable_col);
             column.column = std::move(mutable_column);

--- a/tests/queries/0_stateless/02133_issue_32458.sql
+++ b/tests/queries/0_stateless/02133_issue_32458.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+
+CREATE TABLE t1 (`id` Int32, `key` String) ENGINE = Memory;
+CREATE TABLE t2 (`id` Int32, `key` String) ENGINE = Memory;
+
+INSERT INTO t1 VALUES (0, '');
+INSERT INTO t2 VALUES (0, '');
+
+SELECT * FROM t1 ANY INNER JOIN t2 ON ((NULL = t1.key) = t2.id) AND (('' = t1.key) = t2.id);
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash in `JoinCommon::removeColumnNullability`, close #32458
