### PR TITLE
Improve black check: show diff in the output

### DIFF
--- a/utils/check-style/check-black
+++ b/utils/check-style/check-black
@@ -6,7 +6,7 @@ set -e
 GIT_ROOT=$(git rev-parse --show-cdup)
 GIT_ROOT=${GIT_ROOT:-.}
 tmp=$(mktemp)
-if ! find "$GIT_ROOT" -name '*.py' -not -path "$GIT_ROOT/contrib/*" -exec black --check {} + 1>"$tmp" 2>&1; then
+if ! find "$GIT_ROOT" -name '*.py' -not -path "$GIT_ROOT/contrib/*" -exec black --check --diff {} + 1>"$tmp" 2>&1; then
   # Show the result only if some files need formatting
   cat "$tmp"
 fi


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add diff to a black output.

Example:

```
--- tests/ci/build_report_check.py	2022-03-28 11:49:34.118392 +0000
+++ tests/ci/build_report_check.py	2022-03-28 11:51:08.269402 +0000
@@ -149,11 +149,15 @@
                     )
 
     some_builds_are_missing = len(build_reports_map) < len(reports_order)
 
     if some_builds_are_missing:
-        logging.info("Expected to get %s build results, got %s", len(reports_order), len(build_reports_map))
+        logging.info(
+            "Expected to get %s build results, got %s",
+            len(reports_order),
+            len(build_reports_map),
+        )
     else:
         logging.info("Got exactly %s builds", len(build_reports_map))
```