### PR TITLE
Improve install on FreeBSD #33384

### DIFF
--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -233,6 +233,9 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
             path.pop_back();
 
         fs::path binary_self_path(path);
+#elif defined(OS_FREEBSD)
+        /// https://stackoverflow.com/questions/1023306/finding-current-executables-path-without-proc-self-exe
+        fs::path binary_self_path = "/proc/curproc/file";
 #else
         fs::path binary_self_path = "/proc/self/exe";
 #endif

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -153,10 +153,12 @@ static void createGroup(const String & group_name)
     if (!group_name.empty())
     {
 #if defined(OS_DARWIN)
-
         // TODO: implement.
-
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unable to create a group in macOS");
+#elif defined(OS_FREEBSD)
+        std::string command = fmt::format("pw groupadd {}", group_name);
+        fmt::print(" {}\n", command);
+        executeScript(command);
 #else
         std::string command = fmt::format("groupadd -r {}", group_name);
         fmt::print(" {}\n", command);
@@ -170,10 +172,14 @@ static void createUser(const String & user_name, [[maybe_unused]] const String &
     if (!user_name.empty())
     {
 #if defined(OS_DARWIN)
-
         // TODO: implement.
-
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unable to create a user in macOS");
+#elif defined(OS_FREEBSD)
+        std::string command = group_name.empty()
+            ? fmt::format("pw useradd -s /bin/false -d /nonexistent -n {}", user_name)
+            : fmt::format("pw useradd -s /bin/false -d /nonexistent -g {} -n {}", group_name, user_name);
+        fmt::print(" {}\n", command);
+        executeScript(command);
 #else
         std::string command = group_name.empty()
             ? fmt::format("useradd -r --shell /bin/false --home-dir /nonexistent --user-group {}", user_name)

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -235,7 +235,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
         fs::path binary_self_path(path);
 #elif defined(OS_FREEBSD)
         /// https://stackoverflow.com/questions/1023306/finding-current-executables-path-without-proc-self-exe
-        fs::path binary_self_path = "/proc/curproc/file";
+        fs::path binary_self_path = argc >= 1 ? argv[0] : "/proc/curproc/file";
 #else
         fs::path binary_self_path = "/proc/self/exe";
 #endif

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -924,7 +924,7 @@ namespace
         if (!user.empty())
         {
 #if defined(OS_FREEBSD)
-            command = fmt::format("su -m '{}' -c '{}', user, command);
+            command = fmt::format("su -m '{}' -c '{}'", user, command);
 #else
             bool may_need_sudo = geteuid() != 0;
             if (may_need_sudo)

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -919,7 +919,13 @@ namespace
                     command = fmt::format("sudo -u '{}' {}", user, command);
             }
             else
+            {
+#if defined(OS_FREEBSD)
+                command = fmt::format("su -m '{}' -c '{}', user, command);
+#else
                 command = fmt::format("su -s /bin/sh '{}' -c '{}'", user, command);
+#endif
+            }
         }
 
         fmt::print("Will run {}\n", command);


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make installation script working on FreeBSD. This closes #33384.


We don't have CI for FreeBSD, so this fix has to be tested manually.