### PR TITLE
fix hang up with command 'drop table system.query_log sync'

### DIFF
--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -168,6 +168,8 @@ public:
     void shutdown() override
     {
         stopFlushThread();
+
+        auto table = DatabaseCatalog::instance().tryGetTable(table_id, getContext());
         if (table)
             table->flushAndShutdown();
     }
@@ -186,7 +188,6 @@ private:
     /* Saving thread data */
     const StorageID table_id;
     const String storage_def;
-    StoragePtr table;
     String create_query;
     String old_create_query;
     bool is_prepared = false;
@@ -525,7 +526,7 @@ void SystemLog<LogElement>::prepareTable()
 {
     String description = table_id.getNameForLogs();
 
-    table = DatabaseCatalog::instance().tryGetTable(table_id, getContext());
+    auto table = DatabaseCatalog::instance().tryGetTable(table_id, getContext());
 
     if (table)
     {

--- a/tests/queries/0_stateless/02167_hang_in_drop_query_log_sync.sh
+++ b/tests/queries/0_stateless/02167_hang_in_drop_query_log_sync.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck source=../shell_config.sh
-. "$CURDIR"/../shell_config.sh
-
-timeout 3s $CLICKHOUSE_CLIENT --receive_timeout=2 -q "DROP TABLE system.query_log sync;" 2>&1 | grep -o "Timeout exceeded"

--- a/tests/queries/0_stateless/02167_hang_in_drop_query_log_sync.sh
+++ b/tests/queries/0_stateless/02167_hang_in_drop_query_log_sync.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+timeout 3s $CLICKHOUSE_CLIENT --receive_timeout=2 -q "DROP TABLE system.query_log sync;" 2>&1 | grep -o "Timeout exceeded"


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Detailed description / Documentation draft:
Problem phenomenon：
When I use 'drop table system.query_log sync', the client will hangup.
Problem root cause：
When called to dropTableDataTask() in process of drop table,  the table.unique() return false. This is because 'table' in Class SystemLog does not free the smart pointer.

