### PR TITLE
Functions dictGet, dictHas implicit key cast

### DIFF
--- a/src/DataTypes/DataTypesNumber.h
+++ b/src/DataTypes/DataTypesNumber.h
@@ -12,6 +12,7 @@ namespace DB
 template <typename T>
 class DataTypeNumber final : public DataTypeNumberBase<T>
 {
+public:
     bool equals(const IDataType & rhs) const override { return typeid(rhs) == typeid(*this); }
 
     bool canBeUsedAsVersion() const override { return true; }

--- a/src/Dictionaries/DictionaryStructure.h
+++ b/src/Dictionaries/DictionaryStructure.h
@@ -120,6 +120,7 @@ struct DictionaryStructure final
 
     DictionaryStructure(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
 
+    DataTypes getKeyTypes() const;
     void validateKeyTypes(const DataTypes & key_types) const;
 
     const DictionaryAttribute & getAttribute(const std::string & attribute_name) const;

--- a/src/Dictionaries/IDictionary.h
+++ b/src/Dictionaries/IDictionary.h
@@ -7,6 +7,7 @@
 #include <Columns/ColumnsNumber.h>
 #include <Interpreters/IExternalLoadable.h>
 #include <Interpreters/StorageID.h>
+#include <Interpreters/castColumn.h>
 #include <Dictionaries/IDictionarySource.h>
 #include <Dictionaries/DictionaryStructure.h>
 #include <DataTypes/IDataType.h>
@@ -17,6 +18,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
+    extern const int TYPE_MISMATCH;
 }
 
 class IDictionary;
@@ -107,11 +109,45 @@ public:
     virtual bool isInjective(const std::string & attribute_name) const = 0;
 
     /** Subclass must provide key type that is supported by dictionary.
-      * Client will use that key type to provide valid key columns for `getColumn` and `has` functions.
+      * Client will use that key type to provide valid key columns for `getColumn` and `hasKeys` functions.
       */
     virtual DictionaryKeyType getKeyType() const = 0;
 
     virtual DictionarySpecialKeyType getSpecialKeyType() const { return DictionarySpecialKeyType::None; }
+
+    /** Convert key columns for getColumn, hasKeys functions to match dictionary key column types.
+      * Default implementation convert key columns into DictionaryStructure key types.
+      * Subclass can override this method if keys for getColumn, hasKeys functions
+      * are different from DictionaryStructure keys. Or to prevent implicit conversion of key columns.
+      */
+    virtual void convertKeyColumns(Columns & key_columns, DataTypes & key_types) const
+    {
+        const auto & dictionary_structure = getStructure();
+        auto key_attributes_types = dictionary_structure.getKeyTypes();
+        size_t key_attributes_types_size = key_attributes_types.size();
+        size_t key_types_size = key_types.size();
+
+        if (key_types_size != key_attributes_types_size)
+            throw Exception(ErrorCodes::TYPE_MISMATCH,
+                "Dictionary {} key lookup structure does not match, expected {}",
+                getFullName(),
+                dictionary_structure.getKeyDescription());
+
+        for (size_t key_attribute_type_index = 0; key_attribute_type_index < key_attributes_types_size; ++key_attribute_type_index)
+        {
+            const auto & key_attribute_type = key_attributes_types[key_attribute_type_index];
+            auto & key_type = key_types[key_attribute_type_index];
+
+            if (key_attribute_type->equals(*key_type))
+                continue;
+
+            auto & key_column_to_cast = key_columns[key_attribute_type_index];
+            ColumnWithTypeAndName column_to_cast = {key_column_to_cast, key_type, ""};
+            auto casted_column = castColumnAccurate(std::move(column_to_cast), key_attribute_type);
+            key_column_to_cast = std::move(casted_column);
+            key_type = key_attribute_type;
+        }
+    }
 
     /** Subclass must validate key columns and keys types
       * and return column representation of dictionary attribute.

--- a/src/Dictionaries/IPAddressDictionary.cpp
+++ b/src/Dictionaries/IPAddressDictionary.cpp
@@ -209,6 +209,11 @@ IPAddressDictionary::IPAddressDictionary(
     calculateBytesAllocated();
 }
 
+void IPAddressDictionary::convertKeyColumns(Columns &, DataTypes &) const
+{
+    /// Do not perform any implicit keys convertion for IPAddressDictionary
+}
+
 ColumnPtr IPAddressDictionary::getColumn(
     const std::string & attribute_name,
     const DataTypePtr & result_type,

--- a/src/Dictionaries/IPAddressDictionary.cpp
+++ b/src/Dictionaries/IPAddressDictionary.cpp
@@ -211,7 +211,7 @@ IPAddressDictionary::IPAddressDictionary(
 
 void IPAddressDictionary::convertKeyColumns(Columns &, DataTypes &) const
 {
-    /// Do not perform any implicit keys convertion for IPAddressDictionary
+    /// Do not perform any implicit keys conversion for IPAddressDictionary
 }
 
 ColumnPtr IPAddressDictionary::getColumn(

--- a/src/Dictionaries/IPAddressDictionary.h
+++ b/src/Dictionaries/IPAddressDictionary.h
@@ -69,6 +69,8 @@ public:
 
     DictionaryKeyType getKeyType() const override { return DictionaryKeyType::Complex; }
 
+    void convertKeyColumns(Columns & key_columns, DataTypes & key_types) const override;
+
     ColumnPtr getColumn(
         const std::string& attribute_name,
         const DataTypePtr & result_type,

--- a/src/Dictionaries/PolygonDictionary.cpp
+++ b/src/Dictionaries/PolygonDictionary.cpp
@@ -6,6 +6,7 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnTuple.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionHelpers.h>
 #include <QueryPipeline/Pipe.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
@@ -39,6 +40,29 @@ IPolygonDictionary::IPolygonDictionary(
     setup();
     loadData();
     calculateBytesAllocated();
+}
+
+void IPolygonDictionary::convertKeyColumns(Columns & key_columns, DataTypes & key_types) const
+{
+    if (key_columns.size() != 2)
+        throw Exception(ErrorCodes::TYPE_MISMATCH,
+            "Dictionary {} key lookup structure does not match, expected two columns of coordinates with type Float64",
+            getFullName());
+
+    auto float_64_type = std::make_shared<DataTypeFloat64>();
+    size_t key_types_size = key_types.size();
+    for (size_t key_type_index = 0; key_type_index < key_types_size; ++key_type_index)
+    {
+        auto & key_type = key_types[key_type_index];
+        if (float_64_type->equals(*key_type))
+            continue;
+
+        auto & key_column_to_cast = key_columns[key_type_index];
+        ColumnWithTypeAndName column_to_cast = {key_column_to_cast, key_type, ""};
+        auto casted_column = castColumnAccurate(std::move(column_to_cast), float_64_type);
+        key_column_to_cast = std::move(casted_column);
+        key_type = float_64_type;
+    }
 }
 
 ColumnPtr IPolygonDictionary::getColumn(

--- a/src/Dictionaries/PolygonDictionary.h
+++ b/src/Dictionaries/PolygonDictionary.h
@@ -95,6 +95,8 @@ public:
 
     DictionaryKeyType getKeyType() const override { return DictionaryKeyType::Complex; }
 
+    void convertKeyColumns(Columns & key_columns, DataTypes & key_types) const override;
+
     ColumnPtr getColumn(
         const std::string& attribute_name,
         const DataTypePtr & result_type,

--- a/tests/queries/0_stateless/02176_dict_get_has_implicit_key_cast.reference
+++ b/tests/queries/0_stateless/02176_dict_get_has_implicit_key_cast.reference
@@ -1,0 +1,14 @@
+Value
+Value
+Value
+1
+1
+1
+Value
+Value
+Value
+Value
+1
+1
+1
+1

--- a/tests/queries/0_stateless/02176_dict_get_has_implicit_key_cast.sql
+++ b/tests/queries/0_stateless/02176_dict_get_has_implicit_key_cast.sql
@@ -1,0 +1,67 @@
+DROP TABLE IF EXISTS 02176_test_simple_key_table;
+CREATE TABLE 02176_test_simple_key_table
+(
+    id UInt64,
+    value String
+) ENGINE=TinyLog;
+
+INSERT INTO 02176_test_simple_key_table VALUES (0, 'Value');
+
+DROP DICTIONARY IF EXISTS 02176_test_simple_key_dictionary;
+CREATE DICTIONARY 02176_test_simple_key_dictionary
+(
+    id UInt64,
+    value String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '02176_test_simple_key_table'))
+LAYOUT(DIRECT());
+
+SELECT dictGet('02176_test_simple_key_dictionary', 'value', toUInt64(0));
+SELECT dictGet('02176_test_simple_key_dictionary', 'value', toUInt8(0));
+SELECT dictGet('02176_test_simple_key_dictionary', 'value', '0');
+SELECT dictGet('02176_test_simple_key_dictionary', 'value', [0]); --{serverError 43}
+
+SELECT dictHas('02176_test_simple_key_dictionary', toUInt64(0));
+SELECT dictHas('02176_test_simple_key_dictionary', toUInt8(0));
+SELECT dictHas('02176_test_simple_key_dictionary', '0');
+SELECT dictHas('02176_test_simple_key_dictionary', [0]); --{serverError 43}
+
+DROP DICTIONARY 02176_test_simple_key_dictionary;
+DROP TABLE 02176_test_simple_key_table;
+
+DROP TABLE IF EXISTS 02176_test_complex_key_table;
+CREATE TABLE 02176_test_complex_key_table
+(
+    id UInt64,
+    id_key String,
+    value String
+) ENGINE=TinyLog;
+
+INSERT INTO 02176_test_complex_key_table VALUES (0, '0', 'Value');
+
+DROP DICTIONARY IF EXISTS 02176_test_complex_key_dictionary;
+CREATE DICTIONARY 02176_test_complex_key_dictionary
+(
+    id UInt64,
+    id_key String,
+    value String
+)
+PRIMARY KEY id, id_key
+SOURCE(CLICKHOUSE(TABLE '02176_test_complex_key_table'))
+LAYOUT(COMPLEX_KEY_DIRECT());
+
+SELECT dictGet('02176_test_complex_key_dictionary', 'value', tuple(toUInt64(0), '0'));
+SELECT dictGet('02176_test_complex_key_dictionary', 'value', tuple(toUInt8(0), '0'));
+SELECT dictGet('02176_test_complex_key_dictionary', 'value', tuple('0', '0'));
+SELECT dictGet('02176_test_complex_key_dictionary', 'value', tuple([0], '0')); --{serverError 43}
+SELECT dictGet('02176_test_complex_key_dictionary', 'value', tuple(toUInt64(0), 0));
+
+SELECT dictHas('02176_test_complex_key_dictionary', tuple(toUInt64(0), '0'));
+SELECT dictHas('02176_test_complex_key_dictionary', tuple(toUInt8(0), '0'));
+SELECT dictHas('02176_test_complex_key_dictionary', tuple('0', '0'));
+SELECT dictHas('02176_test_complex_key_dictionary', tuple([0], '0')); --{serverError 43}
+SELECT dictHas('02176_test_complex_key_dictionary', tuple(toUInt64(0), 0));
+
+DROP DICTIONARY 02176_test_complex_key_dictionary;
+DROP TABLE 02176_test_complex_key_table;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Functions `dictGet`, `dictHas` implicitly cast key argument to dictionary key structure, if they are different.
