### PR TITLE
Fix installation documentation typo

### DIFF
--- a/docs/_includes/install/deb.sh
+++ b/docs/_includes/install/deb.sh
@@ -1,11 +1,11 @@
-sudo apt-get install apt-transport-https ca-certificates dirmngr
+sudo apt-get install -y apt-transport-https ca-certificates dirmngr
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754
 
-echo "deb https://packages.clickhouse.com/deb stable main/" | sudo tee \
+echo "deb https://packages.clickhouse.com/deb stable main" | sudo tee \
     /etc/apt/sources.list.d/clickhouse.list
 sudo apt-get update
 
 sudo apt-get install -y clickhouse-server clickhouse-client
 
 sudo service clickhouse-server start
-clickhouse-client # or "clickhouse-client --password" if you set up a password.
+clickhouse-client # or "clickhouse-client --password" if you've set up a password.


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

Fix a tiny typo

fixes #35121 