### PR TITLE
Fix shared hermetic builds on Arch linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,11 @@ if (MAKE_STATIC_LIBRARIES)
     endif ()
 else ()
     set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+    # This is required for clang on Arch linux, that uses PIE by default.
+    # See enable-SSP-and-PIE-by-default.patch [1].
+    #
+    #   [1]: https://github.com/archlinux/svntogit-packages/blob/6e681aa860e65ad46a1387081482eb875c2200f2/trunk/enable-SSP-and-PIE-by-default.patch
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -no-pie")
 endif ()
 
 if (ENABLE_TESTS)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

On Arch linux clang uses PIE by default, and so it requires Scrt1.o:

    $ /usr/bin/clang++ --target=x86_64-linux-gnu --sysroot=/src/ch/clickhouse/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc --gcc-toolchain=/src/ch/clickhouse/cmake/linux/../../contrib/sysroot/linux-x86_64 --gcc-toolchain=/src/ch/clickhouse/cmake/linux/../../contrib/sysroot/linux-x86_64 -std=c++20 ... -o base/base/tests/dump_variable ...
    clang version 13.0.0
    Target: x86_64-unknown-linux-gnu
    Thread model: posix
    InstalledDir: /usr/bin
    Found candidate GCC installation: /src/ch/clickhouse/cmake/linux/../../contrib/sysroot/linux-x86_64/lib/gcc/x86_64-linux-gnu/9
    Selected GCC installation: /src/ch/clickhouse/cmake/linux/../../contrib/sysroot/linux-x86_64/lib/gcc/x86_64-linux-gnu/9
    Candidate multilib: .;@m64
    Selected multilib: .;@m64
     "/usr/bin/ld.lld" --sysroot=/src/ch/clickhouse/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -pie -export-dynamic --eh-frame-hdr -m elf_x86_64 -export-dynamic -dynamic-linker /lib64/ld-linux-x86-64.so.2 -o base/base/tests/dump_variable Scrt1.o ...
             ^^^^^^^

Cc: @Algunenano 
Follow-up for: #32731
Follow-up for: #32968
Refs: https://github.com/archlinux/svntogit-packages/blob/6e681aa860e65ad46a1387081482eb875c2200f2/trunk/enable-SSP-and-PIE-by-default.patch