### PR TITLE
Fix 00900_long_parquet_load

### DIFF
--- a/tests/queries/0_stateless/00900_long_parquet_load.reference
+++ b/tests/queries/0_stateless/00900_long_parquet_load.reference
@@ -339,6 +339,9 @@ Code: 33. DB::ParsingEx---tion: Error while reading Parquet data: IOError: Unkno
 (NULL)
 === Try load data from single_nan.parquet
 \N
+=== Try load data from test_setting_input_format_use_lowercase_column_name.parquet
+123	1
+456	2
 === Try load data from userdata1.parquet
 1454486129	1	Amanda	Jordan	ajordan0@com.com	Female	1.197.201.2	6759521864920116	Indonesia	3/8/1971	49756.53	Internal Auditor	1E+02
 1454519043	2	Albert	Freeman	afreeman1@is.gd	Male	218.111.175.34		Canada	1/16/1968	150280.17	Accountant IV	

--- a/tests/queries/0_stateless/00900_long_parquet_load.sh
+++ b/tests/queries/0_stateless/00900_long_parquet_load.sh
@@ -40,10 +40,12 @@ DATA_DIR=$CUR_DIR/data_parquet
 #   Code: 349. DB::Ex---tion: Can not insert NULL data into non-nullable column "phoneNumbers": data for INSERT was parsed from stdin
 
 for NAME in $(find "$DATA_DIR"/*.parquet -print0 | xargs -0 -n 1 basename | LC_ALL=C sort); do
-    echo === Try load data from "$NAME"
-
     JSON=$DATA_DIR/$NAME.json
     COLUMNS_FILE=$DATA_DIR/$NAME.columns
+
+    ([ -z "$PARQUET_READER" ] || [ ! -s "$PARQUET_READER" ]) && [ ! -s "$COLUMNS_FILE" ] && continue
+
+    echo === Try load data from "$NAME"
 
     # If you want change or add .parquet file - rm data_parquet/*.json data_parquet/*.columns
     [ -n "$PARQUET_READER" ] && [ ! -s "$COLUMNS_FILE" ] && [ ! -s "$JSON" ] && "$PARQUET_READER" --json "$DATA_DIR"/"$NAME" > "$JSON"

--- a/tests/queries/0_stateless/data_parquet/test_setting_input_format_use_lowercase_column_name.parquet.columns
+++ b/tests/queries/0_stateless/data_parquet/test_setting_input_format_use_lowercase_column_name.parquet.columns
@@ -1,0 +1,1 @@
+`Id` Nullable(String), `Score` Nullable(Int32)


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Add `.columns` for `.parquet` added in https://github.com/ClickHouse/ClickHouse/pull/35145
