### PR TITLE
Fix shadow warning when building

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionIf.cpp
+++ b/src/AggregateFunctions/AggregateFunctionIf.cpp
@@ -72,9 +72,9 @@ private:
     using Base = AggregateFunctionNullBase<result_is_nullable, serialize_flag,
         AggregateFunctionIfNullUnary<result_is_nullable, serialize_flag>>;
 
-    inline bool singleFilter(const IColumn ** columns, size_t row_num, size_t num_arguments) const
+    inline bool singleFilter(const IColumn ** columns, size_t row_num, size_t num_arguments_) const
     {
-        const IColumn * filter_column = columns[num_arguments - 1];
+        const IColumn * filter_column = columns[num_arguments_ - 1];
 
         if (filter_is_nullable)
         {


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix shadow warning when building 

```

[1680/1912] Building CXX object src/AggregateFunctions/CMakeFiles/clickhouse_aggregate_functions.dir/AggregateFunctionIf.cpp.o
/data1/liyang/cppproject/OfficialClickhouse/clickhouse/src/AggregateFunctions/AggregateFunctionIf.cpp:75:79: warning: declaration shadows a field of 'AggregateFunctionIfNullUnary<result_is_nullable, serialize_flag>' [-Wshadow]
    inline bool singleFilter(const IColumn ** columns, size_t row_num, size_t num_arguments) const
                                                                              ^
/data1/liyang/cppproject/OfficialClickhouse/clickhouse/src/AggregateFunctions/AggregateFunctionIf.cpp:53:12: note: previous declaration is here
    size_t num_arguments;
           ^
1 warning generated.

```

