### PR TITLE
Fix wrong OK_SKIP labels

### DIFF
--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -18,7 +18,7 @@ TRUSTED_ORG_IDS = {
     54801242,  # clickhouse
 }
 
-OK_SKIP_LABELS = {"release", "pr-documentation", "pr-doc-fix"}
+OK_SKIP_LABELS = {"release", "pr-backport", "pr-cherrypick"}
 CAN_BE_TESTED_LABEL = "can be tested"
 DO_NOT_TEST_LABEL = "do not test"
 FORCE_TESTS_LABEL = "force tests"


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix previously wrong OK_SKIP_LABELS in run_check.py