### PR TITLE
Add IAST::QueryKind enum and use it in query limiter

### DIFF
--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -271,11 +271,7 @@ public:
     /// User -> queries
     using UserToQueries = std::unordered_map<String, ProcessListForUser>;
 
-    struct QueryKindAmounts
-    {
-        QueryAmount insert;
-        QueryAmount select;
-    };
+    using QueryKindAmounts = std::unordered_map<IAST::QueryKind, QueryAmount>;
 
 protected:
     friend class ProcessListEntry;
@@ -306,10 +302,10 @@ protected:
     size_t max_select_queries_amount = 0;
 
     /// amount of queries by query kind.
-    QueryKindAmounts * query_kind_amounts = new QueryKindAmounts{0, 0};
+    QueryKindAmounts query_kind_amounts;
 
-    void increaseQueryKindAmount(const IAST::QueryKind & query_kind) const;
-    void decreaseQueryKindAmount(const IAST::QueryKind & query_kind) const;
+    void increaseQueryKindAmount(const IAST::QueryKind & query_kind);
+    void decreaseQueryKindAmount(const IAST::QueryKind & query_kind);
     QueryAmount getQueryKindAmount(const IAST::QueryKind & query_kind) const;
 
 public:

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -128,7 +128,7 @@ public:
         const String & query_,
         const ClientInfo & client_info_,
         QueryPriorities::Handle && priority_handle_,
-        const IAST::QueryKind & query_kind_
+        IAST::QueryKind query_kind_
         );
 
     ~QueryStatus();

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -9,6 +9,7 @@
 #include <QueryPipeline/ExecutionSpeedLimits.h>
 #include <Storages/IStorage_fwd.h>
 #include <Poco/Condition.h>
+#include <Parsers/IAST.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/CurrentThread.h>
 #include <Common/MemoryTracker.h>
@@ -118,7 +119,7 @@ protected:
 
     ProcessListForUser * user_process_list = nullptr;
 
-    String query_kind;
+    IAST::QueryKind query_kind;
 
 public:
 
@@ -127,7 +128,7 @@ public:
         const String & query_,
         const ClientInfo & client_info_,
         QueryPriorities::Handle && priority_handle_,
-        const String & query_kind_
+        const IAST::QueryKind & query_kind_
         );
 
     ~QueryStatus();
@@ -270,7 +271,11 @@ public:
     /// User -> queries
     using UserToQueries = std::unordered_map<String, ProcessListForUser>;
 
-    using QueryKindToAmount = std::unordered_map<String, QueryAmount>;
+    struct QueryKindAmounts
+    {
+        QueryAmount insert;
+        QueryAmount select;
+    };
 
 protected:
     friend class ProcessListEntry;
@@ -301,11 +306,11 @@ protected:
     size_t max_select_queries_amount = 0;
 
     /// amount of queries by query kind.
-    QueryKindToAmount query_kind_amounts;
+    QueryKindAmounts * query_kind_amounts = new QueryKindAmounts{0, 0};
 
-    void increaseQueryKindAmount(const String & query_kind);
-    void decreaseQueryKindAmount(const String & query_kind);
-    QueryAmount getQueryKindAmount(const String & query_kind);
+    void increaseQueryKindAmount(const IAST::QueryKind & query_kind) const;
+    void decreaseQueryKindAmount(const IAST::QueryKind & query_kind) const;
+    QueryAmount getQueryKindAmount(const IAST::QueryKind & query_kind) const;
 
 public:
     using EntryPtr = std::shared_ptr<ProcessListEntry>;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -57,6 +57,8 @@
 #include <Processors/Executors/CompletedPipelineExecutor.h>
 #include <Processors/Sources/WaitForAsyncInsertSource.h>
 
+#include <base/EnumReflection.h>
+
 #include <random>
 
 
@@ -271,7 +273,7 @@ static void onExceptionBeforeStart(const String & query_for_logging, ContextPtr 
     // Try log query_kind if ast is valid
     if (ast)
     {
-        elem.query_kind = ast->getQueryKindString();
+        elem.query_kind = magic_enum::enum_name(ast->getQueryKind());
         if (settings.log_formatted_queries)
             elem.formatted_query = queryToString(ast);
     }

--- a/src/Parsers/ASTAlterQuery.h
+++ b/src/Parsers/ASTAlterQuery.h
@@ -247,6 +247,7 @@ public:
     }
 
     const char * getQueryKindString() const override { return "Alter"; }
+    virtual QueryKind getQueryKind() const override { return QueryKind::Alter; }
 
 protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;

--- a/src/Parsers/ASTAlterQuery.h
+++ b/src/Parsers/ASTAlterQuery.h
@@ -246,7 +246,6 @@ public:
         return removeOnCluster<ASTAlterQuery>(clone(), new_database);
     }
 
-    const char * getQueryKindString() const override { return "Alter"; }
     virtual QueryKind getQueryKind() const override { return QueryKind::Alter; }
 
 protected:

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -113,7 +113,6 @@ public:
 
     bool isView() const { return is_ordinary_view || is_materialized_view || is_live_view || is_window_view; }
 
-    const char * getQueryKindString() const override { return "Create"; }
     virtual QueryKind getQueryKind() const override { return QueryKind::Create; }
 
 protected:

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -114,6 +114,7 @@ public:
     bool isView() const { return is_ordinary_view || is_materialized_view || is_live_view || is_window_view; }
 
     const char * getQueryKindString() const override { return "Create"; }
+    virtual QueryKind getQueryKind() const override { return QueryKind::Create; }
 
 protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;

--- a/src/Parsers/ASTDropQuery.h
+++ b/src/Parsers/ASTDropQuery.h
@@ -46,6 +46,7 @@ public:
     }
 
     const char * getQueryKindString() const override { return "Drop"; }
+    virtual QueryKind getQueryKind() const override { return QueryKind::Drop; }
 
 protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;

--- a/src/Parsers/ASTDropQuery.h
+++ b/src/Parsers/ASTDropQuery.h
@@ -45,7 +45,6 @@ public:
         return removeOnCluster<ASTDropQuery>(clone(), new_database);
     }
 
-    const char * getQueryKindString() const override { return "Drop"; }
     virtual QueryKind getQueryKind() const override { return QueryKind::Drop; }
 
 protected:

--- a/src/Parsers/ASTInsertQuery.h
+++ b/src/Parsers/ASTInsertQuery.h
@@ -67,6 +67,7 @@ public:
     }
 
     const char * getQueryKindString() const override { return "Insert"; }
+    virtual QueryKind getQueryKind() const override { return QueryKind::Insert; }
 
 protected:
     void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;

--- a/src/Parsers/ASTInsertQuery.h
+++ b/src/Parsers/ASTInsertQuery.h
@@ -66,7 +66,6 @@ public:
         return res;
     }
 
-    const char * getQueryKindString() const override { return "Insert"; }
     virtual QueryKind getQueryKind() const override { return QueryKind::Insert; }
 
 protected:

--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -66,6 +66,7 @@ public:
     }
 
     const char * getQueryKindString() const override { return "Rename"; }
+    virtual QueryKind getQueryKind() const override { return QueryKind::Rename; }
 
 protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override

--- a/src/Parsers/ASTRenameQuery.h
+++ b/src/Parsers/ASTRenameQuery.h
@@ -65,7 +65,6 @@ public:
         return query_ptr;
     }
 
-    const char * getQueryKindString() const override { return "Rename"; }
     virtual QueryKind getQueryKind() const override { return QueryKind::Rename; }
 
 protected:

--- a/src/Parsers/ASTSelectIntersectExceptQuery.h
+++ b/src/Parsers/ASTSelectIntersectExceptQuery.h
@@ -22,7 +22,6 @@ public:
 
     void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
-    const char * getQueryKindString() const override { return "SelectIntersectExcept"; }
     virtual QueryKind getQueryKind() const override { return QueryKind::SelectIntersectExcept; }
 
     ASTs getListOfSelects() const;

--- a/src/Parsers/ASTSelectIntersectExceptQuery.h
+++ b/src/Parsers/ASTSelectIntersectExceptQuery.h
@@ -23,6 +23,7 @@ public:
     void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     const char * getQueryKindString() const override { return "SelectIntersectExcept"; }
+    virtual QueryKind getQueryKind() const override { return QueryKind::SelectIntersectExcept; }
 
     ASTs getListOfSelects() const;
 

--- a/src/Parsers/ASTSelectQuery.h
+++ b/src/Parsers/ASTSelectQuery.h
@@ -136,6 +136,7 @@ public:
     void setFinal();
 
     const char * getQueryKindString() const override { return "Select"; }
+    virtual QueryKind getQueryKind() const override { return QueryKind::Select; }
 
 protected:
     void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;

--- a/src/Parsers/ASTSelectQuery.h
+++ b/src/Parsers/ASTSelectQuery.h
@@ -135,7 +135,6 @@ public:
 
     void setFinal();
 
-    const char * getQueryKindString() const override { return "Select"; }
     virtual QueryKind getQueryKind() const override { return QueryKind::Select; }
 
 protected:

--- a/src/Parsers/ASTSelectWithUnionQuery.h
+++ b/src/Parsers/ASTSelectWithUnionQuery.h
@@ -18,6 +18,7 @@ public:
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
     const char * getQueryKindString() const override { return "Select"; }
+    virtual QueryKind getQueryKind() const override { return QueryKind::Select; }
 
     SelectUnionMode union_mode;
 

--- a/src/Parsers/ASTSelectWithUnionQuery.h
+++ b/src/Parsers/ASTSelectWithUnionQuery.h
@@ -17,7 +17,6 @@ public:
 
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
 
-    const char * getQueryKindString() const override { return "Select"; }
     virtual QueryKind getQueryKind() const override { return QueryKind::Select; }
 
     SelectUnionMode union_mode;

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -108,6 +108,7 @@ public:
     }
 
     const char * getQueryKindString() const override { return "System"; }
+    virtual QueryKind getQueryKind() const override { return QueryKind::System; }
 
 protected:
 

--- a/src/Parsers/ASTSystemQuery.h
+++ b/src/Parsers/ASTSystemQuery.h
@@ -107,7 +107,6 @@ public:
         return removeOnCluster<ASTSystemQuery>(clone(), new_database);
     }
 
-    const char * getQueryKindString() const override { return "System"; }
     virtual QueryKind getQueryKind() const override { return QueryKind::System; }
 
 protected:

--- a/src/Parsers/Access/ASTGrantQuery.h
+++ b/src/Parsers/Access/ASTGrantQuery.h
@@ -35,5 +35,6 @@ public:
     void replaceCurrentUserTag(const String & current_user_name) const;
     ASTPtr getRewrittenASTWithoutOnCluster(const std::string &) const override { return removeOnCluster<ASTGrantQuery>(clone()); }
     const char * getQueryKindString() const override { return is_revoke ? "Revoke" : "Grant"; }
+    virtual QueryKind getQueryKind() const override { return is_revoke ? QueryKind::Revoke : QueryKind::Grant; }
 };
 }

--- a/src/Parsers/Access/ASTGrantQuery.h
+++ b/src/Parsers/Access/ASTGrantQuery.h
@@ -34,7 +34,6 @@ public:
     void replaceEmptyDatabase(const String & current_database);
     void replaceCurrentUserTag(const String & current_user_name) const;
     ASTPtr getRewrittenASTWithoutOnCluster(const std::string &) const override { return removeOnCluster<ASTGrantQuery>(clone()); }
-    const char * getQueryKindString() const override { return is_revoke ? "Revoke" : "Grant"; }
     virtual QueryKind getQueryKind() const override { return is_revoke ? QueryKind::Revoke : QueryKind::Grant; }
 };
 }

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -248,7 +248,23 @@ public:
     // Return query_kind string representation of this AST query.
     virtual const char * getQueryKindString() const { return ""; }
 
-public:
+    enum QueryKind
+    {
+        None,
+        Alter,
+        Create,
+        Drop,
+        Grant,
+        Insert,
+        Rename,
+        Revoke,
+        SelectIntersectExcept,
+        Select,
+        System,
+    };
+    /// Return QueryKind of this AST query.
+    virtual QueryKind getQueryKind() const { return QueryKind::None; }
+
     /// For syntax highlighting.
     static const char * hilite_keyword;
     static const char * hilite_identifier;

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -245,9 +245,6 @@ public:
 
     void cloneChildren();
 
-    // Return query_kind string representation of this AST query.
-    virtual const char * getQueryKindString() const { return ""; }
-
     enum QueryKind
     {
         None,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Add enum QueryKind for IAST class
- Use IAST::QueryKind instead of strings in QueryKindAmount

Follow up for #32609