### PR TITLE
Fix schema inference for TSKV format while using small max_read_buffer_size

### DIFF
--- a/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -241,7 +241,7 @@ std::unordered_map<String, DataTypePtr> TSKVSchemaReader::readRowAndGetNamesAndD
 
     std::unordered_map<String, DataTypePtr> names_and_types;
     StringRef name_ref;
-    String name;
+    String name_buf;
     String value;
     do
     {

--- a/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -250,7 +250,7 @@ std::unordered_map<String, DataTypePtr> TSKVSchemaReader::readRowAndGetNamesAndD
         if (has_value)
         {
             readEscapedString(value, in);
-            names_and_types[name] = determineDataTypeByEscapingRule(value, format_settings, FormatSettings::EscapingRule::Escaped);
+            names_and_types[std::move(name)] = determineDataTypeByEscapingRule(value, format_settings, FormatSettings::EscapingRule::Escaped);
         }
         else
         {

--- a/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -4,7 +4,6 @@
 #include <Formats/EscapingRuleUtils.h>
 #include <DataTypes/Serializations/SerializationNullable.h>
 #include <DataTypes/DataTypeString.h>
-#include <DataTypes/DataTypeNullable.h>
 
 
 namespace DB
@@ -242,15 +241,16 @@ std::unordered_map<String, DataTypePtr> TSKVSchemaReader::readRowAndGetNamesAndD
 
     std::unordered_map<String, DataTypePtr> names_and_types;
     StringRef name_ref;
-    String name_tmp;
+    String name;
     String value;
     do
     {
-        bool has_value = readName(in, name_ref, name_tmp);
+        bool has_value = readName(in, name_ref, name);
+        name = String(name_ref);
         if (has_value)
         {
             readEscapedString(value, in);
-            names_and_types[String(name_ref)] = determineDataTypeByEscapingRule(value, format_settings, FormatSettings::EscapingRule::Escaped);
+            names_and_types[name] = determineDataTypeByEscapingRule(value, format_settings, FormatSettings::EscapingRule::Escaped);
         }
         else
         {

--- a/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -245,8 +245,8 @@ std::unordered_map<String, DataTypePtr> TSKVSchemaReader::readRowAndGetNamesAndD
     String value;
     do
     {
-        bool has_value = readName(in, name_ref, name);
-        name = String(name_ref);
+        bool has_value = readName(in, name_ref, name_buf);
+        String name = String(name_ref);
         if (has_value)
         {
             readEscapedString(value, in);

--- a/tests/queries/0_stateless/02240_tskv_schema_inference_bug.reference
+++ b/tests/queries/0_stateless/02240_tskv_schema_inference_bug.reference
@@ -1,0 +1,8 @@
+b	Nullable(String)					
+c	Nullable(String)					
+a	Nullable(String)					
+s1	\N	1
+}	[2]	2
+\N	\N	\N
+\N	\N	\N
+\N	[3]	\N

--- a/tests/queries/0_stateless/02240_tskv_schema_inference_bug.sh
+++ b/tests/queries/0_stateless/02240_tskv_schema_inference_bug.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tags: no-parallel, no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+USER_FILES_PATH=$(clickhouse-client --query "select _path,_file from file('nonexist.txt', 'CSV', 'val1 char')" 2>&1 | grep Exception | awk '{gsub("/nonexist.txt","",$9); print $9}')
+FILE_NAME=test_02240.data
+DATA_FILE=${USER_FILES_PATH:?}/$FILE_NAME
+
+touch $DATA_FILE
+
+echo -e 'a=1\tb=s1\tc=\N
+c=[2]\ta=2\tb=\N}
+
+a=\N
+c=[3]\ta=\N'  > $DATA_FILE
+$CLICKHOUSE_CLIENT --max_read_buffer_size=4 -q "desc file('$FILE_NAME', 'TSKV')"
+$CLICKHOUSE_CLIENT --max_read_buffer_size=4 -q "select * from file('$FILE_NAME', 'TSKV')"
+


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix schema inference for TSKV format while using small max_read_buffer_size.
