### PR TITLE
Fix flaky test `test_system_merges/test.py::test_merge_simple`

### DIFF
--- a/tests/integration/test_system_merges/test.py
+++ b/tests/integration/test_system_merges/test.py
@@ -124,7 +124,7 @@ def test_merge_simple(started_cluster, replicated):
 
         assert (
             node_check.query(
-                "SELECT * FROM system.merges WHERE table = '{name}'".format(
+                "SELECT * FROM system.merges WHERE table = '{name}' and progress < 1".format(
                     name=table_name
                 )
             )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/35946/1309e781b624fdfa5c5886eb25f5f2ee52c5fe89/integration_tests__asan__actions__[1/3].html

```
>           assert (
                node_check.query(
                    "SELECT * FROM system.merges WHERE table = '{name}'".format(
                        name=table_name
                    )
                )
                == ""
            )
E           assert ('test\tmerge_simple\t5.959181641\t1\t3\t'\n "['all_0_0_0','all_1_1_0','all_2_2_0']\tall_0_2_1\t"\n "['/var/lib/clickhouse/data/test/merge_simple/all_0_0_0/','/var/lib/clickhouse/data/test/merge_simple/all_1_1_0/','/var/lib/clickhouse/data/test/merge_simple/all_2_2_0/']\t"\n '/var/lib/clickhouse/data/test/merge_simple/all_0_2_1/\tall\t0\t255\t6\t24\t'\n '3\t0\t0\t0\t0\t34\tREGULAR\tHorizontal\n') == ''
E             + test	merge_simple	5.959181641	1	3	['all_0_0_0','all_1_1_0','all_2_2_0']	all_0_2_1	['/var/lib/clickhouse/data/test/merge_simple/all_0_0_0/','/var/lib/clickhouse/data/test/merge_simple/all_1_1_0/','/var/lib/clickhouse/data/test/merge_simple/all_2_2_0/']	/var/lib/clickhouse/data/test/merge_simple/all_0_2_1/	all	0	255	6	24	3	0	0	0	0	34	REGULAR	Horizontal

```
