### PR TITLE
Do not use squashing for materialized views (fixes excessive memory usage)

### DIFF
--- a/src/Processors/Transforms/buildPushingToViewsChain.cpp
+++ b/src/Processors/Transforms/buildPushingToViewsChain.cpp
@@ -297,7 +297,11 @@ Chain buildPushingToViewsChain(
                     insert_columns.emplace_back(column.name);
             }
 
-            InterpreterInsertQuery interpreter(nullptr, insert_context, false, false, false);
+            /// Create interpreter w/o squashing
+            /// since we have squashing (SquashingChunksTransform) for each block.
+            InterpreterInsertQuery interpreter(nullptr, insert_context,
+                /* allow_materialized_= */ false,
+                /* no_squash_= */ true);
             out = interpreter.buildChain(inner_table, inner_metadata_snapshot, insert_columns, view_thread_status, view_counter_ms);
             out.addStorageHolder(dependent_table);
             out.addStorageHolder(inner_table);

--- a/tests/queries/0_stateless/02223_mv_aggregator_leak.sql
+++ b/tests/queries/0_stateless/02223_mv_aggregator_leak.sql
@@ -1,0 +1,18 @@
+drop table if exists mv_02223;
+drop table if exists in_02223;
+drop table if exists out_02223;
+
+create table in_02223 (key UInt64) engine=Null();
+create table out_02223 (keys AggregateFunction(uniqExact, String)) engine=Null();
+
+create materialized view mv_02223 to out_02223 as select uniqExactState(toString(key)) as keys from in_02223 group by intDiv(key, 1000);
+
+-- Here SET is used (over SETTINGS in INSERT) to test it on 19.x
+-- since the issue was introduced in 19.11.12.69
+-- https://github.com/ClickHouse/ClickHouse/pull/3796
+set max_memory_usage=200000000;
+insert into in_02223 select * from numbers(10000000);
+
+drop table mv_02223;
+drop table out_02223;
+drop table in_02223;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not use squashing for materialized views (fixes excessive memory usage)

During pushing data to views there is one interpreter for INSERT that is
created with squashing, that will not release memory for aggregate
states.

You can see this live leak by using [jemalloc profiler](https://github.com/ClickHouse/ClickHouse/files/8142067/jeprof.latest.pdf) and increasing
mmap threshold to 128MB (MMAP_THRESHOLD):

<details>

    $ MALLOC_CONF=prof:true,prof_accum:true,lg_prof_interval:29 clickhouse-server &

    $ jeprof --text clickhouse-server --base jeprof.*.0.* $(ls -t jeprof.*.heap | head -1) --focus DB::AggregateFunctionUniq::merge
    Using local file clickhouse-server.
    Using local file jeprof.130773.91.i91.heap.
    addr2line: DWARF error: section .debug_info is larger than its filesize! (0x9b4c5 vs 0x865d0)
    addr2line: DWARF error: section .debug_info is larger than its filesize! (0x5b43cc vs 0x429a58)
    Total: 10270.3 MB
     10175.5 100.0% 100.0%  10175.5 100.0% Allocator::realloc
         0.0   0.0% 100.0%  10175.5 100.0% AllocatorWithStackMemory::realloc
         0.0   0.0% 100.0%  10175.5 100.0% DB::AggregateFunctionUniq::merge
         0.0   0.0% 100.0%  10175.5 100.0% DB::ColumnAggregateFunction::insertFrom
         0.0   0.0% 100.0%  10175.5 100.0% DB::ColumnAggregateFunction::insertMergeFrom@25cba0
         0.0   0.0% 100.0%  10175.5 100.0% DB::ColumnAggregateFunction::insertMergeFrom@25cc40
         0.0   0.0% 100.0%  10175.5 100.0% DB::ColumnAggregateFunction::insertRangeFrom
         0.0   0.0% 100.0%  10175.5 100.0% DB::ExceptionKeepingTransform::work
         0.0   0.0% 100.0%  10175.5 100.0% DB::ExecutionThreadContext::executeTask
         0.0   0.0% 100.0%  10175.5 100.0% DB::PipelineExecutor::execute
         0.0   0.0% 100.0%  10175.5 100.0% DB::PipelineExecutor::executeImpl
         0.0   0.0% 100.0%  10175.5 100.0% DB::PipelineExecutor::executeSingleThread
         0.0   0.0% 100.0%  10175.5 100.0% DB::PipelineExecutor::executeStepImpl
         0.0   0.0% 100.0%  10175.5 100.0% DB::SquashingChunksTransform::onConsume
         0.0   0.0% 100.0%  10175.5 100.0% DB::SquashingChunksTransform::work
         0.0   0.0% 100.0%  10175.5 100.0% DB::SquashingTransform::add
         0.0   0.0% 100.0%  10175.5 100.0% DB::SquashingTransform::addImpl
         0.0   0.0% 100.0%  10175.5 100.0% DB::SquashingTransform::append

</details>

Example of a query from tests:

    :) insert into in_02223 select * from numbers(1e12) settings max_memory_usage='100Gi'

Before the patch:

    2022.02.25 14:42:25.425536 [ 130786 ] {ac814e81-1430-4530-8aab-6ce1b2ad03fd} <Debug> MemoryTracker: Peak memory usage (for query): 20.46 GiB.
    Ok.
    Query was cancelled.
    0 rows in set. Elapsed: 883.833 sec. Processed 1.33 billion rows, 10.63 GB (1.50 million rows/s., 12.02 MB/s.)

After:

    2022.02.25 14:54:19.877537 [ 134271 ] {78461af3-ae1e-4a7f-a78d-a32b64152874} <Debug> MemoryTracker: Peak memory usage (for query): 94.43 MiB.
    Ok.
    Query was cancelled.
    0 rows in set. Elapsed: 548.303 sec. Processed 886.02 million rows, 7.09 GB (1.62 million rows/s., 12.93 MB/s.)

Refs: #3796 (19.11.12.69+)