### PR TITLE
fix/doc: close code highlight before tuplePlus

### DIFF
--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -240,6 +240,7 @@ Result:
 ┌─tupleToNameValuePairs(tuple(3, 2, 1))─┐
 │ [('1',3),('2',2),('3',1)]             │
 └───────────────────────────────────────┘
+```
 
 ## tuplePlus {#tupleplus}
 

--- a/docs/ru/sql-reference/functions/tuple-functions.md
+++ b/docs/ru/sql-reference/functions/tuple-functions.md
@@ -237,6 +237,7 @@ SELECT tupleToNameValuePairs(tuple(3, 2, 1));
 ┌─tupleToNameValuePairs(tuple(3, 2, 1))─┐
 │ [('1',3),('2',2),('3',1)]             │
 └───────────────────────────────────────┘
+```
 
 ## tuplePlus {#tupleplus}
 


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Detailed description / Documentation draft:
Only `en` and `ru` folders were affected by these missing backticks; `jp` and `zh` were fine.


> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
