### PR TITLE
fix performance: MergeTreeRangeReader immediately return if pre where matc…

### DIFF
--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -645,12 +645,12 @@ MergeTreeRangeReader::ReadResult MergeTreeRangeReader::read(size_t max_rows, Mar
     {
         read_result = prev_reader->read(max_rows, ranges);
 
-        size_t num_read_rows;
-        Columns columns = continueReadingChain(read_result, num_read_rows);
-
         /// Nothing to do. Return empty result.
         if (read_result.num_rows == 0)
             return read_result;
+
+        size_t num_read_rows;
+        Columns columns = continueReadingChain(read_result, num_read_rows);
 
         bool has_columns = false;
         size_t total_bytes = 0;


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Improve MergeTree read performance, if per where has 0 rows, immediately return.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
