### PR TITLE
Remove columns list in columns transformer

### DIFF
--- a/src/Parsers/ASTColumnsMatcher.cpp
+++ b/src/Parsers/ASTColumnsMatcher.cpp
@@ -57,6 +57,8 @@ void ASTColumnsMatcher::setPattern(String pattern)
 
 bool ASTColumnsMatcher::isColumnMatching(const String & column_name) const
 {
+    if (!column_matcher)
+        throw Exception("Logical error in ASTColumnsMatcher: the regular expression is not set", ErrorCodes::LOGICAL_ERROR);
     return RE2::PartialMatch(column_name, *column_matcher);
 }
 

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1787,26 +1787,15 @@ bool ParserColumnsMatcher::parseImpl(Pos & pos, ASTPtr & node, Expected & expect
         return false;
     ++pos;
 
-    ASTPtr column_list;
     ASTPtr regex_node;
-    if (!columns_p.parse(pos, column_list, expected) && !regex.parse(pos, regex_node, expected))
-        return false;
 
     if (pos->type != TokenType::ClosingRoundBracket)
         return false;
     ++pos;
 
     auto res = std::make_shared<ASTColumnsMatcher>();
-    if (column_list)
-    {
-        res->column_list = column_list;
-        res->children.push_back(res->column_list);
-    }
-    else
-    {
-        res->setPattern(regex_node->as<ASTLiteral &>().value.get<String>());
-        res->children.push_back(regex_node);
-    }
+    res->setPattern(regex_node->as<ASTLiteral &>().value.get<String>());
+    res->children.push_back(regex_node);
 
     ParserColumnsTransformers transformers_p(allowed_transformers);
     ASTPtr transformer;

--- a/tests/queries/0_stateless/01470_columns_transformers.reference
+++ b/tests/queries/0_stateless/01470_columns_transformers.reference
@@ -68,25 +68,3 @@ SELECT
     j,
     k
 FROM columns_transformers
-220	18	347
-SELECT
-    sum(i),
-    sum(j),
-    sum(k)
-FROM columns_transformers
-100	10	100	10	324	10
-120	8	120	8	23	8
-SELECT
-    i,
-    j,
-    toFloat64(i),
-    toFloat64(j),
-    toFloat64(k),
-    j
-FROM columns_transformers
-[110]	[9]	[173.5]
-SELECT
-    quantiles(0.5)(i),
-    quantiles(0.5)(j),
-    quantiles(0.5)(k)
-FROM columns_transformers

--- a/tests/queries/0_stateless/01470_columns_transformers.sql
+++ b/tests/queries/0_stateless/01470_columns_transformers.sql
@@ -41,16 +41,4 @@ EXPLAIN SYNTAX SELECT a.* APPLY(toDate) REPLACE(i + 1 AS i) APPLY(any) from colu
 -- Multiple REPLACE in a row
 EXPLAIN SYNTAX SELECT * REPLACE(i + 1 AS i) REPLACE(i + 1 AS i) from columns_transformers;
 
--- Explicit column list
-SELECT COLUMNS(i, j, k) APPLY(sum) from columns_transformers;
-EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(sum) from columns_transformers;
-
--- Multiple column matchers and transformers
-SELECT i, j, COLUMNS(i, j, k) APPLY(toFloat64), COLUMNS(i, j) EXCEPT (i) from columns_transformers;
-EXPLAIN SYNTAX SELECT i, j, COLUMNS(i, j, k) APPLY(toFloat64), COLUMNS(i, j) EXCEPT (i) from columns_transformers;
-
--- APPLY with parameterized function
-SELECT COLUMNS(i, j, k) APPLY(quantiles(0.5)) from columns_transformers;
-EXPLAIN SYNTAX SELECT COLUMNS(i, j, k) APPLY(quantiles(0.5)) from columns_transformers;
-
 DROP TABLE columns_transformers;


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove a feature of `COLUMNS` matcher with explicit list (`SELECT COLUMNS(a, b, c)`), because it can trigger null pointer dereference. Closes #36416.