### PR TITLE
Fix logic for upload upload_master_static_binaries

### DIFF
--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -191,7 +191,7 @@ def upload_master_static_binaries(
         return
     elif build_config["package_type"] != "binary":
         return
-    elif pr_info.base_ref == "master":
+    elif pr_info.base_ref != "master":
         return
 
     s3_path = "/".join(


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
Following up #33559 