### PR TITLE
Update clickhouse-keeper.md

### DIFF
--- a/docs/en/operations/clickhouse-keeper.md
+++ b/docs/en/operations/clickhouse-keeper.md
@@ -108,7 +108,8 @@ Examples of configuration for quorum with three nodes can be found in [integrati
 ClickHouse Keeper is bundled into the ClickHouse server package, just add configuration of `<keeper_server>` and start ClickHouse server as always. If you want to run standalone ClickHouse Keeper you can start it in a similar way with:
 
 ```bash
-clickhouse-keeper --config /etc/your_path_to_config/config.xml --daemon
+clickhouse keeper --config /etc/your_path_to_config/config.xml --daemon
+example: clickhouse keeper --config /etc/clickhouse-server/config.d/keeper_config.xml
 ```
 
 ## Four Letter Word Commands {#four-letter-word-commands}


### PR DESCRIPTION
fix the run command and add example


- Documentation (changelog entry is not required)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
