### PR TITLE
Improve `--no-*` options code in ci scripts

### DIFF
--- a/tests/ci/push_to_artifactory.py
+++ b/tests/ci/push_to_artifactory.py
@@ -253,15 +253,21 @@ def parse_args() -> argparse.Namespace:
         default="https://clickhousedb.jfrog.io/artifactory",
         help="SaaS Artifactory url",
     )
+    parser.add_argument("--artifactory", default=True, help=argparse.SUPPRESS)
     parser.add_argument(
         "-n",
         "--no-artifactory",
-        action="store_true",
+        action="store_false",
+        dest="artifactory",
+        default=argparse.SUPPRESS,
         help="do not push packages to artifactory",
     )
+    parser.add_argument("--force-download", default=True, help=argparse.SUPPRESS)
     parser.add_argument(
         "--no-force-download",
-        action="store_true",
+        action="store_false",
+        dest="force_download",
+        default=argparse.SUPPRESS,
         help="do not download packages again if they exist already",
     )
 
@@ -303,10 +309,10 @@ def main():
         args.commit,
         args.check_name,
         args.release.version,
-        not args.no_force_download,
+        args.force_download,
     )
     art_client = None
-    if not args.no_artifactory:
+    if args.artifactory:
         art_client = Artifactory(args.artifactory_url, args.release.type)
 
     if args.deb:

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -78,21 +78,21 @@ class Release:
         self._git.update()
         self.version = get_version_from_repo()
 
-    def do(self, no_check_dirty: bool, no_check_branch: bool, no_prestable: bool):
+    def do(self, check_dirty: bool, check_branch: bool, with_prestable: bool):
 
-        if not no_check_dirty:
+        if check_dirty:
             logging.info("Checking if repo is clean")
             self.run("git diff HEAD --exit-code")
 
         self.set_release_branch()
 
-        if not no_check_branch:
+        if check_branch:
             self.check_branch()
 
         with self._checkout(self.release_commit, True):
             if self.release_type in self.BIG:
                 # Checkout to the commit, it will provide the correct current version
-                if no_prestable:
+                if with_prestable:
                     logging.info("Skipping prestable stage")
                 else:
                     with self.prestable():
@@ -406,27 +406,37 @@ def parse_args() -> argparse.Namespace:
         help="a release type, new branch is created only for 'major' and 'minor'",
     )
     parser.add_argument(
-        "--no-prestable",
-        action="store_true",
-        help=f"for release types in {Release.BIG} skip creating prestable release and "
-        "release branch",
-    )
-    parser.add_argument(
         "--commit",
         default=git.sha,
         type=commit,
         help="commit create a release, default to HEAD",
     )
+    parser.add_argument("--with-prestable", default=True, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--no-prestable",
+        dest="with_prestable",
+        action="store_false",
+        default=argparse.SUPPRESS,
+        help=f"if set, for release types in {Release.BIG} skip creating prestable "
+        "release and  release branch",
+    )
+    parser.add_argument("--check-dirty", default=True, help=argparse.SUPPRESS)
     parser.add_argument(
         "--no-check-dirty",
-        action="store_true",
-        help="(dangerous) skip check repository for uncommited changes",
+        dest="check_dirty",
+        action="store_false",
+        default=argparse.SUPPRESS,
+        help="(dangerous) if set, skip check repository for uncommited changes",
     )
+    parser.add_argument("--check-branch", default=True, help=argparse.SUPPRESS)
     parser.add_argument(
         "--no-check-branch",
-        action="store_true",
-        help="(debug or development only) by default, 'major' and 'minor' types work "
-        "only for master, and 'patch' works only for a release branches, that name "
+        dest="check_branch",
+        action="store_false",
+        default=argparse.SUPPRESS,
+        help="(debug or development only) if set, skip the branch check for a run. "
+        "By default, 'major' and 'minor' types workonly for master, and 'patch' works "
+        "only for a release branches, that name "
         "should be the same as '$MAJOR.$MINOR' version, e.g. 22.2",
     )
 
@@ -439,7 +449,7 @@ def main():
     repo = Repo(args.repo, args.remote_protocol)
     release = Release(repo, args.commit, args.release_type)
 
-    release.do(args.no_check_dirty, args.no_check_branch, args.no_prestable)
+    release.do(args.check_dirty, args.check_branch, args.with_prestable)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve CI scripts arguments

Description:
When `argparse.SUPPRESS` is used for `help`, it suppresses the help for a virtual argument. Then `argparse.SUPPRESS` is used for the `default` to not confuse a user in help. Example:

```
python3 docker_manifests_merge.py -h
usage: docker_manifests_merge.py [-h] --suffix SUFFIXES [--path PATH] [--no-reports] [--no-push-images]

The program gets images from changed_images_*.json, merges imeges with different architectures into one manifest and pushes back
to docker hub

options:
  -h, --help         show this help message and exit
  --suffix SUFFIXES  suffixes for existing images' tags. More than two should be given (default: None)
  --path PATH        path to changed_images_*.json files (default:
                     /home/felixoid/Space/Felixoid/github/ClickHouse/ClickHouse/tests/ci/tmp)
  --no-reports       don't push reports to S3 and github
  --no-push-images   don't push images to docker hub
```

VS a former version:

```
python3 docker_manifests_merge.py -h
usage: docker_manifests_merge.py [-h] --suffix SUFFIXES [--path PATH] [--no-reports] [--no-push-images]

The program gets images from changed_images_*.json, merges imeges with different architectures into one manifest and pushes back
to docker hub

options:
  -h, --help         show this help message and exit
  --suffix SUFFIXES  suffixes for existing images' tags. More than two should be given (default: None)
  --path PATH        path to changed_images_*.json files (default:
                     /home/felixoid/Space/Felixoid/github/ClickHouse/ClickHouse/tests/ci/tmp)
  --no-reports       don't push reports to S3 and github (default: False)
  --no-push-images   don't push images to docker hub (default: False)
```