### PR TITLE
clang-tidy reported potential chance for divide by zero exception

### DIFF
--- a/src/AggregateFunctions/ReservoirSampler.h
+++ b/src/AggregateFunctions/ReservoirSampler.h
@@ -239,6 +239,7 @@ private:
 
     UInt64 genRandom(size_t lim)
     {
+        assert(lim > 0);
         /// With a large number of values, we will generate random numbers several times slower.
         if (lim <= static_cast<UInt64>(rng.max()))
             return static_cast<UInt32>(rng()) % static_cast<UInt32>(lim);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
clang-tidy reported lim is of type size_t (unsigned int), if zero is passed there is potential chance to give divide by zero exception.
