### PR TITLE
Functions calculation after sorting

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -1527,6 +1527,20 @@ ActionsDAG::SplitResult ActionsDAG::splitActionsBeforeArrayJoin(const NameSet & 
     return res;
 }
 
+ActionsDAG::SplitResult ActionsDAG::splitActionsBySortingDescription(const SortDescription & sort_description) const
+{
+    std::unordered_set<const Node *> split_nodes;
+    for (const auto & sort_column : sort_description)
+    {
+        const auto * node = tryFindInIndex(sort_column.column_name);
+        if (node)
+            split_nodes.insert(node);
+    }
+    auto res = split(split_nodes);
+    res.second->project_input = project_input;
+    return res;
+}
+
 ActionsDAG::SplitResult ActionsDAG::splitActionsForFilter(const std::string & column_name) const
 {
     const auto * node = tryFindInIndex(column_name);

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -1533,6 +1533,10 @@ ActionsDAG::SplitResult ActionsDAG::splitActionsBySortingDescription(const NameS
     for (const auto & sort_column : sort_columns)
         if (const auto * node = tryFindInIndex(sort_column))
             split_nodes.insert(node);
+        else
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR, "Sorting column {} wasn't found in the ActionsDAG's index. DAG:\n{}", sort_column, dumpDAG());
+
     auto res = split(split_nodes);
     res.second->project_input = project_input;
     return res;

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -1527,15 +1527,12 @@ ActionsDAG::SplitResult ActionsDAG::splitActionsBeforeArrayJoin(const NameSet & 
     return res;
 }
 
-ActionsDAG::SplitResult ActionsDAG::splitActionsBySortingDescription(const SortDescription & sort_description) const
+ActionsDAG::SplitResult ActionsDAG::splitActionsBySortingDescription(const NameSet & sort_columns) const
 {
     std::unordered_set<const Node *> split_nodes;
-    for (const auto & sort_column : sort_description)
-    {
-        const auto * node = tryFindInIndex(sort_column.column_name);
-        if (node)
+    for (const auto & sort_column : sort_columns)
+        if (const auto * node = tryFindInIndex(sort_column))
             split_nodes.insert(node);
-    }
     auto res = split(split_nodes);
     res.second->project_input = project_input;
     return res;

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -7,6 +7,8 @@
 
 #include "config_core.h"
 
+#include <Core/SortDescription.h>
+
 namespace DB
 {
 
@@ -273,6 +275,9 @@ public:
     /// Splits actions into two parts. First part has minimal size sufficient for calculation of column_name.
     /// Index of initial actions must contain column_name.
     SplitResult splitActionsForFilter(const std::string & column_name) const;
+
+    ///
+    SplitResult splitActionsBySortingDescription(const SortDescription & sort_description) const;
 
     /// Create actions which may calculate part of filter using only available_inputs.
     /// If nothing may be calculated, returns nullptr.

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -7,8 +7,6 @@
 
 #include "config_core.h"
 
-#include <Core/SortDescription.h>
-
 namespace DB
 {
 
@@ -276,8 +274,9 @@ public:
     /// Index of initial actions must contain column_name.
     SplitResult splitActionsForFilter(const std::string & column_name) const;
 
-    ///
-    SplitResult splitActionsBySortingDescription(const SortDescription & sort_description) const;
+    /// Splits actions into two parts. The first part contains all the calculations required to calculate sort_columns.
+    /// The second contains the rest.
+    SplitResult splitActionsBySortingDescription(const NameSet & sort_columns) const;
 
     /// Create actions which may calculate part of filter using only available_inputs.
     /// If nothing may be calculated, returns nullptr.

--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -44,16 +44,19 @@ size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &);
 /// May split FilterStep and push down only part of it.
 size_t tryPushDownFilter(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes);
 
+///
+size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes);
+
 inline const auto & getOptimizations()
 {
-    static const std::array<Optimization, 5> optimizations =
-    {{
+    static const std::array<Optimization, 6> optimizations = {{
         {tryLiftUpArrayJoin, "liftUpArrayJoin", &QueryPlanOptimizationSettings::optimize_plan},
         {tryPushDownLimit, "pushDownLimit", &QueryPlanOptimizationSettings::optimize_plan},
         {trySplitFilter, "splitFilter", &QueryPlanOptimizationSettings::optimize_plan},
         {tryMergeExpressions, "mergeExpressions", &QueryPlanOptimizationSettings::optimize_plan},
         {tryPushDownFilter, "pushDownFilter", &QueryPlanOptimizationSettings::filter_push_down},
-     }};
+        {tryExecuteFunctionsAfterSorting, "liftUpFunctions", &QueryPlanOptimizationSettings::optimize_plan},
+    }};
 
     return optimizations;
 }

--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -44,8 +44,8 @@ size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &);
 /// May split FilterStep and push down only part of it.
 size_t tryPushDownFilter(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes);
 
-/// Move ExpressionStep up if possible.
-/// May split ExpressionStep and lift up only part of it.
+/// Move ExpressionStep after SortingStep if possible.
+/// May split ExpressionStep and lift up only a part of it.
 size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes);
 
 inline const auto & getOptimizations()

--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -44,7 +44,8 @@ size_t tryMergeExpressions(QueryPlan::Node * parent_node, QueryPlan::Nodes &);
 /// May split FilterStep and push down only part of it.
 size_t tryPushDownFilter(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes);
 
-///
+/// Move ExpressionStep up if possible.
+/// May split ExpressionStep and lift up only part of it.
 size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes);
 
 inline const auto & getOptimizations()

--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -15,28 +15,12 @@ namespace ErrorCodes
 namespace
 {
 
-void swapSortingAndUnneededCalculations(DB::QueryPlan::Node * parent_node, DB::ActionsDAGPtr && unneeded_for_sorting)
+const DB::DataStream & getChildOutputStream(DB::QueryPlan::Node & node)
 {
-    DB::QueryPlan::Node * child_node = parent_node->children.front();
-
-    auto & parent_step = parent_node->step;
-    auto & child_step = child_node->step;
-    auto * sorting_step = typeid_cast<DB::SortingStep *>(parent_step.get());
-
-    // Sorting -> Expression
-    std::swap(parent_step, child_step);
-    // Expression -> Sorting
-
-    if (child_node->children.size() != 1)
-        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "SortingStep is expected to have only one input stream.");
-    sorting_step->updateInputStream(child_node->children.front()->step->getOutputStream());
-    auto input_header = sorting_step->getInputStreams().front().header;
-    sorting_step->updateOutputStream(std::move(input_header));
-
-    auto description = parent_node->step->getStepDescription();
-    parent_step = std::make_unique<DB::ExpressionStep>(child_step->getOutputStream(), std::move(unneeded_for_sorting));
-    parent_step->setStepDescription(description + " [lifted up part]");
-    // UnneededCalculations -> Sorting
+    if (node.children.size() != 1)
+        throw DB::Exception(
+            DB::ErrorCodes::LOGICAL_ERROR, "Node \"{}\" is expected to have only one child.", node.step->getStepDescription());
+    return node.children.front()->step->getOutputStream();
 }
 
 }
@@ -68,20 +52,26 @@ size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan:
     if (unneeded_for_sorting->trivial())
         return 0;
 
-    if (child_node->children.size() != 1)
-        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "ExpressionStep is expected to have only one input stream.");
-
     // Sorting (parent_node) -> Expression (child_node)
     auto & node_with_needed = nodes.emplace_back();
     std::swap(node_with_needed.children, child_node->children);
     child_node->children = {&node_with_needed};
-    node_with_needed.step
-        = std::make_unique<ExpressionStep>(node_with_needed.children.front()->step->getOutputStream(), std::move(needed_for_sorting));
-    node_with_needed.step->setStepDescription(child_step->getStepDescription());
 
+    node_with_needed.step = std::make_unique<ExpressionStep>(getChildOutputStream(node_with_needed), std::move(needed_for_sorting));
+    node_with_needed.step->setStepDescription(child_step->getStepDescription());
     // Sorting (parent_node) -> so far the origin Expression (child_node) -> NeededCalculations (node_with_needed)
-    swapSortingAndUnneededCalculations(parent_node, std::move(unneeded_for_sorting));
-    // UneededCalculations (child_node) -> Sorting (parent_node) -> NeededCalculations (node_with_needed)
+
+    std::swap(parent_step, child_step);
+    // so far the origin Expression (parent_node) -> Sorting (child_node) -> NeededCalculations (node_with_needed)
+
+    sorting_step->updateInputStream(getChildOutputStream(*child_node));
+    auto input_header = sorting_step->getInputStreams().at(0).header;
+    sorting_step->updateOutputStream(std::move(input_header));
+
+    auto description = parent_step->getStepDescription();
+    parent_step = std::make_unique<DB::ExpressionStep>(child_step->getOutputStream(), std::move(unneeded_for_sorting));
+    parent_step->setStepDescription(description + " [lifted up part]");
+    // UneededCalculations (parent_node) -> Sorting (child_node) -> NeededCalculations (node_with_needed)
 
     return 3;
 }

--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -9,7 +9,7 @@
 namespace DB::QueryPlanOptimizations
 {
 
-void swapSortingAndUnnecessaryCalculation(QueryPlan::Node * parent_node, ActionsDAGPtr && unneeded_for_sorting)
+void swapSortingAndUnneededCalculations(QueryPlan::Node * parent_node, ActionsDAGPtr && unneeded_for_sorting)
 {
     QueryPlan::Node * child_node = parent_node->children.front();
 
@@ -22,17 +22,11 @@ void swapSortingAndUnnecessaryCalculation(QueryPlan::Node * parent_node, Actions
     // Expression -> Sorting
 
     sorting_step->updateInputStream(child_node->children.at(0)->step->getOutputStream());
-    LOG_TRACE(
-        &Poco::Logger::get("Optimizer"), "New Sorting input header: {}", sorting_step->getInputStreams().at(0).header.dumpStructure());
     auto input_header = sorting_step->getInputStreams().at(0).header;
-    LOG_TRACE(&Poco::Logger::get("Optimizer"), "Old Sorting output header: {}", sorting_step->getOutputStream().header.dumpStructure());
     sorting_step->updateOutputStream(std::move(input_header));
-    LOG_TRACE(&Poco::Logger::get("Optimizer"), "New Sorting output header: {}", sorting_step->getOutputStream().header.dumpStructure());
+
     auto description = parent_node->step->getStepDescription();
     parent_step = std::make_unique<ExpressionStep>(child_step->getOutputStream(), std::move(unneeded_for_sorting));
-    LOG_TRACE(
-        &Poco::Logger::get("Optimizer"), "New Expression input header: {}", parent_step->getInputStreams().at(0).header.dumpStructure());
-    LOG_TRACE(&Poco::Logger::get("Optimizer"), "New Expression output header: {}", parent_step->getOutputStream().header.dumpStructure());
     parent_step->setStepDescription(description + " [lifted up part]");
     // UnneededCalculations -> Sorting
 }
@@ -55,35 +49,22 @@ size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan:
     NameSet sort_columns;
     for (const auto & col : sorting_step->getSortDescription())
         sort_columns.insert(col.column_name);
-    const auto & expression = expression_step->getExpression();
-    auto [needed_for_sorting, unneeded_for_sorting] = expression->splitActionsBySortingDescription(sort_columns);
-    LOG_TRACE(&Poco::Logger::get("Optimizer"), "Original Expression: {}", expression->dumpDAG());
-    LOG_TRACE(&Poco::Logger::get("Optimizer"), "Needed for Sorting: {}", needed_for_sorting->dumpDAG());
-    LOG_TRACE(&Poco::Logger::get("Optimizer"), "Unneeded for Sorting: {}", unneeded_for_sorting->dumpDAG());
-
-    auto description = child_step->getStepDescription();
+    auto [needed_for_sorting, unneeded_for_sorting] = expression_step->getExpression()->splitActionsBySortingDescription(sort_columns);
 
     // No calculations can be postponed.
     if (unneeded_for_sorting->trivial())
         return 0;
 
-    // Everything can be done after the sorting.
-    /*if (needed_for_sorting->trivial())
-    {
-        swapSortingAndUnnecessaryCalculation(parent_node, std::move(unneeded_for_sorting));
-        return 2;
-    }*/
-
     // Sorting (parent_node) -> Expression (child_node)
     auto & node_with_needed = nodes.emplace_back();
-    node_with_needed.children.swap(child_node->children);
-    child_node->children.emplace_back(&node_with_needed);
+    std::swap(node_with_needed.children, child_node->children);
+    child_node->children = {&node_with_needed};
     node_with_needed.step
         = std::make_unique<ExpressionStep>(node_with_needed.children.at(0)->step->getOutputStream(), std::move(needed_for_sorting));
-    node_with_needed.step->setStepDescription(std::move(description));
+    node_with_needed.step->setStepDescription(child_step->getStepDescription());
 
     // Sorting (parent_node) -> so far the origin Expression (child_node) -> NeededCalculations (node_with_needed)
-    swapSortingAndUnnecessaryCalculation(parent_node, std::move(unneeded_for_sorting));
+    swapSortingAndUnneededCalculations(parent_node, std::move(unneeded_for_sorting));
     // UneededCalculations (child_node) -> Sorting (parent_node) -> NeededCalculations (node_with_needed)
 
     return 3;

--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -9,7 +9,7 @@
 namespace DB::QueryPlanOptimizations
 {
 
-void swapSortingAndUnnecessaryCalculation(QueryPlan::Node * parent_node, ActionsDAGPtr && actions)
+void swapSortingAndUnnecessaryCalculation(QueryPlan::Node * parent_node, ActionsDAGPtr && unneeded_for_sorting)
 {
     QueryPlan::Node * child_node = parent_node->children.front();
 
@@ -17,14 +17,24 @@ void swapSortingAndUnnecessaryCalculation(QueryPlan::Node * parent_node, Actions
     auto & child_step = child_node->step;
     auto * sorting_step = typeid_cast<SortingStep *>(parent_step.get());
 
-    // Sorting -> UnnecessaryCalculations
+    // Sorting -> Expression
     std::swap(parent_step, child_step);
-    // UnnecessaryCalculations -> Sorting
+    // Expression -> Sorting
 
     sorting_step->updateInputStream(child_node->children.at(0)->step->getOutputStream());
-    auto input_header = child_step->getInputStreams().at(0).header;
+    LOG_TRACE(
+        &Poco::Logger::get("Optimizer"), "New Sorting input header: {}", sorting_step->getInputStreams().at(0).header.dumpStructure());
+    auto input_header = sorting_step->getInputStreams().at(0).header;
+    LOG_TRACE(&Poco::Logger::get("Optimizer"), "Old Sorting output header: {}", sorting_step->getOutputStream().header.dumpStructure());
     sorting_step->updateOutputStream(std::move(input_header));
-    parent_step = std::make_unique<ExpressionStep>(child_step->getOutputStream(), std::move(actions));
+    LOG_TRACE(&Poco::Logger::get("Optimizer"), "New Sorting output header: {}", sorting_step->getOutputStream().header.dumpStructure());
+    auto description = parent_node->step->getStepDescription();
+    parent_step = std::make_unique<ExpressionStep>(child_step->getOutputStream(), std::move(unneeded_for_sorting));
+    LOG_TRACE(
+        &Poco::Logger::get("Optimizer"), "New Expression input header: {}", parent_step->getInputStreams().at(0).header.dumpStructure());
+    LOG_TRACE(&Poco::Logger::get("Optimizer"), "New Expression output header: {}", parent_step->getOutputStream().header.dumpStructure());
+    parent_step->setStepDescription(description + " [lifted up part]");
+    // UnneededCalculations -> Sorting
 }
 
 size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes)
@@ -46,31 +56,35 @@ size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan:
     for (const auto & col : sorting_step->getSortDescription())
         sort_columns.insert(col.column_name);
     const auto & expression = expression_step->getExpression();
-    auto split_actions = expression->splitActionsBySortingDescription(sort_columns);
-    LOG_TRACE(&Poco::Logger::get("Optimizer"), "source: {}", expression->dumpDAG());
-    LOG_TRACE(&Poco::Logger::get("Optimizer"), "first: {}", split_actions.first->dumpDAG());
-    LOG_TRACE(&Poco::Logger::get("Optimizer"), "second: {}", split_actions.second->dumpDAG());
+    auto [needed_for_sorting, unneeded_for_sorting] = expression->splitActionsBySortingDescription(sort_columns);
+    LOG_TRACE(&Poco::Logger::get("Optimizer"), "Original Expression: {}", expression->dumpDAG());
+    LOG_TRACE(&Poco::Logger::get("Optimizer"), "Needed for Sorting: {}", needed_for_sorting->dumpDAG());
+    LOG_TRACE(&Poco::Logger::get("Optimizer"), "Unneeded for Sorting: {}", unneeded_for_sorting->dumpDAG());
+
+    auto description = child_step->getStepDescription();
 
     // No calculations can be postponed.
-    if (split_actions.second->trivial())
+    if (unneeded_for_sorting->trivial())
         return 0;
 
     // Everything can be done after the sorting.
-    if (split_actions.first->trivial())
+    /*if (needed_for_sorting->trivial())
     {
-        swapSortingAndUnnecessaryCalculation(parent_node, std::move(split_actions.second));
+        swapSortingAndUnnecessaryCalculation(parent_node, std::move(unneeded_for_sorting));
         return 2;
-    }
+    }*/
 
-    // Sorting -> Expression
-    auto & node = nodes.emplace_back();
-    node.children.swap(child_node->children);
-    child_node->children.emplace_back(&node);
-    node.step = std::make_unique<ExpressionStep>(node.children.at(0)->step->getOutputStream(), std::move(split_actions.first));
+    // Sorting (parent_node) -> Expression (child_node)
+    auto & node_with_needed = nodes.emplace_back();
+    node_with_needed.children.swap(child_node->children);
+    child_node->children.emplace_back(&node_with_needed);
+    node_with_needed.step
+        = std::make_unique<ExpressionStep>(node_with_needed.children.at(0)->step->getOutputStream(), std::move(needed_for_sorting));
+    node_with_needed.step->setStepDescription(std::move(description));
 
-    // Sorting (parent_node) -> UnnecessaryCalculations (child_node) -> NecessaryCalculations (node)
-    swapSortingAndUnnecessaryCalculation(parent_node, std::move(split_actions.second));
-    // UnnecessaryCalculations (child_node) -> Sorting (parent_node) -> NecessaryCalculations (node)
+    // Sorting (parent_node) -> so far the origin Expression (child_node) -> NeededCalculations (node_with_needed)
+    swapSortingAndUnnecessaryCalculation(parent_node, std::move(unneeded_for_sorting));
+    // UneededCalculations (child_node) -> Sorting (parent_node) -> NeededCalculations (node_with_needed)
 
     return 3;
 }

--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -2,34 +2,47 @@
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/SortingStep.h>
+#include <Common/Exception.h>
 
-#include <base/logger_useful.h>
-#include <Poco/Logger.h>
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+}
 
-namespace DB::QueryPlanOptimizations
+namespace
 {
 
-void swapSortingAndUnneededCalculations(QueryPlan::Node * parent_node, ActionsDAGPtr && unneeded_for_sorting)
+void swapSortingAndUnneededCalculations(DB::QueryPlan::Node * parent_node, DB::ActionsDAGPtr && unneeded_for_sorting)
 {
-    QueryPlan::Node * child_node = parent_node->children.front();
+    DB::QueryPlan::Node * child_node = parent_node->children.front();
 
     auto & parent_step = parent_node->step;
     auto & child_step = child_node->step;
-    auto * sorting_step = typeid_cast<SortingStep *>(parent_step.get());
+    auto * sorting_step = typeid_cast<DB::SortingStep *>(parent_step.get());
 
     // Sorting -> Expression
     std::swap(parent_step, child_step);
     // Expression -> Sorting
 
-    sorting_step->updateInputStream(child_node->children.at(0)->step->getOutputStream());
-    auto input_header = sorting_step->getInputStreams().at(0).header;
+    if (child_node->children.size() != 1)
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "SortingStep is expected to have only one input stream.");
+    sorting_step->updateInputStream(child_node->children.front()->step->getOutputStream());
+    auto input_header = sorting_step->getInputStreams().front().header;
     sorting_step->updateOutputStream(std::move(input_header));
 
     auto description = parent_node->step->getStepDescription();
-    parent_step = std::make_unique<ExpressionStep>(child_step->getOutputStream(), std::move(unneeded_for_sorting));
+    parent_step = std::make_unique<DB::ExpressionStep>(child_step->getOutputStream(), std::move(unneeded_for_sorting));
     parent_step->setStepDescription(description + " [lifted up part]");
     // UnneededCalculations -> Sorting
 }
+
+}
+
+namespace DB::QueryPlanOptimizations
+{
 
 size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes)
 {
@@ -55,12 +68,15 @@ size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan:
     if (unneeded_for_sorting->trivial())
         return 0;
 
+    if (child_node->children.size() != 1)
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "ExpressionStep is expected to have only one input stream.");
+
     // Sorting (parent_node) -> Expression (child_node)
     auto & node_with_needed = nodes.emplace_back();
     std::swap(node_with_needed.children, child_node->children);
     child_node->children = {&node_with_needed};
     node_with_needed.step
-        = std::make_unique<ExpressionStep>(node_with_needed.children.at(0)->step->getOutputStream(), std::move(needed_for_sorting));
+        = std::make_unique<ExpressionStep>(node_with_needed.children.front()->step->getOutputStream(), std::move(needed_for_sorting));
     node_with_needed.step->setStepDescription(child_step->getStepDescription());
 
     // Sorting (parent_node) -> so far the origin Expression (child_node) -> NeededCalculations (node_with_needed)

--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -42,11 +42,14 @@ size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan:
     if (!sorting_step || !expression_step)
         return 0;
 
-    const auto & sort_columns = sorting_step->getSortDescription();
+    NameSet sort_columns;
+    for (const auto & col : sorting_step->getSortDescription())
+        sort_columns.insert(col.column_name);
+
     const auto & expression = expression_step->getExpression();
 
     for (auto sc : sort_columns)
-        LOG_TRACE(&Poco::Logger::get("Optimizer"), "sort_columns: {}", sc.column_name);
+        LOG_TRACE(&Poco::Logger::get("Optimizer"), "sort_columns: {}", fmt::join(sort_columns, ", "));
 
     auto split_actions = expression->splitActionsBySortingDescription(sort_columns);
     LOG_TRACE(&Poco::Logger::get("Optimizer"), "source: {}", expression->dumpDAG());

--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -18,8 +18,7 @@ namespace
 const DB::DataStream & getChildOutputStream(DB::QueryPlan::Node & node)
 {
     if (node.children.size() != 1)
-        throw DB::Exception(
-            DB::ErrorCodes::LOGICAL_ERROR, "Node \"{}\" is expected to have only one child.", node.step->getStepDescription());
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Node \"{}\" is expected to have only one child.", node.step->getName());
     return node.children.front()->step->getOutputStream();
 }
 

--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -1,0 +1,80 @@
+#include <Interpreters/ActionsDAG.h>
+#include <Processors/QueryPlan/ExpressionStep.h>
+#include <Processors/QueryPlan/Optimizations/Optimizations.h>
+#include <Processors/QueryPlan/SortingStep.h>
+
+#include <base/logger_useful.h>
+#include <Poco/Logger.h>
+
+namespace DB::QueryPlanOptimizations
+{
+
+void swapSortingAndUnnecessaryCalculation(QueryPlan::Node * parent_node, ActionsDAGPtr && actions)
+{
+    QueryPlan::Node * child_node = parent_node->children.front();
+
+    auto & parent_step = parent_node->step;
+    auto & child_step = child_node->step;
+    auto * sorting_step = typeid_cast<SortingStep *>(parent_step.get());
+
+    // Sorting -> UnnecessaryCalculations
+    std::swap(parent_step, child_step);
+    // UnnecessaryCalculations -> Sorting
+
+    sorting_step->updateInputStream(child_node->children.at(0)->step->getOutputStream());
+    auto input_header = child_step->getInputStreams().at(0).header;
+    sorting_step->updateOutputStream(input_header);
+    parent_step = std::make_unique<ExpressionStep>(child_step->getOutputStream(), std::move(actions));
+}
+
+size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes)
+{
+    if (parent_node->children.size() != 1)
+        return 0;
+
+    QueryPlan::Node * child_node = parent_node->children.front();
+
+    auto & parent_step = parent_node->step;
+    auto & child_step = child_node->step;
+    auto * sorting_step = typeid_cast<SortingStep *>(parent_step.get());
+    auto * expression_step = typeid_cast<ExpressionStep *>(child_step.get());
+
+    if (!sorting_step || !expression_step)
+        return 0;
+
+    const auto & sort_columns = sorting_step->getSortDescription();
+    const auto & expression = expression_step->getExpression();
+
+    for (auto sc : sort_columns)
+        LOG_TRACE(&Poco::Logger::get("Optimizer"), "sort_columns: {}", sc.column_name);
+
+    auto split_actions = expression->splitActionsBySortingDescription(sort_columns);
+    LOG_TRACE(&Poco::Logger::get("Optimizer"), "source: {}", expression->dumpDAG());
+    LOG_TRACE(&Poco::Logger::get("Optimizer"), "first: {}", split_actions.first->dumpDAG());
+    LOG_TRACE(&Poco::Logger::get("Optimizer"), "second: {}", split_actions.second->dumpDAG());
+
+    // No calculations can be postponed.
+    if (split_actions.second->trivial())
+        return 0;
+
+    // Everything can be done after the sorting.
+    if (split_actions.first->trivial())
+    {
+        swapSortingAndUnnecessaryCalculation(parent_node, std::move(split_actions.second));
+        return 2;
+    }
+
+    // Sorting -> Expression
+    auto & node = nodes.emplace_back();
+
+    node.children.swap(child_node->children);
+    child_node->children.emplace_back(&node);
+
+    node.step = std::make_unique<ExpressionStep>(node.children.at(0)->step->getOutputStream(), std::move(split_actions.first));
+    // Sorting (parent_node) -> UnnecessaryCalculations (child_node) -> NecessaryCalculations (node)
+    swapSortingAndUnnecessaryCalculation(parent_node, std::move(split_actions.second));
+    // UnnecessaryCalculations (child_node) -> Sorting (parent_node) -> NecessaryCalculations (node)
+
+    return 3;
+}
+}

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -92,7 +92,7 @@ SortingStep::SortingStep(
 void SortingStep::updateInputStream(DataStream input_stream)
 {
     input_streams.clear();
-    input_streams.push_back(std::move(input_stream));
+    input_streams.emplace_back(std::move(input_stream));
 }
 
 void SortingStep::updateOutputStream(Block result_header)

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -1,11 +1,12 @@
+#include <stdexcept>
+#include <IO/Operators.h>
+#include <Processors/Merges/MergingSortedTransform.h>
 #include <Processors/QueryPlan/SortingStep.h>
-#include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Processors/Transforms/FinishSortingTransform.h>
+#include <Processors/Transforms/LimitsCheckingTransform.h>
 #include <Processors/Transforms/MergeSortingTransform.h>
 #include <Processors/Transforms/PartialSortingTransform.h>
-#include <Processors/Transforms/FinishSortingTransform.h>
-#include <Processors/Merges/MergingSortedTransform.h>
-#include <Processors/Transforms/LimitsCheckingTransform.h>
-#include <IO/Operators.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Common/JSONBuilder.h>
 
 namespace DB
@@ -86,6 +87,19 @@ SortingStep::SortingStep(
     /// TODO: check input_stream is partially sorted (each port) by the same description.
     output_stream->sort_description = result_description;
     output_stream->sort_mode = DataStream::SortMode::Stream;
+}
+
+void SortingStep::updateInputStream(const DataStream & input_stream)
+{
+    input_streams.clear();
+    input_streams.emplace_back(input_stream);
+}
+
+void SortingStep::updateOutputStream(Block result_header)
+{
+    if (input_streams.size() != 1)
+        throw std::runtime_error{"wasted"};
+    output_stream = createOutputStream(input_streams.at(0), result_header, getDataStreamTraits());
 }
 
 void SortingStep::updateLimit(size_t limit_)

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -98,6 +98,7 @@ void SortingStep::updateInputStream(DataStream input_stream)
 void SortingStep::updateOutputStream(Block result_header)
 {
     output_stream = createOutputStream(input_streams.front(), std::move(result_header), getDataStreamTraits());
+    updateDistinctColumns(output_stream->header, output_stream->distinct_columns);
 }
 
 void SortingStep::updateLimit(size_t limit_)

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -97,7 +97,7 @@ void SortingStep::updateInputStream(DataStream input_stream)
 
 void SortingStep::updateOutputStream(Block result_header)
 {
-    output_stream = createOutputStream(input_streams.front(), std::move(result_header), getDataStreamTraits());
+    output_stream = createOutputStream(input_streams.at(0), std::move(result_header), getDataStreamTraits());
     updateDistinctColumns(output_stream->header, output_stream->distinct_columns);
 }
 

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -89,17 +89,15 @@ SortingStep::SortingStep(
     output_stream->sort_mode = DataStream::SortMode::Stream;
 }
 
-void SortingStep::updateInputStream(const DataStream & input_stream)
+void SortingStep::updateInputStream(DataStream input_stream)
 {
     input_streams.clear();
-    input_streams.emplace_back(input_stream);
+    input_streams.push_back(std::move(input_stream));
 }
 
 void SortingStep::updateOutputStream(Block result_header)
 {
-    if (input_streams.size() != 1)
-        throw std::runtime_error{"wasted"};
-    output_stream = createOutputStream(input_streams.at(0), result_header, getDataStreamTraits());
+    output_stream = createOutputStream(input_streams.front(), std::move(result_header), getDataStreamTraits());
 }
 
 void SortingStep::updateLimit(size_t limit_)

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -49,6 +49,11 @@ public:
     /// Add limit or change it to lower value.
     void updateLimit(size_t limit_);
 
+    void updateInputStream(const DataStream & input_stream);
+    void updateOutputStream(Block result_header);
+
+    SortDescription getSortDescription() const { return result_description; }
+
 private:
 
     enum class Type

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -49,7 +49,7 @@ public:
     /// Add limit or change it to lower value.
     void updateLimit(size_t limit_);
 
-    void updateInputStream(const DataStream & input_stream);
+    void updateInputStream(DataStream input_stream);
     void updateOutputStream(Block result_header);
 
     SortDescription getSortDescription() const { return result_description; }

--- a/tests/performance/function_calculation_after_sorting_and_limit.xml
+++ b/tests/performance/function_calculation_after_sorting_and_limit.xml
@@ -1,0 +1,4 @@
+<test>
+    <query>SELECT sipHash64(number) FROM numbers(1e8) ORDER BY number LIMIT 5</query>
+    <query>SELECT sipHash64(number) FROM numbers(1e8) ORDER BY number + 1 LIMIT 5</query>
+</test>

--- a/tests/queries/0_stateless/01576_alias_column_rewrite.reference
+++ b/tests/queries/0_stateless/01576_alias_column_rewrite.reference
@@ -35,10 +35,11 @@ Expression (Projection)
           ReadFromMergeTree (default.test_table)
 Expression (Projection)
   Limit (preliminary LIMIT (without OFFSET))
-    Sorting
-      Expression (Before ORDER BY)
-        SettingQuotaAndLimits (Set limits and quota after reading from storage)
-          ReadFromMergeTree (default.test_table)
+    Expression (Before ORDER BY [lifted up part])
+      Sorting
+        Expression (Before ORDER BY)
+          SettingQuotaAndLimits (Set limits and quota after reading from storage)
+            ReadFromMergeTree (default.test_table)
 optimize_aggregation_in_order
 Expression ((Projection + Before ORDER BY))
   Aggregating

--- a/tests/queries/0_stateless/01591_window_functions.reference
+++ b/tests/queries/0_stateless/01591_window_functions.reference
@@ -925,10 +925,11 @@ Expression ((Projection + Before ORDER BY))
   Window (Window step for window \'ORDER BY o ASC, number ASC\')
     Sorting (Sorting for window \'ORDER BY o ASC, number ASC\')
       Window (Window step for window \'ORDER BY number ASC\')
-        Sorting (Sorting for window \'ORDER BY number ASC\')
-          Expression ((Before window functions + (Projection + Before ORDER BY)))
-            SettingQuotaAndLimits (Set limits and quota after reading from storage)
-              ReadFromStorage (SystemNumbers)
+        Expression ((Before window functions + (Projection + Before ORDER BY)) [lifted up part])
+          Sorting (Sorting for window \'ORDER BY number ASC\')
+            Expression ((Before window functions + (Projection + Before ORDER BY)))
+              SettingQuotaAndLimits (Set limits and quota after reading from storage)
+                ReadFromStorage (SystemNumbers)
 -- A test case for the sort comparator found by fuzzer.
 SELECT
     max(number) OVER (ORDER BY number DESC NULLS FIRST),

--- a/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
+++ b/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
@@ -10,8 +10,8 @@ set max_block_size=40960;
 --     MergeSortingTransform: Re-merging intermediate ORDER BY data (20 blocks with 819200 rows) to save memory consumption
 --     MergeSortingTransform: Memory usage is lowered from 186.25 MiB to 95.00 MiB
 --     MergeSortingTransform: Re-merging is not useful (memory usage was not lowered by remerge_sort_lowered_memory_bytes_ratio=2.0)
-select repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by v1, v2 limit 400e3 format Null; -- { serverError 241 }
-select repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by v1, v2 limit 400e3 settings remerge_sort_lowered_memory_bytes_ratio=2. format Null; -- { serverError 241 }
+select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by v1, v2 limit 400e3 format Null; -- { serverError 241 }
+select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by v1, v2 limit 400e3 settings remerge_sort_lowered_memory_bytes_ratio=2. format Null; -- { serverError 241 }
 
 -- remerge_sort_lowered_memory_bytes_ratio 1.9 is good (need at least 1.91/0.98=1.94)
 --     MergeSortingTransform: Re-merging intermediate ORDER BY data (20 blocks with 819200 rows) to save memory consumption

--- a/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
+++ b/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
@@ -10,8 +10,8 @@ set max_block_size=40960;
 --     MergeSortingTransform: Re-merging intermediate ORDER BY data (20 blocks with 819200 rows) to save memory consumption
 --     MergeSortingTransform: Memory usage is lowered from 186.25 MiB to 95.00 MiB
 --     MergeSortingTransform: Re-merging is not useful (memory usage was not lowered by remerge_sort_lowered_memory_bytes_ratio=2.0)
-select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by k limit 400e3 format Null; -- { serverError 241 }}
-select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by k limit 400e3 settings remerge_sort_lowered_memory_bytes_ratio=2. format Null;
+select repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by v1, v2 limit 400e3 format Null; -- { serverError 241 }
+select repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by v1, v2 limit 400e3 settings remerge_sort_lowered_memory_bytes_ratio=2. format Null; -- { serverError 241 }
 
 -- remerge_sort_lowered_memory_bytes_ratio 1.9 is good (need at least 1.91/0.98=1.94)
 --     MergeSortingTransform: Re-merging intermediate ORDER BY data (20 blocks with 819200 rows) to save memory consumption

--- a/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
+++ b/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
@@ -10,8 +10,8 @@ set max_block_size=40960;
 --     MergeSortingTransform: Re-merging intermediate ORDER BY data (20 blocks with 819200 rows) to save memory consumption
 --     MergeSortingTransform: Memory usage is lowered from 186.25 MiB to 95.00 MiB
 --     MergeSortingTransform: Re-merging is not useful (memory usage was not lowered by remerge_sort_lowered_memory_bytes_ratio=2.0)
-select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by k limit 400e3 format Null; -- { serverError 241 }
-select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by k limit 400e3 settings remerge_sort_lowered_memory_bytes_ratio=2. format Null; -- { serverError 241 }
+select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by k limit 400e3 format Null;
+select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by k limit 400e3 settings remerge_sort_lowered_memory_bytes_ratio=2. format Null;
 
 -- remerge_sort_lowered_memory_bytes_ratio 1.9 is good (need at least 1.91/0.98=1.94)
 --     MergeSortingTransform: Re-merging intermediate ORDER BY data (20 blocks with 819200 rows) to save memory consumption

--- a/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
+++ b/tests/queries/0_stateless/01600_remerge_sort_lowered_memory_bytes_ratio.sql
@@ -10,7 +10,7 @@ set max_block_size=40960;
 --     MergeSortingTransform: Re-merging intermediate ORDER BY data (20 blocks with 819200 rows) to save memory consumption
 --     MergeSortingTransform: Memory usage is lowered from 186.25 MiB to 95.00 MiB
 --     MergeSortingTransform: Re-merging is not useful (memory usage was not lowered by remerge_sort_lowered_memory_bytes_ratio=2.0)
-select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by k limit 400e3 format Null;
+select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by k limit 400e3 format Null; -- { serverError 241 }}
 select number k, repeat(toString(number), 11) v1, repeat(toString(number), 12) v2 from numbers(3e6) order by k limit 400e3 settings remerge_sort_lowered_memory_bytes_ratio=2. format Null;
 
 -- remerge_sort_lowered_memory_bytes_ratio 1.9 is good (need at least 1.91/0.98=1.94)

--- a/tests/queries/0_stateless/01655_plan_optimizations.reference
+++ b/tests/queries/0_stateless/01655_plan_optimizations.reference
@@ -148,6 +148,7 @@ Expression
 Limit
 Expression
 Sorting
+Expression
 > Expression should be divided into two subexpressions and only one of them should be moved after Sorting
 Expression
 Limit

--- a/tests/queries/0_stateless/01655_plan_optimizations.reference
+++ b/tests/queries/0_stateless/01655_plan_optimizations.reference
@@ -155,3 +155,5 @@ Limit
 Expression
 Sorting
 Expression
+> this query should be executed without throwing an exception
+0

--- a/tests/queries/0_stateless/01655_plan_optimizations.reference
+++ b/tests/queries/0_stateless/01655_plan_optimizations.reference
@@ -143,17 +143,11 @@ Filter
 2	3
 2	3
 > function calculation should be done after sorting and limit (if possible)
-> the whole Expression node could be moved after Sorting
-Expression
-Limit
-Expression
-Sorting
-Expression
 > Expression should be divided into two subexpressions and only one of them should be moved after Sorting
-Expression
-Limit
-Expression
+Expression (Before ORDER BY [lifted up part])
+FUNCTION sipHash64
 Sorting
-Expression
+Expression (Before ORDER BY)
+FUNCTION plus
 > this query should be executed without throwing an exception
 0

--- a/tests/queries/0_stateless/01655_plan_optimizations.reference
+++ b/tests/queries/0_stateless/01655_plan_optimizations.reference
@@ -148,7 +148,7 @@ Expression
 Limit
 Expression
 Sorting
-> Expression should be divided into two subnodes and only one of them could be moved after Sorting
+> Expression should be divided into two subexpressions and only one of them should be moved after Sorting
 Expression
 Limit
 Expression

--- a/tests/queries/0_stateless/01655_plan_optimizations.reference
+++ b/tests/queries/0_stateless/01655_plan_optimizations.reference
@@ -142,3 +142,15 @@ Filter
 Filter
 2	3
 2	3
+> function calculation should be done after sorting and limit (if possible)
+> the whole Expression node could be moved after Sorting
+Expression
+Limit
+Expression
+Sorting
+> Expression should be divided into two subnodes and only one of them could be moved after Sorting
+Expression
+Limit
+Expression
+Sorting
+Expression

--- a/tests/queries/0_stateless/01655_plan_optimizations.sh
+++ b/tests/queries/0_stateless/01655_plan_optimizations.sh
@@ -206,3 +206,6 @@ echo "> Expression should be divided into two subexpressions and only one of the
 $CLICKHOUSE_CLIENT -q "
     explain select sipHash64(number) from numbers(100) order by number + 1 limit 5" |
     sed 's/ //g' | grep -o "^ *\(Expression\|Limit\|Sorting\)"
+echo "> this query should be executed without throwing an exception"
+$CLICKHOUSE_CLIENT -q "
+    select throwIf(number = 5) from (select * from numbers(10)) order by number limit 1"

--- a/tests/queries/0_stateless/01655_plan_optimizations.sh
+++ b/tests/queries/0_stateless/01655_plan_optimizations.sh
@@ -198,14 +198,10 @@ $CLICKHOUSE_CLIENT -q "
     ) where a != 1 settings enable_optimize_predicate_expression = 0"
 
 echo "> function calculation should be done after sorting and limit (if possible)"
-echo "> the whole Expression node could be moved after Sorting"
-$CLICKHOUSE_CLIENT -q "
-    explain select sipHash64(number) from numbers(100) order by number limit 5" |
-    sed 's/ //g' | grep -o "^ *\(Expression\|Limit\|Sorting\)"
 echo "> Expression should be divided into two subexpressions and only one of them should be moved after Sorting"
 $CLICKHOUSE_CLIENT -q "
-    explain select sipHash64(number) from numbers(100) order by number + 1 limit 5" |
-    sed 's/ //g' | grep -o "^ *\(Expression\|Limit\|Sorting\)"
+    explain actions = 1 select number as n, sipHash64(n) from numbers(100) order by number + 1 limit 5" |
+    sed 's/^ *//g' | grep -o "^ *\(Expression (Before ORDER BY.*)\|Sorting\|FUNCTION \w\+\)"
 echo "> this query should be executed without throwing an exception"
 $CLICKHOUSE_CLIENT -q "
     select throwIf(number = 5) from (select * from numbers(10)) order by number limit 1"

--- a/tests/queries/0_stateless/01655_plan_optimizations.sh
+++ b/tests/queries/0_stateless/01655_plan_optimizations.sh
@@ -202,7 +202,7 @@ echo "> the whole Expression node could be moved after Sorting"
 $CLICKHOUSE_CLIENT -q "
     explain select sipHash64(number) from numbers(100) order by number limit 5" |
     sed 's/ //g' | grep -o "^ *\(Expression\|Limit\|Sorting\)"
-echo "> Expression should be divided into two subnodes and only one of them could be moved after Sorting"
+echo "> Expression should be divided into two subexpressions and only one of them should be moved after Sorting"
 $CLICKHOUSE_CLIENT -q "
     explain select sipHash64(number) from numbers(100) order by number + 1 limit 5" |
     sed 's/ //g' | grep -o "^ *\(Expression\|Limit\|Sorting\)"

--- a/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.reference
+++ b/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.reference
@@ -7,13 +7,15 @@
 ExpressionTransform
   (Limit)
   Limit
-    (Sorting)
-    MergingSortedTransform 2 → 1
-      (Expression)
-      ExpressionTransform × 2
-        (SettingQuotaAndLimits)
-          (ReadFromMergeTree)
-          MergeTreeInOrder × 2 0 → 1
+    (Expression)
+    ExpressionTransform
+      (Sorting)
+      MergingSortedTransform 2 → 1
+        (Expression)
+        ExpressionTransform × 2
+          (SettingQuotaAndLimits)
+            (ReadFromMergeTree)
+            MergeTreeInOrder × 2 0 → 1
 2020-10-01	9
 2020-10-01	9
 2020-10-01	9
@@ -23,16 +25,18 @@ ExpressionTransform
 ExpressionTransform
   (Limit)
   Limit
-    (Sorting)
-    MergingSortedTransform 2 → 1
-      (Expression)
-      ExpressionTransform × 2
-        (SettingQuotaAndLimits)
-          (ReadFromMergeTree)
-          ReverseTransform
-            MergeTreeReverse 0 → 1
-              ReverseTransform
-                MergeTreeReverse 0 → 1
+    (Expression)
+    ExpressionTransform
+      (Sorting)
+      MergingSortedTransform 2 → 1
+        (Expression)
+        ExpressionTransform × 2
+          (SettingQuotaAndLimits)
+            (ReadFromMergeTree)
+            ReverseTransform
+              MergeTreeReverse 0 → 1
+                ReverseTransform
+                  MergeTreeReverse 0 → 1
 2020-10-01	9
 2020-10-01	9
 2020-10-01	9
@@ -42,15 +46,17 @@ ExpressionTransform
 ExpressionTransform
   (Limit)
   Limit
-    (Sorting)
-    FinishSortingTransform
-      PartialSortingTransform
-        MergingSortedTransform 2 → 1
-          (Expression)
-          ExpressionTransform × 2
-            (SettingQuotaAndLimits)
-              (ReadFromMergeTree)
-              MergeTreeInOrder × 2 0 → 1
+    (Expression)
+    ExpressionTransform
+      (Sorting)
+      FinishSortingTransform
+        PartialSortingTransform
+          MergingSortedTransform 2 → 1
+            (Expression)
+            ExpressionTransform × 2
+              (SettingQuotaAndLimits)
+                (ReadFromMergeTree)
+                MergeTreeInOrder × 2 0 → 1
 2020-10-11	0
 2020-10-11	0
 2020-10-11	0


### PR DESCRIPTION
Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A new query plan optimization. Evaluate functions after `ORDER BY` when possible. As an example, for a query `SELECT sipHash64(number) FROM numbers(1e8) ORDER BY number LIMIT 5`, function `sipHash64` would be evaluated after `ORDER BY` and `LIMIT`, which gives ~20x speed up.

Calculation of functions that are not required to calculate sorting columns is now moved after SortingStep in the query plan. 

Closes #11103.