### PR TITLE
Fix test `test_s3_zero_copy_replication`

### DIFF
--- a/tests/integration/test_s3_zero_copy_replication/test.py
+++ b/tests/integration/test_s3_zero_copy_replication/test.py
@@ -361,6 +361,7 @@ def test_s3_zero_copy_with_ttl_delete(cluster, large_data, iterations):
             )
 
         node1.query("OPTIMIZE TABLE ttl_delete_test FINAL")
+
         node1.query("SYSTEM SYNC REPLICA ttl_delete_test")
         node2.query("SYSTEM SYNC REPLICA ttl_delete_test")
 

--- a/tests/integration/test_s3_zero_copy_replication/test.py
+++ b/tests/integration/test_s3_zero_copy_replication/test.py
@@ -361,6 +361,7 @@ def test_s3_zero_copy_with_ttl_delete(cluster, large_data, iterations):
             )
 
         node1.query("OPTIMIZE TABLE ttl_delete_test FINAL")
+        node1.query("SYSTEM SYNC REPLICA ttl_delete_test")
         node2.query("SYSTEM SYNC REPLICA ttl_delete_test")
 
         if large_data:


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`OPTIMIZE TABLE ttl_delete_test FINAL` may do nothing due to `Cannot select parts for optimization: Part all_0_0_0 has already been assigned a merge into all_0_0_1` if TTL merge is already assigned, we should wait for `node1` to execute this merge