### PR TITLE
Column transformer RENAME

### DIFF
--- a/docs/en/sql-reference/statements/insert-into.md
+++ b/docs/en/sql-reference/statements/insert-into.md
@@ -13,7 +13,7 @@ Inserts data into a table.
 INSERT INTO [db.]table [(c1, c2, c3)] VALUES (v11, v12, v13), (v21, v22, v23), ...
 ```
 
-You can specify a list of columns to insert using  the `(c1, c2, c3)`. You can also use an expression with column [matcher](../../sql-reference/statements/select/index.md#asterisk) such as `*` and/or [modifiers](../../sql-reference/statements/select/index.md#select-modifiers) such as [APPLY](../../sql-reference/statements/select/index.md#apply-modifier), [EXCEPT](../../sql-reference/statements/select/index.md#except-modifier), [REPLACE](../../sql-reference/statements/select/index.md#replace-modifier).
+You can specify a list of columns to insert using  the `(c1, c2, c3)`. You can also use an expression with column [matcher](../../sql-reference/statements/select/index.md#asterisk) such as `*` and/or [modifiers](../../sql-reference/statements/select/index.md#select-modifiers) such as [APPLY](../../sql-reference/statements/select/index.md#apply-modifier), [EXCEPT](../../sql-reference/statements/select/index.md#except-modifier), [REPLACE](../../sql-reference/statements/select/index.md#replace-modifier), [RENAME](../../sql-reference/statements/select/index.md#rename-modifier).
 
 For example, consider the table:
 

--- a/docs/en/sql-reference/statements/select/index.md
+++ b/docs/en/sql-reference/statements/select/index.md
@@ -172,12 +172,12 @@ You can use the following modifiers in `SELECT` queries.
 
 ### APPLY {#apply-modifier}
 
-Allows you to invoke some function for each row returned by an outer table expression of a query.
+Allows you to invoke some function for each row returned by an outer table expression of a query. An optional string argument can be used to change the output names of each column. The result name is a concatenation of the input string and the original column name before applying the function.
 
 **Syntax:**
 
 ``` sql
-SELECT <expr> APPLY( <func> ) FROM [db.]table_name
+SELECT <expr> APPLY( <func>[, <string_literal>] ) FROM [db.]table_name
 ```
 
 **Example:**
@@ -192,6 +192,16 @@ SELECT * APPLY(sum) FROM columns_transformers;
 ┌─sum(i)─┬─sum(j)─┬─sum(k)─┐
 │    220 │     18 │    347 │
 └────────┴────────┴────────┘
+```
+
+``` sql
+SELECT * APPLY(sum, '') FROM columns_transformers;
+```
+
+```
+┌───i─┬──j─┬───k─┐
+│ 220 │ 18 │ 347 │
+└─────┴────┴─────┘
 ```
 
 ### EXCEPT {#except-modifier}
@@ -242,9 +252,32 @@ SELECT * REPLACE(i + 1 AS i) from columns_transformers;
 └─────┴────┴─────┘
 ```
 
+### RENAME {#rename-modifier}
+
+Specifies the names of all columns using a string of format pattern, in which `{0}` denotes the original column name, while `{1}` denotes the ordinal index of each column.
+
+**Syntax:**
+
+``` sql
+SELECT <expr> RENAME <string_literal> FROM [db.]table_name
+```
+
+**Example:**
+
+``` sql
+SELECT * EXCEPT (i) RENAME '{0}_col_{1}' from columns_transformers;
+```
+
+```
+┌─j_col_0─┬─k_col_1─┐
+│      10 │     324 │
+│       8 │      23 │
+└─────────┴─────────┘
+```
+
 ### Modifier Combinations {#modifier-combinations}
 
-You can use each modifier separately or combine them.
+You can use each modifier separately or combine them. The RENAME modifier can only be specified at last.
 
 **Examples:**
 

--- a/docs/en/sql-reference/statements/select/index.md
+++ b/docs/en/sql-reference/statements/select/index.md
@@ -172,7 +172,7 @@ You can use the following modifiers in `SELECT` queries.
 
 ### APPLY {#apply-modifier}
 
-Allows you to invoke some function for each row returned by an outer table expression of a query. An optional string argument can be used to change the output names of each column. The result name is a concatenation of the input string and the original column name before applying the function.
+Allows you to invoke some function for each row returned by an outer table expression of a query. An optional string argument can be used to change the output names of each column similar to format pattern, in which `{0}` denotes the original column name, while `{1}` denotes the ordinal index of each column.
 
 **Syntax:**
 
@@ -195,7 +195,7 @@ SELECT * APPLY(sum) FROM columns_transformers;
 ```
 
 ``` sql
-SELECT * APPLY(sum, '') FROM columns_transformers;
+SELECT * APPLY(sum, '{}') FROM columns_transformers;
 ```
 
 ```

--- a/src/Parsers/ASTColumnsTransformers.h
+++ b/src/Parsers/ASTColumnsTransformers.h
@@ -39,7 +39,8 @@ public:
     ASTPtr lambda;
     String lambda_arg;
 
-    std::optional<String> column_name_prefix;
+    // Case 3 APPLY (x -> quantile(0.9)(x), {}_p90)
+    std::optional<String> rename_format;
 
 protected:
     void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;

--- a/src/Parsers/ASTColumnsTransformers.h
+++ b/src/Parsers/ASTColumnsTransformers.h
@@ -39,7 +39,7 @@ public:
     ASTPtr lambda;
     String lambda_arg;
 
-    String column_name_prefix;
+    std::optional<String> column_name_prefix;
 
 protected:
     void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
@@ -104,6 +104,23 @@ protected:
 
 private:
     static void replaceChildren(ASTPtr & node, const ASTPtr & replacement, const String & name);
+};
+
+class ASTColumnsRenameTransformer : public IASTColumnsTransformer
+{
+public:
+    String getID(char) const override { return "ColumnsRenameTransformer"; }
+    ASTPtr clone() const override
+    {
+        auto clone = std::make_shared<ASTColumnsRenameTransformer>(*this);
+        clone->cloneChildren();
+        return clone;
+    }
+    void transform(ASTs & nodes) const override;
+
+    String rename_format;
+protected:
+    void formatImpl(const FormatSettings & settings, FormatState &, FormatStateStacked) const override;
 };
 
 }

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1887,7 +1887,7 @@ bool ParserColumnsTransformers::parseImpl(Pos & pos, ASTPtr & node, Expected & e
             }
         }
 
-        std::optional<String> column_name_prefix;
+        std::optional<String> rename_format;
         if (with_open_round_bracket && pos->type == TokenType::Comma)
         {
             ++pos;
@@ -1897,7 +1897,7 @@ bool ParserColumnsTransformers::parseImpl(Pos & pos, ASTPtr & node, Expected & e
             if (!parser_string_literal.parse(pos, ast_prefix_name, expected))
                 return false;
 
-            column_name_prefix = ast_prefix_name->as<ASTLiteral &>().value.get<const String &>();
+            rename_format = ast_prefix_name->as<ASTLiteral &>().value.get<const String &>();
         }
 
         if (with_open_round_bracket)
@@ -1918,7 +1918,7 @@ bool ParserColumnsTransformers::parseImpl(Pos & pos, ASTPtr & node, Expected & e
             res->func_name = getIdentifierName(func_name);
             res->parameters = expr_list_args;
         }
-        res->column_name_prefix = column_name_prefix;
+        res->rename_format = rename_format;
         node = std::move(res);
         return true;
     }

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -82,9 +82,11 @@ public:
         APPLY,
         EXCEPT,
         REPLACE,
+        RENAME,
     };
     using ColumnTransformers = MultiEnum<ColumnTransformer, UInt8>;
-    static constexpr auto AllTransformers = ColumnTransformers{ColumnTransformer::APPLY, ColumnTransformer::EXCEPT, ColumnTransformer::REPLACE};
+    static constexpr auto AllTransformers
+        = ColumnTransformers{ColumnTransformer::APPLY, ColumnTransformer::EXCEPT, ColumnTransformer::REPLACE, ColumnTransformer::RENAME};
 
     explicit ParserColumnsTransformers(ColumnTransformers allowed_transformers_ = AllTransformers, bool is_strict_ = false)
         : allowed_transformers(allowed_transformers_)

--- a/tests/queries/0_stateless/01470_columns_transformers.reference
+++ b/tests/queries/0_stateless/01470_columns_transformers.reference
@@ -90,3 +90,27 @@ SELECT
     quantiles(0.5)(j),
     quantiles(0.5)(k)
 FROM columns_transformers
+SELECT
+    sum(i) AS i,
+    sum(j) AS j,
+    sum(k) AS k
+FROM columns_transformers
+SELECT
+    sum(i) AS sum_i,
+    sum(j) AS sum_j,
+    sum(k) AS sum_k
+FROM columns_transformers
+SELECT
+    (sum(i) AS i) - 1 AS `sum_minus(sum(i), 1)_minus_one`,
+    (sum(j) AS j) - 1 AS `sum_minus(sum(j), 1)_minus_one`,
+    (sum(k) AS k) - 1 AS `sum_minus(sum(k), 1)_minus_one`
+FROM columns_transformers
+SELECT
+    (sum(i) AS i) - 1 AS `sum_minus(sum(i), 1)_minus_one`,
+    (sum(j) AS j) - 1 AS `sum_minus(sum(j), 1)_minus_one`,
+    (sum(k) AS k) - 1 AS `sum_minus(sum(k), 1)_minus_one`
+FROM columns_transformers
+SELECT
+    i AS col_i_0,
+    k AS col_k_1
+FROM columns_transformers

--- a/tests/queries/0_stateless/01470_columns_transformers.sql
+++ b/tests/queries/0_stateless/01470_columns_transformers.sql
@@ -53,15 +53,15 @@ EXPLAIN SYNTAX SELECT i, j, COLUMNS(i, j, k) APPLY(toFloat64), COLUMNS(i, j) EXC
 SELECT COLUMNS(i, j, k) APPLY(quantiles(0.5)) from columns_transformers;
 EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(quantiles(0.5)) from columns_transformers;
 
--- APPLY with naming prefix
-EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') from columns_transformers;
-EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, 'sum_') from columns_transformers;
+-- APPLY with format string
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '{}') from columns_transformers;
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, 'sum_{}') from columns_transformers;
 
 -- RENAME
-EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') APPLY(x->x-1, '') RENAME 'sum_{}_minus_one' from columns_transformers;
-EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') APPLY(x->x-1, '') RENAME 'sum_{0}_minus_one' from columns_transformers;
-EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') APPLY(x->x-1, '') RENAME 'sum_{2}_minus_one' from columns_transformers; -- { serverError 36 }
-EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') APPLY(x->x-1, '') RENAME 'sum_{}{}{}_minus_one' from columns_transformers; -- { serverError 36 }
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '{}') APPLY(x->x-1, '{}') RENAME 'sum_{}_minus_one' from columns_transformers;
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '{}') APPLY(x->x-1, '{}') RENAME 'sum_{0}_minus_one' from columns_transformers;
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '{}') APPLY(x->x-1, '{}') RENAME 'sum_{2}_minus_one' from columns_transformers; -- { serverError 36 }
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '{}') APPLY(x->x-1, '{}') RENAME 'sum_{}{}{}_minus_one' from columns_transformers; -- { serverError 36 }
 
 EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) EXCEPT j RENAME 'col_{0}_{1}' from columns_transformers;
 EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) RENAME 'col_{0}_{1}' EXCEPT j from columns_transformers;  -- { clientError 62 }

--- a/tests/queries/0_stateless/01470_columns_transformers.sql
+++ b/tests/queries/0_stateless/01470_columns_transformers.sql
@@ -53,4 +53,17 @@ EXPLAIN SYNTAX SELECT i, j, COLUMNS(i, j, k) APPLY(toFloat64), COLUMNS(i, j) EXC
 SELECT COLUMNS(i, j, k) APPLY(quantiles(0.5)) from columns_transformers;
 EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(quantiles(0.5)) from columns_transformers;
 
+-- APPLY with naming prefix
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') from columns_transformers;
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, 'sum_') from columns_transformers;
+
+-- RENAME
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') APPLY(x->x-1, '') RENAME 'sum_{}_minus_one' from columns_transformers;
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') APPLY(x->x-1, '') RENAME 'sum_{0}_minus_one' from columns_transformers;
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') APPLY(x->x-1, '') RENAME 'sum_{2}_minus_one' from columns_transformers; -- { serverError 36 }
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum, '') APPLY(x->x-1, '') RENAME 'sum_{}{}{}_minus_one' from columns_transformers; -- { serverError 36 }
+
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) EXCEPT j RENAME 'col_{0}_{1}' from columns_transformers;
+EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) RENAME 'col_{0}_{1}' EXCEPT j from columns_transformers;  -- { clientError 62 }
+
 DROP TABLE columns_transformers;


### PR DESCRIPTION
Changelog category (leave one):
- New Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add RENAME column transformer to control how columns are named after transformation. This is for https://github.com/ClickHouse/ClickHouse/issues/30411 . It's based on https://github.com/ClickHouse/ClickHouse/pull/35651


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
