### PR TITLE
Fix misleading error message in type inference when list of files is empty

### DIFF
--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -264,12 +264,12 @@ ColumnsDescription StorageFile::getTableStructureFromFile(
     const std::optional<FormatSettings> & format_settings,
     ContextPtr context)
 {
+    if (paths.empty())
+        throw Exception(
+            "Cannot get table structure from file, because no files match specified name", ErrorCodes::INCORRECT_FILE_NAME);
+
     if (format == "Distributed")
     {
-        if (paths.empty())
-            throw Exception(
-                "Cannot get table structure from file, because no files match specified name", ErrorCodes::INCORRECT_FILE_NAME);
-
         auto source = StorageDistributedDirectoryMonitor::createSourceFromFile(paths[0]);
         return ColumnsDescription(source->getOutputs().front().getHeader().getNamesAndTypesList());
     }


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix misleading error message in type inference when list of files is empty. #36317


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
