### PR TITLE
warm up for test_kafka_json_as_string_no_kdc

### DIFF
--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -630,7 +630,7 @@ class ClickhouseIntegrationTestsRunner:
             random.shuffle(items_to_run)
 
         for group, tests in items_to_run:
-            logging.info("Running test group %s countaining %s tests", group, len(tests))
+            logging.info("Running test group %s containing %s tests", group, len(tests))
             group_counters, group_test_times, log_paths = self.try_run_test_group(repo_path, group, tests, MAX_RETRY, NUM_WORKERS)
             total_tests = 0
             for counter, value in group_counters.items():

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -97,6 +97,9 @@ def test_kafka_json_as_string(kafka_cluster):
     assert instance.contains_in_log("Parsing of message (topic: kafka_json_as_string, partition: 0, offset: 1) return no rows")
 
 def test_kafka_json_as_string_no_kdc(kafka_cluster):
+    # When the test is run alone (not preceded by any other kerberized kafka test),
+    # we need a ticket to
+    # assert instance.contains_in_log("Ticket expired")
     instance.query('''
         CREATE TABLE test.kafka_no_kdc_warm_up (field String)
             ENGINE = Kafka

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -97,6 +97,19 @@ def test_kafka_json_as_string(kafka_cluster):
     assert instance.contains_in_log("Parsing of message (topic: kafka_json_as_string, partition: 0, offset: 1) return no rows")
 
 def test_kafka_json_as_string_no_kdc(kafka_cluster):
+    instance.query('''
+        CREATE TABLE test.kafka_no_kdc_warm_up (field String)
+            ENGINE = Kafka
+            SETTINGS kafka_broker_list = 'kerberized_kafka1:19092',
+                     kafka_topic_list = 'kafka_json_as_string_no_kdc_warm_up',
+                     kafka_group_name = 'kafka_json_as_string_no_kdc_warm_up',
+                     kafka_commit_on_select = 1,
+                     kafka_format = 'JSONAsString',
+                     kafka_flush_interval_ms=1000;
+        ''')
+
+    instance.query('SELECT * FROM test.kafka_no_kdc_warm_up;')
+
     kafka_produce(kafka_cluster, 'kafka_json_as_string_no_kdc', ['{"t": 123, "e": {"x": "woof"} }', '', '{"t": 124, "e": {"x": "test"} }', '{"F1":"V1","F2":{"F21":"V21","F22":{},"F23":"V23","F24":"2019-12-24T16:28:04"},"F3":"V3"}'])
 
     kafka_cluster.pause_container('kafka_kerberos')


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
Addresses https://github.com/ClickHouse/ClickHouse/issues/32644

A bug  in test_kafka_json_as_string_no_kdc fixed.
When the test is run alone (not preceded by any other kerberized kafka test), the assertion instance.contains_in_log("Ticket expired") is failed because there is no ticket at all.