### PR TITLE
Pass -no-pie to the linker call to disable it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,7 +447,7 @@ if (MAKE_STATIC_LIBRARIES)
         # It's disabled for ARM because otherwise ClickHouse cannot run on Android.
         set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-pie")
         set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fno-pie")
-        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no-pie")
+        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie -Wl,-no-pie")
     endif ()
 else ()
     set (CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

With clang with PIE enabled by default (only ArchLinux build AFAIK, because we are special flowers) passing `-Wl,-no-pie` doesn't really work because yet, it is passed to the linker but not the clang itself which ends up introducing the dependencies itself:

```
$ clang++ -fno-pie -Wl,-no-pie contrib/llvm/llvm/utils/TableGen/CMakeFiles/llvm-tblgen.dir/AsmMatcherEmitter.cpp.o -o contrib/llvm/llvm/bin/llvm-tblgen  '-###' -v
clang version 13.0.0
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-pc-linux-gnu/11.1.0
Found candidate GCC installation: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0
Selected GCC installation: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Selected multilib: .;@m64
 "/usr/bin/ld" "-pie" "--eh-frame-hdr" "-m" "elf_x86_64" "-dynamic-linker" "/lib64/ld-linux-x86-64.so.2" "-o" "contrib/llvm/llvm/bin/llvm-tblgen" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../lib64/Scrt1.o" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../lib64/crti.o" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/crtbeginS.o" "-L/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0" "-L/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../lib64" "-L/lib/../lib64" "-L/usr/lib/../lib64" "-L/usr/bin/../lib" "-L/lib" "-L/usr/lib" "-no-pie" "contrib/llvm/llvm/utils/TableGen/CMakeFiles/llvm-tblgen.dir/AsmMatcherEmitter.cpp.o" "-lstdc++" "-lm" "-lgcc_s" "-lgcc" "-lc" "-lgcc_s" "-lgcc" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/crtendS.o" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../lib64/crtn.o"
```

Notice the `-pie` at the start but also using `Scrt1.o` instead of the expected `crt1.o`.

Adding `-no-pie` in the clang call fixes it and uses the no-pie version of the linker:

```
$ clang++ -fno-pie -Wl,-no-pie contrib/llvm/llvm/utils/TableGen/CMakeFiles/llvm-tblgen.dir/AsmMatcherEmitter.cpp.o -o contrib/llvm/llvm/bin/llvm-tblgen  '-###' -v -no-pie
clang version 13.0.0
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-pc-linux-gnu/11.1.0
Found candidate GCC installation: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0
Selected GCC installation: /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Selected multilib: .;@m64
 "/usr/bin/ld" "--eh-frame-hdr" "-m" "elf_x86_64" "-dynamic-linker" "/lib64/ld-linux-x86-64.so.2" "-o" "contrib/llvm/llvm/bin/llvm-tblgen" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../lib64/crt1.o" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../lib64/crti.o" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/crtbegin.o" "-L/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0" "-L/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../lib64" "-L/lib/../lib64" "-L/usr/lib/../lib64" "-L/usr/bin/../lib" "-L/lib" "-L/usr/lib" "-no-pie" "contrib/llvm/llvm/utils/TableGen/CMakeFiles/llvm-tblgen.dir/AsmMatcherEmitter.cpp.o" "-lstdc++" "-lm" "-lgcc_s" "-lgcc" "-lc" "-lgcc_s" "-lgcc" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/crtend.o" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../lib64/crtn.o"
```

Again, this only was affecting Archlinux because there clang has PIE enabled by default. Other builds didn't need to disable pie because it wasn't on to begin with.

References https://github.com/ClickHouse/ClickHouse/issues/31764 