### PR TITLE
Fix cancel-lambda for closed PRs

### DIFF
--- a/tests/ci/cancel_and_rerun_workflow_lambda/app.py
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/app.py
@@ -160,7 +160,11 @@ def get_workflow_description_fallback(event_data) -> List[WorkflowDescription]:
     workflows_data = []
     i = 1
     for i in range(1, 6):
-        workflows = _exec_get_with_retry(f"{request_url}&page={i}")
+        try:
+            workflows = _exec_get_with_retry(f"{request_url}&page={i}")
+        except Exception as e:
+            print(f"Exception occured, still continue: {e}")
+            continue
         if not workflows["workflow_runs"]:
             break
         # Prefilter workflows

--- a/tests/ci/team_keys_lambda/app.py
+++ b/tests/ci/team_keys_lambda/app.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
-import requests
 import argparse
 import json
 
 from threading import Thread
 from queue import Queue
+
+import requests  # type: ignore
 
 
 def get_org_team_members(token: str, org: str, team_slug: str) -> tuple:
@@ -37,7 +38,7 @@ def get_members_keys(members: tuple) -> str:
                 self.results.append(f"# {m}\n{response.text}")
                 self.queue.task_done()
 
-    q = Queue()
+    q = Queue()  # type: Queue
     workers = []
     for m in members:
         q.put(m)
@@ -61,7 +62,7 @@ def get_members_keys(members: tuple) -> str:
 
 
 def get_token_from_aws() -> str:
-    import boto3
+    import boto3  # type: ignore
 
     secret_name = "clickhouse_robot_token"
     session = boto3.session.Session()
@@ -81,6 +82,8 @@ def main(token: str, org: str, team_slug: str) -> str:
 
 
 def handler(event, context):
+    _ = context
+    _ = event
     token = get_token_from_aws()
     result = {
         "statusCode": 200,

--- a/tests/ci/workflow_approve_rerun_lambda/Dockerfile
+++ b/tests/ci/workflow_approve_rerun_lambda/Dockerfile
@@ -1,13 +1,13 @@
 FROM public.ecr.aws/lambda/python:3.9
 
-# Copy function code
-COPY app.py ${LAMBDA_TASK_ROOT}
-
 # Install the function's dependencies using file requirements.txt
 # from your project folder.
 
 COPY requirements.txt  .
 RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+# Copy function code
+COPY app.py ${LAMBDA_TASK_ROOT}
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "app.handler" ]

--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -394,7 +394,7 @@ def rerun_workflow(workflow_description, token):
 def main(event):
     token = get_token_from_aws()
     event_data = json.loads(event["body"])
-    print("The body received:", event_data)
+    print("The body received:", event["body"])
     workflow_description = get_workflow_description_from_event(event_data)
 
     print("Got workflow description", workflow_description)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Filter workflows locally for last 500 workflows as a fallback, see https://github.community/t/actions-runs-filtering-is-broken/244940