### PR TITLE
Make minmax_count projection backward compatible

### DIFF
--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -181,19 +181,19 @@ public:
     /// because each projection can provide some columns as inputs to substitute certain sub-DAGs
     /// (expressions). Consider the following example:
     /// CREATE TABLE tbl (dt DateTime, val UInt64,
-    ///                   PROJECTION p_hour (SELECT SUM(val) GROUP BY toStartOfHour(dt)));
+    ///                   PROJECTION p_hour (SELECT sum(val) GROUP BY toStartOfHour(dt)));
     ///
-    /// Query: SELECT toStartOfHour(dt), SUM(val) FROM tbl GROUP BY toStartOfHour(dt);
+    /// Query: SELECT toStartOfHour(dt), sum(val) FROM tbl GROUP BY toStartOfHour(dt);
     ///
     /// We will have an ActionsDAG like this:
-    /// FUNCTION: toStartOfHour(dt)       SUM(val)
+    /// FUNCTION: toStartOfHour(dt)       sum(val)
     ///                 ^                   ^
     ///                 |                   |
     /// INPUT:          dt                  val
     ///
     /// Now we traverse the DAG and see if any FUNCTION node can be replaced by projection's INPUT node.
     /// The result DAG will be:
-    /// INPUT:  toStartOfHour(dt)       SUM(val)
+    /// INPUT:  toStartOfHour(dt)       sum(val)
     ///
     /// We don't need aggregate columns from projection because they are matched after DAG.
     /// Currently we use canonical names of each node to find matches. It can be improved after we

--- a/src/Interpreters/FunctionNameNormalizer.h
+++ b/src/Interpreters/FunctionNameNormalizer.h
@@ -5,6 +5,13 @@
 namespace DB
 {
 
+/// Rewrite function names to their canonical forms.
+/// For example, rewrite (1) to (2)
+/// (1) SELECT suM(1), AVG(2);
+/// (2) SELECT sum(1), avg(2);
+///
+/// It's used to help projection query analysis matching function nodes by their canonical names.
+/// See the comment of ActionsDAG::foldActionsByProjection for details.
 struct FunctionNameNormalizer
 {
     static void visit(IAST *);

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -21,6 +21,7 @@
 #include <AggregateFunctions/parseAggregateFunctionParameters.h>
 
 #include <Interpreters/Context.h>
+#include <Interpreters/FunctionNameNormalizer.h>
 #include <Interpreters/evaluateConstantExpression.h>
 
 
@@ -566,9 +567,11 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         }
 
         auto minmax_columns = metadata.getColumnsRequiredForPartitionKey();
+        auto partition_key = metadata.partition_key.expression_list_ast->clone();
+        FunctionNameNormalizer().visit(partition_key.get());
         auto primary_key_asts = metadata.primary_key.expression_list_ast->children;
         metadata.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-            args.columns, metadata.partition_key.expression_list_ast, minmax_columns, primary_key_asts, args.getContext()));
+            args.columns, partition_key, minmax_columns, primary_key_asts, args.getContext()));
 
         if (args.storage_def->sample_by)
             metadata.sampling_key = KeyDescription::getKeyFromAST(args.storage_def->sample_by->ptr(), metadata.columns, args.getContext());
@@ -648,9 +651,11 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         ++arg_num;
 
         auto minmax_columns = metadata.getColumnsRequiredForPartitionKey();
+        auto partition_key = metadata.partition_key.expression_list_ast->clone();
+        FunctionNameNormalizer().visit(partition_key.get());
         auto primary_key_asts = metadata.primary_key.expression_list_ast->children;
         metadata.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-            args.columns, metadata.partition_key.expression_list_ast, minmax_columns, primary_key_asts, args.getContext()));
+            args.columns, partition_key, minmax_columns, primary_key_asts, args.getContext()));
 
         const auto * ast = engine_args[arg_num]->as<ASTLiteral>();
         if (ast && ast->value.getType() == Field::Types::UInt64)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix unexpected table loading error when partition key contains alias function names during server upgrade.

The following table cannot be loaded in 22.3 (Only old servers can generate such table definition)
```
test.sql

ATTACH TABLE test
(
    `ds` String
)
ENGINE = MergeTree
PARTITION BY substr(ds, 1, 8)
ORDER BY ds
SETTINGS index_granularity = 8192
```

Mark as bug fix because it prevents user from upgrading to latest LTS version.

I'm not sure how to write a proper test for it.

It's similar with https://github.com/ClickHouse/ClickHouse/pull/33933 , which somehow introduces another backward incompatibility: old server cannot upgrade because local metadata isn't normalized but zk metadata does. This PR also fixes this issue.

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
