### PR TITLE
Decrease severity for "Reading ... ranges ..." log message to Trace

### DIFF
--- a/src/Storages/MergeTree/MergeTreeInOrderSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeInOrderSelectProcessor.h
@@ -15,7 +15,7 @@ public:
     explicit MergeTreeInOrderSelectProcessor(Args &&... args)
         : MergeTreeSelectProcessor{std::forward<Args>(args)...}
     {
-        LOG_DEBUG(log, "Reading {} ranges in order from part {}, approx. {} rows starting from {}",
+        LOG_TRACE(log, "Reading {} ranges in order from part {}, approx. {} rows starting from {}",
             all_mark_ranges.size(), data_part->name, total_rows,
             data_part->index_granularity.getMarkStartingRow(all_mark_ranges.front().begin));
     }

--- a/src/Storages/MergeTree/MergeTreeReverseSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeReverseSelectProcessor.h
@@ -16,7 +16,7 @@ public:
     explicit MergeTreeReverseSelectProcessor(Args &&... args)
         : MergeTreeSelectProcessor{std::forward<Args>(args)...}
     {
-        LOG_DEBUG(log, "Reading {} ranges in reverse order from part {}, approx. {} rows starting from {}",
+        LOG_TRACE(log, "Reading {} ranges in reverse order from part {}, approx. {} rows starting from {}",
             all_mark_ranges.size(), data_part->name, total_rows,
             data_part->index_granularity.getMarkStartingRow(all_mark_ranges.front().begin));
     }


### PR DESCRIPTION
That way with `send_logs_level='debug'`, you will not get verbose
information that you already has, since there is summary row:

    Selected ... parts by partition key, ... parts by primary key, ... marks by primary key, ... marks to read from ... ranges

Changelog category (leave one):
- Not for changelog (changelog entry is not required)