### PR TITLE
Add friendly message to notify user this instance

### DIFF
--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -17,6 +17,8 @@ $ docker run -d --name some-clickhouse-server --ulimit nofile=262144:262144 clic
 
 By default ClickHouse will be accessible only via docker network. See the [networking section below](#networking).
 
+By default, starting above server instance will be run as default user without password.
+
 ### connect to it from a native client
 ```bash
 $ docker run -it --rm --link some-clickhouse-server:clickhouse-server clickhouse/clickhouse-client --host clickhouse-server


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
N/A


Detailed description / Documentation draft:
- This message I think should be great and friendly for users to know this server instance with the default authentication credentials.