### PR TITLE
Ancient cmake version cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,23 +328,9 @@ if (ENABLE_BUILD_PROFILING)
      endif ()
 endif ()
 
-if (${CMAKE_VERSION} VERSION_LESS "3.12.4")
-    # CMake < 3.12 doesn't support setting 20 as a C++ standard version.
-    # We will add C++ standard controlling flag in CMAKE_CXX_FLAGS manually for now.
-
-    if (COMPILER_GCC OR COMPILER_CLANG)
-        # to make numeric_limits<__int128> works with GCC
-        set (_CXX_STANDARD "gnu++2a")
-    else ()
-        set (_CXX_STANDARD "c++2a")
-    endif ()
-
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=${_CXX_STANDARD}")
-else ()
-    set (CMAKE_CXX_STANDARD 20)
-    set (CMAKE_CXX_EXTENSIONS ON) # Same as gnu++2a (ON) vs c++2a (OFF): https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html
-    set (CMAKE_CXX_STANDARD_REQUIRED ON)
-endif ()
+set (CMAKE_CXX_STANDARD 20)
+set (CMAKE_CXX_EXTENSIONS ON) # Same as gnu++2a (ON) vs c++2a (OFF): https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set (CMAKE_C_STANDARD 11)
 set (CMAKE_C_EXTENSIONS ON)

--- a/cmake/analysis.cmake
+++ b/cmake/analysis.cmake
@@ -2,10 +2,6 @@
 option (ENABLE_CLANG_TIDY "Use clang-tidy static analyzer" OFF)
 
 if (ENABLE_CLANG_TIDY)
-    if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
-        message(FATAL_ERROR "clang-tidy requires CMake version at least 3.6.")
-    endif()
-
     find_program (CLANG_TIDY_PATH NAMES "clang-tidy" "clang-tidy-13" "clang-tidy-12" "clang-tidy-11" "clang-tidy-10" "clang-tidy-9" "clang-tidy-8")
 
     if (CLANG_TIDY_PATH)

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -13,7 +13,7 @@ execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version)
 if (COMPILER_GCC)
     # Require minimum version of gcc
     set (GCC_MINIMUM_VERSION 11)
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${GCC_MINIMUM_VERSION} AND NOT CMAKE_VERSION VERSION_LESS 2.8.9)
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${GCC_MINIMUM_VERSION})
         message (FATAL_ERROR "GCC version must be at least ${GCC_MINIMUM_VERSION}. For example, if GCC ${GCC_MINIMUM_VERSION} is available under gcc-${GCC_MINIMUM_VERSION}, g++-${GCC_MINIMUM_VERSION} names, do the following: export CC=gcc-${GCC_MINIMUM_VERSION} CXX=g++-${GCC_MINIMUM_VERSION}; rm -rf CMakeCache.txt CMakeFiles; and re run cmake or ./release.")
     endif ()
 

--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -75,7 +75,7 @@ This will create the `programs/clickhouse` executable, which can be used with `c
 The build requires the following components:
 
 -   Git (is used only to checkout the sources, it’s not needed for the build)
--   CMake 3.10 or newer
+-   CMake 3.14 or newer
 -   Ninja
 -   C++ compiler: clang-13 or newer
 -   Linker: lld


### PR DESCRIPTION
The first line in CMakeLists.txt says the minimum CMake version is3.14 --> removing special code for earlier CMake versions. 

This is a continuation of #36567.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)