### PR TITLE
Fix aggregation in order with distributed_aggregation_memory_efficient=0

### DIFF
--- a/src/Processors/Transforms/MergingAggregatedTransform.cpp
+++ b/src/Processors/Transforms/MergingAggregatedTransform.cpp
@@ -1,5 +1,6 @@
 #include <Processors/Transforms/MergingAggregatedTransform.h>
 #include <Processors/Transforms/AggregatingTransform.h>
+#include <Processors/Transforms/AggregatingInOrderTransform.h>
 
 namespace DB
 {
@@ -34,21 +35,30 @@ void MergingAggregatedTransform::consume(Chunk chunk)
     if (!info)
         throw Exception("Chunk info was not set for chunk in MergingAggregatedTransform.", ErrorCodes::LOGICAL_ERROR);
 
-    const auto * agg_info = typeid_cast<const AggregatedChunkInfo *>(info.get());
-    if (!agg_info)
+    if (const auto * agg_info = typeid_cast<const AggregatedChunkInfo *>(info.get()))
+    {
+        /** If the remote servers used a two-level aggregation method,
+        *  then blocks will contain information about the number of the bucket.
+        * Then the calculations can be parallelized by buckets.
+        * We decompose the blocks to the bucket numbers indicated in them.
+        */
+
+        auto block = getInputPort().getHeader().cloneWithColumns(chunk.getColumns());
+        block.info.is_overflows = agg_info->is_overflows;
+        block.info.bucket_num = agg_info->bucket_num;
+
+        bucket_to_blocks[agg_info->bucket_num].emplace_back(std::move(block));
+    }
+    else if (const auto * in_order_info = typeid_cast<const ChunkInfoWithAllocatedBytes *>(info.get()))
+    {
+        auto block = getInputPort().getHeader().cloneWithColumns(chunk.getColumns());
+        block.info.is_overflows = false;
+        block.info.bucket_num = -1;
+
+        bucket_to_blocks[block.info.bucket_num].emplace_back(std::move(block));
+    }
+    else
         throw Exception("Chunk should have AggregatedChunkInfo in MergingAggregatedTransform.", ErrorCodes::LOGICAL_ERROR);
-
-    /** If the remote servers used a two-level aggregation method,
-      *  then blocks will contain information about the number of the bucket.
-      * Then the calculations can be parallelized by buckets.
-      * We decompose the blocks to the bucket numbers indicated in them.
-      */
-
-    auto block = getInputPort().getHeader().cloneWithColumns(chunk.getColumns());
-    block.info.is_overflows = agg_info->is_overflows;
-    block.info.bucket_num = agg_info->bucket_num;
-
-    bucket_to_blocks[agg_info->bucket_num].emplace_back(std::move(block));
 }
 
 Chunk MergingAggregatedTransform::generate()

--- a/tests/queries/0_stateless/02176_optimize_aggregation_in_order_empty.reference
+++ b/tests/queries/0_stateless/02176_optimize_aggregation_in_order_empty.reference
@@ -5,4 +5,5 @@
 --   "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform"
 -- at first and after
 --   "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform"
-select count() from remote('127.{1,2}', currentDatabase(), data_02176) where key = 0 group by key settings optimize_aggregation_in_order=1;
+select count() from remote('127.{1,2}', currentDatabase(), data_02176) where key = 0 group by key;
+select count() from remote('127.{1,2}', currentDatabase(), data_02176) where key = 0 group by key settings distributed_aggregation_memory_efficient=0;

--- a/tests/queries/0_stateless/02176_optimize_aggregation_in_order_empty.sql
+++ b/tests/queries/0_stateless/02176_optimize_aggregation_in_order_empty.sql
@@ -1,6 +1,8 @@
 drop table if exists data_02176;
 create table data_02176 (key Int) Engine=MergeTree() order by key;
 
+set optimize_aggregation_in_order=1;
+
 -- { echoOn }
 
 -- regression for optimize_aggregation_in_order with empty result set
@@ -8,7 +10,8 @@ create table data_02176 (key Int) Engine=MergeTree() order by key;
 --   "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform"
 -- at first and after
 --   "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform"
-select count() from remote('127.{1,2}', currentDatabase(), data_02176) where key = 0 group by key settings optimize_aggregation_in_order=1;
+select count() from remote('127.{1,2}', currentDatabase(), data_02176) where key = 0 group by key;
+select count() from remote('127.{1,2}', currentDatabase(), data_02176) where key = 0 group by key settings distributed_aggregation_memory_efficient=0;
 
 -- { echoOff }
 drop table data_02176;

--- a/tests/queries/0_stateless/02177_merge_optimize_aggregation_in_order.reference
+++ b/tests/queries/0_stateless/02177_merge_optimize_aggregation_in_order.reference
@@ -2,5 +2,7 @@
 
 -- regression for optimize_aggregation_in_order
 -- that cause "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform" error
-select count() from remote('127.{1,2}', currentDatabase(), data_02177) group by key settings optimize_aggregation_in_order=1;
+select count() from remote('127.{1,2}', currentDatabase(), data_02177) group by key;
+2
+select count() from remote('127.{1,2}', currentDatabase(), data_02177) group by key settings distributed_aggregation_memory_efficient=0;
 2

--- a/tests/queries/0_stateless/02177_merge_optimize_aggregation_in_order.sql
+++ b/tests/queries/0_stateless/02177_merge_optimize_aggregation_in_order.sql
@@ -2,11 +2,14 @@ drop table if exists data_02177;
 create table data_02177 (key Int) Engine=MergeTree() order by key;
 insert into data_02177 values (1);
 
+set optimize_aggregation_in_order=1;
+
 -- { echoOn }
 
 -- regression for optimize_aggregation_in_order
 -- that cause "Chunk should have AggregatedChunkInfo in GroupingAggregatedTransform" error
-select count() from remote('127.{1,2}', currentDatabase(), data_02177) group by key settings optimize_aggregation_in_order=1;
+select count() from remote('127.{1,2}', currentDatabase(), data_02177) group by key;
+select count() from remote('127.{1,2}', currentDatabase(), data_02177) group by key settings distributed_aggregation_memory_efficient=0;
 
 -- { echoOff }
 drop table data_02177;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix exception `Chunk should have AggregatedChunkInfo in MergingAggregatedTransform` (in case of `optimize_aggregation_in_order=1` and `distributed_aggregation_memory_efficient=0`). Fixes #34526.