### PR TITLE
fix typo

### DIFF
--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -514,7 +514,7 @@ XMLDocumentPtr ConfigProcessor::processConfig(
     else
     {
         /// These embedded files added during build with some cmake magic.
-        /// Look at the end of programs/sever/CMakeLists.txt.
+        /// Look at the end of programs/server/CMakeLists.txt.
         std::string embedded_name;
         if (path == "config.xml")
             embedded_name = "embedded.xml";


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
