### PR TITLE
Adding Fractional Second (ms) Support to formatDateTime

### DIFF
--- a/src/Functions/formatDateTime.cpp
+++ b/src/Functions/formatDateTime.cpp
@@ -20,6 +20,7 @@
 
 #include <type_traits>
 
+//testing
 
 namespace DB
 {

--- a/src/Functions/formatDateTime.cpp
+++ b/src/Functions/formatDateTime.cpp
@@ -20,8 +20,6 @@
 
 #include <type_traits>
 
-//testing
-
 namespace DB
 {
 namespace ErrorCodes
@@ -264,6 +262,11 @@ private:
         static void second(char * target, Time source, const DateLUTImpl & timezone)
         {
             writeNumber2(target, ToSecondImpl::execute(source, timezone));
+        }
+
+        static void sFraction(char * target, Time source, const DateLUTImpl & timezone)
+        {
+            writeNumber3(target, ToSecondImpl::execute(source, timezone));
         }
 
         static void ISO8601Time(char * target, Time source, const DateLUTImpl & timezone) // NOLINT
@@ -657,6 +660,12 @@ public:
                     case 'S':
                         add_instruction_or_shift(&Action<T>::second, 2);
                         result.append("00");
+                        break;
+
+                    // Fractions of a Second (ms)
+                    case 'f':
+                        add_instruction_or_shift(&Action<T>::sFraction, 3);
+                        result.append(".000");
                         break;
 
                     // ISO 8601 time format (HH:MM:SS), equivalent to %H:%M:%S 14:55:02


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adding a fraction of a second field to formatDateTime. Specifically, adding millisecond support to FormatDateTime field. 
