### PR TITLE
Try remove trash from StorageFileLog

### DIFF
--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -141,9 +141,6 @@ void DatabaseAtomic::dropTable(ContextPtr local_context, const String & table_na
     if (table->storesDataOnDisk())
         tryRemoveSymlink(table_name);
 
-    if (table->dropTableImmediately())
-        table->drop();
-
     /// Notify DatabaseCatalog that table was dropped. It will remove table data in background.
     /// Cleanup is performed outside of database to allow easily DROP DATABASE without waiting for cleanup to complete.
     DatabaseCatalog::instance().enqueueDroppedTableCleanup(table->getStorageID(), table, table_metadata_path_drop, no_delay);

--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -95,8 +95,9 @@ StorageFileLog::StorageFileLog(
 void StorageFileLog::loadMetaFiles(bool attach)
 {
     const auto & storage = getStorageID();
+    /// FIXME Why do we need separate directory? Why not to use data directory?
     root_meta_path
-        = std::filesystem::path(getContext()->getPath()) / ".filelog_storage_metadata" / storage.getDatabaseName() / storage.getTableName();
+        = std::filesystem::path(getContext()->getPath()) / "filelog_storage_metadata" / DatabaseCatalog::getPathForUUID(storage.uuid);
 
     /// Attach table
     if (attach)

--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -97,7 +97,7 @@ void StorageFileLog::loadMetaFiles(bool attach)
     const auto & storage = getStorageID();
     /// FIXME Why do we need separate directory? Why not to use data directory?
     root_meta_path
-        = std::filesystem::path(getContext()->getPath()) / "filelog_storage_metadata" / DatabaseCatalog::getPathForUUID(storage.uuid);
+        = std::filesystem::path(getContext()->getPath()) / "stream_engines/filelog/" / DatabaseCatalog::getPathForUUID(storage.uuid);
 
     /// Attach table
     if (attach)

--- a/src/Storages/FileLog/StorageFileLog.h
+++ b/src/Storages/FileLog/StorageFileLog.h
@@ -52,12 +52,6 @@ public:
 
     void drop() override;
 
-    /// We need to call drop() immediately to remove meta data directory,
-    /// otherwise, if another filelog table with same name created before
-    /// the table be dropped finally, then its meta data directory will
-    /// be deleted by this table drop finally
-    bool dropTableImmediately() override { return true; }
-
     const auto & getFormatName() const { return format_name; }
 
     enum class FileStatus

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -598,10 +598,6 @@ public:
     /// Does not takes underlying Storage (if any) into account.
     virtual std::optional<UInt64> lifetimeBytes() const { return {}; }
 
-    /// Should table->drop be called at once or with delay (in case of atomic database engine).
-    /// Needed for integration engines, when there must be no delay for calling drop() method.
-    virtual bool dropTableImmediately() { return false; }
-
 private:
     /// Lock required for alter queries (lockForAlter).
     /// Allows to execute only one simultaneous alter query.


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It was awful idea to introduce `dropTableImmediately()` property, because it allows to "enable" race conditions between `DROP TABLE` and other queries.