### PR TITLE
Fix creating materialized view with subquery after server restart

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -6,6 +6,7 @@
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterCreateQuery.h>
+#include <Interpreters/ApplyWithSubqueryVisitor.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ParserCreateQuery.h>
@@ -54,6 +55,9 @@ std::pair<String, StoragePtr> createTableFromAST(
 {
     ast_create_query.attach = true;
     ast_create_query.setDatabase(database_name);
+
+    if (ast_create_query.select && ast_create_query.isView())
+        ApplyWithSubqueryVisitor().visit(*ast_create_query.select);
 
     if (ast_create_query.as_table_function)
     {

--- a/tests/integration/test_materialized_view_restart_server/test.py
+++ b/tests/integration/test_materialized_view_restart_server/test.py
@@ -1,0 +1,23 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", stay_alive=True)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_materialized_view_with_subquery(start_cluster):
+    node.query("create table test (x UInt32) engine=TineLog()")
+    node.query("create materialized view mv engine = TinyLog() as with subquery as (select * from test) select * from subquery")
+    node.restart_clickhouse(kill=True)
+    node.query("insert into test select 1")
+    result = node.query("select * from mv")
+    assert int(result) == 1

--- a/tests/integration/test_materialized_view_restart_server/test.py
+++ b/tests/integration/test_materialized_view_restart_server/test.py
@@ -15,7 +15,7 @@ def start_cluster():
 
 
 def test_materialized_view_with_subquery(start_cluster):
-    node.query("create table test (x UInt32) engine=TineLog()")
+    node.query("create table test (x UInt32) engine=TinyLog()")
     node.query(
         "create materialized view mv engine = TinyLog() as with subquery as (select * from test) select * from subquery"
     )

--- a/tests/integration/test_materialized_view_restart_server/test.py
+++ b/tests/integration/test_materialized_view_restart_server/test.py
@@ -16,7 +16,9 @@ def start_cluster():
 
 def test_materialized_view_with_subquery(start_cluster):
     node.query("create table test (x UInt32) engine=TineLog()")
-    node.query("create materialized view mv engine = TinyLog() as with subquery as (select * from test) select * from subquery")
+    node.query(
+        "create materialized view mv engine = TinyLog() as with subquery as (select * from test) select * from subquery"
+    )
     node.restart_clickhouse(kill=True)
     node.query("insert into test select 1")
     result = node.query("select * from mv")


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug in creating materialized view with subquery after server restart. Materialized view was not getting updated after inserts into underlying table after server restart. Closes https://github.com/ClickHouse/ClickHouse/issues/35511


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
