### PR TITLE
Improvements for `parallel_distributed_insert_select` (and related)

### DIFF
--- a/src/Interpreters/Cluster.h
+++ b/src/Interpreters/Cluster.h
@@ -207,7 +207,6 @@ public:
 
     using ShardsInfo = std::vector<ShardInfo>;
 
-    String getHashOfAddresses() const { return hash_of_addresses; }
     const ShardsInfo & getShardsInfo() const { return shards_info; }
     const AddressesWithFailover & getShardsAddresses() const { return addresses_with_failover; }
 
@@ -263,7 +262,6 @@ private:
     /// Inter-server secret
     String secret;
 
-    String hash_of_addresses;
     /// Description of the cluster shards.
     ShardsInfo shards_info;
     /// Any remote shard.

--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -116,7 +116,7 @@ void executeQuery(
 
     const Settings & settings = context->getSettingsRef();
 
-    if (settings.max_distributed_depth && context->getClientInfo().distributed_depth > settings.max_distributed_depth)
+    if (settings.max_distributed_depth && context->getClientInfo().distributed_depth >= settings.max_distributed_depth)
         throw Exception("Maximum distributed depth exceeded", ErrorCodes::TOO_LARGE_DISTRIBUTED_DEPTH);
 
     std::vector<QueryPlanPtr> plans;

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -125,7 +125,7 @@ DistributedSink::DistributedSink(
     , log(&Poco::Logger::get("DistributedBlockOutputStream"))
 {
     const auto & settings = context->getSettingsRef();
-    if (settings.max_distributed_depth && context->getClientInfo().distributed_depth > settings.max_distributed_depth)
+    if (settings.max_distributed_depth && context->getClientInfo().distributed_depth >= settings.max_distributed_depth)
         throw Exception("Maximum distributed depth exceeded", ErrorCodes::TOO_LARGE_DISTRIBUTED_DEPTH);
     context->getClientInfo().distributed_depth += 1;
     random_shard_insert = settings.insert_distributed_one_random_shard && !storage.has_sharding_key;

--- a/src/Storages/ExternalDataSourceConfiguration.h
+++ b/src/Storages/ExternalDataSourceConfiguration.h
@@ -16,7 +16,7 @@ struct ExternalDataSourceConfiguration
 {
     String host;
     UInt16 port = 0;
-    String username;
+    String username = "default";
     String password;
     String database;
     String table;

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -763,6 +763,8 @@ QueryPipelineBuilderPtr StorageDistributed::distributedWrite(const ASTInsertQuer
     if (settings.parallel_distributed_insert_select == PARALLEL_DISTRIBUTED_INSERT_SELECT_ALL)
     {
         new_query->table_id = StorageID(getRemoteDatabaseName(), getRemoteTableName());
+        /// Reset table function for INSERT INTO remote()/cluster()
+        new_query->table_function.reset();
     }
 
     const auto & cluster = getCluster();

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -735,6 +735,9 @@ QueryPipelineBuilderPtr StorageDistributed::distributedWrite(const ASTInsertQuer
 
     if (!storage_src || storage_src->getClusterName() != getClusterName())
     {
+        LOG_WARNING(log, "Parallel distributed INSERT SELECT is not possible (source cluster={}, destination cluster={})",
+            storage_src ? storage_src->getClusterName() : "<not a Distributed table>",
+            getClusterName());
         return nullptr;
     }
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -739,9 +739,16 @@ QueryPipelineBuilderPtr StorageDistributed::distributedWrite(const ASTInsertQuer
 
     if (!storage_src || storage_src->getClusterName() != getClusterName())
     {
-        LOG_WARNING(log, "Parallel distributed INSERT SELECT is not possible (source cluster={}, destination cluster={})",
-            storage_src ? storage_src->getClusterName() : "<not a Distributed table>",
-            getClusterName());
+        /// The warning should be produced only for root queries,
+        /// since in case of parallel_distributed_insert_select=1,
+        /// it will produce warning for the rewritten insert,
+        /// since destination table is still Distributed there.
+        if (local_context->getClientInfo().distributed_depth == 0)
+        {
+            LOG_WARNING(log, "Parallel distributed INSERT SELECT is not possible (source cluster={}, destination cluster={})",
+                storage_src ? storage_src->getClusterName() : "<not a Distributed table>",
+                getClusterName());
+        }
         return nullptr;
     }
 

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -706,7 +706,7 @@ SinkToStoragePtr StorageDistributed::write(const ASTPtr &, const StorageMetadata
 QueryPipelineBuilderPtr StorageDistributed::distributedWrite(const ASTInsertQuery & query, ContextPtr local_context)
 {
     const Settings & settings = local_context->getSettingsRef();
-    if (settings.max_distributed_depth && local_context->getClientInfo().distributed_depth > settings.max_distributed_depth)
+    if (settings.max_distributed_depth && local_context->getClientInfo().distributed_depth >= settings.max_distributed_depth)
         throw Exception("Maximum distributed depth exceeded", ErrorCodes::TOO_LARGE_DISTRIBUTED_DEPTH);
 
     std::shared_ptr<StorageDistributed> storage_src;

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -114,8 +114,6 @@ public:
     /// Used by InterpreterInsertQuery
     std::string getRemoteDatabaseName() const { return remote_database; }
     std::string getRemoteTableName() const { return remote_table; }
-    /// Returns empty string if tables is used by TableFunctionRemote
-    std::string getClusterName() const { return cluster_name; }
     ClusterPtr getCluster() const;
 
     /// Used by InterpreterSystemQuery
@@ -201,6 +199,7 @@ private:
     std::optional<QueryProcessingStage::Enum> getOptimizedQueryProcessingStage(const SelectQueryInfo & query_info, const Settings & settings) const;
 
     size_t getRandomShardIndex(const Cluster::ShardsInfo & shards);
+    std::string getClusterName() const { return cluster_name.empty() ? "<remote>" : cluster_name; }
 
     const DistributedSettings & getDistributedSettingsRef() const { return distributed_settings; }
 

--- a/tests/queries/0_stateless/02224_parallel_distributed_insert_select_cluster.reference
+++ b/tests/queries/0_stateless/02224_parallel_distributed_insert_select_cluster.reference
@@ -1,0 +1,27 @@
+-- { echoOn }
+truncate table dst_02224;
+insert into function cluster('test_cluster_two_shards', currentDatabase(), dst_02224, key)
+select * from cluster('test_cluster_two_shards', currentDatabase(), src_02224, key)
+settings parallel_distributed_insert_select=1, max_distributed_depth=1; -- { serverError TOO_LARGE_DISTRIBUTED_DEPTH }
+select * from dst_02224;
+truncate table dst_02224;
+insert into function cluster('test_cluster_two_shards', currentDatabase(), dst_02224, key)
+select * from cluster('test_cluster_two_shards', currentDatabase(), src_02224, key)
+settings parallel_distributed_insert_select=1, max_distributed_depth=2;
+select * from dst_02224;
+1
+1
+truncate table dst_02224;
+insert into function cluster('test_cluster_two_shards', currentDatabase(), dst_02224, key)
+select * from cluster('test_cluster_two_shards', currentDatabase(), src_02224, key)
+settings parallel_distributed_insert_select=2, max_distributed_depth=1;
+select * from dst_02224;
+1
+1
+truncate table dst_02224;
+insert into function remote('127.{1,2}', currentDatabase(), dst_02224, key)
+select * from remote('127.{1,2}', currentDatabase(), src_02224, key)
+settings parallel_distributed_insert_select=2, max_distributed_depth=1;
+select * from dst_02224;
+1
+1

--- a/tests/queries/0_stateless/02224_parallel_distributed_insert_select_cluster.sql
+++ b/tests/queries/0_stateless/02224_parallel_distributed_insert_select_cluster.sql
@@ -1,0 +1,34 @@
+drop table if exists dst_02224;
+drop table if exists src_02224;
+create table dst_02224 (key Int) engine=Memory();
+create table src_02224 (key Int) engine=Memory();
+insert into src_02224 values (1);
+
+-- { echoOn }
+truncate table dst_02224;
+insert into function cluster('test_cluster_two_shards', currentDatabase(), dst_02224, key)
+select * from cluster('test_cluster_two_shards', currentDatabase(), src_02224, key)
+settings parallel_distributed_insert_select=1, max_distributed_depth=1; -- { serverError TOO_LARGE_DISTRIBUTED_DEPTH }
+select * from dst_02224;
+
+truncate table dst_02224;
+insert into function cluster('test_cluster_two_shards', currentDatabase(), dst_02224, key)
+select * from cluster('test_cluster_two_shards', currentDatabase(), src_02224, key)
+settings parallel_distributed_insert_select=1, max_distributed_depth=2;
+select * from dst_02224;
+
+truncate table dst_02224;
+insert into function cluster('test_cluster_two_shards', currentDatabase(), dst_02224, key)
+select * from cluster('test_cluster_two_shards', currentDatabase(), src_02224, key)
+settings parallel_distributed_insert_select=2, max_distributed_depth=1;
+select * from dst_02224;
+
+truncate table dst_02224;
+insert into function remote('127.{1,2}', currentDatabase(), dst_02224, key)
+select * from remote('127.{1,2}', currentDatabase(), src_02224, key)
+settings parallel_distributed_insert_select=2, max_distributed_depth=1;
+select * from dst_02224;
+-- { echoOff }
+
+drop table src_02224;
+drop table dst_02224;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support `remote()`/`cluster()` for `parallel_distributed_insert_select=2`.

Changes:
- `remote()`/`cluster()` was not support by the `parallel_distributed_insert_select=2` before, i.e. it stills tries to `INSERT` into `Distributed` table, the problem was that it does not reset `table_function`.
- now it will compare not just cluster name, but all addresses in the cluster (since cluster name is an empty string for `remote()`/`cluster()`)
- `max_distributed_depth` was ignored for `parallel_distributed_insert_select` before, fix this too, to allow more robust tests.
- `max_distributed_depth=1` allows two queries (since depth starts from 0 and strict compare was used), address this to make it able to limit the depth to one query
- if parallel distributed INSERT SELECT is not possible (`parallel_distributed_insert_select`), now the warning will be printed (it is good for tests, and should not affect user, since `send_logs_level=none` by default)
- make default user match w/o sharding_key and w/ (before it was empty w/o sharding_key, and default w/ sharding_key)

*See also commit history*