### PR TITLE
handle interrupt properly inside ClickHouseBenchmark tool

### DIFF
--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -343,7 +343,7 @@ private:
         // call exit(1) so that the program actually exits on interrupts like SIGINT
         if (interrupt_received)
         {
-            exit(1);
+            _exit(1);
         }
 
         pool.wait();

--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -1,12 +1,8 @@
 #include <unistd.h>
 #include <stdlib.h>
-#include <fcntl.h>
 #include <signal.h>
-#include <time.h>
 #include <iostream>
-#include <fstream>
 #include <iomanip>
-#include <random>
 #include <pcg_random.hpp>
 #include <Poco/Util/Application.h>
 #include <Common/Stopwatch.h>
@@ -23,7 +19,6 @@
 #include <IO/WriteBufferFromFileDescriptor.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/ReadHelpers.h>
-#include <IO/WriteHelpers.h>
 #include <IO/Operators.h>
 #include <IO/ConnectionTimeouts.h>
 #include <IO/ConnectionTimeoutsContext.h>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:

Handles interrupt properly inside ClickHouseBenchmark tool. Currently the interrupt is checked but not handled properly.
This PR checks for interrupt and if it happens, sets `interrupt_received` to true (inside `tryPushQueryInteractively`) and 
handles it by exiting with exit(1). Tested with `Ctrl + C` when running the benchmark tool:
```
^CStopping launch of queries. SIGINT received.
[2]    109533 done                 echo "SELECT * FROM system.numbers LIMIT 100000 OFFSET 100000" | 
       109534 abort (core dumped)  ./clickhouse-benchmark -i 1000
``` 

Relates to: #32586