### PR TITLE
fix variable name in h3 misc funcs

### DIFF
--- a/src/Functions/h3CellAreaM2.cpp
+++ b/src/Functions/h3CellAreaM2.cpp
@@ -60,8 +60,8 @@ public:
 
         for (size_t row = 0; row < input_rows_count; ++row)
         {
-            const UInt64 resolution = data[row];
-            Float64 res = cellAreaM2(resolution);
+            const UInt64 index = data[row];
+            Float64 res = cellAreaM2(index);
             dst_data[row] = res;
         }
 

--- a/src/Functions/h3CellAreaRads2.cpp
+++ b/src/Functions/h3CellAreaRads2.cpp
@@ -60,8 +60,8 @@ public:
 
         for (size_t row = 0; row < input_rows_count; ++row)
         {
-            const UInt64 resolution = data[row];
-            Float64 res = cellAreaRads2(resolution);
+            const UInt64 index = data[row];
+            Float64 res = cellAreaRads2(index);
             dst_data[row] = res;
         }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
Minor fix to variable names in a couple of places. Should have been called index, but somehow called resolution.

Related to  #33479 cc: @kitaisreal 