### PR TITLE
Try fix flaky test: order for test_s3_zero_copy_replication

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -77,6 +77,7 @@ RUN python3 -m pip install \
     psycopg2-binary==2.8.6 \
     pymongo==3.11.0 \
     pytest \
+    pytest-order==1.0.0 \
     pytest-timeout \
     pytest-xdist \
     pytest-repeat \

--- a/tests/integration/test_s3_zero_copy_replication/test.py
+++ b/tests/integration/test_s3_zero_copy_replication/test.py
@@ -60,6 +60,8 @@ def wait_for_active_parts(node, num_expected_parts, table_name, timeout=30):
     assert num_parts == num_expected_parts
 
 
+# Result of `get_large_objects_count` can be changed in other tests, so run this case at the beginning
+@pytest.mark.order(0)
 @pytest.mark.parametrize(
     "policy", ["s3"]
 )


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


It brings `pytest-order` to runner, I suppose it can be useful for other integration tests as well.