### PR TITLE
Fix CREATE AS for ReplicatedMergeTree with default arguments

### DIFF
--- a/src/Common/Macros.cpp
+++ b/src/Common/Macros.cpp
@@ -92,7 +92,7 @@ String Macros::expand(const String & s,
             res += info.table_id.table_name;
             info.expanded_table = true;
         }
-        else if (macro_name == "uuid")
+        else if (macro_name == "uuid" && !info.expand_special_macros_only)
         {
             if (info.table_id.uuid == UUIDHelpers::Nil)
                 throw Exception("Macro 'uuid' and empty arguments of ReplicatedMergeTree "
@@ -109,12 +109,12 @@ String Macros::expand(const String & s,
         else if (info.shard && macro_name == "shard")
         {
             res += *info.shard;
-            info.expanded_uuid = true;
+            info.expanded_other = true;
         }
         else if (info.replica && macro_name == "replica")
         {
             res += *info.replica;
-            info.expanded_uuid = true;
+            info.expanded_other = true;
         }
         else if (info.ignore_unknown || info.expand_special_macros_only)
         {

--- a/src/Databases/DatabaseAtomic.h
+++ b/src/Databases/DatabaseAtomic.h
@@ -63,7 +63,7 @@ public:
 
     void waitDetachedTableNotInUse(const UUID & uuid) override;
     void checkDetachedTableNotInUse(const UUID & uuid) override;
-    void setDetachedTableNotInUseForce(const UUID & uuid);
+    void setDetachedTableNotInUseForce(const UUID & uuid) override;
 
 protected:
     void commitAlterTable(const StorageID & table_id, const String & table_metadata_tmp_path, const String & table_metadata_path, const String & statement, ContextPtr query_context) override;

--- a/src/Databases/DatabaseAtomic.h
+++ b/src/Databases/DatabaseAtomic.h
@@ -76,6 +76,8 @@ protected:
 
     void tryCreateMetadataSymlink();
 
+    virtual bool allowMoveTableToOtherDatabaseEngine(IDatabase & /*to_database*/) const { return false; }
+
     //TODO store path in DatabaseWithOwnTables::tables
     using NameToPathMap = std::unordered_map<String, String>;
     NameToPathMap table_name_to_path;

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -415,11 +415,13 @@ void DatabaseOnDisk::renameTable(
     }
     catch (const Exception &)
     {
+        setDetachedTableNotInUseForce(prev_uuid);
         attachTable(local_context, table_name, table, table_data_relative_path);
         throw;
     }
     catch (const Poco::Exception & e)
     {
+        setDetachedTableNotInUseForce(prev_uuid);
         attachTable(local_context, table_name, table, table_data_relative_path);
         /// Better diagnostics.
         throw Exception{Exception::CreateFromPocoTag{}, e};

--- a/src/Databases/DatabaseOnDisk.h
+++ b/src/Databases/DatabaseOnDisk.h
@@ -95,6 +95,7 @@ protected:
                                    const String & table_metadata_tmp_path, const String & table_metadata_path, ContextPtr query_context);
 
     virtual void removeDetachedPermanentlyFlag(ContextPtr context, const String & table_name, const String & table_metadata_path, bool attach) const;
+    virtual void setDetachedTableNotInUseForce(const UUID & /*uuid*/) {}
 
     const String metadata_path;
     const String data_path;

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -45,6 +45,7 @@ namespace ErrorCodes
 
 static constexpr const char * DROPPED_MARK = "DROPPED";
 static constexpr const char * BROKEN_TABLES_SUFFIX = "_broken_tables";
+static constexpr const char * BROKEN_REPLICATED_TABLES_SUFFIX = "_broken_replicated_tables";
 
 
 zkutil::ZooKeeperPtr DatabaseReplicated::getZooKeeper() const
@@ -505,6 +506,9 @@ static UUID getTableUUIDIfReplicated(const String & metadata, ContextPtr context
 
 void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeeper, UInt32 our_log_ptr, UInt32 max_log_ptr)
 {
+    is_recovering = true;
+    SCOPE_EXIT({ is_recovering = false; });
+
     /// Let's compare local (possibly outdated) metadata with (most actual) metadata stored in ZooKeeper
     /// and try to update the set of local tables.
     /// We could drop all local tables and create the new ones just like it's new replica.
@@ -582,6 +586,7 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
 
     String db_name = getDatabaseName();
     String to_db_name = getDatabaseName() + BROKEN_TABLES_SUFFIX;
+    String to_db_name_replicated = getDatabaseName() + BROKEN_REPLICATED_TABLES_SUFFIX;
     if (total_tables * db_settings.max_broken_tables_ratio < tables_to_detach.size())
         throw Exception(ErrorCodes::DATABASE_REPLICATION_FAILED, "Too many tables to recreate: {} of {}", tables_to_detach.size(), total_tables);
     else if (!tables_to_detach.empty())
@@ -592,6 +597,13 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
         /// and make possible creation of new table with the same UUID.
         String query = fmt::format("CREATE DATABASE IF NOT EXISTS {} ENGINE=Ordinary", backQuoteIfNeed(to_db_name));
         auto query_context = Context::createCopy(getContext());
+        executeQuery(query, query_context, true);
+
+        /// But we want to avoid discarding UUID of ReplicatedMergeTree tables, because it will not work
+        /// if zookeeper_path contains {uuid} macro. Replicated database do not recreate replicated tables on recovery,
+        /// so it's ok to save UUID of replicated table.
+        query = fmt::format("CREATE DATABASE IF NOT EXISTS {} ENGINE=Atomic", backQuoteIfNeed(to_db_name_replicated));
+        query_context = Context::createCopy(getContext());
         executeQuery(query, query_context, true);
     }
 
@@ -607,6 +619,18 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
 
         auto table = tryGetTable(table_name, getContext());
 
+        auto move_table_to_database = [&](const String & broken_table_name, const String & to_database_name)
+        {
+            /// Table probably stores some data. Let's move it to another database.
+            String to_name = fmt::format("{}_{}_{}", broken_table_name, max_log_ptr, thread_local_rng() % 1000);
+            LOG_DEBUG(log, "Will RENAME TABLE {} TO {}.{}", backQuoteIfNeed(broken_table_name), backQuoteIfNeed(to_database_name), backQuoteIfNeed(to_name));
+            assert(db_name < to_database_name);
+            DDLGuardPtr to_table_guard = DatabaseCatalog::instance().getDDLGuard(to_database_name, to_name);
+            auto to_db_ptr = DatabaseCatalog::instance().getDatabase(to_database_name);
+            DatabaseAtomic::renameTable(make_query_context(), broken_table_name, *to_db_ptr, to_name, false, false);
+            ++moved_tables;
+        };
+
         if (!table->storesDataOnDisk())
         {
             LOG_DEBUG(log, "Will DROP TABLE {}, because it does not store data on disk and can be safely dropped", backQuoteIfNeed(table_name));
@@ -616,16 +640,13 @@ void DatabaseReplicated::recoverLostReplica(const ZooKeeperPtr & current_zookeep
             table->flushAndShutdown();
             DatabaseAtomic::dropTable(make_query_context(), table_name, true);
         }
+        else if (!table->supportsReplication())
+        {
+            move_table_to_database(table_name, to_db_name);
+        }
         else
         {
-            /// Table probably stores some data. Let's move it to another database.
-            String to_name = fmt::format("{}_{}_{}", table_name, max_log_ptr, thread_local_rng() % 1000);
-            LOG_DEBUG(log, "Will RENAME TABLE {} TO {}.{}", backQuoteIfNeed(table_name), backQuoteIfNeed(to_db_name), backQuoteIfNeed(to_name));
-            assert(db_name < to_db_name);
-            DDLGuardPtr to_table_guard = DatabaseCatalog::instance().getDDLGuard(to_db_name, to_name);
-            auto to_db_ptr = DatabaseCatalog::instance().getDatabase(to_db_name);
-            DatabaseAtomic::renameTable(make_query_context(), table_name, *to_db_ptr, to_name, false, false);
-            ++moved_tables;
+            move_table_to_database(table_name, to_db_name_replicated);
         }
     }
 

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -411,6 +411,8 @@ void DatabaseReplicated::checkQueryValid(const ASTPtr & query, ContextPtr query_
 
             Macros::MacroExpansionInfo info;
             info.table_id = {getDatabaseName(), create->getTable(), create->uuid};
+            info.shard = getShardName();
+            info.replica = getReplicaName();
             query_context->getMacros()->expand(maybe_path, info);
             bool maybe_shard_macros = info.expanded_other;
             info.expanded_other = false;

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -112,7 +112,7 @@ private:
     zkutil::ZooKeeperPtr getZooKeeper() const;
 
     std::atomic_bool is_readonly = true;
-    bool is_recovering = false;
+    std::atomic_bool is_recovering = false;
     std::unique_ptr<DatabaseReplicatedDDLWorker> ddl_worker;
     UInt32 max_log_ptr_at_creation = 0;
 

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -98,6 +98,11 @@ private:
 
     void createEmptyLogEntry(const ZooKeeperPtr & current_zookeeper);
 
+    bool allowMoveTableToOtherDatabaseEngine(IDatabase & to_database) const override
+    {
+        return is_recovering && typeid_cast<DatabaseAtomic *>(&to_database);
+    }
+
     String zookeeper_path;
     String shard_name;
     String replica_name;
@@ -107,6 +112,7 @@ private:
     zkutil::ZooKeeperPtr getZooKeeper() const;
 
     std::atomic_bool is_readonly = true;
+    bool is_recovering = false;
     std::unique_ptr<DatabaseReplicatedDDLWorker> ddl_worker;
     UInt32 max_log_ptr_at_creation = 0;
 

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -416,7 +416,7 @@ public:
         throw Exception("Truncate is not supported by storage " + getName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
-    virtual void checkTableCanBeRenamed() const {}
+    virtual void checkTableCanBeRenamed(const StorageID & /*new_name*/) const {}
 
     /** Rename the table.
       * Renaming a name in a file with metadata, the name in the list of tables in the RAM, is done separately.

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -307,7 +307,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
     /// For Replicated.
     String zookeeper_path;
     String replica_name;
-    bool allow_renaming = true;
+    StorageReplicatedMergeTree::RenamingRestrictions renaming_restrictions = StorageReplicatedMergeTree::RenamingRestrictions::ALLOW_ANY;
 
     if (replicated)
     {
@@ -376,7 +376,6 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         bool allow_uuid_macro = is_on_cluster || is_replicated_database || args.query.attach;
 
         /// Unfold {database} and {table} macro on table creation, so table can be renamed.
-        /// We also unfold {uuid} macro, so path will not be broken after moving table from Atomic to Ordinary database.
         if (!args.attach)
         {
             if (is_replicated_database && !is_extended_storage_def)
@@ -386,12 +385,13 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             /// NOTE: it's not recursive
             info.expand_special_macros_only = true;
             info.table_id = args.table_id;
-            if (!allow_uuid_macro)
-                info.table_id.uuid = UUIDHelpers::Nil;
+            /// Avoid unfolding {uuid} macro on this step.
+            /// We did unfold it in previous versions to make moving table from Atomic to Ordinary database work correctly,
+            /// but now it's not allowed (and it was the only reason to unfold {uuid} macro).
+            info.table_id.uuid = UUIDHelpers::Nil;
             zookeeper_path = args.getContext()->getMacros()->expand(zookeeper_path, info);
 
             info.level = 0;
-            info.table_id.uuid = UUIDHelpers::Nil;
             replica_name = args.getContext()->getMacros()->expand(replica_name, info);
         }
 
@@ -419,8 +419,11 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         /// We do not allow renaming table with these macros in metadata, because zookeeper_path will be broken after RENAME TABLE.
         /// NOTE: it may happen if table was created by older version of ClickHouse (< 20.10) and macros was not unfolded on table creation
         /// or if one of these macros is recursively expanded from some other macro.
+        /// Also do not allow to move table from Atomic to Ordinary database if there's {uuid} macro
         if (info.expanded_database || info.expanded_table)
-            allow_renaming = false;
+            renaming_restrictions = StorageReplicatedMergeTree::RenamingRestrictions::DO_NOT_ALLOW;
+        else if (info.expanded_uuid)
+            renaming_restrictions = StorageReplicatedMergeTree::RenamingRestrictions::ALLOW_PRESERVING_UUID;
     }
 
     /// This merging param maybe used as part of sorting key
@@ -681,7 +684,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             merging_params,
             std::move(storage_settings),
             args.has_force_restore_data_flag,
-            allow_renaming);
+            renaming_restrictions);
     else
         return StorageMergeTree::create(
             args.table_id,

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -143,7 +143,14 @@ public:
 
     void truncate(const ASTPtr &, const StorageMetadataPtr &, ContextPtr query_context, TableExclusiveLockHolder &) override;
 
-    void checkTableCanBeRenamed() const override;
+    enum RenamingRestrictions
+    {
+        ALLOW_ANY,
+        ALLOW_PRESERVING_UUID,
+        DO_NOT_ALLOW,
+    };
+
+    void checkTableCanBeRenamed(const StorageID & new_name) const override;
 
     void rename(const String & new_path_to_table_data, const StorageID & new_table_id) override;
 
@@ -414,7 +421,7 @@ private:
     bool other_replicas_fixed_granularity = false;
 
     /// Do not allow RENAME TABLE if zookeeper_path contains {database} or {table} macro
-    const bool allow_renaming;
+    const RenamingRestrictions renaming_restrictions;
 
     const size_t replicated_fetches_pool_size;
 
@@ -799,7 +806,7 @@ protected:
         const MergingParams & merging_params_,
         std::unique_ptr<MergeTreeSettings> settings_,
         bool has_force_restore_data_flag,
-        bool allow_renaming_);
+        RenamingRestrictions renaming_restrictions_);
 };
 
 String getPartNamePossiblyFake(MergeTreeDataFormatVersion format_version, const MergeTreePartInfo & part_info);

--- a/tests/integration/test_distributed_ddl/test.py
+++ b/tests/integration/test_distributed_ddl/test.py
@@ -510,7 +510,7 @@ def test_replicated_without_arguments(test_cluster):
     )
     assert (
         instance.query("SHOW CREATE test_atomic.rmt FORMAT TSVRaw")
-        == "CREATE TABLE test_atomic.rmt\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = ReplicatedMergeTree('/clickhouse/tables/12345678-0000-4000-8000-000000000001/{shard}', '{replica}')\nORDER BY n\nSETTINGS index_granularity = 8192\n"
+        == "CREATE TABLE test_atomic.rmt\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = ReplicatedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')\nORDER BY n\nSETTINGS index_granularity = 8192\n"
     )
     test_cluster.ddl_check_query(
         instance,

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -727,10 +727,10 @@ def test_recover_staled_replica(started_cluster):
         == f"{test_recover_staled_replica_run}\n"
     )
     assert (
-            dummy_node.query(
-                "SELECT count() FROM system.tables WHERE database='recover_broken_replicated_tables'"
-            )
-            == f"{test_recover_staled_replica_run}\n"
+        dummy_node.query(
+            "SELECT count() FROM system.tables WHERE database='recover_broken_replicated_tables'"
+        )
+        == f"{test_recover_staled_replica_run}\n"
     )
     test_recover_staled_replica_run += 1
     table = dummy_node.query(
@@ -744,7 +744,9 @@ def test_recover_staled_replica(started_cluster):
         "SHOW TABLES FROM recover_broken_replicated_tables LIKE 'rmt5_29_%' LIMIT 1"
     ).strip()
     assert (
-        dummy_node.query("SELECT (*,).1 FROM recover_broken_replicated_tables.{}".format(table))
+        dummy_node.query(
+            "SELECT (*,).1 FROM recover_broken_replicated_tables.{}".format(table)
+        )
         == "42\n"
     )
 

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -111,7 +111,7 @@ def test_create_replicated_table(started_cluster):
 
     expected = (
         "CREATE TABLE testdb.replicated_table\\n(\\n    `d` Date,\\n    `k` UInt64,\\n    `i32` Int32\\n)\\n"
-        "ENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/uuid/{shard}\\', \\'{replica}\\')\\n"
+        "ENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')\\n"
         "PARTITION BY toYYYYMM(d)\\nORDER BY k\\nSETTINGS index_granularity = 8192"
     )
     assert_create_query([main_node, dummy_node], "testdb.replicated_table", expected)
@@ -164,7 +164,7 @@ def test_simple_alter_table(started_cluster, engine):
     full_engine = (
         engine
         if not "Replicated" in engine
-        else engine + "(\\'/clickhouse/tables/uuid/{shard}\\', \\'{replica}\\')"
+        else engine + "(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')"
     )
     expected = (
         "CREATE TABLE {}\\n(\\n    `CounterID` UInt32,\\n    `StartDate` Date,\\n    `UserID` UInt32,\\n"
@@ -191,7 +191,7 @@ def test_simple_alter_table(started_cluster, engine):
     full_engine = (
         engine
         if not "Replicated" in engine
-        else engine + "(\\'/clickhouse/tables/uuid/{shard}\\', \\'{replica}\\')"
+        else engine + "(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')"
     )
     expected = (
         "CREATE TABLE {}\\n(\\n    `CounterID` UInt32,\\n    `StartDate` Date,\\n    `UserID` UInt32,\\n"
@@ -459,7 +459,7 @@ def test_alters_from_different_replicas(started_cluster):
     expected = (
         "CREATE TABLE testdb.concurrent_test\\n(\\n    `CounterID` UInt32,\\n    `StartDate` Date,\\n    `UserID` UInt32,\\n"
         "    `VisitID` UInt32,\\n    `NestedColumn.A` Array(UInt8),\\n    `NestedColumn.S` Array(String),\\n    `ToDrop` UInt32\\n)\\n"
-        "ENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/uuid/{shard}\\', \\'{replica}\\')\\nORDER BY CounterID\\nSETTINGS index_granularity = 8192"
+        "ENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')\\nORDER BY CounterID\\nSETTINGS index_granularity = 8192"
     )
 
     assert_create_query([main_node, competing_node], "testdb.concurrent_test", expected)
@@ -474,7 +474,7 @@ def test_alters_from_different_replicas(started_cluster):
     expected = (
         "CREATE TABLE testdb.concurrent_test\\n(\\n    `CounterID` UInt32,\\n    `StartDate` Date,\\n    `UserID` UInt32,\\n"
         "    `VisitID` UInt32,\\n    `NestedColumn.A` Array(UInt8),\\n    `NestedColumn.S` Array(String),\\n    `ToDrop` UInt32\\n)\\n"
-        "ENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/uuid/{shard}\\', \\'{replica}\\')\\nORDER BY CounterID\\nSETTINGS index_granularity = 8192"
+        "ENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')\\nORDER BY CounterID\\nSETTINGS index_granularity = 8192"
     )
 
     # test_snapshot_and_snapshot_recover
@@ -521,7 +521,7 @@ def test_alters_from_different_replicas(started_cluster):
     expected = (
         "CREATE TABLE testdb.concurrent_test\\n(\\n    `CounterID` UInt32,\\n    `StartDate` Date,\\n    `UserID` UInt32,\\n"
         "    `VisitID` UInt32,\\n    `NestedColumn.A` Array(UInt8),\\n    `NestedColumn.S` Array(String),\\n    `ToDrop` UInt32\\n)\\n"
-        "ENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/uuid/{shard}\\', \\'{replica}\\')\\nORDER BY CounterID\\nSETTINGS index_granularity = 8192"
+        "ENGINE = ReplicatedMergeTree(\\'/clickhouse/tables/{uuid}/{shard}\\', \\'{replica}\\')\\nORDER BY CounterID\\nSETTINGS index_granularity = 8192"
     )
 
     assert_create_query([main_node, competing_node], "testdb.concurrent_test", expected)

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -724,7 +724,13 @@ def test_recover_staled_replica(started_cluster):
         dummy_node.query(
             "SELECT count() FROM system.tables WHERE database='recover_broken_tables'"
         )
-        == f"{2*test_recover_staled_replica_run}\n"
+        == f"{test_recover_staled_replica_run}\n"
+    )
+    assert (
+            dummy_node.query(
+                "SELECT count() FROM system.tables WHERE database='recover_broken_replicated_tables'"
+            )
+            == f"{test_recover_staled_replica_run}\n"
     )
     test_recover_staled_replica_run += 1
     table = dummy_node.query(
@@ -735,10 +741,10 @@ def test_recover_staled_replica(started_cluster):
         == "42\n"
     )
     table = dummy_node.query(
-        "SHOW TABLES FROM recover_broken_tables LIKE 'rmt5_29_%' LIMIT 1"
+        "SHOW TABLES FROM recover_broken_replicated_tables LIKE 'rmt5_29_%' LIMIT 1"
     ).strip()
     assert (
-        dummy_node.query("SELECT (*,).1 FROM recover_broken_tables.{}".format(table))
+        dummy_node.query("SELECT (*,).1 FROM recover_broken_replicated_tables.{}".format(table))
         == "42\n"
     )
 

--- a/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.reference
+++ b/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.reference
@@ -2,6 +2,6 @@ CREATE TABLE default.rmt\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = Replic
 CREATE TABLE default.rmt1\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/test_01148/{shard}/default/rmt\', \'{replica}\')\nORDER BY n\nSETTINGS index_granularity = 8192
 CREATE TABLE default.rmt\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = ReplicatedMergeTree(\'{default_path_test}test_01148\', \'{default_name_test}\')\nORDER BY n\nSETTINGS index_granularity = 8192
 CREATE TABLE default.rmt\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = ReplicatedMergeTree(\'{default_path_test}test_01148\', \'{default_name_test}\')\nORDER BY n\nSETTINGS index_granularity = 8192
-CREATE TABLE default.rmt2\n(\n    `n` Int32\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/{uuid}/{shard}\', \'{replica}\')\nPRIMARY KEY n\nORDER BY n\nSETTINGS index_granularity = 8192
-CREATE TABLE default.rmt3\n(\n    `n` Int32\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/{uuid}/{shard}\', \'{replica}\')\nPRIMARY KEY n\nORDER BY n\nSETTINGS index_granularity = 8192
+CREATE TABLE test_01148_atomic.rmt2\n(\n    `n` Int32\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/{uuid}/{shard}\', \'{replica}\')\nPRIMARY KEY n\nORDER BY n\nSETTINGS index_granularity = 8192
+CREATE TABLE test_01148_atomic.rmt3\n(\n    `n` Int32\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/{uuid}/{shard}\', \'{replica}\')\nPRIMARY KEY n\nORDER BY n\nSETTINGS index_granularity = 8192
 CREATE TABLE imdb_01148.anything\n(\n    `director_id` UInt64,\n    `movie_id` UInt64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/{uuid}/{shard}\', \'{replica}\')\nORDER BY (director_id, movie_id)\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.reference
+++ b/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.reference
@@ -2,3 +2,6 @@ CREATE TABLE default.rmt\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = Replic
 CREATE TABLE default.rmt1\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/test_01148/{shard}/default/rmt\', \'{replica}\')\nORDER BY n\nSETTINGS index_granularity = 8192
 CREATE TABLE default.rmt\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = ReplicatedMergeTree(\'{default_path_test}test_01148\', \'{default_name_test}\')\nORDER BY n\nSETTINGS index_granularity = 8192
 CREATE TABLE default.rmt\n(\n    `n` UInt64,\n    `s` String\n)\nENGINE = ReplicatedMergeTree(\'{default_path_test}test_01148\', \'{default_name_test}\')\nORDER BY n\nSETTINGS index_granularity = 8192
+CREATE TABLE default.rmt2\n(\n    `n` Int32\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/{uuid}/{shard}\', \'{replica}\')\nPRIMARY KEY n\nORDER BY n\nSETTINGS index_granularity = 8192
+CREATE TABLE default.rmt3\n(\n    `n` Int32\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/{uuid}/{shard}\', \'{replica}\')\nPRIMARY KEY n\nORDER BY n\nSETTINGS index_granularity = 8192
+CREATE TABLE imdb_01148.anything\n(\n    `director_id` UInt64,\n    `movie_id` UInt64\n)\nENGINE = ReplicatedMergeTree(\'/clickhouse/tables/{uuid}/{shard}\', \'{replica}\')\nORDER BY (director_id, movie_id)\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.sql
+++ b/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.sql
@@ -20,6 +20,7 @@ DETACH TABLE rmt;
 ATTACH TABLE rmt;
 SHOW CREATE TABLE rmt;
 
+SET distributed_ddl_output_mode='none';
 DROP DATABASE IF EXISTS test_01148_atomic;
 CREATE DATABASE test_01148_atomic ENGINE=Atomic;
 CREATE TABLE test_01148_atomic.rmt2 ON CLUSTER test_shard_localhost (n int, PRIMARY KEY n) ENGINE=ReplicatedMergeTree;

--- a/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.sql
+++ b/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.sql
@@ -38,6 +38,7 @@ DROP DATABASE test_01148_atomic;
 DROP TABLE rmt;
 DROP TABLE rmt1;
 
+SET allow_experimental_database_replicated=1;
 DROP DATABASE IF EXISTS imdb_01148;
 CREATE DATABASE imdb_01148 ENGINE = Replicated('/test/databases/imdb_01148', '{shard}', '{replica}');
 CREATE TABLE imdb_01148.movie_directors (`director_id` UInt64, `movie_id` UInt64) ENGINE = ReplicatedMergeTree ORDER BY (director_id, movie_id) SETTINGS index_granularity = 8192;

--- a/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.sql
+++ b/tests/queries/0_stateless/01148_zookeeper_path_macros_unfolding.sql
@@ -20,22 +20,23 @@ DETACH TABLE rmt;
 ATTACH TABLE rmt;
 SHOW CREATE TABLE rmt;
 
-CREATE TABLE rmt2 ON CLUSTER test_shard_localhost (n int, PRIMARY KEY n) ENGINE=ReplicatedMergeTree;
-CREATE TABLE rmt3 AS rmt2; -- { serverError 62 }
-CREATE TABLE rmt4 ON CLUSTER test_shard_localhost AS rmt2;
-SHOW CREATE TABLE rmt2;
-RENAME TABLE rmt4 to rmt3;
-SHOW CREATE TABLE rmt3;
+DROP DATABASE IF EXISTS test_01148_atomic;
+CREATE DATABASE test_01148_atomic ENGINE=Atomic;
+CREATE TABLE test_01148_atomic.rmt2 ON CLUSTER test_shard_localhost (n int, PRIMARY KEY n) ENGINE=ReplicatedMergeTree;
+CREATE TABLE test_01148_atomic.rmt3 AS test_01148_atomic.rmt2; -- { serverError 62 }
+CREATE TABLE test_01148_atomic.rmt4 ON CLUSTER test_shard_localhost AS test_01148_atomic.rmt2;
+SHOW CREATE TABLE test_01148_atomic.rmt2;
+RENAME TABLE test_01148_atomic.rmt4 to test_01148_atomic.rmt3;
+SHOW CREATE TABLE test_01148_atomic.rmt3;
 
 DROP DATABASE IF EXISTS test_01148_ordinary;
 CREATE DATABASE test_01148_ordinary ENGINE=Ordinary;
-RENAME TABLE rmt3 to test_01148_ordinary.rmt3; -- { serverError 48 }
+RENAME TABLE test_01148_atomic.rmt3 to test_01148_ordinary.rmt3; -- { serverError 48 }
 DROP DATABASE test_01148_ordinary;
+DROP DATABASE test_01148_atomic;
 
 DROP TABLE rmt;
 DROP TABLE rmt1;
-DROP TABLE rmt2;
-DROP TABLE rmt3;
 
 DROP DATABASE IF EXISTS imdb_01148;
 CREATE DATABASE imdb_01148 ENGINE = Replicated('/test/databases/imdb_01148', '{shard}', '{replica}');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`CREATE TABLE ... AS` might fail with `Replica ... already exists` even if `ReplicatedMergeTree` table was created with default arguments. It's fixed. Now `{uuid}` macro is not unfolded when saving table metadata. Therefore, it's not allowed to move `ReplicatedMergeTree` table from `Atomic` to `Ordinary` database if `zookeeper_path` contains `{uuid}` macro (or table was created with default engine arguments). Fixes #35577.
