### PR TITLE
Fix null pointer dereference in low cardinality data

### DIFF
--- a/src/DataTypes/Serializations/SerializationLowCardinality.cpp
+++ b/src/DataTypes/Serializations/SerializationLowCardinality.cpp
@@ -636,6 +636,9 @@ void SerializationLowCardinality::deserializeBinaryBulkWithMultipleStreams(
 
         if (!low_cardinality_state->index_type.need_global_dictionary)
         {
+            if(additional_keys == nullptr)
+                throw Exception("No additional keys found.", ErrorCodes::INCORRECT_DATA);
+
             ColumnPtr keys_column = additional_keys;
             if (low_cardinality_state->null_map)
                 keys_column = ColumnNullable::create(additional_keys, low_cardinality_state->null_map);
@@ -662,6 +665,9 @@ void SerializationLowCardinality::deserializeBinaryBulkWithMultipleStreams(
 
             if (!maps.additional_keys_map->empty())
             {
+                if(additional_keys == nullptr)
+                    throw Exception("No additional keys found.", ErrorCodes::INCORRECT_DATA);
+
                 auto used_add_keys = additional_keys->index(*maps.additional_keys_map, 0);
 
                 if (dictionary_type->isNullable())

--- a/tests/queries/0_stateless/02010_lc_native.python
+++ b/tests/queries/0_stateless/02010_lc_native.python
@@ -302,11 +302,44 @@ def insertLowCardinalityRowWithIncorrectDictType():
         print(readException(s))
         s.close()
 
+def insertLowCardinalityRowWithIncorrectAdditionalKeys():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(30)
+        s.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
+        sendHello(s)
+        receiveHello(s)
+        sendQuery(s, 'insert into {}.tab format TSV'.format(CLICKHOUSE_DATABASE))
+
+        # external tables
+        sendEmptyBlock(s)
+        readHeader(s)
+
+        # Data
+        ba = bytearray()
+        writeVarUInt(2, ba) # Data
+        writeStringBinary('', ba)
+        serializeBlockInfo(ba)
+        writeVarUInt(1, ba) # rows
+        writeVarUInt(1, ba) # columns
+        writeStringBinary('x', ba)
+        writeStringBinary('LowCardinality(String)', ba)
+        ba.extend([1] + [0] * 7) # SharedDictionariesWithAdditionalKeys
+        ba.extend([3, 0] + [0] * 6) # indexes type: UInt64 [3], with  NO additional keys [0]
+        ba.extend([1] + [0] * 7) # num_keys in dict
+        writeStringBinary('hello', ba) # key
+        ba.extend([1] + [0] * 7) # num_indexes
+        ba.extend([0] * 8) # UInt64 index (0 for 'hello')
+        s.sendall(ba)
+
+        assertPacket(readVarUInt(s), 2)
+        print(readException(s))
+        s.close()
 
 def main():
     insertValidLowCardinalityRow()
     insertLowCardinalityRowWithIndexOverflow()
     insertLowCardinalityRowWithIncorrectDictType()
+    insertLowCardinalityRowWithIncorrectAdditionalKeys()
 
 if __name__ == "__main__":
     main()

--- a/tests/queries/0_stateless/02010_lc_native.reference
+++ b/tests/queries/0_stateless/02010_lc_native.reference
@@ -6,3 +6,6 @@ code 117:  Index for LowCardinality is out of range. Dictionary size is 1, but f
 Rows 0 Columns 1
 Column x type LowCardinality(String)
 code 117:  LowCardinality indexes serialization type for Native format cannot use global dictionary
+Rows 0 Columns 1
+Column x type LowCardinality(String)
+code 117:  No additional keys found.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:

- Bug Fix

Changelog entry:

Fix null pointer dereference in low cardinality data when deserializing LowCardinality data in the Native format.

Detailed description / Documentation draft:

When deserializing LowCardinality data in the Native format it is possible for an attacker to cause ClickHouse to crash with a null pointer dereference.

In original code, if the flag index_type.has_additional_keys is false(which can be set to false in binary file or when sending data through native protocol by an attacker) and the code is expecting additional keys to be used in normal cases, the null pointer dereferencing happens since the false flag will cause addtional_keys to be nullptr by following code:

```
if (low_cardinality_state->index_type.has_additional_keys)
            read_additional_keys();
else
            low_cardinality_state->additional_keys = nullptr;
```
The fix is to add code to check if it is nullptr before the usage and throw exceptions if it is the case.
