### PR TITLE
Fix minor bug in TTL and flaky test

### DIFF
--- a/src/Processors/Transforms/TTLTransform.cpp
+++ b/src/Processors/Transforms/TTLTransform.cpp
@@ -139,8 +139,10 @@ void TTLTransform::finalize()
 
     if (delete_algorithm)
     {
-        size_t rows_removed = all_data_dropped ? data_part->rows_count : delete_algorithm->getNumberOfRemovedRows();
-        LOG_DEBUG(log, "Removed {} rows with expired TTL from part {}", rows_removed, data_part->name);
+        if (all_data_dropped)
+            LOG_DEBUG(log, "Removed all rows from part {} due to expired TTL", data_part->name);
+        else
+            LOG_DEBUG(log, "Removed {} rows with expired TTL from part {}", delete_algorithm->getNumberOfRemovedRows(), data_part->name);
     }
 }
 

--- a/tests/queries/0_stateless/01282_system_parts_ttl_info.sql
+++ b/tests/queries/0_stateless/01282_system_parts_ttl_info.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS ttl;
-CREATE TABLE ttl (d DateTime) ENGINE = MergeTree ORDER BY tuple() TTL d + INTERVAL 10 DAY;
+CREATE TABLE ttl (d DateTime) ENGINE = MergeTree ORDER BY tuple() TTL d + INTERVAL 10 DAY SETTINGS remove_empty_parts=0;
 SYSTEM STOP MERGES ttl;
 INSERT INTO ttl VALUES ('2000-01-01 01:02:03'), ('2000-02-03 04:05:06');
 SELECT rows, delete_ttl_info_min, delete_ttl_info_max, move_ttl_info.expression, move_ttl_info.min, move_ttl_info.max FROM system.parts WHERE database = currentDatabase() AND table = 'ttl';


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Detailed description / Documentation draft:
Seems like `data_part->rows_count` is always zero if all data were dropped
Also test might fail due to empty parts cleanup
