### PR TITLE
Add systemctl way to run server as daemon

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -152,6 +152,12 @@ If you do not have `service` command, run as
 $ sudo /etc/init.d/clickhouse-server start
 ```
 
+If you have `systemctl` command, run as
+
+``` bash
+$ sudo systemctl start clickhouse-server.service
+```
+
 See the logs in the `/var/log/clickhouse-server/` directory.
 
 If the server does not start, check the configurations in the file `/etc/clickhouse-server/config.xml`.

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -143,6 +143,12 @@ On Gentoo, you can just use `emerge clickhouse` to install ClickHouse from sourc
 To start the server as a daemon, run:
 
 ``` bash
+$ sudo clickhouse start
+```
+
+There are also another ways to run ClickHouse:
+
+``` bash
 $ sudo service clickhouse-server start
 ```
 


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
N/A


Detailed description / Documentation draft:

- Adding new way about using `systemctl` to run the DB server as the daemon if this command is available.