### PR TITLE
Fix consecutive backward seeks in seekable read buffers

### DIFF
--- a/src/Compression/CachedCompressedReadBuffer.cpp
+++ b/src/Compression/CachedCompressedReadBuffer.cpp
@@ -105,7 +105,7 @@ void CachedCompressedReadBuffer::seek(size_t offset_in_compressed_file, size_t o
         /// We will discard our working_buffer, but have to account rest bytes
         bytes += offset();
         /// No data, everything discarded
-        pos = working_buffer.end();
+        resetWorkingBuffer();
         owned_cell.reset();
 
         /// Remember required offset in decompressed block which will be set in

--- a/src/Compression/CompressedReadBufferFromFile.cpp
+++ b/src/Compression/CompressedReadBufferFromFile.cpp
@@ -80,7 +80,7 @@ void CompressedReadBufferFromFile::seek(size_t offset_in_compressed_file, size_t
         /// We will discard our working_buffer, but have to account rest bytes
         bytes += offset();
         /// No data, everything discarded
-        pos = working_buffer.end();
+        resetWorkingBuffer();
         size_compressed = 0;
         /// Remember required offset in decompressed block which will be set in
         /// the next ReadBuffer::next() call

--- a/src/Disks/IO/AsynchronousReadIndirectBufferFromRemoteFS.cpp
+++ b/src/Disks/IO/AsynchronousReadIndirectBufferFromRemoteFS.cpp
@@ -243,7 +243,7 @@ off_t AsynchronousReadIndirectBufferFromRemoteFS::seek(off_t offset_, int whence
         prefetch_future = {};
     }
 
-    pos = working_buffer.end();
+    resetWorkingBuffer();
 
     /**
     * Lazy ignore. Save number of bytes to ignore and ignore it either for prefetch buffer or current buffer.

--- a/src/Disks/IO/ReadIndirectBufferFromRemoteFS.cpp
+++ b/src/Disks/IO/ReadIndirectBufferFromRemoteFS.cpp
@@ -64,7 +64,7 @@ off_t ReadIndirectBufferFromRemoteFS::seek(off_t offset_, int whence)
         throw Exception("Only SEEK_SET or SEEK_CUR modes are allowed.", ErrorCodes::CANNOT_SEEK_THROUGH_FILE);
 
     impl->reset();
-    pos = working_buffer.end();
+    resetWorkingBuffer();
 
     return impl->file_offset_of_buffer_end;
 }

--- a/src/IO/AsynchronousReadBufferFromFileDescriptor.cpp
+++ b/src/IO/AsynchronousReadBufferFromFileDescriptor.cpp
@@ -181,8 +181,8 @@ off_t AsynchronousReadBufferFromFileDescriptor::seek(off_t offset, int whence)
 
         off_t offset_after_seek_pos = new_pos - seek_pos;
 
-        /// First put position at the end of the buffer so the next read will fetch new data to the buffer.
-        pos = working_buffer.end();
+        /// First reset the buffer so the next read will fetch new data to the buffer.
+        resetWorkingBuffer();
 
         /// Just update the info about the next position in file.
 

--- a/src/IO/BufferBase.h
+++ b/src/IO/BufferBase.h
@@ -100,7 +100,7 @@ protected:
     void resetWorkingBuffer()
     {
         /// Move position to the end of buffer to trigger call of 'next' on next reading.
-        /// Discard all data in current working buffer to prevent wrong assumtions on content
+        /// Discard all data in current working buffer to prevent wrong assumptions on content
         /// of buffer, e.g. for optimizations of seeks in seekable buffers.
         working_buffer.resize(0);
         pos = working_buffer.end();

--- a/src/IO/BufferBase.h
+++ b/src/IO/BufferBase.h
@@ -97,6 +97,15 @@ public:
     bool isPadded() const { return padded; }
 
 protected:
+    void resetWorkingBuffer()
+    {
+        /// Move position to the end of buffer to trigger call of 'next' on next reading.
+        /// Discard all data in current working buffer to prevent wrong assumtions on content
+        /// of buffer, e.g. for optimizations of seeks in seekable buffers.
+        working_buffer.resize(0);
+        pos = working_buffer.end();
+    }
+
     /// Read/write position.
     Position pos;
 

--- a/src/IO/ReadBufferFromEncryptedFile.cpp
+++ b/src/IO/ReadBufferFromEncryptedFile.cpp
@@ -56,7 +56,7 @@ off_t ReadBufferFromEncryptedFile::seek(off_t off, int whence)
         offset = new_pos;
 
         /// No more reading from the current working buffer until next() is called.
-        pos = working_buffer.end();
+        resetWorkingBuffer();
         assert(!hasPendingData());
     }
 

--- a/src/IO/ReadBufferFromFileDescriptor.h
+++ b/src/IO/ReadBufferFromFileDescriptor.h
@@ -62,9 +62,6 @@ public:
 private:
     /// Assuming file descriptor supports 'select', check that we have data to read or wait until timeout.
     bool poll(size_t timeout_microseconds);
-
-    /// If it's true then we cannot assume on content of buffer to optimize seek calls.
-    bool buffer_is_dirty = true;
 };
 
 

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -187,7 +187,7 @@ off_t ReadBufferFromS3::seek(off_t offset_, int whence)
             }
         }
 
-        pos = working_buffer.end();
+        resetWorkingBuffer();
         if (impl)
         {
             ProfileEvents::increment(ProfileEvents::ReadBufferSeekCancelConnection);

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -498,7 +498,7 @@ namespace detail
                 impl.reset();
             }
 
-            pos = working_buffer.end();
+            resetWorkingBuffer();
             read_range.begin = offset_;
             read_range.end = std::nullopt;
             offset_from_begin_pos = 0;

--- a/src/Storages/HDFS/ReadBufferFromHDFS.cpp
+++ b/src/Storages/HDFS/ReadBufferFromHDFS.cpp
@@ -173,7 +173,7 @@ off_t ReadBufferFromHDFS::seek(off_t offset_, int whence)
         return getPosition();
     }
 
-    pos = working_buffer.end();
+    resetWorkingBuffer();
     impl->seek(offset_, whence);
     return impl->getPosition();
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better implementation of #34327.