### PR TITLE
Fix quick start for FreeBSD

### DIFF
--- a/docs/_includes/install/freebsd.sh
+++ b/docs/_includes/install/freebsd.sh
@@ -1,3 +1,3 @@
-wget 'https://builds.clickhouse.com/master/freebsd/clickhouse'
+fetch 'https://builds.clickhouse.com/master/freebsd/clickhouse'
 chmod a+x ./clickhouse
-sudo ./clickhouse install
+su -m root -c './clickhouse install'


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Continuation of #33418.