### PR TITLE
Fix test test_postgresql_replica_database_engine_2/test.py::test_table_schema_changes_2

### DIFF
--- a/src/Storages/ReadFinalForExternalReplicaStorage.cpp
+++ b/src/Storages/ReadFinalForExternalReplicaStorage.cpp
@@ -57,6 +57,7 @@ Pipe readFinalFromNestedStorage(
 
     Pipe pipe = nested_storage->read(require_columns_name, nested_metadata, query_info, context, processed_stage, max_block_size, num_streams);
     pipe.addTableLock(lock);
+    pipe.addStorageHolder(nested_storage);
 
     if (!expressions->children.empty() && !pipe.empty())
     {


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add missing lock for storage. Fixes possible race with table deletion.
