### PR TITLE
Support ZSTD compression for Arrow

### DIFF
--- a/contrib/arrow-cmake/CMakeLists.txt
+++ b/contrib/arrow-cmake/CMakeLists.txt
@@ -364,10 +364,8 @@ SET(ARROW_SRCS "${LIBRARY_DIR}/util/compression_snappy.cc" ${ARROW_SRCS})
 add_definitions(-DARROW_WITH_ZLIB)
 SET(ARROW_SRCS "${LIBRARY_DIR}/util/compression_zlib.cc" ${ARROW_SRCS})
 
-if (ARROW_WITH_ZSTD)
-    add_definitions(-DARROW_WITH_ZSTD)
-    SET(ARROW_SRCS "${LIBRARY_DIR}/util/compression_zstd.cc" ${ARROW_SRCS})
-endif ()
+add_definitions(-DARROW_WITH_ZSTD)
+SET(ARROW_SRCS "${LIBRARY_DIR}/util/compression_zstd.cc" ${ARROW_SRCS})
 
 
 add_library(_arrow ${ARROW_SRCS})
@@ -382,7 +380,6 @@ target_link_libraries(_arrow PRIVATE
     ch_contrib::lz4
     ch_contrib::snappy
     ch_contrib::zlib
-    ch_contrib::zstd
     ch_contrib::zstd
 )
 target_link_libraries(_arrow PUBLIC _orc)


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Accidentally ZSTD support for Arrow was not being built. This fixes #35283