### PR TITLE
Do not require writable source directory for generating krb5 error tables

### DIFF
--- a/contrib/krb5-cmake/CMakeLists.txt
+++ b/contrib/krb5-cmake/CMakeLists.txt
@@ -16,6 +16,7 @@ if(NOT AWK_PROGRAM)
 endif()
 
 set(KRB5_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/krb5/src")
+set(KRB5_ET_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}/include_private")
 
 set(ALL_SRCS
     "${KRB5_SOURCE_DIR}/util/et/et_name.c"
@@ -90,7 +91,6 @@ set(ALL_SRCS
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/get_tkt_flags.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/set_allowable_enctypes.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/k5sealiov.c"
-    "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/gssapi_err_krb5.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/canon_name.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/inq_cred.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/export_sec_context.c"
@@ -143,11 +143,12 @@ set(ALL_SRCS
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_buffer_set.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_set.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_token.c"
-    "${KRB5_SOURCE_DIR}/lib/gssapi/generic/gssapi_err_generic.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/disp_major_status.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_seqstate.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/util_errmap.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/generic/rel_buffer.c"
+    "${KRB5_ET_BIN_DIR}/lib/gssapi/krb5/gssapi_err_krb5.c"
+    "${KRB5_ET_BIN_DIR}/lib/gssapi/generic/gssapi_err_generic.c"
 
     "${KRB5_SOURCE_DIR}/lib/gssapi/spnego/spnego_mech.c"
     "${KRB5_SOURCE_DIR}/lib/gssapi/spnego/negoex_util.c"
@@ -256,8 +257,8 @@ set(ALL_SRCS
     "${KRB5_SOURCE_DIR}/util/profile/prof_parse.c"
     "${KRB5_SOURCE_DIR}/util/profile/prof_get.c"
     "${KRB5_SOURCE_DIR}/util/profile/prof_set.c"
-    "${KRB5_SOURCE_DIR}/util/profile/prof_err.c"
     "${KRB5_SOURCE_DIR}/util/profile/prof_init.c"
+    "${KRB5_ET_BIN_DIR}/util/profile/prof_err.c"
     "${KRB5_SOURCE_DIR}/lib/krb5/krb/fwd_tgt.c"
     "${KRB5_SOURCE_DIR}/lib/krb5/krb/conv_creds.c"
     "${KRB5_SOURCE_DIR}/lib/krb5/krb/fast.c"
@@ -450,13 +451,12 @@ set(ALL_SRCS
 
 
 
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/k5e1_err.c"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/kdb5_err.c"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/asn1_err.c"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/krb5_err.c"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/krb524_err.c"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/kv5m_err.c"
-
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/k5e1_err.c"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/kdb5_err.c"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/asn1_err.c"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/krb5_err.c"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/krb524_err.c"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/kv5m_err.c"
 
 
     "${KRB5_SOURCE_DIR}/lib/krb5/rcache/rc_base.c"
@@ -473,7 +473,7 @@ set(ALL_SRCS
 )
 
 add_custom_command(
-    OUTPUT "${KRB5_SOURCE_DIR}/util/et/compile_et"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/compile_et"
     COMMAND /bin/sh
     ./config_script
     ./compile_et.sh
@@ -481,50 +481,17 @@ add_custom_command(
     ${AWK_PROGRAM}
     sed
     >
-    compile_et
+    ${CMAKE_CURRENT_BINARY_DIR}/compile_et
     DEPENDS "${KRB5_SOURCE_DIR}/util/et/compile_et.sh" "${KRB5_SOURCE_DIR}/util/et/config_script"
     WORKING_DIRECTORY "${KRB5_SOURCE_DIR}/util/et"
 )
 
-file(GLOB_RECURSE ET_FILES
-    "${KRB5_SOURCE_DIR}/*.et"
-)
-
-function(preprocess_et out_var)
-  set(result)
-  foreach(in_f ${ARGN})
-    string(REPLACE
-        .et
-        .c
-        F_C
-        ${in_f}
-    )
-    string(REPLACE
-        .et
-        .h
-        F_H
-        ${in_f}
-    )
-
-    get_filename_component(ET_PATH ${in_f} DIRECTORY)
-
-    add_custom_command(OUTPUT ${F_C} ${F_H}
-      COMMAND perl "${KRB5_SOURCE_DIR}/util/et/compile_et" -d "${KRB5_SOURCE_DIR}/util/et" ${in_f}
-      DEPENDS ${in_f} "${KRB5_SOURCE_DIR}/util/et/compile_et"
-      WORKING_DIRECTORY ${ET_PATH}
-      VERBATIM
-      )
-    list(APPEND result ${F_C})
-  endforeach()
-  set(${out_var} "${result}" PARENT_SCOPE)
-endfunction()
-
 add_custom_command(
-    OUTPUT "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/error_map.h"
+    OUTPUT "${KRB5_ET_BIN_DIR}/error_map.h"
     COMMAND perl
     -I../../../util
     ../../../util/gen-map.pl
-    -oerror_map.h
+    -o${KRB5_ET_BIN_DIR}/error_map.h
     NAME=gsserrmap
     KEY=OM_uint32
     VALUE=char*
@@ -536,22 +503,21 @@ add_custom_command(
 
 add_custom_target(
     ERROR_MAP_H
-    DEPENDS "${KRB5_SOURCE_DIR}/lib/gssapi/krb5/error_map.h"
+    DEPENDS "${KRB5_ET_BIN_DIR}/error_map.h"
     VERBATIM
 )
 
 add_custom_command(
-    OUTPUT "${KRB5_SOURCE_DIR}/lib/gssapi/generic/errmap.h"
-    COMMAND perl -w -I../../../util  ../../../util/gen.pl bimap errmap.h NAME=mecherrmap LEFT=OM_uint32 RIGHT=struct\ mecherror LEFTPRINT=print_OM_uint32 RIGHTPRINT=mecherror_print LEFTCMP=cmp_OM_uint32 RIGHTCMP=mecherror_cmp
+    OUTPUT "${KRB5_ET_BIN_DIR}/errmap.h"
+    COMMAND perl -w -I../../../util  ../../../util/gen.pl bimap ${KRB5_ET_BIN_DIR}/errmap.h NAME=mecherrmap LEFT=OM_uint32 RIGHT=struct\ mecherror LEFTPRINT=print_OM_uint32 RIGHTPRINT=mecherror_print LEFTCMP=cmp_OM_uint32 RIGHTCMP=mecherror_cmp
     WORKING_DIRECTORY "${KRB5_SOURCE_DIR}/lib/gssapi/generic"
 )
 
 add_custom_target(
     ERRMAP_H
-    DEPENDS "${KRB5_SOURCE_DIR}/lib/gssapi/generic/errmap.h"
+    DEPENDS "${KRB5_ET_BIN_DIR}/errmap.h"
     VERBATIM
 )
-
 add_custom_target(
     KRB_5_H
     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/include/krb5/krb5.h"
@@ -567,7 +533,40 @@ add_dependencies(
     KRB_5_H
 )
 
-preprocess_et(processed_et_files ${ET_FILES})
+#
+# Generate error tables
+#
+function(preprocess_et et_path)
+    string(REPLACE .et .c F_C ${et_path})
+    string(REPLACE .et .h F_H ${et_path})
+    get_filename_component(et_dir ${et_path} DIRECTORY)
+    get_filename_component(et_name ${et_path} NAME_WLE)
+
+    add_custom_command(OUTPUT ${F_C} ${F_H} ${KRB5_ET_BIN_DIR}/${et_name}.h
+        COMMAND perl "${CMAKE_CURRENT_BINARY_DIR}/compile_et" -d "${KRB5_SOURCE_DIR}/util/et" ${et_path}
+        # for #include w/o path (via -iquote)
+        COMMAND ${CMAKE_COMMAND} -E create_symlink ${F_H} ${KRB5_ET_BIN_DIR}/${et_name}.h
+        DEPENDS ${et_path} "${CMAKE_CURRENT_BINARY_DIR}/compile_et"
+        WORKING_DIRECTORY ${et_dir}
+        VERBATIM
+    )
+endfunction()
+
+function(generate_error_tables)
+    file(GLOB_RECURSE ET_FILES "${KRB5_SOURCE_DIR}/*.et")
+    foreach(et_path ${ET_FILES})
+        string(REPLACE ${KRB5_SOURCE_DIR} ${KRB5_ET_BIN_DIR} et_bin_path ${et_path})
+        string(REPLACE / _ et_target_name ${et_path})
+        get_filename_component(et_bin_dir ${et_bin_path} DIRECTORY)
+        add_custom_command(OUTPUT ${et_bin_path}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${et_bin_dir}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${et_path} ${et_bin_path}
+            VERBATIM
+        )
+        preprocess_et(${et_bin_path})
+    endforeach()
+endfunction()
+generate_error_tables()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     add_custom_command(
@@ -634,12 +633,12 @@ file(MAKE_DIRECTORY
 
 SET(KRBHDEP
     "${KRB5_SOURCE_DIR}/include/krb5/krb5.hin"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/krb5_err.h"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/k5e1_err.h"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/kdb5_err.h"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/kv5m_err.h"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/krb524_err.h"
-    "${KRB5_SOURCE_DIR}/lib/krb5/error_tables/asn1_err.h"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/krb5_err.h"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/k5e1_err.h"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/kdb5_err.h"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/kv5m_err.h"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/krb524_err.h"
+    "${KRB5_ET_BIN_DIR}/lib/krb5/error_tables/asn1_err.h"
 )
 
 # cmake < 3.18 does not have 'cat' command
@@ -654,6 +653,11 @@ add_custom_command(
 target_include_directories(_krb5 SYSTEM BEFORE PUBLIC
     "${KRB5_SOURCE_DIR}/include"
     "${CMAKE_CURRENT_BINARY_DIR}/include"
+)
+
+target_compile_options(_krb5 PRIVATE
+    # For '#include "file.h"'
+    -iquote "${CMAKE_CURRENT_BINARY_DIR}/include_private"
 )
 
 target_include_directories(_krb5 PRIVATE


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc @ilejn 

Note, AFAICS this is the only bit that was required writable source directory, so now you can bind mount source folder in read-only mode and plus git will not find anything untracked.