### PR TITLE
fix crash when you use clickhouse-git-import with invalid parameter

### DIFF
--- a/programs/compressor/Compressor.cpp
+++ b/programs/compressor/Compressor.cpp
@@ -66,40 +66,40 @@ int mainEntryClickHouseCompressor(int argc, char ** argv)
     using namespace DB;
     namespace po = boost::program_options;
 
-    po::options_description desc = createOptionsDescription("Allowed options", getTerminalWidth());
-    desc.add_options()
-        ("help,h", "produce help message")
-        ("input", po::value<std::string>()->value_name("INPUT"), "input file")
-        ("output", po::value<std::string>()->value_name("OUTPUT"), "output file")
-        ("decompress,d", "decompress")
-        ("offset-in-compressed-file", po::value<size_t>()->default_value(0ULL), "offset to the compressed block (i.e. physical file offset)")
-        ("offset-in-decompressed-block", po::value<size_t>()->default_value(0ULL), "offset to the decompressed block (i.e. virtual offset)")
-        ("block-size,b", po::value<unsigned>()->default_value(DBMS_DEFAULT_BUFFER_SIZE), "compress in blocks of specified size")
-        ("hc", "use LZ4HC instead of LZ4")
-        ("zstd", "use ZSTD instead of LZ4")
-        ("codec", po::value<std::vector<std::string>>()->multitoken(), "use codecs combination instead of LZ4")
-        ("level", po::value<int>(), "compression level for codecs specified via flags")
-        ("none", "use no compression instead of LZ4")
-        ("stat", "print block statistics of compressed data")
-    ;
-
-    po::positional_options_description positional_desc;
-    positional_desc.add("input", 1);
-    positional_desc.add("output", 1);
-
-    po::variables_map options;
-    po::store(po::command_line_parser(argc, argv).options(desc).positional(positional_desc).run(), options);
-
-    if (options.count("help"))
-    {
-        std::cout << "Usage: " << argv[0] << " [options] < INPUT > OUTPUT" << std::endl;
-        std::cout << "Usage: " << argv[0] << " [options] INPUT OUTPUT" << std::endl;
-        std::cout << desc << std::endl;
-        return 0;
-    }
-
     try
     {
+        po::options_description desc = createOptionsDescription("Allowed options", getTerminalWidth());
+        desc.add_options()
+            ("help,h", "produce help message")
+            ("input", po::value<std::string>()->value_name("INPUT"), "input file")
+            ("output", po::value<std::string>()->value_name("OUTPUT"), "output file")
+            ("decompress,d", "decompress")
+            ("offset-in-compressed-file", po::value<size_t>()->default_value(0ULL), "offset to the compressed block (i.e. physical file offset)")
+            ("offset-in-decompressed-block", po::value<size_t>()->default_value(0ULL), "offset to the decompressed block (i.e. virtual offset)")
+            ("block-size,b", po::value<unsigned>()->default_value(DBMS_DEFAULT_BUFFER_SIZE), "compress in blocks of specified size")
+            ("hc", "use LZ4HC instead of LZ4")
+            ("zstd", "use ZSTD instead of LZ4")
+            ("codec", po::value<std::vector<std::string>>()->multitoken(), "use codecs combination instead of LZ4")
+            ("level", po::value<int>(), "compression level for codecs specified via flags")
+            ("none", "use no compression instead of LZ4")
+            ("stat", "print block statistics of compressed data")
+        ;
+
+        po::positional_options_description positional_desc;
+        positional_desc.add("input", 1);
+        positional_desc.add("output", 1);
+
+        po::variables_map options;
+        po::store(po::command_line_parser(argc, argv).options(desc).positional(positional_desc).run(), options);
+
+        if (options.count("help"))
+        {
+            std::cout << "Usage: " << argv[0] << " [options] < INPUT > OUTPUT" << std::endl;
+            std::cout << "Usage: " << argv[0] << " [options] INPUT OUTPUT" << std::endl;
+            std::cout << desc << std::endl;
+            return 0;
+        }
+
         bool decompress = options.count("decompress");
         bool use_lz4hc = options.count("hc");
         bool use_zstd = options.count("zstd");

--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -44,40 +44,40 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
 {
     using namespace DB;
 
-    boost::program_options::options_description desc = createOptionsDescription("Allowed options", getTerminalWidth());
-    desc.add_options()
-        ("query", po::value<std::string>(), "query to format")
-        ("help,h", "produce help message")
-        ("hilite", "add syntax highlight with ANSI terminal escape sequences")
-        ("oneline", "format in single line")
-        ("quiet,q", "just check syntax, no output on success")
-        ("multiquery,n", "allow multiple queries in the same file")
-        ("obfuscate", "obfuscate instead of formatting")
-        ("backslash", "add a backslash at the end of each line of the formatted query")
-        ("allow_settings_after_format_in_insert", "Allow SETTINGS after FORMAT, but note, that this is not always safe")
-        ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
-    ;
-
-    Settings cmd_settings;
-    for (const auto & field : cmd_settings.all())
-    {
-        if (field.getName() == "max_parser_depth" || field.getName() == "max_query_size")
-            cmd_settings.addProgramOption(desc, field);
-    }
-
-    boost::program_options::variables_map options;
-    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), options);
-    po::notify(options);
-
-    if (options.count("help"))
-    {
-        std::cout << "Usage: " << argv[0] << " [options] < query" << std::endl;
-        std::cout << desc << std::endl;
-        return 1;
-    }
-
     try
     {
+        boost::program_options::options_description desc = createOptionsDescription("Allowed options", getTerminalWidth());
+        desc.add_options()
+            ("query", po::value<std::string>(), "query to format")
+            ("help,h", "produce help message")
+            ("hilite", "add syntax highlight with ANSI terminal escape sequences")
+            ("oneline", "format in single line")
+            ("quiet,q", "just check syntax, no output on success")
+            ("multiquery,n", "allow multiple queries in the same file")
+            ("obfuscate", "obfuscate instead of formatting")
+            ("backslash", "add a backslash at the end of each line of the formatted query")
+            ("allow_settings_after_format_in_insert", "Allow SETTINGS after FORMAT, but note, that this is not always safe")
+            ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
+        ;
+
+        Settings cmd_settings;
+        for (const auto & field : cmd_settings.all())
+        {
+            if (field.getName() == "max_parser_depth" || field.getName() == "max_query_size")
+                cmd_settings.addProgramOption(desc, field);
+        }
+
+        boost::program_options::variables_map options;
+        boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), options);
+        po::notify(options);
+
+        if (options.count("help"))
+        {
+            std::cout << "Usage: " << argv[0] << " [options] < query" << std::endl;
+            std::cout << desc << std::endl;
+            return 1;
+        }
+
         bool hilite = options.count("hilite");
         bool oneline = options.count("oneline");
         bool quiet = options.count("quiet");

--- a/programs/git-import/git-import.cpp
+++ b/programs/git-import/git-import.cpp
@@ -1231,5 +1231,5 @@ try
 catch (...)
 {
     std::cerr << DB::getCurrentExceptionMessage(true) << '\n';
-    throw;
+    return DB::getCurrentExceptionCode();
 }


### PR DESCRIPTION
for example:
clickhouse-git-import -xxx

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

