### PR TITLE
Fix DiskLocal rename methods without parent folders

### DIFF
--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -261,7 +261,10 @@ void DiskLocal::clearDirectory(const String & path)
 
 void DiskLocal::moveDirectory(const String & from_path, const String & to_path)
 {
-    fs::rename(fs::path(disk_path) / from_path, fs::path(disk_path) / to_path);
+    fs::path from_dir = fs::path(disk_path) / from_path;
+    fs::path to_dir = fs::path(disk_path) / to_path;
+    fs::create_directories(to_dir.parent_path());
+    fs::rename(from_dir, to_dir);
 }
 
 DiskDirectoryIteratorPtr DiskLocal::iterateDirectory(const String & path)
@@ -275,14 +278,15 @@ DiskDirectoryIteratorPtr DiskLocal::iterateDirectory(const String & path)
 
 void DiskLocal::moveFile(const String & from_path, const String & to_path)
 {
-    fs::rename(fs::path(disk_path) / from_path, fs::path(disk_path) / to_path);
+    fs::path from_file = fs::path(disk_path) / from_path;
+    fs::path to_file = fs::path(disk_path) / to_path;
+    fs::create_directories(to_file.parent_path());
+    fs::rename(from_file, to_file);
 }
 
 void DiskLocal::replaceFile(const String & from_path, const String & to_path)
 {
-    fs::path from_file = fs::path(disk_path) / from_path;
-    fs::path to_file = fs::path(disk_path) / to_path;
-    fs::rename(from_file, to_file);
+    moveFile(from_path, to_path);
 }
 
 std::unique_ptr<ReadBufferFromFileBase> DiskLocal::readFile(const String & path, const ReadSettings & settings, std::optional<size_t> read_hint, std::optional<size_t> file_size) const


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Create parent directories in DiskLocal moveDirectory, moveFile, replaceFile methods.


Detailed description / Documentation draft:
Sometimes move methods called when purpose parent directory does not exists.
In this cases request fails with error like
```
2022.01.10 11:55:06.078012 [ 255 ] {24ad8cc5-1ed4-49af-8ee4-9ad72b65d34d} <Error> executeQuery: std::exception. Code: 1001, type: std::__1::__fs::filesystem::filesystem_error, e.what() = filesystem error: in rename: No such file or directory [/var/lib/clickhouse/disks/s3/store/ff5/ff55d5a3-d684-423b-bf55-d5a3d684223b/0_1_1_0/] [/var/lib/clickhouse/disks/s3/store/ff5/ff55d5a3-d684-423b-bf55-d5a3d684223b/detached/0_1_1_0]
Cannot print extra info for Poco::Exception (version 21.12.3.32 (official build)) (from 10.10.249.8:48008) (in query: SYSTEM RESTART DISK s3), Stack trace (when copying this message, always include the lines below):

0. std::runtime_error::runtime_error(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x1924062d in ?
1. std::__1::system_error::system_error(std::__1::error_code, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x1924a297 in ?
2. ? @ 0x191ef602 in ?
3. ? @ 0x191eeedd in ?
4. ? @ 0x191f22f8 in ?
5. std::__1::__fs::filesystem::__rename(std::__1::__fs::filesystem::path const&, std::__1::__fs::filesystem::path const&, std::__1::error_code*) @ 0x191f89b5 in ?
6. DB::DiskLocal::moveDirectory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x12bb780f in /usr/bin/clickhouse
7. DB::DiskS3::restoreFileOperations(DB::DiskS3::RestoreInformation const&) @ 0x12bd67d9 in /usr/bin/clickhouse
8. DB::DiskS3::restore() @ 0x12bc8ecf in /usr/bin/clickhouse
9. DB::DiskS3::startup() @ 0x12bc7635 in /usr/bin/clickhouse
10. DB::DiskRestartProxy::restart() @ 0x12c0271c in /usr/bin/clickhouse
11. DB::InterpreterSystemQuery::restartDisk(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) @ 0x132e9b91 in /usr/bin/clickhouse
12. DB::InterpreterSystemQuery::execute() @ 0x132dfcb2 in /usr/bin/clickhouse
13. ? @ 0x135289f0 in /usr/bin/clickhouse
14. DB::executeQuery(DB::ReadBuffer&, DB::WriteBuffer&, bool, std::__1::shared_ptr<DB::Context>, std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>, std::__1::optional<DB::FormatSettings> const&) @ 0x1352be7c in /usr/bin/clickhouse
15. DB::HTTPHandler::processQuery(DB::HTTPServerRequest&, DB::HTMLForm&, DB::HTTPServerResponse&, DB::HTTPHandler::Output&, std::__1::optional<DB::CurrentThread::QueryScope>&) @ 0x13d8e5da in /usr/bin/clickhouse
16. DB::HTTPHandler::handleRequest(DB::HTTPServerRequest&, DB::HTTPServerResponse&) @ 0x13d92ce7 in /usr/bin/clickhouse
17. DB::HTTPServerConnection::run() @ 0x13ff5eca in /usr/bin/clickhouse
18. Poco::Net::TCPServerConnection::start() @ 0x16f3d6af in /usr/bin/clickhouse
19. Poco::Net::TCPServerDispatcher::run() @ 0x16f3fb01 in /usr/bin/clickhouse
20. Poco::PooledThread::run() @ 0x1704e889 in /usr/bin/clickhouse
21. Poco::ThreadImpl::runnableEntry(void*) @ 0x1704bf80 in /usr/bin/clickhouse
22. start_thread @ 0x76db in /lib/x86_64-linux-gnu/libpthread-2.27.so
23. clone @ 0x12171f in /lib/x86_64-linux-gnu/libc-2.27.so
```
(In this sample 'detached' subdirectory does not exists)
