### PR TITLE
Slightly reduce memory usage for parsing collections (by using move ctor)

### DIFF
--- a/src/Parsers/ASTLiteral.h
+++ b/src/Parsers/ASTLiteral.h
@@ -15,8 +15,7 @@ namespace DB
 class ASTLiteral : public ASTWithAlias
 {
 public:
-    explicit ASTLiteral(Field && value_) : value(value_) {}
-    explicit ASTLiteral(const Field & value_) : value(value_) {}
+    explicit ASTLiteral(Field value_) : value(std::move(value_)) {}
 
     Field value;
 

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1639,7 +1639,7 @@ bool ParserCollectionOfLiterals<Collection>::parseImpl(Pos & pos, ASTPtr & node,
                 if (std::is_same_v<Collection, Tuple> && arr.size() == 1)
                     return false;
 
-                literal = std::make_shared<ASTLiteral>(arr);
+                literal = std::make_shared<ASTLiteral>(std::move(arr));
                 literal->begin = literal_begin;
                 literal->end = ++pos;
                 node = literal;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Slightly reduce memory usage for parsing collections (can be visible only for huge arrays/tuples)

Detailed description / Documentation draft:
In case you pass array in VALUES section (ValuesBlockInputFormat), it
will be copied after it had been created.
This is not significant if array is small, however if you have huge
enough array, then this can become significant (especially for array of
bool, since for each element will be used Field anyway, and it's size is
56 byte).

Here is a simple reproducer:

    $ curl -sS 'http://127.1:8123/?input_format_values_deduce_templates_of_expressions=0' -d@- <<<"insert into function null('_ Int') values (length([0,$(yes 1, | head -n2000000 | tr -d '\n')1]))"

But note, that there is lots of work (evalute constant expressions from #6781)
after parsing collection, and so total memory usage for query does not
changed a lot (hence - no test).