### PR TITLE
Add explicit table info to the scan node of query plan and pipeline

### DIFF
--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -1,17 +1,22 @@
-#include <Processors/QueryPlan/QueryPlan.h>
-#include <Processors/QueryPlan/IQueryPlanStep.h>
-#include <Processors/QueryPlan/ReadFromMergeTree.h>
-#include <QueryPipeline/QueryPipelineBuilder.h>
-#include <IO/WriteBuffer.h>
-#include <IO/Operators.h>
+#include <stack>
+
+#include <Common/JSONBuilder.h>
+
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/ArrayJoinAction.h>
-#include <stack>
+
+#include <IO/Operators.h>
+#include <IO/WriteBuffer.h>
+
+#include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
+#include <Processors/QueryPlan/IQueryPlanStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
-#include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
+#include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
-#include <Common/JSONBuilder.h>
+
+#include <QueryPipeline/QueryPipelineBuilder.h>
+
 
 namespace DB
 {

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -1,5 +1,6 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/IQueryPlanStep.h>
+#include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <IO/WriteBuffer.h>
 #include <IO/Operators.h>
@@ -387,7 +388,15 @@ void QueryPlan::explainPlan(WriteBuffer & buffer, const ExplainPlanOptions & opt
 
 static void explainPipelineStep(IQueryPlanStep & step, IQueryPlanStep::FormatSettings & settings)
 {
-    settings.out << String(settings.offset, settings.indent_char) << "(" << step.getName() << ")\n";
+    // Add explicit description to the scan node of pipeline.
+    if (ReadFromMergeTree::READ_FROM_MERGETREE_NAME == step.getName())
+    {
+        settings.out << String(settings.offset, settings.indent_char) << "(" << step.getName() << " " << step.getStepDescription() << ")\n";
+    }
+    else
+    {
+        settings.out << String(settings.offset, settings.indent_char) << "(" << step.getName() << ")\n";
+    }
     size_t current_offset = settings.offset;
     step.describePipeline(settings);
     if (current_offset == settings.offset)

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -388,15 +388,8 @@ void QueryPlan::explainPlan(WriteBuffer & buffer, const ExplainPlanOptions & opt
 
 static void explainPipelineStep(IQueryPlanStep & step, IQueryPlanStep::FormatSettings & settings)
 {
-    // Add explicit description to the scan node of pipeline.
-    if (ReadFromMergeTree::READ_FROM_MERGETREE_NAME == step.getName())
-    {
-        settings.out << String(settings.offset, settings.indent_char) << "(" << step.getName() << " " << step.getStepDescription() << ")\n";
-    }
-    else
-    {
-        settings.out << String(settings.offset, settings.indent_char) << "(" << step.getName() << ")\n";
-    }
+    settings.out << String(settings.offset, settings.indent_char) << "(" << step.getName() << ")\n";
+
     size_t current_offset = settings.offset;
     step.describePipeline(settings);
     if (current_offset == settings.offset)

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -45,8 +45,6 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-const std::string ReadFromMergeTree::READ_FROM_MERGETREE_NAME = "ReadFromMergeTree";
-
 static MergeTreeReaderSettings getMergeTreeReaderSettings(const ContextPtr & context)
 {
     const auto & settings = context->getSettingsRef();

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -45,6 +45,8 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+const std::string ReadFromMergeTree::READ_FROM_MERGETREE_NAME = "ReadFromMergeTree";
+
 static MergeTreeReaderSettings getMergeTreeReaderSettings(const ContextPtr & context)
 {
     const auto & settings = context->getSettingsRef();
@@ -112,6 +114,9 @@ ReadFromMergeTree::ReadFromMergeTree(
 
     if (enable_parallel_reading)
         read_task_callback = context->getMergeTreeReadTaskCallback();
+
+    /// Add explicit description.
+    setStepDescription(data.getStorageID().getFullNameNotQuoted());
 }
 
 Pipe ReadFromMergeTree::readFromPool(

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -100,8 +100,8 @@ public:
         bool enable_parallel_reading
     );
 
-    static const std::string READ_FROM_MERGETREE_NAME;
-    String getName() const override { return READ_FROM_MERGETREE_NAME; }
+    static constexpr auto name = "ReadFromMergeTree";
+    String getName() const override { return name; }
 
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -100,7 +100,8 @@ public:
         bool enable_parallel_reading
     );
 
-    String getName() const override { return "ReadFromMergeTree"; }
+    static const std::string READ_FROM_MERGETREE_NAME;
+    String getName() const override { return READ_FROM_MERGETREE_NAME; }
 
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
 

--- a/tests/queries/0_stateless/01562_optimize_monotonous_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01562_optimize_monotonous_functions_in_order_by.reference
@@ -9,7 +9,7 @@ Expression (Projection)
     Sorting (Sorting for ORDER BY)
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
-          ReadFromMergeTree
+          ReadFromMergeTree (default.test_order_by)
 SELECT
     timestamp,
     key
@@ -21,7 +21,7 @@ Expression (Projection)
     Sorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
-          ReadFromMergeTree
+          ReadFromMergeTree (default.test_order_by)
 SELECT
     timestamp,
     key
@@ -35,7 +35,7 @@ Expression (Projection)
     Sorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
-          ReadFromMergeTree
+          ReadFromMergeTree (default.test_order_by)
 SELECT
     timestamp,
     key

--- a/tests/queries/0_stateless/01576_alias_column_rewrite.reference
+++ b/tests/queries/0_stateless/01576_alias_column_rewrite.reference
@@ -26,35 +26,35 @@ Expression (Projection)
     Sorting (Sorting for ORDER BY)
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
-          ReadFromMergeTree
+          ReadFromMergeTree (default.test_table)
 Expression (Projection)
   Limit (preliminary LIMIT (without OFFSET))
     Sorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
-          ReadFromMergeTree
+          ReadFromMergeTree (default.test_table)
 Expression (Projection)
   Limit (preliminary LIMIT (without OFFSET))
     Sorting
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
-          ReadFromMergeTree
+          ReadFromMergeTree (default.test_table)
 optimize_aggregation_in_order
 Expression ((Projection + Before ORDER BY))
   Aggregating
     Expression (Before GROUP BY)
       SettingQuotaAndLimits (Set limits and quota after reading from storage)
-        ReadFromMergeTree
+        ReadFromMergeTree (default.test_table)
 Expression ((Projection + Before ORDER BY))
   Aggregating
     Expression (Before GROUP BY)
       SettingQuotaAndLimits (Set limits and quota after reading from storage)
-        ReadFromMergeTree
+        ReadFromMergeTree (default.test_table)
 Expression ((Projection + Before ORDER BY))
   Aggregating
     Expression (Before GROUP BY)
       SettingQuotaAndLimits (Set limits and quota after reading from storage)
-        ReadFromMergeTree
+        ReadFromMergeTree (default.test_table)
 second-index
 1
 1

--- a/tests/queries/0_stateless/01786_explain_merge_tree.reference
+++ b/tests/queries/0_stateless/01786_explain_merge_tree.reference
@@ -1,4 +1,4 @@
-      ReadFromMergeTree
+      ReadFromMergeTree (default.test_index)
       Indexes:
         MinMax
           Keys: 
@@ -32,6 +32,7 @@
           Granules: 1/2
 -----------------
                   "Node Type": "ReadFromMergeTree",
+                  "Description": "default.test_index",
                   "Indexes": [
                     {
                       "Type": "MinMax",
@@ -89,16 +90,16 @@
   }
 ]
 -----------------
-          ReadFromMergeTree
+          ReadFromMergeTree (default.test_index)
           ReadType: InOrder
           Parts: 1
           Granules: 3
 -----------------
-          ReadFromMergeTree
+          ReadFromMergeTree (default.test_index)
           ReadType: InReverseOrder
           Parts: 1
           Granules: 3
-      ReadFromMergeTree
+      ReadFromMergeTree (default.idx)
       Indexes:
         PrimaryKey
           Keys: 


### PR DESCRIPTION

Changelog category (leave one):
- Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add explicit table info to the scan node of query plan and pipeline


Detailed description:

`:) explain plan select * from table1 t1 left join table2 t2 on t1.name = t2.name;`

Before:
```
┌─explain──────────────────────────────────────────────────────────────────────────────────────┐
│ Expression ((Projection + Before ORDER BY))                                                  │
│   Join (JOIN)                                                                                │
│     Expression (Before JOIN)                                                                 │
│       SettingQuotaAndLimits (Set limits and quota after reading from storage)                │
│         ReadFromMergeTree                                                                    │
│     Expression ((Joined actions + (Rename joined columns + (Projection + Before ORDER BY)))) │
│       SettingQuotaAndLimits (Set limits and quota after reading from storage)                │
│         ReadFromMergeTree                                                                    │
└──────────────────────────────────────────────────────────────────────────────────────────────┘
```
After:
```
┌─explain──────────────────────────────────────────────────────────────────────────────────────┐
│ Expression ((Projection + Before ORDER BY))                                                  │
│   Join (JOIN)                                                                                │
│     Expression (Before JOIN)                                                                 │
│       SettingQuotaAndLimits (Set limits and quota after reading from storage)                │
│         ReadFromMergeTree (default.table1)                                                   │
│     Expression ((Joined actions + (Rename joined columns + (Projection + Before ORDER BY)))) │
│       SettingQuotaAndLimits (Set limits and quota after reading from storage)                │
│         ReadFromMergeTree (default.table2)                                                   │
└──────────────────────────────────────────────────────────────────────────────────────────────┘
```

:) explain pipeline select * from table1 t1 left join table2 t2 on t1.name = t2.name;
Before:
```
┌─explain──────────────────────────────────┐
│ (Expression)                             │
│ ExpressionTransform × 24                 │
│   (Join)                                 │
│   JoiningTransform × 24 2 → 1            │
│     Resize 1 → 24                        │
│       FillingRightJoinSide               │
│         Resize 24 → 1                    │
│           (Expression)                   │
│           ExpressionTransform × 24       │
│             (SettingQuotaAndLimits)      │
│               (ReadFromMergeTree)        │
│               MergeTreeThread × 24 0 → 1 │
│           (Expression)                   │
│           ExpressionTransform × 24       │
│             (SettingQuotaAndLimits)      │
│               (ReadFromMergeTree)        │
│               MergeTreeThread × 24 0 → 1 │
└──────────────────────────────────────────┘
```
After:
```
┌─explain──────────────────────────────────────────┐
│ (Expression)                                     │
│ ExpressionTransform × 24                         │
│   (Join)                                         │
│   JoiningTransform × 24 2 → 1                    │
│     Resize 1 → 24                                │
│       FillingRightJoinSide                       │
│         Resize 24 → 1                            │
│           (Expression)                           │
│           ExpressionTransform × 24               │
│             (SettingQuotaAndLimits)              │
│               (ReadFromMergeTree default.table1) │
│               MergeTreeThread × 24 0 → 1         │
│           (Expression)                           │
│           ExpressionTransform × 24               │
│             (SettingQuotaAndLimits)              │
│               (ReadFromMergeTree default.table2) │
│               MergeTreeThread × 24 0 → 1         │
└──────────────────────────────────────────────────┘
```



> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
