### PR TITLE
Fix race in zero copy replication

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7715,7 +7715,12 @@ void StorageReplicatedMergeTree::createZeroCopyLockNode(const zkutil::ZooKeeperP
     {
         try
         {
-            zookeeper->createAncestors(zookeeper_node);
+            /// Ephemeral locks can be created only when we fetch shared data.
+            /// So it never require to create ancestors. If we create them
+            /// race condition with source replica drop is possible.
+            if (mode == zkutil::CreateMode::Persistent)
+                zookeeper->createAncestors(zookeeper_node);
+
             if (replace_existing_lock && zookeeper->exists(zookeeper_node))
             {
                 Coordination::Requests ops;


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug in S3 zero-copy replication which can lead to errors like `Found parts with the same min block and with the same max block as the missing part` after concurrent fetch/drop table.

Test report: https://s3.amazonaws.com/clickhouse-test-reports/35275/a7298a98b9cfe3a2a76e7bbaf1ea71b4a7008e28/stateless_tests__release__s3_storage__actions_/runlog.log