### PR TITLE
RangeHashedDictionary refactoring

### DIFF
--- a/src/Common/IntervalTree.h
+++ b/src/Common/IntervalTree.h
@@ -291,6 +291,15 @@ public:
 
     size_t getIntervalsSize() const { return intervals_size; }
 
+    size_t getSizeInBytes() const
+    {
+        size_t nodes_size_in_bytes = nodes.size() * sizeof(Node);
+        size_t intervals_size_in_bytes = sorted_intervals.size() * sizeof(IntervalWithValue);
+        size_t result = nodes_size_in_bytes + intervals_size_in_bytes;
+
+        return result;
+    }
+
 private:
     struct Node
     {

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -523,6 +523,7 @@ inline bool isBool(const DataTypePtr & data_type)
 template <typename DataType> constexpr bool IsDataTypeDecimal = false;
 template <typename DataType> constexpr bool IsDataTypeNumber = false;
 template <typename DataType> constexpr bool IsDataTypeDateOrDateTime = false;
+template <typename DataType> constexpr bool IsDataTypeEnum = false;
 
 template <typename DataType> constexpr bool IsDataTypeDecimalOrNumber = IsDataTypeDecimal<DataType> || IsDataTypeNumber<DataType>;
 
@@ -546,5 +547,10 @@ template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDate> = true;
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDate32> = true;
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDateTime> = true;
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDateTime64> = true;
+
+template <typename T>
+class DataTypeEnum;
+
+template <typename T> inline constexpr bool IsDataTypeEnum<DataTypeEnum<T>> = true;
 
 }

--- a/src/Dictionaries/DictionarySource.cpp
+++ b/src/Dictionaries/DictionarySource.cpp
@@ -60,8 +60,8 @@ private:
         const auto & attributes_types_to_read = coordinator->getAttributesTypesToRead();
         const auto & attributes_default_values_columns = coordinator->getAttributesDefaultValuesColumns();
 
-        const auto & dictionary = coordinator->getDictionary();
-        auto attributes_columns = dictionary->getColumns(
+        const auto & read_columns_func = coordinator->getReadColumnsFunc();
+        auto attributes_columns = read_columns_func(
             attributes_names_to_read,
             attributes_types_to_read,
             key_columns,

--- a/src/Dictionaries/DictionaryStructure.cpp
+++ b/src/Dictionaries/DictionaryStructure.cpp
@@ -417,7 +417,7 @@ void DictionaryStructure::parseRangeConfiguration(const Poco::Util::AbstractConf
     if (!valid_range)
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "Dictionary structure type of 'range_min' and 'range_max' should be an Integer, Flaot, Decimal, Date, Date32, DateTime DateTime64, or Enum."
+            "Dictionary structure type of 'range_min' and 'range_max' should be an Integer, Float, Decimal, Date, Date32, DateTime DateTime64, or Enum."
             " Actual 'range_min' and 'range_max' type is {}",
             range_min->type->getName());
     }

--- a/src/Dictionaries/DictionaryStructure.cpp
+++ b/src/Dictionaries/DictionaryStructure.cpp
@@ -382,7 +382,8 @@ std::vector<DictionaryAttribute> DictionaryStructure::getAttributes(
 
 void DictionaryStructure::parseRangeConfiguration(const Poco::Util::AbstractConfiguration & config, const std::string & structure_prefix)
 {
-    const char * range_default_type = "Date";
+    static constexpr auto range_default_type = "Date";
+
     if (config.has(structure_prefix + ".range_min"))
         range_min.emplace(makeDictionaryTypedSpecialAttribute(config, structure_prefix + ".range_min", range_default_type));
 
@@ -395,7 +396,10 @@ void DictionaryStructure::parseRangeConfiguration(const Poco::Util::AbstractConf
             "Dictionary structure should have both 'range_min' and 'range_max' either specified or not.");
     }
 
-    if (range_min && range_max && !range_min->type->equals(*range_max->type))
+    if (!range_min)
+        return;
+
+    if (!range_min->type->equals(*range_max->type))
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
             "Dictionary structure 'range_min' and 'range_max' should have same type, "
@@ -405,7 +409,7 @@ void DictionaryStructure::parseRangeConfiguration(const Poco::Util::AbstractConf
             range_max->type->getName());
     }
 
-    if (range_min && !range_min->type->isValueRepresentedByInteger())
+    if (!range_min->type->isValueRepresentedByInteger())
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
             "Dictionary structure type of 'range_min' and 'range_max' should be an integer, Date, DateTime, or Enum."
@@ -413,7 +417,7 @@ void DictionaryStructure::parseRangeConfiguration(const Poco::Util::AbstractConf
             range_min->type->getName());
     }
 
-    if ((range_min && !range_min->expression.empty()) || (range_max && !range_max->expression.empty()))
+    if (!range_min->expression.empty() || !range_max->expression.empty())
         has_expressions = true;
 }
 

--- a/src/Dictionaries/DictionaryStructure.cpp
+++ b/src/Dictionaries/DictionaryStructure.cpp
@@ -409,10 +409,15 @@ void DictionaryStructure::parseRangeConfiguration(const Poco::Util::AbstractConf
             range_max->type->getName());
     }
 
-    if (!range_min->type->isValueRepresentedByInteger())
+    WhichDataType range_type(range_min->type);
+
+    bool valid_range = range_type.isInt() || range_type.isUInt() || range_type.isDecimal() || range_type.isFloat() || range_type.isEnum()
+        || range_type.isDate() || range_type.isDate32() || range_type.isDateTime() || range_type.isDateTime64();
+
+    if (!valid_range)
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "Dictionary structure type of 'range_min' and 'range_max' should be an integer, Date, DateTime, or Enum."
+            "Dictionary structure type of 'range_min' and 'range_max' should be an Integer, Flaot, Decimal, Date, Date32, DateTime DateTime64, or Enum."
             " Actual 'range_min' and 'range_max' type is {}",
             range_min->type->getName());
     }

--- a/src/Dictionaries/RangeHashedDictionary.cpp
+++ b/src/Dictionaries/RangeHashedDictionary.cpp
@@ -26,6 +26,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int DICTIONARY_IS_EMPTY;
     extern const int UNSUPPORTED_METHOD;
+    extern const int TYPE_MISMATCH;
 }
 
 
@@ -87,7 +88,7 @@ ColumnPtr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getC
         vec_null_map_to = &col_null_map_to->getData();
     }
 
-    auto type_call = [&](const auto &dictionary_attribute_type)
+    auto type_call = [&](const auto & dictionary_attribute_type)
     {
         using Type = std::decay_t<decltype(dictionary_attribute_type)>;
         using AttributeType = typename Type::AttributeType;
@@ -172,6 +173,106 @@ ColumnPtr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getC
 }
 
 template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
+ColumnPtr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getColumnInternal(
+    const std::string & attribute_name,
+    const DataTypePtr & result_type,
+    const PaddedPODArray<UInt64> & key_to_index) const
+{
+    ColumnPtr result;
+
+    const auto & dictionary_attribute = dict_struct.getAttribute(attribute_name, result_type);
+    const size_t attribute_index = dict_struct.attribute_name_to_index.find(attribute_name)->second;
+    const auto & attribute = attributes[attribute_index];
+
+    size_t keys_size = key_to_index.size();
+    bool is_attribute_nullable = attribute.is_value_nullable.has_value();
+
+    ColumnUInt8::MutablePtr col_null_map_to;
+    ColumnUInt8::Container * vec_null_map_to = nullptr;
+    if (is_attribute_nullable)
+    {
+        col_null_map_to = ColumnUInt8::create(keys_size, false);
+        vec_null_map_to = &col_null_map_to->getData();
+    }
+
+    auto type_call = [&](const auto & dictionary_attribute_type)
+    {
+        using Type = std::decay_t<decltype(dictionary_attribute_type)>;
+        using AttributeType = typename Type::AttributeType;
+        using ValueType = DictionaryValueType<AttributeType>;
+        using ColumnProvider = DictionaryAttributeColumnProvider<AttributeType>;
+
+        auto column = ColumnProvider::getColumn(dictionary_attribute, keys_size);
+
+        if constexpr (std::is_same_v<ValueType, Array>)
+        {
+            auto * out = column.get();
+
+            getItemsInternalImpl<ValueType, false>(
+                attribute,
+                key_to_index,
+                [&](size_t, const Array & value, bool)
+                {
+                    out->insert(value);
+                });
+        }
+        else if constexpr (std::is_same_v<ValueType, StringRef>)
+        {
+            auto * out = column.get();
+
+            if (is_attribute_nullable)
+                getItemsInternalImpl<ValueType, true>(
+                    attribute,
+                    key_to_index,
+                    [&](size_t row, const StringRef value, bool is_null)
+                    {
+                        (*vec_null_map_to)[row] = is_null;
+                        out->insertData(value.data, value.size);
+                    });
+            else
+                getItemsInternalImpl<ValueType, false>(
+                    attribute,
+                    key_to_index,
+                    [&](size_t, const StringRef value, bool)
+                    {
+                        out->insertData(value.data, value.size);
+                    });
+        }
+        else
+        {
+            auto & out = column->getData();
+
+            if (is_attribute_nullable)
+                getItemsInternalImpl<ValueType, true>(
+                    attribute,
+                    key_to_index,
+                    [&](size_t row, const auto value, bool is_null)
+                    {
+                        (*vec_null_map_to)[row] = is_null;
+                        out[row] = value;
+                    });
+            else
+                getItemsInternalImpl<ValueType, false>(
+                    attribute,
+                    key_to_index,
+                    [&](size_t row, const auto value, bool)
+                    {
+                        out[row] = value;
+                    });
+        }
+
+        result = std::move(column);
+    };
+
+    callOnDictionaryAttributeType(attribute.type, type_call);
+
+    if (is_attribute_nullable)
+        result = ColumnNullable::create(std::move(result), std::move(col_null_map_to));
+
+    return result;
+}
+
+template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
 ColumnUInt8::Ptr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::hasKeys(const Columns & key_columns, const DataTypes & key_types) const
 {
     if (dictionary_key_type == DictionaryKeyType::Complex)
@@ -185,8 +286,13 @@ ColumnUInt8::Ptr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType
     ColumnWithTypeAndName column_to_cast = {range_storage_column->convertToFullColumnIfConst(), key_types.back(), ""};
     auto range_column_updated = castColumnAccurate(column_to_cast, dict_struct.range_min->type);
 
-    const auto & range_column = assert_cast<const RangeColumnType &>(*range_column_updated);
-    const auto & range_column_data = range_column.getData();
+    const auto * range_column = typeid_cast<const RangeColumnType *>(range_column_updated.get());
+    if (!range_column)
+        throw Exception(ErrorCodes::TYPE_MISMATCH,
+            "Dictionary {} range column type should be equal to {}",
+            getFullName(),
+            dict_struct.range_min->type->getName());
+    const auto & range_column_data = range_column->getData();
 
     auto key_columns_copy = key_columns;
     key_columns_copy.pop_back();
@@ -363,33 +469,42 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getItemsI
             const auto date = range_column_data[key_index];
             const auto & interval_tree = it->getMapped();
 
-            size_t min_value_index = 0;
-            std::optional<RangeInterval> min_range;
+            size_t value_index = 0;
+            std::optional<RangeInterval> range;
 
-            interval_tree.find(date, [&](auto & interval, auto & value_index)
+            interval_tree.find(date, [&](auto & interval, auto & interval_value_index)
             {
-                if (min_range && interval < *min_range)
+                if (range)
                 {
-                    min_range = interval;
-                    min_value_index = value_index;
+                    if (likely(configuration.lookup_strategy == RangeHashedDictionaryLookupStrategy::min) && interval < *range)
+                    {
+                        range = interval;
+                        value_index = interval_value_index;
+                    }
+                    else if (configuration.lookup_strategy == RangeHashedDictionaryLookupStrategy::max && interval > * range)
+                    {
+                        range = interval;
+                        value_index = interval_value_index;
+                    }
                 }
                 else
                 {
-                    min_range = interval;
-                    min_value_index = value_index;
+                    range = interval;
+                    value_index = interval_value_index;
                 }
 
                 return true;
             });
 
-            if (min_range.has_value())
+            if (range.has_value())
             {
                 ++keys_found;
 
+                AttributeType value = container[value_index];
+
                 if constexpr (is_nullable)
                 {
-                    AttributeType value = container[min_value_index];
-                    bool is_null = (*attribute.is_value_nullable)[min_value_index];
+                    bool is_null = (*attribute.is_value_nullable)[value_index];
 
                     if (!is_null)
                         set_value(key_index, value, false);
@@ -398,7 +513,6 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getItemsI
                 }
                 else
                 {
-                    AttributeType value = container[min_value_index];
                     set_value(key_index, value, false);
                 }
 
@@ -417,6 +531,53 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getItemsI
 
     query_count.fetch_add(keys_size, std::memory_order_relaxed);
     found_count.fetch_add(keys_found, std::memory_order_relaxed);
+}
+
+template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
+template <typename AttributeType, bool is_nullable, typename ValueSetter>
+void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getItemsInternalImpl(
+        const Attribute & attribute,
+        const PaddedPODArray<UInt64> & key_to_index,
+        ValueSetter && set_value) const
+{
+    size_t keys_size = key_to_index.size();
+
+    const auto & container = std::get<AttributeContainerType<AttributeType>>(attribute.container);
+    size_t container_size = container.size();
+
+    for (size_t key_index = 0; key_index < keys_size; ++key_index)
+    {
+        UInt64 container_index = key_to_index[key_index];
+
+        if (unlikely(container_index >= container_size))
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Dictionary {} expected attribute container index {} must be less than attribute container size {}",
+                getFullName(),
+                container_index,
+                container_size
+            );
+        }
+
+        AttributeType value = container[container_index];
+
+        if constexpr (is_nullable)
+        {
+            bool is_null = (*attribute.is_value_nullable)[container_index];
+
+            if (!is_null)
+                set_value(key_index, value, false);
+            else
+                set_value(key_index, value, true);
+        }
+        else
+        {
+            set_value(key_index, value, false);
+        }
+    }
+
+    query_count.fetch_add(keys_size, std::memory_order_relaxed);
+    found_count.fetch_add(keys_size, std::memory_order_relaxed);
 }
 
 template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
@@ -512,14 +673,14 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::blockToAt
     const auto * min_range_column_typed = typeid_cast<const RangeColumnType *>(min_range_column);
     if (!min_range_column_typed)
         throw Exception(ErrorCodes::TYPE_MISMATCH,
-            "Dictionary {} range min should be equal to {}",
+            "Dictionary {} range min column type should be equal to {}",
             getFullName(),
             dict_struct.range_min->type->getName());
 
     const auto * max_range_column_typed = typeid_cast<const RangeColumnType *>(max_range_column);
     if (!max_range_column_typed)
         throw Exception(ErrorCodes::TYPE_MISMATCH,
-            "Dictionary {} range max should be equal to {}",
+            "Dictionary {} range max column type should be equal to {}",
             getFullName(),
             dict_struct.range_max->type->getName());
 
@@ -644,14 +805,13 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::setAttrib
 template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
 Pipe RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::read(const Names & column_names, size_t max_block_size, size_t num_streams) const
 {
-    auto range_key_column = dict_struct.range_min->type->createColumn();
+    auto key_to_index_column = ColumnUInt64::create();
     auto range_min_column = dict_struct.range_min->type->createColumn();
 
-    auto * range_key_column_typed = typeid_cast<RangeColumnType *>(range_key_column.get());
     auto * range_min_column_typed = typeid_cast<RangeColumnType *>(range_min_column.get());
-    if (!range_min_column_typed || !range_key_column_typed)
+    if (!range_min_column_typed)
         throw Exception(ErrorCodes::TYPE_MISMATCH,
-            "Dictionary {} range min should be equal to {}",
+            "Dictionary {} range min column type should be equal to {}",
             getFullName(),
             dict_struct.range_min->type->getName());
 
@@ -660,30 +820,28 @@ Pipe RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::read(cons
     auto * range_max_column_typed = typeid_cast<RangeColumnType *>(range_max_column.get());
     if (!range_max_column_typed)
         throw Exception(ErrorCodes::TYPE_MISMATCH,
-            "Dictionary {} range max should be equal to {}",
+            "Dictionary {} range max column type should be equal to {}",
             getFullName(),
             dict_struct.range_max->type->getName());
 
     PaddedPODArray<KeyType> keys;
-    auto & range_key_column_data = range_key_column_typed->getData();
+    auto & key_to_index_column_data = key_to_index_column->getData();
     auto & range_min_column_data = range_min_column_typed->getData();
     auto & range_max_column_data = range_max_column_typed->getData();
 
     const auto & container = key_attribute.container;
 
-    size_t container_size = container.size();
-
-    keys.reserve(container_size);
-    range_key_column_data.reserve(container_size);
-    range_min_column_data.reserve(container_size);
-    range_max_column_data.reserve(container_size);
+    keys.reserve(element_count);
+    key_to_index_column_data.reserve(element_count);
+    range_min_column_data.reserve(element_count);
+    range_max_column_data.reserve(element_count);
 
     for (const auto & key : container)
     {
-        for (const auto & [interval, _] : key.getMapped())
+        for (const auto & [interval, index] : key.getMapped())
         {
-            keys.push_back(key.getKey());
-            range_key_column_data.push_back(interval.left);
+            keys.emplace_back(key.getKey());
+            key_to_index_column_data.emplace_back(index);
             range_min_column_data.push_back(interval.left);
             range_max_column_data.push_back(interval.right);
         }
@@ -703,12 +861,54 @@ Pipe RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::read(cons
         key_columns = deserializeColumnsWithTypeAndNameFromKeys(dict_struct, keys, 0, keys.size());
     }
 
-    key_columns.emplace_back(ColumnWithTypeAndName{std::move(range_key_column), dict_struct.range_min->type, ""});
+    key_columns.emplace_back(ColumnWithTypeAndName{std::move(key_to_index_column), std::make_shared<DataTypeUInt64>(), ""});
 
     ColumnsWithTypeAndName data_columns = {std::move(range_min_column_with_type), std::move(range_max_column_with_type)};
 
     std::shared_ptr<const IDictionary> dictionary = shared_from_this();
-    auto coordinator = DictionarySourceCoordinator::create(dictionary, column_names, std::move(key_columns), std::move(data_columns), max_block_size);
+
+    DictionarySourceCoordinator::ReadColumnsFunc read_keys_func = [dictionary_copy = dictionary](
+        const Strings & attribute_names,
+        const DataTypes & result_types,
+        const Columns & key_columns,
+        const DataTypes,
+        const Columns &)
+    {
+        auto range_dictionary_ptr = std::static_pointer_cast<const RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>>(dictionary_copy);
+
+        size_t attribute_names_size = attribute_names.size();
+
+        Columns result;
+        result.reserve(attribute_names_size);
+
+        auto key_column = key_columns.back();
+
+        const auto * key_to_index_column = typeid_cast<const ColumnUInt64 *>(key_column.get());
+        if (!key_to_index_column)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Dictionary {} read expect indexes column with type UInt64",
+                range_dictionary_ptr->getFullName());
+
+        const auto & data = key_to_index_column->getData();
+
+        for (size_t i = 0; i < attribute_names_size; ++i)
+        {
+            const auto & attribute_name = attribute_names[i];
+            const auto & result_type = result_types[i];
+
+            result.emplace_back(range_dictionary_ptr->getColumnInternal(attribute_name, result_type, data));
+        }
+
+        return result;
+    };
+
+    auto coordinator = DictionarySourceCoordinator::create(
+        dictionary,
+        column_names,
+        std::move(key_columns),
+        std::move(data_columns),
+        max_block_size,
+        std::move(read_keys_func));
     auto result = coordinator->read(num_streams);
 
     return result;
@@ -723,7 +923,7 @@ static DictionaryPtr createRangeHashedDictionary(const std::string & full_name,
 {
     static constexpr auto layout_name = dictionary_key_type == DictionaryKeyType::Simple ? "range_hashed" : "complex_key_range_hashed";
 
-    if (dictionary_key_type == DictionaryKeyType::Simple)
+    if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
     {
         if (dict_struct.key)
             throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "'key' is not supported for dictionary of layout 'range_hashed'");
@@ -744,11 +944,21 @@ static DictionaryPtr createRangeHashedDictionary(const std::string & full_name,
     const auto dict_id = StorageID::fromDictionaryConfig(config, config_prefix);
     const DictionaryLifetime dict_lifetime{config, config_prefix + ".lifetime"};
     const bool require_nonempty = config.getBool(config_prefix + ".require_nonempty", false);
-    const bool convert_null_range_bound_to_open = config.getBool(config_prefix + ".convert_null_range_bound_to_open", true);
+
+    String dictionary_layout_prefix = config_prefix + ".layout." + layout_name;
+    const bool convert_null_range_bound_to_open = config.getBool(dictionary_layout_prefix + ".convert_null_range_bound_to_open", true);
+    String range_lookup_strategy = config.getString(dictionary_layout_prefix + ".range_lookup_strategy", "min");
+    RangeHashedDictionaryLookupStrategy lookup_strategy = RangeHashedDictionaryLookupStrategy::min;
+
+    if (range_lookup_strategy == "min")
+        lookup_strategy = RangeHashedDictionaryLookupStrategy::min;
+    else if (range_lookup_strategy == "max")
+        lookup_strategy = RangeHashedDictionaryLookupStrategy::max;
 
     RangeHashedDictionaryConfiguration configuration
     {
         .convert_null_range_bound_to_open = convert_null_range_bound_to_open,
+        .lookup_strategy = lookup_strategy,
         .require_nonempty = require_nonempty
     };
 
@@ -763,7 +973,7 @@ static DictionaryPtr createRangeHashedDictionary(const std::string & full_name,
 
         if constexpr (IsDataTypeDecimalOrNumber<DataType> || IsDataTypeDateOrDateTime<DataType> || IsDataTypeEnum<DataType>)
         {
-            result = std::make_unique<RangeHashedDictionary<DictionaryKeyType::Simple, DataType>>(
+            result = std::make_unique<RangeHashedDictionary<dictionary_key_type, DataType>>(
                 dict_id,
                 dict_struct,
                 std::move(source_ptr),

--- a/src/Dictionaries/RangeHashedDictionary.cpp
+++ b/src/Dictionaries/RangeHashedDictionary.cpp
@@ -1,13 +1,12 @@
 #include <Dictionaries/RangeHashedDictionary.h>
 
+#include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypesDecimal.h>
+#include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDate32.h>
 #include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeDateTime64.h>
-#include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/DataTypesDecimal.h>
-#include <DataTypes/DataTypeEnum.h>
 
 #include <Columns/ColumnNullable.h>
 
@@ -30,8 +29,8 @@ namespace ErrorCodes
 }
 
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::RangeHashedDictionary(
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+RangeHashedDictionary<dictionary_key_type, RangeColumnType>::RangeHashedDictionary(
     const StorageID & dict_id_,
     const DictionaryStructure & dict_struct_,
     DictionarySourcePtr source_ptr_,
@@ -50,8 +49,8 @@ RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::RangeHashedDic
     calculateBytesAllocated();
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-ColumnPtr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getColumn(
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+ColumnPtr RangeHashedDictionary<dictionary_key_type, RangeColumnType>::getColumn(
     const std::string & attribute_name,
     const DataTypePtr & result_type,
     const Columns & key_columns,
@@ -172,8 +171,8 @@ ColumnPtr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getC
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-ColumnPtr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getColumnInternal(
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+ColumnPtr RangeHashedDictionary<dictionary_key_type, RangeColumnType>::getColumnInternal(
     const std::string & attribute_name,
     const DataTypePtr & result_type,
     const PaddedPODArray<UInt64> & key_to_index) const
@@ -272,8 +271,8 @@ ColumnPtr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getC
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-ColumnUInt8::Ptr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::hasKeys(const Columns & key_columns, const DataTypes & key_types) const
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+ColumnUInt8::Ptr RangeHashedDictionary<dictionary_key_type, RangeColumnType>::hasKeys(const Columns & key_columns, const DataTypes & key_types) const
 {
     if (dictionary_key_type == DictionaryKeyType::Complex)
     {
@@ -332,8 +331,8 @@ ColumnUInt8::Ptr RangeHashedDictionary<dictionary_key_type, RangeStorageDataType
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::createAttributes()
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+void RangeHashedDictionary<dictionary_key_type, RangeColumnType>::createAttributes()
 {
     const auto size = dict_struct.attributes.size();
     attributes.reserve(size);
@@ -348,8 +347,8 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::createAtt
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::loadData()
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+void RangeHashedDictionary<dictionary_key_type, RangeColumnType>::loadData()
 {
     if (!source_ptr->hasUpdateField())
     {
@@ -377,8 +376,8 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::loadData(
             "{}: dictionary source is empty and 'require_nonempty' property is set.");
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::calculateBytesAllocated()
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+void RangeHashedDictionary<dictionary_key_type, RangeColumnType>::calculateBytesAllocated()
 {
     bucket_count = key_attribute.container.getBufferSizeInCells();
 
@@ -437,9 +436,9 @@ typename RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::Attri
     return attribute;
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
 template <typename AttributeType, bool is_nullable, typename ValueSetter, typename DefaultValueExtractor>
-void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getItemsImpl(
+void RangeHashedDictionary<dictionary_key_type, RangeColumnType>::getItemsImpl(
     const Attribute & attribute,
     const Columns & key_columns,
     ValueSetter && set_value,
@@ -533,9 +532,9 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getItemsI
     found_count.fetch_add(keys_found, std::memory_order_relaxed);
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
 template <typename AttributeType, bool is_nullable, typename ValueSetter>
-void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::getItemsInternalImpl(
+void RangeHashedDictionary<dictionary_key_type, RangeColumnType>::getItemsInternalImpl(
         const Attribute & attribute,
         const PaddedPODArray<UInt64> & key_to_index,
         ValueSetter && set_value) const
@@ -620,8 +619,8 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::updateDat
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::blockToAttributes(const Block & block)
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+void RangeHashedDictionary<dictionary_key_type, RangeColumnType>::blockToAttributes(const Block & block)
 {
     size_t attributes_size = attributes.size();
     size_t dictionary_keys_size = dict_struct.getKeysSize();
@@ -754,9 +753,9 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::blockToAt
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
 template <typename T>
-void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::setAttributeValueImpl(Attribute & attribute, const Field & value)
+void RangeHashedDictionary<dictionary_key_type, RangeColumnType>::setAttributeValueImpl(Attribute & attribute, const Field & value)
 {
     using ValueType = DictionaryValueType<T>;
 
@@ -788,8 +787,8 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::setAttrib
     container.back() = value_to_insert;
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::setAttributeValue(Attribute & attribute, const Field & value)
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+void RangeHashedDictionary<dictionary_key_type, RangeColumnType>::setAttributeValue(Attribute & attribute, const Field & value)
 {
     auto type_call = [&](const auto & dictionary_attribute_type)
     {
@@ -802,8 +801,8 @@ void RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::setAttrib
     callOnDictionaryAttributeType(attribute.type, type_call);
 }
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
-Pipe RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::read(const Names & column_names, size_t max_block_size, size_t num_streams) const
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
+Pipe RangeHashedDictionary<dictionary_key_type, RangeColumnType>::read(const Names & column_names, size_t max_block_size, size_t num_streams) const
 {
     auto key_to_index_column = ColumnUInt64::create();
     auto range_min_column = dict_struct.range_min->type->createColumn();
@@ -874,7 +873,7 @@ Pipe RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>::read(cons
         const DataTypes,
         const Columns &)
     {
-        auto range_dictionary_ptr = std::static_pointer_cast<const RangeHashedDictionary<dictionary_key_type, RangeStorageDataType>>(dictionary_copy);
+        auto range_dictionary_ptr = std::static_pointer_cast<const RangeHashedDictionary<dictionary_key_type, RangeColumnType>>(dictionary_copy);
 
         size_t attribute_names_size = attribute_names.size();
 
@@ -973,7 +972,8 @@ static DictionaryPtr createRangeHashedDictionary(const std::string & full_name,
 
         if constexpr (IsDataTypeDecimalOrNumber<DataType> || IsDataTypeDateOrDateTime<DataType> || IsDataTypeEnum<DataType>)
         {
-            result = std::make_unique<RangeHashedDictionary<dictionary_key_type, DataType>>(
+            using ColumnType = typename DataType::ColumnType;
+            result = std::make_unique<RangeHashedDictionary<dictionary_key_type, ColumnType>>(
                 dict_id,
                 dict_struct,
                 std::move(source_ptr),

--- a/src/Dictionaries/RangeHashedDictionary.h
+++ b/src/Dictionaries/RangeHashedDictionary.h
@@ -19,9 +19,16 @@
 namespace DB
 {
 
+enum class RangeHashedDictionaryLookupStrategy
+{
+    min,
+    max
+};
+
 struct RangeHashedDictionaryConfiguration
 {
     bool convert_null_range_bound_to_open;
+    RangeHashedDictionaryLookupStrategy lookup_strategy;
     bool require_nonempty;
 };
 
@@ -88,7 +95,7 @@ public:
     DictionarySpecialKeyType getSpecialKeyType() const override { return DictionarySpecialKeyType::Range;}
 
     ColumnPtr getColumn(
-        const std::string& attribute_name,
+        const std::string & attribute_name,
         const DataTypePtr & result_type,
         const Columns & key_columns,
         const DataTypes & key_types,
@@ -166,6 +173,17 @@ private:
         const Columns & key_columns,
         ValueSetter && set_value,
         DefaultValueExtractor & default_value_extractor) const;
+
+    ColumnPtr getColumnInternal(
+        const std::string & attribute_name,
+        const DataTypePtr & result_type,
+        const PaddedPODArray<UInt64> & key_to_index) const;
+
+    template <typename AttributeType, bool is_nullable, typename ValueSetter>
+    void getItemsInternalImpl(
+        const Attribute & attribute,
+        const PaddedPODArray<UInt64> & key_to_index,
+        ValueSetter && set_value) const;
 
     void updateData();
 

--- a/src/Dictionaries/RangeHashedDictionary.h
+++ b/src/Dictionaries/RangeHashedDictionary.h
@@ -32,13 +32,12 @@ struct RangeHashedDictionaryConfiguration
     bool require_nonempty;
 };
 
-template <DictionaryKeyType dictionary_key_type, typename RangeStorageDataType>
+template <DictionaryKeyType dictionary_key_type, typename RangeColumnType>
 class RangeHashedDictionary final : public IDictionary
 {
 public:
     using KeyType = std::conditional_t<dictionary_key_type == DictionaryKeyType::Simple, UInt64, StringRef>;
-    using RangeStorageType = typename RangeStorageDataType::FieldType;
-    using RangeColumnType = typename RangeStorageDataType::ColumnType;
+    using RangeStorageType = typename RangeColumnType::ValueType;
 
     RangeHashedDictionary(
         const StorageID & dict_id_,

--- a/tests/queries/0_stateless/02179_range_hashed_dictionary_invalid_interval.reference
+++ b/tests/queries/0_stateless/02179_range_hashed_dictionary_invalid_interval.reference
@@ -3,3 +3,5 @@ DefaultValue
 1
 0
 0	15	20	Value
+0	10	0	Value
+0	15	10	Value

--- a/tests/queries/0_stateless/02183_dictionary_no_attributes.reference
+++ b/tests/queries/0_stateless/02183_dictionary_no_attributes.reference
@@ -38,3 +38,7 @@ PolygonDictionary
 1
 0
 [[[(0,0),(0,1),(1,1),(1,0)]]]
+RangeHashedDictionary
+0	0	1
+1
+0

--- a/tests/queries/0_stateless/02183_dictionary_no_attributes.sql
+++ b/tests/queries/0_stateless/02183_dictionary_no_attributes.sql
@@ -170,7 +170,7 @@ CREATE TABLE 02183_range_dictionary_source_table
 )
 ENGINE = TinyLog;
 
-INSERT INTO 02183_range_dictionary_source_table VALUES(1, 0, 1);
+INSERT INTO 02183_range_dictionary_source_table VALUES(0, 0, 1);
 
 DROP DICTIONARY IF EXISTS 02183_range_dictionary;
 CREATE DICTIONARY 02183_range_dictionary
@@ -185,7 +185,10 @@ LAYOUT(RANGE_HASHED())
 RANGE(MIN start MAX end)
 LIFETIME(0);
 
-SELECT * FROM 02183_range_dictionary; -- {serverError 1}
+SELECT 'RangeHashedDictionary';
+SELECT * FROM 02183_range_dictionary;
+SELECT dictHas('02183_range_dictionary', 0, 0);
+SELECT dictHas('02183_range_dictionary', 0, 2);
 
 DROP DICTIONARY 02183_range_dictionary;
 DROP TABLE 02183_range_dictionary_source_table;

--- a/tests/queries/0_stateless/02184_range_hashed_dictionary_outside_range_values.reference
+++ b/tests/queries/0_stateless/02184_range_hashed_dictionary_outside_range_values.reference
@@ -1,0 +1,3 @@
+1	0	18446744073709551615	value0	value1	value2
+('value0','value1','value2')
+1

--- a/tests/queries/0_stateless/02184_range_hashed_dictionary_outside_range_values.sql
+++ b/tests/queries/0_stateless/02184_range_hashed_dictionary_outside_range_values.sql
@@ -1,0 +1,36 @@
+DROP TABLE IF EXISTS 02184_range_dictionary_source_table;
+CREATE TABLE 02184_range_dictionary_source_table
+(
+    id UInt64,
+    start UInt64,
+    end UInt64,
+    value_0 String,
+    value_1 String,
+    value_2 String
+)
+ENGINE = TinyLog;
+
+INSERT INTO 02184_range_dictionary_source_table VALUES (1, 0, 18446744073709551615, 'value0', 'value1', 'value2');
+
+DROP DICTIONARY IF EXISTS 02184_range_dictionary;
+CREATE DICTIONARY 02184_range_dictionary
+(
+    id UInt64,
+    start UInt64,
+    end UInt64,
+    value_0 String,
+    value_1 String,
+    value_2 String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '02184_range_dictionary_source_table'))
+LAYOUT(RANGE_HASHED())
+RANGE(MIN start MAX end)
+LIFETIME(0);
+
+SELECT * FROM 02184_range_dictionary;
+SELECT dictGet('02184_range_dictionary', ('value_0', 'value_1', 'value_2'), 1, 18446744073709551615);
+SELECT dictHas('02184_range_dictionary', 1, 18446744073709551615);
+
+DROP DICTIONARY 02184_range_dictionary;
+DROP TABLE 02184_range_dictionary_source_table;

--- a/tests/queries/0_stateless/02185_range_hashed_dictionary_open_ranges.reference
+++ b/tests/queries/0_stateless/02185_range_hashed_dictionary_open_ranges.reference
@@ -1,0 +1,22 @@
+Source table
+0	\N	5000	Value0
+0	5001	10000	Value1
+0	10001	\N	Value2
+Dictionary convert_null_range_bound_to_open = 1
+0	5001	10000	Value1
+0	0	5000	Value0
+0	10001	18446744073709551615	Value2
+Value0
+Value1
+Value2
+1
+1
+1
+Dictionary convert_null_range_bound_to_open = 0
+0	5001	10000	Value1
+DefaultValue
+Value1
+DefaultValue
+0
+1
+0

--- a/tests/queries/0_stateless/02185_range_hashed_dictionary_open_ranges.sql
+++ b/tests/queries/0_stateless/02185_range_hashed_dictionary_open_ranges.sql
@@ -1,0 +1,63 @@
+DROP TABLE IF EXISTS 02185_range_dictionary_source_table;
+CREATE TABLE 02185_range_dictionary_source_table
+(
+    id UInt64,
+    start Nullable(UInt64),
+    end Nullable(UInt64),
+    value String
+)
+ENGINE = TinyLog;
+
+INSERT INTO 02185_range_dictionary_source_table VALUES (0, NULL, 5000, 'Value0'), (0, 5001, 10000, 'Value1'), (0, 10001, NULL, 'Value2');
+
+SELECT 'Source table';
+SELECT * FROM 02185_range_dictionary_source_table;
+
+DROP DICTIONARY IF EXISTS 02185_range_dictionary;
+CREATE DICTIONARY 02185_range_dictionary
+(
+    id UInt64,
+    start UInt64,
+    end UInt64,
+    value String DEFAULT 'DefaultValue'
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '02185_range_dictionary_source_table'))
+LAYOUT(RANGE_HASHED(convert_null_range_bound_to_open 1))
+RANGE(MIN start MAX end)
+LIFETIME(0);
+
+SELECT 'Dictionary convert_null_range_bound_to_open = 1';
+SELECT * FROM 02185_range_dictionary;
+SELECT dictGet('02185_range_dictionary', 'value', 0, 0);
+SELECT dictGet('02185_range_dictionary', 'value', 0, 5001);
+SELECT dictGet('02185_range_dictionary', 'value', 0, 10001);
+SELECT dictHas('02185_range_dictionary', 0, 0);
+SELECT dictHas('02185_range_dictionary', 0, 5001);
+SELECT dictHas('02185_range_dictionary', 0, 10001);
+
+DROP DICTIONARY 02185_range_dictionary;
+
+CREATE DICTIONARY 02185_range_dictionary
+(
+    id UInt64,
+    start UInt64,
+    end UInt64,
+    value String DEFAULT 'DefaultValue'
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '02185_range_dictionary_source_table'))
+LAYOUT(RANGE_HASHED(convert_null_range_bound_to_open 0))
+RANGE(MIN start MAX end)
+LIFETIME(0);
+
+SELECT 'Dictionary convert_null_range_bound_to_open = 0';
+SELECT * FROM 02185_range_dictionary;
+SELECT dictGet('02185_range_dictionary', 'value', 0, 0);
+SELECT dictGet('02185_range_dictionary', 'value', 0, 5001);
+SELECT dictGet('02185_range_dictionary', 'value', 0, 10001);
+SELECT dictHas('02185_range_dictionary', 0, 0);
+SELECT dictHas('02185_range_dictionary', 0, 5001);
+SELECT dictHas('02185_range_dictionary', 0, 10001);
+
+DROP TABLE 02185_range_dictionary_source_table;

--- a/tests/queries/0_stateless/02186_range_hashed_dictionary_intersecting_intervals.reference
+++ b/tests/queries/0_stateless/02186_range_hashed_dictionary_intersecting_intervals.reference
@@ -1,0 +1,18 @@
+Source table
+1	2020-01-01	2100-01-01	Value0
+1	2020-01-02	2100-01-01	Value1
+1	2020-01-03	2100-01-01	Value2
+Dictionary .range_lookup_strategy = min
+1	2020-01-01	2100-01-01	Value0
+1	2020-01-02	2100-01-01	Value1
+1	2020-01-03	2100-01-01	Value2
+Value0
+Value0
+Value0
+Dictionary .range_lookup_strategy = max
+1	2020-01-01	2100-01-01	Value0
+1	2020-01-02	2100-01-01	Value1
+1	2020-01-03	2100-01-01	Value2
+Value0
+Value1
+Value2

--- a/tests/queries/0_stateless/02186_range_hashed_dictionary_intersecting_intervals.sql
+++ b/tests/queries/0_stateless/02186_range_hashed_dictionary_intersecting_intervals.sql
@@ -1,0 +1,64 @@
+DROP TABLE IF EXISTS 02186_range_dictionary_source_table;
+CREATE TABLE 02186_range_dictionary_source_table
+(
+    id UInt64,
+    start Date,
+    end Date,
+    value String
+)
+Engine = TinyLog;
+
+INSERT INTO 02186_range_dictionary_source_table VALUES (1, '2020-01-01', '2100-01-01', 'Value0');
+INSERT INTO 02186_range_dictionary_source_table VALUES (1, '2020-01-02', '2100-01-01', 'Value1');
+INSERT INTO 02186_range_dictionary_source_table VALUES (1, '2020-01-03', '2100-01-01', 'Value2');
+
+SELECT 'Source table';
+SELECT * FROM 02186_range_dictionary_source_table;
+
+DROP DICTIONARY IF EXISTS 02186_range_dictionary;
+CREATE DICTIONARY 02186_range_dictionary
+(
+    id UInt64,
+    start Date,
+    end Date,
+    value String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '02186_range_dictionary_source_table'))
+LAYOUT(RANGE_HASHED(range_lookup_strategy 'min'))
+RANGE(MIN start MAX end)
+LIFETIME(0);
+
+SELECT 'Dictionary .range_lookup_strategy = min';
+
+SELECT * FROM 02186_range_dictionary;
+
+select dictGet('02186_range_dictionary', 'value', toUInt64(1), toDate('2020-01-01'));
+select dictGet('02186_range_dictionary', 'value', toUInt64(1), toDate('2020-01-02'));
+select dictGet('02186_range_dictionary', 'value', toUInt64(1), toDate('2020-01-03'));
+
+DROP DICTIONARY 02186_range_dictionary;
+
+CREATE DICTIONARY 02186_range_dictionary
+(
+    id UInt64,
+    start Date,
+    end Date,
+    value String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '02186_range_dictionary_source_table'))
+LAYOUT(RANGE_HASHED(range_lookup_strategy 'max'))
+RANGE(MIN start MAX end)
+LIFETIME(0);
+
+SELECT 'Dictionary .range_lookup_strategy = max';
+
+SELECT * FROM 02186_range_dictionary;
+
+select dictGet('02186_range_dictionary', 'value', toUInt64(1), toDate('2020-01-01'));
+select dictGet('02186_range_dictionary', 'value', toUInt64(1), toDate('2020-01-02'));
+select dictGet('02186_range_dictionary', 'value', toUInt64(1), toDate('2020-01-03'));
+
+DROP DICTIONARY 02186_range_dictionary;
+DROP TABLE 02186_range_dictionary_source_table;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`RangeHashedDictionary` improvements. Improve performance of load time if there are multiple attributes. Allow to create without attributes. Added option to specify strategy when intervals `start` and `end` have `Nullable` type `convert_null_range_bound_to_open` by default is `true`. Closes #29791. Allow to specify `Float`, `Decimal`, `DateTime64`, `Int128`, `Int256`, `UInt128`, `UInt256`  as range types. `RangeHashedDictionary` added support for range values that extend `Int64` type. Closes #28322. Added option `range_lookup_strategy` to specify range lookup type `min`, `max` by default is `min` . Closes #21647. Fixed allocated bytes calculations. Fixed type name in `system.dictionaries` in case of `ComplexKeyHashedDictionary`.
