### PR TITLE
CLANG-TIDY : Fixed performance-move-const-arg

### DIFF
--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -239,7 +239,7 @@ void KeeperStateMachine::create_snapshot(
 
     LOG_DEBUG(log, "In memory snapshot {} created, queueing task to flash to disk", s.get_last_log_idx());
     /// Flush snapshot to disk in a separate thread.
-    if (!snapshots_queue.push(std::move(snapshot_task)))
+    if (!snapshots_queue.push(snapshot_task))
         LOG_WARNING(log, "Cannot push snapshot task into queue");
 }
 

--- a/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -337,7 +337,7 @@ static ColumnWithTypeAndName readColumnFromArrowColumn(
         auto nested_column = readColumnFromArrowColumn(arrow_column, column_name, format_name, true, dictionary_values, read_ints_as_dates);
         auto nullmap_column = readByteMapFromArrowColumn(arrow_column);
         auto nullable_type = std::make_shared<DataTypeNullable>(std::move(nested_column.type));
-        auto nullable_column = ColumnNullable::create(std::move(nested_column.column), std::move(nullmap_column));
+        auto nullable_column = ColumnNullable::create(nested_column.column, nullmap_column);
         return {std::move(nullable_column), std::move(nullable_type), column_name};
     }
 
@@ -384,7 +384,7 @@ static ColumnWithTypeAndName readColumnFromArrowColumn(
 
             const auto * tuple_column = assert_cast<const ColumnTuple *>(nested_column.column.get());
             const auto * tuple_type = assert_cast<const DataTypeTuple *>(nested_column.type.get());
-            auto map_column = ColumnMap::create(std::move(tuple_column->getColumnPtr(0)), std::move(tuple_column->getColumnPtr(1)), std::move(offsets_column));
+            auto map_column = ColumnMap::create(tuple_column->getColumnPtr(0), tuple_column->getColumnPtr(1), offsets_column);
             auto map_type = std::make_shared<DataTypeMap>(tuple_type->getElements()[0], tuple_type->getElements()[1]);
             return {std::move(map_column), std::move(map_type), column_name};
         }
@@ -393,7 +393,7 @@ static ColumnWithTypeAndName readColumnFromArrowColumn(
             auto arrow_nested_column = getNestedArrowColumn(arrow_column);
             auto nested_column = readColumnFromArrowColumn(arrow_nested_column, column_name, format_name, false, dictionary_values, read_ints_as_dates);
             auto offsets_column = readOffsetsFromArrowListColumn(arrow_column);
-            auto array_column = ColumnArray::create(std::move(nested_column.column), std::move(offsets_column));
+            auto array_column = ColumnArray::create(nested_column.column, offsets_column);
             auto array_type = std::make_shared<DataTypeArray>(nested_column.type);
             return {std::move(array_column), std::move(array_type), column_name};
         }
@@ -458,7 +458,7 @@ static ColumnWithTypeAndName readColumnFromArrowColumn(
 
             auto arrow_indexes_column = std::make_shared<arrow::ChunkedArray>(indexes_array);
             auto indexes_column = readColumnWithIndexesData(arrow_indexes_column);
-            auto lc_column = ColumnLowCardinality::create(dict_values->column, std::move(indexes_column));
+            auto lc_column = ColumnLowCardinality::create(dict_values->column, indexes_column);
             auto lc_type = std::make_shared<DataTypeLowCardinality>(dict_values->type);
             return {std::move(lc_column), std::move(lc_type), column_name};
         }
@@ -507,7 +507,7 @@ Block ArrowColumnToCHColumn::arrowSchemaToCHHeader(const arrow::Schema & schema,
 
         sample_columns.emplace_back(std::move(sample_column));
     }
-    return Block(std::move(sample_columns));
+    return Block(sample_columns);
 }
 
 ArrowColumnToCHColumn::ArrowColumnToCHColumn(

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -658,7 +658,7 @@ namespace DB
                 auto nested_arrow_type = getArrowType(nested_types[i], tuple_column->getColumnPtr(i), name, format_name, out_is_column_nullable);
                 nested_fields.push_back(std::make_shared<arrow::Field>(name, nested_arrow_type, *out_is_column_nullable));
             }
-            return arrow::struct_(std::move(nested_fields));
+            return arrow::struct_(nested_fields);
         }
 
         if (column_type->lowCardinality())


### PR DESCRIPTION
Changelog category 
- Not for changelog 

Changelog entry :
This PR fixed Clang-Tidy Checker issue: performance-move-const-arg Where std::move is not meaningful when done on const reference arguments.
More details can be found here : https://clang.llvm.org/extra/clang-tidy/checks/performance-move-const-arg.html


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
