### PR TITLE
Doc. Window Functions are not experimental starting from 21.9

### DIFF
--- a/docs/en/sql-reference/window-functions/index.md
+++ b/docs/en/sql-reference/window-functions/index.md
@@ -3,7 +3,7 @@ toc_priority: 62
 toc_title: Window Functions
 ---
 
-# [experimental] Window Functions
+# Window Functions
 
 ClickHouse supports the standard grammar for defining windows and window functions. The following features are currently supported:
 


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)
