### PR TITLE
fix ttl merge schedule bug

### DIFF
--- a/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
+++ b/src/Storages/MergeTree/BackgroundJobsAssignee.cpp
@@ -50,10 +50,11 @@ void BackgroundJobsAssignee::postpone()
 }
 
 
-void BackgroundJobsAssignee::scheduleMergeMutateTask(ExecutableTaskPtr merge_task)
+bool BackgroundJobsAssignee::scheduleMergeMutateTask(ExecutableTaskPtr merge_task)
 {
     bool res = getContext()->getMergeMutateExecutor()->trySchedule(merge_task);
     res ? trigger() : postpone();
+    return res;
 }
 
 

--- a/src/Storages/MergeTree/BackgroundJobsAssignee.h
+++ b/src/Storages/MergeTree/BackgroundJobsAssignee.h
@@ -66,7 +66,7 @@ public:
     void postpone();
     void finish();
 
-    void scheduleMergeMutateTask(ExecutableTaskPtr merge_task);
+    bool scheduleMergeMutateTask(ExecutableTaskPtr merge_task);
     void scheduleFetchTask(ExecutableTaskPtr fetch_task);
     void scheduleMoveTask(ExecutableTaskPtr move_task);
     void scheduleCommonTask(ExecutableTaskPtr common_task, bool need_trigger);

--- a/src/Storages/MergeTree/MergeList.h
+++ b/src/Storages/MergeTree/MergeList.h
@@ -195,6 +195,11 @@ public:
         ++merges_with_ttl_counter;
     }
 
+    void cancelMergeWithTTL()
+    {
+        --merges_with_ttl_counter;
+    }
+
     size_t getMergesWithTTLCount() const
     {
         return merges_with_ttl_counter;

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1034,7 +1034,9 @@ bool StorageMergeTree::scheduleDataProcessingJob(BackgroundJobsAssignee & assign
     if (merge_entry)
     {
         auto task = std::make_shared<MergePlainMergeTreeTask>(*this, metadata_snapshot, false, Names{}, merge_entry, share_lock, common_assignee_trigger);
-        assignee.scheduleMergeMutateTask(task);
+        bool scheduled = assignee.scheduleMergeMutateTask(task);
+        if (!scheduled && isTTLMergeType(merge_entry->future_part->merge_type))
+            getContext()->getMergeList().cancelMergeWithTTL();
         return true;
     }
     if (mutate_entry)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

TTL merge may not be scheduled again if BackgroundExecutor is busy.
--we increase merges_with_ttl_counter in selectPartsToMerge()
--merge task will be ignored if BackgroundExecutor is busy
--merges_with_ttl_counter will not be decrease

As for StorageReplicatedMergeTree, this problem still exist in version 21.x,  but not exist in version 22.x  because we increase merges_with_ttl_counter after merge task submitted

#30645

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
