### PR TITLE
Remove a code section

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/uniq.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/uniq.md
@@ -24,9 +24,7 @@ Function:
 
 -   Calculates a hash for all parameters in the aggregate, then uses it in calculations.
 
--   Uses an adaptive sampling algorithm. For the calculation state, the function uses a sample of element hash values up to 65536.
-
-        This algorithm is very accurate and very efficient on the CPU. When the query contains several of these functions, using `uniq` is almost as fast as using other aggregate functions.
+-   Uses an adaptive sampling algorithm. For the calculation state, the function uses a sample of element hash values up to 65536. This algorithm is very accurate and very efficient on the CPU. When the query contains several of these functions, using `uniq` is almost as fast as using other aggregate functions.
 
 -   Provides the result deterministically (it does not depend on the query processing order).
 


### PR DESCRIPTION
I removed a sentence that was in a code section, it didn't feel that it was intended initially.

Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Just removed a code section that shouldn't be there
