### PR TITLE
Fix 02149_read_in_order_fixed_prefix

### DIFF
--- a/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.sql
+++ b/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.sql
@@ -1,3 +1,4 @@
+SET max_threads = 0;
 DROP TABLE IF EXISTS t_read_in_order;
 
 CREATE TABLE t_read_in_order(date Date, i UInt64, v UInt64)


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)