### PR TITLE
Add documentation for memory overcommit

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1616,3 +1616,14 @@ Possible values:
 
 Default value: `10000`.
 
+## global_memory_usage_overcommit_max_wait_microseconds {#global_memory_usage_overcommit_max_wait_microseconds}
+
+Sets maximum waiting time for global overcommit tracker.
+
+Possible values:
+
+-   Positive integer.
+
+Default value: `0`.
+
+

--- a/docs/en/operations/settings/memory-overcommit.md
+++ b/docs/en/operations/settings/memory-overcommit.md
@@ -1,0 +1,31 @@
+# Memory overcommit
+
+Memory overcommit is an experimental technique intended to allow to set more flexible memory limits for queries.
+
+The idea of this technique is to introduce settings which can represent guaranteed memory amount of memory a query can use.
+When memory overcommit is enabled and memory limit is reached ClickHouse will select the most overcommit query and try to free memory by killing this query.
+
+When memory limit is reached any query will wait some time during atempt to allocate new memory.
+If selected query is killed and memory is freed within waiting timeout, query will continue execution after waiting, otherwise it'll be killed too.
+
+Selection of query to stop is performed by either global or user overcommit trackers depending on what memory limit is reached.
+
+## User overcommit tracker
+
+User overcommit tracker finds a query with the biggest overcommit ratio in the user's query list.
+Overcommit ratio is computed as number of allocated bytes divided by value of `max_guaranteed_memory_usage` setting.
+
+Waiting timeout is set by `memory_usage_overcommit_max_wait_microseconds` setting.
+
+**Example**
+
+```sql
+SELECT number FROM numbers(1000) GROUP BY number SETTINGS max_guaranteed_memory_usage=4000, memory_usage_overcommit_max_wait_microseconds=500
+```
+
+## Global overcommit tracker
+
+Global overcommit tracker finds a query with the biggest overcommit ratio in the list of all queries.
+In this case overcommit ratio is computed as number of allocated bytes divided by value of `max_guaranteed_memory_usage_for_user` setting.
+
+Waiting timeout is set by `global_memory_usage_overcommit_max_wait_microseconds` parameter in the configuration file.

--- a/docs/en/operations/settings/memory-overcommit.md
+++ b/docs/en/operations/settings/memory-overcommit.md
@@ -3,7 +3,7 @@
 Memory overcommit is an experimental technique intended to allow to set more flexible memory limits for queries.
 
 The idea of this technique is to introduce settings which can represent guaranteed amount of memory a query can use.
-When memory overcommit is enabled and memory limit is reached ClickHouse will select the most overcommit query and try to free memory by killing this query.
+When memory overcommit is enabled and the memory limit is reached ClickHouse will select the most overcommitted query and try to free memory by killing this query.
 
 When memory limit is reached any query will wait some time during atempt to allocate new memory.
 If selected query is killed and memory is freed within waiting timeout, query will continue execution after waiting, otherwise it'll be killed too.

--- a/docs/en/operations/settings/memory-overcommit.md
+++ b/docs/en/operations/settings/memory-overcommit.md
@@ -8,7 +8,7 @@ When memory overcommit is enabled and memory limit is reached ClickHouse will se
 When memory limit is reached any query will wait some time during atempt to allocate new memory.
 If selected query is killed and memory is freed within waiting timeout, query will continue execution after waiting, otherwise it'll be killed too.
 
-Selection of query to stop is performed by either global or user overcommit trackers depending on what memory limit is reached.
+Selection of query to stop or kill is performed by either global or user overcommit trackers depending on what memory limit is reached.
 
 ## User overcommit tracker
 

--- a/docs/en/operations/settings/memory-overcommit.md
+++ b/docs/en/operations/settings/memory-overcommit.md
@@ -2,7 +2,7 @@
 
 Memory overcommit is an experimental technique intended to allow to set more flexible memory limits for queries.
 
-The idea of this technique is to introduce settings which can represent guaranteed memory amount of memory a query can use.
+The idea of this technique is to introduce settings which can represent guaranteed amount of memory a query can use.
 When memory overcommit is enabled and memory limit is reached ClickHouse will select the most overcommit query and try to free memory by killing this query.
 
 When memory limit is reached any query will wait some time during atempt to allocate new memory.

--- a/docs/en/operations/settings/memory-overcommit.md
+++ b/docs/en/operations/settings/memory-overcommit.md
@@ -6,7 +6,7 @@ The idea of this technique is to introduce settings which can represent guarante
 When memory overcommit is enabled and the memory limit is reached ClickHouse will select the most overcommitted query and try to free memory by killing this query.
 
 When memory limit is reached any query will wait some time during atempt to allocate new memory.
-If selected query is killed and memory is freed within waiting timeout, query will continue execution after waiting, otherwise it'll be killed too.
+If timeout is passed and memory is freed, the query continues execution. Otherwise an exception will be thrown and the query is killed.
 
 Selection of query to stop or kill is performed by either global or user overcommit trackers depending on what memory limit is reached.
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -4226,7 +4226,7 @@ Default value: `0`.
 
 ## memory_usage_overcommit_max_wait_microseconds
 
-Maximum time thread will wait for memory to be freed in the case of memory overcommit on user level.
+Maximum time thread will wait for memory to be freed in the case of memory overcommit on a user level.
 If the timeout is reached and memory is not freed, an exception is thrown.
 Read more about [memory overcommit](memory-overcommit.md).
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -4227,7 +4227,7 @@ Default value: `0`.
 ## memory_usage_overcommit_max_wait_microseconds
 
 Maximum time thread will wait for memory to be freed in the case of memory overcommit on user level.
-If timeout is reached and memory is not freed, exception is thrown.
+If the timeout is reached and memory is not freed, an exception is thrown.
 Read more about [memory overcommit](memory-overcommit.md).
 
 Default value: `0`.

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -4207,10 +4207,36 @@ Possible values:
 -   0 — Disabled.
 -   1 — Enabled. The wait time equal shutdown_wait_unfinished config.
 
-Default value: 0.
+Default value: `0`.
 
 ## shutdown_wait_unfinished
 
 The waiting time in seconds for currently handled connections when shutdown server.
 
-Default Value: 5.
+Default Value: `5`.
+
+## max_guaranteed_memory_usage
+
+Maximum guaranteed memory usage for processing of single query.
+It represents soft limit in case when hard limit is reached on user level.
+Zero means unlimited.
+Read more about [memory overcommit](memory-overcommit.md).
+
+Default value: `0`.
+
+## memory_usage_overcommit_max_wait_microseconds
+
+Maximum time thread will wait for memory to be freed in the case of memory overcommit on user level.
+If timeout is reached and memory is not freed, exception is thrown.
+Read more about [memory overcommit](memory-overcommit.md).
+
+Default value: `0`.
+
+## max_guaranteed_memory_usage_for_user
+
+Maximum guaranteed memory usage for processing all concurrently running queries for the user.
+It represents soft limit in case when hard limit is reached on global level.
+Zero means unlimited.
+Read more about [memory overcommit](memory-overcommit.md).
+
+Default value: `0`.

--- a/src/Common/OvercommitTracker.cpp
+++ b/src/Common/OvercommitTracker.cpp
@@ -23,7 +23,7 @@ void OvercommitTracker::setMaxWaitTime(UInt64 wait_time)
 
 bool OvercommitTracker::needToStopQuery(MemoryTracker * tracker)
 {
-    // NOTE: DO NOT CHANGE THE ORDER OF LOCKS
+    // NOTE: Do not change the order of locks
     //
     // global_mutex must be acquired before overcommit_m, because
     // method OvercommitTracker::unsubscribe(MemoryTracker *) is

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -351,15 +351,6 @@ public:
         max_size = max_size_;
     }
 
-    // Before calling this method you should be sure
-    // that lock is acquired.
-    template <typename F>
-    void processEachQueryStatus(F && func) const
-    {
-        for (auto && query : processes)
-            func(query);
-    }
-
     void setMaxInsertQueriesAmount(size_t max_insert_queries_amount_)
     {
         std::lock_guard lock(mutex);


### PR DESCRIPTION
Changelog category (leave one):

- Documentation (changelog entry is not required)

Followup #31182 #34591 
cc @alesapin 