### PR TITLE
Fix check table in case when there exist sparse columns

### DIFF
--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -98,7 +98,8 @@ IMergeTreeDataPart::Checksums checkDataPart(
         };
     };
 
-    SerializationInfoByName serialization_infos(columns_txt, {});
+    auto ratio_of_defaults = data_part->storage.getSettings()->ratio_of_defaults_for_sparse_serialization;
+    SerializationInfoByName serialization_infos(columns_txt, SerializationInfo::Settings{ratio_of_defaults, false});
     auto serialization_path = path + IMergeTreeDataPart::SERIALIZATION_FILE_NAME;
 
     if (disk->exists(serialization_path))

--- a/tests/queries/0_stateless/02235_check_table_sparse_serialization.reference
+++ b/tests/queries/0_stateless/02235_check_table_sparse_serialization.reference
@@ -1,0 +1,4 @@
+all_1_1_0	a	Default
+all_2_2_0	a	Sparse
+all_1_1_0	1	
+all_2_2_0	1	

--- a/tests/queries/0_stateless/02235_check_table_sparse_serialization.sql
+++ b/tests/queries/0_stateless/02235_check_table_sparse_serialization.sql
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS t_sparse_02235;
+
+CREATE TABLE t_sparse_02235 (a UInt8) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0.9;
+
+SYSTEM STOP MERGES t_sparse_02235;
+
+INSERT INTO t_sparse_02235 SELECT 1 FROM numbers(1000);
+INSERT INTO t_sparse_02235 SELECT 0 FROM numbers(1000);
+
+SELECT name, column, serialization_kind FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_sparse_02235'
+ORDER BY name, column;
+
+SET check_query_single_value_result = 0;
+CHECK TABLE t_sparse_02235;
+
+DROP TABLE t_sparse_02235;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `CHECK TABLE` query in case when sparse columns are enabled in table.

Fixes #35192.
