### PR TITLE
Add support for atomic exchange in OSX

### DIFF
--- a/src/Common/atomicRename.cpp
+++ b/src/Common/atomicRename.cpp
@@ -1,4 +1,4 @@
-#include <Common/renameat2.h>
+#include <Common/atomicRename.h>
 #include <Common/Exception.h>
 #include <Common/VersionNumber.h>
 #include <Poco/Environment.h>
@@ -55,7 +55,7 @@ namespace ErrorCodes
 namespace DB
 {
 
-static bool supportsRenameat2Impl()
+static bool supportsAtomicRenameImpl()
 {
     VersionNumber renameat2_minimal_version(3, 15, 0);
     VersionNumber linux_version(Poco::Environment::osVersion());
@@ -64,7 +64,7 @@ static bool supportsRenameat2Impl()
 
 static bool renameat2(const std::string & old_path, const std::string & new_path, int flags)
 {
-    if (!supportsRenameat2())
+    if (!supportsAtomicRename())
         return false;
     if (old_path.empty() || new_path.empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot rename {} to {}: path is empty", old_path, new_path);
@@ -93,13 +93,66 @@ static bool renameat2(const std::string & old_path, const std::string & new_path
     throwFromErrnoWithPath(fmt::format("Cannot rename {} to {}", old_path, new_path), new_path, ErrorCodes::SYSTEM_ERROR);
 }
 
-bool supportsRenameat2()
+bool supportsAtomicRename()
 {
-    static bool supports = supportsRenameat2Impl();
+    static bool supports = supportsAtomicRenameImpl();
     return supports;
 }
 
 }
+
+#elif defined(__APPLE__)
+
+// Includes
+#include <dlfcn.h>  // For dlsym
+#include <stdio.h>  // For renamex_np
+#include <string.h> // For stderror
+
+#ifndef RENAME_SWAP
+    #define RENAME_SWAP 0x00000002
+#endif
+#ifndef RENAME_EXCL
+    #define RENAME_EXCL 0x00000004
+#endif
+
+
+#define RENAME_NOREPLACE RENAME_EXCL
+#define RENAME_EXCHANGE RENAME_SWAP
+
+
+static bool renameat2(const std::string & old_path, const std::string & new_path, int flags)
+{
+    auto fun = dlsym(RTLD_DEFAULT, "renamex_np");
+    if (fun == NULL)
+        return false;
+
+    if (old_path.empty() || new_path.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot rename {} to {}: path is empty", old_path, new_path);
+
+    /// int olddirfd (ignored for absolute oldpath), const char *oldpath,
+    /// int newdirfd (ignored for absolute newpath), const char *newpath,
+    /// unsigned int flags
+    if (0 == (*fun)(old_path.c_str(), AT_FDCWD, new_path.c_str(), flags))
+        return true;
+    int errnum = errno;
+
+    if ((errnum == ENOTSUP) || (errnum == EINVAL)
+        return false;
+    if (errnum == EEXIST)
+        throwFromErrno(fmt::format("Cannot rename {} to {} because the second path already exists", old_path, new_path), ErrorCodes::ATOMIC_RENAME_FAIL);
+    if (errnum == ENOENT)
+        throwFromErrno(fmt::format("Paths cannot be exchanged because {} or {} does not exist", old_path, new_path), ErrorCodes::ATOMIC_RENAME_FAIL);
+    throwFromErrnoWithPath(fmt::format("Cannot rename {} to {}: {}", old_path, new_path, stderror(errnum)), new_path, ErrorCodes::SYSTEM_ERROR);
+}
+
+
+
+static bool supportsAtomicRenameImpl()
+{
+    auto fun = dlsym(RTLD_DEFAULT, "renamex_np");
+    return fun != NULL;
+}
+
 
 #else
 
@@ -114,7 +167,7 @@ static bool renameat2(const std::string &, const std::string &, int)
     return false;
 }
 
-bool supportsRenameat2()
+bool supportsAtomicRename()
 {
     return false;
 }

--- a/src/Common/atomicRename.h
+++ b/src/Common/atomicRename.h
@@ -6,7 +6,7 @@ namespace DB
 {
 
 /// Returns true, if the following functions supported by the system
-bool supportsRenameat2();
+bool supportsAtomicRename();
 
 /// Atomically rename old_path to new_path. If new_path exists, do not overwrite it and throw exception
 void renameNoReplace(const std::string & old_path, const std::string & new_path);

--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -4,7 +4,7 @@
 #include <IO/WriteHelpers.h>
 #include <IO/ReadBufferFromFile.h>
 #include <Parsers/formatAST.h>
-#include <Common/renameat2.h>
+#include <Common/atomicRename.h>
 #include <Storages/StorageMaterializedView.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExternalDictionariesLoader.h>
@@ -158,7 +158,7 @@ void DatabaseAtomic::renameTable(ContextPtr local_context, const String & table_
         return;
     }
 
-    if (exchange && !supportsRenameat2())
+    if (exchange && !supportsAtomicRename())
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "RENAME EXCHANGE is not supported");
 
     auto & other_db = dynamic_cast<DatabaseAtomic &>(to_database);

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -6,7 +6,7 @@
 #include <Interpreters/Context.h>
 #include <Common/filesystemHelpers.h>
 #include <Common/quoteString.h>
-#include <Common/renameat2.h>
+#include <Common/atomicRename.h>
 #include <Disks/IO/createReadBufferFromFileBase.h>
 
 #include <fstream>

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -12,7 +12,7 @@
 #include <Parsers/formatAST.h>
 #include <IO/ReadHelpers.h>
 #include <Poco/DirectoryIterator.h>
-#include <Common/renameat2.h>
+#include <Common/atomicRename.h>
 #include <Common/CurrentMetrics.h>
 #include <base/logger_useful.h>
 #include <Poco/Util/AbstractConfiguration.h>

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -8,7 +8,7 @@
 #include <Common/typeid_cast.h>
 #include <Common/Macros.h>
 #include <Common/randomSeed.h>
-#include <Common/renameat2.h>
+#include <Common/atomicRename.h>
 #include <Common/hex.h>
 
 #include <Core/Defines.h>


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for atomic exchange in OSX


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

~This is a draft. I've only done a superficial test and it works, but it needs more testing by people using OSX as a main system. I'm opening the PR to check that it builds and have a binary that I can use internally to ask for tests.~

This has been tested with macOS Monterey 12.3 and M1.
