### PR TITLE
Mark build action as failed if it was retried and there was no succeeded builds

### DIFF
--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -240,6 +240,7 @@ def main():
                     "https://s3.amazonaws.com/clickhouse-builds/"
                     + url.replace("+", "%2B").replace(" ", "%20")
                 )
+        success = len(build_urls) > 0
         create_json_artifact(
             TEMP_PATH,
             build_name,
@@ -247,9 +248,13 @@ def main():
             build_urls,
             build_config,
             0,
-            len(build_urls) > 0,
+            success,
         )
-        return
+        # Fail build job if not successeded
+        if not success:
+            sys.exit(1)
+        else:
+            sys.exit(0)
 
     image_name = get_image_name(build_config)
     docker_image = get_image_with_version(IMAGES_PATH, image_name)


### PR DESCRIPTION
Builder actions does not shows errors after retries, for example [1]
failed, but the check is green:

    Dump json report {
      'log_url': 'https://s3.amazonaws.com/clickhouse-builds/35204/c5a71a7f10e9d20b116b3e1db02bb444b203c32a/binary_gcc/build_log.log',
      'build_urls': [], <-- empty
      'build_config': {...},
      'elapsed_seconds': 0, 'status': False
    } to build_urls_binary_gcc.json with env build_urls_{build_name}

  [1]: https://github.com/ClickHouse/ClickHouse/runs/5510262456?check_suite_focus=true#logs

And previous build indeed failed [2]:

    Mar 11 08:19:45 ninja: build stopped: subcommand failed.

  [2]: https://s3.amazonaws.com/clickhouse-builds/35204/c5a71a7f10e9d20b116b3e1db02bb444b203c32a/binary_gcc/build_log.log

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alesapin 
Cc: @Felixoid 