### PR TITLE
Remove invalid IOS setting for RocksDB CMAKE to fix Apple M1 build

### DIFF
--- a/contrib/rocksdb-cmake/CMakeLists.txt
+++ b/contrib/rocksdb-cmake/CMakeLists.txt
@@ -127,11 +127,6 @@ endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   add_definitions(-DOS_MACOSX)
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES arm)
-    add_definitions(-DIOS_CROSS_COMPILE -DROCKSDB_LITE)
-    # no debug info for IOS, that will make our library big
-    add_definitions(-DNDEBUG)
-  endif()
 elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
   add_definitions(-DOS_LINUX)
 elseif(CMAKE_SYSTEM_NAME MATCHES "SunOS")


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The RocksDB Cmake file includes obsolete IOS settings that break Apple M1 builds
