### PR TITLE
Follow-up to #36138

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1176,6 +1176,9 @@ def check_server_started(args):
         except TimeoutError:
             print("\nConnection timeout, will not retry")
             break
+        except Exception as e:
+            print("\nUexpected exception, will not retry: ", str(e))
+            break
 
     print('\nAll connection tries failed')
     sys.stdout.flush()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


#36138
https://s3.amazonaws.com/clickhouse-test-reports/0/6b6671e89f75f3c448b51d2f9eab8b369f8e7fef/stress_test__memory__actions_/runlog.log