### PR TITLE
Dictionaries use single arena for multiple string attributes

### DIFF
--- a/src/Dictionaries/CacheDictionaryStorage.h
+++ b/src/Dictionaries/CacheDictionaryStorage.h
@@ -13,6 +13,7 @@
 #include <Dictionaries/ICacheDictionaryStorage.h>
 #include <Dictionaries/DictionaryHelpers.h>
 
+
 namespace DB
 {
 
@@ -308,7 +309,7 @@ private:
             if (was_inserted)
             {
                 if constexpr (std::is_same_v<KeyType, StringRef>)
-                    cell.key = copyStringInArena(key);
+                    cell.key = copyStringInArena(arena, key);
                 else
                     cell.key = key;
 
@@ -332,8 +333,7 @@ private:
                         else if constexpr (std::is_same_v<ElementType, StringRef>)
                         {
                             const String & string_value = column_value.get<String>();
-                            StringRef string_value_ref = StringRef {string_value.data(), string_value.size()};
-                            StringRef inserted_value = copyStringInArena(string_value_ref);
+                            StringRef inserted_value = copyStringInArena(arena, string_value);
                             container.back() = inserted_value;
                         }
                         else
@@ -353,7 +353,7 @@ private:
                     {
                         char * data = const_cast<char *>(cell.key.data);
                         arena.free(data, cell.key.size);
-                        cell.key = copyStringInArena(key);
+                        cell.key = copyStringInArena(arena, key);
                     }
                     else
                         cell.key = key;
@@ -379,8 +379,7 @@ private:
                         else if constexpr (std::is_same_v<ElementType, StringRef>)
                         {
                             const String & string_value = column_value.get<String>();
-                            StringRef string_ref_value = StringRef {string_value.data(), string_value.size()};
-                            StringRef inserted_value = copyStringInArena(string_ref_value);
+                            StringRef inserted_value = copyStringInArena(arena, string_value);
 
                             if (!cell_was_default)
                             {
@@ -423,7 +422,7 @@ private:
             if (was_inserted)
             {
                 if constexpr (std::is_same_v<KeyType, StringRef>)
-                    cell.key = copyStringInArena(key);
+                    cell.key = copyStringInArena(arena, key);
                 else
                     cell.key = key;
 
@@ -463,7 +462,7 @@ private:
                     {
                         char * data = const_cast<char *>(cell.key.data);
                         arena.free(data, cell.key.size);
-                        cell.key = copyStringInArena(key);
+                        cell.key = copyStringInArena(arena, key);
                     }
                     else
                         cell.key = key;
@@ -524,16 +523,6 @@ private:
     void getAttributeContainer(size_t attribute_index, GetContainerFunc && func) const
     {
         return const_cast<std::decay_t<decltype(*this)> *>(this)->template getAttributeContainer(attribute_index, std::forward<GetContainerFunc>(func));
-    }
-
-    StringRef copyStringInArena(StringRef value_to_copy)
-    {
-        size_t value_to_copy_size = value_to_copy.size;
-        char * place_for_key = arena.alloc(value_to_copy_size);
-        memcpy(reinterpret_cast<void *>(place_for_key), reinterpret_cast<const void *>(value_to_copy.data), value_to_copy_size);
-        StringRef updated_value{place_for_key, value_to_copy_size};
-
-        return updated_value;
     }
 
     template<typename ValueType>

--- a/src/Dictionaries/DictionaryHelpers.h
+++ b/src/Dictionaries/DictionaryHelpers.h
@@ -623,6 +623,17 @@ void mergeBlockWithPipe(
     }
 }
 
+template <typename Arena>
+static StringRef copyStringInArena(Arena & arena, StringRef value)
+{
+    size_t key_size = value.size;
+    char * place_for_key = arena.alloc(key_size);
+    memcpy(reinterpret_cast<void *>(place_for_key), reinterpret_cast<const void *>(value.data), key_size);
+    StringRef result{place_for_key, key_size};
+
+    return result;
+}
+
 /**
  * Returns ColumnVector data as PaddedPodArray.
 

--- a/src/Dictionaries/DirectDictionary.cpp
+++ b/src/Dictionaries/DirectDictionary.cpp
@@ -2,7 +2,6 @@
 
 #include <Core/Defines.h>
 #include <Common/HashTable/HashMap.h>
-#include <DataTypes/DataTypesDecimal.h>
 #include <Functions/FunctionHelpers.h>
 
 #include <Dictionaries/DictionaryFactory.h>

--- a/src/Dictionaries/DirectDictionary.h
+++ b/src/Dictionaries/DirectDictionary.h
@@ -3,15 +3,12 @@
 #include <atomic>
 #include <variant>
 #include <vector>
-#include <Columns/ColumnDecimal.h>
-#include <Columns/ColumnString.h>
-#include <Common/Arena.h>
-#include <Core/Block.h>
-#include <Common/HashTable/HashMap.h>
-#include "DictionaryStructure.h"
-#include "IDictionary.h"
-#include "IDictionarySource.h"
-#include "DictionaryHelpers.h"
+
+#include <Dictionaries/DictionaryStructure.h>
+#include <Dictionaries/IDictionary.h>
+#include <Dictionaries/IDictionarySource.h>
+#include <Dictionaries/DictionaryHelpers.h>
+
 
 namespace DB
 {

--- a/src/Dictionaries/FlatDictionary.cpp
+++ b/src/Dictionaries/FlatDictionary.cpp
@@ -399,9 +399,6 @@ void FlatDictionary::calculateBytesAllocated()
             }
 
             bucket_count = container.capacity();
-
-            if constexpr (std::is_same_v<ValueType, StringRef>)
-                bytes_allocated += sizeof(Arena) + attribute.string_arena->size();
         };
 
         callOnDictionaryAttributeType(attribute.type, type_call);
@@ -414,21 +411,20 @@ void FlatDictionary::calculateBytesAllocated()
 
     if (update_field_loaded_block)
         bytes_allocated += update_field_loaded_block->allocatedBytes();
+
+    bytes_allocated += string_arena.size();
 }
 
 FlatDictionary::Attribute FlatDictionary::createAttribute(const DictionaryAttribute & dictionary_attribute)
 {
     auto is_nullable_set = dictionary_attribute.is_nullable ? std::make_optional<NullableSet>() : std::optional<NullableSet>{};
-    Attribute attribute{dictionary_attribute.underlying_type, std::move(is_nullable_set), {}, {}};
+    Attribute attribute{dictionary_attribute.underlying_type, std::move(is_nullable_set), {}};
 
     auto type_call = [&](const auto & dictionary_attribute_type)
     {
         using Type = std::decay_t<decltype(dictionary_attribute_type)>;
         using AttributeType = typename Type::AttributeType;
         using ValueType = DictionaryValueType<AttributeType>;
-
-        if constexpr (std::is_same_v<ValueType, StringRef>)
-            attribute.string_arena = std::make_unique<Arena>();
 
         attribute.container.emplace<ContainerType<ValueType>>(configuration.initial_array_size, ValueType());
     };
@@ -510,8 +506,8 @@ void FlatDictionary::setAttributeValueImpl(Attribute & attribute, UInt64 key, co
 template <>
 void FlatDictionary::setAttributeValueImpl<String>(Attribute & attribute, UInt64 key, const String & value)
 {
-    const auto * string_in_arena = attribute.string_arena->insert(value.data(), value.size());
-    setAttributeValueImpl(attribute, key, StringRef{string_in_arena, value.size()});
+    auto arena_value = copyStringInArena(string_arena, value);
+    setAttributeValueImpl(attribute, key, arena_value);
 }
 
 void FlatDictionary::setAttributeValue(Attribute & attribute, const UInt64 key, const Field & value)

--- a/src/Dictionaries/FlatDictionary.h
+++ b/src/Dictionaries/FlatDictionary.h
@@ -133,8 +133,6 @@ private:
             ContainerType<StringRef>,
             ContainerType<Array>>
             container;
-
-        std::unique_ptr<Arena> string_arena;
     };
 
     void createAttributes();
@@ -176,6 +174,7 @@ private:
     mutable std::atomic<size_t> found_count{0};
 
     BlockPtr update_field_loaded_block;
+    Arena string_arena;
 };
 
 }

--- a/src/Dictionaries/HashedArrayDictionary.cpp
+++ b/src/Dictionaries/HashedArrayDictionary.cpp
@@ -352,8 +352,7 @@ void HashedArrayDictionary<dictionary_key_type>::createAttributes()
             using ValueType = DictionaryValueType<AttributeType>;
 
             auto is_index_null = dictionary_attribute.is_nullable ? std::make_optional<std::vector<bool>>() : std::optional<std::vector<bool>>{};
-            std::unique_ptr<Arena> string_arena = std::is_same_v<AttributeType, String> ? std::make_unique<Arena>() : nullptr;
-            Attribute attribute{dictionary_attribute.underlying_type, AttributeContainerType<ValueType>(), std::move(is_index_null), std::move(string_arena)};
+            Attribute attribute{dictionary_attribute.underlying_type, AttributeContainerType<ValueType>(), std::move(is_index_null)};
             attributes.emplace_back(std::move(attribute));
         };
 
@@ -431,7 +430,7 @@ void HashedArrayDictionary<dictionary_key_type>::blockToAttributes(const Block &
         }
 
         if constexpr (std::is_same_v<KeyType, StringRef>)
-            key = copyKeyInArena(key);
+            key = copyStringInArena(string_arena, key);
 
         key_attribute.container.insert({key, element_count});
 
@@ -466,11 +465,7 @@ void HashedArrayDictionary<dictionary_key_type>::blockToAttributes(const Block &
                 if constexpr (std::is_same_v<AttributeValueType, StringRef>)
                 {
                     String & value_to_insert = column_value_to_insert.get<String>();
-                    size_t value_to_insert_size = value_to_insert.size();
-
-                    const char * string_in_arena = attribute.string_arena->insert(value_to_insert.data(), value_to_insert_size);
-
-                    StringRef string_in_arena_reference = StringRef{string_in_arena, value_to_insert_size};
+                    StringRef string_in_arena_reference = copyStringInArena(string_arena, value_to_insert);
                     attribute_container.back() = string_in_arena_reference;
                 }
                 else
@@ -677,16 +672,6 @@ void HashedArrayDictionary<dictionary_key_type>::getItemsImpl(
 }
 
 template <DictionaryKeyType dictionary_key_type>
-StringRef HashedArrayDictionary<dictionary_key_type>::copyKeyInArena(StringRef key)
-{
-    size_t key_size = key.size;
-    char * place_for_key = complex_key_arena.alloc(key_size);
-    memcpy(reinterpret_cast<void *>(place_for_key), reinterpret_cast<const void *>(key.data), key_size);
-    StringRef updated_key{place_for_key, key_size};
-    return updated_key;
-}
-
-template <DictionaryKeyType dictionary_key_type>
 void HashedArrayDictionary<dictionary_key_type>::loadData()
 {
     if (!source_ptr->hasUpdateField())
@@ -742,21 +727,15 @@ void HashedArrayDictionary<dictionary_key_type>::calculateBytesAllocated()
             }
 
             bucket_count = container.capacity();
-
-            if constexpr (std::is_same_v<ValueType, StringRef>)
-                bytes_allocated += sizeof(Arena) + attribute.string_arena->size();
         };
 
         callOnDictionaryAttributeType(attribute.type, type_call);
-
-        if (attribute.string_arena)
-            bytes_allocated += attribute.string_arena->size();
 
         if (attribute.is_index_null.has_value())
             bytes_allocated += (*attribute.is_index_null).size();
     }
 
-    bytes_allocated += complex_key_arena.size();
+    bytes_allocated += string_arena.size();
 
     if (update_field_loaded_block)
         bytes_allocated += update_field_loaded_block->allocatedBytes();

--- a/src/Dictionaries/HashedArrayDictionary.h
+++ b/src/Dictionaries/HashedArrayDictionary.h
@@ -155,7 +155,6 @@ private:
             container;
 
         std::optional<std::vector<bool>> is_index_null;
-        std::unique_ptr<Arena> string_arena;
     };
 
     struct KeyAttribute final
@@ -205,8 +204,6 @@ private:
 
     void resize(size_t added_rows);
 
-    StringRef copyKeyInArena(StringRef key);
-
     const DictionaryStructure dict_struct;
     const DictionarySourcePtr source_ptr;
     const HashedArrayDictionaryStorageConfiguration configuration;
@@ -222,7 +219,7 @@ private:
     mutable std::atomic<size_t> found_count{0};
 
     BlockPtr update_field_loaded_block;
-    Arena complex_key_arena;
+    Arena string_arena;
 };
 
 extern template class HashedArrayDictionary<DictionaryKeyType::Simple>;

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -239,7 +239,7 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchy(ColumnPtr 
             if (it != parent_keys_map.end())
                 result = getValueFromCell(it);
 
-            keys_found +=result.has_value();
+            keys_found += result.has_value();
 
             return result;
         };
@@ -354,8 +354,7 @@ void HashedDictionary<dictionary_key_type, sparse>::createAttributes()
             using ValueType = DictionaryValueType<AttributeType>;
 
             auto is_nullable_set = dictionary_attribute.is_nullable ? std::make_optional<NullableSet>() : std::optional<NullableSet>{};
-            std::unique_ptr<Arena> string_arena = std::is_same_v<AttributeType, String> ? std::make_unique<Arena>() : nullptr;
-            Attribute attribute{dictionary_attribute.underlying_type, std::move(is_nullable_set), CollectionType<ValueType>(), std::move(string_arena)};
+            Attribute attribute{dictionary_attribute.underlying_type, std::move(is_nullable_set), CollectionType<ValueType>()};
             attributes.emplace_back(std::move(attribute));
         };
 
@@ -449,7 +448,7 @@ void HashedDictionary<dictionary_key_type, sparse>::blockToAttributes(const Bloc
                 }
 
                 if constexpr (std::is_same_v<KeyType, StringRef>)
-                    key = copyKeyInArena(key);
+                    key = copyStringInArena(string_arena, key);
 
                 attribute_column.get(key_index, column_value_to_insert);
 
@@ -463,12 +462,8 @@ void HashedDictionary<dictionary_key_type, sparse>::blockToAttributes(const Bloc
                 if constexpr (std::is_same_v<AttributeValueType, StringRef>)
                 {
                     String & value_to_insert = column_value_to_insert.get<String>();
-                    size_t value_to_insert_size = value_to_insert.size();
-
-                    const char * string_in_arena = attribute.string_arena->insert(value_to_insert.data(), value_to_insert_size);
-
-                    StringRef string_in_arena_reference = StringRef{string_in_arena, value_to_insert_size};
-                    container.insert({key, string_in_arena_reference});
+                    StringRef arena_value = copyStringInArena(string_arena, value_to_insert);
+                    container.insert({key, arena_value});
                 }
                 else
                 {
@@ -549,16 +544,6 @@ void HashedDictionary<dictionary_key_type, sparse>::getItemsImpl(
 }
 
 template <DictionaryKeyType dictionary_key_type, bool sparse>
-StringRef HashedDictionary<dictionary_key_type, sparse>::copyKeyInArena(StringRef key)
-{
-    size_t key_size = key.size;
-    char * place_for_key = complex_key_arena.alloc(key_size);
-    memcpy(reinterpret_cast<void *>(place_for_key), reinterpret_cast<const void *>(key.data), key_size);
-    StringRef updated_key{place_for_key, key_size};
-    return updated_key;
-}
-
-template <DictionaryKeyType dictionary_key_type, bool sparse>
 void HashedDictionary<dictionary_key_type, sparse>::loadData()
 {
     if (!source_ptr->hasUpdateField())
@@ -631,16 +616,13 @@ void HashedDictionary<dictionary_key_type, sparse>::calculateBytesAllocated()
             }
         });
 
-        if (attributes[i].string_arena)
-            bytes_allocated += attributes[i].string_arena->size();
-
         bytes_allocated += sizeof(attributes[i].is_nullable_set);
 
         if (attributes[i].is_nullable_set.has_value())
             bytes_allocated = attributes[i].is_nullable_set->getBufferSizeInBytes();
     }
 
-    bytes_allocated += complex_key_arena.size();
+    bytes_allocated += string_arena.size();
 
     if (update_field_loaded_block)
         bytes_allocated += update_field_loaded_block->allocatedBytes();

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -173,8 +173,6 @@ private:
             CollectionType<StringRef>,
             CollectionType<Array>>
             container;
-
-        std::unique_ptr<Arena> string_arena;
     };
 
     void createAttributes();
@@ -202,8 +200,6 @@ private:
 
     void resize(size_t added_rows);
 
-    StringRef copyKeyInArena(StringRef key);
-
     const DictionaryStructure dict_struct;
     const DictionarySourcePtr source_ptr;
     const HashedDictionaryStorageConfiguration configuration;
@@ -217,7 +213,7 @@ private:
     mutable std::atomic<size_t> found_count{0};
 
     BlockPtr update_field_loaded_block;
-    Arena complex_key_arena;
+    Arena string_arena;
 };
 
 extern template class HashedDictionary<DictionaryKeyType::Simple, false>;

--- a/src/Dictionaries/PolygonDictionary.h
+++ b/src/Dictionaries/PolygonDictionary.h
@@ -3,16 +3,14 @@
 #include <atomic>
 #include <variant>
 #include <Core/Block.h>
-#include <Columns/ColumnDecimal.h>
-#include <Columns/ColumnString.h>
-#include <Common/Arena.h>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
 
-#include "DictionaryStructure.h"
-#include "IDictionary.h"
-#include "IDictionarySource.h"
-#include "DictionaryHelpers.h"
+#include <Dictionaries/DictionaryStructure.h>
+#include <Dictionaries/IDictionary.h>
+#include <Dictionaries/IDictionarySource.h>
+#include <Dictionaries/DictionaryHelpers.h>
+
 
 namespace DB
 {

--- a/src/Dictionaries/RangeHashedDictionary.cpp
+++ b/src/Dictionaries/RangeHashedDictionary.cpp
@@ -345,9 +345,6 @@ void RangeHashedDictionary<dictionary_key_type>::calculateBytesAllocated()
             const auto & collection = std::get<CollectionType<ValueType>>(attribute.maps);
             bytes_allocated += sizeof(CollectionType<ValueType>) + collection.getBufferSizeInBytes();
             bucket_count = collection.getBufferSizeInCells();
-
-            if constexpr (std::is_same_v<ValueType, StringRef>)
-                bytes_allocated += sizeof(Arena) + attribute.string_arena->size();
         };
 
         callOnDictionaryAttributeType(attribute.type, type_call);
@@ -358,21 +355,20 @@ void RangeHashedDictionary<dictionary_key_type>::calculateBytesAllocated()
 
     if (update_field_loaded_block)
         bytes_allocated += update_field_loaded_block->allocatedBytes();
+
+    bytes_allocated += string_arena.size();
 }
 
 template <DictionaryKeyType dictionary_key_type>
 typename RangeHashedDictionary<dictionary_key_type>::Attribute RangeHashedDictionary<dictionary_key_type>::createAttribute(const DictionaryAttribute & dictionary_attribute)
 {
-    Attribute attribute{dictionary_attribute.underlying_type, dictionary_attribute.is_nullable, {}, {}};
+    Attribute attribute{dictionary_attribute.underlying_type, dictionary_attribute.is_nullable, {}};
 
     auto type_call = [&](const auto &dictionary_attribute_type)
     {
         using Type = std::decay_t<decltype(dictionary_attribute_type)>;
         using AttributeType = typename Type::AttributeType;
         using ValueType = DictionaryValueType<AttributeType>;
-
-        if constexpr (std::is_same_v<AttributeType, String>)
-            attribute.string_arena = std::make_unique<Arena>();
 
         attribute.maps = CollectionType<ValueType>();
     };
@@ -544,7 +540,7 @@ void RangeHashedDictionary<dictionary_key_type>::blockToAttributes(const Block &
             }
 
             if constexpr (std::is_same_v<KeyType, StringRef>)
-                key = copyKeyInArena(key);
+                key = copyStringInArena(string_arena, key);
 
             setAttributeValue(attribute, key, Range{lower_bound, upper_bound}, attribute_column[key_index]);
             keys_extractor.rollbackCurrentKey();
@@ -572,8 +568,7 @@ void RangeHashedDictionary<dictionary_key_type>::setAttributeValueImpl(Attribute
         if constexpr (std::is_same_v<T, String>)
         {
             const auto & string = value.get<String>();
-            const auto * string_in_arena = attribute.string_arena->insert(string.data(), string.size());
-            const StringRef string_ref{string_in_arena, string.size()};
+            StringRef string_ref = copyStringInArena(string_arena, string);
             value_to_insert = Value<ValueType>{ range, { string_ref }};
         }
         else
@@ -669,16 +664,6 @@ void RangeHashedDictionary<dictionary_key_type>::getKeysAndDates(
                     end_dates.back() = 0;
         }
     }
-}
-
-template <DictionaryKeyType dictionary_key_type>
-StringRef RangeHashedDictionary<dictionary_key_type>::copyKeyInArena(StringRef key)
-{
-    size_t key_size = key.size;
-    char * place_for_key = complex_key_arena.alloc(key_size);
-    memcpy(reinterpret_cast<void *>(place_for_key), reinterpret_cast<const void *>(key.data), key_size);
-    StringRef updated_key{place_for_key, key_size};
-    return updated_key;
 }
 
 template <DictionaryKeyType dictionary_key_type>

--- a/src/Dictionaries/RangeHashedDictionary.h
+++ b/src/Dictionaries/RangeHashedDictionary.h
@@ -139,7 +139,6 @@ private:
             CollectionType<StringRef>,
             CollectionType<Array>>
             maps;
-        std::unique_ptr<Arena> string_arena;
     };
 
     void createAttributes();
@@ -162,9 +161,9 @@ private:
     void blockToAttributes(const Block & block);
 
     template <typename T>
-    static void setAttributeValueImpl(Attribute & attribute, KeyType key, const Range & range, const Field & value);
+    void setAttributeValueImpl(Attribute & attribute, KeyType key, const Range & range, const Field & value);
 
-    static void setAttributeValue(Attribute & attribute, KeyType key, const Range & range, const Field & value);
+    void setAttributeValue(Attribute & attribute, KeyType key, const Range & range, const Field & value);
 
     template <typename RangeType>
     void getKeysAndDates(
@@ -184,8 +183,6 @@ private:
         const PaddedPODArray<RangeType> & block_start_dates,
         const PaddedPODArray<RangeType> & block_end_dates) const;
 
-    StringRef copyKeyInArena(StringRef key);
-
     const DictionaryStructure dict_struct;
     const DictionarySourcePtr source_ptr;
     const DictionaryLifetime dict_lifetime;
@@ -200,6 +197,7 @@ private:
     size_t bucket_count = 0;
     mutable std::atomic<size_t> query_count{0};
     mutable std::atomic<size_t> found_count{0};
+    Arena string_arena;
 };
 
 }

--- a/src/Dictionaries/SSDCacheDictionaryStorage.h
+++ b/src/Dictionaries/SSDCacheDictionaryStorage.h
@@ -1148,10 +1148,7 @@ private:
             if constexpr (dictionary_key_type == DictionaryKeyType::Complex)
             {
                 /// Copy complex key into arena and put in cache
-                size_t key_size = key.size;
-                char * place_for_key = complex_key_arena.alloc(key_size);
-                memcpy(reinterpret_cast<void *>(place_for_key), reinterpret_cast<const void *>(key.data), key_size);
-                KeyType updated_key{place_for_key, key_size};
+                KeyType updated_key = copyStringInArena(complex_key_arena, key);
                 ssd_cache_key.key = updated_key;
             }
 


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reduce allocated memory for dictionaries with string attributes.
