### PR TITLE
Update external-dicts-dict-polygon.md

### DIFF
--- a/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-polygon.md
+++ b/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-polygon.md
@@ -41,7 +41,7 @@ Example of a polygon dictionary configuration:
 </dictionary>
 ```
 
-Tne corresponding [DDL-query](../../../sql-reference/statements/create/dictionary.md#create-dictionary-query):
+The corresponding [DDL-query](../../../sql-reference/statements/create/dictionary.md#create-dictionary-query):
 ``` sql
 CREATE DICTIONARY polygon_dict_name (
     key Array(Array(Array(Array(Float64)))),


### PR DESCRIPTION
fix a typo `tne` -> `the`

Changelog category (leave one):
- Documentation (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:
...
fix a typo in chapter `SQL Reference/Dictionaries/External Dictionaries`

> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
