### PR TITLE
tidy up python files in integration tests 

### DIFF
--- a/tests/ci/cherry_pick_utils/cherrypick.py
+++ b/tests/ci/cherry_pick_utils/cherrypick.py
@@ -22,7 +22,6 @@ except:
 import argparse
 from enum import Enum
 import logging
-import os
 import subprocess
 import sys
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,6 +26,7 @@ def cleanup_environment():
             logging.debug(f"No running containers")
     except Exception as e:
         logging.exception(f"cleanup_environment:{str(e)}")
+        pass
 
     yield
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,6 @@ from helpers.cluster import run_and_check
 import pytest
 import logging
 import os
-from helpers.test_tools import TSV
 from helpers.network import _NetworkManager
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,7 +27,6 @@ def cleanup_environment():
             logging.debug(f"No running containers")
     except Exception as e:
         logging.exception(f"cleanup_environment:{str(e)}")
-        pass
 
     yield
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -31,7 +31,7 @@ from kazoo.exceptions import KazooException
 from minio import Minio
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
-from helpers.test_tools import assert_eq_with_retry, exec_query_with_retry
+from helpers.test_tools import exec_query_with_retry
 from helpers import pytest_xdist_logging_to_separate_files
 from helpers.client import QueryRuntimeException
 

--- a/tests/integration/helpers/hdfs_api.py
+++ b/tests/integration/helpers/hdfs_api.py
@@ -69,7 +69,7 @@ class HDFSApi(object):
 
             os.environ["KRB5_CONFIG"] = instantiated_krb_conf
 
-            cmd = "(kinit -R -t {keytab} -k {principal} || (sleep 5 && kinit -R -t {keytab} -k {principal})) ; klist".format(instantiated_krb_conf=instantiated_krb_conf, keytab=self.keytab, principal=self.principal)
+            cmd = "(kinit -R -t {keytab} -k {principal} || (sleep 5 && kinit -R -t {keytab} -k {principal})) ; klist".format(keytab=self.keytab, principal=self.principal)
 
             start = time.time()
 
@@ -137,7 +137,7 @@ class HDFSApi(object):
         response = self.req_wrapper(requests.put, 307,
             url="{protocol}://{ip}:{port}/webhdfs/v1{path}?op=CREATE".format(protocol=self.protocol, ip=self.hdfs_ip,
                                                                             port=self.proxy_port,
-                                                                            path=path, user=self.user),
+                                                                            path=path),
             allow_redirects=False,
             headers={'host': str(self.hdfs_ip)},
             params={'overwrite' : 'true'},

--- a/tests/integration/helpers/hdfs_api.py
+++ b/tests/integration/helpers/hdfs_api.py
@@ -6,7 +6,6 @@ import time
 from tempfile import NamedTemporaryFile
 import requests
 import requests_kerberos as reqkerb
-import socket
 import tempfile
 import logging
 import os

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -217,7 +217,6 @@ class _NetworkManager:
                                                                  # /run/xtables.lock passed inside for correct iptables --wait
                                                                  volumes={'/run/xtables.lock': {'bind': '/run/xtables.lock', 'mode': 'ro' }},
                                                                  detach=True, network_mode='host')
-            container_id = self._container.id
             self._container_expire_time = time.time() + self.container_expire_timeout
 
         return self._container

--- a/tests/integration/helpers/uexpect.py
+++ b/tests/integration/helpers/uexpect.py
@@ -179,6 +179,7 @@ class IO(object):
                 raise TimeoutError(timeout)
         if not data and raise_exception:
             raise TimeoutError(timeout)
+        pass
 
         return data
 

--- a/tests/integration/helpers/uexpect.py
+++ b/tests/integration/helpers/uexpect.py
@@ -177,9 +177,9 @@ class IO(object):
                 return data
             if raise_exception:
                 raise TimeoutError(timeout)
+            pass
         if not data and raise_exception:
             raise TimeoutError(timeout)
-        pass
 
         return data
 

--- a/tests/integration/helpers/uexpect.py
+++ b/tests/integration/helpers/uexpect.py
@@ -177,7 +177,6 @@ class IO(object):
                 return data
             if raise_exception:
                 raise TimeoutError(timeout)
-            pass
         if not data and raise_exception:
             raise TimeoutError(timeout)
 

--- a/tests/integration/test_attach_without_fetching/test.py
+++ b/tests/integration/test_attach_without_fetching/test.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 import logging
 

--- a/tests/integration/test_broken_part_during_merge/test.py
+++ b/tests/integration/test_broken_part_during_merge/test.py
@@ -4,7 +4,6 @@ from helpers.cluster import ClickHouseCluster
 from multiprocessing.dummy import Pool
 from helpers.network import PartitionManager
 from helpers.corrupt_part_data_on_disk import corrupt_part_data_on_disk
-import time
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_broken_part_during_merge/test.py
+++ b/tests/integration/test_broken_part_during_merge/test.py
@@ -2,7 +2,6 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 from multiprocessing.dummy import Pool
-from helpers.network import PartitionManager
 from helpers.corrupt_part_data_on_disk import corrupt_part_data_on_disk
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_catboost_model_config_reload/test.py
+++ b/tests/integration/test_catboost_model_config_reload/test.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 
 import pytest
 

--- a/tests/integration/test_catboost_model_first_evaluate/test.py
+++ b/tests/integration/test_catboost_model_first_evaluate/test.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 
 import pytest
 

--- a/tests/integration/test_catboost_model_reload/test.py
+++ b/tests/integration/test_catboost_model_reload/test.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 
 import pytest
 

--- a/tests/integration/test_cluster_copier/test.py
+++ b/tests/integration/test_cluster_copier/test.py
@@ -9,7 +9,6 @@ import random
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-import docker
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))

--- a/tests/integration/test_cluster_copier/test.py
+++ b/tests/integration/test_cluster_copier/test.py
@@ -6,7 +6,6 @@ import kazoo
 import pytest
 import string
 import random
-from contextlib import contextmanager
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 

--- a/tests/integration/test_cluster_copier/test_three_nodes.py
+++ b/tests/integration/test_cluster_copier/test_three_nodes.py
@@ -7,7 +7,6 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-import docker
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))

--- a/tests/integration/test_cluster_copier/test_trivial.py
+++ b/tests/integration/test_cluster_copier/test_trivial.py
@@ -9,7 +9,6 @@ from helpers.test_tools import TSV
 
 import kazoo
 import pytest
-import docker
 
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/integration/test_cluster_copier/test_two_nodes.py
+++ b/tests/integration/test_cluster_copier/test_two_nodes.py
@@ -7,7 +7,6 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-import docker
 
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))

--- a/tests/integration/test_codec_encrypted/test.py
+++ b/tests/integration/test_codec_encrypted/test.py
@@ -1,7 +1,5 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_compression_codec_read/test.py
+++ b/tests/integration/test_compression_codec_read/test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_compression_nested_columns/test.py
+++ b/tests/integration/test_compression_nested_columns/test.py
@@ -1,5 +1,3 @@
-import random
-import string
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_concurrent_queries_restriction_by_query_kind/test.py
+++ b/tests/integration/test_concurrent_queries_restriction_by_query_kind/test.py
@@ -1,5 +1,4 @@
 import time
-from multiprocessing.dummy import Pool
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_config_xml_full/test.py
+++ b/tests/integration/test_config_xml_full/test.py
@@ -1,6 +1,4 @@
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_xml_full/test.py
+++ b/tests/integration/test_config_xml_full/test.py
@@ -1,7 +1,3 @@
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
 import helpers
 import pytest

--- a/tests/integration/test_config_xml_main/test.py
+++ b/tests/integration/test_config_xml_main/test.py
@@ -1,9 +1,5 @@
 
 
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
 import helpers
 import pytest

--- a/tests/integration/test_config_xml_main/test.py
+++ b/tests/integration/test_config_xml_main/test.py
@@ -1,8 +1,6 @@
 
 
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_xml_yaml_mix/test.py
+++ b/tests/integration/test_config_xml_yaml_mix/test.py
@@ -1,6 +1,4 @@
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_xml_yaml_mix/test.py
+++ b/tests/integration/test_config_xml_yaml_mix/test.py
@@ -1,7 +1,3 @@
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
 import helpers
 import pytest

--- a/tests/integration/test_config_yaml_full/test.py
+++ b/tests/integration/test_config_yaml_full/test.py
@@ -1,6 +1,4 @@
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 def test_yaml_full_conf():

--- a/tests/integration/test_config_yaml_full/test.py
+++ b/tests/integration/test_config_yaml_full/test.py
@@ -1,7 +1,3 @@
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
 import helpers
 import pytest

--- a/tests/integration/test_config_yaml_main/test.py
+++ b/tests/integration/test_config_yaml_main/test.py
@@ -1,6 +1,4 @@
 
-import helpers
-import pytest
 from helpers.cluster import ClickHouseCluster
 
 

--- a/tests/integration/test_config_yaml_main/test.py
+++ b/tests/integration/test_config_yaml_main/test.py
@@ -1,7 +1,3 @@
-import time
-import threading
-from os import path as p, unlink
-from tempfile import NamedTemporaryFile
 
 import helpers
 import pytest

--- a/tests/integration/test_ddl_worker_non_leader/test.py
+++ b/tests/integration/test_ddl_worker_non_leader/test.py
@@ -2,7 +2,6 @@ import pytest
 import time
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
-from helpers.client import QueryRuntimeException
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/remote_servers.xml'], with_zookeeper=True)

--- a/tests/integration/test_default_compression_codec/test.py
+++ b/tests/integration/test_default_compression_codec/test.py
@@ -2,7 +2,6 @@ import random
 import string
 import logging
 import pytest
-import time
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
@@ -1,5 +1,4 @@
 import os
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceCassandra
 
 SOURCE = None

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
@@ -1,5 +1,4 @@
 import os 
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceClickHouse
 
 SOURCE = SourceClickHouse("LocalClickHouse", "localhost", "9000", "local_node", "9000", "default", "")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
@@ -1,5 +1,4 @@
 import os
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceClickHouse
 
 SOURCE = SourceClickHouse("RemoteClickHouse", "localhost", "9000", "clickhouse_remote", "9000", "default", "")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_cache.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_cache.py
@@ -1,5 +1,4 @@
 import os 
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_cache.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_cache.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceExecutableCache
 
 SOURCE = SourceExecutableCache("ExecutableCache", "localhost", "9000", "cache_node", "9000", "", "")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
@@ -1,5 +1,4 @@
 import os 
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceExecutableHashed
 
 SOURCE = SourceExecutableHashed("ExecutableHashed", "localhost", "9000", "hashed_node", "9000", "", "")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
@@ -1,5 +1,4 @@
 import os
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceFile
 
 SOURCE = SourceFile("File", "localhost", "9000", "file_node", "9000", "", "")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
@@ -1,5 +1,4 @@
 import os
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceHTTP
 
 SOURCE = SourceHTTP("SourceHTTP", "localhost", "9000", "clickhouse_h", "9000", "", "")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceHTTPS
 
 SOURCE = SourceHTTPS("SourceHTTPS", "localhost", "9000", "clickhouse_hs", "9000", "", "")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
@@ -1,5 +1,4 @@
 import os
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceMongo
 
 SOURCE = None

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
@@ -1,5 +1,4 @@
 import os
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo_uri.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo_uri.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceMongoURI
 
 SOURCE = None

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo_uri.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo_uri.py
@@ -1,5 +1,4 @@
 import os 
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
@@ -1,5 +1,4 @@
 import os
-import math
 import pytest
 
 from .common import *

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
@@ -4,7 +4,6 @@ import pytest
 from .common import *
 
 from helpers.cluster import ClickHouseCluster
-from helpers.dictionary import Field, Row, Dictionary, DictionaryStructure, Layout
 from helpers.external_sources import SourceMySQL
 
 SOURCE = None

--- a/tests/integration/test_dictionaries_config_reload/test.py
+++ b/tests/integration/test_dictionaries_config_reload/test.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import time
-import logging
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/integration/test_dictionaries_postgresql/test.py
+++ b/tests/integration/test_dictionaries_postgresql/test.py
@@ -1,7 +1,6 @@
 import pytest
 import time
 import psycopg2
-from multiprocessing.dummy import Pool
 
 from helpers.cluster import ClickHouseCluster
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT

--- a/tests/integration/test_dictionaries_update_field/test.py
+++ b/tests/integration/test_dictionaries_update_field/test.py
@@ -3,7 +3,6 @@ import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.cluster import ClickHouseKiller
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
@@ -1,6 +1,5 @@
 
 
-import os
 import random
 import string
 import time

--- a/tests/integration/test_disabled_mysql_server/test.py
+++ b/tests/integration/test_disabled_mysql_server/test.py
@@ -1,9 +1,6 @@
-import time
 import contextlib
 import pymysql.cursors
 import pytest
-import os
-import subprocess
 
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster, get_docker_compose_path

--- a/tests/integration/test_disabled_mysql_server/test.py
+++ b/tests/integration/test_disabled_mysql_server/test.py
@@ -2,8 +2,7 @@ import contextlib
 import pymysql.cursors
 import pytest
 
-from helpers.client import QueryRuntimeException
-from helpers.cluster import ClickHouseCluster, get_docker_compose_path
+from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_disk_over_web_server/test.py
+++ b/tests/integration/test_disk_over_web_server/test.py
@@ -48,9 +48,9 @@ def test_usage(cluster, node_name):
             ATTACH TABLE test{} UUID '{}'
             (id Int32) ENGINE = MergeTree() ORDER BY id
             SETTINGS storage_policy = 'web';
-        """.format(i, uuids[i], i, i))
+        """.format(i, uuids[i]))
 
-        result = node2.query("SELECT * FROM test{} settings max_threads=20".format(i))
+        node2.query("SELECT * FROM test{} settings max_threads=20".format(i))
 
         result = node2.query("SELECT count() FROM test{}".format(i))
         assert(int(result) == 500000 * (i+1))

--- a/tests/integration/test_disk_over_web_server/test.py
+++ b/tests/integration/test_disk_over_web_server/test.py
@@ -66,7 +66,6 @@ def test_usage(cluster, node_name):
 
 
 def test_incorrect_usage(cluster):
-    node1 = cluster.instances["node1"]
     node2 = cluster.instances["node3"]
     global uuids
     node2.query("""

--- a/tests/integration/test_distributed_ddl/test.py
+++ b/tests/integration/test_distributed_ddl/test.py
@@ -7,7 +7,6 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from helpers.network import PartitionManager
 from helpers.test_tools import TSV
 from .cluster import ClickHouseClusterWithDDLHelpers
 

--- a/tests/integration/test_drop_replica/test.py
+++ b/tests/integration/test_drop_replica/test.py
@@ -1,4 +1,3 @@
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_drop_replica/test.py
+++ b/tests/integration/test_drop_replica/test.py
@@ -1,7 +1,6 @@
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
 
 
 def fill_nodes(nodes, shard):

--- a/tests/integration/test_executable_dictionary/user_scripts/input.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 import sys
-import os
-import signal
 
 if __name__ == '__main__':
     for line in sys.stdin:

--- a/tests/integration/test_executable_dictionary/user_scripts/input_implicit_signalled.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input_implicit_signalled.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import signal
-import time
 
 if __name__ == '__main__':
     for line in sys.stdin:

--- a/tests/integration/test_executable_dictionary/user_scripts/input_implicit_slow.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input_implicit_slow.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 import sys
-import os
-import signal
 import time
 
 if __name__ == '__main__':

--- a/tests/integration/test_executable_dictionary/user_scripts/input_signalled.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input_signalled.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import signal
-import time
 
 if __name__ == '__main__':
     for line in sys.stdin:

--- a/tests/integration/test_executable_dictionary/user_scripts/input_slow.py
+++ b/tests/integration/test_executable_dictionary/user_scripts/input_slow.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 import sys
-import os
-import signal
 import time
 
 if __name__ == '__main__':

--- a/tests/integration/test_executable_user_defined_function/test.py
+++ b/tests/integration/test_executable_user_defined_function/test.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 
 import pytest
 

--- a/tests/integration/test_executable_user_defined_function/user_scripts/input_signalled.py
+++ b/tests/integration/test_executable_user_defined_function/user_scripts/input_signalled.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import signal
-import time
 
 if __name__ == '__main__':
     for line in sys.stdin:

--- a/tests/integration/test_executable_user_defined_function/user_scripts/input_slow.py
+++ b/tests/integration/test_executable_user_defined_function/user_scripts/input_slow.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 import sys
-import os
-import signal
 import time
 
 if __name__ == '__main__':

--- a/tests/integration/test_executable_user_defined_functions_config_reload/test.py
+++ b/tests/integration/test_executable_user_defined_functions_config_reload/test.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import time
-import logging
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/integration/test_extreme_deduplication/test.py
+++ b/tests/integration/test_extreme_deduplication/test.py
@@ -24,7 +24,6 @@ def started_cluster():
         yield cluster
 
     finally:
-        pass
         cluster.shutdown()
 
 

--- a/tests/integration/test_fetch_partition_should_reset_mutation/test.py
+++ b/tests/integration/test_fetch_partition_should_reset_mutation/test.py
@@ -1,5 +1,4 @@
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 

--- a/tests/integration/test_fetch_partition_with_outdated_parts/test.py
+++ b/tests/integration/test_fetch_partition_with_outdated_parts/test.py
@@ -1,7 +1,5 @@
 from __future__ import print_function
 from helpers.cluster import ClickHouseCluster
-from helpers.client import QueryRuntimeException
-import helpers
 import pytest
 
 

--- a/tests/integration/test_hedged_requests/test.py
+++ b/tests/integration/test_hedged_requests/test.py
@@ -7,7 +7,6 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_hedged_requests_parallel/test.py
+++ b/tests/integration/test_hedged_requests_parallel/test.py
@@ -7,7 +7,6 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_host_ip_change/test.py
+++ b/tests/integration/test_host_ip_change/test.py
@@ -93,6 +93,7 @@ def cluster_with_dns_cache_update():
 
     finally:
         cluster.shutdown()
+        pass
 
 
 # node3 is a source, node4 downloads data

--- a/tests/integration/test_host_ip_change/test.py
+++ b/tests/integration/test_host_ip_change/test.py
@@ -39,7 +39,6 @@ def cluster_without_dns_cache_update():
 
     finally:
         cluster.shutdown()
-        pass
 
 
 # node1 is a source, node2 downloads data
@@ -94,7 +93,6 @@ def cluster_with_dns_cache_update():
 
     finally:
         cluster.shutdown()
-        pass
 
 
 # node3 is a source, node4 downloads data

--- a/tests/integration/test_host_ip_change/test.py
+++ b/tests/integration/test_host_ip_change/test.py
@@ -93,7 +93,6 @@ def cluster_with_dns_cache_update():
 
     finally:
         cluster.shutdown()
-        pass
 
 
 # node3 is a source, node4 downloads data

--- a/tests/integration/test_jbod_balancer/test.py
+++ b/tests/integration/test_jbod_balancer/test.py
@@ -1,8 +1,3 @@
-import json
-import random
-import re
-import string
-import threading
 import time
 from multiprocessing.dummy import Pool
 

--- a/tests/integration/test_jbod_balancer/test.py
+++ b/tests/integration/test_jbod_balancer/test.py
@@ -2,7 +2,6 @@ import time
 from multiprocessing.dummy import Pool
 
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_jdbc_bridge/test.py
+++ b/tests/integration/test_jdbc_bridge/test.py
@@ -1,11 +1,9 @@
 import logging
-import os.path as p
 import pytest
 import uuid
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-from string import Template
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance("instance", main_configs=["configs/jdbc_bridge.xml"], with_jdbc_bridge=True)

--- a/tests/integration/test_join_set_family_s3/test.py
+++ b/tests/integration/test_join_set_family_s3/test.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_keeper_auth/test.py
+++ b/tests/integration/test_keeper_auth/test.py
@@ -1,8 +1,8 @@
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from kazoo.client import KazooClient, KazooState
-from kazoo.security import ACL, make_digest_acl, make_acl
+from kazoo.client import KazooClient
+from kazoo.security import make_acl
 from kazoo.exceptions import AuthFailedError, InvalidACLError, NoAuthError, KazooException
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_keeper_back_to_back/test.py
+++ b/tests/integration/test_keeper_back_to_back/test.py
@@ -8,7 +8,7 @@ from multiprocessing.dummy import Pool
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', main_configs=['configs/enable_keeper.xml'], with_zookeeper=True, use_keeper=False)
-from kazoo.client import KazooClient, KazooState, KeeperState
+from kazoo.client import KazooClient, KazooState
 
 def get_genuine_zk():
     print("Zoo1", cluster.get_instance_ip("zoo1"))

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -2,8 +2,6 @@ import socket
 import pytest
 from helpers.cluster import ClickHouseCluster
 import time
-from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
 import csv
 import re
 
@@ -15,7 +13,7 @@ node2 = cluster.add_instance('node2', main_configs=['configs/enable_keeper2.xml'
 node3 = cluster.add_instance('node3', main_configs=['configs/enable_keeper3.xml'],
                              stay_alive=True)
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -1,14 +1,9 @@
 import socket
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
 import time
-from multiprocessing.dummy import Pool
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
-from io import StringIO
 import csv
 import re
 

--- a/tests/integration/test_keeper_four_word_command/test_white_list.py
+++ b/tests/integration/test_keeper_four_word_command/test_white_list.py
@@ -8,7 +8,7 @@ node1 = cluster.add_instance('node1', main_configs=['configs/keeper_config_with_
 node2 = cluster.add_instance('node2', main_configs=['configs/keeper_config_without_white_list.xml'], stay_alive=True)
 node3 = cluster.add_instance('node3', main_configs=['configs/keeper_config_with_white_list_all.xml'], stay_alive=True)
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -8,7 +8,7 @@ node1 = cluster.add_instance('node1', main_configs=['configs/enable_secure_keepe
 node2 = cluster.add_instance('node2', main_configs=['configs/enable_secure_keeper2.xml', 'configs/ssl_conf.xml', 'configs/server.crt', 'configs/server.key', 'configs/rootCA.pem'])
 node3 = cluster.add_instance('node3', main_configs=['configs/enable_secure_keeper3.xml', 'configs/ssl_conf.xml', 'configs/server.crt', 'configs/server.key', 'configs/rootCA.pem'])
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_keeper_internal_secure/test.py
+++ b/tests/integration/test_keeper_internal_secure/test.py
@@ -2,10 +2,6 @@
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
-import time
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/enable_secure_keeper1.xml', 'configs/ssl_conf.xml', 'configs/server.crt', 'configs/server.key', 'configs/rootCA.pem'])

--- a/tests/integration/test_keeper_multinode_blocade_leader/test.py
+++ b/tests/integration/test_keeper_multinode_blocade_leader/test.py
@@ -1,10 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
 import time
-from multiprocessing.dummy import Pool
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
 

--- a/tests/integration/test_keeper_multinode_blocade_leader/test.py
+++ b/tests/integration/test_keeper_multinode_blocade_leader/test.py
@@ -9,7 +9,7 @@ node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml'
 node2 = cluster.add_instance('node2', main_configs=['configs/enable_keeper2.xml', 'configs/use_keeper.xml'], stay_alive=True)
 node3 = cluster.add_instance('node3', main_configs=['configs/enable_keeper3.xml', 'configs/use_keeper.xml'], stay_alive=True)
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 """
 In this test, we blockade RAFT leader and check that the whole system is

--- a/tests/integration/test_keeper_multinode_simple/test.py
+++ b/tests/integration/test_keeper_multinode_simple/test.py
@@ -1,10 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
 import time
-from multiprocessing.dummy import Pool
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
 

--- a/tests/integration/test_keeper_multinode_simple/test.py
+++ b/tests/integration/test_keeper_multinode_simple/test.py
@@ -9,7 +9,7 @@ node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml'
 node2 = cluster.add_instance('node2', main_configs=['configs/enable_keeper2.xml', 'configs/use_keeper.xml'], stay_alive=True)
 node3 = cluster.add_instance('node3', main_configs=['configs/enable_keeper3.xml', 'configs/use_keeper.xml'], stay_alive=True)
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_keeper_nodes_add/test.py
+++ b/tests/integration/test_keeper_nodes_add/test.py
@@ -4,9 +4,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 import os
 from multiprocessing.dummy import Pool
-from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'configs')

--- a/tests/integration/test_keeper_nodes_add/test.py
+++ b/tests/integration/test_keeper_nodes_add/test.py
@@ -2,10 +2,7 @@
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
 import os
-import time
 from multiprocessing.dummy import Pool
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry

--- a/tests/integration/test_keeper_nodes_move/test.py
+++ b/tests/integration/test_keeper_nodes_move/test.py
@@ -5,8 +5,6 @@
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
 import os
 import time
 from multiprocessing.dummy import Pool

--- a/tests/integration/test_keeper_nodes_move/test.py
+++ b/tests/integration/test_keeper_nodes_move/test.py
@@ -8,9 +8,7 @@ from helpers.cluster import ClickHouseCluster
 import os
 import time
 from multiprocessing.dummy import Pool
-from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'configs')

--- a/tests/integration/test_keeper_nodes_remove/test.py
+++ b/tests/integration/test_keeper_nodes_remove/test.py
@@ -3,7 +3,7 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 import os
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'configs')

--- a/tests/integration/test_keeper_persistent_log/test.py
+++ b/tests/integration/test_keeper_persistent_log/test.py
@@ -4,7 +4,6 @@ from helpers.cluster import ClickHouseCluster
 import random
 import string
 import os
-import time
 from kazoo.client import KazooClient, KazooState
 
 

--- a/tests/integration/test_keeper_persistent_log/test.py
+++ b/tests/integration/test_keeper_persistent_log/test.py
@@ -4,7 +4,7 @@ from helpers.cluster import ClickHouseCluster
 import random
 import string
 import os
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_keeper_persistent_log_multinode/test.py
+++ b/tests/integration/test_keeper_persistent_log_multinode/test.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
-import time
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml', 'configs/use_keeper.xml'], stay_alive=True)

--- a/tests/integration/test_keeper_persistent_log_multinode/test.py
+++ b/tests/integration/test_keeper_persistent_log_multinode/test.py
@@ -7,7 +7,7 @@ node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml'
 node2 = cluster.add_instance('node2', main_configs=['configs/enable_keeper2.xml', 'configs/use_keeper.xml'], stay_alive=True)
 node3 = cluster.add_instance('node3', main_configs=['configs/enable_keeper3.xml', 'configs/use_keeper.xml'], stay_alive=True)
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_keeper_restore_from_snapshot/test.py
+++ b/tests/integration/test_keeper_restore_from_snapshot/test.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
-import time
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml'], stay_alive=True)

--- a/tests/integration/test_keeper_restore_from_snapshot/test.py
+++ b/tests/integration/test_keeper_restore_from_snapshot/test.py
@@ -7,7 +7,7 @@ node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml'
 node2 = cluster.add_instance('node2', main_configs=['configs/enable_keeper2.xml'], stay_alive=True)
 node3 = cluster.add_instance('node3', main_configs=['configs/enable_keeper3.xml'], stay_alive=True)
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_keeper_secure_client/test.py
+++ b/tests/integration/test_keeper_secure_client/test.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 import pytest
 from helpers.cluster import ClickHouseCluster
-import string
-import os
-import time
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/enable_secure_keeper.xml', 'configs/ssl_conf.xml', "configs/dhparam.pem", "configs/server.crt", "configs/server.key"])

--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -5,9 +5,7 @@ from helpers.cluster import ClickHouseCluster
 from multiprocessing.dummy import Pool
 from kazoo.client import KazooClient, KazooState
 import random
-import string
 import os
-import time
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/keeper_config1.xml'], stay_alive=True)

--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -3,7 +3,7 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 from multiprocessing.dummy import Pool
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 import random
 import os
 

--- a/tests/integration/test_keeper_snapshots/test.py
+++ b/tests/integration/test_keeper_snapshots/test.py
@@ -6,7 +6,6 @@ from helpers.cluster import ClickHouseCluster
 import random
 import string
 import os
-import time
 from kazoo.client import KazooClient, KazooState
 
 

--- a/tests/integration/test_keeper_snapshots/test.py
+++ b/tests/integration/test_keeper_snapshots/test.py
@@ -6,7 +6,7 @@ from helpers.cluster import ClickHouseCluster
 import random
 import string
 import os
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_keeper_snapshots_multinode/test.py
+++ b/tests/integration/test_keeper_snapshots_multinode/test.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
-import time
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml'], stay_alive=True)

--- a/tests/integration/test_keeper_snapshots_multinode/test.py
+++ b/tests/integration/test_keeper_snapshots_multinode/test.py
@@ -7,7 +7,7 @@ node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml'
 node2 = cluster.add_instance('node2', main_configs=['configs/enable_keeper2.xml'], stay_alive=True)
 node3 = cluster.add_instance('node3', main_configs=['configs/enable_keeper3.xml'], stay_alive=True)
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_keeper_three_nodes_start/test.py
+++ b/tests/integration/test_keeper_three_nodes_start/test.py
@@ -3,11 +3,6 @@
 #!/usr/bin/env python3
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
-import time
-from multiprocessing.dummy import Pool
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
 from kazoo.client import KazooClient, KazooState

--- a/tests/integration/test_keeper_three_nodes_start/test.py
+++ b/tests/integration/test_keeper_three_nodes_start/test.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 
 #!/usr/bin/env python3
-import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml'], stay_alive=True)

--- a/tests/integration/test_keeper_three_nodes_two_alive/test.py
+++ b/tests/integration/test_keeper_three_nodes_two_alive/test.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
 import time
 from multiprocessing.dummy import Pool
 from helpers.network import PartitionManager

--- a/tests/integration/test_keeper_three_nodes_two_alive/test.py
+++ b/tests/integration/test_keeper_three_nodes_two_alive/test.py
@@ -3,9 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 import time
 from multiprocessing.dummy import Pool
-from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml', 'configs/keeper_conf.xml'], stay_alive=True)

--- a/tests/integration/test_keeper_two_nodes_cluster/test.py
+++ b/tests/integration/test_keeper_two_nodes_cluster/test.py
@@ -4,13 +4,12 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 import time
 from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', main_configs=['configs/enable_keeper1.xml', 'configs/use_keeper.xml'], stay_alive=True)
 node2 = cluster.add_instance('node2', main_configs=['configs/enable_keeper2.xml', 'configs/use_keeper.xml'], stay_alive=True)
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_keeper_two_nodes_cluster/test.py
+++ b/tests/integration/test_keeper_two_nodes_cluster/test.py
@@ -2,11 +2,7 @@
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-import random
-import string
-import os
 import time
-from multiprocessing.dummy import Pool
 from helpers.network import PartitionManager
 from helpers.test_tools import assert_eq_with_retry
 

--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 import pytest
 from helpers.cluster import ClickHouseCluster
-from kazoo.client import KazooClient, KazooState
-from kazoo.security import ACL, make_digest_acl, make_acl
-from kazoo.exceptions import AuthFailedError, InvalidACLError, NoAuthError, KazooException
+from kazoo.client import KazooClient
+from kazoo.security import make_acl
 import os
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_library_bridge/test.py
+++ b/tests/integration/test_library_bridge/test.py
@@ -1,5 +1,4 @@
 import os
-import os.path as p
 import pytest
 import time
 import logging

--- a/tests/integration/test_library_bridge/test.py
+++ b/tests/integration/test_library_bridge/test.py
@@ -3,7 +3,7 @@ import pytest
 import time
 import logging
 
-from helpers.cluster import ClickHouseCluster, run_and_check
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_library_bridge/test.py
+++ b/tests/integration/test_library_bridge/test.py
@@ -31,7 +31,6 @@ def ch_cluster():
     try:
         cluster.start()
         instance.query('CREATE DATABASE test')
-        container_lib_path = '/etc/clickhouse-server/config.d/dictionarites_lib/dict_lib.cpp'
 
         instance.copy_file_to_container(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/dict_lib.cpp"),
                                                         "/etc/clickhouse-server/config.d/dictionaries_lib/dict_lib.cpp")

--- a/tests/integration/test_log_family_hdfs/test.py
+++ b/tests/integration/test_log_family_hdfs/test.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_log_family_s3/test.py
+++ b/tests/integration/test_log_family_s3/test.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_log_lz4_streaming/test.py
+++ b/tests/integration/test_log_lz4_streaming/test.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_lost_part_during_startup/test.py
+++ b/tests/integration/test_lost_part_during_startup/test.py
@@ -3,7 +3,6 @@ import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_zookeeper=True, stay_alive=True)

--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -5,7 +5,6 @@ import pytest
 from helpers.network import PartitionManager
 import logging
 from helpers.client import QueryRuntimeException
-from helpers.cluster import get_docker_compose_path, run_and_check
 
 import threading
 from helpers.test_tools import assert_eq_with_retry

--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -6,10 +6,8 @@ from helpers.network import PartitionManager
 import logging
 from helpers.client import QueryRuntimeException
 from helpers.cluster import get_docker_compose_path, run_and_check
-import random
 
 import threading
-from multiprocessing.dummy import Pool
 from helpers.test_tools import assert_eq_with_retry
 
 def check_query(clickhouse_node, query, result_set, retry_count=10, interval_seconds=3):

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -1,8 +1,4 @@
-import os
-import os.path as p
 import time
-import pwd
-import re
 import pymysql.cursors
 import pytest
 from helpers.cluster import ClickHouseCluster, ClickHouseInstance, get_docker_compose_path, run_and_check

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -1,8 +1,7 @@
 import time
 import pymysql.cursors
 import pytest
-from helpers.cluster import ClickHouseCluster, ClickHouseInstance, get_docker_compose_path, run_and_check
-import docker
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance, get_docker_compose_path
 import logging
 
 from . import materialize_with_ddl

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -188,7 +188,6 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical, node_name):
 def test_alter_table_columns(cluster, node_name):
     node = cluster.instances[node_name]
     create_table(node, "s3_test")
-    minio = cluster.minio_client
 
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-03', 4096)))
     node.query("INSERT INTO s3_test VALUES {}".format(generate_values('2020-01-03', 4096, -1)))

--- a/tests/integration/test_mutations_hardlinks/test.py
+++ b/tests/integration/test_mutations_hardlinks/test.py
@@ -123,6 +123,7 @@ def test_delete_and_drop_mutation(started_cluster):
                 break
         except:
             print("Result", result)
+            pass
 
         time.sleep(0.5)
 

--- a/tests/integration/test_mutations_hardlinks/test.py
+++ b/tests/integration/test_mutations_hardlinks/test.py
@@ -123,7 +123,6 @@ def test_delete_and_drop_mutation(started_cluster):
                 break
         except:
             print("Result", result)
-            pass
 
         time.sleep(0.5)
 

--- a/tests/integration/test_mutations_with_merge_tree/test.py
+++ b/tests/integration/test_mutations_with_merge_tree/test.py
@@ -179,12 +179,10 @@ def test_mutations_will_not_hang_for_non_existing_parts_async(started_cluster):
         def count_and_sum_is_done():
             return instance_test_mutations.query(f"SELECT count(), sum(is_done) FROM system.mutations WHERE table = '{name}' SETTINGS force_index_by_date = 0, force_primary_key = 0 FORMAT CSV").splitlines()
 
-        all_done = False
         for wait_times_for_mutation in range(100):  # wait for replication 80 seconds max
             time.sleep(0.8)
 
             if count_and_sum_is_done() == ["34,34"]:
-                all_done = True
                 break
 
         print(instance_test_mutations.query(

--- a/tests/integration/test_odbc_interaction/test.py
+++ b/tests/integration/test_odbc_interaction/test.py
@@ -4,7 +4,6 @@ import psycopg2
 import pymysql.cursors
 import pytest
 import logging
-import os.path
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry

--- a/tests/integration/test_optimize_on_insert/test.py
+++ b/tests/integration/test_optimize_on_insert/test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_partition/test.py
+++ b/tests/integration/test_partition/test.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 

--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -5,7 +5,6 @@ import struct
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
 from helpers.test_tools import TSV
 from helpers.test_tools import assert_eq_with_retry, exec_query_with_retry
 

--- a/tests/integration/test_postgresql_database_engine/test.py
+++ b/tests/integration/test_postgresql_database_engine/test.py
@@ -2,7 +2,6 @@ import pytest
 import psycopg2
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_postgresql_database_engine/test.py
+++ b/tests/integration/test_postgresql_database_engine/test.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 import psycopg2
 
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_postgresql_replica_database_engine_1/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_1/test.py
@@ -1,7 +1,6 @@
 import pytest
 import time
 import psycopg2
-import os.path as p
 import random
 
 from helpers.cluster import ClickHouseCluster
@@ -9,7 +8,6 @@ from helpers.test_tools import assert_eq_with_retry
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from helpers.test_tools import TSV
 
-from random import randrange
 import threading
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_postgresql_replica_database_engine_1/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_1/test.py
@@ -4,9 +4,7 @@ import psycopg2
 import random
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-from helpers.test_tools import TSV
 
 import threading
 

--- a/tests/integration/test_postgresql_replica_database_engine_2/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_2/test.py
@@ -6,7 +6,6 @@ import random
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-from helpers.test_tools import TSV
 
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_postgresql_replica_database_engine_2/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_2/test.py
@@ -1,7 +1,6 @@
 import pytest
 import time
 import psycopg2
-import os.path as p
 import random
 
 from helpers.cluster import ClickHouseCluster
@@ -9,8 +8,6 @@ from helpers.test_tools import assert_eq_with_retry
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from helpers.test_tools import TSV
 
-from random import randrange
-import threading
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance',

--- a/tests/integration/test_profile_events_s3/test.py
+++ b/tests/integration/test_profile_events_s3/test.py
@@ -158,7 +158,7 @@ def test_profile_events(cluster):
         "get_requests"]
     assert metrics3["S3WriteRequestsCount"] - metrics2["S3WriteRequestsCount"] == minio3["set_requests"] - minio2[
         "set_requests"]
-    stat3 = get_query_stat(instance, query3)
+    # stat3 = get_query_stat(instance, query3)
     # With async reads profile events are not updated fully because reads are done in a separate thread.
     #for metric in stat3:
     #    print(metric)

--- a/tests/integration/test_random_inserts/test.py
+++ b/tests/integration/test_random_inserts/test.py
@@ -27,7 +27,6 @@ def started_cluster():
         yield cluster
 
     finally:
-        pass
         cluster.shutdown()
 
 

--- a/tests/integration/test_recovery_replica/test.py
+++ b/tests/integration/test_recovery_replica/test.py
@@ -1,4 +1,3 @@
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_reload_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_reload_auxiliary_zookeepers/test.py
@@ -3,7 +3,6 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException
-from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", with_zookeeper=True)

--- a/tests/integration/test_reload_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_reload_auxiliary_zookeepers/test.py
@@ -1,6 +1,5 @@
 import time
 import pytest
-import os
 
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException

--- a/tests/integration/test_reload_clusters_config/test.py
+++ b/tests/integration/test_reload_clusters_config/test.py
@@ -6,8 +6,6 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', with_zookeeper=True, main_configs=['configs/remote_servers.xml'])

--- a/tests/integration/test_reload_clusters_config/test.py
+++ b/tests/integration/test_reload_clusters_config/test.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 
 import pytest
 

--- a/tests/integration/test_reload_zookeeper/test.py
+++ b/tests/integration/test_reload_zookeeper/test.py
@@ -1,6 +1,5 @@
 import time
 import pytest
-import os
 
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException

--- a/tests/integration/test_rename_column/test.py
+++ b/tests/integration/test_rename_column/test.py
@@ -129,7 +129,7 @@ def insert(node, table_name, chunk=1000, col_names=None, iterations=1, ignore_ex
             node.query(";\n".join(query))
         except QueryRuntimeException as ex:
             if not ignore_exception:
-                raise
+                raise ex
 
 
 def select(node, table_name, col_name="num", expected_result=None, iterations=1, ignore_exception=False, slow=False,
@@ -150,7 +150,7 @@ def select(node, table_name, col_name="num", expected_result=None, iterations=1,
                     assert r == expected_result
             except QueryRuntimeException as ex:
                 if not ignore_exception:
-                    raise
+                    raise ex
             break
 
 
@@ -162,7 +162,7 @@ def rename_column(node, table_name, name, new_name, iterations=1, ignore_excepti
             ))
         except QueryRuntimeException as ex:
             if not ignore_exception:
-                raise
+                raise ex
 
 
 def rename_column_on_cluster(node, table_name, name, new_name, iterations=1, ignore_exception=False):
@@ -173,7 +173,7 @@ def rename_column_on_cluster(node, table_name, name, new_name, iterations=1, ign
             ))
         except QueryRuntimeException as ex:
             if not ignore_exception:
-                raise
+                raise ex
 
 
 def alter_move(node, table_name, iterations=1, ignore_exception=False):
@@ -185,7 +185,7 @@ def alter_move(node, table_name, iterations=1, ignore_exception=False):
                        .format(table_name=table_name, move_part=move_part, move_volume=move_volume))
         except QueryRuntimeException as ex:
             if not ignore_exception:
-                raise
+                raise ex
 
 
 def test_rename_parallel_same_node(started_cluster):

--- a/tests/integration/test_replica_is_active/test.py
+++ b/tests/integration/test_replica_is_active/test.py
@@ -1,5 +1,4 @@
 import pytest
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -377,8 +377,8 @@ def test_recover_staled_replica(started_cluster):
 
         inner_table = ".inner_id." + dummy_node.query_with_retry("SELECT uuid FROM system.tables WHERE database='recover' AND name='mv1'").strip()
         main_node.query_with_retry("ALTER TABLE recover.`{}` MODIFY COLUMN n int DEFAULT 42".format(inner_table), settings=settings)
-        main_node.query_with_retry("ALTER TABLE recover.mv1 MODIFY QUERY SELECT m FROM recover.rmt1".format(inner_table), settings=settings)
-        main_node.query_with_retry("RENAME TABLE recover.mv2 TO recover.mv3".format(inner_table), settings=settings)
+        main_node.query_with_retry("ALTER TABLE recover.mv1 MODIFY QUERY SELECT m FROM recover.rmt1", settings=settings)
+        main_node.query_with_retry("RENAME TABLE recover.mv2 TO recover.mv3", settings=settings)
 
         main_node.query_with_retry("CREATE TABLE recover.tmp AS recover.m1", settings=settings)
         main_node.query_with_retry("DROP TABLE recover.tmp", settings=settings)

--- a/tests/integration/test_replicated_fetches_bandwidth/test.py
+++ b/tests/integration/test_replicated_fetches_bandwidth/test.py
@@ -4,7 +4,6 @@ import pytest
 import random
 import string
 from helpers.network import NetThroughput
-import subprocess
 import time
 import statistics
 

--- a/tests/integration/test_replicated_merge_tree_encrypted_disk/test.py
+++ b/tests/integration/test_replicated_merge_tree_encrypted_disk/test.py
@@ -1,6 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, TSV
+from helpers.test_tools import TSV
 import os
 
 

--- a/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
+++ b/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
@@ -1,6 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, TSV
+from helpers.test_tools import TSV
 import os
 
 

--- a/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_replicated_merge_tree_with_auxiliary_zookeepers/test.py
@@ -1,6 +1,5 @@
 import time
 
-import helpers.client as client
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.client import QueryRuntimeException

--- a/tests/integration/test_restore_replica/test.py
+++ b/tests/integration/test_restore_replica/test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.cluster import ClickHouseKiller
 from helpers.test_tools import assert_eq_with_retry
 
 def fill_nodes(nodes):

--- a/tests/integration/test_restore_replica/test.py
+++ b/tests/integration/test_restore_replica/test.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_secure_socket/test.py
+++ b/tests/integration/test_secure_socket/test.py
@@ -1,4 +1,3 @@
-import os.path
 import time
 
 import pytest

--- a/tests/integration/test_secure_socket/test.py
+++ b/tests/integration/test_secure_socket/test.py
@@ -2,7 +2,6 @@ import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_select_access_rights/test.py
+++ b/tests/integration/test_select_access_rights/test.py
@@ -1,6 +1,5 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance')

--- a/tests/integration/test_sharding_key_from_default_column/test.py
+++ b/tests/integration/test_sharding_key_from_default_column/test.py
@@ -1,5 +1,4 @@
 import pytest
-import itertools
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 

--- a/tests/integration/test_storage_hdfs/test.py
+++ b/tests/integration/test_storage_hdfs/test.py
@@ -1,4 +1,3 @@
-import os
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_storage_hdfs/test.py
+++ b/tests/integration/test_storage_hdfs/test.py
@@ -268,8 +268,6 @@ def test_truncate_table(started_cluster):
 
 
 def test_partition_by(started_cluster):
-    hdfs_api = started_cluster.hdfs_api
-
     table_format = "column1 UInt32, column2 UInt32, column3 UInt32"
     file_name = "test_{_partition_id}"
     partition_by = "column3"
@@ -296,8 +294,6 @@ def test_partition_by(started_cluster):
 
 
 def test_seekable_formats(started_cluster):
-    hdfs_api = started_cluster.hdfs_api
-
     table_function = f"hdfs('hdfs://hdfs1:9000/parquet', 'Parquet', 'a Int32, b String')"
     node1.query(f"insert into table function {table_function} SELECT number, randomString(100) FROM numbers(5000000)")
 

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -150,7 +150,6 @@ def kafka_produce_protobuf_messages(kafka_cluster, topic, start_index, num_messa
     logging.debug(("Produced {} messages for topic {}".format(num_messages, topic)))
 
 def kafka_produce_protobuf_messages_no_delimeters(kafka_cluster, topic, start_index, num_messages):
-    data = ''
     producer = KafkaProducer(bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port))
     for i in range(start_index, start_index + num_messages):
         msg = kafka_pb2.KeyValuePair()
@@ -1796,7 +1795,7 @@ def test_kafka_virtual_columns2(kafka_cluster):
 
     instance.wait_for_log_line('kafka.*Committed offset 2.*virt2_[01]', repetitions=4, look_behind_lines=6000)
 
-    members = describe_consumer_group(kafka_cluster, 'virt2')
+    # members = describe_consumer_group(kafka_cluster, 'virt2')
     # pprint.pprint(members)
     # members[0]['client_id'] = 'ClickHouse-instance-test-kafka-0'
     # members[1]['client_id'] = 'ClickHouse-instance-test-kafka-1'

--- a/tests/integration/test_storage_kerberized_hdfs/test.py
+++ b/tests/integration/test_storage_kerberized_hdfs/test.py
@@ -60,17 +60,17 @@ def test_write_storage_not_expired(started_cluster):
     assert select_read == "1\tMark\t72.53\n"
 
 def test_two_users(started_cluster):
-    hdfs_api = started_cluster.hdfs_api
-
     node1.query("create table HDFSStorOne (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://kerberizedhdfs1:9010/storage_user_one', 'TSV')")
     node1.query("insert into HDFSStorOne values (1, 'Real', 86.00)")
 
     node1.query("create table HDFSStorTwo (id UInt32, name String, weight Float64) ENGINE = HDFS('hdfs://suser@kerberizedhdfs1:9010/user/specuser/storage_user_two', 'TSV')")
     node1.query("insert into HDFSStorTwo values (1, 'Ideal', 74.00)")
 
-    select_read_1 = node1.query("select * from hdfs('hdfs://kerberizedhdfs1:9010/user/specuser/storage_user_two', 'TSV', 'id UInt64, text String, number Float64')")
+    #select_read_1
+    node1.query("select * from hdfs('hdfs://kerberizedhdfs1:9010/user/specuser/storage_user_two', 'TSV', 'id UInt64, text String, number Float64')")
 
-    select_read_2 = node1.query("select * from hdfs('hdfs://suser@kerberizedhdfs1:9010/storage_user_one', 'TSV', 'id UInt64, text String, number Float64')")
+    # select_read_2
+    node1.query("select * from hdfs('hdfs://suser@kerberizedhdfs1:9010/storage_user_one', 'TSV', 'id UInt64, text String, number Float64')")
 
 def test_read_table_expired(started_cluster):
     hdfs_api = started_cluster.hdfs_api
@@ -82,7 +82,8 @@ def test_read_table_expired(started_cluster):
     time.sleep(15)
 
     try:
-        select_read = node1.query("select * from hdfs('hdfs://reloginuser&kerberizedhdfs1:9010/simple_table_function', 'TSV', 'id UInt64, text String, number Float64')")
+        # select_read
+        node1.query("select * from hdfs('hdfs://reloginuser&kerberizedhdfs1:9010/simple_table_function', 'TSV', 'id UInt64, text String, number Float64')")
         assert False, "Exception have to be thrown"
     except Exception as ex:
         assert "DB::Exception: kinit failure:" in str(ex)

--- a/tests/integration/test_storage_kerberized_hdfs/test.py
+++ b/tests/integration/test_storage_kerberized_hdfs/test.py
@@ -1,10 +1,8 @@
 import time
 import pytest
 
-import os
 
 from helpers.cluster import ClickHouseCluster
-import subprocess
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance('node1', with_kerberized_hdfs=True, user_configs=[], main_configs=['configs/hdfs.xml'])

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -1,6 +1,3 @@
-import os.path as p
-import random
-import threading
 import time
 import pytest
 import logging
@@ -10,14 +7,11 @@ from helpers.test_tools import TSV
 from helpers.client import QueryRuntimeException
 from helpers.network import PartitionManager
 
-import json
-import subprocess
 import kafka.errors
 from kafka import KafkaAdminClient, KafkaProducer, KafkaConsumer, BrokerConnection
 from kafka.admin import NewTopic
 from kafka.protocol.admin import DescribeGroupsResponse_v1, DescribeGroupsRequest_v1
 from kafka.protocol.group import MemberAssignment
-import socket
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance',

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -4,14 +4,8 @@ import logging
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-from helpers.client import QueryRuntimeException
-from helpers.network import PartitionManager
 
-import kafka.errors
-from kafka import KafkaAdminClient, KafkaProducer, KafkaConsumer, BrokerConnection
-from kafka.admin import NewTopic
-from kafka.protocol.admin import DescribeGroupsResponse_v1, DescribeGroupsRequest_v1
-from kafka.protocol.group import MemberAssignment
+from kafka import KafkaProducer
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance',

--- a/tests/integration/test_storage_postgresql_replica/test.py
+++ b/tests/integration/test_storage_postgresql_replica/test.py
@@ -4,7 +4,6 @@ import psycopg2
 import os.path as p
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from helpers.test_tools import TSV
 

--- a/tests/integration/test_storage_postgresql_replica/test.py
+++ b/tests/integration/test_storage_postgresql_replica/test.py
@@ -8,7 +8,6 @@ from helpers.test_tools import assert_eq_with_retry
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from helpers.test_tools import TSV
 
-import threading
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance', main_configs=['configs/log_conf.xml'], with_postgres=True, stay_alive=True)

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -752,7 +752,6 @@ def test_rabbitmq_insert_headers_exchange(rabbitmq_cluster):
     insert_messages = []
 
     def onReceived(channel, method, properties, body):
-        i = 0
         insert_messages.append(body.decode())
         if (len(insert_messages) == 50):
             channel.stop_consuming()

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -6,7 +6,6 @@ import threading
 import logging
 import time
 from random import randrange
-import math
 
 import pika
 import pytest

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -586,7 +586,6 @@ def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
 
 def test_rabbitmq_mv_combo(rabbitmq_cluster):
     NUM_MV = 5
-    NUM_CONSUMERS = 4
 
     instance.query('''
         CREATE TABLE test.rabbitmq (key UInt64, value UInt64)
@@ -2023,7 +2022,6 @@ def test_rabbitmq_queue_consume(rabbitmq_cluster):
     def produce():
         connection = pika.BlockingConnection(parameters)
         channel = connection.channel()
-        messages = []
         for _ in range(messages_num):
             message = json.dumps({'key': i[0], 'value': i[0]})
             channel.basic_publish(exchange='', routing_key='rabbit_queue', body=message)
@@ -2170,7 +2168,6 @@ def test_rabbitmq_drop_mv(rabbitmq_cluster):
     connection = pika.BlockingConnection(parameters)
     channel = connection.channel()
 
-    messages = []
     for i in range(20):
         channel.basic_publish(exchange='mv', routing_key='', body=json.dumps({'key': i, 'value': i}))
 
@@ -2207,8 +2204,6 @@ def test_rabbitmq_drop_mv(rabbitmq_cluster):
 
 
 def test_rabbitmq_random_detach(rabbitmq_cluster):
-    NUM_CONSUMERS = 2
-    NUM_QUEUES = 2
     instance.query('''
         CREATE TABLE test.rabbitmq (key UInt64, value UInt64)
             ENGINE = RabbitMQ

--- a/tests/integration/test_storage_s3/s3_mocks/mock_s3.py
+++ b/tests/integration/test_storage_s3/s3_mocks/mock_s3.py
@@ -1,6 +1,6 @@
 import sys
 
-from bottle import abort, route, run, request, response
+from bottle import request, response, route, run
 
 
 @route('/redirected/<_path:path>')

--- a/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
+++ b/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
@@ -1,8 +1,6 @@
 import http.server
 import random
 import re
-import socket
-import struct
 import sys
 
 

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -470,7 +470,6 @@ def _test_s3_glob_scheherazade(started_cluster):
     bucket = started_cluster.minio_bucket
     instance = started_cluster.instances["dummy"]  # type: ClickHouseInstance
     table_format = "column1 UInt32, column2 UInt32, column3 UInt32"
-    max_path = ""
     values = "(1, 1, 1)"
     nights_per_job = 1001 // 30
     jobs = []
@@ -642,7 +641,7 @@ def _test_storage_s3_get_unstable(started_cluster):
     bucket = started_cluster.minio_bucket
     instance = started_cluster.instances["dummy"]
     table_format = "column1 Int64, column2 Int64, column3 Int64, column4 Int64"
-    get_query = f"SELECT count(), sum(column3), sum(column4) FROM s3('http://resolver:8081/{started_cluster.minio_bucket}/test.csv', 'CSV', '{table_format}') FORMAT CSV"
+    get_query = f"SELECT count(), sum(column3), sum(column4) FROM s3('http://resolver:8081/{bucket}/test.csv', 'CSV', '{table_format}') FORMAT CSV"
     result = run_query(instance, get_query)
     assert result.splitlines() == ["500001,500000,0"]
 

--- a/tests/integration/test_system_clusters_actual_information/test.py
+++ b/tests/integration/test_system_clusters_actual_information/test.py
@@ -7,7 +7,6 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from helpers.cluster import ClickHouseCluster
-from helpers.network import PartitionManager
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance('node', with_zookeeper=True, main_configs=['configs/remote_servers.xml'])

--- a/tests/integration/test_system_metrics/test.py
+++ b/tests/integration/test_system_metrics/test.py
@@ -1,4 +1,3 @@
-import time
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/integration/test_system_queries/test.py
+++ b/tests/integration/test_system_queries/test.py
@@ -29,7 +29,6 @@ def started_cluster():
         yield cluster
 
     finally:
-        pass
         cluster.shutdown()
 
 

--- a/tests/integration/test_system_queries/test.py
+++ b/tests/integration/test_system_queries/test.py
@@ -29,6 +29,7 @@ def started_cluster():
         yield cluster
 
     finally:
+        pass
         cluster.shutdown()
 
 

--- a/tests/integration/test_system_replicated_fetches/test.py
+++ b/tests/integration/test_system_replicated_fetches/test.py
@@ -5,7 +5,6 @@ import pytest
 import time
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
-from helpers.test_tools import assert_eq_with_retry
 import random
 import string
 import json

--- a/tests/integration/test_table_functions_access_rights/test.py
+++ b/tests/integration/test_table_functions_access_rights/test.py
@@ -1,6 +1,5 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance('instance')

--- a/tests/integration/test_tcp_handler_http_responses/test_case.py
+++ b/tests/integration/test_tcp_handler_http_responses/test_case.py
@@ -1,5 +1,4 @@
 """Test HTTP responses given by the TCP Handler."""
-from pathlib import Path
 import pytest
 from helpers.cluster import ClickHouseCluster
 import requests

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1,5 +1,4 @@
 import random
-import string
 import threading
 import time
 from multiprocessing.dummy import Pool

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -200,7 +200,6 @@ def test_moves_work_after_storage_policy_change(started_cluster, name, engine):
             """ALTER TABLE {name} MODIFY TTL now()-3600 TO DISK 'jbod1', d1 TO DISK 'external'""".format(name=name))
 
         wait_expire_1 = 12
-        wait_expire_2 = 4
         time_1 = time.time() + wait_expire_1
 
         data = []  # 10MB in total

--- a/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
+++ b/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
@@ -30,6 +30,7 @@ def test_user_zero_database_access(start_cluster):
         node.exec_in_container(
             ["bash", "-c", "/usr/bin/clickhouse client --user 'has_access' --query 'DROP DATABASE test'"], user='root')
     except Exception as ex:
+        print(ex)
         assert False, "user with access rights can't drop database test"
 
     try:
@@ -37,6 +38,7 @@ def test_user_zero_database_access(start_cluster):
             ["bash", "-c", "/usr/bin/clickhouse client --user 'has_access' --query 'CREATE DATABASE test'"],
             user='root')
     except Exception as ex:
+        print(ex)
         assert False, "user with access rights can't create database test"
 
     try:
@@ -63,10 +65,12 @@ def test_user_zero_database_access(start_cluster):
         node.exec_in_container(
             ["bash", "-c", "/usr/bin/clickhouse client --user 'default' --query 'CREATE DATABASE test2'"], user='root')
     except Exception as ex:
+        print(ex)
         assert False, "user with full access rights can't create database test2"
 
     try:
         node.exec_in_container(
             ["bash", "-c", "/usr/bin/clickhouse client --user 'default' --query 'DROP DATABASE test2'"], user='root')
     except Exception as ex:
+        print(ex)
         assert False, "user with full access rights can't drop database test2"

--- a/tests/integration/test_version_update/test.py
+++ b/tests/integration/test_version_update/test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from helpers.cluster import ClickHouseCluster
-from helpers.test_tools import assert_eq_with_retry, exec_query_with_retry
 cluster = ClickHouseCluster(__file__)
 
 

--- a/tests/integration/test_version_update_after_mutation/test.py
+++ b/tests/integration/test_version_update_after_mutation/test.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry, exec_query_with_retry

--- a/tests/integration/test_zookeeper_config/test_password.py
+++ b/tests/integration/test_zookeeper_config/test_password.py
@@ -1,6 +1,5 @@
 
 
-import time
 import pytest
 from helpers.cluster import ClickHouseCluster
 

--- a/tests/integration/test_zookeeper_config/test_secure.py
+++ b/tests/integration/test_zookeeper_config/test_secure.py
@@ -1,6 +1,5 @@
 import threading
 import os 
-from tempfile import NamedTemporaryFile
 
 import pytest
 from helpers.cluster import ClickHouseCluster

--- a/tests/queries/0_stateless/00960_live_view_watch_events_live.py
+++ b/tests/queries/0_stateless/00960_live_view_watch_events_live.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/00962_live_view_periodic_refresh.py
+++ b/tests/queries/0_stateless/00962_live_view_periodic_refresh.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/00962_live_view_periodic_refresh_and_timeout.py
+++ b/tests/queries/0_stateless/00962_live_view_periodic_refresh_and_timeout.py
@@ -4,7 +4,6 @@
 import os
 import sys
 import time
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/00962_live_view_periodic_refresh_dictionary.py
+++ b/tests/queries/0_stateless/00962_live_view_periodic_refresh_dictionary.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/00962_live_view_periodic_refresh_dictionary.py
+++ b/tests/queries/0_stateless/00962_live_view_periodic_refresh_dictionary.py
@@ -7,7 +7,7 @@ import sys
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))
 
-from client import client, prompt, end_of_block
+from client import client, prompt
 
 log = None
 # uncomment the line below for debugging

--- a/tests/queries/0_stateless/00962_temporary_live_view_watch_live.py
+++ b/tests/queries/0_stateless/00962_temporary_live_view_watch_live.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/00964_live_view_watch_events_heartbeat.py
+++ b/tests/queries/0_stateless/00964_live_view_watch_events_heartbeat.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/00964_live_view_watch_events_heartbeat.py
+++ b/tests/queries/0_stateless/00964_live_view_watch_events_heartbeat.py
@@ -7,7 +7,7 @@ import sys
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))
 
-from client import client, prompt, end_of_block
+from client import client, prompt
 
 log = None
 # uncomment the line below for debugging

--- a/tests/queries/0_stateless/00965_live_view_watch_heartbeat.py
+++ b/tests/queries/0_stateless/00965_live_view_watch_heartbeat.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/00966_live_view_watch_events_http.py
+++ b/tests/queries/0_stateless/00966_live_view_watch_events_http.py
@@ -7,7 +7,7 @@ import sys
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))
 
-from client import client, prompt, end_of_block
+from client import client, prompt
 from httpclient import client as http_client
 
 log = None

--- a/tests/queries/0_stateless/00967_live_view_watch_http.py
+++ b/tests/queries/0_stateless/00967_live_view_watch_http.py
@@ -7,7 +7,7 @@ import sys
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))
 
-from client import client, prompt, end_of_block
+from client import client, prompt
 from httpclient import client as http_client
 
 log = None

--- a/tests/queries/0_stateless/00970_live_view_watch_events_http_heartbeat.py
+++ b/tests/queries/0_stateless/00970_live_view_watch_events_http_heartbeat.py
@@ -7,7 +7,7 @@ import sys
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))
 
-from client import client, prompt, end_of_block
+from client import client, prompt
 from httpclient import client as http_client
 
 log = None

--- a/tests/queries/0_stateless/00971_live_view_watch_http_heartbeat.py
+++ b/tests/queries/0_stateless/00971_live_view_watch_http_heartbeat.py
@@ -7,7 +7,7 @@ import sys
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))
 
-from client import client, prompt, end_of_block
+from client import client, prompt
 from httpclient import client as http_client
 
 log = None

--- a/tests/queries/0_stateless/00979_live_view_watch_continuous_aggregates.py
+++ b/tests/queries/0_stateless/00979_live_view_watch_continuous_aggregates.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/00979_live_view_watch_continuous_aggregates.py
+++ b/tests/queries/0_stateless/00979_live_view_watch_continuous_aggregates.py
@@ -7,7 +7,7 @@ import sys
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))
 
-from client import client, prompt, end_of_block
+from client import client, prompt
 
 log = None
 # uncomment the line below for debugging

--- a/tests/queries/0_stateless/00979_live_view_watch_live.py
+++ b/tests/queries/0_stateless/00979_live_view_watch_live.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/00979_live_view_watch_live_with_subquery.py
+++ b/tests/queries/0_stateless/00979_live_view_watch_live_with_subquery.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/01056_window_view_proc_hop_watch.py
+++ b/tests/queries/0_stateless/01056_window_view_proc_hop_watch.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/01059_window_view_event_hop_watch_strict_asc.py
+++ b/tests/queries/0_stateless/01059_window_view_event_hop_watch_strict_asc.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/01062_window_view_event_hop_watch_asc.py
+++ b/tests/queries/0_stateless/01062_window_view_event_hop_watch_asc.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/01065_window_view_event_hop_watch_bounded.py
+++ b/tests/queries/0_stateless/01065_window_view_event_hop_watch_bounded.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/01069_window_view_proc_tumble_watch.py
+++ b/tests/queries/0_stateless/01069_window_view_proc_tumble_watch.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/01070_window_view_watch_events.py
+++ b/tests/queries/0_stateless/01070_window_view_watch_events.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/01246_insert_into_watch_live_view.py
+++ b/tests/queries/0_stateless/01246_insert_into_watch_live_view.py
@@ -3,8 +3,6 @@
 
 import os
 import sys
-import time
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/01246_insert_into_watch_live_view.py
+++ b/tests/queries/0_stateless/01246_insert_into_watch_live_view.py
@@ -7,7 +7,7 @@ import sys
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))
 
-from client import client, prompt, end_of_block
+from client import client, prompt
 
 log = None
 # uncomment the line below for debugging

--- a/tests/queries/0_stateless/01921_test_progress_bar.py
+++ b/tests/queries/0_stateless/01921_test_progress_bar.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import sys
-import signal
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, 'helpers'))

--- a/tests/queries/0_stateless/helpers/httpexpect.py
+++ b/tests/queries/0_stateless/helpers/httpexpect.py
@@ -21,7 +21,7 @@ sys.path.insert(0, CURDIR)
 import uexpect
 
 from threading import Thread, Event
-from queue import Queue, Empty
+from queue import Queue
 
 class IO(uexpect.IO):
     def __init__(self, connection, response, queue, reader):

--- a/tests/queries/0_stateless/helpers/protobuf_length_delimited_encoder.py
+++ b/tests/queries/0_stateless/helpers/protobuf_length_delimited_encoder.py
@@ -5,7 +5,6 @@
 
 import argparse
 import os.path
-import struct
 import subprocess
 import sys
 import tempfile

--- a/tests/queries/0_stateless/helpers/pure_http_client.py
+++ b/tests/queries/0_stateless/helpers/pure_http_client.py
@@ -1,6 +1,5 @@
 import os
 import io
-import sys
 import requests
 import time
 import pandas as pd

--- a/tests/queries/0_stateless/helpers/uexpect.py
+++ b/tests/queries/0_stateless/helpers/uexpect.py
@@ -39,7 +39,6 @@ class ExpectTimeoutError(Exception):
             s += 'for %s ' % repr(self.pattern.pattern)
         if self.buffer:
             s += 'buffer %s' % repr(self.buffer[:])
-            #s += ' or \'%s\'' % ','.join(['%x' % ord(c) for c in self.buffer[:]])
         return s
 
 class IO(object):
@@ -175,6 +174,7 @@ class IO(object):
                 return data
             if raise_exception:
                 raise TimeoutError(timeout)
+            pass
         if not data and raise_exception:
             raise TimeoutError(timeout)
 

--- a/tests/queries/0_stateless/helpers/uexpect.py
+++ b/tests/queries/0_stateless/helpers/uexpect.py
@@ -14,7 +14,6 @@
 import os
 import pty
 import time
-import sys
 import re
 
 from threading import Thread, Event
@@ -176,7 +175,6 @@ class IO(object):
                 return data
             if raise_exception:
                 raise TimeoutError(timeout)
-            pass
         if not data and raise_exception:
             raise TimeoutError(timeout)
 

--- a/tests/testflows/aes_encryption/tests/compatibility/select.py
+++ b/tests/testflows/aes_encryption/tests/compatibility/select.py
@@ -112,8 +112,6 @@ def decrypt_unique(self):
     """
     node = self.context.node
     key = f"{'1' * 64}"
-    iv = f"{'2' * 64}"
-    aad = "some random aad"
 
     with table("user_table", """
             CREATE TABLE {name}

--- a/tests/testflows/aes_encryption/tests/compatibility/select.py
+++ b/tests/testflows/aes_encryption/tests/compatibility/select.py
@@ -2,10 +2,9 @@ import textwrap
 from contextlib import contextmanager
 
 from testflows.core import *
-from testflows.asserts.helpers import varname
-from testflows.asserts import values, error, snapshot
+from testflows.asserts import error
 
-from aes_encryption.tests.common import modes, mysql_modes
+from aes_encryption.tests.common import modes
 
 @contextmanager
 def table(name, sql):

--- a/tests/testflows/aes_encryption/tests/encrypt_mysql.py
+++ b/tests/testflows/aes_encryption/tests/encrypt_mysql.py
@@ -229,7 +229,6 @@ def key_parameter_types(self):
     of either `String` or `FixedString` types.
     """
     plaintext = "'hello there'"
-    iv = "'0123456789123456'"
     mode = "'aes-128-cbc'"
     key = "'0123456789123456'"
 

--- a/tests/testflows/datetime64_extended_range/common.py
+++ b/tests/testflows/datetime64_extended_range/common.py
@@ -1,2 +1,0 @@
-from testflows.core import *
-from helpers.common import *

--- a/tests/testflows/datetime64_extended_range/tests/date_time_functions.py
+++ b/tests/testflows/datetime64_extended_range/tests/date_time_functions.py
@@ -57,7 +57,6 @@ def to_date_part(self, py_func, ch_func):
                             with By(f"localizing {dt} using {tz1} timezone"):
                                 time_tz1 = pytz.timezone(tz1).localize(dt)
                             with And(f"converting {tz1} local datetime {dt} to {tz2} timezone"):
-                                time_tz2 = time_tz1.astimezone(pytz.timezone(tz2))
                             with And(f"calling the '{py_func}' method of the datetime object to get expected result"):
                                 result = eval(f"(time_tz2.{py_func}")
                             expected = f"{result}"
@@ -120,8 +119,6 @@ def to_day_of(self, py_func, ch_func):
                 for tz1, tz2 in itertools.product(timezones, timezones):
                     with When(f"{dt} {tz1} -> {tz2}"):
                         with By("Computing expected result using pytz"):
-                            time_tz1 = pytz.timezone(tz1).localize(dt)
-                            time_tz2 = time_tz1.astimezone(pytz.timezone(tz2))
                             result = eval(f"time_tz2.timetuple().{py_func}")
                             if py_func == "tm_wday":
                                 result += 1
@@ -179,8 +176,6 @@ def to_time_part(self, py_func, ch_func):
                 for tz1, tz2 in itertools.product(timezones, timezones):
                     with Step(f"{dt} {tz1} -> {tz2}"):
                         with By("computing expected result using pytz"):
-                            time_tz1 = pytz.timezone(tz1).localize(dt)
-                            time_tz2 = time_tz1.astimezone(pytz.timezone(tz2))
                             result = eval(f"time_tz2.{py_func}")
                             expected = f"{result}"
                         with And("forming a ClickHouse query"):

--- a/tests/testflows/datetime64_extended_range/tests/generic.py
+++ b/tests/testflows/datetime64_extended_range/tests/generic.py
@@ -99,8 +99,6 @@ def comparison_check(self):
         for tz1, tz2 in itertools.product(timezones, timezones):
             dt1_str = dt_1.strftime("%Y-%m-%d %H:%M:%S")
             dt2_str = dt_2.strftime("%Y-%m-%d %H:%M:%S")
-            dt1 = pytz.timezone(tz1).localize(dt_1)
-            dt2 = pytz.timezone(tz2).localize(dt_2)
 
             with When(f"{dt1_str} {tz1}, {dt2_str} {tz2}"):
                 for c in comparators:

--- a/tests/testflows/datetime64_extended_range/tests/type_conversion.py
+++ b/tests/testflows/datetime64_extended_range/tests/type_conversion.py
@@ -1,10 +1,7 @@
 import time
 import pytz
 import decimal
-import itertools
-import numpy as np
 from dateutil.tz import tzlocal
-import dateutil.relativedelta as rd
 from testflows.core import *
 
 from datetime64_extended_range.requirements.requirements import *

--- a/tests/testflows/datetime64_extended_range/tests/type_conversion.py
+++ b/tests/testflows/datetime64_extended_range/tests/type_conversion.py
@@ -4,7 +4,6 @@ import decimal
 import itertools
 import numpy as np
 from dateutil.tz import tzlocal
-from datetime import datetime, timedelta
 import dateutil.relativedelta as rd
 from testflows.core import *
 

--- a/tests/testflows/extended_precision_data_types/tests/arithmetic.py
+++ b/tests/testflows/extended_precision_data_types/tests/arithmetic.py
@@ -1,5 +1,3 @@
-import os
-import textwrap
 
 from extended_precision_data_types.requirements import *
 from extended_precision_data_types.common import *

--- a/tests/testflows/extended_precision_data_types/tests/conversion.py
+++ b/tests/testflows/extended_precision_data_types/tests/conversion.py
@@ -1,4 +1,3 @@
-import os
 import textwrap
 
 from extended_precision_data_types.requirements import *

--- a/tests/testflows/extended_precision_data_types/tests/feature.py
+++ b/tests/testflows/extended_precision_data_types/tests/feature.py
@@ -1,6 +1,4 @@
 from testflows.core import *
-from testflows.core.name import basename, parentname
-from testflows._core.testtype import TestSubType
 
 @TestFeature
 @Name("tests")

--- a/tests/testflows/extended_precision_data_types/tests/logical.py
+++ b/tests/testflows/extended_precision_data_types/tests/logical.py
@@ -16,8 +16,6 @@ Examples_list_dec =  [tuple(list(func)+[Name(f'{func[0]} - Decimal256')]) for fu
 def log_int_inline(self, func, int_type, min, max, node=None):
     """Check logical functions with Int128, Int256, and UInt256 using inline tests.
     """
-    table_name = f'table_{getuid()}'
-
     if node is None:
         node = self.context.node
 

--- a/tests/testflows/extended_precision_data_types/tests/table.py
+++ b/tests/testflows/extended_precision_data_types/tests/table.py
@@ -1,6 +1,5 @@
 from testflows.core import *
 from testflows.asserts import error
-from contextlib import contextmanager
 
 from extended_precision_data_types.requirements import *
 from extended_precision_data_types.common import *

--- a/tests/testflows/helpers/cluster.py
+++ b/tests/testflows/helpers/cluster.py
@@ -10,7 +10,6 @@ from testflows.core import *
 from testflows.asserts import error
 from testflows.connect import Shell as ShellBase
 from testflows.uexpect import ExpectTimeoutError
-from testflows._core.testtype import TestSubType
 
 class Shell(ShellBase):
     def __exit__(self, type, value, traceback):

--- a/tests/testflows/helpers/cluster.py
+++ b/tests/testflows/helpers/cluster.py
@@ -32,6 +32,7 @@ class Shell(ShellBase):
 class QueryRuntimeException(Exception):
     """Exception during query execution on the server.
     """
+    pass
 
 class Node(object):
     """Generic cluster node.

--- a/tests/testflows/helpers/cluster.py
+++ b/tests/testflows/helpers/cluster.py
@@ -33,7 +33,6 @@ class Shell(ShellBase):
 class QueryRuntimeException(Exception):
     """Exception during query execution on the server.
     """
-    pass
 
 class Node(object):
     """Generic cluster node.

--- a/tests/testflows/kerberos/tests/common.py
+++ b/tests/testflows/kerberos/tests/common.py
@@ -1,6 +1,5 @@
 from testflows.core import *
 from testflows.asserts import error
-from contextlib import contextmanager
 import xml.etree.ElementTree as xmltree
 
 import time

--- a/tests/testflows/kerberos/tests/config.py
+++ b/tests/testflows/kerberos/tests/config.py
@@ -2,7 +2,6 @@ from testflows.core import *
 from kerberos.tests.common import *
 from kerberos.requirements.requirements import *
 
-import itertools
 
 
 @TestScenario

--- a/tests/testflows/kerberos/tests/config.py
+++ b/tests/testflows/kerberos/tests/config.py
@@ -2,8 +2,6 @@ from testflows.core import *
 from kerberos.tests.common import *
 from kerberos.requirements.requirements import *
 
-import time
-import datetime
 import itertools
 
 

--- a/tests/testflows/ldap/authentication/tests/common.py
+++ b/tests/testflows/ldap/authentication/tests/common.py
@@ -3,7 +3,6 @@ import uuid
 import time
 import string
 import random
-import textwrap
 import xml.etree.ElementTree as xmltree
 
 from collections import namedtuple

--- a/tests/testflows/ldap/authentication/tests/connections.py
+++ b/tests/testflows/ldap/authentication/tests/connections.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from ldap.authentication.tests.common import login
 from ldap.authentication.requirements import *

--- a/tests/testflows/ldap/authentication/tests/multiple_servers.py
+++ b/tests/testflows/ldap/authentication/tests/multiple_servers.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from ldap.authentication.tests.common import login
 from ldap.authentication.requirements import RQ_SRS_007_LDAP_Authentication_MultipleServers

--- a/tests/testflows/ldap/authentication/tests/user_config.py
+++ b/tests/testflows/ldap/authentication/tests/user_config.py
@@ -117,7 +117,6 @@ def ldap_and_password(self):
     is specified for the same user. We expect an error message to be present in the log
     and login attempt to fail.
     """
-    node = self.context.node
     servers = {
         "openldap1": {
             "host": "openldap1", "port": "389", "enable_tls": "no",

--- a/tests/testflows/ldap/external_user_directory/tests/common.py
+++ b/tests/testflows/ldap/external_user_directory/tests/common.py
@@ -5,12 +5,8 @@ from contextlib import contextmanager
 import testflows.settings as settings
 from testflows.core import *
 from testflows.asserts import error
-from ldap.authentication.tests.common import getuid, Config, ldap_servers, add_config, modify_config, restart
+from ldap.authentication.tests.common import Config, add_config, getuid, ldap_servers
 from ldap.authentication.tests.common import xmltree, xml_indent, xml_append, xml_with_utf8
-from ldap.authentication.tests.common import ldap_user, ldap_users, add_user_to_ldap, delete_user_from_ldap
-from ldap.authentication.tests.common import change_user_password_in_ldap, change_user_cn_in_ldap
-from ldap.authentication.tests.common import create_ldap_servers_config_content
-from ldap.authentication.tests.common import randomword
 
 @contextmanager
 def table(name, create_statement, on_cluster=False):

--- a/tests/testflows/ldap/external_user_directory/tests/connections.py
+++ b/tests/testflows/ldap/external_user_directory/tests/connections.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from ldap.external_user_directory.tests.common import login
 from ldap.external_user_directory.requirements import *

--- a/tests/testflows/ldap/external_user_directory/tests/restart.py
+++ b/tests/testflows/ldap/external_user_directory/tests/restart.py
@@ -2,7 +2,6 @@ import random
 
 from helpers.common import Pool, join
 from testflows.core import *
-from testflows.asserts import error
 
 from ldap.external_user_directory.tests.common import *
 from ldap.external_user_directory.requirements import *

--- a/tests/testflows/ldap/external_user_directory/tests/server_config.py
+++ b/tests/testflows/ldap/external_user_directory/tests/server_config.py
@@ -45,7 +45,6 @@ def empty_host(self, tail=30, timeout=300):
     """Check that server returns an error when LDAP server
     host value is empty.
     """
-    node = current().context.node
     message = "DB::Exception: Empty 'host' entry"
 
     servers = {"foo": {"host": "", "port": "389", "enable_tls": "no"}}

--- a/tests/testflows/ldap/external_user_directory/tests/simple.py
+++ b/tests/testflows/ldap/external_user_directory/tests/simple.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from ldap.external_user_directory.tests.common import login
 

--- a/tests/testflows/ldap/role_mapping/tests/server_config.py
+++ b/tests/testflows/ldap/role_mapping/tests/server_config.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from ldap.role_mapping.requirements import *
 

--- a/tests/testflows/map_type/tests/common.py
+++ b/tests/testflows/map_type/tests/common.py
@@ -1,5 +1,4 @@
 import uuid
-from collections import namedtuple
 
 from testflows.core import *
 from testflows.core.name import basename, parentname

--- a/tests/testflows/rbac/helper/common.py
+++ b/tests/testflows/rbac/helper/common.py
@@ -1,6 +1,5 @@
 import uuid
 
-import testflows.settings as settings
 
 from contextlib import contextmanager
 
@@ -8,7 +7,6 @@ from testflows.core.name import basename, parentname
 from testflows._core.testtype import TestSubType
 from testflows.core import *
 
-from helpers.common import Pool, join, run_scenario, instrument_clickhouse_server_log
 from rbac.helper.tables import table_types
 
 def permutations(table_count=1):

--- a/tests/testflows/rbac/tests/privileges/admin_option.py
+++ b/tests/testflows/rbac/tests/privileges/admin_option.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/all_role.py
+++ b/tests/testflows/rbac/tests/privileges/all_role.py
@@ -3,7 +3,6 @@ from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *
-import rbac.helper.errors as errors
 
 @TestScenario
 def privilege_check(self, node=None):

--- a/tests/testflows/rbac/tests/privileges/alter/alter_constraint.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_constraint.py
@@ -1,7 +1,6 @@
 import json
 
 from testflows.core import *
-from testflows.core import threading
 from testflows.asserts import error
 
 from rbac.requirements import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_delete.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_delete.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_fetch.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_fetch.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_freeze.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_freeze.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_index.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_index.py
@@ -1,7 +1,6 @@
 import json
 import random
 
-from testflows._core.cli.arg.parser import parser
 from testflows.core import *
 from testflows.asserts import error
 

--- a/tests/testflows/rbac/tests/privileges/alter/alter_move.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_move.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_quota.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_quota.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_role.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_role.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_row_policy.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_row_policy.py
@@ -875,7 +875,6 @@ def dist_table(self, node=None):
 
     if node is None:
         node = self.context.node
-        node2 = self.context.node2
 
     try:
         with Given("I have a table on a cluster"):

--- a/tests/testflows/rbac/tests/privileges/alter/alter_settings_profile.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_settings_profile.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_ttl.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_ttl.py
@@ -1,7 +1,6 @@
 import json
 
 from testflows.core import *
-from testflows.core import threading
 from testflows.asserts import error
 
 from rbac.requirements import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_update.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_update.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/alter/alter_user.py
+++ b/tests/testflows/rbac/tests/privileges/alter/alter_user.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/create/create_quota.py
+++ b/tests/testflows/rbac/tests/privileges/create/create_quota.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/create/create_role.py
+++ b/tests/testflows/rbac/tests/privileges/create/create_role.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/create/create_settings_profile.py
+++ b/tests/testflows/rbac/tests/privileges/create/create_settings_profile.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/create/create_table.py
+++ b/tests/testflows/rbac/tests/privileges/create/create_table.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/create/create_user.py
+++ b/tests/testflows/rbac/tests/privileges/create/create_user.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/dictGet.py
+++ b/tests/testflows/rbac/tests/privileges/dictGet.py
@@ -1,4 +1,3 @@
-import os
 
 from contextlib import contextmanager
 

--- a/tests/testflows/rbac/tests/privileges/distributed_table.py
+++ b/tests/testflows/rbac/tests/privileges/distributed_table.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/distributed_table.py
+++ b/tests/testflows/rbac/tests/privileges/distributed_table.py
@@ -216,7 +216,7 @@ def create_with_privilege(self, user_name, grant_target_name, node=None):
     table0_name = f"table0_{getuid()}"
     table1_name = f"table1_{getuid()}"
 
-    exitcode, message = errors.not_enough_privileges(name=f"{user_name}")
+    errors.not_enough_privileges(name=f"{user_name}")
     cluster = self.context.cluster_name
 
     if node is None:
@@ -402,7 +402,7 @@ def select_with_privilege(self, user_name, grant_target_name, node=None):
     table0_name = f"table0_{getuid()}"
     table1_name = f"table1_{getuid()}"
 
-    exitcode, message = errors.not_enough_privileges(name=f"{user_name}")
+    errors.not_enough_privileges(name=f"{user_name}")
     cluster = self.context.cluster_name
 
     if node is None:

--- a/tests/testflows/rbac/tests/privileges/drop/drop_quota.py
+++ b/tests/testflows/rbac/tests/privileges/drop/drop_quota.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/drop/drop_role.py
+++ b/tests/testflows/rbac/tests/privileges/drop/drop_role.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/drop/drop_settings_profile.py
+++ b/tests/testflows/rbac/tests/privileges/drop/drop_settings_profile.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/drop/drop_user.py
+++ b/tests/testflows/rbac/tests/privileges/drop/drop_user.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/grant_option.py
+++ b/tests/testflows/rbac/tests/privileges/grant_option.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/insert.py
+++ b/tests/testflows/rbac/tests/privileges/insert.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 import json
 
 from testflows.core import *

--- a/tests/testflows/rbac/tests/privileges/introspection.py
+++ b/tests/testflows/rbac/tests/privileges/introspection.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/public_tables.py
+++ b/tests/testflows/rbac/tests/privileges/public_tables.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 
 from testflows.core import *
 from testflows.asserts import error

--- a/tests/testflows/rbac/tests/privileges/role_admin.py
+++ b/tests/testflows/rbac/tests/privileges/role_admin.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/select.py
+++ b/tests/testflows/rbac/tests/privileges/select.py
@@ -371,7 +371,6 @@ def user_with_privilege_on_cluster(self, table_type, node=None):
     privilege granted on a cluster.
     """
     user_name = f"user_{getuid()}"
-    role_name = f"role_{getuid()}"
     table_name = f"table_{getuid()}"
 
     if node is None:

--- a/tests/testflows/rbac/tests/privileges/select.py
+++ b/tests/testflows/rbac/tests/privileges/select.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager
-import json
 
 from testflows.core import *
 from testflows.asserts import error

--- a/tests/testflows/rbac/tests/privileges/show/show_columns.py
+++ b/tests/testflows/rbac/tests/privileges/show/show_columns.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/show/show_quotas.py
+++ b/tests/testflows/rbac/tests/privileges/show/show_quotas.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/show/show_roles.py
+++ b/tests/testflows/rbac/tests/privileges/show/show_roles.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/show/show_row_policies.py
+++ b/tests/testflows/rbac/tests/privileges/show/show_row_policies.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/show/show_settings_profiles.py
+++ b/tests/testflows/rbac/tests/privileges/show/show_settings_profiles.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/show/show_users.py
+++ b/tests/testflows/rbac/tests/privileges/show/show_users.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/sources.py
+++ b/tests/testflows/rbac/tests/privileges/sources.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/drop_cache.py
+++ b/tests/testflows/rbac/tests/privileges/system/drop_cache.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/fetches.py
+++ b/tests/testflows/rbac/tests/privileges/system/fetches.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/flush.py
+++ b/tests/testflows/rbac/tests/privileges/system/flush.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/merges.py
+++ b/tests/testflows/rbac/tests/privileges/system/merges.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/moves.py
+++ b/tests/testflows/rbac/tests/privileges/system/moves.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/reload.py
+++ b/tests/testflows/rbac/tests/privileges/system/reload.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/replication_queues.py
+++ b/tests/testflows/rbac/tests/privileges/system/replication_queues.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/restart_replica.py
+++ b/tests/testflows/rbac/tests/privileges/system/restart_replica.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/sends.py
+++ b/tests/testflows/rbac/tests/privileges/system/sends.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/sync_replica.py
+++ b/tests/testflows/rbac/tests/privileges/system/sync_replica.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/privileges/system/ttl_merges.py
+++ b/tests/testflows/rbac/tests/privileges/system/ttl_merges.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import error
 
 from rbac.requirements import *
 from rbac.helper.common import *

--- a/tests/testflows/rbac/tests/syntax/alter_quota.py
+++ b/tests/testflows/rbac/tests/syntax/alter_quota.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 
 from testflows.core import *
 

--- a/tests/testflows/rbac/tests/syntax/alter_settings_profile.py
+++ b/tests/testflows/rbac/tests/syntax/alter_settings_profile.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 
 from testflows.core import *
 

--- a/tests/testflows/rbac/tests/views/materialized_view.py
+++ b/tests/testflows/rbac/tests/views/materialized_view.py
@@ -631,7 +631,6 @@ def create_with_populate(self, user_name, grant_target_name, node=None):
     """Check that user is only able to create the view after INSERT privilege is granted.
     """
     view_name = f"view_{getuid()}"
-    table_name = f"table_{getuid()}"
     exitcode, message = errors.not_enough_privileges(name=f"{user_name}")
 
     if node is None:

--- a/tests/testflows/window_functions/tests/aggregate_funcs.py
+++ b/tests/testflows/window_functions/tests/aggregate_funcs.py
@@ -1,5 +1,4 @@
 from testflows.core import *
-from testflows.asserts import values, error, snapshot
 
 from window_functions.requirements import *
 from window_functions.tests.common import *


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:

Attempt cleaning up integration tests. Removes (almost all of the) unused imports (as indicated by pyflake) and tried the best to clean up a bunch of unused variables, args etc in the test files wherever I could spot.