### PR TITLE
Remove old Playground

### DIFF
--- a/docs/en/getting-started/playground.md
+++ b/docs/en/getting-started/playground.md
@@ -5,30 +5,19 @@ toc_title: Playground
 
 # ClickHouse Playground {#clickhouse-playground}
 
-!!! warning "Warning"
-    This service is deprecated and will be replaced in foreseeable future.
-
-[ClickHouse Playground](https://play.clickhouse.com) allows people to experiment with ClickHouse by running queries instantly, without setting up their server or cluster.
-Several example datasets are available in Playground as well as sample queries that show ClickHouse features. There’s also a selection of ClickHouse LTS releases to experiment with.
+[ClickHouse Playground](https://play.clickhouse.com/play?user=play) allows people to experiment with ClickHouse by running queries instantly, without setting up their server or cluster.
+Several example datasets are available in Playground.
 
 You can make queries to Playground using any HTTP client, for example [curl](https://curl.haxx.se) or [wget](https://www.gnu.org/software/wget/), or set up a connection using [JDBC](../interfaces/jdbc.md) or [ODBC](../interfaces/odbc.md) drivers. More information about software products that support ClickHouse is available [here](../interfaces/index.md).
 
 ## Credentials {#credentials}
 
-| Parameter           | Value                                   |
-|:--------------------|:----------------------------------------|
-| HTTPS endpoint      | `https://play-api.clickhouse.com:8443` |
-| Native TCP endpoint | `play-api.clickhouse.com:9440`         |
-| User                | `playground`                            |
-| Password            | `clickhouse`                            |
-
-There are additional endpoints with specific ClickHouse releases to experiment with their differences (ports and user/password are the same as above):
-
--   20.3 LTS: `play-api-v20-3.clickhouse.com`
--   19.14 LTS: `play-api-v19-14.clickhouse.com`
-
-!!! note "Note"
-    All these endpoints require a secure TLS connection.
+| Parameter           | Value                              |
+|:--------------------|:-----------------------------------|
+| HTTPS endpoint      | `https://play.clickhouse.com:443/` |
+| Native TCP endpoint | `play.clickhouse.com:9440`         |
+| User                | `explorer` or `play`               |
+| Password            | (empty)                            |
 
 ## Limitations {#limitations}
 
@@ -37,23 +26,18 @@ The queries are executed as a read-only user. It implies some limitations:
 -   DDL queries are not allowed
 -   INSERT queries are not allowed
 
-The following settings are also enforced:
-
-- [max_result_bytes=10485760](../operations/settings/query-complexity/#max-result-bytes)
-- [max_result_rows=2000](../operations/settings/query-complexity/#setting-max_result_rows)
-- [result_overflow_mode=break](../operations/settings/query-complexity/#result-overflow-mode)
-- [max_execution_time=60000](../operations/settings/query-complexity/#max-execution-time)
+The service also have quotas on its usage.
 
 ## Examples {#examples}
 
 HTTPS endpoint example with `curl`:
 
 ``` bash
-curl "https://play-api.clickhouse.com:8443/?query=SELECT+'Play+ClickHouse\!';&user=playground&password=clickhouse&database=datasets"
+curl "https://play.clickhouse.com/?user=explorer" --data-binary "SELECT 'Play ClickHouse'"
 ```
 
 TCP endpoint example with [CLI](../interfaces/cli.md):
 
 ``` bash
-clickhouse client --secure -h play-api.clickhouse.com --port 9440 -u playground --password clickhouse -q "SELECT 'Play ClickHouse\!'"
+clickhouse client --secure --host play.clickhouse.com --user explorer
 ```

--- a/docs/ja/getting-started/playground.md
+++ b/docs/ja/getting-started/playground.md
@@ -5,58 +5,39 @@ toc_title: Playground
 
 # ClickHouse Playground {#clickhouse-playground}
 
-!!! warning "Warning"
-    This service is deprecated and will be replaced in foreseeable future.
+[ClickHouse Playground](https://play.clickhouse.com/play?user=play) allows people to experiment with ClickHouse by running queries instantly, without setting up their server or cluster.
+Several example datasets are available in Playground.
 
-[ClickHouse Playground](https://play.clickhouse.com) では、サーバーやクラスタを設定することなく、即座にクエリを実行して ClickHouse を試すことができます。
-いくつかの例のデータセットは、Playground だけでなく、ClickHouse の機能を示すサンプルクエリとして利用可能です. また、 ClickHouse の LTS リリースで試すこともできます。
+You can make queries to Playground using any HTTP client, for example [curl](https://curl.haxx.se) or [wget](https://www.gnu.org/software/wget/), or set up a connection using [JDBC](../interfaces/jdbc.md) or [ODBC](../interfaces/odbc.md) drivers. More information about software products that support ClickHouse is available [here](../interfaces/index.md).
 
-任意の HTTP クライアントを使用してプレイグラウンドへのクエリを作成することができます。例えば[curl](https://curl.haxx.se)、[wget](https://www.gnu.org/software/wget/)、[JDBC](../interfaces/jdbc.md)または[ODBC](../interfaces/odbc.md)ドライバを使用して接続を設定します。
-ClickHouse をサポートするソフトウェア製品の詳細情報は[こちら](../interfaces/index.md)をご覧ください。
+## Credentials {#credentials}
 
-## 資格情報 {#credentials}
+| Parameter           | Value                              |
+|:--------------------|:-----------------------------------|
+| HTTPS endpoint      | `https://play.clickhouse.com:443/` |
+| Native TCP endpoint | `play.clickhouse.com:9440`         |
+| User                | `explorer` or `play`               |
+| Password            | (empty)                            |
 
-| パラメータ                    | 値                                      |
-| :---------------------------- | :-------------------------------------- |
-| HTTPS エンドポイント          | `https://play-api.clickhouse.com:8443` |
-| ネイティブ TCP エンドポイント | `play-api.clickhouse.com:9440`         |
-| ユーザ名                      | `playgrounnd`                           |
-| パスワード                    | `clickhouse`                            |
+## Limitations {#limitations}
 
+The queries are executed as a read-only user. It implies some limitations:
 
-特定のClickHouseのリリースで試すために、追加のエンドポイントがあります。（ポートとユーザー/パスワードは上記と同じです）。
+-   DDL queries are not allowed
+-   INSERT queries are not allowed
 
-- 20.3 LTS: `play-api-v20-3.clickhouse.com`
-- 19.14 LTS: `play-api-v19-14.clickhouse.com`
+The service also have quotas on its usage.
 
-!!! note "備考"
-これらのエンドポイントはすべて、安全なTLS接続が必要です。
+## Examples {#examples}
 
-
-## 制限事項 {#limitations}
-
-クエリは読み取り専用のユーザとして実行されます。これにはいくつかの制限があります。
-
-- DDL クエリは許可されていません。
-- INSERT クエリは許可されていません。
-
-また、以下の設定がなされています。
-
-- [max_result_bytes=10485760](../operations/settings/query_complexity/#max-result-bytes)
-- [max_result_rows=2000](../operations/settings/query_complexity/#setting-max_result_rows)
-- [result_overflow_mode=break](../operations/settings/query_complexity/#result-overflow-mode)
-- [max_execution_time=60000](../operations/settings/query_complexity/#max-execution-time)
-
-## 例 {#examples}
-
-`curl` を用いて HTTPSエンドポイントへ接続する例:
+HTTPS endpoint example with `curl`:
 
 ``` bash
-curl "https://play-api.clickhouse.com:8443/?query=SELECT+'Play+ClickHouse\!';&user=playground&password=clickhouse&database=datasets"
+curl "https://play.clickhouse.com/?user=explorer" --data-binary "SELECT 'Play ClickHouse'"
 ```
 
-[CLI](../interfaces/cli.md) で TCP エンドポイントへ接続する例:
+TCP endpoint example with [CLI](../interfaces/cli.md):
 
 ``` bash
-clickhouse client --secure -h play-api.clickhouse.com --port 9440 -u playground --password clickhouse -q "SELECT 'Play ClickHouse\!'"
+clickhouse client --secure --host play.clickhouse.com --user explorer
 ```

--- a/docs/ru/getting-started/playground.md
+++ b/docs/ru/getting-started/playground.md
@@ -5,53 +5,39 @@ toc_title: Playground
 
 # ClickHouse Playground {#clickhouse-playground}
 
-!!! warning "Warning"
-    This service is deprecated and will be replaced in foreseeable future.
+[ClickHouse Playground](https://play.clickhouse.com/play?user=play) allows people to experiment with ClickHouse by running queries instantly, without setting up their server or cluster.
+Several example datasets are available in Playground.
 
-[ClickHouse Playground](https://play.clickhouse.com) позволяет пользователям экспериментировать с ClickHouse, мгновенно выполняя запросы без настройки своего сервера или кластера.
-В Playground доступны несколько тестовых массивов данных, а также примеры запросов, которые показывают возможности ClickHouse. Кроме того, вы можете выбрать LTS релиз ClickHouse, который хотите протестировать.
+You can make queries to Playground using any HTTP client, for example [curl](https://curl.haxx.se) or [wget](https://www.gnu.org/software/wget/), or set up a connection using [JDBC](../interfaces/jdbc.md) or [ODBC](../interfaces/odbc.md) drivers. More information about software products that support ClickHouse is available [here](../interfaces/index.md).
 
-Вы можете отправлять запросы к Playground с помощью любого HTTP-клиента, например [curl](https://curl.haxx.se) или [wget](https://www.gnu.org/software/wget/), также можно установить соединение с помощью драйверов [JDBC](../interfaces/jdbc.md) или [ODBC](../interfaces/odbc.md). Более подробная информация о программных продуктах, поддерживающих ClickHouse, доступна [здесь](../interfaces/index.md).
+## Credentials {#credentials}
 
-## Параметры доступа {#credentials}
+| Parameter           | Value                              |
+|:--------------------|:-----------------------------------|
+| HTTPS endpoint      | `https://play.clickhouse.com:443/` |
+| Native TCP endpoint | `play.clickhouse.com:9440`         |
+| User                | `explorer` or `play`               |
+| Password            | (empty)                            |
 
-| Параметр            | Значение                                |
-|:--------------------|:----------------------------------------|
-| Конечная точка HTTPS| `https://play-api.clickhouse.com:8443` |
-| Конечная точка TCP  | `play-api.clickhouse.com:9440`         |
-| Пользователь        | `playground`                            |
-| Пароль              | `clickhouse`                            |
+## Limitations {#limitations}
 
-Также можно подключаться к ClickHouse определённых релизов, чтобы протестировать их различия (порты и пользователь / пароль остаются неизменными):
+The queries are executed as a read-only user. It implies some limitations:
 
--   20.3 LTS: `play-api-v20-3.clickhouse.com`
--   19.14 LTS: `play-api-v19-14.clickhouse.com`
+-   DDL queries are not allowed
+-   INSERT queries are not allowed
 
-!!! note "Примечание"
-    Для всех этих конечных точек требуется безопасное соединение TLS.
+The service also have quotas on its usage.
 
-## Ограничения {#limitations}
+## Examples {#examples}
 
-Запросы выполняются под пользователем с правами `readonly`, для которого есть следующие ограничения:
-- запрещены DDL запросы
-- запрещены INSERT запросы
-
-Также установлены следующие опции:
-- [max_result_bytes=10485760](../operations/settings/query-complexity.md#max-result-bytes)
-- [max_result_rows=2000](../operations/settings/query-complexity.md#setting-max_result_rows)
-- [result_overflow_mode=break](../operations/settings/query-complexity.md#result-overflow-mode)
-- [max_execution_time=60000](../operations/settings/query-complexity.md#max-execution-time)
-
-## Примеры {#examples}
-
-Пример конечной точки HTTPS с `curl`:
+HTTPS endpoint example with `curl`:
 
 ``` bash
-curl "https://play-api.clickhouse.com:8443/?query=SELECT+'Play+ClickHouse\!';&user=playground&password=clickhouse&database=datasets"
+curl "https://play.clickhouse.com/?user=explorer" --data-binary "SELECT 'Play ClickHouse'"
 ```
 
-Пример конечной точки TCP с [CLI](../interfaces/cli.md):
+TCP endpoint example with [CLI](../interfaces/cli.md):
 
 ``` bash
-clickhouse client --secure -h play-api.clickhouse.com --port 9440 -u playground --password clickhouse -q "SELECT 'Play ClickHouse\!'"
+clickhouse client --secure --host play.clickhouse.com --user explorer
 ```

--- a/docs/zh/getting-started/playground.md
+++ b/docs/zh/getting-started/playground.md
@@ -3,62 +3,41 @@ toc_priority: 14
 toc_title: 体验平台
 ---
 
-# ClickHouse体验平台 {#clickhouse-playground}
+# ClickHouse Playground {#clickhouse-playground}
 
-!!! warning "Warning"
-    This service is deprecated and will be replaced in foreseeable future.
+[ClickHouse Playground](https://play.clickhouse.com/play?user=play) allows people to experiment with ClickHouse by running queries instantly, without setting up their server or cluster.
+Several example datasets are available in Playground.
 
-[ClickHouse体验平台](https://play.clickhouse.com?file=welcome) 允许人们通过即时运行查询来尝试ClickHouse，而无需设置他们的服务器或集群。
-
-体验平台中提供几个示例数据集以及显示ClickHouse特性的示例查询。还有一些ClickHouse LTS版本可供尝试。
-
-您可以使用任何HTTP客户端对ClickHouse体验平台进行查询，例如[curl](https://curl.haxx.se)或者[wget](https://www.gnu.org/software/wget/),或使用[JDBC](../interfaces/jdbc.md)或者[ODBC](../interfaces/odbc.md)驱动连接。关于支持ClickHouse的软件产品的更多信息详见[here](../interfaces/index.md).
+You can make queries to Playground using any HTTP client, for example [curl](https://curl.haxx.se) or [wget](https://www.gnu.org/software/wget/), or set up a connection using [JDBC](../interfaces/jdbc.md) or [ODBC](../interfaces/odbc.md) drivers. More information about software products that support ClickHouse is available [here](../interfaces/index.md).
 
 ## Credentials {#credentials}
 
-| 参数                 | 值                                      |
-|:--------------------|:----------------------------------------|
-| HTTPS端点           | `https://play-api.clickhouse.com:8443` |
-| TCP端点             | `play-api.clickhouse.com:9440`         |
-| 用户                | `playground`                            |
-| 密码                | `clickhouse`                            |
+| Parameter           | Value                              |
+|:--------------------|:-----------------------------------|
+| HTTPS endpoint      | `https://play.clickhouse.com:443/` |
+| Native TCP endpoint | `play.clickhouse.com:9440`         |
+| User                | `explorer` or `play`               |
+| Password            | (empty)                            |
 
-还有一些带有特定ClickHouse版本的附加信息来试验它们之间的差异(端口和用户/密码与上面相同):
+## Limitations {#limitations}
 
--   20.3 LTS: `play-api-v20-3.clickhouse.com`
--   19.14 LTS: `play-api-v19-14.clickhouse.com`
+The queries are executed as a read-only user. It implies some limitations:
 
-!!! note "注意"
-    所有这些端点都需要安全的TLS连接。
+-   DDL queries are not allowed
+-   INSERT queries are not allowed
 
-## 查询限制 {#limitations}
+The service also have quotas on its usage.
 
-查询以只读用户身份执行。 这意味着一些局限性:
+## Examples {#examples}
 
--   不允许DDL查询
--   不允许插入查询
-
-还强制执行以下设置:
-- [max_result_bytes=10485760](../operations/settings/query-complexity/#max-result-bytes)
-- [max_result_rows=2000](../operations/settings/query-complexity/#setting-max_result_rows)
-- [result_overflow_mode=break](../operations/settings/query-complexity/#result-overflow-mode)
-- [max_execution_time=60000](../operations/settings/query-complexity/#max-execution-time)
-
-ClickHouse体验还有如下：
-[ClickHouse管理服务](https://cloud.yandex.com/services/managed-clickhouse)
-实例托管 [Yandex云](https://cloud.yandex.com/)。
-更多信息 [云提供商](../commercial/cloud.md)。
-
-## 示例 {#examples}
-
-使用`curl`连接Https服务：
+HTTPS endpoint example with `curl`:
 
 ``` bash
-curl "https://play-api.clickhouse.com:8443/?query=SELECT+'Play+ClickHouse\!';&user=playground&password=clickhouse&database=datasets"
+curl "https://play.clickhouse.com/?user=explorer" --data-binary "SELECT 'Play ClickHouse'"
 ```
 
-TCP连接示例[CLI](../interfaces/cli.md):
+TCP endpoint example with [CLI](../interfaces/cli.md):
 
 ``` bash
-clickhouse client --secure -h play-api.clickhouse.com --port 9440 -u playground --password clickhouse -q "SELECT 'Play ClickHouse\!'"
+clickhouse client --secure --host play.clickhouse.com --user explorer
 ```


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)

This closes #10824.
