### PR TITLE
Backport/fix release workflow

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -9,6 +9,18 @@ on: # yamllint disable-line rule:truthy
     branches:
       - 'backport/**'
 jobs:
+  PythonUnitTests:
+    runs-on: [self-hosted, style-checker]
+    steps:
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Python unit tests
+        run: |
+          cd "$GITHUB_WORKSPACE/tests/ci"
+          python3 -m unittest discover -s . -p '*_test.py'
   DockerHubPushAarch64:
     runs-on: [self-hosted, style-checker-aarch64]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
     - name: Check docker clickhouse/clickhouse-server building
       run: |
         cd "$GITHUB_WORKSPACE/tests/ci"
-        python3 docker_server.py --release-type auto
-        python3 docker_server.py --release-type auto --no-ubuntu \
+        python3 docker_server.py --release-type auto --version "${{ github.ref }}"
+        python3 docker_server.py --release-type auto --version "${{ github.ref }}" --no-ubuntu \
           --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper
     - name: Cleanup
       if: always()

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -16,7 +16,6 @@ from commit_status_helper import post_commit_status
 from docker_images_check import DockerImage
 from env_helper import CI, GITHUB_RUN_URL, RUNNER_TEMP, S3_BUILDS_BUCKET
 from get_robot_token import get_best_robot_token, get_parameter_from_ssm
-from git_helper import removeprefix
 from pr_info import PRInfo
 from s3_helper import S3Helper
 from stopwatch import Stopwatch
@@ -25,8 +24,7 @@ from version_helper import (
     ClickHouseVersion,
     get_tagged_versions,
     get_version_from_repo,
-    get_version_from_string,
-    get_version_from_tag,
+    version_arg,
 )
 
 TEMP_PATH = p.join(RUNNER_TEMP, "docker_images_check")
@@ -112,22 +110,6 @@ def parse_args() -> argparse.Namespace:
     )
 
     return parser.parse_args()
-
-
-def version_arg(version: str) -> ClickHouseVersion:
-    version = removeprefix(version, "refs/tags/")
-    try:
-        return get_version_from_string(version)
-    except ValueError:
-        pass
-    try:
-        return get_version_from_tag(version)
-    except ValueError:
-        pass
-
-    raise argparse.ArgumentTypeError(
-        f"version {version} does not match tag of plain version"
-    )
 
 
 def auto_release_type(version: ClickHouseVersion, release_type: str) -> str:

--- a/tests/ci/docker_test.py
+++ b/tests/ci/docker_test.py
@@ -9,7 +9,7 @@ from pr_info import PRInfo
 import docker_images_check as di
 
 with patch("git_helper.Git"):
-    from version_helper import get_version_from_string, get_tagged_versions
+    from version_helper import get_version_from_string
     import docker_server as ds
 
 # di.logging.basicConfig(level=di.logging.INFO)
@@ -251,7 +251,8 @@ class TestDockerServer(unittest.TestCase):
             get_version_from_string("2.2.1.1"),
             get_version_from_string("2.2.2.1"),
         ]
-        cases = (
+
+        cases_less = (
             (get_version_from_string("1.0.1.1"), "minor"),
             (get_version_from_string("1.1.2.1"), "minor"),
             (get_version_from_string("1.3.1.1"), "major"),
@@ -260,8 +261,18 @@ class TestDockerServer(unittest.TestCase):
             (get_version_from_string("2.2.3.1"), "latest"),
             (get_version_from_string("2.3.1.1"), "latest"),
         )
-        _ = get_tagged_versions()
-        for case in cases:
+        for case in cases_less:
+            release = ds.auto_release_type(case[0], "auto")
+            self.assertEqual(case[1], release)
+
+        cases_equal = (
+            (get_version_from_string("1.1.1.1"), "minor"),
+            (get_version_from_string("1.2.1.1"), "major"),
+            (get_version_from_string("2.1.1.1"), "minor"),
+            (get_version_from_string("2.2.1.1"), "patch"),
+            (get_version_from_string("2.2.2.1"), "latest"),
+        )
+        for case in cases_equal:
             release = ds.auto_release_type(case[0], "auto")
             self.assertEqual(case[1], release)
 

--- a/tests/ci/git_helper.py
+++ b/tests/ci/git_helper.py
@@ -93,7 +93,7 @@ class Git:
         if value == "":
             return
         if not self._tag_pattern.match(value):
-            raise Exception(f"last tag {value} doesn't match the pattern")
+            raise ValueError(f"last tag {value} doesn't match the pattern")
 
     @property
     def latest_tag(self) -> str:

--- a/tests/ci/push_to_artifactory.py
+++ b/tests/ci/push_to_artifactory.py
@@ -40,13 +40,12 @@ class Packages:
             "_".join((name, version, arch + ".deb")) for name, arch in self.packages
         )
 
-        rev = "2"
         self.rpm = tuple(
-            "-".join((name, version, rev + "." + self.rpm_arch[arch] + ".rpm"))
+            "-".join((name, version + "." + self.rpm_arch[arch] + ".rpm"))
             for name, arch in self.packages
         )
 
-        self.tgz = tuple(f"{name}-{version}.tgz" for name, _ in self.packages)
+        self.tgz = tuple(f"{name}-{version}-amd64.tgz" for name, _ in self.packages)
 
     def arch(self, deb_pkg: str) -> str:
         if deb_pkg not in self.deb:

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import logging
 import os.path as p
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, ArgumentTypeError
 from typing import Dict, List, Tuple, Union
 
 from git_helper import Git, removeprefix
@@ -218,6 +218,20 @@ def get_version_from_tag(tag: str) -> ClickHouseVersion:
     git.check_tag(tag)
     tag = tag[1:].split("-")[0]
     return get_version_from_string(tag)
+
+
+def version_arg(version: str) -> ClickHouseVersion:
+    version = removeprefix(version, "refs/tags/")
+    try:
+        return get_version_from_string(version)
+    except ValueError:
+        pass
+    try:
+        return get_version_from_tag(version)
+    except ValueError:
+        pass
+
+    raise ArgumentTypeError(f"version {version} does not match tag of plain version")
 
 
 def get_tagged_versions() -> List[ClickHouseVersion]:

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -150,6 +150,9 @@ class ClickHouseVersion:
 
         return False
 
+    def __le__(self, other: "ClickHouseVersion") -> bool:
+        return self == other or self < other
+
 
 class VersionType:
     LTS = "lts"

--- a/tests/ci/version_test.py
+++ b/tests/ci/version_test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import unittest
+from argparse import ArgumentTypeError
+
+import version_helper as vh
+
+
+class TestFunctions(unittest.TestCase):
+    def test_version_arg(self):
+        cases = (
+            ("0.0.0.0", vh.get_version_from_string("0.0.0.0")),
+            ("1.1.1.2", vh.get_version_from_string("1.1.1.2")),
+            ("v1.1.1.2-lts", vh.get_version_from_string("1.1.1.2")),
+            ("v1.1.1.2-prestable", vh.get_version_from_string("1.1.1.2")),
+            ("v1.1.1.2-stable", vh.get_version_from_string("1.1.1.2")),
+            ("v1.1.1.2-testing", vh.get_version_from_string("1.1.1.2")),
+            ("refs/tags/v1.1.1.2-testing", vh.get_version_from_string("1.1.1.2")),
+        )
+        for case in cases:
+            version = vh.version_arg(case[0])
+            self.assertEqual(case[1], version)
+        error_cases = (
+            "0.0.0",
+            "1.1.1.a",
+            "1.1.1.1.1",
+            "1.1.1.2-testing",
+            "v1.1.1.2-testin",
+            "refs/tags/v1.1.1.2-testin",
+        )
+        for case in error_cases:
+            with self.assertRaises(ArgumentTypeError):
+                version = vh.version_arg(case[0])


### PR DESCRIPTION
Fix release issue found during yesterday's release

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add `_le_` method for ClickHouseVersion
- Fix auto_version for existing tag
- docker_server now support getting version from tags
- Add python unit tests to backport workflow