### PR TITLE
fixed /common/example cow_compositions.cpp clone the inner column when there is no need

### DIFF
--- a/src/Common/examples/cow_compositions.cpp
+++ b/src/Common/examples/cow_compositions.cpp
@@ -52,7 +52,7 @@ private:
     {
         std::cerr << "Mutating\n";
         auto res = shallowMutate();
-        res->wrapped = IColumn::mutate(wrapped);
+        res->wrapped = IColumn::mutate(std::move(res->wrapped).detach());
         return res;
     }
 


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the /common/examples/cow_compositions.cpp, it will not clone the inner column when there is no need


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
