### PR TITLE
fix typo

### DIFF
--- a/docs/en/operations/utilities/index.md
+++ b/docs/en/operations/utilities/index.md
@@ -6,7 +6,7 @@ toc_title: Overview
 
 # ClickHouse Utility {#clickhouse-utility}
 
--   [clickhouse-local](../../operations/utilities/clickhouse-local.md) — Allows running SQL queries on data without stopping the ClickHouse server, similar to how `awk` does this.
+-   [clickhouse-local](../../operations/utilities/clickhouse-local.md) — Allows running SQL queries on data without starting the ClickHouse server, similar to how `awk` does this.
 -   [clickhouse-copier](../../operations/utilities/clickhouse-copier.md) — Copies (and reshards) data from one cluster to another cluster.
 -   [clickhouse-benchmark](../../operations/utilities/clickhouse-benchmark.md) — Loads server with the custom queries and settings.
 -   [clickhouse-format](../../operations/utilities/clickhouse-format.md) — Enables formatting input queries.


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)