### PR TITLE
Support `optimize_read_in_order` if prefix of sorting key is already sorted

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1924,6 +1924,7 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
                 {
                     query_info.projection->order_optimizer = std::make_shared<ReadInOrderOptimizer>(
                         // TODO Do we need a projection variant for this field?
+                        query,
                         analysis_result.order_by_elements_actions,
                         getSortDescription(query, context),
                         query_info.syntax_analyzer_result);
@@ -1931,7 +1932,10 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
                 else
                 {
                     query_info.order_optimizer = std::make_shared<ReadInOrderOptimizer>(
-                        analysis_result.order_by_elements_actions, getSortDescription(query, context), query_info.syntax_analyzer_result);
+                        query,
+                        analysis_result.order_by_elements_actions,
+                        getSortDescription(query, context),
+                        query_info.syntax_analyzer_result);
                 }
             }
             else
@@ -1939,6 +1943,7 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
                 if (query_info.projection)
                 {
                     query_info.projection->order_optimizer = std::make_shared<ReadInOrderOptimizer>(
+                        query,
                         query_info.projection->group_by_elements_actions,
                         getSortDescriptionFromGroupBy(query),
                         query_info.syntax_analyzer_result);
@@ -1946,7 +1951,10 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
                 else
                 {
                     query_info.order_optimizer = std::make_shared<ReadInOrderOptimizer>(
-                        analysis_result.group_by_elements_actions, getSortDescriptionFromGroupBy(query), query_info.syntax_analyzer_result);
+                        query,
+                        analysis_result.group_by_elements_actions,
+                        getSortDescriptionFromGroupBy(query),
+                        query_info.syntax_analyzer_result);
                 }
             }
 

--- a/src/Interpreters/TreeCNFConverter.cpp
+++ b/src/Interpreters/TreeCNFConverter.cpp
@@ -26,7 +26,7 @@ bool isLogicalFunction(const ASTFunction & func)
 size_t countAtoms(const ASTPtr & node)
 {
     checkStackSize();
-    if (node->as<ASTIdentifier>())
+    if (node->as<ASTIdentifier>() || node->as<ASTLiteral>())
         return 1;
 
     const auto * func = node->as<ASTFunction>();

--- a/src/Interpreters/TreeCNFConverter.h
+++ b/src/Interpreters/TreeCNFConverter.h
@@ -89,15 +89,6 @@ public:
         return *this;
     }
 
-    template <typename F>
-    const CNFQuery & iterateAtoms(F func) const
-    {
-        for (const auto & group : statements)
-            for (const auto & atom : group)
-                func(atom);
-        return *this;
-    }
-
     CNFQuery & appendGroup(AndGroup&& and_group)
     {
         for (auto && or_group : and_group)

--- a/src/Interpreters/TreeCNFConverter.h
+++ b/src/Interpreters/TreeCNFConverter.h
@@ -89,6 +89,15 @@ public:
         return *this;
     }
 
+    template <typename F>
+    const CNFQuery & iterateAtoms(F func) const
+    {
+        for (const auto & group : statements)
+            for (const auto & atom : group)
+                func(atom);
+        return *this;
+    }
+
     CNFQuery & appendGroup(AndGroup&& and_group)
     {
         for (auto && or_group : and_group)

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -365,7 +365,6 @@ static ActionsDAGPtr createProjection(const Block & header)
 Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsWithOrder(
     RangesInDataParts && parts_with_ranges,
     const Names & column_names,
-    const ActionsDAGPtr & sorting_key_prefix_expr,
     ActionsDAGPtr & out_projection,
     const InputOrderInfoPtr & input_order_info)
 {
@@ -507,10 +506,19 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsWithOrder(
 
     if (need_preliminary_merge)
     {
+        size_t fixed_prefix_size = input_order_info->order_key_fixed_prefix_descr.size();
+        size_t prefix_size = fixed_prefix_size + input_order_info->order_key_prefix_descr.size();
+
+        auto order_key_prefix_ast = metadata_snapshot->getSortingKey().expression_list_ast->clone();
+        order_key_prefix_ast->children.resize(prefix_size);
+
+        auto syntax_result = TreeRewriter(context).analyze(order_key_prefix_ast, metadata_snapshot->getColumns().getAllPhysical());
+        auto sorting_key_prefix_expr = ExpressionAnalyzer(order_key_prefix_ast, syntax_result, context).getActionsDAG(false);
+        const auto & sorting_columns = metadata_snapshot->getSortingKey().column_names;
+
         SortDescription sort_description;
-        for (size_t j = 0; j < input_order_info->order_key_prefix_descr.size(); ++j)
-            sort_description.emplace_back(metadata_snapshot->getSortingKey().column_names[j],
-                                          input_order_info->direction, 1);
+        for (size_t j = 0; j < prefix_size; ++j)
+            sort_description.emplace_back(sorting_columns[j], input_order_info->direction);
 
         auto sorting_key_expr = std::make_shared<ExpressionActions>(sorting_key_prefix_expr);
 
@@ -1048,17 +1056,9 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
     }
     else if ((settings.optimize_read_in_order || settings.optimize_aggregation_in_order) && input_order_info)
     {
-        size_t prefix_size = input_order_info->order_key_prefix_descr.size();
-        auto order_key_prefix_ast = metadata_snapshot->getSortingKey().expression_list_ast->clone();
-        order_key_prefix_ast->children.resize(prefix_size);
-
-        auto syntax_result = TreeRewriter(context).analyze(order_key_prefix_ast, metadata_snapshot->getColumns().getAllPhysical());
-        auto sorting_key_prefix_expr = ExpressionAnalyzer(order_key_prefix_ast, syntax_result, context).getActionsDAG(false);
-
         pipe = spreadMarkRangesAmongStreamsWithOrder(
             std::move(result.parts_with_ranges),
             column_names_to_read,
-            sorting_key_prefix_expr,
             result_projection,
             input_order_info);
     }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -173,7 +173,6 @@ private:
     Pipe spreadMarkRangesAmongStreamsWithOrder(
         RangesInDataParts && parts_with_ranges,
         const Names & column_names,
-        const ActionsDAGPtr & sorting_key_prefix_expr,
         ActionsDAGPtr & out_projection,
         const InputOrderInfoPtr & input_order_info);
 

--- a/src/Storages/ReadInOrderOptimizer.cpp
+++ b/src/Storages/ReadInOrderOptimizer.cpp
@@ -6,6 +6,8 @@
 #include <Interpreters/replaceAliasColumnsInQuery.h>
 #include <Functions/IFunction.h>
 #include <Interpreters/TableJoin.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTFunction.h>
 
 namespace DB
 {
@@ -15,13 +17,152 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+namespace
+{
+
+ASTPtr getFixedPoint(const ASTPtr & ast)
+{
+    const auto * func = ast->as<ASTFunction>();
+    if (!func || func->name != "equals")
+        return nullptr;
+
+    const auto & lhs = func->arguments->children[0];
+    const auto & rhs = func->arguments->children[1];
+
+    if (lhs->as<ASTLiteral>())
+        return rhs;
+
+    if (rhs->as<ASTLiteral>())
+        return lhs;
+
+    return nullptr;
+}
+
+size_t calculateFixedPrefixSize(
+    const ASTSelectQuery & query, const Names & sorting_key_columns)
+{
+    ASTPtr condition;
+    if (query.where() && query.prewhere())
+        condition = makeASTFunction("and", query.where(), query.prewhere());
+    else if (query.where())
+        condition = query.where();
+    else if (query.prewhere())
+        condition = query.prewhere();
+
+    if (!condition)
+        return 0;
+
+    /// Convert condition to CNF for more convinient analysis.
+    auto cnf = TreeCNFConverter::tryConvertToCNF(condition);
+    if (!cnf)
+        return 0;
+
+    NameSet fixed_points;
+
+    /// If we met expression like 'column = x', where 'x' is literal,
+    /// in clause of size 1 in CNF, then we can guarantee
+    /// that in all filtered rows 'column' will be equal to 'x'.
+    cnf->iterateGroups([&](const auto & group)
+    {
+        if (group.size() == 1 && !group.begin()->negative)
+        {
+            auto fixed_point = getFixedPoint(group.begin()->ast);
+            if (fixed_point)
+                fixed_points.insert(fixed_point->getColumnName());
+        }
+    });
+
+    size_t prefix_size = 0;
+    for (const auto & column_name : sorting_key_columns)
+    {
+        if (!fixed_points.contains(column_name))
+            break;
+
+        ++prefix_size;
+    }
+
+    return prefix_size;
+}
+
+/// Optimize in case of exact match with order key element
+/// or in some simple cases when order key element is wrapped into monotonic function.
+/// Returns on of {-1, 0, 1} - direction of the match. 0 means - doesn't match.
+int matchSortDescriptionAndKey(
+    const ExpressionActions::Actions & actions,
+    const SortColumnDescription & sort_column,
+    const String & sorting_key_column)
+{
+    /// If required order depend on collation, it cannot be matched with primary key order.
+    /// Because primary keys cannot have collations.
+    if (sort_column.collator)
+        return 0;
+
+    int current_direction = sort_column.direction;
+    /// For the path: order by (sort_column, ...)
+    if (sort_column.column_name == sorting_key_column)
+        return current_direction;
+
+    /// For the path: order by (function(sort_column), ...)
+    /// Allow only one simple monotonic functions with one argument
+    /// Why not allow multi monotonic functions?
+    bool found_function = false;
+
+    for (const auto & action : actions)
+    {
+        if (action.node->type != ActionsDAG::ActionType::FUNCTION)
+            continue;
+
+        if (found_function)
+        {
+            current_direction = 0;
+            break;
+        }
+        else
+        {
+            found_function = true;
+        }
+
+        if (action.node->children.size() != 1 || action.node->children.at(0)->result_name != sorting_key_column)
+        {
+            current_direction = 0;
+            break;
+        }
+
+        const auto & func = *action.node->function_base;
+        if (!func.hasInformationAboutMonotonicity())
+        {
+            current_direction = 0;
+            break;
+        }
+
+        auto monotonicity = func.getMonotonicityForRange(*func.getArgumentTypes().at(0), {}, {});
+        if (!monotonicity.is_monotonic)
+        {
+            current_direction = 0;
+            break;
+        }
+        else if (!monotonicity.is_positive)
+        {
+            current_direction *= -1;
+        }
+    }
+
+    if (!found_function)
+        current_direction = 0;
+
+    return current_direction;
+}
+
+}
 
 ReadInOrderOptimizer::ReadInOrderOptimizer(
+    const ASTSelectQuery & query_,
     const ManyExpressionActions & elements_actions_,
     const SortDescription & required_sort_description_,
     const TreeRewriterResultPtr & syntax_result)
     : elements_actions(elements_actions_)
     , required_sort_description(required_sort_description_)
+    , query(query_)
 {
     if (elements_actions.size() != required_sort_description.size())
         throw Exception("Sizes of sort description and actions are mismatched", ErrorCodes::LOGICAL_ERROR);
@@ -35,126 +176,78 @@ ReadInOrderOptimizer::ReadInOrderOptimizer(
     array_join_result_to_source = syntax_result->array_join_result_to_source;
 }
 
-InputOrderInfoPtr ReadInOrderOptimizer::getInputOrder(const StorageMetadataPtr & metadata_snapshot, ContextPtr context, UInt64 limit) const
+InputOrderInfoPtr ReadInOrderOptimizer::getInputOrderImpl(
+    const StorageMetadataPtr & metadata_snapshot,
+    const SortDescription & description,
+    const ManyExpressionActions & actions,
+    UInt64 limit) const
 {
-    Names sorting_key_columns = metadata_snapshot->getSortingKeyColumns();
-    if (!metadata_snapshot->hasSortingKey())
-        return {};
-
+    auto sorting_key_columns = metadata_snapshot->getSortingKeyColumns();
     SortDescription order_key_prefix_descr;
-    int read_direction = required_sort_description.at(0).direction;
+    int read_direction = description.at(0).direction;
 
-    size_t prefix_size = std::min(required_sort_description.size(), sorting_key_columns.size());
-    auto aliased_columns = metadata_snapshot->getColumns().getAliases();
+    size_t fixed_prefix_size = calculateFixedPrefixSize(query, sorting_key_columns);
+    size_t descr_prefix_size = std::min(description.size(), sorting_key_columns.size() - fixed_prefix_size);
 
-    for (size_t i = 0; i < prefix_size; ++i)
+    for (size_t i = 0; i < descr_prefix_size; ++i)
     {
-        if (forbidden_columns.count(required_sort_description[i].column_name))
+        if (forbidden_columns.count(description[i].column_name))
             break;
 
-        /// Optimize in case of exact match with order key element
-        ///  or in some simple cases when order key element is wrapped into monotonic function.
-        auto apply_order_judge = [&] (const ExpressionActions::Actions & actions, const String & sort_column)
-        {
-            /// If required order depend on collation, it cannot be matched with primary key order.
-            /// Because primary keys cannot have collations.
-            if (required_sort_description[i].collator)
-                return false;
+        int current_direction = matchSortDescriptionAndKey(
+            actions[i]->getActions(), description[i], sorting_key_columns[i + fixed_prefix_size]);
 
-            int current_direction = required_sort_description[i].direction;
-            /// For the path: order by (sort_column, ...)
-            if (sort_column == sorting_key_columns[i] && current_direction == read_direction)
-            {
-                return true;
-            }
-            /// For the path: order by (function(sort_column), ...)
-            /// Allow only one simple monotonic functions with one argument
-            /// Why not allow multi monotonic functions?
-            else
-            {
-                bool found_function = false;
-
-                for (const auto & action : actions)
-                {
-                    if (action.node->type != ActionsDAG::ActionType::FUNCTION)
-                    {
-                        continue;
-                    }
-
-                    if (found_function)
-                    {
-                        current_direction = 0;
-                        break;
-                    }
-                    else
-                        found_function = true;
-
-                    if (action.node->children.size() != 1 || action.node->children.at(0)->result_name != sorting_key_columns[i])
-                    {
-                        current_direction = 0;
-                        break;
-                    }
-
-                    const auto & func = *action.node->function_base;
-                    if (!func.hasInformationAboutMonotonicity())
-                    {
-                        current_direction = 0;
-                        break;
-                    }
-
-                    auto monotonicity = func.getMonotonicityForRange(*func.getArgumentTypes().at(0), {}, {});
-                    if (!monotonicity.is_monotonic)
-                    {
-                        current_direction = 0;
-                        break;
-                    }
-                    else if (!monotonicity.is_positive)
-                        current_direction *= -1;
-                }
-
-                if (!found_function)
-                    current_direction = 0;
-
-                if (!current_direction || (i > 0 && current_direction != read_direction))
-                    return false;
-
-                if (i == 0)
-                    read_direction = current_direction;
-
-                return true;
-            }
-        };
-
-        const auto & actions = elements_actions[i]->getActions();
-        bool ok;
-        /// check if it's alias column
-        /// currently we only support alias column without any function wrapper
-        /// ie: `order by aliased_column` can have this optimization, but `order by function(aliased_column)` can not.
-        /// This suits most cases.
-        if (context->getSettingsRef().optimize_respect_aliases && aliased_columns.contains(required_sort_description[i].column_name))
-        {
-            auto column_expr = metadata_snapshot->getColumns().get(required_sort_description[i].column_name).default_desc.expression->clone();
-            replaceAliasColumnsInQuery(column_expr, metadata_snapshot->getColumns(), array_join_result_to_source, context);
-
-            auto syntax_analyzer_result = TreeRewriter(context).analyze(column_expr, metadata_snapshot->getColumns().getAll());
-            const auto expression_analyzer = ExpressionAnalyzer(column_expr, syntax_analyzer_result, context).getActions(true);
-            const auto & alias_actions = expression_analyzer->getActions();
-
-            ok = apply_order_judge(alias_actions, column_expr->getColumnName());
-        }
-        else
-            ok = apply_order_judge(actions, required_sort_description[i].column_name);
-
-        if (ok)
-            order_key_prefix_descr.push_back(required_sort_description[i]);
-        else
+        if (!current_direction || (i > 0 && current_direction != read_direction))
             break;
+
+        if (i == 0)
+            read_direction = current_direction;
+
+        order_key_prefix_descr.push_back(required_sort_description[i]);
     }
 
     if (order_key_prefix_descr.empty())
         return {};
 
     return std::make_shared<InputOrderInfo>(std::move(order_key_prefix_descr), read_direction, limit);
+}
+
+InputOrderInfoPtr ReadInOrderOptimizer::getInputOrder(
+    const StorageMetadataPtr & metadata_snapshot, ContextPtr context, UInt64 limit) const
+{
+    if (!metadata_snapshot->hasSortingKey())
+        return {};
+
+    auto aliased_columns = metadata_snapshot->getColumns().getAliases();
+
+    /// Replace alias column with proper expressions.
+    /// Currently we only support alias column without any function wrapper,
+    /// i.e.: `order by aliased_column` can have this optimization, but `order by function(aliased_column)` can not.
+    /// This suits most cases.
+    if (context->getSettingsRef().optimize_respect_aliases && !aliased_columns.empty())
+    {
+        SortDescription aliases_sort_description = required_sort_description;
+        ManyExpressionActions aliases_actions = elements_actions;
+
+        for (size_t i = 0; i < required_sort_description.size(); ++i)
+        {
+            if (!aliased_columns.contains(required_sort_description[i].column_name))
+                continue;
+
+            auto column_expr = metadata_snapshot->getColumns().get(required_sort_description[i].column_name).default_desc.expression->clone();
+            replaceAliasColumnsInQuery(column_expr, metadata_snapshot->getColumns(), array_join_result_to_source, context);
+
+            auto syntax_analyzer_result = TreeRewriter(context).analyze(column_expr, metadata_snapshot->getColumns().getAll());
+            auto expression_analyzer = ExpressionAnalyzer(column_expr, syntax_analyzer_result, context);
+
+            aliases_sort_description[i].column_name = column_expr->getColumnName();
+            aliases_actions[i] = expression_analyzer.getActions(true);
+        }
+
+        return getInputOrderImpl(metadata_snapshot, aliases_sort_description, aliases_actions, limit);
+    }
+
+    return getInputOrderImpl(metadata_snapshot, required_sort_description, elements_actions, limit);
 }
 
 }

--- a/src/Storages/ReadInOrderOptimizer.h
+++ b/src/Storages/ReadInOrderOptimizer.h
@@ -18,6 +18,7 @@ class ReadInOrderOptimizer
 {
 public:
     ReadInOrderOptimizer(
+        const ASTSelectQuery & query,
         const ManyExpressionActions & elements_actions,
         const SortDescription & required_sort_description,
         const TreeRewriterResultPtr & syntax_result);
@@ -25,10 +26,17 @@ public:
     InputOrderInfoPtr getInputOrder(const StorageMetadataPtr & metadata_snapshot, ContextPtr context, UInt64 limit = 0) const;
 
 private:
+    InputOrderInfoPtr getInputOrderImpl(
+        const StorageMetadataPtr & metadata_snapshot,
+        const SortDescription & description,
+        const ManyExpressionActions & actions,
+        UInt64 limit) const;
+
     /// Actions for every element of order expression to analyze functions for monotonicity
     ManyExpressionActions elements_actions;
     NameSet forbidden_columns;
     NameToNameMap array_join_result_to_source;
     SortDescription required_sort_description;
+    const ASTSelectQuery & query;
 };
 }

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -87,19 +87,22 @@ struct FilterDAGInfo
 
 struct InputOrderInfo
 {
+    SortDescription order_key_fixed_prefix_descr;
     SortDescription order_key_prefix_descr;
     int direction;
     UInt64 limit;
 
-    InputOrderInfo(const SortDescription & order_key_prefix_descr_, int direction_, UInt64 limit_)
-        : order_key_prefix_descr(order_key_prefix_descr_), direction(direction_), limit(limit_) {}
-
-    bool operator ==(const InputOrderInfo & other) const
+    InputOrderInfo(
+        const SortDescription & order_key_fixed_prefix_descr_,
+        const SortDescription & order_key_prefix_descr_,
+        int direction_, UInt64 limit_)
+        : order_key_fixed_prefix_descr(order_key_fixed_prefix_descr_)
+        , order_key_prefix_descr(order_key_prefix_descr_)
+        , direction(direction_), limit(limit_)
     {
-        return order_key_prefix_descr == other.order_key_prefix_descr && direction == other.direction;
     }
 
-    bool operator !=(const InputOrderInfo & other) const { return !(*this == other); }
+    bool operator==(const InputOrderInfo &) const = default;
 };
 
 class IMergeTreeDataPart;

--- a/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.reference
+++ b/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.reference
@@ -1,0 +1,79 @@
+2020-10-11	0
+2020-10-11	0
+2020-10-11	0
+2020-10-11	0
+2020-10-11	0
+2020-10-11	0
+2020-10-11	0
+2020-10-11	0
+2020-10-11	0
+2020-10-11	0
+(Expression)
+ExpressionTransform
+  (Limit)
+  Limit
+    (Sorting)
+      (Expression)
+      ExpressionTransform
+        (Filter)
+        FilterTransform
+          (SettingQuotaAndLimits)
+            (ReadFromMergeTree)
+            MergeTreeInOrder 0 → 1
+2020-10-11	0	0
+2020-10-11	0	10
+2020-10-11	0	20
+2020-10-11	0	30
+2020-10-11	0	40
+2020-10-11	0	50
+2020-10-11	0	60
+2020-10-11	0	70
+2020-10-11	0	80
+2020-10-11	0	90
+(Expression)
+ExpressionTransform
+  (Limit)
+  Limit
+    (Sorting)
+    FinishSortingTransform
+      PartialSortingTransform
+        (Expression)
+        ExpressionTransform
+          (Filter)
+          FilterTransform
+            (SettingQuotaAndLimits)
+              (ReadFromMergeTree)
+              MergeTreeInOrder 0 → 1
+2020-10-12	0
+2020-10-12	1
+2020-10-12	2
+2020-10-12	3
+2020-10-12	4
+2020-10-12	5
+2020-10-12	6
+2020-10-12	7
+2020-10-12	8
+2020-10-12	9
+(Expression)
+ExpressionTransform
+  (Limit)
+  Limit
+    (Sorting)
+      (Expression)
+      ExpressionTransform
+        (Filter)
+        FilterTransform
+          (SettingQuotaAndLimits)
+            (ReadFromMergeTree)
+            ReverseTransform
+              MergeTreeReverse 0 → 1
+2020-10-12	99999
+2020-10-12	99998
+2020-10-12	99997
+2020-10-12	99996
+2020-10-12	99995
+2020-10-12	99994
+2020-10-12	99993
+2020-10-12	99992
+2020-10-12	99991
+2020-10-12	99990

--- a/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.reference
+++ b/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.reference
@@ -1,8 +1,56 @@
-2020-10-11	0
-2020-10-11	0
-2020-10-11	0
-2020-10-11	0
-2020-10-11	0
+2020-10-01	0
+2020-10-01	0
+2020-10-01	0
+2020-10-01	0
+2020-10-01	0
+(Expression)
+ExpressionTransform
+  (Limit)
+  Limit
+    (Sorting)
+    MergingSortedTransform 2 → 1
+      (Expression)
+      ExpressionTransform × 2
+        (SettingQuotaAndLimits)
+          (ReadFromMergeTree)
+          MergeTreeInOrder × 2 0 → 1
+2020-10-01	9
+2020-10-01	9
+2020-10-01	9
+2020-10-01	9
+2020-10-01	9
+(Expression)
+ExpressionTransform
+  (Limit)
+  Limit
+    (Sorting)
+    MergingSortedTransform 2 → 1
+      (Expression)
+      ExpressionTransform × 2
+        (SettingQuotaAndLimits)
+          (ReadFromMergeTree)
+          ReverseTransform
+            MergeTreeReverse 0 → 1
+              ReverseTransform
+                MergeTreeReverse 0 → 1
+2020-10-01	9
+2020-10-01	9
+2020-10-01	9
+2020-10-01	9
+2020-10-01	9
+(Expression)
+ExpressionTransform
+  (Limit)
+  Limit
+    (Sorting)
+    FinishSortingTransform
+      PartialSortingTransform
+        MergingSortedTransform 2 → 1
+          (Expression)
+          ExpressionTransform × 2
+            (SettingQuotaAndLimits)
+              (ReadFromMergeTree)
+              MergeTreeInOrder × 2 0 → 1
 2020-10-11	0
 2020-10-11	0
 2020-10-11	0
@@ -25,11 +73,6 @@ ExpressionTransform
 2020-10-11	0	20
 2020-10-11	0	30
 2020-10-11	0	40
-2020-10-11	0	50
-2020-10-11	0	60
-2020-10-11	0	70
-2020-10-11	0	80
-2020-10-11	0	90
 (Expression)
 ExpressionTransform
   (Limit)
@@ -49,11 +92,6 @@ ExpressionTransform
 2020-10-12	2
 2020-10-12	3
 2020-10-12	4
-2020-10-12	5
-2020-10-12	6
-2020-10-12	7
-2020-10-12	8
-2020-10-12	9
 (Expression)
 ExpressionTransform
   (Limit)
@@ -72,8 +110,46 @@ ExpressionTransform
 2020-10-12	99997
 2020-10-12	99996
 2020-10-12	99995
-2020-10-12	99994
-2020-10-12	99993
-2020-10-12	99992
-2020-10-12	99991
-2020-10-12	99990
+1	2
+1	2
+1	3
+1	3
+1	4
+1	4
+========
+1	4
+1	4
+1	3
+1	3
+1	2
+1	2
+(Expression)
+ExpressionTransform
+  (Limit)
+  Limit
+    (Sorting)
+      (Expression)
+      ExpressionTransform
+        (SettingQuotaAndLimits)
+          (ReadFromMergeTree)
+          MergeTreeInOrder 0 → 1
+2020-10-10 00:00:00	0.01
+2020-10-10 00:00:00	0.01
+2020-10-10 00:00:00	0.01
+2020-10-10 00:00:00	0.01
+2020-10-10 00:00:00	0.01
+(Expression)
+ExpressionTransform
+  (Limit)
+  Limit
+    (Sorting)
+      (Expression)
+      ExpressionTransform
+        (SettingQuotaAndLimits)
+          (ReadFromMergeTree)
+          MergeTreeInOrder 0 → 1
+2020-10-10 00:00:00	0.01
+2020-10-10 00:00:00	0.01
+2020-10-10 00:00:00	0.01
+2020-10-10 00:00:00	0.01
+2020-10-10 00:00:00	0.01

--- a/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.sql
+++ b/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.sql
@@ -1,0 +1,21 @@
+DROP TABLE IF EXISTS t_read_in_order;
+
+CREATE TABLE t_read_in_order(date Date, i UInt64, v UInt64)
+ENGINE = MergeTree ORDER BY (date, i);
+
+INSERT INTO t_read_in_order SELECT '2020-10-10', number % 10, number FROM numbers(100000);
+INSERT INTO t_read_in_order SELECT '2020-10-11', number % 10, number FROM numbers(100000);
+
+SELECT date, i FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i LIMIT 10;
+EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i LIMIT 10;
+
+SELECT * FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i, v LIMIT 10;
+EXPLAIN PIPELINE SELECT * FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i, v LIMIT 10;
+
+INSERT INTO t_read_in_order SELECT '2020-10-12', number, number FROM numbers(100000);
+SELECT date, i FROM t_read_in_order WHERE date = '2020-10-12' ORDER BY i LIMIT 10;
+
+EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order WHERE date = '2020-10-12' ORDER BY i DESC LIMIT 10;
+SELECT date, i FROM t_read_in_order WHERE date = '2020-10-12' ORDER BY i DESC LIMIT 10;
+
+DROP TABLE t_read_in_order;

--- a/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.sql
+++ b/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.sql
@@ -6,16 +6,53 @@ ENGINE = MergeTree ORDER BY (date, i);
 INSERT INTO t_read_in_order SELECT '2020-10-10', number % 10, number FROM numbers(100000);
 INSERT INTO t_read_in_order SELECT '2020-10-11', number % 10, number FROM numbers(100000);
 
-SELECT date, i FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i LIMIT 10;
-EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i LIMIT 10;
+SELECT toStartOfMonth(date) as d, i FROM t_read_in_order ORDER BY d, i LIMIT 5;
+EXPLAIN PIPELINE SELECT toStartOfMonth(date) as d, i FROM t_read_in_order ORDER BY d, i LIMIT 5;
 
-SELECT * FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i, v LIMIT 10;
-EXPLAIN PIPELINE SELECT * FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i, v LIMIT 10;
+SELECT toStartOfMonth(date) as d, i FROM t_read_in_order ORDER BY d DESC, -i LIMIT 5;
+EXPLAIN PIPELINE SELECT toStartOfMonth(date) as d, i FROM t_read_in_order ORDER BY d DESC, -i LIMIT 5;
+
+-- Here FinishSorting is used, because directions don't match.
+SELECT toStartOfMonth(date) as d, i FROM t_read_in_order ORDER BY d, -i LIMIT 5;
+EXPLAIN PIPELINE SELECT toStartOfMonth(date) as d, i FROM t_read_in_order ORDER BY d, -i LIMIT 5;
+
+SELECT date, i FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i LIMIT 5;
+EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i LIMIT 5;
+
+SELECT * FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i, v LIMIT 5;
+EXPLAIN PIPELINE SELECT * FROM t_read_in_order WHERE date = '2020-10-11' ORDER BY i, v LIMIT 5;
 
 INSERT INTO t_read_in_order SELECT '2020-10-12', number, number FROM numbers(100000);
-SELECT date, i FROM t_read_in_order WHERE date = '2020-10-12' ORDER BY i LIMIT 10;
 
-EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order WHERE date = '2020-10-12' ORDER BY i DESC LIMIT 10;
-SELECT date, i FROM t_read_in_order WHERE date = '2020-10-12' ORDER BY i DESC LIMIT 10;
+SELECT date, i FROM t_read_in_order WHERE date = '2020-10-12' ORDER BY i LIMIT 5;
+
+EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order WHERE date = '2020-10-12' ORDER BY i DESC LIMIT 5;
+SELECT date, i FROM t_read_in_order WHERE date = '2020-10-12' ORDER BY i DESC LIMIT 5;
+
+DROP TABLE IF EXISTS t_read_in_order;
+
+CREATE TABLE t_read_in_order(a UInt32, b UInt32)
+ENGINE = MergeTree ORDER BY (a, b)
+SETTINGS index_granularity = 3;
+
+SYSTEM STOP MERGES t_read_in_order;
+
+INSERT INTO t_read_in_order VALUES (0, 100), (1, 2), (1, 3), (1, 4), (2, 5);
+INSERT INTO t_read_in_order VALUES (0, 100), (1, 2), (1, 3), (1, 4), (2, 5);
+
+SELECT a, b FROM t_read_in_order WHERE a = 1 ORDER BY b SETTINGS read_in_order_two_level_merge_threshold = 1;
+SELECT '========';
+SELECT a, b FROM t_read_in_order WHERE a = 1 ORDER BY b DESC SETTINGS read_in_order_two_level_merge_threshold = 1;
 
 DROP TABLE t_read_in_order;
+
+CREATE TABLE t_read_in_order(dt DateTime, d Decimal64(5), v UInt64)
+ENGINE = MergeTree ORDER BY (toStartOfDay(dt), d);
+
+INSERT INTO t_read_in_order SELECT toDateTime('2020-10-10 00:00:00') + number, 1 / (number % 100 + 1), number FROM numbers(1000);
+
+EXPLAIN PIPELINE SELECT toStartOfDay(dt) as date, d FROM t_read_in_order ORDER BY date, round(d) LIMIT 5;
+SELECT toStartOfDay(dt) as date, d FROM t_read_in_order ORDER BY date, round(d) LIMIT 5;
+
+EXPLAIN PIPELINE SELECT toStartOfDay(dt) as date, d FROM t_read_in_order ORDER BY date, round(d) LIMIT 5;
+SELECT toStartOfDay(dt) as date, d FROM t_read_in_order WHERE date = '2020-10-10' ORDER BY round(d) LIMIT 5;

--- a/tests/queries/0_stateless/02149_read_in_order_fixed_prefix_negative.reference
+++ b/tests/queries/0_stateless/02149_read_in_order_fixed_prefix_negative.reference
@@ -1,0 +1,5 @@
+MergeSorting
+MergeSorting
+MergeSorting
+MergeSorting
+MergeSorting

--- a/tests/queries/0_stateless/02149_read_in_order_fixed_prefix_negative.sh
+++ b/tests/queries/0_stateless/02149_read_in_order_fixed_prefix_negative.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_read_in_order_2";
+
+$CLICKHOUSE_CLIENT -q "CREATE TABLE t_read_in_order_2(date Date, i UInt64, v UInt64) ENGINE = MergeTree ORDER BY (date, i)"
+
+$CLICKHOUSE_CLIENT -q "INSERT INTO t_read_in_order_2 SELECT '2020-10-10', number % 10, number FROM numbers(100000)"
+$CLICKHOUSE_CLIENT -q "INSERT INTO t_read_in_order_2 SELECT '2020-10-11', number % 10, number FROM numbers(100000)"
+
+$CLICKHOUSE_CLIENT -q "EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order_2 WHERE date = '2020-10-11' OR date = '2020-10-12' ORDER BY i DESC LIMIT 10" | grep -o "MergeSorting"
+$CLICKHOUSE_CLIENT -q "EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order_2 WHERE date >= '2020-10-11' ORDER BY i DESC LIMIT 10" | grep -o "MergeSorting"
+$CLICKHOUSE_CLIENT -q "EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order_2 WHERE date = '2020-10-11' OR v = 100 ORDER BY i DESC LIMIT 10" | grep -o "MergeSorting"
+$CLICKHOUSE_CLIENT -q "EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order_2 WHERE date != '2020-10-11' ORDER BY i DESC LIMIT 10" | grep -o "MergeSorting"
+$CLICKHOUSE_CLIENT -q "EXPLAIN PIPELINE SELECT date, i FROM t_read_in_order_2 WHERE NOT (date = '2020-10-11') ORDER BY i DESC LIMIT 10" | grep -o "MergeSorting"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_read_in_order_2";


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support `optimize_read_in_order` if prefix of sorting key is already sorted. E.g. if we have sorting key `ORDER BY (a, b)` in table and query with `WHERE a = const ORDER BY b` clauses, now it will be applied reading in order of sorting key instead of full sort.

Resolves #7102.