### PR TITLE
Update quick-start commands

### DIFF
--- a/docs/_includes/install/deb.sh
+++ b/docs/_includes/install/deb.sh
@@ -8,4 +8,4 @@ sudo apt-get update
 sudo apt-get install -y clickhouse-server clickhouse-client
 
 sudo service clickhouse-server start
-clickhouse-client
+clickhouse-client --password

--- a/docs/_includes/install/rpm.sh
+++ b/docs/_includes/install/rpm.sh
@@ -4,4 +4,4 @@ sudo yum-config-manager --add-repo https://repo.clickhouse.com/rpm/clickhouse.re
 sudo yum install clickhouse-server clickhouse-client
 
 sudo /etc/init.d/clickhouse-server start
-clickhouse-client
+clickhouse-client --password


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Updates the quick-start commands for deb and rpm to include the `--password` option.