### PR TITLE
Fix perf test `reinterpret_as`

### DIFF
--- a/tests/performance/reinterpret_as.xml
+++ b/tests/performance/reinterpret_as.xml
@@ -191,7 +191,7 @@
             toInt256(number) as d,
             toString(number) as f,
             toFixedString(f, 20) as g
-        FROM numbers_mt(200000000)
+        FROM numbers_mt(100000000)
         SETTINGS max_threads = 8
         FORMAT Null
     </query>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
