### PR TITLE
Fix exception catch in IDiskRemote

### DIFF
--- a/src/Disks/IDiskRemote.cpp
+++ b/src/Disks/IDiskRemote.cpp
@@ -364,9 +364,9 @@ void IDiskRemote::getRemotePathsRecursive(const String & local_path, std::vector
         {
             paths_map.emplace_back(local_path, getRemotePaths(local_path));
         }
-        catch (const Exception & e)
+        catch (const ErrnoException & e)
         {
-            if (e.code() == ErrorCodes::FILE_DOESNT_EXIST)
+            if (e.getErrno() == ENOENT)
                 return;
             throw;
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Looks like still not fixed: 
```
2022-04-22 01:34:40 [bf8255b9e2cb] 2022.04.22 01:34:40.059045 [ 22486 ] {c3652945-a52b-42af-ab9d-ca46bcbe27bc}  void DB::IDiskRemote::Metadata::load(): Code: 107. DB::ErrnoException: Cannot open file /var/lib/clickhouse/disks/s3/store/4f7/4f76ecf5-f49d-48eb-8075-f82b652254b3/all_1_1_0/primary.idx, errno: 2, strerror: No such file or directory. (FILE_DOESNT_EXIST), Stack trace (when copying this message, always include the lines below):
2022-04-22 01:34:40 
2022-04-22 01:34:40 0. DB::Exception::Exception(std::__1::basic_string, std::__1::allocator > const&, int, bool) @ 0xb6fb0ba in /usr/bin/clickhouse
2022-04-22 01:34:40 1. DB::throwFromErrnoWithPath(std::__1::basic_string, std::__1::allocator > const&, std::__1::basic_string, std::__1::allocator > const&, int, int) @ 0xb6fc58a in /usr/bin/clickhouse
2022-04-22 01:34:40 2. DB::OpenedFile::open(int) @ 0x1533ea2b in /usr/bin/clickhouse
2022-04-22 01:34:40 3. DB::OpenedFileCache::get(std::__1::basic_string, std::__1::allocator > const&, int) @ 0x1533d2d5 in /usr/bin/clickhouse
2022-04-22 01:34:40 4. DB::ReadBufferFromFilePReadWithDescriptorsCache::ReadBufferFromFilePReadWithDescriptorsCache(std::__1::basic_string, std::__1::allocator > const&, unsigned long, int, char*, unsigned long, std::__1::optional) @ 0x1533cf1f in /usr/bin/clickhouse
2022-04-22 01:34:40 5. ? @ 0x1533c690 in /usr/bin/clickhouse
2022-04-22 01:34:40 6. DB::createReadBufferFromFileBase(std::__1::basic_string, std::__1::allocator > const&, DB::ReadSettings const&, std::__1::optional, std::__1::optional, int, char*, unsigned long) @ 0x1533c555 in /usr/bin/clickhouse
2022-04-22 01:34:40 7. DB::DiskLocal::readFile(std::__1::basic_string, std::__1::allocator > const&, DB::ReadSettings const&, std::__1::optional, std::__1::optional) const @ 0x159bbac8 in /usr/bin/clickhouse
2022-04-22 01:34:40 8. DB::IDiskRemote::Metadata::load() @ 0x159d0589 in /usr/bin/clickhouse
2022-04-22 01:34:40 9. DB::IDiskRemote::Metadata::readMetadata(std::__1::basic_string, std::__1::allocator > const&, std::__1::shared_ptr, std::__1::basic_string, std::__1::allocator > const&) @ 0x159d0410 in /usr/bin/clickhouse
2022-04-22 01:34:40 10. DB::IDiskRemote::getRemotePaths(std::__1::basic_string, std::__1::allocator > const&) const @ 0x159d385c in /usr/bin/clickhouse
2022-04-22 01:34:40 11. DB::IDiskRemote::getRemotePathsRecursive(std::__1::basic_string, std::__1::allocator > const&, std::__1::vector, std::__1::allocator >, std::__1::vector, std::__1::allocator >, std::__1::allocator, std::__1::allocator > > > >, std::__1::allocator, std::__1::allocator >, std::__1::vector, std::__1::allocator >, std::__1::allocator, std::__1::allocator > > > > > >&) @ 0x159d3c9a in /usr/bin/clickhouse

```