### PR TITLE
Fix Weak Regular Expression (Keypath)

### DIFF
--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -168,7 +168,7 @@ private:
     inline static const String RESTORE_FILE_NAME = "restore";
 
     /// Key has format: ../../r{revision}-{operation}
-    const re2::RE2 key_regexp {".*/r(\\d+)-(\\w+).*"};
+    const re2::RE2 key_regexp {".*/r(\\d+)-(\\w+)$"};
 
     /// Object contains information about schema version.
     inline static const String SCHEMA_VERSION_OBJECT = ".SCHEMA_VERSION";


### PR DESCRIPTION
Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix Regular Expression while key path search.

Detailed description / Documentation draft:

Problem Descripton:
==================
The “key_regexp” constant in the “DiskS3” class contains a regular expression (RegEx) for checking a key path.
However, the RegEx starts and ends with “.*”.
This is a wildcard that an attacker could use to exploit this file path check by padding the beginning and end with whatever path they’d like.

Recommendation:
==============
Tighten up the RegEx by replacing the “.*” at the beginning and end with more specific items.

Fix:
===
Replace the .* at the end with $ as there is no need to continue after the key file.
Leave the beginning .* as is because the path for the key can have any characters or in any path of the system.


Committer: Mahesh Reddy
email: mahesh.reddy@ibm.com
