### PR TITLE
Better pr info for unknown events

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -112,11 +112,26 @@ class PRInfo:
                     self.diff_url = pull_request['diff_url']
         else:
             print(json.dumps(github_event, sort_keys=True, indent=4))
-            raise Exception("Cannot detect type of event")
+            self.sha = os.getenv("GITHUB_SHA")
+            self.number = 0
+            self.labels = {}
+            repo_prefix = f"{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}"
+            self.task_url = f"{repo_prefix}/actions/runs/{GITHUB_RUN_ID or '0'}"
+            self.commit_html_url = f"{repo_prefix}/commits/{self.sha}"
+            self.repo_full_name = GITHUB_REPOSITORY
+            self.pr_html_url = f"{repo_prefix}/commits/master"
+            self.base_ref = "master"
+            self.base_name = self.repo_full_name
+            self.head_ref = "master"
+            self.head_name = self.repo_full_name
+
         if need_changed_files:
             self.fetch_changed_files()
 
     def fetch_changed_files(self):
+        if not self.diff_url:
+            raise Exception("Diff URL cannot be find for event")
+
         if 'commits' in self.event and self.number == 0:
             response = requests.get(self.diff_url)
             response.raise_for_status()


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


