### PR TITLE
Changelog. uniq*States are incompatible (UUID)

### DIFF
--- a/docs/en/whats-new/changelog/2021.md
+++ b/docs/en/whats-new/changelog/2021.md
@@ -1018,6 +1018,9 @@ toc_title: '2021'
 
 ### ClickHouse release 21.6, 2021-06-05
 
+#### Backward Incompatible Change
+* uniqState / uniqHLL12State / uniqCombinedState / uniqCombined64State produce incompatible states with `UUID` type. [#33607](https://github.com/ClickHouse/ClickHouse/issues/33607).
+
 #### Upgrade Notes
 
 * `zstd` compression library is updated to v1.5.0. You may get messages about "checksum does not match" in replication. These messages are expected due to update of compression algorithm and you can ignore them. These messages are informational and do not indicate any kinds of undesired behaviour.


### PR DESCRIPTION
uniqState / uniqHLL12State / uniqCombinedState / uniqCombined64State Backward Incompatible from 21.6 with UUID

Changelog category (leave one):
- Documentation (changelog entry is not required)
