### PR TITLE
Fix race in DiskCacheWrapper

### DIFF
--- a/src/Disks/DiskCacheWrapper.cpp
+++ b/src/Disks/DiskCacheWrapper.cpp
@@ -65,8 +65,9 @@ std::shared_ptr<FileDownloadMetadata> DiskCacheWrapper::acquireDownloadMetadata(
     std::unique_lock<std::mutex> lock{mutex};
 
     auto it = file_downloads.find(path);
-    if (it != file_downloads.end() && !it->second.expired())
-        return it->second.lock();
+    if (it != file_downloads.end())
+        if (auto x = it->second.lock())
+            return x;
 
     std::shared_ptr<FileDownloadMetadata> metadata(
         new FileDownloadMetadata,


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix potential race condition when doing remote disk read. cc @Jokser 

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/