### PR TITLE
Specify clang version for CC / CXX bc no symlinks

### DIFF
--- a/docs/en/development/developer-instruction.md
+++ b/docs/en/development/developer-instruction.md
@@ -158,6 +158,8 @@ While inside the `build` directory, configure your build by running CMake. Befor
     export CC=clang CXX=clang++
     cmake ..
 
+If you installed clang using the automatic installation script above, also specify the version of clang installed in the first command, e.g. `export CC=clang-13 CXX=clang++-13`. The clang version will be in the script output.
+
 The `CC` variable specifies the compiler for C (short for C Compiler), and `CXX` variable instructs which C++ compiler is to be used for building.
 
 For a faster build, you can resort to the `debug` build type - a build with no optimizations. For that supply the following parameter `-D CMAKE_BUILD_TYPE=Debug`:


### PR DESCRIPTION
The proposed script for installing clang (sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)) doesn't automatically create symlinks from clang-XX to clang. Thus we need to either specify the version like clang-13 or instruct the user to create symlinks. I think the former is easier.

Changelog category (leave one):
- Documentation (changelog entry is not required)