### PR TITLE
Change default theme to dark

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -763,13 +763,8 @@
     if (theme) {
         setColorTheme(theme);
     } else {
-        /// Obtain system-level user preference
-        let media_query_list = window.matchMedia('prefers-color-scheme: dark')
-
-        if (media_query_list.matches) {
-            /// Set without saving to localstorage
-            document.documentElement.setAttribute('data-theme', 'dark');
-        }
+        /// Use dark theme by default
+        document.documentElement.setAttribute('data-theme', 'dark');
 
         /// There is a rumor that on some computers, the theme is changing automatically on day/night.
         media_query_list.addEventListener('change', function(e) {


### PR DESCRIPTION
If we use dark mode by default, then there is no need to check the user's local OS preference. (Not sure if it's worthy of a mention in the changelog.)

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Change the default theme for the Play UI to dark mode


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
