### PR TITLE
Improve the performance of the `ANY` aggregation function by acting over batches.

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -49,6 +49,7 @@ private:
 
 public:
     static constexpr bool is_nullable = false;
+    static constexpr bool is_any = false;
 
     bool has() const
     {
@@ -471,6 +472,7 @@ private:
 
 public:
     static constexpr bool is_nullable = false;
+    static constexpr bool is_any = false;
 
     bool has() const
     {
@@ -696,6 +698,7 @@ private:
 
 public:
     static constexpr bool is_nullable = false;
+    static constexpr bool is_any = false;
 
     bool has() const
     {
@@ -930,6 +933,7 @@ template <typename Data>
 struct AggregateFunctionAnyData : Data
 {
     using Self = AggregateFunctionAnyData;
+    static constexpr bool is_any = true;
 
     bool changeIfBetter(const IColumn & column, size_t row_num, Arena * arena) { return this->changeFirstTime(column, row_num, arena); }
     bool changeIfBetter(const Self & to, Arena * arena)                        { return this->changeFirstTime(to, arena); }
@@ -1120,6 +1124,8 @@ struct AggregateFunctionAnyHeavyData : Data
 template <typename Data>
 class AggregateFunctionsSingleValue final : public IAggregateFunctionDataHelper<Data, AggregateFunctionsSingleValue<Data>>
 {
+    static constexpr bool is_any = Data::is_any;
+
 private:
     SerializationPtr serialization;
 
@@ -1150,6 +1156,75 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn ** columns, size_t row_num, Arena * arena) const override
     {
         this->data(place).changeIfBetter(*columns[0], row_num, arena);
+    }
+
+    void addBatchSinglePlace(
+        size_t batch_size, AggregateDataPtr place, const IColumn ** columns, Arena * arena, ssize_t if_argument_pos) const override
+    {
+        if constexpr (is_any)
+            if (this->data(place).has())
+                return;
+        if (if_argument_pos >= 0)
+        {
+            const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
+            for (size_t i = 0; i < batch_size; ++i)
+            {
+                if (flags[i])
+                {
+                    this->data(place).changeIfBetter(*columns[0], i, arena);
+                    if constexpr (is_any)
+                        break;
+                }
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < batch_size; ++i)
+            {
+                this->data(place).changeIfBetter(*columns[0], i, arena);
+                if constexpr (is_any)
+                    break;
+            }
+        }
+    }
+
+    void addBatchSinglePlaceNotNull(
+        size_t batch_size,
+        AggregateDataPtr place,
+        const IColumn ** columns,
+        const UInt8 * null_map,
+        Arena * arena,
+        ssize_t if_argument_pos = -1) const override
+    {
+        if constexpr (is_any)
+            if (this->data(place).has())
+                return;
+
+        if (if_argument_pos >= 0)
+        {
+            const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
+            for (size_t i = 0; i < batch_size; ++i)
+            {
+                if (!null_map[i] && flags[i])
+                {
+                    this->data(place).changeIfBetter(*columns[0], i, arena);
+                    if constexpr (is_any)
+                        break;
+                }
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < batch_size; ++i)
+            {
+                if (!null_map[i])
+                {
+                    this->data(place).changeIfBetter(*columns[0], i, arena);
+                    if constexpr (is_any)
+                        break;
+                }
+            }
+        }
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena * arena) const override

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -21,6 +21,6 @@ TODO @akuzm
 ### How to validate single test
 
 ```
-pip3 install clickhouse_driver
+pip3 install clickhouse_driver scipy
 ../../docker/test/performance-comparison/perf.py --runs 1 insert_parallel.xml
 ```


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve the performance of the `ANY` aggregation function by acting over batches.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

Stop processing data as soon as an element has been saved. In most situations, i.e. when some element is saved, this leads to nice improvements:

Quick benchmark:

### Any
```
./programs/clickhouse benchmark --query 'Select any(number) from numbers(1000000000)' -i 20
```

* Master


```
Queries executed: 20.
localhost:9000, queries 20, QPS: 3.481, RPS: 3480741146.794, MiB/s: 26555.947, result RPS: 3.481, result MiB/s: 0.000.
0.000%          0.283 sec.
```

* Changes:
```
Queries executed: 20.
localhost:9000, queries 20, QPS: 3.845, RPS: 3845155687.009, MiB/s: 29336.210, result RPS: 3.845, result MiB/s: 0.000.
0.000%          0.252 sec.
```


### AnyIf

```
./programs/clickhouse benchmark --query 'Select anyIf(number, number > 0) from numbers(1000000000)' -i 20
```

* Master
```
Queries executed: 20.
localhost:9000, queries 20, QPS: 0.679, RPS: 679409111.125, MiB/s: 5183.480, result RPS: 0.679, result MiB/s: 0.000.
0.000%          1.397 sec.
```


* Changes

```
Queries executed: 20.
localhost:9000, queries 20, QPS: 1.086, RPS: 1085583240.480, MiB/s: 8282.343, result RPS: 1.086, result MiB/s: 0.000.
0.000%          0.894 sec
```

### AnyIf (Nullable)

```
./programs/clickhouse benchmark --query 'Select anyIf(number, number > 0) from (Select toNullable(number) as number FROM numbers(1000000000))' -i 20
```

* Master

```
Queries executed: 20.
localhost:9000, queries 20, QPS: 0.673, RPS: 672793289.616, MiB/s: 5133.005, result RPS: 0.673, result MiB/s: 0.000.
0.000%          1.414 sec.

```


* Changes:

```
Queries executed: 20.
localhost:9000, queries 20, QPS: 0.936, RPS: 936020885.318, MiB/s: 7141.273, result RPS: 0.936, result MiB/s: 0.000.
0.000%          1.029 sec.
```


Note that this only applies to ANY(). I might end up specialising things even more in further PRs to improve other aggregate functions.