### PR TITLE
Proper hardlink tracking of remote meta files

### DIFF
--- a/src/Disks/IDiskRemote.h
+++ b/src/Disks/IDiskRemote.h
@@ -157,11 +157,14 @@ protected:
     const String remote_fs_root_path;
 
     DiskPtr metadata_disk;
+    std::mutex metadata_mutex;
 
 private:
     void removeMeta(const String & path, RemoteFSPathKeeperPtr fs_paths_keeper);
 
     void removeMetaRecursive(const String & path, RemoteFSPathKeeperPtr fs_paths_keeper);
+
+    size_t removeMetaFileAndReturnNumOfHardlinks(const String & path);
 
     bool tryReserve(UInt64 bytes);
 
@@ -208,6 +211,7 @@ struct IDiskRemote::Metadata : RemoteMetadata
     size_t total_size = 0;
 
     /// Number of references (hardlinks) to this metadata file.
+    /// NOTE: Deprecated.
     UInt32 ref_count = 0;
 
     /// Flag indicates that file is read only.

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7185,7 +7185,7 @@ bool StorageReplicatedMergeTree::unlockSharedData(const IMergeTreeDataPart & par
         return true;
 
     auto ref_count = part.getNumberOfRefereneces();
-    if (ref_count > 0) /// Keep part shard info for frozen backups
+    if (ref_count > 1) /// Keep part shard info for frozen backups
         return false;
 
     return unlockSharedDataByID(part.getUniqueId(), getTableSharedID(), name, replica_name, disk, zookeeper, *getSettings(), log,
@@ -7763,8 +7763,7 @@ bool StorageReplicatedMergeTree::removeSharedDetachedPart(DiskPtr disk, const St
         fs::path checksums = fs::path(path) / "checksums.txt";
         if (disk->exists(checksums))
         {
-            auto ref_count = disk->getRefCount(checksums);
-            if (ref_count == 0)
+            if (disk->getRefCount(checksums) <= 1)
             {
                 String id = disk->getUniqueId(checksums);
                 keep_shared = !StorageReplicatedMergeTree::unlockSharedDataByID(id, table_uuid, part_name,


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Proper hardlink tracking of remote meta files. Mark as improvement because it's not a 100% fix.

Currently we use a `ref_count` field in meta file to track hardlinks, which is not thread-safe. Consider the following:

File X has three hardlinks: X1, X2, X3. We will have meta.ref_count = 2 (counting from 0).

Then Thread A tries to remove X1 and Thread B tries to remove X2 simultaneously.

Both Thread A and Thread B read meta.ref_count = 2.

Both Thread A and Thread B decrement the reference in memory, and write it back. Now we have meta.ref_count = 1.

Both Thread A and Thread B remove the file. Now we have File X with only one reference: X3. 

Thread C tries to remove X3, however, it notices that (meta.ref_count == 1) > 0. It only removes the local file.

Now we have a dangling remote object.

cc @kssenii 

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
