### PR TITLE
Delete nodes with attributes `remove` or `replace` if they didn't merge

### DIFF
--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -139,7 +139,7 @@ static bool allWhitespace(const std::string & s)
     return s.find_first_not_of(" \t\n\r") == std::string::npos;
 }
 
-static void removeNodesWithAttributesRecursively(Node * root)
+static void deleteAttributesRecursive(Node * root)
 {
     const NodeListPtr children = root->childNodes();
     std::vector<Node *> children_to_delete;
@@ -151,13 +151,14 @@ static void removeNodesWithAttributesRecursively(Node * root)
         if (child->nodeType() == Node::ELEMENT_NODE)
         {
             Element & child_element = dynamic_cast<Element &>(*child);
-            bool remove = child_element.hasAttribute("remove");
-            bool replace = child_element.hasAttribute("replace");
 
-            if (remove || replace)
+            if (child_element.hasAttribute("replace"))
+                child_element.removeAttribute("replace");
+
+            if (child_element.hasAttribute("remove"))
                 children_to_delete.push_back(child);
             else
-                removeNodesWithAttributesRecursively(child);
+                deleteAttributesRecursive(child);
         }
     }
 
@@ -231,7 +232,7 @@ void ConfigProcessor::mergeRecursive(XMLDocumentPtr config, Node * config_root, 
             /// Since we didn't find a pair to this node in default config, we will paste it as is.
             /// But it may have some child nodes which have attributes like "replace" or "remove".
             /// They are useless in preprocessed configuration.
-            removeNodesWithAttributesRecursively(with_node);
+            deleteAttributesRecursive(with_node);
             NodePtr new_node = config->importNode(with_node, true);
             config_root->appendChild(new_node);
         }

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -139,6 +139,34 @@ static bool allWhitespace(const std::string & s)
     return s.find_first_not_of(" \t\n\r") == std::string::npos;
 }
 
+static void removeNodesWithAttributesRecursively(Node * root)
+{
+    const NodeListPtr children = root->childNodes();
+    std::vector<Node *> children_to_delete;
+
+    for (size_t i = 0, size = children->length(); i < size; ++i)
+    {
+        Node * child = children->item(i);
+
+        if (child->nodeType() == Node::ELEMENT_NODE)
+        {
+            Element & child_element = dynamic_cast<Element &>(*child);
+            bool remove = child_element.hasAttribute("remove");
+            bool replace = child_element.hasAttribute("replace");
+
+            if (remove || replace)
+                children_to_delete.push_back(child);
+            else
+                removeNodesWithAttributesRecursively(child);
+        }
+    }
+
+    for (auto * child : children_to_delete)
+    {
+        root->removeChild(child);
+    }
+}
+
 void ConfigProcessor::mergeRecursive(XMLDocumentPtr config, Node * config_root, const Node * with_root)
 {
     const NodeListPtr with_nodes = with_root->childNodes();
@@ -200,6 +228,10 @@ void ConfigProcessor::mergeRecursive(XMLDocumentPtr config, Node * config_root, 
         }
         if (!merged && !remove)
         {
+            /// Since we didn't find a pair to this node in default config, we will paste it as is.
+            /// But it may have some child nodes which have attributes like "replace" or "remove".
+            /// They are useless in preprocessed configuration.
+            removeNodesWithAttributesRecursively(with_node);
             NodePtr new_node = config->importNode(with_node, true);
             config_root->appendChild(new_node);
         }

--- a/src/Common/tests/gtest_merge_configs.cpp
+++ b/src/Common/tests/gtest_merge_configs.cpp
@@ -2,11 +2,11 @@
 
 #include <filesystem>
 
+#include <base/scope_guard.h>
 #include <Common/filesystemHelpers.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/WriteHelpers.h>
 #include <Common/Config/ConfigProcessor.h>
-#include <Poco/AutoPtr.h>
 #include <Poco/Util/XMLConfiguration.h>
 
 

--- a/src/Common/tests/gtest_merge_configs.cpp
+++ b/src/Common/tests/gtest_merge_configs.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include <Common/filesystemHelpers.h>
+#include <IO/WriteBufferFromFile.h>
+#include <IO/WriteHelpers.h>
+#include <Common/Config/ConfigProcessor.h>
+#include <Poco/AutoPtr.h>
+#include <Poco/Util/XMLConfiguration.h>
+
+
+TEST(Config, MergeConfigsOneSided)
+{
+    using namespace DB;
+    namespace fs = std::filesystem;
+    using File = Poco::File;
+
+    fs::create_directories(fs::path("/tmp/"));
+
+    auto config_file = std::make_unique<File>("/tmp/config.yml");
+
+    {
+        WriteBufferFromFile out(config_file->path());
+        std::string data = R"YAML(
+clickhouse:
+  field1: "1"
+  field2: "2"
+)YAML";
+        writeString(data, out);
+    }
+
+    auto system_tables_file = std::make_unique<File>("/tmp/config.d/system_tables.yml");
+
+    {
+        WriteBufferFromFile out(system_tables_file->path());
+        std::string data = R"YAML(
+clickhouse:
+  text_log:
+    database: system
+    table: text_log
+    partition_by:
+      "@remove": "1"
+    engine:
+      - "@replace" : "1"
+      - "ENGINE MergeTree"
+    flush_interval_milliseconds: 7500
+    level: debug
+)YAML";
+        writeString(data, out);
+    }
+
+
+    DB::ConfigProcessor processor(config_file->path(), /* throw_on_bad_incl = */ false, /* log_to_console = */ false);
+    bool has_zk_includes;
+    DB::XMLDocumentPtr config_xml = processor.processConfig(&has_zk_includes);
+    DB::ConfigurationPtr configuration(new Poco::Util::XMLConfiguration(config_xml));
+
+
+    ASSERT_EQ("1", configuration->getString("clickhouse.field1"));
+    ASSERT_EQ("2", configuration->getString("clickhouse.field2"));
+    ASSERT_EQ("system", configuration->getString("clickhouse.text_log.database"));
+    ASSERT_EQ("text_log", configuration->getString("clickhouse.text_log.table"));
+    ASSERT_EQ("ENGINE MergeTree", configuration->getString("clickhouse.text_log.engine"));
+    ASSERT_FALSE(configuration->has("clickhouse.text_log.partition_by"));
+}
+
+
+TEST(Config, MergeConfigsTwoSided)
+{
+    using namespace DB;
+    namespace fs = std::filesystem;
+    using File = Poco::File;
+
+    fs::create_directories(fs::path("/tmp/"));
+
+    auto config_file = std::make_unique<File>("/tmp/config.yml");
+
+    {
+        WriteBufferFromFile out(config_file->path());
+        std::string data = R"YAML(
+clickhouse:
+  field1: "1"
+  field2: "2"
+  text_log:
+    database: system
+    table: text_log
+    partition_by: "toYYYYMMDD(Something)"
+    engine: "ENGINE Memory"
+    flush_interval_milliseconds: 7500
+    level: debug
+)YAML";
+        writeString(data, out);
+    }
+
+    auto system_tables_file = std::make_unique<File>("/tmp/config.d/system_tables.yml");
+
+    {
+        WriteBufferFromFile out(system_tables_file->path());
+        std::string data = R"YAML(
+clickhouse:
+  field3: "3"
+  field4: "4"
+  text_log:
+    database: system
+    table: text_log
+    partition_by:
+      "@remove": "1"
+    engine:
+      - "@replace" : "1"
+      - "ENGINE MergeTree"
+    flush_interval_milliseconds: 7500
+    level: debug
+)YAML";
+        writeString(data, out);
+    }
+
+
+    DB::ConfigProcessor processor(config_file->path(), /* throw_on_bad_incl = */ false, /* log_to_console = */ false);
+    bool has_zk_includes;
+    DB::XMLDocumentPtr config_xml = processor.processConfig(&has_zk_includes);
+    DB::ConfigurationPtr configuration(new Poco::Util::XMLConfiguration(config_xml));
+
+
+    ASSERT_EQ("1", configuration->getString("clickhouse.field1"));
+    ASSERT_EQ("2", configuration->getString("clickhouse.field2"));
+    ASSERT_EQ("3", configuration->getString("clickhouse.field3"));
+    ASSERT_EQ("4", configuration->getString("clickhouse.field4"));
+    ASSERT_EQ("system", configuration->getString("clickhouse.text_log.database"));
+    ASSERT_EQ("text_log", configuration->getString("clickhouse.text_log.table"));
+    ASSERT_EQ("ENGINE MergeTree", configuration->getString("clickhouse.text_log.engine"));
+    ASSERT_FALSE(configuration->has("clickhouse.text_log.partition_by"));
+}

--- a/src/Common/tests/gtest_merge_configs.cpp
+++ b/src/Common/tests/gtest_merge_configs.cpp
@@ -16,11 +16,14 @@ TEST(Config, MergeConfigsOneSided)
     namespace fs = std::filesystem;
     using File = Poco::File;
 
-    fs::create_directories(fs::path("/tmp/"));
+    auto path = fs::path("/tmp/test_merge_configs/");
 
-    auto config_file = std::make_unique<File>("/tmp/config.yml");
-    SCOPE_EXIT({ config_file->remove(); });
+    fs::create_directories(path);
+    fs::create_directories(path / "config.d");
+    SCOPE_EXIT({ fs::remove_all(path); });
 
+    auto config_file = std::make_unique<File>(path / "config.yaml");
+    
     {
         WriteBufferFromFile out(config_file->path());
         std::string data = R"YAML(
@@ -31,8 +34,7 @@ clickhouse:
         writeString(data, out);
     }
 
-    auto system_tables_file = std::make_unique<File>("/tmp/config.d/system_tables.yml");
-    SCOPE_EXIT({ system_tables_file->remove(); });
+    auto system_tables_file = std::make_unique<File>(path / "config.d/system_tables.yaml");
 
     {
         WriteBufferFromFile out(system_tables_file->path());
@@ -74,10 +76,13 @@ TEST(Config, MergeConfigsTwoSided)
     namespace fs = std::filesystem;
     using File = Poco::File;
 
-    fs::create_directories(fs::path("/tmp/"));
+    auto path = fs::path("/tmp/test_merge_configs/");
 
-    auto config_file = std::make_unique<File>("/tmp/config.yml");
-    SCOPE_EXIT({ config_file->remove(); });
+    fs::create_directories(path);
+    fs::create_directories(path / "config.d");
+    SCOPE_EXIT({ fs::remove_all(path); });
+
+    auto config_file = std::make_unique<File>(path / "config.yaml");
 
     {
         WriteBufferFromFile out(config_file->path());
@@ -96,8 +101,7 @@ clickhouse:
         writeString(data, out);
     }
 
-    auto system_tables_file = std::make_unique<File>("/tmp/config.d/system_tables.yml");
-    SCOPE_EXIT({ system_tables_file->remove(); });
+    auto system_tables_file = std::make_unique<File>(path / "config.d/system_tables.yaml");
 
     {
         WriteBufferFromFile out(system_tables_file->path());

--- a/src/Common/tests/gtest_merge_configs.cpp
+++ b/src/Common/tests/gtest_merge_configs.cpp
@@ -23,7 +23,7 @@ TEST(Config, MergeConfigsOneSided)
     SCOPE_EXIT({ fs::remove_all(path); });
 
     auto config_file = std::make_unique<File>(path / "config.yaml");
-    
+
     {
         WriteBufferFromFile out(config_file->path());
         std::string data = R"YAML(

--- a/src/Common/tests/gtest_merge_configs.cpp
+++ b/src/Common/tests/gtest_merge_configs.cpp
@@ -19,6 +19,7 @@ TEST(Config, MergeConfigsOneSided)
     fs::create_directories(fs::path("/tmp/"));
 
     auto config_file = std::make_unique<File>("/tmp/config.yml");
+    SCOPE_EXIT({ config_file->remove(); });
 
     {
         WriteBufferFromFile out(config_file->path());
@@ -31,6 +32,7 @@ clickhouse:
     }
 
     auto system_tables_file = std::make_unique<File>("/tmp/config.d/system_tables.yml");
+    SCOPE_EXIT({ system_tables_file->remove(); });
 
     {
         WriteBufferFromFile out(system_tables_file->path());
@@ -75,6 +77,7 @@ TEST(Config, MergeConfigsTwoSided)
     fs::create_directories(fs::path("/tmp/"));
 
     auto config_file = std::make_unique<File>("/tmp/config.yml");
+    SCOPE_EXIT({ config_file->remove(); });
 
     {
         WriteBufferFromFile out(config_file->path());
@@ -94,6 +97,7 @@ clickhouse:
     }
 
     auto system_tables_file = std::make_unique<File>("/tmp/config.d/system_tables.yml");
+    SCOPE_EXIT({ system_tables_file->remove(); });
 
     {
         WriteBufferFromFile out(system_tables_file->path());

--- a/src/Common/tests/gtest_merge_configs.cpp
+++ b/src/Common/tests/gtest_merge_configs.cpp
@@ -24,8 +24,8 @@ TEST(Config, MergeConfigsOneSided)
         WriteBufferFromFile out(config_file->path());
         std::string data = R"YAML(
 clickhouse:
-  field1: "1"
-  field2: "2"
+  field1 : "1"
+  field2 : "2"
 )YAML";
         writeString(data, out);
     }
@@ -36,7 +36,7 @@ clickhouse:
         WriteBufferFromFile out(system_tables_file->path());
         std::string data = R"YAML(
 clickhouse:
-  text_log:
+  text_log :
     database: system
     table: text_log
     partition_by:
@@ -80,9 +80,9 @@ TEST(Config, MergeConfigsTwoSided)
         WriteBufferFromFile out(config_file->path());
         std::string data = R"YAML(
 clickhouse:
-  field1: "1"
-  field2: "2"
-  text_log:
+  field1 : "1"
+  field2 : "2"
+  text_log :
     database: system
     table: text_log
     partition_by: "toYYYYMMDD(Something)"
@@ -99,9 +99,9 @@ clickhouse:
         WriteBufferFromFile out(system_tables_file->path());
         std::string data = R"YAML(
 clickhouse:
-  field3: "3"
-  field4: "4"
-  text_log:
+  field3 : "3"
+  field4 : "4"
+  text_log :
     database: system
     table: text_log
     partition_by:

--- a/src/Common/tests/gtest_merge_configs.cpp
+++ b/src/Common/tests/gtest_merge_configs.cpp
@@ -24,8 +24,8 @@ TEST(Config, MergeConfigsOneSided)
         WriteBufferFromFile out(config_file->path());
         std::string data = R"YAML(
 clickhouse:
-  field1 : "1"
-  field2 : "2"
+    field1: "1"
+    field2: "2"
 )YAML";
         writeString(data, out);
     }
@@ -36,16 +36,16 @@ clickhouse:
         WriteBufferFromFile out(system_tables_file->path());
         std::string data = R"YAML(
 clickhouse:
-  text_log :
-    database: system
-    table: text_log
-    partition_by:
-      "@remove": "1"
-    engine:
-      - "@replace" : "1"
-      - "ENGINE MergeTree"
-    flush_interval_milliseconds: 7500
-    level: debug
+    text_log:
+        database: system
+        table: text_log
+        partition_by:
+            "@remove": "1"
+        engine:
+            - "@replace" : "1"
+            - "ENGINE MergeTree"
+        flush_interval_milliseconds: 7500
+        level: debug
 )YAML";
         writeString(data, out);
     }
@@ -80,15 +80,15 @@ TEST(Config, MergeConfigsTwoSided)
         WriteBufferFromFile out(config_file->path());
         std::string data = R"YAML(
 clickhouse:
-  field1 : "1"
-  field2 : "2"
-  text_log :
-    database: system
-    table: text_log
-    partition_by: "toYYYYMMDD(Something)"
-    engine: "ENGINE Memory"
-    flush_interval_milliseconds: 7500
-    level: debug
+    field1 : "1"
+    field2 : "2"
+    text_log :
+        database: system
+        table: text_log
+        partition_by: "toYYYYMMDD(Something)"
+        engine: "ENGINE Memory"
+        flush_interval_milliseconds: 7500
+        level: debug
 )YAML";
         writeString(data, out);
     }
@@ -99,18 +99,18 @@ clickhouse:
         WriteBufferFromFile out(system_tables_file->path());
         std::string data = R"YAML(
 clickhouse:
-  field3 : "3"
-  field4 : "4"
-  text_log :
-    database: system
-    table: text_log
-    partition_by:
-      "@remove": "1"
-    engine:
-      - "@replace" : "1"
-      - "ENGINE MergeTree"
-    flush_interval_milliseconds: 7500
-    level: debug
+    field3 : "3"
+    field4 : "4"
+    text_log :
+        database: system
+        table: text_log
+        partition_by:
+            "@remove": "1"
+        engine:
+            - "@replace" : "1"
+            - "ENGINE MergeTree"
+        flush_interval_milliseconds: 7500
+        level: debug
 )YAML";
         writeString(data, out);
     }


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


I want the `remove` attribute to act like: if there is a node with exactly the same name and path in default config, then we delete it  (this is current behavior). But if there is no node with such a name, then we don't have to include that `remove` attribute to the preprocessed config, it will be self-destroyed. For `replace` we just delete the attribute, but keep the field

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
