### PR TITLE
Cleanup build: .gitignore more debian directories, libpqxx-cmake without configure_file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /build_*
 /build-*
 /tests/venv
+/obj-x86_64-linux-gnu/
 
 # logs
 *.log

--- a/contrib/libpqxx-cmake/CMakeLists.txt
+++ b/contrib/libpqxx-cmake/CMakeLists.txt
@@ -68,12 +68,3 @@ add_library(libpqxx ${SRCS} ${HDRS})
 target_link_libraries(libpqxx PUBLIC ${LIBPQ_LIBRARY})
 target_include_directories (libpqxx SYSTEM PRIVATE "${LIBRARY_DIR}/include")
 
-# crutch
-set(CM_CONFIG_H_IN "${LIBRARY_DIR}/include/pqxx/config.h.in")
-set(CM_CONFIG_PUB "${LIBRARY_DIR}/include/pqxx/config-public-compiler.h")
-set(CM_CONFIG_INT "${LIBRARY_DIR}/include/pqxx/config-internal-compiler.h")
-set(CM_CONFIG_PQ "${LIBRARY_DIR}/include/pqxx/config-internal-libpq.h")
-
-configure_file("${CM_CONFIG_H_IN}" "${CM_CONFIG_INT}" @ONLY)
-configure_file("${CM_CONFIG_H_IN}" "${CM_CONFIG_PUB}" @ONLY)
-configure_file("${CM_CONFIG_H_IN}" "${CM_CONFIG_PQ}" @ONLY)

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -2,9 +2,16 @@ control
 copyright
 tmp/
 clickhouse-benchmark/
+clickhouse-client.docs
 clickhouse-client/
+clickhouse-common-static-dbg/
+clickhouse-common-static.docs
+clickhouse-common-static/
 clickhouse-server-base/
 clickhouse-server-common/
+clickhouse-server/
+clickhouse-test/
+debhelper-build-stamp
 files
 *.debhelper.log
 *.debhelper


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:
Less files and submodules will be modified after build

> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
