### PR TITLE
Pin jinja2 to 3.0.3 to have working jinja2.contextfilter

### DIFF
--- a/docs/tools/requirements.txt
+++ b/docs/tools/requirements.txt
@@ -10,7 +10,7 @@ cssmin==0.2.0
 future==0.18.2
 htmlmin==0.1.12
 idna==2.10
-Jinja2>=3.0.3
+Jinja2==3.0.3
 jinja2-highlight==0.6.1
 jsmin==3.0.0
 livereload==2.6.3


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix docs building by pinning a Jinja2 to a previous stable version
