### PR TITLE
Disable long-running (>30) fast tests

### DIFF
--- a/tests/queries/0_stateless/00183_skip_unavailable_shards.sql
+++ b/tests/queries/0_stateless/00183_skip_unavailable_shards.sql
@@ -1,4 +1,4 @@
--- Tags: shard
+-- Tags: shard, no-fasttest
 
 SET send_logs_level = 'fatal';
 SELECT count() FROM remote('{127,1}.0.0.{2,3}', system.one) SETTINGS skip_unavailable_shards = 1;

--- a/tests/queries/0_stateless/01014_lazy_database_concurrent_recreate_reattach_and_show_tables.sh
+++ b/tests/queries/0_stateless/01014_lazy_database_concurrent_recreate_reattach_and_show_tables.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01034_move_partition_from_table_zookeeper.sh
+++ b/tests/queries/0_stateless/01034_move_partition_from_table_zookeeper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: zookeeper
+# Tags: zookeeper, no-fasttest
 
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=none
 

--- a/tests/queries/0_stateless/01035_concurrent_move_partition_from_table_zookeeper.sh
+++ b/tests/queries/0_stateless/01035_concurrent_move_partition_from_table_zookeeper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-parallel
+# Tags: zookeeper, no-parallel, no-fasttest
 
 set -e
 

--- a/tests/queries/0_stateless/01114_database_atomic.sh
+++ b/tests/queries/0_stateless/01114_database_atomic.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
+# Tag no-fasttest: 45 seconds running
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01287_max_execution_speed.sql
+++ b/tests/queries/0_stateless/01287_max_execution_speed.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 SET min_execution_speed = 100000000000, timeout_before_checking_execution_speed = 0.1;
 SELECT count() FROM system.numbers; -- { serverError 160 }
 SELECT 'Ok (1)';

--- a/tests/queries/0_stateless/01593_concurrent_alter_mutations_kill.sh
+++ b/tests/queries/0_stateless/01593_concurrent_alter_mutations_kill.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
+++ b/tests/queries/0_stateless/01599_multiline_input_and_singleline_comments.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/expect -f
+# Tags: no-fasttest
+# Tag no-fasttest: 180 seconds running
 
 log_user 0
 set timeout 60

--- a/tests/queries/0_stateless/02015_shard_crash_clang_12_build.sh
+++ b/tests/queries/0_stateless/02015_shard_crash_clang_12_build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: shard
+# Tags: shard, no-fasttest
 
 # This test reproduces crash in case of insufficient coroutines stack size
 

--- a/tests/queries/0_stateless/02100_multiple_hosts_command_line_set.sh
+++ b/tests/queries/0_stateless/02100_multiple_hosts_command_line_set.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02122_parallel_formatting.sh
+++ b/tests/queries/0_stateless/02122_parallel_formatting.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
All disabled tests run longer than 30 seconds

After patch:

```
2022-03-18 19:53:34 Using queries from '/ClickHouse/tests/queries' directory
2022-03-18 19:59:26 All tests have finished
```

Before:

```
2022-03-18 19:40:33 Using queries from '/ClickHouse/tests/queries' directory
2022-03-18 19:51:36 All tests have finished.
```

5 minutes less