### PR TITLE
docker: fix root squashed data dirs

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -65,7 +65,12 @@ do
     # check if variable not empty
     [ -z "$dir" ] && continue
     # ensure directories exist
-    if ! mkdir -p "$dir"; then
+    if [ "$DO_CHOWN" = "1" ]; then
+      mkdir="mkdir"
+    else
+      mkdir="$gosu mkdir"
+    fi
+    if ! $mkdir -p "$dir"; then
         echo "Couldn't create necessary directory: $dir"
         exit 1
     fi


### PR DESCRIPTION
if we use some root squashed volume mappings in docker
`uid=0` is actually `uid=nobody`
thus FS operations with `uid=0` will fail miserably
and overall it's a strange idea to create dirs under root when
`DO_NOT_CHOWN` is in effect...

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
