### PR TITLE
Fix clang-tidy

### DIFF
--- a/src/Storages/System/StorageSystemPartsBase.cpp
+++ b/src/Storages/System/StorageSystemPartsBase.cpp
@@ -26,7 +26,7 @@ namespace ErrorCodes
     extern const int TABLE_IS_DROPPED;
 }
 
-bool StorageSystemPartsBase::hasStateColumn(const Names & column_names, const StorageSnapshotPtr & storage_snapshot) const
+bool StorageSystemPartsBase::hasStateColumn(const Names & column_names, const StorageSnapshotPtr & storage_snapshot)
 {
     bool has_state_column = false;
     Names real_column_names;

--- a/src/Storages/System/StorageSystemPartsBase.h
+++ b/src/Storages/System/StorageSystemPartsBase.h
@@ -70,7 +70,7 @@ public:
     bool isSystemStorage() const override { return true; }
 
 private:
-    bool hasStateColumn(const Names & column_names, const StorageSnapshotPtr & storage_snapshot) const;
+    static bool hasStateColumn(const Names & column_names, const StorageSnapshotPtr & storage_snapshot);
 
 protected:
     const FormatSettings format_settings;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)