### PR TITLE
Do not generate uuid for table when create on cluster when its database has no uuid

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.h
+++ b/src/Interpreters/InterpreterCreateQuery.h
@@ -90,7 +90,7 @@ private:
     /// Inserts data in created table if it's CREATE ... SELECT
     BlockIO fillTableIfNeeded(const ASTCreateQuery & create);
 
-    void assertOrSetUUID(ASTCreateQuery & create, const DatabasePtr & database) const;
+    static void assertOrSetUUID(ASTCreateQuery & create, ContextPtr context, const DatabasePtr & database, bool internal = false);
 
     ASTPtr query_ptr;
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not generate uuid for table when create on cluster when its database has no uuid. This fix : https://github.com/ClickHouse/ClickHouse/issues/33975