### PR TITLE
Support uuid for postgres engines

### DIFF
--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -8,6 +8,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypesDecimal.h>
+#include <DataTypes/DataTypeUUID.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <boost/algorithm/string/split.hpp>
@@ -97,6 +98,8 @@ static DataTypePtr convertPostgreSQLDataType(String & type, Fn<void()> auto && r
         res = std::make_shared<DataTypeDateTime64>(6);
     else if (type == "date")
         res = std::make_shared<DataTypeDate>();
+    else if (type == "uuid")
+        res = std::make_shared<DataTypeUUID>();
     else if (type.starts_with("numeric"))
     {
         /// Numeric and decimal will both end up here as numeric. If it has type and precision,

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -468,6 +468,17 @@ def test_datetime64(started_cluster):
     assert(result.strip() == '1960-01-01 20:00:00.000000')
 
 
+def test_uuid(started_cluster):
+    cursor = started_cluster.postgres_conn.cursor()
+    cursor.execute("drop table if exists test")
+    cursor.execute("create table test (u uuid)")
+    cursor.execute("""CREATE EXTENSION IF NOT EXISTS "uuid-ossp";""")
+    cursor.execute("insert into test select uuid_generate_v1();")
+
+    result = node1.query("select toTypeName(u) from postgresql(postgres1, table='test')")
+    assert(result.strip() == 'Nullable(UUID)')
+
+
 if __name__ == '__main__':
     cluster.start()
     input("Cluster created, press any key to destroy...")


### PR DESCRIPTION
Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support uuid for postgres engines. Closes https://github.com/ClickHouse/ClickHouse/issues/35384.