### PR TITLE
Require mutations for per-table TTL only when it had been changed

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -822,9 +822,7 @@ bool AlterCommand::isTTLAlter(const StorageInMemoryMetadata & metadata) const
         if (!metadata.table_ttl.definition_ast)
             return true;
         /// If TTL had not been changed, do not require mutations
-        if (queryToString(metadata.table_ttl.definition_ast) == queryToString(ttl))
-            return false;
-        return true;
+        return queryToString(metadata.table_ttl.definition_ast) != queryToString(ttl);
     }
 
     if (!ttl || type != MODIFY_COLUMN)

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -818,22 +818,29 @@ bool AlterCommand::isCommentAlter() const
 bool AlterCommand::isTTLAlter(const StorageInMemoryMetadata & metadata) const
 {
     if (type == MODIFY_TTL)
+    {
+        if (!metadata.table_ttl.definition_ast)
+            return true;
+        /// If TTL had not been changed, do not require mutations
+        if (queryToString(metadata.table_ttl.definition_ast) == queryToString(ttl))
+            return false;
         return true;
+    }
 
     if (!ttl || type != MODIFY_COLUMN)
         return false;
 
-    bool ttl_changed = true;
+    bool column_ttl_changed = true;
     for (const auto & [name, ttl_ast] : metadata.columns.getColumnTTLs())
     {
         if (name == column_name && queryToString(*ttl) == queryToString(*ttl_ast))
         {
-            ttl_changed = false;
+            column_ttl_changed = false;
             break;
         }
     }
 
-    return ttl_changed;
+    return column_ttl_changed;
 }
 
 bool AlterCommand::isRemovingProperty() const

--- a/tests/queries/0_stateless/02265_per_table_ttl_mutation_on_change.reference
+++ b/tests/queries/0_stateless/02265_per_table_ttl_mutation_on_change.reference
@@ -1,0 +1,22 @@
+-- { echoOn }
+alter table per_table_ttl_02265 modify TTL date + interval 1 month;
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+1
+alter table per_table_ttl_02265 modify TTL date + interval 1 month;
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+1
+alter table per_table_ttl_02265 modify TTL date + interval 2 month;
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+2
+alter table per_table_ttl_02265 modify TTL date + interval 2 month group by key set value = argMax(value, date);
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+3
+alter table per_table_ttl_02265 modify TTL date + interval 2 month group by key set value = argMax(value, date);
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+3
+alter table per_table_ttl_02265 modify TTL date + interval 2 month recompress codec(ZSTD(17));
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+4
+alter table per_table_ttl_02265 modify TTL date + interval 2 month recompress codec(ZSTD(17));
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+4

--- a/tests/queries/0_stateless/02265_per_table_ttl_mutation_on_change.sql
+++ b/tests/queries/0_stateless/02265_per_table_ttl_mutation_on_change.sql
@@ -1,0 +1,22 @@
+drop table if exists per_table_ttl_02265;
+create table per_table_ttl_02265 (key Int, date Date, value String) engine=MergeTree() order by key;
+insert into per_table_ttl_02265 values (1, today(), '1');
+
+-- { echoOn }
+alter table per_table_ttl_02265 modify TTL date + interval 1 month;
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+alter table per_table_ttl_02265 modify TTL date + interval 1 month;
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+alter table per_table_ttl_02265 modify TTL date + interval 2 month;
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+alter table per_table_ttl_02265 modify TTL date + interval 2 month group by key set value = argMax(value, date);
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+alter table per_table_ttl_02265 modify TTL date + interval 2 month group by key set value = argMax(value, date);
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+alter table per_table_ttl_02265 modify TTL date + interval 2 month recompress codec(ZSTD(17));
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+alter table per_table_ttl_02265 modify TTL date + interval 2 month recompress codec(ZSTD(17));
+select count() from system.mutations where database = currentDatabase() and table = 'per_table_ttl_02265';
+
+-- { echoOff }
+drop table per_table_ttl_02265;


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Require mutations for per-table TTL only when it had been changed

Before this patch only per-column TTL did not requires mutation if it
had not been changed, after per-table TTL will also check whether it had
been changed or not.

Cc: @CurtizJ 