### PR TITLE
Optimize MergeTreePartsMover

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -122,6 +122,9 @@ bool MergeTreePartsMover::selectPartsForMove(
     time_t time_of_move = time(nullptr);
 
     auto metadata_snapshot = data->getInMemoryMetadataPtr();
+    
+    if (need_to_move.empty() && !metadata_snapshot->hasAnyMoveTTL())
+        return false;
 
     for (const auto & part : data_parts)
     {

--- a/src/Storages/MergeTree/MergeTreePartsMover.cpp
+++ b/src/Storages/MergeTree/MergeTreePartsMover.cpp
@@ -122,7 +122,7 @@ bool MergeTreePartsMover::selectPartsForMove(
     time_t time_of_move = time(nullptr);
 
     auto metadata_snapshot = data->getInMemoryMetadataPtr();
-    
+
     if (need_to_move.empty() && !metadata_snapshot->hasAnyMoveTTL())
         return false;
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

When the table has a lot of parts, I find that the move thread pool consumes a lot of cpu to find parts that can be moved, but in fact there is no part that can be moved, which is very wasteful of cpu. I think that when the moving conditions are not met, you can advance End, no need to traverse all parts
