### PR TITLE
Remove useless ZooKeeper dependency from test

### DIFF
--- a/tests/integration/test_distributed_inter_server_secret/test.py
+++ b/tests/integration/test_distributed_inter_server_secret/test.py
@@ -13,7 +13,6 @@ cluster = ClickHouseCluster(__file__)
 
 def make_instance(name, cfg):
     return cluster.add_instance(name,
-        with_zookeeper=True,
         main_configs=['configs/remote_servers.xml', cfg],
         user_configs=['configs/users.xml'])
 # _n1/_n2 contains cluster with different <secret> -- should fail


### PR DESCRIPTION
Save some CPU cycles.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
