### PR TITLE
Avoid pushing to port with data inside DelayedSource

### DIFF
--- a/src/Processors/Sources/DelayedSource.cpp
+++ b/src/Processors/Sources/DelayedSource.cpp
@@ -64,7 +64,7 @@ IProcessor::Status DelayedSource::prepare()
             continue;
         }
 
-        if (!output->isNeeded())
+        if (!output->canPush())
             return Status::PortFull;
 
         if (input->isFinished())


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible rare error `Cannot push block to port which already has data`. Avoid pushing to port with data inside `DelayedSource`.

