### PR TITLE
Fix materialised postrgesql adding new table after manually removing it

### DIFF
--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -34,6 +34,7 @@ namespace ErrorCodes
     extern const int QUERY_NOT_ALLOWED;
     extern const int UNKNOWN_TABLE;
     extern const int BAD_ARGUMENTS;
+    extern const int NOT_IMPLEMENTED;
 }
 
 DatabaseMaterializedPostgreSQL::DatabaseMaterializedPostgreSQL(
@@ -309,8 +310,12 @@ void DatabaseMaterializedPostgreSQL::attachTable(ContextPtr context_, const Stri
     }
 }
 
+StoragePtr DatabaseMaterializedPostgreSQL::detachTable(ContextPtr, const String &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "DETACH TABLE not allowed, use DETACH PERMANENTLY");
+}
 
-StoragePtr DatabaseMaterializedPostgreSQL::detachTable(ContextPtr context_, const String & table_name)
+void DatabaseMaterializedPostgreSQL::detachTablePermanently(ContextPtr, const String & table_name)
 {
     /// If there is query context then we need to detach materialized storage.
     /// If there is no query context then we need to detach internal storage from atomic database.
@@ -360,11 +365,6 @@ StoragePtr DatabaseMaterializedPostgreSQL::detachTable(ContextPtr context_, cons
         }
 
         materialized_tables.erase(table_name);
-        return nullptr;
-    }
-    else
-    {
-        return DatabaseAtomic::detachTable(context_, table_name);
     }
 }
 

--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.h
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.h
@@ -51,6 +51,8 @@ public:
 
     void attachTable(ContextPtr context, const String & table_name, const StoragePtr & table, const String & relative_table_path) override;
 
+    void detachTablePermanently(ContextPtr context, const String & table_name) override;
+
     StoragePtr detachTable(ContextPtr context, const String & table_name) override;
 
     void dropTable(ContextPtr local_context, const String & name, bool no_delay) override;

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -645,6 +645,10 @@ void MaterializedPostgreSQLConsumer::addNested(
     assert(!storages.contains(postgres_table_name));
     storages.emplace(postgres_table_name, nested_storage_info);
 
+    auto it = deleted_tables.find(postgres_table_name);
+    if (it != deleted_tables.end())
+        deleted_tables.erase(it);
+
     /// Replication consumer will read wall and check for currently processed table whether it is allowed to start applying
     /// changes to this table.
     waiting_list[postgres_table_name] = table_start_lsn;
@@ -663,7 +667,9 @@ void MaterializedPostgreSQLConsumer::updateNested(const String & table_name, Sto
 
 void MaterializedPostgreSQLConsumer::removeNested(const String & postgres_table_name)
 {
-    storages.erase(postgres_table_name);
+    auto it = storages.find(postgres_table_name);
+    if (it != storages.end())
+        storages.erase(it);
     deleted_tables.insert(postgres_table_name);
 }
 
@@ -727,6 +733,7 @@ bool MaterializedPostgreSQLConsumer::readFromReplicationSlot()
             {
                 if (e.code() == ErrorCodes::POSTGRESQL_REPLICATION_INTERNAL_ERROR)
                     continue;
+
                 throw;
             }
         }

--- a/tests/integration/test_postgresql_replica_database_engine_2/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_2/test.py
@@ -114,6 +114,8 @@ def test_add_new_table_to_replication(started_cluster):
     assert(result[:63] == "CREATE DATABASE test_database\\nENGINE = MaterializedPostgreSQL(")
     assert(result[-222:] == ")\\nSETTINGS materialized_postgresql_tables_list = \\'postgresql_replica_0,postgresql_replica_1,postgresql_replica_2,postgresql_replica_3,postgresql_replica_4,postgresql_replica_5,postgresql_replica_6,postgresql_replica_7\\'\n")
 
+    instance.query(f"INSERT INTO postgres_database.{table_name} SELECT number, number from numbers(10000, 10000)")
+
     result = instance.query("SHOW TABLES FROM test_database")
     assert(result == "postgresql_replica_0\npostgresql_replica_1\npostgresql_replica_2\npostgresql_replica_3\npostgresql_replica_4\npostgresql_replica_5\npostgresql_replica_6\npostgresql_replica_7\n")
     check_several_tables_are_synchronized(instance, NUM_TABLES + 3)
@@ -133,7 +135,7 @@ def test_remove_table_from_replication(started_cluster):
     assert(result[-59:] == "\\'postgres_database\\', \\'postgres\\', \\'mysecretpassword\\')\n")
 
     table_name = 'postgresql_replica_4'
-    instance.query(f'DETACH TABLE test_database.{table_name}');
+    instance.query(f'DETACH TABLE test_database.{table_name} PERMANENTLY');
     result = instance.query_and_get_error(f'SELECT * FROM test_database.{table_name}')
     assert("doesn't exist" in result)
 
@@ -147,13 +149,15 @@ def test_remove_table_from_replication(started_cluster):
     instance.query(f'ATTACH TABLE test_database.{table_name}');
     check_tables_are_synchronized(instance, table_name);
     check_several_tables_are_synchronized(instance, NUM_TABLES)
+    instance.query(f"INSERT INTO postgres_database.{table_name} SELECT number, number from numbers(10000, 10000)")
+    check_tables_are_synchronized(instance, table_name);
 
     result = instance.query('SHOW CREATE DATABASE test_database')
     assert(result[:63] == "CREATE DATABASE test_database\\nENGINE = MaterializedPostgreSQL(")
     assert(result[-159:] == ")\\nSETTINGS materialized_postgresql_tables_list = \\'postgresql_replica_0,postgresql_replica_1,postgresql_replica_2,postgresql_replica_3,postgresql_replica_4\\'\n")
 
     table_name = 'postgresql_replica_1'
-    instance.query(f'DETACH TABLE test_database.{table_name}');
+    instance.query(f'DETACH TABLE test_database.{table_name} PERMANENTLY');
     result = instance.query('SHOW CREATE DATABASE test_database')
     assert(result[:63] == "CREATE DATABASE test_database\\nENGINE = MaterializedPostgreSQL(")
     assert(result[-138:] == ")\\nSETTINGS materialized_postgresql_tables_list = \\'postgresql_replica_0,postgresql_replica_2,postgresql_replica_3,postgresql_replica_4\\'\n")
@@ -162,7 +166,7 @@ def test_remove_table_from_replication(started_cluster):
     cursor.execute(f'drop table if exists postgresql_replica_0;')
 
     # Removing from replication table which does not exist in PostgreSQL must be ok.
-    instance.query('DETACH TABLE test_database.postgresql_replica_0');
+    instance.query('DETACH TABLE test_database.postgresql_replica_0 PERMANENTLY');
     assert instance.contains_in_log("from publication, because table does not exist in PostgreSQL")
 
 
@@ -236,7 +240,7 @@ def test_database_with_single_non_default_schema(started_cluster):
 
     print('DETACH-ATTACH')
     detached_table_name = "postgresql_replica_1"
-    instance.query(f"DETACH TABLE {materialized_db}.{detached_table_name}")
+    instance.query(f"DETACH TABLE {materialized_db}.{detached_table_name} PERMANENTLY")
     assert not instance.contains_in_log("from publication, because table does not exist in PostgreSQL")
     instance.query(f"ATTACH TABLE {materialized_db}.{detached_table_name}")
     check_tables_are_synchronized(instance, detached_table_name, postgres_database=clickhouse_postgres_db);
@@ -306,7 +310,7 @@ def test_database_with_multiple_non_default_schemas_1(started_cluster):
 
     print('DETACH-ATTACH')
     detached_table_name = "postgresql_replica_1"
-    instance.query(f"DETACH TABLE {materialized_db}.`{schema_name}.{detached_table_name}`")
+    instance.query(f"DETACH TABLE {materialized_db}.`{schema_name}.{detached_table_name}` PERMANENTLY")
     assert not instance.contains_in_log("from publication, because table does not exist in PostgreSQL")
     instance.query(f"ATTACH TABLE {materialized_db}.`{schema_name}.{detached_table_name}`")
     assert_show_tables("test_schema.postgresql_replica_0\ntest_schema.postgresql_replica_1\ntest_schema.postgresql_replica_2\ntest_schema.postgresql_replica_3\ntest_schema.postgresql_replica_4\n")
@@ -385,7 +389,7 @@ def test_database_with_multiple_non_default_schemas_2(started_cluster):
     detached_table_name = "postgresql_replica_1"
     detached_table_schema = "schema0"
     clickhouse_postgres_db = f'clickhouse_postgres_db0'
-    instance.query(f"DETACH TABLE {materialized_db}.`{detached_table_schema}.{detached_table_name}`")
+    instance.query(f"DETACH TABLE {materialized_db}.`{detached_table_schema}.{detached_table_name}` PERMANENTLY")
     assert not instance.contains_in_log("from publication, because table does not exist in PostgreSQL")
     instance.query(f"ATTACH TABLE {materialized_db}.`{detached_table_schema}.{detached_table_name}`")
     assert_show_tables("schema0.postgresql_replica_0\nschema0.postgresql_replica_1\nschema1.postgresql_replica_0\nschema1.postgresql_replica_1\n")


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix materialised postrgesql adding new table to replication (ATTACH TABLE) after manually removing (DETACH TABLE). Closes https://github.com/ClickHouse/ClickHouse/issues/33800. Closes https://github.com/ClickHouse/ClickHouse/issues/34922. Closes https://github.com/ClickHouse/ClickHouse/issues/34315.