### PR TITLE
Fix possible segfault in DatabasePostgreSQL::getCreateTableQuery

### DIFF
--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -406,13 +406,24 @@ ASTPtr DatabasePostgreSQL::getCreateTableQueryImpl(const String & table_name, Co
     ASTs storage_children = ast_storage->children;
     auto storage_engine_arguments = ast_storage->engine->arguments;
 
-    /// Remove extra engine argument (`schema` and `use_table_cache`)
-    if (storage_engine_arguments->children.size() >= 5)
-        storage_engine_arguments->children.resize(4);
+    if (storage_engine_arguments->children.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected number of arguments: {}", storage_engine_arguments->children.size());
 
-    /// Add table_name to engine arguments
-    assert(storage_engine_arguments->children.size() >= 2);
-    storage_engine_arguments->children.insert(storage_engine_arguments->children.begin() + 2, std::make_shared<ASTLiteral>(table_id.table_name));
+    /// Check for named collection.
+    if (typeid_cast<ASTIdentifier *>(storage_engine_arguments->children[0].get()))
+    {
+        storage_engine_arguments->children.push_back(makeASTFunction("equals", std::make_shared<ASTIdentifier>("table"), std::make_shared<ASTLiteral>(table_id.table_name)));
+    }
+    else
+    {
+        /// Remove extra engine argument (`schema` and `use_table_cache`)
+        if (storage_engine_arguments->children.size() >= 5)
+            storage_engine_arguments->children.resize(4);
+
+        /// Add table_name to engine arguments.
+        if (storage_engine_arguments->children.size() >= 2)
+            storage_engine_arguments->children.insert(storage_engine_arguments->children.begin() + 2, std::make_shared<ASTLiteral>(table_id.table_name));
+    }
 
     return create_table_query;
 }

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -407,7 +407,7 @@ ASTPtr DatabasePostgreSQL::getCreateTableQueryImpl(const String & table_name, Co
     auto storage_engine_arguments = ast_storage->engine->arguments;
 
     if (storage_engine_arguments->children.empty())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected number of arguments: {}", storage_engine_arguments->children.size());
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected number of arguments: {}", storage_engine_arguments->children.size());
 
     /// Check for named collection.
     if (typeid_cast<ASTIdentifier *>(storage_engine_arguments->children[0].get()))

--- a/tests/integration/test_postgresql_database_engine/test.py
+++ b/tests/integration/test_postgresql_database_engine/test.py
@@ -226,6 +226,10 @@ def test_predefined_connection_configuration(started_cluster):
 
     node1.query("DROP DATABASE IF EXISTS postgres_database")
     node1.query("CREATE DATABASE postgres_database ENGINE = PostgreSQL(postgres1)")
+
+    result = node1.query("select create_table_query from system.tables where database ='postgres_database'")
+    assert(result.strip().endswith("ENGINE = PostgreSQL(postgres1, table = \\'test_table\\')"))
+
     node1.query("INSERT INTO postgres_database.test_table SELECT number, number from numbers(100)")
     assert (node1.query(f"SELECT count() FROM postgres_database.test_table").rstrip() == '100')
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segfault in Postgres database when getting create table query if database was created using named collections. Closes https://github.com/ClickHouse/ClickHouse/issues/35312.


