### PR TITLE
Fix allow_experimental_projection_optimization with enable_global_with_statement

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -286,7 +286,6 @@ InterpreterSelectQuery::InterpreterSelectQuery(
 
     query_info.ignore_projections = options.ignore_projections;
     query_info.is_projection_query = options.is_projection_query;
-    query_info.original_query = query_ptr->clone();
 
     initSettings();
     const Settings & settings = context->getSettingsRef();
@@ -309,6 +308,8 @@ InterpreterSelectQuery::InterpreterSelectQuery(
             ApplyWithAliasVisitor().visit(query_ptr);
         ApplyWithSubqueryVisitor().visit(query_ptr);
     }
+
+    query_info.original_query = query_ptr->clone();
 
     JoinedTables joined_tables(getSubqueryContext(context), getSelectQuery(), options.with_all_cols);
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4730,11 +4730,16 @@ std::optional<ProjectionCandidate> MergeTreeData::getQueryProcessingStageWithAgg
     if (select_query->join())
         return std::nullopt;
 
+    auto query_options = SelectQueryOptions(
+        QueryProcessingStage::WithMergeableState,
+        /* depth */ 1,
+        /* is_subquery_= */ true
+    ).ignoreProjections().ignoreAlias();
     InterpreterSelectQuery select(
         query_ptr,
         query_context,
-        SelectQueryOptions{QueryProcessingStage::WithMergeableState}.ignoreProjections().ignoreAlias(),
-        query_info.sets /* prepared_sets */);
+        query_options,
+        /* prepared_sets_= */ query_info.sets);
     const auto & analysis_result = select.getAnalysisResult();
     query_info.sets = std::move(select.getQueryAnalyzer()->getPreparedSets());
 

--- a/tests/queries/0_stateless/02222_allow_experimental_projection_optimization__enable_global_with_statement.reference
+++ b/tests/queries/0_stateless/02222_allow_experimental_projection_optimization__enable_global_with_statement.reference
@@ -1,0 +1,14 @@
+-- { echoOn }
+WITH
+    (SELECT * FROM data_02222) AS bm1,
+    (SELECT * FROM data_02222) AS bm2,
+    (SELECT * FROM data_02222) AS bm3,
+    (SELECT * FROM data_02222) AS bm4,
+    (SELECT * FROM data_02222) AS bm5,
+    (SELECT * FROM data_02222) AS bm6,
+    (SELECT * FROM data_02222) AS bm7,
+    (SELECT * FROM data_02222) AS bm8,
+    (SELECT * FROM data_02222) AS bm9,
+    (SELECT * FROM data_02222) AS bm10
+SELECT bm1, bm2, bm3, bm4, bm5, bm6, bm7, bm8, bm9, bm10 FROM data_02222;
+0	0	0	0	0	0	0	0	0	0

--- a/tests/queries/0_stateless/02222_allow_experimental_projection_optimization__enable_global_with_statement.sql
+++ b/tests/queries/0_stateless/02222_allow_experimental_projection_optimization__enable_global_with_statement.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS data_02222;
+CREATE TABLE data_02222 engine=MergeTree() ORDER BY dummy AS SELECT * FROM system.one;
+-- { echoOn }
+WITH
+    (SELECT * FROM data_02222) AS bm1,
+    (SELECT * FROM data_02222) AS bm2,
+    (SELECT * FROM data_02222) AS bm3,
+    (SELECT * FROM data_02222) AS bm4,
+    (SELECT * FROM data_02222) AS bm5,
+    (SELECT * FROM data_02222) AS bm6,
+    (SELECT * FROM data_02222) AS bm7,
+    (SELECT * FROM data_02222) AS bm8,
+    (SELECT * FROM data_02222) AS bm9,
+    (SELECT * FROM data_02222) AS bm10
+SELECT bm1, bm2, bm3, bm4, bm5, bm6, bm7, bm8, bm9, bm10 FROM data_02222;
+-- { echoOff }
+DROP TABLE data_02222;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `allow_experimental_projection_optimization` with `enable_global_with_statement` (before it may lead to `Stack size too large` error in case of multiple expressions in `WITH` clause, and also it executes scalar subqueries again and again, so not it will be more optimal).

allow_experimental_projection_optimization requires one more
InterpreterSelectQuery, which with enable_global_with_statement will
apply ApplyWithAliasVisitor if the query is not subquery.

But this should not be done for queries from
MergeTreeData::getQueryProcessingStage()/getQueryProcessingStageWithAggregateProjections()
since this will duplicate WITH statements over and over.

This will also fix scalar.xml perf tests, that leads to the following
error now:

    scalar.query0.prewarm0: DB::Exception: Stack size too large.

And since it has very long query in the log, this leads to the following
perf test error:

    _csv.Error: field larger than field limit (131072)

Cc: @amosbird 
Refs: #34456