### PR TITLE
Fix parallel loading of data parts

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -54,6 +54,7 @@ void ThreadPoolImpl<Thread>::setMaxThreads(size_t value)
 {
     std::lock_guard lock(mutex);
     max_threads = value;
+    /// We have to also adjust queue size, because it limits the number of scheduled and already running jobs in total.
     queue_size = std::max(queue_size, max_threads);
     jobs.reserve(queue_size);
 }

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -54,6 +54,8 @@ void ThreadPoolImpl<Thread>::setMaxThreads(size_t value)
 {
     std::lock_guard lock(mutex);
     max_threads = value;
+    queue_size = std::max(queue_size, max_threads);
+    jobs.reserve(queue_size);
 }
 
 template <typename Thread>

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1286,7 +1286,6 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
         return;
     }
 
-
     DataPartsVector broken_parts_to_detach;
     DataPartsVector duplicate_parts_to_remove;
 
@@ -1356,7 +1355,6 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
     }
 
     calculateColumnAndSecondaryIndexSizesImpl();
-
 
     LOG_DEBUG(log, "Loaded data parts ({} items)", data_parts_indexes.size());
 }


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up loading of data parts. It was not parallelized before: the setting `part_loading_threads` did not have effect. See #4699.