### PR TITLE
Bad assert cause system crash in local cache

### DIFF
--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -650,7 +650,7 @@ void FileSegment::assertDetachedStatus() const
 {
     assert(
         (download_state == State::EMPTY) || (download_state == State::PARTIALLY_DOWNLOADED)
-        || (download_state == State::PARTIALLY_DOWNLOADED_NO_CONTINUATION) || (downloaded_stated == State::SKIP_CACHE));
+        || (download_state == State::PARTIALLY_DOWNLOADED_NO_CONTINUATION) || (download_state == State::SKIP_CACHE));
 }
 
 FileSegmentPtr FileSegment::getSnapshot(const FileSegmentPtr & file_segment, std::lock_guard<std::mutex> & /* cache_lock */)

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -561,6 +561,7 @@ void FileSegment::completeImpl(std::lock_guard<std::mutex> & cache_lock, std::lo
             * in FileSegmentsHolder represent a contiguous range, so we can resize
             * it only when nobody needs it.
             */
+            download_state = State::PARTIALLY_DOWNLOADED_NO_CONTINUATION;
             LOG_TEST(log, "Resize cell {} to downloaded: {}", range().toString(), current_downloaded_size);
             cache->reduceSizeToDownloaded(key(), offset(), cache_lock, segment_lock);
         }
@@ -649,8 +650,8 @@ void FileSegment::assertNotDetached() const
 void FileSegment::assertDetachedStatus() const
 {
     assert(
-        (download_state == State::EMPTY) || (download_state == State::PARTIALLY_DOWNLOADED)
-        || (download_state == State::PARTIALLY_DOWNLOADED_NO_CONTINUATION) || (download_state == State::SKIP_CACHE));
+        (download_state == State::EMPTY) || (download_state == State::PARTIALLY_DOWNLOADED_NO_CONTINUATION)
+        || (download_state == State::SKIP_CACHE));
 }
 
 FileSegmentPtr FileSegment::getSnapshot(const FileSegmentPtr & file_segment, std::lock_guard<std::mutex> & /* cache_lock */)

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -646,6 +646,13 @@ void FileSegment::assertNotDetached() const
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Operation not allowed, file segment is detached");
 }
 
+void FileSegment::assertDetachedStatus() const
+{
+    assert(
+        (download_state == State::EMPTY) || (download_state == State::PARTIALLY_DOWNLOADED)
+        || (download_state == State::PARTIALLY_DOWNLOADED_NO_CONTINUATION) || (downloaded_stated == State::SKIP_CACHE));
+}
+
 FileSegmentPtr FileSegment::getSnapshot(const FileSegmentPtr & file_segment, std::lock_guard<std::mutex> & /* cache_lock */)
 {
     auto snapshot = std::make_shared<FileSegment>(
@@ -683,7 +690,7 @@ FileSegmentsHolder::~FileSegmentsHolder()
         {
             /// This file segment is not owned by cache, so it will be destructed
             /// at this point, therefore no completion required.
-            assert(file_segment->state() == FileSegment::State::EMPTY);
+            file_segment->assertDetachedStatus();
             file_segment_it = file_segments.erase(current_file_segment_it);
             continue;
         }

--- a/src/Common/FileSegment.h
+++ b/src/Common/FileSegment.h
@@ -151,6 +151,7 @@ private:
     String getInfoForLogImpl(std::lock_guard<std::mutex> & segment_lock) const;
     void assertCorrectnessImpl(std::lock_guard<std::mutex> & segment_lock) const;
     void assertNotDetached() const;
+    void assertDetachedStatus() const;
 
     void setDownloaded(std::lock_guard<std::mutex> & segment_lock);
     void setDownloadFailed(std::lock_guard<std::mutex> & segment_lock);

--- a/src/Common/FileSegment.h
+++ b/src/Common/FileSegment.h
@@ -153,6 +153,7 @@ private:
     void assertNotDetached() const;
     void assertDetachedStatus() const;
 
+
     void setDownloaded(std::lock_guard<std::mutex> & segment_lock);
     void setDownloadFailed(std::lock_guard<std::mutex> & segment_lock);
     bool isDownloaderImpl(std::lock_guard<std::mutex> & segment_lock) const;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix

### Changelog entry:
In FileSegmentsHolder::~FileSegmentsHolder(), when a segment is set to detach, it will assert its state is empty. However, in FileSegment::completeImpl(), when detach is set to true, its state may be PARTIALLY_DOWNLOADED_NO_CONTINUATION or SKIP_CACHE or PARTIALLY_DOWNLOADED, thus cause error in FileSegmentsHolder::~FileSegmentsHolder().
```
if (file_segment->detached)
{
    /// This file segment is not owned by cache, so it will be destructed
    /// at this point, therefore no completion required.
    assert(file_segment->state() == FileSegment::State::EMPTY);
    file_segment_it = file_segments.erase(current_file_segment_it);
    continue;
}
```