### PR TITLE
support `<secure/>` in cluster configuration.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -567,6 +567,7 @@ if (ENABLE_TESTS AND USE_GTEST)
         clickhouse_storages_system
         dbms
         clickhouse_common_zookeeper
+        clickhouse_common_config
         string_utils)
 
     add_check(unit_tests_dbms)

--- a/src/Common/Config/CMakeLists.txt
+++ b/src/Common/Config/CMakeLists.txt
@@ -4,6 +4,7 @@ set (SRCS
     configReadClient.cpp
     ConfigReloader.cpp
     YAMLParser.cpp
+    ConfigHelper.cpp
 )
 
 add_library(clickhouse_common_config ${SRCS})

--- a/src/Common/Config/ConfigHelper.cpp
+++ b/src/Common/Config/ConfigHelper.cpp
@@ -13,7 +13,7 @@ bool getBool(const Poco::Util::AbstractConfiguration & config, const std::string
         return default_;
     Poco::Util::AbstractConfiguration::Keys sub_keys;
     config.keys(key, sub_keys);
-    if (sub_keys.size() == 0 && config.getString(key).size() == 0)
+    if (sub_keys.empty() && config.getString(key).empty())
         return empty_as;
     return config.getBool(key, default_);
 }

--- a/src/Common/Config/ConfigHelper.cpp
+++ b/src/Common/Config/ConfigHelper.cpp
@@ -1,0 +1,23 @@
+#include <Common/Config/ConfigHelper.h>
+#include <Poco/Util/AbstractConfiguration.h>
+
+namespace DB
+{
+
+namespace ConfigHelper
+{
+
+bool getBool(const Poco::Util::AbstractConfiguration & config, const std::string & key, bool default_, bool empty_as)
+{
+    if (!config.has(key))
+        return default_;
+    Poco::Util::AbstractConfiguration::Keys sub_keys;
+    config.keys(key, sub_keys);
+    if (sub_keys.size() == 0 && config.getString(key).size() == 0)
+        return empty_as;
+    return config.getBool(key, default_);
+}
+
+}
+
+}

--- a/src/Common/Config/ConfigHelper.h
+++ b/src/Common/Config/ConfigHelper.h
@@ -11,6 +11,8 @@ namespace Poco
 namespace DB::ConfigHelper
 {
 
+/// The behavior is like `config.getBool(key, default_)`,
+/// except when the tag is empty (aka. self-closing), `empty_as` will be used instead of throwing Poco::Exception.
 bool getBool(const Poco::Util::AbstractConfiguration & config, const std::string & key, bool default_, bool empty_as);
 
 }

--- a/src/Common/Config/ConfigHelper.h
+++ b/src/Common/Config/ConfigHelper.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace Poco
+{
+    namespace Util
+    {
+        class AbstractConfiguration;
+    }
+}
+
+namespace DB::ConfigHelper
+{
+
+bool getBool(const Poco::Util::AbstractConfiguration & config, const std::string & key, bool default_, bool empty_as);
+
+}

--- a/src/Common/tests/gtest_config_helper.cpp
+++ b/src/Common/tests/gtest_config_helper.cpp
@@ -1,0 +1,37 @@
+#include <Common/Config/ConfigHelper.h>
+#include <Poco/AutoPtr.h>
+#include <Poco/Util/XMLConfiguration.h>
+#include <Poco/DOM/DOMParser.h>
+
+#include <gtest/gtest.h>
+
+
+using namespace DB;
+
+TEST(Common, ConfigHelper_getBool)
+{
+    std::string xml(R"CONFIG(<clickhouse>
+    <zero_as_false>0</zero_as_false>
+    <one_as_true>1</one_as_true>
+    <yes_as_true>Yes</yes_as_true>
+    <empty_as_true_1/>
+    <empty_as_true_2></empty_as_true_2>
+    <has_empty_child_1><empty_child/></has_empty_child_1>
+    <has_empty_child_2><empty_child/><child>1</child></has_empty_child_2>
+    <has_child_1><child>1</child></has_child_1>
+    <has_child_2><child0>Yes</child0><child>1</child></has_child_2>
+</clickhouse>)CONFIG");
+
+    Poco::XML::DOMParser dom_parser;
+    Poco::AutoPtr<Poco::XML::Document> document = dom_parser.parseString(xml);
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config = new Poco::Util::XMLConfiguration(document);
+    EXPECT_EQ(ConfigHelper::getBool(*config, "zero_as_false", false, true), false);
+    EXPECT_EQ(ConfigHelper::getBool(*config, "one_as_true", false, true), true);
+    EXPECT_EQ(ConfigHelper::getBool(*config, "yes_as_true", false, true), true);
+    EXPECT_EQ(ConfigHelper::getBool(*config, "empty_as_true_1", false, true), true);
+    EXPECT_EQ(ConfigHelper::getBool(*config, "empty_as_true_2", false, true), true);
+    ASSERT_THROW(ConfigHelper::getBool(*config, "has_empty_child_1", false, true), Poco::Exception);
+    EXPECT_EQ(ConfigHelper::getBool(*config, "has_empty_child_2", false, true), true);
+    EXPECT_EQ(ConfigHelper::getBool(*config, "has_child_1", false, true), true);
+    ASSERT_THROW(ConfigHelper::getBool(*config, "has_child_2", false, true), Poco::Exception);
+}

--- a/src/Common/tests/gtest_config_helper.cpp
+++ b/src/Common/tests/gtest_config_helper.cpp
@@ -8,7 +8,7 @@
 
 using namespace DB;
 
-TEST(Common, ConfigHelper_getBool)
+TEST(Common, ConfigHelperGetBool)
 {
     std::string xml(R"CONFIG(<clickhouse>
     <zero_as_false>0</zero_as_false>

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -5,6 +5,7 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/parseAddress.h>
 #include <Common/Config/AbstractConfigurationComparison.h>
+#include <Common/Config/ConfigHelper.h>
 #include <Core/Settings.h>
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
@@ -101,7 +102,7 @@ Cluster::Address::Address(
     user = config.getString(config_prefix + ".user", "default");
     password = config.getString(config_prefix + ".password", "");
     default_database = config.getString(config_prefix + ".default_database", "");
-    secure = config.getBool(config_prefix + ".secure", false) ? Protocol::Secure::Enable : Protocol::Secure::Disable;
+    secure = ConfigHelper::getBool(config, config_prefix + ".secure", false, /* empty_as */true) ? Protocol::Secure::Enable : Protocol::Secure::Disable;
     priority = config.getInt(config_prefix + ".priority", 1);
     const char * port_type = secure == Protocol::Secure::Enable ? "tcp_port_secure" : "tcp_port";
     is_local = isLocal(config.getInt(port_type, 0));

--- a/tests/integration/test_config_xml_full/configs/config.xml
+++ b/tests/integration/test_config_xml_full/configs/config.xml
@@ -639,6 +639,24 @@
                 </replica>
             </shard>
         </test_shard_localhost_secure>
+        <test_shard_localhost_secure_empty_tag>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>9440</port>
+                    <secure></secure>
+                </replica>
+            </shard>
+        </test_shard_localhost_secure_empty_tag>
+        <test_shard_localhost_secure_empty_tag_2>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>9440</port>
+                    <secure />
+                </replica>
+            </shard>
+        </test_shard_localhost_secure_empty_tag_2>
         <test_unavailable_shard>
             <shard>
                 <replica>

--- a/tests/integration/test_config_yaml_full/configs/config.yaml
+++ b/tests/integration/test_config_yaml_full/configs/config.yaml
@@ -100,6 +100,12 @@ remote_servers:
         host: localhost
         port: 9440
         secure: 1
+  test_shard_localhost_secure_empty_tag:
+    shard:
+      replica:
+        host: localhost
+        port: 9440
+        secure:
   test_unavailable_shard:
     shard:
       - replica:


### PR DESCRIPTION
Changelog category (leave one):

- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
support `<secure/>` in cluster configuration. Close #33270


Detailed description / Documentation draft:
See #33270 
