### PR TITLE
Document behaviour of quantile variants for empty numeric sequences

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/quantile.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/quantile.md
@@ -10,6 +10,8 @@ This function applies [reservoir sampling](https://en.wikipedia.org/wiki/Reservo
 
 When using multiple `quantile*` functions with different levels in a query, the internal states are not combined (that is, the query works less efficiently than it could). In this case, use the [quantiles](../../../sql-reference/aggregate-functions/reference/quantiles.md#quantiles) function.
 
+Note that for an empty numeric sequence, `quantile` will return NaN, but its `quantile*` variants will return either NaN or a default value for the sequence type, depending on the variant.
+
 **Syntax**
 
 ``` sql


### PR DESCRIPTION
Changelog category (leave one):
- Documentation

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Document the different for empty numeric sequences between `quantile` and variants like `quantileExact`

The difference in behaviour for empty numeric sequences of `quantile` and its variants like `quantileExact` is not described in the docs, and was a surprise for a team at our company when they switched from `medianIf` to `medianExactIf`. While technically maybe it could be deduced from the properties of `quantile` and its variants, it's not clear after a brief reading of the docs. We suggest adding this line to `quantile` documentation to make the reader aware that e.g. `quantileExact` might not be a drop-in replacement for `quantile` in all cases, only trading performance for accuracy.

Thanks!

Jakub Kuklis
Contentsquare