### PR TITLE
Fix empty chunk in with total transform

### DIFF
--- a/src/Processors/Transforms/TotalsHavingTransform.cpp
+++ b/src/Processors/Transforms/TotalsHavingTransform.cpp
@@ -138,7 +138,7 @@ IProcessor::Status TotalsHavingTransform::prepare()
     if (!totals_output.canPush())
         return Status::PortFull;
 
-    if (!totals)
+    if (!total_prepared)
         return Status::Ready;
 
     totals_output.push(std::move(totals));
@@ -312,6 +312,8 @@ void TotalsHavingTransform::prepareTotals()
         /// Note: after expression totals may have several rows if `arrayJoin` was used in expression.
         totals = Chunk(block.getColumns(), num_rows);
     }
+
+    total_prepared = true;
 }
 
 }

--- a/src/Processors/Transforms/TotalsHavingTransform.h
+++ b/src/Processors/Transforms/TotalsHavingTransform.h
@@ -46,6 +46,7 @@ protected:
     void transform(Chunk & chunk) override;
 
     bool finished_transform = false;
+    bool total_prepared = false;
     Chunk totals;
 
 private:

--- a/tests/queries/0_stateless/02233_with_total_empty_chunk.sql
+++ b/tests/queries/0_stateless/02233_with_total_empty_chunk.sql
@@ -1,0 +1,1 @@
+SELECT (NULL, NULL, NULL, NULL, NULL, NULL, NULL) FROM numbers(0) GROUP BY number WITH TOTALS HAVING sum(number) <= arrayJoin([]);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error in query with `WITH TOTALS` in case if `HAVING` returned empty result. This fixes https://github.com/ClickHouse/ClickHouse/issues/33711


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
