### PR TITLE
Add options for clickhouse-format. 

### DIFF
--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -57,8 +57,12 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
     ;
 
+    Settings cmd_settings;
+    cmd_settings.addFormatOptions(desc);
+
     boost::program_options::variables_map options;
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), options);
+    po::notify(options);
 
     if (options.count("help"))
     {
@@ -149,7 +153,8 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             ParserQuery parser(end);
             do
             {
-                ASTPtr res = parseQueryAndMovePosition(parser, pos, end, "query", multiple, 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
+                ASTPtr res = parseQueryAndMovePosition(
+                    parser, pos, end, "query", multiple, cmd_settings.max_query_size, cmd_settings.max_parser_depth);
                 /// For insert query with data(INSERT INTO ... VALUES ...), will lead to format fail,
                 /// should throw exception early and make exception message more readable.
                 if (const auto * insert_query = res->as<ASTInsertQuery>(); insert_query && insert_query->data)
@@ -222,6 +227,5 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         std::cerr << getCurrentExceptionMessage(true) << '\n';
         return getCurrentExceptionCode();
     }
-
     return 0;
 }

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -58,7 +58,11 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
     ;
 
     Settings cmd_settings;
-    cmd_settings.addFormatOptions(desc);
+    for (const auto & field : cmd_settings.all())
+    {
+        if (field.getName() == "max_parser_depth" || field.getName() == "max_query_size")
+            cmd_settings.addProgramOption(desc, field);
+    }
 
     boost::program_options::variables_map options;
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), options);

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -85,14 +85,26 @@ void Settings::addProgramOptions(boost::program_options::options_description & o
 {
     for (const auto & field : all())
     {
-        const std::string_view name = field.getName();
-        auto on_program_option
-            = boost::function1<void, const std::string &>([this, name](const std::string & value) { set(name, value); });
-        options.add(boost::shared_ptr<boost::program_options::option_description>(new boost::program_options::option_description(
-            name.data(),
-            boost::program_options::value<std::string>()->composing()->notifier(on_program_option),
-            field.getDescription())));
+        addProgramOption(options, field);
     }
+}
+
+void Settings::addFormatOptions(boost::program_options::options_description & options)
+{
+    for (const auto & field : all())
+    {
+        const auto & name = field.getName();
+        if (formatSettingNames.count(name))
+            addProgramOption(options, field);
+    }
+}
+
+void Settings::addProgramOption(boost::program_options::options_description & options, const SettingFieldRef & field)
+{
+    const std::string_view name = field.getName();
+    auto on_program_option = boost::function1<void, const std::string &>([this, name](const std::string & value) { set(name, value); });
+    options.add(boost::shared_ptr<boost::program_options::option_description>(new boost::program_options::option_description(
+        name.data(), boost::program_options::value<std::string>()->composing()->notifier(on_program_option), field.getDescription())));
 }
 
 void Settings::checkNoSettingNamesAtTopLevel(const Poco::Util::AbstractConfiguration & config, const String & config_path)

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -89,16 +89,6 @@ void Settings::addProgramOptions(boost::program_options::options_description & o
     }
 }
 
-void Settings::addFormatOptions(boost::program_options::options_description & options)
-{
-    for (const auto & field : all())
-    {
-        const auto & name = field.getName();
-        if (formatSettingNames.count(name))
-            addProgramOption(options, field);
-    }
-}
-
 void Settings::addProgramOption(boost::program_options::options_description & options, const SettingFieldRef & field)
 {
     const std::string_view name = field.getName();

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -712,21 +712,13 @@ struct Settings : public BaseSettings<SettingsTraits>, public IHints<2, Settings
     /// (Don't forget to call notify() on the `variables_map` after parsing it!)
     void addProgramOptions(boost::program_options::options_description & options);
 
-    /// Adds program options for clickhouse-format to set the settings from a command line.
-    /// (Don't forget to call notify() on the `variables_map` after parsing it!)
-    void addFormatOptions(boost::program_options::options_description & options);
-
     /// Check that there is no user-level settings at the top level in config.
     /// This is a common source of mistake (user don't know where to write user-level setting).
     static void checkNoSettingNamesAtTopLevel(const Poco::Util::AbstractConfiguration & config, const String & config_path);
 
     std::vector<String> getAllRegisteredNames() const override;
 
-private:
     void addProgramOption(boost::program_options::options_description & options, const SettingFieldRef & field);
-
-    inline static const std::unordered_set<String> formatSettingNames
-        = {"max_parser_depth", "max_query_size"};
 };
 
 /*

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -712,11 +712,21 @@ struct Settings : public BaseSettings<SettingsTraits>, public IHints<2, Settings
     /// (Don't forget to call notify() on the `variables_map` after parsing it!)
     void addProgramOptions(boost::program_options::options_description & options);
 
+    /// Adds program options for clickhouse-format to set the settings from a command line.
+    /// (Don't forget to call notify() on the `variables_map` after parsing it!)
+    void addFormatOptions(boost::program_options::options_description & options);
+
     /// Check that there is no user-level settings at the top level in config.
     /// This is a common source of mistake (user don't know where to write user-level setting).
     static void checkNoSettingNamesAtTopLevel(const Poco::Util::AbstractConfiguration & config, const String & config_path);
 
     std::vector<String> getAllRegisteredNames() const override;
+
+private:
+    void addProgramOption(boost::program_options::options_description & options, const SettingFieldRef & field);
+
+    inline static const std::unordered_set<String> formatSettingNames
+        = {"max_parser_depth", "max_query_size"};
 };
 
 /*


### PR DESCRIPTION
Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add options for clickhouse-format. Which close https://github.com/ClickHouse/ClickHouse/issues/30528
- max_query_size 
- max_parser_depth

```
$ ./clickhouse format  -h                    
Usage: ./clickhouse [options] < query
Allowed options:
  --query arg            query to format
  -h [ --help ]          produce help message
  --hilite               add syntax highlight with ANSI terminal escape sequences
  --oneline              format in single line
  -q [ --quiet ]         just check syntax, no output on success
  -n [ --multiquery ]    allow multiple queries in the same file
  --obfuscate            obfuscate instead of formatting
  --backslash            add a backslash at the end of each line of the formatted query
  --seed arg             seed (arbitrary string) that determines the result of obfuscation
  --max_query_size arg   Which part of the query can be read into RAM for parsing (the remaining data for INSERT, if any, is read later)
  --max_parser_depth arg Maximum parser depth (recursion depth of recursive descend parser).



$ ./clickhouse format  --max_query_size  3    
select 1    
Code: 62. DB::Exception: Syntax error (query): failed at position 1 ('select'): select 1
. Max query size exceeded: 'select'. (SYNTAX_ERROR), Stack trace (when copying this message, always include the lines below):

0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x1541b90c in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0xa667a7a in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
2. DB::parseQueryAndMovePosition(DB::IParser&, char const*&, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long, unsigned long) @ 0x1385d500 in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
3. mainEntryClickHouseFormat(int, char**) @ 0xa7994d9 in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
4. main @ 0xa6616e1 in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
5. __libc_start_main @ 0x7f6568c7f0b3 in ?
6. _start @ 0xa66106e in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
 (version 22.2.1.1)


$ ./clickhouse format  --max_parser_depth  1               
select n from (select number as n from system.numbers limit 100) 
Code: 306. DB::Exception: Maximum parse depth (1) exceeded. Consider rising max_parser_depth parameter. (TOO_DEEP_RECURSION), Stack trace (when copying this message, always include the lines below):

0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x1541b90c in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0xa667a7a in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
2. DB::IParserBase::parse(DB::IParser::Pos&, std::__1::shared_ptr<DB::IAST>&, DB::Expected&) @ 0x13819c77 in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
3. DB::ParserQuery::parseImpl(DB::IParser::Pos&, std::__1::shared_ptr<DB::IAST>&, DB::Expected&) @ 0x1383474e in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
4. DB::IParserBase::parse(DB::IParser::Pos&, std::__1::shared_ptr<DB::IAST>&, DB::Expected&) @ 0x13819a99 in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
5. DB::tryParseQuery(DB::IParser&, char const*&, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long, unsigned long) @ 0x1385c66d in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
6. DB::parseQueryAndMovePosition(DB::IParser&, char const*&, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long, unsigned long) @ 0x1385d49a in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
7. mainEntryClickHouseFormat(int, char**) @ 0xa7994d9 in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
8. main @ 0xa6616e1 in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
9. __libc_start_main @ 0x7fb5747250b3 in ?
10. _start @ 0xa66106e in /data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse
 (version 22.2.1.1) 
```