### PR TITLE
return const for function getMacro if not distributed query

### DIFF
--- a/src/Functions/getMacro.cpp
+++ b/src/Functions/getMacro.cpp
@@ -27,15 +27,19 @@ class FunctionGetMacro : public IFunction
 {
 private:
     MultiVersion<Macros>::Version macros;
+    bool is_distributed;
 
 public:
     static constexpr auto name = "getMacro";
     static FunctionPtr create(ContextPtr context)
     {
-        return std::make_shared<FunctionGetMacro>(context->getMacros());
+        return std::make_shared<FunctionGetMacro>(context->getMacros(), context->isDistributed());
     }
 
-    explicit FunctionGetMacro(MultiVersion<Macros>::Version macros_) : macros(std::move(macros_)) {}
+    explicit FunctionGetMacro(MultiVersion<Macros>::Version macros_, bool is_distributed_)
+        : macros(std::move(macros_)), is_distributed(is_distributed_)
+    {
+    }
 
     String getName() const override
     {
@@ -48,8 +52,11 @@ public:
 
     bool isDeterministicInScopeOfQuery() const override
     {
-        return false;
+        return true;
     }
+
+    /// getMacro may return different values on different shards/replicas, so it's not constant for distributed query
+    bool isSuitableForConstantFolding() const override { return !is_distributed; }
 
     size_t getNumberOfArguments() const override
     {
@@ -63,9 +70,6 @@ public:
         return std::make_shared<DataTypeString>();
     }
 
-    /** convertToFullColumn needed because in distributed query processing,
-      *    each server returns its own value.
-      */
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
         const IColumn * arg_column = arguments[0].column.get();
@@ -74,8 +78,7 @@ public:
         if (!arg_string)
             throw Exception("The argument of function " + getName() + " must be constant String", ErrorCodes::ILLEGAL_COLUMN);
 
-        return result_type->createColumnConst(
-            input_rows_count, macros->getValue(arg_string->getDataAt(0).toString()))->convertToFullColumnIfConst();
+        return result_type->createColumnConst(input_rows_count, macros->getValue(arg_string->getDataAt(0).toString()));
     }
 };
 

--- a/tests/queries/0_stateless/01016_macros.reference
+++ b/tests/queries/0_stateless/01016_macros.reference
@@ -1,2 +1,3 @@
 test	Hello, world!
 Hello, world!
+1

--- a/tests/queries/0_stateless/01016_macros.sql
+++ b/tests/queries/0_stateless/01016_macros.sql
@@ -1,2 +1,3 @@
 SELECT * FROM system.macros WHERE macro = 'test';
 SELECT getMacro('test');
+select isConstant(getMacro('test'));


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Return const for function getMacro if not in distributed query. Close https://github.com/ClickHouse/ClickHouse/issues/34727 