### PR TITLE
Fix data race in StorageFile

### DIFF
--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -239,8 +239,11 @@ ColumnsDescription StorageFile::getTableStructureFromFileDescriptor(ContextPtr c
 
     auto columns = readSchemaFromFormat(format_name, format_settings, read_buffer_creator, context, peekable_read_buffer_from_fd);
     if (peekable_read_buffer_from_fd)
+    {
         /// If we have created read buffer in readSchemaFromFormat we should rollback to checkpoint.
         assert_cast<PeekableReadBuffer *>(peekable_read_buffer_from_fd.get())->rollbackToCheckpoint();
+        has_peekable_read_buffer_from_fd = true;
+    }
     return columns;
 }
 
@@ -620,8 +623,16 @@ Pipe StorageFile::read(
                 return metadata_snapshot->getColumns();
         };
 
+        /// In case of reading from fd we have to check whether we have already created
+        /// the read buffer from it in Storage constructor (for schema inference) or not.
+        /// If yes, then we should use it in StorageFileSource. Atomic bool flag is needed
+        /// to prevent data race in case of parallel reads.
+        std::unique_ptr<ReadBuffer> read_buffer;
+        if (has_peekable_read_buffer_from_fd.exchange(false))
+            read_buffer = std::move(peekable_read_buffer_from_fd);
+
         pipes.emplace_back(std::make_shared<StorageFileSource>(
-            this_ptr, metadata_snapshot, context, max_block_size, files_info, get_columns_for_format(), std::move(peekable_read_buffer_from_fd)));
+            this_ptr, metadata_snapshot, context, max_block_size, files_info, get_columns_for_format(), std::move(read_buffer)));
     }
 
     return Pipe::unitePipes(std::move(pipes));

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -129,6 +129,7 @@ private:
     /// is file descriptor. See getTableStructureFromFileDescriptor.
     std::unique_ptr<ReadBuffer> read_buffer_from_fd;
     std::unique_ptr<ReadBuffer> peekable_read_buffer_from_fd;
+    std::atomic<bool> has_peekable_read_buffer_from_fd;
 };
 
 }

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -129,45 +129,7 @@ private:
     /// is file descriptor. See getTableStructureFromFileDescriptor.
     std::unique_ptr<ReadBuffer> read_buffer_from_fd;
     std::unique_ptr<ReadBuffer> peekable_read_buffer_from_fd;
-    std::atomic<bool> has_peekable_read_buffer_from_fd = false 
-￼ 
-ClickHouse
-/
-ClickHouse
-Public
- Watch 668 
-Fork 4.3k
-￼ Starred 21.9k
-Code
-Issues
-1.7k
-Pull requests
-172
-Discussions
-Actions
-Projects
-Wiki
-Security
-32
-Insights
-￼Edit
- Code
-Fix data race in StorageFile #34113
- Open
-Avogar wants to merge 1 commit into ClickHouse:master from Avogar:data-race
-+13 −1 
- Conversation 1
- Commits 1
- Checks 84
- Files changed 2
-Changes from all commits 
-File filter 
-Conversations 
-Jump to 
- 
-0 / 2 files viewed
-Review changes 
-;
+    std::atomic<bool> has_peekable_read_buffer_from_fd = false;
 };
 
 }

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -129,7 +129,45 @@ private:
     /// is file descriptor. See getTableStructureFromFileDescriptor.
     std::unique_ptr<ReadBuffer> read_buffer_from_fd;
     std::unique_ptr<ReadBuffer> peekable_read_buffer_from_fd;
-    std::atomic<bool> has_peekable_read_buffer_from_fd;
+    std::atomic<bool> has_peekable_read_buffer_from_fd = false 
+￼ 
+ClickHouse
+/
+ClickHouse
+Public
+ Watch 668 
+Fork 4.3k
+￼ Starred 21.9k
+Code
+Issues
+1.7k
+Pull requests
+172
+Discussions
+Actions
+Projects
+Wiki
+Security
+32
+Insights
+￼Edit
+ Code
+Fix data race in StorageFile #34113
+ Open
+Avogar wants to merge 1 commit into ClickHouse:master from Avogar:data-race
++13 −1 
+ Conversation 1
+ Commits 1
+ Checks 84
+ Files changed 2
+Changes from all commits 
+File filter 
+Conversations 
+Jump to 
+ 
+0 / 2 files viewed
+Review changes 
+;
 };
 
 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible data race in StorageFile that was introduced in https://github.com/ClickHouse/ClickHouse/pull/33960. Closes https://github.com/ClickHouse/ClickHouse/issues/34111