### PR TITLE
Fix flaky test `01091_num_threads`

### DIFF
--- a/tests/queries/0_stateless/01091_num_threads.sql
+++ b/tests/queries/0_stateless/01091_num_threads.sql
@@ -1,5 +1,6 @@
 set log_queries=1;
 set log_query_threads=1;
+set max_threads=0;
 
 WITH 01091 AS id SELECT 1;
 SYSTEM FLUSH LOGS;


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)



