### PR TITLE
Fix inner table parser in window view

### DIFF
--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -596,7 +596,7 @@ std::shared_ptr<ASTCreateQuery> StorageWindowView::getInnerTableCreateQuery(
         column_dec->name = column.name;
         column_dec->type = ast;
         columns_list->children.push_back(column_dec);
-        if(!is_time_column_func_now && !has_window_id)
+        if (!is_time_column_func_now && !has_window_id)
         {
             if (startsWith(column.name, "windowID"))
                 has_window_id = true;

--- a/tests/queries/0_stateless/01047_window_view_parser_inner_table.reference
+++ b/tests/queries/0_stateless/01047_window_view_parser_inner_table.reference
@@ -1,8 +1,12 @@
 ---TUMBLE---
+||---DEFAULT ENGINE WITH DATA COLUMN ALIAS---
+CREATE TABLE test_01047.`.inner.wv`\n(\n    `b` Int32,\n    `windowID(timestamp, toIntervalSecond(\'1\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nPRIMARY KEY `windowID(timestamp, toIntervalSecond(\'1\'))`\nORDER BY (`windowID(timestamp, toIntervalSecond(\'1\'))`, b)\nSETTINGS index_granularity = 8192
 ||---WINDOW COLUMN NAME---
 CREATE TABLE test_01047.`.inner.wv`\n(\n    `windowID(timestamp, toIntervalSecond(\'1\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nORDER BY `windowID(timestamp, toIntervalSecond(\'1\'))`\nSETTINGS index_granularity = 8192
 ||---WINDOW COLUMN ALIAS---
 CREATE TABLE test_01047.`.inner.wv`\n(\n    `windowID(timestamp, toIntervalSecond(\'1\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nORDER BY `windowID(timestamp, toIntervalSecond(\'1\'))`\nSETTINGS index_granularity = 8192
+||---DATA COLUMN ALIAS---
+CREATE TABLE test_01047.`.inner.wv`\n(\n    `b` Int32,\n    `windowID(timestamp, toIntervalSecond(\'1\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nORDER BY b\nSETTINGS index_granularity = 8192
 ||---IDENTIFIER---
 CREATE TABLE test_01047.`.inner.wv`\n(\n    `b` Int32,\n    `windowID(timestamp, toIntervalSecond(\'1\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nPRIMARY KEY `windowID(timestamp, toIntervalSecond(\'1\'))`\nORDER BY (`windowID(timestamp, toIntervalSecond(\'1\'))`, b)\nSETTINGS index_granularity = 8192
 ||---FUNCTION---
@@ -10,10 +14,14 @@ CREATE TABLE test_01047.`.inner.wv`\n(\n    `plus(a, b)` Int64,\n    `windowID(t
 ||---PARTITION---
 CREATE TABLE test_01047.`.inner.wv`\n(\n    `windowID(____timestamp, toIntervalSecond(\'1\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nPARTITION BY `windowID(____timestamp, toIntervalSecond(\'1\'))`\nORDER BY `windowID(____timestamp, toIntervalSecond(\'1\'))`\nSETTINGS index_granularity = 8192
 ---HOP---
+||---DEFAULT ENGINE WITH DATA COLUMN ALIAS---
+CREATE TABLE test_01047.`.inner.wv`\n(\n    `b` Int32,\n    `windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nPRIMARY KEY `windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))`\nORDER BY (`windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))`, b)\nSETTINGS index_granularity = 8192
 ||---WINDOW COLUMN NAME---
 CREATE TABLE test_01047.`.inner.wv`\n(\n    `windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nORDER BY `windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))`\nSETTINGS index_granularity = 8192
 ||---WINDOW COLUMN ALIAS---
 CREATE TABLE test_01047.`.inner.wv`\n(\n    `windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nORDER BY `windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))`\nSETTINGS index_granularity = 8192
+||---DATA COLUMN ALIAS---
+CREATE TABLE test_01047.`.inner.wv`\n(\n    `b` Int32,\n    `windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nORDER BY b\nSETTINGS index_granularity = 8192
 ||---IDENTIFIER---
 CREATE TABLE test_01047.`.inner.wv`\n(\n    `b` Int32,\n    `windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))` UInt32,\n    `count(a)` AggregateFunction(count, Int32)\n)\nENGINE = AggregatingMergeTree\nPRIMARY KEY `windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))`\nORDER BY (`windowID(timestamp, toIntervalSecond(\'1\'), toIntervalSecond(\'3\'))`, b)\nSETTINGS index_granularity = 8192
 ||---FUNCTION---

--- a/tests/queries/0_stateless/01047_window_view_parser_inner_table.sql
+++ b/tests/queries/0_stateless/01047_window_view_parser_inner_table.sql
@@ -9,6 +9,12 @@ DROP TABLE IF EXISTS test_01047.mt;
 CREATE TABLE test_01047.mt(a Int32, b Int32, timestamp DateTime) ENGINE=MergeTree ORDER BY tuple();
 
 SELECT '---TUMBLE---';
+SELECT '||---DEFAULT ENGINE WITH DATA COLUMN ALIAS---';
+DROP TABLE IF EXISTS test_01047.wv;
+DROP TABLE IF EXISTS test_01047.`.inner.wv`;
+CREATE WINDOW VIEW test_01047.wv AS SELECT count(a) AS count, b as id FROM test_01047.mt GROUP BY id, tumble(timestamp, INTERVAL '1' SECOND);
+SHOW CREATE TABLE test_01047.`.inner.wv`;
+
 SELECT '||---WINDOW COLUMN NAME---';
 DROP TABLE IF EXISTS test_01047.wv;
 DROP TABLE IF EXISTS test_01047.`.inner.wv`;
@@ -19,6 +25,12 @@ SELECT '||---WINDOW COLUMN ALIAS---';
 DROP TABLE IF EXISTS test_01047.wv;
 DROP TABLE IF EXISTS test_01047.`.inner.wv`;
 CREATE WINDOW VIEW test_01047.wv ENGINE AggregatingMergeTree ORDER BY wid AS SELECT count(a) AS count, tumble(timestamp, INTERVAL '1' SECOND) AS wid FROM test_01047.mt GROUP BY wid;
+SHOW CREATE TABLE test_01047.`.inner.wv`;
+
+SELECT '||---DATA COLUMN ALIAS---';
+DROP TABLE IF EXISTS test_01047.wv;
+DROP TABLE IF EXISTS test_01047.`.inner.wv`;
+CREATE WINDOW VIEW test_01047.wv ENGINE AggregatingMergeTree ORDER BY id AS SELECT count(a) AS count, b as id FROM test_01047.mt GROUP BY id, tumble(timestamp, INTERVAL '1' SECOND);
 SHOW CREATE TABLE test_01047.`.inner.wv`;
 
 SELECT '||---IDENTIFIER---';
@@ -41,6 +53,12 @@ SHOW CREATE TABLE test_01047.`.inner.wv`;
 
 
 SELECT '---HOP---';
+SELECT '||---DEFAULT ENGINE WITH DATA COLUMN ALIAS---';
+DROP TABLE IF EXISTS test_01047.wv;
+DROP TABLE IF EXISTS test_01047.`.inner.wv`;
+CREATE WINDOW VIEW test_01047.wv AS SELECT count(a) AS count, b as id FROM test_01047.mt GROUP BY id, hop(timestamp, INTERVAL '1' SECOND, INTERVAL '3' SECOND);
+SHOW CREATE TABLE test_01047.`.inner.wv`;
+
 SELECT '||---WINDOW COLUMN NAME---';
 DROP TABLE IF EXISTS test_01047.wv;
 DROP TABLE IF EXISTS test_01047.`.inner.wv`;
@@ -51,6 +69,12 @@ SELECT '||---WINDOW COLUMN ALIAS---';
 DROP TABLE IF EXISTS test_01047.wv;
 DROP TABLE IF EXISTS test_01047.`.inner.wv`;
 CREATE WINDOW VIEW test_01047.wv ENGINE AggregatingMergeTree ORDER BY wid AS SELECT count(a) AS count, hop(timestamp, INTERVAL '1' SECOND, INTERVAL '3' SECOND) AS wid FROM test_01047.mt GROUP BY wid;
+SHOW CREATE TABLE test_01047.`.inner.wv`;
+
+SELECT '||---DATA COLUMN ALIAS---';
+DROP TABLE IF EXISTS test_01047.wv;
+DROP TABLE IF EXISTS test_01047.`.inner.wv`;
+CREATE WINDOW VIEW test_01047.wv ENGINE AggregatingMergeTree ORDER BY id AS SELECT count(a) AS count, b as id FROM test_01047.mt GROUP BY id, hop(timestamp, INTERVAL '1' SECOND, INTERVAL '3' SECOND);
 SHOW CREATE TABLE test_01047.`.inner.wv`;
 
 SELECT '||---IDENTIFIER---';


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md): 

Fix inner table parser in window view


Detailed description / Documentation draft:

This PR fixes the following bugs for generating `inner_create_query` in WindowView.

1. Default engine but group by a data column with an alias. (`id` in the following example)

```
CREATE WINDOW VIEW test_01047.wv AS SELECT count(a) AS count, b as id FROM test_01047.mt GROUP BY id, tumble(timestamp, INTERVAL '1' SECOND);
```

2. Use the alias of a data column in the engine clause. (`id` in the following example)

```
CREATE WINDOW VIEW test_01047.wv ENGINE AggregatingMergeTree ORDER BY id AS SELECT count(a) AS count, b as id FROM test_01047.mt GROUP BY id, tumble(timestamp, INTERVAL '1' SECOND);
```