### PR TITLE
Prepared partitions differ from raw data

### DIFF
--- a/docs/en/getting-started/example-datasets/ontime.md
+++ b/docs/en/getting-started/example-datasets/ontime.md
@@ -159,6 +159,10 @@ $ clickhouse-client --query "select count(*) from datasets.ontime"
 !!! info "Info"
     If you will run the queries described below, you have to use the full table name, `datasets.ontime`.
 
+
+!!! info "Info"
+    If you are using the prepared partitions or the Online Playground replace any occurrence of `IATA_CODE_Reporting_Airline` or `IATA_CODE_Reporting_Airline AS Carrier` with Carrier (see `describe ontime`).
+
 ## Queries {#queries}
 
 Q0.

--- a/docs/en/getting-started/example-datasets/ontime.md
+++ b/docs/en/getting-started/example-datasets/ontime.md
@@ -161,7 +161,7 @@ $ clickhouse-client --query "select count(*) from datasets.ontime"
 
 
 !!! info "Info"
-    If you are using the prepared partitions or the Online Playground replace any occurrence of `IATA_CODE_Reporting_Airline` or `IATA_CODE_Reporting_Airline AS Carrier` with Carrier (see `describe ontime`).
+    If you are using the prepared partitions or the Online Playground replace any occurrence of `IATA_CODE_Reporting_Airline` or `IATA_CODE_Reporting_Airline AS Carrier` in the following queries with `Carrier` (see `describe ontime`).
 
 ## Queries {#queries}
 


### PR DESCRIPTION
In both the system exposed at `gh-api.clickhouse.com/play` and in the prepared partitions the field `IATA_CODE_Reporting_Airline` has been renamed as `Carrier`, which breaks many of the queries.

Note: I assume that the raw data uses `IATA_CODE_Reporting_Airline`, but I do not have disk space to test.

### Changelog category (leave one):

- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
