### PR TITLE
Slightly optimize Array/Tuple/Map

### DIFF
--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -127,19 +127,8 @@ size_t ColumnArray::size() const
 
 Field ColumnArray::operator[](size_t n) const
 {
-    size_t offset = offsetAt(n);
-    size_t size = sizeAt(n);
-
-    if (size > max_array_size_as_field)
-        throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "Array of size {} is too large to be manipulated as single field, maximum size {}",
-            size, max_array_size_as_field);
-
-    Array res;
-    res.reserve(size);
-
-    for (size_t i = 0; i < size; ++i)
-        res.push_back(getData()[offset + i]);
-
+    Field res;
+    get(n, res);
     return res;
 }
 

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -1,5 +1,3 @@
-#include <string.h> // memcpy
-
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnString.h>
@@ -9,12 +7,7 @@
 #include <Columns/ColumnsCommon.h>
 #include <Columns/ColumnCompressed.h>
 #include <Columns/MaskOperations.h>
-
-#include <base/unaligned.h>
-#include <base/sort.h>
-
 #include <Processors/Transforms/ColumnGathererTransform.h>
-
 #include <Common/Exception.h>
 #include <Common/Arena.h>
 #include <Common/SipHash.h>
@@ -22,6 +15,8 @@
 #include <Common/assert_cast.h>
 #include <Common/WeakHash.h>
 #include <Common/HashTable/Hash.h>
+#include <base/unaligned.h>
+#include <cstring> // memcpy
 
 
 namespace DB

--- a/src/Columns/ColumnMap.cpp
+++ b/src/Columns/ColumnMap.cpp
@@ -4,8 +4,6 @@
 #include <Processors/Transforms/ColumnGathererTransform.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
-#include <base/map.h>
-#include <base/range.h>
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
 #include <Common/WeakHash.h>

--- a/src/Columns/ColumnMap.cpp
+++ b/src/Columns/ColumnMap.cpp
@@ -64,8 +64,9 @@ MutableColumnPtr ColumnMap::cloneResized(size_t new_size) const
 
 Field ColumnMap::operator[](size_t n) const
 {
-    auto array = DB::get<Array>((*nested)[n]);
-    return Map(std::make_move_iterator(array.begin()), std::make_move_iterator(array.end()));
+    Field res;
+    get(n, res);
+    return res;
 }
 
 void ColumnMap::get(size_t n, Field & res) const
@@ -74,11 +75,12 @@ void ColumnMap::get(size_t n, Field & res) const
     size_t offset = offsets[n - 1];
     size_t size = offsets[n] - offsets[n - 1];
 
-    res = Map(size);
+    res = Map();
     auto & map = DB::get<Map &>(res);
+    map.reserve(size);
 
     for (size_t i = 0; i < size; ++i)
-        getNestedData().get(offset + i, map[i]);
+        map.push_back(getNestedData()[offset + i]);
 }
 
 bool ColumnMap::isDefaultAt(size_t n) const

--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -9,9 +9,6 @@
 #include <Common/WeakHash.h>
 #include <Common/assert_cast.h>
 #include <Common/typeid_cast.h>
-#include <base/sort.h>
-#include <base/map.h>
-#include <base/range.h>
 #include <DataTypes/Serializations/SerializationInfoTuple.h>
 
 
@@ -114,7 +111,7 @@ void ColumnTuple::get(size_t n, Field & res) const
     Tuple & res_tuple = DB::get<Tuple &>(res);
     res_tuple.reserve(tuple_size);
 
-    for (const auto i : collections::range(0, tuple_size))
+    for (size_t i = 0; i < tuple_size; ++i)
         res_tuple.push_back((*columns[i])[n]);
 }
 
@@ -487,7 +484,7 @@ void ColumnTuple::getExtremes(Field & min, Field & max) const
     Tuple min_tuple(tuple_size);
     Tuple max_tuple(tuple_size);
 
-    for (const auto i : collections::range(0, tuple_size))
+    for (size_t i = 0; i < tuple_size; ++i)
         columns[i]->getExtremes(min_tuple[i], max_tuple[i]);
 
     min = min_tuple;
@@ -508,7 +505,7 @@ bool ColumnTuple::structureEquals(const IColumn & rhs) const
         if (tuple_size != rhs_tuple->columns.size())
             return false;
 
-        for (const auto i : collections::range(0, tuple_size))
+        for (size_t i = 0; i < tuple_size; ++i)
             if (!columns[i]->structureEquals(*rhs_tuple->columns[i]))
                 return false;
 

--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -101,17 +101,21 @@ MutableColumnPtr ColumnTuple::cloneResized(size_t new_size) const
 
 Field ColumnTuple::operator[](size_t n) const
 {
-    return collections::map<Tuple>(columns, [n] (const auto & column) { return (*column)[n]; });
+    Field res;
+    get(n, res);
+    return res;
 }
 
 void ColumnTuple::get(size_t n, Field & res) const
 {
     const size_t tuple_size = columns.size();
-    Tuple tuple(tuple_size);
-    for (const auto i : collections::range(0, tuple_size))
-        columns[i]->get(n, tuple[i]);
 
-    res = tuple;
+    res = Tuple();
+    Tuple & res_tuple = DB::get<Tuple &>(res);
+    res_tuple.reserve(tuple_size);
+
+    for (const auto i : collections::range(0, tuple_size))
+        res_tuple.push_back((*columns[i])[n]);
 }
 
 bool ColumnTuple::isDefaultAt(size_t n) const

--- a/src/DataTypes/Serializations/SerializationArray.cpp
+++ b/src/DataTypes/Serializations/SerializationArray.cpp
@@ -37,10 +37,11 @@ void SerializationArray::deserializeBinary(Field & field, ReadBuffer & istr) con
 {
     size_t size;
     readVarUInt(size, istr);
-    field = Array(size);
+    field = Array();
     Array & arr = get<Array &>(field);
+    arr.reserve(size);
     for (size_t i = 0; i < size; ++i)
-        nested->deserializeBinary(arr[i], istr);
+        nested->deserializeBinary(arr.emplace_back(), istr);
 }
 
 

--- a/src/DataTypes/Serializations/SerializationMap.cpp
+++ b/src/DataTypes/Serializations/SerializationMap.cpp
@@ -53,13 +53,15 @@ void SerializationMap::deserializeBinary(Field & field, ReadBuffer & istr) const
 {
     size_t size;
     readVarUInt(size, istr);
-    field = Map(size);
-    for (auto & elem : field.get<Map &>())
+    field = Map();
+    Map & map = field.get<Map &>();
+    map.reserve(size);
+    for (size_t i = 0; i < size; ++i)
     {
         Tuple tuple(2);
         key->deserializeBinary(tuple[0], istr);
         value->deserializeBinary(tuple[1], istr);
-        elem = std::move(tuple);
+        map.push_back(std::move(tuple));
     }
 }
 

--- a/src/DataTypes/Serializations/SerializationTuple.cpp
+++ b/src/DataTypes/Serializations/SerializationTuple.cpp
@@ -44,11 +44,11 @@ void SerializationTuple::deserializeBinary(Field & field, ReadBuffer & istr) con
 {
     const size_t size = elems.size();
 
-    Tuple tuple(size);
+    field = Tuple();
+    Tuple & tuple = get<Tuple &>(field);
+    tuple.reserve(size);
     for (const auto i : collections::range(0, size))
-        elems[i]->deserializeBinary(tuple[i], istr);
-
-    field = tuple;
+        elems[i]->deserializeBinary(tuple.emplace_back(), istr);
 }
 
 void SerializationTuple::serializeBinary(const IColumn & column, size_t row_num, WriteBuffer & ostr) const

--- a/src/DataTypes/Serializations/SerializationTuple.cpp
+++ b/src/DataTypes/Serializations/SerializationTuple.cpp
@@ -1,4 +1,3 @@
-#include <base/range.h>
 #include <DataTypes/Serializations/SerializationTuple.h>
 #include <DataTypes/Serializations/SerializationInfoTuple.h>
 #include <DataTypes/DataTypeTuple.h>
@@ -47,7 +46,7 @@ void SerializationTuple::deserializeBinary(Field & field, ReadBuffer & istr) con
     field = Tuple();
     Tuple & tuple = get<Tuple &>(field);
     tuple.reserve(size);
-    for (const auto i : collections::range(0, size))
+    for (size_t i = 0; i < size; ++i)
         elems[i]->deserializeBinary(tuple.emplace_back(), istr);
 }
 
@@ -73,7 +72,7 @@ static void addElementSafe(size_t num_elems, IColumn & column, F && impl)
 
         // Check that all columns now have the same size.
         size_t new_size = column.size();
-        for (auto i : collections::range(1, num_elems))
+        for (size_t i = 1; i < num_elems; ++i)
         {
             const auto & element_column = extractElementColumn(column, i);
             if (element_column.size() != new_size)
@@ -87,7 +86,7 @@ static void addElementSafe(size_t num_elems, IColumn & column, F && impl)
     }
     catch (...)
     {
-        for (const auto & i : collections::range(0, num_elems))
+        for (size_t i = 0; i < num_elems; ++i)
         {
             auto & element_column = extractElementColumn(column, i);
             if (element_column.size() > old_size)
@@ -102,7 +101,7 @@ void SerializationTuple::deserializeBinary(IColumn & column, ReadBuffer & istr) 
 {
     addElementSafe(elems.size(), column, [&]
     {
-        for (const auto & i : collections::range(0, elems.size()))
+        for (size_t i = 0; i < elems.size(); ++i)
             elems[i]->deserializeBinary(extractElementColumn(column, i), istr);
     });
 }
@@ -110,7 +109,7 @@ void SerializationTuple::deserializeBinary(IColumn & column, ReadBuffer & istr) 
 void SerializationTuple::serializeText(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
     writeChar('(', ostr);
-    for (const auto i : collections::range(0, elems.size()))
+    for (size_t i = 0; i < elems.size(); ++i)
     {
         if (i != 0)
             writeChar(',', ostr);
@@ -126,7 +125,7 @@ void SerializationTuple::deserializeText(IColumn & column, ReadBuffer & istr, co
 
     addElementSafe(elems.size(), column, [&]
     {
-        for (const auto i : collections::range(0, size))
+        for (size_t i = 0; i < size; ++i)
         {
             skipWhitespaceIfAny(istr);
             if (i != 0)
@@ -158,7 +157,7 @@ void SerializationTuple::serializeTextJSON(const IColumn & column, size_t row_nu
         && have_explicit_names)
     {
         writeChar('{', ostr);
-        for (const auto i : collections::range(0, elems.size()))
+        for (size_t i = 0; i < elems.size(); ++i)
         {
             if (i != 0)
             {
@@ -173,7 +172,7 @@ void SerializationTuple::serializeTextJSON(const IColumn & column, size_t row_nu
     else
     {
         writeChar('[', ostr);
-        for (const auto i : collections::range(0, elems.size()))
+        for (size_t i = 0; i < elems.size(); ++i)
         {
             if (i != 0)
                 writeChar(',', ostr);
@@ -195,7 +194,7 @@ void SerializationTuple::deserializeTextJSON(IColumn & column, ReadBuffer & istr
         addElementSafe(elems.size(), column, [&]
         {
             // Require all elements but in arbitrary order.
-            for (auto i : collections::range(0, elems.size()))
+            for (size_t i = 0; i < elems.size(); ++i)
             {
                 if (i > 0)
                 {
@@ -226,7 +225,7 @@ void SerializationTuple::deserializeTextJSON(IColumn & column, ReadBuffer & istr
 
         addElementSafe(elems.size(), column, [&]
         {
-            for (const auto i : collections::range(0, size))
+            for (size_t i = 0; i < size; ++i)
             {
                 skipWhitespaceIfAny(istr);
                 if (i != 0)
@@ -246,7 +245,7 @@ void SerializationTuple::deserializeTextJSON(IColumn & column, ReadBuffer & istr
 void SerializationTuple::serializeTextXML(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
     writeCString("<tuple>", ostr);
-    for (const auto i : collections::range(0, elems.size()))
+    for (size_t i = 0; i < elems.size(); ++i)
     {
         writeCString("<elem>", ostr);
         elems[i]->serializeTextXML(extractElementColumn(column, i), row_num, ostr, settings);
@@ -257,7 +256,7 @@ void SerializationTuple::serializeTextXML(const IColumn & column, size_t row_num
 
 void SerializationTuple::serializeTextCSV(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    for (const auto i : collections::range(0, elems.size()))
+    for (size_t i = 0; i < elems.size(); ++i)
     {
         if (i != 0)
             writeChar(settings.csv.tuple_delimiter, ostr);
@@ -270,7 +269,7 @@ void SerializationTuple::deserializeTextCSV(IColumn & column, ReadBuffer & istr,
     addElementSafe(elems.size(), column, [&]
     {
         const size_t size = elems.size();
-        for (const auto i : collections::range(0, size))
+        for (size_t i = 0; i < size; ++i)
         {
             if (i != 0)
             {
@@ -362,7 +361,7 @@ void SerializationTuple::serializeBinaryBulkWithMultipleStreams(
 {
     auto * tuple_state = checkAndGetState<SerializeBinaryBulkStateTuple>(state);
 
-    for (const auto i : collections::range(0, elems.size()))
+    for (size_t i = 0; i < elems.size(); ++i)
     {
         const auto & element_col = extractElementColumn(column, i);
         elems[i]->serializeBinaryBulkWithMultipleStreams(element_col, offset, limit, settings, tuple_state->states[i]);
@@ -382,7 +381,7 @@ void SerializationTuple::deserializeBinaryBulkWithMultipleStreams(
     auto & column_tuple = assert_cast<ColumnTuple &>(*mutable_column);
 
     settings.avg_value_size_hint = 0;
-    for (const auto i : collections::range(0, elems.size()))
+    for (size_t i = 0; i < elems.size(); ++i)
         elems[i]->deserializeBinaryBulkWithMultipleStreams(column_tuple.getColumnPtr(i), limit, settings, tuple_state->states[i], cache);
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It is less important for Tuple/Map since they are unlikely to be as large as arrays, but still.

Follow-up for: #34074