### PR TITLE
Dictionaries remove unnecessary copy of keys during read

### DIFF
--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -494,7 +494,8 @@ Pipe CacheDictionary<dictionary_key_type>::read(const Names & column_names, size
         if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
         {
             auto keys = cache_storage_ptr->getCachedSimpleKeys();
-            key_columns = {ColumnWithTypeAndName(getColumnFromPODArray(keys), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
+            auto keys_column = getColumnFromPODArray(std::move(keys));
+            key_columns = {ColumnWithTypeAndName(std::move(keys_column), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
         }
         else
         {

--- a/src/Dictionaries/DictionaryHelpers.h
+++ b/src/Dictionaries/DictionaryHelpers.h
@@ -683,6 +683,15 @@ static ColumnPtr getColumnFromPODArray(const PaddedPODArray<T> & array)
 }
 
 template <typename T>
+static ColumnPtr getColumnFromPODArray(PaddedPODArray<T> && array)
+{
+    auto column_vector = ColumnVector<T>::create();
+    column_vector->getData() = std::move(array);
+
+    return column_vector;
+}
+
+template <typename T>
 static ColumnPtr getColumnFromPODArray(const PaddedPODArray<T> & array, size_t start, size_t length)
 {
     auto column_vector = ColumnVector<T>::create();

--- a/src/Dictionaries/FlatDictionary.cpp
+++ b/src/Dictionaries/FlatDictionary.cpp
@@ -547,7 +547,8 @@ Pipe FlatDictionary::read(const Names & column_names, size_t max_block_size, siz
         if (loaded_keys[key_index])
             keys.push_back(key_index);
 
-    ColumnsWithTypeAndName key_columns = {ColumnWithTypeAndName(getColumnFromPODArray(keys), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
+    auto keys_column = getColumnFromPODArray(std::move(keys));
+    ColumnsWithTypeAndName key_columns = {ColumnWithTypeAndName(std::move(keys_column), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
 
     std::shared_ptr<const IDictionary> dictionary = shared_from_this();
     auto coordinator = DictionarySourceCoordinator::create(dictionary, column_names, std::move(key_columns), max_block_size);

--- a/src/Dictionaries/HashedArrayDictionary.cpp
+++ b/src/Dictionaries/HashedArrayDictionary.cpp
@@ -753,9 +753,14 @@ Pipe HashedArrayDictionary<dictionary_key_type>::read(const Names & column_names
     ColumnsWithTypeAndName key_columns;
 
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
-        key_columns = {ColumnWithTypeAndName(getColumnFromPODArray(keys), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
+    {
+        auto keys_column = getColumnFromPODArray(std::move(keys));
+        key_columns = {ColumnWithTypeAndName(std::move(keys_column), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
+    }
     else
+    {
         key_columns = deserializeColumnsWithTypeAndNameFromKeys(dict_struct, keys, 0, keys.size());
+    }
 
     std::shared_ptr<const IDictionary> dictionary = shared_from_this();
     auto coordinator = DictionarySourceCoordinator::create(dictionary, column_names, std::move(key_columns), max_block_size);

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -661,9 +661,14 @@ Pipe HashedDictionary<dictionary_key_type, sparse>::read(const Names & column_na
     ColumnsWithTypeAndName key_columns;
 
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
-        key_columns = {ColumnWithTypeAndName(getColumnFromPODArray(keys), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
+    {
+        auto keys_column = getColumnFromPODArray(std::move(keys));
+        key_columns = {ColumnWithTypeAndName(std::move(keys_column), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
+    }
     else
+    {
         key_columns = deserializeColumnsWithTypeAndNameFromKeys(dict_struct, keys, 0, keys.size());
+    }
 
     std::shared_ptr<const IDictionary> dictionary = shared_from_this();
     auto coordinator = DictionarySourceCoordinator::create(dictionary, column_names, std::move(key_columns), max_block_size);

--- a/src/Dictionaries/RangeHashedDictionary.cpp
+++ b/src/Dictionaries/RangeHashedDictionary.cpp
@@ -715,19 +715,28 @@ Pipe RangeHashedDictionary<dictionary_key_type>::read(const Names & column_names
             using RangeType = typename LeftDataType::FieldType;
 
             PaddedPODArray<KeyType> keys;
-            PaddedPODArray<RangeType> start_dates;
-            PaddedPODArray<RangeType> end_dates;
-            getKeysAndDates(keys, start_dates, end_dates);
+            PaddedPODArray<RangeType> range_start;
+            PaddedPODArray<RangeType> range_end;
+            getKeysAndDates(keys, range_start, range_end);
 
-            range_min_column = ColumnWithTypeAndName{getColumnFromPODArray(start_dates), dict_struct.range_min->type, dict_struct.range_min->name};
-            range_max_column = ColumnWithTypeAndName{getColumnFromPODArray(end_dates), dict_struct.range_max->type, dict_struct.range_max->name};
+            auto date_column = getColumnFromPODArray(makeDateKeys(range_start, range_end));
+
+            auto range_start_column = getColumnFromPODArray(std::move(range_start));
+            range_min_column = ColumnWithTypeAndName{std::move(range_start_column), dict_struct.range_min->type, dict_struct.range_min->name};
+
+            auto range_end_column = getColumnFromPODArray(std::move(range_end));
+            range_max_column = ColumnWithTypeAndName{std::move(range_end_column), dict_struct.range_max->type, dict_struct.range_max->name};
 
             if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
-                key_columns = {ColumnWithTypeAndName(getColumnFromPODArray(keys), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
+            {
+                auto keys_column = getColumnFromPODArray(std::move(keys));
+                key_columns = {ColumnWithTypeAndName(std::move(keys_column), std::make_shared<DataTypeUInt64>(), dict_struct.id->name)};
+            }
             else
+            {
                 key_columns = deserializeColumnsWithTypeAndNameFromKeys(dict_struct, keys, 0, keys.size());
+            }
 
-            auto date_column = getColumnFromPODArray(makeDateKeys(start_dates, end_dates));
             key_columns.emplace_back(ColumnWithTypeAndName{std::move(date_column), std::make_shared<DataTypeInt64>(), ""});
 
             return true;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Dictionaries remove unnecessary copy of keys during read.

