### PR TITLE
Allow to cancel some sources which failed to cancel

### DIFF
--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.h
@@ -27,6 +27,11 @@ public:
 private:
     Chunk generate() override;
 
+    void onCancel() override
+    {
+        is_stopped = 1;
+    }
+
     // Whether to use ArrowStream format
     bool stream;
     // This field is only used for ArrowStream format
@@ -42,6 +47,8 @@ private:
     const FormatSettings format_settings;
 
     void prepareReader();
+
+    std::atomic<int> is_stopped{0};
 };
 
 }

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
@@ -140,7 +140,7 @@ arrow::Status ArrowInputStreamFromReadBuffer::Close()
     return arrow::Status();
 }
 
-std::shared_ptr<arrow::io::RandomAccessFile> asArrowFile(ReadBuffer & in, const FormatSettings & settings)
+std::shared_ptr<arrow::io::RandomAccessFile> asArrowFile(ReadBuffer & in, const FormatSettings & settings, std::atomic<int> & is_cancelled)
 {
     if (auto * fd_in = dynamic_cast<ReadBufferFromFileDescriptor *>(&in))
     {
@@ -160,7 +160,7 @@ std::shared_ptr<arrow::io::RandomAccessFile> asArrowFile(ReadBuffer & in, const 
     std::string file_data;
     {
         WriteBufferFromString file_buffer(file_data);
-        copyData(in, file_buffer);
+        copyData(in, file_buffer, is_cancelled);
     }
 
     return std::make_shared<arrow::io::BufferReader>(arrow::Buffer::FromString(std::move(file_data)));

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.h
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.h
@@ -86,7 +86,7 @@ private:
     ARROW_DISALLOW_COPY_AND_ASSIGN(ArrowInputStreamFromReadBuffer);
 };
 
-std::shared_ptr<arrow::io::RandomAccessFile> asArrowFile(ReadBuffer & in, const FormatSettings & settings);
+std::shared_ptr<arrow::io::RandomAccessFile> asArrowFile(ReadBuffer & in, const FormatSettings & settings, std::atomic<int> & is_cancelled);
 
 }
 

--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.h
@@ -29,6 +29,11 @@ public:
 protected:
     Chunk generate() override;
 
+    void onCancel() override
+    {
+        is_stopped = 1;
+    }
+
 private:
 
     // TODO: check that this class implements every part of its parent
@@ -45,6 +50,8 @@ private:
     const FormatSettings format_settings;
 
     void prepareReader();
+
+    std::atomic<int> is_stopped{0};
 };
 
 }

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -28,6 +28,11 @@ private:
 
     void prepareReader();
 
+    void onCancel() override
+    {
+        is_stopped = 1;
+    }
+
     std::unique_ptr<parquet::arrow::FileReader> file_reader;
     int row_group_total = 0;
     // indices of columns to read from Parquet file
@@ -35,6 +40,8 @@ private:
     std::unique_ptr<ArrowColumnToCHColumn> arrow_column_to_ch_column;
     int row_group_current = 0;
     const FormatSettings format_settings;
+
+    std::atomic<int> is_stopped{0};
 };
 
 }

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -176,6 +176,12 @@ HDFSSource::HDFSSource(
     initialize();
 }
 
+void HDFSSource::onCancel()
+{
+    if (reader)
+        reader->cancel();
+}
+
 bool HDFSSource::initialize()
 {
     current_path = (*file_iterator)();

--- a/src/Storages/HDFS/StorageHDFS.h
+++ b/src/Storages/HDFS/StorageHDFS.h
@@ -118,6 +118,8 @@ public:
 
     Chunk generate() override;
 
+    void onCancel() override;
+
 private:
     StorageHDFSPtr storage;
     StorageMetadataPtr metadata_snapshot;

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -222,6 +222,13 @@ StorageS3Source::StorageS3Source(
 }
 
 
+void StorageS3Source::onCancel()
+{
+    if (reader)
+        reader->cancel();
+}
+
+
 bool StorageS3Source::initialize()
 {
     String current_key = (*file_iterator)();

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -68,6 +68,8 @@ public:
 
     Chunk generate() override;
 
+    void onCancel() override;
+
 private:
     String name;
     String bucket;

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -107,6 +107,12 @@ namespace
         };
         using URIInfoPtr = std::shared_ptr<URIInfo>;
 
+        void onCancel() override
+        {
+            if (reader)
+                reader->cancel();
+        }
+
         StorageURLSource(
             URIInfoPtr uri_info_,
             const std::string & http_method,


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to cancel formats Arrow / Parquet / ORC which failed to be cancelled it case of big files and setting input_format_allow_seeks as false. Closes https://github.com/ClickHouse/ClickHouse/issues/29678.