### PR TITLE
Fetch submodules in parallel

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -178,7 +178,7 @@ function clone_submodules
         )
 
         git submodule sync
-        git submodule update --depth 1 --init "${SUBMODULES_TO_UPDATE[@]}"
+        git submodule update --jobs "$(nproc)" --depth 1 --init "${SUBMODULES_TO_UPDATE[@]}"
         git submodule foreach git reset --hard
         git submodule foreach git checkout @ -f
         git submodule foreach git clean -xfd


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fetching submodules in parallel in fasttets.

TODO: migrate checkout to a python script, think about reducing traffic by using `depth=0` only for release builds.