### PR TITLE
Fix wrong schema inference for unquoted dates in CSV

### DIFF
--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -262,7 +262,7 @@ static bool evaluateConstantExpressionFromString(const StringRef & field, DataTy
 
     /// FIXME: Our parser cannot parse maps in the form of '{key : value}' that is used in text formats.
     bool parsed = parser.parse(token_iterator, ast, expected);
-    if (!parsed)
+    if (!parsed || !token_iterator->isEnd())
         return false;
 
     try

--- a/tests/queries/0_stateless/02228_unquoted_dates_in_csv_schema_inference.reference
+++ b/tests/queries/0_stateless/02228_unquoted_dates_in_csv_schema_inference.reference
@@ -1,0 +1,1 @@
+c1	Nullable(String)					

--- a/tests/queries/0_stateless/02228_unquoted_dates_in_csv_schema_inference.sh
+++ b/tests/queries/0_stateless/02228_unquoted_dates_in_csv_schema_inference.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+echo "2020-02-01 16:00:00" | $CLICKHOUSE_LOCAL -q "desc table table" --input-format "CSV" --file=-
+


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix wrong schema inference for unquoted dates in CSV. Closes https://github.com/ClickHouse/ClickHouse/issues/34768

