### PR TITLE
Fix null pointer of TreeRewriterResult::storage_snapshot

### DIFF
--- a/src/Interpreters/TreeOptimizer.cpp
+++ b/src/Interpreters/TreeOptimizer.cpp
@@ -751,7 +751,7 @@ void TreeOptimizer::apply(ASTPtr & query, TreeRewriterResult & result,
     if (settings.convert_query_to_cnf)
         converted_to_cnf = convertQueryToCNF(select_query);
 
-    if (converted_to_cnf && settings.optimize_using_constraints)
+    if (converted_to_cnf && settings.optimize_using_constraints && result.storage_snapshot)
     {
         optimizeWithConstraints(select_query, result.aliases, result.source_columns_set,
             tables_with_columns, result.storage_snapshot->metadata, settings.optimize_append_index);


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix failed tests in: https://s3.amazonaws.com/clickhouse-test-reports/35422/32348779fd0bac5276727cfc01e75c625ecc69b9/fuzzer_astfuzzerubsan,actions//report.html
