### PR TITLE
Fix latest build links

### DIFF
--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+from typing import Dict, TypeVar
+
+ConfValue = TypeVar("ConfValue", str, bool)
+BuildConfig = Dict[str, ConfValue]
+
 CI_CONFIG = {
     "build_config": {
         "package_release": {
@@ -334,4 +339,4 @@ CI_CONFIG = {
             "required_build": "performance",
         },
     },
-}
+}  # type: dict

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -41,6 +41,9 @@ class PRInfo:
                 github_event = {'commits': 1, 'after': 'HEAD', 'ref': None}
         self.event = github_event
         self.changed_files = set([])
+        ref = github_event.get("ref", "refs/head/master")
+        if ref.startswith('refs/heads/'):
+            ref = ref[11:]
 
         # workflow completed event, used for PRs only
         if 'action' in github_event and github_event['action'] == 'completed':
@@ -93,10 +96,10 @@ class PRInfo:
             if pull_request is None or pull_request['state'] == 'closed':  # it's merged PR to master
                 self.number = 0
                 self.labels = {}
-                self.pr_html_url = f"{repo_prefix}/commits/master"
-                self.base_ref = "master"
+                self.pr_html_url = f"{repo_prefix}/commits/{ref}"
+                self.base_ref = ref
                 self.base_name = self.repo_full_name
-                self.head_ref = "master"
+                self.head_ref = ref
                 self.head_name = self.repo_full_name
                 self.diff_url = \
                     f"https://api.github.com/repos/{GITHUB_REPOSITORY}/compare/{github_event['before']}...{self.sha}"
@@ -126,10 +129,10 @@ class PRInfo:
             self.task_url = f"{repo_prefix}/actions/runs/{GITHUB_RUN_ID or '0'}"
             self.commit_html_url = f"{repo_prefix}/commits/{self.sha}"
             self.repo_full_name = GITHUB_REPOSITORY
-            self.pr_html_url = f"{repo_prefix}/commits/master"
-            self.base_ref = "master"
+            self.pr_html_url = f"{repo_prefix}/commits/{ref}"
+            self.base_ref = ref
             self.base_name = self.repo_full_name
-            self.head_ref = "master"
+            self.head_ref = ref
             self.head_name = self.repo_full_name
 
         if need_changed_files:

--- a/tests/ci/tee_popen.py
+++ b/tests/ci/tee_popen.py
@@ -15,11 +15,19 @@ class TeePopen:
         self.command = command
         self.log_file = log_file
         self.env = env
+        self.process = None
 
     def __enter__(self):
-        # pylint: disable=W0201
-        self.process = Popen(self.command, shell=True, universal_newlines=True, env=self.env, stderr=STDOUT, stdout=PIPE, bufsize=1)
-        self.log_file = open(self.log_file, 'w', encoding='utf-8')
+        self.process = Popen(
+            self.command,
+            shell=True,
+            universal_newlines=True,
+            env=self.env,
+            stderr=STDOUT,
+            stdout=PIPE,
+            bufsize=1,
+        )
+        self.log_file = open(self.log_file, "w", encoding="utf-8")
         return self
 
     def __exit__(self, t, value, traceback):


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
During migration from Yandex to github actions we've lost static links to the latest master ([doc](https://clickhouse.com/docs/en/getting-started/install/#from-single-binary))  
It solves issue #33480 partially 