### PR TITLE
Fix typo

### DIFF
--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -165,7 +165,7 @@ DECLARE_SETTING_ENUM(DistributedDDLOutputMode)
 
 enum class HandleKafkaErrorMode
 {
-    DEFAULT = 0, // Ignore errors whit threshold.
+    DEFAULT = 0, // Ignore errors with threshold.
     STREAM, // Put errors to stream in the virtual column named ``_error.
     /*FIXED_SYSTEM_TABLE, Put errors to in a fixed system table likey system.kafka_errors. This is not implemented now.  */
     /*CUSTOM_SYSTEM_TABLE, Put errors to in a custom system table. This is not implemented now.  */


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


A typo was introduced in #21850.