### PR TITLE
Minor improvement for hung check

### DIFF
--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -215,6 +215,8 @@ if __name__ == "__main__":
             "--client-option", "max_untracked_memory=1Gi",
             "--client-option", "max_memory_usage_for_user=0",
             "--client-option", "memory_profiler_step=1Gi",
+            # Use system database to avoid CREATE/DROP DATABASE queries
+            "--database=system",
             "--hung-check",
             "00001_select_1"
         ])

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -198,7 +198,11 @@ if __name__ == "__main__":
     logging.info("Logs compressed")
 
     if args.hung_check:
-        have_long_running_queries = prepare_for_hung_check(args.drop_databases)
+        try:
+            have_long_running_queries = prepare_for_hung_check(args.drop_databases)
+        except Exception as ex:
+            have_long_running_queries = True
+            print("Failed to prepare for hung check", ex)
         logging.info("Checking if some queries hung")
         cmd = ' '.join([args.test_cmd,
             # Do not track memory allocations up to 1Gi,

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -131,7 +131,7 @@ def prepare_for_hung_check(drop_databases):
                     Popen(command, shell=True)
                 break
             except Exception as ex:
-                print("Failed to SHOW or DROP databasese, will retry", ex)
+                logging.error("Failed to SHOW or DROP databasese, will retry %s", str(ex))
                 time.sleep(i)
         else:
             raise Exception("Cannot drop databases after stress tests. Probably server consumed too much memory and cannot execute simple queries")
@@ -202,7 +202,7 @@ if __name__ == "__main__":
             have_long_running_queries = prepare_for_hung_check(args.drop_databases)
         except Exception as ex:
             have_long_running_queries = True
-            print("Failed to prepare for hung check", ex)
+            logging.error("Failed to prepare for hung check %s", str(ex))
         logging.info("Checking if some queries hung")
         cmd = ' '.join([args.test_cmd,
             # Do not track memory allocations up to 1Gi,

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1173,6 +1173,9 @@ def check_server_started(args):
             retry_count -= 1
             sleep(0.5)
             continue
+        except TimeoutError:
+            print("\nConnection timeout, will not retry")
+            break
 
     print('\nAll connection tries failed')
     sys.stdout.flush()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`DROP DATABASE` query hung, so the script failed to get stacktraces:
```
Connecting to ClickHouse server... OK
Traceback (most recent call last):
  File "/usr/bin/clickhouse-test", line 1647, in <module>
    main(args)
  File "/usr/bin/clickhouse-test", line 1380, in main
    create_common_database(args, "test")
  File "/usr/bin/clickhouse-test", line 1370, in create_common_database
    clickhouse_execute(args, "CREATE DATABASE IF NOT EXISTS " + db_name + get_db_engine(args, db_name))
  File "/usr/bin/clickhouse-test", line 118, in clickhouse_execute
    return clickhouse_execute_http(base_args, query, timeout, settings).strip()
  File "/usr/bin/clickhouse-test", line 110, in clickhouse_execute_http
    res = client.getresponse()
  File "/usr/lib/python3.8/http/client.py", line 1348, in getresponse
    response.begin()
  File "/usr/lib/python3.8/http/client.py", line 316, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.8/http/client.py", line 277, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib/python3.8/socket.py", line 669, in readinto
    return self._sock.recv_into(b)
socket.timeout: timed out
2022-04-11 14:27:35,648 Hung check failed with exit code 1
2022-04-11 14:27:35,648 Stress test finished
+ echo -e 'Test script exit code\tOK'
+ stop
+ clickhouse stop
Code: 210. DB::NetException: Connection reset by peer, while reading from socket ([::1]:9000): while receiving packet from localhost:9000: (in query: DROP DATABASE test). (NETWORK_ERROR)
```