### PR TITLE
Generic configuration reload

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -977,6 +977,8 @@ if (ThreadFuzzer::instance().isEffective())
             CertificateReloader::instance().tryLoad(*config);
 #endif
             ProfileEvents::increment(ProfileEvents::MainConfigLoads);
+
+            global_context->setConfig(config);
         },
         /* already_loaded = */ false);  /// Reload it right now (initial loading)
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Generic configuration reload (this will apply changes for `named_collections`/... w/o server restart)

Before this patch there were separate reloading for particular config
parts, for example:
- remote_servers
- keeper_config
- dictionaries
- UDF
- macros
...

But what it misses is reloading of the main configuration it self, so
places that uses config directly will not use new values, for example:
- named collections
...

Fix this by adding proper reload.