### PR TITLE
Add `left`, `right`, `leftUTF8`, `rightUTF8` functions.

### DIFF
--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -347,18 +347,31 @@ void NO_INLINE sliceDynamicOffsetUnbounded(Source && src, Sink && sink, const IC
     }
 }
 
-template <typename Source, typename Sink>
-void NO_INLINE sliceDynamicOffsetBounded(Source && src, Sink && sink, const IColumn & offset_column, const IColumn & length_column)
-{
-    const bool is_offset_null = offset_column.onlyNull();
-    const auto * offset_nullable = typeid_cast<const ColumnNullable *>(&offset_column);
-    const ColumnUInt8::Container * offset_null_map = offset_nullable ? &offset_nullable->getNullMapData() : nullptr;
-    const IColumn * offset_nested_column = offset_nullable ? &offset_nullable->getNestedColumn() : &offset_column;
 
-    const bool is_length_null = length_column.onlyNull();
-    const auto * length_nullable = typeid_cast<const ColumnNullable *>(&length_column);
-    const ColumnUInt8::Container * length_null_map = length_nullable ? &length_nullable->getNullMapData() : nullptr;
-    const IColumn * length_nested_column = length_nullable ? &length_nullable->getNestedColumn() : &length_column;
+template <bool inverse_offset, typename Source, typename Sink>
+static void sliceDynamicOffsetBoundedImpl(Source && src, Sink && sink, const IColumn * offset_column, const IColumn * length_column)
+{
+    const bool is_offset_null = !offset_column || offset_column->onlyNull();
+    const ColumnUInt8::Container * offset_null_map = nullptr;
+    const IColumn * offset_nested_column = nullptr;
+
+    if (!is_offset_null)
+    {
+        const auto * offset_nullable = typeid_cast<const ColumnNullable *>(offset_column);
+        offset_null_map = offset_nullable ? &offset_nullable->getNullMapData() : nullptr;
+        offset_nested_column = offset_nullable ? &offset_nullable->getNestedColumn() : offset_column;
+    }
+
+    const bool is_length_null = !length_column || length_column->onlyNull();
+    const ColumnUInt8::Container * length_null_map = nullptr;
+    const IColumn * length_nested_column = nullptr;
+
+    if (!is_length_null)
+    {
+        const auto * length_nullable = typeid_cast<const ColumnNullable *>(length_column);
+        length_null_map = length_nullable ? &length_nullable->getNullMapData() : nullptr;
+        length_nested_column = length_nullable ? &length_nullable->getNestedColumn() : length_column;
+    }
 
     while (!src.isEnd())
     {
@@ -376,9 +389,19 @@ void NO_INLINE sliceDynamicOffsetBounded(Source && src, Sink && sink, const ICol
             typename std::decay_t<Source>::Slice slice;
 
             if (offset > 0)
-                slice = src.getSliceFromLeft(offset - 1, size);
+            {
+                if constexpr (inverse_offset)
+                    slice = src.getSliceFromRight(offset - 1, size);
+                else
+                    slice = src.getSliceFromLeft(offset - 1, size);
+            }
             else
-                slice = src.getSliceFromRight(-UInt64(offset), size);
+            {
+                if constexpr (inverse_offset)
+                    slice = src.getSliceFromLeft(-UInt64(offset), size);
+                else
+                    slice = src.getSliceFromRight(-UInt64(offset), size);
+            }
 
             writeSlice(slice, sink);
         }
@@ -386,6 +409,26 @@ void NO_INLINE sliceDynamicOffsetBounded(Source && src, Sink && sink, const ICol
         sink.next();
         src.next();
     }
+}
+
+
+template <typename Source, typename Sink>
+void NO_INLINE sliceDynamicOffsetBounded(Source && src, Sink && sink, const IColumn & offset_column, const IColumn & length_column)
+{
+    sliceDynamicOffsetBoundedImpl<false>(std::forward<Source>(src), std::forward<Sink>(sink), &offset_column, &length_column);
+}
+
+/// Similar to above, but with no offset.
+template <typename Source, typename Sink>
+void NO_INLINE sliceFromLeftDynamicLength(Source && src, Sink && sink, const IColumn & length_column)
+{
+    sliceDynamicOffsetBoundedImpl<false>(std::forward<Source>(src), std::forward<Sink>(sink), nullptr, &length_column);
+}
+
+template <typename Source, typename Sink>
+void NO_INLINE sliceFromRightDynamicLength(Source && src, Sink && sink, const IColumn & length_column)
+{
+    sliceDynamicOffsetBoundedImpl<true>(std::forward<Source>(src), std::forward<Sink>(sink), nullptr, &length_column);
 }
 
 

--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -636,6 +636,7 @@ bool insliceEqualElements(const NumericArraySlice<T> & first [[maybe_unused]],
     else
         return accurate::equalsOp(first.data[first_ind], first.data[second_ind]);
 }
+
 inline ALWAYS_INLINE bool insliceEqualElements(const GenericArraySlice & first, size_t first_ind, size_t second_ind)
 {
     return first.elements->compareAt(first_ind + first.begin, second_ind + first.begin, *first.elements, -1) == 0;

--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -348,7 +348,7 @@ void NO_INLINE sliceDynamicOffsetUnbounded(Source && src, Sink && sink, const IC
 }
 
 
-template <bool inverse_offset, typename Source, typename Sink>
+template <bool inverse, typename Source, typename Sink>
 static void sliceDynamicOffsetBoundedImpl(Source && src, Sink && sink, const IColumn * offset_column, const IColumn * length_column)
 {
     const bool is_offset_null = !offset_column || offset_column->onlyNull();
@@ -390,14 +390,14 @@ static void sliceDynamicOffsetBoundedImpl(Source && src, Sink && sink, const ICo
 
             if (offset > 0)
             {
-                if constexpr (inverse_offset)
-                    slice = src.getSliceFromRight(offset - 1, size);
+                if constexpr (inverse)
+                    slice = src.getSliceFromRight(size + offset - 1, size);
                 else
                     slice = src.getSliceFromLeft(offset - 1, size);
             }
             else
             {
-                if constexpr (inverse_offset)
+                if constexpr (inverse)
                     slice = src.getSliceFromLeft(-UInt64(offset), size);
                 else
                     slice = src.getSliceFromRight(-UInt64(offset), size);

--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -391,9 +391,9 @@ static void sliceDynamicOffsetBoundedImpl(Source && src, Sink && sink, const ICo
             if (offset > 0)
             {
                 if constexpr (inverse)
-                    slice = src.getSliceFromRight(size + offset - 1, size);
+                    slice = src.getSliceFromRight(UInt64(size) + UInt64(offset) - 1, size);
                 else
-                    slice = src.getSliceFromLeft(offset - 1, size);
+                    slice = src.getSliceFromLeft(UInt64(offset) - 1, size);
             }
             else
             {

--- a/src/Functions/GatherUtils/GatherUtils.h
+++ b/src/Functions/GatherUtils/GatherUtils.h
@@ -32,9 +32,9 @@ namespace DB::GatherUtils
 
 enum class ArraySearchType
 {
-  Any, // Corresponds to the hasAny array function
-  All, // Corresponds to the hasAll array function
-  Substr // Corresponds to the hasSubstr array function
+    Any, // Corresponds to the hasAny array function
+    All, // Corresponds to the hasAll array function
+    Substr // Corresponds to the hasSubstr array function
 };
 
 std::unique_ptr<IArraySource> createArraySource(const ColumnArray & col, bool is_const, size_t total_rows);

--- a/src/Functions/GatherUtils/GatherUtils.h
+++ b/src/Functions/GatherUtils/GatherUtils.h
@@ -52,6 +52,9 @@ ColumnArray::MutablePtr sliceFromRightConstantOffsetBounded(IArraySource & src, 
 ColumnArray::MutablePtr sliceDynamicOffsetUnbounded(IArraySource & src, const IColumn & offset_column);
 ColumnArray::MutablePtr sliceDynamicOffsetBounded(IArraySource & src, const IColumn & offset_column, const IColumn & length_column);
 
+ColumnArray::MutablePtr sliceFromLeftDynamicLength(IArraySource & src, const IColumn & length_column);
+ColumnArray::MutablePtr sliceFromRightDynamicLength(IArraySource & src, const IColumn & length_column);
+
 void sliceHasAny(IArraySource & first, IArraySource & second, ColumnUInt8 & result);
 void sliceHasAll(IArraySource & first, IArraySource & second, ColumnUInt8 & result);
 void sliceHasSubstr(IArraySource & first, IArraySource & second, ColumnUInt8 & result);

--- a/src/Functions/GatherUtils/Sources.h
+++ b/src/Functions/GatherUtils/Sources.h
@@ -358,6 +358,11 @@ struct UTF8StringSource : public StringSource
         return pos;
     }
 
+    size_t getElementSize() const
+    {
+        return UTF8::countCodePoints(&elements[prev_offset], StringSource::getElementSize());
+    }
+
     Slice getSliceFromLeft(size_t offset) const
     {
         const auto * begin = &elements[prev_offset];

--- a/src/Functions/GatherUtils/sliceFromLeftDynamicLength.cpp
+++ b/src/Functions/GatherUtils/sliceFromLeftDynamicLength.cpp
@@ -1,0 +1,60 @@
+#ifndef __clang_analyzer__ // It's too hard to analyze.
+
+#include "GatherUtils.h"
+#include "Selectors.h"
+#include "Algorithms.h"
+
+namespace DB::GatherUtils
+{
+
+namespace
+{
+
+struct Selector : public ArraySourceSelector<Selector>
+{
+    template <typename Source>
+    static void selectSource(bool is_const, bool is_nullable, Source && source,
+                             const IColumn & length_column, ColumnArray::MutablePtr & result)
+    {
+        using SourceType = typename std::decay<Source>::type;
+        using Sink = typename SourceType::SinkType;
+
+        if (is_nullable)
+        {
+            using NullableSource = NullableArraySource<SourceType>;
+            using NullableSink = typename NullableSource::SinkType;
+
+            auto & nullable_source = static_cast<NullableSource &>(source);
+
+            result = ColumnArray::create(nullable_source.createValuesColumn());
+            NullableSink sink(result->getData(), result->getOffsets(), source.getColumnSize());
+
+            if (is_const)
+                sliceFromLeftDynamicLength(static_cast<ConstSource<NullableSource> &>(source), sink, length_column);
+            else
+                sliceFromLeftDynamicLength(static_cast<NullableSource &>(source), sink, length_column);
+        }
+        else
+        {
+            result = ColumnArray::create(source.createValuesColumn());
+            Sink sink(result->getData(), result->getOffsets(), source.getColumnSize());
+
+            if (is_const)
+                sliceFromLeftDynamicLength(static_cast<ConstSource<SourceType> &>(source), sink, length_column);
+            else
+                sliceFromLeftDynamicLength(source, sink, length_column);
+        }
+    }
+};
+
+}
+
+ColumnArray::MutablePtr sliceFromLeftDynamicLength(IArraySource & src, const IColumn & length_column)
+{
+    ColumnArray::MutablePtr res;
+    Selector::select(src, length_column, res);
+    return res;
+}
+}
+
+#endif

--- a/src/Functions/GatherUtils/sliceFromRightDynamicLength.cpp
+++ b/src/Functions/GatherUtils/sliceFromRightDynamicLength.cpp
@@ -1,0 +1,60 @@
+#ifndef __clang_analyzer__ // It's too hard to analyze.
+
+#include "GatherUtils.h"
+#include "Selectors.h"
+#include "Algorithms.h"
+
+namespace DB::GatherUtils
+{
+
+namespace
+{
+
+struct Selector : public ArraySourceSelector<Selector>
+{
+    template <typename Source>
+    static void selectSource(bool is_const, bool is_nullable, Source && source,
+                             const IColumn & length_column, ColumnArray::MutablePtr & result)
+    {
+        using SourceType = typename std::decay<Source>::type;
+        using Sink = typename SourceType::SinkType;
+
+        if (is_nullable)
+        {
+            using NullableSource = NullableArraySource<SourceType>;
+            using NullableSink = typename NullableSource::SinkType;
+
+            auto & nullable_source = static_cast<NullableSource &>(source);
+
+            result = ColumnArray::create(nullable_source.createValuesColumn());
+            NullableSink sink(result->getData(), result->getOffsets(), source.getColumnSize());
+
+            if (is_const)
+                sliceFromRightDynamicLength(static_cast<ConstSource<NullableSource> &>(source), sink, length_column);
+            else
+                sliceFromRightDynamicLength(static_cast<NullableSource &>(source), sink, length_column);
+        }
+        else
+        {
+            result = ColumnArray::create(source.createValuesColumn());
+            Sink sink(result->getData(), result->getOffsets(), source.getColumnSize());
+
+            if (is_const)
+                sliceFromRightDynamicLength(static_cast<ConstSource<SourceType> &>(source), sink, length_column);
+            else
+                sliceFromRightDynamicLength(source, sink, length_column);
+        }
+    }
+};
+
+}
+
+ColumnArray::MutablePtr sliceFromRightDynamicLength(IArraySource & src, const IColumn & length_column)
+{
+    ColumnArray::MutablePtr res;
+    Selector::select(src, length_column, res);
+    return res;
+}
+}
+
+#endif

--- a/src/Functions/LeftRight.h
+++ b/src/Functions/LeftRight.h
@@ -85,7 +85,7 @@ public:
         else
         {
             if (column_length_const)
-                sliceFromRightConstantOffsetBounded(source, StringSink(*col_res, input_rows_count), 0, length_value);
+                sliceFromRightConstantOffsetUnbounded(source, StringSink(*col_res, input_rows_count), length_value);
             else
                 sliceFromRightDynamicLength(source, StringSink(*col_res, input_rows_count), *column_length);
         }

--- a/src/Functions/LeftRight.h
+++ b/src/Functions/LeftRight.h
@@ -1,0 +1,143 @@
+#include <DataTypes/DataTypeString.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnConst.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Functions/GatherUtils/GatherUtils.h>
+#include <Functions/GatherUtils/Sources.h>
+#include <Functions/GatherUtils/Sinks.h>
+#include <Functions/GatherUtils/Slices.h>
+#include <Functions/GatherUtils/Algorithms.h>
+#include <IO/WriteHelpers.h>
+
+
+namespace DB
+{
+
+using namespace GatherUtils;
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_COLUMN;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+enum class SubstringDirection
+{
+    Left,
+    Right
+};
+
+template <bool is_utf8, SubstringDirection direction>
+class FunctionLeftRight : public IFunction
+{
+public:
+    static constexpr auto name = direction == SubstringDirection::Left
+        ? (is_utf8 ? "leftUTF8" : "left")
+        : (is_utf8 ? "rightUTF8" : "right");
+
+    static FunctionPtr create(ContextPtr)
+    {
+        return std::make_shared<FunctionLeftRight>();
+    }
+
+    String getName() const override
+    {
+        return name;
+    }
+
+    bool isVariadic() const override { return false; }
+    size_t getNumberOfArguments() const override { return 2; }
+
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+    bool useDefaultImplementationForConstants() const override { return true; }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    {
+        if ((is_utf8 && !isString(arguments[0])) || !isStringOrFixedString(arguments[0]))
+            throw Exception("Illegal type " + arguments[0]->getName() + " of argument of function " + getName(), ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
+        if (!isNativeNumber(arguments[1]))
+            throw Exception("Illegal type " + arguments[1]->getName()
+                    + " of second argument of function "
+                    + getName(),
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
+        return std::make_shared<DataTypeString>();
+    }
+
+    template <typename Source>
+    ColumnPtr executeForSource(const ColumnPtr & column_length,
+                          const ColumnConst * column_length_const,
+                          Int64 length_value, Source && source,
+                          size_t input_rows_count) const
+    {
+        auto col_res = ColumnString::create();
+
+        if constexpr (direction == SubstringDirection::Left)
+        {
+            if (column_length_const)
+                sliceFromLeftConstantOffsetBounded(source, StringSink(*col_res, input_rows_count), 0, length_value);
+            else
+                sliceFromLeftDynamicLength(source, StringSink(*col_res, input_rows_count), *column_length);
+        }
+        else
+        {
+            if (column_length_const)
+                sliceFromRightConstantOffsetBounded(source, StringSink(*col_res, input_rows_count), 0, length_value);
+            else
+                sliceFromRightDynamicLength(source, StringSink(*col_res, input_rows_count), *column_length);
+        }
+
+        return col_res;
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    {
+        ColumnPtr column_string = arguments[0].column;
+        ColumnPtr column_length = arguments[1].column;
+
+        const ColumnConst * column_length_const = checkAndGetColumn<ColumnConst>(column_length.get());
+
+        Int64 length_value = 0;
+
+        if (column_length_const)
+            length_value = column_length_const->getInt(0);
+
+        if constexpr (is_utf8)
+        {
+            if (const ColumnString * col = checkAndGetColumn<ColumnString>(column_string.get()))
+                return executeForSource(column_length, column_length_const,
+                    length_value, UTF8StringSource(*col), input_rows_count);
+            else if (const ColumnConst * col_const = checkAndGetColumnConst<ColumnString>(column_string.get()))
+                return executeForSource(column_length, column_length_const,
+                    length_value, ConstSource<UTF8StringSource>(*col_const), input_rows_count);
+            else
+                throw Exception(
+                    "Illegal column " + arguments[0].column->getName() + " of first argument of function " + getName(),
+                    ErrorCodes::ILLEGAL_COLUMN);
+        }
+        else
+        {
+            if (const ColumnString * col = checkAndGetColumn<ColumnString>(column_string.get()))
+                return executeForSource(column_length, column_length_const,
+                    length_value, StringSource(*col), input_rows_count);
+            else if (const ColumnFixedString * col_fixed = checkAndGetColumn<ColumnFixedString>(column_string.get()))
+                return executeForSource(column_length, column_length_const,
+                    length_value, FixedStringSource(*col_fixed), input_rows_count);
+            else if (const ColumnConst * col_const = checkAndGetColumnConst<ColumnString>(column_string.get()))
+                return executeForSource(column_length, column_length_const,
+                    length_value, ConstSource<StringSource>(*col_const), input_rows_count);
+            else if (const ColumnConst * col_const_fixed = checkAndGetColumnConst<ColumnFixedString>(column_string.get()))
+                return executeForSource(column_length, column_length_const,
+                    length_value, ConstSource<FixedStringSource>(*col_const_fixed), input_rows_count);
+            else
+                throw Exception(
+                    "Illegal column " + arguments[0].column->getName() + " of first argument of function " + getName(),
+                    ErrorCodes::ILLEGAL_COLUMN);
+        }
+    }
+};
+
+}

--- a/src/Functions/LeftRight.h
+++ b/src/Functions/LeftRight.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <DataTypes/DataTypeString.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnFixedString.h>

--- a/src/Functions/left.cpp
+++ b/src/Functions/left.cpp
@@ -1,0 +1,13 @@
+#include <Functions/FunctionFactory.h>
+#include <Functions/LeftRight.h>
+
+namespace DB
+{
+
+void registerFunctionLeft(FunctionFactory & factory)
+{
+    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Left>>(FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Left>>(FunctionFactory::CaseSensitive);
+}
+
+}

--- a/src/Functions/registerFunctionsString.cpp
+++ b/src/Functions/registerFunctionsString.cpp
@@ -23,6 +23,8 @@ void registerFunctionsConcat(FunctionFactory &);
 void registerFunctionFormat(FunctionFactory &);
 void registerFunctionFormatRow(FunctionFactory &);
 void registerFunctionSubstring(FunctionFactory &);
+void registerFunctionLeft(FunctionFactory &);
+void registerFunctionRight(FunctionFactory &);
 void registerFunctionCRC(FunctionFactory &);
 void registerFunctionAppendTrailingCharIfAbsent(FunctionFactory &);
 void registerFunctionStartsWith(FunctionFactory &);
@@ -74,6 +76,8 @@ void registerFunctionsString(FunctionFactory & factory)
     registerFunctionFormat(factory);
     registerFunctionFormatRow(factory);
     registerFunctionSubstring(factory);
+    registerFunctionLeft(factory);
+    registerFunctionRight(factory);
     registerFunctionAppendTrailingCharIfAbsent(factory);
     registerFunctionStartsWith(factory);
     registerFunctionEndsWith(factory);

--- a/src/Functions/right.cpp
+++ b/src/Functions/right.cpp
@@ -1,0 +1,13 @@
+#include <Functions/FunctionFactory.h>
+#include <Functions/LeftRight.h>
+
+namespace DB
+{
+
+void registerFunctionRight(FunctionFactory & factory)
+{
+    factory.registerFunction<FunctionLeftRight<false, SubstringDirection::Right>>(FunctionFactory::CaseInsensitive);
+    factory.registerFunction<FunctionLeftRight<true, SubstringDirection::Right>>(FunctionFactory::CaseSensitive);
+}
+
+}

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1261,92 +1261,6 @@ bool ParserTrimExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expect
     return true;
 }
 
-bool ParserLeftExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
-{
-    /// Rewrites left(expr, length) to SUBSTRING(expr, 1, length)
-
-    ASTPtr expr_node;
-    ASTPtr start_node;
-    ASTPtr length_node;
-
-    if (!ParserKeyword("LEFT").ignore(pos, expected))
-        return false;
-
-    if (pos->type != TokenType::OpeningRoundBracket)
-        return false;
-    ++pos;
-
-    if (!ParserExpression().parse(pos, expr_node, expected))
-        return false;
-
-    ParserToken(TokenType::Comma).ignore(pos, expected);
-
-    if (!ParserExpression().parse(pos, length_node, expected))
-        return false;
-
-    if (pos->type != TokenType::ClosingRoundBracket)
-        return false;
-    ++pos;
-
-    auto expr_list_args = std::make_shared<ASTExpressionList>();
-    start_node = std::make_shared<ASTLiteral>(1);
-    expr_list_args->children = {expr_node, start_node, length_node};
-
-    auto func_node = std::make_shared<ASTFunction>();
-    func_node->name = "substring";
-    func_node->arguments = std::move(expr_list_args);
-    func_node->children.push_back(func_node->arguments);
-
-    node = std::move(func_node);
-    return true;
-}
-
-bool ParserRightExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
-{
-    /// Rewrites RIGHT(expr, length) to substring(expr, -length)
-
-    ASTPtr expr_node;
-    ASTPtr length_node;
-
-    if (!ParserKeyword("RIGHT").ignore(pos, expected))
-        return false;
-
-    if (pos->type != TokenType::OpeningRoundBracket)
-        return false;
-    ++pos;
-
-    if (!ParserExpression().parse(pos, expr_node, expected))
-        return false;
-
-    ParserToken(TokenType::Comma).ignore(pos, expected);
-
-    if (!ParserExpression().parse(pos, length_node, expected))
-        return false;
-
-    if (pos->type != TokenType::ClosingRoundBracket)
-        return false;
-    ++pos;
-
-    auto start_expr_list_args = std::make_shared<ASTExpressionList>();
-    start_expr_list_args->children = {length_node};
-
-    auto start_node = std::make_shared<ASTFunction>();
-    start_node->name = "negate";
-    start_node->arguments = std::move(start_expr_list_args);
-    start_node->children.push_back(start_node->arguments);
-
-    auto expr_list_args = std::make_shared<ASTExpressionList>();
-    expr_list_args->children = {expr_node, start_node};
-
-    auto func_node = std::make_shared<ASTFunction>();
-    func_node->name = "substring";
-    func_node->arguments = std::move(expr_list_args);
-    func_node->children.push_back(func_node->arguments);
-
-    node = std::move(func_node);
-    return true;
-}
-
 bool ParserExtractExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     if (!ParserKeyword("EXTRACT").ignore(pos, expected))
@@ -2272,8 +2186,6 @@ bool ParserExpressionElement::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
         || ParserDateDiffExpression().parse(pos, node, expected)
         || ParserSubstringExpression().parse(pos, node, expected)
         || ParserTrimExpression().parse(pos, node, expected)
-        || ParserLeftExpression().parse(pos, node, expected)
-        || ParserRightExpression().parse(pos, node, expected)
         || ParserCase().parse(pos, node, expected)
         || ParserColumnsMatcher().parse(pos, node, expected) /// before ParserFunction because it can be also parsed as a function.
         || ParserFunction().parse(pos, node, expected)

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -250,20 +250,6 @@ protected:
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 
-class ParserLeftExpression : public IParserBase
-{
-protected:
-    const char * getName() const override { return "LEFT expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
-};
-
-class ParserRightExpression : public IParserBase
-{
-protected:
-    const char * getName() const override { return "RIGHT expression"; }
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
-};
-
 class ParserExtractExpression : public IParserBase
 {
 protected:

--- a/src/Storages/System/StorageSystemBuildOptions.generated.cpp.in
+++ b/src/Storages/System/StorageSystemBuildOptions.generated.cpp.in
@@ -51,9 +51,9 @@ const char * auto_config_build[]
     "USE_FILELOG", "@USE_FILELOG@",
     "USE_BZIP2", "@USE_BZIP2@",
     "GIT_HASH", "@GIT_HASH@",
-    "GIT_BRANCH", "@GIT_BRANCH@",
+    "GIT_BRANCH", R"IRjaNsZIL9Yh7FQ4(@GIT_BRANCH@)IRjaNsZIL9Yh7FQ4",
     "GIT_DATE", "@GIT_DATE@",
-    "GIT_COMMIT_SUBJECT", "@GIT_COMMIT_SUBJECT@",
+    "GIT_COMMIT_SUBJECT", R"Gi17KJMlbGCjErEN(@GIT_COMMIT_SUBJECT@)Gi17KJMlbGCjErEN",
 
     nullptr, nullptr
 };

--- a/tests/queries/0_stateless/02159_left_right.reference
+++ b/tests/queries/0_stateless/02159_left_right.reference
@@ -1,0 +1,230 @@
+-- { echo }
+
+SELECT left('Hello', 3);
+Hel
+SELECT left('Hello', -3);
+He
+SELECT left('Hello', 5);
+Hello
+SELECT left('Hello', -5);
+
+SELECT left('Hello', 6);
+Hello
+SELECT left('Hello', -6);
+
+SELECT left('Hello', 0);
+
+SELECT left('Hello', NULL);
+\N
+SELECT left(materialize('Привет'), 4);
+Пр
+SELECT LEFT('Привет', -4);
+Прив
+SELECT left(toNullable('Привет'), 12);
+Привет
+SELECT lEFT('Привет', -12);
+
+SELECT left(materialize(toNullable('Привет')), 13);
+Привет
+SELECT left('Привет', -13);
+
+SELECT Left('Привет', 0);
+
+SELECT left('Привет', NULL);
+\N
+SELECT leftUTF8('Привет', 4);
+Прив
+SELECT leftUTF8('Привет', -4);
+Пр
+SELECT leftUTF8('Привет', 12);
+Привет
+SELECT leftUTF8('Привет', -12);
+
+SELECT leftUTF8('Привет', 13);
+Привет
+SELECT leftUTF8('Привет', -13);
+
+SELECT leftUTF8('Привет', 0);
+
+SELECT leftUTF8('Привет', NULL);
+\N
+SELECT left('Hello', number) FROM numbers(10);
+
+H
+He
+Hel
+Hell
+Hello
+Hello
+Hello
+Hello
+Hello
+SELECT leftUTF8('Привет', number) FROM numbers(10);
+
+П
+Пр
+При
+Прив
+Приве
+Привет
+Привет
+Привет
+Привет
+SELECT left('Hello', -number) FROM numbers(10);
+
+Hell
+Hel
+He
+H
+
+
+
+
+
+SELECT leftUTF8('Привет', -number) FROM numbers(10);
+
+Приве
+Прив
+При
+Пр
+П
+
+
+
+
+SELECT leftUTF8('Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
+\N
+П
+Прив
+\N
+Пр
+Приве
+\N
+Привет
+
+\N
+SELECT leftUTF8(number < 5 ? 'Hello' : 'Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
+\N
+H
+Hel
+\N
+H
+Приве
+\N
+Привет
+
+\N
+SELECT right('Hello', 3);
+llo
+SELECT right('Hello', -3);
+lo
+SELECT right('Hello', 5);
+Hello
+SELECT right('Hello', -5);
+
+SELECT right('Hello', 6);
+Hello
+SELECT right('Hello', -6);
+
+SELECT right('Hello', 0);
+
+SELECT right('Hello', NULL);
+\N
+SELECT RIGHT(materialize('Привет'), 4);
+ет
+SELECT right('Привет', -4);
+ивет
+SELECT Right(toNullable('Привет'), 12);
+Привет
+SELECT right('Привет', -12);
+
+SELECT rIGHT(materialize(toNullable('Привет')), 13);
+Привет
+SELECT right('Привет', -13);
+
+SELECT rIgHt('Привет', 0);
+
+SELECT RiGhT('Привет', NULL);
+\N
+SELECT rightUTF8('Привет', 4);
+ивет
+SELECT rightUTF8('Привет', -4);
+ет
+SELECT rightUTF8('Привет', 12);
+Привет
+SELECT rightUTF8('Привет', -12);
+
+SELECT rightUTF8('Привет', 13);
+Привет
+SELECT rightUTF8('Привет', -13);
+
+SELECT rightUTF8('Привет', 0);
+
+SELECT rightUTF8('Привет', NULL);
+\N
+SELECT right('Hello', number) FROM numbers(10);
+
+o
+lo
+llo
+ello
+Hello
+Hello
+Hello
+Hello
+Hello
+SELECT rightUTF8('Привет', number) FROM numbers(10);
+
+т
+ет
+вет
+ивет
+ривет
+Привет
+Привет
+Привет
+Привет
+SELECT right('Hello', -number) FROM numbers(10);
+
+ello
+llo
+lo
+o
+
+
+
+
+
+SELECT rightUTF8('Привет', -number) FROM numbers(10);
+
+ривет
+ивет
+вет
+ет
+т
+
+
+
+
+SELECT rightUTF8('Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
+\N
+т
+ивет
+\N
+ет
+ривет
+\N
+Привет
+
+\N
+SELECT rightUTF8(number < 5 ? 'Hello' : 'Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
+\N
+o
+llo
+\N
+o
+ривет
+\N
+Привет
+
+\N

--- a/tests/queries/0_stateless/02159_left_right.sql
+++ b/tests/queries/0_stateless/02159_left_right.sql
@@ -1,0 +1,71 @@
+-- { echo }
+
+SELECT left('Hello', 3);
+SELECT left('Hello', -3);
+SELECT left('Hello', 5);
+SELECT left('Hello', -5);
+SELECT left('Hello', 6);
+SELECT left('Hello', -6);
+SELECT left('Hello', 0);
+SELECT left('Hello', NULL);
+
+SELECT left(materialize('Привет'), 4);
+SELECT LEFT('Привет', -4);
+SELECT left(toNullable('Привет'), 12);
+SELECT lEFT('Привет', -12);
+SELECT left(materialize(toNullable('Привет')), 13);
+SELECT left('Привет', -13);
+SELECT Left('Привет', 0);
+SELECT left('Привет', NULL);
+
+SELECT leftUTF8('Привет', 4);
+SELECT leftUTF8('Привет', -4);
+SELECT leftUTF8('Привет', 12);
+SELECT leftUTF8('Привет', -12);
+SELECT leftUTF8('Привет', 13);
+SELECT leftUTF8('Привет', -13);
+SELECT leftUTF8('Привет', 0);
+SELECT leftUTF8('Привет', NULL);
+
+SELECT left('Hello', number) FROM numbers(10);
+SELECT leftUTF8('Привет', number) FROM numbers(10);
+SELECT left('Hello', -number) FROM numbers(10);
+SELECT leftUTF8('Привет', -number) FROM numbers(10);
+
+SELECT leftUTF8('Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
+SELECT leftUTF8(number < 5 ? 'Hello' : 'Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
+
+SELECT right('Hello', 3);
+SELECT right('Hello', -3);
+SELECT right('Hello', 5);
+SELECT right('Hello', -5);
+SELECT right('Hello', 6);
+SELECT right('Hello', -6);
+SELECT right('Hello', 0);
+SELECT right('Hello', NULL);
+
+SELECT RIGHT(materialize('Привет'), 4);
+SELECT right('Привет', -4);
+SELECT Right(toNullable('Привет'), 12);
+SELECT right('Привет', -12);
+SELECT rIGHT(materialize(toNullable('Привет')), 13);
+SELECT right('Привет', -13);
+SELECT rIgHt('Привет', 0);
+SELECT RiGhT('Привет', NULL);
+
+SELECT rightUTF8('Привет', 4);
+SELECT rightUTF8('Привет', -4);
+SELECT rightUTF8('Привет', 12);
+SELECT rightUTF8('Привет', -12);
+SELECT rightUTF8('Привет', 13);
+SELECT rightUTF8('Привет', -13);
+SELECT rightUTF8('Привет', 0);
+SELECT rightUTF8('Привет', NULL);
+
+SELECT right('Hello', number) FROM numbers(10);
+SELECT rightUTF8('Привет', number) FROM numbers(10);
+SELECT right('Hello', -number) FROM numbers(10);
+SELECT rightUTF8('Привет', -number) FROM numbers(10);
+
+SELECT rightUTF8('Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
+SELECT rightUTF8(number < 5 ? 'Hello' : 'Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);


### PR DESCRIPTION
Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `left`, `right`, `leftUTF8`, `rightUTF8` functions. Fix error in implementation of `substringUTF8` function with negative offset (offset from the end of string). The functions `left` and `right` were previously implemented in parser. Upgrade notes: distributed queries with `left` or `right` functions without aliases may throw exception if cluster contains different versions of clickhouse-server. If you are upgrading your cluster and encounter this error, you should finish upgrading your cluster to ensure all nodes have the same version. Also you can add aliases (`AS something`) to the columns in your queries to avoid this issue.