### PR TITLE
Improve exceptions usage in access control

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -30,6 +30,7 @@ namespace ErrorCodes
 {
     extern const int UNKNOWN_ELEMENT_IN_CONFIG;
     extern const int UNKNOWN_SETTING;
+    extern const int AUTHENTICATION_FAILED;
 }
 
 
@@ -393,7 +394,18 @@ void AccessControl::addStoragesFromMainConfig(
 
 UUID AccessControl::authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address) const
 {
-    return MultipleAccessStorage::authenticate(credentials, address, *external_authenticators);
+    try
+    {
+        return MultipleAccessStorage::authenticate(credentials, address, *external_authenticators);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(getLogger(), "from: " + address.toString() + ", user: " + credentials.getUserName()  + ": Authentication failed");
+
+        /// We use the same message for all authentication failures because we don't want to give away any unnecessary information for security reasons,
+        /// only the log will show the exact reason.
+        throw Exception(credentials.getUserName() + ": Authentication failed: password is incorrect or there is no user with such name", ErrorCodes::AUTHENTICATION_FAILED);
+    }
 }
 
 void AccessControl::setExternalAuthenticatorsConfig(const Poco::Util::AbstractConfiguration & config)

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -391,9 +391,9 @@ void AccessControl::addStoragesFromMainConfig(
 }
 
 
-UUID AccessControl::login(const Credentials & credentials, const Poco::Net::IPAddress & address) const
+UUID AccessControl::authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address) const
 {
-    return MultipleAccessStorage::login(credentials, address, *external_authenticators);
+    return MultipleAccessStorage::authenticate(credentials, address, *external_authenticators);
 }
 
 void AccessControl::setExternalAuthenticatorsConfig(const Poco::Util::AbstractConfiguration & config)

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -112,7 +112,7 @@ public:
     bool isSettingNameAllowed(const std::string_view & name) const;
     void checkSettingNameIsAllowed(const std::string_view & name) const;
 
-    UUID login(const Credentials & credentials, const Poco::Net::IPAddress & address) const;
+    UUID authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address) const;
     void setExternalAuthenticatorsConfig(const Poco::Util::AbstractConfiguration & config);
 
     std::shared_ptr<const ContextAccess> getContextAccess(

--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -457,12 +457,6 @@ String DiskAccessStorage::readNameImpl(const UUID & id) const
 }
 
 
-bool DiskAccessStorage::canInsertImpl(const AccessEntityPtr &) const
-{
-    return !readonly;
-}
-
-
 UUID DiskAccessStorage::insertImpl(const AccessEntityPtr & new_entity, bool replace_if_exists)
 {
     Notifications notifications;

--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -426,7 +426,7 @@ std::vector<UUID> DiskAccessStorage::findAllImpl(AccessEntityType type) const
     return res;
 }
 
-bool DiskAccessStorage::existsImpl(const UUID & id) const
+bool DiskAccessStorage::exists(const UUID & id) const
 {
     std::lock_guard lock{mutex};
     return entries_by_id.count(id);
@@ -675,7 +675,7 @@ scope_guard DiskAccessStorage::subscribeForChangesImpl(AccessEntityType type, co
     };
 }
 
-bool DiskAccessStorage::hasSubscriptionImpl(const UUID & id) const
+bool DiskAccessStorage::hasSubscription(const UUID & id) const
 {
     std::lock_guard lock{mutex};
     auto it = entries_by_id.find(id);
@@ -687,7 +687,7 @@ bool DiskAccessStorage::hasSubscriptionImpl(const UUID & id) const
     return false;
 }
 
-bool DiskAccessStorage::hasSubscriptionImpl(AccessEntityType type) const
+bool DiskAccessStorage::hasSubscription(AccessEntityType type) const
 {
     std::lock_guard lock{mutex};
     const auto & handlers = handlers_by_type[static_cast<size_t>(type)];

--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -486,10 +486,10 @@ bool DiskAccessStorage::insertNoLock(const UUID & id, const AccessEntityPtr & ne
     const String & name = new_entity->getName();
     AccessEntityType type = new_entity->getType();
 
+    /// Check that we can insert.
     if (readonly)
         throwReadonlyCannotInsert(type, name);
 
-    /// Check that we can insert.
     auto & entries_by_name = entries_by_name_and_type[static_cast<size_t>(type)];
     auto it_by_name = entries_by_name.find(name);
     bool name_collision = (it_by_name != entries_by_name.end());
@@ -590,6 +590,7 @@ bool DiskAccessStorage::updateNoLock(const UUID & id, const UpdateFunc & update_
     Entry & entry = it->second;
     if (readonly)
         throwReadonlyCannotUpdate(entry.type, entry.name);
+
     if (!entry.entity)
         entry.entity = readAccessEntityFromDisk(id);
     auto old_entity = entry.entity;

--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -433,12 +433,17 @@ bool DiskAccessStorage::exists(const UUID & id) const
 }
 
 
-AccessEntityPtr DiskAccessStorage::readImpl(const UUID & id) const
+AccessEntityPtr DiskAccessStorage::readImpl(const UUID & id, bool throw_if_not_exists) const
 {
     std::lock_guard lock{mutex};
     auto it = entries_by_id.find(id);
     if (it == entries_by_id.end())
-        throwNotFound(id);
+    {
+        if (throw_if_not_exists)
+            throwNotFound(id);
+        else
+            return nullptr;
+    }
 
     const auto & entry = it->second;
     if (!entry.entity)
@@ -447,13 +452,18 @@ AccessEntityPtr DiskAccessStorage::readImpl(const UUID & id) const
 }
 
 
-String DiskAccessStorage::readNameImpl(const UUID & id) const
+std::optional<String> DiskAccessStorage::readNameImpl(const UUID & id, bool throw_if_not_exists) const
 {
     std::lock_guard lock{mutex};
     auto it = entries_by_id.find(id);
     if (it == entries_by_id.end())
-        throwNotFound(id);
-    return String{it->second.name};
+    {
+        if (throw_if_not_exists)
+            throwNotFound(id);
+        else
+            return std::nullopt;
+    }
+    return it->second.name;
 }
 
 

--- a/src/Access/DiskAccessStorage.h
+++ b/src/Access/DiskAccessStorage.h
@@ -33,8 +33,8 @@ public:
 private:
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    AccessEntityPtr readImpl(const UUID & id) const override;
-    String readNameImpl(const UUID & id) const override;
+    AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
+    std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/DiskAccessStorage.h
+++ b/src/Access/DiskAccessStorage.h
@@ -24,7 +24,7 @@ public:
     bool isPathEqual(const String & directory_path_) const;
 
     void setReadOnly(bool readonly_) { readonly = readonly_; }
-    bool isReadOnly() const { return readonly; }
+    bool isReadOnly() const override { return readonly; }
 
     bool exists(const UUID & id) const override;
     bool hasSubscription(const UUID & id) const override;
@@ -35,7 +35,6 @@ private:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID & id) const override;
-    bool canInsertImpl(const AccessEntityPtr & entity) const override;
     UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/DiskAccessStorage.h
+++ b/src/Access/DiskAccessStorage.h
@@ -37,7 +37,7 @@ private:
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
-    void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
+    bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
 
@@ -52,7 +52,7 @@ private:
 
     bool insertNoLock(const UUID & id, const AccessEntityPtr & new_entity, bool replace_if_exists, bool throw_if_exists, Notifications & notifications);
     bool removeNoLock(const UUID & id, bool throw_if_not_exists, Notifications & notifications);
-    void updateNoLock(const UUID & id, const UpdateFunc & update_func, Notifications & notifications);
+    bool updateNoLock(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists, Notifications & notifications);
 
     AccessEntityPtr readAccessEntityFromDisk(const UUID & id) const;
     void writeAccessEntityToDisk(const UUID & id, const IAccessEntity & entity) const;

--- a/src/Access/DiskAccessStorage.h
+++ b/src/Access/DiskAccessStorage.h
@@ -36,7 +36,7 @@ private:
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
-    void removeImpl(const UUID & id) override;
+    bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
@@ -51,7 +51,7 @@ private:
     void stopListsWritingThread();
 
     bool insertNoLock(const UUID & id, const AccessEntityPtr & new_entity, bool replace_if_exists, bool throw_if_exists, Notifications & notifications);
-    void removeNoLock(const UUID & id, Notifications & notifications);
+    bool removeNoLock(const UUID & id, bool throw_if_not_exists, Notifications & notifications);
     void updateNoLock(const UUID & id, const UpdateFunc & update_func, Notifications & notifications);
 
     AccessEntityPtr readAccessEntityFromDisk(const UUID & id) const;

--- a/src/Access/DiskAccessStorage.h
+++ b/src/Access/DiskAccessStorage.h
@@ -35,7 +35,7 @@ private:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
-    UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
+    std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
@@ -50,7 +50,7 @@ private:
     void listsWritingThreadFunc();
     void stopListsWritingThread();
 
-    void insertNoLock(const UUID & id, const AccessEntityPtr & new_entity, bool replace_if_exists, Notifications & notifications);
+    bool insertNoLock(const UUID & id, const AccessEntityPtr & new_entity, bool replace_if_exists, bool throw_if_exists, Notifications & notifications);
     void removeNoLock(const UUID & id, Notifications & notifications);
     void updateNoLock(const UUID & id, const UpdateFunc & update_func, Notifications & notifications);
 

--- a/src/Access/DiskAccessStorage.h
+++ b/src/Access/DiskAccessStorage.h
@@ -26,10 +26,13 @@ public:
     void setReadOnly(bool readonly_) { readonly = readonly_; }
     bool isReadOnly() const { return readonly; }
 
+    bool exists(const UUID & id) const override;
+    bool hasSubscription(const UUID & id) const override;
+    bool hasSubscription(AccessEntityType type) const override;
+
 private:
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    bool existsImpl(const UUID & id) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID & id) const override;
     bool canInsertImpl(const AccessEntityPtr & entity) const override;
@@ -38,8 +41,6 @@ private:
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
-    bool hasSubscriptionImpl(const UUID & id) const override;
-    bool hasSubscriptionImpl(AccessEntityType type) const override;
 
     void clear();
     bool readLists();

--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -504,18 +504,6 @@ bool IAccessStorage::isAddressAllowedImpl(const User & user, const Poco::Net::IP
 }
 
 
-UUID IAccessStorage::getIDOfLoggedUser(const String & user_name) const
-{
-    return getIDOfLoggedUserImpl(user_name);
-}
-
-
-UUID IAccessStorage::getIDOfLoggedUserImpl(const String & user_name) const
-{
-    return getID<User>(user_name);
-}
-
-
 UUID IAccessStorage::generateRandomID()
 {
     static Poco::UUIDGenerator generator;

--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -175,12 +175,6 @@ std::vector<UUID> IAccessStorage::getIDs(AccessEntityType type, const Strings & 
 }
 
 
-bool IAccessStorage::exists(const UUID & id) const
-{
-    return existsImpl(id);
-}
-
-
 AccessEntityPtr IAccessStorage::tryReadBase(const UUID & id) const
 {
     AccessEntityPtr entity;
@@ -421,18 +415,6 @@ scope_guard IAccessStorage::subscribeForChanges(const std::vector<UUID> & ids, c
 }
 
 
-bool IAccessStorage::hasSubscription(AccessEntityType type) const
-{
-    return hasSubscriptionImpl(type);
-}
-
-
-bool IAccessStorage::hasSubscription(const UUID & id) const
-{
-    return hasSubscriptionImpl(id);
-}
-
-
 void IAccessStorage::notify(const Notifications & notifications)
 {
     for (const auto & [fn, id, new_entity] : notifications)
@@ -440,7 +422,7 @@ void IAccessStorage::notify(const Notifications & notifications)
 }
 
 
-UUID IAccessStorage::login(
+UUID IAccessStorage::authenticate(
     const Credentials & credentials,
     const Poco::Net::IPAddress & address,
     const ExternalAuthenticators & external_authenticators,
@@ -448,7 +430,7 @@ UUID IAccessStorage::login(
 {
     try
     {
-        return loginImpl(credentials, address, external_authenticators);
+        return authenticateImpl(credentials, address, external_authenticators);
     }
     catch (...)
     {
@@ -461,7 +443,7 @@ UUID IAccessStorage::login(
 }
 
 
-UUID IAccessStorage::loginImpl(
+UUID IAccessStorage::authenticateImpl(
     const Credentials & credentials,
     const Poco::Net::IPAddress & address,
     const ExternalAuthenticators & external_authenticators) const
@@ -470,10 +452,10 @@ UUID IAccessStorage::loginImpl(
     {
         if (auto user = tryRead<User>(*id))
         {
-            if (!isAddressAllowedImpl(*user, address))
+            if (!isAddressAllowed(*user, address))
                 throwAddressNotAllowed(address);
 
-            if (!areCredentialsValidImpl(*user, credentials, external_authenticators))
+            if (!areCredentialsValid(*user, credentials, external_authenticators))
                 throwInvalidCredentials();
 
             return *id;
@@ -483,7 +465,7 @@ UUID IAccessStorage::loginImpl(
 }
 
 
-bool IAccessStorage::areCredentialsValidImpl(
+bool IAccessStorage::areCredentialsValid(
     const User & user,
     const Credentials & credentials,
     const ExternalAuthenticators & external_authenticators) const
@@ -498,7 +480,7 @@ bool IAccessStorage::areCredentialsValidImpl(
 }
 
 
-bool IAccessStorage::isAddressAllowedImpl(const User & user, const Poco::Net::IPAddress & address) const
+bool IAccessStorage::isAddressAllowed(const User & user, const Poco::Net::IPAddress & address) const
 {
     return user.allowed_client_hosts.contains(address);
 }

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -70,10 +70,10 @@ public:
 
     /// Reads an entity. Throws an exception if not found.
     template <typename EntityClassT = IAccessEntity>
-    std::shared_ptr<const EntityClassT> read(const UUID & id) const;
+    std::shared_ptr<const EntityClassT> read(const UUID & id, bool throw_if_not_exists = true) const;
 
     template <typename EntityClassT = IAccessEntity>
-    std::shared_ptr<const EntityClassT> read(const String & name) const;
+    std::shared_ptr<const EntityClassT> read(const String & name, bool throw_if_not_exists = true) const;
 
     /// Reads an entity. Returns nullptr if not found.
     template <typename EntityClassT = IAccessEntity>
@@ -84,7 +84,8 @@ public:
 
     /// Reads only name of an entity.
     String readName(const UUID & id) const;
-    Strings readNames(const std::vector<UUID> & ids) const;
+    std::optional<String> readName(const UUID & id, bool throw_if_not_exists) const;
+    Strings readNames(const std::vector<UUID> & ids, bool throw_if_not_exists = true) const;
     std::optional<String> tryReadName(const UUID & id) const;
     Strings tryReadNames(const std::vector<UUID> & ids) const;
 
@@ -148,8 +149,8 @@ public:
 protected:
     virtual std::optional<UUID> findImpl(AccessEntityType type, const String & name) const = 0;
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const = 0;
-    virtual AccessEntityPtr readImpl(const UUID & id) const = 0;
-    virtual String readNameImpl(const UUID & id) const = 0;
+    virtual AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const = 0;
+    virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const;
     virtual UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) = 0;
     virtual void removeImpl(const UUID & id) = 0;
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) = 0;
@@ -181,23 +182,22 @@ protected:
     static void notify(const Notifications & notifications);
 
 private:
-    AccessEntityPtr tryReadBase(const UUID & id) const;
-
     const String storage_name;
     mutable std::atomic<Poco::Logger *> log = nullptr;
 };
 
 
 template <typename EntityClassT>
-std::shared_ptr<const EntityClassT> IAccessStorage::read(const UUID & id) const
+std::shared_ptr<const EntityClassT> IAccessStorage::read(const UUID & id, bool throw_if_not_exists) const
 {
-    auto entity = readImpl(id);
+    auto entity = readImpl(id, throw_if_not_exists);
     if constexpr (std::is_same_v<EntityClassT, IAccessEntity>)
         return entity;
     else
     {
-        auto ptr = typeid_cast<std::shared_ptr<const EntityClassT>>(entity);
-        if (ptr)
+        if (!entity)
+            return nullptr;
+        if (auto ptr = typeid_cast<std::shared_ptr<const EntityClassT>>(entity))
             return ptr;
         throwBadCast(id, entity->getType(), entity->getName(), EntityClassT::TYPE);
     }
@@ -205,26 +205,27 @@ std::shared_ptr<const EntityClassT> IAccessStorage::read(const UUID & id) const
 
 
 template <typename EntityClassT>
-std::shared_ptr<const EntityClassT> IAccessStorage::read(const String & name) const
+std::shared_ptr<const EntityClassT> IAccessStorage::read(const String & name, bool throw_if_not_exists) const
 {
-    return read<EntityClassT>(getID<EntityClassT>(name));
+    if (auto id = find<EntityClassT>(name))
+        return read<EntityClassT>(*id, throw_if_not_exists);
+    if (throw_if_not_exists)
+        throwNotFound(EntityClassT::TYPE, name);
+    else
+        return nullptr;
 }
 
 
 template <typename EntityClassT>
 std::shared_ptr<const EntityClassT> IAccessStorage::tryRead(const UUID & id) const
 {
-    auto entity = tryReadBase(id);
-    if (!entity)
-        return nullptr;
-    return typeid_cast<std::shared_ptr<const EntityClassT>>(entity);
+    return read<EntityClassT>(id, false);
 }
 
 
 template <typename EntityClassT>
 std::shared_ptr<const EntityClassT> IAccessStorage::tryRead(const String & name) const
 {
-    auto id = find<EntityClassT>(name);
-    return id ? tryRead<EntityClassT>(*id) : nullptr;
+    return read<EntityClassT>(name, false);
 }
 }

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -105,8 +105,8 @@ public:
     std::vector<UUID> insertOrReplace(const std::vector<AccessEntityPtr> & multiple_entities);
 
     /// Removes an entity from the storage. Throws an exception if couldn't remove.
-    void remove(const UUID & id);
-    void remove(const std::vector<UUID> & ids);
+    bool remove(const UUID & id, bool throw_if_not_exists = true);
+    std::vector<UUID> remove(const std::vector<UUID> & ids, bool throw_if_not_exists = true);
 
     /// Removes an entity from the storage. Returns false if couldn't remove.
     bool tryRemove(const UUID & id);
@@ -153,7 +153,7 @@ protected:
     virtual AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const = 0;
     virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const;
     virtual std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) = 0;
-    virtual void removeImpl(const UUID & id) = 0;
+    virtual bool removeImpl(const UUID & id, bool throw_if_not_exists) = 0;
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) = 0;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const = 0;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const = 0;

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -63,7 +63,7 @@ public:
     std::vector<UUID> getIDs(const Strings & names) const { return getIDs(EntityClassT::TYPE, names); }
 
     /// Returns whether there is an entity with such identifier in the storage.
-    bool exists(const UUID & id) const;
+    virtual bool exists(const UUID & id) const = 0;
 
     /// Reads an entity. Throws an exception if not found.
     template <typename EntityClassT = IAccessEntity>
@@ -139,17 +139,16 @@ public:
     scope_guard subscribeForChanges(const UUID & id, const OnChangedHandler & handler) const;
     scope_guard subscribeForChanges(const std::vector<UUID> & ids, const OnChangedHandler & handler) const;
 
-    bool hasSubscription(AccessEntityType type) const;
-    bool hasSubscription(const UUID & id) const;
+    virtual bool hasSubscription(AccessEntityType type) const = 0;
+    virtual bool hasSubscription(const UUID & id) const = 0;
 
     /// Finds a user, check the provided credentials and returns the ID of the user if they are valid.
     /// Throws an exception if no such user or credentials are invalid.
-    UUID login(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators, bool replace_exception_with_cannot_authenticate = true) const;
+    UUID authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators, bool replace_exception_with_cannot_authenticate = true) const;
 
 protected:
     virtual std::optional<UUID> findImpl(AccessEntityType type, const String & name) const = 0;
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const = 0;
-    virtual bool existsImpl(const UUID & id) const = 0;
     virtual AccessEntityPtr readImpl(const UUID & id) const = 0;
     virtual String readNameImpl(const UUID & id) const = 0;
     virtual bool canInsertImpl(const AccessEntityPtr & entity) const = 0;
@@ -158,11 +157,9 @@ protected:
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) = 0;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const = 0;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const = 0;
-    virtual bool hasSubscriptionImpl(const UUID & id) const = 0;
-    virtual bool hasSubscriptionImpl(AccessEntityType type) const = 0;
-    virtual UUID loginImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const;
-    virtual bool areCredentialsValidImpl(const User & user, const Credentials & credentials, const ExternalAuthenticators & external_authenticators) const;
-    virtual bool isAddressAllowedImpl(const User & user, const Poco::Net::IPAddress & address) const;
+    virtual UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const;
+    virtual bool areCredentialsValid(const User & user, const Credentials & credentials, const ExternalAuthenticators & external_authenticators) const;
+    virtual bool isAddressAllowed(const User & user, const Poco::Net::IPAddress & address) const;
 
     static UUID generateRandomID();
     Poco::Logger * getLogger() const;

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -148,7 +148,8 @@ public:
 
     /// Finds a user, check the provided credentials and returns the ID of the user if they are valid.
     /// Throws an exception if no such user or credentials are invalid.
-    UUID authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators, bool replace_exception_with_cannot_authenticate = true) const;
+    UUID authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const;
+    std::optional<UUID> authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators, bool throw_if_user_not_exists) const;
 
 protected:
     virtual std::optional<UUID> findImpl(AccessEntityType type, const String & name) const = 0;
@@ -160,7 +161,7 @@ protected:
     virtual bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists);
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const = 0;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const = 0;
-    virtual UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const;
+    virtual std::optional<UUID> authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators, bool throw_if_user_not_exists) const;
     virtual bool areCredentialsValid(const User & user, const Credentials & credentials, const ExternalAuthenticators & external_authenticators) const;
     virtual bool isAddressAllowed(const User & user, const Poco::Net::IPAddress & address) const;
 
@@ -179,7 +180,6 @@ protected:
     [[noreturn]] void throwReadonlyCannotRemove(AccessEntityType type, const String & name) const;
     [[noreturn]] static void throwAddressNotAllowed(const Poco::Net::IPAddress & address);
     [[noreturn]] static void throwInvalidCredentials();
-    [[noreturn]] static void throwCannotAuthenticate(const String & user_name);
 
     using Notification = std::tuple<OnChangedHandler, UUID, AccessEntityPtr>;
     using Notifications = std::vector<Notification>;

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -92,7 +92,8 @@ public:
     /// Inserts an entity to the storage. Returns ID of a new entry in the storage.
     /// Throws an exception if the specified name already exists.
     UUID insert(const AccessEntityPtr & entity);
-    std::vector<UUID> insert(const std::vector<AccessEntityPtr> & multiple_entities);
+    std::optional<UUID> insert(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists);
+    std::vector<UUID> insert(const std::vector<AccessEntityPtr> & multiple_entities, bool replace_if_exists = false, bool throw_if_exists = true);
 
     /// Inserts an entity to the storage. Returns ID of a new entry in the storage.
     std::optional<UUID> tryInsert(const AccessEntityPtr & entity);
@@ -151,7 +152,7 @@ protected:
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const = 0;
     virtual AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const = 0;
     virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const;
-    virtual UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) = 0;
+    virtual std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) = 0;
     virtual void removeImpl(const UUID & id) = 0;
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) = 0;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const = 0;

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -37,6 +37,9 @@ public:
     /// Returns true if this storage is readonly.
     virtual bool isReadOnly() const { return false; }
 
+    /// Returns true if this entity is readonly.
+    virtual bool isReadOnly(const UUID &) const { return isReadOnly(); }
+
     /// Returns the identifiers of all the entities of a specified type contained in the storage.
     std::vector<UUID> findAll(AccessEntityType type) const;
 
@@ -152,9 +155,9 @@ protected:
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const = 0;
     virtual AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const = 0;
     virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const;
-    virtual std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) = 0;
-    virtual bool removeImpl(const UUID & id, bool throw_if_not_exists) = 0;
-    virtual bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) = 0;
+    virtual std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists);
+    virtual bool removeImpl(const UUID & id, bool throw_if_not_exists);
+    virtual bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists);
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const = 0;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const = 0;
     virtual UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const;

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -117,8 +117,8 @@ public:
     using UpdateFunc = std::function<AccessEntityPtr(const AccessEntityPtr &)>;
 
     /// Updates an entity stored in the storage. Throws an exception if couldn't update.
-    void update(const UUID & id, const UpdateFunc & update_func);
-    void update(const std::vector<UUID> & ids, const UpdateFunc & update_func);
+    bool update(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists = true);
+    std::vector<UUID> update(const std::vector<UUID> & ids, const UpdateFunc & update_func, bool throw_if_not_exists = true);
 
     /// Updates an entity stored in the storage. Returns false if couldn't update.
     bool tryUpdate(const UUID & id, const UpdateFunc & update_func);
@@ -154,7 +154,7 @@ protected:
     virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const;
     virtual std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) = 0;
     virtual bool removeImpl(const UUID & id, bool throw_if_not_exists) = 0;
-    virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) = 0;
+    virtual bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) = 0;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const = 0;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const = 0;
     virtual UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const;

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -34,6 +34,9 @@ public:
     /// Returns a JSON with the parameters of the storage. It's up to the storage type to fill the JSON.
     virtual String getStorageParamsJSON() const { return "{}"; }
 
+    /// Returns true if this storage is readonly.
+    virtual bool isReadOnly() const { return false; }
+
     /// Returns the identifiers of all the entities of a specified type contained in the storage.
     std::vector<UUID> findAll(AccessEntityType type) const;
 
@@ -84,10 +87,6 @@ public:
     Strings readNames(const std::vector<UUID> & ids) const;
     std::optional<String> tryReadName(const UUID & id) const;
     Strings tryReadNames(const std::vector<UUID> & ids) const;
-
-    /// Returns true if a specified entity can be inserted into this storage.
-    /// This function doesn't check whether there are no entities with such name in the storage.
-    bool canInsert(const AccessEntityPtr & entity) const { return canInsertImpl(entity); }
 
     /// Inserts an entity to the storage. Returns ID of a new entry in the storage.
     /// Throws an exception if the specified name already exists.
@@ -151,7 +150,6 @@ protected:
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const = 0;
     virtual AccessEntityPtr readImpl(const UUID & id) const = 0;
     virtual String readNameImpl(const UUID & id) const = 0;
-    virtual bool canInsertImpl(const AccessEntityPtr & entity) const = 0;
     virtual UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) = 0;
     virtual void removeImpl(const UUID & id) = 0;
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) = 0;

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -146,10 +146,6 @@ public:
     /// Throws an exception if no such user or credentials are invalid.
     UUID login(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators, bool replace_exception_with_cannot_authenticate = true) const;
 
-    /// Returns the ID of a user who has logged in (maybe on another node).
-    /// The function assumes that the password has been already checked somehow, so we can skip checking it now.
-    UUID getIDOfLoggedUser(const String & user_name) const;
-
 protected:
     virtual std::optional<UUID> findImpl(AccessEntityType type, const String & name) const = 0;
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const = 0;
@@ -167,7 +163,6 @@ protected:
     virtual UUID loginImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const;
     virtual bool areCredentialsValidImpl(const User & user, const Credentials & credentials, const ExternalAuthenticators & external_authenticators) const;
     virtual bool isAddressAllowedImpl(const User & user, const Poco::Net::IPAddress & address) const;
-    virtual UUID getIDOfLoggedUserImpl(const String & user_name) const;
 
     static UUID generateRandomID();
     Poco::Logger * getLogger() const;

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -447,12 +447,6 @@ String LDAPAccessStorage::readNameImpl(const UUID & id) const
 }
 
 
-bool LDAPAccessStorage::canInsertImpl(const AccessEntityPtr &) const
-{
-    return false;
-}
-
-
 UUID LDAPAccessStorage::insertImpl(const AccessEntityPtr & entity, bool)
 {
     throwReadonlyCannotInsert(entity->getType(), entity->getName());

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -463,10 +463,12 @@ bool LDAPAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exists)
 }
 
 
-void LDAPAccessStorage::updateImpl(const UUID & id, const UpdateFunc &)
+bool LDAPAccessStorage::updateImpl(const UUID & id, const UpdateFunc &, bool throw_if_not_exists)
 {
     std::scoped_lock lock(mutex);
-    auto entity = read(id);
+    auto entity = read(id, throw_if_not_exists);
+    if (!entity)
+        return false;
     throwReadonlyCannotUpdate(entity->getType(), entity->getName());
 }
 

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -433,17 +433,17 @@ bool LDAPAccessStorage::exists(const UUID & id) const
 }
 
 
-AccessEntityPtr LDAPAccessStorage::readImpl(const UUID & id) const
+AccessEntityPtr LDAPAccessStorage::readImpl(const UUID & id, bool throw_if_not_exists) const
 {
     std::scoped_lock lock(mutex);
-    return memory_storage.read(id);
+    return memory_storage.read(id, throw_if_not_exists);
 }
 
 
-String LDAPAccessStorage::readNameImpl(const UUID & id) const
+std::optional<String> LDAPAccessStorage::readNameImpl(const UUID & id, bool throw_if_not_exists) const
 {
     std::scoped_lock lock(mutex);
-    return memory_storage.readName(id);
+    return memory_storage.readName(id, throw_if_not_exists);
 }
 
 

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -426,7 +426,7 @@ std::vector<UUID> LDAPAccessStorage::findAllImpl(AccessEntityType type) const
 }
 
 
-bool LDAPAccessStorage::existsImpl(const UUID & id) const
+bool LDAPAccessStorage::exists(const UUID & id) const
 {
     std::scoped_lock lock(mutex);
     return memory_storage.exists(id);
@@ -489,20 +489,20 @@ scope_guard LDAPAccessStorage::subscribeForChangesImpl(AccessEntityType type, co
 }
 
 
-bool LDAPAccessStorage::hasSubscriptionImpl(const UUID & id) const
+bool LDAPAccessStorage::hasSubscription(const UUID & id) const
 {
     std::scoped_lock lock(mutex);
     return memory_storage.hasSubscription(id);
 }
 
 
-bool LDAPAccessStorage::hasSubscriptionImpl(AccessEntityType type) const
+bool LDAPAccessStorage::hasSubscription(AccessEntityType type) const
 {
     std::scoped_lock lock(mutex);
     return memory_storage.hasSubscription(type);
 }
 
-UUID LDAPAccessStorage::loginImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const
+UUID LDAPAccessStorage::authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const
 {
     std::scoped_lock lock(mutex);
     LDAPClient::SearchResultsList external_roles;
@@ -511,7 +511,7 @@ UUID LDAPAccessStorage::loginImpl(const Credentials & credentials, const Poco::N
     {
         auto user = memory_storage.read<User>(*id);
 
-        if (!isAddressAllowedImpl(*user, address))
+        if (!isAddressAllowed(*user, address))
             throwAddressNotAllowed(address);
 
         if (typeid_cast<const AlwaysAllowCredentials *>(&credentials))
@@ -533,7 +533,7 @@ UUID LDAPAccessStorage::loginImpl(const Credentials & credentials, const Poco::N
         user->auth_data = AuthenticationData(AuthenticationType::LDAP);
         user->auth_data.setLDAPServerName(ldap_server_name);
 
-        if (!isAddressAllowedImpl(*user, address))
+        if (!isAddressAllowed(*user, address))
             throwAddressNotAllowed(address);
 
         if (typeid_cast<const AlwaysAllowCredentials *>(&credentials))

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -447,7 +447,7 @@ std::optional<String> LDAPAccessStorage::readNameImpl(const UUID & id, bool thro
 }
 
 
-UUID LDAPAccessStorage::insertImpl(const AccessEntityPtr & entity, bool)
+std::optional<UUID> LDAPAccessStorage::insertImpl(const AccessEntityPtr & entity, bool, bool)
 {
     throwReadonlyCannotInsert(entity->getType(), entity->getName());
 }

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -453,10 +453,12 @@ std::optional<UUID> LDAPAccessStorage::insertImpl(const AccessEntityPtr & entity
 }
 
 
-void LDAPAccessStorage::removeImpl(const UUID & id)
+bool LDAPAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exists)
 {
     std::scoped_lock lock(mutex);
-    auto entity = read(id);
+    auto entity = read(id, throw_if_not_exists);
+    if (!entity)
+        return false;
     throwReadonlyCannotRemove(entity->getType(), entity->getName());
 }
 

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -447,32 +447,6 @@ std::optional<String> LDAPAccessStorage::readNameImpl(const UUID & id, bool thro
 }
 
 
-std::optional<UUID> LDAPAccessStorage::insertImpl(const AccessEntityPtr & entity, bool, bool)
-{
-    throwReadonlyCannotInsert(entity->getType(), entity->getName());
-}
-
-
-bool LDAPAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exists)
-{
-    std::scoped_lock lock(mutex);
-    auto entity = read(id, throw_if_not_exists);
-    if (!entity)
-        return false;
-    throwReadonlyCannotRemove(entity->getType(), entity->getName());
-}
-
-
-bool LDAPAccessStorage::updateImpl(const UUID & id, const UpdateFunc &, bool throw_if_not_exists)
-{
-    std::scoped_lock lock(mutex);
-    auto entity = read(id, throw_if_not_exists);
-    if (!entity)
-        return false;
-    throwReadonlyCannotUpdate(entity->getType(), entity->getName());
-}
-
-
 scope_guard LDAPAccessStorage::subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const
 {
     std::scoped_lock lock(mutex);

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -52,7 +52,7 @@ private: // IAccessStorage implementations.
     virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
-    virtual UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;
+    virtual std::optional<UUID> authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators, bool throw_if_user_not_exists) const override;
 
 private:
     void setConfiguration(AccessControl * access_control_, const Poco::Util::AbstractConfiguration & config, const String & prefix);

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -52,7 +52,7 @@ private: // IAccessStorage implementations.
     virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     virtual std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     virtual bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
-    virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
+    virtual bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
     virtual UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -51,7 +51,7 @@ private: // IAccessStorage implementations.
     virtual AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     virtual std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
-    virtual void removeImpl(const UUID & id) override;
+    virtual bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -40,11 +40,13 @@ public:
 public: // IAccessStorage implementations.
     virtual const char * getStorageType() const override;
     virtual String getStorageParamsJSON() const override;
+    virtual bool exists(const UUID & id) const override;
+    virtual bool hasSubscription(const UUID & id) const override;
+    virtual bool hasSubscription(AccessEntityType type) const override;
 
 private: // IAccessStorage implementations.
     virtual std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    virtual bool existsImpl(const UUID & id) const override;
     virtual AccessEntityPtr readImpl(const UUID & id) const override;
     virtual String readNameImpl(const UUID & id) const override;
     virtual bool canInsertImpl(const AccessEntityPtr &) const override;
@@ -53,9 +55,7 @@ private: // IAccessStorage implementations.
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
-    virtual bool hasSubscriptionImpl(const UUID & id) const override;
-    virtual bool hasSubscriptionImpl(AccessEntityType type) const override;
-    virtual UUID loginImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;
+    virtual UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;
 
 private:
     void setConfiguration(AccessControl * access_control_, const Poco::Util::AbstractConfiguration & config, const String & prefix);

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -56,7 +56,6 @@ private: // IAccessStorage implementations.
     virtual bool hasSubscriptionImpl(const UUID & id) const override;
     virtual bool hasSubscriptionImpl(AccessEntityType type) const override;
     virtual UUID loginImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;
-    virtual UUID getIDOfLoggedUserImpl(const String & user_name) const override;
 
 private:
     void setConfiguration(AccessControl * access_control_, const Poco::Util::AbstractConfiguration & config, const String & prefix);

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -50,7 +50,7 @@ private: // IAccessStorage implementations.
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     virtual AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
-    virtual UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
+    virtual std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     virtual void removeImpl(const UUID & id) override;
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -40,6 +40,7 @@ public:
 public: // IAccessStorage implementations.
     virtual const char * getStorageType() const override;
     virtual String getStorageParamsJSON() const override;
+    virtual bool isReadOnly() const override { return true; }
     virtual bool exists(const UUID & id) const override;
     virtual bool hasSubscription(const UUID & id) const override;
     virtual bool hasSubscription(AccessEntityType type) const override;
@@ -49,7 +50,6 @@ private: // IAccessStorage implementations.
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     virtual AccessEntityPtr readImpl(const UUID & id) const override;
     virtual String readNameImpl(const UUID & id) const override;
-    virtual bool canInsertImpl(const AccessEntityPtr &) const override;
     virtual UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     virtual void removeImpl(const UUID & id) override;
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -50,9 +50,6 @@ private: // IAccessStorage implementations.
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     virtual AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
-    virtual std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
-    virtual bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
-    virtual bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
     virtual scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     virtual scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
     virtual UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;

--- a/src/Access/LDAPAccessStorage.h
+++ b/src/Access/LDAPAccessStorage.h
@@ -48,8 +48,8 @@ public: // IAccessStorage implementations.
 private: // IAccessStorage implementations.
     virtual std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     virtual std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    virtual AccessEntityPtr readImpl(const UUID & id) const override;
-    virtual String readNameImpl(const UUID & id) const override;
+    virtual AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
+    virtual std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     virtual UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     virtual void removeImpl(const UUID & id) override;
     virtual void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/MemoryAccessStorage.cpp
+++ b/src/Access/MemoryAccessStorage.cpp
@@ -45,20 +45,19 @@ bool MemoryAccessStorage::exists(const UUID & id) const
 }
 
 
-AccessEntityPtr MemoryAccessStorage::readImpl(const UUID & id) const
+AccessEntityPtr MemoryAccessStorage::readImpl(const UUID & id, bool throw_if_not_exists) const
 {
     std::lock_guard lock{mutex};
     auto it = entries_by_id.find(id);
     if (it == entries_by_id.end())
-        throwNotFound(id);
+    {
+        if (throw_if_not_exists)
+            throwNotFound(id);
+        else
+            return nullptr;
+    }
     const Entry & entry = it->second;
     return entry.entity;
-}
-
-
-String MemoryAccessStorage::readNameImpl(const UUID & id) const
-{
-    return readImpl(id)->getName();
 }
 
 

--- a/src/Access/MemoryAccessStorage.cpp
+++ b/src/Access/MemoryAccessStorage.cpp
@@ -38,7 +38,7 @@ std::vector<UUID> MemoryAccessStorage::findAllImpl(AccessEntityType type) const
 }
 
 
-bool MemoryAccessStorage::existsImpl(const UUID & id) const
+bool MemoryAccessStorage::exists(const UUID & id) const
 {
     std::lock_guard lock{mutex};
     return entries_by_id.count(id);
@@ -304,7 +304,7 @@ scope_guard MemoryAccessStorage::subscribeForChangesImpl(const UUID & id, const 
 }
 
 
-bool MemoryAccessStorage::hasSubscriptionImpl(const UUID & id) const
+bool MemoryAccessStorage::hasSubscription(const UUID & id) const
 {
     std::lock_guard lock{mutex};
     auto it = entries_by_id.find(id);
@@ -317,7 +317,7 @@ bool MemoryAccessStorage::hasSubscriptionImpl(const UUID & id) const
 }
 
 
-bool MemoryAccessStorage::hasSubscriptionImpl(AccessEntityType type) const
+bool MemoryAccessStorage::hasSubscription(AccessEntityType type) const
 {
     std::lock_guard lock{mutex};
     const auto & handlers = handlers_by_type[static_cast<size_t>(type)];

--- a/src/Access/MemoryAccessStorage.h
+++ b/src/Access/MemoryAccessStorage.h
@@ -32,7 +32,6 @@ private:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID & id) const override;
-    bool canInsertImpl(const AccessEntityPtr &) const override { return true; }
     UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/MemoryAccessStorage.h
+++ b/src/Access/MemoryAccessStorage.h
@@ -23,10 +23,13 @@ public:
     void setAll(const std::vector<AccessEntityPtr> & all_entities);
     void setAll(const std::vector<std::pair<UUID, AccessEntityPtr>> & all_entities);
 
+    bool exists(const UUID & id) const override;
+    bool hasSubscription(const UUID & id) const override;
+    bool hasSubscription(AccessEntityType type) const override;
+
 private:
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    bool existsImpl(const UUID & id) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID & id) const override;
     bool canInsertImpl(const AccessEntityPtr &) const override { return true; }
@@ -35,8 +38,6 @@ private:
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
-    bool hasSubscriptionImpl(const UUID & id) const override;
-    bool hasSubscriptionImpl(AccessEntityType type) const override;
 
     struct Entry
     {

--- a/src/Access/MemoryAccessStorage.h
+++ b/src/Access/MemoryAccessStorage.h
@@ -33,7 +33,7 @@ private:
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
-    void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
+    bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
 
@@ -46,7 +46,7 @@ private:
 
     bool insertNoLock(const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists, Notifications & notifications);
     bool removeNoLock(const UUID & id, bool throw_if_not_exists, Notifications & notifications);
-    void updateNoLock(const UUID & id, const UpdateFunc & update_func, Notifications & notifications);
+    bool updateNoLock(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists, Notifications & notifications);
     void setAllNoLock(const std::vector<std::pair<UUID, AccessEntityPtr>> & all_entities, Notifications & notifications);
     void prepareNotifications(const Entry & entry, bool remove, Notifications & notifications) const;
 

--- a/src/Access/MemoryAccessStorage.h
+++ b/src/Access/MemoryAccessStorage.h
@@ -30,8 +30,7 @@ public:
 private:
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    AccessEntityPtr readImpl(const UUID & id) const override;
-    String readNameImpl(const UUID & id) const override;
+    AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/MemoryAccessStorage.h
+++ b/src/Access/MemoryAccessStorage.h
@@ -32,7 +32,7 @@ private:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
-    void removeImpl(const UUID & id) override;
+    bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
@@ -45,7 +45,7 @@ private:
     };
 
     bool insertNoLock(const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists, Notifications & notifications);
-    void removeNoLock(const UUID & id, Notifications & notifications);
+    bool removeNoLock(const UUID & id, bool throw_if_not_exists, Notifications & notifications);
     void updateNoLock(const UUID & id, const UpdateFunc & update_func, Notifications & notifications);
     void setAllNoLock(const std::vector<std::pair<UUID, AccessEntityPtr>> & all_entities, Notifications & notifications);
     void prepareNotifications(const Entry & entry, bool remove, Notifications & notifications) const;

--- a/src/Access/MemoryAccessStorage.h
+++ b/src/Access/MemoryAccessStorage.h
@@ -31,7 +31,7 @@ private:
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
-    UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
+    std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
@@ -44,7 +44,7 @@ private:
         mutable std::list<OnChangedHandler> handlers_by_id;
     };
 
-    void insertNoLock(const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, Notifications & notifications);
+    bool insertNoLock(const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists, Notifications & notifications);
     void removeNoLock(const UUID & id, Notifications & notifications);
     void updateNoLock(const UUID & id, const UpdateFunc & update_func, Notifications & notifications);
     void setAllNoLock(const std::vector<std::pair<UUID, AccessEntityPtr>> & all_entities, Notifications & notifications);

--- a/src/Access/MultipleAccessStorage.cpp
+++ b/src/Access/MultipleAccessStorage.cpp
@@ -192,15 +192,15 @@ String MultipleAccessStorage::readNameImpl(const UUID & id) const
 }
 
 
-bool MultipleAccessStorage::canInsertImpl(const AccessEntityPtr & entity) const
+bool MultipleAccessStorage::isReadOnly() const
 {
     auto storages = getStoragesInternal();
     for (const auto & storage : *storages)
     {
-        if (storage->canInsert(entity))
-            return true;
+        if (!storage->isReadOnly())
+            return false;
     }
-    return false;
+    return true;
 }
 
 
@@ -211,7 +211,7 @@ UUID MultipleAccessStorage::insertImpl(const AccessEntityPtr & entity, bool repl
     std::shared_ptr<IAccessStorage> storage_for_insertion;
     for (const auto & storage : *storages)
     {
-        if (storage->canInsert(entity) ||
+        if (!storage->isReadOnly() ||
             storage->find(entity->getType(), entity->getName()))
         {
             storage_for_insertion = storage;

--- a/src/Access/MultipleAccessStorage.cpp
+++ b/src/Access/MultipleAccessStorage.cpp
@@ -431,31 +431,4 @@ UUID MultipleAccessStorage::loginImpl(const Credentials & credentials, const Poc
     throwNotFound(AccessEntityType::USER, credentials.getUserName());
 }
 
-
-UUID MultipleAccessStorage::getIDOfLoggedUserImpl(const String & user_name) const
-{
-    auto storages = getStoragesInternal();
-    for (const auto & storage : *storages)
-    {
-        try
-        {
-            auto id = storage->getIDOfLoggedUser(user_name);
-            std::lock_guard lock{mutex};
-            ids_cache.set(id, storage);
-            return id;
-        }
-        catch (...)
-        {
-            if (!storage->find(AccessEntityType::USER, user_name))
-            {
-                /// The authentication failed because there no users with such name in the `storage`
-                /// thus we can try to search in other nested storages.
-                continue;
-            }
-            throw;
-        }
-    }
-    throwNotFound(AccessEntityType::USER, user_name);
-}
-
 }

--- a/src/Access/MultipleAccessStorage.cpp
+++ b/src/Access/MultipleAccessStorage.cpp
@@ -243,9 +243,15 @@ std::optional<UUID> MultipleAccessStorage::insertImpl(const AccessEntityPtr & en
 }
 
 
-void MultipleAccessStorage::removeImpl(const UUID & id)
+bool MultipleAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exists)
 {
-    getStorage(id)->remove(id);
+    if (auto storage = findStorage(id))
+        return storage->remove(id, throw_if_not_exists);
+
+    if (throw_if_not_exists)
+        throwNotFound(id);
+    else
+        return false;
 }
 
 

--- a/src/Access/MultipleAccessStorage.cpp
+++ b/src/Access/MultipleAccessStorage.cpp
@@ -180,15 +180,27 @@ ConstStoragePtr MultipleAccessStorage::getStorage(const UUID & id) const
     return const_cast<MultipleAccessStorage *>(this)->getStorage(id);
 }
 
-AccessEntityPtr MultipleAccessStorage::readImpl(const UUID & id) const
+AccessEntityPtr MultipleAccessStorage::readImpl(const UUID & id, bool throw_if_not_exists) const
 {
-    return getStorage(id)->read(id);
+    if (auto storage = findStorage(id))
+        return storage->read(id, throw_if_not_exists);
+
+    if (throw_if_not_exists)
+        throwNotFound(id);
+    else
+        return nullptr;
 }
 
 
-String MultipleAccessStorage::readNameImpl(const UUID & id) const
+std::optional<String> MultipleAccessStorage::readNameImpl(const UUID & id, bool throw_if_not_exists) const
 {
-    return getStorage(id)->readName(id);
+    if (auto storage = findStorage(id))
+        return storage->readName(id, throw_if_not_exists);
+
+    if (throw_if_not_exists)
+        throwNotFound(id);
+    else
+        return std::nullopt;
 }
 
 

--- a/src/Access/MultipleAccessStorage.cpp
+++ b/src/Access/MultipleAccessStorage.cpp
@@ -129,7 +129,7 @@ std::vector<UUID> MultipleAccessStorage::findAllImpl(AccessEntityType type) cons
 }
 
 
-bool MultipleAccessStorage::existsImpl(const UUID & id) const
+bool MultipleAccessStorage::exists(const UUID & id) const
 {
     return findStorage(id) != nullptr;
 }
@@ -275,7 +275,7 @@ scope_guard MultipleAccessStorage::subscribeForChangesImpl(const UUID & id, cons
 }
 
 
-bool MultipleAccessStorage::hasSubscriptionImpl(const UUID & id) const
+bool MultipleAccessStorage::hasSubscription(const UUID & id) const
 {
     auto storages = getStoragesInternal();
     for (const auto & storage : *storages)
@@ -307,7 +307,7 @@ scope_guard MultipleAccessStorage::subscribeForChangesImpl(AccessEntityType type
 }
 
 
-bool MultipleAccessStorage::hasSubscriptionImpl(AccessEntityType type) const
+bool MultipleAccessStorage::hasSubscription(AccessEntityType type) const
 {
     std::lock_guard lock{mutex};
     const auto & handlers = handlers_by_type[static_cast<size_t>(type)];
@@ -405,14 +405,14 @@ void MultipleAccessStorage::updateSubscriptionsToNestedStorages(std::unique_lock
 }
 
 
-UUID MultipleAccessStorage::loginImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const
+UUID MultipleAccessStorage::authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const
 {
     auto storages = getStoragesInternal();
     for (const auto & storage : *storages)
     {
         try
         {
-            auto id = storage->login(credentials, address, external_authenticators, /* replace_exception_with_cannot_authenticate = */ false);
+            auto id = storage->authenticate(credentials, address, external_authenticators, /* replace_exception_with_cannot_authenticate = */ false);
             std::lock_guard lock{mutex};
             ids_cache.set(id, storage);
             return id;

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -34,10 +34,13 @@ public:
     ConstStoragePtr getStorage(const UUID & id) const;
     StoragePtr getStorage(const UUID & id);
 
+    bool exists(const UUID & id) const override;
+    bool hasSubscription(const UUID & id) const override;
+    bool hasSubscription(AccessEntityType type) const override;
+
 protected:
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    bool existsImpl(const UUID & id) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID &id) const override;
     bool canInsertImpl(const AccessEntityPtr & entity) const override;
@@ -46,9 +49,7 @@ protected:
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
-    bool hasSubscriptionImpl(const UUID & id) const override;
-    bool hasSubscriptionImpl(AccessEntityType type) const override;
-    UUID loginImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;
+    UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;
 
 private:
     using Storages = std::vector<StoragePtr>;

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -49,7 +49,6 @@ protected:
     bool hasSubscriptionImpl(const UUID & id) const override;
     bool hasSubscriptionImpl(AccessEntityType type) const override;
     UUID loginImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;
-    UUID getIDOfLoggedUserImpl(const String & user_name) const override;
 
 private:
     using Storages = std::vector<StoragePtr>;

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -44,7 +44,7 @@ protected:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
-    UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
+    std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -45,7 +45,7 @@ protected:
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
-    void removeImpl(const UUID & id) override;
+    bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -22,6 +22,7 @@ public:
 
     const char * getStorageType() const override { return STORAGE_TYPE; }
     bool isReadOnly() const override;
+    bool isReadOnly(const UUID & id) const override;
 
     void setStorages(const std::vector<StoragePtr> & storages);
     void addStorage(const StoragePtr & new_storage);

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -42,8 +42,8 @@ public:
 protected:
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    AccessEntityPtr readImpl(const UUID & id) const override;
-    String readNameImpl(const UUID &id) const override;
+    AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
+    std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -21,6 +21,7 @@ public:
     ~MultipleAccessStorage() override;
 
     const char * getStorageType() const override { return STORAGE_TYPE; }
+    bool isReadOnly() const override;
 
     void setStorages(const std::vector<StoragePtr> & storages);
     void addStorage(const StoragePtr & new_storage);
@@ -43,7 +44,6 @@ protected:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID &id) const override;
-    bool canInsertImpl(const AccessEntityPtr & entity) const override;
     UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -46,7 +46,7 @@ protected:
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
-    void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
+    bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
     UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;

--- a/src/Access/MultipleAccessStorage.h
+++ b/src/Access/MultipleAccessStorage.h
@@ -50,7 +50,7 @@ protected:
     bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
-    UUID authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators) const override;
+    std::optional<UUID> authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators, bool throw_if_user_not_exists) const override;
 
 private:
     using Storages = std::vector<StoragePtr>;

--- a/src/Access/ReplicatedAccessStorage.cpp
+++ b/src/Access/ReplicatedAccessStorage.cpp
@@ -532,20 +532,19 @@ bool ReplicatedAccessStorage::exists(const UUID & id) const
 }
 
 
-AccessEntityPtr ReplicatedAccessStorage::readImpl(const UUID & id) const
+AccessEntityPtr ReplicatedAccessStorage::readImpl(const UUID & id, bool throw_if_not_exists) const
 {
     std::lock_guard lock{mutex};
     const auto it = entries_by_id.find(id);
     if (it == entries_by_id.end())
-        throwNotFound(id);
+    {
+        if (throw_if_not_exists)
+            throwNotFound(id);
+        else
+            return nullptr;
+    }
     const Entry & entry = it->second;
     return entry.entity;
-}
-
-
-String ReplicatedAccessStorage::readNameImpl(const UUID & id) const
-{
-    return readImpl(id)->getName();
 }
 
 

--- a/src/Access/ReplicatedAccessStorage.cpp
+++ b/src/Access/ReplicatedAccessStorage.cpp
@@ -525,7 +525,7 @@ std::vector<UUID> ReplicatedAccessStorage::findAllImpl(AccessEntityType type) co
 }
 
 
-bool ReplicatedAccessStorage::existsImpl(const UUID & id) const
+bool ReplicatedAccessStorage::exists(const UUID & id) const
 {
     std::lock_guard lock{mutex};
     return entries_by_id.count(id);
@@ -598,7 +598,7 @@ scope_guard ReplicatedAccessStorage::subscribeForChangesImpl(const UUID & id, co
 }
 
 
-bool ReplicatedAccessStorage::hasSubscriptionImpl(const UUID & id) const
+bool ReplicatedAccessStorage::hasSubscription(const UUID & id) const
 {
     std::lock_guard lock{mutex};
     const auto & it = entries_by_id.find(id);
@@ -611,7 +611,7 @@ bool ReplicatedAccessStorage::hasSubscriptionImpl(const UUID & id) const
 }
 
 
-bool ReplicatedAccessStorage::hasSubscriptionImpl(AccessEntityType type) const
+bool ReplicatedAccessStorage::hasSubscription(AccessEntityType type) const
 {
     std::lock_guard lock{mutex};
     const auto & handlers = handlers_by_type[static_cast<size_t>(type)];

--- a/src/Access/ReplicatedAccessStorage.h
+++ b/src/Access/ReplicatedAccessStorage.h
@@ -46,11 +46,11 @@ private:
     ConcurrentBoundedQueue<UUID> refresh_queue;
 
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
-    void removeImpl(const UUID & id) override;
+    bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
 
     bool insertZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists);
-    void removeZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id);
+    bool removeZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, bool throw_if_not_exists);
     void updateZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const UpdateFunc & update_func);
 
     void runWorkerThread();

--- a/src/Access/ReplicatedAccessStorage.h
+++ b/src/Access/ReplicatedAccessStorage.h
@@ -77,7 +77,6 @@ private:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID & id) const override;
-    bool canInsertImpl(const AccessEntityPtr &) const override { return true; }
 
     void prepareNotifications(const Entry & entry, bool remove, Notifications & notifications) const;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;

--- a/src/Access/ReplicatedAccessStorage.h
+++ b/src/Access/ReplicatedAccessStorage.h
@@ -75,8 +75,7 @@ private:
 
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    AccessEntityPtr readImpl(const UUID & id) const override;
-    String readNameImpl(const UUID & id) const override;
+    AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
 
     void prepareNotifications(const Entry & entry, bool remove, Notifications & notifications) const;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;

--- a/src/Access/ReplicatedAccessStorage.h
+++ b/src/Access/ReplicatedAccessStorage.h
@@ -32,6 +32,10 @@ public:
     virtual void startup();
     virtual void shutdown();
 
+    bool exists(const UUID & id) const override;
+    bool hasSubscription(const UUID & id) const override;
+    bool hasSubscription(AccessEntityType type) const override;
+
 private:
     String zookeeper_path;
     zkutil::GetZooKeeper get_zookeeper;
@@ -71,7 +75,6 @@ private:
 
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    bool existsImpl(const UUID & id) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID & id) const override;
     bool canInsertImpl(const AccessEntityPtr &) const override { return true; }
@@ -79,8 +82,6 @@ private:
     void prepareNotifications(const Entry & entry, bool remove, Notifications & notifications) const;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
-    bool hasSubscriptionImpl(const UUID & id) const override;
-    bool hasSubscriptionImpl(AccessEntityType type) const override;
 
     mutable std::mutex mutex;
     std::unordered_map<UUID, Entry> entries_by_id;

--- a/src/Access/ReplicatedAccessStorage.h
+++ b/src/Access/ReplicatedAccessStorage.h
@@ -45,11 +45,11 @@ private:
     ThreadFromGlobalPool worker_thread;
     ConcurrentBoundedQueue<UUID> refresh_queue;
 
-    UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
+    std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
 
-    void insertZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists);
+    bool insertZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists);
     void removeZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id);
     void updateZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const UpdateFunc & update_func);
 

--- a/src/Access/ReplicatedAccessStorage.h
+++ b/src/Access/ReplicatedAccessStorage.h
@@ -47,11 +47,11 @@ private:
 
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
-    void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
+    bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
 
     bool insertZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists);
     bool removeZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, bool throw_if_not_exists);
-    void updateZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const UpdateFunc & update_func);
+    bool updateZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists);
 
     void runWorkerThread();
     void resetAfterError();

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -627,9 +627,11 @@ std::optional<UUID> UsersConfigAccessStorage::insertImpl(const AccessEntityPtr &
 }
 
 
-void UsersConfigAccessStorage::removeImpl(const UUID & id)
+bool UsersConfigAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exists)
 {
-    auto entity = read(id);
+    auto entity = read(id, throw_if_not_exists);
+    if (!entity)
+        return false;
     throwReadonlyCannotRemove(entity->getType(), entity->getName());
 }
 

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -603,7 +603,7 @@ std::vector<UUID> UsersConfigAccessStorage::findAllImpl(AccessEntityType type) c
 }
 
 
-bool UsersConfigAccessStorage::existsImpl(const UUID & id) const
+bool UsersConfigAccessStorage::exists(const UUID & id) const
 {
     return memory_storage.exists(id);
 }
@@ -653,13 +653,13 @@ scope_guard UsersConfigAccessStorage::subscribeForChangesImpl(AccessEntityType t
 }
 
 
-bool UsersConfigAccessStorage::hasSubscriptionImpl(const UUID & id) const
+bool UsersConfigAccessStorage::hasSubscription(const UUID & id) const
 {
     return memory_storage.hasSubscription(id);
 }
 
 
-bool UsersConfigAccessStorage::hasSubscriptionImpl(AccessEntityType type) const
+bool UsersConfigAccessStorage::hasSubscription(AccessEntityType type) const
 {
     return memory_storage.hasSubscription(type);
 }

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -609,15 +609,15 @@ bool UsersConfigAccessStorage::exists(const UUID & id) const
 }
 
 
-AccessEntityPtr UsersConfigAccessStorage::readImpl(const UUID & id) const
+AccessEntityPtr UsersConfigAccessStorage::readImpl(const UUID & id, bool throw_if_not_exists) const
 {
-    return memory_storage.read(id);
+    return memory_storage.read(id, throw_if_not_exists);
 }
 
 
-String UsersConfigAccessStorage::readNameImpl(const UUID & id) const
+std::optional<String> UsersConfigAccessStorage::readNameImpl(const UUID & id, bool throw_if_not_exists) const
 {
-    return memory_storage.readName(id);
+    return memory_storage.readName(id, throw_if_not_exists);
 }
 
 

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -636,9 +636,11 @@ bool UsersConfigAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exi
 }
 
 
-void UsersConfigAccessStorage::updateImpl(const UUID & id, const UpdateFunc &)
+bool UsersConfigAccessStorage::updateImpl(const UUID & id, const UpdateFunc &, bool throw_if_not_exists)
 {
-    auto entity = read(id);
+    auto entity = read(id, throw_if_not_exists);
+    if (!entity)
+        return false;
     throwReadonlyCannotUpdate(entity->getType(), entity->getName());
 }
 

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -621,7 +621,7 @@ std::optional<String> UsersConfigAccessStorage::readNameImpl(const UUID & id, bo
 }
 
 
-UUID UsersConfigAccessStorage::insertImpl(const AccessEntityPtr & entity, bool)
+std::optional<UUID> UsersConfigAccessStorage::insertImpl(const AccessEntityPtr & entity, bool, bool)
 {
     throwReadonlyCannotInsert(entity->getType(), entity->getName());
 }

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -621,30 +621,6 @@ std::optional<String> UsersConfigAccessStorage::readNameImpl(const UUID & id, bo
 }
 
 
-std::optional<UUID> UsersConfigAccessStorage::insertImpl(const AccessEntityPtr & entity, bool, bool)
-{
-    throwReadonlyCannotInsert(entity->getType(), entity->getName());
-}
-
-
-bool UsersConfigAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exists)
-{
-    auto entity = read(id, throw_if_not_exists);
-    if (!entity)
-        return false;
-    throwReadonlyCannotRemove(entity->getType(), entity->getName());
-}
-
-
-bool UsersConfigAccessStorage::updateImpl(const UUID & id, const UpdateFunc &, bool throw_if_not_exists)
-{
-    auto entity = read(id, throw_if_not_exists);
-    if (!entity)
-        return false;
-    throwReadonlyCannotUpdate(entity->getType(), entity->getName());
-}
-
-
 scope_guard UsersConfigAccessStorage::subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const
 {
     return memory_storage.subscribeForChanges(id, handler);

--- a/src/Access/UsersConfigAccessStorage.h
+++ b/src/Access/UsersConfigAccessStorage.h
@@ -50,8 +50,8 @@ private:
 
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    AccessEntityPtr readImpl(const UUID & id) const override;
-    String readNameImpl(const UUID & id) const override;
+    AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
+    std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/UsersConfigAccessStorage.h
+++ b/src/Access/UsersConfigAccessStorage.h
@@ -53,7 +53,7 @@ private:
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
-    void removeImpl(const UUID & id) override;
+    bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;

--- a/src/Access/UsersConfigAccessStorage.h
+++ b/src/Access/UsersConfigAccessStorage.h
@@ -40,12 +40,15 @@ public:
     void reload();
     void startPeriodicReloading();
 
+    bool exists(const UUID & id) const override;
+    bool hasSubscription(const UUID & id) const override;
+    bool hasSubscription(AccessEntityType type) const override;
+
 private:
     void parseFromConfig(const Poco::Util::AbstractConfiguration & config);
 
     std::optional<UUID> findImpl(AccessEntityType type, const String & name) const override;
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
-    bool existsImpl(const UUID & id) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID & id) const override;
     bool canInsertImpl(const AccessEntityPtr &) const override { return false; }
@@ -54,8 +57,6 @@ private:
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
-    bool hasSubscriptionImpl(const UUID & id) const override;
-    bool hasSubscriptionImpl(AccessEntityType type) const override;
 
     MemoryAccessStorage memory_storage;
     CheckSettingNameFunction check_setting_name_function;

--- a/src/Access/UsersConfigAccessStorage.h
+++ b/src/Access/UsersConfigAccessStorage.h
@@ -52,9 +52,6 @@ private:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
-    std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
-    bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
-    bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
 

--- a/src/Access/UsersConfigAccessStorage.h
+++ b/src/Access/UsersConfigAccessStorage.h
@@ -52,7 +52,7 @@ private:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
-    UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
+    std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;

--- a/src/Access/UsersConfigAccessStorage.h
+++ b/src/Access/UsersConfigAccessStorage.h
@@ -27,6 +27,7 @@ public:
 
     const char * getStorageType() const override { return STORAGE_TYPE; }
     String getStorageParamsJSON() const override;
+    bool isReadOnly() const override { return true; }
 
     String getPath() const;
     bool isPathEqual(const String & path_) const;
@@ -51,7 +52,6 @@ private:
     std::vector<UUID> findAllImpl(AccessEntityType type) const override;
     AccessEntityPtr readImpl(const UUID & id) const override;
     String readNameImpl(const UUID & id) const override;
-    bool canInsertImpl(const AccessEntityPtr &) const override { return false; }
     UUID insertImpl(const AccessEntityPtr & entity, bool replace_if_exists) override;
     void removeImpl(const UUID & id) override;
     void updateImpl(const UUID & id, const UpdateFunc & update_func) override;

--- a/src/Access/UsersConfigAccessStorage.h
+++ b/src/Access/UsersConfigAccessStorage.h
@@ -54,7 +54,7 @@ private:
     std::optional<String> readNameImpl(const UUID & id, bool throw_if_not_exists) const override;
     std::optional<UUID> insertImpl(const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists) override;
     bool removeImpl(const UUID & id, bool throw_if_not_exists) override;
-    void updateImpl(const UUID & id, const UpdateFunc & update_func) override;
+    bool updateImpl(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists) override;
     scope_guard subscribeForChangesImpl(const UUID & id, const OnChangedHandler & handler) const override;
     scope_guard subscribeForChangesImpl(AccessEntityType type, const OnChangedHandler & handler) const override;
 

--- a/src/Interpreters/Session.cpp
+++ b/src/Interpreters/Session.cpp
@@ -311,7 +311,7 @@ void Session::authenticate(const Credentials & credentials_, const Poco::Net::So
 
     try
     {
-        user_id = global_context->getAccessControl().login(credentials_, address.host());
+        user_id = global_context->getAccessControl().authenticate(credentials_, address.host());
         LOG_DEBUG(log, "{} Authenticated with global context as user {}",
                 toString(auth_id), user_id ? toString(*user_id) : "<EMPTY>");
     }


### PR DESCRIPTION
Changelog category:
- Not for changelog

This PR is mostly refactoring. Exceptions are now thrown only in exceptional cases, so `system.errors` will not contain excessive messages (for example `There is no user foo in users.xml` for an SQL-created user, see https://github.com/ClickHouse/ClickHouse/issues/26835). Also when trying to update readonly and non-readonly access storages in one query, it will throw after updating non-readonly ones, which makes more sense to use commands like `REVOKE role1 FROM ALL`.