### PR TITLE
Print labels to log in run_check.py

### DIFF
--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -255,6 +255,7 @@ if __name__ == "__main__":
     elif SUBMODULE_CHANGED_LABEL in pr_info.labels:
         pr_labels_to_remove.append(SUBMODULE_CHANGED_LABEL)
 
+    print("change labels: add {}, remove {}".format(pr_labels_to_add, pr_labels_to_remove))
     if pr_labels_to_add:
         post_labels(gh, pr_info, pr_labels_to_add)
 


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Sometimes pr labels are not set automatically, it's unclear
e.g. https://github.com/ClickHouse/ClickHouse/pull/35682