### PR TITLE
Don't upload splitted binaries to builds.clickhouse.com

### DIFF
--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -191,6 +191,8 @@ def upload_master_static_binaries(
         return
     elif build_config["package_type"] != "binary":
         return
+    elif build_config["splitted"] == "splitted":
+        return
     elif pr_info.base_ref != "master":
         return
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Ignore split builds in upload_master_static_binaries