### PR TITLE
Fix non-MergeTree engines for system.*_log

### DIFF
--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -22,6 +22,7 @@
 #include <Parsers/formatAST.h>
 #include <Parsers/ASTIndexDeclaration.h>
 #include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ASTFunction.h>
 #include <Storages/IStorage.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Common/setThreadName.h>
@@ -472,8 +473,13 @@ ASTPtr SystemLog<LogElement>::getCreateTableQuery()
 
     /// Write additional (default) settings for MergeTree engine to make it make it possible to compare ASTs
     /// and recreate tables on settings changes.
-    auto storage_settings = std::make_unique<MergeTreeSettings>(getContext()->getMergeTreeSettings());
-    storage_settings->loadFromQuery(*create->storage);
+    const auto & engine = create->storage->engine->as<ASTFunction &>();
+    if (endsWith(engine.name, "MergeTree"))
+    {
+        auto storage_settings = std::make_unique<MergeTreeSettings>(getContext()->getMergeTreeSettings());
+        storage_settings->loadFromQuery(*create->storage);
+    }
+
 
     return create;
 }


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix non-MergeTree engines for system.*_log

Fixes: #34949 (cc @alesapin @nikitamikhaylov )