### PR TITLE
Fix test_async_drain_connection flakiness

### DIFF
--- a/tests/integration/test_async_drain_connection/test.py
+++ b/tests/integration/test_async_drain_connection/test.py
@@ -1,21 +1,21 @@
-import os
-import sys
-import time
-from multiprocessing.dummy import Pool
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+
 import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node", main_configs=["configs/config.xml"])
+node = cluster.add_instance('node', main_configs=['configs/config.xml'])
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def started_cluster():
     try:
         cluster.start()
-        node.query(
-            'create table t (number UInt64) engine = Distributed(test_cluster_two_shards, system, numbers);'
-        )
+        node.query("""
+        create table t (number UInt64)
+        engine = Distributed(test_cluster_two_shards, system, numbers)
+        """)
         yield cluster
 
     finally:
@@ -23,14 +23,11 @@ def started_cluster():
 
 
 def test_filled_async_drain_connection_pool(started_cluster):
-    busy_pool = Pool(10)
-
-    def execute_query(i):
+    def execute_queries(_):
         for _ in range(100):
-            node.query('select * from t where number = 0 limit 2;',
-                       settings={
-                           "sleep_in_receive_cancel_ms": 10000000,
-                           "max_execution_time": 5
-                       })
+            node.query('select * from t where number = 0 limit 2', settings={
+                'sleep_in_receive_cancel_ms': int(10e6),
+                'max_execution_time': 5,
+            })
 
-    p = busy_pool.map(execute_query, range(10))
+    any(map(execute_queries, range(10)))

--- a/tests/integration/test_async_drain_connection/test.py
+++ b/tests/integration/test_async_drain_connection/test.py
@@ -28,6 +28,9 @@ def test_filled_async_drain_connection_pool(started_cluster):
             node.query('select * from t where number = 0 limit 2', settings={
                 'sleep_in_receive_cancel_ms': int(10e6),
                 'max_execution_time': 5,
+                # decrease drain_timeout to make test more stable
+                # (another way is to increase max_execution_time, but this will make test slower)
+                'drain_timeout': 1,
             })
 
     any(map(execute_queries, range(10)))


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix test_async_drain_connection flakiness (and also cleanup the test to make the behavior more explicit, i.e. no dummy pool)

Detailed description / Documentation draft:
Sometimes [1] 5 seconds is not enough, since drain_timeout is 3 seconds,
and 2 seconds sometimes is not enough to do other things, especially
under sanitizers:

    E           Code: 159. DB::Exception: Received from 172.16.1.2:9000. DB::Exception: Timeout exceeded: elapsed 5.019254094 seconds, maximum: 5. Stack trace:

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/0/826f7cb0f53e20e67ef52800cb735bb88a6de658/integration_tests__thread__actions__[4/4].html

Note, that in my env, this test failed constantly before this changes, after it started to pass.

Cc: @amosbird 