### PR TITLE
Try to fix clickhouse-benchmark json report results

### DIFF
--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -548,11 +548,13 @@ private:
             json_out << double_quote << connections[i]->getDescription() << ": {\n";
             json_out << double_quote << "statistics" << ": {\n";
 
-            print_key_value("QPS", info->queries / info->work_time);
-            print_key_value("RPS", info->read_rows / info->work_time);
-            print_key_value("MiBPS", info->read_bytes / info->work_time);
-            print_key_value("RPS_result", info->result_rows / info->work_time);
-            print_key_value("MiBPS_result", info->result_bytes / info->work_time);
+            double seconds = info->work_time / concurrency;
+
+            print_key_value("QPS", info->queries.load() / seconds);
+            print_key_value("RPS", info->read_rows / seconds);
+            print_key_value("MiBPS", info->read_bytes / seconds);
+            print_key_value("RPS_result", info->result_rows / seconds);
+            print_key_value("MiBPS_result", info->result_bytes / seconds);
             print_key_value("num_queries", info->queries.load());
             print_key_value("num_errors", info->errors, false);
 

--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -552,9 +552,9 @@ private:
 
             print_key_value("QPS", info->queries.load() / seconds);
             print_key_value("RPS", info->read_rows / seconds);
-            print_key_value("MiBPS", info->read_bytes / seconds);
+            print_key_value("MiBPS", info->read_bytes / seconds / 1048576);
             print_key_value("RPS_result", info->result_rows / seconds);
-            print_key_value("MiBPS_result", info->result_bytes / seconds);
+            print_key_value("MiBPS_result", info->result_bytes / seconds / 1048576);
             print_key_value("num_queries", info->queries.load());
             print_key_value("num_errors", info->errors, false);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix clickhouse-benchmark json report results

### Description

Results in output json file of Clickhouse-benchmark are not the same with those print by the program directly on the console. 

For example, I ran a test with the command: `echo 'select 1' | clickhouse-benchmark -c 200 --timelimit=5 --delay=0 --json=test.json`. Results I got from console are as below:
```
Loaded 1 queries.
Stopping launch of queries. Requested time limit 5 seconds is exhausted.

Queries executed: 46281.

localhost:9000, queries 46281, QPS: 9357.354, RPS: 9357.354, MiB/s: 0.009, result RPS: 9357.354, result MiB/s: 0.009.

0.000%          0.001 sec.
10.000%         0.003 sec.
20.000%         0.007 sec.
30.000%         0.011 sec.
40.000%         0.015 sec.
50.000%         0.018 sec.
60.000%         0.021 sec.
70.000%         0.025 sec.
80.000%         0.030 sec.
90.000%         0.039 sec.
95.000%         0.054 sec.
99.000%         0.101 sec.
99.900%         0.202 sec.
99.990%         0.386 sec.
```
However, in the test.json, I got such results:
```
{
"localhost:9000": {
"statistics": {
"QPS": 46.78676925249166,
"RPS": 46.78676925249166,
"MiBPS": 46.78676925249166,
"RPS_result": 46.78676925249166,
"MiBPS_result": 46.78676925249166,
"num_queries": 46281,
"num_errors": 0
},
"query_time_percentiles": {
"0": 0.000569562,
"10": 0.00305056,
"20": 0.006975991,
"30": 0.011171956,
"40": 0.01465904,
"50": 0.017763954,
"60": 0.02096275,
"70": 0.024588324,
"80": 0.029603617,
"90": 0.039478898,
"95": 0.05363777,
"99": 0.101422735,
"99.9": 0.201863517,
"99.99": 0.385622063
}
}
}
```

After reading related codes, I found that the time computed in function `report` is not the same with function `reportJSON`. In `Benchmark::report`, the time is computed by `info->work_time / concurrency`, but it is directly `info->work_time` in function `Benchmark::reportJSON`, which should also be computed by `info->work_time / concurrency`. 
