### PR TITLE
Fix format crash when default expression follow EPHEMERAL not literal

### DIFF
--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -10,8 +10,6 @@
 #include <Parsers/IParserBase.h>
 #include <Parsers/ParserDataType.h>
 #include <Poco/String.h>
-#include <Common/StringUtils/StringUtils.h>
-
 
 namespace DB
 {

--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -135,6 +135,7 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
     ParserKeyword s_type{"TYPE"};
     ParserTernaryOperatorExpression expr_parser;
     ParserStringLiteral string_literal_parser;
+    ParserLiteral literal_parser;
     ParserCodec codec_parser;
     ParserExpression expression_parser;
 
@@ -198,11 +199,10 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
     else if (s_ephemeral.ignore(pos, expected))
     {
         default_specifier = "EPHEMERAL";
-        if (!expr_parser.parse(pos, default_expression, expected) && type)
+        if (!literal_parser.parse(pos, default_expression, expected) && type)
             default_expression = std::make_shared<ASTLiteral>(Field());
-        /// The default expression for EPHEMERAL should be ASTLiteral,
-        /// otherwise it will be crash in formatImpl.
-        if (!startsWith(default_expression->getID(), "Literal"))
+
+        if (!default_expression && !type)
             return false;
     }
 

--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -1,15 +1,16 @@
 #pragma once
 
-#include <Parsers/IParserBase.h>
-#include <Parsers/ExpressionElementParsers.h>
-#include <Parsers/ExpressionListParsers.h>
-#include <Parsers/ASTNameTypePair.h>
 #include <Parsers/ASTColumnDeclaration.h>
 #include <Parsers/ASTIdentifier_fwd.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTNameTypePair.h>
 #include <Parsers/CommonParsers.h>
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/IParserBase.h>
 #include <Parsers/ParserDataType.h>
 #include <Poco/String.h>
-#include <Parsers/ASTLiteral.h>
+#include <Common/StringUtils/StringUtils.h>
 
 
 namespace DB
@@ -199,6 +200,10 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
         default_specifier = "EPHEMERAL";
         if (!expr_parser.parse(pos, default_expression, expected) && type)
             default_expression = std::make_shared<ASTLiteral>(Field());
+        /// The default expression for EPHEMERAL should be ASTLiteral,
+        /// otherwise it will be crash in formatImpl.
+        if (!startsWith(default_expression->getID(), "Literal"))
+            return false;
     }
 
     if (require_type && !type && !default_expression)

--- a/tests/queries/0_stateless/02287_ephemeral_format_crash.sql
+++ b/tests/queries/0_stateless/02287_ephemeral_format_crash.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS test;
+
+CREATE TABLE test(a UInt8, b String EPHEMERAL) Engine=Memory();
+
+DROP TABLE test;
+
+CREATE TABLE test(a UInt8, b EPHEMERAL String) Engine=Memory(); -- { clientError SYNTAX_ERROR }
+CREATE TABLE test(a UInt8, b EPHEMERAL 'a' String) Engine=Memory(); -- { clientError SYNTAX_ERROR }
+CREATE TABLE test(a UInt8, b String EPHEMERAL test) Engine=Memory(); -- { clientError SYNTAX_ERROR }
+CREATE TABLE test(a UInt8, b String EPHEMERAL 1+2) Engine=Memory(); -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehaviour in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix format crash when default expression follow EPHEMERAL not literal. Closes #36618.