### PR TITLE
clang-tidy move fix build

### DIFF
--- a/src/Processors/ForkProcessor.cpp
+++ b/src/Processors/ForkProcessor.cpp
@@ -63,9 +63,9 @@ ForkProcessor::Status ForkProcessor::prepare()
         {
             ++num_processed_outputs;
             if (num_processed_outputs == num_active_outputs)
-                output.push(std::move(data)); // NOLINT Can push because no full or unneeded outputs.
+                output.push(std::move(data)); /// NOLINT Can push because no full or unneeded outputs.
             else
-                output.push(data.clone());
+                output.push(data.clone()); /// NOLINT
         }
     }
 

--- a/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -20,7 +20,7 @@ namespace ErrorCodes
 
 
 TSKVRowInputFormat::TSKVRowInputFormat(ReadBuffer & in_, Block header_, Params params_, const FormatSettings & format_settings_)
-    : IRowInputFormat(std::move(header_), in_, std::move(params_)), format_settings(format_settings_), name_map(header_.columns())
+    : IRowInputFormat(header_, in_, std::move(params_)), format_settings(format_settings_), name_map(header_.columns())
 {
     const auto & sample_block = getPort().getHeader();
     size_t num_columns = sample_block.columns();


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix clang-tidy build after we added move warning.
