### PR TITLE
Rebuild all docker images nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,73 @@
+name: NightlyBuilds
+
+env:
+  # Force the stdout and stderr streams to be unbuffered
+  PYTHONUNBUFFERED: 1
+
+"on":
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  DockerHubPushAarch64:
+    runs-on: [self-hosted, style-checker-aarch64]
+    steps:
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Images check
+        run: |
+          cd "$GITHUB_WORKSPACE/tests/ci"
+          python3 docker_images_check.py --suffix aarch64 --all
+      - name: Upload images files to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: changed_images_aarch64
+          path: ${{ runner.temp }}/docker_images_check/changed_images_aarch64.json
+  DockerHubPushAmd64:
+    runs-on: [self-hosted, style-checker]
+    steps:
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Images check
+        run: |
+          cd "$GITHUB_WORKSPACE/tests/ci"
+          python3 docker_images_check.py --suffix amd64 --all
+      - name: Upload images files to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: changed_images_amd64
+          path: ${{ runner.temp }}/docker_images_check/changed_images_amd64.json
+  DockerHubPush:
+    needs: [DockerHubPushAmd64, DockerHubPushAarch64]
+    runs-on: [self-hosted, style-checker]
+    steps:
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Download changed aarch64 images
+        uses: actions/download-artifact@v2
+        with:
+          name: changed_images_aarch64
+          path: ${{ runner.temp }}
+      - name: Download changed amd64 images
+        uses: actions/download-artifact@v2
+        with:
+          name: changed_images_amd64
+          path: ${{ runner.temp }}
+      - name: Images check
+        run: |
+          cd "$GITHUB_WORKSPACE/tests/ci"
+          python3 docker_manifests_merge.py --suffix amd64 --suffix aarch64
+      - name: Upload images files to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: changed_images
+          path: ${{ runner.temp }}/changed_images.json

--- a/docker/images.json
+++ b/docker/images.json
@@ -32,6 +32,7 @@
         "dependent": []
     },
     "docker/test/pvs": {
+        "only_amd64": true,
         "name": "clickhouse/pvs-test",
         "dependent": []
     },
@@ -72,6 +73,7 @@
         "dependent": []
     },
     "docker/test/integration/runner": {
+        "only_amd64": true,
         "name": "clickhouse/integration-tests-runner",
         "dependent": []
     },
@@ -124,6 +126,7 @@
         "dependent": []
     },
     "docker/test/integration/kerberos_kdc": {
+        "only_amd64": true,
         "name": "clickhouse/kerberos-kdc",
         "dependent": []
     },
@@ -137,6 +140,7 @@
          ]
     },
     "docker/test/integration/kerberized_hadoop": {
+        "only_amd64": true,
         "name": "clickhouse/kerberized-hadoop",
         "dependent": []
     },

--- a/docker/test/integration/kerberized_hadoop/Dockerfile
+++ b/docker/test/integration/kerberized_hadoop/Dockerfile
@@ -20,4 +20,4 @@ RUN cd /tmp && \
 	cd commons-daemon-1.0.15-src/src/native/unix && \
 	./configure && \
 	make && \
-	cp ./jsvc /usr/local/hadoop/sbin
+	cp ./jsvc /usr/local/hadoop-2.7.0/sbin

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -58,10 +58,7 @@ RUN apt-get update \
 
 RUN dockerd --version; docker --version
 
-# Architecture of the image when BuildKit/buildx is used
-ARG TARGETARCH
-# FIXME: psycopg2-binary is not available for aarch64, we skip it for now
-RUN test x$TARGETARCH = xarm64 || ( python3 -m pip install \
+RUN python3 -m pip install \
     PyMySQL \
     aerospike==4.0.0 \
     avro==1.10.2 \
@@ -91,7 +88,7 @@ RUN test x$TARGETARCH = xarm64 || ( python3 -m pip install \
     urllib3 \
     requests-kerberos \
     pyhdfs \
-    azure-storage-blob )
+    azure-storage-blob
 
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY dockerd-entrypoint.sh /usr/local/bin/

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update \
 
 RUN dockerd --version; docker --version
 
+# Architecture of the image when BuildKit/buildx is used
 ARG TARGETARCH
 # FIXME: psycopg2-binary is not available for aarch64, we skip it for now
 RUN test x$TARGETARCH = xarm64 || ( python3 -m pip install \

--- a/docker/test/performance-comparison/Dockerfile
+++ b/docker/test/performance-comparison/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t clickhouse/performance-comparison .
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # ARG for quick switch to a given ubuntu mirror
 ARG apt_archive="http://archive.ubuntu.com"

--- a/docker/test/pvs/Dockerfile
+++ b/docker/test/pvs/Dockerfile
@@ -4,11 +4,7 @@
 ARG FROM_TAG=latest
 FROM clickhouse/binary-builder:$FROM_TAG
 
-# PVS studio doesn't support aarch64/arm64, so there is a check for it everywhere
-# We'll produce an empty image for arm64
-ARG TARGETARCH
-
-RUN test x$TARGETARCH = xarm64 || ( apt-get update --yes \
+RUN apt-get update --yes \
     && apt-get install \
         bash \
         wget \
@@ -21,7 +17,7 @@ RUN test x$TARGETARCH = xarm64 || ( apt-get update --yes \
         libprotoc-dev \
         libgrpc++-dev \
         libc-ares-dev \
-        --yes --no-install-recommends )
+        --yes --no-install-recommends
 
 #RUN wget -nv -O - http://files.viva64.com/etc/pubkey.txt | sudo apt-key add -
 #RUN sudo wget -nv -O /etc/apt/sources.list.d/viva64.list http://files.viva64.com/etc/viva64.list
@@ -33,7 +29,7 @@ RUN test x$TARGETARCH = xarm64 || ( apt-get update --yes \
 
 ENV PKG_VERSION="pvs-studio-latest"
 
-RUN test x$TARGETARCH = xarm64 || ( set -x \
+RUN set -x \
     && export PUBKEY_HASHSUM="ad369a2e9d8b8c30f5a9f2eb131121739b79c78e03fef0f016ea51871a5f78cd4e6257b270dca0ac3be3d1f19d885516" \
     && wget -nv https://files.viva64.com/etc/pubkey.txt -O /tmp/pubkey.txt \
     && echo "${PUBKEY_HASHSUM} /tmp/pubkey.txt" | sha384sum -c \
@@ -41,7 +37,7 @@ RUN test x$TARGETARCH = xarm64 || ( set -x \
     && wget -nv "https://files.viva64.com/${PKG_VERSION}.deb" \
     && { debsig-verify ${PKG_VERSION}.deb \
     || echo "WARNING: Some file was just downloaded from the internet without any validation and we are installing it into the system"; } \
-    && dpkg -i "${PKG_VERSION}.deb" )
+    && dpkg -i "${PKG_VERSION}.deb"
 
 ENV CCACHE_DIR=/test_output/ccache
 

--- a/docker/test/testflows/runner/Dockerfile
+++ b/docker/test/testflows/runner/Dockerfile
@@ -43,24 +43,27 @@ RUN pip3 install urllib3 testflows==1.7.20 docker-compose==1.29.1 docker==5.0.0 
 ENV DOCKER_CHANNEL stable
 ENV DOCKER_VERSION 20.10.6
 
-RUN set -eux; \
-  \
-# this "case" statement is generated via "update.sh"
-  \
-  if ! wget -nv -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz"; then \
-    echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from '${DOCKER_CHANNEL}' for '${x86_64}'"; \
-    exit 1; \
-  fi; \
-  \
-  tar --extract \
+# Architecture of the image when BuildKit/buildx is used
+ARG TARGETARCH
+
+# Install docker
+RUN arch=${TARGETARCH:-amd64} \
+  && case $arch in \
+      amd64) rarch=x86_64 ;; \
+      arm64) rarch=aarch64 ;; \
+    esac \
+  && set -eux \
+  && if ! wget -nv -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${rarch}/docker-${DOCKER_VERSION}.tgz"; then \
+    echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from '${DOCKER_CHANNEL}' for '${rarch}'" \
+    && exit 1; \
+  fi \
+  && tar --extract \
     --file docker.tgz \
     --strip-components 1 \
     --directory /usr/local/bin/ \
-  ; \
-  rm docker.tgz; \
-  \
-  dockerd --version; \
-  docker --version
+  && rm docker.tgz \
+  && dockerd --version \
+  && docker --version
 
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY dockerd-entrypoint.sh /usr/local/bin/

--- a/tests/ci/docker_manifests_merge.py
+++ b/tests/ci/docker_manifests_merge.py
@@ -57,7 +57,7 @@ def parse_args() -> argparse.Namespace:
 
     args = parser.parse_args()
     if len(args.suffixes) < 2:
-        raise parser.error("more than two --suffix should be given")
+        parser.error("more than two --suffix should be given")
 
     return args
 
@@ -81,6 +81,7 @@ def strip_suffix(suffix: str, images: Images) -> Images:
 
 
 def check_sources(to_merge: Dict[str, Images]) -> Images:
+    """get a dict {arch1: Images, arch2: Images}"""
     result = {}  # type: Images
     first_suffix = ""
     for suffix, images in to_merge.items():

--- a/tests/ci/docker_test.py
+++ b/tests/ci/docker_test.py
@@ -23,7 +23,11 @@ class TestDockerImageCheck(unittest.TestCase):
             "docker/docs/builder",
         }
         images = sorted(
-            list(di.get_changed_docker_images(pr_info, "/", self.docker_images_path))
+            list(
+                di.get_changed_docker_images(
+                    pr_info, di.get_images_dict("/", self.docker_images_path)
+                )
+            )
         )
         self.maxDiff = None
         expected = sorted(

--- a/tests/ci/tests/docker_images.json
+++ b/tests/ci/tests/docker_images.json
@@ -150,6 +150,7 @@
     },
     "docker/docs/builder": {
         "name": "clickhouse/docs-builder",
+        "only_amd64": true,
         "dependent": [
             "docker/docs/check",
             "docker/docs/release"


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Rebuild docker images on a daily base
- Add `--all` flag to rebuild all images
- Add `only_amd64` parameter for some images
- Revert all workarounds for `only_amd64` images
- Fix all broken images