### PR TITLE
Fix broken workflow dependencies

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -10,7 +10,6 @@ on: # yamllint disable-line rule:truthy
       - 'backport/**'
 jobs:
   DockerHubPushAarch64:
-    needs: CheckLabels
     runs-on: [self-hosted, func-tester-aarch64]
     steps:
       - name: Clear repository
@@ -28,7 +27,6 @@ jobs:
           name: changed_images_aarch64
           path: ${{ runner.temp }}/docker_images_check/changed_images_aarch64.json
   DockerHubPushAmd64:
-    needs: CheckLabels
     runs-on: [self-hosted, style-checker]
     steps:
       - name: Clear repository

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,6 @@ on: # yamllint disable-line rule:truthy
       - 'master'
 jobs:
   DockerHubPushAarch64:
-    needs: CheckLabels
     runs-on: [self-hosted, func-tester-aarch64]
     steps:
       - name: Clear repository
@@ -28,7 +27,6 @@ jobs:
           name: changed_images_aarch64
           path: ${{ runner.temp }}/docker_images_check/changed_images_aarch64.json
   DockerHubPushAmd64:
-    needs: CheckLabels
     runs-on: [self-hosted, style-checker]
     steps:
       - name: Clear repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ on: # yamllint disable-line rule:truthy
   workflow_dispatch:
 jobs:
   DockerHubPushAarch64:
-    needs: CheckLabels
     runs-on: [self-hosted, func-tester-aarch64]
     steps:
       - name: Clear repository
@@ -38,7 +37,6 @@ jobs:
           name: changed_images_aarch64
           path: ${{ runner.temp }}/docker_images_check/changed_images_aarch64.json
   DockerHubPushAmd64:
-    needs: CheckLabels
     runs-on: [self-hosted, style-checker]
     steps:
       - name: Clear repository

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -13,7 +13,6 @@ on: # yamllint disable-line rule:truthy
       - '24.[1-9][1-9]'
 jobs:
   DockerHubPushAarch64:
-    needs: CheckLabels
     runs-on: [self-hosted, func-tester-aarch64]
     steps:
       - name: Clear repository
@@ -31,7 +30,6 @@ jobs:
           name: changed_images_aarch64
           path: ${{ runner.temp }}/docker_images_check/changed_images_aarch64.json
   DockerHubPushAmd64:
-    needs: CheckLabels
     runs-on: [self-hosted, style-checker]
     steps:
       - name: Clear repository


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Copy/paste brought broken dependencies to some workflows