### PR TITLE
Fix builds

### DIFF
--- a/base/base/LineReader.cpp
+++ b/base/base/LineReader.cpp
@@ -4,6 +4,7 @@
 #include <string_view>
 #include <algorithm>
 
+#include <cassert>
 #include <string.h>
 #include <unistd.h>
 #include <sys/select.h>


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Seems like #33201 has suddenly broken all builds:
```
2022-01-28T09:39:28.0002306Z 2022-01-28 09:39:27 [6897/10034] Building CXX object base/base/CMakeFiles/common.dir/LineReader.cpp.o
2022-01-28T09:39:28.0002918Z 2022-01-28 09:39:27 FAILED: base/base/CMakeFiles/common.dir/LineReader.cpp.o 
2022-01-28T09:39:28.0010082Z 2022-01-28 09:39:27 prlimit --as=10000000000 --data=5000000000 --cpu=1000 /usr/bin/ccache /usr/bin/clang++-13 --target=x86_64-linux-gnu --sysroot=/build/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc  -DBOOST_ASIO_STANDALONE=1 -DHAS_RESERVED_IDENTIFIER -DPOCO_ENABLE_CPP11 -DPOCO_HAVE_FD_EPOLL -DPOCO_OS_FAMILY_UNIX -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DWITH_COVERAGE=0 -Iincludes/configs -I../base/base/.. -Ibase/base/.. -I../base/glibc-compatibility/memcpy -I../contrib/cctz/include -isystem ../contrib/libcxx/include -isystem ../contrib/libcxxabi/include -isystem ../contrib/libunwind/include -isystem ../contrib/cityhash102/include -isystem ../contrib/boost -isystem ../contrib/poco/Net/include -isystem ../contrib/poco/Foundation/include -isystem ../contrib/poco/NetSSL_OpenSSL/include -isystem ../contrib/poco/Crypto/include -isystem ../contrib/boringssl/include -isystem ../contrib/poco/Util/include -isystem ../contrib/poco/JSON/include -isystem ../contrib/poco/XML/include -isystem ../contrib/replxx/include -isystem ../contrib/fmtlib-cmake/../fmtlib/include -isystem ../contrib/magic_enum/include --gcc-toolchain=/build/cmake/linux/../../contrib/sysroot/linux-x86_64 --gcc-toolchain=/build/cmake/linux/../../contrib/sysroot/linux-x86_64 -std=c++20 -fdiagnostics-color=always -Xclang -fuse-ctor-homing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/build=. -falign-functions=32   -Wall -Wno-unused-command-line-argument  -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fexperimental-new-pass-manager -Wextra -Wframe-larger-than=65536 -Wpedantic -Wno-vla-extension -Wno-zero-length-array -Wno-c11-extensions -Weverything -Wno-c++98-compat-pedantic -Wno-c++98-compat -Wno-c99-extensions -Wno-conversion -Wno-ctad-maybe-unsupported -Wno-deprecated-dynamic-exception-spec -Wno-disabled-macro-expansion -Wno-documentation-unknown-command -Wno-double-promotion -Wno-exit-time-destructors -Wno-float-equal -Wno-global-constructors -Wno-missing-prototypes -Wno-missing-variable-declarations -Wno-nested-anon-types -Wno-packed -Wno-padded -Wno-shift-sign-overflow -Wno-sign-conversion -Wno-switch-enum -Wno-undefined-func-template -Wno-unused-template -Wno-vla -Wno-weak-template-vtables -Wno-weak-vtables -O2 -g -DNDEBUG -O3  -flto=thin -fwhole-program-vtables -fno-pie   -D OS_LINUX -nostdinc++ -std=gnu++2a -MD -MT base/base/CMakeFiles/common.dir/LineReader.cpp.o -MF base/base/CMakeFiles/common.dir/LineReader.cpp.o.d -o base/base/CMakeFiles/common.dir/LineReader.cpp.o -c ../base/base/LineReader.cpp
2022-01-28T09:39:28.0015203Z 2022-01-28 09:39:27 /build/base/base/LineReader.cpp:113:5: error: use of undeclared identifier 'assert'
2022-01-28T09:39:28.0015896Z 2022-01-28 09:39:27     assert(std::is_sorted(words.begin(), words.end()));
2022-01-28T09:39:28.0016265Z 2022-01-28 09:39:27     ^
2022-01-28T09:39:28.0016811Z 2022-01-28 09:39:27 /build/base/base/LineReader.cpp:114:5: error: use of undeclared identifier 'assert'
2022-01-28T09:39:28.0017434Z 2022-01-28 09:39:27     assert(std::is_sorted(words_no_case.begin(), words_no_case.end(), NoCaseCompare{}));
2022-01-28T09:39:28.0018008Z 2022-01-28 09:39:27     ^
2022-01-28T09:39:28.0018359Z 2022-01-28 09:39:27 2 errors generated.
```
