### PR TITLE
Do not hide exceptions during mutations

### DIFF
--- a/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
+++ b/src/Storages/MergeTree/MutatePlainMergeTreeTask.cpp
@@ -94,6 +94,7 @@ bool MutatePlainMergeTreeTask::executeStep()
             {
                 storage.updateMutationEntriesErrors(future_part, false, getCurrentExceptionMessage(false));
                 write_part_log(ExecutionStatus::fromCurrentException());
+                tryLogCurrentException(__PRETTY_FUNCTION__);
                 return false;
             }
         }


### PR DESCRIPTION
system.mutations includes only the message, but not stacktrace, and it
is not always obvious to understand the culprit w/o stacktrace.

Changelog category (leave one):
- Not for changelog (changelog entry is not required)