### PR TITLE
fix misleading log message in StorageWindowView

### DIFF
--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -877,11 +877,11 @@ void StorageWindowView::threadFuncFireEvent()
     std::unique_lock lock(fire_signal_mutex);
     while (!shutdown_called)
     {
-        LOG_TRACE(log, "Fire events: {}", fire_signal.size());
-
         bool signaled = std::cv_status::no_timeout == fire_signal_condition.wait_for(lock, std::chrono::seconds(5));
         if (!signaled)
             continue;
+
+        LOG_TRACE(log, "Fire events: {}", fire_signal.size());
 
         while (!fire_signal.empty())
         {


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

After finishing the inner loop, the size of fire_signal always 0, which making the log misleading.