### PR TITLE
Use tb64senc for base64Decode on aarch64

### DIFF
--- a/src/Functions/FunctionBase64Conversion.h
+++ b/src/Functions/FunctionBase64Conversion.h
@@ -124,13 +124,26 @@ public:
 
             if constexpr (std::is_same_v<Func, Base64Encode>)
             {
+                /*
+                 * Some bug in sse arm64 implementation?
+                 * `base64Encode(repeat('a', 46))` returns wrong padding character
+                 */
+#if (__aarch64__)
+                outlen = tb64senc(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
+#else
                 outlen = _tb64e(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
+#endif
             }
             else if constexpr (std::is_same_v<Func, Base64Decode>)
             {
                 if (srclen > 0)
                 {
-                    outlen = _tb64d(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
+#if (__aarch64__)
+                outlen = tb64sdec(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
+#else
+                outlen = _tb64d(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
+#endif
+
                     if (!outlen)
                         throw Exception("Failed to " + getName() + " input '" + String(reinterpret_cast<const char *>(source), srclen) + "'", ErrorCodes::INCORRECT_DATA);
                 }


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Ref #33716