### PR TITLE
Fix keeper image for `arm64`

### DIFF
--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -20,6 +20,8 @@ ENV LANG=en_US.UTF-8 \
 COPY --from=glibc-donor /lib/linux-gnu/libc.so.6 /lib/linux-gnu/libdl.so.2 /lib/linux-gnu/libm.so.6 /lib/linux-gnu/libpthread.so.0 /lib/linux-gnu/librt.so.1 /lib/linux-gnu/libnss_dns.so.2 /lib/linux-gnu/libnss_files.so.2 /lib/linux-gnu/libresolv.so.2 /lib/linux-gnu/ld-2.31.so /lib/
 COPY --from=glibc-donor /etc/nsswitch.conf /etc/
 COPY entrypoint.sh /entrypoint.sh
+
+ARG TARGETARCH
 RUN arch=${TARGETARCH:-amd64} \
     && case $arch in \
         amd64) mkdir -p /lib64 && ln -sf /lib/ld-2.31.so /lib64/ld-linux-x86-64.so.2 ;; \


### PR DESCRIPTION
Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


