### PR TITLE
Maybe fix use-after-free inside S3 upload thread

### DIFF
--- a/src/Disks/S3/DiskS3.cpp
+++ b/src/Disks/S3/DiskS3.cpp
@@ -272,6 +272,17 @@ std::unique_ptr<WriteBufferFromFileBase> DiskS3::writeFile(const String & path, 
             SCOPE_EXIT_SAFE(
                 if (thread_group)
                     CurrentThread::detachQueryIfNotDetached();
+
+                /// After we detached from the thread_group, parent for memory_tracker inside ThreadStatus will be reset to it's parent.
+                /// Typically, it may be changes from Process to User.
+                /// Usually it could be ok, because thread pool task is executed before user-level memory tracker is destroyed.
+                /// However, thread could stay alive inside the thread pool, and it's ThreadStatus as well.
+                /// When, finally, we destroy the thread (and the ThreadStatus),
+                /// it can use memory tracker in the ~ThreadStatus in order to alloc/free untracked_memory,\
+                /// and by this time user-level memory tracker may be already destroyed.
+                ///
+                /// As a work-around, reset memory tracker to total, which is always alive.
+                CurrentThread::get().memory_tracker.setParent(&total_memory_tracker);
             );
             callback();
         });


### PR DESCRIPTION


Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/35229/7c84b33918b0b82c159f1948e9dd78d6517c8d4a/stress_test__thread__actions_/stderr.log
