### PR TITLE
keeper: fix memory leak in case of compression is used (default)

### DIFF
--- a/src/IO/ZstdDeflatingAppendableWriteBuffer.cpp
+++ b/src/IO/ZstdDeflatingAppendableWriteBuffer.cpp
@@ -85,7 +85,7 @@ void ZstdDeflatingAppendableWriteBuffer::finalizeImpl()
     if (first_write)
     {
         /// To free cctx
-        finalizeAfter();
+        finalizeZstd();
         /// Nothing was written
         return;
     }
@@ -119,6 +119,11 @@ void ZstdDeflatingAppendableWriteBuffer::finalizeBefore()
 }
 
 void ZstdDeflatingAppendableWriteBuffer::finalizeAfter()
+{
+    finalizeZstd();
+}
+
+void ZstdDeflatingAppendableWriteBuffer::finalizeZstd()
 {
     try
     {

--- a/src/IO/ZstdDeflatingAppendableWriteBuffer.cpp
+++ b/src/IO/ZstdDeflatingAppendableWriteBuffer.cpp
@@ -84,6 +84,8 @@ void ZstdDeflatingAppendableWriteBuffer::finalizeImpl()
 {
     if (first_write)
     {
+        /// To free cctx
+        finalizeAfter();
         /// Nothing was written
         return;
     }

--- a/src/IO/ZstdDeflatingAppendableWriteBuffer.h
+++ b/src/IO/ZstdDeflatingAppendableWriteBuffer.h
@@ -52,6 +52,7 @@ private:
     void finalizeImpl() override;
     void finalizeBefore() override;
     void finalizeAfter() override;
+    void finalizeZstd();
     /// Adding zstd empty block to out.working_buffer
     void addEmptyBlock();
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix memory leak in `clickhouse-keeper` in case of compression is used (default)

In case of compression is used, ZstdDeflatingAppendableWriteBuffer is
used, but it has a leak, since it frees ZSTD_CCtx only if there was
write while this is not correct, since it is created anyway.

This was found with jemalloc profile, keeper-bench and the following
keeper settings:

- force_sync=false
- snapshot_distance=100
- reserved_log_items=0
- rotate_log_storage_interval=100

And here is jemalloc profile with focus:

<details>

```
$ jeprof clickhouse-keeper --focus 'ZstdDeflatingAppendableWriteBuffer' --text --base=$(ls -t jeprof.*.heap | tail -1) $(ls -t jeprof.*.heap | head -1)
Using local file clickhouse-keeper.
Using local file jeprof.29986.696.i696.heap.
addr2line: DWARF error: section .debug_info is larger than its filesize! (0x52f28a vs 0x3a9228)
Total: 7554.7 MB
  7395.3 100.0% 100.0%   7395.3 100.0% prof_backtrace
     0.0   0.0% 100.0%      7.0   0.1% ChangelogWriter
     0.0   0.0% 100.0%      7.0   0.1% DB::Changelog::appendEntry
     0.0   0.0% 100.0%      7.0   0.1% DB::Changelog::rotate
     0.0   0.0% 100.0%   7388.2  99.9% DB::ChangelogWriter::flush
     0.0   0.0% 100.0%   7395.3 100.0% DB::KeeperDispatcher::requestThread
     0.0   0.0% 100.0%      7.0   0.1% DB::KeeperLogStore::append
     0.0   0.0% 100.0%   7388.2  99.9% DB::KeeperLogStore::end_of_append_batch
     0.0   0.0% 100.0%   7395.3 100.0% DB::KeeperServer::putRequestBatch
     0.0   0.0% 100.0%   7388.2  99.9% DB::WriteBuffer::next (inline)
     0.0   0.0% 100.0%   7388.2  99.9% DB::ZstdDeflatingAppendableWriteBuffer::nextImpl
     0.0   0.0% 100.0%   7395.3 100.0% ThreadPoolImpl::worker
     0.0   0.0% 100.0%   7388.2  99.9% ZSTD_CCtx_init_compressStream2
     0.0   0.0% 100.0%   7388.2  99.9% ZSTD_compressBegin_internal
     0.0   0.0% 100.0%   7388.2  99.9% ZSTD_compressStream2
     0.0   0.0% 100.0%      7.0   0.1% ZSTD_createCCtx
     0.0   0.0% 100.0%      7.0   0.1% ZSTD_createCCtx_advanced
     0.0   0.0% 100.0%   7388.2  99.9% ZSTD_cwksp_create (inline)
     0.0   0.0% 100.0%   7388.2  99.9% ZSTD_resetCCtx_internal
     0.0   0.0% 100.0%      7.0   0.1% ZstdDeflatingAppendableWriteBuffer
```

</details>

Cc: @alesapin 