### PR TITLE
use LowCardinality type for _file and _path in some Storages, continue of #34317

### DIFF
--- a/src/DataTypes/DataTypeLowCardinality.h
+++ b/src/DataTypes/DataTypeLowCardinality.h
@@ -13,7 +13,7 @@ private:
     DataTypePtr dictionary_type;
 
 public:
-    DataTypeLowCardinality(DataTypePtr dictionary_type_);
+    explicit DataTypeLowCardinality(DataTypePtr dictionary_type_);
 
     const DataTypePtr & getDictionaryType() const { return dictionary_type; }
 

--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -1,3 +1,4 @@
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <IO/ReadBufferFromFile.h>
@@ -966,7 +967,9 @@ bool StorageFileLog::updateFileInfos()
 
 NamesAndTypesList StorageFileLog::getVirtuals() const
 {
-    return NamesAndTypesList{{"_filename", std::make_shared<DataTypeString>()}, {"_offset", std::make_shared<DataTypeUInt64>()}};
+    return NamesAndTypesList{
+        {"_filename", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
+        {"_offset", std::make_shared<DataTypeUInt64>()}};
 }
 
 Names StorageFileLog::getVirtualColumnNames()

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -258,9 +258,15 @@ Block HDFSSource::getHeader(const StorageMetadataPtr & metadata_snapshot, bool n
     auto header = metadata_snapshot->getSampleBlock();
     /// Note: AddingDefaultsBlockInputStream doesn't change header.
     if (need_path_column)
-        header.insert({DataTypeString().createColumn(), std::make_shared<DataTypeString>(), "_path"});
+        header.insert(
+            {DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn(),
+             std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()),
+             "_path"});
     if (need_file_column)
-        header.insert({DataTypeString().createColumn(), std::make_shared<DataTypeString>(), "_file"});
+        header.insert(
+            {DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn(),
+             std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()),
+             "_file"});
     return header;
 }
 
@@ -378,7 +384,7 @@ Chunk HDFSSource::generate()
         /// Enrich with virtual columns.
         if (need_path_column)
         {
-            auto column = DataTypeString().createColumnConst(num_rows, current_path);
+            auto column = DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumnConst(num_rows, current_path);
             columns.push_back(column->convertToFullColumnIfConst());
         }
 
@@ -387,7 +393,7 @@ Chunk HDFSSource::generate()
             size_t last_slash_pos = current_path.find_last_of('/');
             auto file_name = current_path.substr(last_slash_pos + 1);
 
-            auto column = DataTypeString().createColumnConst(num_rows, std::move(file_name));
+            auto column = DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumnConst(num_rows, std::move(file_name));
             columns.push_back(column->convertToFullColumnIfConst());
         }
 
@@ -689,9 +695,8 @@ void registerStorageHDFS(StorageFactory & factory)
 NamesAndTypesList StorageHDFS::getVirtuals() const
 {
     return NamesAndTypesList{
-        {"_path", std::make_shared<DataTypeString>()},
-        {"_file", std::make_shared<DataTypeString>()}
-    };
+        {"_path", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
+        {"_file", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())}};
 }
 
 }

--- a/src/Storages/HDFS/StorageHDFSCluster.cpp
+++ b/src/Storages/HDFS/StorageHDFSCluster.cpp
@@ -138,9 +138,8 @@ QueryProcessingStage::Enum StorageHDFSCluster::getQueryProcessingStage(
 NamesAndTypesList StorageHDFSCluster::getVirtuals() const
 {
     return NamesAndTypesList{
-        {"_path", std::make_shared<DataTypeString>()},
-        {"_file", std::make_shared<DataTypeString>()}
-    };
+        {"_path", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
+        {"_file", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())}};
 }
 
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -302,13 +302,13 @@ NamesAndTypesList StorageDistributed::getVirtuals() const
     /// NOTE This is weird. Most of these virtual columns are part of MergeTree
     /// tables info. But Distributed is general-purpose engine.
     return NamesAndTypesList{
-            NameAndTypePair("_table", std::make_shared<DataTypeString>()),
-            NameAndTypePair("_part", std::make_shared<DataTypeString>()),
-            NameAndTypePair("_part_index", std::make_shared<DataTypeUInt64>()),
-            NameAndTypePair("_part_uuid", std::make_shared<DataTypeUUID>()),
-            NameAndTypePair("_partition_id", std::make_shared<DataTypeString>()),
-            NameAndTypePair("_sample_factor", std::make_shared<DataTypeFloat64>()),
-            NameAndTypePair("_shard_num", std::make_shared<DataTypeUInt32>()), /// deprecated
+        NameAndTypePair("_table", std::make_shared<DataTypeString>()),
+        NameAndTypePair("_part", std::make_shared<DataTypeString>()),
+        NameAndTypePair("_part_index", std::make_shared<DataTypeUInt64>()),
+        NameAndTypePair("_part_uuid", std::make_shared<DataTypeUUID>()),
+        NameAndTypePair("_partition_id", std::make_shared<DataTypeString>()),
+        NameAndTypePair("_sample_factor", std::make_shared<DataTypeFloat64>()),
+        NameAndTypePair("_shard_num", std::make_shared<DataTypeUInt32>()), /// deprecated
     };
 }
 

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -209,9 +209,15 @@ String StorageS3Source::KeysIterator::next()
 Block StorageS3Source::getHeader(Block sample_block, bool with_path_column, bool with_file_column)
 {
     if (with_path_column)
-        sample_block.insert({DataTypeString().createColumn(), std::make_shared<DataTypeString>(), "_path"});
+        sample_block.insert(
+            {DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn(),
+             std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()),
+             "_path"});
     if (with_file_column)
-        sample_block.insert({DataTypeString().createColumn(), std::make_shared<DataTypeString>(), "_file"});
+        sample_block.insert(
+            {DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn(),
+             std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()),
+             "_file"});
 
     return sample_block;
 }
@@ -305,12 +311,15 @@ Chunk StorageS3Source::generate()
         UInt64 num_rows = chunk.getNumRows();
 
         if (with_path_column)
-            chunk.addColumn(DataTypeString().createColumnConst(num_rows, file_path)->convertToFullColumnIfConst());
+            chunk.addColumn(DataTypeLowCardinality{std::make_shared<DataTypeString>()}
+                                .createColumnConst(num_rows, file_path)
+                                ->convertToFullColumnIfConst());
         if (with_file_column)
         {
             size_t last_slash_pos = file_path.find_last_of('/');
-            chunk.addColumn(DataTypeString().createColumnConst(num_rows, file_path.substr(
-                    last_slash_pos + 1))->convertToFullColumnIfConst());
+            chunk.addColumn(DataTypeLowCardinality{std::make_shared<DataTypeString>()}
+                                .createColumnConst(num_rows, file_path.substr(last_slash_pos + 1))
+                                ->convertToFullColumnIfConst());
         }
 
         return chunk;
@@ -961,9 +970,8 @@ void registerStorageCOS(StorageFactory & factory)
 NamesAndTypesList StorageS3::getVirtuals() const
 {
     return NamesAndTypesList{
-        {"_path", std::make_shared<DataTypeString>()},
-        {"_file", std::make_shared<DataTypeString>()}
-    };
+        {"_path", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
+        {"_file", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())}};
 }
 
 bool StorageS3::supportsPartitionBy() const

--- a/src/Storages/StorageS3Cluster.cpp
+++ b/src/Storages/StorageS3Cluster.cpp
@@ -152,9 +152,8 @@ QueryProcessingStage::Enum StorageS3Cluster::getQueryProcessingStage(
 NamesAndTypesList StorageS3Cluster::getVirtuals() const
 {
     return NamesAndTypesList{
-        {"_path", std::make_shared<DataTypeString>()},
-        {"_file", std::make_shared<DataTypeString>()}
-    };
+        {"_path", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
+        {"_file", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())}};
 }
 
 


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Closes #34300.