### PR TITLE
Added an ability to specify cluster secret in replicated database

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -90,7 +90,7 @@ DatabaseReplicated::DatabaseReplicated(
         zookeeper_path = "/" + zookeeper_path;
 
     if (!db_settings.collection_name.value.empty())
-        fillClusterAuthInfo(db_settings.collection_name.value, context_->getConfigRef());    
+        fillClusterAuthInfo(db_settings.collection_name.value, context_->getConfigRef());
 }
 
 String DatabaseReplicated::getFullReplicaName() const
@@ -219,7 +219,7 @@ void DatabaseReplicated::fillClusterAuthInfo(String collection_name, const Poco:
 
     if (!config_ref.has(config_prefix))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "There is no collection named `{}` in config", collection_name);
-    
+
     cluster_auth_info.cluster_username = config_ref.getString(config_prefix + ".cluster_username", "");
     cluster_auth_info.cluster_password = config_ref.getString(config_prefix + ".cluster_password", "");
     cluster_auth_info.cluster_secret = config_ref.getString(config_prefix + ".cluster_secret", "");

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -208,7 +208,7 @@ ClusterPtr DatabaseReplicated::getClusterImpl() const
         treat_local_port_as_remote,
         cluster_auth_info.cluster_secure_connection,
         /*priority=*/1,
-        getDatabaseName(),
+        database_name,
         cluster_auth_info.cluster_secret);
 }
 

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -88,6 +88,9 @@ DatabaseReplicated::DatabaseReplicated(
     /// If zookeeper chroot prefix is used, path should start with '/', because chroot concatenates without it.
     if (zookeeper_path.front() != '/')
         zookeeper_path = "/" + zookeeper_path;
+
+    if (!db_settings.collection_name.value.empty())
+        fillClusterAuthInfo(db_settings.collection_name.value, context_->getConfigRef());    
 }
 
 String DatabaseReplicated::getFullReplicaName() const
@@ -191,22 +194,36 @@ ClusterPtr DatabaseReplicated::getClusterImpl() const
         shards.back().emplace_back(unescapeForFileName(host_port));
     }
 
-    String username = db_settings.cluster_username;
-    String password = db_settings.cluster_password;
     UInt16 default_port = getContext()->getTCPPort();
-    bool secure = db_settings.cluster_secure_connection;
 
     bool treat_local_as_remote = false;
     bool treat_local_port_as_remote = getContext()->getApplicationType() == Context::ApplicationType::LOCAL;
     return std::make_shared<Cluster>(
         getContext()->getSettingsRef(),
         shards,
-        username,
-        password,
+        cluster_auth_info.cluster_username,
+        cluster_auth_info.cluster_password,
         default_port,
         treat_local_as_remote,
         treat_local_port_as_remote,
-        secure);
+        cluster_auth_info.cluster_secure_connection,
+        /*priority=*/1,
+        getDatabaseName(),
+        cluster_auth_info.cluster_secret);
+}
+
+
+void DatabaseReplicated::fillClusterAuthInfo(String collection_name, const Poco::Util::AbstractConfiguration & config_ref)
+{
+    const auto & config_prefix = fmt::format("named_collections.{}", collection_name);
+
+    if (!config_ref.has(config_prefix))
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "There is no collection named `{}` in config", collection_name);
+    
+    cluster_auth_info.cluster_username = config_ref.getString(config_prefix + ".cluster_username", "");
+    cluster_auth_info.cluster_password = config_ref.getString(config_prefix + ".cluster_password", "");
+    cluster_auth_info.cluster_secret = config_ref.getString(config_prefix + ".cluster_secret", "");
+    cluster_auth_info.cluster_secure_connection = config_ref.getBool(config_prefix + ".cluster_secure_connection", false);
 }
 
 void DatabaseReplicated::tryConnectToZooKeeperAndInitDatabase(bool force_attach)

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -77,10 +77,10 @@ private:
 
     struct 
     {
-        String cluster_username;
+        String cluster_username{"default"};
         String cluster_password;
         String cluster_secret;
-        bool cluster_secure_connection;
+        bool cluster_secure_connection{false};
     } cluster_auth_info;
 
     void fillClusterAuthInfo(String collection_name, const Poco::Util::AbstractConfiguration & config);

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -75,7 +75,7 @@ private:
     bool createDatabaseNodesInZooKeeper(const ZooKeeperPtr & current_zookeeper);
     void createReplicaNodesInZooKeeper(const ZooKeeperPtr & current_zookeeper);
 
-    struct 
+    struct
     {
         String cluster_username{"default"};
         String cluster_password;

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -75,6 +75,16 @@ private:
     bool createDatabaseNodesInZooKeeper(const ZooKeeperPtr & current_zookeeper);
     void createReplicaNodesInZooKeeper(const ZooKeeperPtr & current_zookeeper);
 
+    struct 
+    {
+        String cluster_username;
+        String cluster_password;
+        String cluster_secret;
+        bool cluster_secure_connection;
+    } cluster_auth_info;
+
+    void fillClusterAuthInfo(String collection_name, const Poco::Util::AbstractConfiguration & config);
+
     void checkQueryValid(const ASTPtr & query, ContextPtr query_context) const;
 
     void recoverLostReplica(const ZooKeeperPtr & current_zookeeper, UInt32 our_log_ptr, UInt32 max_log_ptr);

--- a/src/Databases/DatabaseReplicatedSettings.h
+++ b/src/Databases/DatabaseReplicatedSettings.h
@@ -8,12 +8,10 @@ namespace DB
 class ASTStorage;
 
 #define LIST_OF_DATABASE_REPLICATED_SETTINGS(M) \
-    M(Float, max_broken_tables_ratio, 0.5, "Do not recover replica automatically if the ratio of staled tables to all tables is greater", 0) \
+    M(Float,  max_broken_tables_ratio, 0.5, "Do not recover replica automatically if the ratio of staled tables to all tables is greater", 0) \
     M(UInt64, max_replication_lag_to_enqueue, 10, "Replica will throw exception on attempt to execute query if its replication lag greater", 0) \
     M(UInt64, wait_entry_commited_timeout_sec, 3600, "Replicas will try to cancel query if timeout exceed, but initiator host has not executed it yet", 0) \
-    M(String, cluster_username, "default", "Username to use when connecting to hosts of cluster", 0) \
-    M(String, cluster_password, "", "Password to use when connecting to hosts of cluster", 0) \
-    M(Bool, cluster_secure_connection, false, "Enable TLS when connecting to hosts of cluster", 0) \
+    M(String, collection_name, "", "A name of a collection defined in server's config where all info for cluster authentication is defined", 0) \
 
 DECLARE_SETTINGS_TRAITS(DatabaseReplicatedSettingsTraits, LIST_OF_DATABASE_REPLICATED_SETTINGS)
 

--- a/src/Databases/DatabaseReplicatedSettings.h
+++ b/src/Databases/DatabaseReplicatedSettings.h
@@ -7,24 +7,12 @@ namespace DB
 
 class ASTStorage;
 
-#define CONTEMPORARY_DATABASE_REPLICATED_SETTINGS(M) \
+#define LIST_OF_DATABASE_REPLICATED_SETTINGS(M) \
     M(Float,  max_broken_tables_ratio, 0.5, "Do not recover replica automatically if the ratio of staled tables to all tables is greater", 0) \
     M(UInt64, max_replication_lag_to_enqueue, 10, "Replica will throw exception on attempt to execute query if its replication lag greater", 0) \
     M(UInt64, wait_entry_commited_timeout_sec, 3600, "Replicas will try to cancel query if timeout exceed, but initiator host has not executed it yet", 0) \
     M(String, collection_name, "", "A name of a collection defined in server's config where all info for cluster authentication is defined", 0) \
 
-#define MAKE_OBSOLETE_REPLICATED_DATABASE_SETTING(M, TYPE, NAME, DEFAULT) \
-    M(TYPE, NAME, DEFAULT, "Obsolete setting, does nothing.", BaseSettingsHelpers::Flags::OBSOLETE)
-
-#define OBSOLETE_DATABASE_REPLICATED_SETTINGS(M) \
-    /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
-    MAKE_OBSOLETE_REPLICATED_DATABASE_SETTING(M, String, cluster_username, "") \
-    MAKE_OBSOLETE_REPLICATED_DATABASE_SETTING(M, String, cluster_password, "") \
-    MAKE_OBSOLETE_REPLICATED_DATABASE_SETTING(M, Bool, cluster_secure_connection, false) \
-
-#define LIST_OF_DATABASE_REPLICATED_SETTINGS(M)    \
-    CONTEMPORARY_DATABASE_REPLICATED_SETTINGS(M)   \
-    OBSOLETE_DATABASE_REPLICATED_SETTINGS(M)       \
 
 DECLARE_SETTINGS_TRAITS(DatabaseReplicatedSettingsTraits, LIST_OF_DATABASE_REPLICATED_SETTINGS)
 

--- a/src/Databases/DatabaseReplicatedSettings.h
+++ b/src/Databases/DatabaseReplicatedSettings.h
@@ -7,11 +7,24 @@ namespace DB
 
 class ASTStorage;
 
-#define LIST_OF_DATABASE_REPLICATED_SETTINGS(M) \
+#define CONTEMPORARY_DATABASE_REPLICATED_SETTINGS(M) \
     M(Float,  max_broken_tables_ratio, 0.5, "Do not recover replica automatically if the ratio of staled tables to all tables is greater", 0) \
     M(UInt64, max_replication_lag_to_enqueue, 10, "Replica will throw exception on attempt to execute query if its replication lag greater", 0) \
     M(UInt64, wait_entry_commited_timeout_sec, 3600, "Replicas will try to cancel query if timeout exceed, but initiator host has not executed it yet", 0) \
     M(String, collection_name, "", "A name of a collection defined in server's config where all info for cluster authentication is defined", 0) \
+
+#define MAKE_OBSOLETE_REPLICATED_DATABASE_SETTING(M, TYPE, NAME, DEFAULT) \
+    M(TYPE, NAME, DEFAULT, "Obsolete setting, does nothing.", BaseSettingsHelpers::Flags::OBSOLETE)
+
+#define OBSOLETE_DATABASE_REPLICATED_SETTINGS(M) \
+    /** Obsolete settings that do nothing but left for compatibility reasons. Remove each one after half a year of obsolescence. */ \
+    MAKE_OBSOLETE_REPLICATED_DATABASE_SETTING(M, String, cluster_username, "") \
+    MAKE_OBSOLETE_REPLICATED_DATABASE_SETTING(M, String, cluster_password, "") \
+    MAKE_OBSOLETE_REPLICATED_DATABASE_SETTING(M, Bool, cluster_secure_connection, false) \
+
+#define LIST_OF_DATABASE_REPLICATED_SETTINGS(M)    \
+    CONTEMPORARY_DATABASE_REPLICATED_SETTINGS(M)   \
+    OBSOLETE_DATABASE_REPLICATED_SETTINGS(M)       \
 
 DECLARE_SETTINGS_TRAITS(DatabaseReplicatedSettingsTraits, LIST_OF_DATABASE_REPLICATED_SETTINGS)
 

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -132,7 +132,9 @@ Cluster::Address::Address(
     bool secure_,
     Int64 priority_,
     UInt32 shard_index_,
-    UInt32 replica_index_)
+    UInt32 replica_index_,
+    String cluster_name_,
+    String cluster_secret_)
     : user(user_), password(password_)
 {
     bool can_be_local = true;
@@ -164,6 +166,8 @@ Cluster::Address::Address(
     is_local = can_be_local && isLocal(clickhouse_port);
     shard_index = shard_index_;
     replica_index = replica_index_;
+    cluster = cluster_name_;
+    cluster_secret = cluster_secret_;
 }
 
 
@@ -537,9 +541,13 @@ Cluster::Cluster(
     bool treat_local_as_remote,
     bool treat_local_port_as_remote,
     bool secure,
-    Int64 priority)
+    Int64 priority,
+    String cluster_name,
+    String cluster_secret)
 {
     UInt32 current_shard_num = 1;
+
+    secret = cluster_secret;
 
     for (const auto & shard : names)
     {
@@ -554,7 +562,9 @@ Cluster::Cluster(
                 secure,
                 priority,
                 current_shard_num,
-                current.size() + 1);
+                current.size() + 1,
+                cluster_name,
+                cluster_secret);
 
         addresses_with_failover.emplace_back(current);
 
@@ -689,6 +699,9 @@ Cluster::Cluster(Cluster::ReplicasAsShardsTag, const Cluster & from, const Setti
             shards_info.emplace_back(std::move(info));
         }
     }
+
+    /// TODO: Investigate more what is missing
+    secret = from.secret;
 
     initMisc();
 }

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -700,8 +700,8 @@ Cluster::Cluster(Cluster::ReplicasAsShardsTag, const Cluster & from, const Setti
         }
     }
 
-    /// TODO: Investigate more what is missing
     secret = from.secret;
+    name = from.name;
 
     initMisc();
 }
@@ -716,6 +716,9 @@ Cluster::Cluster(Cluster::SubclusterTag, const Cluster & from, const std::vector
         if (!from.addresses_with_failover.empty())
             addresses_with_failover.emplace_back(from.addresses_with_failover.at(index));
     }
+
+    secret = from.secret;
+    name = from.name;
 
     initMisc();
 }

--- a/src/Interpreters/Cluster.h
+++ b/src/Interpreters/Cluster.h
@@ -55,7 +55,9 @@ public:
         bool treat_local_as_remote,
         bool treat_local_port_as_remote,
         bool secure = false,
-        Int64 priority = 1);
+        Int64 priority = 1,
+        String cluster_name = "",
+        String cluster_secret = "");
 
     Cluster(const Cluster &)= delete;
     Cluster & operator=(const Cluster &) = delete;
@@ -127,7 +129,9 @@ public:
             bool secure_ = false,
             Int64 priority_ = 1,
             UInt32 shard_index_ = 0,
-            UInt32 replica_index_ = 0);
+            UInt32 replica_index_ = 0,
+            String cluster_name = "",
+            String cluster_secret_ = "");
 
         /// Returns 'escaped_host_name:port'
         String toString() const;


### PR DESCRIPTION
Changelog category (leave one):

- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added an ability to specify cluster secret in replicated database.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
