### PR TITLE
Decrease default timeout for integration test

### DIFF
--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 python_files = test*.py
 norecursedirs = _instances*
-timeout = 1800
+timeout = 900
 junit_duration_report = call
 junit_suite_name = integration
 log_level = DEBUG


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Detailed description / Documentation draft:
15 minutes should be more than enough
