### PR TITLE
Disable parallel run for 00985_merge_stack_overflow

### DIFF
--- a/tests/queries/0_stateless/00985_merge_stack_overflow.sql
+++ b/tests/queries/0_stateless/00985_merge_stack_overflow.sql
@@ -1,11 +1,14 @@
+-- Tags: no-parallel
+--       ^^^^^^^^^^^ otherwise you may hit TOO_DEEP_RECURSION error during querying system.columns
+
 DROP TABLE IF EXISTS merge1;
 DROP TABLE IF EXISTS merge2;
 
 CREATE TABLE IF NOT EXISTS merge1 (x UInt64) ENGINE = Merge(currentDatabase(), '^merge\\d$');
 CREATE TABLE IF NOT EXISTS merge2 (x UInt64) ENGINE = Merge(currentDatabase(), '^merge\\d$');
 
-SELECT * FROM merge1; -- { serverError 306 }
-SELECT * FROM merge2; -- { serverError 306 }
+SELECT * FROM merge1; -- { serverError TOO_DEEP_RECURSION }
+SELECT * FROM merge2; -- { serverError TOO_DEEP_RECURSION }
 
 DROP TABLE merge1;
 DROP TABLE merge2;

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -184,7 +184,9 @@ tables_with_database_column=(
 tests_with_database_column=( $(
     find $ROOT_PATH/tests/queries -iname '*.sql' -or -iname '*.sh' -or -iname '*.py' -or -iname '*.j2' |
         grep -vP $EXCLUDE_DIRS |
-        xargs grep --with-filename $(printf -- "-e %s " "${tables_with_database_column[@]}") | cut -d: -f1 | sort -u
+        xargs grep --with-filename $(printf -- "-e %s " "${tables_with_database_column[@]}") |
+        grep -v -e ':--' -e ':#' |
+        cut -d: -f1 | sort -u
 ) )
 for test_case in "${tests_with_database_column[@]}"; do
     grep -qE database.*currentDatabase "$test_case" || {


### PR DESCRIPTION
Since parallel queries to system.columns may fail with
TOO_DEEP_RECURSION too.

CI: https://s3.amazonaws.com/clickhouse-test-reports/33201/0013a2fdee26fc11a34ebffaf10f69d7cfff9b3a/fast_test__actions_.html

Changelog category (leave one):
- Not for changelog (changelog entry is not required)