### PR TITLE
Fix test_keeper_back_to_back duplicate error

### DIFF
--- a/tests/integration/test_keeper_back_to_back/test.py
+++ b/tests/integration/test_keeper_back_to_back/test.py
@@ -139,7 +139,7 @@ def assert_eq_stats(stat1, stat2):
     assert stat1.version == stat2.version
     assert stat1.cversion == stat2.cversion
     assert stat1.aversion == stat2.aversion
-    assert stat1.aversion == stat2.aversion
+    assert stat1.ephemeralOwner == stat2.ephemeralOwner
     assert stat1.dataLength == stat2.dataLength
     assert stat1.numChildren == stat2.numChildren
 


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix copypaste error for clickhouse-keeper test.

