### PR TITLE
Forbid to reset non existing settings

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2099,6 +2099,14 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
 
             dropped_columns.emplace(command.column_name);
         }
+        else if (command.type == AlterCommand::RESET_SETTING)
+        {
+            for (const auto & reset_setting : command.settings_resets)
+            {
+                if (!settings.has(reset_setting))
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot reset setting '{}' because it doesn't exist for MergeTree engines family", reset_setting);
+            }
+        }
         else if (command.isRequireMutationStage(getInMemoryMetadata()))
         {
             /// This alter will override data on disk. Let's check that it doesn't

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1909,6 +1909,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
     StorageInMemoryMetadata old_metadata = getInMemoryMetadata();
 
     const auto & settings = local_context->getSettingsRef();
+    const auto & settings_from_storage = getSettings();
 
     if (!settings.allow_non_metadata_alters)
     {
@@ -2103,7 +2104,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
         {
             for (const auto & reset_setting : command.settings_resets)
             {
-                if (!settings.has(reset_setting))
+                if (!settings_from_storage->has(reset_setting))
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot reset setting '{}' because it doesn't exist for MergeTree engines family", reset_setting);
             }
         }

--- a/tests/queries/0_stateless/00980_merge_alter_settings.sql
+++ b/tests/queries/0_stateless/00980_merge_alter_settings.sql
@@ -91,8 +91,8 @@ SHOW CREATE TABLE table_for_reset_setting;
 
 ALTER TABLE table_for_reset_setting RESET SETTING index_granularity; -- { serverError 472 }
 
--- ignore undefined setting
-ALTER TABLE table_for_reset_setting RESET SETTING merge_with_ttl_timeout, unknown_setting;
+-- don't execute alter with incorrect setting
+ALTER TABLE table_for_reset_setting RESET SETTING merge_with_ttl_timeout, unknown_setting; -- { serverError 36 }
 
 ALTER TABLE table_for_reset_setting MODIFY SETTING merge_with_ttl_timeout = 300, max_concurrent_queries = 1;
 

--- a/tests/queries/0_stateless/00980_zookeeper_merge_tree_alter_settings.sql
+++ b/tests/queries/0_stateless/00980_zookeeper_merge_tree_alter_settings.sql
@@ -108,8 +108,8 @@ ATTACH TABLE replicated_table_for_reset_setting1;
 SHOW CREATE TABLE replicated_table_for_reset_setting1;
 SHOW CREATE TABLE replicated_table_for_reset_setting2;
 
--- ignore undefined setting
-ALTER TABLE replicated_table_for_reset_setting1 RESET SETTING check_delay_period, unknown_setting;
+-- don't execute alter with incorrect setting
+ALTER TABLE replicated_table_for_reset_setting1 RESET SETTING check_delay_period, unknown_setting; -- { serverError 36 }
 ALTER TABLE replicated_table_for_reset_setting1 RESET SETTING merge_with_ttl_timeout;
 ALTER TABLE replicated_table_for_reset_setting2 RESET SETTING merge_with_ttl_timeout;
 

--- a/tests/queries/0_stateless/02252_reset_non_existing_setting.sql
+++ b/tests/queries/0_stateless/02252_reset_non_existing_setting.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS most_ordinary_mt;
+
+CREATE TABLE most_ordinary_mt
+(
+   Key UInt64
+)
+ENGINE = MergeTree()
+ORDER BY tuple();
+
+ALTER TABLE most_ordinary_mt RESET SETTING ttl; --{serverError 36}
+ALTER TABLE most_ordinary_mt RESET SETTING allow_remote_fs_zero_copy_replication, xxx;  --{serverError 36}
+
+DROP TABLE IF EXISTS most_ordinary_mt;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now it's not allowed to `ALTER TABLE ... RESET SETTING` for non-existing  settings for MergeTree engines family. Fixes #35816.