### PR TITLE
Hotfix of missing header

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -7,10 +7,10 @@ env:
 on: # yamllint disable-line rule:truthy
   push:
     branches:
-    # 22.1 and 22.10
+      # 22.1 and 22.10
       - '2[1-9].[1-9][0-9]'
       - '2[1-9].[1-9]'
-      
+
 jobs:
   DockerHubPushAarch64:
     runs-on: [self-hosted, func-tester-aarch64]

--- a/base/daemon/BaseDaemon.cpp
+++ b/base/daemon/BaseDaemon.cpp
@@ -50,7 +50,6 @@
 #include <Common/SymbolIndex.h>
 #include <Common/getExecutablePath.h>
 #include <Common/getHashOfLoadedBinary.h>
-#include <Common/setThreadName.h>
 #include <Common/Elf.h>
 #include <Common/setThreadName.h>
 #include <filesystem>

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -22,6 +22,7 @@
 #include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
 #include <Storages/MergeTree/MergeTreeReadPool.h>
 #include <Storages/VirtualColumnUtils.h>
+#include <IO/Operators.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 #include <base/logger_useful.h>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
https://github.com/ClickHouse/ClickHouse/pull/33695 gets merged prematurally. This PR adds the missing header. @alexey-milovidov 


Detailed description / Documentation draft:
.