### PR TITLE
Avx512 memcpy small

### DIFF
--- a/src/Common/memcpySmall.h
+++ b/src/Common/memcpySmall.h
@@ -32,32 +32,34 @@ namespace detail
     {
         while (n > 0)
         {
-          if (n >= 64)
-          {
-            // Load and store 512-bits of integer data from memory into dst. mem_addr
-            _mm512_storeu_si512(reinterpret_cast<__m512i *>(dst),
-            _mm512_loadu_si512(reinterpret_cast<const __m512i *>(src)));
+            if (n >= 64)
+            {
+                /// Load and store 512-bits of integer data from memory into dst. mem_addr
+                _mm512_storeu_si512(reinterpret_cast<__m512i *>(dst),
+                _mm512_loadu_si512(reinterpret_cast<const __m512i *>(src)));
 
-            dst += 64;
-            src += 64;
-            n -= 64;
-          } else if (n >= 32)
-          {
-            _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst),
-            _mm256_loadu_si256(reinterpret_cast<const __m256i *>(src)));
+                dst += 64;
+                src += 64;
+                n -= 64;
+            }
+            else if (n >= 32)
+            {
+                _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst),
+                _mm256_loadu_si256(reinterpret_cast<const __m256i *>(src)));
 
-            dst += 32;
-            src += 32;
-            n -= 32;
-          } else
-          {
-            _mm_storeu_si128(reinterpret_cast<__m128i *>(dst),
-            _mm_loadu_si128(reinterpret_cast<const __m128i *>(src)));
+                dst += 32;
+                src += 32;
+                n -= 32;
+            }
+            else
+            {
+                _mm_storeu_si128(reinterpret_cast<__m128i *>(dst),
+                _mm_loadu_si128(reinterpret_cast<const __m128i *>(src)));
 
-            dst += 16;
-            src += 16;
-            n -= 16;
-          }
+                dst += 16;
+                src += 16;
+                n -= 16;
+            }
         }
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add x86 avx512 support for memcpySmall functions to accelerate memory copy. It works only if you 
compile ClickHouse by yourself.

Detailed description / Documentation draft:
The changes is to implement the memCpy function in memcpySmall.h by using avx512 intrinsic '_mm512_storeu_si512'
and '_mm512_loadu_si512' when copied memory exceed 64bytes. Compared with the original version, functions in the avx512
version can have better performance(memcpySmallAllowReadWriteOverflow15Impl) or the same performance.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/yaqizhao/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/yaqizhao/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{color:#24292F;
	font-size:7.0pt;
	font-family:"Segoe UI", sans-serif;
	mso-font-charset:0;
	text-align:center;
	vertical-align:middle;
	border:.5pt solid windowtext;
	background:white;
	mso-pattern:black none;
	white-space:normal;}
.xl64
	{color:#002060;
	font-size:8.0pt;
	font-family:"Segoe UI", sans-serif;
	mso-font-charset:0;
	text-align:right;
	vertical-align:middle;
	border:.5pt solid windowtext;
	background:white;
	mso-pattern:black none;
	white-space:normal;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



Case(byte) | memcpySmallAllowReadWriteOverflow15(SSE2) | memcpySmallAllowReadWriteOverflow15(AVX512)
-- | -- | --
8 | 20 | 20
16 | 27 | 26
32 | 30 | 24
64 | 39 | 33
128 | 49 | 37
256 | 66 | 44
512 | 75 | 70



</body>

</html>

Test Case:
Q2: SELECT C_NATION,S_NATION,toYear(LO_ORDERDATE) AS year,sum(LO_REVENUE) AS revenue FROM lineorder_flat WHERE C_REGION = 'ASIA' AND S_REGION = 'ASIA' AND year >= 1992 AND year <= 1997 GROUP BY C_NATION, S_NATION, year ORDER BY year ASC, revenue DESC;
Q3:  SELECT toFixedString('foo', 128); SELECT toFixedString('foo', 64); SELECT toFixedString('foo', 32); SELECT toFixedString('foo', 16);
Q4:SELECT toFixedString('foo', 128);
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/yaqizhao/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/yaqizhao/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{color:black;
	font-size:10.5pt;
	font-family:"Intel Clear";
	mso-generic-font-family:auto;
	mso-font-charset:0;
	text-align:center;
	vertical-align:middle;
	border-top:1.0pt solid black;
	border-right:none;
	border-bottom:none;
	border-left:none;
	white-space:normal;}
.xl64
	{color:black;
	font-size:10.5pt;
	font-family:"Intel Clear";
	mso-generic-font-family:auto;
	mso-font-charset:0;
	text-align:center;
	vertical-align:middle;
	white-space:normal;}
.xl65
	{color:black;
	font-family:"Intel Clear";
	mso-generic-font-family:auto;
	mso-font-charset:0;
	text-align:center;
	white-space:normal;}
.xl66
	{color:black;
	font-family:"Intel Clear";
	mso-generic-font-family:auto;
	mso-font-charset:0;
	mso-number-format:Percent;
	text-align:center;
	white-space:normal;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



Query | Baseline  (QPS) | avx512 optimized (QPS) | improvement
-- | -- | -- | --
Q2 | 109 | 112 | ~
Q3 | 2635 | 2700 | 2.80%
Q4 | 1910 | 2024 | 5.90%



</body>

</html>




> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
