### PR TITLE
Recreate system.{*}_log table on settings changes

### DIFF
--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -23,6 +23,7 @@
 #include <Parsers/ASTIndexDeclaration.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Storages/IStorage.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Common/setThreadName.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
 #include <IO/WriteHelpers.h>
@@ -112,9 +113,7 @@ std::shared_ptr<TSystemLog> createSystemLog(
 }
 
 
-/// returns CREATE TABLE query, but with removed:
-/// - UUID
-/// - SETTINGS (for MergeTree)
+/// returns CREATE TABLE query, but with removed UUID
 /// That way it can be used to compare with the SystemLog::getCreateTableQuery()
 ASTPtr getCreateTableQueryClean(const StorageID & table_id, ContextPtr context)
 {
@@ -123,11 +122,6 @@ ASTPtr getCreateTableQueryClean(const StorageID & table_id, ContextPtr context)
     auto & old_create_query_ast = old_ast->as<ASTCreateQuery &>();
     /// Reset UUID
     old_create_query_ast.uuid = UUIDHelpers::Nil;
-    /// Existing table has default settings (i.e. `index_granularity = 8192`), reset them.
-    if (ASTStorage * storage = old_create_query_ast.storage)
-    {
-        storage->reset(storage->settings);
-    }
     return old_ast;
 }
 
@@ -475,6 +469,11 @@ ASTPtr SystemLog<LogElement>::getCreateTableQuery()
         storage_parser, storage_def.data(), storage_def.data() + storage_def.size(),
         "Storage to create table for " + LogElement::name(), 0, DBMS_DEFAULT_MAX_PARSER_DEPTH);
     create->set(create->storage, storage_ast);
+
+    /// Write additional (default) settings for MergeTree engine to make it make it possible to compare ASTs
+    /// and recreate tables on settings changes.
+    auto storage_settings = std::make_unique<MergeTreeSettings>(getContext()->getMergeTreeSettings());
+    storage_settings->loadFromQuery(*create->storage);
 
     return create;
 }

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -12,9 +12,6 @@
 namespace DB
 {
 
-class StorageFileBlockInputStream;
-class StorageFileBlockOutputStream;
-
 class StorageFile final : public shared_ptr_helper<StorageFile>, public IStorage
 {
 friend struct shared_ptr_helper<StorageFile>;


### PR DESCRIPTION
(cherry picked from commit 4ae445c9e227581ea9f1cbe9aa9d1ba82e1236c9)

Changelog category (leave one):

- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Currently, if the user changes the settings of the system tables there will be tons of logs and ClickHouse will rename the tables every minute. This fixes #34929