### PR TITLE
Add on-demand style-checker-aarch64 hosts

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,8 +1,9 @@
 self-hosted-runner:
   labels:
     - builder
+    - func-tester
+    - func-tester-aarch64
     - fuzzer-unit-tester
     - stress-tester
     - style-checker
-    - func-tester-aarch64
-    - func-tester
+    - style-checker-aarch64

--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -10,7 +10,7 @@ on: # yamllint disable-line rule:truthy
       - 'backport/**'
 jobs:
   DockerHubPushAarch64:
-    runs-on: [self-hosted, func-tester-aarch64]
+    runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Clear repository
         run: |

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -30,7 +30,7 @@ jobs:
           python3 run_check.py
   DockerHubPushAarch64:
     needs: CheckLabels
-    runs-on: [self-hosted, func-tester-aarch64]
+    runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Clear repository
         run: |

--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -20,7 +20,7 @@ on: # yamllint disable-line rule:truthy
   workflow_dispatch:
 jobs:
   DockerHubPushAarch64:
-    runs-on: [self-hosted, func-tester-aarch64]
+    runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Clear repository
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,7 +22,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 -m unittest discover -s . -p '*_test.py'
   DockerHubPushAarch64:
-    runs-on: [self-hosted, func-tester-aarch64]
+    runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Clear repository
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,7 +46,7 @@ jobs:
           python3 -m unittest discover -s . -p '*_test.py'
   DockerHubPushAarch64:
     needs: CheckLabels
-    runs-on: [self-hosted, func-tester-aarch64]
+    runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Clear repository
         run: |

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -13,7 +13,7 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   DockerHubPushAarch64:
-    runs-on: [self-hosted, func-tester-aarch64]
+    runs-on: [self-hosted, style-checker-aarch64]
     steps:
       - name: Clear repository
         run: |

--- a/tests/ci/metrics_lambda/app.py
+++ b/tests/ci/metrics_lambda/app.py
@@ -174,6 +174,7 @@ def group_runners_by_tag(listed_runners):
         "fuzzer-unit-tester",
         "stress-tester",
         "style-checker",
+        "style-checker-aarch64",
     ]
     for runner in listed_runners:
         for tag in runner.tags:

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -12,7 +12,7 @@ DIFF_IN_DOCUMENTATION_EXT = [".html", ".md", ".yml", ".txt", ".css", ".js", ".xm
 
 def get_pr_for_commit(sha, ref):
     if not ref:
-        return
+        return None
     try_get_pr_url = f"https://api.github.com/repos/{GITHUB_REPOSITORY}/commits/{sha}/pulls"
     try:
         response = requests.get(try_get_pr_url)


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add on-demand style-checker-aarch64 hosts
- Run dockerpush CI jobs there