### PR TITLE
Fix USE database for clickhouse-local

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -74,6 +74,8 @@ void LocalConnection::sendQuery(
         query_context->setProgressCallback([this] (const Progress & value) { return this->updateProgress(value); });
         query_context->setFileProgressCallback([this](const FileProgress & value) { this->updateProgress(Progress(value)); });
     }
+    if (!current_database.empty())
+        query_context->setCurrentDatabase(current_database);
 
     CurrentThread::QueryScope query_scope_holder(query_context);
 
@@ -427,9 +429,9 @@ void LocalConnection::getServerVersion(
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented");
 }
 
-void LocalConnection::setDefaultDatabase(const String &)
+void LocalConnection::setDefaultDatabase(const String & database)
 {
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented");
+    current_database = database;
 }
 
 UInt64 LocalConnection::getServerRevision(const ConnectionTimeouts &)

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -142,5 +142,7 @@ private:
 
     /// Last "server" packet.
     std::optional<UInt64> next_packet_type;
+
+    String current_database;
 };
 }

--- a/tests/queries/0_stateless/02206_clickhouse_local_use_database.reference
+++ b/tests/queries/0_stateless/02206_clickhouse_local_use_database.reference
@@ -1,0 +1,12 @@
+SHOW TABLES;
+CREATE DATABASE test1;
+CREATE TABLE test1.table1 (a Int32) ENGINE=Memory;
+USE test1;
+SHOW TABLES;
+table1
+CREATE DATABASE test2;
+USE test2;
+SHOW TABLES;
+USE test1;
+SHOW TABLES;
+table1

--- a/tests/queries/0_stateless/02206_clickhouse_local_use_database.sh
+++ b/tests/queries/0_stateless/02206_clickhouse_local_use_database.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+$CLICKHOUSE_LOCAL --echo --multiline --multiquery -q """
+SHOW TABLES;
+CREATE DATABASE test1;
+CREATE TABLE test1.table1 (a Int32) ENGINE=Memory;
+USE test1;
+SHOW TABLES;
+CREATE DATABASE test2;
+USE test2;
+SHOW TABLES;
+USE test1;
+SHOW TABLES;
+"""


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `USE database;` in clickhouse-local (including interactive mode). Closes https://github.com/ClickHouse/ClickHouse/issues/33538.
