### PR TITLE
Fix gtest_archive_reader_and_writer in case of !USE_MINIZIP

### DIFF
--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -328,14 +328,16 @@ TEST_P(ArchiveReaderAndWriterTest, ArchiveNotExist)
 }
 
 
+#if USE_MINIZIP
+
 namespace
 {
     const char * supported_archive_file_exts[] =
     {
-#if USE_MINIZIP
         ".zip",
-#endif
     };
 }
 
 INSTANTIATE_TEST_SUITE_P(All, ArchiveReaderAndWriterTest, ::testing::ValuesIn(supported_archive_file_exts));
+
+#endif


### PR DESCRIPTION
Empty arrays/vectors are not supported by `ValuesIn` (see commit description for an error)

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @vitlibar 