### PR TITLE
Made Azure blob storage to obey ENABLE_LIBRARIES flag

### DIFF
--- a/cmake/find/blob_storage.cmake
+++ b/cmake/find/blob_storage.cmake
@@ -1,6 +1,6 @@
 option(USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY
     "Set to FALSE to use system Azure SDK instead of bundled (OFF currently not implemented)"
-    ON)
+    ${ENABLE_LIBRARIES})
 
 if (USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY)
     set(USE_AZURE_BLOB_STORAGE 1)


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
