### PR TITLE
Add support for BIT data type in MaterializedMySQL

### DIFF
--- a/base/mysqlxx/Row.cpp
+++ b/base/mysqlxx/Row.cpp
@@ -4,6 +4,8 @@
 #include <mysql/mysql.h>
 #endif
 #include <mysqlxx/Row.h>
+
+
 namespace mysqlxx
 {
 

--- a/base/mysqlxx/Row.cpp
+++ b/base/mysqlxx/Row.cpp
@@ -4,8 +4,6 @@
 #include <mysql/mysql.h>
 #endif
 #include <mysqlxx/Row.h>
-
-
 namespace mysqlxx
 {
 
@@ -19,6 +17,14 @@ Value Row::operator[] (const char * name) const
             return operator[](i);
 
     throw Exception(std::string("Unknown column ") + name);
+}
+
+enum enum_field_types Row::getFieldType(size_t i)
+{
+    if (i >= res->getNumFields())
+        throw Exception(std::string("Array Index Overflow"));
+    MYSQL_FIELDS fields = res->getFields();
+    return fields[i].type;
 }
 
 }

--- a/base/mysqlxx/Row.h
+++ b/base/mysqlxx/Row.h
@@ -79,6 +79,8 @@ public:
       */
     operator private_bool_type() const { return row == nullptr ? nullptr : &Row::row; }
 
+    enum enum_field_types getFieldType(size_t i);
+
 private:
     MYSQL_ROW row{};
     ResultBase * res{};

--- a/base/mysqlxx/Types.h
+++ b/base/mysqlxx/Types.h
@@ -16,6 +16,8 @@ using MYSQL_ROW = char**;
 struct st_mysql_field;
 using MYSQL_FIELD = st_mysql_field;
 
+enum struct enum_field_types;
+
 #endif
 
 namespace mysqlxx

--- a/docs/en/engines/database-engines/materialized-mysql.md
+++ b/docs/en/engines/database-engines/materialized-mysql.md
@@ -83,6 +83,7 @@ When working with the `MaterializedMySQL` database engine, [ReplacingMergeTree](
 | VARCHAR, VAR_STRING     | [String](../../sql-reference/data-types/string.md)           |
 | BLOB                    | [String](../../sql-reference/data-types/string.md)           |
 | BINARY                  | [FixedString](../../sql-reference/data-types/fixedstring.md) |
+| BIT                     | [UInt64](../../sql-reference/data-types/int-uint.md)         |
 
 [Nullable](../../sql-reference/data-types/nullable.md) is supported.
 

--- a/src/Core/MySQL/MySQLReplication.cpp
+++ b/src/Core/MySQL/MySQLReplication.cpp
@@ -589,13 +589,9 @@ namespace MySQLReplication
                     {
                         UInt32 bits = ((meta >> 8) * 8) + (meta & 0xff);
                         UInt32 size = (bits + 7) / 8;
-
-                        Bitmap bitmap_value;
-                        String byte_buffer;
-                        byte_buffer.resize(size);
-                        readBigEndianStrict(payload, reinterpret_cast<char *>(byte_buffer.data()), size);
-                        readBitmapFromStr(byte_buffer.c_str(), bitmap_value, size);
-                        row.push_back(Field{UInt64{bitmap_value.to_ulong()}});
+                        UInt64 val = 0UL;
+                        readBigEndianStrict(payload, reinterpret_cast<char *>(&val), size);
+                        row.push_back(val);
                         break;
                     }
                     case MYSQL_TYPE_VARCHAR:

--- a/src/Core/MySQL/MySQLReplication.h
+++ b/src/Core/MySQL/MySQLReplication.h
@@ -78,11 +78,8 @@ namespace MySQLReplication
         }
     }
 
-    inline void readBitmap(ReadBuffer & payload, Bitmap & bitmap, size_t bitmap_size)
+    inline void readBitmapFromStr(const char * byte_buffer, Bitmap & bitmap, size_t bitmap_size)
     {
-        String byte_buffer;
-        byte_buffer.resize(bitmap_size);
-        payload.readStrict(reinterpret_cast<char *>(byte_buffer.data()), bitmap_size);
         bitmap.resize(bitmap_size * 8, false);
         for (size_t i = 0; i < bitmap_size; ++i)
         {
@@ -107,6 +104,14 @@ namespace MySQLReplication
             if ((tmp & 0x80) != 0)
                 bitmap.set(bit + 7);
         }
+    }
+
+    inline void readBitmap(ReadBuffer & payload, Bitmap & bitmap, size_t bitmap_size)
+    {
+        String byte_buffer;
+        byte_buffer.resize(bitmap_size);
+        payload.readStrict(reinterpret_cast<char *>(byte_buffer.data()), bitmap_size);
+        readBitmapFromStr(byte_buffer.c_str(), bitmap, bitmap_size);
     }
 
     class EventBase;

--- a/src/Core/MySQL/MySQLReplication.h
+++ b/src/Core/MySQL/MySQLReplication.h
@@ -78,8 +78,11 @@ namespace MySQLReplication
         }
     }
 
-    inline void readBitmapFromStr(const char * byte_buffer, Bitmap & bitmap, size_t bitmap_size)
+    inline void readBitmap(ReadBuffer & payload, Bitmap & bitmap, size_t bitmap_size)
     {
+        String byte_buffer;
+        byte_buffer.resize(bitmap_size);
+        payload.readStrict(reinterpret_cast<char *>(byte_buffer.data()), bitmap_size);
         bitmap.resize(bitmap_size * 8, false);
         for (size_t i = 0; i < bitmap_size; ++i)
         {
@@ -104,14 +107,6 @@ namespace MySQLReplication
             if ((tmp & 0x80) != 0)
                 bitmap.set(bit + 7);
         }
-    }
-
-    inline void readBitmap(ReadBuffer & payload, Bitmap & bitmap, size_t bitmap_size)
-    {
-        String byte_buffer;
-        byte_buffer.resize(bitmap_size);
-        payload.readStrict(reinterpret_cast<char *>(byte_buffer.data()), bitmap_size);
-        readBitmapFromStr(byte_buffer.c_str(), bitmap, bitmap_size);
     }
 
     class EventBase;

--- a/src/DataTypes/DataTypesNumber.cpp
+++ b/src/DataTypes/DataTypesNumber.cpp
@@ -86,6 +86,7 @@ void registerDataTypeNumbers(DataTypeFactory & factory)
     factory.registerAlias("INT UNSIGNED", "UInt32", DataTypeFactory::CaseInsensitive);
     factory.registerAlias("INTEGER UNSIGNED", "UInt32", DataTypeFactory::CaseInsensitive);
     factory.registerAlias("BIGINT UNSIGNED", "UInt64", DataTypeFactory::CaseInsensitive);
+    factory.registerAlias("BIT", "UInt64", DataTypeFactory::CaseInsensitive);
 }
 
 }

--- a/src/DataTypes/convertMySQLDataType.cpp
+++ b/src/DataTypes/convertMySQLDataType.cpp
@@ -91,6 +91,10 @@ DataTypePtr convertMySQLDataType(MultiEnum<MySQLDataTypesSupport> type_support,
             res = std::make_shared<DataTypeDateTime64>(scale);
         }
     }
+    else if (type_name == "bit")
+    {
+        res = std::make_shared<DataTypeUInt64>();
+    }
     else if (type_support.isSet(MySQLDataTypesSupport::DECIMAL) && (type_name == "numeric" || type_name == "decimal"))
     {
         if (precision <= DecimalUtils::max_precision<Decimal32>)

--- a/src/Interpreters/MySQL/tests/gtest_create_rewritten.cpp
+++ b/src/Interpreters/MySQL/tests/gtest_create_rewritten.cpp
@@ -40,7 +40,7 @@ TEST(MySQLCreateRewritten, ColumnsDataType)
         {"TINYINT", "Int8"}, {"SMALLINT", "Int16"}, {"MEDIUMINT", "Int32"}, {"INT", "Int32"},
         {"INTEGER", "Int32"}, {"BIGINT", "Int64"}, {"FLOAT", "Float32"}, {"DOUBLE", "Float64"},
         {"VARCHAR(10)", "String"}, {"CHAR(10)", "String"}, {"Date", "Date"}, {"DateTime", "DateTime"},
-        {"TIMESTAMP", "DateTime"}, {"BOOLEAN", "Bool"}
+        {"TIMESTAMP", "DateTime"}, {"BOOLEAN", "Bool"}, {"BIT", "UInt64"}
     };
 
     for (const auto & [test_type, mapped_type] : test_types)

--- a/src/Processors/Sources/MySQLSource.cpp
+++ b/src/Processors/Sources/MySQLSource.cpp
@@ -2,6 +2,7 @@
 
 #if USE_MYSQL
 #include <vector>
+#include <Core/MySQL/MySQLReplication.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
@@ -126,7 +127,7 @@ namespace
 {
     using ValueType = ExternalResultDescription::ValueType;
 
-    void insertValue(const IDataType & data_type, IColumn & column, const ValueType type, const mysqlxx::Value & value, size_t & read_bytes_size)
+    void insertValue(const IDataType & data_type, IColumn & column, const ValueType type, const mysqlxx::Value & value, size_t & read_bytes_size, enum enum_field_types mysql_type)
     {
         switch (type)
         {
@@ -143,9 +144,25 @@ namespace
                 read_bytes_size += 4;
                 break;
             case ValueType::vtUInt64:
-                assert_cast<ColumnUInt64 &>(column).insertValue(value.getUInt());
-                read_bytes_size += 8;
+            {
+                //we don't have enum enum_field_types definition in mysqlxx/Types.h, so we use literal values directly here.
+                if (static_cast<int>(mysql_type) == 16)
+                {
+                    size_t n = value.size();
+                    char *start = const_cast<char *>(value.data()), *end = start + n;
+                    std::reverse(start, end);
+                    MySQLReplication::Bitmap bitmap;
+                    MySQLReplication::readBitmapFromStr(value.data(), bitmap, n);
+                    assert_cast<ColumnUInt64 &>(column).insertValue(bitmap.to_ulong());
+                    read_bytes_size += n;
+                }
+                else
+                {
+                    assert_cast<ColumnUInt64 &>(column).insertValue(value.getUInt());
+                    read_bytes_size += 8;
+                }
                 break;
+            }
             case ValueType::vtInt8:
                 assert_cast<ColumnInt8 &>(column).insertValue(value.getInt());
                 read_bytes_size += 1;
@@ -258,12 +275,12 @@ Chunk MySQLSource::generate()
                 {
                     ColumnNullable & column_nullable = assert_cast<ColumnNullable &>(*columns[index]);
                     const auto & data_type = assert_cast<const DataTypeNullable &>(*sample.type);
-                    insertValue(*data_type.getNestedType(), column_nullable.getNestedColumn(), description.types[index].first, value, read_bytes_size);
+                    insertValue(*data_type.getNestedType(), column_nullable.getNestedColumn(), description.types[index].first, value, read_bytes_size, row.getFieldType(position_mapping[index]));
                     column_nullable.getNullMapData().emplace_back(false);
                 }
                 else
                 {
-                    insertValue(*sample.type, *columns[index], description.types[index].first, value, read_bytes_size);
+                    insertValue(*sample.type, *columns[index], description.types[index].first, value, read_bytes_size, row.getFieldType(position_mapping[index]));
                 }
             }
             else

--- a/src/Processors/Sources/MySQLSource.cpp
+++ b/src/Processors/Sources/MySQLSource.cpp
@@ -149,11 +149,10 @@ namespace
                 if (static_cast<int>(mysql_type) == 16)
                 {
                     size_t n = value.size();
-                    char *start = const_cast<char *>(value.data()), *end = start + n;
-                    std::reverse(start, end);
-                    MySQLReplication::Bitmap bitmap;
-                    MySQLReplication::readBitmapFromStr(value.data(), bitmap, n);
-                    assert_cast<ColumnUInt64 &>(column).insertValue(bitmap.to_ulong());
+                    UInt64 val = 0UL;
+                    ReadBufferFromMemory payload(const_cast<char *>(value.data()), n);
+                    MySQLReplication::readBigEndianStrict(payload, reinterpret_cast<char *>(&val), n);
+                    assert_cast<ColumnUInt64 &>(column).insertValue(val);
                     read_bytes_size += n;
                 }
                 else

--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -1124,7 +1124,7 @@ def materialized_database_support_all_kinds_of_mysql_datatype(clickhouse_node, m
         "CREATE DATABASE test_database_datatype ENGINE = MaterializeMySQL('{}:3306', 'test_database_datatype', 'root', 'clickhouse')".format(
             service_name))
 
-    assert "test_database_datatype" in clickhouse_node.query("SHOW DATABASES")
+    check_query(clickhouse_node, "SELECT name FROM system.tables WHERE database = 'test_database_datatype'", "t1\n")
     # full synchronization check
     check_query(clickhouse_node, "SELECT v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v26, v29, v30, v32 FROM test_database_datatype.t1 FORMAT TSV",
                 "1\t1\t11\t9223372036854775807\t-1\t1\t11\t18446744073709551615\t-1.1\t1.1\t-1.111\t1.111\t1.1111\t2021-10-06\ttext\tvarchar\tBLOB\t2021-10-06 18:32:57\t2021-10-06 18:32:57.482786\t2021-10-06 18:32:57\t2021-10-06 18:32:57.482786\t10\t11\tvarbinary\tRED\n")

--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -624,7 +624,7 @@ def err_sync_user_privs_with_materialized_mysql_database(clickhouse_node, mysql_
             service_name))
     assert "priv_err_db" in clickhouse_node.query("SHOW DATABASES")
     assert "test_table_1" not in clickhouse_node.query("SHOW TABLES FROM priv_err_db")
-    clickhouse_node.query("DETACH DATABASE priv_err_db")
+    clickhouse_node.query_with_retry("DETACH DATABASE priv_err_db")
 
     mysql_node.query("REVOKE SELECT ON priv_err_db.* FROM 'test'@'%'")
     time.sleep(3)
@@ -743,7 +743,7 @@ def mysql_kill_sync_thread_restore_test(clickhouse_node, mysql_node, service_nam
             time.sleep(sleep_time)
             clickhouse_node.query("SELECT * FROM test_database.test_table")
 
-    clickhouse_node.query("DETACH DATABASE test_database")
+    clickhouse_node.query_with_retry("DETACH DATABASE test_database")
     clickhouse_node.query("ATTACH DATABASE test_database")
     check_query(clickhouse_node, "SELECT * FROM test_database.test_table ORDER BY id FORMAT TSV", '1\n2\n')
 
@@ -784,7 +784,7 @@ def mysql_killed_while_insert(clickhouse_node, mysql_node, service_name):
 
         mysql_node.alloc_connection()
 
-        clickhouse_node.query("DETACH DATABASE kill_mysql_while_insert")
+        clickhouse_node.query_with_retry("DETACH DATABASE kill_mysql_while_insert")
         clickhouse_node.query("ATTACH DATABASE kill_mysql_while_insert")
 
         result = mysql_node.query_and_get_data("SELECT COUNT(1) FROM kill_mysql_while_insert.test")

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -253,3 +253,7 @@ def test_table_table(started_cluster, started_mysql_8_0, started_mysql_5_7, clic
 def test_table_overrides(started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node):
     materialize_with_ddl.table_overrides(clickhouse_node, started_mysql_5_7, "mysql57")
     materialize_with_ddl.table_overrides(clickhouse_node, started_mysql_8_0, "mysql80")
+
+def test_materialized_database_support_all_kinds_of_mysql_datatype(started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node):
+    materialize_with_ddl.materialized_database_support_all_kinds_of_mysql_datatype(clickhouse_node, started_mysql_8_0, "mysql80")
+    materialize_with_ddl.materialized_database_support_all_kinds_of_mysql_datatype(clickhouse_node, started_mysql_5_7, "mysql57")


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added support for `BIT` data type in `MaterializedMySQL`. Closes #15182,  #32233

