### PR TITLE
Add retries for docker-compose cmd in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -109,6 +109,7 @@ def retry_exception(num, delay, func, exception=Exception, *args, **kwargs):
 def subprocess_check_call(args, detach=False, nothrow=False, num_tries=1):
     # Uncomment for debugging
     #logging.info('run:' + ' '.join(args))
+    delay = 1
     for i in range(num_tries):
         try:
             return run_and_check(args, detach=detach, nothrow=nothrow)
@@ -117,6 +118,8 @@ def subprocess_check_call(args, detach=False, nothrow=False, num_tries=1):
                 raise ex
             else:
                 logging.info("Got execption while executing command: %s", ex)
+                time.sleep(delay)
+                delay = delay * 2
 
 
 def get_odbc_bridge_path():


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Should resolve errors like 
```
Exception: Command ['docker-compose', '--env-file', '/ClickHouse/tests/integration/test_blob_storage_zero_copy_replication/_instances_0/.env', '--project-name', 'roottestblobstoragezerocopyreplication', '--file', '/compose/docker_compose_azurite.yml', '--verbose', 'up', '-d'] return non-zero code 1
...
               compose.service.pull: Pulling azurite1 (mcr.microsoft.com/azure-storage/azurite:)...
E               compose.cli.verbose_proxy.proxy_callable: docker pull <- ('mcr.microsoft.com/azure-storage/azurite', tag='latest', stream=True, platform=None)
E               compose.cli.errors.log_api_error: Get "https://mcr.microsoft.com/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```