### PR TITLE
Fix issue with unquoted expressions in csv schema inference

### DIFF
--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -10,6 +10,7 @@
 #include <Poco/JSON/Parser.h>
 #include <Parsers/TokenIterator.h>
 #include <Parsers/ExpressionListParsers.h>
+#include <Parsers/ASTLiteral.h>
 #include <Interpreters/evaluateConstantExpression.h>
 
 namespace DB
@@ -262,7 +263,7 @@ static bool evaluateConstantExpressionFromString(const StringRef & field, DataTy
 
     /// FIXME: Our parser cannot parse maps in the form of '{key : value}' that is used in text formats.
     bool parsed = parser.parse(token_iterator, ast, expected);
-    if (!parsed || !token_iterator->isEnd())
+    if (!parsed || !token_iterator->isEnd() || !ast->as<const ASTLiteral>())
         return false;
 
     try

--- a/tests/queries/0_stateless/02233_unquoted_expressions_in_csv_schema_inference.reference
+++ b/tests/queries/0_stateless/02233_unquoted_expressions_in_csv_schema_inference.reference
@@ -1,0 +1,4 @@
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					
+c1	Nullable(String)					

--- a/tests/queries/0_stateless/02233_unquoted_expressions_in_csv_schema_inference.sh
+++ b/tests/queries/0_stateless/02233_unquoted_expressions_in_csv_schema_inference.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+echo "2020-02-01" | $CLICKHOUSE_LOCAL -q "desc table table" --input-format "CSV" --file=-
+echo "2020+02" | $CLICKHOUSE_LOCAL -q "desc table table" --input-format "CSV" --file=-
+echo "1 + 1" | $CLICKHOUSE_LOCAL -q "desc table table" --input-format "CSV" --file=-
+echo "200-10" | $CLICKHOUSE_LOCAL -q "desc table table" --input-format "CSV" --file=-
+
+
+


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix issue with unquoted expressions in CSV schema inference.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
