### PR TITLE
AsynchronousMetrics: Ignore inaccessible sensors

### DIFF
--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -109,6 +109,23 @@ void AsynchronousMetrics::openSensors()
             else
                 break;
         }
+
+        file->rewind();
+        Int64 temperature = 0;
+        try
+        {
+            readText(temperature, *file);
+        }
+        catch (const ErrnoException & e)
+        {
+            LOG_WARNING(
+                &Poco::Logger::get("AsynchronousMetrics"),
+                "Thermal monitor '{}' exists but could not be read, error {}.",
+                thermal_device_index,
+                e.getErrno());
+            continue;
+        }
+
         thermal.emplace_back(std::move(file));
     }
 }
@@ -220,6 +237,23 @@ void AsynchronousMetrics::openSensorsChips()
                 ReadBufferFromFilePRead sensor_name_in(sensor_name_file, small_buffer_size);
                 readText(sensor_name, sensor_name_in);
                 std::replace(sensor_name.begin(), sensor_name.end(), ' ', '_');
+            }
+
+            file->rewind();
+            Int64 temperature = 0;
+            try
+            {
+                readText(temperature, *file);
+            }
+            catch (const ErrnoException & e)
+            {
+                LOG_WARNING(
+                    &Poco::Logger::get("AsynchronousMetrics"),
+                    "Hardware monitor '{}', sensor '{}' exists but could not be read, error {}.",
+                    hwmon_name,
+                    sensor_name,
+                    e.getErrno());
+                continue;
             }
 
             hwmon_devices[hwmon_name][sensor_name] = std::move(file);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:

Recently I've started getting constant messages in my local CH machine because of inaccessible sensors:

```
2022.01.14 12:58:51.000936 [ 148649 ] {} <Trace> AsynchronousMetrics: Scanning /sys/class/thermal
2022.01.14 12:58:51.001041 [ 148649 ] {} <Debug> AsynchronousMetrics: Hardware monitor 'iwlwifi_1', sensor '' exists but could not be read, error 61.
2022.01.14 12:58:52.000784 [ 148649 ] {} <Trace> AsynchronousMetrics: Scanning /sys/class/thermal
2022.01.14 12:58:52.003296 [ 148649 ] {} <Debug> AsynchronousMetrics: Hardware monitor 'iwlwifi_1', sensor '' exists but could not be read, error 61.
2022.01.14 12:58:53.000797 [ 148649 ] {} <Trace> AsynchronousMetrics: Scanning /sys/class/thermal
2022.01.14 12:58:53.000923 [ 148649 ] {} <Debug> AsynchronousMetrics: Hardware monitor 'iwlwifi_1', sensor '' exists but could not be read, error 61.
2022.01.14 12:58:54.000805 [ 148649 ] {} <Trace> AsynchronousMetrics: Scanning /sys/class/thermal
2022.01.14 12:58:54.003308 [ 148649 ] {} <Debug> AsynchronousMetrics: Hardware monitor 'iwlwifi_1', sensor '' exists but could not be read, error 61.
2022.01.14 12:58:55.000846 [ 148649 ] {} <Trace> AsynchronousMetrics: Scanning /sys/class/thermal
2022.01.14 12:58:55.000977 [ 148649 ] {} <Debug> AsynchronousMetrics: Hardware monitor 'iwlwifi_1', sensor '' exists but could not be read, error 61.
2022.01.14 12:58:56.000829 [ 148649 ] {} <Trace> AsynchronousMetrics: Scanning /sys/class/thermal
2022.01.14 12:58:56.003359 [ 148649 ] {} <Debug> AsynchronousMetrics: Hardware monitor 'iwlwifi_1', sensor '' exists but could not be read, error 61.
2022.01.14 12:58:57.000672 [ 148649 ] {} <Trace> AsynchronousMetrics: Scanning /sys/class/thermal
2022.01.14 12:58:57.000781 [ 148649 ] {} <Debug> AsynchronousMetrics: Hardware monitor 'iwlwifi_1', sensor '' exists but could not be read, error 61.
```

The current logic is that when you fail to access a sensor you refresh everything, so when there is a sensor that is down and fails everytime it keeps refreshing the whole list of devices and sensors (every second by default!). Instead, attempt to read the sensors once when they are discovered and discard them if they can't be used.