### PR TITLE
support to write merge tree parts in parallel

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -122,6 +122,7 @@ struct Settings;
     M(Bool, enable_mixed_granularity_parts, true, "Enable parts with adaptive and non adaptive granularity", 0) \
     M(MaxThreads, max_part_loading_threads, 0, "The number of threads to load data parts at startup.", 0) \
     M(MaxThreads, max_part_removal_threads, 0, "The number of threads for concurrent removal of inactive data parts. One is usually enough, but in 'Google Compute Environment SSD Persistent Disks' file removal (unlink) operation is extraordinarily slow and you probably have to increase this number (recommended is up to 16).", 0) \
+    M(UInt64, max_part_writing_threads, 0, "The number of threads for concurrent writing data parts. One is usually enough, but for Remote Persistent Disks, file writing operation is extraordinarily slow and you probably have to increase this number (recommended is up to 16).", 0) \
     M(UInt64, concurrent_part_removal_threshold, 100, "Activate concurrent part removal (see 'max_part_removal_threads') only if the number of inactive data parts is at least this.", 0) \
     M(String, storage_policy, "default", "Name of storage disk policy", 0) \
     M(Bool, allow_nullable_key, false, "Allow Nullable types as primary keys.", 0) \

--- a/src/Storages/MergeTree/MergeTreeSink.cpp
+++ b/src/Storages/MergeTree/MergeTreeSink.cpp
@@ -2,7 +2,7 @@
 #include <Storages/MergeTree/MergeTreeDataPartInMemory.h>
 #include <Storages/StorageMergeTree.h>
 #include <Interpreters/PartLog.h>
-
+#include <base/scope_guard_safe.h>
 
 namespace DB
 {
@@ -17,28 +17,71 @@ void MergeTreeSink::onStart()
 
 void MergeTreeSink::consume(Chunk chunk)
 {
-    auto block = getHeader().cloneWithColumns(chunk.detachColumns());
+    const auto settings = storage.getSettings();
+    std::unique_ptr<ThreadPool> pool = nullptr;
+    if (part_blocks.size() > 1 && settings->max_part_writing_threads > 1)
+    {
+        size_t num_threads = std::min<size_t>(settings->max_part_writing_threads, part_blocks.size());
+        pool = std::make_unique<ThreadPool>(num_threads);
+    }
 
+    auto block = getHeader().cloneWithColumns(chunk.detachColumns());
     auto part_blocks = storage.writer.splitBlockIntoParts(block, max_parts_per_block, metadata_snapshot, context);
     for (auto & current_block : part_blocks)
     {
-        Stopwatch watch;
-
-        MergeTreeData::MutableDataPartPtr part = storage.writer.writeTempPart(current_block, metadata_snapshot, context);
-
-        /// If optimize_on_insert setting is true, current_block could become empty after merge
-        /// and we didn't create part.
-        if (!part)
-            continue;
-
-        /// Part can be deduplicated, so increment counters and add to part log only if it's really added
-        if (storage.renameTempPartAndAdd(part, &storage.increment, nullptr, storage.getDeduplicationLog()))
+        if (settings->max_part_writing_threads > 1 && pool != nullptr)
         {
-            PartLog::addNewPart(storage.getContext(), part, watch.elapsed());
-
-            /// Initiate async merge - it will be done if it's good time for merge and if there are space in 'background_pool'.
-            storage.background_operations_assignee.trigger();
+            /// Parallel parts writing.
+            pool->scheduleOrThrowOnError([&, this, thread_group = CurrentThread::getGroup()]()
+            {
+               SCOPE_EXIT_SAFE(
+                    if (thread_group)
+                        CurrentThread::detachQueryIfNotDetached();
+                    );
+               if (thread_group)
+                   CurrentThread::attachTo(thread_group);
+                Stopwatch watch;
+                try
+                {
+                    MergeTreeData::MutableDataPartPtr part = storage.writer.writeTempPart(current_block, metadata_snapshot, context);
+                    /// If optimize_on_insert setting is true, current_block could become empty after merge
+                    /// and we didn't create part.
+                    if (!part)
+                        return ;
+                        /// Part can be deduplicated, so increment counters and add to part log only if it's really added
+                    if (storage.renameTempPartAndAdd(part, &storage.increment, nullptr, storage.getDeduplicationLog()))
+                    {
+                        PartLog::addNewPart(storage.getContext(), part, watch.elapsed());
+                        /// Initiate async merge - it will be done if it's good time for merge and if there are space in 'background_pool'.
+                        storage.background_operations_assignee.trigger();
+                    }
+                }
+                catch (Exception & e)
+                {
+                    LOG_ERROR(&Poco::Logger::get("MergeTreeSink"), "failed to write part block, reason {}", e.displayText());
+                }
+            });
         }
+        else
+        {
+            Stopwatch watch;
+            MergeTreeData::MutableDataPartPtr part = storage.writer.writeTempPart(current_block, metadata_snapshot, context);
+            /// If optimize_on_insert setting is true, current_block could become empty after merge
+            /// and we didn't create part.
+            if (!part)
+                continue;
+            /// Part can be deduplicated, so increment counters and add to part log only if it's really added
+            if (storage.renameTempPartAndAdd(part, &storage.increment, nullptr, storage.getDeduplicationLog()))
+            {
+                PartLog::addNewPart(storage.getContext(), part, watch.elapsed());
+                /// Initiate async merge - it will be done if it's good time for merge and if there are space in 'background_pool'.
+                storage.background_operations_assignee.trigger();
+            }
+        }
+    }
+    if (settings->max_part_writing_threads > 1 && pool != nullptr)
+    {
+        pool->wait();
     }
 }
 


### PR DESCRIPTION
support to write merge tree parts in parallel, which can be controlled by setting max_part_writing_threads in merge tree settings in config.xml, for example
<merge_tree>
    <max_part_writing_threads>10</max_part_writing_threads>
</merge_tree>

Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
support to write merge tree parts in parallel

Detailed description / Documentation draft:
Use the configuration merge_tree.max_part_writing_threads to control the number of threads for writing merge tree parts. By default, there is only one working thread as in the original mechanism. This improvement is very useful when inserting data into remote storage such as s3.

> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
