### PR TITLE
Interserver listen port

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -409,6 +409,18 @@ For more information, see the section “[Configuration files](../../operations/
 <include_from>/etc/metrica.xml</include_from>
 ```
 
+## interserver_listen_host {#interserver-listen-host}
+
+Restriction on hosts that can exchange data between ClickHouse servers.
+The default value equals to `listen_host` setting.
+
+Examples:
+
+``` xml
+<interserver_listen_host>::ffff:a00:1</interserver_listen_host>
+<interserver_listen_host>10.0.0.1</interserver_listen_host>
+```
+
 ## interserver_http_port {#interserver-http-port}
 
 Port for exchanging data between ClickHouse servers.

--- a/docs/ru/operations/server-configuration-parameters/settings.md
+++ b/docs/ru/operations/server-configuration-parameters/settings.md
@@ -407,6 +407,18 @@ ClickHouse проверяет условия для `min_part_size` и `min_part
 <include_from>/etc/metrica.xml</include_from>
 ```
 
+## interserver_listen_host {#interserver-listen-host}
+
+Ограничение по хостам, для обмена между серверами ClickHouse.
+Значение по умолчанию совпадает со значением параметра listen_host
+
+Примеры:
+
+``` xml
+<interserver_listen_host>::ffff:a00:1</interserver_listen_host>
+<interserver_listen_host>10.0.0.1</interserver_listen_host>
+```
+
 ## interserver_http_port {#interserver-http-port}
 
 Порт для обмена между серверами ClickHouse.

--- a/programs/server/Server.h
+++ b/programs/server/Server.h
@@ -87,6 +87,7 @@ private:
     void createServers(
         Poco::Util::AbstractConfiguration & config,
         const std::vector<std::string> & listen_hosts,
+        const std::vector<std::string> & interserver_listen_hosts,
         bool listen_try,
         Poco::ThreadPool & server_pool,
         AsynchronousMetrics & async_metrics,

--- a/programs/server/Server.h
+++ b/programs/server/Server.h
@@ -86,8 +86,8 @@ private:
 
     void createServers(
         Poco::Util::AbstractConfiguration & config,
-        const std::vector<std::string> & listen_hosts,
-        const std::vector<std::string> & interserver_listen_hosts,
+        const Strings & listen_hosts,
+        const Strings & interserver_listen_hosts,
         bool listen_try,
         Poco::ThreadPool & server_pool,
         AsynchronousMetrics & async_metrics,

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -188,6 +188,10 @@
     <listen_host>127.0.0.1</listen_host>
     -->
 
+    <!-- <interserver_listen_host>::</interserver_listen_host> -->
+    <!-- Listen host for communication between replicas. Used for data exchange -->
+    <!-- Default values - equal to listen_host -->
+
     <!-- Don't exit if IPv6 or IPv4 networks are unavailable while trying to listen. -->
     <!-- <listen_try>0</listen_try> -->
 

--- a/tests/integration/test_tcp_handler_interserver_listen_host/configs/config.d/interserver-listen-host.xml
+++ b/tests/integration/test_tcp_handler_interserver_listen_host/configs/config.d/interserver-listen-host.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+	<interserver_listen_host replace="replace">10.0.0.10</interserver_listen_host>
+</clickhouse>

--- a/tests/integration/test_tcp_handler_interserver_listen_host/configs/config.d/no-interserver-listen-host.xml
+++ b/tests/integration/test_tcp_handler_interserver_listen_host/configs/config.d/no-interserver-listen-host.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <interserver_listen_host remove="remove"></interserver_listen_host>
+</clickhouse>

--- a/tests/integration/test_tcp_handler_interserver_listen_host/test_case.py
+++ b/tests/integration/test_tcp_handler_interserver_listen_host/test_case.py
@@ -1,0 +1,52 @@
+"""Test Interserver responses on configured IP."""
+from pathlib import Path
+import pytest
+from helpers.cluster import ClickHouseCluster
+import requests
+import socket
+import time
+
+cluster = ClickHouseCluster(__file__)
+
+INTERSERVER_LISTEN_HOST = '10.0.0.10'
+INTERSERVER_HTTP_PORT = 9009
+
+node_with_interserver_listen_host = cluster.add_instance(
+    'node_with_interserver_listen_host',
+    main_configs=["configs/config.d/interserver-listen-host.xml"],
+    ipv4_address=INTERSERVER_LISTEN_HOST, # used to configure acc. interface in test container
+    ipv6_address='2001:3984:3989::1:1000',
+)
+
+node_without_interserver_listen_host = cluster.add_instance(
+    'node_without_interserver_listen_host',
+    main_configs=["configs/config.d/no-interserver-listen-host.xml"],
+    ipv6_address='2001:3984:3989::2:1000'
+)
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+def test_request_to_node_with_interserver_listen_host(start_cluster):
+    time.sleep(5) # waiting for interserver listener to start
+    response_interserver = requests.get(
+        f'http://{INTERSERVER_LISTEN_HOST}:{INTERSERVER_HTTP_PORT}'
+    )
+    response_client = requests.get(
+        f'http://{node_without_interserver_listen_host.ip_address}:8123'
+    )
+    assert response_interserver.status_code == 200
+    assert "Ok." in response_interserver.text
+    assert response_client.status_code == 200
+
+def test_request_to_node_without_interserver_listen_host(start_cluster):
+    response = requests.get(
+        f'http://{node_without_interserver_listen_host.ip_address}:{INTERSERVER_HTTP_PORT}'
+    )
+    assert response.status_code == 200

--- a/tests/integration/test_tcp_handler_interserver_listen_host/test_case.py
+++ b/tests/integration/test_tcp_handler_interserver_listen_host/test_case.py
@@ -8,21 +8,22 @@ import time
 
 cluster = ClickHouseCluster(__file__)
 
-INTERSERVER_LISTEN_HOST = '10.0.0.10'
+INTERSERVER_LISTEN_HOST = "10.0.0.10"
 INTERSERVER_HTTP_PORT = 9009
 
 node_with_interserver_listen_host = cluster.add_instance(
-    'node_with_interserver_listen_host',
+    "node_with_interserver_listen_host",
     main_configs=["configs/config.d/interserver-listen-host.xml"],
-    ipv4_address=INTERSERVER_LISTEN_HOST, # used to configure acc. interface in test container
-    ipv6_address='2001:3984:3989::1:1000',
+    ipv4_address=INTERSERVER_LISTEN_HOST,  # used to configure acc. interface in test container
+    ipv6_address="2001:3984:3989::1:1000",
 )
 
 node_without_interserver_listen_host = cluster.add_instance(
-    'node_without_interserver_listen_host',
+    "node_without_interserver_listen_host",
     main_configs=["configs/config.d/no-interserver-listen-host.xml"],
-    ipv6_address='2001:3984:3989::2:1000'
+    ipv6_address="2001:3984:3989::2:1000",
 )
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -33,20 +34,22 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_request_to_node_with_interserver_listen_host(start_cluster):
-    time.sleep(5) # waiting for interserver listener to start
+    time.sleep(5)  # waiting for interserver listener to start
     response_interserver = requests.get(
-        f'http://{INTERSERVER_LISTEN_HOST}:{INTERSERVER_HTTP_PORT}'
+        f"http://{INTERSERVER_LISTEN_HOST}:{INTERSERVER_HTTP_PORT}"
     )
     response_client = requests.get(
-        f'http://{node_without_interserver_listen_host.ip_address}:8123'
+        f"http://{node_without_interserver_listen_host.ip_address}:8123"
     )
     assert response_interserver.status_code == 200
     assert "Ok." in response_interserver.text
     assert response_client.status_code == 200
 
+
 def test_request_to_node_without_interserver_listen_host(start_cluster):
     response = requests.get(
-        f'http://{node_without_interserver_listen_host.ip_address}:{INTERSERVER_HTTP_PORT}'
+        f"http://{node_without_interserver_listen_host.ip_address}:{INTERSERVER_HTTP_PORT}"
     )
     assert response.status_code == 200


### PR DESCRIPTION
Changelog category (leave one):

- New Feature

Changelog entry:
Add interserver_listen_host setting to separate TCP/HTTP listen_host and Interserver listener

Detailed description:
sometimes it is required that CH Interserver to listen on one interface, while TCP/HTTP listens on another