### PR TITLE
test for #24410

### DIFF
--- a/tests/queries/0_stateless/02155_create_table_w_timezone.sql
+++ b/tests/queries/0_stateless/02155_create_table_w_timezone.sql
@@ -1,8 +1,8 @@
-create table 02155_t64_tz ( a DateTime64(9, America/Chicago)) Engine = Memory; -- { serverError 62 }
-create table 02155_t_tz ( a DateTime(America/Chicago)) Engine = Memory; -- { serverError 62 }
+create table t02155_t64_tz ( a DateTime64(9, America/Chicago)) Engine = Memory; -- { clientError 62 }
+create table t02155_t_tz ( a DateTime(America/Chicago)) Engine = Memory; -- { clientError 62 }
 
-create table 02155_t64_tz ( a DateTime64(9, 'America/Chicago')) Engine = Memory; 
-create table 02155_t_tz ( a DateTime('America/Chicago')) Engine = Memory; 
+create table t02155_t64_tz ( a DateTime64(9, 'America/Chicago')) Engine = Memory; 
+create table t02155_t_tz ( a DateTime('America/Chicago')) Engine = Memory; 
 
-drop table 02155_t64_tz;
-drop table 02155_t_tz;
+drop table t02155_t64_tz;
+drop table t02155_t_tz;

--- a/tests/queries/0_stateless/02155_create_table_w_timezone.sql
+++ b/tests/queries/0_stateless/02155_create_table_w_timezone.sql
@@ -1,0 +1,8 @@
+create table 02155_t64_tz ( a DateTime64(9, America/Chicago)) Engine = Memory; -- { serverError 62 }
+create table 02155_t_tz ( a DateTime(America/Chicago)) Engine = Memory; -- { serverError 62 }
+
+create table 02155_t64_tz ( a DateTime64(9, 'America/Chicago')) Engine = Memory; 
+create table 02155_t_tz ( a DateTime('America/Chicago')) Engine = Memory; 
+
+drop table 02155_t64_tz;
+drop table 02155_t_tz;


### PR DESCRIPTION
closes: https://github.com/ClickHouse/ClickHouse/issues/24410

>a DateTime(America/Chicago)

Timezone name without quotes should fail.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

