### PR TITLE
gRPC: Send output format back to client

### DIFF
--- a/src/Server/GRPCServer.cpp
+++ b/src/Server/GRPCServer.cpp
@@ -642,6 +642,7 @@ namespace
         void throwIfFailedToReadQueryInfo();
         bool isQueryCancelled();
 
+        void addQueryDetailsToResult();
         void addOutputFormatToResult();
         void addProgressToResult();
         void addTotalsToResult(const Block & totals);
@@ -1151,6 +1152,9 @@ namespace
 
     void Call::generateOutput()
     {
+        /// We add query_id and time_zone to the first result anyway.
+        addQueryDetailsToResult();
+
         if (!io.pipeline.initialized() || io.pipeline.pushing())
             return;
 
@@ -1440,6 +1444,12 @@ namespace
         }
 
         return false;
+    }
+
+    void Call::addQueryDetailsToResult()
+    {
+        *result.mutable_query_id() = query_context->getClientInfo().current_query_id;
+        *result.mutable_time_zone() = DateLUT::instance().getTimeZone();
     }
 
     void Call::addOutputFormatToResult()

--- a/src/Server/GRPCServer.cpp
+++ b/src/Server/GRPCServer.cpp
@@ -642,6 +642,7 @@ namespace
         void throwIfFailedToReadQueryInfo();
         bool isQueryCancelled();
 
+        void addOutputFormatToResult();
         void addProgressToResult();
         void addTotalsToResult(const Block & totals);
         void addExtremesToResult(const Block & extremes);
@@ -1189,6 +1190,8 @@ namespace
                 return true;
             };
 
+            addOutputFormatToResult();
+
             Block block;
             while (check_for_cancel())
             {
@@ -1437,6 +1440,11 @@ namespace
         }
 
         return false;
+    }
+
+    void Call::addOutputFormatToResult()
+    {
+        *result.mutable_output_format() = output_format;
     }
 
     void Call::addProgressToResult()

--- a/src/Server/grpc_protos/clickhouse_grpc.proto
+++ b/src/Server/grpc_protos/clickhouse_grpc.proto
@@ -187,7 +187,11 @@ message Exception {
 
 // Result of execution of a query which is sent back by the ClickHouse server to the client.
 message Result {
-   // Output of the query, represented in the `output_format` or in a format specified in `query`.
+   // The format in which `output`, `totals` and `extremes` are written.
+   // It's either the same as `output_format` specified in `QueryInfo` or the format specified in the query itself.
+   string output_format = 9;
+
+   // Output of the query, represented in the `output_format`.
    bytes output = 1;
    bytes totals = 2;
    bytes extremes = 3;

--- a/src/Server/grpc_protos/clickhouse_grpc.proto
+++ b/src/Server/grpc_protos/clickhouse_grpc.proto
@@ -82,6 +82,9 @@ message QueryInfo {
    // Default output format. If not specified, 'TabSeparated' is used.
    string output_format = 7;
 
+   // Set it if you want the names and the types of output columns to be sent to the client.
+   bool send_output_columns = 24;
+
    repeated ExternalTable external_tables = 8;
 
    string user_name = 9;
@@ -193,6 +196,9 @@ message Result {
    // The format in which `output`, `totals` and `extremes` are written.
    // It's either the same as `output_format` specified in `QueryInfo` or the format specified in the query itself.
    string output_format = 11;
+
+   // The names and types of columns of the result written in `output`.
+   repeated NameAndType output_columns = 12;
 
    // Output of the query, represented in the `output_format`.
    bytes output = 1;

--- a/src/Server/grpc_protos/clickhouse_grpc.proto
+++ b/src/Server/grpc_protos/clickhouse_grpc.proto
@@ -187,9 +187,12 @@ message Exception {
 
 // Result of execution of a query which is sent back by the ClickHouse server to the client.
 message Result {
+   string query_id = 9;
+   string time_zone = 10;
+   
    // The format in which `output`, `totals` and `extremes` are written.
    // It's either the same as `output_format` specified in `QueryInfo` or the format specified in the query itself.
-   string output_format = 9;
+   string output_format = 11;
 
    // Output of the query, represented in the `output_format`.
    bytes output = 1;

--- a/tests/integration/test_grpc_protocol/test.py
+++ b/tests/integration/test_grpc_protocol/test.py
@@ -204,6 +204,19 @@ def test_totals_and_extremes():
     assert query("SELECT x, y FROM t") == "1\t2\n2\t4\n3\t2\n3\t3\n3\t4\n"
     assert query_and_get_extremes("SELECT x, y FROM t", settings={"extremes": "1"}) == "1\t2\n3\t4\n"
 
+def test_get_query_details():
+    result = list(query_no_errors("CREATE TABLE t (a UInt8) ENGINE = Memory"))[0]
+    assert result.output_format == ''
+    assert result.output == b''
+    #
+    result = list(query_no_errors("SELECT 'a', 1", query_id = '', output_format = 'TabSeparated'))[0]
+    assert result.output_format == 'TabSeparated'
+    assert result.output == b'a\t1\n'
+    #
+    result = list(query_no_errors("SELECT 'a' AS x, 1 FORMAT JSONEachRow"))[0]
+    assert result.output_format == 'JSONEachRow'
+    assert result.output == b'{"x":"a","1":1}\n'
+
 def test_errors_handling():
     e = query_and_get_error("")
     #print(e)
@@ -232,6 +245,7 @@ def test_progress():
   read_bytes: 16
   total_rows_to_read: 8
 }
+output_format: "TabSeparated"
 , output: "0\\t0\\n1\\t0\\n"
 , progress {
   read_rows: 2


### PR DESCRIPTION
Changelog category:
- Improvement

Changelog entry:
Added sending of the output format back to client like it's done in HTTP protocol as suggested in https://github.com/ClickHouse/ClickHouse/issues/34362. Closes #34362.