### PR TITLE
Keeper optimization: use distance counter to substitute std::distance

### DIFF
--- a/src/Coordination/SnapshotableHashTable.h
+++ b/src/Coordination/SnapshotableHashTable.h
@@ -15,6 +15,7 @@ struct ListNode
 {
     StringRef key;
     V value;
+    size_t distance_from_begin{0};
 
     bool active_in_map{true};
     bool free_key{false};
@@ -137,7 +138,7 @@ public:
 
         if (!it)
         {
-            ListElem elem{copyStringInArena(key), value, true};
+            ListElem elem{copyStringInArena(key), value, list.empty() ? 0 : list.back().distance_from_begin + 1, true};
             auto itr = list.insert(list.end(), elem);
             bool inserted;
             map.emplace(itr->key, it, inserted, hash_value);
@@ -159,7 +160,7 @@ public:
 
         if (it == map.end())
         {
-            ListElem elem{copyStringInArena(key), value, true};
+            ListElem elem{copyStringInArena(key), value, list.empty() ? 0 : list.back().distance_from_begin + 1, true};
             auto itr = list.insert(list.end(), elem);
             bool inserted;
             map.emplace(itr->key, it, inserted, hash_value);
@@ -171,7 +172,7 @@ public:
             auto list_itr = it->getMapped();
             if (snapshot_mode)
             {
-                ListElem elem{list_itr->key, value, true};
+                ListElem elem{list_itr->key, value, list.back().distance_from_begin + 1, true};
                 list_itr->active_in_map = false;
                 auto new_list_itr = list.insert(list.end(), elem);
                 it->getMapped() = new_list_itr;
@@ -225,26 +226,18 @@ public:
 
         const_iterator ret;
 
-        if (snapshot_mode)
+        /// We in snapshot mode but updating some node which is already more
+        /// fresh than snapshot distance. So it will not participate in
+        /// snapshot and we don't need to copy it.
+        if (snapshot_mode && list_itr->distance_from_begin < snapshot_up_to_size)
         {
-            /// We in snapshot mode but updating some node which is already more
-            /// fresh than snapshot distance. So it will not participate in
-            /// snapshot and we don't need to copy it.
-            size_t distance = std::distance(list.begin(), list_itr);
-            if (distance < snapshot_up_to_size)
-            {
-                auto elem_copy = *(list_itr);
-                list_itr->active_in_map = false;
-                updater(elem_copy.value);
-                auto itr = list.insert(list.end(), elem_copy);
-                it->getMapped() = itr;
-                ret = itr;
-            }
-            else
-            {
-                updater(list_itr->value);
-                ret = list_itr;
-            }
+            auto elem_copy = *(list_itr);
+            list_itr->active_in_map = false;
+            updater(elem_copy.value);
+            elem_copy.distance_from_begin = list.back().distance_from_begin + 1;
+            auto itr = list.insert(list.end(), elem_copy);
+            it->getMapped() = itr;
+            ret = itr;
         }
         else
         {
@@ -276,6 +269,7 @@ public:
     {
         auto start = list.begin();
         auto end = list.end();
+        size_t counter = 0;
         for (auto itr = start; itr != end;)
         {
             if (!itr->active_in_map)
@@ -288,7 +282,8 @@ public:
             else
             {
                 assert(!itr->free_key);
-                itr++;
+                itr->distance_from_begin = counter++;
+                ++itr;
             }
         }
     }

--- a/src/Coordination/SnapshotableHashTable.h
+++ b/src/Coordination/SnapshotableHashTable.h
@@ -284,7 +284,7 @@ public:
                     updateDataSize(CLEAR_OUTDATED_NODES, itr->key.size, itr->value.sizeInBytes(), 0);
                 if (itr->free_key)
                     arena.free(const_cast<char *>(itr->key.data), itr->key.size);
-                /// truely delete list node here, not in erase()
+                /// truly delete list node here, not in erase()
                 itr = list.erase(itr);
             }
             else

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -872,10 +872,12 @@ TEST_P(CoordinationTest, SnapshotableHashMapTrySnapshot)
     EXPECT_EQ(itr->key, "/hello");
     EXPECT_EQ(itr->value, 7);
     EXPECT_EQ(itr->active_in_map, false);
+    EXPECT_EQ(itr->distance_from_begin, 0);
     itr = std::next(itr);
     EXPECT_EQ(itr->key, "/hello");
     EXPECT_EQ(itr->value, 554);
     EXPECT_EQ(itr->active_in_map, true);
+    EXPECT_EQ(itr->distance_from_begin, 1);
     itr = std::next(itr);
     EXPECT_EQ(itr, map_snp.end());
     for (size_t i = 0; i < 5; ++i)
@@ -892,6 +894,7 @@ TEST_P(CoordinationTest, SnapshotableHashMapTrySnapshot)
         EXPECT_EQ(itr->key, "/hello" + std::to_string(i));
         EXPECT_EQ(itr->value, i);
         EXPECT_EQ(itr->active_in_map, true);
+        EXPECT_EQ(itr->distance_from_begin, i + 2);
         itr = std::next(itr);
     }
 
@@ -906,6 +909,7 @@ TEST_P(CoordinationTest, SnapshotableHashMapTrySnapshot)
         EXPECT_EQ(itr->key, "/hello" + std::to_string(i));
         EXPECT_EQ(itr->value, i);
         EXPECT_EQ(itr->active_in_map, i != 3 && i != 2);
+        EXPECT_EQ(itr->distance_from_begin, i + 2);
         itr = std::next(itr);
     }
     map_snp.clearOutdatedNodes();
@@ -916,18 +920,22 @@ TEST_P(CoordinationTest, SnapshotableHashMapTrySnapshot)
     EXPECT_EQ(itr->key, "/hello");
     EXPECT_EQ(itr->value, 554);
     EXPECT_EQ(itr->active_in_map, true);
+    EXPECT_EQ(itr->distance_from_begin, 0);
     itr = std::next(itr);
     EXPECT_EQ(itr->key, "/hello0");
     EXPECT_EQ(itr->value, 0);
     EXPECT_EQ(itr->active_in_map, true);
+    EXPECT_EQ(itr->distance_from_begin, 1);
     itr = std::next(itr);
     EXPECT_EQ(itr->key, "/hello1");
     EXPECT_EQ(itr->value, 1);
     EXPECT_EQ(itr->active_in_map, true);
+    EXPECT_EQ(itr->distance_from_begin, 2);
     itr = std::next(itr);
     EXPECT_EQ(itr->key, "/hello4");
     EXPECT_EQ(itr->value, 4);
     EXPECT_EQ(itr->active_in_map, true);
+    EXPECT_EQ(itr->distance_from_begin, 3);
     itr = std::next(itr);
     EXPECT_EQ(itr, map_snp.end());
     map_snp.disableSnapshotMode();


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
1. calling std::distance on large list will decrease performance, use a counter in Node to substitute.

Effect:
client command: `./utils/keeper-bench/keeper-bench --host=127.0.0.1:12183 -c 30 --generator=create_small_data`
new version:
![image](https://user-images.githubusercontent.com/985418/150912229-db78b6bd-90ad-4475-b098-059a88effcd9.png)

master version 0e37e8b4a09dd6529452dbe767363e366b2a6c3d:
![image](https://user-images.githubusercontent.com/985418/150912669-4639adfc-0172-4a94-9585-21681f6ba326.png)


