### PR TITLE
Update mergetree.md

### DIFF
--- a/docs/zh/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/zh/engines/table-engines/mergetree-family/mergetree.md
@@ -526,7 +526,7 @@ ClickHouse 在数据片段合并时会删除掉过期的数据。
 
 当ClickHouse发现数据过期时, 它将会执行一个计划外的合并。要控制这类合并的频率, 您可以设置 `merge_with_ttl_timeout`。如果该值被设置的太低, 它将引发大量计划外的合并，这可能会消耗大量资源。
 
-如果在合并的过程中执行 `SELECT` 查询, 则可能会得到过期的数据。为了避免这种情况，可以在 `SELECT` 之前使用 [OPTIMIZE](../../../engines/table-engines/mergetree-family/mergetree.md#misc_operations-optimize) 。
+如果在两次合并的时间间隔中执行 `SELECT` 查询, 则可能会得到过期的数据。为了避免这种情况，可以在 `SELECT` 之前使用 [OPTIMIZE](../../../engines/table-engines/mergetree-family/mergetree.md#misc_operations-optimize) 。
 
 ## 使用多个块设备进行数据存储 {#table_engine-mergetree-multiple-volumes}
 


### PR DESCRIPTION
其实我觉得这个翻译并不准确，我的翻译是这样的：“在两次数据合并的间隙中，如果有select查询，则可能会得到过期的数据，那可以在执行Select使用OPTIMIZE 强制触发一次合并来避免这种情况”，主要区别是原翻译把 between merges翻译成合并过程中，我这里翻译是在两次合并之间的间隙。理由如下：在合并过程中，虽然也会导致后面查询的数据不一致性，但是感觉这个因果关系有但是并不那么自然强烈，我觉得它更向表达的是在上次合并结束之后，下一次合并到来之前的这个时间段过期的数据，在这个时间段执行Select查询就一定会查到这些数据，如果要避免这种情况，就是立刻出发一次合并，不要等下一次系统自发的合并，这就是between merges 的意思。个人理解，如有错误，望指正。

Changelog category (leave one):
- Documentation (changelog entry is not required)
