### PR TITLE
Fix ccache with ENABLE_CHECK_HEAVY_BUILDS (ccache 4.0 and 4.1 only affected)

### DIFF
--- a/cmake/find/ccache.cmake
+++ b/cmake/find/ccache.cmake
@@ -32,11 +32,6 @@ if (CCACHE_FOUND AND NOT COMPILER_MATCHES_CCACHE)
    if (CCACHE_VERSION VERSION_GREATER "3.2.0" OR NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
       message(STATUS "Using ${CCACHE_FOUND} ${CCACHE_VERSION}")
 
-      set (CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_FOUND} ${CMAKE_CXX_COMPILER_LAUNCHER})
-      set (CMAKE_C_COMPILER_LAUNCHER ${CCACHE_FOUND} ${CMAKE_C_COMPILER_LAUNCHER})
-
-      set_property (GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_FOUND})
-
       # debian (debhelpers) set SOURCE_DATE_EPOCH environment variable, that is
       # filled from the debian/changelog or current time.
       #
@@ -49,11 +44,14 @@ if (CCACHE_FOUND AND NOT COMPILER_MATCHES_CCACHE)
       # - 4.0+ will ignore SOURCE_DATE_EPOCH environment variable.
       if (CCACHE_VERSION VERSION_GREATER_EQUAL "4.2")
          message(STATUS "ccache is 4.2+ no quirks for SOURCE_DATE_EPOCH required")
+         set(LAUNCHER ${CCACHE_FOUND})
       elseif (CCACHE_VERSION VERSION_GREATER_EQUAL "4.0")
          message(STATUS "Ignore SOURCE_DATE_EPOCH for ccache")
-         set_property (GLOBAL PROPERTY RULE_LAUNCH_COMPILE "env -u SOURCE_DATE_EPOCH")
-         set_property (GLOBAL PROPERTY RULE_LAUNCH_LINK "env -u SOURCE_DATE_EPOCH")
+         set(LAUNCHER env -u SOURCE_DATE_EPOCH ${CCACHE_FOUND})
       endif()
+
+      set (CMAKE_CXX_COMPILER_LAUNCHER ${LAUNCHER} ${CMAKE_CXX_COMPILER_LAUNCHER})
+      set (CMAKE_C_COMPILER_LAUNCHER ${LAUNCHER} ${CMAKE_C_COMPILER_LAUNCHER})
    else ()
       message(${RECONFIGURE_MESSAGE_LEVEL} "Not using ${CCACHE_FOUND} ${CCACHE_VERSION} bug: https://bugzilla.samba.org/show_bug.cgi?id=8118")
    endif ()


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Before this patch ccache 4.0/4.1 has not been working correctly with
ENABLE_CHECK_HEAVY_BUILDS, this was because of mixing
CMAKE_CXX_COMPILER_LAUNCHER/CMAKE_C_COMPILER_LAUNCHER and
RULE_LAUNCH_LINK/RULE_LAUNCH_COMPILE.

Fixes: #28845