### PR TITLE
Optimize normalize_function_names settings, apply it for create/drop queries

### DIFF
--- a/src/Interpreters/InterpreterCreateFunctionQuery.cpp
+++ b/src/Interpreters/InterpreterCreateFunctionQuery.cpp
@@ -24,7 +24,9 @@ namespace ErrorCodes
 
 BlockIO InterpreterCreateFunctionQuery::execute()
 {
-    FunctionNameNormalizer().visit(query_ptr.get());
+    auto current_context = getContext();
+    if (current_context->getSettingsRef().normalize_function_names)
+        FunctionNameNormalizer().visit(query_ptr.get());
     ASTCreateFunctionQuery & create_function_query = query_ptr->as<ASTCreateFunctionQuery &>();
 
     AccessRightsElements access_rights_elements;
@@ -36,7 +38,6 @@ BlockIO InterpreterCreateFunctionQuery::execute()
     if (!create_function_query.cluster.empty())
         return executeDDLQueryOnCluster(query_ptr, getContext(), access_rights_elements);
 
-    auto current_context = getContext();
     current_context->checkAccess(access_rights_elements);
 
     auto & user_defined_function_factory = UserDefinedSQLFunctionFactory::instance();

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1317,7 +1317,8 @@ void InterpreterCreateQuery::prepareOnClusterQuery(ASTCreateQuery & create, Cont
 
 BlockIO InterpreterCreateQuery::execute()
 {
-    FunctionNameNormalizer().visit(query_ptr.get());
+    if (getContext()->getSettingsRef().normalize_function_names)
+        FunctionNameNormalizer().visit(query_ptr.get());
     auto & create = query_ptr->as<ASTCreateQuery &>();
     if (!create.cluster.empty())
     {

--- a/src/Interpreters/InterpreterDropFunctionQuery.cpp
+++ b/src/Interpreters/InterpreterDropFunctionQuery.cpp
@@ -14,7 +14,9 @@ namespace DB
 
 BlockIO InterpreterDropFunctionQuery::execute()
 {
-    FunctionNameNormalizer().visit(query_ptr.get());
+    auto current_context = getContext();
+    if (current_context->getSettingsRef().normalize_function_names)
+        FunctionNameNormalizer().visit(query_ptr.get());
     ASTDropFunctionQuery & drop_function_query = query_ptr->as<ASTDropFunctionQuery &>();
 
     AccessRightsElements access_rights_elements;
@@ -23,7 +25,6 @@ BlockIO InterpreterDropFunctionQuery::execute()
     if (!drop_function_query.cluster.empty())
         return executeDDLQueryOnCluster(query_ptr, getContext(), access_rights_elements);
 
-    auto current_context = getContext();
     current_context->checkAccess(access_rights_elements);
 
     UserDefinedSQLFunctionFactory::instance().unregisterFunction(current_context, drop_function_query.function_name, drop_function_query.if_exists);

--- a/src/Parsers/ParserCreateFunctionQuery.cpp
+++ b/src/Parsers/ParserCreateFunctionQuery.cpp
@@ -7,7 +7,6 @@
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ExpressionListParsers.h>
 
-
 namespace DB
 {
 

--- a/tests/queries/0_stateless/01705_normalize_case_insensitive_function_names.reference
+++ b/tests/queries/0_stateless/01705_normalize_case_insensitive_function_names.reference
@@ -64,3 +64,5 @@ SELECT
     varSamp(1),
     toWeek(toDate('2020-10-24')),
     toYearWeek(toDate('2020-10-24'))
+CREATE MATERIALIZED VIEW test_01705.mv_01705 TO test_01705.dst\n(\n    `day` Date,\n    `cast(sum(number), \'String\')` String\n) AS\nSELECT\n    toDate(itime) AS day,\n    cast(sum(number), \'String\')\nFROM test_01705.src\nGROUP BY day
+CREATE MATERIALIZED VIEW test_01705.mv_01705 TO test_01705.dst\n(\n    `day` Date,\n    `CAST(sum(number), \'String\')` String\n) AS\nSELECT\n    toDate(itime) AS day,\n    CAST(sum(number), \'String\')\nFROM test_01705.src\nGROUP BY day

--- a/tests/queries/0_stateless/01705_normalize_case_insensitive_function_names.sql
+++ b/tests/queries/0_stateless/01705_normalize_case_insensitive_function_names.sql
@@ -1,1 +1,17 @@
 EXPLAIN SYNTAX SELECT CAST(1 AS INT), CEIL(1), CEILING(1), CHAR(49), CHAR_LENGTH('1'), CHARACTER_LENGTH('1'), COALESCE(1), CONCAT('1', '1'), CORR(1, 1), COS(1), COUNT(1), COVAR_POP(1, 1), COVAR_SAMP(1, 1), DATABASE(), DATEDIFF('DAY', toDate('2020-10-24'), toDate('2019-10-24')), EXP(1), FLATTEN([[1]]), FLOOR(1), FQDN(), GREATEST(1), IF(1, 1, 1), IFNULL(1, 1), LCASE('A'), LEAST(1), LENGTH('1'), LN(1), LOCATE('1', '1'), LOG(1), LOG10(1), LOG2(1), LOWER('A'), MAX(1), MID('123', 1, 1), MIN(1), MOD(1, 1), NOT(1), NOW(), NOW64(), NULLIF(1, 1), PI(), POSITION('123', '2'), POW(1, 1), POWER(1, 1), RAND(), REPLACE('1', '1', '2'), REVERSE('123'), ROUND(1), SIN(1), SQRT(1), STDDEV_POP(1), STDDEV_SAMP(1), SUBSTR('123', 2), SUBSTRING('123', 2), SUM(1), TAN(1), TANH(1), TRUNC(1), TRUNCATE(1), UCASE('A'), UPPER('A'), USER(), VAR_POP(1), VAR_SAMP(1), WEEK(toDate('2020-10-24')), YEARWEEK(toDate('2020-10-24')) format TSVRaw;
+
+DROP DATABASE IF EXISTS test_01705;
+CREATE DATABASE test_01705;
+USE test_01705;
+CREATE TABLE src (`number` UInt64, `name` String, `itime` DateTime) ENGINE = MergeTree() PARTITION BY toYYYYMMDD(toDate(itime)) ORDER BY (name, number);
+CREATE TABLE dst (`day` Date, `str_sum` String) ENGINE = MergeTree() PARTITION BY toYYYYMMDD(day) ORDER BY (str_sum);
+
+set normalize_function_names = false;
+DROP TABLE IF EXISTS mv_01705;
+CREATE MATERIALIZED VIEW mv_01705 TO dst AS SELECT toDate(itime) as day, cast(sum(number), 'String') FROM src GROUP BY day;
+SHOW CREATE table mv_01705;
+
+set normalize_function_names = true;
+DROP TABLE IF EXISTS mv_01705;
+CREATE MATERIALIZED VIEW mv_01705 TO dst AS SELECT toDate(itime) as day, cast(sum(number), 'String') FROM src GROUP BY day;
+SHOW CREATE table mv_01705;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Currently settings `normalize_function_names` has no affect on the normalization of create/drop query. This PR applies normalize_function_names for create/drop queries. 
