### PR TITLE
Improve query performance of system tables

### DIFF
--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -88,7 +88,7 @@ static ColumnPtr getFilteredDatabases(const SelectQueryInfo & query_info, Contex
     return block.getByPosition(0).column;
 }
 
-static ColumnPtr getFilteredTables(const ASTPtr & query, ColumnPtr & filtered_databases_column, const Context & context)
+static ColumnPtr getFilteredTables(const ASTPtr & query, ColumnPtr & filtered_databases_column, ContextPtr context)
 {
     MutableColumnPtr column = ColumnString::create();
 

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -88,6 +88,26 @@ static ColumnPtr getFilteredDatabases(const SelectQueryInfo & query_info, Contex
     return block.getByPosition(0).column;
 }
 
+static ColumnPtr getFilteredTables(const ASTPtr & query, ColumnPtr & filtered_databases_column, const Context & context)
+{
+    MutableColumnPtr column = ColumnString::create();
+
+    size_t database_idx = 0;
+    for (; database_idx < filtered_databases_column->size(); ++database_idx)
+    {
+        auto database_name = filtered_databases_column->getDataAt(database_idx).toString();
+        DatabasePtr database = DatabaseCatalog::instance().getDatabase(database_name);
+        DatabaseTablesIteratorPtr table_it = database->getTablesIterator(context);
+
+        for (; table_it->isValid(); table_it->next())
+            column->insert(table_it->name());
+    }
+
+    Block block {ColumnWithTypeAndName(std::move(column), std::make_shared<DataTypeString>(), "name")};
+    VirtualColumnUtils::filterBlockWithQuery(query, block, context);
+    return block.getByPosition(0).column;
+}
+
 /// Avoid heavy operation on tables if we only queried columns that we can get without table object.
 /// Otherwise it will require table initialization for Lazy database.
 static bool needLockStructure(const DatabasePtr & database, const Block & header)
@@ -112,12 +132,19 @@ public:
         Block header,
         UInt64 max_block_size_,
         ColumnPtr databases_,
+        ColumnPtr tables_,
         ContextPtr context_)
         : SourceWithProgress(std::move(header))
         , columns_mask(std::move(columns_mask_))
         , max_block_size(max_block_size_)
         , databases(std::move(databases_))
-        , context(Context::createCopy(context_)) {}
+        , context(Context::createCopy(context_)) 
+    {
+        size_t size = tables_->size();
+        tables.reserve(size);
+        for (size_t idx = 0; idx < size; ++idx)
+            tables.insert(tables_->getDataAt(idx).toString());    
+    }
 
     String getName() const override { return "Tables"; }
 
@@ -239,6 +266,9 @@ protected:
             for (; rows_count < max_block_size && tables_it->isValid(); tables_it->next())
             {
                 auto table_name = tables_it->name();
+                if (!tables.contains(table_name))
+                    continue;
+
                 if (check_access_for_tables && !access->isGranted(AccessType::SHOW_TABLES, database_name, table_name))
                     continue;
 
@@ -514,6 +544,7 @@ private:
     std::vector<UInt8> columns_mask;
     UInt64 max_block_size;
     ColumnPtr databases;
+    NameSet tables;
     size_t database_idx = 0;
     DatabaseTablesIteratorPtr tables_it;
     ContextPtr context;
@@ -552,6 +583,7 @@ Pipe StorageSystemTables::read(
     }
 
     ColumnPtr filtered_databases_column = getFilteredDatabases(query_info, context);
+    ColumnPtr filtered_tables_column = getFilteredTables(query_info.query, filtered_databases_column, context);
 
     return Pipe(std::make_shared<TablesBlockSource>(
         std::move(columns_mask), std::move(res_block), max_block_size, std::move(filtered_databases_column), context));

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -138,12 +138,12 @@ public:
         , columns_mask(std::move(columns_mask_))
         , max_block_size(max_block_size_)
         , databases(std::move(databases_))
-        , context(Context::createCopy(context_)) 
+        , context(Context::createCopy(context_))
     {
         size_t size = tables_->size();
         tables.reserve(size);
         for (size_t idx = 0; idx < size; ++idx)
-            tables.insert(tables_->getDataAt(idx).toString());    
+            tables.insert(tables_->getDataAt(idx).toString());
     }
 
     String getName() const override { return "Tables"; }
@@ -586,7 +586,7 @@ Pipe StorageSystemTables::read(
     ColumnPtr filtered_tables_column = getFilteredTables(query_info.query, filtered_databases_column, context);
 
     return Pipe(std::make_shared<TablesBlockSource>(
-        std::move(columns_mask), std::move(res_block), max_block_size, std::move(filtered_databases_column), context));
+        std::move(columns_mask), std::move(res_block), max_block_size, std::move(filtered_databases_column), std::move(filtered_tables_column), context));
 }
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

In a scenario with a particularly large amount of tables and data, querying the `system.tables` is very slow. The survey found that the acquisition of four fields is very time-consuming. For example `total_rows` , `total_bytes`, `create_table_query`, `engine_full`, my idea is to add an index to the `name` field to filter out unnecessary tables in advance.

```
bigdata-clickhouse-public00.ys :) select  * from system.tables where name = 'xxx';

SELECT *
FROM system.tables
WHERE name = 'xxx'

Ok.

0 rows in set. Elapsed: 22.154 sec. Processed 12.00 thousand rows, 44.54 MB (541.53 rows/s., 2.01 MB/s.)
```