### PR TITLE
clang-tidy report issues with Medium priority

### DIFF
--- a/src/IO/ReadBufferFromFileDescriptor.h
+++ b/src/IO/ReadBufferFromFileDescriptor.h
@@ -39,7 +39,7 @@ public:
     {
     }
 
-    virutal ~ReadBufferFromFileDescriptor()
+    virtual ~ReadBufferFromFileDescriptor()
     {
     }
 

--- a/src/IO/ReadBufferFromFileDescriptor.h
+++ b/src/IO/ReadBufferFromFileDescriptor.h
@@ -39,7 +39,7 @@ public:
     {
     }
 
-    virtual ~ReadBufferFromFileDescriptor()
+    virtual ~ReadBufferFromFileDescriptor() override
     {
     }
 
@@ -84,7 +84,7 @@ public:
     {
         use_pread = true;
     }
-    virtual ~ReadBufferFromFileDescriptorPRead()
+    virtual ~ReadBufferFromFileDescriptorPRead() override
     {
     }
 };

--- a/src/IO/ReadBufferFromFileDescriptor.h
+++ b/src/IO/ReadBufferFromFileDescriptor.h
@@ -38,6 +38,10 @@ public:
         , fd(fd_)
     {
     }
+    
+    virutal ~ReadBufferFromFileDescriptor()
+    {
+    }
 
     int getFD() const
     {
@@ -79,6 +83,9 @@ public:
         : ReadBufferFromFileDescriptor(fd_, buf_size, existing_memory, alignment, file_size_)
     {
         use_pread = true;
+    }
+    virtual ~ReadBufferFromFileDescriptorPRead()
+    {
     }
 };
 

--- a/src/IO/ReadBufferFromFileDescriptor.h
+++ b/src/IO/ReadBufferFromFileDescriptor.h
@@ -38,7 +38,7 @@ public:
         , fd(fd_)
     {
     }
-    
+
     virutal ~ReadBufferFromFileDescriptor()
     {
     }

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1062,7 +1062,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     QualifiedTableName qualified_name{database_name, create.getTable()};
     TableNamesSet loading_dependencies = getDependenciesSetFromCreateQuery(getContext()->getGlobalContext(), qualified_name, query_ptr);
     if (!loading_dependencies.empty())
-        DatabaseCatalog::instance().addLoadingDependencies(std::move(qualified_name), std::move(loading_dependencies));
+        DatabaseCatalog::instance().addLoadingDependencies(qualified_name, std::move(loading_dependencies));
 
     return fillTableIfNeeded(create);
 }

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -185,7 +185,7 @@ Chain InterpreterInsertQuery::buildChain(
     std::atomic_uint64_t * elapsed_counter_ms)
 {
     auto sample = getSampleBlock(columns, table, metadata_snapshot);
-    return buildChainImpl(table, metadata_snapshot, std::move(sample) , thread_status, elapsed_counter_ms);
+    return buildChainImpl(table, metadata_snapshot, sample, thread_status, elapsed_counter_ms);
 }
 
 Chain InterpreterInsertQuery::buildChainImpl(

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -332,7 +332,7 @@ void SystemLog<LogElement>::flushImpl(const std::vector<LogElement> & to_flush, 
         for (const auto & name_and_type : log_element_names_and_types)
             log_element_columns.emplace_back(name_and_type.type, name_and_type.name);
 
-        Block block(std::move(log_element_columns));
+        Block block(log_element_columns);
 
         MutableColumns columns = block.mutateColumns();
         for (const auto & elem : to_flush)

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -122,7 +122,7 @@ void ColumnDescription::readText(ReadBuffer & buf)
             if (col_ast->default_expression)
             {
                 default_desc.kind = columnDefaultKindFromString(col_ast->default_specifier);
-                default_desc.expression = std::move(col_ast->default_expression);
+                default_desc.expression = col_ast->default_expression;
             }
 
             if (col_ast->comment)
@@ -309,7 +309,7 @@ void ColumnsDescription::flattenNested()
             continue;
         }
 
-        ColumnDescription column = std::move(*it);
+        ColumnDescription column = *it;
         removeSubcolumns(column.name);
         it = columns.get<0>().erase(it);
 

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -43,7 +43,7 @@ class StorageDistributed final : public shared_ptr_helper<StorageDistributed>, p
     friend class StorageSystemDistributionQueue;
 
 public:
-    ~StorageDistributed() override;
+    virtual ~StorageDistributed() override;
 
     std::string getName() const override { return "Distributed"; }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
clang-tidy medium priority issues fixed.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
