### PR TITLE
Fix possible mutation stuck due to DROP_RANGE

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -359,7 +359,7 @@ void ReplicatedMergeTreeQueue::updateStateOnQueueEntryRemoval(
 
             virtual_parts.remove(*drop_range_part_name);
 
-            removeCoveredPartsFromMutations(*drop_range_part_name, /*remove_part = */ true, /*remove_covered_parts = */ false);
+            removeCoveredPartsFromMutations(*drop_range_part_name, /*remove_part = */ true, /*remove_covered_parts = */ true);
         }
 
         if (entry->type == LogEntry::DROP_RANGE)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible mutation stuck due to DROP_RANGE

In #27002 this has been fixed by removing current parts from mutations,
but this is not enough since replicas can have different set of parts,
so covered parts should also be removed from the mutations.

Cc: @alesapin 
Cc: @tavplubix 