### PR TITLE
SQLUserDefinedFunctions invalid lambda crash fix

### DIFF
--- a/src/Interpreters/InterpreterCreateFunctionQuery.cpp
+++ b/src/Interpreters/InterpreterCreateFunctionQuery.cpp
@@ -66,7 +66,12 @@ void InterpreterCreateFunctionQuery::validateFunction(ASTPtr function, const Str
 
     for (const auto & argument : tuple_function_arguments.arguments->children)
     {
-        const auto & argument_name = argument->as<ASTIdentifier>()->name();
+        const auto * argument_identifier = argument->as<ASTIdentifier>();
+
+        if (!argument_identifier)
+            throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Lambda argument must be identifier");
+
+        const auto & argument_name = argument_identifier->name();
         auto [_, inserted] = arguments.insert(argument_name);
         if (!inserted)
             throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Identifier {} already used as function parameter", argument_name);

--- a/tests/queries/0_stateless/02181_sql_user_defined_functions_invalid_lambda.sql
+++ b/tests/queries/0_stateless/02181_sql_user_defined_functions_invalid_lambda.sql
@@ -1,0 +1,1 @@
+CREATE FUNCTION 02181_invalid_lambda AS lambda(((x * 2) AS x_doubled) + x_doubled); --{serverError 1}


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash if sql user defined function is created with lambda with non identifier arguments. Closes #33866.

