### PR TITLE
Get rid of fs paths keeper

### DIFF
--- a/src/Disks/AzureBlobStorage/DiskAzureBlobStorage.cpp
+++ b/src/Disks/AzureBlobStorage/DiskAzureBlobStorage.cpp
@@ -32,21 +32,6 @@ DiskAzureBlobStorageSettings::DiskAzureBlobStorageSettings(
     thread_pool_size(thread_pool_size_) {}
 
 
-class AzureBlobStoragePathKeeper : public RemoteFSPathKeeper
-{
-public:
-    /// RemoteFSPathKeeper constructed with a placeholder argument for chunk_limit, it is unused in this class
-    AzureBlobStoragePathKeeper() : RemoteFSPathKeeper(1000) {}
-
-    void addPath(const String & path) override
-    {
-        paths.push_back(path);
-    }
-
-    std::vector<String> paths;
-};
-
-
 DiskAzureBlobStorage::DiskAzureBlobStorage(
     const String & name_,
     DiskPtr metadata_disk_,
@@ -150,35 +135,23 @@ bool DiskAzureBlobStorage::checkUniqueId(const String & id) const
 }
 
 
-void DiskAzureBlobStorage::removeFromRemoteFS(RemoteFSPathKeeperPtr fs_paths_keeper)
+void DiskAzureBlobStorage::removeFromRemoteFS(const std::vector<String> & paths)
 {
-    auto * paths_keeper = dynamic_cast<AzureBlobStoragePathKeeper *>(fs_paths_keeper.get());
-
-    if (paths_keeper)
+    for (const auto & path : paths)
     {
-        for (const auto & path : paths_keeper->paths)
+        try
         {
-            try
-            {
-                auto delete_info = blob_container_client->DeleteBlob(path);
-                if (!delete_info.Value.Deleted)
-                    throw Exception(ErrorCodes::AZURE_BLOB_STORAGE_ERROR, "Failed to delete file in AzureBlob Storage: {}", path);
-            }
-            catch (const Azure::Storage::StorageException & e)
-            {
-                LOG_INFO(log, "Caught an error while deleting file {} : {}", path, e.Message);
-                throw;
-            }
+            auto delete_info = blob_container_client->DeleteBlob(path);
+            if (!delete_info.Value.Deleted)
+                throw Exception(ErrorCodes::AZURE_BLOB_STORAGE_ERROR, "Failed to delete file in AzureBlob Storage: {}", path);
+        }
+        catch (const Azure::Storage::StorageException & e)
+        {
+            LOG_INFO(log, "Caught an error while deleting file {} : {}", path, e.Message);
+            throw;
         }
     }
 }
-
-
-RemoteFSPathKeeperPtr DiskAzureBlobStorage::createFSPathKeeper() const
-{
-    return std::make_shared<AzureBlobStoragePathKeeper>();
-}
-
 
 void DiskAzureBlobStorage::applyNewSettings(const Poco::Util::AbstractConfiguration & config, ContextPtr context, const String &, const DisksMap &)
 {

--- a/src/Disks/AzureBlobStorage/DiskAzureBlobStorage.h
+++ b/src/Disks/AzureBlobStorage/DiskAzureBlobStorage.h
@@ -67,9 +67,7 @@ public:
 
     bool checkUniqueId(const String & id) const override;
 
-    void removeFromRemoteFS(RemoteFSPathKeeperPtr fs_paths_keeper) override;
-
-    RemoteFSPathKeeperPtr createFSPathKeeper() const override;
+    void removeFromRemoteFS(const std::vector<String> & paths) override;
 
     void applyNewSettings(const Poco::Util::AbstractConfiguration & config, ContextPtr context, const String &, const DisksMap &) override;
 

--- a/src/Disks/HDFS/DiskHDFS.cpp
+++ b/src/Disks/HDFS/DiskHDFS.cpp
@@ -30,35 +30,6 @@ namespace ErrorCodes
 }
 
 
-class HDFSPathKeeper : public RemoteFSPathKeeper
-{
-public:
-    using Chunk = std::vector<std::string>;
-    using Chunks = std::list<Chunk>;
-
-    explicit HDFSPathKeeper(size_t chunk_limit_) : RemoteFSPathKeeper(chunk_limit_) {}
-
-    void addPath(const String & path) override
-    {
-        if (chunks.empty() || chunks.back().size() >= chunk_limit)
-        {
-            chunks.push_back(Chunks::value_type());
-            chunks.back().reserve(chunk_limit);
-        }
-        chunks.back().push_back(path.data());
-    }
-
-    void removePaths(Fn<void(Chunk &&)> auto && remove_chunk_func)
-    {
-        for (auto & chunk : chunks)
-            remove_chunk_func(std::move(chunk));
-    }
-
-private:
-    Chunks chunks;
-};
-
-
 DiskHDFS::DiskHDFS(
     const String & disk_name_,
     const String & hdfs_root_path_,
@@ -109,30 +80,17 @@ std::unique_ptr<WriteBufferFromFileBase> DiskHDFS::writeFile(const String & path
     return std::make_unique<WriteIndirectBufferFromRemoteFS>(std::move(hdfs_buffer), std::move(create_metadata_callback), hdfs_path);
 }
 
-
-RemoteFSPathKeeperPtr DiskHDFS::createFSPathKeeper() const
+void DiskHDFS::removeFromRemoteFS(const std::vector<String> & paths)
 {
-    return std::make_shared<HDFSPathKeeper>(settings->objects_chunk_size_to_delete);
-}
+    for (const auto & hdfs_path : paths)
+    {
+        const size_t begin_of_path = hdfs_path.find('/', hdfs_path.find("//") + 2);
 
-
-void DiskHDFS::removeFromRemoteFS(RemoteFSPathKeeperPtr fs_paths_keeper)
-{
-    auto * hdfs_paths_keeper = dynamic_cast<HDFSPathKeeper *>(fs_paths_keeper.get());
-    if (hdfs_paths_keeper)
-        hdfs_paths_keeper->removePaths([&](std::vector<std::string> && chunk)
-        {
-            for (const auto & hdfs_object_path : chunk)
-            {
-                const String & hdfs_path = hdfs_object_path;
-                const size_t begin_of_path = hdfs_path.find('/', hdfs_path.find("//") + 2);
-
-                /// Add path from root to file name
-                int res = hdfsDelete(hdfs_fs.get(), hdfs_path.substr(begin_of_path).c_str(), 0);
-                if (res == -1)
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "HDFSDelete failed with path: " + hdfs_path);
-            }
-        });
+        /// Add path from root to file name
+        int res = hdfsDelete(hdfs_fs.get(), hdfs_path.substr(begin_of_path).c_str(), 0);
+        if (res == -1)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "HDFSDelete failed with path: " + hdfs_path);
+    }
 }
 
 bool DiskHDFS::checkUniqueId(const String & hdfs_uri) const

--- a/src/Disks/HDFS/DiskHDFS.h
+++ b/src/Disks/HDFS/DiskHDFS.h
@@ -62,9 +62,7 @@ public:
 
     std::unique_ptr<WriteBufferFromFileBase> writeFile(const String & path, size_t buf_size, WriteMode mode, const WriteSettings & settings) override;
 
-    void removeFromRemoteFS(RemoteFSPathKeeperPtr fs_paths_keeper) override;
-
-    RemoteFSPathKeeperPtr createFSPathKeeper() const override;
+    void removeFromRemoteFS(const std::vector<String> & paths) override;
 
     /// Check file exists and ClickHouse has an access to it
     /// Overrode in remote disk

--- a/src/Disks/IDiskRemote.h
+++ b/src/Disks/IDiskRemote.h
@@ -21,6 +21,23 @@ namespace CurrentMetrics
 namespace DB
 {
 
+/// Path to blob with it's size
+struct BlobPathWithSize
+{
+    std::string relative_path;
+    uint64_t bytes_size;
+
+    BlobPathWithSize() = default;
+    BlobPathWithSize(const BlobPathWithSize & other) = default;
+
+    BlobPathWithSize(const std::string & relative_path_, uint64_t bytes_size_)
+        : relative_path(relative_path_)
+        , bytes_size(bytes_size_)
+    {}
+};
+
+/// List of blobs with their sizes
+using BlobsPathToSize = std::vector<BlobPathWithSize>;
 
 class IAsynchronousReader;
 using AsynchronousReaderPtr = std::shared_ptr<IAsynchronousReader>;

--- a/src/Disks/S3/DiskS3.h
+++ b/src/Disks/S3/DiskS3.h
@@ -91,9 +91,7 @@ public:
         WriteMode mode,
         const WriteSettings & settings) override;
 
-    void removeFromRemoteFS(RemoteFSPathKeeperPtr keeper) override;
-
-    RemoteFSPathKeeperPtr createFSPathKeeper() const override;
+    void removeFromRemoteFS(const std::vector<String> & paths) override;
 
     void moveFile(const String & from_path, const String & to_path, bool send_metadata);
     void moveFile(const String & from_path, const String & to_path) override;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Get rid of very strange and redundant abstraction.