### PR TITLE
Improve ColumnDecimal, ColumnVector getPermutation performance using pdqsort with RadixSort

### DIFF
--- a/base/base/sort.h
+++ b/base/base/sort.h
@@ -132,6 +132,13 @@ void sort(RandomIt first, RandomIt last)
     ::sort(first, last, comparator());
 }
 
+/** Try to fast sort elements for common sorting patterns:
+  * 1. If elements are already sorted.
+  * 2. If elements are already almost sorted.
+  * 3. If elements are already sorted in reverse order.
+  *
+  * Returns true if fast sort was performed or elements were already sorted, false otherwise.
+  */
 template <typename RandomIt, typename Compare>
 bool trySort(RandomIt first, RandomIt last, Compare compare)
 {
@@ -148,5 +155,5 @@ bool trySort(RandomIt first, RandomIt last)
 {
     using value_type = typename std::iterator_traits<RandomIt>::value_type;
     using comparator = std::less<value_type>;
-    return ::pdqsort_try_sort(first, last, comparator());
+    return ::trySort(first, last, comparator());
 }

--- a/base/base/sort.h
+++ b/base/base/sort.h
@@ -131,3 +131,22 @@ void sort(RandomIt first, RandomIt last)
     using comparator = std::less<value_type>;
     ::sort(first, last, comparator());
 }
+
+template <typename RandomIt, typename Compare>
+bool trySort(RandomIt first, RandomIt last, Compare compare)
+{
+#ifndef NDEBUG
+    ::shuffle(first, last);
+#endif
+
+    ComparatorWrapper<Compare> compare_wrapper = compare;
+    return ::pdqsort_try_sort(first, last, compare_wrapper);
+}
+
+template <typename RandomIt>
+bool trySort(RandomIt first, RandomIt last)
+{
+    using value_type = typename std::iterator_traits<RandomIt>::value_type;
+    using comparator = std::less<value_type>;
+    return ::pdqsort_try_sort(first, last, comparator());
+}

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -4,6 +4,7 @@
 #include <Common/assert_cast.h>
 #include <Common/WeakHash.h>
 #include <Common/HashTable/Hash.h>
+#include <Common/RadixSort.h>
 
 #include <base/unaligned.h>
 #include <base/sort.h>
@@ -138,6 +139,26 @@ void ColumnDecimal<T>::updateHashFast(SipHash & hash) const
     hash.update(reinterpret_cast<const char *>(data.data()), size() * sizeof(data[0]));
 }
 
+namespace
+{
+    template <typename T>
+    struct ValueWithIndex
+    {
+        T value;
+        UInt32 index;
+    };
+
+    template <typename T>
+    struct RadixSortTraits : RadixSortNumTraits<T>
+    {
+        using Element = ValueWithIndex<T>;
+        using Result = size_t;
+
+        static T & extractKey(Element & elem) { return elem.value; }
+        static size_t extractResult(Element & elem) { return elem.index; }
+    };
+}
+
 template <is_decimal T>
 void ColumnDecimal<T>::getPermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                                     size_t limit, int, IColumn::Permutation & res) const
@@ -158,6 +179,39 @@ void ColumnDecimal<T>::getPermutation(IColumn::PermutationSortDirection directio
 
         return data[lhs] > data[rhs];
     };
+
+    size_t data_size = data.size();
+    res.resize(data_size);
+
+    if (limit >= data_size) {
+        limit = 0;
+    }
+
+    if (!limit)
+    {
+        /// A case for radix sort
+        /// LSD RadixSort is stable
+        if constexpr (is_arithmetic_v<NativeT> && !is_big_int_v<NativeT>)
+        {
+            bool reverse = direction == IColumn::PermutationSortDirection::Descending;
+            bool ascending = direction == IColumn::PermutationSortDirection::Ascending;
+            bool sort_is_stable = stability == IColumn::PermutationSortStability::Stable;
+
+            /// TODO: LSD RadixSort is currently not stable if direction is descending
+            bool use_radix_sort = (sort_is_stable && ascending) || !sort_is_stable;
+
+            /// Thresholds on size. Lower threshold is arbitrary. Upper threshold is chosen by the type for histogram counters.
+            if (data_size >= 256 && data_size <= std::numeric_limits<UInt32>::max() && use_radix_sort)
+            {
+                PaddedPODArray<ValueWithIndex<NativeT>> pairs(data_size);
+                for (UInt32 i = 0; i < UInt32(data_size); ++i)
+                    pairs[i] = {data[i].value, i};
+
+                RadixSort<RadixSortTraits<NativeT>>::executeLSD(pairs.data(), data_size, reverse, res.data());
+                return;
+            }
+        }
+    }
 
     if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Unstable)
         this->getPermutationImpl(limit, res, comparator_ascending, DefaultSort(), DefaultPartialSort());

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -16,6 +16,7 @@
 #include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnCompressed.h>
 #include <Columns/MaskOperations.h>
+#include <Columns/RadixSortHelper.h>
 #include <Processors/Transforms/ColumnGathererTransform.h>
 
 
@@ -139,26 +140,6 @@ void ColumnDecimal<T>::updateHashFast(SipHash & hash) const
     hash.update(reinterpret_cast<const char *>(data.data()), size() * sizeof(data[0]));
 }
 
-namespace
-{
-    template <typename T>
-    struct ValueWithIndex
-    {
-        T value;
-        UInt32 index;
-    };
-
-    template <typename T>
-    struct RadixSortTraits : RadixSortNumTraits<T>
-    {
-        using Element = ValueWithIndex<T>;
-        using Result = size_t;
-
-        static T & extractKey(Element & elem) { return elem.value; }
-        static size_t extractResult(Element & elem) { return elem.index; }
-    };
-}
-
 template <is_decimal T>
 void ColumnDecimal<T>::getPermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                                     size_t limit, int, IColumn::Permutation & res) const
@@ -183,16 +164,19 @@ void ColumnDecimal<T>::getPermutation(IColumn::PermutationSortDirection directio
     size_t data_size = data.size();
     res.resize(data_size);
 
-    if (limit >= data_size) {
+    if (limit >= data_size)
         limit = 0;
-    }
 
-    if (!limit)
+    for (size_t i = 0; i < data_size; ++i)
+        res[i] = i;
+
+    if constexpr (is_arithmetic_v<NativeT> && !is_big_int_v<NativeT>)
     {
-        /// A case for radix sort
-        /// LSD RadixSort is stable
-        if constexpr (is_arithmetic_v<NativeT> && !is_big_int_v<NativeT>)
+        if (!limit)
         {
+            /// A case for radix sort
+            /// LSD RadixSort is stable
+
             bool reverse = direction == IColumn::PermutationSortDirection::Descending;
             bool ascending = direction == IColumn::PermutationSortDirection::Ascending;
             bool sort_is_stable = stability == IColumn::PermutationSortStability::Stable;
@@ -203,8 +187,25 @@ void ColumnDecimal<T>::getPermutation(IColumn::PermutationSortDirection directio
             /// Thresholds on size. Lower threshold is arbitrary. Upper threshold is chosen by the type for histogram counters.
             if (data_size >= 256 && data_size <= std::numeric_limits<UInt32>::max() && use_radix_sort)
             {
+                for (size_t i = 0; i < data_size; ++i)
+                    res[i] = i;
+
+                bool try_sort = false;
+
+                if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Unstable)
+                    try_sort = trySort(res.begin(), res.end(), comparator_ascending);
+                else if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Stable)
+                    try_sort = trySort(res.begin(), res.end(), comparator_ascending_stable);
+                else if (direction == IColumn::PermutationSortDirection::Descending && stability == IColumn::PermutationSortStability::Unstable)
+                    try_sort = trySort(res.begin(), res.end(), comparator_descending);
+                else
+                    try_sort = trySort(res.begin(), res.end(), comparator_descending_stable);
+
+                if (try_sort)
+                    return;
+
                 PaddedPODArray<ValueWithIndex<NativeT>> pairs(data_size);
-                for (UInt32 i = 0; i < UInt32(data_size); ++i)
+                for (UInt32 i = 0; i < static_cast<UInt32>(data_size); ++i)
                     pairs[i] = {data[i].value, i};
 
                 RadixSort<RadixSortTraits<NativeT>>::executeLSD(pairs.data(), data_size, reverse, res.data());
@@ -245,7 +246,37 @@ void ColumnDecimal<T>::updatePermutation(IColumn::PermutationSortDirection direc
         return data[lhs] < data[rhs];
     };
     auto equals_comparator = [this](size_t lhs, size_t rhs) { return data[lhs] == data[rhs]; };
-    auto sort = [](auto begin, auto end, auto pred) { ::sort(begin, end, pred); };
+    auto sort = [&](auto begin, auto end, auto pred)
+    {
+        bool reverse = direction == IColumn::PermutationSortDirection::Descending;
+        bool ascending = direction == IColumn::PermutationSortDirection::Ascending;
+        bool sort_is_stable = stability == IColumn::PermutationSortStability::Stable;
+
+        /// TODO: LSD RadixSort is currently not stable if direction is descending
+        bool use_radix_sort = (sort_is_stable && ascending) || !sort_is_stable;
+        size_t size = end - begin;
+
+        if (size >= 256 && size <= std::numeric_limits<UInt32>::max() && use_radix_sort)
+        {
+            bool try_sort = trySort(begin, end, pred);
+            if (try_sort)
+                return;
+
+            PaddedPODArray<ValueWithIndex<NativeT>> pairs(size);
+            size_t index = 0;
+
+            for (auto * it = begin; it != end; ++it)
+            {
+                pairs[index] = {data[*it].value, static_cast<UInt32>(*it)};
+                ++index;
+            }
+
+            RadixSort<RadixSortTraits<NativeT>>::executeLSD(pairs.data(), size, reverse, res.data());
+            return;
+        }
+
+        ::sort(begin, end, pred);
+    };
     auto partial_sort = [](auto begin, auto mid, auto end, auto pred) { ::partial_sort(begin, mid, end, pred); };
 
     if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Unstable)

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -254,31 +254,16 @@ template <typename T>
 void ColumnVector<T>::getPermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                                     size_t limit, int nan_direction_hint, IColumn::Permutation & res) const
 {
-    size_t s = data.size();
-    res.resize(s);
+    size_t data_size = data.size();
+    res.resize(data_size);
 
-    if (s == 0)
+    if (data_size == 0)
         return;
 
-    if (limit >= s)
+    if (limit >= data_size)
         limit = 0;
 
-    if (limit)
-    {
-        for (size_t i = 0; i < s; ++i)
-            res[i] = i;
-
-        if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Unstable)
-            ::partial_sort(res.begin(), res.begin() + limit, res.end(), less(*this, nan_direction_hint));
-        else if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Stable)
-            ::partial_sort(res.begin(), res.begin() + limit, res.end(), less_stable(*this, nan_direction_hint));
-        else if (direction == IColumn::PermutationSortDirection::Descending && stability == IColumn::PermutationSortStability::Unstable)
-            ::partial_sort(res.begin(), res.begin() + limit, res.end(), greater(*this, nan_direction_hint));
-        else if (direction == IColumn::PermutationSortDirection::Descending && stability == IColumn::PermutationSortStability::Stable)
-            ::partial_sort(res.begin(), res.begin() + limit, res.end(), greater_stable(*this, nan_direction_hint));
-    }
-    else
-    {
+    if (!limit) {
         /// A case for radix sort
         /// LSD RadixSort is stable
         if constexpr (is_arithmetic_v<T> && !is_big_int_v<T>)
@@ -291,13 +276,13 @@ void ColumnVector<T>::getPermutation(IColumn::PermutationSortDirection direction
             bool use_radix_sort = (sort_is_stable && ascending && !std::is_floating_point_v<T>) || !sort_is_stable;
 
             /// Thresholds on size. Lower threshold is arbitrary. Upper threshold is chosen by the type for histogram counters.
-            if (s >= 256 && s <= std::numeric_limits<UInt32>::max() && use_radix_sort)
+            if (data_size >= 256 && data_size <= std::numeric_limits<UInt32>::max() && use_radix_sort)
             {
-                PaddedPODArray<ValueWithIndex<T>> pairs(s);
-                for (UInt32 i = 0; i < static_cast<UInt32>(s); ++i)
+                PaddedPODArray<ValueWithIndex<T>> pairs(data_size);
+                for (UInt32 i = 0; i < static_cast<UInt32>(data_size); ++i)
                     pairs[i] = {data[i], i};
 
-                RadixSort<RadixSortTraits<T>>::executeLSD(pairs.data(), s, reverse, res.data());
+                RadixSort<RadixSortTraits<T>>::executeLSD(pairs.data(), data_size, reverse, res.data());
 
                 /// Radix sort treats all NaNs to be greater than all numbers.
                 /// If the user needs the opposite, we must move them accordingly.
@@ -305,9 +290,9 @@ void ColumnVector<T>::getPermutation(IColumn::PermutationSortDirection direction
                 {
                     size_t nans_to_move = 0;
 
-                    for (size_t i = 0; i < s; ++i)
+                    for (size_t i = 0; i < data_size; ++i)
                     {
-                        if (isNaN(data[res[reverse ? i : s - 1 - i]]))
+                        if (isNaN(data[res[reverse ? i : data_size - 1 - i]]))
                             ++nans_to_move;
                         else
                             break;
@@ -315,26 +300,23 @@ void ColumnVector<T>::getPermutation(IColumn::PermutationSortDirection direction
 
                     if (nans_to_move)
                     {
-                        std::rotate(std::begin(res), std::begin(res) + (reverse ? nans_to_move : s - nans_to_move), std::end(res));
+                        std::rotate(std::begin(res), std::begin(res) + (reverse ? nans_to_move : data_size - nans_to_move), std::end(res));
                     }
                 }
+
                 return;
             }
         }
-
-        /// Default sorting algorithm.
-        for (size_t i = 0; i < s; ++i)
-            res[i] = i;
-
-        if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Unstable)
-            ::sort(res.begin(), res.end(), less(*this, nan_direction_hint));
-        else if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Stable)
-            ::sort(res.begin(), res.end(), less_stable(*this, nan_direction_hint));
-        else if (direction == IColumn::PermutationSortDirection::Descending && stability == IColumn::PermutationSortStability::Unstable)
-            ::sort(res.begin(), res.end(), greater(*this, nan_direction_hint));
-        else if (direction == IColumn::PermutationSortDirection::Descending && stability == IColumn::PermutationSortStability::Stable)
-            ::sort(res.begin(), res.end(), greater_stable(*this, nan_direction_hint));
     }
+
+    if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Unstable)
+        this->getPermutationImpl(limit, res, less(*this, nan_direction_hint), DefaultSort(), DefaultPartialSort());
+    else if (direction == IColumn::PermutationSortDirection::Ascending && stability == IColumn::PermutationSortStability::Stable)
+        this->getPermutationImpl(limit, res, less_stable(*this, nan_direction_hint), DefaultSort(), DefaultPartialSort());
+    else if (direction == IColumn::PermutationSortDirection::Descending && stability == IColumn::PermutationSortStability::Unstable)
+        this->getPermutationImpl(limit, res, greater(*this, nan_direction_hint), DefaultSort(), DefaultPartialSort());
+    else
+        this->getPermutationImpl(limit, res, greater_stable(*this, nan_direction_hint), DefaultSort(), DefaultPartialSort());
 }
 
 template <typename T>

--- a/src/Columns/RadixSortHelper.h
+++ b/src/Columns/RadixSortHelper.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Common/RadixSort.h>
+
+namespace DB
+{
+
+template <typename T>
+struct ValueWithIndex
+{
+    T value;
+    UInt32 index;
+};
+
+template <typename T>
+struct RadixSortTraits : RadixSortNumTraits<T>
+{
+    using Element = ValueWithIndex<T>;
+    using Result = size_t;
+
+    static T & extractKey(Element & elem) { return elem.value; }
+    static size_t extractResult(Element & elem) { return elem.index; }
+};
+
+}

--- a/tests/performance/merge_tree_insert.xml
+++ b/tests/performance/merge_tree_insert.xml
@@ -37,9 +37,9 @@
     <create_query>CREATE TABLE merge_tree_insert_5 (value_1 String, value_2 String, value_3 String) ENGINE = MergeTree ORDER BY (value_1, value_2)</create_query>
     <create_query>CREATE TABLE merge_tree_insert_6 (value_1 String, value_2 String, value_3 String) ENGINE = MergeTree ORDER BY (value_1, value_2, value_3)</create_query>
 
-    <create_query>CREATE TABLE merge_tree_insert_4 (value_1 Decimal64(8), value_2  Decimal64(8), value_3  Decimal64(8)) ENGINE = MergeTree ORDER BY (value_1)</create_query>
-    <create_query>CREATE TABLE merge_tree_insert_5 (value_1 Decimal64(8), value_2  Decimal64(8), value_3  Decimal64(8)) ENGINE = MergeTree ORDER BY (value_1, value_2)</create_query>
-    <create_query>CREATE TABLE merge_tree_insert_6 (value_1 Decimal64(8), value_2  Decimal64(8), value_3  Decimal64(8)) ENGINE = MergeTree ORDER BY (value_1, value_2, value_3)</create_query>
+    <create_query>CREATE TABLE merge_tree_insert_7 (value_1 Decimal64(8), value_2  Decimal64(8), value_3  Decimal64(8)) ENGINE = MergeTree ORDER BY (value_1)</create_query>
+    <create_query>CREATE TABLE merge_tree_insert_8 (value_1 Decimal64(8), value_2  Decimal64(8), value_3  Decimal64(8)) ENGINE = MergeTree ORDER BY (value_1, value_2)</create_query>
+    <create_query>CREATE TABLE merge_tree_insert_9 (value_1 Decimal64(8), value_2  Decimal64(8), value_3  Decimal64(8)) ENGINE = MergeTree ORDER BY (value_1, value_2, value_3)</create_query>
 
     <query>INSERT INTO {integer_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 500000</query>
     <query>INSERT INTO {integer_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 1000000</query>
@@ -49,9 +49,9 @@
     <query>INSERT INTO {string_primary_key_table_name} SELECT toString(rand64(0)), toString(rand64(1)), toString(rand64(2)) FROM system.numbers LIMIT 1000000</query>
     <query>INSERT INTO {string_primary_key_table_name} SELECT toString(rand64(0)), toString(rand64(1)), toString(rand64(2)) FROM system.numbers LIMIT 1500000</query>
 
-    <query>INSERT INTO {decimal_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 500000</query>
-    <query>INSERT INTO {decimal_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 1000000</query>
-    <query>INSERT INTO {decimal_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 1500000</query>
+    <query>INSERT INTO {decimal_primary_key_table_name} SELECT rand64(0) % 1000000, rand64(1) % 1500000, rand64(2) % 2000000 FROM system.numbers LIMIT 500000</query>
+    <query>INSERT INTO {decimal_primary_key_table_name} SELECT rand64(0) % 1000000, rand64(1) % 1500000, rand64(2) % 2000000 FROM system.numbers LIMIT 1000000</query>
+    <query>INSERT INTO {decimal_primary_key_table_name} SELECT rand64(0) % 1000000, rand64(1) % 1500000, rand64(2) % 2000000 FROM system.numbers LIMIT 1500000</query>
 
     <drop_query>DROP TABLE IF EXISTS {integer_primary_key_table_name}</drop_query>
     <drop_query>DROP TABLE IF EXISTS {string_primary_key_table_name}</drop_query>

--- a/tests/performance/merge_tree_insert.xml
+++ b/tests/performance/merge_tree_insert.xml
@@ -18,14 +18,28 @@
                 <value>merge_tree_insert_6</value>
             </values>
         </substitution>
+
+        <substitution>
+            <name>decimal_primary_key_table_name</name>
+            <values>
+                <value>merge_tree_insert_7</value>
+                <value>merge_tree_insert_8</value>
+                <value>merge_tree_insert_9</value>
+            </values>
+        </substitution>
     </substitutions>
 
     <create_query>CREATE TABLE merge_tree_insert_1 (value_1 UInt64, value_2 UInt64, value_3 UInt64) ENGINE = MergeTree ORDER BY (value_1)</create_query>
     <create_query>CREATE TABLE merge_tree_insert_2 (value_1 UInt64, value_2 UInt64, value_3 UInt64) ENGINE = MergeTree ORDER BY (value_1, value_2)</create_query>
     <create_query>CREATE TABLE merge_tree_insert_3 (value_1 UInt64, value_2 UInt64, value_3 UInt64) ENGINE = MergeTree ORDER BY (value_1, value_2, value_3)</create_query>
+
     <create_query>CREATE TABLE merge_tree_insert_4 (value_1 String, value_2 String, value_3 String) ENGINE = MergeTree ORDER BY (value_1)</create_query>
     <create_query>CREATE TABLE merge_tree_insert_5 (value_1 String, value_2 String, value_3 String) ENGINE = MergeTree ORDER BY (value_1, value_2)</create_query>
     <create_query>CREATE TABLE merge_tree_insert_6 (value_1 String, value_2 String, value_3 String) ENGINE = MergeTree ORDER BY (value_1, value_2, value_3)</create_query>
+
+    <create_query>CREATE TABLE merge_tree_insert_4 (value_1 Decimal64(8), value_2  Decimal64(8), value_3  Decimal64(8)) ENGINE = MergeTree ORDER BY (value_1)</create_query>
+    <create_query>CREATE TABLE merge_tree_insert_5 (value_1 Decimal64(8), value_2  Decimal64(8), value_3  Decimal64(8)) ENGINE = MergeTree ORDER BY (value_1, value_2)</create_query>
+    <create_query>CREATE TABLE merge_tree_insert_6 (value_1 Decimal64(8), value_2  Decimal64(8), value_3  Decimal64(8)) ENGINE = MergeTree ORDER BY (value_1, value_2, value_3)</create_query>
 
     <query>INSERT INTO {integer_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 500000</query>
     <query>INSERT INTO {integer_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 1000000</query>
@@ -35,7 +49,12 @@
     <query>INSERT INTO {string_primary_key_table_name} SELECT toString(rand64(0)), toString(rand64(1)), toString(rand64(2)) FROM system.numbers LIMIT 1000000</query>
     <query>INSERT INTO {string_primary_key_table_name} SELECT toString(rand64(0)), toString(rand64(1)), toString(rand64(2)) FROM system.numbers LIMIT 1500000</query>
 
+    <query>INSERT INTO {decimal_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 500000</query>
+    <query>INSERT INTO {decimal_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 1000000</query>
+    <query>INSERT INTO {decimal_primary_key_table_name} SELECT rand64(0), rand64(1), rand64(2) FROM system.numbers LIMIT 1500000</query>
+
     <drop_query>DROP TABLE IF EXISTS {integer_primary_key_table_name}</drop_query>
     <drop_query>DROP TABLE IF EXISTS {string_primary_key_table_name}</drop_query>
+    <drop_query>DROP TABLE IF EXISTS {decimal_primary_key_table_name}</drop_query>
 
 </test>

--- a/tests/performance/sort_patterns.xml
+++ b/tests/performance/sort_patterns.xml
@@ -1,0 +1,22 @@
+<test>
+    <substitutions>
+        <substitution>
+            <name>integer_type</name>
+            <values>
+                <value>UInt32</value>
+                <value>UInt64</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>CREATE TABLE sequential_{integer_type} (key {integer_type}, value {integer_type}) Engine = Memory</create_query>
+
+    <fill_query>INSERT INTO sequential_{integer_type} SELECT number, number FROM numbers(10000000)</fill_query>
+
+    <query>SELECT key, value FROM sequential_{integer_type} ORDER BY key;</query>
+    <query>SELECT key, value FROM sequential_{integer_type} ORDER BY key, value;</query>
+    <query>SELECT key, value FROM sequential_{integer_type} ORDER BY key DESC;</query>
+    <query>SELECT key, value FROM sequential_{integer_type} ORDER BY key DESC, value DESC;</query>
+
+    <drop_query>DROP TABLE IF EXISTS sequential_{integer_type}</drop_query>
+</test>

--- a/tests/performance/sort_patterns.xml
+++ b/tests/performance/sort_patterns.xml
@@ -7,16 +7,22 @@
                 <value>UInt64</value>
             </values>
         </substitution>
+        <substitution>
+            <name>sort_expression</name>
+            <values>
+                <value>key</value>
+                <value>key, value</value>
+                <value>key DESC</value>
+                <value>key DESC, value DESC</value>
+            </values>
+        </substitution>
     </substitutions>
 
     <create_query>CREATE TABLE sequential_{integer_type} (key {integer_type}, value {integer_type}) Engine = Memory</create_query>
 
-    <fill_query>INSERT INTO sequential_{integer_type} SELECT number, number FROM numbers(10000000)</fill_query>
+    <fill_query>INSERT INTO sequential_{integer_type} SELECT number, number FROM numbers(500000000)</fill_query>
 
-    <query>SELECT key, value FROM sequential_{integer_type} ORDER BY key;</query>
-    <query>SELECT key, value FROM sequential_{integer_type} ORDER BY key, value;</query>
-    <query>SELECT key, value FROM sequential_{integer_type} ORDER BY key DESC;</query>
-    <query>SELECT key, value FROM sequential_{integer_type} ORDER BY key DESC, value DESC;</query>
+    <query>SELECT key, value FROM sequential_{integer_type} ORDER BY {sort_expression} FORMAT Null</query>
 
     <drop_query>DROP TABLE IF EXISTS sequential_{integer_type}</drop_query>
 </test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve performance of sorting for decimal columns. Improve performance of insertion into MergeTree if ORDER BY contains Decimal column. Improve performance of sorting when data is already sorted or almost sorted. 
