### PR TITLE
Fix data race in StorageURL

### DIFF
--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -224,14 +224,12 @@ namespace
                 }
 
                 Chunk chunk;
+                std::lock_guard lock(reader_mutex);
                 if (reader->pull(chunk))
                     return chunk;
 
-                {
-                    std::lock_guard lock(reader_mutex);
-                    pipeline->reset();
-                    reader.reset();
-                }
+                pipeline->reset();
+                reader.reset();
             }
         }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There was a data race inside the `StoragURLSource`.
`pull` and `cancel` methods in `PullingPipelineExecutor` are not thread safe.
`cancel` is protected by `mutex` inside the `onCancel` method, while `pull` was not in `generate`.

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
