### PR TITLE
Remove broken editing of /etc/hosts

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -45,7 +45,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 ENV DOCKER_CHANNEL stable
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -c -s) ${DOCKER_CHANNEL}"
+RUN add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -c -s) ${DOCKER_CHANNEL}"
 
 RUN apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -58,7 +58,9 @@ RUN apt-get update \
 
 RUN dockerd --version; docker --version
 
-RUN python3 -m pip install \
+ARG TARGETARCH
+# FIXME: psycopg2-binary is not available for aarch64, we skip it for now
+RUN test x$TARGETARCH = xarm64 || ( python3 -m pip install \
     PyMySQL \
     aerospike==4.0.0 \
     avro==1.10.2 \
@@ -88,7 +90,7 @@ RUN python3 -m pip install \
     urllib3 \
     requests-kerberos \
     pyhdfs \
-    azure-storage-blob
+    azure-storage-blob )
 
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY dockerd-entrypoint.sh /usr/local/bin/

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -102,8 +102,6 @@ RUN set -x \
   && echo 'dockremap:165536:65536' >> /etc/subuid \
     && echo 'dockremap:165536:65536' >> /etc/subgid
 
-RUN echo '127.0.0.1 localhost test.com' >> /etc/hosts
-
 EXPOSE 2375
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD ["sh", "-c", "pytest $PYTEST_OPTS"]


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove editing /etc/hosts from Dockerfile


Detailed description / Documentation draft:
`docker build` just silently ignores changes in /etc/hosts, see [comment](https://github.com/moby/buildkit/issues/1267#issuecomment-557212786)

```
Step 18/21 : RUN echo '127.0.0.1 localhost test.com' >> /etc/hosts
 ---> Using cache
 ---> 1325e1681802
...
Successfully tagged clickhouse/integration-tests-runner:latest-amd64
$ docker run -it --rm --entrypoint=cat clickhouse/integration-tests-runner:latest-amd64 /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.17.0.2	7215ebb99e4c
```

`buildx` is broken now, this PR fixes it.