### PR TITLE
Notion for integration tests to build with ENABLE_CLICKHOUSE_ALL=ON

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -61,6 +61,8 @@ set the following environment variables:
 * `CLICKHOUSE_TESTS_CLIENT_BIN_PATH` to choose the client binary.
 * `CLICKHOUSE_TESTS_BASE_CONFIG_DIR` to choose the directory from which base configs (`config.xml` and`users.xml`) are taken.
 
+Please note that if you use separate build (`ENABLE_CLICKHOUSE_ALL=OFF`), you need to build different components, including but not limited to `ENABLE_CLICKHOUSE_LIBRARY_BRIDGE=ON ENABLE_CLICKHOUSE_ODBC_BRIDGE=ON ENABLE_CLICKHOUSE_KEEPER=ON`. So it is easier to use `ENABLE_CLICKHOUSE_ALL=ON`
+
 For tests that use common docker compose files you may need to set up their path with environment variable: `DOCKER_COMPOSE_DIR=$HOME/ClickHouse/docker/test/integration/runner/compose`
 
 ### Running with runner script


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/


May save some time