### PR TITLE
Cleanup trash from Kafka, HDFS and Azure

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -252,7 +252,7 @@ public:
         catch (const Exception & ex)
         {
             if (ex.code() == ErrorCodes::UNKNOWN_FORMAT_VERSION)
-                throw ex;
+                throw;
 
             result.error = true;
             LOG_WARNING(log, "Cannot completely read changelog on path {}, error: {}", filepath, ex.message());

--- a/src/Disks/AzureBlobStorage/DiskAzureBlobStorage.cpp
+++ b/src/Disks/AzureBlobStorage/DiskAzureBlobStorage.cpp
@@ -160,10 +160,10 @@ void DiskAzureBlobStorage::removeFromRemoteFS(RemoteFSPathKeeperPtr fs_paths_kee
                 if (!delete_info.Value.Deleted)
                     throw Exception(ErrorCodes::AZURE_BLOB_STORAGE_ERROR, "Failed to delete file in AzureBlob Storage: {}", path);
             }
-            catch (const Azure::Storage::StorageException& e)
+            catch (const Azure::Storage::StorageException & e)
             {
                 LOG_INFO(log, "Caught an error while deleting file {} : {}", path, e.Message);
-                throw e;
+                throw;
             }
         }
     }

--- a/src/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -83,7 +83,7 @@ bool ReadBufferFromAzureBlobStorage::nextImpl()
         {
             LOG_INFO(log, "Exception caught during Azure Read for file {} at attempt {} : {}", path, i, e.Message);
             if (i + 1 == max_single_read_retries)
-                throw e;
+                throw;
 
             sleepForMilliseconds(sleep_time_with_backoff_milliseconds);
             sleep_time_with_backoff_milliseconds *= 2;
@@ -153,7 +153,7 @@ void ReadBufferFromAzureBlobStorage::initialize()
         {
             LOG_INFO(log, "Exception caught during Azure Download for file {} at offset {} at attempt {} : {}", path, offset, i, e.Message);
             if (i + 1 == max_single_download_retries)
-                throw e;
+                throw;
 
             sleepForMilliseconds(sleep_time_with_backoff_milliseconds);
             sleep_time_with_backoff_milliseconds *= 2;

--- a/src/Storages/HDFS/StorageHDFS.h
+++ b/src/Storages/HDFS/StorageHDFS.h
@@ -33,7 +33,11 @@ public:
 
     SinkToStoragePtr write(const ASTPtr & query, const StorageMetadataPtr & /*metadata_snapshot*/, ContextPtr context) override;
 
-    void truncate(const ASTPtr & query, const StorageMetadataPtr & metadata_snapshot, ContextPtr context_, TableExclusiveLockHolder &) override;
+    void truncate(
+        const ASTPtr & query,
+        const StorageMetadataPtr & metadata_snapshot,
+        ContextPtr local_context,
+        TableExclusiveLockHolder &) override;
 
     NamesAndTypesList getVirtuals() const override;
 

--- a/src/Storages/Kafka/WriteBufferToKafkaProducer.cpp
+++ b/src/Storages/Kafka/WriteBufferToKafkaProducer.cpp
@@ -103,7 +103,7 @@ void WriteBufferToKafkaProducer::countRow(const Columns & columns, size_t curren
                     producer->poll(timeout);
                     continue;
                 }
-                throw e;
+                throw;
             }
 
             break;
@@ -126,7 +126,7 @@ void WriteBufferToKafkaProducer::flush()
         {
             if (e.get_error() == RD_KAFKA_RESP_ERR__TIMED_OUT)
                 continue;
-            throw e;
+            throw;
         }
 
         break;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Kafka, HDFS and Azure were contaminated by trash.