### PR TITLE
Fix missing `noexcept(false)` flag on destructor which causes builds to fail

### DIFF
--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -532,11 +532,8 @@ FileSegmentsHolder::~FileSegmentsHolder()
         }
         catch (...)
         {
-#ifdef NDEBUG
             tryLogCurrentException(__PRETTY_FUNCTION__);
-#else
-            throw;
-#endif
+            assert(false);
         }
     }
 }


### PR DESCRIPTION
For class `FileSegmentsHolder`:
"`throw` will always call `terminate`" without `noexcept(false)` special flag, because "in C++11 destructors default to `noexcept`"

_(Above text is summary error & note message from compiler failing to build)._

---

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
