### PR TITLE
Allow only to specify --log-file without configuration

### DIFF
--- a/base/loggers/Loggers.cpp
+++ b/base/loggers/Loggers.cpp
@@ -247,11 +247,8 @@ void Loggers::updateLevels(Poco::Util::AbstractConfiguration & config, Poco::Log
     if (log_level > max_log_level)
         max_log_level = log_level;
 
-    const auto log_path = config.getString("logger.log", "");
-    if (!log_path.empty())
+    if (log_file)
         split->setLevel("log", log_level);
-    else
-        split->setLevel("log", 0);
 
     // Set level to console
     bool is_daemon = config.getBool("application.runAsDaemon", false);
@@ -263,15 +260,13 @@ void Loggers::updateLevels(Poco::Util::AbstractConfiguration & config, Poco::Log
         split->setLevel("console", 0);
 
     // Set level to errorlog
-    int errorlog_level = 0;
-    const auto errorlog_path = config.getString("logger.errorlog", "");
-    if (!errorlog_path.empty())
+    if (error_log_file)
     {
-        errorlog_level = Poco::Logger::parseLevel(config.getString("logger.errorlog_level", "notice"));
+        int errorlog_level = Poco::Logger::parseLevel(config.getString("logger.errorlog_level", "notice"));
         if (errorlog_level > max_log_level)
             max_log_level = errorlog_level;
+        split->setLevel("errorlog", errorlog_level);
     }
-    split->setLevel("errorlog", errorlog_level);
 
     // Set level to syslog
     int syslog_level = 0;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not reset logging that configured via --log-file/--errorlog-file in case of empty logger.log/logger.errorlog.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
