### PR TITLE
Rerun release workflows

### DIFF
--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -43,6 +43,7 @@ NEED_RERUN_WORKFLOWS = {
     13241696, # PR
     15834118, # Docs
     15522500, # MasterCI
+    15516108, # ReleaseCI
 }
 
 # Individual trusted contirbutors who are not in any trusted organization.


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
