### PR TITLE
Fix inconsistency in DiskLocal

### DIFF
--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -6,6 +6,7 @@
 #include <Interpreters/Context.h>
 #include <Common/filesystemHelpers.h>
 #include <Common/quoteString.h>
+#include <Common/renameat2.h>
 #include <IO/createReadBufferFromFileBase.h>
 
 #include <fstream>
@@ -325,7 +326,7 @@ DiskDirectoryIteratorPtr DiskLocal::iterateDirectory(const String & path)
 
 void DiskLocal::moveFile(const String & from_path, const String & to_path)
 {
-    fs::rename(fs::path(disk_path) / from_path, fs::path(disk_path) / to_path);
+    renameNoReplace(fs::path(disk_path) / from_path, fs::path(disk_path) / to_path);
 }
 
 void DiskLocal::replaceFile(const String & from_path, const String & to_path)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

According to comments in `IDisk.h` `moveFile` should throw exception if file exists:
https://github.com/ClickHouse/ClickHouse/blob/81e56a06a3c617f2f59aa4805718074e8163a7db/src/Disks/IDisk.h#L146-L152

