### PR TITLE
Fix hardcoded page size 

### DIFF
--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -9,6 +9,7 @@
 #include <boost/noncopyable.hpp>
 
 #include <base/strong_typedef.h>
+#include <base/getPageSize.h>
 
 #include <Common/Allocator.h>
 #include <Common/Exception.h>
@@ -196,7 +197,7 @@ protected:
     /// The operation is slow and performed only for debug builds.
     void protectImpl(int prot)
     {
-        static constexpr size_t PROTECT_PAGE_SIZE = 4096;
+        static size_t PROTECT_PAGE_SIZE = ::getPageSize();
 
         char * left_rounded_up = reinterpret_cast<char *>((reinterpret_cast<intptr_t>(c_start) - pad_left + PROTECT_PAGE_SIZE - 1) / PROTECT_PAGE_SIZE * PROTECT_PAGE_SIZE);
         char * right_rounded_down = reinterpret_cast<char *>((reinterpret_cast<intptr_t>(c_end_of_storage) + pad_right) / PROTECT_PAGE_SIZE * PROTECT_PAGE_SIZE);


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Because on my Mac it equals to 16384

