### PR TITLE
Fix azure tests flackyness because of azure server closing connection

### DIFF
--- a/tests/integration/test_merge_tree_azure_blob_storage/test.py
+++ b/tests/integration/test_merge_tree_azure_blob_storage/test.py
@@ -32,6 +32,27 @@ def cluster():
     finally:
         cluster.shutdown()
 
+# Note: use this for selects and inserts and create table queries.
+# For inserts there is no guarantee that retries will not result in duplicates.
+# But it is better to retry anyway because 'Connection was closed by the server' error
+# happens in fact only for inserts because reads already have build-in retries in code.
+def azure_query(node, query, try_num=3):
+    for i in range(try_num):
+        try:
+            return node.query(query)
+        except Exception as ex:
+            retriable_errors = [
+                'DB::Exception: Azure::Core::Http::TransportException: Connection was closed by the server while trying to read a response',
+            ]
+            retry = False
+            for error in retriable_errors:
+                if error in str(ex):
+                    retry = True
+                    logging.info(f"Try num: {i}. Having retriable error: {ex}")
+                    break
+            if not retry or i == try_num - 1:
+                raise Exception(ex)
+            continue
 
 def create_table(node, table_name, **additional_settings):
     settings = {
@@ -53,8 +74,8 @@ def create_table(node, table_name, **additional_settings):
         SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}"""
 
     node.query(f"DROP TABLE IF EXISTS {table_name}")
-    node.query(create_table_statement)
-    assert node.query(f"SELECT COUNT(*) FROM {table_name} FORMAT Values") == "(0)"
+    azure_query(node, create_table_statement)
+    assert azure_query(node, f"SELECT COUNT(*) FROM {table_name} FORMAT Values") == "(0)"
 
 
 def test_create_table(cluster):
@@ -68,13 +89,13 @@ def test_read_after_cache_is_wiped(cluster):
 
     values = "('2021-11-13',3,'hello'),('2021-11-14',4,'heyo')"
 
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {values}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {values}")
 
     # Wipe cache
     cluster.exec_in_container(cluster.get_container_id(NODE_NAME), ["rm", "-rf", "/var/lib/clickhouse/disks/blob_storage_disk/cache/"])
 
     # After cache is populated again, only .bin files should be accessed from Blob Storage.
-    assert node.query(f"SELECT * FROM {TABLE_NAME} order by dt, id FORMAT Values") == values
+    assert azure_query(node, f"SELECT * FROM {TABLE_NAME} order by dt, id FORMAT Values") == values
 
 
 def test_simple_insert_select(cluster):
@@ -82,8 +103,8 @@ def test_simple_insert_select(cluster):
     create_table(node, TABLE_NAME)
 
     values = "('2021-11-13',3,'hello')"
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {values}")
-    assert node.query(f"SELECT dt, id, data FROM {TABLE_NAME} FORMAT Values") == values
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {values}")
+    assert azure_query(node, f"SELECT dt, id, data FROM {TABLE_NAME} FORMAT Values") == values
     blob_container_client = cluster.blob_service_client.get_container_client(CONTAINER_NAME)
     assert len(list(blob_container_client.list_blobs())) >= 12 # 1 format file + 2 skip index files + 9 regular MergeTree files + leftovers from other tests
 
@@ -93,14 +114,14 @@ def test_inserts_selects(cluster):
     create_table(node, TABLE_NAME)
 
     values1 = generate_values('2020-01-03', 4096)
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {values1}")
-    assert node.query(f"SELECT * FROM {TABLE_NAME} order by dt, id FORMAT Values") == values1
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {values1}")
+    assert azure_query(node, f"SELECT * FROM {TABLE_NAME} order by dt, id FORMAT Values") == values1
 
     values2 = generate_values('2020-01-04', 4096)
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {values2}")
-    assert node.query(f"SELECT * FROM {TABLE_NAME} ORDER BY dt, id FORMAT Values") == values1 + "," + values2
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {values2}")
+    assert azure_query(node, f"SELECT * FROM {TABLE_NAME} ORDER BY dt, id FORMAT Values") == values1 + "," + values2
 
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} where id = 1 FORMAT Values") == "(2)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} where id = 1 FORMAT Values") == "(2)"
 
 
 @pytest.mark.parametrize(
@@ -118,20 +139,20 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical):
     create_table(node, TABLE_NAME, **settings)
 
     node.query(f"SYSTEM STOP MERGES {TABLE_NAME}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 1024)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 2048)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 1024, -1)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 2048, -1)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096, -1)}")
-    assert node.query(f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
-    assert node.query(f"SELECT count(distinct(id)) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 1024)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 2048)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 1024, -1)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 2048, -1)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096, -1)}")
+    assert azure_query(node, f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(distinct(id)) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
 
     node.query(f"SYSTEM START MERGES {TABLE_NAME}")
 
     # Wait for merges and old parts deletion
     for attempt in range(0, 10):
-        parts_count = node.query(f"SELECT COUNT(*) FROM system.parts WHERE table = '{TABLE_NAME}' FORMAT Values")
+        parts_count = azure_query(node, f"SELECT COUNT(*) FROM system.parts WHERE table = '{TABLE_NAME}' FORMAT Values")
         if parts_count == "(1)":
             break
 
@@ -140,64 +161,64 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical):
 
         time.sleep(1)
 
-    assert node.query(f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
-    assert node.query(f"SELECT count(distinct(id)) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
+    assert azure_query(node, f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(distinct(id)) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
 
 
 def test_alter_table_columns(cluster):
     node = cluster.instances[NODE_NAME]
     create_table(node, TABLE_NAME)
 
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096, -1)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096, -1)}")
 
     node.query(f"ALTER TABLE {TABLE_NAME} ADD COLUMN col1 UInt64 DEFAULT 1")
     # To ensure parts have been merged
     node.query(f"OPTIMIZE TABLE {TABLE_NAME}")
 
-    assert node.query(f"SELECT sum(col1) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
-    assert node.query(f"SELECT sum(col1) FROM {TABLE_NAME} WHERE id > 0 FORMAT Values") == "(4096)"
+    assert azure_query(node, f"SELECT sum(col1) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
+    assert azure_query(node, f"SELECT sum(col1) FROM {TABLE_NAME} WHERE id > 0 FORMAT Values") == "(4096)"
 
     node.query(f"ALTER TABLE {TABLE_NAME} MODIFY COLUMN col1 String", settings={"mutations_sync": 2})
 
-    assert node.query(f"SELECT distinct(col1) FROM {TABLE_NAME} FORMAT Values") == "('1')"
+    assert azure_query(node, f"SELECT distinct(col1) FROM {TABLE_NAME} FORMAT Values") == "('1')"
 
 
 def test_attach_detach_partition(cluster):
     node = cluster.instances[NODE_NAME]
     create_table(node, TABLE_NAME)
 
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096)}")
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096)}")
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
 
     node.query(f"ALTER TABLE {TABLE_NAME} DETACH PARTITION '2020-01-03'")
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(4096)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(4096)"
 
     node.query(f"ALTER TABLE {TABLE_NAME} ATTACH PARTITION '2020-01-03'")
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
 
     node.query(f"ALTER TABLE {TABLE_NAME} DROP PARTITION '2020-01-03'")
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(4096)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(4096)"
 
     node.query(f"ALTER TABLE {TABLE_NAME} DETACH PARTITION '2020-01-04'")
     node.query(f"ALTER TABLE {TABLE_NAME} DROP DETACHED PARTITION '2020-01-04'", settings={"allow_drop_detached": 1})
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(0)"
 
 
 def test_move_partition_to_another_disk(cluster):
     node = cluster.instances[NODE_NAME]
     create_table(node, TABLE_NAME)
 
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096)}")
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096)}")
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
 
     node.query(f"ALTER TABLE {TABLE_NAME} MOVE PARTITION '2020-01-04' TO DISK '{LOCAL_DISK}'")
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
 
     node.query(f"ALTER TABLE {TABLE_NAME} MOVE PARTITION '2020-01-04' TO DISK '{AZURE_BLOB_STORAGE_DISK}'")
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
 
 
 def test_table_manipulations(cluster):
@@ -210,17 +231,17 @@ def test_table_manipulations(cluster):
     node.query_with_retry(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096)}")
 
     node.query(f"RENAME TABLE {TABLE_NAME} TO {renamed_table}")
-    assert node.query(f"SELECT count(*) FROM {renamed_table} FORMAT Values") == "(8192)"
+    assert azure_query(node, f"SELECT count(*) FROM {renamed_table} FORMAT Values") == "(8192)"
 
     node.query(f"RENAME TABLE {renamed_table} TO {TABLE_NAME}")
     assert node.query(f"CHECK TABLE {TABLE_NAME} FORMAT Values") == "(1)"
 
     node.query(f"DETACH TABLE {TABLE_NAME}")
     node.query(f"ATTACH TABLE {TABLE_NAME}")
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(8192)"
 
     node.query(f"TRUNCATE TABLE {TABLE_NAME}")
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(0)"
 
 
 @pytest.mark.long_run
@@ -230,38 +251,38 @@ def test_move_replace_partition_to_another_table(cluster):
 
     table_clone_name = TABLE_NAME + "_clone"
 
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 256)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 256)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-05', 256, -1)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-06', 256, -1)}")
-    assert node.query(f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(1024)"
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 256)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 256)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-05', 256, -1)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-06', 256, -1)}")
+    assert azure_query(node, f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(1024)"
 
     create_table(node, table_clone_name)
 
     node.query(f"ALTER TABLE {TABLE_NAME} MOVE PARTITION '2020-01-03' TO TABLE {table_clone_name}")
     node.query(f"ALTER TABLE {TABLE_NAME} MOVE PARTITION '2020-01-05' TO TABLE {table_clone_name}")
-    assert node.query(f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(512)"
-    assert node.query(f"SELECT sum(id) FROM {table_clone_name} FORMAT Values") == "(0)"
-    assert node.query(f"SELECT count(*) FROM {table_clone_name} FORMAT Values") == "(512)"
+    assert azure_query(node, f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(512)"
+    assert azure_query(node, f"SELECT sum(id) FROM {table_clone_name} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(*) FROM {table_clone_name} FORMAT Values") == "(512)"
 
     # Add new partitions to source table, but with different values and replace them from copied table.
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 256, -1)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-05', 256)}")
-    assert node.query(f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(1024)"
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 256, -1)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-05', 256)}")
+    assert azure_query(node, f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(1024)"
 
     node.query(f"ALTER TABLE {TABLE_NAME} REPLACE PARTITION '2020-01-03' FROM {table_clone_name}")
     node.query(f"ALTER TABLE {TABLE_NAME} REPLACE PARTITION '2020-01-05' FROM {table_clone_name}")
-    assert node.query(f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(1024)"
-    assert node.query(f"SELECT sum(id) FROM {table_clone_name} FORMAT Values") == "(0)"
-    assert node.query(f"SELECT count(*) FROM {table_clone_name} FORMAT Values") == "(512)"
+    assert azure_query(node, f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(1024)"
+    assert azure_query(node, f"SELECT sum(id) FROM {table_clone_name} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(*) FROM {table_clone_name} FORMAT Values") == "(512)"
 
     node.query(f"DROP TABLE {table_clone_name} NO DELAY")
-    assert node.query(f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
-    assert node.query(f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(1024)"
+    assert azure_query(node, f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+    assert azure_query(node, f"SELECT count(*) FROM {TABLE_NAME} FORMAT Values") == "(1024)"
 
     node.query(f"ALTER TABLE {TABLE_NAME} FREEZE")
 
@@ -275,12 +296,12 @@ def test_freeze_unfreeze(cluster):
     backup1 = 'backup1'
     backup2 = 'backup2'
 
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
     node.query(f"ALTER TABLE {TABLE_NAME} FREEZE WITH NAME '{backup1}'")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096)}")
     node.query(f"ALTER TABLE {TABLE_NAME} FREEZE WITH NAME '{backup2}'")
 
-    node.query(f"TRUNCATE TABLE {TABLE_NAME}")
+    azure_query(node, f"TRUNCATE TABLE {TABLE_NAME}")
 
     # Unfreeze single partition from backup1.
     node.query(f"ALTER TABLE {TABLE_NAME} UNFREEZE PARTITION '2020-01-03' WITH NAME '{backup1}'")
@@ -292,7 +313,7 @@ def test_apply_new_settings(cluster):
     node = cluster.instances[NODE_NAME]
     create_table(node, TABLE_NAME)
 
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-03', 4096)}")
 
     # Force multi-part upload mode.
     replace_config(
@@ -301,7 +322,7 @@ def test_apply_new_settings(cluster):
         "<max_single_part_upload_size>4096</max_single_part_upload_size>")
 
     node.query("SYSTEM RELOAD CONFIG")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096, -1)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096, -1)}")
 
 
 # NOTE: this test takes a couple of minutes when run together with other tests
@@ -313,14 +334,14 @@ def test_restart_during_load(cluster):
     # Force multi-part upload mode.
     replace_config(CONFIG_PATH, "<container_already_exists>false</container_already_exists>", "")
 
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096)}")
-    node.query(f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-05', 4096, -1)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-04', 4096)}")
+    azure_query(node, f"INSERT INTO {TABLE_NAME} VALUES {generate_values('2020-01-05', 4096, -1)}")
 
 
     def read():
         for ii in range(0, 5):
             logging.info(f"Executing {ii} query")
-            assert node.query(f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
+            assert azure_query(node, f"SELECT sum(id) FROM {TABLE_NAME} FORMAT Values") == "(0)"
             logging.info(f"Query {ii} executed")
             time.sleep(0.2)
 
@@ -347,5 +368,5 @@ def test_restart_during_load(cluster):
 def test_big_insert(cluster):
     node = cluster.instances[NODE_NAME]
     create_table(node, TABLE_NAME)
-    node.query(f"INSERT INTO {TABLE_NAME} select '2020-01-03', number, toString(number) from numbers(5000000)")
-    assert int(node.query(f"SELECT count() FROM {TABLE_NAME}")) == 5000000
+    azure_query(node, f"INSERT INTO {TABLE_NAME} select '2020-01-03', number, toString(number) from numbers(5000000)")
+    assert int(azure_query(node, f"SELECT count() FROM {TABLE_NAME}")) == 5000000


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

btw checked locally and even locally error `Azure::Core::Http::TransportException: Connection was closed by the server while trying to read a response.` is reproduced. So such solution helps.