### PR TITLE
Replace old _shard_num implementation with shardNum() function

### DIFF
--- a/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -35,11 +35,9 @@ namespace ClusterProxy
 
 SelectStreamFactory::SelectStreamFactory(
     const Block & header_,
-    QueryProcessingStage::Enum processed_stage_,
-    bool has_virtual_shard_num_column_)
-    : header(header_),
-    processed_stage{processed_stage_},
-    has_virtual_shard_num_column(has_virtual_shard_num_column_)
+    QueryProcessingStage::Enum processed_stage_)
+    : header(header_)
+    , processed_stage{processed_stage_}
 {
 }
 
@@ -102,19 +100,15 @@ void SelectStreamFactory::createForShard(
     Shards & remote_shards,
     UInt32 shard_count)
 {
-    auto modified_query_ast = query_ast->clone();
-    if (has_virtual_shard_num_column)
-        VirtualColumnUtils::rewriteEntityInAst(modified_query_ast, "_shard_num", shard_info.shard_num, "toUInt32");
-
     auto emplace_local_stream = [&]()
     {
-        local_plans.emplace_back(createLocalPlan(modified_query_ast, header, context, processed_stage, shard_info.shard_num, shard_count));
+        local_plans.emplace_back(createLocalPlan(query_ast, header, context, processed_stage, shard_info.shard_num, shard_count));
     };
 
     auto emplace_remote_stream = [&](bool lazy = false, UInt32 local_delay = 0)
     {
         remote_shards.emplace_back(Shard{
-            .query = modified_query_ast,
+            .query = query_ast,
             .header = header,
             .shard_num = shard_info.shard_num,
             .num_replicas = shard_info.getAllNodeCount(),

--- a/src/Interpreters/ClusterProxy/SelectStreamFactory.h
+++ b/src/Interpreters/ClusterProxy/SelectStreamFactory.h
@@ -16,8 +16,7 @@ class SelectStreamFactory final : public IStreamFactory
 public:
     SelectStreamFactory(
         const Block & header_,
-        QueryProcessingStage::Enum processed_stage_,
-        bool has_virtual_shard_num_column_);
+        QueryProcessingStage::Enum processed_stage_);
 
     void createForShard(
         const Cluster::ShardInfo & shard_info,
@@ -32,8 +31,6 @@ public:
 private:
     const Block header;
     QueryProcessingStage::Enum processed_stage;
-
-    bool has_virtual_shard_num_column = false;
 };
 
 }

--- a/src/Interpreters/TreeRewriter.h
+++ b/src/Interpreters/TreeRewriter.h
@@ -70,6 +70,9 @@ struct TreeRewriterResult
     /// Cache isRemote() call for storage, because it may be too heavy.
     bool is_remote_storage = false;
 
+    /// Rewrite _shard_num to shardNum()
+    bool has_virtual_shard_num = false;
+
     /// Results of scalar sub queries
     Scalars scalars;
 

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -217,7 +217,6 @@ public:
     /// Extract data from the backup and put it to the storage.
     virtual RestoreDataTasks restoreFromBackup(const BackupPtr & backup, const String & data_path_in_backup, const ASTs & partitions, ContextMutablePtr context);
 
-protected:
     /// Returns whether the column is virtual - by default all columns are real.
     /// Initially reserved virtual column name may be shadowed by real column.
     bool isVirtualColumn(const String & column_name, const StorageMetadataPtr & metadata_snapshot) const;

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -308,7 +308,7 @@ NamesAndTypesList StorageDistributed::getVirtuals() const
             NameAndTypePair("_part_uuid", std::make_shared<DataTypeUUID>()),
             NameAndTypePair("_partition_id", std::make_shared<DataTypeString>()),
             NameAndTypePair("_sample_factor", std::make_shared<DataTypeFloat64>()),
-            NameAndTypePair("_shard_num", std::make_shared<DataTypeUInt32>()),
+            NameAndTypePair("_shard_num", std::make_shared<DataTypeUInt32>()), /// deprecated
     };
 }
 
@@ -605,8 +605,8 @@ Pipe StorageDistributed::read(
 
 void StorageDistributed::read(
     QueryPlan & query_plan,
-    const Names & column_names,
-    const StorageMetadataPtr & metadata_snapshot,
+    const Names &,
+    const StorageMetadataPtr &,
     SelectQueryInfo & query_info,
     ContextPtr local_context,
     QueryProcessingStage::Enum processed_stage,
@@ -635,10 +635,6 @@ void StorageDistributed::read(
         return;
     }
 
-    bool has_virtual_shard_num_column = std::find(column_names.begin(), column_names.end(), "_shard_num") != column_names.end();
-    if (has_virtual_shard_num_column && !isVirtualColumn("_shard_num", metadata_snapshot))
-        has_virtual_shard_num_column = false;
-
     StorageID main_table = StorageID::createEmpty();
     if (!remote_table_function_ptr)
         main_table = StorageID{remote_database, remote_table};
@@ -646,8 +642,7 @@ void StorageDistributed::read(
     ClusterProxy::SelectStreamFactory select_stream_factory =
         ClusterProxy::SelectStreamFactory(
             header,
-            processed_stage,
-            has_virtual_shard_num_column);
+            processed_stage);
 
     ClusterProxy::executeQuery(
         query_plan, header, processed_stage,

--- a/tests/queries/0_stateless/01018_Distributed__shard_num.reference
+++ b/tests/queries/0_stateless/01018_Distributed__shard_num.reference
@@ -1,37 +1,94 @@
+-- { echoOn }
+
+-- remote(system.one)
+SELECT 'remote(system.one)';
 remote(system.one)
+SELECT * FROM remote('127.0.0.1', system.one);
+0
+SELECT * FROM remote('127.0.0.{1,2}', system.one);
 0
 0
-0
+SELECT _shard_num, * FROM remote('127.0.0.1', system.one);
 1	0
+SELECT _shard_num, * FROM remote('127.0.0.{1,2}', system.one) order by _shard_num;
 1	0
 2	0
+SELECT _shard_num, * FROM remote('127.0.0.{1,2}', system.one) WHERE _shard_num = 1;
 1	0
+-- dist_1 using test_shard_localhost
+SELECT 'dist_1';
 dist_1
-1
-1	10
-10
+SELECT _shard_num FROM dist_1 order by _shard_num;
 1
 1
+SELECT _shard_num FROM dist_1 order by _shard_num;
+1
+1
+SELECT _shard_num, key FROM dist_1 order by _shard_num;
 1	10
 1	20
+SELECT key FROM dist_1;
 10
 20
-dist_2
+SELECT _shard_num FROM dist_1 order by _shard_num;
 1
-2
-1	100
-2	100
-100
-100
-remote(Distributed)
-1	100
-2	100
-JOIN system.clusters
-1	10	localhost	1	9000
-1	20	localhost	1	9000
-Rewrite with alias
+1
+SELECT _shard_num, key FROM dist_1 order by _shard_num, key;
 1	10
 1	20
+SELECT key FROM dist_1;
+10
+20
+-- dist_2 using test_cluster_two_shards_localhost
+SELECT 'dist_2';
+dist_2
+SELECT _shard_num FROM dist_2 order by _shard_num;
+1
+2
+SELECT _shard_num FROM dist_2 order by _shard_num;
+1
+2
+SELECT _shard_num, key FROM dist_2 order by _shard_num, key;
+1	100
+2	100
+SELECT key FROM dist_2;
+100
+100
+-- multiple _shard_num
+SELECT 'remote(Distributed)';
+remote(Distributed)
+SELECT _shard_num, key FROM remote('127.0.0.1', currentDatabase(), dist_2) order by _shard_num, key;
+1	100
+2	100
+-- JOIN system.clusters
+SELECT 'JOIN system.clusters';
+JOIN system.clusters
+SELECT a._shard_num, a.key, b.host_name, b.host_address IN ('::1', '127.0.0.1'), b.port
+FROM (SELECT *, _shard_num FROM dist_1) a
+JOIN system.clusters b
+ON a._shard_num = b.shard_num
+WHERE b.cluster = 'test_cluster_two_shards_localhost';
+1	10	localhost	1	9000
+1	20	localhost	1	9000
+SELECT _shard_num, key, b.host_name, b.host_address IN ('::1', '127.0.0.1'), b.port
+FROM dist_1 a
+JOIN system.clusters b
+ON _shard_num = b.shard_num
+WHERE b.cluster = 'test_cluster_two_shards_localhost'; -- { serverError 403 }
+SELECT 'Rewrite with alias';
+Rewrite with alias
+SELECT a._shard_num, key FROM dist_1 a;
+1	10
+1	20
+-- the same with JOIN, just in case
+SELECT a._shard_num, a.key, b.host_name, b.host_address IN ('::1', '127.0.0.1'), b.port
+FROM dist_1 a
+JOIN system.clusters b
+ON a._shard_num = b.shard_num
+WHERE b.cluster = 'test_cluster_two_shards_localhost'; -- { serverError 47; }
+SELECT 'dist_3';
 dist_3
+SELECT * FROM dist_3;
 100	foo
+SELECT _shard_num, * FROM dist_3 order by _shard_num;
 foo	100	foo

--- a/tests/queries/0_stateless/01018_Distributed__shard_num.reference
+++ b/tests/queries/0_stateless/01018_Distributed__shard_num.reference
@@ -25,10 +25,13 @@ dist_2
 100
 remote(Distributed)
 1	100
-1	100
+2	100
 JOIN system.clusters
 1	10	localhost	1	9000
 1	20	localhost	1	9000
+Rewrite with alias
+1	10
+1	20
 dist_3
 100	foo
 foo	100	foo

--- a/tests/queries/0_stateless/01018_Distributed__shard_num.sql
+++ b/tests/queries/0_stateless/01018_Distributed__shard_num.sql
@@ -3,6 +3,13 @@
 -- make the order static
 SET max_threads = 1;
 
+DROP TABLE IF EXISTS mem1;
+DROP TABLE IF EXISTS mem2;
+DROP TABLE IF EXISTS mem3;
+DROP TABLE IF EXISTS dist_1;
+DROP TABLE IF EXISTS dist_2;
+DROP TABLE IF EXISTS dist_3;
+
 -- remote(system.one)
 SELECT 'remote(system.one)';
 SELECT * FROM remote('127.0.0.1', system.one);

--- a/tests/queries/0_stateless/01018_Distributed__shard_num.sql
+++ b/tests/queries/0_stateless/01018_Distributed__shard_num.sql
@@ -57,8 +57,8 @@ JOIN system.clusters b
 ON _shard_num = b.shard_num
 WHERE b.cluster = 'test_cluster_two_shards_localhost'; -- { serverError 403 }
 
--- rewrite does not work with aliases, hence Missing columns (47)
-SELECT a._shard_num, key FROM dist_1 a; -- { serverError 47; }
+SELECT 'Rewrite with alias';
+SELECT a._shard_num, key FROM dist_1 a;
 -- the same with JOIN, just in case
 SELECT a._shard_num, a.key, b.host_name, b.host_address IN ('::1', '127.0.0.1'), b.port
 FROM dist_1 a

--- a/tests/queries/0_stateless/01018_Distributed__shard_num.sql
+++ b/tests/queries/0_stateless/01018_Distributed__shard_num.sql
@@ -10,6 +10,21 @@ DROP TABLE IF EXISTS dist_1;
 DROP TABLE IF EXISTS dist_2;
 DROP TABLE IF EXISTS dist_3;
 
+CREATE TABLE mem1 (key Int) Engine=Memory();
+INSERT INTO mem1 VALUES (10);
+CREATE TABLE dist_1 AS mem1 Engine=Distributed(test_shard_localhost, currentDatabase(), mem1);
+INSERT INTO dist_1 VALUES (20);
+
+CREATE TABLE mem2 (key Int) Engine=Memory();
+INSERT INTO mem2 VALUES (100);
+CREATE TABLE dist_2 AS mem2 Engine=Distributed(test_cluster_two_shards_localhost, currentDatabase(), mem2);
+
+CREATE TABLE mem3 (key Int, _shard_num String) Engine=Memory();
+INSERT INTO mem3 VALUES (100, 'foo');
+CREATE TABLE dist_3 AS mem3 Engine=Distributed(test_shard_localhost, currentDatabase(), mem3);
+
+-- { echoOn }
+
 -- remote(system.one)
 SELECT 'remote(system.one)';
 SELECT * FROM remote('127.0.0.1', system.one);
@@ -20,27 +35,20 @@ SELECT _shard_num, * FROM remote('127.0.0.{1,2}', system.one) WHERE _shard_num =
 
 -- dist_1 using test_shard_localhost
 SELECT 'dist_1';
-CREATE TABLE mem1 (key Int) Engine=Memory();
-CREATE TABLE dist_1 AS mem1 Engine=Distributed(test_shard_localhost, currentDatabase(), mem1);
 SELECT _shard_num FROM dist_1 order by _shard_num;
 
-INSERT INTO mem1 VALUES (10);
 SELECT _shard_num FROM dist_1 order by _shard_num;
 SELECT _shard_num, key FROM dist_1 order by _shard_num;
 SELECT key FROM dist_1;
 
-INSERT INTO dist_1 VALUES (20);
 SELECT _shard_num FROM dist_1 order by _shard_num;
 SELECT _shard_num, key FROM dist_1 order by _shard_num, key;
 SELECT key FROM dist_1;
 
 -- dist_2 using test_cluster_two_shards_localhost
 SELECT 'dist_2';
-CREATE TABLE mem2 (key Int) Engine=Memory();
-CREATE TABLE dist_2 AS mem2 Engine=Distributed(test_cluster_two_shards_localhost, currentDatabase(), mem2);
 SELECT _shard_num FROM dist_2 order by _shard_num;
 
-INSERT INTO mem2 VALUES (100);
 SELECT _shard_num FROM dist_2 order by _shard_num;
 SELECT _shard_num, key FROM dist_2 order by _shard_num, key;
 SELECT key FROM dist_2;
@@ -74,8 +82,5 @@ ON a._shard_num = b.shard_num
 WHERE b.cluster = 'test_cluster_two_shards_localhost'; -- { serverError 47; }
 
 SELECT 'dist_3';
-CREATE TABLE mem3 (key Int, _shard_num String) Engine=Memory();
-CREATE TABLE dist_3 AS mem3 Engine=Distributed(test_shard_localhost, currentDatabase(), mem3);
-INSERT INTO mem3 VALUES (100, 'foo');
 SELECT * FROM dist_3;
 SELECT _shard_num, * FROM dist_3 order by _shard_num;

--- a/tests/queries/0_stateless/02163_shard_num.reference
+++ b/tests/queries/0_stateless/02163_shard_num.reference
@@ -1,0 +1,17 @@
+-- { echo }
+SELECT shardNum() AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) GROUP BY _shard_num;
+2	1
+1	1
+SELECT shardNum() AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) GROUP BY shard_num;
+2	1
+1	1
+SELECT _shard_num AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) GROUP BY _shard_num;
+2	1
+1	1
+SELECT _shard_num AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) GROUP BY shard_num;
+2	1
+1	1
+SELECT a._shard_num AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) a GROUP BY shard_num;
+2	1
+1	1
+SELECT _shard_num FROM remote('127.1', system.one) AS a INNER JOIN (SELECT _shard_num FROM system.one) AS b USING (dummy); -- { serverError UNKNOWN_IDENTIFIER }

--- a/tests/queries/0_stateless/02163_shard_num.sql
+++ b/tests/queries/0_stateless/02163_shard_num.sql
@@ -1,0 +1,7 @@
+-- { echo }
+SELECT shardNum() AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) GROUP BY _shard_num;
+SELECT shardNum() AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) GROUP BY shard_num;
+SELECT _shard_num AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) GROUP BY _shard_num;
+SELECT _shard_num AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) GROUP BY shard_num;
+SELECT a._shard_num AS shard_num, sum(1) as rows FROM remote('127.{1,2}', system, one) a GROUP BY shard_num;
+SELECT _shard_num FROM remote('127.1', system.one) AS a INNER JOIN (SELECT _shard_num FROM system.one) AS b USING (dummy); -- { serverError UNKNOWN_IDENTIFIER }


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Replace `_shard_num` via constants (from #7624) with `shardNum()` function (from #27020), to avoid possible issues (like those that had been found in #16947)

Detailed description / Documentation draft:
This patch changes the behavior of _shard_num slightly for nested distributed tables,
now it returns nested shard number, but this should be minor.

Cc: @amosbird 