### PR TITLE
Dump ast in dot format

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -575,8 +575,8 @@
         const formatted_rows = formatReadableRows(rows);
         stats.innerText = `Elapsed: ${seconds} sec, read ${formatted_rows} rows, ${formatted_bytes}.`;
 
-        /// We can also render graphs if user performed EXPLAIN PIPELINE graph=1.
-        if (response.data.length > 3 && response.data[0][0] === "digraph" && document.getElementById('query').value.match(/^\s*EXPLAIN/i)) {
+        /// We can also render graphs if user performed EXPLAIN PIPELINE graph=1 or EXPLAIN AST graph = 1
+        if (response.data.length > 3 && response.data[0][0].startsWith("digraph") && document.getElementById('query').value.match(/^\s*EXPLAIN/i)) {
             renderGraph(response);
         } else {
             renderTable(response);

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -277,7 +277,6 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                 dumpASTInDotFormat(*ast.getExplainedQuery(), buf);
             else
                 dumpAST(*ast.getExplainedQuery(), buf);
-            std::cout << "buf:" << buf.str() << std::endl;
             break;
         }
         case ASTExplainQuery::AnalyzedSyntax:
@@ -350,7 +349,6 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                         printPipelineCompact(processors, buf, settings.query_pipeline_options.header);
                     else
                         printPipeline(processors, buf);
-                    std::cout << "buf:" << buf.str() << std::endl;
                 }
                 else
                 {

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -277,6 +277,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                 dumpASTInDotFormat(*ast.getExplainedQuery(), buf);
             else
                 dumpAST(*ast.getExplainedQuery(), buf);
+            std::cout << "buf:" << buf.str() << std::endl;
             break;
         }
         case ASTExplainQuery::AnalyzedSyntax:
@@ -349,6 +350,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                         printPipelineCompact(processors, buf, settings.query_pipeline_options.header);
                     else
                         printPipeline(processors, buf);
+                    std::cout << "buf:" << buf.str() << std::endl;
                 }
                 else
                 {

--- a/src/Parsers/DumpASTNode.h
+++ b/src/Parsers/DumpASTNode.h
@@ -96,7 +96,7 @@ public:
             return;
 
         if (root)
-            (*ostr) << "digraph " << (label ? String(label) : "") << "{\n\trankdir=\"UD\";\n";
+            (*ostr) << "digraph " << (label ? String(label) : "") << "{\n    rankdir=\"UD\";\n";
 
         printNode();
     }
@@ -124,7 +124,7 @@ private:
 
     void printNode() const
     {
-        (*ostr) << "\t" << getNodeId(ast) << "[label=\"";
+        (*ostr) << "    " << getNodeId(ast) << "[label=\"";
         (*ostr) << getASTId();
 
         String alias = ast.tryGetAlias();
@@ -141,7 +141,7 @@ private:
 
     void printEdge(const IAST & parent, const IAST & child) const
     {
-        (*ostr) << "\t" << getNodeId(parent) << " -> " << getNodeId(child) << ";\n";
+        (*ostr) << "    " << getNodeId(parent) << " -> " << getNodeId(child) << ";\n";
     }
 };
 

--- a/src/Parsers/DumpASTNode.h
+++ b/src/Parsers/DumpASTNode.h
@@ -86,6 +86,75 @@ inline void dumpAST(const IAST & ast, WriteBuffer & ostr, DumpASTNode * parent =
         dumpAST(*child, ostr, &dump);
 }
 
+class DumpASTNodeInDotFormat
+{
+public:
+    DumpASTNodeInDotFormat(const IAST & ast_, WriteBuffer * ostr_, bool root_ = true, const char * label_ = nullptr)
+        : ast(ast_), ostr(ostr_), root(root_), label(label_)
+    {
+        if (!ostr)
+            return;
+
+        if (root)
+            (*ostr) << "digraph " << (label ? String(label) : "") << "{\n\trankdir=\"UD\";\n";
+
+        printNode();
+    }
+
+    ~DumpASTNodeInDotFormat()
+    {
+        if (!ostr)
+            return;
+
+        for (const auto & child : ast.children)
+            printEdge(ast, *child);
+
+        if (root)
+            (*ostr) << "}\n";
+    }
+
+private:
+    const IAST & ast;
+    WriteBuffer * ostr;
+    bool root;
+    const char * label;
+
+    String getASTId() const { return ast.getID(' '); }
+    static String getNodeId(const IAST & a) { return "n" + std::to_string(reinterpret_cast<std::uintptr_t>(&a)); }
+
+    void printNode() const
+    {
+        (*ostr) << "\t" << getNodeId(ast) << "[label=\"";
+        (*ostr) << getASTId();
+
+        String alias = ast.tryGetAlias();
+        if (!alias.empty())
+            (*ostr) << " ("
+                    << "alias"
+                    << " " << alias << ")";
+
+        if (!ast.children.empty())
+            (*ostr) << " (children"
+                    << " " << ast.children.size() << ")";
+        (*ostr) << "\"];\n";
+    }
+
+    void printEdge(const IAST & parent, const IAST & child) const
+    {
+        (*ostr) << "\t" << getNodeId(parent) << " -> " << getNodeId(child) << ";\n";
+    }
+};
+
+
+/// Print AST in "dot" format for GraphViz
+/// You can render it with: dot -Tpng ast.dot ast.png
+inline void dumpASTInDotFormat(const IAST & ast, WriteBuffer & ostr, bool root = true)
+{
+    DumpASTNodeInDotFormat dump(ast, &ostr, root);
+    for (const auto & child : ast.children)
+        dumpASTInDotFormat(*child, ostr, false);
+}
+
 
 /// String stream dumped in dtor
 template <bool _enable>


### PR DESCRIPTION
Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
``` sql
) explain ast graph = 1 select * from system.parts;

EXPLAIN AST graph = 1
SELECT *
FROM system.parts

Query id: bf0b8ea6-e65a-4697-b956-4705e6b17806

┌─explain────────────────────────────────────────────────────────────────┐
│ digraph {                                                              │
│     rankdir="UD";                                                      │
│     n135497629874712[label="SelectWithUnionQuery (children 1)"];       │
│     n135325831467992[label="ExpressionList (children 1)"];             │
│     n135377371300248[label="SelectQuery (children 2)"];                │
│     n135325832847912[label="ExpressionList (children 1)"];             │
│     n135325832772952[label="Asterisk"];                                │
│     n135325832847912 -> n135325832772952;                              │
│     n135325831467912[label="TablesInSelectQuery (children 1)"];        │
│     n135377371300376[label="TablesInSelectQueryElement (children 1)"]; │
│     n135411732583032[label="TableExpression (children 1)"];            │
│     n135446091858456[label="TableIdentifier system.parts"];            │
│     n135411732583032 -> n135446091858456;                              │
│     n135377371300376 -> n135411732583032;                              │
│     n135325831467912 -> n135377371300376;                              │
│     n135377371300248 -> n135325832847912;                              │
│     n135377371300248 -> n135325831467912;                              │
│     n135325831467992 -> n135377371300248;                              │
│     n135497629874712 -> n135325831467992;                              │
│ }                                                                      │
└────────────────────────────────────────────────────────────────────────┘
```

Looks like this: 
![image](https://user-images.githubusercontent.com/8181003/157643940-920725e2-cc5f-40bb-a159-29f3b30c7a23.png)

