### PR TITLE
Implement partial GROUP BY key for optimize_aggregation_in_order

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionAvg.h
+++ b/src/AggregateFunctions/AggregateFunctionAvg.h
@@ -225,26 +225,38 @@ public:
     }
 
     void
-    addBatchSinglePlace(size_t batch_size, AggregateDataPtr place, const IColumn ** columns, Arena *, ssize_t if_argument_pos) const final
+    addBatchSinglePlace(
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr place,
+        const IColumn ** columns,
+        Arena *,
+        ssize_t if_argument_pos) const final
     {
         AggregateFunctionSumData<Numerator> sum_data;
         const auto & column = assert_cast<const ColVecType &>(*columns[0]);
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            sum_data.addManyConditional(column.getData().data(), flags.data(), batch_size);
-            this->data(place).denominator += countBytesInFilter(flags.data(), batch_size);
+            sum_data.addManyConditional(column.getData().data(), flags.data(), row_begin, row_end);
+            this->data(place).denominator += countBytesInFilter(flags.data(), row_begin, row_end);
         }
         else
         {
-            sum_data.addMany(column.getData().data(), batch_size);
-            this->data(place).denominator += batch_size;
+            sum_data.addMany(column.getData().data(), row_begin, row_end);
+            this->data(place).denominator += (row_end - row_begin);
         }
         increment(place, sum_data.sum);
     }
 
     void addBatchSinglePlaceNotNull(
-        size_t batch_size, AggregateDataPtr place, const IColumn ** columns, const UInt8 * null_map, Arena *, ssize_t if_argument_pos)
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr place,
+        const IColumn ** columns,
+        const UInt8 * null_map,
+        Arena *,
+        ssize_t if_argument_pos)
         const final
     {
         AggregateFunctionSumData<Numerator> sum_data;
@@ -253,22 +265,22 @@ public:
         {
             /// Merge the 2 sets of flags (null and if) into a single one. This allows us to use parallelizable sums when available
             const auto * if_flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData().data();
-            auto final_flags = std::make_unique<UInt8[]>(batch_size);
+            auto final_flags = std::make_unique<UInt8[]>(row_end);
             size_t used_value = 0;
-            for (size_t i = 0; i < batch_size; ++i)
+            for (size_t i = row_begin; i < row_end; ++i)
             {
                 UInt8 kept = (!null_map[i]) & !!if_flags[i];
                 final_flags[i] = kept;
                 used_value += kept;
             }
 
-            sum_data.addManyConditional(column.getData().data(), final_flags.get(), batch_size);
+            sum_data.addManyConditional(column.getData().data(), final_flags.get(), row_begin, row_end);
             this->data(place).denominator += used_value;
         }
         else
         {
-            sum_data.addManyNotNull(column.getData().data(), null_map, batch_size);
-            this->data(place).denominator += batch_size - countBytesInFilter(null_map, batch_size);
+            sum_data.addManyNotNull(column.getData().data(), null_map, row_begin, row_end);
+            this->data(place).denominator += (row_end - row_begin) - countBytesInFilter(null_map, row_begin, row_end);
         }
         increment(place, sum_data.sum);
     }

--- a/src/AggregateFunctions/AggregateFunctionDistinct.h
+++ b/src/AggregateFunctions/AggregateFunctionDistinct.h
@@ -200,7 +200,7 @@ public:
             arguments_raw[i] = arguments[i].get();
 
         assert(!arguments.empty());
-        nested_func->addBatchSinglePlace(arguments[0]->size(), getNestedPlace(place), arguments_raw.data(), arena);
+        nested_func->addBatchSinglePlace(0, arguments[0]->size(), getNestedPlace(place), arguments_raw.data(), arena);
         nested_func->insertResultInto(getNestedPlace(place), to, arena);
     }
 

--- a/src/AggregateFunctions/AggregateFunctionIf.h
+++ b/src/AggregateFunctions/AggregateFunctionIf.h
@@ -98,31 +98,38 @@ public:
     }
 
     void addBatch(
-        size_t batch_size,
+        size_t row_begin,
+        size_t row_end,
         AggregateDataPtr * places,
         size_t place_offset,
         const IColumn ** columns,
         Arena * arena,
         ssize_t) const override
     {
-        nested_func->addBatch(batch_size, places, place_offset, columns, arena, num_arguments - 1);
+        nested_func->addBatch(row_begin, row_end, places, place_offset, columns, arena, num_arguments - 1);
     }
 
     void addBatchSinglePlace(
-        size_t batch_size, AggregateDataPtr place, const IColumn ** columns, Arena * arena, ssize_t) const override
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr place,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t) const override
     {
-        nested_func->addBatchSinglePlace(batch_size, place, columns, arena, num_arguments - 1);
+        nested_func->addBatchSinglePlace(row_begin, row_end, place, columns, arena, num_arguments - 1);
     }
 
     void addBatchSinglePlaceNotNull(
-        size_t batch_size,
+        size_t row_begin,
+        size_t row_end,
         AggregateDataPtr place,
         const IColumn ** columns,
         const UInt8 * null_map,
         Arena * arena,
         ssize_t) const override
     {
-        nested_func->addBatchSinglePlaceNotNull(batch_size, place, columns, null_map, arena, num_arguments - 1);
+        nested_func->addBatchSinglePlaceNotNull(row_begin, row_end, place, columns, null_map, arena, num_arguments - 1);
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena * arena) const override
@@ -131,13 +138,14 @@ public:
     }
 
     void mergeBatch(
-        size_t batch_size,
+        size_t row_begin,
+        size_t row_end,
         AggregateDataPtr * places,
         size_t place_offset,
         const AggregateDataPtr * rhs,
         Arena * arena) const override
     {
-        nested_func->mergeBatch(batch_size, places, place_offset, rhs, arena);
+        nested_func->mergeBatch(row_begin, row_end, places, place_offset, rhs, arena);
     }
 
     void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override

--- a/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -1159,7 +1159,12 @@ public:
     }
 
     void addBatchSinglePlace(
-        size_t batch_size, AggregateDataPtr place, const IColumn ** columns, Arena * arena, ssize_t if_argument_pos) const override
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr place,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos) const override
     {
         if constexpr (is_any)
             if (this->data(place).has())
@@ -1167,7 +1172,7 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = 0; i < batch_size; ++i)
+            for (size_t i = row_begin; i < row_end; ++i)
             {
                 if (flags[i])
                 {
@@ -1179,7 +1184,7 @@ public:
         }
         else
         {
-            for (size_t i = 0; i < batch_size; ++i)
+            for (size_t i = row_begin; i < row_end; ++i)
             {
                 this->data(place).changeIfBetter(*columns[0], i, arena);
                 if constexpr (is_any)
@@ -1189,7 +1194,8 @@ public:
     }
 
     void addBatchSinglePlaceNotNull( /// NOLINT
-        size_t batch_size,
+        size_t row_begin,
+        size_t row_end,
         AggregateDataPtr place,
         const IColumn ** columns,
         const UInt8 * null_map,
@@ -1203,7 +1209,7 @@ public:
         if (if_argument_pos >= 0)
         {
             const auto & flags = assert_cast<const ColumnUInt8 &>(*columns[if_argument_pos]).getData();
-            for (size_t i = 0; i < batch_size; ++i)
+            for (size_t i = row_begin; i < row_end; ++i)
             {
                 if (!null_map[i] && flags[i])
                 {
@@ -1215,7 +1221,7 @@ public:
         }
         else
         {
-            for (size_t i = 0; i < batch_size; ++i)
+            for (size_t i = row_begin; i < row_end; ++i)
             {
                 if (!null_map[i])
                 {

--- a/src/AggregateFunctions/AggregateFunctionNull.h
+++ b/src/AggregateFunctions/AggregateFunctionNull.h
@@ -307,17 +307,22 @@ public:
     }
 
     void addBatchSinglePlace( /// NOLINT
-        size_t batch_size, AggregateDataPtr place, const IColumn ** columns, Arena * arena, ssize_t if_argument_pos = -1) const override
+        size_t row_begin,
+        size_t row_end,
+        AggregateDataPtr place,
+        const IColumn ** columns,
+        Arena * arena,
+        ssize_t if_argument_pos = -1) const override
     {
         const ColumnNullable * column = assert_cast<const ColumnNullable *>(columns[0]);
         const IColumn * nested_column = &column->getNestedColumn();
         const UInt8 * null_map = column->getNullMapData().data();
 
         this->nested_function->addBatchSinglePlaceNotNull(
-            batch_size, this->nestedPlace(place), &nested_column, null_map, arena, if_argument_pos);
+            row_begin, row_end, this->nestedPlace(place), &nested_column, null_map, arena, if_argument_pos);
 
         if constexpr (result_is_nullable)
-            if (!memoryIsByte(null_map, batch_size, 1))
+            if (!memoryIsByte(null_map, row_begin, row_end, 1))
                 this->setFlag(place);
     }
 

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -54,7 +54,7 @@ MutableColumnPtr ColumnFixedString::cloneResized(size_t size) const
 bool ColumnFixedString::isDefaultAt(size_t index) const
 {
     assert(index < size());
-    return memoryIsZero(chars.data() + index * n, n);
+    return memoryIsZero(chars.data() + index * n, 0, n);
 }
 
 void ColumnFixedString::insert(const Field & x)

--- a/src/Columns/ColumnsCommon.cpp
+++ b/src/Columns/ColumnsCommon.cpp
@@ -27,7 +27,7 @@ static UInt64 toBits64(const Int8 * bytes64)
 }
 #endif
 
-size_t countBytesInFilter(const UInt8 * filt, size_t sz)
+size_t countBytesInFilter(const UInt8 * filt, size_t start, size_t end)
 {
     size_t count = 0;
 
@@ -37,18 +37,20 @@ size_t countBytesInFilter(const UInt8 * filt, size_t sz)
       */
 
     const Int8 * pos = reinterpret_cast<const Int8 *>(filt);
-    const Int8 * end = pos + sz;
+    pos += start;
+
+    const Int8 * end_pos = pos + (end - start);
 
 #if defined(__SSE2__) && defined(__POPCNT__)
-    const Int8 * end64 = pos + sz / 64 * 64;
+    const Int8 * end_pos64 = pos + (end - start) / 64 * 64;
 
-    for (; pos < end64; pos += 64)
+    for (; pos < end_pos64; pos += 64)
         count += __builtin_popcountll(toBits64(pos));
 
     /// TODO Add duff device for tail?
 #endif
 
-    for (; pos < end; ++pos)
+    for (; pos < end_pos; ++pos)
         count += *pos != 0;
 
     return count;
@@ -56,10 +58,10 @@ size_t countBytesInFilter(const UInt8 * filt, size_t sz)
 
 size_t countBytesInFilter(const IColumn::Filter & filt)
 {
-    return countBytesInFilter(filt.data(), filt.size());
+    return countBytesInFilter(filt.data(), 0, filt.size());
 }
 
-size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * null_map)
+size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * null_map, size_t start, size_t end)
 {
     size_t count = 0;
 
@@ -68,20 +70,20 @@ size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * nu
       * It would be better to use != 0, then this does not allow SSE2.
       */
 
-    const Int8 * pos = reinterpret_cast<const Int8 *>(filt.data());
-    const Int8 * pos2 = reinterpret_cast<const Int8 *>(null_map);
-    const Int8 * end = pos + filt.size();
+    const Int8 * pos = reinterpret_cast<const Int8 *>(filt.data()) + start;
+    const Int8 * pos2 = reinterpret_cast<const Int8 *>(null_map) + start;
+    const Int8 * end_pos = pos + (end - start);
 
 #if defined(__SSE2__) && defined(__POPCNT__)
-    const Int8 * end64 = pos + filt.size() / 64 * 64;
+    const Int8 * end_pos64 = pos + (end - start) / 64 * 64;
 
-    for (; pos < end64; pos += 64, pos2 += 64)
+    for (; pos < end_pos64; pos += 64, pos2 += 64)
         count += __builtin_popcountll(toBits64(pos) & ~toBits64(pos2));
 
         /// TODO Add duff device for tail?
 #endif
 
-    for (; pos < end; ++pos, ++pos2)
+    for (; pos < end_pos; ++pos, ++pos2)
         count += (*pos & ~*pos2) != 0;
 
     return count;
@@ -96,17 +98,18 @@ std::vector<size_t> countColumnsSizeInSelector(IColumn::ColumnIndex num_columns,
     return counts;
 }
 
-bool memoryIsByte(const void * data, size_t size, uint8_t byte)
+bool memoryIsByte(const void * data, size_t start, size_t end, uint8_t byte)
 {
+    size_t size = end - start;
     if (size == 0)
         return true;
-    const auto * ptr = reinterpret_cast<const uint8_t *>(data);
+    const auto * ptr = reinterpret_cast<const uint8_t *>(data) + start;
     return *ptr == byte && memcmp(ptr, ptr + 1, size - 1) == 0;
 }
 
-bool memoryIsZero(const void * data, size_t size)
+bool memoryIsZero(const void * data, size_t start, size_t end)
 {
-    return memoryIsByte(data, size, 0x0);
+    return memoryIsByte(data, start, end, 0x0);
 }
 
 namespace ErrorCodes

--- a/src/Columns/ColumnsCommon.h
+++ b/src/Columns/ColumnsCommon.h
@@ -53,17 +53,17 @@ inline UInt64 bytes64MaskToBits64Mask(const UInt8 * bytes64)
 }
 
 /// Counts how many bytes of `filt` are greater than zero.
-size_t countBytesInFilter(const UInt8 * filt, size_t sz);
+size_t countBytesInFilter(const UInt8 * filt, size_t start, size_t end);
 size_t countBytesInFilter(const IColumn::Filter & filt);
-size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * null_map);
+size_t countBytesInFilterWithNull(const IColumn::Filter & filt, const UInt8 * null_map, size_t start, size_t end);
 
 /// Returns vector with num_columns elements. vector[i] is the count of i values in selector.
 /// Selector must contain values from 0 to num_columns - 1. NOTE: this is not checked.
 std::vector<size_t> countColumnsSizeInSelector(IColumn::ColumnIndex num_columns, const IColumn::Selector & selector);
 
 /// Returns true, if the memory contains only zeros.
-bool memoryIsZero(const void * data, size_t size);
-bool memoryIsByte(const void * data, size_t size, uint8_t byte);
+bool memoryIsZero(const void * data, size_t start, size_t end);
+bool memoryIsByte(const void * data, size_t start, size_t end, uint8_t byte);
 
 /// The general implementation of `filter` function for ColumnArray and ColumnString.
 template <typename T>

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -3576,7 +3576,7 @@ private:
                     const auto & nullable_col = assert_cast<const ColumnNullable &>(*col);
                     const auto & null_map = nullable_col.getNullMapData();
 
-                    if (!memoryIsZero(null_map.data(), null_map.size()))
+                    if (!memoryIsZero(null_map.data(), 0, null_map.size()))
                         throw Exception{"Cannot convert NULL value to non-Nullable type",
                                         ErrorCodes::CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN};
                 }

--- a/src/Functions/array/arrayReduce.cpp
+++ b/src/Functions/array/arrayReduce.cpp
@@ -186,7 +186,7 @@ ColumnPtr FunctionArrayReduce::executeImpl(const ColumnsWithTypeAndName & argume
         while (const auto * func = typeid_cast<const AggregateFunctionState *>(that))
             that = func->getNestedFunction().get();
 
-        that->addBatchArray(input_rows_count, places.data(), 0, aggregate_arguments, offsets->data(), arena.get());
+        that->addBatchArray(0, input_rows_count, places.data(), 0, aggregate_arguments, offsets->data(), arena.get());
     }
 
     for (size_t i = 0; i < input_rows_count; ++i)

--- a/src/Functions/initializeAggregation.cpp
+++ b/src/Functions/initializeAggregation.cpp
@@ -147,7 +147,7 @@ ColumnPtr FunctionInitializeAggregation::executeImpl(const ColumnsWithTypeAndNam
         /// Unnest consecutive trailing -State combinators
         while (const auto * func = typeid_cast<const AggregateFunctionState *>(that))
             that = func->getNestedFunction().get();
-        that->addBatch(input_rows_count, places.data(), 0, aggregate_arguments, arena.get());
+        that->addBatch(0, input_rows_count, places.data(), 0, aggregate_arguments, arena.get());
     }
 
     for (size_t i = 0; i < input_rows_count; ++i)

--- a/src/Functions/throwIf.cpp
+++ b/src/Functions/throwIf.cpp
@@ -125,7 +125,7 @@ public:
         if (in)
         {
             const auto & in_data = in->getData();
-            if (!memoryIsZero(in_data.data(), in_data.size() * sizeof(in_data[0])))
+            if (!memoryIsZero(in_data.data(), 0, in_data.size() * sizeof(in_data[0])))
             {
                 throw Exception(ErrorCodes::FUNCTION_THROW_IF_VALUE_IS_NON_ZERO,
                     message.value_or("Value passed to '" + getName() + "' function is non zero"));

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -860,7 +860,8 @@ template <typename Method>
 void NO_INLINE Aggregator::executeImpl(
     Method & method,
     Arena * aggregates_pool,
-    size_t rows,
+    size_t row_begin,
+    size_t row_end,
     ColumnRawPtrs & key_columns,
     AggregateFunctionInstruction * aggregate_instructions,
     bool no_more_keys,
@@ -873,17 +874,17 @@ void NO_INLINE Aggregator::executeImpl(
 #if USE_EMBEDDED_COMPILER
         if (compiled_aggregate_functions_holder && !hasSparseArguments(aggregate_instructions))
         {
-            executeImplBatch<false, true>(method, state, aggregates_pool, rows, aggregate_instructions, overflow_row);
+            executeImplBatch<false, true>(method, state, aggregates_pool, row_begin, row_end, aggregate_instructions, overflow_row);
         }
         else
 #endif
         {
-            executeImplBatch<false, false>(method, state, aggregates_pool, rows, aggregate_instructions, overflow_row);
+            executeImplBatch<false, false>(method, state, aggregates_pool, row_begin, row_end, aggregate_instructions, overflow_row);
         }
     }
     else
     {
-        executeImplBatch<true, false>(method, state, aggregates_pool, rows, aggregate_instructions, overflow_row);
+        executeImplBatch<true, false>(method, state, aggregates_pool, row_begin, row_end, aggregate_instructions, overflow_row);
     }
 }
 
@@ -892,7 +893,8 @@ void NO_INLINE Aggregator::executeImplBatch(
     Method & method,
     typename Method::State & state,
     Arena * aggregates_pool,
-    size_t rows,
+    size_t row_begin,
+    size_t row_end,
     AggregateFunctionInstruction * aggregate_instructions,
     AggregateDataPtr overflow_row) const
 {
@@ -904,7 +906,7 @@ void NO_INLINE Aggregator::executeImplBatch(
 
         /// For all rows.
         AggregateDataPtr place = aggregates_pool->alloc(0);
-        for (size_t i = 0; i < rows; ++i)
+        for (size_t i = row_begin; i < row_end; ++i)
             state.emplaceKey(method.data, i, *aggregates_pool).setMapped(place);
         return;
     }
@@ -928,7 +930,8 @@ void NO_INLINE Aggregator::executeImplBatch(
             for (AggregateFunctionInstruction * inst = aggregate_instructions; inst->that; ++inst)
             {
                 inst->batch_that->addBatchLookupTable8(
-                    rows,
+                    row_begin,
+                    row_end,
                     reinterpret_cast<AggregateDataPtr *>(method.data.data()),
                     inst->state_offset,
                     [&](AggregateDataPtr & aggregate_data)
@@ -944,10 +947,14 @@ void NO_INLINE Aggregator::executeImplBatch(
         }
     }
 
-    std::unique_ptr<AggregateDataPtr[]> places(new AggregateDataPtr[rows]);
+    /// NOTE: only row_end-row_start is required, but:
+    /// - this affects only optimize_aggregation_in_order,
+    /// - this is just a pointer, so it should not be significant,
+    /// - and plus this will require other changes in the interface.
+    std::unique_ptr<AggregateDataPtr[]> places(new AggregateDataPtr[row_end]);
 
     /// For all rows.
-    for (size_t i = 0; i < rows; ++i)
+    for (size_t i = row_begin; i < row_end; ++i)
     {
         AggregateDataPtr aggregate_data = nullptr;
 
@@ -1032,7 +1039,7 @@ void NO_INLINE Aggregator::executeImplBatch(
         }
 
         auto add_into_aggregate_states_function = compiled_aggregate_functions_holder->compiled_aggregate_functions.add_into_aggregate_states_function;
-        add_into_aggregate_states_function(rows, columns_data.data(), places.get());
+        add_into_aggregate_states_function(row_begin, row_end, columns_data.data(), places.get());
     }
 #endif
 
@@ -1048,11 +1055,11 @@ void NO_INLINE Aggregator::executeImplBatch(
         AggregateFunctionInstruction * inst = aggregate_instructions + i;
 
         if (inst->offsets)
-            inst->batch_that->addBatchArray(rows, places.get(), inst->state_offset, inst->batch_arguments, inst->offsets, aggregates_pool);
+            inst->batch_that->addBatchArray(row_begin, row_end, places.get(), inst->state_offset, inst->batch_arguments, inst->offsets, aggregates_pool);
         else if (inst->has_sparse_arguments)
-            inst->batch_that->addBatchSparse(places.get(), inst->state_offset, inst->batch_arguments, aggregates_pool);
+            inst->batch_that->addBatchSparse(row_begin, row_end, places.get(), inst->state_offset, inst->batch_arguments, aggregates_pool);
         else
-            inst->batch_that->addBatch(rows, places.get(), inst->state_offset, inst->batch_arguments, aggregates_pool);
+            inst->batch_that->addBatch(row_begin, row_end, places.get(), inst->state_offset, inst->batch_arguments, aggregates_pool);
     }
 }
 
@@ -1060,10 +1067,13 @@ void NO_INLINE Aggregator::executeImplBatch(
 template <bool use_compiled_functions>
 void NO_INLINE Aggregator::executeWithoutKeyImpl(
     AggregatedDataWithoutKey & res,
-    size_t rows,
+    size_t row_begin, size_t row_end,
     AggregateFunctionInstruction * aggregate_instructions,
     Arena * arena) const
 {
+    if (row_begin == row_end)
+        return;
+
 #if USE_EMBEDDED_COMPILER
     if constexpr (use_compiled_functions)
     {
@@ -1084,7 +1094,7 @@ void NO_INLINE Aggregator::executeWithoutKeyImpl(
         }
 
         auto add_into_aggregate_states_function_single_place = compiled_aggregate_functions_holder->compiled_aggregate_functions.add_into_aggregate_states_function_single_place;
-        add_into_aggregate_states_function_single_place(rows, columns_data.data(), res);
+        add_into_aggregate_states_function_single_place(row_begin, row_end, columns_data.data(), res);
 
 #if defined(MEMORY_SANITIZER)
 
@@ -1115,11 +1125,23 @@ void NO_INLINE Aggregator::executeWithoutKeyImpl(
 
         if (inst->offsets)
             inst->batch_that->addBatchSinglePlace(
-                inst->offsets[static_cast<ssize_t>(rows - 1)], res + inst->state_offset, inst->batch_arguments, arena);
+                0,
+                inst->offsets[static_cast<ssize_t>(row_end - 1)],
+                res + inst->state_offset,
+                inst->batch_arguments,
+                arena);
         else if (inst->has_sparse_arguments)
-            inst->batch_that->addBatchSparseSinglePlace(res + inst->state_offset, inst->batch_arguments, arena);
+            inst->batch_that->addBatchSparseSinglePlace(
+                row_begin, row_end,
+                res + inst->state_offset,
+                inst->batch_arguments,
+                arena);
         else
-            inst->batch_that->addBatchSinglePlace(rows, res + inst->state_offset, inst->batch_arguments, arena);
+            inst->batch_that->addBatchSinglePlace(
+                row_begin, row_end,
+                res + inst->state_offset,
+                inst->batch_arguments,
+                arena);
     }
 }
 
@@ -1211,16 +1233,27 @@ void Aggregator::prepareAggregateInstructions(Columns columns, AggregateColumns 
 }
 
 
-bool Aggregator::executeOnBlock(const Block & block, AggregatedDataVariants & result,
-                                ColumnRawPtrs & key_columns, AggregateColumns & aggregate_columns, bool & no_more_keys) const
+bool Aggregator::executeOnBlock(const Block & block,
+    AggregatedDataVariants & result,
+    ColumnRawPtrs & key_columns,
+    AggregateColumns & aggregate_columns,
+    bool & no_more_keys) const
 {
-    UInt64 num_rows = block.rows();
-    return executeOnBlock(block.getColumns(), num_rows, result, key_columns, aggregate_columns, no_more_keys);
+    return executeOnBlock(block.getColumns(),
+        /* row_begin= */ 0, block.rows(),
+        result,
+        key_columns,
+        aggregate_columns,
+        no_more_keys);
 }
 
 
-bool Aggregator::executeOnBlock(Columns columns, UInt64 num_rows, AggregatedDataVariants & result,
-    ColumnRawPtrs & key_columns, AggregateColumns & aggregate_columns, bool & no_more_keys) const
+bool Aggregator::executeOnBlock(Columns columns,
+    size_t row_begin, size_t row_end,
+    AggregatedDataVariants & result,
+    ColumnRawPtrs & key_columns,
+    AggregateColumns & aggregate_columns,
+    bool & no_more_keys) const
 {
     /// `result` will destroy the states of aggregate functions in the destructor
     result.aggregator = this;
@@ -1276,12 +1309,12 @@ bool Aggregator::executeOnBlock(Columns columns, UInt64 num_rows, AggregatedData
 // #if USE_EMBEDDED_COMPILER
 //         if (compiled_aggregate_functions_holder)
 //         {
-//             executeWithoutKeyImpl<true>(result.without_key, num_rows, aggregate_functions_instructions.data(), result.aggregates_pool);
+//             executeWithoutKeyImpl<true>(result.without_key, row_begin, row_end, aggregate_functions_instructions.data(), result.aggregates_pool);
 //         }
 //         else
 // #endif
         {
-            executeWithoutKeyImpl<false>(result.without_key, num_rows, aggregate_functions_instructions.data(), result.aggregates_pool);
+            executeWithoutKeyImpl<false>(result.without_key, row_begin, row_end, aggregate_functions_instructions.data(), result.aggregates_pool);
         }
     }
     else
@@ -1291,7 +1324,7 @@ bool Aggregator::executeOnBlock(Columns columns, UInt64 num_rows, AggregatedData
 
         #define M(NAME, IS_TWO_LEVEL) \
             else if (result.type == AggregatedDataVariants::Type::NAME) \
-                executeImpl(*result.NAME, result.aggregates_pool, num_rows, key_columns, aggregate_functions_instructions.data(), \
+                executeImpl(*result.NAME, result.aggregates_pool, row_begin, row_end, key_columns, aggregate_functions_instructions.data(), \
                     no_more_keys, overflow_row_ptr);
 
         if (false) {} // NOLINT
@@ -1718,7 +1751,7 @@ void NO_INLINE Aggregator::convertToBlockImplFinal(
             }
 
             auto insert_aggregates_into_columns_function = compiled_functions.insert_aggregates_into_columns_function;
-            insert_aggregates_into_columns_function(places.size(), columns_data.data(), places.data());
+            insert_aggregates_into_columns_function(0, places.size(), columns_data.data(), places.data());
         }
 #endif
 
@@ -1747,7 +1780,7 @@ void NO_INLINE Aggregator::convertToBlockImplFinal(
             bool is_state = aggregate_functions[destroy_index]->isState();
             bool destroy_place_after_insert = !is_state;
 
-            aggregate_functions[destroy_index]->insertResultIntoBatch(places.size(), places.data(), offset, *final_aggregate_column, arena, destroy_place_after_insert);
+            aggregate_functions[destroy_index]->insertResultIntoBatch(0, places.size(), places.data(), offset, *final_aggregate_column, arena, destroy_place_after_insert);
         }
     }
     catch (...)
@@ -1767,7 +1800,7 @@ void NO_INLINE Aggregator::convertToBlockImplFinal(
         }
 
         size_t offset = offsets_of_aggregate_states[aggregate_functions_destroy_index];
-        aggregate_functions[aggregate_functions_destroy_index]->destroyBatch(places.size(), places.data(), offset);
+        aggregate_functions[aggregate_functions_destroy_index]->destroyBatch(0, places.size(), places.data(), offset);
     }
 
     if (exception)
@@ -2527,6 +2560,7 @@ void NO_INLINE Aggregator::mergeStreamsImplCase(
 
     /// For all rows.
     size_t rows = block.rows();
+
     std::unique_ptr<AggregateDataPtr[]> places(new AggregateDataPtr[rows]);
 
     for (size_t i = 0; i < rows; ++i)
@@ -2565,7 +2599,8 @@ void NO_INLINE Aggregator::mergeStreamsImplCase(
     {
         /// Merge state of aggregate functions.
         aggregate_functions[j]->mergeBatch(
-            rows, places.get(), offsets_of_aggregate_states[j],
+            0, rows,
+            places.get(), offsets_of_aggregate_states[j],
             aggregate_columns[j]->data(),
             aggregates_pool);
     }

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -355,11 +355,6 @@ Aggregator::Params::StatsCollectingParams::StatsCollectingParams(
 {
 }
 
-bool Aggregator::Params::StatsCollectingParams::isCollectionAndUseEnabled() const
-{
-    return key != 0;
-}
-
 Block Aggregator::getHeader(bool final) const
 {
     return params.getHeader(final);

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1022,12 +1022,17 @@ public:
     using AggregateFunctionsPlainPtrs = std::vector<const IAggregateFunction *>;
 
     /// Process one block. Return false if the processing should be aborted (with group_by_overflow_mode = 'break').
-    bool executeOnBlock(const Block & block, AggregatedDataVariants & result,
-        ColumnRawPtrs & key_columns, AggregateColumns & aggregate_columns,    /// Passed to not create them anew for each block
+    bool executeOnBlock(const Block & block,
+        AggregatedDataVariants & result,
+        ColumnRawPtrs & key_columns,
+        AggregateColumns & aggregate_columns, /// Passed to not create them anew for each block
         bool & no_more_keys) const;
 
-    bool executeOnBlock(Columns columns, UInt64 num_rows, AggregatedDataVariants & result,
-        ColumnRawPtrs & key_columns, AggregateColumns & aggregate_columns,    /// Passed to not create them anew for each block
+    bool executeOnBlock(Columns columns,
+        size_t row_begin, size_t row_end,
+        AggregatedDataVariants & result,
+        ColumnRawPtrs & key_columns,
+        AggregateColumns & aggregate_columns, /// Passed to not create them anew for each block
         bool & no_more_keys) const;
 
     /// Used for aggregate projection.
@@ -1165,7 +1170,8 @@ private:
     void executeImpl(
         Method & method,
         Arena * aggregates_pool,
-        size_t rows,
+        size_t row_begin,
+        size_t row_end,
         ColumnRawPtrs & key_columns,
         AggregateFunctionInstruction * aggregate_instructions,
         bool no_more_keys,
@@ -1177,7 +1183,8 @@ private:
         Method & method,
         typename Method::State & state,
         Arena * aggregates_pool,
-        size_t rows,
+        size_t row_begin,
+        size_t row_end,
         AggregateFunctionInstruction * aggregate_instructions,
         AggregateDataPtr overflow_row) const;
 
@@ -1185,7 +1192,8 @@ private:
     template <bool use_compiled_functions>
     void executeWithoutKeyImpl(
         AggregatedDataWithoutKey & res,
-        size_t rows,
+        size_t row_begin,
+        size_t row_end,
         AggregateFunctionInstruction * aggregate_instructions,
         Arena * arena) const;
 

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -941,9 +941,10 @@ public:
                 size_t max_entries_for_hash_table_stats_,
                 size_t max_size_to_preallocate_for_aggregation_);
 
-            bool isCollectionAndUseEnabled() const;
+            bool isCollectionAndUseEnabled() const { return key != 0; }
+            void disable() { key = 0; }
 
-            const UInt64 key = 0;
+            UInt64 key = 0;
             const size_t max_entries_for_hash_table_stats = 0;
             const size_t max_size_to_preallocate_for_aggregation = 0;
         };

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1166,6 +1166,26 @@ private:
     void destroyAllAggregateStates(AggregatedDataVariants & result) const;
 
 
+    /// Used for optimize_aggregation_in_order:
+    /// - No two-level aggregation
+    /// - No external aggregation
+    /// - No without_key support (it is implemented using executeOnIntervalWithoutKeyImpl())
+    void executeOnBlockSmall(
+        AggregatedDataVariants & result,
+        size_t row_begin,
+        size_t row_end,
+        ColumnRawPtrs & key_columns,
+        AggregateFunctionInstruction * aggregate_instructions) const;
+
+    void executeImpl(
+        AggregatedDataVariants & result,
+        size_t row_begin,
+        size_t row_end,
+        ColumnRawPtrs & key_columns,
+        AggregateFunctionInstruction * aggregate_instructions,
+        bool no_more_keys = false,
+        AggregateDataPtr overflow_row = nullptr) const;
+
     /// Process one data block, aggregate the data into a hash table.
     template <typename Method>
     void executeImpl(

--- a/src/Interpreters/JIT/compileFunction.h
+++ b/src/Interpreters/JIT/compileFunction.h
@@ -26,6 +26,7 @@ struct ColumnData
   */
 ColumnData getColumnData(const IColumn * column);
 
+using ColumnDataRowsOffset = size_t;
 using ColumnDataRowsSize = size_t;
 
 using JITCompiledFunction = void (*)(ColumnDataRowsSize, ColumnData *);
@@ -51,10 +52,10 @@ struct AggregateFunctionWithOffset
 };
 
 using JITCreateAggregateStatesFunction = void (*)(AggregateDataPtr);
-using JITAddIntoAggregateStatesFunction = void (*)(ColumnDataRowsSize, ColumnData *, AggregateDataPtr *);
-using JITAddIntoAggregateStatesFunctionSinglePlace = void (*)(ColumnDataRowsSize, ColumnData *, AggregateDataPtr);
+using JITAddIntoAggregateStatesFunction = void (*)(ColumnDataRowsOffset, ColumnDataRowsOffset, ColumnData *, AggregateDataPtr *);
+using JITAddIntoAggregateStatesFunctionSinglePlace = void (*)(ColumnDataRowsOffset, ColumnDataRowsOffset, ColumnData *, AggregateDataPtr);
 using JITMergeAggregateStatesFunction = void (*)(AggregateDataPtr, AggregateDataPtr);
-using JITInsertAggregateStatesIntoColumnsFunction = void (*)(ColumnDataRowsSize, ColumnData *, AggregateDataPtr *);
+using JITInsertAggregateStatesIntoColumnsFunction = void (*)(ColumnDataRowsOffset, ColumnDataRowsOffset, ColumnData *, AggregateDataPtr *);
 
 struct CompiledAggregateFunctions
 {

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -57,6 +57,10 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
     pipeline.dropTotalsAndExtremes();
 
     bool allow_to_use_two_level_group_by = pipeline.getNumStreams() > 1 || params.max_bytes_before_external_group_by != 0;
+    /// Disable two-level aggregation for optimize_aggregation_in_order
+    if (group_by_info)
+        allow_to_use_two_level_group_by = false;
+
     if (!allow_to_use_two_level_group_by)
     {
         params.group_by_two_level_threshold = 0;
@@ -71,78 +75,71 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
 
     if (group_by_info)
     {
-        bool need_finish_sorting = (group_by_info->order_key_prefix_descr.size() < group_by_sort_description.size());
-
-        if (need_finish_sorting)
+        if (pipeline.getNumStreams() > 1)
         {
-            /// TOO SLOW
+            /** The pipeline is the following:
+             *
+             * --> AggregatingInOrder                                                  --> MergingAggregatedBucket
+             * --> AggregatingInOrder --> FinishAggregatingInOrder --> ResizeProcessor --> MergingAggregatedBucket
+             * --> AggregatingInOrder                                                  --> MergingAggregatedBucket
+             */
+
+            auto many_data = std::make_shared<ManyAggregatedData>(pipeline.getNumStreams());
+            size_t counter = 0;
+            pipeline.addSimpleTransform([&](const Block & header)
+            {
+                /// We want to merge aggregated data in batches of size
+                /// not greater than 'aggregation_in_order_max_block_bytes'.
+                /// So, we reduce 'max_bytes' value for aggregation in 'merge_threads' times.
+                return std::make_shared<AggregatingInOrderTransform>(
+                    header, transform_params,
+                    group_by_info, group_by_sort_description,
+                    max_block_size, aggregation_in_order_max_block_bytes / merge_threads,
+                    many_data, counter++);
+            });
+
+            aggregating_in_order = collector.detachProcessors(0);
+
+            auto transform = std::make_shared<FinishAggregatingInOrderTransform>(
+                pipeline.getHeader(),
+                pipeline.getNumStreams(),
+                transform_params,
+                group_by_sort_description,
+                max_block_size,
+                aggregation_in_order_max_block_bytes);
+
+            pipeline.addTransform(std::move(transform));
+
+            /// Do merge of aggregated data in parallel.
+            pipeline.resize(merge_threads);
+
+            pipeline.addSimpleTransform([&](const Block &)
+            {
+                return std::make_shared<MergingAggregatedBucketTransform>(transform_params);
+            });
+
+            aggregating_sorted = collector.detachProcessors(1);
         }
         else
         {
-            if (pipeline.getNumStreams() > 1)
+            pipeline.addSimpleTransform([&](const Block & header)
             {
-                /** The pipeline is the following:
-                 *
-                 * --> AggregatingInOrder                                                  --> MergingAggregatedBucket
-                 * --> AggregatingInOrder --> FinishAggregatingInOrder --> ResizeProcessor --> MergingAggregatedBucket
-                 * --> AggregatingInOrder                                                  --> MergingAggregatedBucket
-                 */
+                return std::make_shared<AggregatingInOrderTransform>(
+                    header, transform_params,
+                    group_by_info, group_by_sort_description,
+                    max_block_size, aggregation_in_order_max_block_bytes);
+            });
 
-                auto many_data = std::make_shared<ManyAggregatedData>(pipeline.getNumStreams());
-                size_t counter = 0;
-                pipeline.addSimpleTransform([&](const Block & header)
-                {
-                    /// We want to merge aggregated data in batches of size
-                    /// not greater than 'aggregation_in_order_max_block_bytes'.
-                    /// So, we reduce 'max_bytes' value for aggregation in 'merge_threads' times.
-                    return std::make_shared<AggregatingInOrderTransform>(
-                        header, transform_params, group_by_sort_description,
-                        max_block_size, aggregation_in_order_max_block_bytes / merge_threads,
-                        many_data, counter++);
-                });
-
-                aggregating_in_order = collector.detachProcessors(0);
-
-                auto transform = std::make_shared<FinishAggregatingInOrderTransform>(
-                    pipeline.getHeader(),
-                    pipeline.getNumStreams(),
-                    transform_params,
-                    group_by_sort_description,
-                    max_block_size,
-                    aggregation_in_order_max_block_bytes);
-
-                pipeline.addTransform(std::move(transform));
-
-                /// Do merge of aggregated data in parallel.
-                pipeline.resize(merge_threads);
-
-                pipeline.addSimpleTransform([&](const Block &)
-                {
-                    return std::make_shared<MergingAggregatedBucketTransform>(transform_params);
-                });
-
-                aggregating_sorted = collector.detachProcessors(1);
-            }
-            else
+            pipeline.addSimpleTransform([&](const Block & header)
             {
-                pipeline.addSimpleTransform([&](const Block & header)
-                {
-                    return std::make_shared<AggregatingInOrderTransform>(
-                        header, transform_params, group_by_sort_description,
-                        max_block_size, aggregation_in_order_max_block_bytes);
-                });
+                return std::make_shared<FinalizeAggregatedTransform>(header, transform_params);
+            });
 
-                pipeline.addSimpleTransform([&](const Block & header)
-                {
-                    return std::make_shared<FinalizeAggregatedTransform>(header, transform_params);
-                });
-
-                aggregating_in_order = collector.detachProcessors(0);
-            }
-
-            finalizing = collector.detachProcessors(2);
-            return;
+            aggregating_in_order = collector.detachProcessors(0);
         }
+
+        finalizing = collector.detachProcessors(2);
+        return;
     }
 
     /// If there are several sources, then we perform parallel aggregation

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -57,9 +57,16 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
     pipeline.dropTotalsAndExtremes();
 
     bool allow_to_use_two_level_group_by = pipeline.getNumStreams() > 1 || params.max_bytes_before_external_group_by != 0;
-    /// Disable two-level aggregation for optimize_aggregation_in_order
+
+    /// optimize_aggregation_in_order
     if (group_by_info)
+    {
+        /// two-level aggregation is not supported anyway for in order aggregation.
         allow_to_use_two_level_group_by = false;
+
+        /// It is incorrect for in order aggregation.
+        params.stats_collecting_params.disable();
+    }
 
     if (!allow_to_use_two_level_group_by)
     {

--- a/src/Processors/TTL/TTLAggregationAlgorithm.cpp
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.cpp
@@ -159,8 +159,9 @@ void TTLAggregationAlgorithm::calculateAggregates(const MutableColumns & aggrega
         aggregate_chunk.emplace_back(std::move(chunk_column));
     }
 
-    aggregator->executeOnBlock(aggregate_chunk, length, aggregation_result, key_columns,
-                               columns_for_aggregator, no_more_keys);
+    aggregator->executeOnBlock(
+        aggregate_chunk, /* row_begin= */ 0, length,
+        aggregation_result, key_columns, columns_for_aggregator, no_more_keys);
 
 }
 

--- a/src/Processors/Transforms/AggregatingInOrderTransform.cpp
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.cpp
@@ -1,6 +1,8 @@
 #include <Processors/Transforms/AggregatingInOrderTransform.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <Storages/SelectQueryInfo.h>
 #include <Core/SortCursor.h>
+#include <Interpreters/sortBlock.h>
 #include <base/range.h>
 
 namespace DB
@@ -9,16 +11,19 @@ namespace DB
 AggregatingInOrderTransform::AggregatingInOrderTransform(
     Block header,
     AggregatingTransformParamsPtr params_,
+    InputOrderInfoPtr group_by_info_,
     const SortDescription & group_by_description_,
     size_t max_block_size_, size_t max_block_bytes_)
     : AggregatingInOrderTransform(std::move(header), std::move(params_),
-        group_by_description_, max_block_size_, max_block_bytes_,
+        group_by_info_, group_by_description_,
+        max_block_size_, max_block_bytes_,
         std::make_unique<ManyAggregatedData>(1), 0)
 {
 }
 
 AggregatingInOrderTransform::AggregatingInOrderTransform(
     Block header, AggregatingTransformParamsPtr params_,
+    InputOrderInfoPtr group_by_info_,
     const SortDescription & group_by_description_,
     size_t max_block_size_, size_t max_block_bytes_,
     ManyAggregatedDataPtr many_data_, size_t current_variant)
@@ -26,6 +31,8 @@ AggregatingInOrderTransform::AggregatingInOrderTransform(
     , max_block_size(max_block_size_)
     , max_block_bytes(max_block_bytes_)
     , params(std::move(params_))
+    , group_by_info(group_by_info_)
+    , sort_description(group_by_description_)
     , aggregate_columns(params->params.aggregates_size)
     , many_data(std::move(many_data_))
     , variants(*many_data->variants[current_variant])
@@ -33,8 +40,18 @@ AggregatingInOrderTransform::AggregatingInOrderTransform(
     /// We won't finalize states in order to merge same states (generated due to multi-thread execution) in AggregatingSortedTransform
     res_header = params->getCustomHeader(false);
 
-    for (const auto & column_description : group_by_description_)
+    for (size_t i = 0; i < group_by_info->order_key_prefix_descr.size(); ++i)
+    {
+        const auto & column_description = group_by_description_[i];
         group_by_description.emplace_back(column_description, res_header.getPositionByName(column_description.column_name));
+    }
+
+    if (group_by_info->order_key_prefix_descr.size() < group_by_description_.size())
+    {
+        group_by_key = true;
+        /// group_by_description may contains duplicates, so we use keys_size from Aggregator::params
+        key_columns_raw.resize(params->params.keys_size);
+    }
 }
 
 AggregatingInOrderTransform::~AggregatingInOrderTransform() = default;
@@ -83,16 +100,19 @@ void AggregatingInOrderTransform::consume(Chunk chunk)
     if (!cur_block_size)
     {
         res_key_columns.resize(params->params.keys_size);
-        res_aggregate_columns.resize(params->params.aggregates_size);
-
         for (size_t i = 0; i < params->params.keys_size; ++i)
             res_key_columns[i] = res_header.safeGetByPosition(i).type->createColumn();
 
-        for (size_t i = 0; i < params->params.aggregates_size; ++i)
-            res_aggregate_columns[i] = res_header.safeGetByPosition(i + params->params.keys_size).type->createColumn();
-
         params->aggregator.createStatesAndFillKeyColumnsWithSingleKey(variants, key_columns, key_begin, res_key_columns);
-        params->aggregator.addArenasToAggregateColumns(variants, res_aggregate_columns);
+
+        if (!group_by_key)
+        {
+            res_aggregate_columns.resize(params->params.aggregates_size);
+            for (size_t i = 0; i < params->params.aggregates_size; ++i)
+                res_aggregate_columns[i] = res_header.safeGetByPosition(i + params->params.keys_size).type->createColumn();
+
+            params->aggregator.addArenasToAggregateColumns(variants, res_aggregate_columns);
+        }
         ++cur_block_size;
     }
 
@@ -113,18 +133,32 @@ void AggregatingInOrderTransform::consume(Chunk chunk)
 
         /// Add data to aggr. state if interval is not empty. Empty when haven't found current key in new block.
         if (key_begin != key_end)
-            params->aggregator.executeOnIntervalWithoutKeyImpl(variants, key_begin, key_end, aggregate_function_instructions.data(), variants.aggregates_pool);
+        {
+            if (group_by_key)
+            {
+                bool no_more_keys = false;
+                /// FIXME: suboptimal (create states and requires key_columns_raw)
+                params->aggregator.executeOnBlock(chunk.getColumns(), key_begin, key_end, variants, key_columns_raw, aggregate_columns, no_more_keys);
+            }
+            else
+            {
+                params->aggregator.executeOnIntervalWithoutKeyImpl(variants, key_begin, key_end, aggregate_function_instructions.data(), variants.aggregates_pool);
+            }
+        }
 
         current_memory_usage = getCurrentMemoryUsage() - initial_memory_usage;
 
         /// We finalize last key aggregation state if a new key found.
         if (key_end != rows)
         {
-            params->aggregator.addSingleKeyToAggregateColumns(variants, res_aggregate_columns);
+            if (!group_by_key)
+                params->aggregator.addSingleKeyToAggregateColumns(variants, res_aggregate_columns);
 
             /// If max_block_size is reached we have to stop consuming and generate the block. Save the extra rows into new chunk.
             if (cur_block_size >= max_block_size || cur_block_bytes + current_memory_usage >= max_block_bytes)
             {
+                if (group_by_key)
+                    group_by_block = params->aggregator.prepareBlockAndFillSingleLevel(variants, /* final= */ false);
                 cur_block_bytes += current_memory_usage;
                 finalizeCurrentChunk(std::move(chunk), key_end);
                 return;
@@ -234,19 +268,34 @@ void AggregatingInOrderTransform::generate()
 {
     if (cur_block_size && is_consume_finished)
     {
-        params->aggregator.addSingleKeyToAggregateColumns(variants, res_aggregate_columns);
+        if (group_by_key)
+            group_by_block = params->aggregator.prepareBlockAndFillSingleLevel(variants, /* final= */ false);
+        else
+            params->aggregator.addSingleKeyToAggregateColumns(variants, res_aggregate_columns);
         variants.invalidate();
     }
 
-    Block res = res_header.cloneEmpty();
+    bool group_by_key_needs_empty_block = is_consume_finished && !cur_block_size;
+    if (!group_by_key || group_by_key_needs_empty_block)
+    {
+        Block res = res_header.cloneEmpty();
 
-    for (size_t i = 0; i < res_key_columns.size(); ++i)
-        res.getByPosition(i).column = std::move(res_key_columns[i]);
+        for (size_t i = 0; i < res_key_columns.size(); ++i)
+            res.getByPosition(i).column = std::move(res_key_columns[i]);
 
-    for (size_t i = 0; i < res_aggregate_columns.size(); ++i)
-        res.getByPosition(i + res_key_columns.size()).column = std::move(res_aggregate_columns[i]);
+        for (size_t i = 0; i < res_aggregate_columns.size(); ++i)
+            res.getByPosition(i + res_key_columns.size()).column = std::move(res_aggregate_columns[i]);
 
-    to_push_chunk = convertToChunk(res);
+        to_push_chunk = convertToChunk(res);
+    }
+    else
+    {
+        /// Sorting is required after aggregation, for proper merging, via
+        /// FinishAggregatingInOrderTransform/MergingAggregatedBucketTransform
+        sortBlock(group_by_block, sort_description);
+        to_push_chunk = convertToChunk(group_by_block);
+    }
+
     if (!to_push_chunk.getNumRows())
         return;
 

--- a/src/Processors/Transforms/AggregatingInOrderTransform.cpp
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.cpp
@@ -155,7 +155,7 @@ void AggregatingInOrderTransform::finalizeCurrentChunk(Chunk chunk, size_t key_e
 
     block_end_reached = true;
     need_generate = true;
-    variants.without_key = nullptr;
+    variants.invalidate();
 }
 
 void AggregatingInOrderTransform::work()
@@ -235,7 +235,7 @@ void AggregatingInOrderTransform::generate()
     if (cur_block_size && is_consume_finished)
     {
         params->aggregator.addSingleKeyToAggregateColumns(variants, res_aggregate_columns);
-        variants.without_key = nullptr;
+        variants.invalidate();
     }
 
     Block res = res_header.cloneEmpty();

--- a/src/Processors/Transforms/AggregatingInOrderTransform.h
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.h
@@ -9,6 +9,9 @@
 namespace DB
 {
 
+struct InputOrderInfo;
+using InputOrderInfoPtr = std::shared_ptr<const InputOrderInfo>;
+
 struct ChunkInfoWithAllocatedBytes : public ChunkInfo
 {
     explicit ChunkInfoWithAllocatedBytes(Int64 allocated_bytes_)
@@ -20,12 +23,14 @@ class AggregatingInOrderTransform : public IProcessor
 {
 public:
     AggregatingInOrderTransform(Block header, AggregatingTransformParamsPtr params,
-                                const SortDescription & group_by_description,
+                                InputOrderInfoPtr group_by_info_,
+                                const SortDescription & group_by_description_,
                                 size_t max_block_size_, size_t max_block_bytes_,
                                 ManyAggregatedDataPtr many_data, size_t current_variant);
 
     AggregatingInOrderTransform(Block header, AggregatingTransformParamsPtr params,
-                                const SortDescription & group_by_description,
+                                InputOrderInfoPtr group_by_info_,
+                                const SortDescription & group_by_description_,
                                 size_t max_block_size_, size_t max_block_bytes_);
 
     ~AggregatingInOrderTransform() override;
@@ -51,7 +56,14 @@ private:
     MutableColumns res_aggregate_columns;
 
     AggregatingTransformParamsPtr params;
+
+    InputOrderInfoPtr group_by_info;
+    /// For sortBlock()
+    SortDescription sort_description;
     SortDescriptionWithPositions group_by_description;
+    bool group_by_key = false;
+    Block group_by_block;
+    ColumnRawPtrs key_columns_raw;
 
     Aggregator::AggregateColumns aggregate_columns;
 

--- a/src/Processors/Transforms/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/AggregatingTransform.cpp
@@ -533,7 +533,7 @@ void AggregatingTransform::consume(Chunk chunk)
     }
     else
     {
-        if (!params->aggregator.executeOnBlock(chunk.detachColumns(), num_rows, variants, key_columns, aggregate_columns, no_more_keys))
+        if (!params->aggregator.executeOnBlock(chunk.detachColumns(), 0, num_rows, variants, key_columns, aggregate_columns, no_more_keys))
             is_consume_finished = true;
     }
 }

--- a/src/Processors/Transforms/CheckConstraintsTransform.cpp
+++ b/src/Processors/Transforms/CheckConstraintsTransform.cpp
@@ -64,7 +64,7 @@ void CheckConstraintsTransform::onConsume(Chunk chunk)
                 /// Check if constraint value is nullable
                 const auto & null_map = column_nullable->getNullMapColumn();
                 const PaddedPODArray<UInt8> & null_map_data = null_map.getData();
-                bool null_map_contains_null = !memoryIsZero(null_map_data.raw_data(), null_map_data.size() * sizeof(UInt8));
+                bool null_map_contains_null = !memoryIsZero(null_map_data.raw_data(), 0, null_map_data.size() * sizeof(UInt8));
 
                 if (null_map_contains_null)
                     throw Exception(
@@ -84,7 +84,7 @@ void CheckConstraintsTransform::onConsume(Chunk chunk)
             size_t size = res_column_uint8.size();
 
             /// Is violated.
-            if (!memoryIsByte(res_data, size, 1))
+            if (!memoryIsByte(res_data, 0, size, 1))
             {
                 size_t row_idx = 0;
                 for (; row_idx < size; ++row_idx)

--- a/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix.reference
+++ b/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix.reference
@@ -1,0 +1,205 @@
+
+0	0	0
+-- { echoOn }
+insert into data_02233 select number%10, number%3, number from numbers(100);
+explain pipeline select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1, optimize_aggregation_in_order=1;
+(Expression)
+ExpressionTransform × 2
+  (Sorting)
+  MergeSortingTransform
+    LimitsCheckingTransform
+      PartialSortingTransform
+        (Expression)
+        ExpressionTransform × 2
+          (TotalsHaving)
+          TotalsHavingTransform 1 → 2
+            (Aggregating)
+            FinalizeAggregatedTransform
+              AggregatingInOrderTransform
+                (Expression)
+                ExpressionTransform
+                  (SettingQuotaAndLimits)
+                    (ReadFromMergeTree)
+                    MergeTreeInOrder 0 → 1
+explain pipeline select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1;
+(Expression)
+ExpressionTransform × 2
+  (Sorting)
+  MergeSortingTransform
+    LimitsCheckingTransform
+      PartialSortingTransform
+        (Expression)
+        ExpressionTransform × 2
+          (TotalsHaving)
+          TotalsHavingTransform 1 → 2
+            (Aggregating)
+            AggregatingTransform
+              (Expression)
+              ExpressionTransform
+                (SettingQuotaAndLimits)
+                  (ReadFromMergeTree)
+                  MergeTreeInOrder 0 → 1
+select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1, optimize_aggregation_in_order=1;
+0	0	4
+0	1	3
+0	2	3
+1	0	3
+1	1	4
+1	2	3
+2	0	3
+2	1	3
+2	2	4
+3	0	4
+3	1	3
+3	2	3
+4	0	3
+4	1	4
+4	2	3
+5	0	3
+5	1	3
+5	2	4
+6	0	4
+6	1	3
+6	2	3
+7	0	3
+7	1	4
+7	2	3
+8	0	3
+8	1	3
+8	2	4
+9	0	4
+9	1	3
+9	2	3
+
+0	0	100
+select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1, optimize_aggregation_in_order=1, max_block_size=1;
+0	0	4
+0	1	3
+0	2	3
+1	0	3
+1	1	4
+1	2	3
+2	0	3
+2	1	3
+2	2	4
+3	0	4
+3	1	3
+3	2	3
+4	0	3
+4	1	4
+4	2	3
+5	0	3
+5	1	3
+5	2	4
+6	0	4
+6	1	3
+6	2	3
+7	0	3
+7	1	4
+7	2	3
+8	0	3
+8	1	3
+8	2	4
+9	0	4
+9	1	3
+9	2	3
+
+0	0	100
+select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1;
+0	0	4
+0	1	3
+0	2	3
+1	0	3
+1	1	4
+1	2	3
+2	0	3
+2	1	3
+2	2	4
+3	0	4
+3	1	3
+3	2	3
+4	0	3
+4	1	4
+4	2	3
+5	0	3
+5	1	3
+5	2	4
+6	0	4
+6	1	3
+6	2	3
+7	0	3
+7	1	4
+7	2	3
+8	0	3
+8	1	3
+8	2	4
+9	0	4
+9	1	3
+9	2	3
+
+0	0	100
+-- fuzzer
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key ORDER BY child_key, parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+0	0	0
+0	1	0
+0	2	0
+0	3	0
+0	4	0
+0	5	0
+0	6	0
+0	7	0
+0	8	0
+0	9	0
+1	0	1
+1	1	1
+1	2	1
+1	3	1
+1	4	1
+1	5	1
+1	6	1
+1	7	1
+1	8	1
+1	9	1
+2	0	2
+2	1	2
+2	2	2
+2	3	2
+2	4	2
+2	5	2
+2	6	2
+2	7	2
+2	8	2
+2	9	2
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key WITH TOTALS ORDER BY child_key, parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+0	0	0
+0	1	0
+0	2	0
+0	3	0
+0	4	0
+0	5	0
+0	6	0
+0	7	0
+0	8	0
+0	9	0
+1	0	1
+1	1	1
+1	2	1
+1	3	1
+1	4	1
+1	5	1
+1	6	1
+1	7	1
+1	8	1
+1	9	1
+2	0	2
+2	1	2
+2	2	2
+2	3	2
+2	4	2
+2	5	2
+2	6	2
+2	7	2
+2	8	2
+2	9	2
+
+0	0	0

--- a/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix.sql
+++ b/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix.sql
@@ -1,0 +1,21 @@
+drop table if exists data_02233;
+create table data_02233 (parent_key Int, child_key Int, value Int) engine=MergeTree() order by parent_key;
+
+-- before inserting data, it may produce empty header
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key ORDER BY parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key WITH TOTALS ORDER BY parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+
+-- { echoOn }
+insert into data_02233 select number%10, number%3, number from numbers(100);
+explain pipeline select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1, optimize_aggregation_in_order=1;
+explain pipeline select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1;
+select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1, optimize_aggregation_in_order=1;
+select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1, optimize_aggregation_in_order=1, max_block_size=1;
+select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1;
+
+-- fuzzer
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key ORDER BY child_key, parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key WITH TOTALS ORDER BY child_key, parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+
+-- { echoOff }
+drop table data_02233;

--- a/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix_with_merge.reference
+++ b/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix_with_merge.reference
@@ -1,0 +1,70 @@
+-- { echoOn }
+explain pipeline select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1, optimize_aggregation_in_order=1;
+(Expression)
+ExpressionTransform × 2
+  (Sorting)
+  MergeSortingTransform
+    LimitsCheckingTransform
+      PartialSortingTransform
+        (Expression)
+        ExpressionTransform × 2
+          (TotalsHaving)
+          TotalsHavingTransform 1 → 2
+            (Aggregating)
+            MergingAggregatedBucketTransform
+              FinishAggregatingInOrderTransform 2 → 1
+                AggregatingInOrderTransform × 2
+                  (Expression)
+                  ExpressionTransform × 2
+                    (SettingQuotaAndLimits)
+                      (ReadFromMergeTree)
+                      MergeTreeInOrder × 2 0 → 1
+explain pipeline select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1;
+(Expression)
+ExpressionTransform × 2
+  (Sorting)
+  MergeSortingTransform
+    LimitsCheckingTransform
+      PartialSortingTransform
+        (Expression)
+        ExpressionTransform × 2
+          (TotalsHaving)
+          TotalsHavingTransform 1 → 2
+            (Aggregating)
+            AggregatingTransform
+              (Expression)
+              ExpressionTransform
+                (SettingQuotaAndLimits)
+                  (ReadFromMergeTree)
+                  Concat 2 → 1
+                    MergeTreeInOrder × 2 0 → 1
+select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings optimize_aggregation_in_order=1;
+[1,2]	10	100	2000
+[1,2]	20	200	4000
+
+[1,1,2,2]	0	0	6000
+select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings optimize_aggregation_in_order=1, max_block_size=1;
+[1,2]	10	100	2000
+[1,2]	20	200	4000
+
+[1,1,2,2]	0	0	6000
+-- sum() can be compiled, check that compiled version works correctly
+select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings optimize_aggregation_in_order=1, compile_aggregate_expressions=1, min_count_to_compile_aggregate_expression=0;
+[1,2]	10	100	2000
+[1,2]	20	200	4000
+
+[1,1,2,2]	0	0	6000
+select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key;
+[1,2]	10	100	2000
+[1,2]	20	200	4000
+
+[1,1,2,2]	0	0	6000
+-- fuzzer
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key ORDER BY child_key, parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+100	10	100
+200	20	200
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key WITH TOTALS ORDER BY child_key, parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+100	10	100
+200	20	200
+
+0	0	0

--- a/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix_with_merge.sql
+++ b/tests/queries/0_stateless/02233_optimize_aggregation_in_order_prefix_with_merge.sql
@@ -1,0 +1,21 @@
+drop table if exists data_02233;
+create table data_02233 (partition Int, parent_key Int, child_key Int, value Int) engine=MergeTree() partition by partition order by parent_key;
+
+insert into data_02233 values (1, 10, 100, 1000)(1, 20, 200, 2000);
+insert into data_02233 values (2, 10, 100, 1000)(2, 20, 200, 2000);
+
+-- { echoOn }
+explain pipeline select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1, optimize_aggregation_in_order=1;
+explain pipeline select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings max_threads=1;
+select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings optimize_aggregation_in_order=1;
+select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings optimize_aggregation_in_order=1, max_block_size=1;
+-- sum() can be compiled, check that compiled version works correctly
+select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key settings optimize_aggregation_in_order=1, compile_aggregate_expressions=1, min_count_to_compile_aggregate_expression=0;
+select groupArraySorted(partition), parent_key, child_key, sum(value) from data_02233 group by parent_key, child_key with totals order by parent_key, child_key;
+
+-- fuzzer
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key ORDER BY child_key, parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+SELECT child_key, parent_key, child_key FROM data_02233 GROUP BY parent_key, child_key, child_key WITH TOTALS ORDER BY child_key, parent_key ASC NULLS LAST SETTINGS max_threads = 1, optimize_aggregation_in_order = 1;
+
+-- { echoOff }
+drop table data_02233;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implement partial GROUP BY key for optimize_aggregation_in_order

Suppose you have a table with lots of rows, like:

    create table data_02233 (parent_key Int, child_key Int, value Int) engine=MergeTree() order by parent_key

And you want to do GROUP BY (parent_key, child_key) with optimize_aggregation_in_order:

    select parent_key, child_key, count() from data_02233 group by parent_key, child_key with totals order by parent_key, child_key

Right now, it is not possible, because optimize_aggregation_in_order
supports only w/o key aggregation, i.e. GROUP BY cannot be done inside
unique parent_key region.

Follow-up for: #9113