### PR TITLE
Fixed integer overflow in toStartOfInterval

### DIFF
--- a/src/Functions/toStartOfInterval.cpp
+++ b/src/Functions/toStartOfInterval.cpp
@@ -21,6 +21,7 @@ namespace ErrorCodes
     extern const int ILLEGAL_COLUMN;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int ARGUMENT_OUT_OF_BOUND;
+    extern const int DECIMAL_OVERFLOW;
 }
 
 

--- a/src/Functions/toStartOfInterval.cpp
+++ b/src/Functions/toStartOfInterval.cpp
@@ -1,3 +1,4 @@
+#include <base/arithmeticOverflow.h>
 #include <Common/DateLUTImpl.h>
 #include <Columns/ColumnsNumber.h>
 #include <DataTypes/DataTypeDate.h>
@@ -217,7 +218,9 @@ namespace
         {
             if (scale_multiplier < 1000)
             {
-                Int64 t_milliseconds = t * (static_cast<Int64>(1000) / scale_multiplier);
+                Int64 t_milliseconds = 0;
+                if (common::mulOverflow(t, static_cast<Int64>(1000) / scale_multiplier, t_milliseconds))
+                    throw DB::Exception("Numeric overflow", ErrorCodes::DECIMAL_OVERFLOW);
                 if (likely(t >= 0))
                     return t_milliseconds / milliseconds * milliseconds;
                 else
@@ -252,7 +255,9 @@ namespace
         {
             if (scale_multiplier < 1000000)
             {
-                Int64 t_microseconds = t * (static_cast<Int64>(1000000) / scale_multiplier);
+                Int64 t_microseconds = 0;
+                if (common::mulOverflow(t, static_cast<Int64>(1000000) / scale_multiplier, t_microseconds))
+                    throw DB::Exception("Numeric overflow", ErrorCodes::DECIMAL_OVERFLOW);
                 if (likely(t >= 0))
                     return t_microseconds / microseconds * microseconds;
                 else
@@ -287,7 +292,9 @@ namespace
         {
             if (scale_multiplier < 1000000000)
             {
-                Int64 t_nanoseconds = t * (static_cast<Int64>(1000000000) / scale_multiplier);
+                Int64 t_nanoseconds = 0;
+                if (common::mulOverflow(t, (static_cast<Int64>(1000000000) / scale_multiplier), t_nanoseconds))
+                    throw DB::Exception("Numeric overflow", ErrorCodes::DECIMAL_OVERFLOW);
                 if (likely(t >= 0))
                     return t_nanoseconds / nanoseconds * nanoseconds;
                 else

--- a/tests/queries/0_stateless/02269_to_start_of_interval_overflow.sql
+++ b/tests/queries/0_stateless/02269_to_start_of_interval_overflow.sql
@@ -1,0 +1,6 @@
+select toStartOfInterval(toDateTime64('\0930-12-12 12:12:12.1234567', 3), toIntervalNanosecond(1024)); -- {serverError 407}
+
+SELECT
+    toDateTime64(-9223372036854775808, 1048575, toIntervalNanosecond(9223372036854775806), NULL),
+    toStartOfInterval(toDateTime64(toIntervalNanosecond(toIntervalNanosecond(257), toDateTime64(toStartOfInterval(toDateTime64(NULL)))), '', 100), toIntervalNanosecond(toStartOfInterval(toDateTime64(toIntervalNanosecond(NULL), NULL)), -1)),
+    toStartOfInterval(toDateTime64('\0930-12-12 12:12:12.1234567', 3), toIntervalNanosecond(1024)); -- {serverError 407}


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):



> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
