### PR TITLE
tests/integration: fix waiting of mysql client container

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1109,7 +1109,7 @@ class ClickHouseCluster:
                 errors += [str(ex)]
                 time.sleep(1)
 
-        run_and_check(['docker-compose', 'ps', '--services', '--all'])
+        run_and_check(['docker', 'ps', '--all'])
         logging.error("Can't connect to MySQL Client:{}".format(errors))
         raise Exception("Cannot wait MySQL Client container")
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1101,10 +1101,8 @@ class ClickHouseCluster:
                 info = self.mysql_client_container.client.api.inspect_container(self.mysql_client_container.name)
                 if info['State']['Health']['Status'] == 'healthy':
                     logging.debug("Mysql Client Container Started")
-                    break
+                    return
                 time.sleep(1)
-
-                return
             except Exception as ex:
                 errors += [str(ex)]
                 time.sleep(1)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

healthy means that everything is OK and no need to wait.

And before it works only because mysql container was too slow to start
and wait_mysql_client_to_start() returns only when the status was
unhealthy/starting, which was obviously wrong.

Fixes: #20393 (cc @qoega)