### PR TITLE
Support async inserts in clickhouse-client for queries with inlined data

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -286,7 +286,7 @@ bool Client::executeMultiQuery(const String & all_queries_text)
                 // , where the inline data is delimited by semicolon and not by a
                 // newline.
                 auto * insert_ast = parsed_query->as<ASTInsertQuery>();
-                if (insert_ast && insert_ast->data)
+                if (insert_ast && isSyncInsertWithData(*insert_ast, global_context))
                 {
                     this_query_end = insert_ast->end;
                     adjustQueryEnd(this_query_end, all_queries_end, global_context->getSettingsRef().max_parser_depth);

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -573,6 +573,18 @@ void ClientBase::updateSuggest(const ASTCreateQuery & ast_create)
     suggest->addWords(std::move(new_words));
 }
 
+bool ClientBase::isSyncInsertWithData(const ASTInsertQuery & insert_query, const ContextPtr & context)
+{
+    if (!insert_query.data)
+        return false;
+
+    auto settings = context->getSettings();
+    if (insert_query.settings_ast)
+        settings.applyChanges(insert_query.settings_ast->as<ASTSetQuery>()->changes);
+
+    return !settings.async_insert;
+}
+
 void ClientBase::processTextAsSingleQuery(const String & full_query)
 {
     /// Some parts of a query (result output and formatting) are executed
@@ -597,10 +609,12 @@ void ClientBase::processTextAsSingleQuery(const String & full_query)
             updateSuggest(*create);
     }
 
-    // An INSERT query may have the data that follow query text. Remove the
+    /// An INSERT query may have the data that follow query text. Remove the
     /// Send part of query without data, because data will be sent separately.
-    auto * insert = parsed_query->as<ASTInsertQuery>();
-    if (insert && insert->data)
+    /// For asynchronous inserts we don't extract data, because it's needed
+    /// to be done on server side in that case.
+    const auto * insert = parsed_query->as<ASTInsertQuery>();
+    if (insert && isSyncInsertWithData(*insert, global_context))
         query_to_execute = full_query.substr(0, insert->data - full_query.data());
     else
         query_to_execute = full_query;
@@ -1303,8 +1317,10 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
         if (insert && insert->select)
             insert->tryFindInputFunction(input_function);
 
+        bool is_async_insert = global_context->getSettings().async_insert && insert && insert->hasInlinedData();
+
         /// INSERT query for which data transfer is needed (not an INSERT SELECT or input()) is processed separately.
-        if (insert && (!insert->select || input_function) && !insert->watch)
+        if (insert && (!insert->select || input_function) && !insert->watch && !is_async_insert)
         {
             if (input_function && insert->format.empty())
                 throw Exception("FORMAT must be specified for function input()", ErrorCodes::INVALID_USAGE_OF_INPUT);
@@ -1434,16 +1450,16 @@ MultiQueryProcessingStage ClientBase::analyzeMultiQueryText(
     // row input formats (e.g. TSV) can't tell when the input stops,
     // unlike VALUES.
     auto * insert_ast = parsed_query->as<ASTInsertQuery>();
+    const char * query_to_execute_end = this_query_end;
+
     if (insert_ast && insert_ast->data)
     {
         this_query_end = find_first_symbols<'\n'>(insert_ast->data, all_queries_end);
         insert_ast->end = this_query_end;
-        query_to_execute = all_queries_text.substr(this_query_begin - all_queries_text.data(), insert_ast->data - this_query_begin);
+        query_to_execute_end = isSyncInsertWithData(*insert_ast, global_context) ? insert_ast->data : this_query_end;
     }
-    else
-    {
-        query_to_execute = all_queries_text.substr(this_query_begin - all_queries_text.data(), this_query_end - this_query_begin);
-    }
+
+    query_to_execute = all_queries_text.substr(this_query_begin - all_queries_text.data(), query_to_execute_end - this_query_begin);
 
     // Try to include the trailing comment with test hints. It is just
     // a guess for now, because we don't yet know where the query ends

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -609,10 +609,10 @@ void ClientBase::processTextAsSingleQuery(const String & full_query)
             updateSuggest(*create);
     }
 
-    /// An INSERT query may have the data that follow query text. Remove the
-    /// Send part of query without data, because data will be sent separately.
-    /// For asynchronous inserts we don't extract data, because it's needed
-    /// to be done on server side in that case.
+    /// An INSERT query may have the data that follows query text.
+    /// Send part of the query without data, because data will be sent separately.
+    /// But for asynchronous inserts we don't extract data, because it's needed
+    /// to be done on server side in that case (for coalescing the data from multiple inserts on server side).
     const auto * insert = parsed_query->as<ASTInsertQuery>();
     if (insert && isSyncInsertWithData(*insert, global_context))
         query_to_execute = full_query.substr(0, insert->data - full_query.data());

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -139,6 +139,8 @@ private:
     void updateSuggest(const ASTCreateQuery & ast_create);
 
 protected:
+    static bool isSyncInsertWithData(const ASTInsertQuery & insert_query, const ContextPtr & context);
+
     bool is_interactive = false; /// Use either interactive line editing interface or batch mode.
     bool is_multiquery = false;
     bool delayed_interactive = false;

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -80,6 +80,7 @@
     M(SyncDrainedConnections, "Number of connections drained synchronously.") \
     M(ActiveSyncDrainedConnections, "Number of active connections drained synchronously.") \
     M(AsynchronousReadWait, "Number of threads waiting for asynchronous read.") \
+    M(PendingAsyncInsert, "Number of asynchronous inserts that are waiting for flush.") \
 
 namespace CurrentMetrics
 {

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -8,6 +8,7 @@
     M(Query, "Number of queries to be interpreted and potentially executed. Does not include queries that failed to parse or were rejected due to AST size limits, quota limits or limits on the number of simultaneously running queries. May include internal queries initiated by ClickHouse itself. Does not count subqueries.") \
     M(SelectQuery, "Same as Query, but only for SELECT queries.") \
     M(InsertQuery, "Same as Query, but only for INSERT queries.") \
+    M(AsyncInsertQuery, "Same as InsertQuery, but only for asynchronous INSERT queries.") \
     M(FailedQuery, "Number of failed queries.") \
     M(FailedSelectQuery, "Same as FailedQuery, but only for SELECT queries.") \
     M(FailedInsertQuery, "Same as FailedQuery, but only for INSERT queries.") \

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -24,6 +24,16 @@
 #include <base/logger_useful.h>
 
 
+namespace CurrentMetrics
+{
+    extern const Metric PendingAsyncInsert;
+}
+
+namespace ProfileEvents
+{
+    extern const Event AsyncInsertQuery;
+}
+
 namespace DB
 {
 
@@ -223,6 +233,9 @@ void AsynchronousInsertQueue::pushImpl(InsertData::EntryPtr entry, QueueIterator
 
     if (data->size > max_data_size)
         scheduleDataProcessingJob(it->first, std::move(data), getContext());
+
+    CurrentMetrics::add(CurrentMetrics::PendingAsyncInsert);
+    ProfileEvents::increment(ProfileEvents::AsyncInsertQuery);
 }
 
 void AsynchronousInsertQueue::waitForProcessingQuery(const String & query_id, const Milliseconds & timeout)
@@ -437,6 +450,8 @@ try
     for (const auto & entry : data->entries)
         if (!entry->isFinished())
             entry->finish();
+
+    CurrentMetrics::sub(CurrentMetrics::PendingAsyncInsert, data->entries.size());
 }
 catch (const Exception & e)
 {

--- a/tests/queries/0_stateless/02193_async_insert_tcp_client_1.reference
+++ b/tests/queries/0_stateless/02193_async_insert_tcp_client_1.reference
@@ -1,0 +1,5 @@
+1	aaa
+2	bbb
+3	ccc
+4	ddd
+4	4

--- a/tests/queries/0_stateless/02193_async_insert_tcp_client_1.sql
+++ b/tests/queries/0_stateless/02193_async_insert_tcp_client_1.sql
@@ -1,0 +1,27 @@
+DROP TABLE IF EXISTS t_async_insert_02193_1;
+
+CREATE TABLE t_async_insert_02193_1 (id UInt32, s String) ENGINE = Memory;
+
+INSERT INTO t_async_insert_02193_1 FORMAT CSV SETTINGS async_insert = 1
+1,aaa
+;
+
+INSERT INTO t_async_insert_02193_1 FORMAT Values SETTINGS async_insert = 1 (2, 'bbb');
+
+SET async_insert = 1;
+
+INSERT INTO t_async_insert_02193_1 VALUES (3, 'ccc');
+INSERT INTO t_async_insert_02193_1 FORMAT JSONEachRow {"id": 4, "s": "ddd"};
+
+SELECT * FROM t_async_insert_02193_1 ORDER BY id;
+
+SYSTEM FLUSH LOGS;
+
+SELECT count(), sum(ProfileEvents['AsyncInsertQuery']) FROM system.query_log
+WHERE
+    event_date >= yesterday() AND
+    type = 'QueryFinish' AND
+    current_database = currentDatabase() AND
+    query ILIKE 'INSERT INTO t_async_insert_02193_1%';
+
+DROP TABLE IF EXISTS t_async_insert_02193_1;

--- a/tests/queries/0_stateless/02193_async_insert_tcp_client_2.reference
+++ b/tests/queries/0_stateless/02193_async_insert_tcp_client_2.reference
@@ -1,0 +1,4 @@
+1	aaa
+2	bbb
+3	ccc
+4	ddd

--- a/tests/queries/0_stateless/02193_async_insert_tcp_client_2.sh
+++ b/tests/queries/0_stateless/02193_async_insert_tcp_client_2.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Tags: long
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_async_insert_02193_2"
+
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_async_insert_02193_2 (id UInt32, s String) ENGINE = Memory"
+
+${CLICKHOUSE_CLIENT} -q "INSERT INTO t_async_insert_02193_2 FORMAT CSV SETTINGS async_insert = 1 1,aaa"
+${CLICKHOUSE_CLIENT} -q "INSERT INTO t_async_insert_02193_2 FORMAT Values SETTINGS async_insert = 1 (2, 'bbb')"
+
+${CLICKHOUSE_CLIENT} -q "INSERT INTO t_async_insert_02193_2 VALUES (3, 'ccc')"
+${CLICKHOUSE_CLIENT} -q 'INSERT INTO t_async_insert_02193_2 FORMAT JSONEachRow {"id": 4, "s": "ddd"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM t_async_insert_02193_2 ORDER BY id"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t_async_insert_02193_2"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_async_insert_02193_2"


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support asynchronous inserts in `clickhouse-client` for queries with inlined data.