### PR TITLE
Add composability to casting and index operators

### DIFF
--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -689,7 +689,7 @@ bool ParserUnaryExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 bool ParserCastExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     ASTPtr expr_ast;
-    if (!ParserExpressionElement().parse(pos, expr_ast, expected))
+    if (!elem_parser->parse(pos, expr_ast, expected))
         return false;
 
     ASTPtr type_ast;
@@ -711,7 +711,7 @@ bool ParserArrayElementExpression::parseImpl(Pos & pos, ASTPtr & node, Expected 
 {
     return ParserLeftAssociativeBinaryOperatorList{
         operators,
-        std::make_unique<ParserCastExpression>(),
+        std::make_unique<ParserCastExpression>(std::make_unique<ParserExpressionElement>()),
         std::make_unique<ParserExpressionWithOptionalAlias>(false)
     }.parse(pos, node, expected);
 }
@@ -721,7 +721,7 @@ bool ParserTupleElementExpression::parseImpl(Pos & pos, ASTPtr & node, Expected 
 {
     return ParserLeftAssociativeBinaryOperatorList{
         operators,
-        std::make_unique<ParserArrayElementExpression>(),
+        std::make_unique<ParserCastExpression>(std::make_unique<ParserArrayElementExpression>()),
         std::make_unique<ParserUnsignedInteger>()
     }.parse(pos, node, expected);
 }

--- a/src/Parsers/ExpressionListParsers.h
+++ b/src/Parsers/ExpressionListParsers.h
@@ -203,6 +203,15 @@ protected:
 /// Example: "[1, 1 + 1, 1 + 2]::Array(UInt8)"
 class ParserCastExpression : public IParserBase
 {
+private:
+    ParserPtr elem_parser;
+
+public:
+    ParserCastExpression(ParserPtr && elem_parser_)
+        : elem_parser(std::move(elem_parser_))
+    {
+    }
+
 protected:
     const char * getName() const override { return "CAST expression"; }
 
@@ -238,7 +247,7 @@ class ParserUnaryExpression : public IParserBase
 {
 private:
     static const char * operators[];
-    ParserPrefixUnaryOperatorExpression operator_parser {operators, std::make_unique<ParserTupleElementExpression>()};
+    ParserPrefixUnaryOperatorExpression operator_parser {operators, std::make_unique<ParserCastExpression>(std::make_unique<ParserTupleElementExpression>())};
 
 protected:
     const char * getName() const override { return "unary expression"; }

--- a/tests/queries/0_stateless/01852_cast_operator_4.reference
+++ b/tests/queries/0_stateless/01852_cast_operator_4.reference
@@ -8,6 +8,12 @@ SELECT CAST(CAST(\'[3,4,5]\', \'Array(Int64)\')[2], \'Int8\')
 SELECT CAST(CAST(\'[1,2,3]\', \'Array(UInt64)\')[CAST(CAST([number, number], \'Array(UInt8)\')[number], \'UInt64\')], \'UInt8\')
 FROM numbers(3)
 3
+WITH [3, 4, 5] AS x
+SELECT CAST(x[1], \'Int32\')
+3
 SELECT CAST((3, 4, 5).1, \'Int32\')
 4
 SELECT CAST(CAST((3, 4, 5), \'Tuple(UInt64, UInt64, UInt64)\').1, \'Int32\')
+3
+WITH (3, 4, 5) AS x
+SELECT CAST(x.1, \'Int32\')

--- a/tests/queries/0_stateless/01852_cast_operator_4.reference
+++ b/tests/queries/0_stateless/01852_cast_operator_4.reference
@@ -1,0 +1,13 @@
+3
+SELECT CAST([3, 4, 5][1], \'Int32\')
+4
+SELECT CAST(CAST(\'[3,4,5]\', \'Array(Int64)\')[2], \'Int8\')
+0
+1
+2
+SELECT CAST(CAST(\'[1,2,3]\', \'Array(UInt64)\')[CAST(CAST([number, number], \'Array(UInt8)\')[number], \'UInt64\')], \'UInt8\')
+FROM numbers(3)
+3
+SELECT CAST((3, 4, 5).1, \'Int32\')
+4
+SELECT CAST(CAST((3, 4, 5), \'Tuple(UInt64, UInt64, UInt64)\').1, \'Int32\')

--- a/tests/queries/0_stateless/01852_cast_operator_4.sql
+++ b/tests/queries/0_stateless/01852_cast_operator_4.sql
@@ -1,0 +1,14 @@
+SELECT [3,4,5][1]::Int32;
+EXPLAIN SYNTAX SELECT [3,4,5][1]::Int32;
+
+SELECT [3,4,5]::Array(Int64)[2]::Int8;
+EXPLAIN SYNTAX SELECT [3,4,5]::Array(Int64)[2]::Int8;
+
+SELECT [1,2,3]::Array(UInt64)[[number, number]::Array(UInt8)[number]::UInt64]::UInt8 from numbers(3);
+EXPLAIN SYNTAX SELECT [1,2,3]::Array(UInt64)[[number, number]::Array(UInt8)[number]::UInt64]::UInt8 from numbers(3);
+
+SELECT tuple(3,4,5).1::Int32;
+EXPLAIN SYNTAX SELECT tuple(3,4,5).1::Int32;
+
+SELECT tuple(3,4,5)::Tuple(UInt64, UInt64, UInt64).2::Int32;
+EXPLAIN SYNTAX SELECT tuple(3,4,5)::Tuple(UInt64, UInt64, UInt64).1::Int32;

--- a/tests/queries/0_stateless/01852_cast_operator_4.sql
+++ b/tests/queries/0_stateless/01852_cast_operator_4.sql
@@ -7,8 +7,14 @@ EXPLAIN SYNTAX SELECT [3,4,5]::Array(Int64)[2]::Int8;
 SELECT [1,2,3]::Array(UInt64)[[number, number]::Array(UInt8)[number]::UInt64]::UInt8 from numbers(3);
 EXPLAIN SYNTAX SELECT [1,2,3]::Array(UInt64)[[number, number]::Array(UInt8)[number]::UInt64]::UInt8 from numbers(3);
 
+WITH [3,4,5] AS x SELECT x[1]::Int32;
+EXPLAIN SYNTAX WITH [3,4,5] AS x SELECT x[1]::Int32;
+
 SELECT tuple(3,4,5).1::Int32;
 EXPLAIN SYNTAX SELECT tuple(3,4,5).1::Int32;
 
 SELECT tuple(3,4,5)::Tuple(UInt64, UInt64, UInt64).2::Int32;
 EXPLAIN SYNTAX SELECT tuple(3,4,5)::Tuple(UInt64, UInt64, UInt64).1::Int32;
+
+WITH tuple(3,4,5) AS x SELECT x.1::Int32;
+EXPLAIN SYNTAX WITH tuple(3,4,5) AS x SELECT x.1::Int32;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add ability to compose PostgreSQL-style cast operator `::` with `ArrayElement` and `TupleElement`.

Fixes #34204.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
