### PR TITLE
get credentials from environment variables for clickhouse-client

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -371,6 +371,13 @@ void Client::initialize(Poco::Util::Application & self)
 
     configReadClient(config(), home_path);
 
+    const char * env_user = getenv("CLICKHOUSE_USER");
+    const char * env_password = getenv("CLICKHOUSE_PASSWORD");
+    if (env_user)
+        config().setString("user", env_user);
+    if (env_password)
+        config().setString("password", env_password);
+
     // global_context->setApplicationType(Context::ApplicationType::CLIENT);
     global_context->setQueryParameters(query_parameters);
 

--- a/tests/integration/test_user_zero_database_access/configs/users.xml
+++ b/tests/integration/test_user_zero_database_access/configs/users.xml
@@ -37,6 +37,24 @@
                 <database>db1</database>
             </allow_databases>
         </has_access>
+
+        <env_user_with_password>
+            <password>clickhouse</password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </env_user_with_password>
+
+        <env_user_not_with_password>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </env_user_not_with_password>        
     </users>
 
     <quotas>

--- a/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
+++ b/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
@@ -72,13 +72,15 @@ def test_user_zero_database_access(start_cluster):
         assert False, "user with full access rights can't drop database test2"
     
     try:
-        node.exec_in_container(
-            ["bash", "-c", "export CLICKHOUSE_USER=env_user_not_with_password && /usr/bin/clickhouse client --query 'SELECT 1'"], user='root')
+        name = node.exec_in_container(
+            ["bash", "-c", "export CLICKHOUSE_USER=env_user_not_with_password && /usr/bin/clickhouse client --query 'SELECT currentUser()'"], user='root')
+        assert name.strip() == "env_user_not_with_password"
     except Exception as ex:
         assert False, "set env CLICKHOUSE_USER can not connect server"
 
     try:
-        node.exec_in_container(
-            ["bash", "-c", "export CLICKHOUSE_USER=env_user_with_password && export CLICKHOUSE_PASSWORD=clickhouse && /usr/bin/clickhouse client --query 'SELECT 1'"], user='root')
+        name = node.exec_in_container(
+            ["bash", "-c", "export CLICKHOUSE_USER=env_user_with_password && export CLICKHOUSE_PASSWORD=clickhouse && /usr/bin/clickhouse client --query 'SELECT currentUser()'"], user='root')
+        assert name.strip() == "env_user_with_password"
     except Exception as ex:
         assert False, "set env CLICKHOUSE_USER CLICKHOUSE_PASSWORD can not connect server"

--- a/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
+++ b/tests/integration/test_user_zero_database_access/test_user_zero_database_access.py
@@ -70,3 +70,15 @@ def test_user_zero_database_access(start_cluster):
             ["bash", "-c", "/usr/bin/clickhouse client --user 'default' --query 'DROP DATABASE test2'"], user='root')
     except Exception as ex:
         assert False, "user with full access rights can't drop database test2"
+    
+    try:
+        node.exec_in_container(
+            ["bash", "-c", "export CLICKHOUSE_USER=env_user_not_with_password && /usr/bin/clickhouse client --query 'SELECT 1'"], user='root')
+    except Exception as ex:
+        assert False, "set env CLICKHOUSE_USER can not connect server"
+
+    try:
+        node.exec_in_container(
+            ["bash", "-c", "export CLICKHOUSE_USER=env_user_with_password && export CLICKHOUSE_PASSWORD=clickhouse && /usr/bin/clickhouse client --query 'SELECT 1'"], user='root')
+    except Exception as ex:
+        assert False, "set env CLICKHOUSE_USER CLICKHOUSE_PASSWORD can not connect server"


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry:
- When use clickhouse-client logining, If user and password is not specified in command line or configuration file, get them from `CLICKHOUSE_USER`  and `CLICKHOUSE_PASSWORD` environment variables. Close https://github.com/ClickHouse/ClickHouse/issues/34538