### PR TITLE
Client interactive suggest (extract info from CREATE queries)

### DIFF
--- a/base/base/LineReader.cpp
+++ b/base/base/LineReader.cpp
@@ -36,7 +36,7 @@ bool hasInputData()
 
 }
 
-LineReader::Suggest::Words LineReader::Suggest::getCompletions(const String & prefix, size_t prefix_length)
+replxx::Replxx::completions_t LineReader::Suggest::getCompletions(const String & prefix, size_t prefix_length)
 {
     std::string_view last_word;
 
@@ -64,7 +64,7 @@ LineReader::Suggest::Words LineReader::Suggest::getCompletions(const String & pr
             return strncmp(s.data(), prefix_searched.data(), prefix_length) < 0;
         });
 
-    return Words(range.first, range.second);
+    return replxx::Replxx::completions_t(range.first, range.second);
 }
 
 void LineReader::Suggest::addWords(Words && new_words)

--- a/base/base/LineReader.cpp
+++ b/base/base/LineReader.cpp
@@ -65,6 +65,27 @@ std::optional<LineReader::Suggest::WordsRange> LineReader::Suggest::getCompletio
         });
 }
 
+void LineReader::Suggest::addWords(const std::vector<std::string> & new_words)
+{
+    for (const auto & new_word : new_words)
+    {
+        if (std::binary_search(words.begin(), words.end(), new_word))
+            continue;
+
+        words.push_back(new_word);
+        words_no_case.push_back(new_word);
+    }
+
+    std::sort(words.begin(), words.end());
+    std::sort(words_no_case.begin(), words_no_case.end(), [](const std::string & str1, const std::string & str2)
+    {
+        return std::lexicographical_compare(begin(str1), end(str1), begin(str2), end(str2), [](const char char1, const char char2)
+        {
+            return std::tolower(char1) < std::tolower(char2);
+        });
+    });
+}
+
 LineReader::LineReader(const String & history_file_path_, bool multiline_, Patterns extenders_, Patterns delimiters_)
     : history_file_path(history_file_path_), multiline(multiline_), extenders(std::move(extenders_)), delimiters(std::move(delimiters_))
 {

--- a/base/base/LineReader.h
+++ b/base/base/LineReader.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <base/types.h>
-
+#include <mutex>
 #include <atomic>
 #include <vector>
 #include <optional>
+
+#include <base/types.h>
 
 class LineReader
 {
@@ -12,15 +13,16 @@ public:
     struct Suggest
     {
         using Words = std::vector<std::string>;
-        using WordsRange = std::pair<Words::const_iterator, Words::const_iterator>;
 
+        /// Get vector for the matched range of words if any.
+        Words getCompletions(const String & prefix, size_t prefix_length);
+        void addWords(Words && new_words);
+
+    private:
         Words words;
         Words words_no_case;
-        std::atomic<bool> ready{false};
 
-        /// Get iterators for the matched range of words if any.
-        std::optional<WordsRange> getCompletions(const String & prefix, size_t prefix_length) const;
-        void addWords(const std::vector<std::string> & new_words);
+        std::mutex mutex;
     };
 
     using Patterns = std::vector<const char *>;

--- a/base/base/LineReader.h
+++ b/base/base/LineReader.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <vector>
 #include <optional>
+#include <replxx.hxx>
 
 #include <base/types.h>
 
@@ -15,7 +16,7 @@ public:
         using Words = std::vector<std::string>;
 
         /// Get vector for the matched range of words if any.
-        Words getCompletions(const String & prefix, size_t prefix_length);
+        replxx::Replxx::completions_t getCompletions(const String & prefix, size_t prefix_length);
         void addWords(Words && new_words);
 
     private:

--- a/base/base/LineReader.h
+++ b/base/base/LineReader.h
@@ -20,6 +20,7 @@ public:
 
         /// Get iterators for the matched range of words if any.
         std::optional<WordsRange> getCompletions(const String & prefix, size_t prefix_length) const;
+        void addWords(const std::vector<std::string> & new_words);
     };
 
     using Patterns = std::vector<const char *>;

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -133,7 +133,7 @@ void convertHistoryFile(const std::string & path, replxx::Replxx & rx)
 }
 
 ReplxxLineReader::ReplxxLineReader(
-    const Suggest & suggest,
+    Suggest & suggest,
     const String & history_file_path_,
     bool multiline_,
     Patterns extenders_,
@@ -179,9 +179,8 @@ ReplxxLineReader::ReplxxLineReader(
 
     auto callback = [&suggest] (const String & context, size_t context_size)
     {
-        if (auto range = suggest.getCompletions(context, context_size))
-            return Replxx::completions_t(range->first, range->second);
-        return Replxx::completions_t();
+        auto words = suggest.getCompletions(context, context_size);
+        return Replxx::completions_t(words.begin(), words.end());
     };
 
     rx.set_completion_callback(callback);

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -179,8 +179,7 @@ ReplxxLineReader::ReplxxLineReader(
 
     auto callback = [&suggest] (const String & context, size_t context_size)
     {
-        auto words = suggest.getCompletions(context, context_size);
-        return Replxx::completions_t(words.begin(), words.end());
+        return suggest.getCompletions(context, context_size);
     };
 
     rx.set_completion_callback(callback);

--- a/base/base/ReplxxLineReader.h
+++ b/base/base/ReplxxLineReader.h
@@ -9,7 +9,7 @@ class ReplxxLineReader : public LineReader
 {
 public:
     ReplxxLineReader(
-        const Suggest & suggest,
+        Suggest & suggest,
         const String & history_file_path,
         bool multiline,
         Patterns extenders_,

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -570,7 +570,7 @@ void ClientBase::updateSuggest(const ASTCreateQuery & ast_create)
         }
     }
 
-    suggest->addWords(new_words);
+    suggest->addWords(std::move(new_words));
 }
 
 void ClientBase::processTextAsSingleQuery(const String & full_query)
@@ -593,7 +593,7 @@ void ClientBase::processTextAsSingleQuery(const String & full_query)
     {
         /// Do not update suggest, until suggestion will be ready
         /// (this will avoid extra complexity)
-        if (suggest && suggest->ready)
+        if (suggest)
             updateSuggest(*create);
     }
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -48,6 +48,7 @@
 #include <Parsers/ASTQueryWithOutput.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTColumnDeclaration.h>
 
 #include <Processors/Formats/Impl/NullFormat.h>
 #include <Processors/Formats/IInputFormat.h>
@@ -552,6 +553,25 @@ void ClientBase::initLogsOutputStream()
     }
 }
 
+void ClientBase::updateSuggest(const ASTCreateQuery & ast_create)
+{
+    std::vector<std::string> new_words;
+
+    if (ast_create.database)
+        new_words.push_back(ast_create.getDatabase());
+    new_words.push_back(ast_create.getTable());
+
+    if (ast_create.columns_list && ast_create.columns_list->columns)
+    {
+        for (const auto & elem : ast_create.columns_list->columns->children)
+        {
+            if (const auto * column = elem->as<ASTColumnDeclaration>())
+                new_words.push_back(column->name);
+        }
+    }
+
+    suggest->addWords(new_words);
+}
 
 void ClientBase::processTextAsSingleQuery(const String & full_query)
 {
@@ -564,6 +584,18 @@ void ClientBase::processTextAsSingleQuery(const String & full_query)
         return;
 
     String query_to_execute;
+
+    /// Query will be parsed before checking the result because error does not
+    /// always means a problem, i.e. if table already exists, and it is no a
+    /// huge problem if suggestion will be added even on error, since this is
+    /// just suggestion.
+    if (auto * create = parsed_query->as<ASTCreateQuery>())
+    {
+        /// Do not update suggest, until suggestion will be ready
+        /// (this will avoid extra complexity)
+        if (suggest && suggest->ready)
+            updateSuggest(*create);
+    }
 
     // An INSERT query may have the data that follow query text. Remove the
     /// Send part of query without data, because data will be sent separately.
@@ -1463,7 +1495,6 @@ void ClientBase::runInteractive()
     /// Initialize DateLUT here to avoid counting time spent here as query execution time.
     const auto local_tz = DateLUT::instance().getTimeZone();
 
-    std::optional<Suggest> suggest;
     suggest.emplace();
     if (load_suggestions)
     {

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -136,6 +136,8 @@ private:
     void readArguments(int argc, char ** argv, Arguments & common_arguments, std::vector<Arguments> & external_tables_arguments);
     void parseAndCheckOptions(OptionsDescription & options_description, po::variables_map & options, Arguments & arguments);
 
+    void updateSuggest(const ASTCreateQuery & ast_create);
+
 protected:
     bool is_interactive = false; /// Use either interactive line editing interface or batch mode.
     bool is_multiquery = false;
@@ -144,6 +146,8 @@ protected:
     bool echo_queries = false; /// Print queries before execution in batch mode.
     bool ignore_error = false; /// In case of errors, don't print error message, continue to next query. Only applicable for non-interactive mode.
     bool print_time_to_stderr = false; /// Output execution time to stderr in batch mode.
+
+    std::optional<Suggest> suggest;
     bool load_suggestions = false;
 
     std::vector<String> queries_files; /// If not empty, queries will be read from these files

--- a/src/Client/Suggest.cpp
+++ b/src/Client/Suggest.cpp
@@ -29,19 +29,21 @@ namespace ErrorCodes
 Suggest::Suggest()
 {
     /// Keywords may be not up to date with ClickHouse parser.
-    words = {"CREATE",       "DATABASE", "IF",     "NOT",       "EXISTS",   "TEMPORARY",   "TABLE",    "ON",          "CLUSTER", "DEFAULT",
-             "MATERIALIZED", "ALIAS",    "ENGINE", "AS",        "VIEW",     "POPULATE",    "SETTINGS", "ATTACH",      "DETACH",  "DROP",
-             "RENAME",       "TO",       "ALTER",  "ADD",       "MODIFY",   "CLEAR",       "COLUMN",   "AFTER",       "COPY",    "PROJECT",
-             "PRIMARY",      "KEY",      "CHECK",  "PARTITION", "PART",     "FREEZE",      "FETCH",    "FROM",        "SHOW",    "INTO",
-             "OUTFILE",      "FORMAT",   "TABLES", "DATABASES", "LIKE",     "PROCESSLIST", "CASE",     "WHEN",        "THEN",    "ELSE",
-             "END",          "DESCRIBE", "DESC",   "USE",       "SET",      "OPTIMIZE",    "FINAL",    "DEDUPLICATE", "INSERT",  "VALUES",
-             "SELECT",       "DISTINCT", "SAMPLE", "ARRAY",     "JOIN",     "GLOBAL",      "LOCAL",    "ANY",         "ALL",     "INNER",
-             "LEFT",         "RIGHT",    "FULL",   "OUTER",     "CROSS",    "USING",       "PREWHERE", "WHERE",       "GROUP",   "BY",
-             "WITH",         "TOTALS",   "HAVING", "ORDER",     "COLLATE",  "LIMIT",       "UNION",    "AND",         "OR",      "ASC",
-             "IN",           "KILL",     "QUERY",  "SYNC",      "ASYNC",    "TEST",        "BETWEEN",  "TRUNCATE",    "USER",    "ROLE",
-             "PROFILE",      "QUOTA",    "POLICY", "ROW",       "GRANT",    "REVOKE",      "OPTION",   "ADMIN",       "EXCEPT",  "REPLACE",
-             "IDENTIFIED",   "HOST",     "NAME",   "READONLY",  "WRITABLE", "PERMISSIVE",  "FOR",      "RESTRICTIVE", "RANDOMIZED",
-             "INTERVAL",     "LIMITS",   "ONLY",   "TRACKING",  "IP",       "REGEXP",      "ILIKE"};
+    new_words = {
+        "CREATE",       "DATABASE", "IF",     "NOT",       "EXISTS",   "TEMPORARY",   "TABLE",    "ON",          "CLUSTER", "DEFAULT",
+        "MATERIALIZED", "ALIAS",    "ENGINE", "AS",        "VIEW",     "POPULATE",    "SETTINGS", "ATTACH",      "DETACH",  "DROP",
+        "RENAME",       "TO",       "ALTER",  "ADD",       "MODIFY",   "CLEAR",       "COLUMN",   "AFTER",       "COPY",    "PROJECT",
+        "PRIMARY",      "KEY",      "CHECK",  "PARTITION", "PART",     "FREEZE",      "FETCH",    "FROM",        "SHOW",    "INTO",
+        "OUTFILE",      "FORMAT",   "TABLES", "DATABASES", "LIKE",     "PROCESSLIST", "CASE",     "WHEN",        "THEN",    "ELSE",
+        "END",          "DESCRIBE", "DESC",   "USE",       "SET",      "OPTIMIZE",    "FINAL",    "DEDUPLICATE", "INSERT",  "VALUES",
+        "SELECT",       "DISTINCT", "SAMPLE", "ARRAY",     "JOIN",     "GLOBAL",      "LOCAL",    "ANY",         "ALL",     "INNER",
+        "LEFT",         "RIGHT",    "FULL",   "OUTER",     "CROSS",    "USING",       "PREWHERE", "WHERE",       "GROUP",   "BY",
+        "WITH",         "TOTALS",   "HAVING", "ORDER",     "COLLATE",  "LIMIT",       "UNION",    "AND",         "OR",      "ASC",
+        "IN",           "KILL",     "QUERY",  "SYNC",      "ASYNC",    "TEST",        "BETWEEN",  "TRUNCATE",    "USER",    "ROLE",
+        "PROFILE",      "QUOTA",    "POLICY", "ROW",       "GRANT",    "REVOKE",      "OPTION",   "ADMIN",       "EXCEPT",  "REPLACE",
+        "IDENTIFIED",   "HOST",     "NAME",   "READONLY",  "WRITABLE", "PERMISSIVE",  "FOR",      "RESTRICTIVE", "RANDOMIZED",
+        "INTERVAL",     "LIMITS",   "ONLY",   "TRACKING",  "IP",       "REGEXP",      "ILIKE",
+    };
 }
 
 static String getLoadSuggestionQuery(Int32 suggestion_limit, bool basic_suggestion)
@@ -125,17 +127,7 @@ void Suggest::load(ContextPtr context, const ConnectionParameters & connection_p
 
         /// Note that keyword suggestions are available even if we cannot load data from server.
 
-        std::sort(words.begin(), words.end());
-        words_no_case = words;
-        std::sort(words_no_case.begin(), words_no_case.end(), [](const std::string & str1, const std::string & str2)
-        {
-            return std::lexicographical_compare(begin(str1), end(str1), begin(str2), end(str2), [](const char char1, const char char2)
-            {
-                return std::tolower(char1) < std::tolower(char2);
-            });
-        });
-
-        ready = true;
+        addWords(std::move(new_words));
     });
 }
 
@@ -191,7 +183,7 @@ void Suggest::fillWordsFromBlock(const Block & block)
 
     size_t rows = block.rows();
     for (size_t i = 0; i < rows; ++i)
-        words.emplace_back(column.getDataAt(i).toString());
+        new_words.emplace_back(column.getDataAt(i).toString());
 }
 
 template

--- a/src/Client/Suggest.cpp
+++ b/src/Client/Suggest.cpp
@@ -29,7 +29,7 @@ namespace ErrorCodes
 Suggest::Suggest()
 {
     /// Keywords may be not up to date with ClickHouse parser.
-    new_words = {
+    addWords({
         "CREATE",       "DATABASE", "IF",     "NOT",       "EXISTS",   "TEMPORARY",   "TABLE",    "ON",          "CLUSTER", "DEFAULT",
         "MATERIALIZED", "ALIAS",    "ENGINE", "AS",        "VIEW",     "POPULATE",    "SETTINGS", "ATTACH",      "DETACH",  "DROP",
         "RENAME",       "TO",       "ALTER",  "ADD",       "MODIFY",   "CLEAR",       "COLUMN",   "AFTER",       "COPY",    "PROJECT",
@@ -43,7 +43,7 @@ Suggest::Suggest()
         "PROFILE",      "QUOTA",    "POLICY", "ROW",       "GRANT",    "REVOKE",      "OPTION",   "ADMIN",       "EXCEPT",  "REPLACE",
         "IDENTIFIED",   "HOST",     "NAME",   "READONLY",  "WRITABLE", "PERMISSIVE",  "FOR",      "RESTRICTIVE", "RANDOMIZED",
         "INTERVAL",     "LIMITS",   "ONLY",   "TRACKING",  "IP",       "REGEXP",      "ILIKE",
-    };
+    });
 }
 
 static String getLoadSuggestionQuery(Int32 suggestion_limit, bool basic_suggestion)
@@ -126,8 +126,6 @@ void Suggest::load(ContextPtr context, const ConnectionParameters & connection_p
         }
 
         /// Note that keyword suggestions are available even if we cannot load data from server.
-
-        addWords(std::move(new_words));
     });
 }
 
@@ -182,8 +180,14 @@ void Suggest::fillWordsFromBlock(const Block & block)
     const ColumnString & column = typeid_cast<const ColumnString &>(*block.getByPosition(0).column);
 
     size_t rows = block.rows();
+
+    Words new_words;
+    new_words.reserve(rows);
     for (size_t i = 0; i < rows; ++i)
+    {
         new_words.emplace_back(column.getDataAt(i).toString());
+    }
+    addWords(std::move(new_words));
 }
 
 template

--- a/src/Client/Suggest.h
+++ b/src/Client/Suggest.h
@@ -38,8 +38,6 @@ private:
 
     /// Words are fetched asynchronously.
     std::thread loading_thread;
-
-    Words new_words;
 };
 
 }

--- a/src/Client/Suggest.h
+++ b/src/Client/Suggest.h
@@ -38,6 +38,8 @@ private:
 
     /// Words are fetched asynchronously.
     std::thread loading_thread;
+
+    Words new_words;
 };
 
 }

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
@@ -34,7 +34,8 @@ while {$is_done == 0} {
     }
 }
 set timeout 60
-send -- ""
+# Ctrl-C
+send -- "\3"
 expect ":) "
 
 # Generate UIUD to avoid matching old database/tables/columns from previous test runs.
@@ -54,21 +55,24 @@ send -- "new_${uuid}_data"
 expect "new_${uuid}_data"
 send -- "\t"
 expect "base"
-send -- ""
+# Ctrl-C
+send -- "\3"
 expect ":) "
 
 send -- "new_${uuid}_ta"
 expect "new_${uuid}_ta"
 send -- "\t"
 expect "ble"
-send -- ""
+# Ctrl-C
+send -- "\3"
 expect ":) "
 
 send -- "new_${uuid}_col"
 expect "new_${uuid}_col"
 send -- "\t"
 expect "umn"
-send -- ""
+# Ctrl-C
+send -- "\3"
 expect ":) "
 
 # Cleanup
@@ -77,5 +81,6 @@ expect ":) "
 send -- "drop table new_${uuid}_table\r"
 expect ":) "
 
-send -- ""
+# Ctrl-D
+send -- "\4"
 expect eof

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
@@ -7,7 +7,6 @@ match_max 100000
 # A default timeout action is to do nothing, change it to fail
 expect_after {
     timeout {
-        send_user "FAILED (uuid=$uuid)\n"
         exit 1
     }
 }
@@ -37,21 +36,18 @@ while {$is_done == 0} {
 set timeout 60
 send -- ""
 expect ":) "
-send_user "Completion loaded\n"
 
 # Generate UIUD to avoid matching old database/tables/columns from previous test runs.
 send -- "select 'begin-' || replace(toString(generateUUIDv4()), '-', '') || '-end' format TSV\r"
 expect -re TSV.*TSV.*begin-(.*)-end.*
 set uuid $expect_out(1,string)
 expect ":) "
-send_user "UUID generated\n"
 
 # Create
 send -- "create database new_${uuid}_database\r"
 expect ":) "
 send -- "create table new_${uuid}_table (new_${uuid}_column Int) engine=Null()\r"
 expect ":) "
-send_user "Structure created\n"
 
 # Check completion
 send -- "new_${uuid}_data"
@@ -60,7 +56,6 @@ send -- "\t"
 expect "base"
 send -- ""
 expect ":) "
-send_user "Database completion works\n"
 
 send -- "new_${uuid}_ta"
 expect "new_${uuid}_ta"
@@ -68,7 +63,6 @@ send -- "\t"
 expect "ble"
 send -- ""
 expect ":) "
-send_user "Table completion works\n"
 
 send -- "new_${uuid}_col"
 expect "new_${uuid}_col"
@@ -76,14 +70,12 @@ send -- "\t"
 expect "umn"
 send -- ""
 expect ":) "
-send_user "Column completion works\n"
 
 # Cleanup
 send -- "drop database new_${uuid}_database\r"
 expect ":) "
 send -- "drop table new_${uuid}_table\r"
 expect ":) "
-send_user "Cleanup\n"
 
 send -- ""
 expect eof

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
@@ -1,0 +1,89 @@
+#!/usr/bin/expect -f
+
+log_user 0
+set timeout 60
+set uuid ""
+match_max 100000
+# A default timeout action is to do nothing, change it to fail
+expect_after {
+    timeout {
+        send_user "FAILED (uuid=$uuid)\n"
+        exit 1
+    }
+}
+
+set basedir [file dirname $argv0]
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT"
+expect ":) "
+
+# Make a query
+send -- "set max_distributed"
+expect "set max_distributed"
+
+# Wait for suggestions to load, they are loaded in background
+set is_done 0
+set timeout 1
+while {$is_done == 0} {
+    send -- "\t"
+    expect {
+        "_" {
+            set is_done 1
+        }
+        default {
+            # Reset the expect_after
+        }
+    }
+}
+set timeout 60
+send -- ""
+expect ":) "
+send_user "Completion loaded\n"
+
+# Generate UIUD to avoid matching old database/tables/columns from previous test runs.
+send -- "select 'begin-' || replace(toString(generateUUIDv4()), '-', '') || '-end' format TSV\r"
+expect -re TSV.*TSV.*begin-(.*)-end.*
+set uuid $expect_out(1,string)
+expect ":) "
+send_user "UUID generated\n"
+
+# Create
+send -- "create database new_${uuid}_database\r"
+expect ":) "
+send -- "create table new_${uuid}_table (new_${uuid}_column Int) engine=Null()\r"
+expect ":) "
+send_user "Structure created\n"
+
+# Check completion
+send -- "new_${uuid}_data"
+expect "new_${uuid}_data"
+send -- "\t"
+expect "base"
+send -- ""
+expect ":) "
+send_user "Database completion works\n"
+
+send -- "new_${uuid}_ta"
+expect "new_${uuid}_ta"
+send -- "\t"
+expect "ble"
+send -- ""
+expect ":) "
+send_user "Table completion works\n"
+
+send -- "new_${uuid}_col"
+expect "new_${uuid}_col"
+send -- "\t"
+expect "umn"
+send -- ""
+expect ":) "
+send_user "Column completion works\n"
+
+# Cleanup
+send -- "drop database new_${uuid}_database\r"
+expect ":) "
+send -- "drop table new_${uuid}_table\r"
+expect ":) "
+send_user "Cleanup\n"
+
+send -- ""
+expect eof

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
@@ -4,41 +4,16 @@ log_user 0
 set timeout 60
 set uuid ""
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from read.
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT"
-# wait until the process will be spawned to avoid terminating "expect" with "eof":
-#
-#     send: sending "set max_distributed" to { exp4 }
-#
-#     expect: does "" (spawn_id exp4) match glob pattern ":)"? no
-#     expect: read eof
-#     expect: set expect_out(spawn_id) "exp0"
-#     expect: set expect_out(buffer) ""
-#     send: sending "set max_distributed" to { exp4 }
-#
-#     expect: does "" (spawn_id exp4) match glob pattern "set max_distributed"? no
-#
-#
-# NOTE: this is especially important since random database has "_" prefix,
-# and this may break the whole test (see expect "_" below).
-set is_done 0
-while {$is_done == 0} {
-    send -- "\t"
-    expect {
-        ":) " {
-            set is_done 1
-        }
-        default {
-        }
-    }
-}
+expect ":) "
 
 # Make a query
 send -- "set max_distributed"

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
@@ -13,7 +13,32 @@ expect_after {
 
 set basedir [file dirname $argv0]
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT"
-expect ":) "
+# wait until the process will be spawned to avoid terminating "expect" with "eof":
+#
+#     send: sending "set max_distributed" to { exp4 }
+#
+#     expect: does "" (spawn_id exp4) match glob pattern ":)"? no
+#     expect: read eof
+#     expect: set expect_out(spawn_id) "exp0"
+#     expect: set expect_out(buffer) ""
+#     send: sending "set max_distributed" to { exp4 }
+#
+#     expect: does "" (spawn_id exp4) match glob pattern "set max_distributed"? no
+#
+#
+# NOTE: this is especially important since random database has "_" prefix,
+# and this may break the whole test (see expect "_" below).
+set is_done 0
+while {$is_done == 0} {
+    send -- "\t"
+    expect {
+        ":) " {
+            set is_done 1
+        }
+        default {
+        }
+    }
+}
 
 # Make a query
 send -- "set max_distributed"

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.reference
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.reference
@@ -1,0 +1,7 @@
+Completion loaded
+UUID generated
+Structure created
+Database completion works
+Table completion works
+Column completion works
+Cleanup

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.reference
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.reference
@@ -1,7 +1,0 @@
-Completion loaded
-UUID generated
-Structure created
-Database completion works
-Table completion works
-Column completion works
-Cleanup


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Client interactive suggest (extract info from CREATE queries)

Detailed description / Documentation draft:
This will parse CREATE queries and add the following things to
completion list for clickhouse-client/clickhouse-local:
- table
- database
- columns

Supersedes: #32370