### PR TITLE
fix incorrect metric: StorageBufferBytes

### DIFF
--- a/src/Storages/StorageBuffer.cpp
+++ b/src/Storages/StorageBuffer.cpp
@@ -455,10 +455,8 @@ static void appendBlock(const Block & from, Block & to)
     size_t rows = from.rows();
     size_t bytes = from.bytes();
 
-    CurrentMetrics::add(CurrentMetrics::StorageBufferRows, rows);
-    CurrentMetrics::add(CurrentMetrics::StorageBufferBytes, bytes);
-
     size_t old_rows = to.rows();
+    size_t old_bytes = to.bytes();
 
     MutableColumnPtr last_col;
     try
@@ -468,6 +466,8 @@ static void appendBlock(const Block & from, Block & to)
         if (to.rows() == 0)
         {
             to = from;
+            CurrentMetrics::add(CurrentMetrics::StorageBufferRows, rows);
+            CurrentMetrics::add(CurrentMetrics::StorageBufferBytes, bytes);
         }
         else
         {
@@ -480,6 +480,8 @@ static void appendBlock(const Block & from, Block & to)
 
                 to.getByPosition(column_no).column = std::move(last_col);
             }
+            CurrentMetrics::add(CurrentMetrics::StorageBufferRows, rows);
+            CurrentMetrics::add(CurrentMetrics::StorageBufferBytes, to.bytes() - old_bytes);
         }
     }
     catch (...)

--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -71,7 +71,7 @@ def test_metrics_storage_buffer_size(start_cluster):
         (
             `str` LowCardinality(String)
         )
-        ENGINE = Buffer('test', 'test_table', 1, 5, 5, 1000, 100000, 100000, 10000000);
+        ENGINE = Buffer('test', 'test_mem_table', 1, 5, 5, 1000, 100000, 100000, 10000000);
     ''')
     node1.query("INSERT INTO test.buffer_table VALUES('hello');")
     node1.query("INSERT INTO test.buffer_table VALUES('hello');")

--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -59,6 +59,7 @@ def test_readonly_metrics(start_cluster):
         node1.query("ATTACH TABLE test.test_table")
         assert_eq_with_retry(node1, "SELECT value FROM system.metrics WHERE metric = 'ReadonlyReplica'", "0\n", retry_count=300, sleep_time=1)
 
+#For LowCardinality-columns, the bytes for N rows is not N*size of 1 row.
 def test_metrics_storage_buffer_size(start_cluster):
     node1.query('''
         CREATE TABLE test.test_mem_table


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en


Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix incorrect metric: StorageBufferBytes

Detailed description / Documentation draft:
the metric StorageBufferBytes for buffer table is incorrect when there is a Lowcardinality Field. 

