### PR TITLE
Fixed warnings of clang-tidy check "bugprone-branch-clone"

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -125,13 +125,9 @@ std::vector<String> Client::loadWarningMessages()
                 continue;
 
             case Protocol::Server::Progress:
-                continue;
             case Protocol::Server::ProfileInfo:
-                continue;
             case Protocol::Server::Totals:
-                continue;
             case Protocol::Server::Extremes:
-                continue;
             case Protocol::Server::Log:
                 continue;
 

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -849,8 +849,8 @@ Packet Connection::receivePacket()
 
         switch (res.type)
         {
-            case Protocol::Server::Data: [[fallthrough]];
-            case Protocol::Server::Totals: [[fallthrough]];
+            case Protocol::Server::Data:
+            case Protocol::Server::Totals:
             case Protocol::Server::Extremes:
                 res.block = receiveData();
                 return res;

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -392,9 +392,9 @@ Packet LocalConnection::receivePacket()
     packet.type = next_packet_type.value();
     switch (next_packet_type.value())
     {
-        case Protocol::Server::Totals: [[fallthrough]];
-        case Protocol::Server::Extremes: [[fallthrough]];
-        case Protocol::Server::Log: [[fallthrough]];
+        case Protocol::Server::Totals:
+        case Protocol::Server::Extremes:
+        case Protocol::Server::Log:
         case Protocol::Server::Data:
         case Protocol::Server::ProfileEvents:
         {

--- a/src/Client/Suggest.cpp
+++ b/src/Client/Suggest.cpp
@@ -144,15 +144,10 @@ void Suggest::fetch(IServerConnection & connection, const ConnectionTimeouts & t
                 continue;
 
             case Protocol::Server::Progress:
-                continue;
             case Protocol::Server::ProfileInfo:
-                continue;
             case Protocol::Server::Totals:
-                continue;
             case Protocol::Server::Extremes:
-                continue;
             case Protocol::Server::Log:
-                continue;
             case Protocol::Server::ProfileEvents:
                 continue;
 

--- a/src/Common/IntervalKind.cpp
+++ b/src/Common/IntervalKind.cpp
@@ -13,9 +13,9 @@ Int32 IntervalKind::toAvgSeconds() const
 {
     switch (kind)
     {
-        case IntervalKind::Nanosecond: return 0;    /// fractional parts of seconds have 0 seconds
-        case IntervalKind::Microsecond: return 0;
-        case IntervalKind::Millisecond: return 0;
+        case IntervalKind::Nanosecond:
+        case IntervalKind::Microsecond:
+        case IntervalKind::Millisecond: return 0; /// fractional parts of seconds have 0 seconds
         case IntervalKind::Second: return 1;
         case IntervalKind::Minute: return 60;
         case IntervalKind::Hour: return 3600;

--- a/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
+++ b/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
@@ -78,9 +78,9 @@ void insertPostgreSQLValue(
         case ExternalResultDescription::ValueType::vtFloat64:
             assert_cast<ColumnFloat64 &>(column).insertValue(pqxx::from_string<double>(value));
             break;
-        case ExternalResultDescription::ValueType::vtEnum8:[[fallthrough]];
-        case ExternalResultDescription::ValueType::vtEnum16:[[fallthrough]];
-        case ExternalResultDescription::ValueType::vtFixedString:[[fallthrough]];
+        case ExternalResultDescription::ValueType::vtEnum8:
+        case ExternalResultDescription::ValueType::vtEnum16:
+        case ExternalResultDescription::ValueType::vtFixedString:
         case ExternalResultDescription::ValueType::vtString:
             assert_cast<ColumnString &>(column).insertData(value.data(), value.size());
             break;

--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -525,8 +525,8 @@ DataTypePtr getDefaultDataTypeForEscapingRule(FormatSettings::EscapingRule escap
 {
     switch (escaping_rule)
     {
-        case FormatSettings::EscapingRule::CSV: [[fallthrough]];
-        case FormatSettings::EscapingRule::Escaped: [[fallthrough]];
+        case FormatSettings::EscapingRule::CSV:
+        case FormatSettings::EscapingRule::Escaped:
         case FormatSettings::EscapingRule::Raw:
             return makeNullable(std::make_shared<DataTypeString>());
         default:

--- a/src/Formats/ProtobufSerializer.cpp
+++ b/src/Formats/ProtobufSerializer.cpp
@@ -3362,12 +3362,12 @@ namespace
 
         switch (field_descriptor->type())
         {
-            case FieldTypeId::TYPE_SFIXED32: [[fallthrough]];
-            case FieldTypeId::TYPE_SINT32: [[fallthrough]];
+            case FieldTypeId::TYPE_SFIXED32:
+            case FieldTypeId::TYPE_SINT32:
             case FieldTypeId::TYPE_INT32:
                 return {field_descriptor->name(), std::make_shared<DataTypeInt32>()};
-            case FieldTypeId::TYPE_SFIXED64: [[fallthrough]];
-            case FieldTypeId::TYPE_SINT64: [[fallthrough]];
+            case FieldTypeId::TYPE_SFIXED64:
+            case FieldTypeId::TYPE_SINT64:
             case FieldTypeId::TYPE_INT64:
                 return {field_descriptor->name(), std::make_shared<DataTypeInt64>()};
             case FieldTypeId::TYPE_BOOL:
@@ -3376,13 +3376,13 @@ namespace
                 return {field_descriptor->name(), std::make_shared<DataTypeFloat32>()};
             case FieldTypeId::TYPE_DOUBLE:
                 return {field_descriptor->name(), std::make_shared<DataTypeFloat64>()};
-            case FieldTypeId::TYPE_UINT32: [[fallthrough]];
+            case FieldTypeId::TYPE_UINT32:
             case FieldTypeId::TYPE_FIXED32:
                 return {field_descriptor->name(), std::make_shared<DataTypeUInt32>()};
-            case FieldTypeId::TYPE_UINT64: [[fallthrough]];
+            case FieldTypeId::TYPE_UINT64:
             case FieldTypeId::TYPE_FIXED64:
                 return {field_descriptor->name(), std::make_shared<DataTypeUInt64>()};
-            case FieldTypeId::TYPE_BYTES: [[fallthrough]];
+            case FieldTypeId::TYPE_BYTES:
             case FieldTypeId::TYPE_STRING:
                 return {field_descriptor->name(), std::make_shared<DataTypeString>()};
             case FieldTypeId::TYPE_ENUM:
@@ -3403,7 +3403,7 @@ namespace
                 else
                     throw Exception("ClickHouse supports only 8-bit and 16-bit enums", ErrorCodes::BAD_ARGUMENTS);
             }
-            case FieldTypeId::TYPE_GROUP: [[fallthrough]];
+            case FieldTypeId::TYPE_GROUP:
             case FieldTypeId::TYPE_MESSAGE:
             {
                 const auto * message_descriptor = field_descriptor->message_type();

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -324,7 +324,6 @@ void AggregatedDataVariants::init(Type type_, std::optional<size_t> size_hint)
     switch (type_)
     {
         case Type::EMPTY:
-            break;
         case Type::without_key:
             break;
 

--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -401,9 +401,9 @@ AccessRightsElements InterpreterAlterQuery::getRequiredAccessForCommand(const AS
             required_access.emplace_back(AccessType::ALTER_FETCH_PARTITION, database, table);
             break;
         }
-        case ASTAlterCommand::FREEZE_PARTITION: [[fallthrough]];
-        case ASTAlterCommand::FREEZE_ALL: [[fallthrough]];
-        case ASTAlterCommand::UNFREEZE_PARTITION: [[fallthrough]];
+        case ASTAlterCommand::FREEZE_PARTITION:
+        case ASTAlterCommand::FREEZE_ALL:
+        case ASTAlterCommand::UNFREEZE_PARTITION:
         case ASTAlterCommand::UNFREEZE_ALL:
         {
             required_access.emplace_back(AccessType::ALTER_FREEZE_PARTITION, database, table);

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -767,18 +767,18 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
 
     switch (query.type)
     {
-        case Type::SHUTDOWN: [[fallthrough]];
-        case Type::KILL: [[fallthrough]];
+        case Type::SHUTDOWN:
+        case Type::KILL:
         case Type::SUSPEND:
         {
             required_access.emplace_back(AccessType::SYSTEM_SHUTDOWN);
             break;
         }
-        case Type::DROP_DNS_CACHE: [[fallthrough]];
-        case Type::DROP_MARK_CACHE: [[fallthrough]];
-        case Type::DROP_MMAP_CACHE: [[fallthrough]];
+        case Type::DROP_DNS_CACHE:
+        case Type::DROP_MARK_CACHE:
+        case Type::DROP_MMAP_CACHE:
 #if USE_EMBEDDED_COMPILER
-        case Type::DROP_COMPILED_EXPRESSION_CACHE: [[fallthrough]];
+        case Type::DROP_COMPILED_EXPRESSION_CACHE:
 #endif
         case Type::DROP_UNCOMPRESSED_CACHE:
         case Type::DROP_INDEX_MARK_CACHE:
@@ -788,20 +788,20 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
             required_access.emplace_back(AccessType::SYSTEM_DROP_CACHE);
             break;
         }
-        case Type::RELOAD_DICTIONARY: [[fallthrough]];
-        case Type::RELOAD_DICTIONARIES: [[fallthrough]];
+        case Type::RELOAD_DICTIONARY:
+        case Type::RELOAD_DICTIONARIES:
         case Type::RELOAD_EMBEDDED_DICTIONARIES:
         {
             required_access.emplace_back(AccessType::SYSTEM_RELOAD_DICTIONARY);
             break;
         }
-        case Type::RELOAD_MODEL: [[fallthrough]];
+        case Type::RELOAD_MODEL:
         case Type::RELOAD_MODELS:
         {
             required_access.emplace_back(AccessType::SYSTEM_RELOAD_MODEL);
             break;
         }
-        case Type::RELOAD_FUNCTION: [[fallthrough]];
+        case Type::RELOAD_FUNCTION:
         case Type::RELOAD_FUNCTIONS:
         {
             required_access.emplace_back(AccessType::SYSTEM_RELOAD_FUNCTION);
@@ -817,7 +817,7 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
             required_access.emplace_back(AccessType::SYSTEM_RELOAD_SYMBOLS);
             break;
         }
-        case Type::STOP_MERGES: [[fallthrough]];
+        case Type::STOP_MERGES:
         case Type::START_MERGES:
         {
             if (!query.table)
@@ -826,7 +826,7 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
                 required_access.emplace_back(AccessType::SYSTEM_MERGES, query.getDatabase(), query.getTable());
             break;
         }
-        case Type::STOP_TTL_MERGES: [[fallthrough]];
+        case Type::STOP_TTL_MERGES:
         case Type::START_TTL_MERGES:
         {
             if (!query.table)
@@ -835,7 +835,7 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
                 required_access.emplace_back(AccessType::SYSTEM_TTL_MERGES, query.getDatabase(), query.getTable());
             break;
         }
-        case Type::STOP_MOVES: [[fallthrough]];
+        case Type::STOP_MOVES:
         case Type::START_MOVES:
         {
             if (!query.table)
@@ -844,7 +844,7 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
                 required_access.emplace_back(AccessType::SYSTEM_MOVES, query.getDatabase(), query.getTable());
             break;
         }
-        case Type::STOP_FETCHES: [[fallthrough]];
+        case Type::STOP_FETCHES:
         case Type::START_FETCHES:
         {
             if (!query.table)
@@ -853,7 +853,7 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
                 required_access.emplace_back(AccessType::SYSTEM_FETCHES, query.getDatabase(), query.getTable());
             break;
         }
-        case Type::STOP_DISTRIBUTED_SENDS: [[fallthrough]];
+        case Type::STOP_DISTRIBUTED_SENDS:
         case Type::START_DISTRIBUTED_SENDS:
         {
             if (!query.table)
@@ -862,7 +862,7 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
                 required_access.emplace_back(AccessType::SYSTEM_DISTRIBUTED_SENDS, query.getDatabase(), query.getTable());
             break;
         }
-        case Type::STOP_REPLICATED_SENDS: [[fallthrough]];
+        case Type::STOP_REPLICATED_SENDS:
         case Type::START_REPLICATED_SENDS:
         {
             if (!query.table)
@@ -871,7 +871,7 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
                 required_access.emplace_back(AccessType::SYSTEM_REPLICATED_SENDS, query.getDatabase(), query.getTable());
             break;
         }
-        case Type::STOP_REPLICATION_QUEUES: [[fallthrough]];
+        case Type::STOP_REPLICATION_QUEUES:
         case Type::START_REPLICATION_QUEUES:
         {
             if (!query.table)
@@ -920,11 +920,11 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
             required_access.emplace_back(AccessType::SYSTEM_RESTART_DISK);
             break;
         }
-        case Type::STOP_LISTEN_QUERIES: break;
-        case Type::START_LISTEN_QUERIES: break;
-        case Type::STOP_THREAD_FUZZER: break;
-        case Type::START_THREAD_FUZZER: break;
-        case Type::UNKNOWN: break;
+        case Type::STOP_LISTEN_QUERIES:
+        case Type::START_LISTEN_QUERIES:
+        case Type::STOP_THREAD_FUZZER:
+        case Type::START_THREAD_FUZZER:
+        case Type::UNKNOWN:
         case Type::END: break;
     }
     return required_access;

--- a/src/Parsers/ASTTablesInSelectQuery.cpp
+++ b/src/Parsers/ASTTablesInSelectQuery.cpp
@@ -158,7 +158,6 @@ void ASTTableJoin::formatImplBeforeTable(const FormatSettings & settings, Format
     switch (locality)
     {
         case Locality::Unspecified:
-            break;
         case Locality::Local:
             break;
         case Locality::Global:

--- a/src/Parsers/Lexer.cpp
+++ b/src/Parsers/Lexer.cpp
@@ -72,11 +72,11 @@ Token Lexer::nextTokenImpl()
 
     switch (*pos)
     {
-        case ' ': [[fallthrough]];
-        case '\t': [[fallthrough]];
-        case '\n': [[fallthrough]];
-        case '\r': [[fallthrough]];
-        case '\f': [[fallthrough]];
+        case ' ':
+        case '\t':
+        case '\n':
+        case '\r':
+        case '\f':
         case '\v':
         {
             ++pos;
@@ -85,15 +85,15 @@ Token Lexer::nextTokenImpl()
             return Token(TokenType::Whitespace, token_begin, pos);
         }
 
-        case '0': [[fallthrough]];
-        case '1': [[fallthrough]];
-        case '2': [[fallthrough]];
-        case '3': [[fallthrough]];
-        case '4': [[fallthrough]];
-        case '5': [[fallthrough]];
-        case '6': [[fallthrough]];
-        case '7': [[fallthrough]];
-        case '8': [[fallthrough]];
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
         case '9':
         {
             /// The task is not to parse a number or check correctness, but only to skip it.

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -386,8 +386,8 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(avro::Node
         }
         case avro::AVRO_SYMBOLIC:
             return createDeserializeFn(avro::resolveSymbol(root_node), target_type);
-        case avro::AVRO_MAP: [[fallthrough]];
-        case avro::AVRO_RECORD: [[fallthrough]];
+        case avro::AVRO_MAP:
+        case avro::AVRO_RECORD:
         default:
             break;
     }

--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -315,9 +315,7 @@ namespace
         switch (kind)
         {
             case IntervalKind::Nanosecond:
-                throw Exception("Fractional seconds are not supported by windows yet", ErrorCodes::SYNTAX_ERROR);
             case IntervalKind::Microsecond:
-                throw Exception("Fractional seconds are not supported by windows yet", ErrorCodes::SYNTAX_ERROR);
             case IntervalKind::Millisecond:
                 throw Exception("Fractional seconds are not supported by windows yet", ErrorCodes::SYNTAX_ERROR);
 #define CASE_WINDOW_KIND(KIND) \
@@ -752,9 +750,7 @@ UInt32 StorageWindowView::getWindowLowerBound(UInt32 time_sec)
     switch (window_interval_kind)
     {
         case IntervalKind::Nanosecond:
-            throw Exception("Fractional seconds are not supported by windows yet", ErrorCodes::SYNTAX_ERROR);
         case IntervalKind::Microsecond:
-            throw Exception("Fractional seconds are not supported by windows yet", ErrorCodes::SYNTAX_ERROR);
         case IntervalKind::Millisecond:
             throw Exception("Fractional seconds are not supported by windows yet", ErrorCodes::SYNTAX_ERROR);
 #define CASE_WINDOW_KIND(KIND) \
@@ -793,9 +789,7 @@ UInt32 StorageWindowView::getWindowUpperBound(UInt32 time_sec)
     switch (window_interval_kind)
     {
         case IntervalKind::Nanosecond:
-            throw Exception("Fractional seconds are not supported by window view yet", ErrorCodes::SYNTAX_ERROR);
         case IntervalKind::Microsecond:
-            throw Exception("Fractional seconds are not supported by window view yet", ErrorCodes::SYNTAX_ERROR);
         case IntervalKind::Millisecond:
             throw Exception("Fractional seconds are not supported by window view yet", ErrorCodes::SYNTAX_ERROR);
 


### PR DESCRIPTION
The check is currently *not* part of .clang-tidy. It complains about:
(1) "switch has multiple consecutive identical branches"
(2) "repeated branch in conditional chain"

On (1): Lots of findings in switches were about redundant
"[[fallthrough]]" in places where the compiler would not warn anyways. I
have cleaned these up.

On (2): In if-else_if-else chains, fixing the warning would usually
mean concatenating multiple if-conditions. As this would reduce
readability in most cases, I did not fix these places.

Because of (2), I also refrained from adding "bugprone-branch-clone" to
.clang-tidy.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)