### PR TITLE
Make test_input_format_parallel_parsing_memory_tracking less flaky

### DIFF
--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/conf.xml
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/conf.xml
@@ -1,4 +1,18 @@
 <clickhouse>
     <!-- make it fail earlier -->
     <max_server_memory_usage>3000000000</max_server_memory_usage> <!-- 3GB -->
+
+    <query_thread_log remove="remove"/>
+    <query_log remove="remove" />
+    <query_views_log remove="remove" />
+    <metric_log remove="remove"/>
+    <text_log remove="remove"/>
+    <trace_log remove="remove"/>
+    <asynchronous_metric_log remove="remove" />
+    <session_log remove="remove" />
+    <part_log remove="remove" />
+    <crash_log remove="remove" />
+    <opentelemetry_span_log remove="remove" />
+    <!-- just in case it will be enabled by default -->
+    <zookeeper_log remove="remove" />
 </clickhouse>

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/conf.xml
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/configs/conf.xml
@@ -1,6 +1,11 @@
 <clickhouse>
-    <!-- make it fail earlier -->
-    <max_server_memory_usage>3000000000</max_server_memory_usage> <!-- 3GB -->
+    <!-- To make it fail earlier, we will limit max_server_memory_usage explicitly.
+
+         Also note, that usually it is enough 3Gi,
+         but TSan uses 2.8+- GiB of RAM w/o just at start,
+         so this limit had been increased to 4GB
+    -->
+    <max_server_memory_usage>4000000000</max_server_memory_usage>
 
     <query_thread_log remove="remove"/>
     <query_log remove="remove" />

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
@@ -26,14 +26,11 @@ def start_cluster():
 # max_memory_usage_for_user cannot be used, since the memory for user accounted
 # correctly, only total is not
 def test_memory_tracking_total():
-    instance.query('''
-        CREATE TABLE null (row String) ENGINE=Null;
-    ''')
+    instance.query('CREATE TABLE null (row String) ENGINE=Null')
     instance.exec_in_container(['bash', '-c',
                                 'clickhouse local -q "SELECT arrayStringConcat(arrayMap(x->toString(cityHash64(x)), range(1000)), \' \') from numbers(10000)" > data.json'])
     for it in range(0, 20):
         # the problem can be triggered only via HTTP,
         # since clickhouse-client parses the data by itself.
         assert instance.exec_in_container(['curl', '--silent', '--show-error', '--data-binary', '@data.json',
-                                           'http://127.1:8123/?query=INSERT%20INTO%20null%20FORMAT%20TSV']) == '', 'Failed on {} iteration'.format(
-            it)
+                                           'http://127.1:8123/?query=INSERT%20INTO%20null%20FORMAT%20TSV']) == '', f'Failed on {it} iteration'

--- a/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
+++ b/tests/integration/test_input_format_parallel_parsing_memory_tracking/test.py
@@ -24,7 +24,7 @@ def start_cluster():
 
 
 # max_memory_usage_for_user cannot be used, since the memory for user accounted
-# correctly, only total is not
+# correctly, only total is not (it is set via conf.xml)
 def test_memory_tracking_total():
     instance.query('CREATE TABLE null (row String) ENGINE=Null')
     instance.exec_in_container(['bash', '-c',


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changes:
- Reduce memory usage, by disabling system tables, that may consume memory too.
- increase max_server_memory_usage (since TSan binary uses 2.8GB just after start, w/o any queries executed)

Also note, that failures with "curl: (56) Recv failure: Connection reset
by peer" like [1] is due to memory, since the server was under memory
pressure, and was not able even to accept the connection:

<details>

    2021.12.25 00:22:02.957658 [ 54 ] {} <Error> ThreadStatus: Code: 241. DB::Exception: Memory limit (total) exceeded: would use 2.81 GiB (attempt to allocate chunk of 2097182 bytes), maximum: 2.79 GiB. (MEMORY_LIMIT_EXCEEDED), Stack trace (when copying this message, always include the lines below):

    0. ./obj-x86_64-linux-gnu/../contrib/libcxx/include/exception:0: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x1addca1b in /usr/bin/clickhouse
    1. ./obj-x86_64-linux-gnu/../src/Common/Exception.cpp:57: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0xa0e993c in /usr/bin/clickhouse
    2. ./obj-x86_64-linux-gnu/../contrib/libcxx/include/string:1444: DB::Exception::Exception<char const*, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, char const*&&, char const*&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&, long&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&) @ 0xa11344b in /usr/bin/clickhouse
    3. ./obj-x86_64-linux-gnu/../src/Common/MemoryTracker.cpp:226: MemoryTracker::allocImpl(long, bool) @ 0xa11220c in /usr/bin/clickhouse
    4. ./obj-x86_64-linux-gnu/../src/Common/MemoryTracker.cpp:258: MemoryTracker::allocImpl(long, bool) @ 0xa111faa in /usr/bin/clickhouse
    5. ./obj-x86_64-linux-gnu/../src/Common/MemoryTracker.cpp:264: MemoryTracker::alloc(long) @ 0xa112bc6 in /usr/bin/clickhouse
    6. ./obj-x86_64-linux-gnu/../src/Common/ThreadStatus.cpp:152: DB::ThreadStatus::~ThreadStatus() @ 0xa10e182 in /usr/bin/clickhouse
    7. ./obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:518: DB::TCPHandler::runImpl() @ 0x17c4192d in /usr/bin/clickhouse
    8. ./obj-x86_64-linux-gnu/../src/Server/TCPHandler.cpp:1909: DB::TCPHandler::run() @ 0x17c55328 in /usr/bin/clickhouse
    9. ./obj-x86_64-linux-gnu/../contrib/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x1ac19f03 in /usr/bin/clickhouse
    10. ./obj-x86_64-linux-gnu/../contrib/libcxx/include/memory:1397: Poco::Net::TCPServerDispatcher::run() @ 0x1ac1a773 in /usr/bin/clickhouse
    11. ./obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/ThreadPool.cpp:213: Poco::PooledThread::run() @ 0x1ae7e796 in /usr/bin/clickhouse
    12. ./obj-x86_64-linux-gnu/../contrib/poco/Foundation/src/Thread.cpp:56: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x1ae7c930 in /usr/bin/clickhouse
    13. ./obj-x86_64-linux-gnu/../contrib/poco/Foundation/include/Poco/SharedPtr.h:277: Poco::ThreadImpl::runnableEntry(void*) @ 0x1ae7afa8 in /usr/bin/clickhouse
    14. __tsan_thread_start_func @ 0xa039dfd in /usr/bin/clickhouse
    15. ? @ 0x7f4c565cf609 in ?
    16. clone @ 0x7f4c564f6293 in ?
     (version 21.13.1.1305)

</details>

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/33140/b4420cfa3e834ab9026914978697ded3180122a0/integration_tests__thread__actions__[3/4].html

Follow-up for: #12672