### PR TITLE
Update AsynchronousReadIndirectBufferFromRemoteFS.h

### DIFF
--- a/src/Disks/IO/AsynchronousReadIndirectBufferFromRemoteFS.h
+++ b/src/Disks/IO/AsynchronousReadIndirectBufferFromRemoteFS.h
@@ -32,7 +32,7 @@ public:
     explicit AsynchronousReadIndirectBufferFromRemoteFS(
         AsynchronousReaderPtr reader_, const ReadSettings & settings_,
         std::shared_ptr<ReadBufferFromRemoteFSGather> impl_,
-        size_t min_bytes_for_seek = 1024 * 1024);
+        size_t min_bytes_for_seek = DBMS_DEFAULT_BUFFER_SIZE);
 
     ~AsynchronousReadIndirectBufferFromRemoteFS() override;
 


### PR DESCRIPTION
update 1024 * 1024 to DBMS_DEFAULT_BUFFER_SIZE

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
