### PR TITLE
Fix 01814_distributed_push_down_limit flakiness

### DIFF
--- a/tests/queries/0_stateless/01814_distributed_push_down_limit.sh
+++ b/tests/queries/0_stateless/01814_distributed_push_down_limit.sh
@@ -71,6 +71,7 @@ function test_distributed_push_down_limit_with_query_log()
             where
                 event_date >= yesterday()
                 and query_kind = 'Select' /* exclude DESC TABLE */
+                and type = 'QueryFinish'
                 and initial_query_id = '$query_id' and initial_query_id != query_id;
     " | xargs # convert new lines to spaces
 }


### PR DESCRIPTION
Before it was possible that the query was already cancelled, and so you
will get ExceptionWhileProcessing and QueryFinish:

    ┌─query───────────────────────────────────────────────────────────────────┬─query_id─────────────────────────────┬─read_rows─┬─type─────────────────────┐
    │ SELECT `key` FROM `test_qvcjdo`.`data_01814` GROUP BY `key` LIMIT 0, 10 │ 2d39bfd6-f0e7-404a-9990-7703f7a4ec3a │        40 │ QueryFinish              │
    │ SELECT `key` FROM `test_qvcjdo`.`data_01814` GROUP BY `key` LIMIT 0, 10 │ d930bf54-e965-42fd-9d48-5e54a588187a │        40 │ QueryFinish              │
    │ SELECT `key` FROM `test_qvcjdo`.`data_01814` GROUP BY `key` LIMIT 0, 10 │ d930bf54-e965-42fd-9d48-5e54a588187a │        40 │ ExceptionWhileProcessing │
    └─────────────────────────────────────────────────────────────────────────┴──────────────────────────────────────┴───────────┴──────────────────────────┘

And so you will got more then two rows.

CI: https://s3.amazonaws.com/clickhouse-test-reports/33660/a4e8e61d57eab14116983a340c65e5e2d7039ed5/stateless_tests__release__wide_parts_enabled__actions_.html

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alexey-milovidov 