### PR TITLE
Add more checks with remoteHostsFilter

### DIFF
--- a/src/Dictionaries/CassandraDictionarySource.cpp
+++ b/src/Dictionaries/CassandraDictionarySource.cpp
@@ -25,9 +25,10 @@ void registerDictionarySourceCassandra(DictionarySourceFactory & factory)
 #if USE_CASSANDRA
     setupCassandraDriverLibraryLogging(CASS_LOG_INFO);
 
-    global_context->getRemoteHostFilter().checkHostAndPort(config.getString(config_prefix + ".host"), toString(config.getUInt(config_prefix + ".port", 0)));
+    auto source_config_prefix = config_prefix + ".cassandra";
+    global_context->getRemoteHostFilter().checkHostAndPort(config.getString(source_config_prefix + ".host"), toString(config.getUInt(source_config_prefix + ".port", 0)));
 
-    return std::make_unique<CassandraDictionarySource>(dict_struct, config, config_prefix + ".cassandra", sample_block);
+    return std::make_unique<CassandraDictionarySource>(dict_struct, config, source_config_prefix, sample_block);
 #else
     throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
         "Dictionary source of type `cassandra` is disabled because ClickHouse was built without cassandra support.");

--- a/src/Dictionaries/CassandraDictionarySource.cpp
+++ b/src/Dictionaries/CassandraDictionarySource.cpp
@@ -18,7 +18,7 @@ void registerDictionarySourceCassandra(DictionarySourceFactory & factory)
                                    [[maybe_unused]] const Poco::Util::AbstractConfiguration & config,
                                    [[maybe_unused]] const std::string & config_prefix,
                                    [[maybe_unused]] Block & sample_block,
-                                                    ContextPtr global_context,
+                                   [[maybe_unused]] ContextPtr global_context,
                                                     const std::string & /* default_database */,
                                                     bool /*created_from_ddl*/) -> DictionarySourcePtr
     {

--- a/src/Dictionaries/RedisDictionarySource.cpp
+++ b/src/Dictionaries/RedisDictionarySource.cpp
@@ -8,6 +8,7 @@
 #include <Poco/Redis/Command.h>
 #include <Poco/Redis/Type.h>
 #include <Poco/Util/AbstractConfiguration.h>
+#include <Interpreters/Context.h>
 
 #include <IO/WriteHelpers.h>
 
@@ -40,15 +41,20 @@ namespace DB
                                     const Poco::Util::AbstractConfiguration & config,
                                     const String & config_prefix,
                                     Block & sample_block,
-                                    ContextPtr /* global_context */,
+                                    ContextPtr global_context,
                                     const std::string & /* default_database */,
                                     bool /* created_from_ddl */) -> DictionarySourcePtr {
 
             auto redis_config_prefix = config_prefix + ".redis";
+
+            auto host = config.getString(redis_config_prefix + ".host");
+            auto port = config.getUInt(redis_config_prefix + ".port");
+            global_context->getRemoteHostFilter().checkHostAndPort(host, toString(port));
+
             RedisDictionarySource::Configuration configuration =
             {
-                .host = config.getString(redis_config_prefix + ".host"),
-                .port = static_cast<UInt16>(config.getUInt(redis_config_prefix + ".port")),
+                .host = host,
+                .port = static_cast<UInt16>(port),
                 .db_index = config.getUInt(redis_config_prefix + ".db_index", 0),
                 .password = config.getString(redis_config_prefix + ".password", ""),
                 .storage_type = parseStorageType(config.getString(redis_config_prefix + ".storage_type", "")),

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -90,6 +90,8 @@ StorageRabbitMQ::StorageRabbitMQ(
         , is_attach(is_attach_)
 {
     auto parsed_address = parseAddress(getContext()->getMacros()->expand(rabbitmq_settings->rabbitmq_host_port), 5672);
+    context_->getRemoteHostFilter().checkHostAndPort(parsed_address.first, toString(parsed_address.second));
+
     auto rabbitmq_username = rabbitmq_settings->rabbitmq_username.value;
     auto rabbitmq_password = rabbitmq_settings->rabbitmq_password.value;
     configuration =

--- a/src/Storages/StorageMongoDB.cpp
+++ b/src/Storages/StorageMongoDB.cpp
@@ -156,6 +156,8 @@ StorageMongoDBConfiguration StorageMongoDB::getConfiguration(ASTs engine_args, C
 
     }
 
+    context->getRemoteHostFilter().checkHostAndPort(configuration.host, toString(configuration.port));
+
     return configuration;
 }
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


For s3, hive, hdfs such checks already exist.