### PR TITLE
Ignore per-column TTL in CREATE TABLE AS if new table engine does not support it

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -642,6 +642,11 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
             properties.indices = as_storage_metadata->getSecondaryIndices();
             properties.projections = as_storage_metadata->getProjections().clone();
         }
+        else
+        {
+            /// Only MergeTree support TTL
+            properties.columns.resetColumnTTLs();
+        }
 
         properties.constraints = as_storage_metadata->getConstraints();
     }

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -635,6 +635,22 @@ ColumnsDescription::ColumnTTLs ColumnsDescription::getColumnTTLs() const
     return ret;
 }
 
+void ColumnsDescription::resetColumnTTLs()
+{
+    std::vector<ColumnDescription> old_columns;
+    old_columns.reserve(columns.size());
+    for (const auto & col : columns)
+        old_columns.emplace_back(col);
+
+    columns.clear();
+
+    for (auto & col : old_columns)
+    {
+        col.ttl.reset();
+        add(col);
+    }
+}
+
 
 String ColumnsDescription::toString() const
 {

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -104,6 +104,7 @@ public:
 
     using ColumnTTLs = std::unordered_map<String, ASTPtr>;
     ColumnTTLs getColumnTTLs() const;
+    void resetColumnTTLs();
 
     bool has(const String & column_name) const;
     bool hasNested(const String & column_name) const;

--- a/tests/queries/0_stateless/02230_create_table_as_ignore_ttl.reference
+++ b/tests/queries/0_stateless/02230_create_table_as_ignore_ttl.reference
@@ -1,0 +1,32 @@
+CREATE TABLE default.data_02230_ttl
+(
+    `date` Date,
+    `key` Int32
+)
+ENGINE = MergeTree
+ORDER BY key
+TTL date + 14
+SETTINGS index_granularity = 8192
+CREATE TABLE default.null_02230_ttl
+(
+    `date` Date,
+    `key` Int32
+)
+ENGINE = Null
+CREATE TABLE default.data_02230_column_ttl
+(
+    `date` Date,
+    `value` Int32 TTL date + 7,
+    `key` Int32
+)
+ENGINE = MergeTree
+ORDER BY key
+TTL date + 14
+SETTINGS index_granularity = 8192
+CREATE TABLE default.null_02230_column_ttl
+(
+    `date` Date,
+    `value` Int32,
+    `key` Int32
+)
+ENGINE = Null

--- a/tests/queries/0_stateless/02230_create_table_as_ignore_ttl.sql
+++ b/tests/queries/0_stateless/02230_create_table_as_ignore_ttl.sql
@@ -1,0 +1,18 @@
+drop table if exists data_02230_ttl;
+drop table if exists null_02230_ttl;
+create table data_02230_ttl (date Date, key Int) Engine=MergeTree() order by key TTL date + 14;
+show create data_02230_ttl format TSVRaw;
+create table null_02230_ttl engine=Null() as data_02230_ttl;
+show create null_02230_ttl format TSVRaw;
+drop table data_02230_ttl;
+drop table null_02230_ttl;
+
+drop table if exists data_02230_column_ttl;
+drop table if exists null_02230_column_ttl;
+create table data_02230_column_ttl (date Date, value Int TTL date + 7, key Int) Engine=MergeTree() order by key TTL date + 14;
+show create data_02230_column_ttl format TSVRaw;
+create table null_02230_column_ttl engine=Null() as data_02230_column_ttl;
+-- check that order of columns is the same
+show create null_02230_column_ttl format TSVRaw;
+drop table data_02230_column_ttl;
+drop table null_02230_column_ttl;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Ignore per-column `TTL` in `CREATE TABLE AS` if new table engine does not support it (i.e. if the engine is not of  `MergeTree` family)

Follow-up for: #6968