### PR TITLE
Wait for RabbitMQ container to actually start when it was restarted in test on purpose

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -35,22 +35,11 @@ def rabbitmq_check_result(result, check=False, ref_file='test_rabbitmq_json.refe
         else:
             return TSV(result) == TSV(reference)
 
-def check_rabbitmq_is_available(rabbitmq_id):
-    p = subprocess.Popen(('docker',
-                        'exec',
-                        '-i',
-                        rabbitmq_id,
-                        'rabbitmqctl',
-                        'await_startup'),
-                        stdout=subprocess.PIPE)
-    p.communicate()
-    return p.returncode == 0
-
 def wait_rabbitmq_to_start(rabbitmq_docker_id, timeout=180):
     start = time.time()
     while time.time() - start < timeout:
         try:
-            if check_rabbitmq_is_available(rabbitmq_docker_id):
+            if instance.cluster.check_rabbitmq_is_available(rabbitmq_docker_id):
                 logging.debug("RabbitMQ is available")
                 return
             time.sleep(0.5)

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -35,6 +35,28 @@ def rabbitmq_check_result(result, check=False, ref_file='test_rabbitmq_json.refe
         else:
             return TSV(result) == TSV(reference)
 
+def check_rabbitmq_is_available(rabbitmq_id):
+    p = subprocess.Popen(('docker',
+                        'exec',
+                        '-i',
+                        rabbitmq_id,
+                        'rabbitmqctl',
+                        'await_startup'),
+                        stdout=subprocess.PIPE)
+    p.communicate()
+    return p.returncode == 0
+
+def wait_rabbitmq_to_start(rabbitmq_docker_id, timeout=180):
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            if check_rabbitmq_is_available(rabbitmq_docker_id):
+                logging.debug("RabbitMQ is available")
+                return
+            time.sleep(0.5)
+        except Exception as ex:
+            logging.debug("Can't connect to RabbitMQ " + str(ex))
+            time.sleep(0.5)
 
 def kill_rabbitmq(rabbitmq_id):
     p = subprocess.Popen(('docker', 'stop', rabbitmq_id), stdout=subprocess.PIPE)
@@ -45,7 +67,7 @@ def kill_rabbitmq(rabbitmq_id):
 def revive_rabbitmq(rabbitmq_id):
     p = subprocess.Popen(('docker', 'start', rabbitmq_id), stdout=subprocess.PIPE)
     p.communicate()
-    return p.returncode == 0
+    wait_rabbitmq_to_start(rabbitmq_id)
 
 
 # Fixtures


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Should fix such failure https://s3.amazonaws.com/clickhouse-test-reports/0/fcdbf8737ac3142730cc43f51b1210a7e28b8f68/integration_tests__asan__actions__[1/3].html (`DB::Exception: Cannot connect to rabbitmq1:5672.`)
