### PR TITLE
Allow LowCardinality strings for ngrambf_v1/tokenbf_v1 indexes. Fixes #21865

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -709,7 +709,7 @@ void bloomFilterIndexValidator(const IndexDescription & index, bool /*attach*/)
         {
             const auto & array_type = assert_cast<const DataTypeArray &>(*index_data_type);
             data_type = WhichDataType(array_type.getNestedType());
-        } 
+        }
         else if (data_type.isLowCarnality())
         {
             const auto & low_cardinality = assert_cast<const DataTypeLowCardinality &>(*index_data_type);

--- a/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -709,10 +709,15 @@ void bloomFilterIndexValidator(const IndexDescription & index, bool /*attach*/)
         {
             const auto & array_type = assert_cast<const DataTypeArray &>(*index_data_type);
             data_type = WhichDataType(array_type.getNestedType());
+        } 
+        else if (data_type.isLowCarnality())
+        {
+            const auto & low_cardinality = assert_cast<const DataTypeLowCardinality &>(*index_data_type);
+            data_type = WhichDataType(low_cardinality.getDictionaryType());
         }
 
         if (!data_type.isString() && !data_type.isFixedString())
-            throw Exception("Bloom filter index can be used only with `String`, `FixedString` column or Array with `String` or `FixedString` values column.", ErrorCodes::INCORRECT_QUERY);
+            throw Exception("Bloom filter index can be used only with `String`, `FixedString`, `LowCardinality(String)`, `LowCardinality(FixedString)` column or Array with `String` or `FixedString` values column.", ErrorCodes::INCORRECT_QUERY);
     }
 
     if (index.type == NgramTokenExtractor::getName())

--- a/tests/queries/0_stateless/02226_low_cardinality_text_bloom_filter_index.reference
+++ b/tests/queries/0_stateless/02226_low_cardinality_text_bloom_filter_index.reference
@@ -1,0 +1,24 @@
+lc_bf_tokenbf
+1	K1	K1ZZZZZZ
+2	K2	K2ZZZZZZ
+lc_fixed_bf_tokenbf
+1	K1	K1ZZZZZZ
+2	K2	K2ZZZZZZ
+lc_ngram
+1	K1	K1ZZZZZZ
+2	K2	K2ZZZZZZ
+lc_fixed_ngram
+1	K1	K1ZZZZZZ
+2	K2	K2ZZZZZZ
+lc_bf_tokenbf
+3	abCD3ef	abCD3ef\0
+4	abCD4ef	abCD4ef\0
+lc_fixed_bf_tokenbf
+3	abCD3ef	abCD3ef\0
+4	abCD4ef	abCD4ef\0
+lc_ngram
+3	abCD3ef	abCD3ef\0
+4	abCD4ef	abCD4ef\0
+lc_fixed_ngram
+3	abCD3ef	abCD3ef\0
+4	abCD4ef	abCD4ef\0

--- a/tests/queries/0_stateless/02226_low_cardinality_text_bloom_filter_index.sql
+++ b/tests/queries/0_stateless/02226_low_cardinality_text_bloom_filter_index.sql
@@ -1,0 +1,69 @@
+DROP TABLE IF EXISTS bf_tokenbf_lowcard_test;
+DROP TABLE IF EXISTS bf_ngram_lowcard_test;
+
+CREATE TABLE bf_tokenbf_lowcard_test
+(
+    row_id UInt32,
+    lc LowCardinality(String),
+    lc_fixed LowCardinality(FixedString(8)),
+    INDEX lc_bf_tokenbf lc TYPE tokenbf_v1(256,2,0) GRANULARITY 1,
+    INDEX lc_fixed_bf_tokenbf lc_fixed TYPE tokenbf_v1(256,2,0) GRANULARITY 1
+) Engine=MergeTree() ORDER BY row_id SETTINGS index_granularity = 1;
+
+CREATE TABLE bf_ngram_lowcard_test
+(
+    row_id UInt32,
+    lc LowCardinality(String),
+    lc_fixed LowCardinality(FixedString(8)),
+    INDEX lc_ngram lc TYPE ngrambf_v1(4,256,2,0) GRANULARITY 1,
+    INDEX lc_fixed_ngram lc_fixed TYPE ngrambf_v1(4,256,2,0) GRANULARITY 1
+) Engine=MergeTree() ORDER BY row_id SETTINGS index_granularity = 1;
+
+INSERT INTO bf_tokenbf_lowcard_test VALUES (1, 'K1', 'K1ZZZZZZ'), (2, 'K2', 'K2ZZZZZZ');
+INSERT INTO bf_ngram_lowcard_test VALUES (1, 'K1', 'K1ZZZZZZ'), (2, 'K2', 'K2ZZZZZZ');
+INSERT INTO bf_tokenbf_lowcard_test VALUES (3, 'abCD3ef', 'abCD3ef'), (4, 'abCD4ef', 'abCD4ef');
+INSERT INTO bf_ngram_lowcard_test   VALUES (3, 'abCD3ef', 'abCD3ef'), (4, 'abCD4ef', 'abCD4ef');
+
+SELECT 'lc_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc, 'K1') SETTINGS force_data_skipping_indices='lc_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc, 'K2') SETTINGS force_data_skipping_indices='lc_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc, 'K3') SETTINGS force_data_skipping_indices='lc_bf_tokenbf';
+
+SELECT 'lc_fixed_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc_fixed, 'K1ZZZZZZ') SETTINGS force_data_skipping_indices='lc_fixed_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc_fixed, 'K2ZZZZZZ') SETTINGS force_data_skipping_indices='lc_fixed_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc_fixed, 'K3ZZZZZZ') SETTINGS force_data_skipping_indices='lc_fixed_bf_tokenbf';
+
+SELECT 'lc_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc, 'K1') SETTINGS force_data_skipping_indices='lc_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc, 'K2') SETTINGS force_data_skipping_indices='lc_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc, 'K3') SETTINGS force_data_skipping_indices='lc_ngram';
+
+SELECT 'lc_fixed_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc_fixed, 'K1ZZZZZZ') SETTINGS force_data_skipping_indices='lc_fixed_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc_fixed, 'K2ZZZZZZ') SETTINGS force_data_skipping_indices='lc_fixed_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc_fixed, 'K3ZZZZZZ') SETTINGS force_data_skipping_indices='lc_fixed_ngram';
+
+
+SELECT 'lc_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc, '%CD3%') SETTINGS force_data_skipping_indices='lc_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc, '%CD4%') SETTINGS force_data_skipping_indices='lc_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc, '%CD5%') SETTINGS force_data_skipping_indices='lc_bf_tokenbf';
+
+SELECT 'lc_fixed_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc_fixed, '%CD3%') SETTINGS force_data_skipping_indices='lc_fixed_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc_fixed, '%CD4%') SETTINGS force_data_skipping_indices='lc_fixed_bf_tokenbf';
+SELECT * FROM bf_tokenbf_lowcard_test WHERE like(lc_fixed, '%CD5%') SETTINGS force_data_skipping_indices='lc_fixed_bf_tokenbf';
+
+SELECT 'lc_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc, '%CD3%') SETTINGS force_data_skipping_indices='lc_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc, '%CD4%') SETTINGS force_data_skipping_indices='lc_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc, '%CD5%') SETTINGS force_data_skipping_indices='lc_ngram';
+
+SELECT 'lc_fixed_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc_fixed, '%CD3%') SETTINGS force_data_skipping_indices='lc_fixed_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc_fixed, '%CD4%') SETTINGS force_data_skipping_indices='lc_fixed_ngram';
+SELECT * FROM bf_ngram_lowcard_test WHERE like(lc_fixed, '%CD5%') SETTINGS force_data_skipping_indices='lc_fixed_ngram';
+
+DROP TABLE bf_tokenbf_lowcard_test;
+DROP TABLE bf_ngram_lowcard_test;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow LowCardinality strings for ngrambf_v1/tokenbf_v1 indexes. Closes #21865.


I wanted to use LowCardinality(String) along with an ngrambf index. Issue #21865 suggests that LowCardinality(String) and LowCardinality(FixedString) can be accepted for ngrambf and tokenbf indexes, and that the check for allowable types can be simply begin to accept these types, and it should work. Here, I've simply loosened the type check, and added a test that exercises it. 

Compiling and running queries for LowCardinality(String) indexed by ngrambf/tokenbf seems to work fine.

That said, please don't assume that I know what I'm doing, I don't have much understanding of the various moving parts here. Someone who understands the codebase better should definitely look over these changes.
