### PR TITLE
Minor refactor to prefer C++ Standard Algorithms

### DIFF
--- a/src/Storages/System/StorageSystemZooKeeper.cpp
+++ b/src/Storages/System/StorageSystemZooKeeper.cpp
@@ -286,9 +286,12 @@ void StorageSystemZooKeeper::fillData(MutableColumns & res_columns, ContextPtr c
         }
 
         std::vector<std::future<Coordination::GetResponse>> futures;
-        futures.reserve(nodes.size());
-        for (const String & node : nodes)
-            futures.push_back(zookeeper->asyncTryGet(path_part + '/' + node));
+        futures.reserve(std::size(nodes));
+        std::transform(
+            std::begin(nodes),
+            std::end(nodes),
+            std::back_inserter(futures),
+            [&zookeeper, &path_part](const String & node) { return zookeeper->asyncTryGet(path_part + '/' + node); });
 
         for (size_t i = 0, size = nodes.size(); i < size; ++i)
         {

--- a/src/Storages/System/StorageSystemZooKeeper.cpp
+++ b/src/Storages/System/StorageSystemZooKeeper.cpp
@@ -136,8 +136,11 @@ static bool extractPathImpl(const IAST & elem, Paths & res, ContextPtr context, 
             }
             else if (Tuple tuple; literal->value.tryGet(tuple))
             {
-                for (auto element : tuple)
-                    res.emplace_back(element.safeGet<String>(), ZkPathType::Exact);
+                std::transform(
+                    std::begin(tuple),
+                    std::end(tuple),
+                    std::back_inserter(res),
+                    [](auto element) { return std::make_pair(element.template safeGet<String>(), ZkPathType::Exact); });
             }
             else
                 return false;

--- a/src/Storages/System/StorageSystemZooKeeper.cpp
+++ b/src/Storages/System/StorageSystemZooKeeper.cpp
@@ -83,11 +83,11 @@ static bool extractPathImpl(const IAST & elem, Paths & res, ContextPtr context, 
 
     if (function->name == "and")
     {
-        for (const auto & child : function->arguments->children)
-            if (extractPathImpl(*child, res, context, allow_unrestricted))
-                return true;
-
-        return false;
+        const auto & children = function->arguments->children;
+        return std::any_of(
+            std::begin(children),
+            std::end(children),
+            [&](const auto & child) { return extractPathImpl(*child, res, context, allow_unrestricted); });
     }
 
     const auto & args = function->arguments->as<ASTExpressionList &>();


### PR DESCRIPTION
For translation unit: `StorageSystemZooKeeper`:

* Refactored some `ranged-for` loops to their standard library's equivalent.
  * _Long-term maintainability and testing of the codebase improves as the standard library abstraction is supported (by the C++ standards committee) for many future years ahead._

---
(EDIT: So, I have not so much personal preference in styles btw,) this PR only follows the suggestions for projects from:
* Sonarsource static analysis website: ["STL algorithms and range-based for loops should be preferred to traditional for loops"](https://rules.sonarsource.com/cpp/RSPEC-5566/) .
* On the recommended C++ Core Guidelines website:  [SL.1: Use libraries wherever possible](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rsl-lib), and especially [SL.2: Prefer the standard library to other libraries](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rsl-sl).
  _This PR's text is a more neutral version of SL.2's text._ :sweat_smile: 

---
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


