### PR TITLE
Fix parsing queries with FROM INFILE statement again

### DIFF
--- a/src/Parsers/ASTInsertQuery.cpp
+++ b/src/Parsers/ASTInsertQuery.cpp
@@ -79,6 +79,13 @@ void ASTInsertQuery::formatImpl(const FormatSettings & settings, FormatState & s
         settings.ostr << ")";
     }
 
+    if (infile)
+    {
+        settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM INFILE " << (settings.hilite ? hilite_none : "") << infile->as<ASTLiteral &>().value.safeGet<std::string>();
+        if (compression)
+            settings.ostr << (settings.hilite ? hilite_keyword : "") << " COMPRESSION " << (settings.hilite ? hilite_none : "") << compression->as<ASTLiteral &>().value.safeGet<std::string>();
+    }
+
     if (select)
     {
         settings.ostr << " ";
@@ -91,12 +98,6 @@ void ASTInsertQuery::formatImpl(const FormatSettings & settings, FormatState & s
     }
     else
     {
-        if (infile)
-        {
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM INFILE " << (settings.hilite ? hilite_none : "") << infile->as<ASTLiteral &>().value.safeGet<std::string>();
-            if (compression)
-                settings.ostr << (settings.hilite ? hilite_keyword : "") << " COMPRESSION " << (settings.hilite ? hilite_none : "") << compression->as<ASTLiteral &>().value.safeGet<std::string>();
-        }
         if (!format.empty())
         {
             settings.ostr << (settings.hilite ? hilite_keyword : "") << " FORMAT " << (settings.hilite ? hilite_none : "") << format;

--- a/tests/queries/0_stateless/02165_insert_from_infile.reference
+++ b/tests/queries/0_stateless/02165_insert_from_infile.reference
@@ -1,0 +1,5 @@
+INSERT INTO test FROM INFILE data.file SELECT x
+FROM input(\'x UInt32\')
+INSERT INTO test FROM INFILE data.file WITH number AS x
+SELECT number
+FROM input(\'number UInt32\')

--- a/tests/queries/0_stateless/02165_insert_from_infile.sql
+++ b/tests/queries/0_stateless/02165_insert_from_infile.sql
@@ -1,4 +1,4 @@
-EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' SELECT 1; -- { clientError SYNTAX_ERROR }
+EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' SELECT x from input('x UInt32') FORMAT TSV;
 EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' WATCH view; -- { clientError SYNTAX_ERROR }
 EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' VALUES (1) -- { clientError SYNTAX_ERROR }
-EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' WITH number AS x SELECT number FROM numbers(10); -- { clientError SYNTAX_ERROR }
+EXPLAIN SYNTAX INSERT INTO test FROM INFILE 'data.file' WITH number AS x SELECT number FROM input('number UInt32');


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Revrert bad fix from https://github.com/ClickHouse/ClickHouse/pull/33521 (it didn't consider the case `INSERT INTO t FROM INFILE 'file' SELECT ... FROM input(...) FORMAT fmt`) and make another one that fixes `EXPLAIN SYNTAX`