### PR TITLE
Revert "clang-tidy report issues with Medium priority"

### DIFF
--- a/src/IO/ReadBufferFromFileDescriptor.h
+++ b/src/IO/ReadBufferFromFileDescriptor.h
@@ -39,10 +39,6 @@ public:
     {
     }
 
-    virtual ~ReadBufferFromFileDescriptor() override
-    {
-    }
-
     int getFD() const
     {
         return fd;
@@ -83,9 +79,6 @@ public:
         : ReadBufferFromFileDescriptor(fd_, buf_size, existing_memory, alignment, file_size_)
     {
         use_pread = true;
-    }
-    virtual ~ReadBufferFromFileDescriptorPRead() override
-    {
     }
 };
 

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -379,7 +379,7 @@ void SystemLog<LogElement>::flushImpl(const std::vector<LogElement> & to_flush, 
         for (const auto & name_and_type : log_element_names_and_types)
             log_element_columns.emplace_back(name_and_type.type, name_and_type.name);
 
-        Block block(log_element_columns);
+        Block block(std::move(log_element_columns));
 
         MutableColumns columns = block.mutateColumns();
         for (const auto & elem : to_flush)

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -122,7 +122,7 @@ void ColumnDescription::readText(ReadBuffer & buf)
             if (col_ast->default_expression)
             {
                 default_desc.kind = columnDefaultKindFromString(col_ast->default_specifier);
-                default_desc.expression = col_ast->default_expression;
+                default_desc.expression = std::move(col_ast->default_expression);
             }
 
             if (col_ast->comment)

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -44,7 +44,7 @@ class StorageDistributed final : public shared_ptr_helper<StorageDistributed>, p
     friend class StorageSystemDistributionQueue;
 
 public:
-    virtual ~StorageDistributed() override;
+    ~StorageDistributed() override;
 
     std::string getName() const override { return "Distributed"; }
 


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#35184

@kitaisreal Looks like ALL the changes in this PR are wrong.
People just blindly applied changes without reading the code.