### PR TITLE
read columns pruning for hive

### DIFF
--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -548,7 +548,7 @@ bool StorageHive::isColumnOriented() const
     return format_name == "Parquet" || format_name == "ORC";
 }
 
-Block StorageHive::getActualColumnsToRead(Block sample_block, const Block & header_block, const NameSet & partition_columns)
+Block StorageHive::getActualColumnsToRead(Block sample_block, const Block & header_block, const NameSet & partition_columns) const
 {
     if (!isColumnOriented())
         return header_block;

--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -131,13 +131,13 @@ public:
         // hive table header doesn't contain partition columns, we need at least one column to read.
         if (!to_read_block.columns())
         {
+            all_to_read_are_partition_columns = true;
             for (size_t i = 0; i < header_block.columns(); ++i)
             {
                 auto & col = header_block.getByPosition(i);
                 if (source_info->partition_name_types.contains(col.name))
                     continue;
                 to_read_block.insert(0, col);
-                all_to_read_are_partition_columns = true;
                 break;
             }
         }
@@ -636,7 +636,7 @@ Pipe StorageHive::read(
         if (column == "_file")
             sources_info->need_file_column = true;
     }
-    // Columming pruning only support parque and orc which are used arrow to read
+    // Columms pruning only support parque and orc which are used arrow to read
     if (format_name != "Parquet" && format_name != "ORC")
         to_read_block = sample_block;
 

--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -543,7 +543,7 @@ HiveFilePtr StorageHive::createHiveFileIfNeeded(
     }
     return hive_file;
 }
-bool StorageHive::isColumnOriented()
+bool StorageHive::isColumnOriented() const
 {
     return format_name == "Parquet" || format_name == "ORC";
 }

--- a/src/Storages/Hive/StorageHive.h
+++ b/src/Storages/Hive/StorageHive.h
@@ -52,7 +52,7 @@ public:
     SinkToStoragePtr write(const ASTPtr & /*query*/, const StorageMetadataPtr & metadata_snapshot, ContextPtr /*context*/) override;
 
     NamesAndTypesList getVirtuals() const override;
-    
+
     bool isColumnOriented() const override;
 
 protected:

--- a/src/Storages/Hive/StorageHive.h
+++ b/src/Storages/Hive/StorageHive.h
@@ -88,6 +88,9 @@ private:
     HiveFilePtr
     createHiveFileIfNeeded(const FileInfo & file_info, const FieldVector & fields, SelectQueryInfo & query_info, ContextPtr context_);
 
+    bool isColumnOriented();
+    Block getActualColumnsToRead(Block sample_block, const Block & header_block, const NameSet & partition_columns);
+
     String hive_metastore_url;
 
     /// Hive database and table

--- a/src/Storages/Hive/StorageHive.h
+++ b/src/Storages/Hive/StorageHive.h
@@ -52,6 +52,8 @@ public:
     SinkToStoragePtr write(const ASTPtr & /*query*/, const StorageMetadataPtr & metadata_snapshot, ContextPtr /*context*/) override;
 
     NamesAndTypesList getVirtuals() const override;
+    
+    bool isColumnOriented() const override;
 
 protected:
     friend class StorageHiveSource;
@@ -88,7 +90,6 @@ private:
     HiveFilePtr
     createHiveFileIfNeeded(const FileInfo & file_info, const FieldVector & fields, SelectQueryInfo & query_info, ContextPtr context_);
 
-    bool isColumnOriented();
     Block getActualColumnsToRead(Block sample_block, const Block & header_block, const NameSet & partition_columns);
 
     String hive_metastore_url;

--- a/src/Storages/Hive/StorageHive.h
+++ b/src/Storages/Hive/StorageHive.h
@@ -90,7 +90,7 @@ private:
     HiveFilePtr
     createHiveFileIfNeeded(const FileInfo & file_info, const FieldVector & fields, SelectQueryInfo & query_info, ContextPtr context_);
 
-    Block getActualColumnsToRead(Block sample_block, const Block & header_block, const NameSet & partition_columns);
+    Block getActualColumnsToRead(Block sample_block, const Block & header_block, const NameSet & partition_columns) const;
 
     String hive_metastore_url;
 

--- a/src/Storages/Hive/StorageHive.h
+++ b/src/Storages/Hive/StorageHive.h
@@ -90,7 +90,7 @@ private:
     HiveFilePtr
     createHiveFileIfNeeded(const FileInfo & file_info, const FieldVector & fields, SelectQueryInfo & query_info, ContextPtr context_);
 
-    Block getActualColumnsToRead(Block sample_block, const Block & header_block, const NameSet & partition_columns) const;
+    void getActualColumnsToRead(Block & sample_block, const Block & header_block, const NameSet & partition_columns) const;
 
     String hive_metastore_url;
 


### PR DESCRIPTION
Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

remove unnecessary columns for reading parquet/orc files.

with following query
```
select count(*) from hive_test_table where day = '2022-02-20' and hour = '00'
``` 

without columns pruning
```
┌──count()─┐
│ 19773257 │
└──────────┘

1 rows in set. Elapsed: 5.066 sec. Processed 19.77 million rows, 4.07 GB (3.90 million rows/s., 802.74 MB/s.)
```

with columns pruning
```
┌──count()─┐
│ 19773257 │
└──────────┘

1 rows in set. Elapsed: 1.897 sec. Processed 19.77 million rows, 1.84 KB (10.42 million rows/s., 970.05 B/s.)
```

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
