### PR TITLE
Rerun failed jobs only for failed workflowa

### DIFF
--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -379,12 +379,16 @@ def check_need_to_rerun(workflow_description):
 
 def rerun_workflow(workflow_description, token):
     print("Going to rerun workflow")
-    _exec_post_with_retry(workflow_description.rerun_url, token)
+    try:
+        _exec_post_with_retry(f"{workflow_description.rerun_url}-failed-jobs", token)
+    except Exception:
+        _exec_post_with_retry(workflow_description.rerun_url, token)
 
 
 def main(event):
     token = get_token_from_aws()
     event_data = json.loads(event["body"])
+    print("The body received:", event_data)
     workflow_description = get_workflow_description_from_event(event_data)
 
     print("Got workflow description", workflow_description)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Only failed jobs of workflows will be rerun. The lambda is already pushed