### PR TITLE
Fix building ubuntu image from deb-repo

### DIFF
--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -94,8 +94,9 @@ RUN arch=${TARGETARCH:-amd64} \
         && apt-get update \
         && apt-get --yes -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" upgrade \
         && for package in ${PACKAGES}; do \
-            apt-get install --allow-unauthenticated --yes --no-install-recommends "${package}=${VERSION}" || exit 1 \
+            packages="${packages} ${package}=${VERSION}" \
         ; done \
+        && apt-get install --allow-unauthenticated --yes --no-install-recommends ${packages} || exit 1 \
     ; fi \
     && clickhouse-local -q 'SELECT * FROM system.build_options' \
     && rm -rf \


### PR DESCRIPTION
Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `apt-get` command to install all packages at once.

It's tested in https://github.com/ClickHouse/ClickHouse/issues/35906