### PR TITLE
Support explain create function query

### DIFF
--- a/src/Interpreters/InterpreterCreateFunctionQuery.cpp
+++ b/src/Interpreters/InterpreterCreateFunctionQuery.cpp
@@ -41,7 +41,7 @@ BlockIO InterpreterCreateFunctionQuery::execute()
 
     auto & user_defined_function_factory = UserDefinedSQLFunctionFactory::instance();
 
-    auto & function_name = create_function_query.function_name;
+    auto function_name = create_function_query.getFunctionName();
 
     bool if_not_exists = create_function_query.if_not_exists;
     bool replace = create_function_query.or_replace;

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -25,6 +25,7 @@
 #include <QueryPipeline/printPipeline.h>
 
 #include <Common/JSONBuilder.h>
+#include "Parsers/formatAST.h"
 
 namespace DB
 {

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -25,7 +25,6 @@
 #include <QueryPipeline/printPipeline.h>
 
 #include <Common/JSONBuilder.h>
-#include "Parsers/formatAST.h"
 
 namespace DB
 {

--- a/src/Interpreters/UserDefinedSQLFunctionVisitor.cpp
+++ b/src/Interpreters/UserDefinedSQLFunctionVisitor.cpp
@@ -59,7 +59,7 @@ ASTPtr UserDefinedSQLFunctionMatcher::tryToReplaceFunction(const ASTFunction & f
     if (function_arguments.size() != identifiers_raw.size())
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
             "Function {} expects {} arguments actual arguments {}",
-            create_function_query->function_name,
+            create_function_query->getFunctionName(),
             identifiers_raw.size(),
             function_arguments.size());
 

--- a/src/Parsers/ASTCreateFunctionQuery.cpp
+++ b/src/Parsers/ASTCreateFunctionQuery.cpp
@@ -10,7 +10,15 @@ namespace DB
 
 ASTPtr ASTCreateFunctionQuery::clone() const
 {
-    return std::make_shared<ASTCreateFunctionQuery>(*this);
+    auto res = std::make_shared<ASTCreateFunctionQuery>(*this);
+    res->children.clear();
+
+    res->function_name = function_name->clone();
+    res->children.push_back(res->function_name);
+
+    res->function_core = function_core->clone();
+    res->children.push_back(res->function_core);
+    return res;
 }
 
 void ASTCreateFunctionQuery::formatImpl(const IAST::FormatSettings & settings, IAST::FormatState & state, IAST::FormatStateStacked frame) const
@@ -27,12 +35,19 @@ void ASTCreateFunctionQuery::formatImpl(const IAST::FormatSettings & settings, I
 
     settings.ostr << (settings.hilite ? hilite_none : "");
 
-    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(function_name) << (settings.hilite ? hilite_none : "");
+    settings.ostr << (settings.hilite ? hilite_identifier : "") << backQuoteIfNeed(getFunctionName()) << (settings.hilite ? hilite_none : "");
 
     formatOnCluster(settings);
 
     settings.ostr << (settings.hilite ? hilite_keyword : "") << " AS " << (settings.hilite ? hilite_none : "");
     function_core->formatImpl(settings, state, frame);
+}
+
+String ASTCreateFunctionQuery::getFunctionName() const
+{
+    String name;
+    tryGetIdentifierNameInto(function_name, name);
+    return name;
 }
 
 }

--- a/src/Parsers/ASTCreateFunctionQuery.h
+++ b/src/Parsers/ASTCreateFunctionQuery.h
@@ -10,19 +10,21 @@ namespace DB
 class ASTCreateFunctionQuery : public IAST, public ASTQueryWithOnCluster
 {
 public:
-    String function_name;
+    ASTPtr function_name;
     ASTPtr function_core;
 
     bool or_replace = false;
     bool if_not_exists = false;
 
-    String getID(char) const override { return "CreateFunctionQuery"; }
+    String getID(char delim) const override { return "CreateFunctionQuery" + (delim + getFunctionName()); }
 
     ASTPtr clone() const override;
 
     void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
 
     ASTPtr getRewrittenASTWithoutOnCluster(const std::string &) const override { return removeOnCluster<ASTCreateFunctionQuery>(clone()); }
+
+    String getFunctionName() const;
 };
 
 }

--- a/src/Parsers/ParserCreateFunctionQuery.cpp
+++ b/src/Parsers/ParserCreateFunctionQuery.cpp
@@ -59,8 +59,12 @@ bool ParserCreateFunctionQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Exp
     auto create_function_query = std::make_shared<ASTCreateFunctionQuery>();
     node = create_function_query;
 
-    create_function_query->function_name = function_name->as<ASTIdentifier &>().name();
+    create_function_query->function_name = function_name;
+    create_function_query->children.push_back(function_name);
+
     create_function_query->function_core = function_core;
+    create_function_query->children.push_back(function_core);
+
     create_function_query->or_replace = or_replace;
     create_function_query->if_not_exists = if_not_exists;
     create_function_query->cluster = std::move(cluster_str);

--- a/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.reference
+++ b/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.reference
@@ -7,3 +7,14 @@ AlterQuery  t1 (children 2)
      Function today (children 1)
       ExpressionList
  Identifier t1
+CreateFunctionQuery double (children 2)
+ Identifier double
+ Function lambda (children 1)
+  ExpressionList (children 2)
+   Function tuple (children 1)
+    ExpressionList (children 1)
+     Identifier n
+   Function multiply (children 1)
+    ExpressionList (children 2)
+     Literal UInt64_2
+     Identifier n

--- a/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
+++ b/tests/queries/0_stateless/01604_explain_ast_of_nonselect_query.sql
@@ -1,2 +1,3 @@
 explain ast; -- { clientError 62 }
-explain ast alter table t1 delete where date = today()
+explain ast alter table t1 delete where date = today();
+explain ast create function double AS  (n) -> 2*n;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support explain create function query
``` sql 
 :)  explain ast create function  mycast AS  (n) -> cast(n as String);
EXPLAIN AST
CREATE FUNCTION mycast AS n -> CAST(n, 'String')

Query id: 2b579104-8e36-490c-a2ea-42722c4fde5e

┌─explain─────────────────────────────────┐
│ CreateFunctionQuery mycast (children 2) │
│  Identifier mycast                      │
│  Function lambda (children 1)           │
│   ExpressionList (children 2)           │
│    Function tuple (children 1)          │
│     ExpressionList (children 1)         │
│      Identifier n                       │
│    Function CAST (children 1)           │
│     ExpressionList (children 2)         │
│      Identifier n                       │
│      Literal 'String'                   │
└─────────────────────────────────────────┘

11 rows in set. Elapsed: 0.007 sec. 

```

