### PR TITLE
Keeper change log no need to clone log entry

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -54,11 +54,6 @@ ChangelogFileDescription getChangelogFileDescription(const std::string & path_st
     return result;
 }
 
-LogEntryPtr makeClone(const LogEntryPtr & entry)
-{
-    return cs_new<nuraft::log_entry>(entry->get_term(), nuraft::buffer::clone(entry->get_buf()), entry->get_val_type());
-}
-
 Checksum computeRecordChecksum(const ChangelogRecord & record)
 {
     SipHash hash;
@@ -519,7 +514,7 @@ void Changelog::appendEntry(uint64_t index, const LogEntryPtr & log_entry)
         rotate(index);
 
     current_writer->appendRecord(buildRecord(index, log_entry));
-    logs[index] = makeClone(log_entry);
+    logs[index] = log_entry;
     max_log_id = index;
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Little improvement no need to clone log entry.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
