### PR TITLE
Use connection pool in HiveMetastoreClient

### DIFF
--- a/src/Storages/Hive/HiveCommon.cpp
+++ b/src/Storages/Hive/HiveCommon.cpp
@@ -259,8 +259,8 @@ std::shared_ptr<ThriftHiveMetastoreClient> HiveMetastoreClientFactory::createThr
     socket->setConnTimeout(hive_metastore_client_conn_timeout_ms);
     socket->setRecvTimeout(hive_metastore_client_recv_timeout_ms);
     socket->setSendTimeout(hive_metastore_client_send_timeout_ms);
-    std::shared_ptr<TTransport> transport(new TBufferedTransport(socket));
-    std::shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
+    std::shared_ptr<TTransport> transport = std::make_shared<TBufferedTransport>(socket);
+    std::shared_ptr<TProtocol> protocol = std::make_shared<TBinaryProtocol>(transport);
     std::shared_ptr<ThriftHiveMetastoreClient> thrift_client = std::make_shared<ThriftHiveMetastoreClient>(protocol);
     try
     {
@@ -268,7 +268,7 @@ std::shared_ptr<ThriftHiveMetastoreClient> HiveMetastoreClientFactory::createThr
     }
     catch (TException & tx)
     {
-        throw Exception("connect to hive metastore:" + name + " failed." + tx.what(), ErrorCodes::BAD_ARGUMENTS);
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "connect to hive metastore: {} failed. {}", name, tx.what());
     }
     return thrift_client;
 }

--- a/src/Storages/Hive/HiveCommon.cpp
+++ b/src/Storages/Hive/HiveCommon.cpp
@@ -47,7 +47,7 @@ bool HiveMetastoreClient::shouldUpdateTableMetadata(
 void HiveMetastoreClient::tryCallHiveClient(std::function<void(ThriftHiveMetastoreClientPool::Entry &)> func)
 {
     int i = 0;
-    String err_msg;   
+    String err_msg;
     for (; i < max_retry; ++i)
     {
         auto client = client_pool.get(get_client_timeout);

--- a/src/Storages/Hive/HiveCommon.h
+++ b/src/Storages/Hive/HiveCommon.h
@@ -26,12 +26,7 @@ public:
     using Object = Apache::Hadoop::Hive::ThriftHiveMetastoreClient;
     using ObjectPtr = std::shared_ptr<Object>;
     using Entry = PoolBase<Apache::Hadoop::Hive::ThriftHiveMetastoreClient>::Entry;
-    explicit ThriftHiveMetastoreClientPool(ThriftHiveMetastoreClientBuilder builder_)
-        : PoolBase<Object>(max_connections, &Poco::Logger::get("ThriftHiveMetastoreClientPool"))
-        , builder(builder_)
-    {
-
-    }
+    explicit ThriftHiveMetastoreClientPool(ThriftHiveMetastoreClientBuilder builder_);
 
 protected:
     ObjectPtr allocObject() override
@@ -41,9 +36,6 @@ protected:
 
 private:
     ThriftHiveMetastoreClientBuilder builder;
-
-    const static unsigned max_connections;
-
 };
 class HiveMetastoreClient : public WithContext
 {
@@ -150,9 +142,6 @@ private:
     ThriftHiveMetastoreClientPool client_pool;
 
     Poco::Logger * log = &Poco::Logger::get("HiveMetastoreClient");
-
-    const int max_retry = 3;
-    const UInt64 get_client_timeout = 1000000;
 };
 
 using HiveMetastoreClientPtr = std::shared_ptr<HiveMetastoreClient>;
@@ -168,10 +157,6 @@ public:
 private:
     std::mutex mutex;
     std::map<String, HiveMetastoreClientPtr> clients;
-
-    const static int conn_timeout_ms;
-    const static int recv_timeout_ms;
-    const static int send_timeout_ms;
 };
 
 }

--- a/src/Storages/Hive/HiveCommon.h
+++ b/src/Storages/Hive/HiveCommon.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <Common/config.h>
 
 #if USE_HIVE
@@ -10,12 +11,40 @@
 
 #include <base/types.h>
 #include <Common/LRUCache.h>
+#include <Common/PoolBase.h>
 #include <Storages/HDFS/HDFSCommon.h>
 
 
 namespace DB
 {
 
+using ThriftHiveMetastoreClientBuilder = std::function<std::shared_ptr<Apache::Hadoop::Hive::ThriftHiveMetastoreClient>()>;
+
+class ThriftHiveMetastoreClientPool : public PoolBase<Apache::Hadoop::Hive::ThriftHiveMetastoreClient>
+{
+public:
+    using Object = Apache::Hadoop::Hive::ThriftHiveMetastoreClient;
+    using ObjectPtr = std::shared_ptr<Object>;
+    using Entry = PoolBase<Apache::Hadoop::Hive::ThriftHiveMetastoreClient>::Entry;
+    explicit ThriftHiveMetastoreClientPool(ThriftHiveMetastoreClientBuilder builder_)
+        : PoolBase<Object>(max_connections, &Poco::Logger::get("ThriftHiveMetastoreClientPool"))
+        , builder(builder_)
+    {
+
+    }
+
+protected:
+    ObjectPtr allocObject() override
+    {
+        return builder();
+    }
+
+private:
+    ThriftHiveMetastoreClientBuilder builder;
+
+    const static unsigned max_connections;
+
+};
 class HiveMetastoreClient : public WithContext
 {
 public:
@@ -26,7 +55,9 @@ public:
         UInt64 last_modify_time; /// In ms
         size_t size;
 
-        FileInfo() = default;
+        explicit FileInfo() = default;
+        FileInfo & operator = (const FileInfo &) = default;
+        FileInfo(const FileInfo &) = default;
         FileInfo(const String & path_, UInt64 last_modify_time_, size_t size_)
             : path(path_), last_modify_time(last_modify_time_), size(size_)
         {
@@ -94,17 +125,18 @@ public:
 
     using HiveTableMetadataPtr = std::shared_ptr<HiveMetastoreClient::HiveTableMetadata>;
 
-    explicit HiveMetastoreClient(std::shared_ptr<Apache::Hadoop::Hive::ThriftHiveMetastoreClient> client_, ContextPtr context_)
-        : WithContext(context_), client(client_), table_metadata_cache(1000)
+    explicit HiveMetastoreClient(ThriftHiveMetastoreClientBuilder builder_, ContextPtr context_)
+        : WithContext(context_)
+        , table_metadata_cache(1000)
+        , client_pool(builder_)
     {
     }
 
+
     HiveTableMetadataPtr getTableMetadata(const String & db_name, const String & table_name);
+    // Access hive table information by hive client
+    std::shared_ptr<Apache::Hadoop::Hive::Table> getHiveTable(const String & db_name, const String & table_name);
     void clearTableMetadata(const String & db_name, const String & table_name);
-    void setClient(std::shared_ptr<Apache::Hadoop::Hive::ThriftHiveMetastoreClient> client_);
-    bool isExpired() const { return expired; }
-    void setExpired() { expired = true; }
-    void clearExpired() { expired = false; }
 
 private:
     static String getCacheKey(const String & db_name, const String & table_name)  { return db_name + "." + table_name; }
@@ -112,12 +144,15 @@ private:
     bool shouldUpdateTableMetadata(
         const String & db_name, const String & table_name, const std::vector<Apache::Hadoop::Hive::Partition> & partitions);
 
-    std::shared_ptr<Apache::Hadoop::Hive::ThriftHiveMetastoreClient> client;
+    void tryCallHiveClient(std::function<void(ThriftHiveMetastoreClientPool::Entry &)> func);
+
     LRUCache<String, HiveTableMetadata> table_metadata_cache;
-    mutable std::mutex mutex;
-    std::atomic<bool> expired{false};
+    ThriftHiveMetastoreClientPool client_pool;
 
     Poco::Logger * log = &Poco::Logger::get("HiveMetastoreClient");
+
+    const int max_retry = 3;
+    const UInt64 get_client_timeout = 1000000;
 };
 
 using HiveMetastoreClientPtr = std::shared_ptr<HiveMetastoreClient>;
@@ -128,13 +163,15 @@ public:
 
     HiveMetastoreClientPtr getOrCreate(const String & name, ContextPtr context);
 
+    static std::shared_ptr<Apache::Hadoop::Hive::ThriftHiveMetastoreClient> createThriftHiveMetastoreClient(const String & name);
+
 private:
     std::mutex mutex;
     std::map<String, HiveMetastoreClientPtr> clients;
 
-    const int conn_timeout_ms = 10000;
-    const int recv_timeout_ms = 10000;
-    const int send_timeout_ms = 10000;
+    const static int conn_timeout_ms;
+    const static int recv_timeout_ms;
+    const static int send_timeout_ms;
 };
 
 }

--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -286,14 +286,22 @@ StorageHive::StorageHive(
     storage_metadata.setConstraints(constraints_);
     storage_metadata.setComment(comment_);
     setInMemoryMetadata(storage_metadata);
+}
+
+void StorageHive::lazyInitialize()
+{
+    std::lock_guard lock{init_mutex};
+    if (has_initialized)
+        return;
+
 
     auto hive_metastore_client = HiveMetastoreClientFactory::instance().getOrCreate(hive_metastore_url, getContext());
-    auto hive_table_metadata = hive_metastore_client->getTableMetadata(hive_database, hive_table);
+    auto hive_table_metadata = hive_metastore_client->getHiveTable(hive_database, hive_table);
 
-    hdfs_namenode_url = getNameNodeUrl(hive_table_metadata->getTable()->sd.location);
-    table_schema = hive_table_metadata->getTable()->sd.cols;
+    hdfs_namenode_url = getNameNodeUrl(hive_table_metadata->sd.location);
+    table_schema = hive_table_metadata->sd.cols;
 
-    FileFormat hdfs_file_format = IHiveFile::toFileFormat(hive_table_metadata->getTable()->sd.inputFormat);
+    FileFormat hdfs_file_format = IHiveFile::toFileFormat(hive_table_metadata->sd.inputFormat);
     switch (hdfs_file_format)
     {
         case FileFormat::TEXT:
@@ -331,6 +339,7 @@ StorageHive::StorageHive(
     }
 
     initMinMaxIndexExpression();
+    has_initialized = true;
 }
 
 void StorageHive::initMinMaxIndexExpression()
@@ -552,6 +561,8 @@ Pipe StorageHive::read(
     size_t max_block_size,
     unsigned num_streams)
 {
+    lazyInitialize();
+
     HDFSBuilderWrapper builder = createHDFSBuilder(hdfs_namenode_url, context_->getGlobalContext()->getConfigRef());
     HDFSFSPtr fs = createHDFSFS(builder.get());
     auto hive_metastore_client = HiveMetastoreClientFactory::instance().getOrCreate(hive_metastore_url, getContext());

--- a/src/Storages/Hive/StorageHive.h
+++ b/src/Storages/Hive/StorageHive.h
@@ -94,6 +94,9 @@ private:
     String hive_database;
     String hive_table;
 
+    std::mutex init_mutex;
+    bool has_initialized = false;
+
     /// Hive table meta
     std::vector<Apache::Hadoop::Hive::FieldSchema> table_schema;
     Names text_input_field_names; /// Defines schema of hive file, only used when text input format is TEXT
@@ -116,6 +119,8 @@ private:
     std::shared_ptr<HiveSettings> storage_settings;
 
     Poco::Logger * log = &Poco::Logger::get("StorageHive");
+
+    void lazyInitialize();
 };
 }
 


### PR DESCRIPTION

Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use connection pool for hive metastore client

1. remove lock for hive metastore client access
2. auto reconnect when connection is broken


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
