### PR TITLE
Fix bug in client that led to 'Connection reset by peer' in server

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1194,7 +1194,7 @@ bool ClientBase::receiveEndOfQuery()
 
             case Protocol::Server::Progress:
                 onProgress(packet.progress);
-                return true;
+                break;
 
             default:
                 throw NetException(


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug in client that led to 'Connection reset by peer' in server. Closes https://github.com/ClickHouse/ClickHouse/issues/33309


Detailed description / Documentation draft:
Such queries led to `Connection reset by peer, while reading from socket` error in server:
```sh
echo "1" | clickhouse-client -q "insert into t select x from input('x UInt32') format CSV"
```
Now it's fixed.