### PR TITLE
fix wrong testcase in gtest_Parser

### DIFF
--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -198,7 +198,7 @@ SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'source_table'))
 LAYOUT(FLAT())
 LIFETIME(MIN 0 MAX 1000)
 COMMENT 'Test dictionary with comment';
-sql",
+)sql",
         R"sql(CREATE DICTIONARY `2024_dictionary_with_comment`
 (
     `id` UInt64,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:

The testcase is broken, because of the lack of `)`, an important part of `Raw String`.
Although, they both pass test, because they check different things.

In originally, the testcase checks
the sql
```
CREATE DICTIONARY 2024_dictionary_with_comment
(
    id UInt64,
    value String
)
PRIMARY KEY id
SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'source_table'))
LAYOUT(FLAT())
LIFETIME(MIN 0 MAX 1000)
COMMENT 'Test dictionary with comment';
```

should be parsed as 

```
CREATE DICTIONARY `2024_dictionary_with_comment`
(
    `id` UInt64,
    `value` String
)
PRIMARY KEY id
SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'source_table'))
LIFETIME(MIN 0 MAX 1000)
LAYOUT(FLAT())
COMMENT 'Test dictionary with comment'
```

But with the remove of the `)`, the test becomes checking

```
CREATE DICTIONARY 2024_dictionary_with_comment
        (
             id UInt64,
                 value String
        )
        PRIMARY KEY id
        SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'source_table'))
        LAYOUT(FLAT())
        LIFETIME(MIN 0 MAX 1000)
        COMMENT 'Test dictionary with comment';
    sql",
    R"sql(CREATE DICTIONARY `2024_dictionary_with_comment`
    (
        `id` UInt64,
            `value` String
            )
            PRIMARY KEY id
            SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'source_table'))
            LIFETIME(MIN 0 MAX 1000)
            LAYOUT(FLAT())
            COMMENT 'Test dictionary with comment'
```
to throw a Exception.


A simple POC
```
#include <iostream>
#include <string>
#include <string_view>

struct ParserTestCase
{
        const std::string_view input_text;
        const char * expected_ast = nullptr;
};

int main()
{
    ParserTestCase wrong{
        R"sql(CREATE DICTIONARY 2024_dictionary_with_comment
            (
                 id UInt64,
                     value String
            )
            PRIMARY KEY id
            SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'source_table'))
            LAYOUT(FLAT())
            LIFETIME(MIN 0 MAX 1000)
            COMMENT 'Test dictionary with comment';
        sql",
        R"sql(CREATE DICTIONARY `2024_dictionary_with_comment`
        (
            `id` UInt64,
                `value` String
                )
                PRIMARY KEY id
                SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'source_table'))
                LIFETIME(MIN 0 MAX 1000)
                LAYOUT(FLAT())
                COMMENT 'Test dictionary with comment')sql"
    };

    ParserTestCase right{
        R"sql(CREATE DICTIONARY 2024_dictionary_with_comment
            (
                 id UInt64,
                     value String
            )
            PRIMARY KEY id
            SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'source_table'))
            LAYOUT(FLAT())
            LIFETIME(MIN 0 MAX 1000)
            COMMENT 'Test dictionary with comment';
        )sql",
        R"sql(CREATE DICTIONARY `2024_dictionary_with_comment`
        (
            `id` UInt64,
            `value` String
            )
            PRIMARY KEY id
            SOURCE(CLICKHOUSE(HOST 'localhost' PORT tcpPort() TABLE 'source_table'))
            LIFETIME(MIN 0 MAX 1000)
            LAYOUT(FLAT())
            COMMENT 'Test dictionary with comment')sql"
    };

    std::cout << "=========what RIGHT looks like========" << std::endl;
    std::cout << "------RIGHT input_text------" << std::endl;
    std::cout << right.input_text << std::endl;
    std::cout << "------RIGHT expected_ast------" << std::endl;
    std::cout << right.expected_ast << std::endl;
    std::cout << "=========what WRONG looks like========" << std::endl;
    std::cout << "------WRONG input_text------" << std::endl;
    std::cout << wrong.input_text << std::endl;
    std::cout << "------WRONG expected_ast------" << std::endl;
    std::cout << wrong.expected_ast << std::endl;

}
```
![2021-12-17-212943_1592x1628_scrot](https://user-images.githubusercontent.com/3500109/146552080-77259ce7-19d1-4ba6-be21-efde57eeacf0.png)


