### PR TITLE
RFC: Eliminate race window between selecting parts to merge and merge entry creation

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -87,11 +87,11 @@ void ReplicatedMergeTreeQueue::initialize(zkutil::ZooKeeperPtr zookeeper)
     LOG_TRACE(log, "Queue initialized");
 }
 
-bool ReplicatedMergeTreeQueue::isVirtualPart(const MergeTreeData::DataPartPtr & data_part) const
+bool ReplicatedMergeTreeQueue::isVirtualPart(const MergeTreePartInfo & part_info, const std::string & part_name) const
 {
     std::lock_guard lock(state_mutex);
-    auto virtual_part_name = virtual_parts.getContainingPart(data_part->info);
-    return !virtual_part_name.empty() && virtual_part_name != data_part->name;
+    auto virtual_part_name = virtual_parts.getContainingPart(part_info);
+    return !virtual_part_name.empty() && virtual_part_name != part_name;
 }
 
 bool ReplicatedMergeTreeQueue::checkPartInQueueAndGetSourceParts(const String & part_name, Strings & source_parts) const

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -391,7 +391,7 @@ public:
     bool tryFinalizeMutations(zkutil::ZooKeeperPtr zookeeper);
 
     /// Checks that part is already in virtual parts
-    bool isVirtualPart(const MergeTreeData::DataPartPtr & data_part) const;
+    bool isVirtualPart(const MergeTreePartInfo & part_info, const std::string & part_name) const;
 
     /// Check that part produced by some entry in queue and get source parts for it.
     /// If there are several entries return largest source_parts set. This rarely possible

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2964,7 +2964,7 @@ bool StorageReplicatedMergeTree::canExecuteFetch(const ReplicatedMergeTreeLogEnt
 
 bool StorageReplicatedMergeTree::partIsAssignedToBackgroundOperation(const DataPartPtr & part) const
 {
-    return queue.isVirtualPart(part);
+    return queue.isVirtualPart(part->info, part->name);
 }
 
 void StorageReplicatedMergeTree::mergeSelectingTask()

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -560,7 +560,7 @@ private:
     CreateMergeEntryResult createLogEntryToMergeParts(
         zkutil::ZooKeeperPtr & zookeeper,
         const DataPartsVector & parts,
-        const String & merged_name,
+        const MergeTreePartInfo & merged_info, const String & merged_name,
         const UUID & merged_part_uuid,
         const MergeTreeDataPartType & merged_part_type,
         bool deduplicate,


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Eliminate race window between selecting parts to merge and merge entry creation (fix one more case of `Logical error: 'Part X intersects previous part Y. It is a bug or a result of manual intervention in the ZooKeeper data.'.` error)

CI founds [1] intersecting parts while running 01459_manual_write_to_replicas test:

<details>

    2022.01.15 23:07:24.387149 [ 750 ] {} <Debug> test_98ynp9.r4 (MergerMutator): Selected 9 parts from all_1_15_1 to all_31_31_0
    2022.01.15 23:07:24.541640 [ 763 ] {} <Test> test_98ynp9.r4 (ReplicatedMergeTreeQueue): Insert entry queue-0000000020 to queue with type MERGE_PARTS with virtual parts [all_1_28_2]
    2022.01.15 23:07:25.327639 [ 750 ] {} <Trace> test_98ynp9.r4: Created log entry /clickhouse/tables/01459_manual_write_to_replicas_test_98ynp9/r/log/log-0000000021 for merge all_1_31_2

    # What goes after, not that important, just to show the error and the flow
    ...
    2022.01.15 23:08:02.078376 [ 790 ] {} <Warning> test_98ynp9.r4 (ReplicatedMergeTreeRestartingThread): ZooKeeper session has expired. Switching to a new session.
    ...
    2022.01.15 23:08:04.792227 [ 790 ] {} <Trace> test_98ynp9.r4 (ReplicatedMergeTreeQueue): Initializing parts in queue
    ...
    2022.01.15 23:08:04.868563 [ 790 ] {} <Debug> test_98ynp9.r4 (ReplicatedMergeTreeQueue): Loading queue from /clickhouse/tables/01459_manual_write_to_replicas_test_98ynp9/r/replicas/r4/queue
    2022.01.15 23:08:04.949219 [ 790 ] {} <Debug> test_98ynp9.r4 (ReplicatedMergeTreeQueue): Having 0 queue entries to load, 1 entries already loaded.
    2022.01.15 23:08:05.398827 [ 790 ] {} <Debug> test_98ynp9.r4 (ReplicatedMergeTreeQueue): Pulling 1 entries to queue: log-0000000021 - log-0000000021
    2022.01.15 23:08:05.417492 [ 790 ] {} <Test> test_98ynp9.r4 (ReplicatedMergeTreeQueue): Insert entry queue-0000000021 to queue with type MERGE_PARTS with virtual parts [all_1_31_2]
    2022.01.15 23:08:05.424624 [ 790 ] {} <Fatal> : Logical error: 'Part all_1_31_2 intersects previous part all_1_28_2. It is a bug or a result of manual intervention in the ZooKeeper data.'.

</details>

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/33665/16adcc166608b922f7351a8eedcfb483d63d7513/stress_test__debug__actions_.html

The reason AFAICS that there is a race window between selecting parts to
merge and merge entry in zookeeper had been created, that you can see in
first 3 lines of the log.

Refs: #26876 
Cc: @tavplubix 
Cc: @alesapin 