### PR TITLE
Fix release_branches workflow for some cases

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -7,10 +7,10 @@ env:
 on: # yamllint disable-line rule:truthy
   push:
     branches:
-      - '21.[1-9][1-9]'
-      - '22.[1-9][1-9]'
-      - '23.[1-9][1-9]'
-      - '24.[1-9][1-9]'
+    # 22.1 and 22.10
+      - '2[1-9].[1-9][0-9]'
+      - '2[1-9].[1-9]'
+      
 jobs:
   DockerHubPushAarch64:
     runs-on: [self-hosted, func-tester-aarch64]


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:
Fix branch globbing