### PR TITLE
Fix possible 01506_buffer_table_alter_block_structure_2 flakiness

### DIFF
--- a/tests/queries/0_stateless/01506_buffer_table_alter_block_structure_2.sql
+++ b/tests/queries/0_stateless/01506_buffer_table_alter_block_structure_2.sql
@@ -5,12 +5,11 @@ CREATE TABLE buf_dest (timestamp DateTime)
 ENGINE = MergeTree PARTITION BY toYYYYMMDD(timestamp)
 ORDER BY (timestamp);
 
-CREATE TABLE buf (timestamp DateTime) Engine = Buffer(currentDatabase(), buf_dest, 16, 0.1, 0.1, 2000000, 20000000, 100000000, 300000000);;
+CREATE TABLE buf (timestamp DateTime) Engine = Buffer(currentDatabase(), buf_dest, 16, 86400, 86400, 2000000, 20000000, 100000000, 300000000);;
 
 INSERT INTO buf (timestamp) VALUES (toDateTime('2020-01-01 00:05:00'));
 
---- wait for buffer to flush
-SELECT sleep(1) from numbers(1) settings max_block_size=1 format Null;
+OPTIMIZE TABLE buf;
 
 ALTER TABLE buf_dest ADD COLUMN s String;
 ALTER TABLE buf ADD COLUMN s String;


### PR DESCRIPTION
SELECT from Buffer table is racy, so you can get data from the
underlying table but not from the Buffer itself, since in parallel with
SELECT, Buffer, can flush it's data to the underlying table.

It is hard to avoid with the current architecture, since this will
require to holding lock until the data will be read from the Buffer, and
this is not a good alternative.

So let's fix the test instead, but not relying on background flush (TTL
increased).

Here is an example of a test failure [1]:

    2022.03.12 20:56:58.141182 [ 678 ] {011e7d25-82a9-4ab6-8cb0-dcbbc84f9581} <Debug> executeQuery: (from [::1]:33324) (comment: 01506_buffer_table_alter_block_structure_2.sql) SELECT * FROM buf ORDER BY timestamp;
    2022.03.12 20:56:58.162709 [ 678 ] {011e7d25-82a9-4ab6-8cb0-dcbbc84f9581} <Trace> MergeTreeInOrderSelectProcessor: Reading 1 ranges in order from part 20200101_1_1_0, approx. 1 rows starting from 0
    2022.03.12 20:56:59.144663 [ 615 ] {} <Trace> test_bdtzgu.buf_dest (79ba36b2-0e90-4bbb-b55f-a42b605b362b): Renaming temporary part tmp_insert_20200101_2_2_0 to 20200101_2_2_0.
    2022.03.12 20:56:59.147550 [ 615 ] {} <Debug> StorageBuffer (test_bdtzgu.buf): Flushing buffer with 1 rows, 18 bytes, age 1 seconds, took 19 ms (bg).
    2022.03.12 20:56:59.391774 [ 678 ] {011e7d25-82a9-4ab6-8cb0-dcbbc84f9581} <Information> executeQuery: Read 1 rows, 13.00 B in 1.250102785 sec., 0 rows/sec., 10.40 B/sec.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/0/044cd6b861c1f4f00c6c24c4020799b676de6d34/stateless_tests__memory__actions__[1/3].html

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alexey-milovidov 
Cc: @KochetovNicolai 