### PR TITLE
Combining our lexer with replxx for better multiple line editing

### DIFF
--- a/base/base/LineReader.cpp
+++ b/base/base/LineReader.cpp
@@ -81,7 +81,7 @@ replxx::Replxx::completions_t LineReader::Suggest::getCompletions(const String &
     std::lock_guard lock(mutex);
 
     /// Only perform case sensitive completion when the prefix string contains any uppercase characters
-    if (std::none_of(prefix.begin(), prefix.end(), [&](auto c) { return c >= 'A' && c <= 'Z'; }))
+    if (std::none_of(prefix.begin(), prefix.end(), [](char32_t x) { return iswupper(static_cast<wint_t>(x)); }))
         range = std::equal_range(
             words_no_case.begin(), words_no_case.end(), last_word, [prefix_length](std::string_view s, std::string_view prefix_searched)
             {

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -191,7 +191,8 @@ ReplxxLineReader::ReplxxLineReader(
     auto commit_action = [this](char32_t code)
     {
         /// If we allow multiline and there is already something in the input, start a newline.
-        if (multiline && !replxx_last_is_delimiter)
+        /// NOTE: Lexer is only available if we use highlighter.
+        if (highlighter && multiline && !replxx_last_is_delimiter)
             return rx.invoke(Replxx::ACTION::NEW_LINE, code);
         replxx_last_is_delimiter = false;
         return rx.invoke(Replxx::ACTION::COMMIT_LINE, code);

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -179,6 +179,7 @@ ReplxxLineReader::ReplxxLineReader(
     rx.set_completion_callback(callback);
     rx.set_complete_on_empty(false);
     rx.set_word_break_characters(word_break_characters);
+    rx.set_ignore_case(true);
 
     if (highlighter)
         rx.set_highlighter_callback(highlighter);

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -25,13 +25,6 @@ void trim(String & s)
     s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
 }
 
-/// Check if string ends with given character after skipping whitespaces.
-bool ends_with(const std::string_view & s, const std::string_view & p)
-{
-    auto ss = std::string_view(s.data(), s.rend() - std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }));
-    return ss.ends_with(p);
-}
-
 std::string getEditor()
 {
     const char * editor = std::getenv("EDITOR");
@@ -132,6 +125,7 @@ void convertHistoryFile(const std::string & path, replxx::Replxx & rx)
 
 }
 
+bool replxx_last_is_delimiter = false;
 ReplxxLineReader::ReplxxLineReader(
     Suggest & suggest,
     const String & history_file_path_,
@@ -196,21 +190,10 @@ ReplxxLineReader::ReplxxLineReader(
 
     auto commit_action = [this](char32_t code)
     {
-        std::string_view str = rx.get_state().text();
-
-        /// Always commit line when we see extender at the end. It will start a new prompt.
-        for (const auto * extender : extenders)
-            if (ends_with(str, extender))
-                return rx.invoke(Replxx::ACTION::COMMIT_LINE, code);
-
-        /// If we see an delimiter at the end, commit right away.
-        for (const auto * delimiter : delimiters)
-            if (ends_with(str, delimiter))
-                return rx.invoke(Replxx::ACTION::COMMIT_LINE, code);
-
         /// If we allow multiline and there is already something in the input, start a newline.
-        if (multiline && !input.empty())
+        if (multiline && !replxx_last_is_delimiter)
             return rx.invoke(Replxx::ACTION::NEW_LINE, code);
+        replxx_last_is_delimiter = false;
         return rx.invoke(Replxx::ACTION::COMMIT_LINE, code);
     };
     /// bind C-j to ENTER action.

--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -125,7 +125,12 @@ void convertHistoryFile(const std::string & path, replxx::Replxx & rx)
 
 }
 
-bool replxx_last_is_delimiter = false;
+static bool replxx_last_is_delimiter = false;
+void ReplxxLineReader::setLastIsDelimiter(bool flag)
+{
+    replxx_last_is_delimiter = flag;
+}
+
 ReplxxLineReader::ReplxxLineReader(
     Suggest & suggest,
     const String & history_file_path_,

--- a/base/base/ReplxxLineReader.h
+++ b/base/base/ReplxxLineReader.h
@@ -19,6 +19,9 @@ public:
 
     void enableBracketedPaste() override;
 
+    /// If highlight is on, we will set a flag to denote whether the last token is a delimiter.
+    /// This is useful to determine the behavior of <ENTER> key when multiline is enabled.
+    static void setLastIsDelimiter(bool flag);
 private:
     InputStatus readOneLine(const String & prompt) override;
     void addToHistory(const String & line) override;

--- a/src/Client/ClientBaseHelpers.cpp
+++ b/src/Client/ClientBaseHelpers.cpp
@@ -6,10 +6,6 @@
 #include <Parsers/Lexer.h>
 #include <Common/UTF8Helpers.h>
 
-#if USE_REPLXX
-extern bool replxx_last_is_delimiter;
-#endif
-
 namespace DB
 {
 
@@ -156,9 +152,9 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
     for (Token token = lexer.nextToken(); !token.isEnd(); token = lexer.nextToken())
     {
         if (token.type == TokenType::Semicolon || token.type == TokenType::VerticalDelimiter)
-            replxx_last_is_delimiter = true;
+            ReplxxLineReader::setLastIsDelimiter(true);
         else if (token.type != TokenType::Whitespace)
-            replxx_last_is_delimiter = false;
+            ReplxxLineReader::setLastIsDelimiter(false);
 
         size_t utf8_len = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(token.begin), token.size());
         for (size_t code_point_index = 0; code_point_index < utf8_len; ++code_point_index)

--- a/src/Client/ClientBaseHelpers.cpp
+++ b/src/Client/ClientBaseHelpers.cpp
@@ -6,6 +6,9 @@
 #include <Parsers/Lexer.h>
 #include <Common/UTF8Helpers.h>
 
+#if USE_REPLXX
+extern bool replxx_last_is_delimiter;
+#endif
 
 namespace DB
 {
@@ -114,6 +117,7 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
 
             {TokenType::Comma, replxx::color::bold(Replxx::Color::DEFAULT)},
             {TokenType::Semicolon, replxx::color::bold(Replxx::Color::DEFAULT)},
+            {TokenType::VerticalDelimiter, replxx::color::bold(Replxx::Color::DEFAULT)},
             {TokenType::Dot, replxx::color::bold(Replxx::Color::DEFAULT)},
             {TokenType::Asterisk, replxx::color::bold(Replxx::Color::DEFAULT)},
             {TokenType::HereDoc, Replxx::Color::CYAN},
@@ -151,6 +155,11 @@ void highlight(const String & query, std::vector<replxx::Replxx::Color> & colors
 
     for (Token token = lexer.nextToken(); !token.isEnd(); token = lexer.nextToken())
     {
+        if (token.type == TokenType::Semicolon || token.type == TokenType::VerticalDelimiter)
+            replxx_last_is_delimiter = true;
+        else if (token.type != TokenType::Whitespace)
+            replxx_last_is_delimiter = false;
+
         size_t utf8_len = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(token.begin), token.size());
         for (size_t code_point_index = 0; code_point_index < utf8_len; ++code_point_index)
         {

--- a/src/Parsers/Lexer.cpp
+++ b/src/Parsers/Lexer.cpp
@@ -335,6 +335,13 @@ Token Lexer::nextTokenImpl()
                 return Token(TokenType::DoubleAt, token_begin, ++pos);
             return Token(TokenType::At, token_begin, pos);
         }
+        case '\\':
+        {
+            ++pos;
+            if (pos < end && *pos == 'G')
+                return Token(TokenType::VerticalDelimiter, token_begin, ++pos);
+            return Token(TokenType::Error, token_begin, pos);
+        }
 
         default:
             if (*pos == '$')

--- a/src/Parsers/Lexer.h
+++ b/src/Parsers/Lexer.h
@@ -28,6 +28,7 @@ namespace DB
     \
     M(Comma) \
     M(Semicolon) \
+    M(VerticalDelimiter)      /** Vertical delimiter \G */ \
     M(Dot)                    /** Compound identifiers, like a.b or tuple access operator a.1, (x, y).2. */ \
                               /** Need to be distinguished from floating point number with omitted integer part: .1 */ \
     \

--- a/tests/queries/0_stateless/01293_client_interactive_vertical_multiline.expect
+++ b/tests/queries/0_stateless/01293_client_interactive_vertical_multiline.expect
@@ -1,7 +1,7 @@
 #!/usr/bin/expect -f
 
 log_user 0
-set timeout 60
+set timeout 10
 match_max 100000
 
 expect_after {
@@ -10,6 +10,9 @@ expect_after {
     # A default timeout action is to do nothing, change it to fail
     timeout { exit 1 }
 }
+
+# useful debugging configuration
+# exp_internal 1
 
 set basedir [file dirname $argv0]
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion"
@@ -41,7 +44,7 @@ expect ":) "
 send -- ""
 expect eof
 
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion --multiline"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion --highlight 0 --multiline"
 expect ":) "
 
 send -- "SELECT 1;\r"


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improving the experience of multiple line editing for clickhouse-client. This is a follow-up of https://github.com/ClickHouse/ClickHouse/pull/31123

This PR also contains replxx bump https://github.com/ClickHouse-Extras/replxx/pull/19 which fixes https://github.com/ClickHouse/ClickHouse/issues/32399

NOTE: This PR extends our lexer in that `\G` has a special type: `TokenType::VerticalDelimiter`

NOTE: Make sure `--highlight` is on (default) to take full advantage.

NOTE: This PR also ignores case for history search and completion.  (The feature was reverted when we switch to upstream replxx, now it's available officially)

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
