### PR TITLE
Add expire() in PoolBase

### DIFF
--- a/src/Common/PoolBase.h
+++ b/src/Common/PoolBase.h
@@ -89,7 +89,7 @@ public:
         const Object & operator*() const &  { return *data->data.object; }
 
         /**
-         * Expire an object to make it reallocated later
+         * Expire an object to make it reallocated later.
          */
         void expire()
         {

--- a/src/Common/PoolBase.h
+++ b/src/Common/PoolBase.h
@@ -123,7 +123,7 @@ public:
         {
             for (auto & item : items)
                 if (!item->in_use)
-                { 
+                {
                     if (!item->is_expired)
                         return Entry(*item);
                     else

--- a/src/Common/tests/gtest_poolbase.cpp
+++ b/src/Common/tests/gtest_poolbase.cpp
@@ -1,0 +1,52 @@
+#include <memory>
+#include <gtest/gtest.h>
+#include <Common/PoolBase.h>
+#include <Poco/Logger.h>
+using namespace DB;
+
+class PoolObject
+{
+public:
+    int x = 0;
+};
+
+class MyPoolBase : public PoolBase<PoolObject>
+{
+public:
+    using Object = PoolBase<PoolObject>::Object;
+    using ObjectPtr = std::shared_ptr<Object>;
+    using Ptr = PoolBase<PoolObject>::Ptr;
+
+    int last_destroy_value = 0;
+    MyPoolBase() : PoolBase<PoolObject>(100, &Poco::Logger::get("MyPoolBase")) { }
+
+protected:
+    ObjectPtr allocObject() override { return std::make_shared<Object>(); }
+
+    void expireObject(ObjectPtr obj) override
+    {
+        LOG_TRACE(log, "expire object");
+        ASSERT_TRUE(obj->x == 100);
+        last_destroy_value = obj->x;
+    }
+};
+
+TEST(PoolBase, testDestroy1)
+{
+    MyPoolBase pool;
+    {
+        auto obj_entry = pool.get(-1);
+        ASSERT_TRUE(!obj_entry.isNull());
+        obj_entry->x = 100;
+        obj_entry.expire();
+    }
+    ASSERT_EQ(1, pool.aliveSize());
+
+    {
+        auto obj_entry = pool.get(-1);
+        ASSERT_TRUE(!obj_entry.isNull());
+        ASSERT_EQ(obj_entry->x, 0);
+        ASSERT_EQ(1, pool.aliveSize());
+    }
+    ASSERT_EQ(100, pool.last_destroy_value);
+}

--- a/src/Common/tests/gtest_poolbase.cpp
+++ b/src/Common/tests/gtest_poolbase.cpp
@@ -40,13 +40,13 @@ TEST(PoolBase, testDestroy1)
         obj_entry->x = 100;
         obj_entry.expire();
     }
-    ASSERT_EQ(1, pool.aliveSize());
+    ASSERT_EQ(1, pool.size());
 
     {
         auto obj_entry = pool.get(-1);
         ASSERT_TRUE(!obj_entry.isNull());
         ASSERT_EQ(obj_entry->x, 0);
-        ASSERT_EQ(1, pool.aliveSize());
+        ASSERT_EQ(1, pool.size());
     }
     ASSERT_EQ(100, pool.last_destroy_value);
 }


### PR DESCRIPTION
Changelog category (leave one):
- New Feature



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add a new method `expire()` in PoolBase which is used to reallocate an invalid object in the pool.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
