### PR TITLE
Fix 00284_external_aggregation.sql

### DIFF
--- a/tests/queries/0_stateless/00284_external_aggregation.sql
+++ b/tests/queries/0_stateless/00284_external_aggregation.sql
@@ -2,6 +2,8 @@
 
 SET max_bytes_before_external_group_by = 100000000;
 SET max_memory_usage = 410000000;
+SET group_by_two_level_threshold = 100000;
+SET group_by_two_level_threshold_bytes = 50000000;
 
 SELECT sum(k), sum(c) FROM (SELECT number AS k, count() AS c FROM (SELECT * FROM system.numbers LIMIT 10000000) GROUP BY k);
 SELECT sum(k), sum(c), max(u) FROM (SELECT number AS k, count() AS c, uniqArray(range(number % 16)) AS u FROM (SELECT * FROM system.numbers LIMIT 1000000) GROUP BY k);


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It became flaky after #34092
https://s3.amazonaws.com/clickhouse-test-reports/24258/c8d6c13c2dec8fecb4f9ec85dccbcd0f563c248b/stateless_tests__thread__actions__[2/3]/runlog.log
