### PR TITLE
Add missing fmt::runtime() in MergeTreeBackgroundExecutor (fixes the build)

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -97,7 +97,7 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
     catch (const Exception & e)
     {
         if (e.code() == ErrorCodes::ABORTED)    /// Cancelled merging parts is not an error - log as info.
-            LOG_INFO(log, getCurrentExceptionMessage(false));
+            LOG_INFO(log, fmt::runtime(getCurrentExceptionMessage(false)));
         else
             tryLogCurrentException(__PRETTY_FUNCTION__);
     }
@@ -148,7 +148,7 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         catch (const Exception & e)
         {
             if (e.code() == ErrorCodes::ABORTED)    /// Cancelled merging parts is not an error - log as info.
-                LOG_INFO(log, getCurrentExceptionMessage(false));
+                LOG_INFO(log, fmt::runtime(getCurrentExceptionMessage(false)));
             else
                 tryLogCurrentException(__PRETTY_FUNCTION__);
         }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: #34232 (cc @alexey-milovidov @alesapin )
Refs: #34223