### PR TITLE
Add redirect for cloud page

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -6,6 +6,7 @@ changelog/2017.md whats-new/changelog/2017.md
 changelog/2018.md whats-new/changelog/2018.md
 changelog/2019.md whats-new/changelog/2019.md
 changelog/index.md whats-new/changelog/index.md
+commercial/cloud.md https://clickhouse.com/cloud/
 data_types/array.md sql-reference/data-types/array.md
 data_types/boolean.md sql-reference/data-types/boolean.md
 data_types/date.md sql-reference/data-types/date.md

--- a/docs/tools/redirects.py
+++ b/docs/tools/redirects.py
@@ -31,7 +31,12 @@ def build_redirect_html(args, base_prefix, lang, output_dir, from_path, to_path)
         from_path.replace('/index.md', '/index.html').replace('.md', '/index.html')
     )
     target_path = to_path.replace('/index.md', '/').replace('.md', '/')
-    to_url = f'/{base_prefix}/{lang}/{target_path}'
+
+    if target_path[0:7] != 'http://' and target_path[0:8] != 'https://':
+        to_url = f'/{base_prefix}/{lang}/{target_path}'
+    else:
+        to_url = target_path
+
     to_url = to_url.strip()
     write_redirect_html(out_path, to_url)
 


### PR DESCRIPTION
Adds a redirect from `docs/en/commercial/cloud` to https://clickhouse.com/cloud/

Changelog category (leave one):
- Documentation (changelog entry is not required)
- Not for changelog (changelog entry is not required)
