### PR TITLE
Fix Context leak in case of cancel_http_readonly_queries_on_client_close

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -776,7 +776,7 @@ void HTTPHandler::processQuery(
 
     if (settings.readonly > 0 && settings.cancel_http_readonly_queries_on_client_close)
     {
-        append_callback([context = context, &request](const Progress &)
+        append_callback([&context, &request](const Progress &)
         {
             /// Assume that at the point this method is called no one is reading data from the socket any more:
             /// should be true for read-only queries.

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -719,9 +719,16 @@ void HTTPHandler::processQuery(
     context->checkSettingsConstraints(settings_changes);
     context->applySettingsChanges(settings_changes);
 
-    // Set the query id supplied by the user, if any, and also update the OpenTelemetry fields.
+    /// Set the query id supplied by the user, if any, and also update the OpenTelemetry fields.
     context->setCurrentQueryId(params.get("query_id", request.get("X-ClickHouse-Query-Id", "")));
 
+    /// Initialize query scope, once query_id is initialized.
+    /// (To track as much allocations as possible)
+    query_scope.emplace(context);
+
+    /// NOTE: this may create pretty huge allocations that will not be accounted in trace_log,
+    /// because memory_profiler_sample_probability/memory_profiler_step are not applied yet,
+    /// they will be applied in ProcessList::insert() from executeQuery() itself.
     const auto & query = getQuery(request, params, context);
     std::unique_ptr<ReadBuffer> in_param = std::make_unique<ReadBufferFromString>(query);
     in = has_external_data ? std::move(in_param) : std::make_unique<ConcatReadBuffer>(*in_param, *in_post_maybe_compressed);
@@ -779,8 +786,6 @@ void HTTPHandler::processQuery(
     }
 
     customizeContext(request, context);
-
-    query_scope.emplace(context);
 
     executeQuery(*in, *used_output.out_maybe_delayed_and_compressed, /* allow_into_outfile = */ false, context,
         [&response] (const String & current_query_id, const String & content_type, const String & format, const String & timezone)

--- a/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.reference
+++ b/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.reference
@@ -1,0 +1,16 @@
+Checking input_format_parallel_parsing=false&
+1
+Checking input_format_parallel_parsing=false&cancel_http_readonly_queries_on_client_close=1&readonly=1
+1
+Checking input_format_parallel_parsing=false&send_progress_in_http_headers=true
+1
+Checking input_format_parallel_parsing=false&cancel_http_readonly_queries_on_client_close=1&readonly=1&send_progress_in_http_headers=true
+1
+Checking input_format_parallel_parsing=true&
+1
+Checking input_format_parallel_parsing=true&cancel_http_readonly_queries_on_client_close=1&readonly=1
+1
+Checking input_format_parallel_parsing=true&send_progress_in_http_headers=true
+1
+Checking input_format_parallel_parsing=true&cancel_http_readonly_queries_on_client_close=1&readonly=1&send_progress_in_http_headers=true
+1

--- a/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
+++ b/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Tags: no-tsan
+#       ^^^^^^^
+# TSan does not supports tracing.
 
 # Regression for proper release of Context,
 # via tracking memory of external tables.

--- a/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
+++ b/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
@@ -15,7 +15,7 @@ $CLICKHOUSE_CLIENT -q "SELECT toString(number) FROM numbers(1e6) FORMAT TSV" > "
 function run_and_check()
 {
     local query_id
-    query_id="$(uuidgen)"
+    query_id="$(${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" --data-binary @- <<<'SELECT generateUUIDv4()')"
 
     echo "Checking $*"
 

--- a/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
+++ b/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Regression for proper release of Context,
+# via tracking memory of external tables.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+tmp_file=$(mktemp "$CURDIR/clickhouse.XXXXXX.csv")
+trap 'rm $tmp_file' EXIT
+
+$CLICKHOUSE_CLIENT -q "SELECT toString(number) FROM numbers(1e6) FORMAT TSV" > "$tmp_file"
+
+function run_and_check()
+{
+    local query_id
+    query_id="$(uuidgen)"
+
+    echo "Checking $*"
+
+    # Run query with external table (implicit StorageMemory user)
+    $CLICKHOUSE_CURL -sS -F "s=@$tmp_file;" "$CLICKHOUSE_URL&s_structure=key+Int&query=SELECT+count()+FROM+s&memory_profiler_sample_probability=1&query_id=$query_id&$*" -o /dev/null
+
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" --data-binary @- <<<'SYSTEM FLUSH LOGS'
+
+    # Check that temporary table had been destroyed.
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&allow_introspection_functions=1" --data-binary @- <<<"
+    WITH arrayStringConcat(arrayMap(x -> demangle(addressToSymbol(x)), trace), '\n') AS sym
+    SELECT count()>0 FROM system.trace_log
+    WHERE
+        sym LIKE '%DB::StorageMemory::drop%\n%TemporaryTableHolder::~TemporaryTableHolder%' AND
+        query_id = '$query_id'
+    "
+}
+
+for input_format_parallel_parsing in false true; do
+    query_args_variants=(
+        ""
+        "cancel_http_readonly_queries_on_client_close=1&readonly=1"
+        "send_progress_in_http_headers=true"
+        # nested progress callback
+        "cancel_http_readonly_queries_on_client_close=1&readonly=1&send_progress_in_http_headers=true"
+    )
+    for query_args in "${query_args_variants[@]}"; do
+        run_and_check "input_format_parallel_parsing=$input_format_parallel_parsing&$query_args"
+    done
+done


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix Context leak in case of cancel_http_readonly_queries_on_client_close (i.e. leaking of external tables that had been uploaded the the server and other resources).

Detailed description / Documentation draft:
To handle cancel_http_readonly_queries_on_client_close=true context
attaches progress callback with holding a copy of the current context,
and this creates recursive context reference and so shared_ptr will be
never released.

One example of a memory leak, external tables passed with HTTP query
(s_structure + file upload), since they are stored in the context, and
can occupate enough memory to make it visible to user.

Note, that the lifetime of the Context should be fine, since callback
can be called only when query is executed.

Fixes: #32750