### PR TITLE
Fix DESCRIBE TABLE query formatting

### DIFF
--- a/src/Parsers/TablePropertiesQueriesASTs.h
+++ b/src/Parsers/TablePropertiesQueriesASTs.h
@@ -127,7 +127,7 @@ protected:
     void formatQueryImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override
     {
         settings.ostr << (settings.hilite ? hilite_keyword : "")
-                      << "DESCRIBE TABLE " << (settings.hilite ? hilite_none : "");
+                      << "DESCRIBE TABLE" << (settings.hilite ? hilite_none : "");
         table_expression->formatImpl(settings, state, frame);
     }
 

--- a/tests/queries/0_stateless/02181_format_describe_query.reference
+++ b/tests/queries/0_stateless/02181_format_describe_query.reference
@@ -1,0 +1,3 @@
+DESCRIBE TABLE file('data.csv')
+DESCRIBE TABLE table
+DESCRIBE TABLE file('data.csv')

--- a/tests/queries/0_stateless/02181_format_describe_query.sh
+++ b/tests/queries/0_stateless/02181_format_describe_query.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_FORMAT --query="DESCRIBE file('data.csv')"
+$CLICKHOUSE_FORMAT --query="DESCRIBE TABLE table"
+$CLICKHOUSE_FORMAT --query="DESC file('data.csv')"
+


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Don't write additional space in DESCRIBE TABLE query formatting.
