### PR TITLE
Fix zookeeper library dependency from interpreters (by marking library STATIC)

### DIFF
--- a/src/Common/ZooKeeper/CMakeLists.txt
+++ b/src/Common/ZooKeeper/CMakeLists.txt
@@ -3,7 +3,12 @@ include("${ClickHouse_SOURCE_DIR}/cmake/dbms_glob_sources.cmake")
 add_headers_and_sources(clickhouse_common_zookeeper .)
 
 # for clickhouse server
-add_library(clickhouse_common_zookeeper ${clickhouse_common_zookeeper_headers} ${clickhouse_common_zookeeper_sources})
+#
+# NOTE: this library depends from Interpreters (DB::SystemLog<DB::ZooKeeperLogElement>::add),
+# and so it should be STATIC because otherwise:
+# - it will either fail to compile with -Wl,--unresolved-symbols=report-all
+# - or it will report errors at runtime
+add_library(clickhouse_common_zookeeper STATIC ${clickhouse_common_zookeeper_headers} ${clickhouse_common_zookeeper_sources})
 target_compile_definitions (clickhouse_common_zookeeper PRIVATE -DZOOKEEPER_LOG)
 target_link_libraries (clickhouse_common_zookeeper
     PUBLIC


### PR DESCRIPTION
This had been introduced in #33534, and an attempt to fix this had been
made in #33844 but it was not strictly correct, since there is undefined
reference to `DB::SystemLog<DB::ZooKeeperLogElement>::add`:

    $ nm -D ./src/Common/ZooKeeper/libclickhouse_common_zookeeperd.so | fgrep SystemLog | c++filt
          U DB::SystemLog<DB::ZooKeeperLogElement>::add(DB::ZooKeeperLogElement const&)

That patch works, because default is not
`-Wl,--unresolved-symbols=report-all`, so I guess shared build on OSX
may after #33844.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @tavplubix 