### PR TITLE
Native Format Parsing - Integer Overflow Resizing Arrays

### DIFF
--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -37,7 +37,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int CANNOT_MPROTECT;
-    extern const int CANNOT_ALLOCATE_MEMORY;
 }
 
 /** A dynamic array for POD types.
@@ -105,12 +104,12 @@ protected:
     char * c_end_of_storage = null;    /// Does not include pad_right.
 
     /// The amount of memory occupied by the num_elements of the elements.
-    static size_t byte_size(size_t num_elements) 
+    static size_t byte_size(size_t num_elements)
     {
-        size_t test;
-        if (__builtin_mul_overflow(num_elements, ELEMENT_SIZE, &test))
-            throw Exception("Amount of memory requested to allocate is more than allowed", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
-        else 
+        size_t result;
+        if (__builtin_mul_overflow(num_elements, ELEMENT_SIZE, &result))
+            return result;
+        else
             return num_elements * ELEMENT_SIZE;
     }
     

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -108,10 +108,10 @@ protected:
     static size_t byte_size(size_t num_elements) 
     {
         size_t test;
-        if (__builtin_mul_overflow(num_elements,ELEMENT_SIZE, &test))
-           throw Exception("Amount of memory requested to allocate is more than allowed", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+        if (__builtin_mul_overflow(num_elements, ELEMENT_SIZE, &test))
+            throw Exception("Amount of memory requested to allocate is more than allowed", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
         else 
-           return (num_elements * ELEMENT_SIZE);
+            return num_elements * ELEMENT_SIZE;
     }
     
     /// Minimum amount of memory to allocate for num_elements, including padding.

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -37,6 +37,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int CANNOT_MPROTECT;
+    extern const int CANNOT_ALLOCATE_MEMORY;
 }
 
 /** A dynamic array for POD types.
@@ -104,8 +105,14 @@ protected:
     char * c_end_of_storage = null;    /// Does not include pad_right.
 
     /// The amount of memory occupied by the num_elements of the elements.
-    static size_t byte_size(size_t num_elements) { return num_elements * ELEMENT_SIZE; }
-
+    static size_t byte_size(size_t num_elements) 
+    {
+        if (num_elements > SIZE_MAX/ELEMENT_SIZE) 
+           throw Exception("Amount of memory requested to allocate is more than allowed", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+        else 
+           return (num_elements * ELEMENT_SIZE);
+    }
+    
     /// Minimum amount of memory to allocate for num_elements, including padding.
     static size_t minimum_memory_for_elements(size_t num_elements) { return byte_size(num_elements) + pad_right + pad_left; }
 

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -37,7 +37,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int CANNOT_MPROTECT;
-    extern const int CANNOT_ALLOCATE_MEMORY;
 }
 
 /** A dynamic array for POD types.
@@ -107,9 +106,9 @@ protected:
     /// The amount of memory occupied by the num_elements of the elements.
     static size_t byte_size(size_t num_elements) 
     {
-        size_t test;
-        if (__builtin_mul_overflow(num_elements, ELEMENT_SIZE, &test))
-            throw Exception("Amount of memory requested to allocate is more than allowed", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+        size_t result;
+        if (__builtin_mul_overflow(num_elements, ELEMENT_SIZE, &result))
+            return result;
         else 
             return num_elements * ELEMENT_SIZE;
     }

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -109,7 +109,7 @@ protected:
         size_t result;
         if (__builtin_mul_overflow(num_elements, ELEMENT_SIZE, &result))
             return result;
-        else 
+        else
             return num_elements * ELEMENT_SIZE;
     }
     

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -107,7 +107,8 @@ protected:
     /// The amount of memory occupied by the num_elements of the elements.
     static size_t byte_size(size_t num_elements) 
     {
-        if (num_elements > SIZE_MAX/ELEMENT_SIZE) 
+        size_t test;
+        if (__builtin_mul_overflow(num_elements,ELEMENT_SIZE, &test))
            throw Exception("Amount of memory requested to allocate is more than allowed", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
         else 
            return (num_elements * ELEMENT_SIZE);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Integer overflow to resize the arrays causes heap corrupt 


Detailed description / Documentation draft:
Problem Description:
Attacker can take advantage and abuse the overflow of integer to write to the heap.
the argument - num_elements to function byte_size function which is a 64-bit unsigned integer on the machines and it can
overflow due to the multiplication by ELEMENT_SIZE and/or the addition of the padding sizes.
The result of this arithmetic is passed to the allocation (realloc) that is expected to hold
num_elements items. If an overflow occurred during these arithmetic operations, then the
PODArray instance will believe the array can hold a much larger amount than was actually
allocated. When those items are initialized they will overwrite adjacent data on the heap.

Solution proposed:
As part of fix to address Integer overflow, proper check added in PODArray.h to prevent integer overflow conditions prior to allocations or copy operations using the results of the calculations. and also Throwing exception when CH requests for larger than MAX_SIZE.

Committer: Rajkumar Varada 