### PR TITLE
Attempt to fix freeBSD build

### DIFF
--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -539,14 +539,14 @@ catch (...)
 
 struct DiskWriteCheckData
 {
-    constexpr static size_t PAGE_SIZE = 4096;
-    char data[PAGE_SIZE]{};
+    constexpr static size_t PAGE_SIZE_IN_BYTES = 4096;
+    char data[PAGE_SIZE_IN_BYTES]{};
     DiskWriteCheckData()
     {
         static const char * magic_string = "ClickHouse disk local write check";
         static size_t magic_string_len = strlen(magic_string);
         memcpy(data, magic_string, magic_string_len);
-        memcpy(data + PAGE_SIZE - magic_string_len, magic_string, magic_string_len);
+        memcpy(data + PAGE_SIZE_IN_BYTES - magic_string_len, magic_string, magic_string_len);
     }
 };
 
@@ -557,7 +557,7 @@ try
     String tmp_template = fs::path(disk_path) / "";
     {
         auto buf = WriteBufferFromTemporaryFile::create(tmp_template);
-        buf->write(data.data, data.PAGE_SIZE);
+        buf->write(data.data, data.PAGE_SIZE_IN_BYTES);
         buf->sync();
     }
     return true;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

Initially I thought the issue might be harder but it seems it's just clashing with some internal freebsd macros. Let's try renaming and see if that helps.


Closes https://github.com/ClickHouse/ClickHouse/issues/34616