### PR TITLE
Don't run 01318_long_unsuccessful_mutation_zookeeper test in backward compatibility check

### DIFF
--- a/tests/queries/0_stateless/01318_long_unsuccessful_mutation_zookeeper.sh
+++ b/tests/queries/0_stateless/01318_long_unsuccessful_mutation_zookeeper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, zookeeper, no-parallel
+# Tags: long, zookeeper, no-parallel, no-backward-compatibility-check
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)
