### PR TITLE
Fix SortingStep::updateOutputStream()

### DIFF
--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -98,6 +98,8 @@ void SortingStep::updateInputStream(DataStream input_stream)
 void SortingStep::updateOutputStream(Block result_header)
 {
     output_stream = createOutputStream(input_streams.at(0), std::move(result_header), getDataStreamTraits());
+    output_stream->sort_description = result_description;
+    output_stream->sort_mode = DataStream::SortMode::Stream;
     updateDistinctColumns(output_stream->header, output_stream->distinct_columns);
 }
 

--- a/tests/performance/function_calculation_after_sorting_and_limit.xml
+++ b/tests/performance/function_calculation_after_sorting_and_limit.xml
@@ -1,4 +1,5 @@
 <test>
     <query>SELECT sipHash64(number) FROM numbers(1e8) ORDER BY number LIMIT 5</query>
     <query>SELECT sipHash64(number) FROM numbers(1e8) ORDER BY number + 1 LIMIT 5</query>
+    <query>SELECT sipHash64(number) FROM numbers(1e8) ORDER BY number + 1 LIMIT 99999995, 5</query>
 </test>

--- a/tests/queries/0_stateless/01576_alias_column_rewrite.reference
+++ b/tests/queries/0_stateless/01576_alias_column_rewrite.reference
@@ -33,13 +33,12 @@ Expression (Projection)
       Expression (Before ORDER BY)
         SettingQuotaAndLimits (Set limits and quota after reading from storage)
           ReadFromMergeTree (default.test_table)
-Expression (Projection)
+Expression ((Projection + Before ORDER BY [lifted up part]))
   Limit (preliminary LIMIT (without OFFSET))
-    Expression (Before ORDER BY [lifted up part])
-      Sorting
-        Expression (Before ORDER BY)
-          SettingQuotaAndLimits (Set limits and quota after reading from storage)
-            ReadFromMergeTree (default.test_table)
+    Sorting
+      Expression (Before ORDER BY)
+        SettingQuotaAndLimits (Set limits and quota after reading from storage)
+          ReadFromMergeTree (default.test_table)
 optimize_aggregation_in_order
 Expression ((Projection + Before ORDER BY))
   Aggregating

--- a/tests/queries/0_stateless/01655_plan_optimizations.reference
+++ b/tests/queries/0_stateless/01655_plan_optimizations.reference
@@ -144,7 +144,7 @@ Filter
 2	3
 > function calculation should be done after sorting and limit (if possible)
 > Expression should be divided into two subexpressions and only one of them should be moved after Sorting
-Expression (Before ORDER BY [lifted up part])
+Expression ((Projection + Before ORDER BY [lifted up part]))
 FUNCTION sipHash64
 Sorting
 Expression (Before ORDER BY)

--- a/tests/queries/0_stateless/01655_plan_optimizations.sh
+++ b/tests/queries/0_stateless/01655_plan_optimizations.sh
@@ -201,7 +201,7 @@ echo "> function calculation should be done after sorting and limit (if possible
 echo "> Expression should be divided into two subexpressions and only one of them should be moved after Sorting"
 $CLICKHOUSE_CLIENT -q "
     explain actions = 1 select number as n, sipHash64(n) from numbers(100) order by number + 1 limit 5" |
-    sed 's/^ *//g' | grep -o "^ *\(Expression (Before ORDER BY.*)\|Sorting\|FUNCTION \w\+\)"
+    sed 's/^ *//g' | grep -o "^ *\(Expression (.*Before ORDER BY.*)\|Sorting\|FUNCTION \w\+\)"
 echo "> this query should be executed without throwing an exception"
 $CLICKHOUSE_CLIENT -q "
     select throwIf(number = 5) from (select * from numbers(10)) order by number limit 1"

--- a/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.reference
+++ b/tests/queries/0_stateless/02149_read_in_order_fixed_prefix.reference
@@ -7,15 +7,13 @@
 ExpressionTransform
   (Limit)
   Limit
-    (Expression)
-    ExpressionTransform
-      (Sorting)
-      MergingSortedTransform 2 → 1
-        (Expression)
-        ExpressionTransform × 2
-          (SettingQuotaAndLimits)
-            (ReadFromMergeTree)
-            MergeTreeInOrder × 2 0 → 1
+    (Sorting)
+    MergingSortedTransform 2 → 1
+      (Expression)
+      ExpressionTransform × 2
+        (SettingQuotaAndLimits)
+          (ReadFromMergeTree)
+          MergeTreeInOrder × 2 0 → 1
 2020-10-01	9
 2020-10-01	9
 2020-10-01	9
@@ -25,18 +23,16 @@ ExpressionTransform
 ExpressionTransform
   (Limit)
   Limit
-    (Expression)
-    ExpressionTransform
-      (Sorting)
-      MergingSortedTransform 2 → 1
-        (Expression)
-        ExpressionTransform × 2
-          (SettingQuotaAndLimits)
-            (ReadFromMergeTree)
-            ReverseTransform
-              MergeTreeReverse 0 → 1
-                ReverseTransform
-                  MergeTreeReverse 0 → 1
+    (Sorting)
+    MergingSortedTransform 2 → 1
+      (Expression)
+      ExpressionTransform × 2
+        (SettingQuotaAndLimits)
+          (ReadFromMergeTree)
+          ReverseTransform
+            MergeTreeReverse 0 → 1
+              ReverseTransform
+                MergeTreeReverse 0 → 1
 2020-10-01	9
 2020-10-01	9
 2020-10-01	9
@@ -46,17 +42,15 @@ ExpressionTransform
 ExpressionTransform
   (Limit)
   Limit
-    (Expression)
-    ExpressionTransform
-      (Sorting)
-      FinishSortingTransform
-        PartialSortingTransform
-          MergingSortedTransform 2 → 1
-            (Expression)
-            ExpressionTransform × 2
-              (SettingQuotaAndLimits)
-                (ReadFromMergeTree)
-                MergeTreeInOrder × 2 0 → 1
+    (Sorting)
+    FinishSortingTransform
+      PartialSortingTransform
+        MergingSortedTransform 2 → 1
+          (Expression)
+          ExpressionTransform × 2
+            (SettingQuotaAndLimits)
+              (ReadFromMergeTree)
+              MergeTreeInOrder × 2 0 → 1
 2020-10-11	0
 2020-10-11	0
 2020-10-11	0


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We were unable to push down limit steps in some cases 'cause `sort_description` was sometimes lost.
`SELECT sipHash64(number) FROM numbers(1e8) ORDER BY number + 1 LIMIT 99999995, 5` is now 2s faster.