### PR TITLE
Use just index to split performance tests by group

### DIFF
--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -211,13 +211,8 @@ function run_tests
     if [ -v CHPC_TEST_RUN_BY_HASH_TOTAL ]; then
         # filter tests array in bash https://stackoverflow.com/a/40375567
         for index in "${!test_files[@]}"; do
-            # sorry for this, just calculating hash(test_name) % total_tests_group == my_test_group_num
-            test_hash_result=$(echo test_files[$index] | perl -ne 'use Digest::MD5 qw(md5); print unpack('Q', md5($_)) % $ENV{CHPC_TEST_RUN_BY_HASH_TOTAL} == $ENV{CHPC_TEST_RUN_BY_HASH_NUM};')
-            # BTW, for some reason when hash(test_name) % total_tests_group != my_test_group_num perl outputs nothing, not zero
-            if [ "$test_hash_result" != "1" ]; then
-                # deleting element from array
+            [ $(( index % CHPC_TEST_RUN_BY_HASH_TOTAL )) != "$CHPC_TEST_RUN_BY_HASH_NUM" ] && \
                 unset -v 'test_files[$index]'
-            fi
         done
         # to have sequential indexes...
         test_files=("${test_files[@]}")

--- a/tests/performance/file_table_function.xml
+++ b/tests/performance/file_table_function.xml
@@ -31,24 +31,24 @@
 
     <query>
         INSERT INTO FUNCTION file('test_file', '{format}', 'key UInt64, value UInt64')
-        SELECT number, number FROM numbers(1000000)
+        SELECT number, number FROM numbers(50000)
     </query>
 
     <query>
         INSERT INTO FUNCTION file('test_file', '{format}', 'key UInt64, value1 UInt64, value2 UInt64, value3 UInt64, value4 UInt64, value5 UInt64')
-        SELECT number, number, number, number, number, number FROM numbers(1000000)
+        SELECT number, number, number, number, number, number FROM numbers(50000)
     </query>
 
     <query>
         INSERT INTO FUNCTION file('test_file_{{_partition_id}}', '{format}', 'partition_id UInt64, value UInt64')
         PARTITION BY partition_id
-        SELECT (number % {partitions_count}) as partition_id, number FROM numbers(1000000)
+        SELECT (number % {partitions_count}) as partition_id, number FROM numbers(50000)
     </query>
 
     <query>
         INSERT INTO FUNCTION file('test_file_{{_partition_id}}', '{format}', 'partition_id UInt64, value1 UInt64, value2 UInt64, value3 UInt64, value4 UInt64, value5 UInt64')
         PARTITION BY partition_id
-        SELECT (number % {partitions_count}) as partition_id, number, number, number, number, number FROM numbers(1000000)
+        SELECT (number % {partitions_count}) as partition_id, number, number, number, number, number FROM numbers(50000)
     </query>
 
 </test>

--- a/tests/performance/file_table_function.xml
+++ b/tests/performance/file_table_function.xml
@@ -31,14 +31,15 @@
 
     <query>
         INSERT INTO FUNCTION file('test_file', '{format}', 'key UInt64, value UInt64')
-        SELECT number, number FROM numbers(50000)
+        SELECT number, number FROM numbers(10000000)
     </query>
 
     <query>
         INSERT INTO FUNCTION file('test_file', '{format}', 'key UInt64, value1 UInt64, value2 UInt64, value3 UInt64, value4 UInt64, value5 UInt64')
-        SELECT number, number, number, number, number, number FROM numbers(50000)
+        SELECT number, number, number, number, number, number FROM numbers(1000000)
     </query>
 
+    <!-- Disabled in 36538, broken now
     <query>
         INSERT INTO FUNCTION file('test_file_{{_partition_id}}', '{format}', 'partition_id UInt64, value UInt64')
         PARTITION BY partition_id
@@ -50,5 +51,6 @@
         PARTITION BY partition_id
         SELECT (number % {partitions_count}) as partition_id, number, number, number, number, number FROM numbers(50000)
     </query>
+    -->
 
 </test>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now tests are imbalanced, let's see if it will help