### PR TITLE
Make `test_storage_s3` less flaky

### DIFF
--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -814,6 +814,7 @@ def test_seekable_formats(started_cluster):
     result = instance.query(f"SELECT count() FROM {table_function}")
     assert(int(result) == 5000000)
 
+    instance.query("SYSTEM FLUSH LOGS")
     result = instance.query(f"SELECT formatReadableSize(memory_usage) FROM system.query_log WHERE startsWith(query, 'SELECT count() FROM s3') AND memory_usage > 0 ORDER BY event_time desc")
     print(result[:3])
     assert(int(result[:3]) < 200)
@@ -837,6 +838,7 @@ def test_seekable_formats_url(started_cluster):
     result = instance.query(f"SELECT count() FROM {table_function}")
     assert(int(result) == 5000000)
 
+    instance.query("SYSTEM FLUSH LOGS")
     result = instance.query(f"SELECT formatReadableSize(memory_usage) FROM system.query_log WHERE startsWith(query, 'SELECT count() FROM url') AND memory_usage > 0 ORDER BY event_time desc")
     print(result[:3])
     assert(int(result[:3]) < 200)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @kssenii 