### PR TITLE
Fix reading in order of sorting key from `Distributed` and `Merge` tables

### DIFF
--- a/tests/queries/0_stateless/02147_order_by_optimizations.reference
+++ b/tests/queries/0_stateless/02147_order_by_optimizations.reference
@@ -1,0 +1,21 @@
+SELECT
+    date,
+    v
+FROM t_02147
+ORDER BY
+    toStartOfHour(date) ASC,
+    v ASC
+SELECT
+    date,
+    v
+FROM t_02147_dist
+ORDER BY
+    toStartOfHour(date) ASC,
+    v ASC
+SELECT
+    date,
+    v
+FROM t_02147_merge
+ORDER BY
+    toStartOfHour(date) ASC,
+    v ASC

--- a/tests/queries/0_stateless/02147_order_by_optimizations.sql
+++ b/tests/queries/0_stateless/02147_order_by_optimizations.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS t_02147;
+DROP TABLE IF EXISTS t_02147_dist;
+DROP TABLE IF EXISTS t_02147_merge;
+
+CREATE TABLE t_02147 (date DateTime, v UInt32)
+ENGINE = MergeTree ORDER BY toStartOfHour(date);
+
+CREATE TABLE t_02147_dist AS t_02147 ENGINE = Distributed(test_shard_localhost, currentDatabase(), t_02147);
+CREATE TABLE t_02147_merge AS t_02147 ENGINE = Merge(currentDatabase(), 't_02147');
+
+SET optimize_monotonous_functions_in_order_by = 1;
+
+EXPLAIN SYNTAX SELECT * FROM t_02147 ORDER BY toStartOfHour(date), v;
+EXPLAIN SYNTAX SELECT * FROM t_02147_dist ORDER BY toStartOfHour(date), v;
+EXPLAIN SYNTAX SELECT * FROM t_02147_merge ORDER BY toStartOfHour(date), v;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `optimize_read_in_order` optimization in case when table engine is `Distributed` or `Merge` and its underlying `MergeTree` tables have monotonous function in prefix of sorting key.

Fixes #32512
Fixes #20009
