### PR TITLE
Add backport workflow rerun

### DIFF
--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -23,7 +23,7 @@ SUSPICIOUS_PATTERNS = [
 ]
 
 MAX_RETRY = 5
-MAX_WORKFLOW_RERUN = 5
+MAX_WORKFLOW_RERUN = 7
 
 WorkflowDescription = namedtuple('WorkflowDescription',
                                  ['name', 'action', 'run_id', 'event', 'workflow_id', 'conclusion', 'status', 'api_url',
@@ -44,6 +44,7 @@ NEED_RERUN_WORKFLOWS = {
     15834118, # Docs
     15522500, # MasterCI
     15516108, # ReleaseCI
+    15797242, # BackportPR
 }
 
 # Individual trusted contirbutors who are not in any trusted organization.


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
