### PR TITLE
Fix clang-tidy diagnostics related to std::move and noexcept

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,6 +33,8 @@ Checks: '-*,
     performance-no-automatic-move,
     performance-trivially-destructible,
     performance-unnecessary-copy-initialization,
+    performance-noexcept-move-constructor,
+    performance-move-const-arg,
 
     readability-avoid-const-params-in-decls,
     readability-const-return-type,

--- a/src/Dictionaries/SSDCacheDictionaryStorage.h
+++ b/src/Dictionaries/SSDCacheDictionaryStorage.h
@@ -761,9 +761,9 @@ private:
 
         FileDescriptor() = default;
 
-        FileDescriptor(FileDescriptor && rhs) : fd(rhs.fd) { rhs.fd = -1; }
+        FileDescriptor(FileDescriptor && rhs) noexcept : fd(rhs.fd) { rhs.fd = -1; }
 
-        FileDescriptor & operator=(FileDescriptor && rhs)
+        FileDescriptor & operator=(FileDescriptor && rhs) noexcept
         {
             if (this == &rhs)
                 return *this;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1057,7 +1057,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     QualifiedTableName qualified_name{database_name, create.getTable()};
     TableNamesSet loading_dependencies = getDependenciesSetFromCreateQuery(getContext()->getGlobalContext(), qualified_name, query_ptr);
     if (!loading_dependencies.empty())
-        DatabaseCatalog::instance().addLoadingDependencies(std::move(qualified_name), std::move(loading_dependencies));
+        DatabaseCatalog::instance().addLoadingDependencies(qualified_name, std::move(loading_dependencies));
 
     return fillTableIfNeeded(create);
 }

--- a/src/QueryPipeline/BlockIO.cpp
+++ b/src/QueryPipeline/BlockIO.cpp
@@ -23,7 +23,7 @@ void BlockIO::reset()
     /// TODO Do we need also reset callbacks? In which order?
 }
 
-BlockIO & BlockIO::operator= (BlockIO && rhs)
+BlockIO & BlockIO::operator= (BlockIO && rhs) noexcept
 {
     if (this == &rhs)
         return *this;

--- a/src/QueryPipeline/BlockIO.h
+++ b/src/QueryPipeline/BlockIO.h
@@ -14,7 +14,7 @@ struct BlockIO
     BlockIO() = default;
     BlockIO(BlockIO &&) = default;
 
-    BlockIO & operator= (BlockIO && rhs);
+    BlockIO & operator= (BlockIO && rhs) noexcept;
     ~BlockIO();
 
     BlockIO(const BlockIO &) = delete;

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -105,8 +105,8 @@ MergedBlockOutputStream::Finalizer::~Finalizer()
     }
 }
 
-MergedBlockOutputStream::Finalizer::Finalizer(Finalizer &&) = default;
-MergedBlockOutputStream::Finalizer & MergedBlockOutputStream::Finalizer::operator=(Finalizer &&) = default;
+MergedBlockOutputStream::Finalizer::Finalizer(Finalizer &&) noexcept = default;
+MergedBlockOutputStream::Finalizer & MergedBlockOutputStream::Finalizer::operator=(Finalizer &&) noexcept = default;
 MergedBlockOutputStream::Finalizer::Finalizer(std::unique_ptr<Impl> impl_) : impl(std::move(impl_)) {}
 
 void MergedBlockOutputStream::finalizePart(

--- a/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -42,8 +42,8 @@ public:
 
         explicit Finalizer(std::unique_ptr<Impl> impl_);
         ~Finalizer();
-        Finalizer(Finalizer &&);
-        Finalizer & operator=(Finalizer &&);
+        Finalizer(Finalizer &&) noexcept;
+        Finalizer & operator=(Finalizer &&) noexcept;
 
         void finish();
     };


### PR DESCRIPTION
This commit fixes the vulnerable code related to std::move and noexcept identified by clangtidy tool.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This commit fixes the vulnerable code related to std::move and noexcept identified by clangtidy tool.
