### PR TITLE
fix filebuffer pos in RemoteReadBuffer

### DIFF
--- a/src/Storages/Cache/ExternalDataSourceCache.cpp
+++ b/src/Storages/Cache/ExternalDataSourceCache.cpp
@@ -94,6 +94,8 @@ bool RemoteReadBuffer::nextImpl()
         return status;
     }
 
+    //file_buffer::pos should increase correspondingly when RemoteReadBuffer is consumed, otherwise start_offset will be incorrect.
+    local_file_holder->file_buffer->position() = local_file_holder->file_buffer->buffer().begin() + BufferBase::offset();
     auto start_offset = local_file_holder->file_buffer->getPosition();
     auto end_offset = start_offset + local_file_holder->file_buffer->internalBuffer().size();
     local_file_holder->file_cache_controller->value().waitMoreData(start_offset, end_offset);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix filebuffer pos in RemoteReadBuffer
When RemoteReadBuffer is consumed, its pos will increase, for example in HadoopSnappyReadBuffer::nextImpl.
![image](https://user-images.githubusercontent.com/80669699/160880640-8535a701-63bd-42e9-a2c2-e5f215bcd96b.png)

The bug is that `local_file_holder->file_buffer::pos` not increase correspondingly, which lead to a smaller `start_offset` and `end_offset`. And later in `local_file_holder->file_buffer->next()`, it would read data larger than `end_offset`, which is still downloading.
![image](https://user-images.githubusercontent.com/80669699/160889621-136259c3-6a2b-4b06-8bfe-2b3e099af22e.png)
![image](https://user-images.githubusercontent.com/80669699/160886641-8d79fc7a-2655-4dbd-b852-8d7017e969e3.png)

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
