### PR TITLE
Respect library type for contrib libraries

### DIFF
--- a/contrib/lemmagen-c-cmake/CMakeLists.txt
+++ b/contrib/lemmagen-c-cmake/CMakeLists.txt
@@ -5,6 +5,6 @@ set(SRCS
     "${LIBRARY_DIR}/src/RdrLemmatizer.cpp"
 )
 
-add_library(_lemmagen STATIC ${SRCS})
+add_library(_lemmagen ${SRCS})
 target_include_directories(_lemmagen SYSTEM PUBLIC "${LEMMAGEN_INCLUDE_DIR}")
 add_library(ch_contrib::lemmagen ALIAS _lemmagen)

--- a/contrib/libstemmer-c-cmake/CMakeLists.txt
+++ b/contrib/libstemmer-c-cmake/CMakeLists.txt
@@ -27,6 +27,6 @@ FOREACH ( LINE ${_CONTENT} )
 endforeach ()
 
 # all the sources parsed. Now just add the lib
-add_library(_stemmer STATIC ${_SOURCES} ${_HEADERS} )
+add_library(_stemmer ${_SOURCES} ${_HEADERS} )
 target_include_directories(_stemmer SYSTEM PUBLIC "${STEMMER_INCLUDE_DIR}")
 add_library(ch_contrib::stemmer ALIAS _stemmer)

--- a/contrib/mariadb-connector-c-cmake/CMakeLists.txt
+++ b/contrib/mariadb-connector-c-cmake/CMakeLists.txt
@@ -239,7 +239,7 @@ endif()
 set(LIBMARIADB_SOURCES ${LIBMARIADB_SOURCES} ${CC_SOURCE_DIR}/libmariadb/mariadb_async.c ${CC_SOURCE_DIR}/libmariadb/ma_context.c)
 
 
-add_library(_mariadbclient STATIC ${LIBMARIADB_SOURCES})
+add_library(_mariadbclient ${LIBMARIADB_SOURCES})
 target_link_libraries(_mariadbclient ${SYSTEM_LIBS})
 
 target_include_directories(_mariadbclient PRIVATE ${CC_BINARY_DIR}/include-private)

--- a/contrib/rocksdb-cmake/CMakeLists.txt
+++ b/contrib/rocksdb-cmake/CMakeLists.txt
@@ -539,7 +539,7 @@ if(WITH_FOLLY_DISTRIBUTED_MUTEX)
     "${ROCKSDB_SOURCE_DIR}/third-party/folly/folly/synchronization/WaitOptions.cpp")
 endif()
 
-add_library(_rocksdb STATIC ${SOURCES})
+add_library(_rocksdb ${SOURCES})
 add_library(ch_contrib::rocksdb ALIAS _rocksdb)
 target_link_libraries(_rocksdb PRIVATE ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 # SYSTEM is required to overcome some issues


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The following libraries forces STATIC:
- rockdb
- libstemmer-c
- lemmagen
- mariadb-connector-c

This is a preparation for `USE_STATIC_LIBRARIES=OFF`