### PR TITLE
Do not ignore eof in expect tests

### DIFF
--- a/tests/queries/0_stateless/01176_mysql_client_interactive.expect
+++ b/tests/queries/0_stateless/01176_mysql_client_interactive.expect
@@ -5,11 +5,12 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
+
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/01179_insert_values_semicolon.expect
+++ b/tests/queries/0_stateless/01179_insert_values_semicolon.expect
@@ -3,11 +3,11 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/01179_insert_values_semicolon.expect
+++ b/tests/queries/0_stateless/01179_insert_values_semicolon.expect
@@ -1,4 +1,5 @@
 #!/usr/bin/expect -f
+# Tags: long
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/01180_client_syntax_errors.expect
+++ b/tests/queries/0_stateless/01180_client_syntax_errors.expect
@@ -3,11 +3,11 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/01293_client_interactive_vertical_multiline.expect
+++ b/tests/queries/0_stateless/01293_client_interactive_vertical_multiline.expect
@@ -4,11 +4,11 @@ log_user 0
 set timeout 60
 match_max 100000
 
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/01293_client_interactive_vertical_singleline.expect
+++ b/tests/queries/0_stateless/01293_client_interactive_vertical_singleline.expect
@@ -3,11 +3,11 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/01300_client_save_history_when_terminated_long.expect
+++ b/tests/queries/0_stateless/01300_client_save_history_when_terminated_long.expect
@@ -4,11 +4,11 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 set basedir [file dirname $argv0]
 

--- a/tests/queries/0_stateless/01370_client_autocomplete_word_break_characters.expect
+++ b/tests/queries/0_stateless/01370_client_autocomplete_word_break_characters.expect
@@ -3,11 +3,11 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/01520_client_print_query_id.expect
+++ b/tests/queries/0_stateless/01520_client_print_query_id.expect
@@ -3,11 +3,11 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
+++ b/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
@@ -1,4 +1,5 @@
 #!/usr/bin/expect -f
+# Tags: long
 
 # This is a separate test, because we want to test the interactive mode.
 # https://github.com/ClickHouse/ClickHouse/issues/19353

--- a/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
+++ b/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
@@ -7,11 +7,11 @@ log_user 0
 set timeout 60
 match_max 100000
 
-# A default timeout action is to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/01676_long_clickhouse_client_autocomplete.sh
+++ b/tests/queries/0_stateless/01676_long_clickhouse_client_autocomplete.sh
@@ -20,11 +20,11 @@ function test_completion_word_client()
 log_user 0
 set timeout 3
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 spawn bash -c "$CLICKHOUSE_CLIENT_BINARY $CLICKHOUSE_CLIENT_OPT"
@@ -104,11 +104,11 @@ function test_completion_word_local()
 log_user 0
 set timeout 3
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 spawn bash -c "$CLICKHOUSE_LOCAL"

--- a/tests/queries/0_stateless/01755_client_highlight_multi_line_comment_regression.expect
+++ b/tests/queries/0_stateless/01755_client_highlight_multi_line_comment_regression.expect
@@ -3,11 +3,11 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 2
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/01910_client_replxx_container_overflow_long.expect
+++ b/tests/queries/0_stateless/01910_client_replxx_container_overflow_long.expect
@@ -4,11 +4,11 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 set basedir [file dirname $argv0]
 

--- a/tests/queries/0_stateless/01933_client_replxx_convert_history.expect
+++ b/tests/queries/0_stateless/01933_client_replxx_convert_history.expect
@@ -5,11 +5,11 @@
 log_user 0
 set timeout 60
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 set basedir [file dirname $argv0]
 

--- a/tests/queries/0_stateless/01945_show_debug_warning.expect
+++ b/tests/queries/0_stateless/01945_show_debug_warning.expect
@@ -7,11 +7,11 @@ log_user 0
 set timeout 60
 match_max 100000
 
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/02003_memory_limit_in_client.expect
+++ b/tests/queries/0_stateless/02003_memory_limit_in_client.expect
@@ -8,11 +8,11 @@ log_user 0
 set timeout 60
 match_max 100000
 
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/02047_client_exception.expect
+++ b/tests/queries/0_stateless/02047_client_exception.expect
@@ -4,11 +4,11 @@ log_user 0
 set timeout 20
 match_max 100000
 
-# A default timeout action is to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/02049_clickhouse_local_merge_tree.expect
+++ b/tests/queries/0_stateless/02049_clickhouse_local_merge_tree.expect
@@ -4,12 +4,11 @@ log_user 0
 set timeout 20
 match_max 100000
 
-# A default timeout action is to fail
 expect_after {
-    timeout {
-        exit 1
-    }
-
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/02105_backslash_letter_commands.expect
+++ b/tests/queries/0_stateless/02105_backslash_letter_commands.expect
@@ -3,11 +3,11 @@
 log_user 0
 set timeout 02
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
@@ -12,15 +12,17 @@ expect_after {
     timeout { exit 1 }
 }
 
-spawn bash -c "\$CLICKHOUSE_TESTS_DIR/helpers/02112_prepare.sh"
-
 set basedir [file dirname $argv0]
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT --disable_suggestion --interactive --queries-file \$CURDIR/file_02112"
+
+system "$basedir/helpers/02112_prepare.sh"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT --disable_suggestion --interactive --queries-file $basedir/file_02112"
 expect ":) "
 
 send -- "select * from t format TSV\r"
 expect "1"
 expect ":) "
 
-spawn bash -c "\$CLICKHOUSE_TESTS_DIR/helpers/02112_clean.sh"
+send ""
+expect eof
 
+system "$basedir/helpers/02112_clean.sh"

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
@@ -5,13 +5,12 @@ log_user 0
 set timeout 20
 match_max 100000
 
-# A default timeout action is to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
-
 
 spawn bash -c "\$CLICKHOUSE_TESTS_DIR/helpers/02112_prepare.sh"
 

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_local.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_local.expect
@@ -4,11 +4,11 @@ log_user 0
 set timeout 20
 match_max 100000
 
-# A default timeout action is to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
@@ -12,15 +12,17 @@ expect_after {
     timeout { exit 1 }
 }
 
-spawn bash -c "\$CLICKHOUSE_TESTS_DIR/helpers/02112_prepare.sh"
-
 set basedir [file dirname $argv0]
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_LOCAL --disable_suggestion --interactive --queries-file \$CURDIR/file_02112"
+
+system "$basedir/helpers/02112_prepare.sh"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_LOCAL --disable_suggestion --interactive --queries-file $basedir/file_02112"
 expect ":) "
 
 send -- "select * from t format TSV\r"
 expect "1"
 expect ":) "
 
-spawn bash -c "\$CLICKHOUSE_TESTS_DIR/helpers/02112_clean.sh"
+send ""
+expect eof
 
+system "$basedir/helpers/02112_clean.sh"

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
@@ -5,13 +5,12 @@ log_user 0
 set timeout 20
 match_max 100000
 
-# A default timeout action is to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
-
 
 spawn bash -c "\$CLICKHOUSE_TESTS_DIR/helpers/02112_prepare.sh"
 

--- a/tests/queries/0_stateless/02116_interactive_hello.expect
+++ b/tests/queries/0_stateless/02116_interactive_hello.expect
@@ -4,11 +4,11 @@ log_user 0
 set timeout 60
 match_max 100000
 
-# A default timeout action is to do nothing, change it to fail
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 set basedir [file dirname $argv0]

--- a/tests/queries/0_stateless/02116_interactive_hello.expect
+++ b/tests/queries/0_stateless/02116_interactive_hello.expect
@@ -1,4 +1,5 @@
 #!/usr/bin/expect -f
+# Tags: long
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/02132_client_history_navigation.expect
+++ b/tests/queries/0_stateless/02132_client_history_navigation.expect
@@ -3,11 +3,12 @@
 log_user 0
 set timeout 3
 match_max 100000
-# A default timeout action is to do nothing, change it to fail
+
 expect_after {
-    timeout {
-        exit 1
-    }
+    # Do not ignore eof from expect
+    eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    timeout { exit 1 }
 }
 
 # useful debugging configuration

--- a/tests/queries/0_stateless/helpers/02112_clean.sh
+++ b/tests/queries/0_stateless/helpers/02112_clean.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-FILE=${CURDIR}/file_02112
-if [ -f $FILE ]; then
-    rm $FILE
-fi
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FILE=${CURDIR}/../file_02112
+rm "$FILE"

--- a/tests/queries/0_stateless/helpers/02112_prepare.sh
+++ b/tests/queries/0_stateless/helpers/02112_prepare.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-FILE=${CURDIR}/file_02112
-if [ -f $FILE ]; then
-    rm $FILE
-fi
-echo "drop table if exists t;create table t(i Int32) engine=Memory; insert into t select 1" >> $FILE
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FILE=${CURDIR}/../file_02112
+echo "drop table if exists t;create table t(i Int32) engine=Memory; insert into t select 1" > "$FILE"


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

expect_after that adjusts default timeout handler, reseted eof handler,
and this tell expect that it can ignore eof from read, consider the
following example:

<details>

    #!/usr/bin/expect -f

    exp_internal 1
    log_user 1
    set timeout 4
    match_max 100000

    expect_after {
        # eof { exp_continue }
        timeout {
            exit 1
        }
    }

    spawn bash -c "sleep 1; echo ':) '"
    expect ":) "

    $ ./expect.expect < /dev/null
    spawn bash -c sleep 1; echo ':) '
    parent: waiting for sync byte
    parent: telling child to go ahead
    parent: now unsynchronized from child
    spawn: returns {6614}

    expect: does "" (spawn_id exp4) match glob pattern ":) "? no
    expect: read eof
                 ^^^
    expect: set expect_out(spawn_id) "exp0"
    expect: set expect_out(buffer) ""

And with uncommented eof handler:

    $ ./expect.expect < /dev/null
    spawn bash -c sleep 1; echo ':) '
    parent: waiting for sync byte
    parent: telling child to go ahead
    parent: now unsynchronized from child
    spawn: returns {17959}

    expect: does "" (spawn_id exp4) match glob pattern ":) "? no
    expect: read eof
    expect: set expect_out(spawn_id) "exp0"
    expect: set expect_out(buffer) ""
    expect: continuing expect after update

    expect: does "" (spawn_id exp4) match glob pattern ":) "? no

    expect: does ":) \r\n" (spawn_id exp4) match glob pattern ":) "? yes
    expect: set expect_out(0,string) ":) "
    expect: set expect_out(spawn_id) "exp4"
    expect: set expect_out(buffer) ":) "

</details>