### PR TITLE
Clean meta cache when part is broken during part loading phase

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -635,24 +635,32 @@ void IMergeTreeDataPart::loadColumnsChecksumsIndexes(bool require_columns_checks
     /// Motivation: memory for index is shared between queries - not belong to the query itself.
     MemoryTrackerBlockerInThread temporarily_disable_memory_tracker(VariableContext::Global);
 
-    loadUUID();
-    loadColumns(require_columns_checksums);
-    loadChecksums(require_columns_checksums);
-    loadIndexGranularity();
-    calculateColumnsAndSecondaryIndicesSizesOnDisk();
-    loadIndex();     /// Must be called after loadIndexGranularity as it uses the value of `index_granularity`
-    loadRowsCount(); /// Must be called after loadIndexGranularity() as it uses the value of `index_granularity`.
-    loadPartitionAndMinMaxIndex();
-    if (!parent_part)
-    {
-        loadTTLInfos();
-        loadProjections(require_columns_checksums, check_consistency);
+    try {
+      loadUUID();
+      loadColumns(require_columns_checksums);
+      loadChecksums(require_columns_checksums);
+      loadIndexGranularity();
+      calculateColumnsAndSecondaryIndicesSizesOnDisk();
+      loadIndex();     /// Must be called after loadIndexGranularity as it uses the value of `index_granularity`
+      loadRowsCount(); /// Must be called after loadIndexGranularity() as it uses the value of `index_granularity`.
+      loadPartitionAndMinMaxIndex();
+      if (!parent_part)
+      {
+          loadTTLInfos();
+          loadProjections(require_columns_checksums, check_consistency);
+      }
+
+      if (check_consistency)
+          checkConsistency(require_columns_checksums);
+
+      loadDefaultCompressionCodec();
+    } catch (...) {
+      // There could be conditions that data part to be loaded is broken, but some of meta infos are already written
+      // into meta data before exception, need to clean them all.
+      metadata_manager->deleteAll(/*include_projection*/true);
+      metadata_manager->assertAllDeleted(/*include_projection*/true);
+      throw;
     }
-
-    if (check_consistency)
-        checkConsistency(require_columns_checksums);
-
-    loadDefaultCompressionCodec();
 }
 
 void IMergeTreeDataPart::appendFilesOfColumnsChecksumsIndexes(Strings & files, bool include_projection) const


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Found one potential issue for #32928. There could be conditions that data part to be loaded is broken, but some of meta infos are already written into meta data before exception in `IMergeTreeDataPart::loadColumnsChecksumsIndexes()`. Need to clean up the dirty meta when exception happens.

Thanks for the feature from @[taiyang-li](https://github.com/taiyang-li).

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
