### PR TITLE
Better cmake script for azure blob 2

### DIFF
--- a/cmake/find/blob_storage.cmake
+++ b/cmake/find/blob_storage.cmake
@@ -1,32 +1,29 @@
 option (ENABLE_AZURE_BLOB_STORAGE "Enable Azure blob storage" ${ENABLE_LIBRARIES})
 
-if (ENABLE_AZURE_BLOB_STORAGE)
-    set(USE_AZURE_BLOB_STORAGE 1)
-    set(AZURE_BLOB_STORAGE_LIBRARY azure_sdk)
-else()
-    return()
-endif()
-
 option(USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY
     "Set to FALSE to use system Azure SDK instead of bundled (OFF currently not implemented)"
     ON)
 
-if ((NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/azure/sdk"
-        OR NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/azure/cmake-modules")
-        AND USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY)
-    message (WARNING "submodule contrib/azure is missing. to fix try run: \n git submodule update --init")
-    set(USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY OFF)
-    set(USE_AZURE_BLOB_STORAGE 0)
-endif ()
+if (ENABLE_AZURE_BLOB_STORAGE)
+    set(USE_AZURE_BLOB_STORAGE 1)
+    set(AZURE_BLOB_STORAGE_LIBRARY azure_sdk)
 
-if (NOT USE_INTERNAL_SSL_LIBRARY AND USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY)
-    message (FATAL_ERROR "Currently Blob Storage support can be built only with internal SSL library")
+    if ((NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/azure/sdk"
+            OR NOT EXISTS "${ClickHouse_SOURCE_DIR}/contrib/azure/cmake-modules")
+            AND USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY)
+        message (WARNING "submodule contrib/azure is missing. to fix try run: \n git submodule update --init")
+        set(USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY OFF)
+        set(USE_AZURE_BLOB_STORAGE 0)
+    endif ()
+
+    if (NOT USE_INTERNAL_SSL_LIBRARY AND USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY)
+        message (FATAL_ERROR "Currently Blob Storage support can be built only with internal SSL library")
+    endif()
+
+    if (NOT USE_INTERNAL_CURL AND USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY)
+        message (FATAL_ERROR "Currently Blob Storage support can be built only with internal curl library")
+    endif()
+
 endif()
 
-if (NOT USE_INTERNAL_CURL AND USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY)
-    message (FATAL_ERROR "Currently Blob Storage support can be built only with internal curl library")
-endif()
-
-if (USE_AZURE_BLOB_STORAGE)
-    message (STATUS "Using Azure Blob Storage - ${USE_AZURE_BLOB_STORAGE}")
-endif()
+message (STATUS "Using Azure Blob Storage - ${USE_AZURE_BLOB_STORAGE}")

--- a/cmake/find/blob_storage.cmake
+++ b/cmake/find/blob_storage.cmake
@@ -1,10 +1,10 @@
 option (ENABLE_AZURE_BLOB_STORAGE "Enable Azure blob storage" ${ENABLE_LIBRARIES})
 
-option(USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY
-    "Set to FALSE to use system Azure SDK instead of bundled (OFF currently not implemented)"
-    ON)
-
 if (ENABLE_AZURE_BLOB_STORAGE)
+    option(USE_INTERNAL_AZURE_BLOB_STORAGE_LIBRARY
+        "Set to FALSE to use system Azure SDK instead of bundled (OFF currently not implemented)"
+        ON)
+
     set(USE_AZURE_BLOB_STORAGE 1)
     set(AZURE_BLOB_STORAGE_LIBRARY azure_sdk)
 


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid strict checking when ENABLE_AZURE_BLOB_STORAGE = 0. This is another try on behalf of https://github.com/ClickHouse/ClickHouse/pull/33219 , which was reverted likely due to CI issues.

Detailed description / Documentation draft:
.