### PR TITLE
If data type has DEFAULT NULL in table definition, make data type Nullable

### DIFF
--- a/tests/queries/0_stateless/02266_auto_add_nullable.reference
+++ b/tests/queries/0_stateless/02266_auto_add_nullable.reference
@@ -1,0 +1,6 @@
+val0	Nullable(Int8)	DEFAULT	NULL			
+val1	Nullable(Int8)	DEFAULT	NULL			
+val2	Nullable(UInt8)	DEFAULT	NULL			
+val3	Nullable(String)	DEFAULT	NULL			
+val4	LowCardinality(Nullable(Int8))	DEFAULT	NULL			
+val5	LowCardinality(Nullable(Int8))	DEFAULT	NULL			

--- a/tests/queries/0_stateless/02266_auto_add_nullable.sql
+++ b/tests/queries/0_stateless/02266_auto_add_nullable.sql
@@ -1,0 +1,17 @@
+SET allow_suspicious_low_cardinality_types = 1;
+DROP TABLE IF EXISTS 02266_auto_add_nullable;
+
+CREATE TABLE 02266_auto_add_nullable
+(
+    val0 Int8 DEFAULT NULL,
+    val1 Nullable(Int8) DEFAULT NULL,
+    val2 UInt8 DEFAULT NUll,
+    val3 String DEFAULT null,
+    val4 LowCardinality(Int8) DEFAULT NULL,
+    val5 LowCardinality(Nullable(Int8)) DEFAULT NULL
+)
+ENGINE = MergeTree order by tuple();
+
+DESCRIBE TABLE 02266_auto_add_nullable;
+
+DROP TABLE IF EXISTS 02266_auto_add_nullable;


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If someone writes DEFAULT NULL in table definition, make data type Nullable. #35887


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
