### PR TITLE
Fix flaky test `01532_primary_key_without_order_by_zookeeper`

### DIFF
--- a/tests/queries/0_stateless/01532_primary_key_without_order_by_zookeeper.reference
+++ b/tests/queries/0_stateless/01532_primary_key_without_order_by_zookeeper.reference
@@ -9,8 +9,8 @@ CREATE TABLE default.merge_tree_pk_sql\n(\n    `key` UInt64,\n    `value` String
 1	c
 2	b
 1	c	0
-2	e	555
 2	b	0
+2	e	555
 CREATE TABLE default.merge_tree_pk_sql\n(\n    `key` UInt64,\n    `value` String,\n    `key2` UInt64\n)\nENGINE = ReplacingMergeTree\nPRIMARY KEY key\nORDER BY (key, key2)\nSETTINGS index_granularity = 8192
 CREATE TABLE default.replicated_merge_tree_pk_sql\n(\n    `key` UInt64,\n    `value` String\n)\nENGINE = ReplicatedReplacingMergeTree(\'/clickhouse/test/01532_primary_key_without\', \'r1\')\nPRIMARY KEY key\nORDER BY key\nSETTINGS index_granularity = 8192
 1	a
@@ -18,6 +18,6 @@ CREATE TABLE default.replicated_merge_tree_pk_sql\n(\n    `key` UInt64,\n    `va
 1	c
 2	b
 1	c	0
-2	e	555
 2	b	0
+2	e	555
 CREATE TABLE default.replicated_merge_tree_pk_sql\n(\n    `key` UInt64,\n    `value` String,\n    `key2` UInt64\n)\nENGINE = ReplicatedReplacingMergeTree(\'/clickhouse/test/01532_primary_key_without\', \'r1\')\nPRIMARY KEY key\nORDER BY (key, key2)\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/01532_primary_key_without_order_by_zookeeper.sql
+++ b/tests/queries/0_stateless/01532_primary_key_without_order_by_zookeeper.sql
@@ -15,14 +15,14 @@ SHOW CREATE TABLE merge_tree_pk;
 INSERT INTO merge_tree_pk VALUES (1, 'a');
 INSERT INTO merge_tree_pk VALUES (2, 'b');
 
-SELECT * FROM merge_tree_pk ORDER BY key;
+SELECT * FROM merge_tree_pk ORDER BY key, value;
 
 INSERT INTO merge_tree_pk VALUES (1, 'c');
 
 DETACH TABLE merge_tree_pk;
 ATTACH TABLE merge_tree_pk;
 
-SELECT * FROM merge_tree_pk FINAL ORDER BY key;
+SELECT * FROM merge_tree_pk FINAL ORDER BY key, value;
 
 DROP TABLE IF EXISTS merge_tree_pk;
 
@@ -41,14 +41,14 @@ SHOW CREATE TABLE merge_tree_pk_sql;
 INSERT INTO merge_tree_pk_sql VALUES (1, 'a');
 INSERT INTO merge_tree_pk_sql VALUES (2, 'b');
 
-SELECT * FROM merge_tree_pk_sql ORDER BY key;
+SELECT * FROM merge_tree_pk_sql ORDER BY key, value;
 
 INSERT INTO merge_tree_pk_sql VALUES (1, 'c');
 
 DETACH TABLE merge_tree_pk_sql;
 ATTACH TABLE merge_tree_pk_sql;
 
-SELECT * FROM merge_tree_pk_sql FINAL ORDER BY key;
+SELECT * FROM merge_tree_pk_sql FINAL ORDER BY key, value;
 
 ALTER TABLE merge_tree_pk_sql ADD COLUMN key2 UInt64, MODIFY ORDER BY (key, key2);
 
@@ -56,7 +56,7 @@ INSERT INTO merge_tree_pk_sql VALUES (2, 'd', 555);
 
 INSERT INTO merge_tree_pk_sql VALUES (2, 'e', 555);
 
-SELECT * FROM merge_tree_pk_sql FINAL ORDER BY key;
+SELECT * FROM merge_tree_pk_sql FINAL ORDER BY key, value;
 
 SHOW CREATE TABLE merge_tree_pk_sql;
 
@@ -77,14 +77,14 @@ SHOW CREATE TABLE replicated_merge_tree_pk_sql;
 INSERT INTO replicated_merge_tree_pk_sql VALUES (1, 'a');
 INSERT INTO replicated_merge_tree_pk_sql VALUES (2, 'b');
 
-SELECT * FROM replicated_merge_tree_pk_sql ORDER BY key;
+SELECT * FROM replicated_merge_tree_pk_sql ORDER BY key, value;
 
 INSERT INTO replicated_merge_tree_pk_sql VALUES (1, 'c');
 
 DETACH TABLE replicated_merge_tree_pk_sql;
 ATTACH TABLE replicated_merge_tree_pk_sql;
 
-SELECT * FROM replicated_merge_tree_pk_sql FINAL ORDER BY key;
+SELECT * FROM replicated_merge_tree_pk_sql FINAL ORDER BY key, value;
 
 ALTER TABLE replicated_merge_tree_pk_sql ADD COLUMN key2 UInt64, MODIFY ORDER BY (key, key2);
 
@@ -92,7 +92,7 @@ INSERT INTO replicated_merge_tree_pk_sql VALUES (2, 'd', 555);
 
 INSERT INTO replicated_merge_tree_pk_sql VALUES (2, 'e', 555);
 
-SELECT * FROM replicated_merge_tree_pk_sql FINAL ORDER BY key;
+SELECT * FROM replicated_merge_tree_pk_sql FINAL ORDER BY key, value;
 
 DETACH TABLE replicated_merge_tree_pk_sql;
 ATTACH TABLE replicated_merge_tree_pk_sql;

--- a/tests/queries/0_stateless/01532_primary_key_without_order_by_zookeeper.sql
+++ b/tests/queries/0_stateless/01532_primary_key_without_order_by_zookeeper.sql
@@ -1,4 +1,4 @@
--- Tags: zookeeper
+-- Tags: zookeeper, no-parallel
 
 DROP TABLE IF EXISTS merge_tree_pk;
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

