### PR TITLE
RabbitMQ tests fix

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -67,8 +67,8 @@ def rabbitmq_cluster():
 def rabbitmq_setup_teardown():
     print("RabbitMQ is available - running test")
     yield  # run test
-    for table_name in ['view', 'consumer', 'rabbitmq']:
-        instance.query(f'DROP TABLE IF EXISTS test.{table_name}')
+    instance.query(f'DROP DATABASE test')
+    instance.query('CREATE DATABASE test')
 
 
 # Tests

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -67,7 +67,7 @@ def rabbitmq_cluster():
 def rabbitmq_setup_teardown():
     print("RabbitMQ is available - running test")
     yield  # run test
-    instance.query(f'DROP DATABASE test')
+    instance.query('DROP DATABASE test')
     instance.query('CREATE DATABASE test')
 
 

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -67,7 +67,7 @@ def rabbitmq_cluster():
 def rabbitmq_setup_teardown():
     print("RabbitMQ is available - running test")
     yield  # run test
-    instance.query('DROP DATABASE test')
+    instance.query('DROP DATABASE test NO DELAY')
     instance.query('CREATE DATABASE test')
 
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Make sure no trash remains after tests which affects other tests.