### PR TITLE
Fix bug in URL engine

### DIFF
--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -479,10 +479,11 @@ ColumnsDescription IStorageURLBase::getTableStructureFromData(
     }
     else
     {
-        auto parsed_uri = Poco::URI(uri);
-        StorageURLSource::setCredentials(credentials, parsed_uri);
         read_buffer_creator = [&]()
         {
+            auto parsed_uri = Poco::URI(uri);
+            StorageURLSource::setCredentials(credentials, parsed_uri);
+            
             return wrapReadBufferWithCompressionMethod(
                 std::make_unique<ReadWriteBufferFromHTTP>(
                     parsed_uri,

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -483,7 +483,7 @@ ColumnsDescription IStorageURLBase::getTableStructureFromData(
         {
             auto parsed_uri = Poco::URI(uri);
             StorageURLSource::setCredentials(credentials, parsed_uri);
-            
+
             return wrapReadBufferWithCompressionMethod(
                 std::make_unique<ReadWriteBufferFromHTTP>(
                     parsed_uri,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The bug was introduced in https://github.com/ClickHouse/ClickHouse/pull/34392 while resolving conflicts.
