### PR TITLE
Fix formatting of INSERT INFILE queries (missing quotes)

### DIFF
--- a/src/Parsers/ASTInsertQuery.cpp
+++ b/src/Parsers/ASTInsertQuery.cpp
@@ -81,9 +81,17 @@ void ASTInsertQuery::formatImpl(const FormatSettings & settings, FormatState & s
 
     if (infile)
     {
-        settings.ostr << (settings.hilite ? hilite_keyword : "") << " FROM INFILE " << (settings.hilite ? hilite_none : "") << infile->as<ASTLiteral &>().value.safeGet<std::string>();
+        settings.ostr
+            << (settings.hilite ? hilite_keyword : "")
+            << " FROM INFILE "
+            << (settings.hilite ? hilite_none : "")
+            << quoteString(infile->as<ASTLiteral &>().value.safeGet<std::string>());
         if (compression)
-            settings.ostr << (settings.hilite ? hilite_keyword : "") << " COMPRESSION " << (settings.hilite ? hilite_none : "") << compression->as<ASTLiteral &>().value.safeGet<std::string>();
+            settings.ostr
+                << (settings.hilite ? hilite_keyword : "")
+                << " COMPRESSION "
+                << (settings.hilite ? hilite_none : "")
+                << compression->as<ASTLiteral &>().value.safeGet<std::string>();
     }
 
     if (select)

--- a/src/Parsers/ASTInsertQuery.cpp
+++ b/src/Parsers/ASTInsertQuery.cpp
@@ -91,7 +91,7 @@ void ASTInsertQuery::formatImpl(const FormatSettings & settings, FormatState & s
                 << (settings.hilite ? hilite_keyword : "")
                 << " COMPRESSION "
                 << (settings.hilite ? hilite_none : "")
-                << compression->as<ASTLiteral &>().value.safeGet<std::string>();
+                << quoteString(compression->as<ASTLiteral &>().value.safeGet<std::string>());
     }
 
     if (select)

--- a/tests/queries/0_stateless/02165_insert_from_infile.reference
+++ b/tests/queries/0_stateless/02165_insert_from_infile.reference
@@ -1,5 +1,5 @@
-INSERT INTO test FROM INFILE data.file SELECT x
+INSERT INTO test FROM INFILE \'data.file\' SELECT x
 FROM input(\'x UInt32\')
-INSERT INTO test FROM INFILE data.file WITH number AS x
+INSERT INTO test FROM INFILE \'data.file\' WITH number AS x
 SELECT number
 FROM input(\'number UInt32\')

--- a/tests/queries/0_stateless/02264_format_insert_compression.reference
+++ b/tests/queries/0_stateless/02264_format_insert_compression.reference
@@ -1,0 +1,3 @@
+-- { echo }
+EXPLAIN SYNTAX INSERT INTO foo FROM INFILE '/dev/null' COMPRESSION 'gz';
+INSERT INTO foo FROM INFILE \'/dev/null\' COMPRESSION \'gz\'

--- a/tests/queries/0_stateless/02264_format_insert_compression.sql
+++ b/tests/queries/0_stateless/02264_format_insert_compression.sql
@@ -1,0 +1,2 @@
+-- { echo }
+EXPLAIN SYNTAX INSERT INTO foo FROM INFILE '/dev/null' COMPRESSION 'gz';

--- a/tests/queries/0_stateless/02264_format_insert_infile.reference
+++ b/tests/queries/0_stateless/02264_format_insert_infile.reference
@@ -1,0 +1,3 @@
+-- { echo }
+EXPLAIN SYNTAX INSERT INTO foo FROM INFILE '/dev/null';
+INSERT INTO foo FROM INFILE \'/dev/null\'

--- a/tests/queries/0_stateless/02264_format_insert_infile.sql
+++ b/tests/queries/0_stateless/02264_format_insert_infile.sql
@@ -1,0 +1,2 @@
+-- { echo }
+EXPLAIN SYNTAX INSERT INTO foo FROM INFILE '/dev/null';


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix formatting of INSERT INFILE queries (missing quotes)

*NOTE: seems that this is a minor problem since such queries should not be re-serialized (i.e. as distributed queries does)*