### PR TITLE
Stop processing multiqueries in clickhouse-client/local on SIGINT

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -233,7 +233,7 @@ public:
 void interruptSignalHandler(int signum)
 {
     if (exit_on_signal.test_and_set())
-        _exit(signum);
+        _exit(128 + signum);
 }
 
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -229,7 +229,7 @@ public:
     static bool cancelled() { return exit_on_signal.test(); }
 };
 
-/// This signal handler is set only for sigint.
+/// This signal handler is set only for SIGINT.
 void interruptSignalHandler(int signum)
 {
     if (exit_on_signal.test_and_set())
@@ -243,22 +243,22 @@ ClientBase::ClientBase() = default;
 
 void ClientBase::setupSignalHandler()
 {
-     exit_on_signal.test_and_set();
+    exit_on_signal.test_and_set();
 
-     struct sigaction new_act;
-     memset(&new_act, 0, sizeof(new_act));
+    struct sigaction new_act;
+    memset(&new_act, 0, sizeof(new_act));
 
-     new_act.sa_handler = interruptSignalHandler;
-     new_act.sa_flags = 0;
+    new_act.sa_handler = interruptSignalHandler;
+    new_act.sa_flags = 0;
 
 #if defined(OS_DARWIN)
     sigemptyset(&new_act.sa_mask);
 #else
-     if (sigemptyset(&new_act.sa_mask))
+    if (sigemptyset(&new_act.sa_mask))
         throw Exception(ErrorCodes::CANNOT_SET_SIGNAL_HANDLER, "Cannot set signal handler.");
 #endif
 
-     if (sigaction(SIGINT, &new_act, nullptr))
+    if (sigaction(SIGINT, &new_act, nullptr))
         throw Exception(ErrorCodes::CANNOT_SET_SIGNAL_HANDLER, "Cannot set signal handler.");
 }
 

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -108,7 +108,7 @@ protected:
 
 private:
     void receiveResult(ASTPtr parsed_query);
-    bool receiveAndProcessPacket(ASTPtr parsed_query, bool cancelled);
+    bool receiveAndProcessPacket(ASTPtr parsed_query, bool cancelled_);
     void receiveLogs(ASTPtr parsed_query);
     bool receiveSampleBlock(Block & out, ColumnsDescription & columns_description, ASTPtr parsed_query);
     bool receiveEndOfQuery();
@@ -259,6 +259,8 @@ protected:
     };
 
     std::vector<HostAndPort> hosts_and_ports{};
+
+    bool cancelled = false;
 };
 
 }

--- a/tests/queries/0_stateless/02229_client_stop_multiquery_in_SIGINT.sh
+++ b/tests/queries/0_stateless/02229_client_stop_multiquery_in_SIGINT.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+timeout -s INT 3s $CLICKHOUSE_CLIENT --max_block_size 1 -nm -q "
+    SELECT sleep(1) FROM numbers(100) FORMAT Null;
+    SELECT 'FAIL';
+"
+
+timeout -s INT 3s $CLICKHOUSE_LOCAL --max_block_size 1 -nm -q "
+    SELECT sleep(1) FROM numbers(100) FORMAT Null;
+    SELECT 'FAIL';
+"
+
+exit 0


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)