### PR TITLE
Change severity of the "Cancelled merging parts" message in logs

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -3,10 +3,18 @@
 #include <algorithm>
 
 #include <Common/setThreadName.h>
+#include <Common/Exception.h>
 #include <Storages/MergeTree/BackgroundJobsAssignee.h>
+
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int ABORTED;
+}
+
 
 template <class Queue>
 void MergeTreeBackgroundExecutor<Queue>::wait()
@@ -86,11 +94,17 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         ALLOW_ALLOCATIONS_IN_SCOPE;
         need_execute_again = item->task->executeStep();
     }
+    catch (const Exception & e)
+    {
+        if (e.code() == ErrorCodes::ABORTED)    /// Cancelled merging parts is not an error - log as info.
+            LOG_INFO(log, getCurrentExceptionMessage(false));
+        else
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
     catch (...)
     {
         tryLogCurrentException(__PRETTY_FUNCTION__);
     }
-
 
     if (need_execute_again)
     {
@@ -118,7 +132,6 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         return;
     }
 
-
     {
         std::lock_guard guard(mutex);
         erase_from_active();
@@ -132,11 +145,17 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
             /// But it is rather safe, because we have try...catch block here, and another one in ThreadPool.
             item->task->onCompleted();
         }
+        catch (const Exception & e)
+        {
+            if (e.code() == ErrorCodes::ABORTED)    /// Cancelled merging parts is not an error - log as info.
+                LOG_INFO(log, getCurrentExceptionMessage(false));
+            else
+                tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
         }
-
 
         /// We have to call reset() under a lock, otherwise a race is possible.
         /// Imagine, that task is finally completed (last execution returned false),

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -159,7 +159,6 @@ template <class Queue>
 class MergeTreeBackgroundExecutor final : public shared_ptr_helper<MergeTreeBackgroundExecutor<Queue>>
 {
 public:
-
     MergeTreeBackgroundExecutor(
         String name_,
         size_t threads_count_,
@@ -194,7 +193,6 @@ public:
     void wait();
 
 private:
-
     String name;
     size_t threads_count{0};
     size_t max_tasks_count{0};
@@ -210,6 +208,7 @@ private:
     std::condition_variable has_tasks;
     std::atomic_bool shutdown{false};
     ThreadPool pool;
+    Poco::Logger * log = &Poco::Logger::get("MergeTreeBackgroundExecutor");
 };
 
 extern template class MergeTreeBackgroundExecutor<MergeMutateRuntimeQueue>;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Change severity of the "Cancelled merging parts" message in logs, because it's not an error. This closes #34148.