### PR TITLE
parallel reading files for FileLog Engine

### DIFF
--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -723,6 +723,7 @@ bool StorageFileLog::streamToViews()
     size_t rows = 0;
     {
         block_io.pipeline.complete(std::move(input));
+        block_io.pipeline.setNumThreads(max_streams_number);
         block_io.pipeline.setProgressCallback([&](const Progress & progress) { rows += progress.read_rows.load(); });
         CompletedPipelineExecutor executor(block_io.pipeline);
         executor.execute();


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


