### PR TITLE
Allow to control connection timeouts for mysql

### DIFF
--- a/base/mysqlxx/PoolWithFailover.cpp
+++ b/base/mysqlxx/PoolWithFailover.cpp
@@ -82,7 +82,9 @@ PoolWithFailover::PoolWithFailover(
         unsigned default_connections_,
         unsigned max_connections_,
         size_t max_tries_,
-        uint64_t wait_timeout_)
+        uint64_t wait_timeout_,
+        size_t connect_timeout_,
+        size_t rw_timeout_)
     : max_tries(max_tries_)
     , shareable(false)
     , wait_timeout(wait_timeout_)
@@ -93,8 +95,8 @@ PoolWithFailover::PoolWithFailover(
         replicas_by_priority[0].emplace_back(std::make_shared<Pool>(database,
             host, user, password, port,
             /* socket_ = */ "",
-            MYSQLXX_DEFAULT_TIMEOUT,
-            MYSQLXX_DEFAULT_RW_TIMEOUT,
+            connect_timeout_,
+            rw_timeout_,
             default_connections_,
             max_connections_));
     }

--- a/base/mysqlxx/PoolWithFailover.h
+++ b/base/mysqlxx/PoolWithFailover.h
@@ -6,6 +6,7 @@
 #define MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_START_CONNECTIONS 1
 #define MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_MAX_CONNECTIONS 16
 #define MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES 3
+#define MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_CONNECTION_WAIT_TIMEOUT 5 /// in seconds
 
 
 namespace mysqlxx
@@ -121,7 +122,9 @@ namespace mysqlxx
             unsigned default_connections_ = MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_START_CONNECTIONS,
             unsigned max_connections_ = MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_MAX_CONNECTIONS,
             size_t max_tries_ = MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES,
-            uint64_t wait_timeout_ = UINT64_MAX);
+            uint64_t wait_timeout_ = MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_CONNECTION_WAIT_TIMEOUT,
+            size_t connect_timeout = MYSQLXX_DEFAULT_TIMEOUT,
+            size_t rw_timeout = MYSQLXX_DEFAULT_RW_TIMEOUT);
 
         PoolWithFailover(const PoolWithFailover & other);
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -499,8 +499,8 @@ class IColumn;
     \
     M(UInt64, external_storage_max_read_rows, 0, "Limit maximum number of rows when table with external engine should flush history data. Now supported only for MySQL table engine, database engine, dictionary and MaterializedMySQL. If equal to 0, this setting is disabled", 0) \
     M(UInt64, external_storage_max_read_bytes, 0, "Limit maximum number of bytes when table with external engine should flush history data. Now supported only for MySQL table engine, database engine, dictionary and MaterializedMySQL. If equal to 0, this setting is disabled", 0)  \
-    M(UInt64, external_storage_connect_timeout, 60, "Connect timeout. Now supported only for MySQL", 0)  \
-    M(UInt64, external_storage_rw_timeout, 1800, "Read/write timeout. Now supported only for MySQL", 0)  \
+    M(UInt64, external_storage_connect_timeout_sec, DBMS_DEFAULT_CONNECT_TIMEOUT_SEC, "Connect timeout in seconds. Now supported only for MySQL", 0)  \
+    M(UInt64, external_storage_rw_timeout_sec, DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, "Read/write timeout in seconds. Now supported only for MySQL", 0)  \
     \
     M(UnionMode, union_default_mode, UnionMode::Unspecified, "Set default Union Mode in SelectWithUnion query. Possible values: empty string, 'ALL', 'DISTINCT'. If empty, query without Union Mode will throw exception.", 0) \
     M(Bool, optimize_aggregators_of_group_by_keys, true, "Eliminates min/max/any/anyLast aggregators of GROUP BY keys in SELECT section", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -496,8 +496,12 @@ class IColumn;
     M(Bool, database_replicated_always_detach_permanently, false, "Execute DETACH TABLE as DETACH TABLE PERMANENTLY if database engine is Replicated", 0) \
     M(DistributedDDLOutputMode, distributed_ddl_output_mode, DistributedDDLOutputMode::THROW, "Format of distributed DDL query result", 0) \
     M(UInt64, distributed_ddl_entry_format_version, 1, "Version of DDL entry to write into ZooKeeper", 0) \
+    \
     M(UInt64, external_storage_max_read_rows, 0, "Limit maximum number of rows when table with external engine should flush history data. Now supported only for MySQL table engine, database engine, dictionary and MaterializedMySQL. If equal to 0, this setting is disabled", 0) \
     M(UInt64, external_storage_max_read_bytes, 0, "Limit maximum number of bytes when table with external engine should flush history data. Now supported only for MySQL table engine, database engine, dictionary and MaterializedMySQL. If equal to 0, this setting is disabled", 0)  \
+    M(UInt64, external_storage_connect_timeout, 60, "Connect timeout. Now supported only for MySQL", 0)  \
+    M(UInt64, external_storage_rw_timeout, 1800, "Read/write timeout. Now supported only for MySQL", 0)  \
+    \
     M(UnionMode, union_default_mode, UnionMode::Unspecified, "Set default Union Mode in SelectWithUnion query. Possible values: empty string, 'ALL', 'DISTINCT'. If empty, query without Union Mode will throw exception.", 0) \
     M(Bool, optimize_aggregators_of_group_by_keys, true, "Eliminates min/max/any/anyLast aggregators of GROUP BY keys in SELECT section", 0) \
     M(Bool, optimize_group_by_function_keys, true, "Eliminates functions of other keys in GROUP BY section", 0) \

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -23,6 +23,8 @@
 #    include <Databases/MySQL/ConnectionMySQLSettings.h>
 #    include <Databases/MySQL/DatabaseMySQL.h>
 #    include <Databases/MySQL/MaterializedMySQLSettings.h>
+#    include <Storages/MySQL/MySQLHelpers.h>
+#    include <Storages/MySQL/MySQLSettings.h>
 #    include <Databases/MySQL/DatabaseMaterializedMySQL.h>
 #    include <mysqlxx/Pool.h>
 #endif
@@ -198,7 +200,8 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
             if (engine_name == "MySQL")
             {
                 auto mysql_database_settings = std::make_unique<ConnectionMySQLSettings>();
-                auto mysql_pool = mysqlxx::PoolWithFailover(configuration.database, configuration.addresses, configuration.username, configuration.password);
+                MySQLSettings mysql_settings;
+                auto mysql_pool = createMySQLPoolWithFailover(configuration, mysql_settings);
 
                 mysql_database_settings->loadFromQueryContext(context);
                 mysql_database_settings->loadFromQuery(*engine_define); /// higher priority

--- a/src/Databases/MySQL/ConnectionMySQLSettings.cpp
+++ b/src/Databases/MySQL/ConnectionMySQLSettings.cpp
@@ -14,7 +14,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
-IMPLEMENT_SETTINGS_TRAITS(ConnectionMySQLSettingsTraits, LIST_OF_CONNECTION_MYSQL_SETTINGS)
+IMPLEMENT_SETTINGS_TRAITS(ConnectionMySQLSettingsTraits, LIST_OF_MYSQL_DATABASE_SETTINGS)
 
 void ConnectionMySQLSettings::loadFromQuery(ASTStorage & storage_def)
 {

--- a/src/Databases/MySQL/ConnectionMySQLSettings.h
+++ b/src/Databases/MySQL/ConnectionMySQLSettings.h
@@ -4,6 +4,7 @@
 #include <Core/Defines.h>
 #include <Core/SettingsEnums.h>
 #include <Interpreters/Context_fwd.h>
+#include <Storages/MySQL/MySQLSettings.h>
 
 namespace DB
 {
@@ -17,7 +18,11 @@ class ASTStorage;
 #define APPLY_FOR_IMMUTABLE_CONNECTION_MYSQL_SETTINGS(M) \
     M(mysql_datatypes_support_level)
 
-DECLARE_SETTINGS_TRAITS(ConnectionMySQLSettingsTraits, LIST_OF_CONNECTION_MYSQL_SETTINGS)
+#define LIST_OF_MYSQL_DATABASE_SETTINGS(M) \
+    LIST_OF_CONNECTION_MYSQL_SETTINGS(M) \
+    LIST_OF_MYSQL_SETTINGS(M)
+
+DECLARE_SETTINGS_TRAITS(ConnectionMySQLSettingsTraits, LIST_OF_MYSQL_DATABASE_SETTINGS)
 
 
 /** Settings for the MySQL database engine.

--- a/src/Dictionaries/MySQLDictionarySource.cpp
+++ b/src/Dictionaries/MySQLDictionarySource.cpp
@@ -14,6 +14,8 @@
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipeline.h>
 #include <Storages/ExternalDataSourceConfiguration.h>
+#include <Storages/MySQL/MySQLHelpers.h>
+#include <Storages/MySQL/MySQLSettings.h>
 
 
 namespace DB
@@ -46,13 +48,17 @@ void registerDictionarySourceMysql(DictionarySourceFactory & factory)
 
         auto settings_config_prefix = config_prefix + ".mysql";
         std::shared_ptr<mysqlxx::PoolWithFailover> pool;
-        ExternalDataSourceConfiguration configuration;
+        StorageMySQLConfiguration configuration;
         auto named_collection = created_from_ddl ? getExternalDataSourceConfiguration(config, settings_config_prefix, global_context) : std::nullopt;
         if (named_collection)
         {
-            configuration = *named_collection;
-            std::vector<std::pair<String, UInt16>> addresses{std::make_pair(configuration.host, configuration.port)};
-            pool = std::make_shared<mysqlxx::PoolWithFailover>(configuration.database, addresses, configuration.username, configuration.password);
+            configuration.set(*named_collection);
+            configuration.addresses = {std::make_pair(configuration.host, configuration.port)};
+            MySQLSettings mysql_settings;
+            const auto & settings = global_context->getSettingsRef();
+            mysql_settings.connect_timeout = settings.external_storage_connect_timeout;
+            mysql_settings.read_write_timeout = settings.external_storage_rw_timeout;
+            pool = std::make_shared<mysqlxx::PoolWithFailover>(createMySQLPoolWithFailover(configuration, mysql_settings));
         }
         else
         {

--- a/src/Dictionaries/MySQLDictionarySource.cpp
+++ b/src/Dictionaries/MySQLDictionarySource.cpp
@@ -56,8 +56,8 @@ void registerDictionarySourceMysql(DictionarySourceFactory & factory)
             configuration.addresses = {std::make_pair(configuration.host, configuration.port)};
             MySQLSettings mysql_settings;
             const auto & settings = global_context->getSettingsRef();
-            mysql_settings.connect_timeout = settings.external_storage_connect_timeout;
-            mysql_settings.read_write_timeout = settings.external_storage_rw_timeout;
+            mysql_settings.connect_timeout = settings.external_storage_connect_timeout_sec;
+            mysql_settings.read_write_timeout = settings.external_storage_rw_timeout_sec;
             pool = std::make_shared<mysqlxx::PoolWithFailover>(createMySQLPoolWithFailover(configuration, mysql_settings));
         }
         else

--- a/src/Storages/ExternalDataSourceConfiguration.cpp
+++ b/src/Storages/ExternalDataSourceConfiguration.cpp
@@ -54,6 +54,7 @@ void ExternalDataSourceConfiguration::set(const ExternalDataSourceConfiguration 
     database = conf.database;
     table = conf.table;
     schema = conf.schema;
+    addresses = conf.addresses;
     addresses_expr = conf.addresses_expr;
 }
 

--- a/src/Storages/MySQL/MySQLHelpers.cpp
+++ b/src/Storages/MySQL/MySQLHelpers.cpp
@@ -1,0 +1,26 @@
+#include "MySQLHelpers.h"
+
+#if USE_MYSQL
+#include <mysqlxx/PoolWithFailover.h>
+#include <Storages/ExternalDataSourceConfiguration.h>
+#include <Storages/MySQL/MySQLSettings.h>
+
+namespace DB
+{
+
+mysqlxx::PoolWithFailover
+createMySQLPoolWithFailover(const StorageMySQLConfiguration & configuration, const MySQLSettings & mysql_settings)
+{
+    return mysqlxx::PoolWithFailover(
+        configuration.database, configuration.addresses, configuration.username, configuration.password,
+        MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_START_CONNECTIONS,
+        mysql_settings.connection_pool_size,
+        mysql_settings.connection_max_tries,
+        mysql_settings.connection_wait_timeout,
+        mysql_settings.connect_timeout,
+        mysql_settings.read_write_timeout);
+}
+
+}
+
+#endif

--- a/src/Storages/MySQL/MySQLHelpers.h
+++ b/src/Storages/MySQL/MySQLHelpers.h
@@ -1,0 +1,18 @@
+#include "config_core.h"
+
+#if USE_MYSQL
+#include <Interpreters/Context_fwd.h>
+
+namespace mysqlxx { class PoolWithFailover; }
+
+namespace DB
+{
+struct StorageMySQLConfiguration;
+struct MySQLSettings;
+
+mysqlxx::PoolWithFailover
+createMySQLPoolWithFailover(const StorageMySQLConfiguration & configuration, const MySQLSettings & mysql_settings);
+
+}
+
+#endif

--- a/src/Storages/MySQL/MySQLHelpers.h
+++ b/src/Storages/MySQL/MySQLHelpers.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "config_core.h"
 
 #if USE_MYSQL

--- a/src/Storages/MySQL/MySQLSettings.h
+++ b/src/Storages/MySQL/MySQLSettings.h
@@ -19,8 +19,8 @@ class ASTStorage;
     M(UInt64, connection_max_tries, 3, "Number of retries for pool with failover", 0) \
     M(UInt64, connection_wait_timeout, 5, "Timeout (in seconds) for waiting for free connection (in case of there is already connection_pool_size active connections), 0 - do not wait.", 0) \
     M(Bool, connection_auto_close, true, "Auto-close connection after query execution, i.e. disable connection reuse.", 0) \
-    M(UInt64, connect_timeout, 60, "Connect timeout", 0) \
-    M(UInt64, read_write_timeout, 1800, "Read/write timeout", 0) \
+    M(UInt64, connect_timeout, DBMS_DEFAULT_CONNECT_TIMEOUT_SEC, "Connect timeout (in seconds)", 0) \
+    M(UInt64, read_write_timeout, DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, "Read/write timeout (in seconds)", 0) \
 
 DECLARE_SETTINGS_TRAITS(MySQLSettingsTraits, LIST_OF_MYSQL_SETTINGS)
 

--- a/src/Storages/MySQL/MySQLSettings.h
+++ b/src/Storages/MySQL/MySQLSettings.h
@@ -19,6 +19,8 @@ class ASTStorage;
     M(UInt64, connection_max_tries, 3, "Number of retries for pool with failover", 0) \
     M(UInt64, connection_wait_timeout, 5, "Timeout (in seconds) for waiting for free connection (in case of there is already connection_pool_size active connections), 0 - do not wait.", 0) \
     M(Bool, connection_auto_close, true, "Auto-close connection after query execution, i.e. disable connection reuse.", 0) \
+    M(UInt64, connect_timeout, 60, "Connect timeout", 0) \
+    M(UInt64, read_write_timeout, 1800, "Read/write timeout", 0) \
 
 DECLARE_SETTINGS_TRAITS(MySQLSettingsTraits, LIST_OF_MYSQL_SETTINGS)
 

--- a/src/Storages/StorageMySQL.cpp
+++ b/src/Storages/StorageMySQL.cpp
@@ -4,6 +4,7 @@
 
 #include <Storages/StorageFactory.h>
 #include <Storages/transformQueryForExternalDatabase.h>
+#include <Storages/MySQL/MySQLHelpers.h>
 #include <Processors/Sources/MySQLSource.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Core/Settings.h>
@@ -306,13 +307,7 @@ void registerStorageMySQL(StorageFactory & factory)
         if (!mysql_settings.connection_pool_size)
             throw Exception("connection_pool_size cannot be zero.", ErrorCodes::BAD_ARGUMENTS);
 
-        mysqlxx::PoolWithFailover pool(
-            configuration.database, configuration.addresses,
-            configuration.username, configuration.password,
-            MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_START_CONNECTIONS,
-            mysql_settings.connection_pool_size,
-            mysql_settings.connection_max_tries,
-            mysql_settings.connection_wait_timeout);
+        mysqlxx::PoolWithFailover pool = createMySQLPoolWithFailover(configuration, mysql_settings);
 
         return StorageMySQL::create(
             args.table_id,

--- a/src/TableFunctions/TableFunctionMySQL.cpp
+++ b/src/TableFunctions/TableFunctionMySQL.cpp
@@ -40,8 +40,8 @@ void TableFunctionMySQL::parseArguments(const ASTPtr & ast_function, ContextPtr 
     configuration = StorageMySQL::getConfiguration(args_func.arguments->children, context);
     MySQLSettings mysql_settings;
     const auto & settings = context->getSettingsRef();
-    mysql_settings.connect_timeout = settings.external_storage_connect_timeout;
-    mysql_settings.read_write_timeout = settings.external_storage_rw_timeout;
+    mysql_settings.connect_timeout = settings.external_storage_connect_timeout_sec;
+    mysql_settings.read_write_timeout = settings.external_storage_rw_timeout_sec;
     pool.emplace(createMySQLPoolWithFailover(*configuration, mysql_settings));
 }
 

--- a/src/TableFunctions/TableFunctionMySQL.cpp
+++ b/src/TableFunctions/TableFunctionMySQL.cpp
@@ -8,6 +8,7 @@
 #include <Parsers/ASTFunction.h>
 #include <Storages/StorageMySQL.h>
 #include <Storages/MySQL/MySQLSettings.h>
+#include <Storages/MySQL/MySQLHelpers.h>
 #include <TableFunctions/ITableFunction.h>
 #include <TableFunctions/TableFunctionFactory.h>
 #include <TableFunctions/TableFunctionMySQL.h>
@@ -37,7 +38,11 @@ void TableFunctionMySQL::parseArguments(const ASTPtr & ast_function, ContextPtr 
         throw Exception("Table function 'mysql' must have arguments.", ErrorCodes::LOGICAL_ERROR);
 
     configuration = StorageMySQL::getConfiguration(args_func.arguments->children, context);
-    pool.emplace(configuration->database, configuration->addresses, configuration->username, configuration->password);
+    MySQLSettings mysql_settings;
+    const auto & settings = context->getSettingsRef();
+    mysql_settings.connect_timeout = settings.external_storage_connect_timeout;
+    mysql_settings.read_write_timeout = settings.external_storage_rw_timeout;
+    pool.emplace(createMySQLPoolWithFailover(*configuration, mysql_settings));
 }
 
 ColumnsDescription TableFunctionMySQL::getActualTableStructure(ContextPtr context) const

--- a/tests/queries/0_stateless/01293_show_settings.reference
+++ b/tests/queries/0_stateless/01293_show_settings.reference
@@ -2,7 +2,7 @@ send_timeout	Seconds	300
 connect_timeout	Seconds	10
 connect_timeout_with_failover_ms	Milliseconds	2000
 connect_timeout_with_failover_secure_ms	Milliseconds	3000
-external_storage_connect_timeout	UInt64	60
+external_storage_connect_timeout_sec	UInt64	10
 max_memory_usage	UInt64	10000000000
 max_untracked_memory	UInt64	1048576
 memory_profiler_step	UInt64	1048576

--- a/tests/queries/0_stateless/01293_show_settings.reference
+++ b/tests/queries/0_stateless/01293_show_settings.reference
@@ -2,6 +2,7 @@ send_timeout	Seconds	300
 connect_timeout	Seconds	10
 connect_timeout_with_failover_ms	Milliseconds	2000
 connect_timeout_with_failover_secure_ms	Milliseconds	3000
+external_storage_connect_timeout	UInt64	60
 max_memory_usage	UInt64	10000000000
 max_untracked_memory	UInt64	1048576
 memory_profiler_step	UInt64	1048576


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to control connection timeouts for mysql (previously was supported only for dictionary source). Closes https://github.com/ClickHouse/ClickHouse/issues/16669. Previously default connect_timeout was rather small, now it is configurable.
