### PR TITLE
Add settings for multipart upload part size in s3

### DIFF
--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -6,8 +6,8 @@ name: TagsStableWorkflow
 on: # yamllint disable-line rule:truthy
   push:
     tags:
-    - 'v*-stable'
-    - 'v*-lts'
+      - 'v*-stable'
+      - 'v*-lts'
 
 
 jobs:

--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -6,8 +6,8 @@ name: TagsStableWorkflow
 on: # yamllint disable-line rule:truthy
   push:
     tags:
-      - 'v*-stable'
-      - 'v*-lts'
+    - 'v*-stable'
+    - 'v*-lts'
 
 
 jobs:

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -70,7 +70,9 @@ class IColumn;
     M(UInt64, idle_connection_timeout, 3600, "Close idle TCP connections after specified number of seconds.", 0) \
     M(UInt64, distributed_connections_pool_size, 1024, "Maximum number of connections with one remote server in the pool.", 0) \
     M(UInt64, connections_with_failover_max_tries, DBMS_CONNECTION_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES, "The maximum number of attempts to connect to replicas.", 0) \
-    M(UInt64, s3_min_upload_part_size, 32*1024*1024, "The minimum size of part to upload during multipart upload to S3.", 0) \
+    M(UInt64, s3_min_upload_part_size, 16*1024*1024, "The minimum size of part to upload during multipart upload to S3.", 0) \
+    M(UInt64, s3_upload_part_size_multiply_factor, 2, "Multiply s3_min_upload_part_size by this factor each time s3_multiply_parts_count_threshold parts were uploaded from a single write to S3.", 0) \
+    M(UInt64, s3_upload_part_size_multiply_parts_count_threshold, 1000, "Each time this number of parts was uploaded to S3 s3_min_upload_part_size multiplied by s3_upload_part_size_multiply_factor.", 0) \
     M(UInt64, s3_max_single_part_upload_size, 32*1024*1024, "The maximum size of object to upload using singlepart upload to S3.", 0) \
     M(UInt64, s3_max_single_read_retries, 4, "The maximum number of retries during single S3 read.", 0) \
     M(UInt64, s3_max_redirects, 10, "Max number of S3 redirects hops allowed.", 0) \

--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -283,6 +283,8 @@ std::unique_ptr<WriteBufferFromFileBase> DiskS3::writeFile(const String & path, 
         bucket,
         metadata.remote_fs_root_path + s3_path,
         settings->s3_min_upload_part_size,
+        settings->s3_upload_part_size_multiply_factor,
+        settings->s3_upload_part_size_multiply_parts_count_threshold,
         settings->s3_max_single_part_upload_size,
         std::move(object_metadata),
         buf_size,
@@ -338,6 +340,8 @@ void DiskS3::createFileOperationObject(const String & operation_name, UInt64 rev
         bucket,
         remote_fs_root_path + key,
         settings->s3_min_upload_part_size,
+        settings->s3_upload_part_size_multiply_factor,
+        settings->s3_upload_part_size_multiply_parts_count_threshold,
         settings->s3_max_single_part_upload_size,
         metadata);
 
@@ -417,6 +421,8 @@ void DiskS3::saveSchemaVersion(const int & version)
         bucket,
         remote_fs_root_path + SCHEMA_VERSION_OBJECT,
         settings->s3_min_upload_part_size,
+        settings->s3_upload_part_size_multiply_factor,
+        settings->s3_upload_part_size_multiply_parts_count_threshold,
         settings->s3_max_single_part_upload_size);
 
     writeIntText(version, buffer);
@@ -1076,6 +1082,8 @@ DiskS3Settings::DiskS3Settings(
     const std::shared_ptr<Aws::S3::S3Client> & client_,
     size_t s3_max_single_read_retries_,
     size_t s3_min_upload_part_size_,
+    size_t s3_upload_part_size_multiply_factor_,
+    size_t s3_upload_part_size_multiply_parts_count_threshold_,
     size_t s3_max_single_part_upload_size_,
     size_t min_bytes_for_seek_,
     bool send_metadata_,
@@ -1085,6 +1093,8 @@ DiskS3Settings::DiskS3Settings(
     : client(client_)
     , s3_max_single_read_retries(s3_max_single_read_retries_)
     , s3_min_upload_part_size(s3_min_upload_part_size_)
+    , s3_upload_part_size_multiply_factor(s3_upload_part_size_multiply_factor_)
+    , s3_upload_part_size_multiply_parts_count_threshold(s3_upload_part_size_multiply_parts_count_threshold_)
     , s3_max_single_part_upload_size(s3_max_single_part_upload_size_)
     , min_bytes_for_seek(min_bytes_for_seek_)
     , send_metadata(send_metadata_)

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -29,6 +29,8 @@ struct DiskS3Settings
         const std::shared_ptr<Aws::S3::S3Client> & client_,
         size_t s3_max_single_read_retries_,
         size_t s3_min_upload_part_size_,
+        size_t s3_upload_part_size_multiply_factor_,
+        size_t s3_upload_part_size_multiply_parts_count_threshold_,
         size_t s3_max_single_part_upload_size_,
         size_t min_bytes_for_seek_,
         bool send_metadata_,
@@ -39,6 +41,8 @@ struct DiskS3Settings
     std::shared_ptr<Aws::S3::S3Client> client;
     size_t s3_max_single_read_retries;
     size_t s3_min_upload_part_size;
+    size_t s3_upload_part_size_multiply_factor;
+    size_t s3_upload_part_size_multiply_parts_count_threshold;
     size_t s3_max_single_part_upload_size;
     size_t min_bytes_for_seek;
     bool send_metadata;

--- a/src/Disks/S3/registerDiskS3.cpp
+++ b/src/Disks/S3/registerDiskS3.cpp
@@ -155,6 +155,8 @@ std::unique_ptr<DiskS3Settings> getSettings(const Poco::Util::AbstractConfigurat
         getClient(config, config_prefix, context),
         config.getUInt64(config_prefix + ".s3_max_single_read_retries", context->getSettingsRef().s3_max_single_read_retries),
         config.getUInt64(config_prefix + ".s3_min_upload_part_size", context->getSettingsRef().s3_min_upload_part_size),
+        config.getUInt64(config_prefix + ".s3_upload_part_size_multiply_factor", context->getSettingsRef().s3_upload_part_size_multiply_factor),
+        config.getUInt64(config_prefix + ".s3_upload_part_size_multiply_parts_count_threshold", context->getSettingsRef().s3_upload_part_size_multiply_parts_count_threshold),
         config.getUInt64(config_prefix + ".s3_max_single_part_upload_size", context->getSettingsRef().s3_max_single_part_upload_size),
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),
         config.getBool(config_prefix + ".send_metadata", false),

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -54,6 +54,8 @@ WriteBufferFromS3::WriteBufferFromS3(
     const String & bucket_,
     const String & key_,
     size_t minimum_upload_part_size_,
+    size_t upload_part_size_multiply_factor_,
+    size_t upload_part_size_multiply_threshold_,
     size_t max_single_part_upload_size_,
     std::optional<std::map<String, String>> object_metadata_,
     size_t buffer_size_,
@@ -63,7 +65,9 @@ WriteBufferFromS3::WriteBufferFromS3(
     , key(key_)
     , object_metadata(std::move(object_metadata_))
     , client_ptr(std::move(client_ptr_))
-    , minimum_upload_part_size(minimum_upload_part_size_)
+    , upload_part_size(minimum_upload_part_size_)
+    , upload_part_size_multiply_factor(upload_part_size_multiply_factor_)
+    , upload_part_size_multiply_threshold(upload_part_size_multiply_threshold_)
     , max_single_part_upload_size(max_single_part_upload_size_)
     , schedule(std::move(schedule_))
 {
@@ -85,9 +89,10 @@ void WriteBufferFromS3::nextImpl()
     if (multipart_upload_id.empty() && last_part_size > max_single_part_upload_size)
         createMultipartUpload();
 
-    if (!multipart_upload_id.empty() && last_part_size > minimum_upload_part_size)
+    if (!multipart_upload_id.empty() && last_part_size > upload_part_size)
     {
         writePart();
+
         allocateBuffer();
     }
 
@@ -96,6 +101,9 @@ void WriteBufferFromS3::nextImpl()
 
 void WriteBufferFromS3::allocateBuffer()
 {
+   if (total_parts_uploaded != 0 && total_parts_uploaded % upload_part_size_multiply_threshold == 0)
+       upload_part_size *= upload_part_size_multiply_factor;
+
     temporary_buffer = Aws::MakeShared<Aws::StringStream>("temporary buffer");
     temporary_buffer->exceptions(std::ios::badbit);
     last_part_size = 0;
@@ -239,6 +247,8 @@ void WriteBufferFromS3::processUploadRequest(UploadPartTask & task)
     }
     else
         throw Exception(outcome.GetError().GetMessage(), ErrorCodes::S3_ERROR);
+
+    total_parts_uploaded++;
 }
 
 void WriteBufferFromS3::completeMultipartUpload()

--- a/src/IO/WriteBufferFromS3.h
+++ b/src/IO/WriteBufferFromS3.h
@@ -47,6 +47,8 @@ public:
         const String & bucket_,
         const String & key_,
         size_t minimum_upload_part_size_,
+        size_t upload_part_size_multiply_factor_,
+        size_t upload_part_size_multiply_threshold_,
         size_t max_single_part_upload_size_,
         std::optional<std::map<String, String>> object_metadata_ = std::nullopt,
         size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE,
@@ -85,11 +87,14 @@ private:
     String key;
     std::optional<std::map<String, String>> object_metadata;
     std::shared_ptr<Aws::S3::S3Client> client_ptr;
-    size_t minimum_upload_part_size;
-    size_t max_single_part_upload_size;
+    size_t upload_part_size;
+    const size_t upload_part_size_multiply_factor;
+    const size_t upload_part_size_multiply_threshold;
+    const size_t max_single_part_upload_size;
     /// Buffer to accumulate data.
     std::shared_ptr<Aws::StringStream> temporary_buffer;
-    size_t last_part_size;
+    size_t last_part_size = 0;
+    std::atomic<size_t> total_parts_uploaded = 0;
 
     /// Upload in S3 is made in parts.
     /// We initiate upload, then upload each part and get ETag as a response, and then finalizeImpl() upload with listing all our parts.

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -385,13 +385,18 @@ public:
         const String & bucket,
         const String & key,
         size_t min_upload_part_size,
+        size_t upload_part_size_multiply_factor,
+        size_t upload_part_size_multiply_parts_count_threshold,
         size_t max_single_part_upload_size)
         : SinkToStorage(sample_block_)
         , sample_block(sample_block_)
         , format_settings(format_settings_)
     {
         write_buf = wrapWriteBufferWithCompressionMethod(
-            std::make_unique<WriteBufferFromS3>(client, bucket, key, min_upload_part_size, max_single_part_upload_size), compression_method, 3);
+            std::make_unique<WriteBufferFromS3>(
+                client, bucket, key, min_upload_part_size,
+                upload_part_size_multiply_factor, upload_part_size_multiply_parts_count_threshold,
+                max_single_part_upload_size), compression_method, 3);
         writer = FormatFactory::instance().getOutputFormatParallelIfPossible(format, *write_buf, sample_block, context, {}, format_settings);
     }
 
@@ -440,6 +445,8 @@ public:
         const String & bucket_,
         const String & key_,
         size_t min_upload_part_size_,
+        size_t upload_part_size_multiply_factor_,
+        size_t upload_part_size_multiply_parts_count_threshold_,
         size_t max_single_part_upload_size_)
         : PartitionedSink(partition_by, context_, sample_block_)
         , format(format_)
@@ -450,6 +457,8 @@ public:
         , bucket(bucket_)
         , key(key_)
         , min_upload_part_size(min_upload_part_size_)
+        , upload_part_size_multiply_factor(upload_part_size_multiply_factor_)
+        , upload_part_size_multiply_parts_count_threshold(upload_part_size_multiply_parts_count_threshold_)
         , max_single_part_upload_size(max_single_part_upload_size_)
         , format_settings(format_settings_)
     {
@@ -473,6 +482,8 @@ public:
             partition_bucket,
             partition_key,
             min_upload_part_size,
+            upload_part_size_multiply_factor,
+            upload_part_size_multiply_parts_count_threshold,
             max_single_part_upload_size
         );
     }
@@ -487,6 +498,8 @@ private:
     const String bucket;
     const String key;
     size_t min_upload_part_size;
+    size_t upload_part_size_multiply_factor;
+    size_t upload_part_size_multiply_parts_count_threshold;
     size_t max_single_part_upload_size;
     std::optional<FormatSettings> format_settings;
 
@@ -527,6 +540,8 @@ StorageS3::StorageS3(
     const String & format_name_,
     UInt64 max_single_read_retries_,
     UInt64 min_upload_part_size_,
+    UInt64 upload_part_size_multiply_factor_,
+    UInt64 upload_part_size_multiply_parts_count_threshold_,
     UInt64 max_single_part_upload_size_,
     UInt64 max_connections_,
     const ColumnsDescription & columns_,
@@ -543,6 +558,8 @@ StorageS3::StorageS3(
     , format_name(format_name_)
     , max_single_read_retries(max_single_read_retries_)
     , min_upload_part_size(min_upload_part_size_)
+    , upload_part_size_multiply_factor(upload_part_size_multiply_factor_)
+    , upload_part_size_multiply_parts_count_threshold(upload_part_size_multiply_parts_count_threshold_)
     , max_single_part_upload_size(max_single_part_upload_size_)
     , compression_method(compression_method_)
     , name(uri_.storage_name)
@@ -669,6 +686,8 @@ SinkToStoragePtr StorageS3::write(const ASTPtr & query, const StorageMetadataPtr
             client_auth.uri.bucket,
             keys.back(),
             min_upload_part_size,
+            upload_part_size_multiply_factor,
+            upload_part_size_multiply_parts_count_threshold,
             max_single_part_upload_size);
     }
     else
@@ -712,6 +731,8 @@ SinkToStoragePtr StorageS3::write(const ASTPtr & query, const StorageMetadataPtr
             client_auth.uri.bucket,
             keys.back(),
             min_upload_part_size,
+            upload_part_size_multiply_factor,
+            upload_part_size_multiply_parts_count_threshold,
             max_single_part_upload_size);
     }
 }
@@ -923,7 +944,10 @@ void registerStorageS3Impl(const String & name, StorageFactory & factory)
         S3::URI s3_uri(Poco::URI(configuration.url));
         auto max_single_read_retries = args.getLocalContext()->getSettingsRef().s3_max_single_read_retries;
         auto min_upload_part_size = args.getLocalContext()->getSettingsRef().s3_min_upload_part_size;
+        auto upload_part_size_multiply_factor = args.getLocalContext()->getSettingsRef().s3_upload_part_size_multiply_factor;
+        auto upload_part_size_multiply_parts_count_threshold = args.getLocalContext()->getSettingsRef().s3_upload_part_size_multiply_parts_count_threshold;
         auto max_single_part_upload_size = args.getLocalContext()->getSettingsRef().s3_max_single_part_upload_size;
+
         auto max_connections = args.getLocalContext()->getSettingsRef().s3_max_connections;
 
         ASTPtr partition_by;
@@ -938,6 +962,8 @@ void registerStorageS3Impl(const String & name, StorageFactory & factory)
             configuration.format,
             max_single_read_retries,
             min_upload_part_size,
+            upload_part_size_multiply_factor,
+            upload_part_size_multiply_parts_count_threshold,
             max_single_part_upload_size,
             max_connections,
             args.columns,

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -126,6 +126,8 @@ public:
         const String & format_name_,
         UInt64 max_single_read_retries_,
         UInt64 min_upload_part_size_,
+        UInt64 upload_part_size_multiply_factor_,
+        UInt64 upload_part_size_multiply_parts_count_threshold_,
         UInt64 max_single_part_upload_size_,
         UInt64 max_connections_,
         const ColumnsDescription & columns_,
@@ -193,6 +195,8 @@ private:
     String format_name;
     UInt64 max_single_read_retries;
     size_t min_upload_part_size;
+    size_t upload_part_size_multiply_factor;
+    size_t upload_part_size_multiply_parts_count_threshold;
     size_t max_single_part_upload_size;
     String compression_method;
     String name;

--- a/src/TableFunctions/TableFunctionS3.cpp
+++ b/src/TableFunctions/TableFunctionS3.cpp
@@ -148,6 +148,8 @@ StoragePtr TableFunctionS3::executeImpl(const ASTPtr & /*ast_function*/, Context
     S3::URI s3_uri (uri);
     UInt64 max_single_read_retries = context->getSettingsRef().s3_max_single_read_retries;
     UInt64 min_upload_part_size = context->getSettingsRef().s3_min_upload_part_size;
+    UInt64 upload_part_size_multiply_factor = context->getSettingsRef().s3_upload_part_size_multiply_factor;
+    UInt64 upload_part_size_multiply_parts_count_threshold = context->getSettingsRef().s3_upload_part_size_multiply_parts_count_threshold;
     UInt64 max_single_part_upload_size = context->getSettingsRef().s3_max_single_part_upload_size;
     UInt64 max_connections = context->getSettingsRef().s3_max_connections;
 
@@ -163,6 +165,8 @@ StoragePtr TableFunctionS3::executeImpl(const ASTPtr & /*ast_function*/, Context
         s3_configuration->format,
         max_single_read_retries,
         min_upload_part_size,
+        upload_part_size_multiply_factor,
+        upload_part_size_multiply_parts_count_threshold,
         max_single_part_upload_size,
         max_connections,
         getActualTableStructure(context),

--- a/src/TableFunctions/TableFunctionS3Cluster.cpp
+++ b/src/TableFunctions/TableFunctionS3Cluster.cpp
@@ -109,6 +109,8 @@ StoragePtr TableFunctionS3Cluster::executeImpl(
         /// Actually this parameters are not used
         UInt64 max_single_read_retries = context->getSettingsRef().s3_max_single_read_retries;
         UInt64 min_upload_part_size = context->getSettingsRef().s3_min_upload_part_size;
+        UInt64 upload_part_size_multiply_factor = context->getSettingsRef().s3_upload_part_size_multiply_factor;
+        UInt64 upload_part_size_multiply_parts_count_threshold = context->getSettingsRef().s3_upload_part_size_multiply_parts_count_threshold;
         UInt64 max_single_part_upload_size = context->getSettingsRef().s3_max_single_part_upload_size;
         UInt64 max_connections = context->getSettingsRef().s3_max_connections;
         storage = StorageS3::create(
@@ -119,6 +121,8 @@ StoragePtr TableFunctionS3Cluster::executeImpl(
             format,
             max_single_read_retries,
             min_upload_part_size,
+            upload_part_size_multiply_factor,
+            upload_part_size_multiply_parts_count_threshold,
             max_single_part_upload_size,
             max_connections,
             getActualTableStructure(context),


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add two new settings: `s3_upload_part_size_multiply_factor` and `s3_upload_part_size_multiply_parts_count_threshold`. Now each time `s3_upload_part_size_multiply_parts_count_threshold` uploaded to S3 from a single query `s3_min_upload_part_size` multiplied by `s3_upload_part_size_multiply_factor`. Fixes #34244.
