### PR TITLE
Keeper memory optimization by not holding snapshot in memory

### DIFF
--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -526,5 +526,33 @@ void KeeperSnapshotManager::removeSnapshot(uint64_t log_idx)
     existing_snapshots.erase(itr);
 }
 
+std::pair<std::string, std::error_code> KeeperSnapshotManager::serializeSnapshotToDisk(const KeeperStorageSnapshot & snapshot)
+{
+    auto up_to_log_idx = snapshot.snapshot_meta->get_last_log_idx();
+    auto snapshot_file_name = getSnapshotFileName(up_to_log_idx, compress_snapshots_zstd);
+    auto tmp_snapshot_file_name = "tmp_" + snapshot_file_name;
+    std::string tmp_snapshot_path = std::filesystem::path{snapshots_path} / tmp_snapshot_file_name;
+    std::string new_snapshot_path = std::filesystem::path{snapshots_path} / snapshot_file_name;
+
+    auto writer = std::make_unique<WriteBufferFromFile>(tmp_snapshot_path, O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC| O_APPEND);
+    std::unique_ptr<WriteBuffer> compressed_writer;
+    if (compress_snapshots_zstd)
+        compressed_writer = wrapWriteBufferWithCompressionMethod(std::move(writer), CompressionMethod::Zstd, 3);
+    else
+        compressed_writer = std::make_unique<CompressedWriteBuffer>(*writer);
+
+    KeeperStorageSnapshot::serialize(snapshot, *compressed_writer);
+    compressed_writer->finalize();
+    compressed_writer->sync();
+
+    std::error_code ec;
+    std::filesystem::rename(tmp_snapshot_path, new_snapshot_path, ec);
+    if (!ec)
+    {
+        existing_snapshots.emplace(up_to_log_idx, new_snapshot_path);
+        removeOutdatedSnapshotsIfNeeded();
+    }
+    return {new_snapshot_path, ec};
+}
 
 }

--- a/src/Coordination/KeeperSnapshotManager.h
+++ b/src/Coordination/KeeperSnapshotManager.h
@@ -135,10 +135,14 @@ public:
     {
         if (!existing_snapshots.empty())
         {
-            auto & path = existing_snapshots.at(getLatestSnapshotIndex());
+            const auto & path = existing_snapshots.at(getLatestSnapshotIndex());
             std::error_code ec;
             if (std::filesystem::exists(path, ec))
                 return path;
+            else
+            {
+                std::cerr << "Snapshot path " << path << " does not exist" << std::endl;
+            }
         }
         return "";
     }

--- a/src/Coordination/KeeperSnapshotManager.h
+++ b/src/Coordination/KeeperSnapshotManager.h
@@ -139,10 +139,6 @@ public:
             std::error_code ec;
             if (std::filesystem::exists(path, ec))
                 return path;
-            else
-            {
-                std::cerr << "Snapshot path " << path << " does not exist" << std::endl;
-            }
         }
         return "";
     }

--- a/src/Coordination/KeeperSnapshotManager.h
+++ b/src/Coordination/KeeperSnapshotManager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <filesystem>
 #include <system_error>
 #include <libnuraft/nuraft.hxx>
 #include <Coordination/KeeperStorage.h>
@@ -133,7 +134,12 @@ public:
     std::string getLatestSnapshotPath() const
     {
         if (!existing_snapshots.empty())
-            return existing_snapshots.at(getLatestSnapshotIndex());
+        {
+            auto & path = existing_snapshots.at(getLatestSnapshotIndex());
+            std::error_code ec;
+            if (std::filesystem::exists(path, ec))
+                return path;
+        }
         return "";
     }
 

--- a/src/Coordination/KeeperSnapshotManager.h
+++ b/src/Coordination/KeeperSnapshotManager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <system_error>
 #include <libnuraft/nuraft.hxx>
 #include <Coordination/KeeperStorage.h>
 #include <IO/WriteBuffer.h>
@@ -101,6 +102,9 @@ public:
     /// Serialize already compressed snapshot to disk (return path)
     std::string serializeSnapshotBufferToDisk(nuraft::buffer & buffer, uint64_t up_to_log_idx);
 
+    /// Serialize snapshot directly to disk
+    std::pair<std::string, std::error_code> serializeSnapshotToDisk(const KeeperStorageSnapshot & snapshot);
+
     SnapshotDeserializationResult deserializeSnapshotFromBuffer(nuraft::ptr<nuraft::buffer> buffer) const;
 
     /// Deserialize snapshot with log index up_to_log_idx from disk into compressed nuraft buffer.
@@ -124,6 +128,13 @@ public:
         if (!existing_snapshots.empty())
             return existing_snapshots.rbegin()->first;
         return 0;
+    }
+
+    std::string getLatestSnapshotPath() const
+    {
+        if (!existing_snapshots.empty())
+            return existing_snapshots.at(getLatestSnapshotIndex());
+        return "";
     }
 
 private:

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -320,7 +320,7 @@ int KeeperStateMachine::read_logical_snp_obj(
         }
         auto file_size = ::lseek(fd, 0, SEEK_END);
         ::lseek(fd, 0, SEEK_SET);
-        auto* chunk = reinterpret_cast<nuraft::byte*>(::mmap(nullptr, file_size, PROT_READ, MAP_FILE | MAP_SHARED, fd, 0));
+        auto * chunk = reinterpret_cast<nuraft::byte *>(::mmap(nullptr, file_size, PROT_READ, MAP_FILE | MAP_SHARED, fd, 0));
         if (chunk == MAP_FAILED)
         {
             LOG_WARNING(log, "Error mmapping {}.", latest_snapshot_path);

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -297,7 +297,7 @@ static int bufferFromFile(Poco::Logger * log, const std::string & path, nuraft::
     LOG_INFO(log, "Opening file {} for read_logical_snp_obj", path);
     if (fd < 0)
     {
-        LOG_WARNING(log, "Error opening {}, error: {}", path, std::strerror(errno));
+        LOG_WARNING(log, "Error opening {}, error: {}, errno: {}", path, std::strerror(errno), errno);
         return errno;
     }
     auto file_size = ::lseek(fd, 0, SEEK_END);
@@ -305,10 +305,11 @@ static int bufferFromFile(Poco::Logger * log, const std::string & path, nuraft::
     auto* chunk = reinterpret_cast<nuraft::byte*>(::mmap(nullptr, file_size, PROT_READ, MAP_FILE | MAP_SHARED, fd, 0));
     if (chunk == MAP_FAILED)
     {
-        LOG_WARNING(log, "Error mmapping {}, error: {}", path, std::strerror(errno));
+        LOG_WARNING(log, "Error mmapping {}, error: {}, errno: {}", path, std::strerror(errno), errno);
         ::close(fd);
         return errno;
     }
+    data_out->alloc(file_size);
     data_out->put_raw(chunk, file_size);
     ::munmap(chunk, file_size);
     ::close(fd);

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -309,7 +309,7 @@ static int bufferFromFile(Poco::Logger * log, const std::string & path, nuraft::
         ::close(fd);
         return errno;
     }
-    data_out->alloc(file_size);
+    data_out = nuraft::buffer::alloc(file_size);
     data_out->put_raw(chunk, file_size);
     ::munmap(chunk, file_size);
     ::close(fd);

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -204,10 +204,6 @@ void KeeperStateMachine::create_snapshot(
         {
             {   /// Read storage data without locks and create snapshot
                 std::lock_guard lock(snapshots_lock);
-                auto snapshot_buf = snapshot_manager.serializeSnapshotToBuffer(*snapshot);
-                auto result_path = snapshot_manager.serializeSnapshotBufferToDisk(*snapshot_buf, snapshot->snapshot_meta->get_last_log_idx());
-                latest_snapshot_buf = snapshot_buf;
-                latest_snapshot_meta = snapshot->snapshot_meta;
                 auto [path, error_code]= snapshot_manager.serializeSnapshotToDisk(*snapshot);
                 if (error_code)
                 {
@@ -215,6 +211,7 @@ void KeeperStateMachine::create_snapshot(
                             snapshot->snapshot_meta->get_last_log_idx(), error_code.message());
                 }
                 latest_snapshot_path = path;
+                latest_snapshot_meta = snapshot->snapshot_meta;
                 LOG_DEBUG(log, "Created persistent snapshot {} with path {}", latest_snapshot_meta->get_last_log_idx(), path);
             }
 

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -302,7 +302,7 @@ static int bufferFromFile(Poco::Logger * log, const std::string & path, nuraft::
     }
     auto file_size = ::lseek(fd, 0, SEEK_END);
     ::lseek(fd, 0, SEEK_SET);
-    auto* chunk = reinterpret_cast<nuraft::byte*>(::mmap(nullptr, file_size, PROT_READ, MAP_FILE | MAP_SHARED, fd, 0));
+    auto * chunk = reinterpret_cast<nuraft::byte *>(::mmap(nullptr, file_size, PROT_READ, MAP_FILE | MAP_SHARED, fd, 0));
     if (chunk == MAP_FAILED)
     {
         LOG_WARNING(log, "Error mmapping {}, error: {}, errno: {}", path, std::strerror(errno), errno);

--- a/src/Coordination/KeeperStateMachine.h
+++ b/src/Coordination/KeeperStateMachine.h
@@ -105,6 +105,7 @@ private:
     /// In our state machine we always have a single snapshot which is stored
     /// in memory in compressed (serialized) format.
     SnapshotMetadataPtr latest_snapshot_meta = nullptr;
+    std::string latest_snapshot_path;
     nuraft::ptr<nuraft::buffer> latest_snapshot_buf = nullptr;
 
     CoordinationSettingsPtr coordination_settings;


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't hold the latest snapshot in memory, instead, reading the snapshot if needed, sequence reading is fast to 200+MBps even on HDD using mmap system call.
Writing snapshot data directly to disk using compression method without holding original data and compressed data in memory.

Effect: about 20% saving memory
client command: `./utils/keeper-bench/keeper-bench --host=127.0.0.1:12183 -c 128 --generator=create_small_data`
new version:
![image](https://user-images.githubusercontent.com/985418/153876343-33a85de9-293f-4cf9-977b-05a0321f7815.png)

master version(34092fa2a31dadff5efbd301e7d5582c925ab916):
![image](https://user-images.githubusercontent.com/985418/153876432-4bd97d9f-de4f-4a7c-9229-6c0907376eb2.png)
