### PR TITLE
Make stateless tests with s3 always green

### DIFF
--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -282,6 +282,7 @@ CI_CONFIG = {
         },
         "Stateless tests (release, s3 storage, actions)": {
             "required_build": "package_release",
+            "force_tests": True,
         },
         "Stress test (address, actions)": {
             "required_build": "package_asan",


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Stateless tests with s3 are broken in master for one week:
https://play.clickhouse.com/play?user=play#c2VsZWN0IAp0b1N0YXJ0T2ZEYXkoY2hlY2tfc3RhcnRfdGltZSkgYXMgZCwgc3VtKGNoZWNrX3N0YXR1cyA9ICdzdWNjZXNzJykgYXMgcywgc3VtKGNoZWNrX3N0YXR1cyA9ICdmYWlsdXJlJykgYXMgZiwgcm91bmQoZiAvIGMgLCAyKSBhcyBmciwKY291bnQoKSBhcyBjCmZyb20gY2hlY2tzIHdoZXJlICcyMDIyLTAzLTAxJyA8PSBjaGVja19zdGFydF90aW1lIGFuZCBjaGVja19uYW1lIGlsaWtlICclc3RhdGVsZXNzJXMzJScgYW5kIHB1bGxfcmVxdWVzdF9udW1iZXI9MCBncm91cCBieSBkIG9yZGVyIGJ5IGQgZGVzYw==
