### PR TITLE
disable animation on docs menu

### DIFF
--- a/website/templates/docs/sidebar-item.html
+++ b/website/templates/docs/sidebar-item.html
@@ -4,7 +4,7 @@
 <a href="{{ base_url }}/{{ nav_item.children[0].url }}" title="{{ nav_item.title[:-14] }}" class="nav-link{% if nav_item.active%} text-white active{% else %} text-light{% endif %} text-wrap d-inline-block w-100 px-0">{{ nav_item.title[:-14] }}</a>
 {% elif nav_item.children %}
 <a href="#sidebar-{{ path }}" data-toggle="collapse" aria-expanded="{% if level < collapsed_threshold %}true{% else %}false{% endif %}" aria-controls="sidebar-{{ path }}" title="{{ nav_item.title }}" class="nav-link text-light dropdown-toggle px-0">{{ nav_item.title }}</a>
-<div id="sidebar-{{ path }}" class="nav flex-column collapse{% if level < collapsed_threshold %} show{% endif %}">
+<div id="sidebar-{{ path }}" class="nav flex-column collapse{% if level < collapsed_threshold %} show{% endif %}" style="transition-duration: unset;">
     <nav class="nav flex-column pl-2">
     {% set base = path %}
     {% for nav_item in nav_item.children %}


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Disable it by request from @alexey-milovidov  in https://github.com/ClickHouse/ClickHouse/issues/32812#issuecomment-1017117260

The animation is caused by `bootstrap.js`,  and it can be controlled by `transition-duration`.

https://github.com/ClickHouse/ClickHouse/blob/4046b8f0b21e2c1f97e4b7c89e07ee7d7b8f5ed1/website/js/bootstrap.js#L1384
https://github.com/ClickHouse/ClickHouse/blob/4046b8f0b21e2c1f97e4b7c89e07ee7d7b8f5ed1/website/js/bootstrap.js#L1434