### PR TITLE
Fix possible memory_tracker use-after-free (for async s3 writes) for merges/mutations

### DIFF
--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -117,6 +117,10 @@ public:
     void setSoftLimit(Int64 value);
     void setHardLimit(Int64 value);
 
+    Int64 getHardLimit() const
+    {
+        return hard_limit.load(std::memory_order_relaxed);
+    }
     Int64 getSoftLimit() const
     {
         return soft_limit.load(std::memory_order_relaxed);

--- a/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MergeFromLogEntryTask.cpp
@@ -187,9 +187,7 @@ std::pair<bool, ReplicatedMergeMutateTaskBase::PartLogWriter> MergeFromLogEntryT
     merge_mutate_entry = storage.getContext()->getMergeList().insert(
         storage.getStorageID(),
         future_merged_part,
-        settings.memory_profiler_step,
-        settings.memory_profiler_sample_probability,
-        settings.max_untracked_memory);
+        settings);
 
     transaction_ptr = std::make_unique<MergeTreeData::Transaction>(storage);
     stopwatch_ptr = std::make_unique<Stopwatch>();

--- a/src/Storages/MergeTree/MergeList.cpp
+++ b/src/Storages/MergeTree/MergeList.cpp
@@ -16,23 +16,8 @@ MemoryTrackerThreadSwitcher::MemoryTrackerThreadSwitcher(MergeListEntry & merge_
 {
     // Each merge is executed into separate background processing pool thread
     background_thread_memory_tracker = CurrentThread::getMemoryTracker();
-    if (background_thread_memory_tracker)
-    {
-        /// From the query context it will be ("for thread") memory tracker with VariableContext::Thread level,
-        /// which does not have any limits and sampling settings configured.
-        /// And parent for this memory tracker should be ("(for query)") with VariableContext::Process level,
-        /// that has limits and sampling configured.
-        MemoryTracker * parent;
-        if (background_thread_memory_tracker->level == VariableContext::Thread &&
-            (parent = background_thread_memory_tracker->getParent()) &&
-            parent != &total_memory_tracker)
-        {
-            background_thread_memory_tracker = parent;
-        }
-
-        background_thread_memory_tracker_prev_parent = background_thread_memory_tracker->getParent();
-        background_thread_memory_tracker->setParent(&merge_list_entry->memory_tracker);
-    }
+    background_thread_memory_tracker_prev_parent = background_thread_memory_tracker->getParent();
+    background_thread_memory_tracker->setParent(&merge_list_entry->memory_tracker);
 
     prev_untracked_memory_limit = current_thread->untracked_memory_limit;
     current_thread->untracked_memory_limit = merge_list_entry->max_untracked_memory;
@@ -50,9 +35,7 @@ MemoryTrackerThreadSwitcher::MemoryTrackerThreadSwitcher(MergeListEntry & merge_
 MemoryTrackerThreadSwitcher::~MemoryTrackerThreadSwitcher()
 {
     // Unplug memory_tracker from current background processing pool thread
-
-    if (background_thread_memory_tracker)
-        background_thread_memory_tracker->setParent(background_thread_memory_tracker_prev_parent);
+    background_thread_memory_tracker->setParent(background_thread_memory_tracker_prev_parent);
 
     current_thread->untracked_memory_limit = prev_untracked_memory_limit;
 
@@ -65,16 +48,14 @@ MemoryTrackerThreadSwitcher::~MemoryTrackerThreadSwitcher()
 MergeListElement::MergeListElement(
     const StorageID & table_id_,
     FutureMergedMutatedPartPtr future_part,
-    UInt64 memory_profiler_step,
-    UInt64 memory_profiler_sample_probability,
-    UInt64 max_untracked_memory_)
+    const Settings & settings)
     : table_id{table_id_}
     , partition_id{future_part->part_info.partition_id}
     , result_part_name{future_part->name}
     , result_part_path{future_part->path}
     , result_part_info{future_part->part_info}
     , num_parts{future_part->parts.size()}
-    , max_untracked_memory(max_untracked_memory_)
+    , max_untracked_memory(settings.max_untracked_memory)
     , query_id(table_id.getShortName() + "::" + result_part_name)
     , thread_id{getThreadId()}
     , merge_type{future_part->merge_type}
@@ -97,8 +78,33 @@ MergeListElement::MergeListElement(
     }
 
     memory_tracker.setDescription("Mutate/Merge");
-    memory_tracker.setProfilerStep(memory_profiler_step);
-    memory_tracker.setSampleProbability(memory_profiler_sample_probability);
+    /// MemoryTracker settings should be set here, because
+    /// later (see MemoryTrackerThreadSwitcher)
+    /// parent memory tracker will be changed, and if merge executed from the
+    /// query (OPTIMIZE TABLE), all settings will be lost (since
+    /// current_thread::memory_tracker will have Thread level MemoryTracker,
+    /// which does not have any settings itself, it relies on the settings of the
+    /// thread_group::memory_tracker, but MemoryTrackerThreadSwitcher will reset parent).
+    memory_tracker.setProfilerStep(settings.memory_profiler_step);
+    memory_tracker.setSampleProbability(settings.memory_profiler_sample_probability);
+    memory_tracker.setSoftLimit(settings.max_guaranteed_memory_usage);
+    if (settings.memory_tracker_fault_probability)
+        memory_tracker.setFaultProbability(settings.memory_tracker_fault_probability);
+
+    /// Let's try to copy memory related settings from the query,
+    /// since settings that we have here is not from query, but global, from the table.
+    ///
+    /// NOTE: Remember, that Thread level MemoryTracker does not have any settings,
+    /// so it's parent is required.
+    MemoryTracker * query_memory_tracker = CurrentThread::getMemoryTracker();
+    MemoryTracker * parent_query_memory_tracker;
+    if (query_memory_tracker->level == VariableContext::Thread &&
+        (parent_query_memory_tracker = query_memory_tracker->getParent()) &&
+        parent_query_memory_tracker != &total_memory_tracker)
+    {
+        memory_tracker.setOrRaiseHardLimit(parent_query_memory_tracker->getHardLimit());
+    }
+
 }
 
 MergeInfo MergeListElement::getInfo() const

--- a/src/Storages/MergeTree/MergeList.h
+++ b/src/Storages/MergeTree/MergeList.h
@@ -58,6 +58,8 @@ using FutureMergedMutatedPartPtr = std::shared_ptr<FutureMergedMutatedPart>;
 struct MergeListElement;
 using MergeListEntry = BackgroundProcessListEntry<MergeListElement, MergeInfo>;
 
+struct Settings;
+
 
 /**
  * Since merge is executed with multiple threads, this class
@@ -127,9 +129,7 @@ struct MergeListElement : boost::noncopyable
     MergeListElement(
         const StorageID & table_id_,
         FutureMergedMutatedPartPtr future_part,
-        UInt64 memory_profiler_step,
-        UInt64 memory_profiler_sample_probability,
-        UInt64 max_untracked_memory_);
+        const Settings & settings);
 
     MergeInfo getInfo() const;
 

--- a/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MergePlainMergeTreeTask.cpp
@@ -81,9 +81,7 @@ void MergePlainMergeTreeTask::prepare()
     merge_list_entry = storage.getContext()->getMergeList().insert(
         storage.getStorageID(),
         future_part,
-        settings.memory_profiler_step,
-        settings.memory_profiler_sample_probability,
-        settings.max_untracked_memory);
+        settings);
 
     write_part_log = [this] (const ExecutionStatus & execution_status)
     {

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -585,12 +585,7 @@ bool MergeTask::MergeProjectionsStage::mergeMinMaxIndexAndPrepareProjections() c
             projection_future_part,
             projection.metadata,
             global_ctx->merge_entry,
-            std::make_unique<MergeListElement>(
-                (*global_ctx->merge_entry)->table_id,
-                projection_future_part,
-                settings.memory_profiler_step,
-                settings.memory_profiler_sample_probability,
-                settings.max_untracked_memory),
+            std::make_unique<MergeListElement>((*global_ctx->merge_entry)->table_id, projection_future_part, settings),
             global_ctx->time_of_merge,
             global_ctx->context,
             global_ctx->space_reservation,

--- a/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
+++ b/src/Storages/MergeTree/MutateFromLogEntryTask.cpp
@@ -116,9 +116,7 @@ std::pair<bool, ReplicatedMergeMutateTaskBase::PartLogWriter> MutateFromLogEntry
     merge_mutate_entry = storage.getContext()->getMergeList().insert(
         storage.getStorageID(),
         future_mutated_part,
-        settings.memory_profiler_step,
-        settings.memory_profiler_sample_probability,
-        settings.max_untracked_memory);
+        settings);
 
     stopwatch_ptr = std::make_unique<Stopwatch>();
 

--- a/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
@@ -32,9 +32,7 @@ void MutatePlainMergeTreeTask::prepare()
     merge_list_entry = storage.getContext()->getMergeList().insert(
         storage.getStorageID(),
         future_part,
-        settings.memory_profiler_step,
-        settings.memory_profiler_sample_probability,
-        settings.max_untracked_memory);
+        settings);
 
     stopwatch = std::make_unique<Stopwatch>();
 

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -633,12 +633,7 @@ public:
                 projection_future_part,
                 projection.metadata,
                 ctx->mutate_entry,
-                std::make_unique<MergeListElement>(
-                    (*ctx->mutate_entry)->table_id,
-                    projection_future_part,
-                    settings.memory_profiler_step,
-                    settings.memory_profiler_sample_probability,
-                    settings.max_untracked_memory),
+                std::make_unique<MergeListElement>((*ctx->mutate_entry)->table_id, projection_future_part, settings),
                 *ctx->holder,
                 ctx->time_of_mutation,
                 ctx->context,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible memory_tracker use-after-free (for async s3 writes) for merges/mutations

Detailed description:
There are two possible cases for execution merges/mutations:
1) from background thread
2) from OPTIMIZE TABLE query

1) is pretty simple, it's memory tracking structure is as follow:

```
    current_thread::memory_tracker = level=Thread / description="(for thread)" ==
      background_thread_memory_tracker = level=Thread / description="(for thread)"
    current_thread::memory_tracker.parent = level=Global / description="(total)"
```

  So as you can see it is pretty simple and MemoryTrackerThreadSwitcher
  does not do anything icky for this case.

2) is complex, it's memory tracking structure is as follow:

```
    current_thread::memory_tracker = level=Thread / description="(for thread)"
    current_thread::memory_tracker.parent = level=Process / description="(for query)" ==
      background_thread_memory_tracker = level=Process / description="(for query)"
```

  Before this patch to track memory (and related things, like sampling,
  profiling and so on) for OPTIMIZE TABLE query dirty hacks was done to
  do this, since current_thread memory_tracker was of Thread scope, that
  does not have any limits.

  And so if will change parent for it to Merge/Mutate memory tracker
  (which also does not have some of settings) it will not be correctly
  tracked.

  To address this Merge/Mutate was set as parent not to the
  current_thread memory_tracker but to it's parent, since it's scope is
  Process with all settings.

  But that parent's memory_tracker is the memory_tracker of the
  thread_group, and so if you will have nested ThreadPool inside
  merge/mutate (this is the case for s3 async writes, which has been
  added in https://github.com/ClickHouse/ClickHouse/pull/33291) you may get use-after-free of memory_tracker.

  Consider the following example:

    MemoryTrackerThreadSwitcher()
      thread_group.memory_tracker.parent = merge_list_entry->memory_tracker
      (see also background_thread_memory_tracker above)

    CurrentThread::attachTo()
      current_thread.memory_tracker.parent = thread_group.memory_tracker

    CurrentThread::detachQuery()
      current_thread.memory_tracker.parent = thread_group.memory_tracker.parent
      # and this is equal to merge_list_entry->memory_tracker

    ~MemoryTrackerThreadSwitcher()
      thread_group.memory_tracker = thread_group.memory_tracker.parent

  So after the following we will get incorrect memory_tracker (from the
  mege_list_entry) when the next job in that ThreadPool will not have
  thread_group, since in this case it will not try to update the
  current_thread.memory_tracker.parent and use-after-free will happens.

So to address the (2) issue, settings from the parent memory_tracker
should be copied to the merge_list_entry->memory_tracker, to avoid
playing with parent memory tracker.

Note, that settings from the query (OPTIMIZE TABLE) is not available at
that time, so it cannot be used (instead of parent's memory tracker
settings).

*NOTE: Marked as `Not for changelog` since s3 async writes had not been enabled yet*

Refs: #33291 (cc @KochetovNicolai )
Refs: #34692 (cc @amosbird )
Refs: #34581 