### PR TITLE
Slight performance improvement of "reinterpret" function

### DIFF
--- a/src/Functions/reinterpretAs.cpp
+++ b/src/Functions/reinterpretAs.cpp
@@ -24,6 +24,7 @@
 
 #include <base/unaligned.h>
 
+
 namespace DB
 {
 namespace ErrorCodes
@@ -174,16 +175,14 @@ public:
                     const auto & offsets_from = col_from->getOffsets();
                     size_t size = offsets_from.size();
                     auto & vec_res = col_res->getData();
-                    vec_res.resize(size);
+                    vec_res.resize_fill(size);
 
                     size_t offset = 0;
                     for (size_t i = 0; i < size; ++i)
                     {
-                        ToFieldType value{};
-                        memcpy(&value,
+                        memcpy(&vec_res[i],
                             &data_from[offset],
                             std::min(static_cast<UInt64>(sizeof(ToFieldType)), offsets_from[i] - offset - 1));
-                        vec_res[i] = value;
                         offset = offsets_from[i];
                     }
 
@@ -201,15 +200,18 @@ public:
                     size_t step = col_from_fixed->getN();
                     size_t size = data_from.size() / step;
                     auto & vec_res = col_res->getData();
-                    vec_res.resize(size);
 
                     size_t offset = 0;
                     size_t copy_size = std::min(step, sizeof(ToFieldType));
+
+                    if (sizeof(ToFieldType) <= step)
+                        vec_res.resize(size);
+                    else
+                        vec_res.resize_fill(size);
+
                     for (size_t i = 0; i < size; ++i)
                     {
-                        ToFieldType value{};
-                        memcpy(&value, &data_from[offset], copy_size);
-                        vec_res[i] = value;
+                        memcpy(&vec_res[i], &data_from[offset], copy_size);
                         offset += step;
                     }
 
@@ -288,7 +290,7 @@ private:
         {
             StringRef data = src.getDataAt(i);
 
-            std::memcpy(&data_to[offset], data.data, std::min(n, data.size));
+            memcpy(&data_to[offset], data.data, std::min(n, data.size));
             offset += n;
         }
     }
@@ -347,9 +349,12 @@ private:
         using To = typename ToContainer::value_type;
 
         size_t size = from.size();
-        to.resize_fill(size);
-
         static constexpr size_t copy_size = std::min(sizeof(From), sizeof(To));
+
+        if (sizeof(To) <= sizeof(From))
+            to.resize(size);
+        else
+            to.resize_fill(size);
 
         for (size_t i = 0; i < size; ++i)
             memcpy(static_cast<void*>(&to[i]), static_cast<const void*>(&from[i]), copy_size);


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Slight performance improvement of `reinterpret` function.


Detailed description / Documentation draft:

Was:

```
localhost:9000, queries 24, QPS: 2.068, RPS: 413693233.016, MiB/s: 3156.229, result RPS: 0.000, result MiB/s: 0.000.

0.000%          0.452 sec.
10.000%         0.458 sec.
20.000%         0.460 sec.
30.000%         0.463 sec.
40.000%         0.470 sec.
50.000%         0.480 sec.
60.000%         0.484 sec.
70.000%         0.495 sec.
80.000%         0.513 sec.
90.000%         0.521 sec.
95.000%         0.527 sec.
99.000%         0.536 sec.
99.900%         0.536 sec.
99.990%         0.536 sec.
```

Now:

```
localhost:9000, queries 34, QPS: 2.122, RPS: 424415529.072, MiB/s: 3238.034, result RPS: 0.000, result MiB/s: 0.000.

0.000%          0.405 sec.
10.000%         0.435 sec.
20.000%         0.450 sec.
30.000%         0.455 sec.
40.000%         0.464 sec.
50.000%         0.471 sec.
60.000%         0.478 sec.
70.000%         0.488 sec.
80.000%         0.495 sec.
90.000%         0.505 sec.
95.000%         0.519 sec.
99.000%         0.531 sec.
99.900%         0.531 sec.
99.990%         0.531 sec.
```