### PR TITLE
Better check for kafka_num_consumers

### DIFF
--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -779,11 +779,13 @@ void registerStorageKafka(StorageFactory & factory)
         #undef CHECK_KAFKA_STORAGE_ARGUMENT
 
         auto num_consumers = kafka_settings->kafka_num_consumers.value;
-        auto physical_cpu_cores = getNumberOfPhysicalCPUCores();
+        auto max_consumers = std::max<uint32_t>(getNumberOfPhysicalCPUCores(), 16);
 
-        if (num_consumers > physical_cpu_cores)
+        if (num_consumers > max_consumers)
         {
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Number of consumers can not be bigger than {}", physical_cpu_cores);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Number of consumers can not be bigger than {}, it just doesn't make sense. "
+                            "Note that kafka_num_consumers is not number of consumers for Kafka partitions -- they are managed by Kafka client library. "
+                            "kafka_num_consumers is internal amount of threads for ClickHouse and it shouldn't be big", max_consumers);
         }
         else if (num_consumers < 1)
         {

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -783,9 +783,12 @@ void registerStorageKafka(StorageFactory & factory)
 
         if (num_consumers > max_consumers)
         {
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Number of consumers can not be bigger than {}, it just doesn't make sense. "
-                            "Note that kafka_num_consumers is not number of consumers for Kafka partitions -- they are managed by Kafka client library. "
-                            "kafka_num_consumers is internal amount of threads for ClickHouse and it shouldn't be big", max_consumers);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "The number of consumers can not be bigger than {}. "
+                            "A single consumer can read any number of partitions. Extra consumers are relatively expensive, "
+                            "and using a lot of them can lead to high memory and CPU usage. To achieve better performance "
+                            "of getting data from Kafka, consider using a setting kafka_thread_per_consumer=1, "
+                            "and ensure you have enough threads in MessageBrokerSchedulePool (background_message_broker_schedule_pool_size). "
+                            "See also https://clickhouse.com/docs/integrations/kafka/kafka-table-engine#tuning-performance", max_consumers);
         }
         else if (num_consumers < 1)
         {


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now `kafka_num_consumers` can be bigger than amount of physical cores in case of low resource machine (less than 16 cores).
