### PR TITLE
clickhouse-local send profile info

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -214,15 +214,15 @@ bool LocalConnection::poll(size_t)
     if (next_packet_type)
         return true;
 
-    if (send_progress && (state->after_send_progress.elapsedMicroseconds() >= query_context->getSettingsRef().interactive_delay))
-    {
-        state->after_send_progress.restart();
-        next_packet_type = Protocol::Server::Progress;
-        return true;
-    }
-
     if (!state->is_finished)
     {
+        if (send_progress && (state->after_send_progress.elapsedMicroseconds() >= query_context->getSettingsRef().interactive_delay))
+        {
+            state->after_send_progress.restart();
+            next_packet_type = Protocol::Server::Progress;
+            return true;
+        }
+
         try
         {
             pollImpl();
@@ -278,6 +278,18 @@ bool LocalConnection::poll(size_t)
         {
             next_packet_type = Protocol::Server::Extremes;
             state->block.emplace(extremes);
+            return true;
+        }
+    }
+
+    if (state->is_finished && !state->sent_profile_info)
+    {
+        state->sent_profile_info = true;
+
+        if (state->executor)
+        {
+            next_packet_type = Protocol::Server::ProfileInfo;
+            state->profile_info = state->executor->getProfileInfo();
             return true;
         }
     }
@@ -345,6 +357,16 @@ Packet LocalConnection::receivePacket()
             {
                 packet.block = std::move(state->block.value());
                 state->block.reset();
+            }
+            next_packet_type.reset();
+            break;
+        }
+        case Protocol::Server::ProfileInfo:
+        {
+            if (state->profile_info)
+            {
+                packet.profile_info = std::move(*state->profile_info);
+                state->profile_info.reset();
             }
             next_packet_type.reset();
             break;

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -35,6 +35,7 @@ struct LocalQueryState
     /// Current block to be sent next.
     std::optional<Block> block;
     std::optional<ColumnsDescription> columns_description;
+    std::optional<ProfileInfo> profile_info;
 
     /// Is request cancelled
     bool is_cancelled = false;
@@ -43,6 +44,7 @@ struct LocalQueryState
     bool sent_totals = false;
     bool sent_extremes = false;
     bool sent_progress = false;
+    bool sent_profile_info = false;
 
     /// To output progress, the difference after the previous sending of progress.
     Progress progress;

--- a/tests/queries/0_stateless/02153_clickhouse_local_profile_info.reference
+++ b/tests/queries/0_stateless/02153_clickhouse_local_profile_info.reference
@@ -1,0 +1,32 @@
+{
+	"meta":
+	[
+		{
+			"name": "count()",
+			"type": "UInt64"
+		},
+		{
+			"name": "n",
+			"type": "UInt8"
+		}
+	],
+
+	"data":
+	[
+		{
+			"count()": "1",
+			"n": 1
+		}
+	],
+
+	"totals":
+	{
+		"count()": "3",
+		"n": 0
+	},
+
+	"rows": 1,
+
+	"rows_before_limit_at_least": 3,
+
+	"statistics":

--- a/tests/queries/0_stateless/02153_clickhouse_local_profile_info.sh
+++ b/tests/queries/0_stateless/02153_clickhouse_local_profile_info.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_LOCAL} --query "SELECT count(), arrayJoin([1, 2, 3]) AS n GROUP BY n WITH TOTALS ORDER BY n LIMIT 1 FORMAT JSON;" 2>&1 | head -32
+


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Send profile info in clickhouse-local. Closes https://github.com/ClickHouse/ClickHouse/issues/33093.