### PR TITLE
clickhouse-test: use basename of the test for *.sh tests

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -564,7 +564,7 @@ class TestCase:
         database = args.testcase_database
 
         # This is for .sh tests
-        os.environ["CLICKHOUSE_LOG_COMMENT"] = self.case_file
+        os.environ["CLICKHOUSE_LOG_COMMENT"] = args.testcase_basename
 
         params = {
             'client': client + ' --database=' + database,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)