### PR TITLE
fix json error after downgrade

### DIFF
--- a/src/Common/FileChecker.cpp
+++ b/src/Common/FileChecker.cpp
@@ -153,7 +153,7 @@ void FileChecker::load()
     }
     JSON json(out.str());
 
-    JSON files = json["yandex"];
+    JSON files = json.has("clickhouse") ? json["clickhouse"] : json["yandex"];
     for (const JSON file : files) // NOLINT
         map[unescapeForFileName(file.getName())] = file.getValue()["size"].toUInt();
 }


### PR DESCRIPTION
Error after downgrading from 21.11 to 21.8

ClickHouse 21.11 creates a file with "clickhouse" element, while 21.8 expects "yandex"

```
<Error> Application: Caught exception while loading metadata: Poco::Exception. Code: 1000, e.code() = 0, e.displayText() = JSONException: JSON: there is no element 'yandex' in object., Stack trace (when copying this message, always include the lines below)
```