### PR TITLE
Fix clickhouse local interactive exception case

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -214,6 +214,12 @@ bool LocalConnection::poll(size_t)
     if (next_packet_type)
         return true;
 
+    if (state->exception)
+    {
+        next_packet_type = Protocol::Server::Exception;
+        return true;
+    }
+
     if (!state->is_finished)
     {
         if (send_progress && (state->after_send_progress.elapsedMicroseconds() >= query_context->getSettingsRef().interactive_delay))

--- a/tests/queries/0_stateless/02164_clickhouse_local_interactive_exception.expect
+++ b/tests/queries/0_stateless/02164_clickhouse_local_interactive_exception.expect
@@ -1,0 +1,21 @@
+#!/usr/bin/expect -f
+
+log_user 0
+set timeout 20
+match_max 100000
+
+expect_after {
+    eof { exp_continue }
+    timeout { exit 1 }
+}
+
+set basedir [file dirname $argv0]
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_LOCAL  --disable_suggestion"
+
+expect ":) "
+send -- "insert into table function null() format TSV some trash here 123 \n 456\r"
+expect -re ".*DB::Exception: Table function 'null' requires 'structure'.*\r"
+expect ":) "
+
+send -- ""
+expect eof


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Funny case, only reproduced in interactive and only if it is the very first query after local was started.