### PR TITLE
Fix cgroups cores detection

### DIFF
--- a/src/Common/getNumberOfPhysicalCPUCores.cpp
+++ b/src/Common/getNumberOfPhysicalCPUCores.cpp
@@ -38,21 +38,7 @@ unsigned getCGroupLimitedCPUCores(unsigned default_cpu_count)
         quota_count = ceil(static_cast<float>(cgroup_quota) / static_cast<float>(cgroup_period));
     }
 
-    // Share number (typically a number relative to 1024) (2048 typically expresses 2 CPUs worth of processing)
-    // -1 for no share setup
-    int cgroup_share = read_from("/sys/fs/cgroup/cpu/cpu.shares", -1);
-    // Convert 1024 to no shares setup
-    if (cgroup_share == 1024)
-        cgroup_share = -1;
-
-#    define PER_CPU_SHARES 1024
-    unsigned share_count = default_cpu_count;
-    if (cgroup_share > -1)
-    {
-        share_count = ceil(static_cast<float>(cgroup_share) / static_cast<float>(PER_CPU_SHARES));
-    }
-
-    return std::min(default_cpu_count, std::min(share_count, quota_count));
+    return std::min(default_cpu_count, quota_count);
 }
 #endif // OS_LINUX
 
@@ -91,6 +77,7 @@ unsigned getNumberOfPhysicalCPUCores()
             cpu_count = std::thread::hardware_concurrency();
 
 #if defined(OS_LINUX)
+        /// TODO: add a setting for disabling that, similar to UseContainerSupport in java
         cpu_count = getCGroupLimitedCPUCores(cpu_count);
 #endif // OS_LINUX
         return cpu_count;


### PR DESCRIPTION
In Kubernetes shares are calculated from resources.requests.cpu, quota & period - from limits.

When you configure only requests without limits - the container still can use all the cores. So you see all the cores the system has.
(because of requests the pod just can't be scheduled on the node which have fewer CPUs)
So the effective CPU count is all the available cores if you don't have limits, or calculated from quota & period if you have the limits.

See the details of the problem https://kb.altinity.com/altinity-kb-setup-and-maintenance/cgroups_k8s/ 

Some info on cores calculation in cgroups: https://github.com/openjdk/jdk/blob/e07fd395bdc314867886a621ec76cf74a5f76b89/src/hotspot/os/linux/cgroupSubsystem_linux.cpp#L499-L512 

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Respect only quota & period from groups, ignore shares (which are not really limit the number of the cores which can be used)

/cc @JaySon-Huang @Felixoid 