### PR TITLE
Fix clang tidy

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -569,8 +569,10 @@ if (ThreadFuzzer::instance().isEffective())
         [&]() -> std::vector<ProtocolServerMetrics>
         {
             std::vector<ProtocolServerMetrics> metrics;
+            metrics.reserve(servers_to_start_before_tables.size());
             for (const auto & server : servers_to_start_before_tables)
                 metrics.emplace_back(ProtocolServerMetrics{server.getPortName(), server.currentThreads()});
+
             std::lock_guard lock(servers_lock);
             for (const auto & server : servers)
                 metrics.emplace_back(ProtocolServerMetrics{server.getPortName(), server.currentThreads()});


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Actually just suppression for warning. Preallocation is not important here.