### PR TITLE
Fix tests with event_time/event_date = today(), and add a style check

### DIFF
--- a/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.sql
+++ b/tests/queries/0_stateless/01756_optimize_skip_unused_shards_rewrite_in.sql
@@ -32,7 +32,7 @@ select '(0, 2)';
 with (select currentDatabase()) as id_no select *, ignore(id_no) from dist_01756 where dummy in (0, 2);
 system flush logs;
 select query from system.query_log where
-    event_date = today() and
+    event_date >= yesterday() and
     event_time > now() - interval 1 hour and
     not is_initial_query and
     query not like '%system%query_log%' and
@@ -51,7 +51,7 @@ select 'optimize_skip_unused_shards_rewrite_in(0, 2)';
 with (select currentDatabase()) as id_02 select *, ignore(id_02) from dist_01756 where dummy in (0, 2);
 system flush logs;
 select query from system.query_log where
-    event_date = today() and
+    event_date >= yesterday() and
     event_time > now() - interval 1 hour and
     not is_initial_query and
     query not like '%system%query_log%' and
@@ -63,7 +63,7 @@ select 'optimize_skip_unused_shards_rewrite_in(2,)';
 with (select currentDatabase()) as id_2 select *, ignore(id_2) from dist_01756 where dummy in (2,);
 system flush logs;
 select query from system.query_log where
-    event_date = today() and
+    event_date >= yesterday() and
     event_time > now() - interval 1 hour and
     not is_initial_query and
     query not like '%system%query_log%' and
@@ -75,7 +75,7 @@ select 'optimize_skip_unused_shards_rewrite_in(0,)';
 with (select currentDatabase()) as id_0 select *, ignore(id_0) from dist_01756 where dummy in (0,);
 system flush logs;
 select query from system.query_log where
-    event_date = today() and
+    event_date >= yesterday() and
     event_time > now() - interval 1 hour and
     not is_initial_query and
     query not like '%system%query_log%' and

--- a/tests/queries/0_stateless/01810_max_part_removal_threads_long.sh
+++ b/tests/queries/0_stateless/01810_max_part_removal_threads_long.sh
@@ -20,7 +20,7 @@ $CLICKHOUSE_CLIENT -nm -q """
     insert into data_01810 select * from numbers(50);
     drop table data_01810 settings log_queries=1;
     system flush logs;
-    select throwIf(length(thread_ids)<50) from system.query_log where event_date = today() and current_database = currentDatabase() and query = 'drop table data_01810 settings log_queries=1;' and type = 'QueryFinish' format Null;
+    select throwIf(length(thread_ids)<50) from system.query_log where event_date >= yesterday() and current_database = currentDatabase() and query = 'drop table data_01810 settings log_queries=1;' and type = 'QueryFinish' format Null;
 """
 
 # ReplicatedMergeTree
@@ -31,7 +31,7 @@ $CLICKHOUSE_CLIENT -nm -q """
     insert into rep_data_01810 select * from numbers(50);
     drop table rep_data_01810 settings log_queries=1;
     system flush logs;
-    select throwIf(length(thread_ids)<50) from system.query_log where event_date = today() and current_database = currentDatabase() and query = 'drop table rep_data_01810 settings log_queries=1;' and type = 'QueryFinish' format Null;
+    select throwIf(length(thread_ids)<50) from system.query_log where event_date >= yesterday() and current_database = currentDatabase() and query = 'drop table rep_data_01810 settings log_queries=1;' and type = 'QueryFinish' format Null;
 """
 
 $CLICKHOUSE_CLIENT -nm -q "drop database ordinary_$CLICKHOUSE_DATABASE"

--- a/tests/queries/0_stateless/01814_distributed_push_down_limit.sh
+++ b/tests/queries/0_stateless/01814_distributed_push_down_limit.sh
@@ -69,7 +69,7 @@ function test_distributed_push_down_limit_with_query_log()
         system flush logs;
         select read_rows from system.query_log
             where
-                event_date = today()
+                event_date >= yesterday()
                 and query_kind = 'Select' /* exclude DESC TABLE */
                 and initial_query_id = '$query_id' and initial_query_id != query_id;
     " | xargs # convert new lines to spaces

--- a/tests/queries/0_stateless/02015_global_in_threads.sh
+++ b/tests/queries/0_stateless/02015_global_in_threads.sh
@@ -6,4 +6,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ${CLICKHOUSE_CLIENT} --log_queries=1 --max_threads=32 --query_id "2015_${CLICKHOUSE_DATABASE}_query" -q "select count() from remote('127.0.0.{2,3}', numbers(10)) where number global in (select number % 5 from numbers_mt(1000000))"
 ${CLICKHOUSE_CLIENT} -q "system flush logs"
-${CLICKHOUSE_CLIENT} -q "select length(thread_ids) >= 32 from system.query_log where event_date = today() and query_id = '2015_${CLICKHOUSE_DATABASE}_query' and type = 'QueryFinish' and current_database = currentDatabase()"
+${CLICKHOUSE_CLIENT} -q "select length(thread_ids) >= 32 from system.query_log where event_date >= yesterday() and query_id = '2015_${CLICKHOUSE_DATABASE}_query' and type = 'QueryFinish' and current_database = currentDatabase()"

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -184,7 +184,6 @@ tables_with_database_column=(
 tests_with_database_column=( $(
     find $ROOT_PATH/tests/queries -iname '*.sql' -or -iname '*.sh' -or -iname '*.py' -or -iname '*.j2' |
         grep -vP $EXCLUDE_DIRS |
-        grep -v -x -e $ROOT_PATH/tests/queries/query_test.py |
         xargs grep --with-filename $(printf -- "-e %s " "${tables_with_database_column[@]}") | cut -d: -f1 | sort -u
 ) )
 for test_case in "${tests_with_database_column[@]}"; do

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -298,6 +298,20 @@ for src in "${sources_with_std_cerr_cout[@]}"; do
     fi
 done
 
+# Queries with event_date should have yesterday() not today()
+#
+# NOTE: it is not that accuate, but at least something.
+tests_with_event_time_date=( $(
+    find $ROOT_PATH/tests/queries -iname '*.sql' -or -iname '*.sh' -or -iname '*.py' -or -iname '*.j2' |
+        grep -vP $EXCLUDE_DIRS |
+        xargs grep --with-filename -e event_time -e event_date | cut -d: -f1 | sort -u
+) )
+for test_case in "${tests_with_event_time_date[@]}"; do
+    cat "$test_case" | tr '\n' ' ' | grep -q -i -e 'WHERE.*event_date[ ]*=[ ]*today()' -e 'WHERE.*event_date[ ]*=[ ]*today()' && {
+        echo "event_time/event_date should be filtered using >=yesterday() in $test_case (to avoid flakiness)"
+    }
+done
+
 # Conflict markers
 find $ROOT_PATH/{src,base,programs,utils,tests,docs,website,cmake} -name '*.md' -or -name '*.cpp' -or -name '*.h' |
     xargs grep -P '^(<<<<<<<|=======|>>>>>>>)$' | grep -P '.' && echo "Conflict markers are found in files"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix tests with event_time/event_date = today(), and add a style check

Detailed description / Documentation draft:
This will fix failures like in [1], from query_log from artifacts:

<details>

```sql
    SELECT
        query,
        event_time
    FROM system.query_log
    WHERE (NOT is_initial_query) AND (query NOT LIKE '%system%query_log%') AND (query LIKE concat('WITH%', 'test_84qkvq', '%AS `id_no` %')) AND (type = 'QueryFinish')

    Query id: c5d70aba-b0aa-4f92-bdb3-29547b9aabb1

    ┌─query──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────event_time─┐
    │ WITH _CAST('test_84qkvq', 'Nullable(String)') AS `id_no` SELECT `one`.`dummy`, ignore(`id_no`) FROM `system`.`one` WHERE `dummy` IN (0, 2) │ 2021-12-25 23:59:59 │
    │ WITH _CAST('test_84qkvq', 'Nullable(String)') AS `id_no` SELECT `one`.`dummy`, ignore(`id_no`) FROM `system`.`one` WHERE `dummy` IN (0, 2) │ 2021-12-25 23:59:59 │
    └────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴─────────────────────┘

    2 rows in set. Elapsed: 0.032 sec.

```

</details>

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/33175/465a9bf615e1b233606460f956c09f71931c99a2/stateless_tests__debug__actions__[2/3].html