### PR TITLE
Fix release branches filter

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -2,10 +2,10 @@ name: ReleaseCI
 on: # yamllint disable-line rule:truthy
   push:
     branches:
-      - '21.**'
-      - '22.**'
-      - '23.**'
-      - '24.**'
+      - '21.[1-9][1-9]'
+      - '22.[1-9][1-9]'
+      - '23.[1-9][1-9]'
+      - '24.[1-9][1-9]'
 jobs:
   DockerHubPush:
     runs-on: [self-hosted, style-checker]


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


