### PR TITLE
Skip 01086_odbc_roundtrip for aarch, disable force_tests

### DIFF
--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -231,7 +231,6 @@ CI_CONFIG = {
         },
         "Stateful tests (aarch64, actions)": {
             "required_build": "package_aarch64",
-            "force_tests": True,
         },
         "Stateful tests (release, DatabaseOrdinary, actions)": {
             "required_build": "package_release",
@@ -259,7 +258,6 @@ CI_CONFIG = {
         },
         "Stateless tests (aarch64, actions)": {
             "required_build": "package_aarch64",
-            "force_tests": True,
         },
         "Stateless tests (release, wide parts enabled, actions)": {
             "required_build": "package_release",

--- a/tests/queries/0_stateless/01086_odbc_roundtrip.sh
+++ b/tests/queries/0_stateless/01086_odbc_roundtrip.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-asan, no-msan, no-fasttest
+# Tags: no-asan, no-msan, no-fasttest, no-cpu-aarch64
 # Tag no-msan: can't pass because odbc libraries are not instrumented
+# Tag no-cpu-aarch64: clickhouse-odbc is not setup for arm
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Close https://github.com/ClickHouse/ClickHouse/issues/33716

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
