### PR TITLE
RFC: Fix ALTER DROP COLUMN of nested column with compact parts

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -785,7 +785,7 @@ bool AlterCommand::isRequireMutationStage(const StorageInMemoryMetadata & metada
 
     /// Drop alias is metadata alter, in other case mutation is required.
     if (type == DROP_COLUMN)
-        return metadata.columns.hasPhysical(column_name);
+        return metadata.columns.hasColumnOrNested(GetColumnsOptions::AllPhysical, column_name);
 
     if (type != MODIFY_COLUMN || data_type == nullptr)
         return false;

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -397,6 +397,15 @@ NamesAndTypesList ColumnsDescription::getSubcolumns(const String & name_in_stora
     return NamesAndTypesList(range.first, range.second);
 }
 
+NamesAndTypesList ColumnsDescription::getNested(const String & column_name) const
+{
+    auto range = getNameRange(columns, column_name);
+    NamesAndTypesList nested;
+    for (auto & it = range.first; it != range.second; ++it)
+        nested.emplace_back(it->name, it->type);
+    return nested;
+}
+
 void ColumnsDescription::addSubcolumnsToList(NamesAndTypesList & source_list) const
 {
     NamesAndTypesList subcolumns_list;

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -603,6 +603,13 @@ bool ColumnsDescription::hasColumnOrSubcolumn(GetColumnsOptions::Kind kind, cons
             || hasSubcolumn(column_name);
 }
 
+bool ColumnsDescription::hasColumnOrNested(GetColumnsOptions::Kind kind, const String & column_name) const
+{
+    auto range = getNameRange(columns, column_name);
+    return range.first != range.second &&
+        defaultKindToGetKind(range.first->default_desc.kind) & kind;
+}
+
 bool ColumnsDescription::hasDefaults() const
 {
     for (const auto & column : columns)

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -167,6 +167,7 @@ public:
 
     bool hasPhysical(const String & column_name) const;
     bool hasColumnOrSubcolumn(GetColumnsOptions::Kind kind, const String & column_name) const;
+    bool hasColumnOrNested(GetColumnsOptions::Kind kind, const String & column_name) const;
 
     NameAndTypePair getPhysical(const String & column_name) const;
     NameAndTypePair getColumnOrSubcolumn(GetColumnsOptions::Kind kind, const String & column_name) const;

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -127,7 +127,10 @@ public:
     NamesAndTypesList getEphemeral() const;
     NamesAndTypesList getAllPhysical() const; /// ordinary + materialized.
     NamesAndTypesList getAll() const; /// ordinary + materialized + aliases + ephemeral
+    /// Returns .size0/.null/...
     NamesAndTypesList getSubcolumns(const String & name_in_storage) const;
+    /// Returns column_name.*
+    NamesAndTypesList getNested(const String & column_name) const;
 
     using ColumnTTLs = std::unordered_map<String, ASTPtr>;
     ColumnTTLs getColumnTTLs() const;

--- a/tests/queries/0_stateless/02260_alter_compact_part_drop_nested_column.sql.j2
+++ b/tests/queries/0_stateless/02260_alter_compact_part_drop_nested_column.sql.j2
@@ -1,0 +1,17 @@
+{# force compact parts and wide #}
+{% for min_bytes_for_wide_part in [100000, 0] %}
+DROP TABLE IF EXISTS compact_alter_{{ min_bytes_for_wide_part }};
+CREATE TABLE compact_alter_{{ min_bytes_for_wide_part }} (d Date, s String, k UInt64) ENGINE=MergeTree() PARTITION BY d ORDER BY k SETTINGS min_bytes_for_wide_part={{ min_bytes_for_wide_part }};
+
+INSERT INTO compact_alter_{{ min_bytes_for_wide_part }} VALUES ('2015-01-01', '2015-01-01 00:00:00', 10);
+
+ALTER TABLE compact_alter_{{ min_bytes_for_wide_part }} ADD COLUMN n.d Int;
+-- force columns creation
+OPTIMIZE TABLE compact_alter_{{ min_bytes_for_wide_part }} FINAL;
+-- this command will not drop n.d from compact part columns.txt
+ALTER TABLE compact_alter_{{ min_bytes_for_wide_part }} DROP COLUMN n;
+-- and now modify column will trigger READ_COLUMN of n.d, and it will bail
+ALTER TABLE compact_alter_{{ min_bytes_for_wide_part }} MODIFY COLUMN s DateTime('UTC') DEFAULT '1970-01-01 00:00:00';
+
+DROP TABLE compact_alter_{{ min_bytes_for_wide_part }};
+{% endfor %}


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix ALTER DROP COLUMN of nested column with compact parts (i.e. `ALTER TABLE x DROP COLUMN n`, when there is column `n.d`)

ALTER DROP COLUMN of nested column did not requires mutation before, and
so it leaves nested column as-is, and in case of compact parts
subsequent alter, that requires mutation, will trigger READ_COLUMN of
that nested column (because it exists in part), but it will fail because
there is no such column in the table already.

Here is example of such a failure on CI, test `00062_replicated_merge_tree_alter_zookeeper_long` - [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/35459/52099b23a1cb9a7ff036c5c60aa037c999b333ef/stateless_tests__thread__actions__[1/3].html

Only the last patch in this series is a real fix, other patches either doing some cleanup (i.e. remove unused functions, move some code), or introduces new functions for the fix.

Cc: @CurtizJ 