### PR TITLE
tests/integration/cleanup_environment: fix obtaining PYTEST_CLEANUP_CONTAINERS

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,12 +8,12 @@ from helpers.network import _NetworkManager
 @pytest.fixture(autouse=True, scope="session")
 def cleanup_environment():
     try:
-        if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS")) == 1:
+        if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS", 0)) == 1:
             logging.debug(f"Cleaning all iptables rules")
             _NetworkManager.clean_all_user_iptables_rules()
         result = run_and_check(['docker ps | wc -l'], shell=True)
         if int(result) > 1:
-            if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS")) != 1:
+            if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS", 0)) != 1:
                 logging.warning(f"Docker containters({int(result)}) are running before tests run. They can be left from previous pytest run and cause test failures.\n"\
                                 "You can set env PYTEST_CLEANUP_CONTAINERS=1 or use runner with --cleanup-containers argument to enable automatic containers cleanup.")
             else:


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes the following error:

```
2021-12-17 23:27:55 [ 327 ] ERROR : cleanup_environment:int() argument must be a string, a bytes-like object or a number, not 'NoneType' (conftest.py:29, cleanup_environment)
Traceback (most recent call last):
  File "/ClickHouse/tests/integration/conftest.py", line 11, in cleanup_environment
    if int(os.environ.get("PYTEST_CLEANUP_CONTAINERS")) == 1:
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

Cc: @qoega 