### PR TITLE
Fix 01161_all_system_tables

### DIFF
--- a/tests/queries/0_stateless/01129_dict_get_join_lose_constness.sql
+++ b/tests/queries/0_stateless/01129_dict_get_join_lose_constness.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel
+
 DROP DICTIONARY IF EXISTS system.dict1;
 
 CREATE DICTIONARY IF NOT EXISTS system.dict1

--- a/tests/queries/0_stateless/01161_all_system_tables.sh
+++ b/tests/queries/0_stateless/01161_all_system_tables.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+
+# Server may ignore some exceptions, but it still print exceptions to logs and (at least in CI) sends Error and Warning log messages to client
+# making test fail because of non-empty stderr. Ignore such log messages.
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01161_all_system_tables.sh
+++ b/tests/queries/0_stateless/01161_all_system_tables.sh
@@ -14,10 +14,9 @@ LIMIT=10000
 
 function run_selects()
 {
-    # NOTE sistem.dist1 is from 01129_dict_get_join_lose_constness, let's ignore it
     thread_num=$1
     readarray -t tables_arr < <(${CLICKHOUSE_CLIENT} -q "SELECT database || '.' || name FROM system.tables
-    WHERE database in ('system', 'information_schema', 'INFORMATION_SCHEMA') and name!='zookeeper' and name!='merge_tree_metadata_cache' and name != 'dict1'
+    WHERE database in ('system', 'information_schema', 'INFORMATION_SCHEMA') and name!='zookeeper' and name!='merge_tree_metadata_cache'
     AND sipHash64(name || toString($RAND)) % $THREADS = $thread_num")
 
     for t in "${tables_arr[@]}"

--- a/tests/queries/0_stateless/01161_all_system_tables.sh
+++ b/tests/queries/0_stateless/01161_all_system_tables.sh
@@ -14,9 +14,10 @@ LIMIT=10000
 
 function run_selects()
 {
+    # NOTE sistem.dist1 is from 01129_dict_get_join_lose_constness, let's ignore it
     thread_num=$1
     readarray -t tables_arr < <(${CLICKHOUSE_CLIENT} -q "SELECT database || '.' || name FROM system.tables
-    WHERE database in ('system', 'information_schema', 'INFORMATION_SCHEMA') and name!='zookeeper' and name!='merge_tree_metadata_cache'
+    WHERE database in ('system', 'information_schema', 'INFORMATION_SCHEMA') and name!='zookeeper' and name!='merge_tree_metadata_cache' and name != 'dict1'
     AND sipHash64(name || toString($RAND)) % $THREADS = $thread_num")
 
     for t in "${tables_arr[@]}"

--- a/tests/queries/0_stateless/01161_all_system_tables.sh
+++ b/tests/queries/0_stateless/01161_all_system_tables.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Based on the [logs](https://s3.amazonaws.com/clickhouse-test-reports/36439/04e3356d509ea3e562e3455f1ca7f0c4cbf652e5/stateless_tests__release__databasereplicated__actions__[2/2].html) the mistake seems to be related to parallel execution of the test.

The strange part was that it already had `no-parallel` tag but based on the `clickhouse-test` code it needs to be either first line or instantly after shebang.

cc @kssenii (you added the tag so you're probably aware how test works in detail)

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
