### PR TITLE
Fix alignment for aligned_alloc() to fix build for glibc2.35+

### DIFF
--- a/src/Common/malloc.cpp
+++ b/src/Common/malloc.cpp
@@ -38,7 +38,7 @@ static void dummyFunctionForInterposing()
     ignore(calloc(0, 0)); // -V575 NOLINT
     ignore(realloc(nullptr, 0)); // -V575 NOLINT
     ignore(posix_memalign(&dummy, 0, 0)); // -V575 NOLINT
-    ignore(aligned_alloc(0, 0)); // -V575 NOLINT
+    ignore(aligned_alloc(1, 0)); // -V575 NOLINT
     ignore(valloc(0)); // -V575 NOLINT
     ignore(memalign(0, 0)); // -V575 NOLINT
 #if !defined(USE_MUSL)


### PR DESCRIPTION
In glibc2.35+ alloc_align added for aligned_alloc() alignment argument
8a9a59311551e833ca064de44ac23b193e1b704d ("Add alloc_align attribute to
memalign et al"), and this will cause an error:

    /src/ch/clickhouse/src/Common/malloc.cpp:41:26: error: requested alignment is not a power of 2 [-Werror,-Wnon-power-of-two-alignment]
        ignore(aligned_alloc(0, 0)); // -V575 NOLINT

Changelog category (leave one):
- Not for changelog (changelog entry is not required)