### PR TITLE
Fixed crash of the LDAP authorization process if there are parentheses in the user_dn variable

### DIFF
--- a/docs/ru/operations/monitoring.md
+++ b/docs/ru/operations/monitoring.md
@@ -37,7 +37,7 @@ ClickHouse собирает:
 
 Можно настроить экспорт метрик из ClickHouse в [Graphite](https://github.com/graphite-project). Смотрите секцию [graphite](server-configuration-parameters/settings.md#server_configuration_parameters-graphite) конфигурационного файла ClickHouse. Перед настройкой экспорта метрик необходимо настроить Graphite, как указано в [официальном руководстве](https://graphite.readthedocs.io/en/latest/install.html).
 
-Можно настроить экспорт метрик из ClickHouse в [Prometheus](https://prometheus.io). Смотрите [prometheus](server-configuration-parameters/settings.md#server_configuration_parameters-prometheus) конфигурационного файла ClickHouse. Перед настройкой экспорта метрик необходимо настроить Prometheus, как указано в [официальном руководстве](https://prometheus.io/docs/prometheus/latest/installation/).
+Можно настроить экспорт метрик из ClickHouse в [Prometheus](https://prometheus.io). Смотрите секцию [prometheus](server-configuration-parameters/settings.md#server_configuration_parameters-prometheus) конфигурационного файла ClickHouse. Перед настройкой экспорта метрик необходимо настроить Prometheus, как указано в [официальном руководстве](https://prometheus.io/docs/prometheus/latest/installation/).
 
 Также, можно отслеживать доступность сервера через HTTP API. Отправьте `HTTP GET` к ресурсу `/ping`. Если сервер доступен, он отвечает `200 OK`.
 

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -96,7 +96,7 @@ namespace
         return dest;
     }
     
-    auto escapeForLDAPFilter(const String & src)
+    auto escapeForFilter(const String & src)
     {
         String dest;
         dest.reserve(src.size() * 2);

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -352,7 +352,7 @@ void LDAPClient::openConnection()
                 if (user_dn_search_results.size() > 1)
                     throw Exception("Failed to detect user DN: more than one entry in the search results", ErrorCodes::LDAP_ERROR);
 
-                final_user_dn = escapeForFilter(*user_dn_search_results.begin());
+                final_user_dn = *user_dn_search_results.begin();
             }
 
             break;
@@ -399,10 +399,10 @@ LDAPClient::SearchResults LDAPClient::search(const SearchParams & search_params)
     });
 
     const auto final_search_filter = replacePlaceholders(search_params.search_filter, {
-        {"{user_name}", final_user_name},
-        {"{bind_dn}", final_bind_dn},
-        {"{user_dn}", final_user_dn},
-        {"{base_dn}", final_base_dn}
+        {"{user_name}", escapeForFilter(final_user_name)},
+        {"{bind_dn}", escapeForFilter(final_bind_dn)},
+        {"{user_dn}", escapeForFilter(final_user_dn)},
+        {"{base_dn}", escapeForFilter(final_base_dn)}
     });
 
     char * attrs[] = { const_cast<char *>(search_params.attribute.c_str()), nullptr };

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -69,7 +69,7 @@ namespace
 
     std::recursive_mutex ldap_global_mutex;
 
-    auto escapeForLDAP(const String & src)
+    auto escapeForDN(const String & src)
     {
         String dest;
         dest.reserve(src.size() * 2);
@@ -327,7 +327,7 @@ void LDAPClient::openConnection()
     if (params.enable_tls == LDAPClient::Params::TLSEnable::YES_STARTTLS)
         diag(ldap_start_tls_s(handle, nullptr, nullptr));
 
-    final_user_name = escapeForLDAP(params.user);
+    final_user_name = escapeForDN(params.user);
     final_bind_dn = replacePlaceholders(params.bind_dn, { {"{user_name}", final_user_name} });
     final_user_dn = final_bind_dn; // The default value... may be updated right after a successful bind.
 

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -105,11 +105,20 @@ namespace
         {
             switch (ch)
             {
+                case '*':
+                    dest += "\\2A";
+                    break;
                 case '(':
                     dest += "\\28";
                     break;
                 case ')':
                     dest += "\\29";
+                    break;
+                case '\\':
+                    dest += "\\5C";
+                    break;
+                case '\0':
+                    dest += "\\00";
                     break;
                 default:
                     dest += ch;

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -351,7 +351,7 @@ void LDAPClient::openConnection()
                 if (user_dn_search_results.size() > 1)
                     throw Exception("Failed to detect user DN: more than one entry in the search results", ErrorCodes::LDAP_ERROR);
 
-                final_user_dn = escapeForLDAPFilter(*user_dn_search_results.begin());
+                final_user_dn = escapeForFilter(*user_dn_search_results.begin());
             }
 
             break;

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -95,7 +95,6 @@ namespace
 
         return dest;
     }
-    
     auto escapeForFilter(const String & src)
     {
         String dest;

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -95,6 +95,30 @@ namespace
 
         return dest;
     }
+    
+    auto escapeForLDAPFilter(const String & src)
+    {
+        String dest;
+        dest.reserve(src.size() * 2);
+
+        for (auto ch : src)
+        {
+            switch (ch)
+            {
+                case '(':
+                    dest += "\\28";
+                    break;
+                case ')':
+                    dest += "\\29";
+                    break;
+                default:
+                    dest += ch;
+                    break;
+            }
+        }
+
+        return dest;
+    }
 
     auto replacePlaceholders(const String & src, const std::vector<std::pair<String, String>> & pairs)
     {
@@ -319,7 +343,7 @@ void LDAPClient::openConnection()
                 if (user_dn_search_results.size() > 1)
                     throw Exception("Failed to detect user DN: more than one entry in the search results", ErrorCodes::LDAP_ERROR);
 
-                final_user_dn = *user_dn_search_results.begin();
+                final_user_dn = escapeForLDAPFilter(*user_dn_search_results.begin());
             }
 
             break;

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -106,11 +106,15 @@ namespace
             switch (ch)
             {
                 case '(':
+                    dest += "\\28";
+                    break;
                 case ')':
-                    dest += '\\';
-                    break;         
+                    dest += "\\29";
+                    break;
+                default:
+                    dest += ch;
+                    break;
             }
-            dest += ch;
         }
 
         return dest;

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -87,6 +87,8 @@ namespace
                 case ';':
                 case '"':
                 case '=':
+                case '(':
+                case ')':
                     dest += '\\';
                     break;
             }
@@ -96,26 +98,6 @@ namespace
         return dest;
     }
     
-    auto escapeForLDAPFilter(const String & src)
-    {
-        String dest;
-        dest.reserve(src.size() * 2);
-
-        for (auto ch : src)
-        {
-            switch (ch)
-            {
-                case '(':
-                case ')':
-                    dest += '\\';
-                    break;         
-            }
-            dest += ch;
-        }
-
-        return dest;
-    }
-
     auto replacePlaceholders(const String & src, const std::vector<std::pair<String, String>> & pairs)
     {
         String dest = src;
@@ -339,7 +321,7 @@ void LDAPClient::openConnection()
                 if (user_dn_search_results.size() > 1)
                     throw Exception("Failed to detect user DN: more than one entry in the search results", ErrorCodes::LDAP_ERROR);
 
-                final_user_dn = escapeForLDAPFilter(*user_dn_search_results.begin());
+                final_user_dn = escapeForLDAP(*user_dn_search_results.begin());
             }
 
             break;

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -99,7 +99,7 @@ namespace
     auto escapeForFilter(const String & src)
     {
         String dest;
-        dest.reserve(src.size() * 2);
+        dest.reserve(src.size() * 3);
 
         for (auto ch : src)
         {

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -95,6 +95,7 @@ namespace
 
         return dest;
     }
+
     auto escapeForFilter(const String & src)
     {
         String dest;

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -87,8 +87,6 @@ namespace
                 case ';':
                 case '"':
                 case '=':
-                case '(':
-                case ')':
                     dest += '\\';
                     break;
             }
@@ -98,6 +96,26 @@ namespace
         return dest;
     }
     
+    auto escapeForLDAPFilter(const String & src)
+    {
+        String dest;
+        dest.reserve(src.size() * 2);
+
+        for (auto ch : src)
+        {
+            switch (ch)
+            {
+                case '(':
+                case ')':
+                    dest += '\\';
+                    break;         
+            }
+            dest += ch;
+        }
+
+        return dest;
+    }
+
     auto replacePlaceholders(const String & src, const std::vector<std::pair<String, String>> & pairs)
     {
         String dest = src;
@@ -321,7 +339,7 @@ void LDAPClient::openConnection()
                 if (user_dn_search_results.size() > 1)
                     throw Exception("Failed to detect user DN: more than one entry in the search results", ErrorCodes::LDAP_ERROR);
 
-                final_user_dn = escapeForLDAP(*user_dn_search_results.begin());
+                final_user_dn = escapeForLDAPFilter(*user_dn_search_results.begin());
             }
 
             break;

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -106,15 +106,11 @@ namespace
             switch (ch)
             {
                 case '(':
-                    dest += "\\28";
-                    break;
                 case ')':
-                    dest += "\\29";
-                    break;
-                default:
-                    dest += ch;
-                    break;
+                    dest += '\\';
+                    break;         
             }
+            dest += ch;
         }
 
         return dest;


### PR DESCRIPTION
Create a function escapeForLDAPFilter and use it to escape characters '(' and ')' in a final_user_dn variable that we receive from the LDAP server. This is necessary if these characters are present in the user's DN. Otherwise, the entire LDAP authorization process crashes with the error "Bad serach filter"

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Create a function escapeForLDAPFilter and use it to escape characters '(' and ')' in a final_user_dn variable

Detailed description / Documentation draft:
Create a function escapeForLDAPFilter and use it to escape characters '(' and ')' in a final_user_dn variable that we receive from the LDAP server. This is necessary if these characters are present in the user's DN. Otherwise, the entire LDAP authorization process crashes with the error "Bad serach filter". The error was found when setting up authorization in the Clickhouse through LDAP Active Directory server


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
