### PR TITLE
Add retry for Postgres query in case nothing has been fetched yet

### DIFF
--- a/src/Core/PostgreSQL/ConnectionHolder.h
+++ b/src/Core/PostgreSQL/ConnectionHolder.h
@@ -7,12 +7,12 @@
 #include <pqxx/pqxx>
 #include <Core/Types.h>
 #include <base/BorrowedObjectPool.h>
+#include "Connection.h"
 
 
 namespace postgres
 {
 
-using ConnectionPtr = std::unique_ptr<pqxx::connection>;
 using Pool = BorrowedObjectPool<ConnectionPtr>;
 using PoolPtr = std::shared_ptr<Pool>;
 
@@ -28,8 +28,12 @@ public:
 
     pqxx::connection & get()
     {
-        assert(connection != nullptr);
-        return *connection;
+        return connection->getRef();
+    }
+
+    void update()
+    {
+        connection->updateConnection();
     }
 
 private:

--- a/src/Core/PostgreSQL/PoolWithFailover.h
+++ b/src/Core/PostgreSQL/PoolWithFailover.h
@@ -44,12 +44,11 @@ public:
 private:
     struct PoolHolder
     {
-        String connection_string;
+        ConnectionInfo connection_info;
         PoolPtr pool;
-        String name_for_log;
 
-        PoolHolder(const String & connection_string_, size_t pool_size, const String & name_for_log_)
-            : connection_string(connection_string_), pool(std::make_shared<Pool>(pool_size)), name_for_log(name_for_log_) {}
+        PoolHolder(const ConnectionInfo & connection_info_, size_t pool_size)
+            : connection_info(connection_info_), pool(std::make_shared<Pool>(pool_size)) {}
     };
 
     /// Highest priority is 0, the bigger the number in map, the less the priority

--- a/src/Core/PostgreSQL/Utils.cpp
+++ b/src/Core/PostgreSQL/Utils.cpp
@@ -17,7 +17,7 @@ ConnectionInfo formatConnectionString(String dbname, String host, UInt16 port, S
         << " user=" << DB::quote << user
         << " password=" << DB::quote << password
         << " connect_timeout=10";
-    return std::make_pair(out.str(), host + ':' + DB::toString(port));
+    return {out.str(), host + ':' + DB::toString(port)};
 }
 
 String getConnectionForLog(const String & host, UInt16 port)

--- a/src/Processors/Transforms/PostgreSQLSource.cpp
+++ b/src/Processors/Transforms/PostgreSQLSource.cpp
@@ -74,7 +74,17 @@ template<typename T>
 void PostgreSQLSource<T>::onStart()
 {
     if (!tx)
-        tx = std::make_shared<T>(connection_holder->get());
+    {
+        try
+        {
+            tx = std::make_shared<T>(connection_holder->get());
+        }
+        catch (const pqxx::broken_connection &)
+        {
+            connection_holder->update();
+            tx = std::make_shared<T>(connection_holder->get());
+        }
+    }
 
     stream = std::make_unique<pqxx::stream_from>(*tx, pqxx::from_query, std::string_view(query_str));
 }

--- a/src/TableFunctions/TableFunctionPostgreSQL.cpp
+++ b/src/TableFunctions/TableFunctionPostgreSQL.cpp
@@ -50,6 +50,7 @@ ColumnsDescription TableFunctionPostgreSQL::getActualTableStructure(ContextPtr c
 
     if (!columns)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Table structure not returned");
+
     return ColumnsDescription{*columns};
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add retry for Postgres connect in case nothing has been fetched yet. Closes https://github.com/ClickHouse/ClickHouse/issues/33199.
