### PR TITLE
[DOCS] JSON_VALUE return unquoted string after 21.12

### DIFF
--- a/docs/en/sql-reference/functions/json-functions.md
+++ b/docs/en/sql-reference/functions/json-functions.md
@@ -404,7 +404,7 @@ SELECT toTypeName(JSON_VALUE('{"hello":2}', '$.hello'));
 Result:
 
 ``` text
-"world"
+world
 0
 2
 String

--- a/docs/ru/sql-reference/functions/json-functions.md
+++ b/docs/ru/sql-reference/functions/json-functions.md
@@ -407,7 +407,7 @@ SELECT toTypeName(JSON_VALUE('{"hello":2}', '$.hello'));
 Результат:
 
 ``` text
-"world"
+world
 0
 2
 String


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)