### PR TITLE
[RFC] Add replxx/jemalloc into fasttest build of clickhouse

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -173,6 +173,8 @@ function clone_submodules
             contrib/dragonbox
             contrib/fast_float
             contrib/NuRaft
+            contrib/jemalloc
+            contrib/replxx
         )
 
         git submodule sync
@@ -193,6 +195,8 @@ function run_cmake
         "-DENABLE_THINLTO=0"
         "-DUSE_UNWIND=1"
         "-DENABLE_NURAFT=1"
+        "-DENABLE_JEMALLOC=1"
+        "-DENABLE_REPLXX=1"
     )
 
     # TODO remove this? we don't use ccache anyway. An option would be to download it

--- a/tests/queries/0_stateless/01180_client_syntax_errors.expect
+++ b/tests/queries/0_stateless/01180_client_syntax_errors.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/01293_client_interactive_vertical_multiline.expect
+++ b/tests/queries/0_stateless/01293_client_interactive_vertical_multiline.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/01293_client_interactive_vertical_singleline.expect
+++ b/tests/queries/0_stateless/01293_client_interactive_vertical_singleline.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/01300_client_save_history_when_terminated_long.expect
+++ b/tests/queries/0_stateless/01300_client_save_history_when_terminated_long.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/expect -f
-# Tags: long, no-fasttest
+# Tags: long
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/01370_client_autocomplete_word_break_characters.expect
+++ b/tests/queries/0_stateless/01370_client_autocomplete_word_break_characters.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/01520_client_print_query_id.expect
+++ b/tests/queries/0_stateless/01520_client_print_query_id.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
+++ b/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 # This is a separate test, because we want to test the interactive mode.
 # https://github.com/ClickHouse/ClickHouse/issues/19353

--- a/tests/queries/0_stateless/01676_long_clickhouse_client_autocomplete.sh
+++ b/tests/queries/0_stateless/01676_long_clickhouse_client_autocomplete.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest
+# Tags: long
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01755_client_highlight_multi_line_comment_regression.expect
+++ b/tests/queries/0_stateless/01755_client_highlight_multi_line_comment_regression.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/01910_client_replxx_container_overflow_long.expect
+++ b/tests/queries/0_stateless/01910_client_replxx_container_overflow_long.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/expect -f
-# Tags: long, no-fasttest
+# Tags: long
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/01933_client_replxx_convert_history.expect
+++ b/tests/queries/0_stateless/01933_client_replxx_convert_history.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/expect -f
-# Tags: no-parallel, no-fasttest
+# Tags: no-parallel
 # Tag no-parallel: Uses non unique history file
 
 log_user 0

--- a/tests/queries/0_stateless/02003_memory_limit_in_client.expect
+++ b/tests/queries/0_stateless/02003_memory_limit_in_client.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/expect -f
-# Tags: no-parallel, no-fasttest
+# Tags: no-parallel
 
 # This is a test for system.warnings. Testing in interactive mode is necessary,
 # as we want to see certain warnings from client

--- a/tests/queries/0_stateless/02047_client_exception.expect
+++ b/tests/queries/0_stateless/02047_client_exception.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 20

--- a/tests/queries/0_stateless/02049_clickhouse_local_merge_tree.expect
+++ b/tests/queries/0_stateless/02049_clickhouse_local_merge_tree.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 20

--- a/tests/queries/0_stateless/02105_backslash_letter_commands.expect
+++ b/tests/queries/0_stateless/02105_backslash_letter_commands.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 02

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/expect -f
-# Tags: no-parallel, no-fasttest
+# Tags: no-parallel
 
 log_user 0
 set timeout 20

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_local.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_local.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 20

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/expect -f
-# Tags: no-parallel, no-fasttest
+# Tags: no-parallel
 
 log_user 0
 set timeout 20

--- a/tests/queries/0_stateless/02116_interactive_hello.expect
+++ b/tests/queries/0_stateless/02116_interactive_hello.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/02132_client_history_navigation.expect
+++ b/tests/queries/0_stateless/02132_client_history_navigation.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 log_user 0
 set timeout 3


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add replxx/jemalloc into fasttest build of clickhouse

Detailed description / Documentation draft:
Both of the are pretty small, and so should not affect build time, but
will have additional bonus, since jemalloc is the production allocator
and replxx is just useful to use binary with completion (and later some
test can be enabled for fasttest with completion)

Cc: @alesapin 