### PR TITLE
Runtime - Out-of-bounds array dereferencing

### DIFF
--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -52,7 +52,7 @@ static std::string numberFromHost(const std::string & s)
             res += s[j++];
         if (res.size() >= 2)
         {
-            while (!res.empty() && res[0] == '0')
+            while (res.starts_with('0'))
                 res.erase(res.begin());
             return res;
         }

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -46,13 +46,13 @@ static std::string numberFromHost(const std::string & s)
 {
     for (size_t i = 0; i < s.size(); ++i)
     {
-        std::string res;
+        std::string res = "";
         size_t j = i;
         while (j < s.size() && isNumericASCII(s[j]))
             res += s[j++];
         if (res.size() >= 2)
         {
-            while (res[0] == '0')
+            while (!res.empty() && res[0] == '0')
                 res.erase(res.begin());
             return res;
         }

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -46,7 +46,7 @@ static std::string numberFromHost(const std::string & s)
 {
     for (size_t i = 0; i < s.size(); ++i)
     {
-        std::string res = "";
+        std::string res;
         size_t j = i;
         while (j < s.size() && isNumericASCII(s[j]))
             res += s[j++];


### PR DESCRIPTION
Changelog category:
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

**Modified**
```src/Common/Config/ConfigProcessor.cpp``` file to fix potential out-of-bounds array dereferencing issue.

Detailed description / Documentation draft:
Consider the loop below inside ```numberFromHost()``` function:  
```while (res[0] == '0')  res.erase(res.begin());```
Leading zeroes of ```res``` are removed, but there is no check that ```res``` isn’t empty before its ```0’th``` member is accessed. The resulting string, in an unknown state, is then returned.  

To resolved this, C++ STL function ```starts_with()``` is applied.

> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
