### PR TITLE
Fix bug in keeper which can lead to inconsistent snapshots

### DIFF
--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -216,7 +216,7 @@ void KeeperStateMachine::create_snapshot(
                 std::lock_guard lock(storage_and_responses_lock);
                 LOG_TRACE(log, "Clearing garbage after snapshot");
                 /// Turn off "snapshot mode" and clear outdate part of storage state
-                storage->clearGarbageAfterSnapshot(snapshot->snapshot_container_size);
+                storage->clearGarbageAfterSnapshot();
                 LOG_TRACE(log, "Cleared garbage after snapshot");
                 snapshot.reset();
             }

--- a/src/Coordination/KeeperStorage.h
+++ b/src/Coordination/KeeperStorage.h
@@ -177,9 +177,9 @@ public:
     }
 
     /// Clear outdated data from internal container.
-    void clearGarbageAfterSnapshot(size_t up_to_size)
+    void clearGarbageAfterSnapshot()
     {
-        container.clearOutdatedNodes(up_to_size);
+        container.clearOutdatedNodes();
     }
 
     /// Get all active sessions

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -908,7 +908,7 @@ TEST_P(CoordinationTest, SnapshotableHashMapTrySnapshot)
         EXPECT_EQ(itr->active_in_map, i != 3 && i != 2);
         itr = std::next(itr);
     }
-    map_snp.clearOutdatedNodes(map_snp.snapshotSize());
+    map_snp.clearOutdatedNodes();
 
     EXPECT_EQ(map_snp.snapshotSize(), 4);
     EXPECT_EQ(map_snp.size(), 4);
@@ -957,13 +957,13 @@ TEST_P(CoordinationTest, SnapshotableHashMapDataSize)
     hello.updateValue("hello", [](IntNode & value) { value = 2; });
     EXPECT_EQ(hello.getApproximateDataSize(), 18);
 
-    hello.clearOutdatedNodes(hello.snapshotSize());
+    hello.clearOutdatedNodes();
     EXPECT_EQ(hello.getApproximateDataSize(), 9);
 
     hello.erase("hello");
     EXPECT_EQ(hello.getApproximateDataSize(), 9);
 
-    hello.clearOutdatedNodes(hello.snapshotSize());
+    hello.clearOutdatedNodes();
     EXPECT_EQ(hello.getApproximateDataSize(), 0);
 
     /// Node
@@ -990,7 +990,7 @@ TEST_P(CoordinationTest, SnapshotableHashMapDataSize)
     world.updateValue("world", [&](Node & value) { value = n2; });
     EXPECT_EQ(world.getApproximateDataSize(), 196);
 
-    world.clearOutdatedNodes(world.snapshotSize());
+    world.clearOutdatedNodes();
     EXPECT_EQ(world.getApproximateDataSize(), 98);
 
     world.erase("world");
@@ -1170,7 +1170,7 @@ TEST_P(CoordinationTest, TestStorageSnapshotMode)
     }
     EXPECT_TRUE(fs::exists("./snapshots/snapshot_50.bin" + params.extension));
     EXPECT_EQ(storage.container.size(), 26);
-    storage.clearGarbageAfterSnapshot(storage.container.snapshotSize());
+    storage.clearGarbageAfterSnapshot();
     EXPECT_EQ(storage.container.snapshotSize(), 26);
     for (size_t i = 0; i < 50; ++i)
     {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

But only in master, so no backports required (introduced in PR merged yesterday).