### PR TITLE
Explicitly set allow_introspection_functions to 0

### DIFF
--- a/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
+++ b/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
@@ -1,6 +1,6 @@
 -- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-cpu-aarch64
 
-
+SET allow_introspection_functions = 0;
 SELECT addressToLineWithInlines(1); -- { serverError 446 }
 
 SET allow_introspection_functions = 1;


### PR DESCRIPTION
I spent dozen of time trying to understand why this test doesn't work locally

Changelog category (leave one):
- Not for changelog (changelog entry is not required)