### PR TITLE
Return early if azure blob storage is not used, otherwise it might with fail with irrelevant errors

### DIFF
--- a/cmake/find/blob_storage.cmake
+++ b/cmake/find/blob_storage.cmake
@@ -1,13 +1,15 @@
 option (ENABLE_AZURE_BLOB_STORAGE "Enable Azure blob storage" ${ENABLE_LIBRARIES})
 
-option(USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY
-    "Set to FALSE to use system Azure SDK instead of bundled (OFF currently not implemented)"
-    ON)
-
 if (ENABLE_AZURE_BLOB_STORAGE)
     set(USE_AZURE_BLOB_STORAGE 1)
     set(AZURE_BLOB_STORAGE_LIBRARY azure_sdk)
+else()
+    return()
 endif()
+
+option(USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY
+    "Set to FALSE to use system Azure SDK instead of bundled (OFF currently not implemented)"
+    ON)
 
 if ((NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/azure/sdk"
         OR NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/azure/cmake-modules")


### PR DESCRIPTION
Like missing internal ssl library when ENABLE_LIBRARIRES=0

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
