### PR TITLE
Don't print exception twice in client in case of exception in parallel parsing

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1,23 +1,17 @@
 #include <stdlib.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <map>
 #include <iostream>
-#include <fstream>
 #include <iomanip>
-#include <unordered_set>
-#include <algorithm>
 #include <optional>
 #include <base/scope_guard_safe.h>
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <Poco/String.h>
 #include <filesystem>
 #include <string>
 #include "Client.h"
 #include "Core/Protocol.h"
 
-#include <base/argsToConfig.h>
 #include <base/find_symbols.h>
 
 #include <Common/config_version.h>

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -191,7 +191,8 @@ InputFormatPtr FormatFactory::getInput(
 
 
         ParallelParsingInputFormat::Params params{
-            buf, sample, parser_creator, file_segmentation_engine, name, settings.max_threads, settings.min_chunk_bytes_for_parallel_parsing};
+            buf, sample, parser_creator, file_segmentation_engine, name, settings.max_threads, settings.min_chunk_bytes_for_parallel_parsing,
+               context->getApplicationType() == Context::ApplicationType::SERVER};
         return std::make_shared<ParallelParsingInputFormat>(params);
     }
 

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
@@ -137,7 +137,8 @@ void ParallelParsingInputFormat::onBackgroundException(size_t offset)
             if (e->getLineNumber() != -1)
                 e->setLineNumber(e->getLineNumber() + offset);
     }
-    tryLogCurrentException(__PRETTY_FUNCTION__);
+    if (is_server)
+        tryLogCurrentException(__PRETTY_FUNCTION__);
     parsing_finished = true;
     first_parser_finished.set();
     reader_condvar.notify_all();

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.h
@@ -82,6 +82,7 @@ public:
         String format_name;
         size_t max_threads;
         size_t min_chunk_bytes;
+        bool is_server;
     };
 
     explicit ParallelParsingInputFormat(Params params)
@@ -90,6 +91,7 @@ public:
         , file_segmentation_engine(params.file_segmentation_engine)
         , format_name(params.format_name)
         , min_chunk_bytes(params.min_chunk_bytes)
+        , is_server(params.is_server)
         , pool(params.max_threads)
     {
         // One unit for each thread, including segmentator and reader, plus a
@@ -202,6 +204,8 @@ private:
 
     std::atomic<bool> parsing_started{false};
     std::atomic<bool> parsing_finished{false};
+
+    const bool is_server;
 
     /// There are multiple "parsers", that's why we use thread pool.
     ThreadPool pool;


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't print exception twice in client in case of exception in parallel parsing


Detailed description / Documentation draft:
Such query led to double exception printing:
```
insert into test_table format TSV some trash here 123 \n 456
```