### PR TITLE
Fix typo

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -822,7 +822,7 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
             {
                 auto [it, inserted] = merged_indices.try_emplace({index_helper->index.type, index_helper->getGranularity()});
                 if (inserted)
-                    it->second.condition = index_helper->createIndexMergedCondtition(query_info, metadata_snapshot);
+                    it->second.condition = index_helper->createIndexMergedCondition(query_info, metadata_snapshot);
 
                 it->second.addIndex(index_helper);
             }

--- a/src/Storages/MergeTree/MergeTreeIndexHypothesis.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexHypothesis.cpp
@@ -84,7 +84,7 @@ MergeTreeIndexConditionPtr MergeTreeIndexHypothesis::createIndexCondition(
     throw Exception("Not supported", ErrorCodes::LOGICAL_ERROR);
 }
 
-MergeTreeIndexMergedConditionPtr MergeTreeIndexHypothesis::createIndexMergedCondtition(
+MergeTreeIndexMergedConditionPtr MergeTreeIndexHypothesis::createIndexMergedCondition(
     const SelectQueryInfo & query_info, StorageMetadataPtr storage_metadata) const
 {
     return std::make_shared<MergeTreeIndexhypothesisMergedCondition>(

--- a/src/Storages/MergeTree/MergeTreeIndexHypothesis.h
+++ b/src/Storages/MergeTree/MergeTreeIndexHypothesis.h
@@ -70,7 +70,7 @@ public:
     MergeTreeIndexConditionPtr createIndexCondition(
         const SelectQueryInfo & query, ContextPtr context) const override;
 
-    MergeTreeIndexMergedConditionPtr createIndexMergedCondtition(
+    MergeTreeIndexMergedConditionPtr createIndexMergedCondition(
         const SelectQueryInfo & query_info, StorageMetadataPtr storage_metadata) const override;
 
     bool mayBenefitFromIndexForIn(const ASTPtr & node) const override;

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -164,7 +164,7 @@ struct IMergeTreeIndex
     virtual MergeTreeIndexConditionPtr createIndexCondition(
         const SelectQueryInfo & query_info, ContextPtr context) const = 0;
 
-    virtual MergeTreeIndexMergedConditionPtr createIndexMergedCondtition(
+    virtual MergeTreeIndexMergedConditionPtr createIndexMergedCondition(
         const SelectQueryInfo & /*query_info*/, StorageMetadataPtr /*storage_metadata*/) const
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED,


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix typo in createIndexMergedCondition function name.