### PR TITLE
Add option to clickhouse-test to skip aarch64 build

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1317,7 +1317,7 @@ if (ThreadFuzzer::instance().isEffective())
 #endif
 
 #if !defined(__x86_64__)
-    LOG_INFO(log, "Query Profiler is only tested on x86_64. It also known to not work under qemu-user.");
+    LOG_INFO(log, "Query Profiler and TraceCollector is only tested on x86_64. It also known to not work under qemu-user.");
 #endif
 
     if (!hasPHDRCache())

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1078,10 +1078,14 @@ def collect_build_flags(args):
     if value == 0:
         result.append(BuildFlags.POLYMORPHIC_PARTS)
 
-    use_flags = clickhouse_execute(args, "SELECT name FROM system.build_options WHERE name like 'USE_%' AND value in ('ON', '1');")
+    use_flags = clickhouse_execute(args, "SELECT name FROM system.build_options WHERE name like 'USE_%' AND value in ('ON', '1')")
     for use_flag in use_flags.strip().splitlines():
         use_flag = use_flag.decode().lower()
         result.append(use_flag)
+
+    system_processor = clickhouse_execute(args, "SELECT value FROM system.build_options WHERE name = 'SYSTEM_PROCESSOR' LIMIT 1").strip()
+    if system_processor:
+        result.append(f'cpu-{system_processor.decode().lower()}')
 
     return result
 

--- a/tests/queries/0_stateless/00974_query_profiler.sql
+++ b/tests/queries/0_stateless/00974_query_profiler.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest
+-- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64
 -- Tag no-fasttest: Not sure why fail even in sequential mode. Disabled for now to make some progress.
 
 SET allow_introspection_functions = 1;

--- a/tests/queries/0_stateless/01092_memory_profiler.sql
+++ b/tests/queries/0_stateless/01092_memory_profiler.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-parallel, no-fasttest
+-- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-parallel, no-fasttest, no-cpu-aarch64
 
 SET allow_introspection_functions = 1;
 

--- a/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
+++ b/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64
 # Tag no-fasttest: avoid dependency on qemu -- invonvenient when running locally
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -9,8 +9,6 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # If we run sanitized binary under qemu, it will try to slowly allocate 20 TiB until OOM.
 # Don't even try to do that. This test should be disabled for sanitizer builds.
 ${CLICKHOUSE_LOCAL} --query "SELECT max(value LIKE '%sanitize%') FROM system.build_options" | grep -q '1' && echo '@@SKIP@@: Sanitizer build' && exit
-
-${CLICKHOUSE_LOCAL} --query "SELECT value FROM system.build_options WHERE name = 'SYSTEM_PROCESSOR';" | grep -q 'aarch64' && echo '@@SKIP@@: aarch64 build' && exit
 
 command=$(command -v ${CLICKHOUSE_LOCAL})
 

--- a/tests/queries/0_stateless/01473_event_time_microseconds.sql
+++ b/tests/queries/0_stateless/01473_event_time_microseconds.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug
+-- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-cpu-aarch64
 
 -- This file contains tests for the event_time_microseconds field for various tables.
 -- Note: Only event_time_microseconds for asynchronous_metric_log table is tested via

--- a/tests/queries/0_stateless/01526_max_untracked_memory.sh
+++ b/tests/queries/0_stateless/01526_max_untracked_memory.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan
-# Tag no-tsan: requires TraceCollector, does not available under sanitizers
-# Tag no-asan: requires TraceCollector, does not available under sanitizers
-# Tag no-ubsan: requires TraceCollector, does not available under sanitizers
-# Tag no-msan: requires TraceCollector, does not available under sanitizers
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-cpu-aarch64
+# requires TraceCollector, does not available under sanitizers and aarch64
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01569_query_profiler_big_query_id.sh
+++ b/tests/queries/0_stateless/01569_query_profiler_big_query_id.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-cpu-aarch64
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
+++ b/tests/queries/0_stateless/02152_http_external_tables_memory_tracking.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-tsan
-#       ^^^^^^^
+# Tags: no-tsan, no-cpu-aarch64
 # TSan does not supports tracing.
+# trace_log doesn't work on aarch64
 
 # Regression for proper release of Context,
 # via tracking memory of external tables.

--- a/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
+++ b/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug
+-- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-cpu-aarch64
 
 
 SELECT addressToLineWithInlines(1); -- { serverError 446 }


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
