### PR TITLE
Fix processing initial table (--table/stdin) in clickhouse-local

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -388,12 +388,6 @@ void LocalServer::setupUsers()
 }
 
 
-String LocalServer::getQueryTextPrefix()
-{
-    return getInitialCreateTableQuery();
-}
-
-
 void LocalServer::connect()
 {
     connection_parameters = ConnectionParameters(config());
@@ -462,6 +456,10 @@ try
     first_time = false;
     }
 #endif
+
+    String initial_query = getInitialCreateTableQuery();
+    if (!initial_query.empty())
+        processQueryText(initial_query);
 
     if (is_interactive && !delayed_interactive)
     {

--- a/programs/local/LocalServer.h
+++ b/programs/local/LocalServer.h
@@ -37,7 +37,6 @@ protected:
     void processError(const String & query) const override;
     String getName() const override { return "local"; }
 
-    String getQueryTextPrefix() override;
     void printHelpMessage(const OptionsDescription & options_description) override;
 
     void addOptions(OptionsDescription & options_description) override;

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1494,17 +1494,14 @@ void ClientBase::runNonInteractive()
     {
         auto process_multi_query_from_file = [&](const String & file)
         {
-            auto text = getQueryTextPrefix();
             String queries_from_file;
 
             ReadBufferFromFile in(file);
             readStringUntilEOF(queries_from_file, in);
 
-            text += queries_from_file;
-            return executeMultiQuery(text);
+            return executeMultiQuery(queries_from_file);
         };
 
-        /// Read all queries into `text`.
         for (const auto & queries_file : queries_files)
         {
             for (const auto & interleave_file : interleave_queries_files)
@@ -1519,9 +1516,6 @@ void ClientBase::runNonInteractive()
     }
 
     String text;
-    if (is_multiquery)
-        text = getQueryTextPrefix();
-
     if (config().has("query"))
     {
         text += config().getRawString("query"); /// Poco configuration should not process substitutions in form of ${...} inside query.

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -78,9 +78,6 @@ protected:
         String & query_to_execute, ASTPtr & parsed_query, const String & all_queries_text,
         std::optional<Exception> & current_exception);
 
-    /// For non-interactive multi-query mode get queries text prefix.
-    virtual String getQueryTextPrefix() { return ""; }
-
     static void clearTerminal();
     void showClientVersion();
 
@@ -100,9 +97,10 @@ protected:
                                 const std::vector<Arguments> & external_tables_arguments) = 0;
     virtual void processConfig() = 0;
 
-private:
+protected:
     bool processQueryText(const String & text);
 
+private:
     void receiveResult(ASTPtr parsed_query);
     bool receiveAndProcessPacket(ASTPtr parsed_query, bool cancelled);
     void receiveLogs(ASTPtr parsed_query);

--- a/tests/queries/0_stateless/02140_clickhouse_local_queries_file_table.sh
+++ b/tests/queries/0_stateless/02140_clickhouse_local_queries_file_table.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_LOCAL --file /dev/null --structure "key String" --input-format TSVWithNamesAndTypes --queries-file <(echo 'select 1') --queries-file <(echo 'select 2') --format Null

--- a/tests/queries/0_stateless/02141_clickhouse_local_interactive_table.reference
+++ b/tests/queries/0_stateless/02141_clickhouse_local_interactive_table.reference
@@ -1,0 +1,1 @@
+CREATE TABLE _local.table\n(\n    `key` String\n)\nENGINE = File(\'TSVWithNamesAndTypes\', \'/dev/null\')

--- a/tests/queries/0_stateless/02141_clickhouse_local_interactive_table.sh
+++ b/tests/queries/0_stateless/02141_clickhouse_local_interactive_table.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_LOCAL --file /dev/null --structure "key String" --input-format TSVWithNamesAndTypes --interactive --send_logs_level=trace <<<'show create table table'


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix processing initial table (--table/stdin) in clickhouse-local

Detailed description / Documentation draft:
This patch will:
- fix the issue when table had been tried to create multiple times for
  --queries-files
- create these table for --interactive mode (before it works only if you
  had some queries already, i.e. when it run interactive after
  non-interactive)

This will also make ClientBase interface a little bit cleaner, by
removing one abstract method getQueryTextPrefix()

Cc: @kssenii 