### PR TITLE
RFC: Fix "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform"

### DIFF
--- a/src/Processors/Transforms/AggregatingInOrderTransform.cpp
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.cpp
@@ -255,6 +255,8 @@ void AggregatingInOrderTransform::generate()
         res.getByPosition(i + res_key_columns.size()).column = std::move(res_aggregate_columns[i]);
 
     to_push_chunk = convertToChunk(res);
+    if (!to_push_chunk.getNumRows())
+        return;
 
     /// Clear arenas to allow to free them, when chunk will reach the end of pipeline.
     /// It's safe clear them here, because columns with aggregate functions already holds them.

--- a/src/Processors/Transforms/MergingAggregatedMemoryEfficientTransform.cpp
+++ b/src/Processors/Transforms/MergingAggregatedMemoryEfficientTransform.cpp
@@ -1,9 +1,9 @@
 #include <Processors/Transforms/MergingAggregatedMemoryEfficientTransform.h>
-
-#include <Interpreters/Aggregator.h>
 #include <Processors/ISimpleTransform.h>
 #include <Processors/ResizeProcessor.h>
+#include <Processors/Transforms/AggregatingInOrderTransform.h>
 #include <QueryPipeline/Pipe.h>
+#include <Interpreters/Aggregator.h>
 
 namespace DB
 {
@@ -250,22 +250,30 @@ void GroupingAggregatedTransform::addChunk(Chunk chunk, size_t input)
     if (!info)
         throw Exception("Chunk info was not set for chunk in GroupingAggregatedTransform.", ErrorCodes::LOGICAL_ERROR);
 
-    const auto * agg_info = typeid_cast<const AggregatedChunkInfo *>(info.get());
-    if (!agg_info)
-        throw Exception("Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform.", ErrorCodes::LOGICAL_ERROR);
+    if (const auto * agg_info = typeid_cast<const AggregatedChunkInfo *>(info.get()))
+    {
+        Int32 bucket = agg_info->bucket_num;
+        bool is_overflows = agg_info->is_overflows;
 
-    Int32 bucket = agg_info->bucket_num;
-    bool is_overflows = agg_info->is_overflows;
-
-    if (is_overflows)
-        overflow_chunks.emplace_back(std::move(chunk));
-    else if (bucket < 0)
+        if (is_overflows)
+            overflow_chunks.emplace_back(std::move(chunk));
+        else if (bucket < 0)
+            single_level_chunks.emplace_back(std::move(chunk));
+        else
+        {
+            chunks_map[bucket].emplace_back(std::move(chunk));
+            has_two_level = true;
+            last_bucket_number[input] = bucket;
+        }
+    }
+    else if (const auto * in_order_info = typeid_cast<const ChunkInfoWithAllocatedBytes *>(info.get()))
+    {
         single_level_chunks.emplace_back(std::move(chunk));
+    }
     else
     {
-        chunks_map[bucket].emplace_back(std::move(chunk));
-        has_two_level = true;
-        last_bucket_number[input] = bucket;
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Chunk should have AggregatedChunkInfo/ChunkInfoWithAllocatedBytes in GroupingAggregatedTransform.");
     }
 }
 
@@ -318,16 +326,27 @@ void MergingAggregatedBucketTransform::transform(Chunk & chunk)
             throw Exception("Chunk info was not set for chunk in MergingAggregatedBucketTransform.",
                     ErrorCodes::LOGICAL_ERROR);
 
-        const auto * agg_info = typeid_cast<const AggregatedChunkInfo *>(cur_info.get());
-        if (!agg_info)
-            throw Exception("Chunk should have AggregatedChunkInfo in MergingAggregatedBucketTransform.",
-                    ErrorCodes::LOGICAL_ERROR);
+        if (const auto * agg_info = typeid_cast<const AggregatedChunkInfo *>(cur_info.get()))
+        {
+            Block block = header.cloneWithColumns(cur_chunk.detachColumns());
+            block.info.is_overflows = agg_info->is_overflows;
+            block.info.bucket_num = agg_info->bucket_num;
 
-        Block block = header.cloneWithColumns(cur_chunk.detachColumns());
-        block.info.is_overflows = agg_info->is_overflows;
-        block.info.bucket_num = agg_info->bucket_num;
+            blocks_list.emplace_back(std::move(block));
+        }
+        else if (const auto * in_order_info = typeid_cast<const ChunkInfoWithAllocatedBytes *>(cur_info.get()))
+        {
+            Block block = header.cloneWithColumns(cur_chunk.detachColumns());
+            block.info.is_overflows = false;
+            block.info.bucket_num = -1;
 
-        blocks_list.emplace_back(std::move(block));
+            blocks_list.emplace_back(std::move(block));
+        }
+        else
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Chunk should have AggregatedChunkInfo/ChunkInfoWithAllocatedBytes in MergingAggregatedBucketTransform.");
+        }
     }
 
     auto res_info = std::make_shared<AggregatedChunkInfo>();
@@ -379,7 +398,8 @@ void SortingAggregatedTransform::addChunk(Chunk chunk, size_t from_input)
 
     const auto * agg_info = typeid_cast<const AggregatedChunkInfo *>(info.get());
     if (!agg_info)
-        throw Exception("Chunk should have AggregatedChunkInfo in SortingAggregatedTransform.", ErrorCodes::LOGICAL_ERROR);
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Chunk should have AggregatedChunkInfo in SortingAggregatedTransform.");
 
     Int32 bucket = agg_info->bucket_num;
     bool is_overflows = agg_info->is_overflows;
@@ -389,8 +409,10 @@ void SortingAggregatedTransform::addChunk(Chunk chunk, size_t from_input)
     else
     {
         if (chunks[bucket])
-            throw Exception("SortingAggregatedTransform already got bucket with number " + toString(bucket),
-                    ErrorCodes::LOGICAL_ERROR);
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "SortingAggregatedTransform already got bucket with number {}", bucket);
+        }
 
         chunks[bucket] = std::move(chunk);
         last_bucket_number[from_input] = bucket;

--- a/src/Processors/Transforms/MergingAggregatedTransform.cpp
+++ b/src/Processors/Transforms/MergingAggregatedTransform.cpp
@@ -23,7 +23,11 @@ void MergingAggregatedTransform::consume(Chunk chunk)
         LOG_TRACE(log, "Reading blocks of partially aggregated data.");
     }
 
-    total_input_rows += chunk.getNumRows();
+    size_t input_rows = chunk.getNumRows();
+    if (!input_rows)
+        return;
+
+    total_input_rows += input_rows;
     ++total_input_blocks;
 
     const auto & info = chunk.getChunkInfo();

--- a/tests/queries/0_stateless/02176_optimize_aggregation_in_order_empty.reference
+++ b/tests/queries/0_stateless/02176_optimize_aggregation_in_order_empty.reference
@@ -1,0 +1,8 @@
+-- { echoOn }
+
+-- regression for optimize_aggregation_in_order with empty result set
+-- that cause at first
+--   "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform"
+-- at first and after
+--   "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform"
+select count() from remote('127.{1,2}', currentDatabase(), data_02176) where key = 0 group by key settings optimize_aggregation_in_order=1;

--- a/tests/queries/0_stateless/02176_optimize_aggregation_in_order_empty.sql
+++ b/tests/queries/0_stateless/02176_optimize_aggregation_in_order_empty.sql
@@ -1,0 +1,14 @@
+drop table if exists data_02176;
+create table data_02176 (key Int) Engine=MergeTree() order by key;
+
+-- { echoOn }
+
+-- regression for optimize_aggregation_in_order with empty result set
+-- that cause at first
+--   "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform"
+-- at first and after
+--   "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform"
+select count() from remote('127.{1,2}', currentDatabase(), data_02176) where key = 0 group by key settings optimize_aggregation_in_order=1;
+
+-- { echoOff }
+drop table data_02176;

--- a/tests/queries/0_stateless/02177_merge_optimize_aggregation_in_order.reference
+++ b/tests/queries/0_stateless/02177_merge_optimize_aggregation_in_order.reference
@@ -1,0 +1,6 @@
+-- { echoOn }
+
+-- regression for optimize_aggregation_in_order
+-- that cause "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform" error
+select count() from remote('127.{1,2}', currentDatabase(), data_02177) group by key settings optimize_aggregation_in_order=1;
+2

--- a/tests/queries/0_stateless/02177_merge_optimize_aggregation_in_order.sql
+++ b/tests/queries/0_stateless/02177_merge_optimize_aggregation_in_order.sql
@@ -1,0 +1,12 @@
+drop table if exists data_02177;
+create table data_02177 (key Int) Engine=MergeTree() order by key;
+insert into data_02177 values (1);
+
+-- { echoOn }
+
+-- regression for optimize_aggregation_in_order
+-- that cause "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform" error
+select count() from remote('127.{1,2}', currentDatabase(), data_02177) group by key settings optimize_aggregation_in_order=1;
+
+-- { echoOff }
+drop table data_02177;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform` (in case of `optimize_aggregation_in_order=1`)

Detailed description / Documentation draft:
In case of `optimize_aggregation_in_order=1` there will be `ChunkInfoWithAllocatedBytes`.
Also note, that this is the case only when MergeTree has only one part, since in this case there will be no local FinishAggregatingInOrderTransform.

<details>

### one part

```sql
EXPLAIN PIPELINE
SELECT count()
FROM remote('127.{1,2}', currentDatabase(), test_data)
GROUP BY key
SETTINGS optimize_aggregation_in_order = 1, max_threads = 1

┌─explain──────────────────────────────────┐
│ (Expression)                             │
│ ExpressionTransform                      │
│   (MergingAggregated)                    │
│   MergingAggregatedBucketTransform       │
│     GroupingAggregatedTransform 2 → 1    │
│       (SettingQuotaAndLimits)            │
│         (Union)                          │
│           (Aggregating)                  │
│           FinalizeAggregatedTransform    │
│             AggregatingInOrderTransform  │
│               (Expression)               │
│               ExpressionTransform        │
│                 (SettingQuotaAndLimits)  │
│                   (ReadFromMergeTree)    │
│                   MergeTreeInOrder 0 → 1 │
│           (ReadFromRemote)               │
└──────────────────────────────────────────┘

```

### multiple parts

```sql
EXPLAIN PIPELINE
SELECT count()
FROM remote('127.{1,2}', currentDatabase(), test_data)
GROUP BY key
SETTINGS optimize_aggregation_in_order = 1, max_threads = 1

┌─explain─────────────────────────────────────────────┐
│ (Expression)                                        │
│ ExpressionTransform                                 │
│   (MergingAggregated)                               │
│   MergingAggregatedBucketTransform                  │
│     GroupingAggregatedTransform 2 → 1               │
│       (SettingQuotaAndLimits)                       │
│         (Union)                                     │
│           (Aggregating)                             │
│           MergingAggregatedBucketTransform          │
│             FinishAggregatingInOrderTransform 2 → 1 │
│               AggregatingInOrderTransform × 2       │
│                 (Expression)                        │
│                 ExpressionTransform × 2             │
│                   (SettingQuotaAndLimits)           │
│                     (ReadFromMergeTree)             │
│                     MergeTreeInOrder × 2 0 → 1      │
│           (ReadFromRemote)                          │
└─────────────────────────────────────────────────────┘
```

</details>

Cc: @CurtizJ 
Cc: @KochetovNicolai 

Fixes: #30692
Fixes: #31172
Fixes: #30266