### PR TITLE
Fix parsing queries with FROM INFILE statement

### DIFF
--- a/tests/queries/0_stateless/02165_insert_from_infile.sql
+++ b/tests/queries/0_stateless/02165_insert_from_infile.sql
@@ -1,0 +1,4 @@
+EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' SELECT 1; -- { clientError SYNTAX_ERROR }
+EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' WATCH view; -- { clientError SYNTAX_ERROR }
+EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' VALUES (1) -- { clientError SYNTAX_ERROR }
+EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' WITH number AS x SELECT number FROM numbers(10); -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix parsing incorrect queries with FROM INFILE statement

Detailed description / Documentation draft:
Previousely such incorrect queries worked:
```
:) EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' SELECT 1;

EXPLAIN SYNTAX
INSERT INTO test SELECT 1

Query id: 4f5920c2-70b0-4f7b-8af3-e9c7d3849f28

┌─explain───────────────────┐
│ INSERT INTO test SELECT 1 │
└───────────────────────────┘

1 rows in set. Elapsed: 0.002 sec.
```