### PR TITLE
Refactoring dependency for ParserAttachAccessEntity

### DIFF
--- a/src/Access/AccessEntityIO.cpp
+++ b/src/Access/AccessEntityIO.cpp
@@ -16,6 +16,13 @@
 #include <Interpreters/Access/InterpreterGrantQuery.h>
 #include <Interpreters/Access/InterpreterShowCreateAccessEntityQuery.h>
 #include <Interpreters/Access/InterpreterShowGrantsQuery.h>
+#include <Parsers/Access/ASTCreateQuotaQuery.h>
+#include <Parsers/Access/ASTCreateRoleQuery.h>
+#include <Parsers/Access/ASTCreateRowPolicyQuery.h>
+#include <Parsers/Access/ASTCreateSettingsProfileQuery.h>
+#include <Parsers/Access/ASTCreateUserQuery.h>
+#include <Parsers/Access/ASTGrantQuery.h>
+#include <Parsers/ParserAttachAccessEntity.h>
 #include <Parsers/formatAST.h>
 #include <Parsers/parseQuery.h>
 #include <boost/range/algorithm/copy.hpp>

--- a/src/Access/AccessEntityIO.h
+++ b/src/Access/AccessEntityIO.h
@@ -1,50 +1,10 @@
 #pragma once
 
-#include <Parsers/Access/ASTCreateQuotaQuery.h>
-#include <Parsers/Access/ASTCreateRoleQuery.h>
-#include <Parsers/Access/ASTCreateRowPolicyQuery.h>
-#include <Parsers/Access/ASTCreateSettingsProfileQuery.h>
-#include <Parsers/Access/ASTCreateUserQuery.h>
-#include <Parsers/Access/ASTGrantQuery.h>
-#include <Parsers/Access/ParserCreateQuotaQuery.h>
-#include <Parsers/Access/ParserCreateRoleQuery.h>
-#include <Parsers/Access/ParserCreateRowPolicyQuery.h>
-#include <Parsers/Access/ParserCreateSettingsProfileQuery.h>
-#include <Parsers/Access/ParserCreateUserQuery.h>
-#include <Parsers/Access/ParserGrantQuery.h>
 #include <base/types.h>
 #include <memory>
 
 namespace DB
 {
-
-/// Special parser for the 'ATTACH access entity' queries.
-class ParserAttachAccessEntity : public IParserBase
-{
-protected:
-    const char * getName() const override { return "ATTACH access entity query"; }
-
-    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
-    {
-        ParserCreateUserQuery create_user_p;
-        ParserCreateRoleQuery create_role_p;
-        ParserCreateRowPolicyQuery create_policy_p;
-        ParserCreateQuotaQuery create_quota_p;
-        ParserCreateSettingsProfileQuery create_profile_p;
-        ParserGrantQuery grant_p;
-
-        create_user_p.useAttachMode();
-        create_role_p.useAttachMode();
-        create_policy_p.useAttachMode();
-        create_quota_p.useAttachMode();
-        create_profile_p.useAttachMode();
-        grant_p.useAttachMode();
-
-        return create_user_p.parse(pos, node, expected) || create_role_p.parse(pos, node, expected)
-            || create_policy_p.parse(pos, node, expected) || create_quota_p.parse(pos, node, expected)
-            || create_profile_p.parse(pos, node, expected) || grant_p.parse(pos, node, expected);
-    }
-};
 
 struct IAccessEntity;
 using AccessEntityPtr = std::shared_ptr<const IAccessEntity>;

--- a/src/Parsers/ParserAttachAccessEntity.cpp
+++ b/src/Parsers/ParserAttachAccessEntity.cpp
@@ -1,0 +1,33 @@
+#include <Parsers/ParserAttachAccessEntity.h>
+#include <Parsers/Access/ParserCreateQuotaQuery.h>
+#include <Parsers/Access/ParserCreateRoleQuery.h>
+#include <Parsers/Access/ParserCreateRowPolicyQuery.h>
+#include <Parsers/Access/ParserCreateSettingsProfileQuery.h>
+#include <Parsers/Access/ParserCreateUserQuery.h>
+#include <Parsers/Access/ParserGrantQuery.h>
+
+namespace DB
+{
+
+bool ParserAttachAccessEntity::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserCreateUserQuery create_user_p;
+    ParserCreateRoleQuery create_role_p;
+    ParserCreateRowPolicyQuery create_policy_p;
+    ParserCreateQuotaQuery create_quota_p;
+    ParserCreateSettingsProfileQuery create_profile_p;
+    ParserGrantQuery grant_p;
+
+    create_user_p.useAttachMode();
+    create_role_p.useAttachMode();
+    create_policy_p.useAttachMode();
+    create_quota_p.useAttachMode();
+    create_profile_p.useAttachMode();
+    grant_p.useAttachMode();
+
+    return create_user_p.parse(pos, node, expected) || create_role_p.parse(pos, node, expected)
+        || create_policy_p.parse(pos, node, expected) || create_quota_p.parse(pos, node, expected)
+        || create_profile_p.parse(pos, node, expected) || grant_p.parse(pos, node, expected);
+}
+
+}

--- a/src/Parsers/ParserAttachAccessEntity.h
+++ b/src/Parsers/ParserAttachAccessEntity.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Parsers/IParserBase.h>
+
+namespace DB
+{
+
+/// Special parser for the 'ATTACH access entity' queries.
+class ParserAttachAccessEntity : public IParserBase
+{
+protected:
+    const char * getName() const override { return "ATTACH access entity query"; }
+
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+
+};
+
+}

--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -3,13 +3,15 @@
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
+#include <Parsers/Access/ASTCreateUserQuery.h>
+#include <Parsers/Access/ParserCreateUserQuery.h>
 #include <Parsers/ParserAlterQuery.h>
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/ParserOptimizeQuery.h>
 #include <Parsers/ParserQueryWithOutput.h>
+#include <Parsers/ParserAttachAccessEntity.h>
 #include <Parsers/formatAST.h>
 #include <Parsers/parseQuery.h>
-#include "Access/AccessEntityIO.h"
 #include <string_view>
 #include <regex>
 #include <gtest/gtest.h>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

closes #36465
