### PR TITLE
Do not randomize "priority" setting

### DIFF
--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -182,9 +182,7 @@ ASTPtr getCreateTableQueryClean(const StorageID & table_id, ContextPtr context)
 
 }
 
-///
-/// SystemLogs
-///
+
 SystemLogs::SystemLogs(ContextPtr global_context, const Poco::Util::AbstractConfiguration & config)
 {
     query_log = createSystemLog<QueryLog>(global_context, "system", "query_log", config, "query_log");
@@ -273,9 +271,7 @@ void SystemLogs::shutdown()
         log->shutdown();
 }
 
-///
-/// SystemLog
-///
+
 template <typename LogElement>
 SystemLog<LogElement>::SystemLog(
     ContextPtr context_,
@@ -544,7 +540,6 @@ ASTPtr SystemLog<LogElement>::getCreateTableQuery()
         auto storage_settings = std::make_unique<MergeTreeSettings>(getContext()->getMergeTreeSettings());
         storage_settings->loadFromQuery(*create->storage);
     }
-
 
     return create;
 }

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -382,7 +382,6 @@ class SettingsRandomizer:
         "group_by_two_level_threshold_bytes": lambda: 1 if random.random() < 0.1 else 2 ** 60 if random.random() < 0.11 else 50000000,
         "distributed_aggregation_memory_efficient": lambda: random.randint(0, 1),
         "fsync_metadata": lambda: random.randint(0, 1),
-        "priority": lambda: min(3, int(abs(random.gauss(0, 2)))),
         "output_format_parallel_formatting": lambda: random.randint(0, 1),
         "input_format_parallel_parsing": lambda: random.randint(0, 1),
         "min_chunk_bytes_for_parallel_parsing": lambda: max(1024, int(random.gauss(10 * 1024 * 1024, 5 * 1000 * 1000))),


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


`priority` setting cannot be randomized, because it can lead to potentially unbounded waiting and timeout of some queries if other queries with higher priority were run.