### PR TITLE
Fix using multiple LDAP storages in the same config.

### DIFF
--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -516,6 +516,9 @@ std::optional<UUID> LDAPAccessStorage::authenticateImpl(
 
     if (new_user)
     {
+        // TODO: if these were AlwaysAllowCredentials, then mapped external roles are not available here,
+        // since without a password we can't authenticate and retrieve roles from the LDAP server.
+
         assignRolesNoLock(*new_user, external_roles);
         id = memory_storage.insert(new_user);
     }

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -353,6 +353,9 @@ bool LDAPAccessStorage::areLDAPCredentialsValidNoLock(const User & user, const C
     if (credentials.getUserName() != user.getName())
         return false;
 
+    if (typeid_cast<const AlwaysAllowCredentials *>(&credentials))
+        return true;
+
     if (const auto * basic_credentials = dynamic_cast<const BasicCredentials *>(&credentials))
         return external_authenticators.checkLDAPCredentials(ldap_server_name, *basic_credentials, &role_search_params, &role_search_results);
 
@@ -478,53 +481,50 @@ std::optional<UUID> LDAPAccessStorage::authenticateImpl(
     const Credentials & credentials,
     const Poco::Net::IPAddress & address,
     const ExternalAuthenticators & external_authenticators,
-    bool /* throw_if_user_not_exists */) const
+    bool throw_if_user_not_exists) const
 {
     std::scoped_lock lock(mutex);
-    LDAPClient::SearchResultsList external_roles;
     auto id = memory_storage.find<User>(credentials.getUserName());
-    if (id)
+    UserPtr user = id ? memory_storage.read<User>(*id) : nullptr;
+
+    std::shared_ptr<User> new_user;
+    if (!user)
     {
-        auto user = memory_storage.read<User>(*id);
+        // User does not exist, so we create one, and will add it if authentication is successful.
+        new_user = std::make_shared<User>();
+        new_user->setName(credentials.getUserName());
+        new_user->auth_data = AuthenticationData(AuthenticationType::LDAP);
+        new_user->auth_data.setLDAPServerName(ldap_server_name);
+        user = new_user;
+    }
 
-        if (!isAddressAllowed(*user, address))
-            throwAddressNotAllowed(address);
+    if (!isAddressAllowed(*user, address))
+        throwAddressNotAllowed(address);
 
-        if (typeid_cast<const AlwaysAllowCredentials *>(&credentials))
-            return id;
+    LDAPClient::SearchResultsList external_roles;
+    if (!areLDAPCredentialsValidNoLock(*user, credentials, external_authenticators, external_roles))
+    {
+        // We don't know why the authentication has just failed:
+        // either there is no such user in LDAP or the password is not correct.
+        // We treat this situation as if there is no such user because we don't want to block
+        // other storages following this LDAPAccessStorage from trying to authenticate on their own.
+        if (throw_if_user_not_exists)
+            throwNotFound(AccessEntityType::USER, credentials.getUserName());
+        else
+            return {};
+    }
 
-        if (!areLDAPCredentialsValidNoLock(*user, credentials, external_authenticators, external_roles))
-            throwInvalidCredentials();
-
-        // Just in case external_roles are changed. This will be no-op if they are not.
-        updateAssignedRolesNoLock(*id, user->getName(), external_roles);
-
-        return id;
+    if (new_user)
+    {
+        assignRolesNoLock(*new_user, external_roles);
+        id = memory_storage.insert(new_user);
     }
     else
     {
-        // User does not exist, so we create one, and will add it if authentication is successful.
-        auto user = std::make_shared<User>();
-        user->setName(credentials.getUserName());
-        user->auth_data = AuthenticationData(AuthenticationType::LDAP);
-        user->auth_data.setLDAPServerName(ldap_server_name);
-
-        if (!isAddressAllowed(*user, address))
-            throwAddressNotAllowed(address);
-
-        if (typeid_cast<const AlwaysAllowCredentials *>(&credentials))
-        {
-            // TODO: mapped external roles are not available here. Without a password we can't authenticate and retrieve roles from LDAP server.
-            assignRolesNoLock(*user, external_roles);
-            return memory_storage.insert(user);
-        }
-
-        if (!areLDAPCredentialsValidNoLock(*user, credentials, external_authenticators, external_roles))
-            throwInvalidCredentials();
-
-        assignRolesNoLock(*user, external_roles);
-
-        return memory_storage.insert(user);
+        // Just in case external_roles are changed. This will be no-op if they are not.
+        updateAssignedRolesNoLock(*id, user->getName(), external_roles);
     }
+
+    return id;
 }
 }

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -160,7 +160,7 @@ void LDAPClient::diag(const int rc, String text)
     }
 }
 
-void LDAPClient::openConnection()
+bool LDAPClient::openConnection()
 {
     std::scoped_lock lock(ldap_global_mutex);
 
@@ -306,7 +306,10 @@ void LDAPClient::openConnection()
             cred.bv_val = const_cast<char *>(params.password.c_str());
             cred.bv_len = params.password.size();
 
-            diag(ldap_sasl_bind_s(handle, final_bind_dn.c_str(), LDAP_SASL_SIMPLE, &cred, nullptr, nullptr, nullptr));
+            int rc = ldap_sasl_bind_s(handle, final_bind_dn.c_str(), LDAP_SASL_SIMPLE, &cred, nullptr, nullptr, nullptr);
+            if (rc == LDAP_INVALID_CREDENTIALS)
+                return false;
+            diag(rc);
 
             // Once bound, run the user DN search query and update the default value, if asked.
             if (params.user_dn_detection)
@@ -322,7 +325,7 @@ void LDAPClient::openConnection()
                 final_user_dn = *user_dn_search_results.begin();
             }
 
-            break;
+            return true;
         }
 
         default:
@@ -541,8 +544,9 @@ bool LDAPSimpleAuthClient::authenticate(const RoleSearchParamsList * role_search
 
     SCOPE_EXIT({ closeConnection(); });
 
-    // Will throw on any error, including invalid credentials.
-    openConnection();
+    // Will return false on invalid credentials, will throw on any other error.
+    if (!openConnection())
+        return false;
 
     // While connected, run search queries and save the results, if asked.
     if (role_search_params)
@@ -574,7 +578,7 @@ void LDAPClient::diag(const int, String)
     throw Exception("ClickHouse was built without LDAP support", ErrorCodes::FEATURE_IS_NOT_ENABLED_AT_BUILD_TIME);
 }
 
-void LDAPClient::openConnection()
+bool LDAPClient::openConnection()
 {
     throw Exception("ClickHouse was built without LDAP support", ErrorCodes::FEATURE_IS_NOT_ENABLED_AT_BUILD_TIME);
 }

--- a/src/Access/LDAPClient.cpp
+++ b/src/Access/LDAPClient.cpp
@@ -306,10 +306,15 @@ bool LDAPClient::openConnection()
             cred.bv_val = const_cast<char *>(params.password.c_str());
             cred.bv_len = params.password.size();
 
-            int rc = ldap_sasl_bind_s(handle, final_bind_dn.c_str(), LDAP_SASL_SIMPLE, &cred, nullptr, nullptr, nullptr);
-            if (rc == LDAP_INVALID_CREDENTIALS)
-                return false;
-            diag(rc);
+            {
+                const auto rc = ldap_sasl_bind_s(handle, final_bind_dn.c_str(), LDAP_SASL_SIMPLE, &cred, nullptr, nullptr, nullptr);
+
+                // Handle invalid credentials gracefully.
+                if (rc == LDAP_INVALID_CREDENTIALS)
+                    return false;
+
+                diag(rc);
+            }
 
             // Once bound, run the user DN search query and update the default value, if asked.
             if (params.user_dn_detection)

--- a/src/Access/LDAPClient.h
+++ b/src/Access/LDAPClient.h
@@ -134,7 +134,7 @@ public:
 
 protected:
     MAYBE_NORETURN void diag(const int rc, String text = "");
-    MAYBE_NORETURN void openConnection();
+    MAYBE_NORETURN bool openConnection();
     void closeConnection() noexcept;
     SearchResults search(const SearchParams & search_params);
 

--- a/src/Access/MultipleAccessStorage.cpp
+++ b/src/Access/MultipleAccessStorage.cpp
@@ -452,9 +452,11 @@ void MultipleAccessStorage::updateSubscriptionsToNestedStorages(std::unique_lock
 std::optional<UUID> MultipleAccessStorage::authenticateImpl(const Credentials & credentials, const Poco::Net::IPAddress & address, const ExternalAuthenticators & external_authenticators, bool throw_if_user_not_exists) const
 {
     auto storages = getStoragesInternal();
-    for (const auto & storage : *storages)
+    for (size_t i = 0; i != storages->size(); ++i)
     {
-        auto id = storage->authenticate(credentials, address, external_authenticators, /* throw_if_user_not_exists = */ false);
+        const auto & storage = (*storages)[i];
+        bool is_last_storage = (i == storages->size() - 1);
+        auto id = storage->authenticate(credentials, address, external_authenticators, throw_if_user_not_exists && is_last_storage);
         if (id)
         {
             std::lock_guard lock{mutex};


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry:
This PR allows using multiple LDAP storages in the same list of user directories.
It worked earlier but was broken because LDAP tests are disabled (they are part of the testflows tests).

I've fixed some of the testflows test including the one which checks using multiple LDAP storages in the same list of user directories, see https://github.com/ClickHouse/ClickHouse/pull/33575.