### PR TITLE
ASTCreateQuery: Remove usused `tables` member

### DIFF
--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -198,8 +198,6 @@ ASTPtr ASTCreateQuery::clone() const
         res->set(res->storage, storage->clone());
     if (select)
         res->set(res->select, select->clone());
-    if (tables)
-        res->set(res->tables, tables->clone());
     if (table_overrides)
         res->set(res->table_overrides, table_overrides->clone());
 
@@ -432,12 +430,6 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
                       << settings.nl_or_ws << (settings.hilite ? hilite_none : "");
         select->formatImpl(settings, state, frame);
         settings.ostr << (comment ? ")" : "");
-    }
-
-    if (tables)
-    {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " WITH " << (settings.hilite ? hilite_none : "");
-        tables->formatImpl(settings, state, frame);
     }
 
     if (comment)

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -73,7 +73,6 @@ public:
     bool replace_view{false}; /// CREATE OR REPLACE VIEW
 
     ASTColumns * columns_list = nullptr;
-    ASTExpressionList * tables = nullptr;
 
     StorageID to_table_id = StorageID::createEmpty();   /// For CREATE MATERIALIZED VIEW mv TO table.
     UUID to_inner_uuid = UUIDHelpers::Nil;      /// For materialized view with inner table


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

Seems like this was added with the idea to use it with LiveViews but it was left behind during some refactor.