### PR TITLE
Add a way to skip fast tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -142,6 +142,8 @@ jobs:
           sudo rm -fr "$TEMP_PATH"
   FastTest:
     needs: DockerHubPush
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-fast-test') }}
+    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'skip-fast-test') }}
     runs-on: [self-hosted, builder]
     steps:
       - name: Set envs


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add skip-fast-test label for PRs to skip FastTest completely. It will save some time for us in cases where we are 100% sure that the code is not changed.