### PR TITLE
Fix Backward comapatibility check

### DIFF
--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -10,7 +10,7 @@ import logging
 import time
 
 
-def get_options(i):
+def get_options(i, backward_compatibility_check):
     options = []
     client_options = []
     if 0 < i:
@@ -19,7 +19,7 @@ def get_options(i):
     if i % 3 == 1:
         options.append("--db-engine=Ordinary")
 
-    if i % 3 == 2:
+    if i % 3 == 2 and not backward_compatibility_check:
         options.append('''--db-engine="Replicated('/test/db/test_{}', 's1', 'r1')"'''.format(i))
         client_options.append('allow_experimental_database_replicated=1')
 
@@ -57,7 +57,7 @@ def run_func_test(cmd, output_prefix, num_processes, skip_tests_option, global_t
     pipes = []
     for i in range(0, len(output_paths)):
         f = open(output_paths[i], 'w')
-        full_command = "{} {} {} {} {}".format(cmd, get_options(i), global_time_limit_option, skip_tests_option, backward_compatibility_check_option)
+        full_command = "{} {} {} {} {}".format(cmd, get_options(i, backward_compatibility_check), global_time_limit_option, skip_tests_option, backward_compatibility_check_option)
         logging.info("Run func tests '%s'", full_command)
         p = Popen(full_command, shell=True, stdout=f, stderr=f)
         pipes.append(p)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/35956/585cff1e95da919907938e189bf041fb7643371d/stress_test__debug__actions_.html

The problem is that this crash was fixed in #35503, but Backward compatibility check does not take it into account. Let's just disable Replicated databases in Backward compatibility check for now and enable it back after the next release.

cc: @Avogar  
