### PR TITLE
Fix test 02241_remote_filesystem_cache_on_insert for database Ordinary

### DIFF
--- a/src/Storages/System/StorageSystemRemoteDataPaths.cpp
+++ b/src/Storages/System/StorageSystemRemoteDataPaths.cpp
@@ -54,7 +54,6 @@ Pipe StorageSystemRemoteDataPaths::read(
             std::vector<IDisk::LocalPathWithRemotePaths> remote_paths_by_local_path;
             disk->getRemotePathsRecursive("store", remote_paths_by_local_path);
             disk->getRemotePathsRecursive("data", remote_paths_by_local_path);
-            disk->getRemotePathsRecursive("metadata", remote_paths_by_local_path);
 
             FileCachePtr cache;
             auto cache_base_path = disk->getCacheBasePath();

--- a/src/Storages/System/StorageSystemRemoteDataPaths.cpp
+++ b/src/Storages/System/StorageSystemRemoteDataPaths.cpp
@@ -53,6 +53,8 @@ Pipe StorageSystemRemoteDataPaths::read(
         {
             std::vector<IDisk::LocalPathWithRemotePaths> remote_paths_by_local_path;
             disk->getRemotePathsRecursive("store", remote_paths_by_local_path);
+            disk->getRemotePathsRecursive("data", remote_paths_by_local_path);
+            disk->getRemotePathsRecursive("metadata", remote_paths_by_local_path);
 
             FileCachePtr cache;
             auto cache_base_path = disk->getCacheBasePath();


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Closes https://github.com/ClickHouse/ClickHouse/issues/36141.