### PR TITLE
Try to avoid timeoutes in parallel parsing tests

### DIFF
--- a/tests/queries/1_stateful/00159_parallel_formatting_csv_and_friends.sh
+++ b/tests/queries/1_stateful/00159_parallel_formatting_csv_and_friends.sh
@@ -9,11 +9,11 @@ FORMATS=('CSV' 'CSVWithNames')
 for format in "${FORMATS[@]}"
 do
     echo "$format, false";
-    $CLICKHOUSE_CLIENT --output_format_parallel_formatting=false -q \
+    $CLICKHOUSE_CLIENT --max_threads=0 --output_format_parallel_formatting=false -q \
     "SELECT ClientEventTime::DateTime('Asia/Dubai') as a, MobilePhoneModel as b, ClientIP6 as c FROM test.hits ORDER BY a, b, c Format $format" | md5sum
 
     echo "$format, true";
-    $CLICKHOUSE_CLIENT --output_format_parallel_formatting=true -q \
+    $CLICKHOUSE_CLIENT --max_threads=0 --output_format_parallel_formatting=true -q \
     "SELECT ClientEventTime::DateTime('Asia/Dubai') as a, MobilePhoneModel as b, ClientIP6 as c FROM test.hits ORDER BY a, b, c Format $format" | md5sum
 done
 

--- a/tests/queries/1_stateful/00159_parallel_formatting_json_and_friends.sh
+++ b/tests/queries/1_stateful/00159_parallel_formatting_json_and_friends.sh
@@ -11,7 +11,7 @@ FORMATS=('JSONEachRow' 'JSONCompactEachRow' 'JSONCompactStringsEachRow' 'JSONCom
 for format in "${FORMATS[@]}"
 do
     echo "$format, false";
-    $CLICKHOUSE_CLIENT --max_therads=0 --output_format_parallel_formatting=false -q \
+    $CLICKHOUSE_CLIENT --max_threads=0 --output_format_parallel_formatting=false -q \
     "SELECT ClientEventTime::DateTime('Asia/Dubai') as a, MobilePhoneModel as b, ClientIP6 as c FROM test.hits ORDER BY a, b, c LIMIT 3000000 Format $format" | md5sum
 
     echo "$format, true";

--- a/tests/queries/1_stateful/00159_parallel_formatting_json_and_friends.sh
+++ b/tests/queries/1_stateful/00159_parallel_formatting_json_and_friends.sh
@@ -11,10 +11,10 @@ FORMATS=('JSONEachRow' 'JSONCompactEachRow' 'JSONCompactStringsEachRow' 'JSONCom
 for format in "${FORMATS[@]}"
 do
     echo "$format, false";
-    $CLICKHOUSE_CLIENT --output_format_parallel_formatting=false -q \
+    $CLICKHOUSE_CLIENT --max_therads=0 --output_format_parallel_formatting=false -q \
     "SELECT ClientEventTime::DateTime('Asia/Dubai') as a, MobilePhoneModel as b, ClientIP6 as c FROM test.hits ORDER BY a, b, c LIMIT 3000000 Format $format" | md5sum
 
     echo "$format, true";
-    $CLICKHOUSE_CLIENT --output_format_parallel_formatting=true -q \
+    $CLICKHOUSE_CLIENT --max_threads=0 --output_format_parallel_formatting=true -q \
     "SELECT ClientEventTime::DateTime('Asia/Dubai') as a, MobilePhoneModel as b, ClientIP6 as c FROM test.hits ORDER BY a, b, c LIMIT 3000000 Format $format" | md5sum
 done

--- a/tests/queries/1_stateful/00161_parallel_parsing_with_names.sh
+++ b/tests/queries/1_stateful/00161_parallel_parsing_with_names.sh
@@ -13,9 +13,9 @@ do
     $CLICKHOUSE_CLIENT -q "CREATE TABLE parsing_with_names(c FixedString(16), a DateTime('Asia/Dubai'),  b String) ENGINE=Memory()"
 
     echo "$format, false";
-    $CLICKHOUSE_CLIENT --max_block_size=65505 --output_format_parallel_formatting=false -q \
+    $CLICKHOUSE_CLIENT --max_therads=0 --max_block_size=65505 --output_format_parallel_formatting=false -q \
     "SELECT URLRegions as d, toTimeZone(ClientEventTime, 'Asia/Dubai') as a, MobilePhoneModel as b, ParamPrice as e, ClientIP6 as c FROM test.hits LIMIT 50000 Format $format" | \
-    $CLICKHOUSE_CLIENT --max_block_size=65505 --input_format_skip_unknown_fields=1 --input_format_parallel_parsing=false -q "INSERT INTO parsing_with_names FORMAT $format"
+    $CLICKHOUSE_CLIENT --max_threads=0 --max_block_size=65505 --input_format_skip_unknown_fields=1 --input_format_parallel_parsing=false -q "INSERT INTO parsing_with_names FORMAT $format"
 
     $CLICKHOUSE_CLIENT -q "SELECT * FROM parsing_with_names;" | md5sum
     $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS parsing_with_names"
@@ -23,9 +23,9 @@ do
 
     $CLICKHOUSE_CLIENT -q "CREATE TABLE parsing_with_names(c FixedString(16), a DateTime('Asia/Dubai'),  b String) ENGINE=Memory()"
     echo "$format, true";
-    $CLICKHOUSE_CLIENT --max_block_size=65505 --output_format_parallel_formatting=false -q \
+    $CLICKHOUSE_CLIENT --max_threads=0 --max_block_size=65505 --output_format_parallel_formatting=false -q \
     "SELECT URLRegions as d, toTimeZone(ClientEventTime, 'Asia/Dubai') as a, MobilePhoneModel as b, ParamPrice as e, ClientIP6 as c FROM test.hits LIMIT 50000 Format $format" | \
-    $CLICKHOUSE_CLIENT --max_block_size=65505 --input_format_skip_unknown_fields=1 --input_format_parallel_parsing=true -q "INSERT INTO parsing_with_names FORMAT $format"
+    $CLICKHOUSE_CLIENT --max_threads=0 --max_block_size=65505 --input_format_skip_unknown_fields=1 --input_format_parallel_parsing=true -q "INSERT INTO parsing_with_names FORMAT $format"
 
     $CLICKHOUSE_CLIENT -q "SELECT * FROM parsing_with_names;" | md5sum
     $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS parsing_with_names"

--- a/tests/queries/1_stateful/00161_parallel_parsing_with_names.sh
+++ b/tests/queries/1_stateful/00161_parallel_parsing_with_names.sh
@@ -13,7 +13,7 @@ do
     $CLICKHOUSE_CLIENT -q "CREATE TABLE parsing_with_names(c FixedString(16), a DateTime('Asia/Dubai'),  b String) ENGINE=Memory()"
 
     echo "$format, false";
-    $CLICKHOUSE_CLIENT --max_therads=0 --max_block_size=65505 --output_format_parallel_formatting=false -q \
+    $CLICKHOUSE_CLIENT --max_threads=0 --max_block_size=65505 --output_format_parallel_formatting=false -q \
     "SELECT URLRegions as d, toTimeZone(ClientEventTime, 'Asia/Dubai') as a, MobilePhoneModel as b, ParamPrice as e, ClientIP6 as c FROM test.hits LIMIT 50000 Format $format" | \
     $CLICKHOUSE_CLIENT --max_threads=0 --max_block_size=65505 --input_format_skip_unknown_fields=1 --input_format_parallel_parsing=false -q "INSERT INTO parsing_with_names FORMAT $format"
 

--- a/tests/queries/1_stateful/00167_parallel_parsing_with_names_and_types.sh
+++ b/tests/queries/1_stateful/00167_parallel_parsing_with_names_and_types.sh
@@ -13,9 +13,9 @@ do
     $CLICKHOUSE_CLIENT -q "CREATE TABLE parsing_with_names(c FixedString(16), a DateTime('Asia/Dubai'),  b String) ENGINE=Memory()"
 
     echo "$format, false";
-    $CLICKHOUSE_CLIENT --output_format_parallel_formatting=false -q \
+    $CLICKHOUSE_CLIENT --max_threads=0 --output_format_parallel_formatting=false -q \
     "SELECT URLRegions as d, toTimeZone(ClientEventTime, 'Asia/Dubai') as a, MobilePhoneModel as b, ParamPrice as e, ClientIP6 as c FROM test.hits LIMIT 5000 Format $format" | \
-    $CLICKHOUSE_CLIENT --input_format_skip_unknown_fields=1 --input_format_parallel_parsing=false -q "INSERT INTO parsing_with_names SETTINGS input_format_null_as_default=0 FORMAT $format"
+    $CLICKHOUSE_CLIENT --max_threads=0 --input_format_skip_unknown_fields=1 --input_format_parallel_parsing=false -q "INSERT INTO parsing_with_names SETTINGS input_format_null_as_default=0 FORMAT $format"
 
     $CLICKHOUSE_CLIENT -q "SELECT * FROM parsing_with_names;" | md5sum
     $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS parsing_with_names"
@@ -23,9 +23,9 @@ do
 
     $CLICKHOUSE_CLIENT -q "CREATE TABLE parsing_with_names(c FixedString(16), a DateTime('Asia/Dubai'),  b String) ENGINE=Memory()"
     echo "$format, true";
-    $CLICKHOUSE_CLIENT --output_format_parallel_formatting=false -q \
+    $CLICKHOUSE_CLIENT --max_threads=0 --output_format_parallel_formatting=false -q \
     "SELECT URLRegions as d, toTimeZone(ClientEventTime, 'Asia/Dubai') as a, MobilePhoneModel as b, ParamPrice as e, ClientIP6 as c FROM test.hits LIMIT 5000 Format $format" | \
-    $CLICKHOUSE_CLIENT --input_format_skip_unknown_fields=1 --input_format_parallel_parsing=true -q "INSERT INTO parsing_with_names SETTINGS input_format_null_as_default=0 FORMAT $format"
+    $CLICKHOUSE_CLIENT --max_threads=0 --input_format_skip_unknown_fields=1 --input_format_parallel_parsing=true -q "INSERT INTO parsing_with_names SETTINGS input_format_null_as_default=0 FORMAT $format"
 
     $CLICKHOUSE_CLIENT -q "SELECT * FROM parsing_with_names;" | md5sum
     $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS parsing_with_names"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

