### PR TITLE
Fix cpu count with cgroup limits

### DIFF
--- a/src/Common/getNumberOfPhysicalCPUCores.cpp
+++ b/src/Common/getNumberOfPhysicalCPUCores.cpp
@@ -1,27 +1,80 @@
 #include "getNumberOfPhysicalCPUCores.h"
 
 #include <Common/config.h>
+#if defined(OS_LINUX)
+#    include <cmath>
+#    include <fstream>
+#endif
 #if USE_CPUID
 #    include <libcpuid/libcpuid.h>
 #endif
 
 #include <thread>
 
+#if defined(OS_LINUX)
+unsigned getCGroupLimitedCPUCores(unsigned default_cpu_count)
+{
+    // Try to look at cgroups limit if it is available.
+    auto read_from = [](const char * filename, int default_value) -> int {
+        std::ifstream infile(filename);
+        if (!infile.is_open())
+        {
+            return default_value;
+        }
+        int idata;
+        if (infile >> idata)
+            return idata;
+        else
+            return default_value;
+    };
+
+    unsigned quota_count = default_cpu_count;
+    // Return the number of milliseconds per period process is guaranteed to run.
+    // -1 for no quota
+    int cgroup_quota = read_from("/sys/fs/cgroup/cpu/cpu.cfs_quota_us", -1);
+    int cgroup_period = read_from("/sys/fs/cgroup/cpu/cpu.cfs_period_us", -1);
+    if (cgroup_quota > -1 && cgroup_period > 0)
+    {
+        quota_count = ceil(static_cast<float>(cgroup_quota) / static_cast<float>(cgroup_period));
+    }
+
+    // Share number (typically a number relative to 1024) (2048 typically expresses 2 CPUs worth of processing)
+    // -1 for no share setup
+    int cgroup_share = read_from("/sys/fs/cgroup/cpu/cpu.shares", -1);
+    // Convert 1024 to no shares setup
+    if (cgroup_share == 1024)
+        cgroup_share = -1;
+
+#    define PER_CPU_SHARES 1024
+    unsigned share_count = default_cpu_count;
+    if (cgroup_share > -1)
+    {
+        share_count = ceil(static_cast<float>(cgroup_share) / static_cast<float>(PER_CPU_SHARES));
+    }
+
+    return std::min(default_cpu_count, std::min(share_count, quota_count));
+}
+#endif // OS_LINUX
 
 unsigned getNumberOfPhysicalCPUCores()
 {
-    static const unsigned number = []
-    {
-#       if USE_CPUID
+    static const unsigned number = [] {
+        unsigned cpu_count = 0; // start with an invalid num
+#if USE_CPUID
+        do
+        {
             cpu_raw_data_t raw_data;
             cpu_id_t data;
 
             /// On Xen VMs, libcpuid returns wrong info (zero number of cores). Fallback to alternative method.
             /// Also, libcpuid does not support some CPUs like AMD Hygon C86 7151.
             if (0 != cpuid_get_raw_data(&raw_data) || 0 != cpu_identify(&raw_data, &data) || data.num_logical_cpus == 0)
-                return std::thread::hardware_concurrency();
+            {
+                // Just fallback
+                break;
+            }
 
-            unsigned res = data.num_cores * data.total_logical_cpus / data.num_logical_cpus;
+            cpu_count = data.num_cores * data.total_logical_cpus / data.num_logical_cpus;
 
             /// Also, libcpuid gives strange result on Google Compute Engine VMs.
             /// Example:
@@ -29,14 +82,18 @@ unsigned getNumberOfPhysicalCPUCores()
             ///  total_logical_cpus = 1,    /// total number of logical cores on all sockets
             ///  num_logical_cpus = 24.     /// number of logical cores on current CPU socket
             /// It means two-way hyper-threading (24 / 12), but contradictory, 'total_logical_cpus' == 1.
-
-            if (res != 0)
-                return res;
-#       endif
+        } while (false);
+#endif
 
         /// As a fallback (also for non-x86 architectures) assume there are no hyper-threading on the system.
         /// (Actually, only Aarch64 is supported).
-        return std::thread::hardware_concurrency();
+        if (cpu_count == 0)
+            cpu_count = std::thread::hardware_concurrency();
+
+#if defined(OS_LINUX)
+        cpu_count = getCGroupLimitedCPUCores(cpu_count);
+#endif // OS_LINUX
+        return cpu_count;
     }();
     return number;
 }

--- a/tests/integration/test_cgroup_limit/test.py
+++ b/tests/integration/test_cgroup_limit/test.py
@@ -7,7 +7,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 
 def run_command_in_container(cmd, *args):
-    # /clickhouse is mounted by interation tests runner
+    # /clickhouse is mounted by integration tests runner
     alternative_binary = os.getenv('CLICKHOUSE_BINARY', '/clickhouse')
     if alternative_binary:
         args += (

--- a/tests/integration/test_cgroup_limit/test.py
+++ b/tests/integration/test_cgroup_limit/test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import os
+import math
+import subprocess
+from tempfile import NamedTemporaryFile
+import pytest
+
+def run_command_in_container(cmd, *args):
+    # /clickhouse is mounted by interation tests runner
+    alternative_binary = os.getenv('CLICKHOUSE_BINARY', '/clickhouse')
+    if alternative_binary:
+        args += (
+            '--volume', f'{alternative_binary}:/usr/bin/clickhouse',
+        )
+
+    return subprocess.check_output(['docker', 'run', '--rm',
+        *args,
+        'ubuntu:20.04',
+        'sh', '-c', cmd,
+    ])
+
+def run_with_cpu_limit(cmd, num_cpus, *args):
+    args += (
+        '--cpus', f'{num_cpus}',
+    )
+    return run_command_in_container(cmd, *args)
+
+def test_cgroup_cpu_limit():
+    for num_cpus in (1, 2, 4, 2.8):
+        result = run_with_cpu_limit('clickhouse local -q "select value from system.settings where name=\'max_threads\'"', num_cpus)
+        expect_output = (r"\'auto({})\'".format(math.ceil(num_cpus))).encode()
+        assert result.strip() == expect_output, f"fail for cpu limit={num_cpus}, result={result.strip()}, expect={expect_output}"
+
+# For manual run
+if __name__ == '__main__':
+    test_cgroup_cpu_limit()

--- a/tests/integration/test_jemalloc_percpu_arena/test.py
+++ b/tests/integration/test_jemalloc_percpu_arena/test.py
@@ -12,7 +12,7 @@ CPU_ID = 4
 
 
 def run_command_in_container(cmd, *args):
-    # /clickhouse is mounted by interation tests runner
+    # /clickhouse is mounted by integration tests runner
     alternative_binary = os.getenv('CLICKHOUSE_BINARY', '/clickhouse')
     if alternative_binary:
         args+=(


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Respect cgroup limits for CPU quota


Detailed description / Documentation draft:
close https://github.com/ClickHouse/ClickHouse/issues/2261, close https://github.com/ClickHouse/ClickHouse/issues/25662
Try to check cgroup limits under `/sys/fs/cgroup/cpu/`. Reference: http://hg.openjdk.java.net/jdk/jdk/rev/7f22774a5f42


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
