### PR TITLE
Benchmark can read auth from environment variables

### DIFF
--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -655,6 +655,9 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             : Ports({default_port});
 
         Strings hosts = options.count("host") ? options["host"].as<Strings>() : Strings({"localhost"});
+        
+        const char * env_user = getenv("CLICKHOUSE_USER");
+        const char * env_password = getenv("CLICKHOUSE_PASSWORD");
 
         Benchmark benchmark(
             options["concurrency"].as<unsigned>(),
@@ -665,8 +668,8 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             options.count("cumulative"),
             options.count("secure"),
             options["database"].as<std::string>(),
-            options["user"].as<std::string>(),
-            options["password"].as<std::string>(),
+            env_user ? env_user : options["user"].as<std::string>(),
+            env_password ? env_password : options["password"].as<std::string>(),            
             options["stage"].as<std::string>(),
             options["randomize"].as<bool>(),
             options["iterations"].as<size_t>(),


### PR DESCRIPTION
This change makes clickhouse-benchmark more compatible with clickhouse-client by allowing it to use
CLICKHOUSE_USER and CLICKHOUSE_PASSWORD from environment variables.

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
clickhouse-benchmark can read auth from environment variables


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
