### PR TITLE
Replace more uses of std::enable_if for SFINAE by concepts

### DIFF
--- a/src/Columns/ColumnArray.h
+++ b/src/Columns/ColumnArray.h
@@ -60,7 +60,8 @@ public:
         return ColumnArray::create(nested_column->assumeMutable());
     }
 
-    template <typename ... Args, typename = typename std::enable_if<IsMutableColumns<Args ...>::value>::type>
+    template <typename ... Args>
+    requires (IsMutableColumns<Args ...>::value)
     static MutablePtr create(Args &&... args) { return Base::create(std::forward<Args>(args)...); }
 
     /** On the index i there is an offset to the beginning of the i + 1 -th element. */

--- a/src/Columns/ColumnMap.h
+++ b/src/Columns/ColumnMap.h
@@ -36,7 +36,8 @@ public:
     static Ptr create(const ColumnPtr & column) { return ColumnMap::create(column->assumeMutable()); }
     static Ptr create(ColumnPtr && arg) { return create(arg); }
 
-    template <typename ... Args, typename = typename std::enable_if<IsMutableColumns<Args ...>::value>::type>
+    template <typename ... Args>
+    requires (IsMutableColumns<Args ...>::value)
     static MutablePtr create(Args &&... args) { return Base::create(std::forward<Args>(args)...); }
 
     std::string getName() const override;

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -41,7 +41,8 @@ public:
         return ColumnNullable::create(nested_column_->assumeMutable(), null_map_->assumeMutable());
     }
 
-    template <typename ... Args, typename = typename std::enable_if<IsMutableColumns<Args ...>::value>::type>
+    template <typename ... Args>
+    requires (IsMutableColumns<Args ...>::value)
     static MutablePtr create(Args &&... args) { return Base::create(std::forward<Args>(args)...); }
 
     const char * getFamilyName() const override { return "Nullable"; }

--- a/src/Columns/ColumnSparse.h
+++ b/src/Columns/ColumnSparse.h
@@ -37,7 +37,8 @@ public:
         return Base::create(values_->assumeMutable(), offsets_->assumeMutable(), size_);
     }
 
-    template <typename TColumnPtr, typename = typename std::enable_if<IsMutableColumns<TColumnPtr>::value>::type>
+    template <typename TColumnPtr>
+    requires IsMutableColumns<TColumnPtr>::value
     static MutablePtr create(TColumnPtr && values_, TColumnPtr && offsets_, size_t size_)
     {
         return Base::create(std::forward<TColumnPtr>(values_), std::forward<TColumnPtr>(offsets_), size_);
@@ -48,7 +49,8 @@ public:
         return Base::create(values_->assumeMutable());
     }
 
-    template <typename TColumnPtr, typename = typename std::enable_if<IsMutableColumns<TColumnPtr>::value>::type>
+    template <typename TColumnPtr>
+    requires IsMutableColumns<TColumnPtr>::value
     static MutablePtr create(TColumnPtr && values_)
     {
         return Base::create(std::forward<TColumnPtr>(values_));

--- a/src/Columns/ColumnTuple.h
+++ b/src/Columns/ColumnTuple.h
@@ -35,7 +35,8 @@ public:
     static Ptr create(const TupleColumns & columns);
     static Ptr create(Columns && arg) { return create(arg); }
 
-    template <typename Arg, typename = typename std::enable_if<std::is_rvalue_reference<Arg &&>::value>::type>
+    template <typename Arg>
+    requires std::is_rvalue_reference_v<Arg &&>
     static MutablePtr create(Arg && arg) { return Base::create(std::forward<Arg>(arg)); }
 
     std::string getName() const override;

--- a/src/Common/Dwarf.cpp
+++ b/src/Common/Dwarf.cpp
@@ -122,7 +122,8 @@ const uint32_t kMaxAbbreviationEntries = 1000;
 
 // Read (bitwise) one object of type T
 template <typename T>
-std::enable_if_t<std::is_trivial_v<T> && std::is_standard_layout_v<T>, T> read(std::string_view & sp)
+requires std::is_trivial_v<T> && std::is_standard_layout_v<T>
+T read(std::string_view & sp)
 {
     SAFE_CHECK(sp.size() >= sizeof(T), "underflow");
     T x;

--- a/src/Common/HashTable/Hash.h
+++ b/src/Common/HashTable/Hash.h
@@ -73,8 +73,8 @@ inline DB::UInt64 intHashCRC32(DB::UInt64 x, DB::UInt64 updated_value)
 }
 
 template <typename T>
-inline typename std::enable_if<(sizeof(T) > sizeof(DB::UInt64)), DB::UInt64>::type
-intHashCRC32(const T & x, DB::UInt64 updated_value)
+requires (sizeof(T) > sizeof(DB::UInt64))
+inline DB::UInt64 intHashCRC32(const T & x, DB::UInt64 updated_value)
 {
     const auto * begin = reinterpret_cast<const char *>(&x);
     for (size_t i = 0; i < sizeof(T); i += sizeof(UInt64))
@@ -155,7 +155,8 @@ inline UInt32 updateWeakHash32(const DB::UInt8 * pos, size_t size, DB::UInt32 up
 }
 
 template <typename T>
-inline size_t DefaultHash64(std::enable_if_t<(sizeof(T) <= sizeof(UInt64)), T> key)
+requires (sizeof(T) <= sizeof(UInt64))
+inline size_t DefaultHash64(T key)
 {
     union
     {
@@ -169,7 +170,8 @@ inline size_t DefaultHash64(std::enable_if_t<(sizeof(T) <= sizeof(UInt64)), T> k
 
 
 template <typename T>
-inline size_t DefaultHash64(std::enable_if_t<(sizeof(T) > sizeof(UInt64)), T> key)
+requires (sizeof(T) > sizeof(UInt64))
+inline size_t DefaultHash64(T key)
 {
     if constexpr (is_big_int_v<T> && sizeof(T) == 16)
     {
@@ -217,7 +219,8 @@ struct DefaultHash<T>
 template <typename T> struct HashCRC32;
 
 template <typename T>
-inline size_t hashCRC32(std::enable_if_t<(sizeof(T) <= sizeof(UInt64)), T> key)
+requires (sizeof(T) <= sizeof(UInt64))
+inline size_t hashCRC32(T key)
 {
     union
     {
@@ -230,7 +233,8 @@ inline size_t hashCRC32(std::enable_if_t<(sizeof(T) <= sizeof(UInt64)), T> key)
 }
 
 template <typename T>
-inline size_t hashCRC32(std::enable_if_t<(sizeof(T) > sizeof(UInt64)), T> key)
+requires (sizeof(T) > sizeof(UInt64))
+inline size_t hashCRC32(T key)
 {
     return intHashCRC32(key, -1);
 }

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -1036,14 +1036,16 @@ public:
         return const_cast<std::decay_t<decltype(*this)> *>(this)->find(x, hash_value);
     }
 
-    std::enable_if_t<Grower::performs_linear_probing_with_single_step, bool>
-    ALWAYS_INLINE erase(const Key & x)
+    template <typename Grower_ = Grower>
+    requires (Grower_::performs_linear_probing_with_single_step)
+    bool ALWAYS_INLINE erase(const Key & x)
     {
         return erase(x, hash(x));
     }
 
-    std::enable_if_t<Grower::performs_linear_probing_with_single_step, bool>
-    ALWAYS_INLINE erase(const Key & x, size_t hash_value)
+    template <typename Grower_ = Grower>
+    requires (Grower_::performs_linear_probing_with_single_step)
+    bool ALWAYS_INLINE erase(const Key & x, size_t hash_value)
     {
         /** Deletion from open addressing hash table without tombstones
           *

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -1036,16 +1036,14 @@ public:
         return const_cast<std::decay_t<decltype(*this)> *>(this)->find(x, hash_value);
     }
 
-    template <typename Grower_ = Grower>
-    requires (Grower_::performs_linear_probing_with_single_step)
-    bool ALWAYS_INLINE erase(const Key & x)
+    std::enable_if_t<Grower::performs_linear_probing_with_single_step, bool>
+    ALWAYS_INLINE erase(const Key & x)
     {
         return erase(x, hash(x));
     }
 
-    template <typename Grower_ = Grower>
-    requires (Grower_::performs_linear_probing_with_single_step)
-    bool ALWAYS_INLINE erase(const Key & x, size_t hash_value)
+    std::enable_if_t<Grower::performs_linear_probing_with_single_step, bool>
+    ALWAYS_INLINE erase(const Key & x, size_t hash_value)
     {
         /** Deletion from open addressing hash table without tombstones
           *

--- a/src/Common/IntervalTree.h
+++ b/src/Common/IntervalTree.h
@@ -129,7 +129,7 @@ public:
 
     IntervalTree() { nodes.resize(1); }
 
-    template <typename TValue = Value, std::enable_if_t<std::is_same_v<TValue, IntervalTreeVoidValue>, bool> = true>
+    template <typename TValue = Value>
     requires std::is_same_v<Value, IntervalTreeVoidValue>
     ALWAYS_INLINE bool emplace(Interval interval)
     {
@@ -157,19 +157,22 @@ public:
         return true;
     }
 
-    template <typename TValue = Value, std::enable_if_t<std::is_same_v<TValue, IntervalTreeVoidValue>, bool> = true>
+    template <typename TValue = Value>
+    requires std::is_same_v<TValue, IntervalTreeVoidValue>
     bool insert(Interval interval)
     {
         return emplace(interval);
     }
 
-    template <typename TValue = Value, std::enable_if_t<!std::is_same_v<TValue, IntervalTreeVoidValue>, bool> = true>
+    template <typename TValue = Value>
+    requires (!std::is_same_v<TValue, IntervalTreeVoidValue>)
     bool insert(Interval interval, const Value & value)
     {
         return emplace(interval, value);
     }
 
-    template <typename TValue = Value, std::enable_if_t<!std::is_same_v<TValue, IntervalTreeVoidValue>, bool> = true>
+    template <typename TValue = Value>
+    requires (!std::is_same_v<TValue, IntervalTreeVoidValue>)
     bool insert(Interval interval, Value && value)
     {
         return emplace(interval, std::move(value));

--- a/src/Common/mysqlxx/mysqlxx/Value.h
+++ b/src/Common/mysqlxx/mysqlxx/Value.h
@@ -259,7 +259,8 @@ namespace details
 {
 // To avoid stack overflow when converting to type with no appropriate c-tor,
 // resulting in endless recursive calls from `Value::get<T>()` to `Value::operator T()` to `Value::get<T>()` to ...
-template <typename T, typename std::enable_if_t<std::is_constructible_v<T, Value>>>
+template <typename T>
+requires std::is_constructible_v<T, Value>
 inline T contructFromValue(const Value & val)
 {
     return T(val);

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -240,7 +240,8 @@ template <> struct NearestFieldTypeImpl<AggregateFunctionStateData> { using Type
 
 // For enum types, use the field type that corresponds to their underlying type.
 template <typename T>
-struct NearestFieldTypeImpl<T, std::enable_if_t<std::is_enum_v<T>>>
+requires std::is_enum_v<T>
+struct NearestFieldTypeImpl<T>
 {
     using Type = NearestFieldType<std::underlying_type_t<T>>;
 };
@@ -669,7 +670,8 @@ private:
     }
 
     template <typename CharT>
-    std::enable_if_t<sizeof(CharT) == 1> assignString(const CharT * data, size_t size)
+    requires (sizeof(CharT) == 1)
+    void assignString(const CharT * data, size_t size)
     {
         assert(which == Types::String);
         String * ptr = reinterpret_cast<String *>(&storage);
@@ -704,7 +706,8 @@ private:
     }
 
     template <typename CharT>
-    std::enable_if_t<sizeof(CharT) == 1> create(const CharT * data, size_t size)
+    requires (sizeof(CharT) == 1)
+    void create(const CharT * data, size_t size)
     {
         new (&storage) String(reinterpret_cast<const char *>(data), size);
         which = Types::String;

--- a/src/Core/MultiEnum.h
+++ b/src/Core/MultiEnum.h
@@ -17,7 +17,8 @@ struct MultiEnum
         : MultiEnum((toBitFlag(v) | ... | 0u))
     {}
 
-    template <typename ValueType, typename = std::enable_if_t<std::is_convertible_v<ValueType, StorageType>>>
+    template <typename ValueType>
+    requires std::is_convertible_v<ValueType, StorageType>
     constexpr explicit MultiEnum(ValueType v)
         : bitset(v)
     {

--- a/src/IO/ReadBufferFromMemory.h
+++ b/src/IO/ReadBufferFromMemory.h
@@ -12,7 +12,8 @@ namespace DB
 class ReadBufferFromMemory : public SeekableReadBuffer
 {
 public:
-    template <typename CharT, typename = std::enable_if_t<sizeof(CharT) == 1>>
+    template <typename CharT>
+    requires (sizeof(CharT) == 1)
     ReadBufferFromMemory(const CharT * buf, size_t size)
         : SeekableReadBuffer(const_cast<char *>(reinterpret_cast<const char *>(buf)), size, 0) {}
 

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -869,8 +869,8 @@ inline void writeDateTimeUnixTimestamp(DateTime64 datetime64, UInt32 scale, Writ
 
 /// Methods for output in binary format.
 template <typename T>
-inline std::enable_if_t<is_arithmetic_v<T>, void>
-writeBinary(const T & x, WriteBuffer & buf) { writePODBinary(x, buf); }
+requires is_arithmetic_v<T>
+inline void writeBinary(const T & x, WriteBuffer & buf) { writePODBinary(x, buf); }
 
 inline void writeBinary(const String & x, WriteBuffer & buf) { writeStringBinary(x, buf); }
 inline void writeBinary(const StringRef & x, WriteBuffer & buf) { writeStringBinary(x, buf); }
@@ -988,8 +988,8 @@ void writeText(Decimal<T> x, UInt32 scale, WriteBuffer & ostr, bool trailing_zer
 
 /// String, date, datetime are in single quotes with C-style escaping. Numbers - without.
 template <typename T>
-inline std::enable_if_t<is_arithmetic_v<T>, void>
-writeQuoted(const T & x, WriteBuffer & buf) { writeText(x, buf); }
+requires is_arithmetic_v<T>
+inline void writeQuoted(const T & x, WriteBuffer & buf) { writeText(x, buf); }
 
 inline void writeQuoted(const String & x, WriteBuffer & buf) { writeQuotedString(x, buf); }
 
@@ -1021,8 +1021,8 @@ inline void writeQuoted(const UUID & x, WriteBuffer & buf)
 
 /// String, date, datetime are in double quotes with C-style escaping. Numbers - without.
 template <typename T>
-inline std::enable_if_t<is_arithmetic_v<T>, void>
-writeDoubleQuoted(const T & x, WriteBuffer & buf) { writeText(x, buf); }
+requires is_arithmetic_v<T>
+inline void writeDoubleQuoted(const T & x, WriteBuffer & buf) { writeText(x, buf); }
 
 inline void writeDoubleQuoted(const String & x, WriteBuffer & buf) { writeDoubleQuotedString(x, buf); }
 
@@ -1054,8 +1054,8 @@ inline void writeDoubleQuoted(const UUID & x, WriteBuffer & buf)
 
 /// String - in double quotes and with CSV-escaping; date, datetime - in double quotes. Numbers - without.
 template <typename T>
-inline std::enable_if_t<is_arithmetic_v<T>, void>
-writeCSV(const T & x, WriteBuffer & buf) { writeText(x, buf); }
+requires is_arithmetic_v<T>
+inline void writeCSV(const T & x, WriteBuffer & buf) { writeText(x, buf); }
 
 inline void writeCSV(const String & x, WriteBuffer & buf) { writeCSVString<>(x, buf); }
 inline void writeCSV(const LocalDate & x, WriteBuffer & buf) { writeDoubleQuoted(x, buf); }
@@ -1124,8 +1124,8 @@ inline void writeNullTerminatedString(const String & s, WriteBuffer & buffer)
 }
 
 template <typename T>
-inline std::enable_if_t<is_arithmetic_v<T> && (sizeof(T) <= 8), void>
-writeBinaryBigEndian(T x, WriteBuffer & buf)    /// Assuming little endian architecture.
+requires is_arithmetic_v<T> && (sizeof(T) <= 8)
+inline void writeBinaryBigEndian(T x, WriteBuffer & buf)    /// Assuming little endian architecture.
 {
     if constexpr (sizeof(x) == 2)
         x = __builtin_bswap16(x);
@@ -1138,8 +1138,8 @@ writeBinaryBigEndian(T x, WriteBuffer & buf)    /// Assuming little endian archi
 }
 
 template <typename T>
-inline std::enable_if_t<is_big_int_v<T>, void>
-writeBinaryBigEndian(const T & x, WriteBuffer & buf)    /// Assuming little endian architecture.
+requires is_big_int_v<T>
+inline void writeBinaryBigEndian(const T & x, WriteBuffer & buf)    /// Assuming little endian architecture.
 {
     for (size_t i = 0; i != std::size(x.items); ++i)
     {


### PR DESCRIPTION
- enable_if is usually regarded as fragile and unreadable
- C++20 concepts are much easier to read and produce more expressive error messages

- this is follow-up to PR #35347 but this time, most of the remaining and more complex usages of enable_if in the codebase were replaced

Changelog category (leave one):
- Not for changelog (changelog entry is not required)