### PR TITLE
Fix ClickHouse name typo in caches.md

### DIFF
--- a/docs/en/operations/caches.md
+++ b/docs/en/operations/caches.md
@@ -5,7 +5,7 @@ toc_title: Caches
 
 # Cache Types {#cache-types}
 
-When performing queries, ClichHouse uses different caches.
+When performing queries, ClickHouse uses different caches.
 
 Main cache types:
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)
