### PR TITLE
Add 'clickhouse-client --password' comment to the scripts used in Qui…

### DIFF
--- a/docs/_includes/install/deb.sh
+++ b/docs/_includes/install/deb.sh
@@ -8,4 +8,4 @@ sudo apt-get update
 sudo apt-get install -y clickhouse-server clickhouse-client
 
 sudo service clickhouse-server start
-clickhouse-client
+clickhouse-client # or "clickhouse-client --password" if you set up a password.

--- a/docs/_includes/install/rpm.sh
+++ b/docs/_includes/install/rpm.sh
@@ -4,4 +4,4 @@ sudo yum-config-manager --add-repo https://repo.clickhouse.com/rpm/clickhouse.re
 sudo yum install clickhouse-server clickhouse-client
 
 sudo /etc/init.d/clickhouse-server start
-clickhouse-client
+clickhouse-client # or "clickhouse-client --password" if you set up a password.


### PR DESCRIPTION
…ck Start Guide https://clickhouse.com/#quick-start

Changelog category (leave one):
- Documentation (changelog entry is not required)

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
Not needed?

The problem is very simple: if I follow the Quick Start Guide for Ubuntu/Debian the last command does not start ClickHouse client and finishes with an error.

 A solution is trivial but I have to google it or read a detailed log of the previous (not the last executed) command.

What should be changed:
```clickhouse-client```

should be replaced with
```clickhouse-client --password```

Below is a complete installation log for a clean Ubuntu:

```
xubuntu@xubuntu:~$ sudo apt-get install apt-transport-https ca-certificates dirmngr
Reading package lists... Done
Building dependency tree       
Reading state information... Done
dirmngr is already the newest version (2.2.19-3ubuntu2.1).
dirmngr set to manually installed.
The following NEW packages will be installed:
  apt-transport-https
The following packages will be upgraded:
  ca-certificates
1 upgraded, 1 newly installed, 0 to remove and 192 not upgraded.
Need to get 150 kB of archives.
After this operation, 161 kB of additional disk space will be used.
Do you want to continue? [Y/n] 
Get:1 http://security.ubuntu.com/ubuntu focal-security/main amd64 ca-certificates all 20210119~20.04.2 [145 kB]
Get:2 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 apt-transport-https all 2.0.6 [4,680 B]
Fetched 150 kB in 1s (149 kB/s)                
Preconfiguring packages ...
(Reading database ... 161160 files and directories currently installed.)
Preparing to unpack .../ca-certificates_20210119~20.04.2_all.deb ...
Unpacking ca-certificates (20210119~20.04.2) over (20210119~20.04.1) ...
Selecting previously unselected package apt-transport-https.
Preparing to unpack .../apt-transport-https_2.0.6_all.deb ...
Unpacking apt-transport-https (2.0.6) ...
Setting up apt-transport-https (2.0.6) ...
Setting up ca-certificates (20210119~20.04.2) ...
Updating certificates in /etc/ssl/certs...
0 added, 1 removed; done.
Processing triggers for man-db (2.9.1-1) ...
Processing triggers for ca-certificates (20210119~20.04.2) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.


xubuntu@xubuntu:~$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E0C56BD4
Executing: /tmp/apt-key-gpghome.vjwE5NXgcT/gpg.1.sh --keyserver hkp://keyserver.ubuntu.com:80 --recv E0C56BD4
gpg: key C8F1E19FE0C56BD4: public key "ClickHouse Repository Key <milovidov@yandex-team.ru>" imported
gpg: Total number processed: 1
gpg:               imported: 1
xubuntu@xubuntu:~$ echo "deb https://repo.clickhouse.com/deb/stable/ main/" | sudo tee \
>     /etc/apt/sources.list.d/clickhouse.list
deb https://repo.clickhouse.com/deb/stable/ main/
xubuntu@xubuntu:~$ sudo apt-get update
Ign:1 cdrom://Xubuntu 20.04.3 LTS _Focal Fossa_ - Release amd64 (20210819.1) focal InRelease
Hit:2 cdrom://Xubuntu 20.04.3 LTS _Focal Fossa_ - Release amd64 (20210819.1) focal Release
Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease                                              
Hit:5 http://archive.ubuntu.com/ubuntu focal InRelease                                                        
Ign:6 https://repo.clickhouse.com/deb/stable main/ InRelease
Hit:7 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Get:8 https://repo.clickhouse.com/deb/stable main/ Release [749 B]
Get:9 https://repo.clickhouse.com/deb/stable main/ Release.gpg [836 B]
Get:10 https://repo.clickhouse.com/deb/stable main/ Packages [230 kB]
Fetched 231 kB in 2s (128 kB/s)    
Reading package lists... Done


xubuntu@xubuntu:~$ sudo apt-get install -y clickhouse-server clickhouse-client
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  clickhouse-common-static
Suggested packages:
  clickhouse-common-static-dbg
The following NEW packages will be installed:
  clickhouse-client clickhouse-common-static clickhouse-server
0 upgraded, 3 newly installed, 0 to remove and 192 not upgraded.
Need to get 216 MB of archives.
After this operation, 711 MB of additional disk space will be used.
Get:1 https://repo.clickhouse.com/deb/stable main/ clickhouse-common-static 22.1.3.7 [215 MB]
Get:2 https://repo.clickhouse.com/deb/stable main/ clickhouse-client 22.1.3.7 [124 kB]                        
Get:3 https://repo.clickhouse.com/deb/stable main/ clickhouse-server 22.1.3.7 [147 kB]                        
Fetched 216 MB in 20s (11.0 MB/s)                                                                             
Selecting previously unselected package clickhouse-common-static.
(Reading database ... 161163 files and directories currently installed.)
Preparing to unpack .../clickhouse-common-static_22.1.3.7_amd64.deb ...
Unpacking clickhouse-common-static (22.1.3.7) ...
Selecting previously unselected package clickhouse-client.
Preparing to unpack .../clickhouse-client_22.1.3.7_all.deb ...
Unpacking clickhouse-client (22.1.3.7) ...
Selecting previously unselected package clickhouse-server.
Preparing to unpack .../clickhouse-server_22.1.3.7_all.deb ...
Unpacking clickhouse-server (22.1.3.7) ...
Setting up clickhouse-common-static (22.1.3.7) ...
Setting up clickhouse-server (22.1.3.7) ...
ClickHouse binary is already located at /usr/bin/clickhouse
Symlink /usr/bin/clickhouse-server already exists but it points to /clickhouse. Will replace the old symlink to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-server to /usr/bin/clickhouse.
Symlink /usr/bin/clickhouse-client already exists but it points to /clickhouse. Will replace the old symlink to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-client to /usr/bin/clickhouse.
Symlink /usr/bin/clickhouse-local already exists but it points to /clickhouse. Will replace the old symlink to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-local to /usr/bin/clickhouse.
Symlink /usr/bin/clickhouse-benchmark already exists but it points to /clickhouse. Will replace the old symlink to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-benchmark to /usr/bin/clickhouse.
Symlink /usr/bin/clickhouse-copier already exists but it points to /clickhouse. Will replace the old symlink to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-copier to /usr/bin/clickhouse.
Symlink /usr/bin/clickhouse-obfuscator already exists but it points to /clickhouse. Will replace the old symlink to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-obfuscator to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-git-import to /usr/bin/clickhouse.
Symlink /usr/bin/clickhouse-compressor already exists but it points to /clickhouse. Will replace the old symlink to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-compressor to /usr/bin/clickhouse.
Symlink /usr/bin/clickhouse-format already exists but it points to /clickhouse. Will replace the old symlink to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-format to /usr/bin/clickhouse.
Symlink /usr/bin/clickhouse-extract-from-config already exists but it points to /clickhouse. Will replace the old symlink to /usr/bin/clickhouse.
Creating symlink /usr/bin/clickhouse-extract-from-config to /usr/bin/clickhouse.
Creating clickhouse group if it does not exist.
 groupadd -r clickhouse
Creating clickhouse user if it does not exist.
 useradd -r --shell /bin/false --home-dir /nonexistent -g clickhouse clickhouse
Will set ulimits for clickhouse user in /etc/security/limits.d/clickhouse.conf.
Creating config directory /etc/clickhouse-server/config.d that is used for tweaks of main server configuration.
Creating config directory /etc/clickhouse-server/users.d that is used for tweaks of users configuration.
Config file /etc/clickhouse-server/config.xml already exists, will keep it and extract path info from it.
/etc/clickhouse-server/config.xml has /var/lib/clickhouse/ as data path.
/etc/clickhouse-server/config.xml has /var/log/clickhouse-server/ as log path.
Users config file /etc/clickhouse-server/users.xml already exists, will keep it and extract users info from it.
Creating log directory /var/log/clickhouse-server/.
Creating data directory /var/lib/clickhouse/.
Creating pid directory /var/run/clickhouse-server.
 chown -R clickhouse:clickhouse '/var/log/clickhouse-server/'
 chown -R clickhouse:clickhouse '/var/run/clickhouse-server'
 chown  clickhouse:clickhouse '/var/lib/clickhouse/'
 groupadd -r clickhouse-bridge
 useradd -r --shell /bin/false --home-dir /nonexistent -g clickhouse-bridge clickhouse-bridge
 chown -R clickhouse-bridge:clickhouse-bridge '/usr/bin/clickhouse-odbc-bridge'
 chown -R clickhouse-bridge:clickhouse-bridge '/usr/bin/clickhouse-library-bridge'
Enter password for default user: 
Password for default user is saved in file /etc/clickhouse-server/users.d/default-password.xml.
Setting capabilities for clickhouse binary. This is optional.
 chown -R clickhouse:clickhouse '/etc/clickhouse-server'

ClickHouse has been successfully installed.

Start clickhouse-server with:
 sudo clickhouse start

Start clickhouse-client with:
 clickhouse-client --password

Synchronizing state of clickhouse-server.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable clickhouse-server
Created symlink /etc/systemd/system/multi-user.target.wants/clickhouse-server.service → /etc/systemd/system/clickhouse-server.service.
Setting up clickhouse-client (22.1.3.7) ...
Processing triggers for systemd (245.4-4ubuntu3.11) ...


xubuntu@xubuntu:~$ sudo service clickhouse-server start


xubuntu@xubuntu:~$ clickhouse-client
ClickHouse client version 22.1.3.7 (official build).
Connecting to localhost:9000 as user default.

If you have installed ClickHouse and forgot password you can reset it in the configuration file.
The password for default user is typically located at /etc/clickhouse-server/users.d/default-password.xml
and deleting this file will reset the password.
See also /etc/clickhouse-server/users.xml on the server where ClickHouse is installed.

Code: 516. DB::Exception: Received from localhost:9000. DB::Exception: default: Authentication failed: password is incorrect or there is no user with such name. (AUTHENTICATION_FAILED)


xubuntu@xubuntu:~$ clickhouse-client --password
ClickHouse client version 22.1.3.7 (official build).
Password for user (default): 
Connecting to localhost:9000 as user default.
Connected to ClickHouse server version 22.1.3 revision 54455.

xubuntu :) Bye.
xubuntu@xubuntu:~$
```