### PR TITLE
keeper SnapshotableHashTable clean optimization

### DIFF
--- a/src/Coordination/SnapshotableHashTable.h
+++ b/src/Coordination/SnapshotableHashTable.h
@@ -36,7 +36,8 @@ private:
     /// Allows to avoid additional copies in updateValue function
     size_t snapshot_up_to_size = 0;
     ArenaWithFreeLists arena;
-    std::vector<Mapped> snapshot_invalid_iters{100000};
+    /// Collect invalid iterators to avoid traversing the whole list
+    std::vector<Mapped> snapshot_invalid_iters;
 
     uint64_t approximate_data_size{0};
 
@@ -197,9 +198,9 @@ public:
         if (snapshot_mode)
         {
             list_itr->active_in_map = false;
+            snapshot_invalid_iters.push_back(list_itr);
             list_itr->free_key = true;
             map.erase(it->getKey());
-            snapshot_invalid_iters.push_back(list_itr);
         }
         else
         {
@@ -238,11 +239,11 @@ public:
             {
                 auto elem_copy = *(list_itr);
                 list_itr->active_in_map = false;
+                snapshot_invalid_iters.push_back(list_itr);
                 updater(elem_copy.value);
                 auto itr = list.insert(list.end(), elem_copy);
                 it->getMapped() = itr;
                 ret = itr;
-                snapshot_invalid_iters.push_back(list_itr);
             }
             else
             {

--- a/src/Coordination/SnapshotableHashTable.h
+++ b/src/Coordination/SnapshotableHashTable.h
@@ -296,19 +296,16 @@ public:
             arena.free(const_cast<char *>(itr->key.data), itr->key.size);
         list.clear();
         updateDataSize(CLEAR, 0, 0, 0);
-        snapshot_invalid_iters.clear();
     }
 
     void enableSnapshotMode(size_t up_to_size)
     {
         snapshot_mode = true;
         snapshot_up_to_size = up_to_size;
-        snapshot_invalid_iters.clear();
     }
 
     void disableSnapshotMode()
     {
-
         snapshot_mode = false;
         snapshot_up_to_size = 0;
     }


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use a vector to collect useless list iterators when doing a snapshot, and in latter clearOutdatedNodes, we can just traverse the vector, not the list, which is faster.
