### PR TITLE
Add versioning for aggreagte function quantiles

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionAggThrow.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAggThrow.cpp
@@ -84,13 +84,13 @@ public:
     {
     }
 
-    void serialize(ConstAggregateDataPtr, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr, WriteBuffer & buf, std::size_t /* version */) const override
     {
         char c = 0;
         buf.write(c);
     }
 
-    void deserialize(AggregateDataPtr /* place */, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr /* place */, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         char c = 0;
         buf.read(c);

--- a/src/AggregateFunctions/AggregateFunctionArgMinMax.h
+++ b/src/AggregateFunctions/AggregateFunctionArgMinMax.h
@@ -79,13 +79,13 @@ public:
             this->data(place).result.change(this->data(rhs).result, arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).result.write(buf, *serialization_res);
         this->data(place).value.write(buf, *serialization_val);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         this->data(place).result.read(buf, *serialization_res, arena);
         this->data(place).value.read(buf, *serialization_val, arena);

--- a/src/AggregateFunctions/AggregateFunctionArray.h
+++ b/src/AggregateFunctions/AggregateFunctionArray.h
@@ -59,6 +59,11 @@ public:
         return nested_func->getDefaultVersion();
     }
 
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        return nested_func->getVersionFromRevision(revision);
+    }
+
     void create(AggregateDataPtr __restrict place) const override
     {
         nested_func->create(place);

--- a/src/AggregateFunctions/AggregateFunctionArray.h
+++ b/src/AggregateFunctions/AggregateFunctionArray.h
@@ -31,7 +31,8 @@ private:
 public:
     AggregateFunctionArray(AggregateFunctionPtr nested_, const DataTypes & arguments, const Array & params_)
         : IAggregateFunctionHelper<AggregateFunctionArray>(arguments, params_)
-        , nested_func(nested_), num_arguments(arguments.size())
+        , nested_func(nested_)
+        , num_arguments(arguments.size())
     {
         assert(parameters == nested_func->getParameters());
         for (const auto & type : arguments)
@@ -47,21 +48,6 @@ public:
     DataTypePtr getReturnType() const override
     {
         return nested_func->getReturnType();
-    }
-
-    bool isVersioned() const override
-    {
-        return nested_func->isVersioned();
-    }
-
-    size_t getDefaultVersion() const override
-    {
-        return nested_func->getDefaultVersion();
-    }
-
-    size_t getVersionFromRevision(size_t revision) const override
-    {
-        return nested_func->getVersionFromRevision(revision);
     }
 
     void create(AggregateDataPtr __restrict place) const override
@@ -126,12 +112,12 @@ public:
         nested_func->merge(place, rhs, arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t version) const override
     {
         nested_func->serialize(place, buf, version);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         nested_func->deserialize(place, buf, version, arena);
     }

--- a/src/AggregateFunctions/AggregateFunctionAvg.h
+++ b/src/AggregateFunctions/AggregateFunctionAvg.h
@@ -96,7 +96,7 @@ public:
         this->data(place).denominator += this->data(rhs).denominator;
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         writeBinary(this->data(place).numerator, buf);
 
@@ -106,7 +106,7 @@ public:
             writeBinary(this->data(place).denominator, buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         readBinary(this->data(place).numerator, buf);
 

--- a/src/AggregateFunctions/AggregateFunctionBitwise.h
+++ b/src/AggregateFunctions/AggregateFunctionBitwise.h
@@ -118,12 +118,12 @@ public:
         this->data(place).update(this->data(rhs).value);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         writeBinary(this->data(place).value, buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         readBinary(this->data(place).value, buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionBoundingRatio.h
+++ b/src/AggregateFunctions/AggregateFunctionBoundingRatio.h
@@ -142,12 +142,12 @@ public:
         data(place).merge(data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionCategoricalInformationValue.h
+++ b/src/AggregateFunctions/AggregateFunctionCategoricalInformationValue.h
@@ -87,12 +87,12 @@ public:
         }
     }
 
-    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         buf.write(place, sizeOfData());
     }
 
-    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         buf.read(place, sizeOfData());
     }

--- a/src/AggregateFunctions/AggregateFunctionCount.h
+++ b/src/AggregateFunctions/AggregateFunctionCount.h
@@ -91,12 +91,12 @@ public:
         data(place).count += data(rhs).count;
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         writeVarUInt(data(place).count, buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         readVarUInt(data(place).count, buf);
     }
@@ -223,12 +223,12 @@ public:
         data(place).count += data(rhs).count;
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         writeVarUInt(data(place).count, buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         readVarUInt(data(place).count, buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionDeltaSum.h
+++ b/src/AggregateFunctions/AggregateFunctionDeltaSum.h
@@ -101,7 +101,7 @@ public:
         // Otherwise lhs either has data or is uninitialized, so we don't need to modify its values.
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         writeIntBinary(this->data(place).sum, buf);
         writeIntBinary(this->data(place).first, buf);
@@ -109,7 +109,7 @@ public:
         writePODBinary<bool>(this->data(place).seen, buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         readIntBinary(this->data(place).sum, buf);
         readIntBinary(this->data(place).first, buf);

--- a/src/AggregateFunctions/AggregateFunctionDeltaSumTimestamp.h
+++ b/src/AggregateFunctions/AggregateFunctionDeltaSumTimestamp.h
@@ -142,7 +142,7 @@ public:
         }
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         writeIntBinary(this->data(place).sum, buf);
         writeIntBinary(this->data(place).first, buf);
@@ -152,7 +152,7 @@ public:
         writePODBinary<bool>(this->data(place).seen, buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         readIntBinary(this->data(place).sum, buf);
         readIntBinary(this->data(place).first, buf);

--- a/src/AggregateFunctions/AggregateFunctionDistinct.h
+++ b/src/AggregateFunctions/AggregateFunctionDistinct.h
@@ -182,12 +182,12 @@ public:
         this->data(place).merge(this->data(rhs), arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         this->data(place).deserialize(buf, arena);
     }

--- a/src/AggregateFunctions/AggregateFunctionEntropy.h
+++ b/src/AggregateFunctions/AggregateFunctionEntropy.h
@@ -125,12 +125,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(const_cast<AggregateDataPtr>(place)).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionExponentialMovingAverage.cpp
+++ b/src/AggregateFunctions/AggregateFunctionExponentialMovingAverage.cpp
@@ -62,13 +62,13 @@ public:
         this->data(place).merge(this->data(rhs), half_decay);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         writeBinary(this->data(place).value, buf);
         writeBinary(this->data(place).time, buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         readBinary(this->data(place).value, buf);
         readBinary(this->data(place).time, buf);

--- a/src/AggregateFunctions/AggregateFunctionForEach.h
+++ b/src/AggregateFunctions/AggregateFunctionForEach.h
@@ -129,17 +129,7 @@ public:
         return std::make_shared<DataTypeArray>(nested_func->getReturnType());
     }
 
-    bool isVersioned() const override
-    {
-        return nested_func->isVersioned();
-    }
-
-    size_t getDefaultVersion() const override
-    {
-        return nested_func->getDefaultVersion();
-    }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
         return nested_func->getVersionFromRevision(revision);
     }
@@ -211,7 +201,7 @@ public:
         }
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         const AggregateFunctionForEachData & state = data(place);
         writeBinary(state.dynamic_array_size, buf);
@@ -224,7 +214,7 @@ public:
         }
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         AggregateFunctionForEachData & state = data(place);
 

--- a/src/AggregateFunctions/AggregateFunctionForEach.h
+++ b/src/AggregateFunctions/AggregateFunctionForEach.h
@@ -139,6 +139,11 @@ public:
         return nested_func->getDefaultVersion();
     }
 
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        return nested_func->getVersionFromRevision(revision);
+    }
+
     void destroy(AggregateDataPtr __restrict place) const noexcept override
     {
         AggregateFunctionForEachData & state = data(place);

--- a/src/AggregateFunctions/AggregateFunctionGroupArray.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupArray.h
@@ -237,7 +237,7 @@ public:
         // if constexpr (Trait::sampler == Sampler::DETERMINATOR)
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         const auto & value = this->data(place).value;
         size_t size = value.size();
@@ -256,7 +256,7 @@ public:
         // if constexpr (Trait::sampler == Sampler::DETERMINATOR)
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         size_t size = 0;
         readVarUInt(size, buf);
@@ -550,7 +550,7 @@ public:
         }
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         writeVarUInt(data(place).value.size(), buf);
 
@@ -570,7 +570,7 @@ public:
         // if constexpr (Trait::sampler == Sampler::DETERMINATOR)
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         UInt64 elems;
         readVarUInt(elems, buf);

--- a/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupArrayInsertAt.h
@@ -145,7 +145,7 @@ public:
                 arr_lhs[i] = arr_rhs[i];
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         const Array & arr = data(place).value;
         size_t size = arr.size();
@@ -165,7 +165,7 @@ public:
         }
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         size_t size = 0;
         readVarUInt(size, buf);

--- a/src/AggregateFunctions/AggregateFunctionGroupArrayMoving.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupArrayMoving.h
@@ -124,7 +124,7 @@ public:
         cur_elems.sum += rhs_elems.sum;
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         const auto & value = this->data(place).value;
         size_t size = value.size();
@@ -132,7 +132,7 @@ public:
         buf.write(reinterpret_cast<const char *>(value.data()), size * sizeof(value[0]));
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         size_t size = 0;
         readVarUInt(size, buf);

--- a/src/AggregateFunctions/AggregateFunctionGroupBitmap.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupBitmap.h
@@ -39,9 +39,9 @@ public:
         this->data(place).rbs.merge(this->data(rhs).rbs);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override { this->data(place).rbs.write(buf); }
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override { this->data(place).rbs.write(buf); }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override { this->data(place).rbs.read(buf); }
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override { this->data(place).rbs.read(buf); }
 
     void insertResultInto(AggregateDataPtr __restrict place, IColumn & to, Arena *) const override
     {
@@ -107,35 +107,25 @@ public:
         }
     }
 
-    bool isVersioned() const override { return true; }
-
-    size_t getDefaultVersion() const override { return 1; }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
-        if (revision >= STATE_VERSION_1_MIN_REVISION)
+        if (!revision.has_value() || *revision >= STATE_VERSION_1_MIN_REVISION)
             return 1;
         else
             return 0;
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, size_t version) const override
     {
-        if (!version)
-            version = getDefaultVersion();
-
-        if (*version >= 1)
+        if (version >= 1)
             DB::writeBoolText(this->data(place).init, buf);
 
         this->data(place).rbs.write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, size_t version, Arena *) const override
     {
-        if (!version)
-            version = getDefaultVersion();
-
-        if (*version >= 1)
+        if (version >= 1)
             DB::readBoolText(this->data(place).init, buf);
         this->data(place).rbs.read(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionGroupUniqArray.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupUniqArray.h
@@ -87,7 +87,7 @@ public:
         }
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         auto & set = this->data(place).value;
         size_t size = set.size();
@@ -96,7 +96,7 @@ public:
             writeIntBinary(elem, buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).value.read(buf);
     }
@@ -169,7 +169,7 @@ public:
         return true;
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         auto & set = this->data(place).value;
         writeVarUInt(set.size(), buf);
@@ -180,7 +180,7 @@ public:
         }
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         auto & set = this->data(place).value;
         size_t size;

--- a/src/AggregateFunctions/AggregateFunctionHistogram.h
+++ b/src/AggregateFunctions/AggregateFunctionHistogram.h
@@ -348,12 +348,12 @@ public:
         this->data(place).merge(this->data(rhs), max_bins);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).read(buf, max_bins);
     }

--- a/src/AggregateFunctions/AggregateFunctionIf.h
+++ b/src/AggregateFunctions/AggregateFunctionIf.h
@@ -56,17 +56,7 @@ public:
         return nested_func->getReturnType();
     }
 
-    bool isVersioned() const override
-    {
-        return nested_func->isVersioned();
-    }
-
-    size_t getDefaultVersion() const override
-    {
-        return nested_func->getDefaultVersion();
-    }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
         return nested_func->getVersionFromRevision(revision);
     }
@@ -145,12 +135,12 @@ public:
         nested_func->mergeBatch(batch_size, places, place_offset, rhs, arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t version) const override
     {
         nested_func->serialize(place, buf, version);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         nested_func->deserialize(place, buf, version, arena);
     }

--- a/src/AggregateFunctions/AggregateFunctionIf.h
+++ b/src/AggregateFunctions/AggregateFunctionIf.h
@@ -66,6 +66,11 @@ public:
         return nested_func->getDefaultVersion();
     }
 
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        return nested_func->getVersionFromRevision(revision);
+    }
+
     void create(AggregateDataPtr __restrict place) const override
     {
         nested_func->create(place);

--- a/src/AggregateFunctions/AggregateFunctionIntervalLengthSum.h
+++ b/src/AggregateFunctions/AggregateFunctionIntervalLengthSum.h
@@ -211,12 +211,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionMLMethod.h
+++ b/src/AggregateFunctions/AggregateFunctionMLMethod.h
@@ -357,9 +357,9 @@ public:
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena *) const override { this->data(place).merge(this->data(rhs)); }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override { this->data(place).write(buf); }
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override { this->data(place).write(buf); }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override { this->data(place).read(buf); }
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override { this->data(place).read(buf); }
 
     void predictValues(
         ConstAggregateDataPtr place,

--- a/src/AggregateFunctions/AggregateFunctionMannWhitney.h
+++ b/src/AggregateFunctions/AggregateFunctionMannWhitney.h
@@ -215,12 +215,12 @@ public:
         a.merge(b, arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         this->data(place).read(buf, arena);
     }

--- a/src/AggregateFunctions/AggregateFunctionMap.h
+++ b/src/AggregateFunctions/AggregateFunctionMap.h
@@ -178,7 +178,7 @@ public:
         }
     }
 
-    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         auto & merged_maps = this->data(place).merged_maps;
         writeVarUInt(merged_maps.size(), buf);
@@ -190,7 +190,7 @@ public:
         }
     }
 
-    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         auto & merged_maps = this->data(place).merged_maps;
         UInt64 size;
@@ -205,7 +205,7 @@ public:
             nested_place = arena->alignedAlloc(nested_func->sizeOfData(), nested_func->alignOfData());
             nested_func->create(nested_place);
             merged_maps.emplace(key, nested_place);
-            nested_func->deserialize(nested_place, buf, std::nullopt, arena);
+            nested_func->deserialize(nested_place, buf, version, arena);
         }
     }
 

--- a/src/AggregateFunctions/AggregateFunctionMaxIntersections.h
+++ b/src/AggregateFunctions/AggregateFunctionMaxIntersections.h
@@ -111,7 +111,7 @@ public:
         cur_elems.value.insert(rhs_elems.value.begin(), rhs_elems.value.end(), arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         const auto & value = this->data(place).value;
         size_t size = value.size();
@@ -119,7 +119,7 @@ public:
         buf.write(reinterpret_cast<const char *>(value.data()), size * sizeof(value[0]));
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         size_t size = 0;
         readVarUInt(size, buf);

--- a/src/AggregateFunctions/AggregateFunctionMeanZTest.h
+++ b/src/AggregateFunctions/AggregateFunctionMeanZTest.h
@@ -105,12 +105,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).read(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionMerge.h
+++ b/src/AggregateFunctions/AggregateFunctionMerge.h
@@ -50,17 +50,7 @@ public:
         return nested_func->getReturnType();
     }
 
-    bool isVersioned() const override
-    {
-        return nested_func->isVersioned();
-    }
-
-    size_t getDefaultVersion() const override
-    {
-        return nested_func->getDefaultVersion();
-    }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
         return nested_func->getVersionFromRevision(revision);
     }
@@ -105,12 +95,12 @@ public:
         nested_func->merge(place, rhs, arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t version) const override
     {
         nested_func->serialize(place, buf, version);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         nested_func->deserialize(place, buf, version, arena);
     }

--- a/src/AggregateFunctions/AggregateFunctionMerge.h
+++ b/src/AggregateFunctions/AggregateFunctionMerge.h
@@ -60,6 +60,11 @@ public:
         return nested_func->getDefaultVersion();
     }
 
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        return nested_func->getVersionFromRevision(revision);
+    }
+
     DataTypePtr getStateType() const override
     {
         return nested_func->getStateType();

--- a/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -1232,12 +1232,12 @@ public:
         this->data(place).changeIfBetter(this->data(rhs), arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf, *serialization);
     }
 
-    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         this->data(place).read(buf, *serialization, arena);
     }

--- a/src/AggregateFunctions/AggregateFunctionNothing.h
+++ b/src/AggregateFunctions/AggregateFunctionNothing.h
@@ -64,12 +64,12 @@ public:
     {
     }
 
-    void serialize(ConstAggregateDataPtr __restrict, WriteBuffer & buf, std::optional<size_t>) const override
+    void serialize(ConstAggregateDataPtr __restrict, WriteBuffer & buf, std::size_t) const override
     {
         writeChar('\0', buf);
     }
 
-    void deserialize(AggregateDataPtr, ReadBuffer & buf, std::optional<size_t>, Arena *) const override
+    void deserialize(AggregateDataPtr, ReadBuffer & buf, std::size_t, Arena *) const override
     {
         [[maybe_unused]] char symbol;
         readChar(symbol, buf);

--- a/src/AggregateFunctions/AggregateFunctionNull.h
+++ b/src/AggregateFunctions/AggregateFunctionNull.h
@@ -103,17 +103,7 @@ public:
             : nested_function->getReturnType();
     }
 
-    bool isVersioned() const override
-    {
-        return nested_function->isVersioned();
-    }
-
-    size_t getDefaultVersion() const override
-    {
-        return nested_function->getDefaultVersion();
-    }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
         return nested_function->getVersionFromRevision(revision);
     }
@@ -152,7 +142,7 @@ public:
         nested_function->merge(nestedPlace(place), nestedPlace(rhs), arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t version) const override
     {
         bool flag = getFlag(place);
         if constexpr (serialize_flag)
@@ -165,7 +155,7 @@ public:
             nested_function->serialize(nestedPlace(place), buf, version);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         bool flag = 1;
         if constexpr (serialize_flag)

--- a/src/AggregateFunctions/AggregateFunctionNull.h
+++ b/src/AggregateFunctions/AggregateFunctionNull.h
@@ -103,6 +103,21 @@ public:
             : nested_function->getReturnType();
     }
 
+    bool isVersioned() const override
+    {
+        return nested_function->isVersioned();
+    }
+
+    size_t getDefaultVersion() const override
+    {
+        return nested_function->getDefaultVersion();
+    }
+
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        return nested_function->getVersionFromRevision(revision);
+    }
+
     void create(AggregateDataPtr __restrict place) const override
     {
         initFlag(place);
@@ -141,7 +156,11 @@ public:
     {
         bool flag = getFlag(place);
         if constexpr (serialize_flag)
-            writeBinary(flag, buf);
+        {
+            if (nested_function->canSerializeFlag(version))
+                writeBinary(flag, buf);
+        }
+
         if (flag)
             nested_function->serialize(nestedPlace(place), buf, version);
     }
@@ -150,7 +169,11 @@ public:
     {
         bool flag = 1;
         if constexpr (serialize_flag)
-            readBinary(flag, buf);
+        {
+            if (nested_function->canSerializeFlag(version))
+                readBinary(flag, buf);
+        }
+
         if (flag)
         {
             setFlag(place);

--- a/src/AggregateFunctions/AggregateFunctionOrFill.h
+++ b/src/AggregateFunctions/AggregateFunctionOrFill.h
@@ -62,6 +62,11 @@ public:
         return nested_function->getDefaultVersion();
     }
 
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        return nested_function->getVersionFromRevision(revision);
+    }
+
     bool isState() const override
     {
         return nested_function->isState();

--- a/src/AggregateFunctions/AggregateFunctionOrFill.h
+++ b/src/AggregateFunctions/AggregateFunctionOrFill.h
@@ -52,17 +52,7 @@ public:
             return nested_function->getName() + "OrDefault";
     }
 
-    bool isVersioned() const override
-    {
-        return nested_function->isVersioned();
-    }
-
-    size_t getDefaultVersion() const override
-    {
-        return nested_function->getDefaultVersion();
-    }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
         return nested_function->getVersionFromRevision(revision);
     }
@@ -224,14 +214,14 @@ public:
             (places[i] + place_offset)[size_of_data] |= rhs[i][size_of_data];
     }
 
-    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::size_t version) const override
     {
         nested_function->serialize(place, buf, version);
 
         writeChar(place[size_of_data], buf);
     }
 
-    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         nested_function->deserialize(place, buf, version, arena);
 

--- a/src/AggregateFunctions/AggregateFunctionQuantile.h
+++ b/src/AggregateFunctions/AggregateFunctionQuantile.h
@@ -90,21 +90,17 @@ public:
             throw Exception("Aggregate function " + getName() + " require one parameter or less", ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
     }
 
-    bool isVersioned() const override { return true; }
-
-    size_t getDefaultVersion() const override { return 0; }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
-        if (revision >= STATE_VERSION_1_MIN_REVISION)
+        if (!revision.has_value() || *revision >= STATE_VERSION_1_MIN_REVISION)
             return 1;
         else
             return 0;
     }
 
-    bool canSerializeFlag(std::optional<size_t> version) const override
+    bool canSerializeFlag(size_t version) const override
     {
-        return version.has_value() && *version > 0;
+        return version > 0;
     }
 
     String getName() const override { return Name::name; }
@@ -155,13 +151,13 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, size_t /* version */) const override
     {
         /// const_cast is required because some data structures apply finalizaton (like compactization) before serializing.
         this->data(const_cast<AggregateDataPtr>(place)).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, size_t /* version */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionRankCorrelation.h
+++ b/src/AggregateFunctions/AggregateFunctionRankCorrelation.h
@@ -82,12 +82,12 @@ public:
         a.merge(b, arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         this->data(place).read(buf, arena);
     }

--- a/src/AggregateFunctions/AggregateFunctionResample.h
+++ b/src/AggregateFunctions/AggregateFunctionResample.h
@@ -157,13 +157,13 @@ public:
             nested_function->merge(place + i * size_of_data, rhs + i * size_of_data, arena);
     }
 
-    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::size_t version) const override
     {
         for (size_t i = 0; i < total; ++i)
             nested_function->serialize(place + i * size_of_data, buf, version);
     }
 
-    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         for (size_t i = 0; i < total; ++i)
             nested_function->deserialize(place + i * size_of_data, buf, version, arena);

--- a/src/AggregateFunctions/AggregateFunctionRetention.h
+++ b/src/AggregateFunctions/AggregateFunctionRetention.h
@@ -115,12 +115,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionSequenceMatch.h
+++ b/src/AggregateFunctions/AggregateFunctionSequenceMatch.h
@@ -153,12 +153,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionSequenceNextNode.h
+++ b/src/AggregateFunctions/AggregateFunctionSequenceNextNode.h
@@ -283,7 +283,7 @@ public:
         data(place).sorted = true;
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         /// Temporarily do a const_cast to sort the values. It helps to reduce the computational burden on the initiator node.
         this->data(const_cast<AggregateDataPtr>(place)).sort();
@@ -316,7 +316,7 @@ public:
         }
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         readBinary(data(place).sorted, buf);
 

--- a/src/AggregateFunctions/AggregateFunctionSimpleLinearRegression.h
+++ b/src/AggregateFunctions/AggregateFunctionSimpleLinearRegression.h
@@ -130,12 +130,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionSimpleState.h
+++ b/src/AggregateFunctions/AggregateFunctionSimpleState.h
@@ -56,6 +56,11 @@ public:
         return nested_func->getDefaultVersion();
     }
 
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        return nested_func->getVersionFromRevision(revision);
+    }
+
     void create(AggregateDataPtr __restrict place) const override { nested_func->create(place); }
 
     void destroy(AggregateDataPtr __restrict place) const noexcept override { nested_func->destroy(place); }

--- a/src/AggregateFunctions/AggregateFunctionSimpleState.h
+++ b/src/AggregateFunctions/AggregateFunctionSimpleState.h
@@ -46,17 +46,7 @@ public:
         return storage_type_arg;
     }
 
-    bool isVersioned() const override
-    {
-        return nested_func->isVersioned();
-    }
-
-    size_t getDefaultVersion() const override
-    {
-        return nested_func->getDefaultVersion();
-    }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
         return nested_func->getVersionFromRevision(revision);
     }
@@ -81,12 +71,12 @@ public:
         nested_func->merge(place, rhs, arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t version) const override
     {
         nested_func->serialize(place, buf, version);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         nested_func->deserialize(place, buf, version, arena);
     }

--- a/src/AggregateFunctions/AggregateFunctionSparkbar.h
+++ b/src/AggregateFunctions/AggregateFunctionSparkbar.h
@@ -303,12 +303,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionState.h
+++ b/src/AggregateFunctions/AggregateFunctionState.h
@@ -52,6 +52,11 @@ public:
         return nested_func->getDefaultVersion();
     }
 
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        return nested_func->getVersionFromRevision(revision);
+    }
+
     void create(AggregateDataPtr __restrict place) const override
     {
         nested_func->create(place);

--- a/src/AggregateFunctions/AggregateFunctionState.h
+++ b/src/AggregateFunctions/AggregateFunctionState.h
@@ -42,17 +42,7 @@ public:
         return nested_func->getStateType();
     }
 
-    bool isVersioned() const override
-    {
-        return nested_func->isVersioned();
-    }
-
-    size_t getDefaultVersion() const override
-    {
-        return nested_func->getDefaultVersion();
-    }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
         return nested_func->getVersionFromRevision(revision);
     }
@@ -92,12 +82,12 @@ public:
         nested_func->merge(place, rhs, arena);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t version) const override
     {
         nested_func->serialize(place, buf, version);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t version, Arena * arena) const override
     {
         nested_func->deserialize(place, buf, version, arena);
     }

--- a/src/AggregateFunctions/AggregateFunctionStatistics.h
+++ b/src/AggregateFunctions/AggregateFunctionStatistics.h
@@ -136,12 +136,12 @@ public:
         this->data(place).mergeWith(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }
@@ -390,12 +390,12 @@ public:
         this->data(place).mergeWith(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionStatisticsSimple.h
+++ b/src/AggregateFunctions/AggregateFunctionStatisticsSimple.h
@@ -148,12 +148,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).read(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -424,12 +424,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).read(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionSumMap.h
+++ b/src/AggregateFunctions/AggregateFunctionSumMap.h
@@ -105,13 +105,9 @@ public:
         }
     }
 
-    bool isVersioned() const override { return true; }
-
-    size_t getDefaultVersion() const override { return 1; }
-
-    size_t getVersionFromRevision(size_t revision) const override
+    size_t getVersionFromRevision(std::optional<size_t> revision) const override
     {
-        if (revision >= STATE_VERSION_1_MIN_REVISION)
+        if (revision >= STATE_VERSION_1_MIN_REVISION || revision == 0)
             return 1;
         else
             return 0;
@@ -282,17 +278,14 @@ public:
         }
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, size_t version) const override
     {
-        if (!version)
-            version = getDefaultVersion();
-
         const auto & merged_maps = this->data(place).merged_maps;
         size_t size = merged_maps.size();
         writeVarUInt(size, buf);
 
         std::function<void(size_t, const Array &)> serialize;
-        switch (*version)
+        switch (version)
         {
             case 0:
             {
@@ -314,17 +307,14 @@ public:
         }
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, size_t version, Arena *) const override
     {
-        if (!version)
-            version = getDefaultVersion();
-
         auto & merged_maps = this->data(place).merged_maps;
         size_t size = 0;
         readVarUInt(size, buf);
 
         std::function<void(size_t, Array &)> deserialize;
-        switch (*version)
+        switch (version)
         {
             case 0:
             {

--- a/src/AggregateFunctions/AggregateFunctionTTest.h
+++ b/src/AggregateFunctions/AggregateFunctionTTest.h
@@ -179,12 +179,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version  */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version  */, Arena *) const override
     {
         this->data(place).read(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionTopK.h
+++ b/src/AggregateFunctions/AggregateFunctionTopK.h
@@ -72,12 +72,12 @@ public:
         set.merge(this->data(rhs).value);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).value.write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version  */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version  */, Arena *) const override
     {
         auto & set = this->data(place).value;
         set.resize(reserved);
@@ -148,12 +148,12 @@ public:
         return true;
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).value.write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena * arena) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena * arena) const override
     {
         auto & set = this->data(place).value;
         set.clear();

--- a/src/AggregateFunctions/AggregateFunctionUniq.h
+++ b/src/AggregateFunctions/AggregateFunctionUniq.h
@@ -242,12 +242,12 @@ public:
         this->data(place).set.merge(this->data(rhs).set);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).set.write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).set.read(buf);
     }
@@ -299,12 +299,12 @@ public:
         this->data(place).set.merge(this->data(rhs).set);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).set.write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).set.read(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionUniqCombined.h
+++ b/src/AggregateFunctions/AggregateFunctionUniqCombined.h
@@ -162,12 +162,12 @@ public:
         this->data(place).set.merge(this->data(rhs).set);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).set.write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).set.read(buf);
     }
@@ -226,12 +226,12 @@ public:
         this->data(place).set.merge(this->data(rhs).set);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).set.write(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version  */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version  */, Arena *) const override
     {
         this->data(place).set.read(buf);
     }

--- a/src/AggregateFunctions/AggregateFunctionUniqUpTo.h
+++ b/src/AggregateFunctions/AggregateFunctionUniqUpTo.h
@@ -209,12 +209,12 @@ public:
         this->data(place).merge(this->data(rhs), threshold);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf, threshold);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version */, Arena *) const override
     {
         this->data(place).read(buf, threshold);
     }
@@ -273,12 +273,12 @@ public:
         this->data(place).merge(this->data(rhs), threshold);
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).write(buf, threshold);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version  */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version  */, Arena *) const override
     {
         this->data(place).read(buf, threshold);
     }

--- a/src/AggregateFunctions/AggregateFunctionWindowFunnel.h
+++ b/src/AggregateFunctions/AggregateFunctionWindowFunnel.h
@@ -283,12 +283,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> /* version */) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t /* version */) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> /* version  */, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t /* version  */, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/CrossTab.h
+++ b/src/AggregateFunctions/CrossTab.h
@@ -154,12 +154,12 @@ public:
         this->data(place).merge(this->data(rhs));
     }
 
-    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t>) const override
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t) const override
     {
         this->data(place).serialize(buf);
     }
 
-    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t>, Arena *) const override
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t, Arena *) const override
     {
         this->data(place).deserialize(buf);
     }

--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <vector>
 #include <type_traits>
 
@@ -89,16 +90,9 @@ public:
         throw Exception("Prediction is not supported for " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
-    virtual bool isVersioned() const { return false; }
+    virtual size_t getVersionFromRevision(std::optional<size_t> /* revision */) const { return 0; }
 
-    virtual size_t getVersionFromRevision(size_t /* revision */) const { return 0; }
-
-    virtual bool canSerializeFlag(std::optional<size_t> /* version */) const { return true; }
-
-    virtual size_t getDefaultVersion() const
-    {
-        return 0;
-    }
+    virtual bool canSerializeFlag(std::size_t /* version */) const { return true; }
 
     virtual ~IAggregateFunction() = default;
 
@@ -132,10 +126,10 @@ public:
     virtual void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena * arena) const = 0;
 
     /// Serializes state (to transmit it over the network, for example).
-    virtual void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version = std::nullopt) const = 0;
+    virtual void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::size_t version = 0) const = 0;
 
     /// Deserializes state. This function is called only for empty (just created) states.
-    virtual void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version = std::nullopt, Arena * arena = nullptr) const = 0;
+    virtual void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::size_t version = 0, Arena * arena = nullptr) const = 0;
 
     /// Returns true if a function requires Arena to handle own states (see add(), merge(), deserialize()).
     virtual bool allocatesMemoryInArena() const = 0;

--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -93,7 +93,12 @@ public:
 
     virtual size_t getVersionFromRevision(size_t /* revision */) const { return 0; }
 
-    virtual size_t getDefaultVersion() const { return 0; }
+    virtual bool canSerializeFlag(std::optional<size_t> /* version */) const { return true; }
+
+    virtual size_t getDefaultVersion() const
+    {
+        return 0;
+    }
 
     virtual ~IAggregateFunction() = default;
 

--- a/src/Columns/ColumnAggregateFunction.cpp
+++ b/src/Columns/ColumnAggregateFunction.cpp
@@ -62,7 +62,7 @@ static String getTypeString(const AggregateFunctionPtr & func, std::optional<siz
 }
 
 
-ColumnAggregateFunction::ColumnAggregateFunction(const AggregateFunctionPtr & func_, std::optional<size_t> version_)
+ColumnAggregateFunction::ColumnAggregateFunction(const AggregateFunctionPtr & func_, size_t version_)
     : func(func_), type_string(getTypeString(func, version_)), version(version_)
 {
 }

--- a/src/Columns/ColumnAggregateFunction.h
+++ b/src/Columns/ColumnAggregateFunction.h
@@ -82,7 +82,7 @@ private:
     /// Name of the type to distinguish different aggregation states.
     String type_string;
 
-    std::optional<size_t> version;
+    size_t version;
 
     ColumnAggregateFunction() = default;
 
@@ -94,7 +94,7 @@ private:
     ///  but ownership of different elements cannot be mixed by different columns.
     void ensureOwnership();
 
-    ColumnAggregateFunction(const AggregateFunctionPtr & func_, std::optional<size_t> version_ = std::nullopt);
+    ColumnAggregateFunction(const AggregateFunctionPtr & func_, size_t version_ = 0);
 
     ColumnAggregateFunction(const AggregateFunctionPtr & func_, const ConstArenas & arenas_);
 

--- a/src/DataTypes/DataTypeAggregateFunction.cpp
+++ b/src/DataTypes/DataTypeAggregateFunction.cpp
@@ -1,3 +1,4 @@
+#include <optional>
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
 
@@ -46,9 +47,7 @@ String DataTypeAggregateFunction::getNameWithoutVersion() const
 
 size_t DataTypeAggregateFunction::getVersion() const
 {
-    if (version)
-        return *version;
-    return function->getDefaultVersion();
+    return version;
 }
 
 
@@ -58,9 +57,8 @@ String DataTypeAggregateFunction::getNameImpl(bool with_version) const
     stream << "AggregateFunction(";
 
     /// If aggregate function does not support versioning its version is 0 and is not printed.
-    auto data_type_version = getVersion();
-    if (with_version && data_type_version)
-        stream << data_type_version << ", ";
+    if (with_version && version > 0)
+        stream << version << ", ";
     stream << function->getName();
 
     if (!parameters.empty())
@@ -135,7 +133,7 @@ static DataTypePtr create(const ASTPtr & arguments)
     AggregateFunctionPtr function;
     DataTypes argument_types;
     Array params_row;
-    std::optional<size_t> version;
+    std::optional<size_t> version = {};
 
     if (!arguments || arguments->children.empty())
         throw Exception("Data type AggregateFunction requires parameters: "

--- a/src/Formats/NativeWriter.cpp
+++ b/src/Formats/NativeWriter.cpp
@@ -117,16 +117,16 @@ void NativeWriter::write(const Block & block)
 
         bool include_version = client_revision >= DBMS_MIN_REVISION_WITH_AGGREGATE_FUNCTIONS_VERSIONING;
         const auto * aggregate_function_data_type = typeid_cast<const DataTypeAggregateFunction *>(column.type.get());
-        if (aggregate_function_data_type && aggregate_function_data_type->isVersioned())
+        if (aggregate_function_data_type)
         {
             if (include_version)
             {
                 auto version = aggregate_function_data_type->getVersionFromRevision(client_revision);
-                aggregate_function_data_type->setVersion(version, /* if_empty */true);
+                aggregate_function_data_type->setVersion(version);
             }
             else
             {
-                aggregate_function_data_type->setVersion(0, /* if_empty */false);
+                aggregate_function_data_type->setVersion(0);
             }
         }
 

--- a/src/Formats/ProtobufSerializer.cpp
+++ b/src/Formats/ProtobufSerializer.cpp
@@ -1694,7 +1694,7 @@ namespace
             {
                 aggregate_function->create(data);
                 ReadBufferFromMemory buf(str.data(), str.length());
-                aggregate_function->deserialize(data, buf, std::nullopt, &arena);
+                aggregate_function->deserialize(data, buf, aggregate_function->getVersionFromRevision({}), &arena);
                 return data;
             }
             catch (...)

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -461,10 +461,10 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
         if (col_decl.type)
         {
             column_type = DataTypeFactory::instance().get(col_decl.type);
-
-            const auto * aggregate_function_type = typeid_cast<const DataTypeAggregateFunction *>(column_type.get());
-            if (attach && aggregate_function_type && aggregate_function_type->isVersioned())
-                aggregate_function_type->setVersion(0, /* if_empty */true);
+            // TODO
+            // const auto * aggregate_function_type = typeid_cast<const DataTypeAggregateFunction *>(column_type.get());
+            // if (attach && aggregate_function_type && aggregate_function_type->isVersioned())
+            //     aggregate_function_type->setVersion(0);
 
             if (col_decl.null_modifier)
             {

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1469,8 +1469,8 @@ struct WindowFunction
     size_t alignOfData() const override { return 1; }
     void add(AggregateDataPtr __restrict, const IColumn **, size_t, Arena *) const override { fail(); }
     void merge(AggregateDataPtr __restrict, ConstAggregateDataPtr, Arena *) const override { fail(); }
-    void serialize(ConstAggregateDataPtr __restrict, WriteBuffer &, std::optional<size_t>) const override { fail(); }
-    void deserialize(AggregateDataPtr __restrict, ReadBuffer &, std::optional<size_t>, Arena *) const override { fail(); }
+    void serialize(ConstAggregateDataPtr __restrict, WriteBuffer &, std::size_t) const override { fail(); }
+    void deserialize(AggregateDataPtr __restrict, ReadBuffer &, std::size_t, Arena *) const override { fail(); }
     void insertResultInto(AggregateDataPtr __restrict, IColumn &, Arena *) const override { fail(); }
 };
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1075,13 +1075,13 @@ void IMergeTreeDataPart::loadColumns(bool require)
     else
     {
         loaded_columns.readText(*volume->getDisk()->readFile(path));
-
-        for (const auto & column : loaded_columns)
-        {
-            const auto * aggregate_function_data_type = typeid_cast<const DataTypeAggregateFunction *>(column.type.get());
-            if (aggregate_function_data_type && aggregate_function_data_type->isVersioned())
-                aggregate_function_data_type->setVersion(0, /* if_empty */true);
-        }
+        // TODO
+        // for (const auto & column : loaded_columns)
+        // {
+        //     const auto * aggregate_function_data_type = typeid_cast<const DataTypeAggregateFunction *>(column.type.get());
+        //     if (aggregate_function_data_type && aggregate_function_data_type->isVersioned())
+        //         aggregate_function_data_type->setVersion(0);
+        // }
     }
 
     SerializationInfo::Settings settings =

--- a/tests/integration/test_backward_compatibility/test_quantiles_state.py
+++ b/tests/integration/test_backward_compatibility/test_quantiles_state.py
@@ -1,0 +1,50 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__, name="quantiles_state")
+node1 = cluster.add_instance("node1", image="yandex/clickhouse-server", tag="21.4",
+                             with_zookeeper=False, stay_alive=True, with_installed_binary=True)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_quantiles_state(start_cluster):
+    node1.query("DROP TABLE IF EXISTS ufeszoe_default")
+    node1.query("DROP TABLE IF EXISTS ufeszoe_1min")
+
+    node1.query("""
+        CREATE TABLE ufeszoe_default (`response` Int64, `duration` Nullable(Int64))
+        ENGINE = MergeTree
+        PARTITION BY (response % 10)
+        ORDER BY (response)
+        SETTINGS index_granularity = 8192
+    """)
+
+    node1.query("""
+        CREATE MATERIALIZED VIEW ufeszoe_1min (
+            `response` Int64,
+            `duration_quantiles` AggregateFunction(quantiles(0.5, 0.75, 0.9, 0.95, 0.99), Nullable(Int64))
+        ) ENGINE = MergeTree
+        PARTITION BY (response % 10)
+        ORDER BY (response)
+        AS SELECT response, quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)(duration) AS duration_quantiles
+        FROM ufeszoe_default GROUP BY response;
+    """)
+
+    node1.query("INSERT INTO ufeszoe_default SELECT number AS `response`, number AS `duration` FROM numbers(100)")
+
+    node1.restart_with_latest_version()
+
+    node1.query("SELECT * FROM ufeszoe_1min")
+
+    node1.query("DROP TABLE IF EXISTS ufeszoe_default")
+    node1.query("DROP TABLE IF EXISTS ufeszoe_1min")

--- a/tests/integration/test_backward_compatibility/test_quantiles_state.py
+++ b/tests/integration/test_backward_compatibility/test_quantiles_state.py
@@ -3,8 +3,11 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__, name="quantiles_state")
-node1 = cluster.add_instance("node1", image="yandex/clickhouse-server", tag="21.4",
-                             with_zookeeper=False, stay_alive=True, with_installed_binary=True)
+nodes = [
+    cluster.add_instance("node1", image="yandex/clickhouse-server", tag="21.4",
+                          with_zookeeper=False, stay_alive=True, with_installed_binary=True),
+    cluster.add_instance("node2", with_zookeeper=False),
+]
 
 
 @pytest.fixture(scope="module")
@@ -17,34 +20,43 @@ def start_cluster():
         cluster.shutdown()
 
 
-def test_quantiles_state(start_cluster):
-    node1.query("DROP TABLE IF EXISTS ufeszoe_default")
-    node1.query("DROP TABLE IF EXISTS ufeszoe_1min")
+def query_all_nodes(query : str):
+    print(">>>> " , query[:100])
+    for n in nodes:
+        print("~~~~ " , n, n.name, query[:100])
+        n.query(query)
+    print("<<<< " , query[:100])
 
-    node1.query("""
-        CREATE TABLE ufeszoe_default (`response` Int64, `duration` Nullable(Int64))
-        ENGINE = MergeTree
-        PARTITION BY (response % 10)
-        ORDER BY (response)
+
+def test_quantiles_state(start_cluster):
+    query_all_nodes("DROP TABLE IF EXISTS ufeszoe_default")
+    query_all_nodes("DROP TABLE IF EXISTS ufeszoe_1min")
+
+    query_all_nodes("""
+        CREATE TABLE ufeszoe_default (
+            `response` Int64, `duration` Nullable(Int64)
+        ) ENGINE = MergeTree PARTITION BY (response % 10) ORDER BY (response)
         SETTINGS index_granularity = 8192
     """)
 
-    node1.query("""
+    query_all_nodes("""
         CREATE MATERIALIZED VIEW ufeszoe_1min (
             `response` Int64,
             `duration_quantiles` AggregateFunction(quantiles(0.5, 0.75, 0.9, 0.95, 0.99), Nullable(Int64))
-        ) ENGINE = MergeTree
-        PARTITION BY (response % 10)
-        ORDER BY (response)
+        ) ENGINE = MergeTree PARTITION BY (response % 10) ORDER BY (response)
         AS SELECT response, quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)(duration) AS duration_quantiles
         FROM ufeszoe_default GROUP BY response;
     """)
 
-    node1.query("INSERT INTO ufeszoe_default SELECT number AS `response`, number AS `duration` FROM numbers(100)")
+    query_all_nodes("INSERT INTO ufeszoe_default SELECT number AS `response`, number AS `duration` FROM numbers(10)")
 
-    node1.restart_with_latest_version()
+    query_all_nodes("SELECT * FROM remote('node{1..2}', default, ufeszoe_1min)")
 
-    node1.query("SELECT * FROM ufeszoe_1min")
+    nodes[0].restart_with_latest_version()
 
-    node1.query("DROP TABLE IF EXISTS ufeszoe_default")
-    node1.query("DROP TABLE IF EXISTS ufeszoe_1min")
+    query_all_nodes("SELECT * FROM ufeszoe_1min")
+
+    query_all_nodes("SELECT * FROM remote('node{1..2}', default, ufeszoe_1min)")
+
+    query_all_nodes("DROP TABLE IF EXISTS ufeszoe_default")
+    query_all_nodes("DROP TABLE IF EXISTS ufeszoe_1min")


### PR DESCRIPTION
Changelog category (leave one):

- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Fix backward incomatibility in `quantiles`, close [#34805](https://github.com/ClickHouse/ClickHouse/issues/34805)
