### PR TITLE
Fix 01370_client_autocomplete_word_break_characters test logic

### DIFF
--- a/tests/queries/0_stateless/01370_client_autocomplete_word_break_characters.expect
+++ b/tests/queries/0_stateless/01370_client_autocomplete_word_break_characters.expect
@@ -20,6 +20,7 @@ expect "SET max_distributed"
 
 # Wait for suggestions to load, they are loaded in background
 set is_done 0
+set timeout 1
 while {$is_done == 0} {
     send -- "\t"
     expect {
@@ -27,10 +28,15 @@ while {$is_done == 0} {
             set is_done 1
         }
         default {
-            sleep 1
+            # expect "_" will wait for timeout,
+            # if completion was not loaded it will fail,
+            # and we will retry,
+            # but for retry on timeout default should be reseted,
+            # this is what for this block.
         }
     }
 }
+set timeout 60
 
 send -- "\3\4"
 expect eof


### PR DESCRIPTION
AFAICS right now it works only because completion loaded too quickly,
since `expect "_"` will block for 60 seconds if completion is not
available.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)