### PR TITLE
Adding /replicas_status request

### DIFF
--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -23,7 +23,7 @@ Web UI can be accessed here: `http://localhost:8123/play`.
 ![Web UI](../images/play.png)
 
 
-In health-check scripts use `GET /ping` request. This handler always returns “Ok.” (with a line feed at the end). Available from version 18.12.13. If users want to get more sophisticated health checks, it can use the `GET /replicas_status` request.
+In health-check scripts use `GET /ping` request. This handler always returns “Ok.” (with a line feed at the end). Available from version 18.12.13. See also `/replicas_status` to check replica's delay.
 
 ``` bash
 $ curl 'http://localhost:8123/ping'

--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -23,10 +23,12 @@ Web UI can be accessed here: `http://localhost:8123/play`.
 ![Web UI](../images/play.png)
 
 
-In health-check scripts use `GET /ping` request. This handler always returns “Ok.” (with a line feed at the end). Available from version 18.12.13.
+In health-check scripts use `GET /ping` or `GET /replicas_status` request. This handler always returns “Ok.” (with a line feed at the end). Available from version 18.12.13.
 
 ``` bash
 $ curl 'http://localhost:8123/ping'
+Ok.
+$ curl 'http://localhost:8123/replicas_status'
 Ok.
 ```
 

--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -23,7 +23,7 @@ Web UI can be accessed here: `http://localhost:8123/play`.
 ![Web UI](../images/play.png)
 
 
-In health-check scripts use `GET /ping` or `GET /replicas_status` request. This handler always returns “Ok.” (with a line feed at the end). Available from version 18.12.13.
+In health-check scripts use `GET /ping` request. This handler always returns “Ok.” (with a line feed at the end). Available from version 18.12.13. If users want to get more sophisticated health checks, it can use the `GET /replicas_status` request.
 
 ``` bash
 $ curl 'http://localhost:8123/ping'


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
N/A


Detailed description / Documentation draft:

- Adding this `/replicas_status` request to let users know another way about checking health status.
