### PR TITLE
Fix getauxval() in glibc-compatibility and fix some leaks (after LSan started to work)

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSimpleState.h
+++ b/src/AggregateFunctions/AggregateFunctionSimpleState.h
@@ -35,18 +35,19 @@ public:
     {
         DataTypeCustomSimpleAggregateFunction::checkSupportedFunctions(nested_func);
 
-        // Need to make a clone because it'll be customized.
-        auto storage_type = DataTypeFactory::instance().get(nested_func->getReturnType()->getName());
-
+        // Need to make a clone to avoid recursive reference.
+        auto storage_type_out = DataTypeFactory::instance().get(nested_func->getReturnType()->getName());
         // Need to make a new function with promoted argument types because SimpleAggregates requires arg_type = return_type.
         AggregateFunctionProperties properties;
         auto function
-            = AggregateFunctionFactory::instance().get(nested_func->getName(), {storage_type}, nested_func->getParameters(), properties);
+            = AggregateFunctionFactory::instance().get(nested_func->getName(), {storage_type_out}, nested_func->getParameters(), properties);
 
+        // Need to make a clone because it'll be customized.
+        auto storage_type_arg = DataTypeFactory::instance().get(nested_func->getReturnType()->getName());
         DataTypeCustomNamePtr custom_name
             = std::make_unique<DataTypeCustomSimpleAggregateFunction>(function, DataTypes{nested_func->getReturnType()}, params);
-        storage_type->setCustomization(std::make_unique<DataTypeCustomDesc>(std::move(custom_name), nullptr));
-        return storage_type;
+        storage_type_arg->setCustomization(std::make_unique<DataTypeCustomDesc>(std::move(custom_name), nullptr));
+        return storage_type_arg;
     }
 
     bool isVersioned() const override

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -61,6 +61,7 @@
 #include <Processors/Sources/WaitForAsyncInsertSource.h>
 
 #include <base/EnumReflection.h>
+#include <base/demangle.h>
 
 #include <random>
 
@@ -659,7 +660,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                 if (context->query_trace_context.trace_id != UUID())
                 {
                     auto * raw_interpreter_ptr = interpreter.get();
-                    std::string class_name(abi::__cxa_demangle(typeid(*raw_interpreter_ptr).name(), nullptr, nullptr, nullptr));
+                    std::string class_name(demangle(typeid(*raw_interpreter_ptr).name()));
                     span = std::make_unique<OpenTelemetrySpanHolder>(class_name + "::execute()");
                 }
                 res = interpreter->execute();

--- a/src/Storages/StorageSQLite.cpp
+++ b/src/Storages/StorageSQLite.cpp
@@ -40,7 +40,6 @@ StorageSQLite::StorageSQLite(
     , WithContext(context_->getGlobalContext())
     , remote_table_name(remote_table_name_)
     , database_path(database_path_)
-    , global_context(context_)
     , sqlite_db(sqlite_db_)
     , log(&Poco::Logger::get("StorageSQLite (" + table_id_.table_name + ")"))
 {

--- a/src/Storages/StorageSQLite.h
+++ b/src/Storages/StorageSQLite.h
@@ -48,7 +48,6 @@ public:
 private:
     String remote_table_name;
     String database_path;
-    ContextPtr global_context;
     SQLitePtr sqlite_db;
     Poco::Logger * log;
 };

--- a/tests/queries/0_stateless/01570_aggregator_combinator_simple_state.reference
+++ b/tests/queries/0_stateless/01570_aggregator_combinator_simple_state.reference
@@ -1,14 +1,31 @@
+-- { echo }
+with anySimpleState(number) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(any, UInt64)	0
+with anyLastSimpleState(number) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(anyLast, UInt64)	0
+with minSimpleState(number) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(min, UInt64)	0
+with maxSimpleState(number) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(max, UInt64)	0
+with sumSimpleState(number) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(sum, UInt64)	0
+with sumWithOverflowSimpleState(number) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(sumWithOverflow, UInt64)	0
+with groupBitAndSimpleState(number) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(groupBitAnd, UInt64)	0
+with groupBitOrSimpleState(number) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(groupBitOr, UInt64)	0
+with groupBitXorSimpleState(number) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(groupBitXor, UInt64)	0
+with sumMapSimpleState(([number], [number])) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(sumMap, Tuple(Array(UInt64), Array(UInt64)))	([],[])
+with minMapSimpleState(([number], [number])) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(minMap, Tuple(Array(UInt64), Array(UInt64)))	([0],[0])
+with maxMapSimpleState(([number], [number])) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(maxMap, Tuple(Array(UInt64), Array(UInt64)))	([0],[0])
+with groupArrayArraySimpleState([number]) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(groupArrayArray, Array(UInt64))	[0]
+with groupUniqArrayArraySimpleState([number]) as c select toTypeName(c), c from numbers(1);
 SimpleAggregateFunction(groupUniqArrayArray, Array(UInt64))	[0]
+-- non-SimpleAggregateFunction
+with countSimpleState(number) as c select toTypeName(c), c from numbers(1); -- { serverError 36 }

--- a/tests/queries/0_stateless/01570_aggregator_combinator_simple_state.sql
+++ b/tests/queries/0_stateless/01570_aggregator_combinator_simple_state.sql
@@ -1,3 +1,4 @@
+-- { echo }
 with anySimpleState(number) as c select toTypeName(c), c from numbers(1);
 with anyLastSimpleState(number) as c select toTypeName(c), c from numbers(1);
 with minSimpleState(number) as c select toTypeName(c), c from numbers(1);


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix getauxval() in glibc-compatibility, this should fix vsyscalls after `setenv` (i.e. timezone is set in config), and LSan (and also fix some leaks that had been found by LSan)

getauxval() from glibc-compatibility did not work always correctly:

- it does not work after setenv(), and this breaks vsyscalls,
  like sched_getcpu() [1] (and BaseDaemon.cpp always set TZ if timezone
  is defined, which is true for CI [2]).

  [1]: https://bugzilla.redhat.com/show_bug.cgi?id=1163404
  [2]: https://github.com/ClickHouse/ClickHouse/pull/32928#issuecomment-1015762717

- another think that is definitely broken is LSan (Leak Sanitizer), it
  relies on worked getauxval() but it does not work if __environ is not
  initialized yet (there is even a commit about this).

  And because of at least one issue hadn't been catched before  https://github.com/ClickHouse/ClickHouse/pull/33840

Fix this by using /proc/self/auxv.

And let's see how many issues will LSan find...

I've verified this patch manually by printing AT_BASE and compared it
with output of LD_SHOW_AUXV.

Cc: @alesapin 
Cc: @filimonov (#27492)
Cc: @alexey-milovidov  (#28132)
Cc: @vitlibar (#15111)