### PR TITLE
Improve schema inference in clickhouse-local

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -321,9 +321,7 @@ static bool checkIfStdinIsRegularFile()
 
 std::string LocalServer::getInitialCreateTableQuery()
 {
-    /// We can create initial table only when we have data for it
-    /// in file or in stdin (we treat stdin as table data if we have query)
-    if (!config().has("table-file") && (!checkIfStdinIsRegularFile() || !config().has("query")))
+    if (!config().has("table-structure") && !config().has("table-file") && !config().has("table-data-format") && (!checkIfStdinIsRegularFile() || !config().has("query")))
         return {};
 
     auto table_name = backQuoteIfNeed(config().getString("table-name", "table"));

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -313,17 +313,17 @@ void LocalServer::cleanup()
 }
 
 
-static bool checkIfStdinIsNotEmpty()
+static bool checkIfStdinIsRegularFile()
 {
     struct stat file_stat;
-    return fstat(STDIN_FILENO, &file_stat) == 0 && (S_ISREG(file_stat.st_mode) || S_ISFIFO(file_stat.st_mode));
+    return fstat(STDIN_FILENO, &file_stat) == 0 && S_ISREG(file_stat.st_mode);
 }
 
 std::string LocalServer::getInitialCreateTableQuery()
 {
     /// We can create initial table only when we have data for it
     /// in file or in stdin (we treat stdin as table data if we have query)
-    if (!config().has("table-file") && (!checkIfStdinIsNotEmpty() || !config().has("query")))
+    if (!config().has("table-file") && (!checkIfStdinIsRegularFile() || !config().has("query")))
         return {};
 
     auto table_name = backQuoteIfNeed(config().getString("table-name", "table"));

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -313,9 +313,17 @@ void LocalServer::cleanup()
 }
 
 
+static bool checkIfStdinIsNotEmpty()
+{
+    struct stat file_stat;
+    return fstat(STDIN_FILENO, &file_stat) == 0 && (S_ISREG(file_stat.st_mode) || S_ISFIFO(file_stat.st_mode));
+}
+
 std::string LocalServer::getInitialCreateTableQuery()
 {
-    if (!config().has("table-structure") && !config().has("table-file") && !config().has("table-data-format"))
+    /// We can create initial table only when we have data for it
+    /// in file or in stdin (we treat stdin as table data if we have query)
+    if (!config().has("table-file") && (!checkIfStdinIsNotEmpty() || !config().has("query")))
         return {};
 
     auto table_name = backQuoteIfNeed(config().getString("table-name", "table"));

--- a/tests/queries/0_stateless/02211_shcema_inference_from_stdin.reference
+++ b/tests/queries/0_stateless/02211_shcema_inference_from_stdin.reference
@@ -1,0 +1,15 @@
+x	Nullable(Float64)					
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+c1	Nullable(String)					
+c2	Nullable(String)					
+c3	Nullable(String)					
+1	2	3

--- a/tests/queries/0_stateless/02211_shcema_inference_from_stdin.sh
+++ b/tests/queries/0_stateless/02211_shcema_inference_from_stdin.sh
@@ -12,6 +12,6 @@ $CLICKHOUSE_LOCAL -q "select * from table" < data.jsoneachrow
 
 rm data.jsoneachrow
 
-echo -e "1\t2\t3" | $CLICKHOUSE_LOCAL -q "desc table table"
-echo -e "1\t2\t3" | $CLICKHOUSE_LOCAL -q "select * from table"
+echo -e "1\t2\t3" | $CLICKHOUSE_LOCAL -q "desc table table" --file=-
+echo -e "1\t2\t3" | $CLICKHOUSE_LOCAL -q "select * from table" --file=-
 

--- a/tests/queries/0_stateless/02211_shcema_inference_from_stdin.sh
+++ b/tests/queries/0_stateless/02211_shcema_inference_from_stdin.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-parallel
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh

--- a/tests/queries/0_stateless/02211_shcema_inference_from_stdin.sh
+++ b/tests/queries/0_stateless/02211_shcema_inference_from_stdin.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+$CLICKHOUSE_LOCAL -q "select toUInt32(number) as x from numbers(10) format JSONEachRow" > data.jsoneachrow
+
+$CLICKHOUSE_LOCAL -q "desc table table" < data.jsoneachrow
+$CLICKHOUSE_LOCAL -q "select * from table" < data.jsoneachrow
+
+rm data.jsoneachrow
+
+echo -e "1\t2\t3" | $CLICKHOUSE_LOCAL -q "desc table table"
+echo -e "1\t2\t3" | $CLICKHOUSE_LOCAL -q "select * from table"
+

--- a/tests/queries/0_stateless/02211_shcema_inference_from_stdin.sh
+++ b/tests/queries/0_stateless/02211_shcema_inference_from_stdin.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# Tags: no-fasttest
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve schema inference in clickhouse-local. Allow to write just `clickhouse-local -q "select * from table" < data.format`
