### PR TITLE
ProfileEvents fixes

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1413,6 +1413,8 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
         progress_indication.clearProgressOutput();
         logs_out_stream->writeProfileEvents(profile_events.last_block);
         logs_out_stream->flush();
+
+        profile_events.last_block = {};
     }
 
     if (is_interactive)

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -201,9 +201,6 @@ void LocalConnection::finishQuery()
 {
     next_packet_type = Protocol::Server::EndOfStream;
 
-    if (!state)
-        return;
-
     if (state->executor)
     {
         state->executor.reset();

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -216,6 +216,7 @@ void LocalConnection::finishQuery()
 
     state->io.onFinish();
     state.reset();
+    last_sent_snapshots.clear();
 }
 
 bool LocalConnection::poll(size_t)

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -323,6 +323,21 @@ bool LocalConnection::poll(size_t)
         }
     }
 
+    if (state->is_finished && !state->sent_profile_events)
+    {
+        state->sent_profile_events = true;
+
+        if (send_profile_events && state->executor)
+        {
+            Block block;
+            state->after_send_profile_events.restart();
+            next_packet_type = Protocol::Server::ProfileEvents;
+            getProfileEvents(block);
+            state->block.emplace(std::move(block));
+            return true;
+        }
+    }
+
     if (state->is_finished)
     {
         finishQuery();

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -47,6 +47,7 @@ struct LocalQueryState
     bool sent_extremes = false;
     bool sent_progress = false;
     bool sent_profile_info = false;
+    bool sent_profile_events = false;
 
     /// To output progress, the difference after the previous sending of progress.
     Progress progress;

--- a/src/Interpreters/ProfileEventsExt.cpp
+++ b/src/Interpreters/ProfileEventsExt.cpp
@@ -105,7 +105,7 @@ void getProfileEvents(
         {"value", std::make_shared<DataTypeInt64>()},
     };
 
-     ColumnsWithTypeAndName temp_columns;
+    ColumnsWithTypeAndName temp_columns;
     for (auto const & name_and_type : column_names_and_types)
         temp_columns.emplace_back(name_and_type.type, name_and_type.name);
 

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -728,6 +728,7 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
             return;
 
         sendData({});
+        last_sent_snapshots.clear();
     }
 
     sendProgress();

--- a/tests/queries/0_stateless/02050_client_profile_events.reference
+++ b/tests/queries/0_stateless/02050_client_profile_events.reference
@@ -1,9 +1,8 @@
 do not print any ProfileEvents packets
 0
 print only last (and also number of rows to provide more info in case of failures)
-100000
-print everything
 [ 0 ] SelectedRows: 131010 (increment)
+print everything
 OK
 print each 100 ms
 OK

--- a/tests/queries/0_stateless/02050_client_profile_events.reference
+++ b/tests/queries/0_stateless/02050_client_profile_events.reference
@@ -6,3 +6,5 @@ print everything
 OK
 print each 100 ms
 OK
+check that ProfileEvents is new for each query
+OK

--- a/tests/queries/0_stateless/02050_client_profile_events.reference
+++ b/tests/queries/0_stateless/02050_client_profile_events.reference
@@ -1,5 +1,9 @@
+do not print any ProfileEvents packets
 0
+print only last (and also number of rows to provide more info in case of failures)
 100000
+print everything
 [ 0 ] SelectedRows: 131010 (increment)
 OK
+print each 100 ms
 OK

--- a/tests/queries/0_stateless/02050_client_profile_events.reference
+++ b/tests/queries/0_stateless/02050_client_profile_events.reference
@@ -2,6 +2,8 @@ do not print any ProfileEvents packets
 0
 print only last (and also number of rows to provide more info in case of failures)
 [ 0 ] SelectedRows: 131010 (increment)
+regression test for incorrect filtering out snapshots
+0
 print everything
 OK
 print each 100 ms

--- a/tests/queries/0_stateless/02050_client_profile_events.reference
+++ b/tests/queries/0_stateless/02050_client_profile_events.reference
@@ -7,6 +7,9 @@ regression test for incorrect filtering out snapshots
 regression test for overlap profile events snapshots between queries
 [ 0 ] SelectedRows: 1 (increment)
 [ 0 ] SelectedRows: 1 (increment)
+regression test for overlap profile events snapshots between queries (clickhouse-local)
+[ 0 ] SelectedRows: 1 (increment)
+[ 0 ] SelectedRows: 1 (increment)
 print everything
 OK
 print each 100 ms

--- a/tests/queries/0_stateless/02050_client_profile_events.reference
+++ b/tests/queries/0_stateless/02050_client_profile_events.reference
@@ -4,6 +4,9 @@ print only last (and also number of rows to provide more info in case of failure
 [ 0 ] SelectedRows: 131010 (increment)
 regression test for incorrect filtering out snapshots
 0
+regression test for overlap profile events snapshots between queries
+[ 0 ] SelectedRows: 1 (increment)
+[ 0 ] SelectedRows: 1 (increment)
 print everything
 OK
 print each 100 ms

--- a/tests/queries/0_stateless/02050_client_profile_events.sh
+++ b/tests/queries/0_stateless/02050_client_profile_events.sh
@@ -10,6 +10,10 @@ $CLICKHOUSE_CLIENT -q 'select * from numbers(1e5) format Null' |& grep -c 'Selec
 echo 'print only last (and also number of rows to provide more info in case of failures)'
 $CLICKHOUSE_CLIENT --max_block_size=65505 --print-profile-events --profile-events-delay-ms=-1 -q 'select * from numbers(1e5)' |& grep -o -e '\[ 0 \] SelectedRows: .*$' -e Exception
 
+echo 'regression test for incorrect filtering out snapshots'
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -n -q 'select 1; select 1' >& /dev/null
+echo $?
+
 echo 'print everything'
 profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
 test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"

--- a/tests/queries/0_stateless/02050_client_profile_events.sh
+++ b/tests/queries/0_stateless/02050_client_profile_events.sh
@@ -17,6 +17,9 @@ echo $?
 echo 'regression test for overlap profile events snapshots between queries'
 $CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -n -q 'select 1; select 1' |& grep -F -o '[ 0 ] SelectedRows: 1 (increment)'
 
+echo 'regression test for overlap profile events snapshots between queries (clickhouse-local)'
+$CLICKHOUSE_LOCAL --print-profile-events --profile-events-delay-ms=-1 -n -q 'select 1; select 1' |& grep -F -o '[ 0 ] SelectedRows: 1 (increment)'
+
 echo 'print everything'
 profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
 test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"

--- a/tests/queries/0_stateless/02050_client_profile_events.sh
+++ b/tests/queries/0_stateless/02050_client_profile_events.sh
@@ -17,3 +17,7 @@ test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"
 echo 'print each 100 ms'
 profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events --profile-events-delay-ms=100 -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
 test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"
+
+echo 'check that ProfileEvents is new for each query'
+sleep_function_calls=$($CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -n -q 'select sleep(1); select 1' |& grep -c 'SleepFunctionCalls')
+test "$sleep_function_calls" -eq 1 && echo OK || echo "FAIL ($sleep_function_calls)"

--- a/tests/queries/0_stateless/02050_client_profile_events.sh
+++ b/tests/queries/0_stateless/02050_client_profile_events.sh
@@ -14,6 +14,9 @@ echo 'regression test for incorrect filtering out snapshots'
 $CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -n -q 'select 1; select 1' >& /dev/null
 echo $?
 
+echo 'regression test for overlap profile events snapshots between queries'
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -n -q 'select 1; select 1' |& grep -F -o '[ 0 ] SelectedRows: 1 (increment)'
+
 echo 'print everything'
 profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
 test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"

--- a/tests/queries/0_stateless/02050_client_profile_events.sh
+++ b/tests/queries/0_stateless/02050_client_profile_events.sh
@@ -8,7 +8,7 @@ echo 'do not print any ProfileEvents packets'
 $CLICKHOUSE_CLIENT -q 'select * from numbers(1e5) format Null' |& grep -c 'SelectedRows'
 
 echo 'print only last (and also number of rows to provide more info in case of failures)'
-$CLICKHOUSE_CLIENT --max_block_size=65505 --print-profile-events --profile-events-delay-ms=-1 -q 'select * from numbers(1e5)' 2> >(grep -o -e '\[ 0 \] SelectedRows: .*$' -e Exception) 1> >(wc -l)
+$CLICKHOUSE_CLIENT --max_block_size=65505 --print-profile-events --profile-events-delay-ms=-1 -q 'select * from numbers(1e5)' |& grep -o -e '\[ 0 \] SelectedRows: .*$' -e Exception
 
 echo 'print everything'
 profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"

--- a/tests/queries/0_stateless/02050_client_profile_events.sh
+++ b/tests/queries/0_stateless/02050_client_profile_events.sh
@@ -4,13 +4,16 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-# do not print any ProfileEvents packets
+echo 'do not print any ProfileEvents packets'
 $CLICKHOUSE_CLIENT -q 'select * from numbers(1e5) format Null' |& grep -c 'SelectedRows'
-# print only last (and also number of rows to provide more info in case of failures)
+
+echo 'print only last (and also number of rows to provide more info in case of failures)'
 $CLICKHOUSE_CLIENT --max_block_size=65505 --print-profile-events --profile-events-delay-ms=-1 -q 'select * from numbers(1e5)' 2> >(grep -o -e '\[ 0 \] SelectedRows: .*$' -e Exception) 1> >(wc -l)
-# print everything
+
+echo 'print everything'
 profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
 test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"
-# print each 100 ms
+
+echo 'print each 100 ms'
 profile_events="$($CLICKHOUSE_CLIENT --max_block_size 1 --print-profile-events --profile-events-delay-ms=100 -q 'select sleep(1) from numbers(2) format Null' |& grep -c 'SelectedRows')"
 test "$profile_events" -gt 1 && echo OK || echo "FAIL ($profile_events)"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changes:

- Fix ProfileEvents overlaps (for multiple queries) in clickhouse-local
- Send ProfileEvents in clickhouse-local on query finish (like server does)
- Remove redundant check from LocalConnection::finishQuery()
- Do not overlap profile events snapshots for queries
- Fix code alignment in ProfileEventsExt
- Fix filtering out snapshots from profile events
- Fix printing ProfileEvents on client for multiple queries
- tests: do not use process substution in 02050_client_profile_events
- tests: improve 02050_client_profile_events