### PR TITLE
Low Cardinality returns different types for equal functions

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -182,6 +182,20 @@ const ActionsDAG::Node & ActionsDAG::addFunction(
         arguments[i] = std::move(argument);
     }
 
+    if (num_arguments > 1 && arguments[0].type != arguments[1].type)
+    {
+        const DataTypeLowCardinality * type_low_cardinality_arg0 = typeid_cast<const DataTypeLowCardinality *>((arguments[0].type).get());
+        const DataTypeLowCardinality * type_low_cardinality_arg1 = typeid_cast<const DataTypeLowCardinality *>((arguments[1].type).get());
+        if (type_low_cardinality_arg0 != nullptr && type_low_cardinality_arg1 == nullptr)
+        {
+            arguments[0].type = arguments[1].type;
+        }
+        else if (type_low_cardinality_arg0 == nullptr && type_low_cardinality_arg1 != nullptr)
+        {
+            arguments[1].type = arguments[0].type;
+        }
+    }
+
     node.function_base = function->build(arguments);
     node.result_type = node.function_base->getResultType();
     node.function = node.function_base->prepare(arguments);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

In ClickHouse, Since equals function in Clickhouse could return both LowCardinality(UInt8) and UInt8 type result depending on the data type in the equals function, There is chance  sometimes run into type conversion errors.

Problem Description: The result of same functions giving different outputs. 
Example : 
equals(toLowCardinality('foo') , 'foo') is returning LowCardinality(UInt8)
equals('foo', 'foo') is returning UInt8.
which is inconsistent.

Solution:
To address this inconsistency, checking whether either of the argument is LowCardinality type and passing to equals function and if they are different then changing them to same type. if both are LowCardinality type, CH works as usual. Also it wont have any negative impact on other dictionary types as the condition is very specific two equals function.

i think Clickhouse should use LowCardinality(UInt8) in the underlying implementation for better performance, but the type of the final result should be consistent datatype like UInt8.

I have verified below scenarios and giving consistent result with the fix:

Desc table(select 'a'='a') returning UInt8
Desc table(select toLowCardinality('a')='a') returning UInt8
SELECT toTypeName(if(toLowCardinality('a') LIKE 'a', 1, 2)) returns UInt8
SELECT toTypeName(if('a' LIKE 'a', 1, 2)) returning UInt8

There is an issue raised for the same:  https://github.com/ClickHouse/ClickHouse/issues/6432

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
