### PR TITLE
Fix CH silently failing when it cannot execute a file

### DIFF
--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -234,6 +234,11 @@ bool createFile(const std::string & path)
     DB::throwFromErrnoWithPath("Cannot create file: " + path, path, DB::ErrorCodes::CANNOT_CREATE_FILE);
 }
 
+bool exists(const std::string & path)
+{
+    return faccessat(AT_FDCWD, path.c_str(), F_OK, AT_EACCESS) == 0;
+}
+
 bool canRead(const std::string & path)
 {
     struct stat st;
@@ -249,7 +254,6 @@ bool canRead(const std::string & path)
     DB::throwFromErrnoWithPath("Cannot check read access to file: " + path, path, DB::ErrorCodes::PATH_ACCESS_DENIED);
 }
 
-
 bool canWrite(const std::string & path)
 {
     struct stat st;
@@ -263,6 +267,13 @@ bool canWrite(const std::string & path)
             return (st.st_mode & S_IWOTH) != 0 || geteuid() == 0;
     }
     DB::throwFromErrnoWithPath("Cannot check write access to file: " + path, path, DB::ErrorCodes::PATH_ACCESS_DENIED);
+}
+
+bool canExecute(const std::string & path)
+{
+    if (exists(path))
+        return faccessat(AT_FDCWD, path.c_str(), X_OK, AT_EACCESS) == 0;
+    DB::throwFromErrnoWithPath("Cannot check execute access to file: " + path, path, DB::ErrorCodes::PATH_ACCESS_DENIED);
 }
 
 time_t getModificationTime(const std::string & path)

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -70,8 +70,10 @@ namespace FS
 {
 bool createFile(const std::string & path);
 
+bool exists(const std::string & path);
 bool canRead(const std::string & path);
 bool canWrite(const std::string & path);
+bool canExecute(const std::string & path);
 
 time_t getModificationTime(const std::string & path);
 Poco::Timestamp getModificationTimestamp(const std::string & path);

--- a/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -7,7 +7,6 @@
 #include <base/logger_useful.h>
 #include <Common/LocalDateTime.h>
 #include <Common/filesystemHelpers.h>
-#include <Common/ShellCommand.h>
 
 #include <Processors/Sources/ShellCommandSource.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
@@ -15,12 +14,10 @@
 
 #include <Interpreters/Context.h>
 #include <IO/WriteHelpers.h>
-#include <IO/ReadHelpers.h>
 
 #include <Dictionaries/DictionarySourceFactory.h>
 #include <Dictionaries/DictionarySourceHelpers.h>
 #include <Dictionaries/DictionaryStructure.h>
-#include <Dictionaries/registerDictionaries.h>
 
 
 namespace DB
@@ -51,9 +48,15 @@ namespace
                 command,
                 user_scripts_path);
 
-        if (!std::filesystem::exists(std::filesystem::path(script_path)))
+        if (!FS::exists(script_path))
             throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
                 "Executable file {} does not exist inside user scripts folder {}",
+                command,
+                user_scripts_path);
+
+        if (!FS::canExecute(script_path))
+            throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
+                "Executable file {} is not executable inside user scripts folder {}",
                 command,
                 user_scripts_path);
 

--- a/src/Dictionaries/ExecutablePoolDictionarySource.cpp
+++ b/src/Dictionaries/ExecutablePoolDictionarySource.cpp
@@ -7,7 +7,6 @@
 #include <base/logger_useful.h>
 #include <Common/LocalDateTime.h>
 #include <Common/filesystemHelpers.h>
-#include <Common/ShellCommand.h>
 
 #include <Processors/Formats/IOutputFormat.h>
 #include <Processors/Sources/ShellCommandSource.h>
@@ -19,7 +18,6 @@
 #include <Dictionaries/DictionarySourceFactory.h>
 #include <Dictionaries/DictionarySourceHelpers.h>
 #include <Dictionaries/DictionaryStructure.h>
-
 
 namespace DB
 {
@@ -113,9 +111,15 @@ Pipe ExecutablePoolDictionarySource::getStreamForBlock(const Block & block)
                 command,
                 user_scripts_path);
 
-        if (!std::filesystem::exists(std::filesystem::path(script_path)))
+        if (!FS::exists(script_path))
             throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
                 "Executable file {} does not exist inside user scripts folder {}",
+                command,
+                user_scripts_path);
+
+        if (!FS::canExecute(script_path))
+            throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
+                "Executable file {} is not executable inside user scripts folder {}",
                 command,
                 user_scripts_path);
 

--- a/src/Interpreters/UserDefinedExecutableFunctionFactory.cpp
+++ b/src/Interpreters/UserDefinedExecutableFunctionFactory.cpp
@@ -4,8 +4,6 @@
 
 #include <Common/filesystemHelpers.h>
 
-#include <IO/WriteHelpers.h>
-
 #include <Processors/Sources/ShellCommandSource.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Formats/formatBlock.h>
@@ -78,9 +76,15 @@ public:
                     command,
                     user_scripts_path);
 
-            if (!std::filesystem::exists(std::filesystem::path(script_path)))
+            if (!FS::exists(script_path))
                 throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
                     "Executable file {} does not exist inside user scripts folder {}",
+                    command,
+                    user_scripts_path);
+
+            if (!FS::canExecute(script_path))
+                throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
+                    "Executable file {} is not executable inside user scripts folder {}",
                     command,
                     user_scripts_path);
 

--- a/src/Storages/StorageExecutable.cpp
+++ b/src/Storages/StorageExecutable.cpp
@@ -1,21 +1,19 @@
 #include <Storages/StorageExecutable.h>
 
 #include <filesystem>
+#include <unistd.h>
 
 #include <boost/algorithm/string/split.hpp>
 
-#include <Common/ShellCommand.h>
 #include <Common/filesystemHelpers.h>
 
 #include <Core/Block.h>
 
-#include <IO/ReadHelpers.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTCreateQuery.h>
 
 #include <QueryPipeline/Pipe.h>
-#include <Processors/ISimpleTransform.h>
 #include <Processors/Executors/CompletedPipelineExecutor.h>
 #include <Processors/Formats/IOutputFormat.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
@@ -123,9 +121,15 @@ Pipe StorageExecutable::read(
             script_name,
             user_scripts_path);
 
-    if (!std::filesystem::exists(std::filesystem::path(script_path)))
+    if (!FS::exists(script_path))
          throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
             "Executable file {} does not exist inside user scripts folder {}",
+            script_name,
+            user_scripts_path);
+
+    if (!FS::canExecute(script_path))
+         throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
+            "Executable file {} is not executable inside user scripts folder {}",
             script_name,
             user_scripts_path);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Throw an exception when CH cannot execute a file instead of displaying success and silently failing.

----

Fix a bug of CH silently failing when using `executable` on a file which CH cannot execute, CH returns successful `OK` and logs show no errors/warnings even though the file failed to execute.

To demo this, consider a file `test_bash.sh` in `user_scripts` which CH cannot execute because the file is either not executable (no `chmod +x`) or it is but CH user has no permission to execute it.

A user would execute the file like so:
```sql
SELECT * FROM executable('test_bash.sh', 'TabSeparated', 'value String')
```

Before my changes it will silently fail:
```sql
Ok.

0 rows in set. Elapsed: 0.002 sec. 
```
With logs showing no errors/warnings.

After my changes:
```sql
0 rows in set. Elapsed: 0.001 sec. 

Received exception from server (version 22.4.1):
DB::Exception: Executable file test_bash.sh does not have executable permissions inside user scripts folder ./user_scripts/. (UNSUPPORTED_METHOD)
```
With logs showing an exception has been thrown.