### PR TITLE
Fix logic for --no-prestable

### DIFF
--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -100,10 +100,10 @@ class Release:
             if self.release_type in self.BIG:
                 # Checkout to the commit, it will provide the correct current version
                 if with_prestable:
-                    logging.info("Skipping prestable stage")
-                else:
                     with self.prestable():
                         logging.info("Prestable part of the releasing is done")
+                else:
+                    logging.info("Skipping prestable stage")
 
                 with self.testing():
                     logging.info("Testing part of the releasing is done")


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reverse `--no-prestable` key to match the logic