### PR TITLE
Minor refactor of read buffers with compression

### DIFF
--- a/src/IO/BrotliReadBuffer.cpp
+++ b/src/IO/BrotliReadBuffer.cpp
@@ -39,7 +39,7 @@ BrotliReadBuffer::BrotliReadBuffer(std::unique_ptr<ReadBuffer> in_, size_t buf_s
         , in_data(nullptr)
         , out_capacity(0)
         , out_data(nullptr)
-        , eof(false)
+        , eof_flag(false)
 {
 }
 
@@ -47,7 +47,7 @@ BrotliReadBuffer::~BrotliReadBuffer() = default;
 
 bool BrotliReadBuffer::nextImpl()
 {
-    if (eof)
+    if (eof_flag)
         return false;
 
     if (!in_available)
@@ -74,7 +74,7 @@ bool BrotliReadBuffer::nextImpl()
     {
         if (in->eof())
         {
-            eof = true;
+            eof_flag = true;
             return !working_buffer.empty();
         }
         else

--- a/src/IO/BrotliReadBuffer.h
+++ b/src/IO/BrotliReadBuffer.h
@@ -32,7 +32,7 @@ private:
     size_t out_capacity;
     uint8_t  * out_data;
 
-    bool eof;
+    bool eof_flag;
 };
 
 }

--- a/src/IO/Bzip2ReadBuffer.cpp
+++ b/src/IO/Bzip2ReadBuffer.cpp
@@ -42,7 +42,7 @@ Bzip2ReadBuffer::Bzip2ReadBuffer(std::unique_ptr<ReadBuffer> in_, size_t buf_siz
         : BufferWithOwnMemory<ReadBuffer>(buf_size, existing_memory, alignment)
         , in(std::move(in_))
         , bz(std::make_unique<Bzip2StateWrapper>())
-        , eof(false)
+        , eof_flag(false)
 {
 }
 
@@ -50,7 +50,7 @@ Bzip2ReadBuffer::~Bzip2ReadBuffer() = default;
 
 bool Bzip2ReadBuffer::nextImpl()
 {
-    if (eof)
+    if (eof_flag)
         return false;
 
     if (!bz->stream.avail_in)
@@ -72,7 +72,7 @@ bool Bzip2ReadBuffer::nextImpl()
     {
         if (in->eof())
         {
-            eof = true;
+            eof_flag = true;
             return !working_buffer.empty();
         }
         else
@@ -91,7 +91,7 @@ bool Bzip2ReadBuffer::nextImpl()
 
     if (in->eof())
     {
-        eof = true;
+        eof_flag = true;
         throw Exception(ErrorCodes::UNEXPECTED_END_OF_FILE, "Unexpected end of bzip2 archive");
     }
 

--- a/src/IO/Bzip2ReadBuffer.h
+++ b/src/IO/Bzip2ReadBuffer.h
@@ -26,7 +26,7 @@ private:
     class Bzip2StateWrapper;
     std::unique_ptr<Bzip2StateWrapper> bz;
 
-    bool eof;
+    bool eof_flag;
 };
 
 }

--- a/src/IO/LZMAInflatingReadBuffer.cpp
+++ b/src/IO/LZMAInflatingReadBuffer.cpp
@@ -7,7 +7,7 @@ namespace ErrorCodes
     extern const int LZMA_STREAM_DECODER_FAILED;
 }
 LZMAInflatingReadBuffer::LZMAInflatingReadBuffer(std::unique_ptr<ReadBuffer> in_, size_t buf_size, char * existing_memory, size_t alignment)
-    : BufferWithOwnMemory<ReadBuffer>(buf_size, existing_memory, alignment), in(std::move(in_)), eof(false)
+    : BufferWithOwnMemory<ReadBuffer>(buf_size, existing_memory, alignment), in(std::move(in_)), eof_flag(false)
 {
     lstr = LZMA_STREAM_INIT;
     lstr.allocator = nullptr;
@@ -36,7 +36,7 @@ LZMAInflatingReadBuffer::~LZMAInflatingReadBuffer()
 
 bool LZMAInflatingReadBuffer::nextImpl()
 {
-    if (eof)
+    if (eof_flag)
         return false;
 
     lzma_action action = LZMA_RUN;
@@ -64,7 +64,7 @@ bool LZMAInflatingReadBuffer::nextImpl()
     {
         if (in->eof())
         {
-            eof = true;
+            eof_flag = true;
             return !working_buffer.empty();
         }
         else

--- a/src/IO/LZMAInflatingReadBuffer.h
+++ b/src/IO/LZMAInflatingReadBuffer.h
@@ -25,7 +25,7 @@ private:
     std::unique_ptr<ReadBuffer> in;
     lzma_stream lstr;
 
-    bool eof;
+    bool eof_flag;
 };
 
 }

--- a/src/IO/Lz4InflatingReadBuffer.cpp
+++ b/src/IO/Lz4InflatingReadBuffer.cpp
@@ -32,7 +32,7 @@ Lz4InflatingReadBuffer::~Lz4InflatingReadBuffer()
 
 bool Lz4InflatingReadBuffer::nextImpl()
 {
-    if (eof)
+    if (eof_flag)
         return false;
 
     if (!in_available)
@@ -66,7 +66,7 @@ bool Lz4InflatingReadBuffer::nextImpl()
 
     if (in->eof())
     {
-        eof = true;
+        eof_flag = true;
         return !working_buffer.empty();
     }
 

--- a/src/IO/Lz4InflatingReadBuffer.h
+++ b/src/IO/Lz4InflatingReadBuffer.h
@@ -35,7 +35,7 @@ private:
     size_t in_available;
     size_t out_available;
 
-    bool eof = false;
+    bool eof_flag = false;
 };
 
 }

--- a/src/IO/ZlibInflatingReadBuffer.cpp
+++ b/src/IO/ZlibInflatingReadBuffer.cpp
@@ -16,7 +16,7 @@ ZlibInflatingReadBuffer::ZlibInflatingReadBuffer(
         size_t alignment)
     : BufferWithOwnMemory<ReadBuffer>(buf_size, existing_memory, alignment)
     , in(std::move(in_))
-    , eof(false)
+    , eof_flag(false)
 {
     zstr.zalloc = nullptr;
     zstr.zfree = nullptr;
@@ -54,7 +54,7 @@ bool ZlibInflatingReadBuffer::nextImpl()
     do
     {
         /// if we already found eof, we shouldn't do anything
-        if (eof)
+        if (eof_flag)
             return false;
 
         /// if there is no available bytes in zstr, move ptr to next available data
@@ -83,7 +83,7 @@ bool ZlibInflatingReadBuffer::nextImpl()
             /// * false if there is no data in working buffer
             if (in->eof())
             {
-                eof = true;
+                eof_flag = true;
                 return !working_buffer.empty();
             }
             /// If it is not end of file, we need to reset zstr and return true, because we still have some data to read

--- a/src/IO/ZlibInflatingReadBuffer.h
+++ b/src/IO/ZlibInflatingReadBuffer.h
@@ -33,7 +33,7 @@ private:
 
     std::unique_ptr<ReadBuffer> in;
     z_stream zstr;
-    bool eof;
+    bool eof_flag;
 };
 
 }

--- a/src/IO/ZstdInflatingReadBuffer.cpp
+++ b/src/IO/ZstdInflatingReadBuffer.cpp
@@ -31,7 +31,7 @@ bool ZstdInflatingReadBuffer::nextImpl()
     do
     {
         // If it is known that end of file was reached, return false
-        if (eof)
+        if (eof_flag)
             return false;
 
         /// If end was reached, get next part
@@ -64,7 +64,7 @@ bool ZstdInflatingReadBuffer::nextImpl()
         /// If end of file is reached, fill eof variable and return true if there is some data in buffer, otherwise return false
         if (in->eof())
         {
-            eof = true;
+            eof_flag = true;
             return !working_buffer.empty();
         }
         /// It is possible, that input buffer is not at eof yet, but nothing was decompressed in current iteration.

--- a/src/IO/ZstdInflatingReadBuffer.h
+++ b/src/IO/ZstdInflatingReadBuffer.h
@@ -31,7 +31,7 @@ private:
     ZSTD_DCtx * dctx;
     ZSTD_inBuffer input;
     ZSTD_outBuffer output;
-    bool eof = false;
+    bool eof_flag = false;
 };
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Rename member variables `bool eof` to avoid shadowing base ReadBuffer class function `eof()`. 