### PR TITLE
Make ORDER BY tuple almost as fast as ORDER BY columns

### DIFF
--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -318,18 +318,15 @@ public:
     virtual void updatePermutation(bool reverse, size_t limit, int nan_direction_hint, Permutation & res, EqualRanges & equal_ranges) const = 0;
 
     /** Equivalent to getPermutation and updatePermutation but collator is used to compare values.
-      * Overrides in String, LowCardinality(String), Nullable(String) and for Array and Tuple, containing them.
+      * Supported for String, LowCardinality(String), Nullable(String) and for Array and Tuple, containing them.
       */
-    virtual void
-    getPermutationWithCollation(const Collator &, bool reverse, size_t limit, int nan_direction_hint, Permutation & res) const
+    virtual void getPermutationWithCollation(const Collator &, bool, size_t, int, Permutation &) const
     {
-        getPermutation(reverse, limit, nan_direction_hint, res);
+        throw Exception("Collations could be specified only for String, LowCardinality(String), Nullable(String) or for Array or Tuple, containing them.", ErrorCodes::BAD_COLLATION);
     }
-
-    virtual void updatePermutationWithCollation(
-        const Collator &, bool reverse, size_t limit, int nan_direction_hint, Permutation & res, EqualRanges & equal_ranges) const
+    virtual void updatePermutationWithCollation(const Collator &, bool, size_t, int, Permutation &, EqualRanges&) const
     {
-        updatePermutation(reverse, limit, nan_direction_hint, res, equal_ranges);
+        throw Exception("Collations could be specified only for String, LowCardinality(String), Nullable(String) or for Array or Tuple, containing them.", ErrorCodes::BAD_COLLATION);
     }
 
     /** Copies each element according offsets parameter.

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -318,15 +318,18 @@ public:
     virtual void updatePermutation(bool reverse, size_t limit, int nan_direction_hint, Permutation & res, EqualRanges & equal_ranges) const = 0;
 
     /** Equivalent to getPermutation and updatePermutation but collator is used to compare values.
-      * Supported for String, LowCardinality(String), Nullable(String) and for Array and Tuple, containing them.
+      * Overrides in String, LowCardinality(String), Nullable(String) and for Array and Tuple, containing them.
       */
-    virtual void getPermutationWithCollation(const Collator &, bool, size_t, int, Permutation &) const
+    virtual void
+    getPermutationWithCollation(const Collator &, bool reverse, size_t limit, int nan_direction_hint, Permutation & res) const
     {
-        throw Exception("Collations could be specified only for String, LowCardinality(String), Nullable(String) or for Array or Tuple, containing them.", ErrorCodes::BAD_COLLATION);
+        getPermutation(reverse, limit, nan_direction_hint, res);
     }
-    virtual void updatePermutationWithCollation(const Collator &, bool, size_t, int, Permutation &, EqualRanges&) const
+
+    virtual void updatePermutationWithCollation(
+        const Collator &, bool reverse, size_t limit, int nan_direction_hint, Permutation & res, EqualRanges & equal_ranges) const
     {
-        throw Exception("Collations could be specified only for String, LowCardinality(String), Nullable(String) or for Array or Tuple, containing them.", ErrorCodes::BAD_COLLATION);
+        updatePermutation(reverse, limit, nan_direction_hint, res, equal_ranges);
     }
 
     /** Copies each element according offsets parameter.

--- a/src/Interpreters/sortBlock.cpp
+++ b/src/Interpreters/sortBlock.cpp
@@ -132,6 +132,18 @@ void sortBlock(Block & block, const SortDescription & description, UInt64 limit)
         return;
 
     ColumnsWithSortDescriptions columns_with_sort_desc = getColumnsWithSortDescription(block, description);
+    bool all_const = true;
+    for (const auto & column : columns_with_sort_desc)
+    {
+        if (!column.column_const)
+        {
+            all_const = false;
+            break;
+        }
+    }
+    if (all_const)
+        return;
+
     IColumn::Permutation perm;
     /// If only one column to sort by
     if (columns_with_sort_desc.size() == 1)
@@ -229,13 +241,9 @@ void sortBlock(Block & block, const SortDescription & description, UInt64 limit)
             }
         }
     }
-
     size_t columns = block.columns();
     for (size_t i = 0; i < columns; ++i)
-    {
-        if (!isColumnConst(*block.getByPosition(i).column))
-            block.getByPosition(i).column = block.getByPosition(i).column->permute(perm, limit);
-    }
+        block.getByPosition(i).column = block.getByPosition(i).column->permute(perm, limit);
 }
 
 

--- a/src/Interpreters/sortBlock.h
+++ b/src/Interpreters/sortBlock.h
@@ -29,18 +29,4 @@ void stableGetPermutation(const Block & block, const SortDescription & descripti
   */
 bool isAlreadySorted(const Block & block, const SortDescription & description);
 
-/// Column with description for sort
-struct ColumnWithSortDescription
-{
-    const IColumn * column = nullptr;
-    SortColumnDescription description;
-
-    /// It means, that this column is ColumnConst
-    bool column_const = false;
-};
-
-using ColumnsWithSortDescriptions = std::vector<ColumnWithSortDescription>;
-
-ColumnsWithSortDescriptions getColumnsWithSortDescription(const Block & block, const SortDescription & description);
-
 }

--- a/tests/performance/order_by_tuple.xml
+++ b/tests/performance/order_by_tuple.xml
@@ -1,0 +1,8 @@
+<test>
+    <tags>
+        <tag>sorting</tag>
+        <tag>comparison</tag>
+    </tags>
+
+    <query>select * from numbers(300000000) order by (1 - number , number + 1 , number) limit 10;</query>
+</test>


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make ORDER BY tuple almost as fast as ORDER BY columns. We have special optimizations for multiple column ORDER BY: https://github.com/ClickHouse/ClickHouse/pull/10831 . It's beneficial to also apply to tuple columns.

```
Before:

select * from numbers(300000000) order by (1 - number , number + 1 , number) limit 10;
2.613 sec.

After:

select * from numbers(300000000) order by (1 - number , number + 1 , number) limit 10;
0.755 sec

No tuple:

select * from numbers(300000000) order by 1 - number , number + 1 , number limit 10;
0.755 sec
```

It's still not 100% the same because we have other optimization techniques like `optimize_monotonous_functions_in_order_by`, which is not applied to inner columns of a tuple. But it's good enough.

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
