### PR TITLE
Use workflow names in approve lambda

### DIFF
--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -6,8 +6,8 @@ import fnmatch
 from collections import namedtuple
 import jwt
 
-import requests
-import boto3
+import requests  # type: ignore
+import boto3  # type: ignore
 
 API_URL = "https://api.github.com/repos/ClickHouse/ClickHouse"
 
@@ -52,18 +52,19 @@ TRUSTED_ORG_IDS = {
     54801242,  # clickhouse
 }
 
-# See {API_URL}/actions/workflows
+# See https://api.github.com/repos/ClickHouse/ClickHouse/actions/workflows
+# Use ID to not inject a malicious workflow
 TRUSTED_WORKFLOW_IDS = {
     14586616,  # Cancel workflows, always trusted
 }
 
 NEED_RERUN_WORKFLOWS = {
-    14738810,  # DocsRelease
-    15834118,  # Docs
-    15522500,  # MasterCI
-    15516108,  # ReleaseCI
-    15797242,  # BackportPR
-    16441423,  # PullRequestCI
+    "BackportPR",
+    "Docs",
+    "DocsRelease",
+    "MasterCI",
+    "PullRequestCI",
+    "ReleaseCI",
 }
 
 # Individual trusted contirbutors who are not in any trusted organization.
@@ -392,10 +393,10 @@ def main(event):
             "completed and failed, let's check for rerun",
         )
 
-        if workflow_description.workflow_id not in NEED_RERUN_WORKFLOWS:
+        if workflow_description.name not in NEED_RERUN_WORKFLOWS:
             print(
                 "Workflow",
-                workflow_description.workflow_id,
+                workflow_description.name,
                 "not in list of rerunable workflows",
             )
             return
@@ -437,7 +438,8 @@ def main(event):
     print(f"Totally have {len(changed_files)} changed files in PR:", changed_files)
     if check_suspicious_changed_files(changed_files):
         print(
-            f"Pull Request {pull_request['number']} has suspicious changes, label it for manuall approve"
+            f"Pull Request {pull_request['number']} has suspicious changes, "
+            "label it for manuall approve"
         )
         label_manual_approve(pull_request, token)
     else:


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use names in workflow-for-rerun, the image is already pushed and used in the lambda