### PR TITLE
make systemd to use EnvironmentFile

### DIFF
--- a/debian/clickhouse-server.service
+++ b/debian/clickhouse-server.service
@@ -16,6 +16,7 @@ Restart=always
 RestartSec=30
 RuntimeDirectory=clickhouse-server
 ExecStart=/usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml --pid-file=/run/clickhouse-server/clickhouse-server.pid
+EnvironmentFile=-/etc/default/clickhouse
 LimitCORE=infinity
 LimitNOFILE=500000
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_IPC_LOCK CAP_SYS_NICE

--- a/debian/clickhouse-server.service
+++ b/debian/clickhouse-server.service
@@ -16,6 +16,7 @@ Restart=always
 RestartSec=30
 RuntimeDirectory=clickhouse-server
 ExecStart=/usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml --pid-file=/run/clickhouse-server/clickhouse-server.pid
+# Minus means that this file is optional.
 EnvironmentFile=-/etc/default/clickhouse
 LimitCORE=infinity
 LimitNOFILE=500000


### PR DESCRIPTION
initV script uses /etc/default/clickhouse

this PR adds the same functionality to systemD script

> EnvironmentFile=-/etc/default/clickhouse

`-` means that  `/etc/default/clickhouse` is optional

I'll document it later.

I don't see how to do CI tests for `clickhouse-server restart`, so no tests. (I tested it manually)

slightly backward incompatible change: `/etc/default/clickhouse` should contain only K/V `param=value`, it's not a bash script anymore.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
