### PR TITLE
Fix session_id_counter for keeper-converter

### DIFF
--- a/src/Coordination/ZooKeeperDataReader.cpp
+++ b/src/Coordination/ZooKeeperDataReader.cpp
@@ -168,7 +168,7 @@ void deserializeKeeperStorageFromSnapshot(KeeperStorage & storage, const std::st
     auto max_session_id = deserializeSessionAndTimeout(storage, reader);
     LOG_INFO(log, "Sessions and timeouts deserialized");
 
-    storage.session_id_counter = max_session_id;
+    storage.session_id_counter = max_session_id + 1; /// session_id_counter poniter to next slot
     deserializeACLMap(storage, reader);
     LOG_INFO(log, "ACLs deserialized");
 

--- a/src/Coordination/ZooKeeperDataReader.cpp
+++ b/src/Coordination/ZooKeeperDataReader.cpp
@@ -168,7 +168,7 @@ void deserializeKeeperStorageFromSnapshot(KeeperStorage & storage, const std::st
     auto max_session_id = deserializeSessionAndTimeout(storage, reader);
     LOG_INFO(log, "Sessions and timeouts deserialized");
 
-    storage.session_id_counter = max_session_id + 1; /// session_id_counter poniter to next slot
+    storage.session_id_counter = max_session_id + 1; /// session_id_counter pointer to next slot
     deserializeACLMap(storage, reader);
     LOG_INFO(log, "ACLs deserialized");
 


### PR DESCRIPTION
Changelog category (leave one):

- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

session_id_counter poniter to next slot. 
