### PR TITLE
Add check_prerequisites to release.py

### DIFF
--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -394,6 +394,12 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--commit",
+        required=True,
+        type=commit,
+        help="commit create a release",
+    )
+    parser.add_argument(
         "--repo",
         default="ClickHouse/ClickHouse",
         help="repository to create the release",
@@ -412,12 +418,6 @@ def parse_args() -> argparse.Namespace:
         choices=Release.BIG + Release.SMALL,
         dest="release_type",
         help="a release type, new branch is created only for 'major' and 'minor'",
-    )
-    parser.add_argument(
-        "--commit",
-        default=git.sha,
-        type=commit,
-        help="commit create a release, default to HEAD",
     )
     parser.add_argument("--with-prestable", default=True, help=argparse.SUPPRESS)
     parser.add_argument(

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -11,7 +11,6 @@ from version_helper import (
     FILE_WITH_VERSION_PATH,
     ClickHouseVersion,
     VersionType,
-    git,
     get_abs_path,
     get_version_from_repo,
     update_cmake_version,

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -78,7 +78,15 @@ class Release:
         self._git.update()
         self.version = get_version_from_repo()
 
+    def check_prerequisites(self):
+        """
+        Check tooling installed in the system
+        """
+        self.run("gh auth status")
+        self.run("git status")
+
     def do(self, check_dirty: bool, check_branch: bool, with_prestable: bool):
+        self.check_prerequisites()
 
         if check_dirty:
             logging.info("Checking if repo is clean")


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Ref https://github.com/ClickHouse/ClickHouse/issues/34900


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
