### PR TITLE
Avx512 memcmp small

### DIFF
--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -134,7 +134,7 @@ else ()
         set (COMPILER_FLAGS "${COMPILER_FLAGS} ${TEST_FLAG}")
     endif ()
 
-    set (TEST_FLAG "-mavx512f -mavx512bw")
+    set (TEST_FLAG "-mavx512f -mavx512bw -mavx512vl")
     set (CMAKE_REQUIRED_FLAGS "${TEST_FLAG} -O0")
     check_cxx_source_compiles("
         #include <immintrin.h>
@@ -143,24 +143,12 @@ else ()
             (void)a;
             auto b = _mm512_add_epi16(__m512i(), __m512i());
             (void)b;
+            auto c = _mm_cmp_epi8_mask(__m128i(), __m128i(), 0);
+            (void)c;
             return 0;
         }
     " HAVE_AVX512)
     if (HAVE_AVX512 AND ENABLE_AVX512)
-        set (COMPILER_FLAGS "${COMPILER_FLAGS} ${TEST_FLAG}")
-    endif ()
-
-    set (TEST_FLAG "-mavx512bw -mavx512vl")
-    set (CMAKE_REQUIRED_FLAGS "${TEST_FLAG} -O0")
-    check_cxx_source_compiles("
-        #include <immintrin.h>
-        int main() {
-            auto mask = _mm_cmp_epi8_mask(__m128i(), __m128i(), 0);
-            (void)mask;
-            return 0;
-        }
-    " HAVE_AVX512_BW_VL)
-    if (HAVE_AVX512_BW_VL AND ENABLE_AVX512)
         set (COMPILER_FLAGS "${COMPILER_FLAGS} ${TEST_FLAG}")
     endif ()
 
@@ -195,10 +183,7 @@ else ()
             set (X86_INTRINSICS_FLAGS "${X86_INTRINSICS_FLAGS} -mbmi")
         endif ()
         if (HAVE_AVX512)
-            set (X86_INTRINSICS_FLAGS "${X86_INTRINSICS_FLAGS} -mavx512f -mavx512bw -mprefer-vector-width=256")
-        endif ()
-        if (HAVE_AVX512_BW_VL)
-            set (X86_INTRINSICS_FLAGS "${X86_INTRINSICS_FLAGS} -mavx512bw -mavx512vl")
+            set (X86_INTRINSICS_FLAGS "${X86_INTRINSICS_FLAGS} -mavx512f -mavx512bw -mavx512vl -mprefer-vector-width=256")
         endif ()
     endif ()
 endif ()

--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -150,6 +150,20 @@ else ()
         set (COMPILER_FLAGS "${COMPILER_FLAGS} ${TEST_FLAG}")
     endif ()
 
+    set (TEST_FLAG "-mavx512bw -mavx512vl")
+    set (CMAKE_REQUIRED_FLAGS "${TEST_FLAG} -O0")
+    check_cxx_source_compiles("
+        #include <immintrin.h>
+        int main() {
+            auto mask = _mm_cmp_epi8_mask(__m128i(), __m128i(), 0);
+            (void)mask;
+            return 0;
+        }
+    " HAVE_AVX512_BW_VL)
+    if (HAVE_AVX512_BW_VL AND ENABLE_AVX512)
+        set (COMPILER_FLAGS "${COMPILER_FLAGS} ${TEST_FLAG}")
+    endif ()
+
     set (TEST_FLAG "-mbmi")
     set (CMAKE_REQUIRED_FLAGS "${TEST_FLAG} -O0")
     check_cxx_source_compiles("
@@ -182,6 +196,9 @@ else ()
         endif ()
         if (HAVE_AVX512)
             set (X86_INTRINSICS_FLAGS "${X86_INTRINSICS_FLAGS} -mavx512f -mavx512bw -mprefer-vector-width=256")
+        endif ()
+        if (HAVE_AVX512_BW_VL)
+            set (X86_INTRINSICS_FLAGS "${X86_INTRINSICS_FLAGS} -mavx512bw -mavx512vl")
         endif ()
     endif ()
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -304,6 +304,7 @@ set_source_files_properties(
         Columns/ColumnsCommon.cpp
         Columns/ColumnVector.cpp
         Columns/ColumnDecimal.cpp
+        Columns/ColumnString.cpp
         PROPERTIES COMPILE_FLAGS "${X86_INTRINSICS_FLAGS}")
 
 if(RE2_LIBRARY)

--- a/src/Common/memcmpSmall.h
+++ b/src/Common/memcmpSmall.h
@@ -25,8 +25,240 @@ inline int cmp(T a, T b)
 /// We can process uninitialized memory in the functions below.
 /// Results don't depend on the values inside uninitialized memory but Memory Sanitizer cannot see it.
 /// Disable optimized functions if compile with Memory Sanitizer.
+#if defined(__AVX512BW__) && defined(__AVX512VL__) && !defined(MEMORY_SANITIZER)
+#include <immintrin.h>
 
-#if defined(__SSE2__) && !defined(MEMORY_SANITIZER)
+
+/** All functions works under the following assumptions:
+  * - it's possible to read up to 15 excessive bytes after end of 'a' and 'b' region;
+  * - memory regions are relatively small and extra loop unrolling is not worth to do.
+  */
+
+/** Variant when memory regions may have different sizes.
+  */
+template <typename Char>
+inline int memcmpSmallAllowOverflow15(const Char * a, size_t a_size, const Char * b, size_t b_size)
+{
+    size_t min_size = std::min(a_size, b_size);
+
+    for (size_t offset = 0; offset < min_size; offset += 16)
+    {
+        uint16_t mask = _mm_cmp_epi8_mask(
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(a + offset)),
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(b + offset)), _MM_CMPINT_NE);
+
+        if (mask)
+        {
+            offset += __builtin_ctz(mask);
+
+            if (offset >= min_size)
+                break;
+
+            return detail::cmp(a[offset], b[offset]);
+        }
+    }
+
+    return detail::cmp(a_size, b_size);
+}
+
+
+/** Variant when memory regions may have different sizes.
+  * But compare the regions as the smaller one is padded with zero bytes up to the size of the larger.
+  * It's needed to hold that: toFixedString('abc', 5) = 'abc'
+  *  for compatibility with SQL standard.
+  */
+template <typename Char>
+inline int memcmpSmallLikeZeroPaddedAllowOverflow15(const Char * a, size_t a_size, const Char * b, size_t b_size)
+{
+    size_t min_size = std::min(a_size, b_size);
+
+    for (size_t offset = 0; offset < min_size; offset += 16)
+    {
+        uint16_t mask = _mm_cmp_epi8_mask(
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(a + offset)),
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(b + offset)), _MM_CMPINT_NE);
+
+        if (mask)
+        {
+            offset += __builtin_ctz(mask);
+
+            if (offset >= min_size)
+                break;
+
+            return detail::cmp(a[offset], b[offset]);
+        }
+    }
+
+    /// The strings are equal up to min_size.
+    /// If the rest of the larger string is zero bytes then the strings are considered equal.
+
+    size_t max_size;
+    const Char * longest;
+    int cmp;
+
+    if (a_size == b_size)
+    {
+        return 0;
+    }
+    else if (a_size > b_size)
+    {
+        max_size = a_size;
+        longest = a;
+        cmp = 1;
+    }
+    else
+    {
+        max_size = b_size;
+        longest = b;
+        cmp = -1;
+    }
+
+    const __m128i zero16 = _mm_setzero_si128();
+
+    for (size_t offset = min_size; offset < max_size; offset += 16)
+    {
+        uint16_t mask = _mm_cmpneq_epi8_mask(
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(longest + offset)),
+            zero16);
+
+        if (mask)
+        {
+            offset += __builtin_ctz(mask);
+
+            if (offset >= max_size)
+                return 0;
+            return cmp;
+        }
+    }
+
+    return 0;
+}
+
+
+/** Variant when memory regions have same size.
+  * TODO Check if the compiler can optimize previous function when the caller pass identical sizes.
+  */
+template <typename Char>
+inline int memcmpSmallAllowOverflow15(const Char * a, const Char * b, size_t size)
+{
+    for (size_t offset = 0; offset < size; offset += 16)
+    {
+        uint16_t mask = _mm_cmp_epi8_mask(
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(a + offset)),
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(b + offset)), _MM_CMPINT_NE);
+
+        if (mask)
+        {
+            offset += __builtin_ctz(mask);
+
+            if (offset >= size)
+                return 0;
+
+            return detail::cmp(a[offset], b[offset]);
+        }
+    }
+
+    return 0;
+}
+
+
+/** Compare memory regions for equality.
+  */
+template <typename Char>
+inline bool memequalSmallAllowOverflow15(const Char * a, size_t a_size, const Char * b, size_t b_size)
+{
+    if (a_size != b_size)
+        return false;
+
+    for (size_t offset = 0; offset < a_size; offset += 16)
+    {
+        uint16_t mask = _mm_cmp_epi8_mask(
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(a + offset)),
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(b + offset)), _MM_CMPINT_NE);
+
+        if (mask)
+        {
+            offset += __builtin_ctz(mask);
+            return offset >= a_size;
+        }
+    }
+
+    return true;
+}
+
+
+/** Variant when the caller know in advance that the size is a multiple of 16.
+  */
+template <typename Char>
+inline int memcmpSmallMultipleOf16(const Char * a, const Char * b, size_t size)
+{
+    for (size_t offset = 0; offset < size; offset += 16)
+    {
+        uint16_t mask = _mm_cmp_epi8_mask(
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(a + offset)),
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(b + offset)), _MM_CMPINT_NE);
+
+        if (mask)
+        {
+            offset += __builtin_ctz(mask);
+            return detail::cmp(a[offset], b[offset]);
+        }
+    }
+
+    return 0;
+}
+
+
+/** Variant when the size is 16 exactly.
+  */
+template <typename Char>
+inline int memcmp16(const Char * a, const Char * b)
+{
+    uint16_t mask = _mm_cmp_epi8_mask(
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(a)),
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(b)), _MM_CMPINT_NE);
+
+    if (mask)
+    {
+        auto offset = __builtin_ctz(mask);
+        return detail::cmp(a[offset], b[offset]);
+    }
+
+    return 0;
+}
+
+
+/** Variant when the size is 16 exactly.
+  */
+inline bool memequal16(const void * a, const void * b)
+{
+    return 0xFFFF == _mm_cmp_epi8_mask(
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(a)),
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(b)), _MM_CMPINT_EQ);
+}
+
+
+/** Compare memory region to zero */
+inline bool memoryIsZeroSmallAllowOverflow15(const void * data, size_t size)
+{
+    const __m128i zero16 = _mm_setzero_si128();
+
+    for (size_t offset = 0; offset < size; offset += 16)
+    {
+        uint16_t mask = _mm_cmp_epi8_mask(zero16,
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(reinterpret_cast<const char *>(data) + offset)), _MM_CMPINT_NE);
+
+        if (mask)
+        {
+            offset += __builtin_ctz(mask);
+            return offset >= size;
+        }
+    }
+
+    return true;
+}
+
+#elif defined(__SSE2__) && !defined(MEMORY_SANITIZER)
 #include <emmintrin.h>
 
 


### PR DESCRIPTION
Co-authored-by: @vesslanjin jun.i.jin@intel.com
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add x86 avx512 support for memcmpSmall functions to accelerate memory comparison.

Detailed description / Documentation draft:
The change is to implement the memCmp functions in memcmpSmall.h by using a AVX512 Intrinsic '_mm_cmp_epi8_mask'. Compared with the SSE version,  functions in the AVX512 version can have better performance (memcmpSmallAllowOverflow15/memcmpSmallLikeZeroPaddedAllowOverflow15/memcmpSmallAllowOverflow15/memcmpSmallMultipleOf16) or same performance (memcmp16/memcmp16/memoryIsZeroSmallAllowOverflow15/memequalSmallAllowOverflow15).

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/qiufengh/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/qiufengh/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{border:.5pt solid windowtext;}
.xl64
	{text-align:center;
	border:.5pt solid windowtext;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



Case | memcmpSmallAllowOverflow15 | memcmpSmallLikeZeroPaddedAllowOverflow15 | memcmpSmallAllowOverflow15 | memequalSmallAllowOverflow15 | memcmpSmallMultipleOf16
-- | -- | -- | -- | -- | --
(lenstr1,   lenstr2, same length) | SSE2 | AVX512 | SSE2 | AVX512 | SSE2 | AVX512 | SSE2 | AVX512 | SSE2 | AVX512
16 32 8 | 23 | 19 | 24 | 20 | 19 | 18 | 14 | 13 | 20 | 18
32 64 15 | 24 | 21 | 25 | 21 | 20 | 19 | 33 | 16 | 21 | 17
64 128 63 | 47 | 35 | 49 | 35 | 44 | 32 | 14 | 14 | 42 | 41
128 256   111 | 75 | 53 | 74 | 53 | 69 | 49 | 14 | 15 | 82 | 46
256 512   222 | 137 | 91 | 138 | 93 | 189 | 85 | 16 | 16 | 130 | 84
1024 2048 1000 | 640 | 402 | 636 | 387 | 654 | 371 | 14 | 13 | 629 | 381
15 31 8 | 43 | 39 | 45 | 39 | 35 | 31 | 19 | 19 | 22 | 19
30 60 15 | 43 | 39 | 45 | 41 | 35 | 31 | 19 | 19 | 36 | 29
60 120 50 | 95 | 68 | 102 | 69 | 89 | 61 | 19 | 19 | 66 | 39
110 240   100 | 137 | 98 | 138 | 98 | 129 | 90 | 19 | 19 | 105 | 67
250 500   222 | 243 | 207 | 242 | 203 | 238 | 156 | 19 | 19 | 233 | 154
1000 2000 1000 | 1081 | 688 | 1061 | 685 | 1046 | 661 | 19 | 19 | 1002 | 640



</body>

</html>





> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/