### PR TITLE
fix storage system.[replicas, mutations, ...]

### DIFF
--- a/src/Storages/RocksDB/StorageSystemRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageSystemRocksDB.cpp
@@ -63,6 +63,9 @@ void StorageSystemRocksDB::fillData(MutableColumns & res_columns, ContextPtr con
         }
     }
 
+    if (tables.empty())
+        return;
+
     MutableColumnPtr col_database_mut = ColumnString::create();
     MutableColumnPtr col_table_mut = ColumnString::create();
 

--- a/src/Storages/System/StorageSystemDistributionQueue.cpp
+++ b/src/Storages/System/StorageSystemDistributionQueue.cpp
@@ -133,6 +133,8 @@ void StorageSystemDistributionQueue::fillData(MutableColumns & res_columns, Cont
         }
     }
 
+    if (tables.empty())
+        return;
 
     MutableColumnPtr col_database_mut = ColumnString::create();
     MutableColumnPtr col_table_mut = ColumnString::create();

--- a/src/Storages/System/StorageSystemMutations.cpp
+++ b/src/Storages/System/StorageSystemMutations.cpp
@@ -66,6 +66,9 @@ void StorageSystemMutations::fillData(MutableColumns & res_columns, ContextPtr c
         }
     }
 
+    if (merge_tree_tables.empty())
+        return;
+
     MutableColumnPtr col_database_mut = ColumnString::create();
     MutableColumnPtr col_table_mut = ColumnString::create();
 

--- a/src/Storages/System/StorageSystemPartMovesBetweenShards.cpp
+++ b/src/Storages/System/StorageSystemPartMovesBetweenShards.cpp
@@ -69,6 +69,8 @@ void StorageSystemPartMovesBetweenShards::fillData(MutableColumns & res_columns,
         }
     }
 
+    if (replicated_tables.empty())
+        return;
 
     MutableColumnPtr col_database_mut = ColumnString::create();
     MutableColumnPtr col_table_mut = ColumnString::create();

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -95,6 +95,8 @@ Pipe StorageSystemReplicas::read(
         }
     }
 
+    if (replicated_tables.empty())
+        return {};
 
     /// Do you need columns that require a ZooKeeper request to compute.
     bool with_zk_fields = false;

--- a/src/Storages/System/StorageSystemReplicationQueue.cpp
+++ b/src/Storages/System/StorageSystemReplicationQueue.cpp
@@ -74,6 +74,8 @@ void StorageSystemReplicationQueue::fillData(MutableColumns & res_columns, Conte
         }
     }
 
+    if (replicated_tables.empty())
+        return;
 
     MutableColumnPtr col_database_mut = ColumnString::create();
     MutableColumnPtr col_table_mut = ColumnString::create();


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Detailed description / Documentation draft:
throw LOGICAL_ERROR(Cannot prepare filter with empty block) while reading system.xxx

If don't have Replicated(XXX)MergeTree, and query with some filters, such as
`select * from system.replicas where table != 'xxx'`
Query will throw logical error, because `VirtualColumnUtils::filterBlockWithQuery` parameters `filtered_block` rows = 0.
