### PR TITLE
FunctionBase64Conversion warning fix

### DIFF
--- a/src/Functions/FunctionBase64Conversion.h
+++ b/src/Functions/FunctionBase64Conversion.h
@@ -128,20 +128,20 @@ public:
                  * Some bug in sse arm64 implementation?
                  * `base64Encode(repeat('a', 46))` returns wrong padding character
                  */
-#if (__aarch64__)
-                outlen = tb64senc(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
+#if defined(__aarch64__)
+                    outlen = tb64senc(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
 #else
-                outlen = _tb64e(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
+                    outlen = _tb64e(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
 #endif
             }
             else if constexpr (std::is_same_v<Func, Base64Decode>)
             {
                 if (srclen > 0)
                 {
-#if (__aarch64__)
-                outlen = tb64sdec(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
+#if defined(__aarch64__)
+                   outlen = tb64sdec(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
 #else
-                outlen = _tb64d(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
+                   outlen = _tb64d(reinterpret_cast<const uint8_t *>(source), srclen, reinterpret_cast<uint8_t *>(dst_pos));
 #endif
 
                     if (!outlen)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

```
FunctionBase64Conversion.h:141:6: warning: '__aarch64__' is not defined, evaluates to 0 [-Wundef]
#if (__aarch64__)
     ^
2 warnings generated.
```
