### PR TITLE
Fix error in sanity checks

### DIFF
--- a/base/base/getAvailableMemoryAmount.cpp
+++ b/base/base/getAvailableMemoryAmount.cpp
@@ -14,8 +14,8 @@
 
 uint64_t getAvailableMemoryAmountOrZero()
 {
-#if defined(_SC_AVPHYS_PAGES) // linux
-    return getPageSize() * sysconf(_SC_AVPHYS_PAGES);
+#if defined(_SC_PHYS_PAGES) // linux
+    return getPageSize() * sysconf(_SC_PHYS_PAGES);
 #elif defined(__FreeBSD__)
     struct vmtotal vmt;
     size_t vmt_size = sizeof(vmt);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The checked memory amount did not account for cache.