### PR TITLE
Use robot-clickhouse as commit's author

### DIFF
--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -27,6 +27,8 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:
+        author: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
+        committer: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
         commit-message: Update version_date.tsv after ${{ env.GITHUB_TAG }}
         branch: auto/${{ env.GITHUB_TAG }}
         delete-branch: true


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use @robot-clickhouse as an author and committer for PRs like https://github.com/ClickHouse/ClickHouse/pull/34685

See https://github.com/peter-evans/create-pull-request/issues/1061