### PR TITLE
Add a patch release for stable/lts packages to release.py

### DIFF
--- a/tests/ci/git_helper.py
+++ b/tests/ci/git_helper.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 from typing import Optional
 
+RELEASE_BRANCH_REGEXP = r"^\d+[.]\d+$"
 TAG_REGEXP = r"^v\d{2}[.][1-9]\d*[.][1-9]\d*[.][1-9]\d*-(testing|prestable|stable|lts)$"
 SHA_REGEXP = r"^([0-9]|[a-f]){40}$"
 
@@ -28,6 +29,13 @@ def commit(name: str):
         raise argparse.ArgumentTypeError(
             "commit hash should contain exactly 40 hex characters"
         )
+    return name
+
+
+def release_branch(name: str):
+    r = re.compile(RELEASE_BRANCH_REGEXP)
+    if not r.match(name):
+        raise argparse.ArgumentTypeError("release branch should be as 12.1")
     return name
 
 

--- a/tests/ci/git_helper.py
+++ b/tests/ci/git_helper.py
@@ -5,9 +5,13 @@ import re
 import subprocess
 from typing import Optional
 
-RELEASE_BRANCH_REGEXP = r"^\d+[.]\d+$"
-TAG_REGEXP = r"^v\d{2}[.][1-9]\d*[.][1-9]\d*[.][1-9]\d*-(testing|prestable|stable|lts)$"
-SHA_REGEXP = r"^([0-9]|[a-f]){40}$"
+# ^ and $ match subline in `multiple\nlines`
+# \A and \Z match only start and end of the whole string
+RELEASE_BRANCH_REGEXP = r"\A\d+[.]\d+\Z"
+TAG_REGEXP = (
+    r"\Av\d{2}[.][1-9]\d*[.][1-9]\d*[.][1-9]\d*-(testing|prestable|stable|lts)\Z"
+)
+SHA_REGEXP = r"\A([0-9]|[a-f]){40}\Z"
 
 
 # Py 3.8 removeprefix and removesuffix

--- a/tests/ci/git_test.py
+++ b/tests/ci/git_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+from unittest.mock import patch
+import os.path as p
+import unittest
+
+from git_helper import Git, Runner
+
+
+class TestRunner(unittest.TestCase):
+    def test_init(self):
+        runner = Runner()
+        self.assertEqual(runner.cwd, p.realpath(p.dirname(__file__)))
+        runner = Runner("/")
+        self.assertEqual(runner.cwd, "/")
+
+    def test_run(self):
+        runner = Runner()
+        output = runner.run("echo 1")
+        self.assertEqual(output, "1")
+
+
+class TestGit(unittest.TestCase):
+    def setUp(self):
+        """we use dummy git object"""
+        run_patcher = patch("git_helper.Runner.run", return_value="")
+        self.run_mock = run_patcher.start()
+        self.addCleanup(run_patcher.stop)
+        update_patcher = patch("git_helper.Git.update")
+        update_mock = update_patcher.start()
+        self.addCleanup(update_patcher.stop)
+        self.git = Git()
+        update_mock.assert_called_once()
+        self.run_mock.assert_called_once()
+        self.git.new_branch = "NEW_BRANCH_NAME"
+        self.git.new_tag = "v21.12.333.22222-stable"
+        self.git.branch = "old_branch"
+        self.git.sha = ""
+        self.git.sha_short = ""
+        self.git.latest_tag = ""
+        self.git.description = ""
+        self.git.commits_since_tag = 0
+
+    def test_tags(self):
+        self.git.new_tag = "v21.12.333.22222-stable"
+        self.git.latest_tag = "v21.12.333.22222-stable"
+        for tag_attr in ("new_tag", "latest_tag"):
+            self.assertEqual(getattr(self.git, tag_attr), "v21.12.333.22222-stable")
+            setattr(self.git, tag_attr, "")
+            self.assertEqual(getattr(self.git, tag_attr), "")
+            for tag in (
+                "v21.12.333-stable",
+                "v21.12.333-prestable",
+                "21.12.333.22222-stable",
+                "v21.12.333.22222-production",
+            ):
+                with self.assertRaises(Exception):
+                    setattr(self.git, tag_attr, tag)
+
+    def test_tweak(self):
+        self.git.commits_since_tag = 0
+        self.assertEqual(self.git.tweak, 1)
+        self.git.commits_since_tag = 2
+        self.assertEqual(self.git.tweak, 2)
+        self.git.latest_tag = "v21.12.333.22222-testing"
+        self.assertEqual(self.git.tweak, 22224)
+        self.git.commits_since_tag = 0
+        self.assertEqual(self.git.tweak, 22222)

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -74,16 +74,20 @@ class Release:
     def check_branch(self, release_type: str):
         if release_type in self.BIG:
             # Commit to spin up the release must belong to a main branch
-            output = self.run(f"git branch --contains={self.release_commit} master")
-            if "master" not in output:
+            branch = "master"
+            output = self.run(f"git branch --contains={self.release_commit} '{branch}'")
+            if branch not in output:
                 raise Exception(
                     f"commit {self.release_commit} must belong to 'master' for "
                     f"{release_type} release"
                 )
-        if release_type in self.SMALL:
+            return
+        elif release_type in self.SMALL:
             branch = f"{self.version.major}.{self.version.minor}"
-            if self._git.branch != branch:
+            output = self.run(f"git branch --contains={self.release_commit} '{branch}'")
+            if branch not in output:
                 raise Exception(f"branch must be '{branch}' for {release_type} release")
+            return
 
     def log_rollback(self):
         if self._rollback_stack:
@@ -287,7 +291,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--type",
         default="minor",
-        # choices=Release.BIG+Release.SMALL, # add support later
         choices=Release.BIG + Release.SMALL,
         dest="release_type",
         help="a release type, new branch is created only for 'major' and 'minor'",
@@ -318,10 +321,6 @@ def parse_args() -> argparse.Namespace:
     )
 
     return parser.parse_args()
-
-
-def prestable():
-    pass
 
 
 def main():


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Added patch release for lts/stable versions together with:
- Release branch check helper
- Different protocols for git remote URL
- Improve some edge cases of the release.py

if fixes #34741, fixes #34742