### PR TITLE
Fix LDAP and Kerberos config handling

### DIFF
--- a/docs/en/operations/external-authenticators/kerberos.md
+++ b/docs/en/operations/external-authenticators/kerberos.md
@@ -52,6 +52,9 @@ With filtering by realm:
 ```
 
 !!! warning "Note"
+    You can define only one `kerberos` section. The presence of multiple `kerberos` sections will force ClickHouse to disable Kerberos authentication.
+
+!!! warning "Note"
     `principal` and `realm` sections cannot be specified at the same time. The presence of both `principal` and `realm` sections will force ClickHouse to disable Kerberos authentication.
 
 

--- a/src/Access/ExternalAuthenticators.cpp
+++ b/src/Access/ExternalAuthenticators.cpp
@@ -283,10 +283,15 @@ void ExternalAuthenticators::setConfiguration(const Poco::Util::AbstractConfigur
         }
     }
 
+    kerberos_params.reset();
     try
     {
         if (kerberos_keys_count > 0)
-            parseKerberosParams(kerberos_params.emplace(), config);
+        {
+            GSSAcceptorContext::Params kerberos_params_tmp;
+            parseKerberosParams(kerberos_params_tmp, config);
+            kerberos_params = std::move(kerberos_params_tmp);
+        }
     }
     catch (...)
     {


### PR DESCRIPTION
Changelog category:
- Not for changelog

Changelog entry:
- Do not allow LDAP server entries with the same name
- If Kerberos config has issues, disable it

Detailed description:
- Properly address #26197