### PR TITLE
Fix cmake for mac.

### DIFF
--- a/src/Common/examples/CMakeLists.txt
+++ b/src/Common/examples/CMakeLists.txt
@@ -78,8 +78,10 @@ target_link_libraries (shell_command_inout PRIVATE clickhouse_common_io)
 add_executable (executable_udf executable_udf.cpp)
 target_link_libraries (executable_udf PRIVATE dbms)
 
-add_executable (hive_metastore_client hive_metastore_client.cpp)
-target_link_libraries (hive_metastore_client PUBLIC ch_contrib::hivemetastore ch_contrib::thrift)
+if (ENABLE_HIVE)
+    add_executable (hive_metastore_client hive_metastore_client.cpp)
+    target_link_libraries (hive_metastore_client PUBLIC ch_contrib::hivemetastore ch_contrib::thrift)
+endif()
 
 add_executable (interval_tree interval_tree.cpp)
 target_link_libraries (interval_tree PRIVATE dbms)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

