### PR TITLE
remove (nearly) duplicated description

### DIFF
--- a/docs/en/sql-reference/functions/tuple-functions.md
+++ b/docs/en/sql-reference/functions/tuple-functions.md
@@ -22,7 +22,7 @@ tuple(x, y, …)
 ## tupleElement {#tupleelement}
 
 A function that allows getting a column from a tuple.
-‘N’ is the column index, starting from 1. N must be a constant. ‘N’ must be a constant. ‘N’ must be a strict postive integer no greater than the size of the tuple.
+‘N’ is the column index, starting from 1. ‘N’ must be a constant. ‘N’ must be a strict postive integer no greater than the size of the tuple.
 There is no cost to execute the function.
 
 The function implements the operator `x.N`.


### PR DESCRIPTION
remove (nearly) duplicated description (details can be seen in the following pic)

![圖片](https://user-images.githubusercontent.com/3983683/153159113-32daec5d-5de7-4da5-9aa2-9060144e3ea1.png)

There are two consecutive sentences that are nearly the same. I think one of them is duplicated.

Changelog category (leave one):
- Documentation (changelog entry is not required)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
