### PR TITLE
Make drop of alias column metadata only

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -763,8 +763,13 @@ bool AlterCommand::isRequireMutationStage(const StorageInMemoryMetadata & metada
     if (isRemovingProperty() || type == REMOVE_TTL || type == REMOVE_SAMPLE_BY)
         return false;
 
-    if (type == DROP_COLUMN || type == DROP_INDEX || type == DROP_PROJECTION || type == RENAME_COLUMN)
+    if (type == DROP_INDEX || type == DROP_PROJECTION || type == RENAME_COLUMN)
         return true;
+
+    /// Drop alias is metadata alter, in other case mutation
+    /// is required.
+    if (type == DROP_COLUMN)
+        return metadata->columns.hasPhysical(column_name);
 
     if (type != MODIFY_COLUMN || data_type == nullptr)
         return false;

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -766,10 +766,9 @@ bool AlterCommand::isRequireMutationStage(const StorageInMemoryMetadata & metada
     if (type == DROP_INDEX || type == DROP_PROJECTION || type == RENAME_COLUMN)
         return true;
 
-    /// Drop alias is metadata alter, in other case mutation
-    /// is required.
+    /// Drop alias is metadata alter, in other case mutation is required.
     if (type == DROP_COLUMN)
-        return metadata->columns.hasPhysical(column_name);
+        return metadata.columns.hasPhysical(column_name);
 
     if (type != MODIFY_COLUMN || data_type == nullptr)
         return false;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now `ALTER TABLE DROP COLUMN columnX` queries for `MergeTree` table engines will work instantly when `columnX` is `ALIAS` column. Fixes #34660.