### PR TITLE
Fix CAST Object to Object with Nullable subcolumns

### DIFF
--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -3283,6 +3283,19 @@ private:
                 return res;
             };
         }
+        else if (checkAndGetDataType<DataTypeObject>(from_type.get()))
+        {
+            return [is_nullable = to_type->hasNullableSubcolumns()] (ColumnsWithTypeAndName & arguments, const DataTypePtr & , const ColumnNullable * , size_t) -> ColumnPtr
+            {
+                auto & column_object = assert_cast<const ColumnObject &>(*arguments.front().column);
+                auto res = ColumnObject::create(is_nullable);
+                for (size_t i = 0; i < column_object.size(); i++)
+                    res->insert(column_object[i]);
+
+                res->finalize();
+                return res;
+            };
+        }
 
         throw Exception(ErrorCodes::TYPE_MISMATCH,
             "Cast to Object can be performed only from flatten named Tuple, Map or String. Got: {}", from_type->getName());

--- a/tests/queries/0_stateless/02287_type_object_convert.reference
+++ b/tests/queries/0_stateless/02287_type_object_convert.reference
@@ -1,0 +1,14 @@
+1	(1)	Tuple(x Nullable(Int8))
+1	(1,NULL)	Tuple(x Nullable(Int8), y Nullable(Int8))
+2	(NULL,2)	Tuple(x Nullable(Int8), y Nullable(Int8))
+1	(1,NULL)	Tuple(x Nullable(Int8), y Nullable(Int8))
+2	(NULL,2)	Tuple(x Nullable(Int8), y Nullable(Int8))
+3	(1,2)	Tuple(x Nullable(Int8), y Nullable(Int8))
+1	1	\N
+2	\N	2
+3	1	2
+1	(1)	Tuple(x Int8)
+1	(1,0)	Tuple(x Int8, y Int8)
+2	(0,2)	Tuple(x Int8, y Int8)
+{"x":1}
+{"x":1}

--- a/tests/queries/0_stateless/02287_type_object_convert.sql
+++ b/tests/queries/0_stateless/02287_type_object_convert.sql
@@ -1,0 +1,30 @@
+-- Tags: no-fasttest
+
+SET allow_experimental_object_type = 1;
+
+DROP TABLE IF EXISTS t_object_convert;
+
+CREATE TABLE t_object_convert(id UInt64, data Object(Nullable('JSON'))) Engine=Memory;
+
+INSERT INTO t_object_convert SELECT 1, CAST(CAST('{"x" : 1}', 'Object(\'json\')'), 'Object(Nullable(\'json\'))');
+SELECT id, data, toTypeName(data) FROM t_object_convert ORDER BY id;
+INSERT INTO t_object_convert SELECT 2, CAST(CAST('{"y" : 2}', 'Object(\'json\')'), 'Object(Nullable(\'json\'))');
+SELECT id, data, toTypeName(data) FROM t_object_convert ORDER BY id;
+INSERT INTO t_object_convert FORMAT JSONEachRow {"id": 3, "data": {"x": 1, "y" : 2}};
+
+SELECT id, data, toTypeName(data) FROM t_object_convert ORDER BY id;
+SELECT id, data.x, data.y FROM t_object_convert ORDER BY id;
+
+
+CREATE TABLE t_object_convert2(id UInt64, data Object('JSON')) Engine=Memory;
+
+INSERT INTO t_object_convert2 SELECT 1, CAST(CAST('{"x" : 1}', 'Object(\'json\')'), 'Object(Nullable(\'json\'))');
+SELECT id, data, toTypeName(data) FROM t_object_convert2 ORDER BY id;
+INSERT INTO t_object_convert2 SELECT 2, CAST(CAST('{"y" : 2}', 'Object(\'json\')'), 'Object(Nullable(\'json\'))');
+SELECT id, data, toTypeName(data) FROM t_object_convert2 ORDER BY id;
+
+DROP TABLE t_object_convert;
+DROP TABLE t_object_convert2;
+
+select CAST(CAST('{"x" : 1}', 'Object(\'json\')'), 'Object(Nullable(\'json\'))');
+select CAST(CAST('{"x" : 1}', 'Object(Nullable(\'json\'))'), 'Object(\'json\')');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to cast columns of type `Object(...)` to `Object(Nullable(...))`.

Closes #36558.

