### PR TITLE
Keeper changelog async delete useless logs

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -594,7 +594,7 @@ void Changelog::compact(uint64_t up_to_log_index)
                 std::error_code ec;
                 std::filesystem::remove(itr->second.path, ec);
                 if (ec)
-                    LOG_WARNING(log, "Failed to remove changelog {} because of compaction, error message: {}", itr->second.path, ec.message());
+                    LOG_WARNING(log, "Failed to remove changelog {} in compaction, error message: {}", itr->second.path, ec.message());
                 else
                     LOG_INFO(log, "Removed changelog {} because of compaction", itr->second.path);
             }
@@ -743,7 +743,7 @@ void Changelog::cleanLogThread()
             if (std::filesystem::remove(path, ec))
                 LOG_INFO(log, "Removed changelog {} because of compaction.", path);
             else
-                LOG_WARNING(log, "Failed to remove changelog {} after compaction: {}", path, ec.message());
+                LOG_WARNING(log, "Failed to remove changelog {} in compaction, error message: {}", path, ec.message());
         }
     }
 }

--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -723,8 +723,6 @@ Changelog::~Changelog()
     {
         flush();
         log_files_to_delete_queue.finish();
-        /// Wait for background thread to finish to remove all logs
-        std::this_thread::sleep_for(std::chrono::milliseconds(2000));
         if (clean_log_thread.joinable())
             clean_log_thread.join();
     }

--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -10,7 +10,6 @@
 #include <Common/Exception.h>
 #include <Common/SipHash.h>
 #include <base/logger_useful.h>
-#include <libnuraft/log_entry.hxx>
 
 
 namespace DB

--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -169,7 +169,6 @@ private:
     /// 128 is enough, even if log is not removed, it's not a problem
     ConcurrentBoundedQueue<std::string> log_files_to_delete_queue{128};
     ThreadFromGlobalPool clean_log_thread;
-    std::atomic_bool shutdown_clean_thread{false};
 };
 
 }

--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <libnuraft/nuraft.hxx>
 #include <city.h>
 #include <optional>

--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <boost/lockfree/spsc_queue.hpp>
 #include <libnuraft/nuraft.hxx>
 #include <city.h>
 #include <optional>
@@ -9,6 +8,7 @@
 #include <IO/HashingWriteBuffer.h>
 #include <IO/CompressionMethod.h>
 #include <Disks/IDisk.h>
+#include <Common/ConcurrentBoundedQueue.h>
 
 namespace DB
 {
@@ -167,7 +167,7 @@ private:
     uint64_t max_log_id = 0;
     /// For compaction, queue of delete not used logs
     /// 128 is enough, even if log is not removed, it's not a problem
-    boost::lockfree::spsc_queue<std::string> del_log_q{128};
+    ConcurrentBoundedQueue<std::string> log_files_to_delete_queue{128};
     ThreadFromGlobalPool clean_log_thread;
     std::atomic_bool shutdown_clean_thread{false};
 };

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <gtest/gtest.h>
 
 #include "config_core.h"
@@ -406,6 +407,7 @@ TEST_P(CoordinationTest, ChangelogTestCompaction)
     EXPECT_TRUE(fs::exists("./logs/changelog_6_10.bin" + params.extension));
 
     changelog.compact(6);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
 
     EXPECT_FALSE(fs::exists("./logs/changelog_1_5.bin" + params.extension));
     EXPECT_TRUE(fs::exists("./logs/changelog_6_10.bin" + params.extension));
@@ -1459,6 +1461,7 @@ TEST_P(CoordinationTest, TestRotateIntervalChanges)
     }
 
     changelog_2.compact(105);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
 
     EXPECT_FALSE(fs::exists("./logs/changelog_1_100.bin" + params.extension));
     EXPECT_TRUE(fs::exists("./logs/changelog_101_110.bin" + params.extension));
@@ -1478,6 +1481,7 @@ TEST_P(CoordinationTest, TestRotateIntervalChanges)
     }
 
     changelog_3.compact(125);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
     EXPECT_FALSE(fs::exists("./logs/changelog_101_110.bin" + params.extension));
     EXPECT_FALSE(fs::exists("./logs/changelog_111_117.bin" + params.extension));
     EXPECT_FALSE(fs::exists("./logs/changelog_118_124.bin" + params.extension));


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Compaction of log store in Nuraft need acquire an inner lock which also used in normal commit process, so we delete useless logs in `compact` method of Changelog class in a background thread. See details on: https://github.com/ClickHouse-Extras/NuRaft/blob/1707a7572aa66ec5d0a2dbe2bf5effa3352e6b2d/src/handle_commit.cxx#L560

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
