### PR TITLE
Projection description

### DIFF
--- a/src/Interpreters/FunctionNameNormalizer.cpp
+++ b/src/Interpreters/FunctionNameNormalizer.cpp
@@ -31,6 +31,7 @@ void FunctionNameNormalizer::visit(IAST * ast)
     // have the same name as function, e.g. Date.
     if (auto * node_decl = ast->as<ASTColumnDeclaration>())
     {
+        visit(node_decl->expr_name.get());
         visit(node_decl->default_expression.get());
         visit(node_decl->ttl.get());
         return;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -619,7 +619,8 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
         if (create.columns_list->projections)
             for (const auto & projection_ast : create.columns_list->projections->children)
             {
-                auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, properties.columns, getContext());
+                auto projection
+                    = ProjectionDescription::getProjectionFromAST(projection_ast, properties.columns, getContext(), create.attach);
                 properties.projections.add(std::move(projection));
             }
 

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1233,7 +1233,11 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                     // expressions before ORDER BY and the preliminary DISTINCT
                     // now, on shards (first_stage).
                     assert(!expressions.before_window);
-                    executeExpression(query_plan, expressions.before_order_by, "Before ORDER BY");
+                    executeExpression(
+                        query_plan,
+                        query_info.projection && query_info.projection->before_order_by ? query_info.projection->before_order_by
+                                                                                        : expressions.before_order_by,
+                        "Before ORDER BY");
                     executeDistinct(query_plan, true, expressions.selected_columns, true);
                 }
             }

--- a/src/Parsers/ASTColumnDeclaration.cpp
+++ b/src/Parsers/ASTColumnDeclaration.cpp
@@ -10,6 +10,11 @@ ASTPtr ASTColumnDeclaration::clone() const
 {
     const auto res = std::make_shared<ASTColumnDeclaration>(*this);
     res->children.clear();
+    if (expr_name)
+    {
+        res->expr_name = expr_name->clone();
+        res->children.push_back(res->expr_name);
+    }
 
     if (type)
     {
@@ -49,6 +54,12 @@ ASTPtr ASTColumnDeclaration::clone() const
 void ASTColumnDeclaration::formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
     frame.need_parens = false;
+
+    if (expr_name)
+    {
+        expr_name->formatImpl(settings, state, frame);
+        settings.ostr << ' ' << (settings.hilite ? hilite_keyword : "") << "AS" << (settings.hilite ? hilite_none : "") << ' ';
+    }
 
     /// We have to always backquote column names to avoid ambiguouty with INDEX and other declarations in CREATE query.
     settings.ostr << backQuote(name);

--- a/src/Parsers/ASTColumnDeclaration.h
+++ b/src/Parsers/ASTColumnDeclaration.h
@@ -11,6 +11,7 @@ namespace DB
 class ASTColumnDeclaration : public IAST
 {
 public:
+    ASTPtr expr_name; /// Used to describe explicit column name mappings in projection description
     String name;
     ASTPtr type;
     std::optional<bool> null_modifier;

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -75,19 +75,6 @@ void ASTStorage::formatImpl(const FormatSettings & s, FormatState & state, Forma
 }
 
 
-class ASTColumnsElement : public IAST
-{
-public:
-    String prefix;
-    IAST * elem;
-
-    String getID(char c) const override { return "ASTColumnsElement for " + elem->getID(c); }
-
-    ASTPtr clone() const override;
-
-    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
-};
-
 ASTPtr ASTColumnsElement::clone() const
 {
     auto res = std::make_shared<ASTColumnsElement>();

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -36,6 +36,19 @@ public:
 
 class ASTExpressionList;
 
+class ASTColumnsElement : public IAST
+{
+public:
+    String prefix;
+    IAST * elem;
+
+    String getID(char c) const override { return "ASTColumnsElement for " + elem->getID(c); }
+
+    ASTPtr clone() const override;
+
+    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+};
+
 class ASTColumns : public IAST
 {
 public:

--- a/src/Parsers/ASTProjectionDeclaration.cpp
+++ b/src/Parsers/ASTProjectionDeclaration.cpp
@@ -9,8 +9,9 @@ ASTPtr ASTProjectionDeclaration::clone() const
 {
     auto res = std::make_shared<ASTProjectionDeclaration>();
     res->name = name;
-    if (query)
-        res->set(res->query, query->clone());
+    if (desc)
+        res->set(res->desc, desc->clone());
+    res->set(res->query, query->clone());
     return res;
 }
 
@@ -20,6 +21,12 @@ void ASTProjectionDeclaration::formatImpl(const FormatSettings & settings, Forma
     settings.ostr << backQuoteIfNeed(name);
     std::string indent_str = settings.one_line ? "" : std::string(4u * frame.indent, ' ');
     std::string nl_or_nothing = settings.one_line ? "" : "\n";
+    if (desc)
+    {
+        settings.ostr << settings.nl_or_ws << indent_str << "(";
+        desc->formatImpl(settings, state, frame);
+        settings.ostr << nl_or_nothing << indent_str << ")";
+    }
     settings.ostr << settings.nl_or_ws << indent_str << "(" << nl_or_nothing;
     FormatStateStacked frame_nested = frame;
     frame_nested.need_parens = false;

--- a/src/Parsers/ASTProjectionDeclaration.h
+++ b/src/Parsers/ASTProjectionDeclaration.h
@@ -11,6 +11,7 @@ class ASTProjectionDeclaration : public IAST
 {
 public:
     String name;
+    IAST * desc;
     IAST * query;
 
     /** Get the text that identifies this element. */

--- a/src/Parsers/ASTProjectionSelectQuery.h
+++ b/src/Parsers/ASTProjectionSelectQuery.h
@@ -6,6 +6,26 @@
 
 namespace DB
 {
+
+class ASTColumns;
+class ASTExpressionList;
+class ASTSetQuery;
+
+class ASTProjectionColumnsWithSettingsAndComment : public IAST
+{
+public:
+    ASTExpressionList * columns = nullptr;
+    ASTExpressionList * indices = nullptr;
+    IAST * comment = nullptr;
+    ASTSetQuery * settings = nullptr;
+
+    String getID(char) const override { return "Projection columns definition with optional settings and comment"; }
+
+    ASTPtr clone() const override;
+
+    void formatImpl(const FormatSettings & s, FormatState & state, FormatStateStacked frame) const override;
+};
+
 /** PROJECTION SELECT query
   */
 class ASTProjectionSelectQuery : public IAST

--- a/src/Parsers/ParserProjectionSelectQuery.cpp
+++ b/src/Parsers/ParserProjectionSelectQuery.cpp
@@ -1,15 +1,193 @@
 #include <memory>
+#include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIndexDeclaration.h>
 #include <Parsers/ASTProjectionSelectQuery.h>
+#include <Parsers/ASTSetQuery.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/IParserBase.h>
+#include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ParserProjectionSelectQuery.h>
+#include <Parsers/ParserSetQuery.h>
 
 
 namespace DB
 {
+
+bool ParserProjectionColumnDeclaration::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserExpression expr_name_parser;
+    ParserIdentifier name_parser;
+    ParserKeyword s_as{"AS"};
+    ParserKeyword s_comment{"COMMENT"};
+    ParserKeyword s_codec{"CODEC"};
+    ParserStringLiteral string_literal_parser;
+    ParserCodec codec_parser;
+
+    /// mandatory expr name
+    ASTPtr expr_name;
+    if (!expr_name_parser.parse(pos, expr_name, expected))
+        return false;
+
+    if (!s_as.ignore(pos, expected))
+        return false;
+
+    /// mandatory column name
+    ASTPtr name;
+    if (!name_parser.parse(pos, name, expected))
+        return false;
+
+    const auto column_declaration = std::make_shared<ASTColumnDeclaration>();
+    tryGetIdentifierNameInto(name, column_declaration->name);
+
+    ASTPtr comment_expression;
+    ASTPtr codec_expression;
+
+    if (s_comment.ignore(pos, expected))
+    {
+        /// should be followed by a string literal
+        if (!string_literal_parser.parse(pos, comment_expression, expected))
+            return false;
+    }
+
+    if (s_codec.ignore(pos, expected))
+    {
+        if (!codec_parser.parse(pos, codec_expression, expected))
+            return false;
+    }
+
+    node = column_declaration;
+
+    if (expr_name)
+    {
+        column_declaration->expr_name = expr_name;
+        column_declaration->children.push_back(std::move(expr_name));
+    }
+
+    if (comment_expression)
+    {
+        column_declaration->comment = comment_expression;
+        column_declaration->children.push_back(std::move(comment_expression));
+    }
+
+    if (codec_expression)
+    {
+        column_declaration->codec = codec_expression;
+        column_declaration->children.push_back(std::move(codec_expression));
+    }
+
+    return true;
+}
+
+bool ParserProjectionDescriptionDeclaration::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserKeyword s_index("INDEX");
+
+    ParserIndexDeclaration index_p;
+    ParserProjectionColumnDeclaration column_p;
+
+    ASTPtr new_node = nullptr;
+
+    if (s_index.ignore(pos, expected))
+    {
+        if (!index_p.parse(pos, new_node, expected))
+            return false;
+    }
+    else
+    {
+        if (!column_p.parse(pos, new_node, expected))
+            return false;
+    }
+
+    node = new_node;
+    return true;
+}
+
+bool ParserProjectionDescriptionDeclarationList::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ASTPtr list;
+    if (!ParserList(std::make_unique<ParserProjectionDescriptionDeclaration>(), std::make_unique<ParserToken>(TokenType::Comma), false)
+             .parse(pos, list, expected))
+        return false;
+
+    ASTPtr columns = std::make_shared<ASTExpressionList>();
+    ASTPtr indices = std::make_shared<ASTExpressionList>();
+
+    for (const auto & elem : list->children)
+    {
+        if (elem->as<ASTColumnDeclaration>())
+            columns->children.push_back(elem);
+        else if (elem->as<ASTIndexDeclaration>())
+            indices->children.push_back(elem);
+        else
+            return false;
+    }
+
+    ParserToken comma_p(TokenType::Comma);
+    ParserKeyword s_settings("SETTINGS");
+    ParserSetQuery settings_p(/* parse_only_internals_ = */ true);
+    ASTPtr settings;
+    ParserKeyword s_comment("COMMENT");
+    ParserStringLiteral string_literal_parser;
+    ASTPtr comment;
+
+    if (comma_p.ignore(pos, expected))
+    {
+        if (s_comment.ignore(pos, expected))
+        {
+            if (!string_literal_parser.parse(pos, comment, expected))
+                return false;
+
+            if (comma_p.ignore(pos, expected))
+            {
+                if (!s_settings.ignore(pos, expected))
+                    return false;
+                if (!settings_p.parse(pos, settings, expected))
+                    return false;
+            }
+        }
+        else if (s_settings.ignore(pos, expected))
+        {
+            if (!settings_p.parse(pos, settings, expected))
+                return false;
+        }
+        else
+            return false;
+    }
+
+    auto res = std::make_shared<ASTProjectionColumnsWithSettingsAndComment>();
+    if (!columns->children.empty())
+        res->set(res->columns, columns);
+    if (!indices->children.empty())
+        res->set(res->indices, indices);
+    if (comment)
+        res->set(res->comment, comment);
+    if (settings)
+        res->set(res->settings, settings);
+    node = res;
+    return true;
+}
+
+bool ParserProjectionDescription::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserToken s_lparen(TokenType::OpeningRoundBracket);
+    ParserToken s_rparen(TokenType::ClosingRoundBracket);
+    ParserProjectionDescriptionDeclarationList projection_properties_p;
+
+    if (!s_lparen.ignore(pos, expected))
+        return false;
+
+    if (!projection_properties_p.parse(pos, node, expected))
+        return false;
+
+    if (!s_rparen.ignore(pos, expected))
+        return false;
+
+    return true;
+}
+
 bool ParserProjectionSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     auto select_query = std::make_shared<ASTProjectionSelectQuery>();
@@ -27,7 +205,7 @@ bool ParserProjectionSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
     ASTPtr with_expression_list;
     ASTPtr select_expression_list;
     ASTPtr group_expression_list;
-    ASTPtr order_expression;
+    ASTPtr order_expression_list;
 
     /// WITH expr list
     {
@@ -38,7 +216,7 @@ bool ParserProjectionSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
         }
     }
 
-    /// SELECT [DISTINCT] [TOP N [WITH TIES]] expr list
+    /// SELECT expr list
     {
         if (!s_select.ignore(pos, expected))
             return false;
@@ -55,31 +233,19 @@ bool ParserProjectionSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
             return false;
     }
 
-    // ORDER BY needs to be an ASTFunction so that we can use it as a sorting key
+    // if order by is speficied, MergeTree engine is used, and order by keys are prepended to the
+    // select list when converting to ASTSelectQuery.
     if (s_order_by.ignore(pos, expected))
     {
-        ASTPtr expr_list;
-        if (!ParserList(std::make_unique<ParserExpression>(), std::make_unique<ParserToken>(TokenType::Comma)).parse(pos, expr_list, expected))
+        if (!ParserList(std::make_unique<ParserExpression>(), std::make_unique<ParserToken>(TokenType::Comma))
+                 .parse(pos, order_expression_list, expected))
             return false;
-
-        if (expr_list->children.size() == 1)
-        {
-            order_expression = expr_list->children.front();
-        }
-        else
-        {
-            auto function_node = std::make_shared<ASTFunction>();
-            function_node->name = "tuple";
-            function_node->arguments = expr_list;
-            function_node->children.push_back(expr_list);
-            order_expression = function_node;
-        }
     }
 
     select_query->setExpression(ASTProjectionSelectQuery::Expression::WITH, std::move(with_expression_list));
     select_query->setExpression(ASTProjectionSelectQuery::Expression::SELECT, std::move(select_expression_list));
     select_query->setExpression(ASTProjectionSelectQuery::Expression::GROUP_BY, std::move(group_expression_list));
-    select_query->setExpression(ASTProjectionSelectQuery::Expression::ORDER_BY, std::move(order_expression));
+    select_query->setExpression(ASTProjectionSelectQuery::Expression::ORDER_BY, std::move(order_expression_list));
     return true;
 }
 

--- a/src/Parsers/ParserProjectionSelectQuery.h
+++ b/src/Parsers/ParserProjectionSelectQuery.h
@@ -6,6 +6,35 @@
 namespace DB
 {
 
+class ParserProjectionColumnDeclaration : public IParserBase
+{
+protected:
+    const char * getName() const  override{ return "projection column declaration"; }
+
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
+class ParserProjectionDescriptionDeclaration : public IParserBase
+{
+protected:
+    const char * getName() const override { return "projection description (column, index) declaration"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
+class ParserProjectionDescriptionDeclarationList : public IParserBase
+{
+protected:
+    const char * getName() const override { return "projection columns and indices"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
+class ParserProjectionDescription : public IParserBase
+{
+protected:
+    const char * getName() const override { return "PROJECTION description"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+};
+
 
 class ParserProjectionSelectQuery : public IParserBase
 {

--- a/src/Storages/MergeTree/FutureMergedMutatedPart.cpp
+++ b/src/Storages/MergeTree/FutureMergedMutatedPart.cpp
@@ -24,7 +24,8 @@ void FutureMergedMutatedPart::assign(MergeTreeData::DataPartsVector parts_)
         future_part_type = std::min(future_part_type, part->getType());
     }
 
-    auto chosen_type = parts_.front()->storage.choosePartTypeOnDisk(sum_bytes_uncompressed, sum_rows);
+    auto chosen_type
+        = parts_.front()->storage.choosePartTypeOnDisk(sum_bytes_uncompressed, sum_rows, parts_.front()->getProjectionSettings());
     future_part_type = std::min(future_part_type, chosen_type);
     assign(std::move(parts_), future_part_type);
 }

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -68,7 +68,8 @@ public:
         const VolumePtr & volume,
         const std::optional<String> & relative_path,
         Type part_type_,
-        const IMergeTreeDataPart * parent_part_);
+        const IMergeTreeDataPart * parent_part_,
+        const ProjectionSettings & projection_settings_);
 
     IMergeTreeDataPart(
         const MergeTreeData & storage_,
@@ -76,7 +77,8 @@ public:
         const VolumePtr & volume,
         const std::optional<String> & relative_path,
         Type part_type_,
-        const IMergeTreeDataPart * parent_part_);
+        const IMergeTreeDataPart * parent_part_,
+        const ProjectionSettings & projection_settings_);
 
     virtual MergeTreeReaderPtr getReader(
         const NamesAndTypesList & columns_,
@@ -179,6 +181,8 @@ public:
     /// Compute part block id for zero level part. Otherwise throws an exception.
     /// If token is not empty, block id is calculated based on it instead of block data
     String getZeroLevelPartBlockID(std::string_view token) const;
+
+    MergeTreeSettingsPtr getStorageSettings() const;
 
     const MergeTreeData & storage;
 
@@ -429,6 +433,8 @@ public:
     /// Required for distinguish different copies of the same part on remote FS.
     String getUniqueId() const;
 
+    const ProjectionSettings & getProjectionSettings() const { return projection_settings; }
+
 protected:
 
     /// Total size of all columns, calculated once in calcuateColumnSizesOnDisk
@@ -452,6 +458,8 @@ protected:
 
     /// Not null when it's a projection part.
     const IMergeTreeDataPart * parent_part;
+
+    ProjectionSettings projection_settings;
 
     std::map<String, std::shared_ptr<IMergeTreeDataPart>> projection_parts;
 

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -217,7 +217,12 @@ NameAndTypePair IMergeTreeReader::getColumnFromPart(const NameAndTypePair & requ
     auto name_in_storage = required_column.getNameInStorage();
 
     ColumnsFromPart::ConstLookupResult it;
-    if (alter_conversions.isColumnRenamed(name_in_storage))
+    if (auto expr_it = metadata_snapshot->expr_name_to_explicit_column_name_mapping.find(name_in_storage);
+        expr_it != metadata_snapshot->expr_name_to_explicit_column_name_mapping.end())
+    {
+        it = columns_from_part.find(expr_it->second);
+    }
+    else if (alter_conversions.isColumnRenamed(name_in_storage))
     {
         String old_name = alter_conversions.getColumnOldName(name_in_storage);
         it = columns_from_part.find(old_name);

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -156,7 +156,8 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare()
         global_ctx->future_part->part_info,
         local_single_disk_volume,
         local_tmp_part_basename,
-        global_ctx->parent_part);
+        global_ctx->parent_part,
+        global_ctx->projection_settings);
 
     global_ctx->new_data_part->uuid = global_ctx->future_part->uuid;
     global_ctx->new_data_part->partition.assign(global_ctx->future_part->getPartition());
@@ -329,7 +330,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::executeImpl()
     {
         global_ctx->rows_written += block.rows();
 
-        const_cast<MergedBlockOutputStream &>(*global_ctx->to).write(block);
+        global_ctx->to->write(block);
 
         UInt64 result_rows = 0;
         UInt64 result_bytes = 0;
@@ -590,6 +591,7 @@ bool MergeTask::MergeProjectionsStage::mergeMinMaxIndexAndPrepareProjections() c
             global_ctx->deduplicate_by_columns,
             projection_merging_params,
             global_ctx->new_data_part.get(),
+            projection.projection_settings,
             ".proj",
             global_ctx->data,
             global_ctx->mutator,

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -8,6 +8,7 @@
 #include <Storages/MergeTree/FutureMergedMutatedPart.h>
 #include <Storages/MergeTree/ColumnSizeEstimator.h>
 #include <Storages/MergeTree/MergedColumnOnlyOutputStream.h>
+#include <Storages/ProjectionsDescription.h>
 #include <Processors/Transforms/ColumnGathererTransform.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Compression/CompressedReadBufferFromFile.h>
@@ -59,6 +60,7 @@ public:
         Names deduplicate_by_columns_,
         MergeTreeData::MergingParams merging_params_,
         const IMergeTreeDataPart * parent_part_,
+        ProjectionSettings projection_settings_,
         String suffix_,
         MergeTreeData * data_,
         MergeTreeDataMergerMutator * mutator_,
@@ -79,6 +81,7 @@ public:
             global_ctx->deduplicate = std::move(deduplicate_);
             global_ctx->deduplicate_by_columns = std::move(deduplicate_by_columns_);
             global_ctx->parent_part = std::move(parent_part_);
+            global_ctx->projection_settings = std::move(projection_settings_);
             global_ctx->data = std::move(data_);
             global_ctx->mutator = std::move(mutator_);
             global_ctx->merges_blocker = std::move(merges_blocker_);
@@ -131,6 +134,7 @@ private:
         FutureMergedMutatedPartPtr future_part{nullptr};
         /// This will be either nullptr or new_data_part, so raw pointer is ok.
         const IMergeTreeDataPart * parent_part{nullptr};
+        ProjectionSettings projection_settings;
         ContextPtr context{nullptr};
         time_t time_of_merge{0};
         ReservationSharedPtr space_reservation{nullptr};

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -219,21 +219,37 @@ public:
     using DataPartsLock = std::unique_lock<std::mutex>;
     DataPartsLock lockParts() const { return DataPartsLock(data_parts_mutex); }
 
-    MergeTreeDataPartType choosePartType(size_t bytes_uncompressed, size_t rows_count) const;
-    MergeTreeDataPartType choosePartTypeOnDisk(size_t bytes_uncompressed, size_t rows_count) const;
+    MergeTreeDataPartType
+    choosePartType(size_t bytes_uncompressed, size_t rows_count, const ProjectionSettings & projection_settings) const;
+    MergeTreeDataPartType
+    choosePartTypeOnDisk(size_t bytes_uncompressed, size_t rows_count, const ProjectionSettings & projection_settings) const;
 
     /// After this method setColumns must be called
-    MutableDataPartPtr createPart(const String & name,
-        MergeTreeDataPartType type, const MergeTreePartInfo & part_info,
-        const VolumePtr & volume, const String & relative_path, const IMergeTreeDataPart * parent_part = nullptr) const;
+    MutableDataPartPtr createPart(
+        const String & name,
+        MergeTreeDataPartType type,
+        const MergeTreePartInfo & part_info,
+        const VolumePtr & volume,
+        const String & relative_path,
+        const IMergeTreeDataPart * parent_part = nullptr,
+        const ProjectionSettings & projection_settings = {}) const;
 
     /// Create part, that already exists on filesystem.
     /// After this methods 'loadColumnsChecksumsIndexes' must be called.
-    MutableDataPartPtr createPart(const String & name,
-        const VolumePtr & volume, const String & relative_path, const IMergeTreeDataPart * parent_part = nullptr) const;
+    MutableDataPartPtr createPart(
+        const String & name,
+        const VolumePtr & volume,
+        const String & relative_path,
+        const IMergeTreeDataPart * parent_part = nullptr,
+        const ProjectionSettings & projection_settings = {}) const;
 
-    MutableDataPartPtr createPart(const String & name, const MergeTreePartInfo & part_info,
-        const VolumePtr & volume, const String & relative_path, const IMergeTreeDataPart * parent_part = nullptr) const;
+    MutableDataPartPtr createPart(
+        const String & name,
+        const MergeTreePartInfo & part_info,
+        const VolumePtr & volume,
+        const String & relative_path,
+        const IMergeTreeDataPart * parent_part = nullptr,
+        const ProjectionSettings & projection_settings = {}) const;
 
     /// Auxiliary object to add a set of parts into the working set in two steps:
     /// * First, as PreActive parts (the parts are ready, but not yet in the active set).

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -417,6 +417,7 @@ MergeTaskPtr MergeTreeDataMergerMutator::mergePartsToTemporaryPart(
     const Names & deduplicate_by_columns,
     const MergeTreeData::MergingParams & merging_params,
     const IMergeTreeDataPart * parent_part,
+    const ProjectionSettings & projection_settings,
     const String & suffix)
 {
     return std::make_shared<MergeTask>(
@@ -431,6 +432,7 @@ MergeTaskPtr MergeTreeDataMergerMutator::mergePartsToTemporaryPart(
         deduplicate_by_columns,
         merging_params,
         parent_part,
+        projection_settings,
         suffix,
         &data,
         this,

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -108,6 +108,7 @@ public:
         const Names & deduplicate_by_columns,
         const MergeTreeData::MergingParams & merging_params,
         const IMergeTreeDataPart * parent_part = nullptr,
+        const ProjectionSettings & projection_settings = {},
         const String & suffix = "");
 
     /// Mutate a single data part with the specified commands. Will create and return a temporary part.

--- a/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartCompact.cpp
@@ -17,23 +17,25 @@ namespace ErrorCodes
 
 
 MergeTreeDataPartCompact::MergeTreeDataPartCompact(
-       MergeTreeData & storage_,
-        const String & name_,
-        const VolumePtr & volume_,
-        const std::optional<String> & relative_path_,
-        const IMergeTreeDataPart * parent_part_)
-    : IMergeTreeDataPart(storage_, name_, volume_, relative_path_, Type::COMPACT, parent_part_)
+    MergeTreeData & storage_,
+    const String & name_,
+    const VolumePtr & volume_,
+    const std::optional<String> & relative_path_,
+    const IMergeTreeDataPart * parent_part_,
+    const ProjectionSettings & projection_settings_)
+    : IMergeTreeDataPart(storage_, name_, volume_, relative_path_, Type::COMPACT, parent_part_, projection_settings_)
 {
 }
 
 MergeTreeDataPartCompact::MergeTreeDataPartCompact(
-        const MergeTreeData & storage_,
-        const String & name_,
-        const MergeTreePartInfo & info_,
-        const VolumePtr & volume_,
-        const std::optional<String> & relative_path_,
-        const IMergeTreeDataPart * parent_part_)
-    : IMergeTreeDataPart(storage_, name_, info_, volume_, relative_path_, Type::COMPACT, parent_part_)
+    const MergeTreeData & storage_,
+    const String & name_,
+    const MergeTreePartInfo & info_,
+    const VolumePtr & volume_,
+    const std::optional<String> & relative_path_,
+    const IMergeTreeDataPart * parent_part_,
+    const ProjectionSettings & projection_settings_)
+    : IMergeTreeDataPart(storage_, name_, info_, volume_, relative_path_, Type::COMPACT, parent_part_, projection_settings_)
 {
 }
 

--- a/src/Storages/MergeTree/MergeTreeDataPartCompact.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartCompact.h
@@ -27,14 +27,16 @@ public:
         const MergeTreePartInfo & info_,
         const VolumePtr & volume_,
         const std::optional<String> & relative_path_ = {},
-        const IMergeTreeDataPart * parent_part_ = nullptr);
+        const IMergeTreeDataPart * parent_part_ = nullptr,
+        const ProjectionSettings & projection_settings_ = {});
 
     MergeTreeDataPartCompact(
         MergeTreeData & storage_,
         const String & name_,
         const VolumePtr & volume_,
         const std::optional<String> & relative_path_ = {},
-        const IMergeTreeDataPart * parent_part_ = nullptr);
+        const IMergeTreeDataPart * parent_part_ = nullptr,
+        const ProjectionSettings & projection_settings_ = {});
 
     MergeTreeReaderPtr getReader(
         const NamesAndTypesList & columns,

--- a/src/Storages/MergeTree/MergeTreeDataPartInMemory.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartInMemory.h
@@ -16,14 +16,16 @@ public:
         const MergeTreePartInfo & info_,
         const VolumePtr & volume_,
         const std::optional<String> & relative_path_ = {},
-        const IMergeTreeDataPart * parent_part_ = nullptr);
+        const IMergeTreeDataPart * parent_part_ = nullptr,
+        const ProjectionSettings & projection_settings_ = {});
 
     MergeTreeDataPartInMemory(
         MergeTreeData & storage_,
         const String & name_,
         const VolumePtr & volume_,
         const std::optional<String> & relative_path_ = {},
-        const IMergeTreeDataPart * parent_part_ = nullptr);
+        const IMergeTreeDataPart * parent_part_ = nullptr,
+        const ProjectionSettings & projection_settings_ = {});
 
     MergeTreeReaderPtr getReader(
         const NamesAndTypesList & columns,

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.cpp
@@ -19,23 +19,25 @@ namespace ErrorCodes
 
 
 MergeTreeDataPartWide::MergeTreeDataPartWide(
-       MergeTreeData & storage_,
-        const String & name_,
-        const VolumePtr & volume_,
-        const std::optional<String> & relative_path_,
-        const IMergeTreeDataPart * parent_part_)
-    : IMergeTreeDataPart(storage_, name_, volume_, relative_path_, Type::WIDE, parent_part_)
+    MergeTreeData & storage_,
+    const String & name_,
+    const VolumePtr & volume_,
+    const std::optional<String> & relative_path_,
+    const IMergeTreeDataPart * parent_part_,
+    const ProjectionSettings & projection_settings_)
+    : IMergeTreeDataPart(storage_, name_, volume_, relative_path_, Type::WIDE, parent_part_, projection_settings_)
 {
 }
 
 MergeTreeDataPartWide::MergeTreeDataPartWide(
-        const MergeTreeData & storage_,
-        const String & name_,
-        const MergeTreePartInfo & info_,
-        const VolumePtr & volume_,
-        const std::optional<String> & relative_path_,
-        const IMergeTreeDataPart * parent_part_)
-    : IMergeTreeDataPart(storage_, name_, info_, volume_, relative_path_, Type::WIDE, parent_part_)
+    const MergeTreeData & storage_,
+    const String & name_,
+    const MergeTreePartInfo & info_,
+    const VolumePtr & volume_,
+    const std::optional<String> & relative_path_,
+    const IMergeTreeDataPart * parent_part_,
+    const ProjectionSettings & projection_settings_)
+    : IMergeTreeDataPart(storage_, name_, info_, volume_, relative_path_, Type::WIDE, parent_part_, projection_settings_)
 {
 }
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.h
@@ -21,14 +21,16 @@ public:
         const MergeTreePartInfo & info_,
         const VolumePtr & volume,
         const std::optional<String> & relative_path_ = {},
-        const IMergeTreeDataPart * parent_part_ = nullptr);
+        const IMergeTreeDataPart * parent_part_ = nullptr,
+        const ProjectionSettings & projection_settings_ = {});
 
     MergeTreeDataPartWide(
         MergeTreeData & storage_,
         const String & name_,
         const VolumePtr & volume,
         const std::optional<String> & relative_path_ = {},
-        const IMergeTreeDataPart * parent_part_ = nullptr);
+        const IMergeTreeDataPart * parent_part_ = nullptr,
+        const ProjectionSettings & projection_settings_ = {});
 
     MergeTreeReaderPtr getReader(
         const NamesAndTypesList & columns,

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -143,7 +143,7 @@ static size_t computeIndexGranularityImpl(
 
 size_t MergeTreeDataPartWriterOnDisk::computeIndexGranularity(const Block & block) const
 {
-    const auto storage_settings = storage.getSettings();
+    const auto storage_settings = data_part->getStorageSettings();
     return computeIndexGranularityImpl(
             block,
             storage_settings->index_granularity_bytes,

--- a/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.cpp
@@ -29,10 +29,11 @@ std::optional<std::string> MergeTreeIndexGranularityInfo::getMarksExtensionFromF
     return {};
 }
 
-MergeTreeIndexGranularityInfo::MergeTreeIndexGranularityInfo(const MergeTreeData & storage, MergeTreeDataPartType type_)
+MergeTreeIndexGranularityInfo::MergeTreeIndexGranularityInfo(
+    const MergeTreeData & storage, MergeTreeDataPartType type_, const MergeTreeSettingsPtr & settings)
     : type(type_)
 {
-    const auto storage_settings = storage.getSettings();
+    const auto storage_settings = settings ? settings : storage.getSettings();
     fixed_index_granularity = storage_settings->index_granularity;
 
     /// Granularity is fixed

--- a/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.h
+++ b/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.h
@@ -9,6 +9,8 @@ namespace DB
 {
 
 class MergeTreeData;
+struct MergeTreeSettings;
+using MergeTreeSettingsPtr = std::shared_ptr<const MergeTreeSettings>;
 
 /// Meta information about index granularity
 struct MergeTreeIndexGranularityInfo
@@ -26,7 +28,7 @@ public:
     /// Approximate bytes size of one granule
     size_t index_granularity_bytes = 0;
 
-    MergeTreeIndexGranularityInfo(const MergeTreeData & storage, MergeTreeDataPartType type_);
+    MergeTreeIndexGranularityInfo(const MergeTreeData & storage, MergeTreeDataPartType type_, const MergeTreeSettingsPtr & settings = {});
 
     void changeGranularityIfRequired(const DiskPtr & disk, const String & path_to_part);
 

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -26,7 +26,7 @@ MergedBlockOutputStream::MergedBlockOutputStream(
 {
     MergeTreeWriterSettings writer_settings(
         storage.getContext()->getSettings(),
-        storage.getSettings(),
+        data_part->getStorageSettings(),
         data_part->index_granularity_info.is_adaptive,
         /* rewrite_primary_key = */ true,
         blocks_are_granules_size);

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -15,19 +15,15 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
     const Block & header_,
     CompressionCodecPtr default_codec,
     const MergeTreeIndices & indices_to_recalc,
-    WrittenOffsetColumns * offset_columns_,
-    const MergeTreeIndexGranularity & index_granularity,
-    const MergeTreeIndexGranularityInfo * index_granularity_info)
+    WrittenOffsetColumns * offset_columns,
+    const MergeTreeIndexGranularity & index_granularity)
     : IMergedBlockOutputStream(data_part, metadata_snapshot_, header_.getNamesAndTypesList(), /*reset_columns=*/ true)
     , header(header_)
 {
-    const auto & global_settings = data_part->storage.getContext()->getSettings();
-    const auto & storage_settings = data_part->storage.getSettings();
-
     MergeTreeWriterSettings writer_settings(
-        global_settings,
-        storage_settings,
-        index_granularity_info ? index_granularity_info->is_adaptive : data_part->storage.canUseAdaptiveGranularity(),
+        storage.getContext()->getSettings(),
+        data_part->getStorageSettings(),
+        data_part->index_granularity_info.is_adaptive,
         /* rewrite_primary_key = */false);
 
     writer = data_part->getWriter(
@@ -42,7 +38,7 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
     if (!writer_on_disk)
         throw Exception("MergedColumnOnlyOutputStream supports only parts stored on disk", ErrorCodes::NOT_IMPLEMENTED);
 
-    writer_on_disk->setWrittenOffsetColumns(offset_columns_);
+    writer_on_disk->setWrittenOffsetColumns(offset_columns);
 }
 
 void MergedColumnOnlyOutputStream::write(const Block & block)

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.h
@@ -17,11 +17,10 @@ public:
         const MergeTreeDataPartPtr & data_part,
         const StorageMetadataPtr & metadata_snapshot_,
         const Block & header_,
-        CompressionCodecPtr default_codec_,
-        const MergeTreeIndices & indices_to_recalc_,
-        WrittenOffsetColumns * offset_columns_ = nullptr,
-        const MergeTreeIndexGranularity & index_granularity = {},
-        const MergeTreeIndexGranularityInfo * index_granularity_info_ = nullptr);
+        CompressionCodecPtr default_codec,
+        const MergeTreeIndices & indices_to_recalc,
+        WrittenOffsetColumns * offset_columns,
+        const MergeTreeIndexGranularity & index_granularity);
 
     Block getHeader() const { return header; }
     void write(const Block & block) override;

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -641,6 +641,7 @@ public:
                 {},
                 projection_merging_params,
                 ctx->new_data_part.get(),
+                projection.projection_settings,
                 ".tmp_proj");
 
             next_level_parts.push_back(executeHere(tmp_part_merge_task));
@@ -1110,8 +1111,7 @@ private:
                 ctx->compression_codec,
                 std::vector<MergeTreeIndexPtr>(ctx->indices_to_recalc.begin(), ctx->indices_to_recalc.end()),
                 nullptr,
-                ctx->source_part->index_granularity,
-                &ctx->source_part->index_granularity_info
+                ctx->source_part->index_granularity
             );
 
             ctx->mutating_pipeline = QueryPipelineBuilder::getPipeline(std::move(builder));

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -135,7 +135,7 @@ IMergeTreeDataPart::Checksums checkDataPart(
             IMergeTreeDataPart::Checksums projection_checksums_data;
             const auto & projection_path = file_path;
 
-            if (part_type == MergeTreeDataPartType::COMPACT)
+            if (projection->getType() == MergeTreeDataPartType::COMPACT)
             {
                 auto proj_path = file_path + MergeTreeDataPartCompact::DATA_FILE_NAME_WITH_EXTENSION;
                 auto file_buf = disk->readFile(proj_path);
@@ -149,12 +149,15 @@ IMergeTreeDataPart::Checksums checkDataPart(
                 const NamesAndTypesList & projection_columns_list = projection->getColumns();
                 for (const auto & projection_column : projection_columns_list)
                 {
-                    get_serialization(projection_column)->enumerateStreams(
-                        [&](const ISerialization::SubstreamPath & substream_path)
-                        {
-                            String projection_file_name = ISerialization::getFileNameForStream(projection_column, substream_path) + ".bin";
-                            projection_checksums_data.files[projection_file_name] = checksum_compressed_file(disk, projection_path + projection_file_name);
-                        });
+                    get_serialization(projection_column)
+                        ->enumerateStreams(
+                            [&](const ISerialization::SubstreamPath & substream_path)
+                            {
+                                String projection_file_name
+                                    = ISerialization::getFileNameForStream(projection_column, substream_path) + ".bin";
+                                projection_checksums_data.files[projection_file_name]
+                                    = checksum_compressed_file(disk, projection_path + projection_file_name);
+                            });
                 }
             }
 

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -578,7 +578,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         if (args.query.columns_list && args.query.columns_list->projections)
             for (auto & projection_ast : args.query.columns_list->projections->children)
             {
-                auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, columns, args.getContext());
+                auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, columns, args.getContext(), args.attach);
                 metadata.projections.add(std::move(projection));
             }
 

--- a/src/Storages/ProjectionsDescription.h
+++ b/src/Storages/ProjectionsDescription.h
@@ -16,8 +16,33 @@
 
 namespace DB
 {
+
+class MergeTreeData;
+struct MergeTreeSettings;
+using MergeTreeSettingsPtr = std::shared_ptr<const MergeTreeSettings>;
 struct StorageInMemoryMetadata;
 using StorageMetadataPtr = std::shared_ptr<const StorageInMemoryMetadata>;
+
+#define LIST_OF_PROJECTION_SETTINGS(M) \
+    M(min_compress_block_size) \
+    M(max_compress_block_size) \
+    M(index_granularity) \
+    M(index_granularity_bytes) \
+    M(min_bytes_for_wide_part) \
+    M(min_rows_for_wide_part) \
+    M(min_bytes_for_compact_part) \
+    M(min_rows_for_compact_part)
+
+struct ProjectionSettings
+{
+#define M(SETTING) \
+    std::optional<UInt64> SETTING;
+    LIST_OF_PROJECTION_SETTINGS(M)
+#undef M
+
+    bool changed = false;
+    MergeTreeSettingsPtr getSettings(const MergeTreeSettingsPtr & settings) const;
+};
 
 /// Description of projections for Storage
 struct ProjectionDescription
@@ -70,7 +95,7 @@ struct ProjectionDescription
     /// partition columns.
     std::vector<size_t> partition_value_indices;
 
-    ASTPtr projection_settings;
+    ProjectionSettings projection_settings;
 
     String comment;
 

--- a/src/Storages/ProjectionsDescription.h
+++ b/src/Storages/ProjectionsDescription.h
@@ -50,6 +50,9 @@ struct ProjectionDescription
     /// Sample block with projection columns. (NOTE: columns in block are empty, but not nullptr)
     Block sample_block;
 
+    /// Same as above, but stores column names without explicit name mapping.
+    Block original_sample_block;
+
     Block sample_block_for_keys;
 
     StorageMetadataPtr metadata;
@@ -67,9 +70,15 @@ struct ProjectionDescription
     /// partition columns.
     std::vector<size_t> partition_value_indices;
 
+    ASTPtr projection_settings;
+
+    String comment;
+
+    ActionsDAGPtr expr_to_explicit_column_dag;
+
     /// Parse projection from definition AST
     static ProjectionDescription
-    getProjectionFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr query_context);
+    getProjectionFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr query_context, bool attach = false);
 
     static ProjectionDescription getMinMaxCountProjection(
         const ColumnsDescription & columns,

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -118,6 +118,7 @@ struct ProjectionCandidate
     String where_column_name;
     bool remove_where_filter = false;
     ActionsDAGPtr before_aggregation;
+    ActionsDAGPtr before_order_by;
     Names required_columns;
     NamesAndTypesList aggregation_keys;
     AggregateDescriptions aggregate_descriptions;

--- a/src/Storages/StorageInMemoryMetadata.h
+++ b/src/Storages/StorageInMemoryMetadata.h
@@ -50,6 +50,12 @@ struct StorageInMemoryMetadata
 
     String comment;
 
+    /// If current metadata describes a projection, it might contain explicit column names used for
+    /// storage only, which is different from the column names in block. This is useful to overcome
+    /// too long file names of projection columns.
+    std::unordered_map<String, String> expr_name_to_explicit_column_name_mapping;
+    std::unordered_map<String, String> explicit_column_name_to_expr_name_mapping;
+
     StorageInMemoryMetadata() = default;
 
     StorageInMemoryMetadata(const StorageInMemoryMetadata & other);

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7556,7 +7556,7 @@ bool StorageReplicatedMergeTree::createEmptyPartInsteadOfLost(zkutil::ZooKeeperP
 
     auto new_data_part = createPart(
         lost_part_name,
-        choosePartType(0, block.rows()),
+        choosePartType(0, block.rows(), {}),
         new_part_info,
         createVolumeFromReservation(reservation, volume),
         TMP_PREFIX + lost_part_name);

--- a/tests/queries/0_stateless/01710_projection_with_description.reference
+++ b/tests/queries/0_stateless/01710_projection_with_description.reference
@@ -1,0 +1,2 @@
+CREATE TABLE default.t\n(\n    `i` Int32,\n    `j` Int32,\n    `k` Int32,\n    `v` String,\n    PROJECTION p\n    (\n        i + j AS `a` CODEC(T64, LZ4),\n        j AS `b`,\n        INDEX i_k k TYPE minmax GRANULARITY 1,\n        COMMENT \'test\',\n        SETTINGS index_granularity = 1\n    )\n    (\n        SELECT \n            i + j,\n            k\n        ORDER BY j\n    )\n)\nENGINE = MergeTree\nORDER BY i\nSETTINGS index_granularity = 8192
+3

--- a/tests/queries/0_stateless/01710_projection_with_description.sql
+++ b/tests/queries/0_stateless/01710_projection_with_description.sql
@@ -1,0 +1,31 @@
+-- Tags: no-s3-storage
+
+drop table if exists t;
+
+CREATE TABLE t
+(
+    `i` int,
+    `j` int,
+    `k` int,
+    `v` String,
+    PROJECTION p
+    (
+        i + j AS `a` CODEC(T64, LZ4),
+        j AS `b`,
+        INDEX i_k k TYPE minmax GRANULARITY 1,
+        COMMENT 'test',
+        SETTINGS index_granularity = 1
+    )
+    (
+        SELECT i + j, k ORDER BY j
+    )
+)
+ENGINE = MergeTree ORDER BY i;
+
+insert into t values (1, 2, 3, 'test'), (4, 5, 6, 'test2'), (7, 8, 9, 'test3');
+
+show create t;
+
+select i + j from t where k = 3 settings force_optimize_projection = 1, max_rows_to_read = 1;
+
+drop table t;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Extend projection declaration with an optional description section. It allows to specify explicit column names, codecs, skip indices for projections. This is a task in https://github.com/ClickHouse/ClickHouse/issues/33678. This is for #28932 #34891.


example:

```
CREATE TABLE x
(
    `i` int,
    `j` int,
    PROJECTION p
    (
        i + j AS `a` CODEC(T64, LZ4),
        i AS `b`,
        INDEX i_j -j TYPE minmax GRANULARITY 1,
        COMMENT 'test',
        SETTINGS index_granularity = 1
    )
    (
        SELECT i + j
        ORDER BY
            i,
            j
    )
)
ENGINE = MergeTree
ORDER BY tuple()
```

TODO:

- [ ] Add tests and documentation
- [ ] Allow primary keys and skip indices to be used when there are explicit columns
- [x] Projection settings and projection comment

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
