### PR TITLE
Adding cURL installation message to notice users

### DIFF
--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -9,7 +9,7 @@ The HTTP interface lets you use ClickHouse on any platform from any programming 
 
 By default, `clickhouse-server` listens for HTTP on port 8123 (this can be changed in the config).
 
-By default, `cURL` command is not available on user operating systems. Please refer this [documentation](https://curl.se/download.html) to install it before running the examples.
+Sometimes, `curl` command is not available on user operating systems. On Ubuntu or Debian, run `sudo apt install curl`. Please refer this [documentation](https://curl.se/download.html) to install it before running the examples.
 
 If you make a `GET /` request without parameters, it returns 200 response code and the string which defined in [http_server_default_response](../operations/server-configuration-parameters/settings.md#server_configuration_parameters-http_server_default_response) default value “Ok.” (with a line feed at the end)
 

--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -9,6 +9,8 @@ The HTTP interface lets you use ClickHouse on any platform from any programming 
 
 By default, `clickhouse-server` listens for HTTP on port 8123 (this can be changed in the config).
 
+By default, `cURL` command is not available on user operating systems. Please refer this [documentation](https://curl.se/download.html) to install it before running the examples.
+
 If you make a `GET /` request without parameters, it returns 200 response code and the string which defined in [http_server_default_response](../operations/server-configuration-parameters/settings.md#server_configuration_parameters-http_server_default_response) default value “Ok.” (with a line feed at the end)
 
 ``` bash


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
N/A


Detailed description / Documentation draft:

- Adding the friendly message to notify users to install `cURL` before running related examples.