### PR TITLE
Fix undefined __pthread_mutex_lock/unlock for glibc 2.34+/DISABLE_HERMETIC_BUILD

### DIFF
--- a/src/Common/ThreadFuzzer.cpp
+++ b/src/Common/ThreadFuzzer.cpp
@@ -25,7 +25,7 @@
     #define THREAD_FUZZER_WRAP_PTHREAD 0
 #endif
 
-/// Starting from glibc 2.34 there is no internal symbols w/o version,
+/// Starting from glibc 2.34 there are no internal symbols without version,
 /// so not __pthread_mutex_lock but __pthread_mutex_lock@2.2.5
 #if defined(OS_LINUX)
     /// You can get version from glibc/sysdeps/unix/sysv/linux/$ARCH/$BITS_OR_BYTE_ORDER/libc.abilist

--- a/src/Common/ThreadFuzzer.cpp
+++ b/src/Common/ThreadFuzzer.cpp
@@ -25,6 +25,28 @@
     #define THREAD_FUZZER_WRAP_PTHREAD 0
 #endif
 
+/// Starting from glibc 2.34 there is no internal symbols w/o version,
+/// so not __pthread_mutex_lock but __pthread_mutex_lock@2.2.5
+#if defined(OS_LINUX)
+    /// You can get version from glibc/sysdeps/unix/sysv/linux/$ARCH/$BITS_OR_BYTE_ORDER/libc.abilist
+    #if defined(__amd64__)
+    #    define GLIBC_SYMVER "GLIBC_2.2.5"
+    #elif defined(__aarch64__)
+    #    define GLIBC_SYMVER "GLIBC_2.17"
+    #elif defined(__riscv) && (__riscv_xlen == 64)
+    #    define GLIBC_SYMVER "GLIBC_2.27"
+    #elif (defined(__PPC64__) || defined(__powerpc64__)) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #    define GLIBC_SYMVER "GLIBC_2.17"
+    #else
+    #    error Your platform is not supported.
+    #endif
+
+    #define GLIBC_COMPAT_SYMBOL(func) __asm__(".symver " #func "," #func "@" GLIBC_SYMVER);
+
+    GLIBC_COMPAT_SYMBOL(__pthread_mutex_unlock)
+    GLIBC_COMPAT_SYMBOL(__pthread_mutex_lock)
+#endif
+
 #if THREAD_FUZZER_WRAP_PTHREAD
 #    define FOR_EACH_WRAPPED_FUNCTION(M) \
         M(int, pthread_mutex_lock, pthread_mutex_t * arg) \


### PR DESCRIPTION
Right now it fails with:

    ld.lld: error: undefined symbol: __pthread_mutex_lock
    >>> referenced by ThreadFuzzer.cpp:300 (./src/Common/ThreadFuzzer.cpp:300)
    >>> src/CMakeFiles/clickhouse_common_io.dir/Common/ThreadFuzzer.cpp.o:(pthread_mutex_lock)
    >>> did you mean: __pthread_mutex_lock@GLIBC_2.2.5
    >>> defined in: /usr/lib/libc.so.6

Here is the list of matched symbols for 2.35:

    $ nm -D /lib/libc.so.6 | fgrep pthread_mutex_lock
    00000000000908a0 T __pthread_mutex_lock@GLIBC_2.2.5
    00000000000908a0 T pthread_mutex_lock@@GLIBC_2.2.5

    $ nm -D /lib/libpthread.so.0 | fgrep -c pthread_mutex_lock
    0

And this is for 2.33:

    $ nm -D /lib/x86_64-linux-gnu/libc.so.6 | fgrep pthread_mutex_lock
    0000000000083eb0 T pthread_mutex_lock@@GLIBC_2.2.5

    $ nm -D /lib/x86_64-linux-gnu/libpthread.so.0 | fgrep pthread_mutex_lock
    000000000000af00 T __pthread_mutex_lock@@GLIBC_2.2.5
    000000000000af00 W pthread_mutex_lock@@GLIBC_2.2.5

Because "likely" starting from 27a448223cb2d3bab191c61303db48cee66f871c
("nptl: Move core mutex functions into libc") [1], __pthread_mutex_lock
is not exported anymore.

  [1]: https://sourceware.org/git/?p=glibc.git;a=commit;h=27a448223cb2d3bab191c61303db48cee66f871c

Changelog category (leave one):
- Not for changelog (changelog entry is not required)