### PR TITLE
Better diagnostics on zero-copy S3 fetch failure

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.h
+++ b/src/Storages/MergeTree/DataPartsExchange.h
@@ -122,6 +122,7 @@ private:
 
     MergeTreeData::MutableDataPartPtr downloadPartToDiskRemoteMeta(
             const String & part_name,
+            const String & part_id,
             const String & replica_path,
             bool to_detached,
             const String & tmp_prefix_,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
