### PR TITLE
Rename `yandexConsistentHash` to `kostikConsistentHash`

### DIFF
--- a/docs/zh/operations/system-tables/functions.md
+++ b/docs/zh/operations/system-tables/functions.md
@@ -15,7 +15,7 @@
 ```
 ┌─name─────────────────────┬─is_aggregate─┬─case_insensitive─┬─alias_to─┐
 │ sumburConsistentHash     │            0 │                0 │          │
-│ yandexConsistentHash     │            0 │                0 │          │
+│ kostikConsistentHash     │            0 │                0 │          │
 │ demangle                 │            0 │                0 │          │
 │ addressToLine            │            0 │                0 │          │
 │ JSONExtractRaw           │            0 │                0 │          │

--- a/src/Functions/kostikConsistentHash.cpp
+++ b/src/Functions/kostikConsistentHash.cpp
@@ -7,9 +7,9 @@ namespace DB
 {
 
 /// An O(1) time and space consistent hash algorithm by Konstantin Oblakov
-struct YandexConsistentHashImpl
+struct KostikConsistentHashImpl
 {
-    static constexpr auto name = "yandexConsistentHash";
+    static constexpr auto name = "kostikConsistentHash";
 
     using HashType = UInt64;
     /// Actually it supports UInt64, but it is efficient only if n <= 32768
@@ -23,12 +23,11 @@ struct YandexConsistentHashImpl
     }
 };
 
-using FunctionYandexConsistentHash = FunctionConsistentHashImpl<YandexConsistentHashImpl>;
+using FunctionKostikConsistentHash = FunctionConsistentHashImpl<KostikConsistentHashImpl>;
 
-void registerFunctionYandexConsistentHash(FunctionFactory & factory)
+void registerFunctionKostikConsistentHash(FunctionFactory & factory)
 {
-    factory.registerFunction<FunctionYandexConsistentHash>();
+    factory.registerFunction<FunctionKostikConsistentHash>();
 }
 
 }
-

--- a/src/Functions/kostikConsistentHash.cpp
+++ b/src/Functions/kostikConsistentHash.cpp
@@ -28,6 +28,7 @@ using FunctionKostikConsistentHash = FunctionConsistentHashImpl<KostikConsistent
 void registerFunctionKostikConsistentHash(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionKostikConsistentHash>();
+    factory.registerAlias("yandexConsistentHash", "kostikConsistentHash");
 }
 
 }

--- a/src/Functions/registerFunctionsConsistentHashing.cpp
+++ b/src/Functions/registerFunctionsConsistentHashing.cpp
@@ -2,12 +2,12 @@ namespace DB
 {
 class FunctionFactory;
 
-void registerFunctionYandexConsistentHash(FunctionFactory & factory);
+void registerFunctionKostikConsistentHash(FunctionFactory & factory);
 void registerFunctionJumpConsistentHash(FunctionFactory & factory);
 
 void registerFunctionsConsistentHashing(FunctionFactory & factory)
 {
-    registerFunctionYandexConsistentHash(factory);
+    registerFunctionKostikConsistentHash(factory);
     registerFunctionJumpConsistentHash(factory);
 }
 

--- a/tests/fuzz/all.dict
+++ b/tests/fuzz/all.dict
@@ -1459,7 +1459,7 @@
 "xor"
 "xxHash32"
 "xxHash64"
-"yandexConsistentHash"
+"kostikConsistentHash"
 "YEAR"
 "yearweek"
 "yesterday"

--- a/tests/fuzz/dictionaries/functions.dict
+++ b/tests/fuzz/dictionaries/functions.dict
@@ -26,7 +26,7 @@
 "toUnixTimestamp64Nano"
 "toUnixTimestamp64Micro"
 "jumpConsistentHash"
-"yandexConsistentHash"
+"kostikConsistentHash"
 "addressToSymbol"
 "toJSONString"
 "JSON_VALUE"

--- a/tests/integration/test_distributed_queries_stress/test.py
+++ b/tests/integration/test_distributed_queries_stress/test.py
@@ -67,10 +67,10 @@ def started_cluster():
             insert into data (key) select * from numbers(10);
 
             create table if not exists dist_one           as data engine=Distributed(one_shard, currentDatabase(), data, key);
-            create table if not exists dist_one_over_dist as data engine=Distributed(one_shard, currentDatabase(), dist_one, yandexConsistentHash(key, 2));
+            create table if not exists dist_one_over_dist as data engine=Distributed(one_shard, currentDatabase(), dist_one, kostikConsistentHash(key, 2));
 
             create table if not exists dist_two as data           engine=Distributed(two_shards, currentDatabase(), data, key);
-            create table if not exists dist_two_over_dist as data engine=Distributed(two_shards, currentDatabase(), dist_two, yandexConsistentHash(key, 2));
+            create table if not exists dist_two_over_dist as data engine=Distributed(two_shards, currentDatabase(), dist_two, kostikConsistentHash(key, 2));
             """
             )
         yield cluster

--- a/tests/performance/consistent_hashes.xml
+++ b/tests/performance/consistent_hashes.xml
@@ -3,7 +3,7 @@
        <substitution>
            <name>hash_func</name>
            <values>
-               <value>yandexConsistentHash</value>
+               <value>kostikConsistentHash</value>
                <value>jumpConsistentHash</value>
            </values>
        </substitution>

--- a/tests/queries/0_stateless/00580_consistent_hashing_functions.sql
+++ b/tests/queries/0_stateless/00580_consistent_hashing_functions.sql
@@ -1,6 +1,6 @@
 -- Tags: no-fasttest
 
 SELECT jumpConsistentHash(1, 1), jumpConsistentHash(42, 57), jumpConsistentHash(256, 1024), jumpConsistentHash(3735883980, 1), jumpConsistentHash(3735883980, 666), jumpConsistentHash(16045690984833335023, 255);
-SELECT yandexConsistentHash(16045690984833335023, 1), yandexConsistentHash(16045690984833335023, 2), yandexConsistentHash(16045690984833335023, 3), yandexConsistentHash(16045690984833335023, 4), yandexConsistentHash(16045690984833335023, 173), yandexConsistentHash(16045690984833335023, 255);
+SELECT kostikConsistentHash(16045690984833335023, 1), kostikConsistentHash(16045690984833335023, 2), kostikConsistentHash(16045690984833335023, 3), kostikConsistentHash(16045690984833335023, 4), kostikConsistentHash(16045690984833335023, 173), kostikConsistentHash(16045690984833335023, 255);
 SELECT jumpConsistentHash(intHash64(number), 787) FROM system.numbers LIMIT 1000000, 2;
-SELECT yandexConsistentHash(16045690984833335023+number-number, 120) FROM system.numbers LIMIT 1000000, 2;
+SELECT kostikConsistentHash(16045690984833335023+number-number, 120) FROM system.numbers LIMIT 1000000, 2;

--- a/tests/queries/0_stateless/00979_yandex_consistent_hash_fpe.sql
+++ b/tests/queries/0_stateless/00979_yandex_consistent_hash_fpe.sql
@@ -1,1 +1,1 @@
-SELECT yandexConsistentHash(-1, 40000); -- { serverError 36 }
+SELECT kostikConsistentHash(-1, 40000); -- { serverError 36 }


### PR DESCRIPTION
Changelog category (leave one):
- Backward Incompatible Change


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Function `yandexConsistentHash` (consistent hashing algorithm by Konstantin "kostik" Oblakov) is renamed to `kostikConsistentHash`. The old name is left as an alias for compatibility. Although this change is backward compatible, we may remove the alias in subsequent releases, that's why it's recommended to update the usages of this function in your apps.