### PR TITLE
Always remove unused actions from addMissingDefaults

### DIFF
--- a/src/Interpreters/addMissingDefaults.cpp
+++ b/src/Interpreters/addMissingDefaults.cpp
@@ -83,10 +83,9 @@ ActionsDAGPtr addMissingDefaults(
     /// Computes explicitly specified values by default and materialized columns.
     if (auto dag = evaluateMissingDefaults(actions->getResultColumns(), required_columns, columns, context, true, null_as_default))
         actions = ActionsDAG::merge(std::move(*actions), std::move(*dag));
-    else
-        /// Removes unused columns and reorders result.
-        /// The same is done in evaluateMissingDefaults if not empty dag is returned.
-        actions->removeUnusedActions(required_columns.getNames());
+
+    /// Removes unused columns and reorders result.
+    actions->removeUnusedActions(required_columns.getNames(), false);
 
     return actions;
 }

--- a/src/Interpreters/addMissingDefaults.cpp
+++ b/src/Interpreters/addMissingDefaults.cpp
@@ -86,6 +86,7 @@ ActionsDAGPtr addMissingDefaults(
 
     /// Removes unused columns and reorders result.
     actions->removeUnusedActions(required_columns.getNames(), false);
+    actions->addMaterializingOutputActions();
 
     return actions;
 }

--- a/src/Interpreters/inplaceBlockConversions.cpp
+++ b/src/Interpreters/inplaceBlockConversions.cpp
@@ -130,7 +130,7 @@ ASTPtr convertRequiredExpressions(Block & block, const NamesAndTypesList & requi
     return conversion_expr_list;
 }
 
-static ActionsDAGPtr createExpressions(
+ActionsDAGPtr createExpressions(
     const Block & header,
     ASTPtr expr_list,
     bool save_unneeded_columns,

--- a/src/Interpreters/inplaceBlockConversions.cpp
+++ b/src/Interpreters/inplaceBlockConversions.cpp
@@ -130,11 +130,10 @@ ASTPtr convertRequiredExpressions(Block & block, const NamesAndTypesList & requi
     return conversion_expr_list;
 }
 
-ActionsDAGPtr createExpressions(
+static ActionsDAGPtr createExpressions(
     const Block & header,
     ASTPtr expr_list,
     bool save_unneeded_columns,
-    const NamesAndTypesList & required_columns,
     ContextPtr context)
 {
     if (!expr_list)
@@ -145,12 +144,6 @@ ActionsDAGPtr createExpressions(
     auto dag = std::make_shared<ActionsDAG>(header.getNamesAndTypesList());
     auto actions = expression_analyzer.getActionsDAG(true, !save_unneeded_columns);
     dag = ActionsDAG::merge(std::move(*dag), std::move(*actions));
-
-    if (save_unneeded_columns)
-    {
-        dag->removeUnusedActions(required_columns.getNames());
-        dag->addMaterializingOutputActions();
-    }
 
     return dag;
 }
@@ -163,7 +156,7 @@ void performRequiredConversions(Block & block, const NamesAndTypesList & require
     if (conversion_expr_list->children.empty())
         return;
 
-    if (auto dag = createExpressions(block, conversion_expr_list, true, required_columns, context))
+    if (auto dag = createExpressions(block, conversion_expr_list, true, context))
     {
         auto expression = std::make_shared<ExpressionActions>(std::move(dag), ExpressionActionsSettings::fromContext(context));
         expression->execute(block);
@@ -182,7 +175,7 @@ ActionsDAGPtr evaluateMissingDefaults(
         return nullptr;
 
     ASTPtr expr_list = defaultRequiredExpressions(header, required_columns, columns, null_as_default);
-    return createExpressions(header, expr_list, save_unneeded_columns, required_columns, context);
+    return createExpressions(header, expr_list, save_unneeded_columns, context);
 }
 
 }

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -192,6 +192,7 @@ void IMergeTreeReader::evaluateMissingDefaults(Block additional_columns, Columns
                 additional_columns, columns, metadata_snapshot->getColumns(), storage.getContext());
         if (dag)
         {
+            dag->addMaterializingOutputActions();
             auto actions = std::make_shared<
                 ExpressionActions>(std::move(dag),
                 ExpressionActionsSettings::fromSettings(storage.getContext()->getSettingsRef()));


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)
