### PR TITLE
remove ATOMIC_FLAG_INIT: depreciated in C++20 and warns in clang-14

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -220,7 +220,7 @@ static void incrementProfileEventsBlock(Block & dst, const Block & src)
 }
 
 
-std::atomic_flag exit_on_signal = ATOMIC_FLAG_INIT;
+std::atomic_flag exit_on_signal;
 
 class QueryInterruptHandler : private boost::noncopyable
 {


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

Background: I attempted to build on Ubuntu 20.04 using the latest version of clang downloaded via `https://apt.llvm.org/llvm.sh` but it seems like a recent change in clang (https://reviews.llvm.org/D112221) leads to the following build failure: `error: macro 'ATOMIC_FLAG_INIT' has been marked as depreciated`