### PR TITLE
Support non-table DDLs on cross replicated cluster

### DIFF
--- a/src/Interpreters/DDLTask.cpp
+++ b/src/Interpreters/DDLTask.cpp
@@ -259,13 +259,17 @@ bool DDLTask::tryFindHostInCluster()
                          * */
                         is_circular_replicated = true;
                         auto * query_with_table = dynamic_cast<ASTQueryWithTableAndOutput *>(query.get());
-                        if (!query_with_table || !query_with_table->database)
+
+                        /// For other DDLs like CREATE USER, there is no database name and should be executed successfully.
+                        if (query_with_table)
                         {
-                            throw Exception(ErrorCodes::INCONSISTENT_CLUSTER_DEFINITION,
-                                            "For a distributed DDL on circular replicated cluster its table name must be qualified by database name.");
+                            if (!query_with_table->database)
+                                throw Exception(ErrorCodes::INCONSISTENT_CLUSTER_DEFINITION,
+                                                "For a distributed DDL on circular replicated cluster its table name must be qualified by database name.");
+
+                            if (default_database == query_with_table->getDatabase())
+                                return true;
                         }
-                        if (default_database == query_with_table->getDatabase())
-                            return true;
                     }
                 }
                 found_exact_match = true;

--- a/tests/integration/test_distributed_ddl_on_cross_replication/test.py
+++ b/tests/integration/test_distributed_ddl_on_cross_replication/test.py
@@ -104,3 +104,11 @@ def test_atomic_database(started_cluster):
     node1.query("INSERT INTO replica_1.rmt VALUES (1, 'test')")
     node2.query("SYSTEM SYNC REPLICA replica_2.rmt", timeout=5)
     assert_eq_with_retry(node2, "SELECT * FROM replica_2.rmt", '1\ttest')
+
+def test_non_query_with_table_ddl(started_cluster):
+    node1.query("CREATE USER A ON CLUSTER cross_3shards_2replicas")
+
+    assert node1.query("SELECT 1", user='A') == "1\n"
+    assert node2.query("SELECT 1", user='A') == "1\n"
+
+    node2.query("DROP USER A ON CLUSTER cross_3shards_2replicas")


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support DDLs like CREATE USER to be executed on cross replicated cluster.

Description:
we can execute CREATE USER on a cluster with one replica, but failed on a cross cluster with two replicas. I think this should work too.

-- DDL
create user A on cluster c_2s_2r;

-- Exception
Code: 371. DB::Exception: For a distributed DDL on circular replicated cluster its table name must be qualified by database name. (INCONSISTENT_CLUSTER_DEFINITION) (version 21.12.3.32 (official build)) 

Cluster definition
        <c_2s_2r>
             <shard>
                 <replica>
                     <host>node1</host>
                     <port>9000</port>
                     <default_database>db_0</default_database>
                 </replica>
                 <replica>
                     <host>node2</host>
                     <port>9000</port>
                     <default_database>db_1</default_database>
                 </replica>
             </shard>
             <shard>
                 <replica>
                     <host>node2</host>
                     <port>9000</port>
                     <default_database>db_0</default_database>
                 </replica>
                 <replica>
                     <host>node1</host>
                     <port>9000</port>
                     <default_database>db_1</default_database>
                 </replica>
             </shard>
        </c_2s_2r>