### PR TITLE
Make `SortDescription::column_name` always non-empty

### DIFF
--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -46,7 +46,8 @@ static ReturnType checkColumnStructure(const ColumnWithTypeAndName & actual, con
         return onError<ReturnType>("Block structure mismatch in " + std::string(context_description) + " stream: different names of columns:\n"
             + actual.dumpStructure() + "\n" + expected.dumpStructure(), code);
 
-    if (!actual.type->equals(*expected.type))
+    if ((actual.type && !expected.type) || (!actual.type && expected.type)
+        || (actual.type && expected.type && !actual.type->equals(*expected.type)))
         return onError<ReturnType>("Block structure mismatch in " + std::string(context_description) + " stream: different types:\n"
             + actual.dumpStructure() + "\n" + expected.dumpStructure(), code);
 

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -15,6 +15,12 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+
 /** Cursor allows to compare rows in different blocks (and parts).
   * Cursor moves inside single block.
   * It is used in priority queue.

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -365,11 +365,11 @@ private:
 };
 
 template <typename TLeftColumns, typename TRightColumns>
-bool less(const Block & header, const TLeftColumns & lhs, const TRightColumns & rhs, size_t i, size_t j, const SortDescription & descr)
+bool less(const TLeftColumns & lhs, const TRightColumns & rhs, size_t i, size_t j, const SortDescriptionsWithPositions & descr)
 {
     for (const auto & elem : descr)
     {
-        size_t ind = header.getPositionByName(elem.column_name);
+        size_t ind = elem.column_number;
         int res = elem.direction * lhs[ind]->compareAt(i, j, *rhs[ind], elem.nulls_direction);
         if (res < 0)
             return true;

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -61,25 +61,21 @@ struct SortCursorImpl
         reset(block, perm);
     }
 
-    SortCursorImpl(const Columns & columns, const SortDescription & desc_, size_t order_ = 0, IColumn::Permutation * perm = nullptr)
+    SortCursorImpl(
+        const Block & header,
+        const Columns & columns,
+        const SortDescription & desc_,
+        size_t order_ = 0,
+        IColumn::Permutation * perm = nullptr)
         : desc(desc_), sort_columns_size(desc.size()), order(order_), need_collation(desc.size())
     {
-        for (auto & column_desc : desc)
-        {
-            if (!column_desc.column_name.empty())
-                throw Exception("SortDescription should contain column position if SortCursor was used without header.",
-                        ErrorCodes::LOGICAL_ERROR);
-        }
-        reset(columns, {}, perm);
+        reset(columns, header, perm);
     }
 
     bool empty() const { return rows == 0; }
 
     /// Set the cursor to the beginning of the new block.
-    void reset(const Block & block, IColumn::Permutation * perm = nullptr)
-    {
-        reset(block.getColumns(), block, perm);
-    }
+    void reset(const Block & block, IColumn::Permutation * perm = nullptr) { reset(block.getColumns(), block, perm); }
 
     /// Set the cursor to the beginning of the new block.
     void reset(const Columns & columns, const Block & block, IColumn::Permutation * perm = nullptr)
@@ -95,9 +91,8 @@ struct SortCursorImpl
         for (size_t j = 0, size = desc.size(); j < size; ++j)
         {
             auto & column_desc = desc[j];
-            size_t column_number = !column_desc.column_name.empty()
-                                   ? block.getPositionByName(column_desc.column_name)
-                                   : column_desc.column_number;
+            size_t column_number
+                = !column_desc.column_name.empty() ? block.getPositionByName(column_desc.column_name) : column_desc.column_number;
             sort_columns.push_back(columns[column_number].get());
 
             need_collation[j] = desc[j].collator != nullptr && sort_columns.back()->isCollationSupported();

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -12,13 +12,8 @@
 #include <Columns/IColumn.h>
 #include <Columns/ColumnString.h>
 
-
 namespace DB
 {
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
 
 /** Cursor allows to compare rows in different blocks (and parts).
   * Cursor moves inside single block.

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -12,14 +12,13 @@
 #include <Columns/IColumn.h>
 #include <Columns/ColumnString.h>
 
+
 namespace DB
 {
-
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
 }
-
 
 /** Cursor allows to compare rows in different blocks (and parts).
   * Cursor moves inside single block.
@@ -81,9 +80,6 @@ struct SortCursorImpl
     /// Set the cursor to the beginning of the new block.
     void reset(const Columns & columns, const Block & block, IColumn::Permutation * perm = nullptr)
     {
-        if (columns.size() > block.columns())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Block doesn't contain all input columns.");
-
         all_columns.clear();
         sort_columns.clear();
 
@@ -95,8 +91,7 @@ struct SortCursorImpl
         for (size_t j = 0, size = desc.size(); j < size; ++j)
         {
             auto & column_desc = desc[j];
-            size_t column_number = block.getPositionByName(column_desc.column_name);
-            sort_columns.push_back(columns[column_number].get());
+            sort_columns.push_back(block.getByName(column_desc.column_name).column.get());
 
             need_collation[j] = desc[j].collator != nullptr && sort_columns.back()->isCollationSupported();
             has_collation |= need_collation[j];

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -365,11 +365,11 @@ private:
 };
 
 template <typename TLeftColumns, typename TRightColumns>
-bool less(const TLeftColumns & lhs, const TRightColumns & rhs, size_t i, size_t j, const SortDescription & descr)
+bool less(const Block & header, const TLeftColumns & lhs, const TRightColumns & rhs, size_t i, size_t j, const SortDescription & descr)
 {
     for (const auto & elem : descr)
     {
-        size_t ind = elem.column_number;
+        size_t ind = header.getPositionByName(elem.column_name);
         int res = elem.direction * lhs[ind]->compareAt(i, j, *rhs[ind], elem.nulls_direction);
         if (res < 0)
             return true;

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -87,7 +87,8 @@ struct SortCursorImpl
         for (size_t j = 0, size = desc.size(); j < size; ++j)
         {
             auto & column_desc = desc[j];
-            sort_columns.push_back(block.getByName(column_desc.column_name).column.get());
+            size_t column_number = block.getPositionByName(column_desc.column_name);
+            sort_columns.push_back(columns[column_number].get());
 
             need_collation[j] = desc[j].collator != nullptr && sort_columns.back()->isCollationSupported();
             has_collation |= need_collation[j];

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -15,10 +15,6 @@
 
 namespace DB
 {
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
 
 /** Cursor allows to compare rows in different blocks (and parts).
   * Cursor moves inside single block.

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -357,12 +357,12 @@ private:
 };
 
 template <typename TLeftColumns, typename TRightColumns>
-bool less(const TLeftColumns & lhs, const TRightColumns & rhs, size_t i, size_t j, const SortDescriptionsWithPositions & descr)
+bool less(const TLeftColumns & lhs, const TRightColumns & rhs, size_t i, size_t j, const SortDescriptionWithPositions & descr)
 {
     for (const auto & elem : descr)
     {
         size_t ind = elem.column_number;
-        int res = elem.direction * lhs[ind]->compareAt(i, j, *rhs[ind], elem.nulls_direction);
+        int res = elem.base.direction * lhs[ind]->compareAt(i, j, *rhs[ind], elem.base.nulls_direction);
         if (res < 0)
             return true;
         else if (res > 0)

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -91,8 +91,7 @@ struct SortCursorImpl
         for (size_t j = 0, size = desc.size(); j < size; ++j)
         {
             auto & column_desc = desc[j];
-            size_t column_number
-                = !column_desc.column_name.empty() ? block.getPositionByName(column_desc.column_name) : column_desc.column_number;
+            size_t column_number = block.getPositionByName(column_desc.column_name);
             sort_columns.push_back(columns[column_number].get());
 
             need_collation[j] = desc[j].collator != nullptr && sort_columns.back()->isCollationSupported();

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -75,6 +75,9 @@ struct SortCursorImpl
     /// Set the cursor to the beginning of the new block.
     void reset(const Columns & columns, const Block & block, IColumn::Permutation * perm = nullptr)
     {
+        if (columns.size() > block.columns())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Block doesn't contain all input columns.");
+
         all_columns.clear();
         sort_columns.clear();
 

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -1,12 +1,13 @@
-#include <Core/SortDescription.h>
 #include <Core/Block.h>
+#include <Core/SortDescription.h>
 #include <IO/Operators.h>
 #include <Common/JSONBuilder.h>
+#include "Core/Field.h"
 
 namespace DB
 {
 
-void dumpSortDescription(const SortDescription & description, const Block & header, WriteBuffer & out)
+void dumpSortDescription(const SortDescription & description, const Block &, WriteBuffer & out)
 {
     bool first = true;
 
@@ -19,14 +20,7 @@ void dumpSortDescription(const SortDescription & description, const Block & head
         if (!desc.column_name.empty())
             out << desc.column_name;
         else
-        {
-            if (desc.column_number < header.columns())
-                out << header.getByPosition(desc.column_number).name;
-            else
-                out << "?";
-
-            out << " (pos " << desc.column_number << ")";
-        }
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty column name.");
 
         if (desc.direction > 0)
             out << " ASC";
@@ -38,17 +32,12 @@ void dumpSortDescription(const SortDescription & description, const Block & head
     }
 }
 
-void SortColumnDescription::explain(JSONBuilder::JSONMap & map, const Block & header) const
+void SortColumnDescription::explain(JSONBuilder::JSONMap & map, const Block &) const
 {
     if (!column_name.empty())
         map.add("Column", column_name);
     else
-    {
-        if (column_number < header.columns())
-            map.add("Column", header.getByPosition(column_number).name);
-
-        map.add("Position", column_number);
-    }
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty column name.");
 
     map.add("Ascending", direction > 0);
     map.add("With Fill", with_fill);

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -6,7 +6,7 @@
 namespace DB
 {
 
-void dumpSortDescription(const SortDescription & description, const Block &, WriteBuffer & out)
+void dumpSortDescription(const SortDescription & description, WriteBuffer & out)
 {
     bool first = true;
 
@@ -28,7 +28,7 @@ void dumpSortDescription(const SortDescription & description, const Block &, Wri
     }
 }
 
-void SortColumnDescription::explain(JSONBuilder::JSONMap & map, const Block &) const
+void SortColumnDescription::explain(JSONBuilder::JSONMap & map) const
 {
     map.add("Column", column_name);
     map.add("Ascending", direction > 0);
@@ -38,17 +38,17 @@ void SortColumnDescription::explain(JSONBuilder::JSONMap & map, const Block &) c
 std::string dumpSortDescription(const SortDescription & description)
 {
     WriteBufferFromOwnString wb;
-    dumpSortDescription(description, Block{}, wb);
+    dumpSortDescription(description, wb);
     return wb.str();
 }
 
-JSONBuilder::ItemPtr explainSortDescription(const SortDescription & description, const Block & header)
+JSONBuilder::ItemPtr explainSortDescription(const SortDescription & description)
 {
     auto json_array = std::make_unique<JSONBuilder::JSONArray>();
     for (const auto & descr : description)
     {
         auto json_map = std::make_unique<JSONBuilder::JSONMap>();
-        descr.explain(*json_map, header);
+        descr.explain(*json_map);
         json_array->add(std::move(json_map));
     }
 

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -7,6 +7,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 void dumpSortDescription(const SortDescription & description, const Block &, WriteBuffer & out)
 {
     bool first = true;

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -6,11 +6,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
-
 void dumpSortDescription(const SortDescription & description, const Block &, WriteBuffer & out)
 {
     bool first = true;

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -2,7 +2,6 @@
 #include <Core/SortDescription.h>
 #include <IO/Operators.h>
 #include <Common/JSONBuilder.h>
-#include "Core/Field.h"
 
 namespace DB
 {
@@ -22,10 +21,7 @@ void dumpSortDescription(const SortDescription & description, const Block &, Wri
             out << ", ";
         first = false;
 
-        if (!desc.column_name.empty())
-            out << desc.column_name;
-        else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty column name.");
+        out << desc.column_name;
 
         if (desc.direction > 0)
             out << " ASC";
@@ -39,11 +35,7 @@ void dumpSortDescription(const SortDescription & description, const Block &, Wri
 
 void SortColumnDescription::explain(JSONBuilder::JSONMap & map, const Block &) const
 {
-    if (!column_name.empty())
-        map.add("Column", column_name);
-    else
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty column name.");
-
+    map.add("Column", column_name);
     map.add("Ascending", direction > 0);
     map.add("With Fill", with_fill);
 }

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -72,7 +72,7 @@ struct SortColumnDescription
         return !(*this == other);
     }
 
-    std::string dump() const { return fmt::format("{}:dir {}nulls ", column_name, direction, nulls_direction); }
+    std::string dump() const { return fmt::format("{}:{}:dir {}nulls ", column_name, direction, nulls_direction); }
 
     void explain(JSONBuilder::JSONMap & map, const Block & header) const;
 };
@@ -83,19 +83,6 @@ struct SortColumnDescriptionWithColumnIndex : SortColumnDescription
 
     SortColumnDescriptionWithColumnIndex(SortColumnDescription descr, size_t column_number_)
         : SortColumnDescription(std::move(descr)), column_number(column_number_)
-    {
-    }
-
-    SortColumnDescriptionWithColumnIndex(
-        const std::string & column_name_,
-        size_t column_number_,
-        int direction_ = 1,
-        int nulls_direction_ = 1,
-        const std::shared_ptr<Collator> & collator_ = nullptr,
-        bool with_fill_ = false,
-        const FillColumnDescription & fill_description_ = {})
-        : SortColumnDescription(column_name_, direction_, nulls_direction_, collator_, with_fill_, fill_description_)
-        , column_number(column_number_)
     {
     }
 };

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -48,13 +48,6 @@ struct SortColumnDescription
     FillColumnDescription fill_description;
 
     explicit SortColumnDescription(
-            size_t column_number_, int direction_ = 1, int nulls_direction_ = 1,
-            const std::shared_ptr<Collator> & collator_ = nullptr,
-            bool with_fill_ = false, const FillColumnDescription & fill_description_ = {})
-            : column_number(column_number_), direction(direction_), nulls_direction(nulls_direction_), collator(collator_)
-            , with_fill(with_fill_), fill_description(fill_description_) {}
-
-    explicit SortColumnDescription(
             const std::string & column_name_, int direction_ = 1, int nulls_direction_ = 1,
             const std::shared_ptr<Collator> & collator_ = nullptr,
             bool with_fill_ = false, const FillColumnDescription & fill_description_ = {})

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -77,8 +77,32 @@ struct SortColumnDescription
     void explain(JSONBuilder::JSONMap & map, const Block & header) const;
 };
 
+struct SortColumnDescriptionWithColumnIndex : SortColumnDescription
+{
+    size_t column_number;
+
+    SortColumnDescriptionWithColumnIndex(SortColumnDescription descr, size_t column_number_)
+        : SortColumnDescription(std::move(descr)), column_number(column_number_)
+    {
+    }
+
+    SortColumnDescriptionWithColumnIndex(
+        const std::string & column_name_,
+        size_t column_number_,
+        int direction_ = 1,
+        int nulls_direction_ = 1,
+        const std::shared_ptr<Collator> & collator_ = nullptr,
+        bool with_fill_ = false,
+        const FillColumnDescription & fill_description_ = {})
+        : SortColumnDescription(column_name_, direction_, nulls_direction_, collator_, with_fill_, fill_description_)
+        , column_number(column_number_)
+    {
+    }
+};
+
 /// Description of the sorting rule for several columns.
 using SortDescription = std::vector<SortColumnDescription>;
+using SortDescriptionsWithPositions = std::vector<SortColumnDescriptionWithColumnIndex>;
 
 /// Outputs user-readable description into `out`.
 void dumpSortDescription(const SortDescription & description, const Block & header, WriteBuffer & out);

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -39,7 +39,7 @@ struct FillColumnDescription
 struct SortColumnDescription
 {
     std::string column_name; /// The name of the column.
-    size_t column_number;    /// Column number (used if no name is given).
+    size_t column_number; /// Column number (used if no name is given).
     int direction;           /// 1 - ascending, -1 - descending.
     int nulls_direction;     /// 1 - NULLs and NaNs are greater, -1 - less.
                              /// To achieve NULLS LAST, set it equal to direction, to achieve NULLS FIRST, set it opposite.

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -39,7 +39,6 @@ struct FillColumnDescription
 struct SortColumnDescription
 {
     std::string column_name; /// The name of the column.
-    size_t column_number; /// Column number (used if no name is given).
     int direction;           /// 1 - ascending, -1 - descending.
     int nulls_direction;     /// 1 - NULLs and NaNs are greater, -1 - less.
                              /// To achieve NULLS LAST, set it equal to direction, to achieve NULLS FIRST, set it opposite.
@@ -48,16 +47,24 @@ struct SortColumnDescription
     FillColumnDescription fill_description;
 
     explicit SortColumnDescription(
-            const std::string & column_name_, int direction_ = 1, int nulls_direction_ = 1,
-            const std::shared_ptr<Collator> & collator_ = nullptr,
-            bool with_fill_ = false, const FillColumnDescription & fill_description_ = {})
-            : column_name(column_name_), column_number(0), direction(direction_), nulls_direction(nulls_direction_)
-            , collator(collator_), with_fill(with_fill_), fill_description(fill_description_) {}
+        const std::string & column_name_,
+        int direction_ = 1,
+        int nulls_direction_ = 1,
+        const std::shared_ptr<Collator> & collator_ = nullptr,
+        bool with_fill_ = false,
+        const FillColumnDescription & fill_description_ = {})
+        : column_name(column_name_)
+        , direction(direction_)
+        , nulls_direction(nulls_direction_)
+        , collator(collator_)
+        , with_fill(with_fill_)
+        , fill_description(fill_description_)
+    {
+    }
 
     bool operator == (const SortColumnDescription & other) const
     {
-        return column_name == other.column_name && column_number == other.column_number
-            && direction == other.direction && nulls_direction == other.nulls_direction;
+        return column_name == other.column_name && direction == other.direction && nulls_direction == other.nulls_direction;
     }
 
     bool operator != (const SortColumnDescription & other) const
@@ -65,10 +72,7 @@ struct SortColumnDescription
         return !(*this == other);
     }
 
-    std::string dump() const
-    {
-        return fmt::format("{}:{}:dir {}nulls ", column_name, column_number, direction, nulls_direction);
-    }
+    std::string dump() const { return fmt::format("{}:dir {}nulls ", column_name, direction, nulls_direction); }
 
     void explain(JSONBuilder::JSONMap & map, const Block & header) const;
 };

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -72,30 +72,30 @@ struct SortColumnDescription
         return !(*this == other);
     }
 
-    std::string dump() const { return fmt::format("{}:{}:dir {}nulls ", column_name, direction, nulls_direction); }
+    std::string dump() const { return fmt::format("{}:dir {}nulls {}", column_name, direction, nulls_direction); }
 
-    void explain(JSONBuilder::JSONMap & map, const Block & header) const;
+    void explain(JSONBuilder::JSONMap & map) const;
 };
 
-struct SortColumnDescriptionWithColumnIndex : SortColumnDescription
+struct SortColumnDescriptionWithColumnIndex
 {
+    SortColumnDescription base;
     size_t column_number;
 
-    SortColumnDescriptionWithColumnIndex(SortColumnDescription descr, size_t column_number_)
-        : SortColumnDescription(std::move(descr)), column_number(column_number_)
+    SortColumnDescriptionWithColumnIndex(SortColumnDescription description_, size_t column_number_)
+        : base(std::move(description_)), column_number(column_number_)
     {
     }
 };
 
 /// Description of the sorting rule for several columns.
 using SortDescription = std::vector<SortColumnDescription>;
-using SortDescriptionsWithPositions = std::vector<SortColumnDescriptionWithColumnIndex>;
+using SortDescriptionWithPositions = std::vector<SortColumnDescriptionWithColumnIndex>;
 
 /// Outputs user-readable description into `out`.
-void dumpSortDescription(const SortDescription & description, const Block & header, WriteBuffer & out);
+void dumpSortDescription(const SortDescription & description, WriteBuffer & out);
 
 std::string dumpSortDescription(const SortDescription & description);
 
-JSONBuilder::ItemPtr explainSortDescription(const SortDescription & description, const Block & header);
-
+JSONBuilder::ItemPtr explainSortDescription(const SortDescription & description);
 }

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2249,10 +2249,6 @@ static bool windowDescriptionComparator(const WindowDescription * _left, const W
             return true;
         else if (left[i].column_name > right[i].column_name)
             return false;
-        else if (left[i].column_number < right[i].column_number)
-            return true;
-        else if (left[i].column_number > right[i].column_number)
-            return false;
         else if (left[i].direction < right[i].direction)
             return true;
         else if (left[i].direction > right[i].direction)

--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -1025,7 +1025,7 @@ std::optional<SortDescription> MutationsInterpreter::getStorageSortDescriptionIf
     for (size_t i = 0; i < sort_columns_size; ++i)
     {
         if (header.has(sort_columns[i]))
-            sort_description.emplace_back(header.getPositionByName(sort_columns[i]), 1, 1);
+            sort_description.emplace_back(sort_columns[i], 1, 1);
         else
             return {};
     }

--- a/src/Interpreters/Set.cpp
+++ b/src/Interpreters/Set.cpp
@@ -430,8 +430,8 @@ MergeTreeSetIndex::MergeTreeSetIndex(const Columns & set_elements, std::vector<K
     SortDescription sort_description;
     for (size_t i = 0; i < tuple_size; ++i)
     {
-        block_to_sort.insert({ ordered_set[i], nullptr, "_" + toString(i) });
-        sort_description.emplace_back(i, 1, 1);
+        block_to_sort.insert({ordered_set[i], nullptr, "_" + toString(i)});
+        sort_description.emplace_back(ordered_set[i]->getName(), 1, 1);
     }
 
     sortBlock(block_to_sort, sort_description);

--- a/src/Interpreters/Set.cpp
+++ b/src/Interpreters/Set.cpp
@@ -430,7 +430,7 @@ MergeTreeSetIndex::MergeTreeSetIndex(const Columns & set_elements, std::vector<K
     SortDescription sort_description;
     for (size_t i = 0; i < tuple_size; ++i)
     {
-        block_to_sort.insert({ordered_set[i], nullptr, "_" + toString(i)});
+        block_to_sort.insert({ordered_set[i], nullptr, ordered_set[i]->getName()});
         sort_description.emplace_back(ordered_set[i]->getName(), 1, 1);
     }
 

--- a/src/Interpreters/sortBlock.cpp
+++ b/src/Interpreters/sortBlock.cpp
@@ -98,9 +98,7 @@ ColumnsWithSortDescriptions getColumnsWithSortDescription(const Block & block, c
     {
         const auto & sort_column_description = description[i];
 
-        const IColumn * column = !sort_column_description.column_name.empty()
-            ? block.getByName(sort_column_description.column_name).column.get()
-            : block.safeGetByPosition(sort_column_description.column_number).column.get();
+        const IColumn * column = block.getByName(sort_column_description.column_name).column.get();
 
         if (isCollationRequired(sort_column_description))
         {

--- a/src/Processors/LimitTransform.cpp
+++ b/src/Processors/LimitTransform.cpp
@@ -42,7 +42,7 @@ LimitTransform::LimitTransform(
         if (!desc.column_name.empty())
             sort_column_positions.push_back(header_.getPositionByName(desc.column_name));
         else
-            sort_column_positions.push_back(desc.column_number);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name empty.");
     }
 }
 

--- a/src/Processors/LimitTransform.cpp
+++ b/src/Processors/LimitTransform.cpp
@@ -38,12 +38,7 @@ LimitTransform::LimitTransform(
     }
 
     for (const auto & desc : description)
-    {
-        if (!desc.column_name.empty())
-            sort_column_positions.push_back(header_.getPositionByName(desc.column_name));
-        else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name empty.");
-    }
+        sort_column_positions.push_back(header_.getPositionByName(desc.column_name));
 }
 
 Chunk LimitTransform::makeChunkWithPreviousRow(const Chunk & chunk, UInt64 row) const

--- a/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
@@ -290,10 +290,10 @@ void AggregatingSortedAlgorithm::AggregatingMergedData::initAggregateDescription
 
 
 AggregatingSortedAlgorithm::AggregatingSortedAlgorithm(
-    const Block & header, size_t num_inputs, SortDescription description_, size_t max_block_size)
-    : IMergingAlgorithmWithDelayedChunk(header, num_inputs, description_)
-    , columns_definition(defineColumns(header, description_))
-    , merged_data(getMergedColumns(header, columns_definition), max_block_size, columns_definition)
+    const Block & header_, size_t num_inputs, SortDescription description_, size_t max_block_size)
+    : IMergingAlgorithmWithDelayedChunk(header_, num_inputs, description_)
+    , columns_definition(defineColumns(header_, description_))
+    , merged_data(getMergedColumns(header_, columns_definition), max_block_size, columns_definition)
 {
 }
 

--- a/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
@@ -104,7 +104,7 @@ static AggregatingSortedAlgorithm::ColumnsDefinition defineColumns(
         /// Included into PK?
         auto it = description.begin();
         for (; it != description.end(); ++it)
-            if (it->column_name == column.name || (it->column_name.empty() && it->column_number == i))
+            if (it->column_name == column.name)
                 break;
 
         if (it != description.end())

--- a/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/AggregatingSortedAlgorithm.cpp
@@ -290,9 +290,8 @@ void AggregatingSortedAlgorithm::AggregatingMergedData::initAggregateDescription
 
 
 AggregatingSortedAlgorithm::AggregatingSortedAlgorithm(
-    const Block & header, size_t num_inputs,
-    SortDescription description_, size_t max_block_size)
-    : IMergingAlgorithmWithDelayedChunk(num_inputs, description_)
+    const Block & header, size_t num_inputs, SortDescription description_, size_t max_block_size)
+    : IMergingAlgorithmWithDelayedChunk(header, num_inputs, description_)
     , columns_definition(defineColumns(header, description_))
     , merged_data(getMergedColumns(header, columns_definition), max_block_size, columns_definition)
 {

--- a/src/Processors/Merges/Algorithms/CollapsingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/CollapsingSortedAlgorithm.cpp
@@ -30,7 +30,7 @@ CollapsingSortedAlgorithm::CollapsingSortedAlgorithm(
     Poco::Logger * log_,
     WriteBuffer * out_row_sources_buf_,
     bool use_average_block_sizes)
-    : IMergingAlgorithmWithSharedChunks(num_inputs, std::move(description_), out_row_sources_buf_, max_row_refs)
+    : IMergingAlgorithmWithSharedChunks(header, num_inputs, std::move(description_), out_row_sources_buf_, max_row_refs)
     , merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
     , sign_column_number(header.getPositionByName(sign_column))
     , only_positive_sign(only_positive_sign_)

--- a/src/Processors/Merges/Algorithms/CollapsingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/CollapsingSortedAlgorithm.cpp
@@ -21,7 +21,7 @@ namespace ErrorCodes
 }
 
 CollapsingSortedAlgorithm::CollapsingSortedAlgorithm(
-    const Block & header,
+    const Block & header_,
     size_t num_inputs,
     SortDescription description_,
     const String & sign_column,
@@ -30,9 +30,9 @@ CollapsingSortedAlgorithm::CollapsingSortedAlgorithm(
     Poco::Logger * log_,
     WriteBuffer * out_row_sources_buf_,
     bool use_average_block_sizes)
-    : IMergingAlgorithmWithSharedChunks(header, num_inputs, std::move(description_), out_row_sources_buf_, max_row_refs)
-    , merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
-    , sign_column_number(header.getPositionByName(sign_column))
+    : IMergingAlgorithmWithSharedChunks(header_, num_inputs, std::move(description_), out_row_sources_buf_, max_row_refs)
+    , merged_data(header_.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
+    , sign_column_number(header_.getPositionByName(sign_column))
     , only_positive_sign(only_positive_sign_)
     , log(log_)
 {

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
@@ -48,7 +48,7 @@ FinishAggregatingInOrderAlgorithm::FinishAggregatingInOrderAlgorithm(
         if (!column_description.column_name.empty())
         {
             column_description.column_number = header_.getPositionByName(column_description.column_name);
-            column_description.column_name.clear();
+            // column_description.column_name.clear();
         }
     }
 }

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
@@ -14,7 +14,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-FinishAggregatingInOrderAlgorithm::State::State(const Chunk & chunk, const SortDescriptionsWithPositions & desc, Int64 total_bytes_)
+FinishAggregatingInOrderAlgorithm::State::State(const Chunk & chunk, const SortDescriptionWithPositions & desc, Int64 total_bytes_)
     : all_columns(chunk.getColumns()), num_rows(chunk.getNumRows()), total_bytes(total_bytes_)
 {
     if (!chunk)
@@ -22,24 +22,17 @@ FinishAggregatingInOrderAlgorithm::State::State(const Chunk & chunk, const SortD
 
     sorting_columns.reserve(desc.size());
     for (const auto & column_desc : desc)
-    {
-        const auto idx = column_desc.column_number;
-        sorting_columns.emplace_back(all_columns[idx].get());
-    }
+        sorting_columns.emplace_back(all_columns[column_desc.column_number].get());
 }
 
 FinishAggregatingInOrderAlgorithm::FinishAggregatingInOrderAlgorithm(
     const Block & header_,
     size_t num_inputs_,
     AggregatingTransformParamsPtr params_,
-    SortDescription description_,
+    const SortDescription & description_,
     size_t max_block_size_,
     size_t max_block_bytes_)
-    : header(header_)
-    , num_inputs(num_inputs_)
-    , params(params_)
-    , max_block_size(max_block_size_)
-    , max_block_bytes(max_block_bytes_)
+    : header(header_), num_inputs(num_inputs_), params(params_), max_block_size(max_block_size_), max_block_bytes(max_block_bytes_)
 {
     for (const auto & column_description : description_)
         description.emplace_back(column_description, header_.getPositionByName(column_description.column_name));

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
@@ -69,6 +69,7 @@ void FinishAggregatingInOrderAlgorithm::consume(Input & input, size_t source_num
     states[source_num] = State{input.chunk, description, arenas_info->allocated_bytes};
 }
 
+// clang-format off
 IMergingAlgorithm::Status FinishAggregatingInOrderAlgorithm::merge()
 {
     if (!inputs_to_update.empty())
@@ -86,12 +87,8 @@ IMergingAlgorithm::Status FinishAggregatingInOrderAlgorithm::merge()
             continue;
 
         if (!best_input
-            || less(
-                states[i].sorting_columns,
-                states[*best_input].sorting_columns,
-                states[i].num_rows - 1,
-                states[*best_input].num_rows - 1,
-                description))
+            || less(states[i].sorting_columns, states[*best_input].sorting_columns,
+                    states[i].num_rows - 1, states[*best_input].num_rows - 1, description))
         {
             best_input = i;
         }
@@ -111,12 +108,11 @@ IMergingAlgorithm::Status FinishAggregatingInOrderAlgorithm::merge()
             continue;
 
         auto indices = collections::range(states[i].current_row, states[i].num_rows);
-        auto it = std::upper_bound(
-            indices.begin(),
-            indices.end(),
-            best_state.num_rows - 1,
+        auto it = std::upper_bound(indices.begin(), indices.end(), best_state.num_rows - 1,
             [&](size_t lhs_pos, size_t rhs_pos)
-            { return less(best_state.sorting_columns, states[i].sorting_columns, lhs_pos, rhs_pos, description); });
+            {
+                return less(best_state.sorting_columns, states[i].sorting_columns, lhs_pos, rhs_pos, description);
+            });
 
         states[i].to_row = (it == indices.end() ? states[i].num_rows : *it);
     }

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
@@ -46,10 +46,7 @@ FinishAggregatingInOrderAlgorithm::FinishAggregatingInOrderAlgorithm(
     for (auto & column_description : description)
     {
         if (!column_description.column_name.empty())
-        {
             column_description.column_number = header_.getPositionByName(column_description.column_name);
-            // column_description.column_name.clear();
-        }
     }
 }
 

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp
@@ -69,7 +69,6 @@ void FinishAggregatingInOrderAlgorithm::consume(Input & input, size_t source_num
     states[source_num] = State{input.chunk, description, arenas_info->allocated_bytes};
 }
 
-// clang-format off
 IMergingAlgorithm::Status FinishAggregatingInOrderAlgorithm::merge()
 {
     if (!inputs_to_update.empty())

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
@@ -41,7 +41,7 @@ public:
         const Block & header_,
         size_t num_inputs_,
         AggregatingTransformParamsPtr params_,
-        SortDescription description_,
+        const SortDescription & description_,
         size_t max_block_size_,
         size_t max_block_bytes_);
 
@@ -69,7 +69,7 @@ private:
         /// Number of bytes in all columns + number of bytes in arena, related to current chunk.
         size_t total_bytes = 0;
 
-        State(const Chunk & chunk, const SortDescriptionsWithPositions & description, Int64 total_bytes_);
+        State(const Chunk & chunk, const SortDescriptionWithPositions & description, Int64 total_bytes_);
         State() = default;
 
         bool isValid() const { return current_row < num_rows; }
@@ -78,7 +78,7 @@ private:
     Block header;
     size_t num_inputs;
     AggregatingTransformParamsPtr params;
-    SortDescriptionsWithPositions description;
+    SortDescriptionWithPositions description;
     size_t max_block_size;
     size_t max_block_bytes;
 

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
@@ -55,7 +55,6 @@ private:
 
     struct State
     {
-        Block header;
         Columns all_columns;
         ColumnRawPtrs sorting_columns;
 
@@ -70,7 +69,7 @@ private:
         /// Number of bytes in all columns + number of bytes in arena, related to current chunk.
         size_t total_bytes = 0;
 
-        State(Block header_, const Chunk & chunk, const SortDescription & description, Int64 total_bytes_);
+        State(const Chunk & chunk, const SortDescriptionsWithPositions & description, Int64 total_bytes_);
         State() = default;
 
         bool isValid() const { return current_row < num_rows; }
@@ -79,7 +78,7 @@ private:
     Block header;
     size_t num_inputs;
     AggregatingTransformParamsPtr params;
-    SortDescription description;
+    SortDescriptionsWithPositions description;
     size_t max_block_size;
     size_t max_block_bytes;
 

--- a/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.h
@@ -55,6 +55,7 @@ private:
 
     struct State
     {
+        Block header;
         Columns all_columns;
         ColumnRawPtrs sorting_columns;
 
@@ -69,7 +70,7 @@ private:
         /// Number of bytes in all columns + number of bytes in arena, related to current chunk.
         size_t total_bytes = 0;
 
-        State(const Chunk & chunk, const SortDescription & description, Int64 total_bytes_);
+        State(Block header_, const Chunk & chunk, const SortDescription & description, Int64 total_bytes_);
         State() = default;
 
         bool isValid() const { return current_row < num_rows; }

--- a/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.cpp
@@ -30,14 +30,14 @@ static GraphiteRollupSortedAlgorithm::ColumnsDefinition defineColumns(
 }
 
 GraphiteRollupSortedAlgorithm::GraphiteRollupSortedAlgorithm(
-    const Block & header,
+    const Block & header_,
     size_t num_inputs,
     SortDescription description_,
     size_t max_block_size,
     Graphite::Params params_,
     time_t time_of_merge_)
-    : IMergingAlgorithmWithSharedChunks(header, num_inputs, std::move(description_), nullptr, max_row_refs)
-    , merged_data(header.cloneEmptyColumns(), false, max_block_size)
+    : IMergingAlgorithmWithSharedChunks(header_, num_inputs, std::move(description_), nullptr, max_row_refs)
+    , merged_data(header_.cloneEmptyColumns(), false, max_block_size)
     , params(std::move(params_))
     , time_of_merge(time_of_merge_)
 {
@@ -54,7 +54,7 @@ GraphiteRollupSortedAlgorithm::GraphiteRollupSortedAlgorithm(
     }
 
     merged_data.allocMemForAggregates(max_size_of_aggregate_state, max_alignment_of_aggregate_state);
-    columns_definition = defineColumns(header, params);
+    columns_definition = defineColumns(header_, params);
 }
 
 UInt32 GraphiteRollupSortedAlgorithm::selectPrecision(const Graphite::Retentions & retentions, time_t time) const

--- a/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/GraphiteRollupSortedAlgorithm.cpp
@@ -30,12 +30,16 @@ static GraphiteRollupSortedAlgorithm::ColumnsDefinition defineColumns(
 }
 
 GraphiteRollupSortedAlgorithm::GraphiteRollupSortedAlgorithm(
-    const Block & header, size_t num_inputs,
-    SortDescription description_, size_t max_block_size,
-    Graphite::Params params_, time_t time_of_merge_)
-    : IMergingAlgorithmWithSharedChunks(num_inputs, std::move(description_), nullptr, max_row_refs)
+    const Block & header,
+    size_t num_inputs,
+    SortDescription description_,
+    size_t max_block_size,
+    Graphite::Params params_,
+    time_t time_of_merge_)
+    : IMergingAlgorithmWithSharedChunks(header, num_inputs, std::move(description_), nullptr, max_row_refs)
     , merged_data(header.cloneEmptyColumns(), false, max_block_size)
-    , params(std::move(params_)), time_of_merge(time_of_merge_)
+    , params(std::move(params_))
+    , time_of_merge(time_of_merge_)
 {
     size_t max_size_of_aggregate_state = 0;
     size_t max_alignment_of_aggregate_state = 1;

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.cpp
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.cpp
@@ -4,8 +4,8 @@
 namespace DB
 {
 
-IMergingAlgorithmWithDelayedChunk::IMergingAlgorithmWithDelayedChunk(const Block & header_, size_t num_inputs, SortDescription description_)
-    : description(std::move(description_)), header(header_), current_inputs(num_inputs), cursors(num_inputs)
+IMergingAlgorithmWithDelayedChunk::IMergingAlgorithmWithDelayedChunk(Block header_, size_t num_inputs, SortDescription description_)
+    : description(std::move(description_)), header(std::move(header_)), current_inputs(num_inputs), cursors(num_inputs)
 {
 }
 

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.cpp
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.cpp
@@ -4,12 +4,8 @@
 namespace DB
 {
 
-IMergingAlgorithmWithDelayedChunk::IMergingAlgorithmWithDelayedChunk(
-    size_t num_inputs,
-    SortDescription description_)
-    : description(std::move(description_))
-    , current_inputs(num_inputs)
-    , cursors(num_inputs)
+IMergingAlgorithmWithDelayedChunk::IMergingAlgorithmWithDelayedChunk(const Block & header_, size_t num_inputs, SortDescription description_)
+    : description(std::move(description_)), header(header_), current_inputs(num_inputs), cursors(num_inputs)
 {
 }
 
@@ -22,7 +18,8 @@ void IMergingAlgorithmWithDelayedChunk::initializeQueue(Inputs inputs)
         if (!current_inputs[source_num].chunk)
             continue;
 
-        cursors[source_num] = SortCursorImpl(current_inputs[source_num].chunk.getColumns(), description, source_num, current_inputs[source_num].permutation);
+        cursors[source_num] = SortCursorImpl(
+            header, current_inputs[source_num].chunk.getColumns(), description, source_num, current_inputs[source_num].permutation);
     }
 
     queue = SortingHeap<SortCursor>(cursors);
@@ -37,7 +34,7 @@ void IMergingAlgorithmWithDelayedChunk::updateCursor(Input & input, size_t sourc
     last_chunk_sort_columns = std::move(cursors[source_num].sort_columns);
 
     current_input.swap(input);
-    cursors[source_num].reset(current_input.chunk.getColumns(), {}, current_input.permutation);
+    cursors[source_num].reset(current_input.chunk.getColumns(), header, current_input.permutation);
 
     queue.push(cursors[source_num]);
 }

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
@@ -10,9 +10,7 @@ namespace DB
 class IMergingAlgorithmWithDelayedChunk : public IMergingAlgorithm
 {
 public:
-    IMergingAlgorithmWithDelayedChunk(
-        size_t num_inputs,
-        SortDescription description_);
+    IMergingAlgorithmWithDelayedChunk(const Block & header_, size_t num_inputs, SortDescription description_);
 
 protected:
     SortingHeap<SortCursor> queue;
@@ -28,6 +26,8 @@ protected:
     bool skipLastRowFor(size_t input_number) const { return current_inputs[input_number].skip_last_row; }
 
 private:
+    Block header;
+
     /// Inputs currently being merged.
     Inputs current_inputs;
     SortCursorImpls cursors;

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithDelayedChunk.h
@@ -10,7 +10,7 @@ namespace DB
 class IMergingAlgorithmWithDelayedChunk : public IMergingAlgorithm
 {
 public:
-    IMergingAlgorithmWithDelayedChunk(const Block & header_, size_t num_inputs, SortDescription description_);
+    IMergingAlgorithmWithDelayedChunk(Block header_, size_t num_inputs, SortDescription description_);
 
 protected:
     SortingHeap<SortCursor> queue;

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.cpp
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.cpp
@@ -53,7 +53,7 @@ void IMergingAlgorithmWithSharedChunks::consume(Input & input, size_t source_num
     auto & source = sources[source_num];
     source.skip_last_row = input.skip_last_row;
     source.chunk = chunk_allocator.alloc(input.chunk);
-    cursors[source_num].reset(source.chunk->getColumns(), {}, input.permutation);
+    cursors[source_num].reset(source.chunk->getColumns(), header, input.permutation);
 
     source.chunk->all_columns = cursors[source_num].all_columns;
     source.chunk->sort_columns = cursors[source_num].sort_columns;

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.cpp
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.cpp
@@ -4,11 +4,9 @@ namespace DB
 {
 
 IMergingAlgorithmWithSharedChunks::IMergingAlgorithmWithSharedChunks(
-    size_t num_inputs,
-    SortDescription description_,
-    WriteBuffer * out_row_sources_buf_,
-    size_t max_row_refs)
-    : description(std::move(description_))
+    Block header_, size_t num_inputs, SortDescription description_, WriteBuffer * out_row_sources_buf_, size_t max_row_refs)
+    : header(std::move(header_))
+    , description(std::move(description_))
     , chunk_allocator(num_inputs + max_row_refs)
     , cursors(num_inputs)
     , sources(num_inputs)
@@ -39,7 +37,7 @@ void IMergingAlgorithmWithSharedChunks::initialize(Inputs inputs)
 
         source.skip_last_row = inputs[source_num].skip_last_row;
         source.chunk = chunk_allocator.alloc(inputs[source_num].chunk);
-        cursors[source_num] = SortCursorImpl(source.chunk->getColumns(), description, source_num, inputs[source_num].permutation);
+        cursors[source_num] = SortCursorImpl(header, source.chunk->getColumns(), description, source_num, inputs[source_num].permutation);
 
         source.chunk->all_columns = cursors[source_num].all_columns;
         source.chunk->sort_columns = cursors[source_num].sort_columns;

--- a/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.h
+++ b/src/Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.h
@@ -10,15 +10,13 @@ class IMergingAlgorithmWithSharedChunks : public IMergingAlgorithm
 {
 public:
     IMergingAlgorithmWithSharedChunks(
-        size_t num_inputs,
-        SortDescription description_,
-        WriteBuffer * out_row_sources_buf_,
-        size_t max_row_refs);
+        Block header_, size_t num_inputs, SortDescription description_, WriteBuffer * out_row_sources_buf_, size_t max_row_refs);
 
     void initialize(Inputs inputs) override;
     void consume(Input & input, size_t source_num) override;
 
 private:
+    Block header;
     SortDescription description;
 
     /// Allocator must be destroyed after source_chunks.

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
@@ -26,13 +26,8 @@ MergingSortedAlgorithm::MergingSortedAlgorithm(
     , current_inputs(num_inputs)
     , cursors(num_inputs)
 {
-    /// Replace column names in description to positions.
     for (auto & column_description : description)
-    {
         has_collation |= column_description.collator != nullptr;
-        if (column_description.column_name.empty())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name empty.");
-    }
 }
 
 void MergingSortedAlgorithm::addInput()

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
@@ -33,7 +33,7 @@ MergingSortedAlgorithm::MergingSortedAlgorithm(
         if (!column_description.column_name.empty())
         {
             column_description.column_number = header.getPositionByName(column_description.column_name);
-            column_description.column_name.clear();
+            // column_description.column_name.clear();
         }
     }
 }
@@ -79,7 +79,7 @@ void MergingSortedAlgorithm::consume(Input & input, size_t source_num)
 {
     prepareChunk(input.chunk);
     current_inputs[source_num].swap(input);
-    cursors[source_num].reset(current_inputs[source_num].chunk.getColumns(), {});
+    cursors[source_num].reset(current_inputs[source_num].chunk.getColumns(), header);
 
     if (has_collation)
         queue_with_collation.push(cursors[source_num]);

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
@@ -22,12 +22,11 @@ MergingSortedAlgorithm::MergingSortedAlgorithm(
     , merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
     , description(std::move(description_))
     , limit(limit_)
+    , has_collation(std::any_of(description.begin(), description.end(), [](const auto & descr) { return descr.collator != nullptr; }))
     , out_row_sources_buf(out_row_sources_buf_)
     , current_inputs(num_inputs)
     , cursors(num_inputs)
 {
-    for (auto & column_description : description)
-        has_collation |= column_description.collator != nullptr;
 }
 
 void MergingSortedAlgorithm::addInput()

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
@@ -30,8 +30,8 @@ MergingSortedAlgorithm::MergingSortedAlgorithm(
     for (auto & column_description : description)
     {
         has_collation |= column_description.collator != nullptr;
-        if (!column_description.column_name.empty())
-            column_description.column_number = header.getPositionByName(column_description.column_name);
+        if (column_description.column_name.empty())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name empty.");
     }
 }
 

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
@@ -11,14 +11,15 @@ namespace ErrorCodes
 }
 
 MergingSortedAlgorithm::MergingSortedAlgorithm(
-    const Block & header,
+    Block header_,
     size_t num_inputs,
     SortDescription description_,
     size_t max_block_size,
     UInt64 limit_,
     WriteBuffer * out_row_sources_buf_,
     bool use_average_block_sizes)
-    : merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
+    : header(std::move(header_))
+    , merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
     , description(std::move(description_))
     , limit(limit_)
     , out_row_sources_buf(out_row_sources_buf_)
@@ -65,7 +66,7 @@ void MergingSortedAlgorithm::initialize(Inputs inputs)
             continue;
 
         prepareChunk(chunk);
-        cursors[source_num] = SortCursorImpl(chunk.getColumns(), description, source_num);
+        cursors[source_num] = SortCursorImpl(header, chunk.getColumns(), description, source_num);
     }
 
     if (has_collation)

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
@@ -31,10 +31,7 @@ MergingSortedAlgorithm::MergingSortedAlgorithm(
     {
         has_collation |= column_description.collator != nullptr;
         if (!column_description.column_name.empty())
-        {
             column_description.column_number = header.getPositionByName(column_description.column_name);
-            // column_description.column_name.clear();
-        }
     }
 }
 

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.h
@@ -14,7 +14,7 @@ class MergingSortedAlgorithm final : public IMergingAlgorithm
 {
 public:
     MergingSortedAlgorithm(
-        const Block & header,
+        Block header_,
         size_t num_inputs,
         SortDescription description_,
         size_t max_block_size,
@@ -31,6 +31,8 @@ public:
     const MergedData & getMergedData() const { return merged_data; }
 
 private:
+    Block header;
+
     MergedData merged_data;
 
     /// Settings

--- a/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.cpp
@@ -5,13 +5,15 @@ namespace DB
 {
 
 ReplacingSortedAlgorithm::ReplacingSortedAlgorithm(
-        const Block & header, size_t num_inputs,
-        SortDescription description_, const String & version_column,
-        size_t max_block_size,
-        WriteBuffer * out_row_sources_buf_,
-        bool use_average_block_sizes)
-        : IMergingAlgorithmWithSharedChunks(num_inputs, std::move(description_), out_row_sources_buf_, max_row_refs)
-        , merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
+    const Block & header,
+    size_t num_inputs,
+    SortDescription description_,
+    const String & version_column,
+    size_t max_block_size,
+    WriteBuffer * out_row_sources_buf_,
+    bool use_average_block_sizes)
+    : IMergingAlgorithmWithSharedChunks(header, num_inputs, std::move(description_), out_row_sources_buf_, max_row_refs)
+    , merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
 {
     if (!version_column.empty())
         version_column_number = header.getPositionByName(version_column);

--- a/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.cpp
@@ -5,18 +5,18 @@ namespace DB
 {
 
 ReplacingSortedAlgorithm::ReplacingSortedAlgorithm(
-    const Block & header,
+    const Block & header_,
     size_t num_inputs,
     SortDescription description_,
     const String & version_column,
     size_t max_block_size,
     WriteBuffer * out_row_sources_buf_,
     bool use_average_block_sizes)
-    : IMergingAlgorithmWithSharedChunks(header, num_inputs, std::move(description_), out_row_sources_buf_, max_row_refs)
-    , merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
+    : IMergingAlgorithmWithSharedChunks(header_, num_inputs, std::move(description_), out_row_sources_buf_, max_row_refs)
+    , merged_data(header_.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
 {
     if (!version_column.empty())
-        version_column_number = header.getPositionByName(version_column);
+        version_column_number = header_.getPositionByName(version_column);
 }
 
 void ReplacingSortedAlgorithm::insertRow()

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -101,7 +101,7 @@ struct SummingSortedAlgorithm::AggregateDescription
 };
 
 
-static bool isInPrimaryKey(const SortDescription & description, const std::string & name, const size_t)
+static bool isInPrimaryKey(const SortDescription & description, const std::string & name)
 {
     for (const auto & desc : description)
         if (desc.column_name == name)
@@ -251,7 +251,7 @@ static SummingSortedAlgorithm::ColumnsDefinition defineColumns(
             }
 
             /// Are they inside the primary key or partition key?
-            if (isInPrimaryKey(description, column.name, i) ||  isInPartitionKey(column.name, partition_key_columns))
+            if (isInPrimaryKey(description, column.name) || isInPartitionKey(column.name, partition_key_columns))
             {
                 def.column_numbers_not_to_aggregate.push_back(i);
                 continue;
@@ -307,7 +307,7 @@ static SummingSortedAlgorithm::ColumnsDefinition defineColumns(
         /// no elements of map could be in primary key
         auto column_num_it = map.second.begin();
         for (; column_num_it != map.second.end(); ++column_num_it)
-            if (isInPrimaryKey(description, header.safeGetByPosition(*column_num_it).name, *column_num_it))
+            if (isInPrimaryKey(description, header.safeGetByPosition(*column_num_it).name))
                 break;
         if (column_num_it != map.second.end())
         {

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -687,12 +687,13 @@ Chunk SummingSortedAlgorithm::SummingMergedData::pull()
 
 
 SummingSortedAlgorithm::SummingSortedAlgorithm(
-    const Block & header, size_t num_inputs,
+    const Block & header,
+    size_t num_inputs,
     SortDescription description_,
     const Names & column_names_to_sum,
     const Names & partition_key_columns,
     size_t max_block_size)
-    : IMergingAlgorithmWithDelayedChunk(num_inputs, std::move(description_))
+    : IMergingAlgorithmWithDelayedChunk(header, num_inputs, std::move(description_))
     , columns_definition(defineColumns(header, description, column_names_to_sum, partition_key_columns))
     , merged_data(getMergedDataColumns(header, columns_definition), max_block_size, columns_definition)
 {

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -101,10 +101,10 @@ struct SummingSortedAlgorithm::AggregateDescription
 };
 
 
-static bool isInPrimaryKey(const SortDescription & description, const std::string & name, const size_t number)
+static bool isInPrimaryKey(const SortDescription & description, const std::string & name, const size_t)
 {
     for (const auto & desc : description)
-        if (desc.column_name == name || (desc.column_name.empty() && desc.column_number == number))
+        if (desc.column_name == name)
             return true;
 
     return false;

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -687,15 +687,15 @@ Chunk SummingSortedAlgorithm::SummingMergedData::pull()
 
 
 SummingSortedAlgorithm::SummingSortedAlgorithm(
-    const Block & header,
+    const Block & header_,
     size_t num_inputs,
     SortDescription description_,
     const Names & column_names_to_sum,
     const Names & partition_key_columns,
     size_t max_block_size)
-    : IMergingAlgorithmWithDelayedChunk(header, num_inputs, std::move(description_))
-    , columns_definition(defineColumns(header, description, column_names_to_sum, partition_key_columns))
-    , merged_data(getMergedDataColumns(header, columns_definition), max_block_size, columns_definition)
+    : IMergingAlgorithmWithDelayedChunk(header_, num_inputs, std::move(description_))
+    , columns_definition(defineColumns(header_, description, column_names_to_sum, partition_key_columns))
+    , merged_data(getMergedDataColumns(header_, columns_definition), max_block_size, columns_definition)
 {
 }
 

--- a/src/Processors/Merges/Algorithms/VersionedCollapsingAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/VersionedCollapsingAlgorithm.cpp
@@ -8,20 +8,20 @@ namespace DB
 static const size_t MAX_ROWS_IN_MULTIVERSION_QUEUE = 8192;
 
 VersionedCollapsingAlgorithm::VersionedCollapsingAlgorithm(
-    const Block & header,
+    const Block & header_,
     size_t num_inputs,
     SortDescription description_,
     const String & sign_column_,
     size_t max_block_size,
     WriteBuffer * out_row_sources_buf_,
     bool use_average_block_sizes)
-    : IMergingAlgorithmWithSharedChunks(header, num_inputs, std::move(description_), out_row_sources_buf_, MAX_ROWS_IN_MULTIVERSION_QUEUE)
-    , merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
+    : IMergingAlgorithmWithSharedChunks(header_, num_inputs, std::move(description_), out_row_sources_buf_, MAX_ROWS_IN_MULTIVERSION_QUEUE)
+    , merged_data(header_.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
     /// -1 for +1 in FixedSizeDequeWithGaps's internal buffer. 3 is a reasonable minimum size to collapse anything.
     , max_rows_in_queue(std::min(std::max<size_t>(3, max_block_size), MAX_ROWS_IN_MULTIVERSION_QUEUE) - 1)
     , current_keys(max_rows_in_queue)
 {
-    sign_column_number = header.getPositionByName(sign_column_);
+    sign_column_number = header_.getPositionByName(sign_column_);
 }
 
 inline ALWAYS_INLINE static void writeRowSourcePart(WriteBuffer & buffer, RowSourcePart row_source)

--- a/src/Processors/Merges/Algorithms/VersionedCollapsingAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/VersionedCollapsingAlgorithm.cpp
@@ -8,13 +8,14 @@ namespace DB
 static const size_t MAX_ROWS_IN_MULTIVERSION_QUEUE = 8192;
 
 VersionedCollapsingAlgorithm::VersionedCollapsingAlgorithm(
-    const Block & header, size_t num_inputs,
-    SortDescription description_, const String & sign_column_,
+    const Block & header,
+    size_t num_inputs,
+    SortDescription description_,
+    const String & sign_column_,
     size_t max_block_size,
     WriteBuffer * out_row_sources_buf_,
     bool use_average_block_sizes)
-    : IMergingAlgorithmWithSharedChunks(
-            num_inputs, std::move(description_), out_row_sources_buf_, MAX_ROWS_IN_MULTIVERSION_QUEUE)
+    : IMergingAlgorithmWithSharedChunks(header, num_inputs, std::move(description_), out_row_sources_buf_, MAX_ROWS_IN_MULTIVERSION_QUEUE)
     , merged_data(header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
     /// -1 for +1 in FixedSizeDequeWithGaps's internal buffer. 3 is a reasonable minimum size to collapse anything.
     , max_rows_in_queue(std::min(std::max<size_t>(3, max_block_size), MAX_ROWS_IN_MULTIVERSION_QUEUE) - 1)

--- a/src/Processors/QueryPlan/FillingStep.cpp
+++ b/src/Processors/QueryPlan/FillingStep.cpp
@@ -48,13 +48,13 @@ void FillingStep::transformPipeline(QueryPipelineBuilder & pipeline, const Build
 void FillingStep::describeActions(FormatSettings & settings) const
 {
     settings.out << String(settings.offset, ' ');
-    dumpSortDescription(sort_description, input_streams.front().header, settings.out);
+    dumpSortDescription(sort_description, settings.out);
     settings.out << '\n';
 }
 
 void FillingStep::describeActions(JSONBuilder::JSONMap & map) const
 {
-    map.add("Sort Description", explainSortDescription(sort_description, input_streams.front().header));
+    map.add("Sort Description", explainSortDescription(sort_description));
 }
 
 }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -612,14 +612,8 @@ static void addMergingFinal(
 
     ColumnNumbers key_columns;
     key_columns.reserve(sort_description.size());
-
     for (const auto & desc : sort_description)
-    {
-        if (!desc.column_name.empty())
-            key_columns.push_back(header.getPositionByName(desc.column_name));
-        else
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name empty.");
-    }
+        key_columns.push_back(header.getPositionByName(desc.column_name));
 
     pipe.addSimpleTransform([&](const Block & stream_header)
     {

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -618,7 +618,7 @@ static void addMergingFinal(
         if (!desc.column_name.empty())
             key_columns.push_back(header.getPositionByName(desc.column_name));
         else
-            key_columns.emplace_back(desc.column_number);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name empty.");
     }
 
     pipe.addSimpleTransform([&](const Block & stream_header)

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -774,9 +774,8 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal(
 
         Names partition_key_columns = metadata_for_reading->getPartitionKey().column_names;
 
-        const auto & header = pipe.getHeader();
         for (size_t i = 0; i < sort_columns_size; ++i)
-            sort_description.emplace_back(header.getPositionByName(sort_columns[i]), 1, 1);
+            sort_description.emplace_back(sort_columns[i], 1, 1);
 
         addMergingFinal(
             pipe,

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -206,17 +206,17 @@ void SortingStep::describeActions(FormatSettings & settings) const
     if (!prefix_description.empty())
     {
         settings.out << prefix << "Prefix sort description: ";
-        dumpSortDescription(prefix_description, input_streams.front().header, settings.out);
+        dumpSortDescription(prefix_description, settings.out);
         settings.out << '\n';
 
         settings.out << prefix << "Result sort description: ";
-        dumpSortDescription(result_description, input_streams.front().header, settings.out);
+        dumpSortDescription(result_description, settings.out);
         settings.out << '\n';
     }
     else
     {
         settings.out << prefix << "Sort description: ";
-        dumpSortDescription(result_description, input_streams.front().header, settings.out);
+        dumpSortDescription(result_description, settings.out);
         settings.out << '\n';
     }
 
@@ -228,11 +228,11 @@ void SortingStep::describeActions(JSONBuilder::JSONMap & map) const
 {
     if (!prefix_description.empty())
     {
-        map.add("Prefix Sort Description", explainSortDescription(prefix_description, input_streams.front().header));
-        map.add("Result Sort Description", explainSortDescription(result_description, input_streams.front().header));
+        map.add("Prefix Sort Description", explainSortDescription(prefix_description));
+        map.add("Result Sort Description", explainSortDescription(result_description));
     }
     else
-        map.add("Sort Description", explainSortDescription(result_description, input_streams.front().header));
+        map.add("Sort Description", explainSortDescription(result_description));
 
     if (limit)
         map.add("Limit", limit);

--- a/src/Processors/QueryPlan/WindowStep.cpp
+++ b/src/Processors/QueryPlan/WindowStep.cpp
@@ -129,7 +129,7 @@ void WindowStep::describeActions(JSONBuilder::JSONMap & map) const
     }
 
     if (!window_description.order_by.empty())
-        map.add("Sort Description", explainSortDescription(window_description.order_by, {}));
+        map.add("Sort Description", explainSortDescription(window_description.order_by));
 
     auto functions_array = std::make_unique<JSONBuilder::JSONArray>();
     for (const auto & func : window_functions)

--- a/src/Processors/Transforms/AggregatingInOrderTransform.cpp
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.cpp
@@ -103,11 +103,11 @@ void AggregatingInOrderTransform::consume(Chunk chunk)
     {
         /// Find the first position of new (not current) key in current chunk
         auto indices = collections::range(key_begin, rows);
-        auto it = std::upper_bound(
-            indices.begin(),
-            indices.end(),
-            cur_block_size - 1,
-            [&](size_t lhs_row, size_t rhs_row) { return less(res_key_columns, key_columns, lhs_row, rhs_row, group_by_description); });
+        auto it = std::upper_bound(indices.begin(), indices.end(), cur_block_size - 1,
+            [&](size_t lhs_row, size_t rhs_row)
+            {
+                return less(res_key_columns, key_columns, lhs_row, rhs_row, group_by_description);
+            });
 
         key_end = (it == indices.end() ? rows : *it);
 

--- a/src/Processors/Transforms/AggregatingInOrderTransform.cpp
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.cpp
@@ -40,7 +40,7 @@ AggregatingInOrderTransform::AggregatingInOrderTransform(
         if (!column_description.column_name.empty())
         {
             column_description.column_number = res_header.getPositionByName(column_description.column_name);
-            column_description.column_name.clear();
+            // column_description.column_name.clear();
         }
     }
 }

--- a/src/Processors/Transforms/AggregatingInOrderTransform.h
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.h
@@ -51,7 +51,7 @@ private:
     MutableColumns res_aggregate_columns;
 
     AggregatingTransformParamsPtr params;
-    SortDescriptionsWithPositions group_by_description;
+    SortDescriptionWithPositions group_by_description;
 
     Aggregator::AggregateColumns aggregate_columns;
 

--- a/src/Processors/Transforms/AggregatingInOrderTransform.h
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.h
@@ -51,7 +51,7 @@ private:
     MutableColumns res_aggregate_columns;
 
     AggregatingTransformParamsPtr params;
-    SortDescription group_by_description;
+    SortDescriptionsWithPositions group_by_description;
 
     Aggregator::AggregateColumns aggregate_columns;
 

--- a/src/Processors/Transforms/CheckSortedTransform.cpp
+++ b/src/Processors/Transforms/CheckSortedTransform.cpp
@@ -12,10 +12,10 @@ namespace ErrorCodes
 extern const int LOGICAL_ERROR;
 }
 
-CheckSortedTransform::CheckSortedTransform(const Block & header, const SortDescription & sort_description_)
+CheckSortedTransform::CheckSortedTransform(const Block & header, const SortDescription & sort_description)
     : ISimpleTransform(header, header, false)
 {
-    for (const auto & column_description : sort_description_)
+    for (const auto & column_description : sort_description)
         sort_description_map.emplace_back(column_description, header.getPositionByName(column_description.column_name));
 }
 
@@ -34,7 +34,7 @@ void CheckSortedTransform::transform(Chunk & chunk)
             const IColumn * left_col = left[column_number].get();
             const IColumn * right_col = right[column_number].get();
 
-            int res = elem.direction * left_col->compareAt(left_index, right_index, *right_col, elem.nulls_direction);
+            int res = elem.base.direction * left_col->compareAt(left_index, right_index, *right_col, elem.base.nulls_direction);
             if (res < 0)
             {
                 return;

--- a/src/Processors/Transforms/CheckSortedTransform.h
+++ b/src/Processors/Transforms/CheckSortedTransform.h
@@ -10,7 +10,7 @@ namespace DB
 class CheckSortedTransform : public ISimpleTransform
 {
 public:
-    CheckSortedTransform(const Block & header, const SortDescription & sort_description_);
+    CheckSortedTransform(const Block & header, const SortDescription & sort_description);
 
     String getName() const override { return "CheckSortedTransform"; }
 
@@ -19,7 +19,7 @@ protected:
     void transform(Chunk & chunk) override;
 
 private:
-    SortDescriptionsWithPositions sort_description_map;
+    SortDescriptionWithPositions sort_description_map;
     Columns last_row;
 };
 }

--- a/src/Processors/Transforms/CheckSortedTransform.h
+++ b/src/Processors/Transforms/CheckSortedTransform.h
@@ -5,14 +5,12 @@
 
 namespace DB
 {
-using SortDescriptionsWithPositions = std::vector<SortColumnDescription>;
-
 /// Streams checks that flow of blocks is sorted in the sort_description order
 /// Othrewise throws exception in readImpl function.
 class CheckSortedTransform : public ISimpleTransform
 {
 public:
-    CheckSortedTransform(Block header_, const SortDescription & sort_description_);
+    CheckSortedTransform(const Block & header, const SortDescription & sort_description_);
 
     String getName() const override { return "CheckSortedTransform"; }
 
@@ -21,11 +19,7 @@ protected:
     void transform(Chunk & chunk) override;
 
 private:
-    Block header;
     SortDescriptionsWithPositions sort_description_map;
     Columns last_row;
-
-    /// Just checks, that all sort_descriptions has column_number
-    static SortDescriptionsWithPositions addPositionsToSortDescriptions(const SortDescription & sort_description);
 };
 }

--- a/src/Processors/Transforms/CheckSortedTransform.h
+++ b/src/Processors/Transforms/CheckSortedTransform.h
@@ -12,9 +12,7 @@ using SortDescriptionsWithPositions = std::vector<SortColumnDescription>;
 class CheckSortedTransform : public ISimpleTransform
 {
 public:
-    CheckSortedTransform(
-        const Block & header_,
-        const SortDescription & sort_description_);
+    CheckSortedTransform(Block header_, const SortDescription & sort_description_);
 
     String getName() const override { return "CheckSortedTransform"; }
 
@@ -23,10 +21,11 @@ protected:
     void transform(Chunk & chunk) override;
 
 private:
+    Block header;
     SortDescriptionsWithPositions sort_description_map;
     Columns last_row;
 
     /// Just checks, that all sort_descriptions has column_number
-    SortDescriptionsWithPositions addPositionsToSortDescriptions(const SortDescription & sort_description);
+    static SortDescriptionsWithPositions addPositionsToSortDescriptions(const SortDescription & sort_description);
 };
 }

--- a/src/Processors/Transforms/DistinctSortedTransform.cpp
+++ b/src/Processors/Transforms/DistinctSortedTransform.cpp
@@ -25,7 +25,7 @@ void DistinctSortedTransform::transform(Chunk & chunk)
         if (column_ptrs.empty())
             return;
 
-        ColumnRawPtrs clearing_hint_columns(getClearingColumns(chunk, column_ptrs));
+        ColumnRawPtrs clearing_hint_columns(getClearingColumns(column_ptrs));
 
         if (data.type == ClearableSetVariants::Type::EMPTY)
             data.init(ClearableSetVariants::chooseMethod(column_ptrs, key_sizes));
@@ -38,7 +38,7 @@ void DistinctSortedTransform::transform(Chunk & chunk)
         {
             case ClearableSetVariants::Type::EMPTY:
                 break;
-#define M(NAME) \
+    #define M(NAME) \
             case ClearableSetVariants::Type::NAME: \
                 has_new_data = buildFilter(*data.NAME, column_ptrs, clearing_hint_columns, filter, rows, data); \
                 break;
@@ -140,14 +140,13 @@ ColumnRawPtrs DistinctSortedTransform::getKeyColumns(const Chunk & chunk) const
     return column_ptrs;
 }
 
-ColumnRawPtrs DistinctSortedTransform::getClearingColumns(const Chunk & chunk, const ColumnRawPtrs & key_columns) const
+ColumnRawPtrs DistinctSortedTransform::getClearingColumns(const ColumnRawPtrs & key_columns) const
 {
     ColumnRawPtrs clearing_hint_columns;
     clearing_hint_columns.reserve(description.size());
     for (const auto & sort_column_description : description)
     {
-        const auto idx = header.getPositionByName(sort_column_description.column_name);
-        const auto * sort_column_ptr = chunk.getColumns().at(idx).get();
+        const auto * sort_column_ptr = header.getByName(sort_column_description.column_name).column.get();
         const auto it = std::find(key_columns.cbegin(), key_columns.cend(), sort_column_ptr);
         if (it != key_columns.cend()) /// if found in key_columns
             clearing_hint_columns.emplace_back(sort_column_ptr);

--- a/src/Processors/Transforms/DistinctSortedTransform.h
+++ b/src/Processors/Transforms/DistinctSortedTransform.h
@@ -22,7 +22,8 @@ class DistinctSortedTransform : public ISimpleTransform
 {
 public:
     /// Empty columns_ means all columns.
-    DistinctSortedTransform(const Block & header, SortDescription sort_description, const SizeLimits & set_size_limits_, UInt64 limit_hint_, const Names & columns);
+    DistinctSortedTransform(
+        Block header_, SortDescription sort_description, const SizeLimits & set_size_limits_, UInt64 limit_hint_, const Names & columns);
 
     String getName() const override { return "DistinctSortedTransform"; }
 
@@ -46,6 +47,7 @@ private:
         size_t rows,
         ClearableSetVariants & variants) const;
 
+    Block header;
     SortDescription description;
 
     struct PreviousChunk

--- a/src/Processors/Transforms/DistinctSortedTransform.h
+++ b/src/Processors/Transforms/DistinctSortedTransform.h
@@ -34,7 +34,7 @@ private:
     ColumnRawPtrs getKeyColumns(const Chunk & chunk) const;
     /// When clearing_columns changed, we can clean HashSet to memory optimization
     /// clearing_columns is a left-prefix of SortDescription exists in key_columns
-    ColumnRawPtrs getClearingColumns(const Chunk & chunk, const ColumnRawPtrs & key_columns) const;
+    ColumnRawPtrs getClearingColumns(const ColumnRawPtrs & key_columns) const;
     static bool rowsEqual(const ColumnRawPtrs & lhs, size_t n, const ColumnRawPtrs & rhs, size_t m);
 
     /// return true if has new data

--- a/src/Processors/Transforms/FinishSortingTransform.cpp
+++ b/src/Processors/Transforms/FinishSortingTransform.cpp
@@ -36,7 +36,8 @@ FinishSortingTransform::FinishSortingTransform(
     /// The target description is modified in SortingTransform constructor.
     /// To avoid doing the same actions with description_sorted just copy it from prefix of target description.
     size_t prefix_size = description_sorted_.size();
-    description_sorted.assign(description.begin(), description.begin() + prefix_size);
+    for (size_t i = 0; i < prefix_size; ++i)
+        description_with_positions.emplace_back(description[i], header_.getPositionByName(description[i].column_name));
 }
 
 void FinishSortingTransform::consume(Chunk chunk)
@@ -64,13 +65,7 @@ void FinishSortingTransform::consume(Chunk chunk)
         while (high - low > 1)
         {
             ssize_t mid = (low + high) / 2;
-            if (!less(
-                    header_without_constants,
-                    last_chunk.getColumns(),
-                    chunk.getColumns(),
-                    last_chunk.getNumRows() - 1,
-                    mid,
-                    description_sorted))
+            if (!less(last_chunk.getColumns(), chunk.getColumns(), last_chunk.getNumRows() - 1, mid, description_with_positions))
                 low = mid;
             else
                 high = mid;

--- a/src/Processors/Transforms/FinishSortingTransform.cpp
+++ b/src/Processors/Transforms/FinishSortingTransform.cpp
@@ -21,10 +21,12 @@ static bool isPrefix(const SortDescription & pref_descr, const SortDescription &
 }
 
 FinishSortingTransform::FinishSortingTransform(
-    const Block & header, const SortDescription & description_sorted_,
+    Block header_,
+    const SortDescription & description_sorted_,
     const SortDescription & description_to_sort_,
-    size_t max_merged_block_size_, UInt64 limit_)
-    : SortingTransform(header, description_to_sort_, max_merged_block_size_, limit_)
+    size_t max_merged_block_size_,
+    UInt64 limit_)
+    : SortingTransform(header_, description_to_sort_, max_merged_block_size_, limit_), header(std::move(header_))
 {
     /// Check for sanity non-modified descriptions
     if (!isPrefix(description_sorted_, description_to_sort_))
@@ -100,7 +102,7 @@ void FinishSortingTransform::generate()
 {
     if (!merge_sorter)
     {
-        merge_sorter = std::make_unique<MergeSorter>(std::move(chunks), description, max_merged_block_size, limit);
+        merge_sorter = std::make_unique<MergeSorter>(header, std::move(chunks), description, max_merged_block_size, limit);
         generated_prefix = true;
     }
 

--- a/src/Processors/Transforms/FinishSortingTransform.cpp
+++ b/src/Processors/Transforms/FinishSortingTransform.cpp
@@ -21,12 +21,12 @@ static bool isPrefix(const SortDescription & pref_descr, const SortDescription &
 }
 
 FinishSortingTransform::FinishSortingTransform(
-    Block header_,
+    const Block & header,
     const SortDescription & description_sorted_,
     const SortDescription & description_to_sort_,
     size_t max_merged_block_size_,
     UInt64 limit_)
-    : SortingTransform(header_, description_to_sort_, max_merged_block_size_, limit_)
+    : SortingTransform(header, description_to_sort_, max_merged_block_size_, limit_)
 {
     /// Check for sanity non-modified descriptions
     if (!isPrefix(description_sorted_, description_to_sort_))
@@ -37,7 +37,7 @@ FinishSortingTransform::FinishSortingTransform(
     /// To avoid doing the same actions with description_sorted just copy it from prefix of target description.
     size_t prefix_size = description_sorted_.size();
     for (size_t i = 0; i < prefix_size; ++i)
-        description_with_positions.emplace_back(description[i], header_.getPositionByName(description[i].column_name));
+        description_with_positions.emplace_back(description[i], header_without_constants.getPositionByName(description[i].column_name));
 }
 
 void FinishSortingTransform::consume(Chunk chunk)

--- a/src/Processors/Transforms/FinishSortingTransform.cpp
+++ b/src/Processors/Transforms/FinishSortingTransform.cpp
@@ -64,7 +64,13 @@ void FinishSortingTransform::consume(Chunk chunk)
         while (high - low > 1)
         {
             ssize_t mid = (low + high) / 2;
-            if (!less(last_chunk.getColumns(), chunk.getColumns(), last_chunk.getNumRows() - 1, mid, description_sorted))
+            if (!less(
+                    header_without_constants,
+                    last_chunk.getColumns(),
+                    chunk.getColumns(),
+                    last_chunk.getNumRows() - 1,
+                    mid,
+                    description_sorted))
                 low = mid;
             else
                 high = mid;

--- a/src/Processors/Transforms/FinishSortingTransform.cpp
+++ b/src/Processors/Transforms/FinishSortingTransform.cpp
@@ -26,7 +26,7 @@ FinishSortingTransform::FinishSortingTransform(
     const SortDescription & description_to_sort_,
     size_t max_merged_block_size_,
     UInt64 limit_)
-    : SortingTransform(header_, description_to_sort_, max_merged_block_size_, limit_), header(std::move(header_))
+    : SortingTransform(header_, description_to_sort_, max_merged_block_size_, limit_)
 {
     /// Check for sanity non-modified descriptions
     if (!isPrefix(description_sorted_, description_to_sort_))
@@ -102,7 +102,8 @@ void FinishSortingTransform::generate()
 {
     if (!merge_sorter)
     {
-        merge_sorter = std::make_unique<MergeSorter>(header, std::move(chunks), description, max_merged_block_size, limit);
+        merge_sorter
+            = std::make_unique<MergeSorter>(header_without_constants, std::move(chunks), description, max_merged_block_size, limit);
         generated_prefix = true;
     }
 

--- a/src/Processors/Transforms/FinishSortingTransform.h
+++ b/src/Processors/Transforms/FinishSortingTransform.h
@@ -11,9 +11,12 @@ class FinishSortingTransform : public SortingTransform
 {
 public:
     /// limit - if not 0, allowed to return just first 'limit' rows in sorted order.
-    FinishSortingTransform(const Block & header, const SortDescription & description_sorted_,
+    FinishSortingTransform(
+        Block header_,
+        const SortDescription & description_sorted_,
         const SortDescription & description_to_sort_,
-        size_t max_merged_block_size_, UInt64 limit_);
+        size_t max_merged_block_size_,
+        UInt64 limit_);
 
     String getName() const override { return "FinishSortingTransform"; }
 
@@ -22,6 +25,7 @@ protected:
     void generate() override;
 
 private:
+    Block header;
     SortDescription description_sorted;
 
     Chunk tail_chunk;

--- a/src/Processors/Transforms/FinishSortingTransform.h
+++ b/src/Processors/Transforms/FinishSortingTransform.h
@@ -25,7 +25,6 @@ protected:
     void generate() override;
 
 private:
-    Block header;
     SortDescription description_sorted;
 
     Chunk tail_chunk;

--- a/src/Processors/Transforms/FinishSortingTransform.h
+++ b/src/Processors/Transforms/FinishSortingTransform.h
@@ -25,7 +25,7 @@ protected:
     void generate() override;
 
 private:
-    SortDescriptionsWithPositions description_with_positions;
+    SortDescriptionWithPositions description_with_positions;
 
     Chunk tail_chunk;
 };

--- a/src/Processors/Transforms/FinishSortingTransform.h
+++ b/src/Processors/Transforms/FinishSortingTransform.h
@@ -12,7 +12,7 @@ class FinishSortingTransform : public SortingTransform
 public:
     /// limit - if not 0, allowed to return just first 'limit' rows in sorted order.
     FinishSortingTransform(
-        Block header_,
+        const Block & header,
         const SortDescription & description_sorted_,
         const SortDescription & description_to_sort_,
         size_t max_merged_block_size_,

--- a/src/Processors/Transforms/FinishSortingTransform.h
+++ b/src/Processors/Transforms/FinishSortingTransform.h
@@ -25,7 +25,7 @@ protected:
     void generate() override;
 
 private:
-    SortDescription description_sorted;
+    SortDescriptionsWithPositions description_with_positions;
 
     Chunk tail_chunk;
 };

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -88,18 +88,24 @@ private:
 };
 
 MergeSortingTransform::MergeSortingTransform(
-    const Block & header,
+    Block header_,
     const SortDescription & description_,
-    size_t max_merged_block_size_, UInt64 limit_,
+    size_t max_merged_block_size_,
+    UInt64 limit_,
     size_t max_bytes_before_remerge_,
     double remerge_lowered_memory_bytes_ratio_,
-    size_t max_bytes_before_external_sort_, VolumePtr tmp_volume_,
+    size_t max_bytes_before_external_sort_,
+    VolumePtr tmp_volume_,
     size_t min_free_disk_space_)
-    : SortingTransform(header, description_, max_merged_block_size_, limit_)
+    : SortingTransform(header_, description_, max_merged_block_size_, limit_)
+    , header(std::move(header_))
     , max_bytes_before_remerge(max_bytes_before_remerge_)
     , remerge_lowered_memory_bytes_ratio(remerge_lowered_memory_bytes_ratio_)
-    , max_bytes_before_external_sort(max_bytes_before_external_sort_), tmp_volume(tmp_volume_)
-    , min_free_disk_space(min_free_disk_space_) {}
+    , max_bytes_before_external_sort(max_bytes_before_external_sort_)
+    , tmp_volume(tmp_volume_)
+    , min_free_disk_space(min_free_disk_space_)
+{
+}
 
 Processors MergeSortingTransform::expandPipeline()
 {
@@ -180,7 +186,7 @@ void MergeSortingTransform::consume(Chunk chunk)
         temporary_files.emplace_back(createTemporaryFile(tmp_path));
 
         const std::string & path = temporary_files.back()->path();
-        merge_sorter = std::make_unique<MergeSorter>(std::move(chunks), description, max_merged_block_size, limit);
+        merge_sorter = std::make_unique<MergeSorter>(header, std::move(chunks), description, max_merged_block_size, limit);
         auto current_processor = std::make_shared<BufferingToFileTransform>(header_without_constants, log, path);
 
         processors.emplace_back(current_processor);
@@ -223,7 +229,7 @@ void MergeSortingTransform::generate()
     if (!generated_prefix)
     {
         if (temporary_files.empty())
-            merge_sorter = std::make_unique<MergeSorter>(std::move(chunks), description, max_merged_block_size, limit);
+            merge_sorter = std::make_unique<MergeSorter>(header, std::move(chunks), description, max_merged_block_size, limit);
         else
         {
             ProfileEvents::increment(ProfileEvents::ExternalSortMerge);
@@ -251,7 +257,7 @@ void MergeSortingTransform::remerge()
     LOG_DEBUG(log, "Re-merging intermediate ORDER BY data ({} blocks with {} rows) to save memory consumption", chunks.size(), sum_rows_in_blocks);
 
     /// NOTE Maybe concat all blocks and partial sort will be faster than merge?
-    MergeSorter remerge_sorter(std::move(chunks), description, max_merged_block_size, limit);
+    MergeSorter remerge_sorter(header, std::move(chunks), description, max_merged_block_size, limit);
 
     Chunks new_chunks;
     size_t new_sum_rows_in_blocks = 0;

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -98,7 +98,6 @@ MergeSortingTransform::MergeSortingTransform(
     VolumePtr tmp_volume_,
     size_t min_free_disk_space_)
     : SortingTransform(header_, description_, max_merged_block_size_, limit_)
-    , header(std::move(header_))
     , max_bytes_before_remerge(max_bytes_before_remerge_)
     , remerge_lowered_memory_bytes_ratio(remerge_lowered_memory_bytes_ratio_)
     , max_bytes_before_external_sort(max_bytes_before_external_sort_)
@@ -230,7 +229,8 @@ void MergeSortingTransform::generate()
     if (!generated_prefix)
     {
         if (temporary_files.empty())
-            merge_sorter = std::make_unique<MergeSorter>(header, std::move(chunks), description, max_merged_block_size, limit);
+            merge_sorter
+                = std::make_unique<MergeSorter>(header_without_constants, std::move(chunks), description, max_merged_block_size, limit);
         else
         {
             ProfileEvents::increment(ProfileEvents::ExternalSortMerge);
@@ -258,7 +258,7 @@ void MergeSortingTransform::remerge()
     LOG_DEBUG(log, "Re-merging intermediate ORDER BY data ({} blocks with {} rows) to save memory consumption", chunks.size(), sum_rows_in_blocks);
 
     /// NOTE Maybe concat all blocks and partial sort will be faster than merge?
-    MergeSorter remerge_sorter(header, std::move(chunks), description, max_merged_block_size, limit);
+    MergeSorter remerge_sorter(header_without_constants, std::move(chunks), description, max_merged_block_size, limit);
 
     Chunks new_chunks;
     size_t new_sum_rows_in_blocks = 0;

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -186,7 +186,8 @@ void MergeSortingTransform::consume(Chunk chunk)
         temporary_files.emplace_back(createTemporaryFile(tmp_path));
 
         const std::string & path = temporary_files.back()->path();
-        merge_sorter = std::make_unique<MergeSorter>(header, std::move(chunks), description, max_merged_block_size, limit);
+        merge_sorter
+            = std::make_unique<MergeSorter>(header_without_constants, std::move(chunks), description, max_merged_block_size, limit);
         auto current_processor = std::make_shared<BufferingToFileTransform>(header_without_constants, log, path);
 
         processors.emplace_back(current_processor);

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -88,7 +88,7 @@ private:
 };
 
 MergeSortingTransform::MergeSortingTransform(
-    Block header_,
+    const Block & header,
     const SortDescription & description_,
     size_t max_merged_block_size_,
     UInt64 limit_,
@@ -97,7 +97,7 @@ MergeSortingTransform::MergeSortingTransform(
     size_t max_bytes_before_external_sort_,
     VolumePtr tmp_volume_,
     size_t min_free_disk_space_)
-    : SortingTransform(header_, description_, max_merged_block_size_, limit_)
+    : SortingTransform(header, description_, max_merged_block_size_, limit_)
     , max_bytes_before_remerge(max_bytes_before_remerge_)
     , remerge_lowered_memory_bytes_ratio(remerge_lowered_memory_bytes_ratio_)
     , max_bytes_before_external_sort(max_bytes_before_external_sort_)

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -18,13 +18,16 @@ class MergeSortingTransform : public SortingTransform
 {
 public:
     /// limit - if not 0, allowed to return just first 'limit' rows in sorted order.
-    MergeSortingTransform(const Block & header,
-                          const SortDescription & description_,
-                          size_t max_merged_block_size_, UInt64 limit_,
-                          size_t max_bytes_before_remerge_,
-                          double remerge_lowered_memory_bytes_ratio_,
-                          size_t max_bytes_before_external_sort_, VolumePtr tmp_volume_,
-                          size_t min_free_disk_space_);
+    MergeSortingTransform(
+        Block header_,
+        const SortDescription & description_,
+        size_t max_merged_block_size_,
+        UInt64 limit_,
+        size_t max_bytes_before_remerge_,
+        double remerge_lowered_memory_bytes_ratio_,
+        size_t max_bytes_before_external_sort_,
+        VolumePtr tmp_volume_,
+        size_t min_free_disk_space_);
 
     String getName() const override { return "MergeSortingTransform"; }
 
@@ -36,6 +39,8 @@ protected:
     Processors expandPipeline() override;
 
 private:
+    Block header;
+
     size_t max_bytes_before_remerge;
     double remerge_lowered_memory_bytes_ratio;
     size_t max_bytes_before_external_sort;

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -19,7 +19,7 @@ class MergeSortingTransform : public SortingTransform
 public:
     /// limit - if not 0, allowed to return just first 'limit' rows in sorted order.
     MergeSortingTransform(
-        Block header_,
+        const Block & header,
         const SortDescription & description_,
         size_t max_merged_block_size_,
         UInt64 limit_,

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -39,8 +39,6 @@ protected:
     Processors expandPipeline() override;
 
 private:
-    Block header;
-
     size_t max_bytes_before_remerge;
     double remerge_lowered_memory_bytes_ratio;
     size_t max_bytes_before_external_sort;

--- a/src/Processors/Transforms/PartialSortingTransform.cpp
+++ b/src/Processors/Transforms/PartialSortingTransform.cpp
@@ -22,9 +22,7 @@ static ColumnRawPtrs extractColumns(const Block & block, const SortDescription &
 
     for (size_t i = 0; i < size; ++i)
     {
-        const IColumn * column = !description[i].column_name.empty()
-            ? block.getByName(description[i].column_name).column.get()
-            : block.safeGetByPosition(description[i].column_number).column.get();
+        const IColumn * column = block.getByName(description[i].column_name).column.get();
         res.emplace_back(column);
     }
 

--- a/src/Processors/Transforms/SortingTransform.cpp
+++ b/src/Processors/Transforms/SortingTransform.cpp
@@ -22,7 +22,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-MergeSorter::MergeSorter(Block header, Chunks chunks_, SortDescription & description_, size_t max_merged_block_size_, UInt64 limit_)
+MergeSorter::MergeSorter(const Block & header, Chunks chunks_, SortDescription & description_, size_t max_merged_block_size_, UInt64 limit_)
     : chunks(std::move(chunks_)), description(description_), max_merged_block_size(max_merged_block_size_), limit(limit_)
 {
     Chunks nonempty_chunks;
@@ -138,13 +138,6 @@ SortingTransform::SortingTransform(
     , limit(limit_)
 {
     const auto & sample = inputs.front().getHeader();
-
-    /// Replace column names to column position in sort_description.
-    for (auto & column_description : description)
-    {
-        if (column_description.column_name.empty())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name empty.");
-    }
 
     /// Remove constants from header and map old indexes to new.
     size_t num_columns = sample.columns();

--- a/src/Processors/Transforms/SortingTransform.cpp
+++ b/src/Processors/Transforms/SortingTransform.cpp
@@ -145,7 +145,7 @@ SortingTransform::SortingTransform(
         if (!column_description.column_name.empty())
         {
             column_description.column_number = sample.getPositionByName(column_description.column_name);
-            column_description.column_name.clear();
+            // column_description.column_name.clear();
         }
     }
 

--- a/src/Processors/Transforms/SortingTransform.cpp
+++ b/src/Processors/Transforms/SortingTransform.cpp
@@ -142,11 +142,8 @@ SortingTransform::SortingTransform(
     /// Replace column names to column position in sort_description.
     for (auto & column_description : description)
     {
-        if (!column_description.column_name.empty())
-        {
-            column_description.column_number = sample.getPositionByName(column_description.column_name);
-            // column_description.column_name.clear();
-        }
+        if (column_description.column_name.empty())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Column name empty.");
     }
 
     /// Remove constants from header and map old indexes to new.
@@ -169,13 +166,10 @@ SortingTransform::SortingTransform(
     description_without_constants.reserve(description.size());
     for (const auto & column_description : description)
     {
-        auto old_pos = column_description.column_number;
+        auto old_pos = header.getPositionByName(column_description.column_name);
         auto new_pos = map[old_pos];
         if (new_pos < num_columns)
-        {
             description_without_constants.push_back(column_description);
-            description_without_constants.back().column_number = new_pos;
-        }
     }
 
     description.swap(description_without_constants);

--- a/src/Processors/Transforms/SortingTransform.cpp
+++ b/src/Processors/Transforms/SortingTransform.cpp
@@ -22,7 +22,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-MergeSorter::MergeSorter(Chunks chunks_, SortDescription & description_, size_t max_merged_block_size_, UInt64 limit_)
+MergeSorter::MergeSorter(Block header, Chunks chunks_, SortDescription & description_, size_t max_merged_block_size_, UInt64 limit_)
     : chunks(std::move(chunks_)), description(description_), max_merged_block_size(max_merged_block_size_), limit(limit_)
 {
     Chunks nonempty_chunks;
@@ -36,7 +36,7 @@ MergeSorter::MergeSorter(Chunks chunks_, SortDescription & description_, size_t 
         /// which can be inefficient.
         convertToFullIfSparse(chunk);
 
-        cursors.emplace_back(chunk.getColumns(), description);
+        cursors.emplace_back(header, chunk.getColumns(), description);
         has_collation |= cursors.back().has_collation;
 
         nonempty_chunks.emplace_back(std::move(chunk));

--- a/src/Processors/Transforms/SortingTransform.h
+++ b/src/Processors/Transforms/SortingTransform.h
@@ -15,7 +15,7 @@ namespace DB
 class MergeSorter
 {
 public:
-    MergeSorter(Block header, Chunks chunks_, SortDescription & description_, size_t max_merged_block_size_, UInt64 limit_);
+    MergeSorter(const Block & header, Chunks chunks_, SortDescription & description_, size_t max_merged_block_size_, UInt64 limit_);
 
     Chunk read();
 
@@ -45,8 +45,8 @@ private:
 class MergeSorterSource : public ISource
 {
 public:
-    MergeSorterSource(Block header, Chunks chunks, SortDescription & description, size_t max_merged_block_size, UInt64 limit)
-        : ISource(header), merge_sorter(std::move(header), std::move(chunks), description, max_merged_block_size, limit)
+    MergeSorterSource(const Block & header, Chunks chunks, SortDescription & description, size_t max_merged_block_size, UInt64 limit)
+        : ISource(header), merge_sorter(header, std::move(chunks), description, max_merged_block_size, limit)
     {
     }
 

--- a/src/Processors/Transforms/SortingTransform.h
+++ b/src/Processors/Transforms/SortingTransform.h
@@ -15,7 +15,7 @@ namespace DB
 class MergeSorter
 {
 public:
-    MergeSorter(Chunks chunks_, SortDescription & description_, size_t max_merged_block_size_, UInt64 limit_);
+    MergeSorter(Block header, Chunks chunks_, SortDescription & description_, size_t max_merged_block_size_, UInt64 limit_);
 
     Chunk read();
 
@@ -46,7 +46,9 @@ class MergeSorterSource : public ISource
 {
 public:
     MergeSorterSource(Block header, Chunks chunks, SortDescription & description, size_t max_merged_block_size, UInt64 limit)
-        : ISource(std::move(header)), merge_sorter(std::move(chunks), description, max_merged_block_size, limit) {}
+        : ISource(header), merge_sorter(std::move(header), std::move(chunks), description, max_merged_block_size, limit)
+    {
+    }
 
     String getName() const override { return "MergeSorterSource"; }
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -782,7 +782,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream()
 
     Block header = pipes.at(0).getHeader();
     for (size_t i = 0; i < sort_columns_size; ++i)
-        sort_description.emplace_back(header.getPositionByName(sort_columns[i]), 1, 1);
+        sort_description.emplace_back(sort_columns[i], 1, 1);
 
     /// The order of the streams is important: when the key is matched, the elements go in the order of the source stream number.
     /// In the merged part, the lines with the same key must be in the ascending order of the identifier of original part,

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -333,7 +333,7 @@ MergeTreeDataWriter::TemporaryPart MergeTreeDataWriter::writeTempPart(
     sort_description.reserve(sort_columns_size);
 
     for (size_t i = 0; i < sort_columns_size; ++i)
-        sort_description.emplace_back(block.getPositionByName(sort_columns[i]), 1, 1);
+        sort_description.emplace_back(sort_columns[i], 1, 1);
 
     ProfileEvents::increment(ProfileEvents::MergeTreeDataWriterBlocks);
 
@@ -521,7 +521,7 @@ MergeTreeDataWriter::TemporaryPart MergeTreeDataWriter::writeProjectionPartImpl(
     sort_description.reserve(sort_columns_size);
 
     for (size_t i = 0; i < sort_columns_size; ++i)
-        sort_description.emplace_back(block.getPositionByName(sort_columns[i]), 1, 1);
+        sort_description.emplace_back(sort_columns[i], 1, 1);
 
     ProfileEvents::increment(ProfileEvents::MergeTreeDataProjectionWriterBlocks);
 


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)

For now, either the name or the number of a column is provided in `SortDescription`. Unfortunately, it is not expressed through the type system, only in comments, and thus it is fairly error-prone, especially for new people.
https://github.com/ClickHouse/ClickHouse/blob/74cf57b4b0aa98cbe37cd386c0b29d72aaf6448f/src/Core/SortDescription.h#L36-L37

Also, it requires some hacks to make it work, e.g.:
https://github.com/ClickHouse/ClickHouse/blob/74cf57b4b0aa98cbe37cd386c0b29d72aaf6448f/src/Processors/Merges/Algorithms/FinishAggregatingInOrderAlgorithm.cpp#L45-L53

So, this pr is aimed to
* make `column_name` always non-empty
* since `SortDescription`-s are created also in places like `InterpreterSelectQuery` where we don't have any headers yet, let's remove `column_number` from `SortColumnDescription` and create a dedicated type `SortColumnDescriptionWithColumnIndex` for cases where it is really needed (for the sake of performance) e.g.
https://github.com/ClickHouse/ClickHouse/blob/1d28dcdf0a546ca2bcff312195d7569fd48258d0/src/Processors/Transforms/FinishSortingTransform.cpp#L39-L40