### PR TITLE
Dictionary PRIMARY KEY parsing fix

### DIFF
--- a/src/Parsers/ParserDictionary.cpp
+++ b/src/Parsers/ParserDictionary.cpp
@@ -188,8 +188,19 @@ bool ParserDictionary::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ASTPtr ast_settings;
 
     /// Primary is required to be the first in dictionary definition
-    if (primary_key_keyword.ignore(pos) && !expression_list_p.parse(pos, primary_key, expected))
-        return false;
+    if (primary_key_keyword.ignore(pos))
+    {
+        bool was_open = false;
+
+        if (open.ignore(pos, expected))
+            was_open = true;
+
+        if (!expression_list_p.parse(pos, primary_key, expected))
+            return false;
+
+        if (was_open && !close.ignore(pos, expected))
+            return false;
+    }
 
     /// Loop is used to avoid strict order of dictionary properties
     while (true)

--- a/tests/queries/0_stateless/02188_parser_dictionary_primary_key.reference
+++ b/tests/queries/0_stateless/02188_parser_dictionary_primary_key.reference
@@ -1,0 +1,8 @@
+Dictionary output
+0	Value
+Dictionary output
+0	Value
+Dictionary output
+0	Value
+Dictionary output
+0	Value

--- a/tests/queries/0_stateless/02188_parser_dictionary_primary_key.sql
+++ b/tests/queries/0_stateless/02188_parser_dictionary_primary_key.sql
@@ -1,0 +1,65 @@
+DROP TABLE IF EXISTS 02188_test_dictionary_source;
+CREATE TABLE 02188_test_dictionary_source
+(
+    id UInt64,
+    value String
+)
+ENGINE=TinyLog;
+
+INSERT INTO 02188_test_dictionary_source VALUES (0, 'Value');
+
+DROP DICTIONARY IF EXISTS 02188_test_dictionary_simple_primary_key;
+CREATE DICTIONARY 02188_test_dictionary_simple_primary_key
+(
+    id UInt64,
+    value String
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '02188_test_dictionary_source'))
+LAYOUT(DIRECT());
+
+SELECT 'Dictionary output';
+SELECT * FROM 02188_test_dictionary_simple_primary_key;
+DROP DICTIONARY 02188_test_dictionary_simple_primary_key;
+
+CREATE DICTIONARY 02188_test_dictionary_simple_primary_key
+(
+    id UInt64,
+    value String
+)
+PRIMARY KEY (id)
+SOURCE(CLICKHOUSE(TABLE '02188_test_dictionary_source'))
+LAYOUT(DIRECT());
+
+SELECT 'Dictionary output';
+SELECT * FROM 02188_test_dictionary_simple_primary_key;
+DROP DICTIONARY 02188_test_dictionary_simple_primary_key;
+
+DROP DICTIONARY IF EXISTS 02188_test_dictionary_complex_primary_key;
+CREATE DICTIONARY 02188_test_dictionary_complex_primary_key
+(
+    id UInt64,
+    value String
+)
+PRIMARY KEY id, value
+SOURCE(CLICKHOUSE(TABLE '02188_test_dictionary_source'))
+LAYOUT(COMPLEX_KEY_DIRECT());
+
+SELECT 'Dictionary output';
+SELECT * FROM 02188_test_dictionary_complex_primary_key;
+DROP DICTIONARY 02188_test_dictionary_complex_primary_key;
+
+CREATE DICTIONARY 02188_test_dictionary_complex_primary_key
+(
+    id UInt64,
+    value String
+)
+PRIMARY KEY (id, value)
+SOURCE(CLICKHOUSE(TABLE '02188_test_dictionary_source'))
+LAYOUT(COMPLEX_KEY_DIRECT());
+
+SELECT 'Dictionary output';
+SELECT * FROM 02188_test_dictionary_complex_primary_key;
+DROP DICTIONARY 02188_test_dictionary_complex_primary_key;
+
+DROP TABLE 02188_test_dictionary_source;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to parse dictionary `PRIMARY KEY` as `PRIMARY KEY (id, value)`, previously supported only `PRIMARY KEY id, value`. Closes #34135.
