### PR TITLE
Avoid busy polling in keeper while searching for changelog files to delete

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -732,7 +732,7 @@ void Changelog::cleanLogThread()
     while (!log_files_to_delete_queue.isFinishedAndEmpty())
     {
         std::string path;
-        if (log_files_to_delete_queue.tryPop(path))
+        if (log_files_to_delete_queue.pop(path))
         {
             std::error_code ec;
             if (std::filesystem::remove(path, ec))


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid busy polling in keeper while searching for changelog files to delete

Fixes: #34534 (cc @zhanglistar)
Cc: @alesapin 