### PR TITLE
Fix to properly handle inserting and removing columns with duplicate names in a Block

### DIFF
--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -174,11 +174,16 @@ void Block::insert(ColumnWithTypeAndName elem)
         throw Exception("Column name in Block cannot be empty", ErrorCodes::AMBIGUOUS_COLUMN_NAME);
 
     auto [it, inserted] = index_by_name.emplace(elem.name, data.size());
-    if (!inserted)
+    if (inserted)
+    {
+        data.emplace_back(std::move(elem));
+    }
+    else
+    {
         checkColumnStructure<void>(data[it->second], elem,
             "(columns with identical name must have identical structure)", true, ErrorCodes::AMBIGUOUS_COLUMN_NAME);
-
-    data.emplace_back(std::move(elem));
+        data[it->second] = std::move(elem);
+    }
 }
 
 

--- a/src/Core/Block.h
+++ b/src/Core/Block.h
@@ -26,7 +26,7 @@ class Block
 {
 private:
     using Container = ColumnsWithTypeAndName;
-    using IndexByName = std::unordered_map<String, size_t>;
+    using IndexByName = std::unordered_map<String, std::list<size_t>>;
 
     Container data;
     IndexByName index_by_name;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
