### PR TITLE
[RFC] perf: do not fail in case of slow queries (to avoid hiding possible issues)

### DIFF
--- a/docker/test/performance-comparison/perf.py
+++ b/docker/test/performance-comparison/perf.py
@@ -354,11 +354,9 @@ for query_index in queries_to_run:
             print(f'query\t{query_index}\t{run_id}\t{conn_index}\t{elapsed}')
 
             if elapsed > args.max_query_seconds:
-                # Stop processing pathologically slow queries, to avoid timing out
-                # the entire test task. This shouldn't really happen, so we don't
-                # need much handling for this case and can just exit.
+                # Do not stop processing pathologically slow queries,
+                # since this may hide errors in other queries.
                 print(f'The query no. {query_index} is taking too long to run ({elapsed} s)', file=sys.stderr)
-                exit(2)
 
         # Be careful with the counter, after this line it's the next iteration
         # already.


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Do not stop processing pathologically slow queries,
since this may hide errors in other queries,
i.e. when the test failed on one of servers (upstream or from PR)
and someone interpret this is as OK with the following comment:

>  "the failure was on the upstream server it is OK, PR should fix it"

Anyway there is almost zero such queries right now, and before merging
something this should be reviewed.
