### PR TITLE
Fix some flaky tests

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1414,6 +1414,9 @@ bool IMergeTreeDataPart::assertHasValidVersionMetadata() const
     if (part_is_probably_removed_from_disk)
         return true;
 
+    if (state == State::Temporary)
+        return true;
+
     DiskPtr disk = volume->getDisk();
     if (!disk->exists(getFullRelativePath()))
         return true;
@@ -1772,6 +1775,7 @@ String IMergeTreeDataPart::getRelativePathForDetachedPart(const String & prefix)
 void IMergeTreeDataPart::renameToDetached(const String & prefix) const
 {
     renameTo(getRelativePathForDetachedPart(prefix), true);
+    part_is_probably_removed_from_disk = true;
 }
 
 void IMergeTreeDataPart::makeCloneInDetached(const String & prefix, const StorageMetadataPtr & /*metadata_snapshot*/) const

--- a/tests/queries/0_stateless/01169_alter_partition_isolation_stress.sh
+++ b/tests/queries/0_stateless/01169_alter_partition_isolation_stress.sh
@@ -17,9 +17,10 @@ $CLICKHOUSE_CLIENT --query "CREATE TABLE dst (n UInt64, type UInt8) ENGINE=Merge
 function thread_insert()
 {
     set -e
-    trap "exit 0" INT
     val=1
-    while true; do
+    trap "STOP_THE_LOOP=1" INT
+    STOP_THE_LOOP=0
+    while [[ $STOP_THE_LOOP != 1 ]]; do
         $CLICKHOUSE_CLIENT --multiquery --query "
         BEGIN TRANSACTION;
         INSERT INTO src VALUES /* ($val, 1) */ ($val, 1);
@@ -91,8 +92,9 @@ function thread_partition_dst_to_src()
 function thread_select()
 {
     set -e
-    trap "exit 0" INT
-    while true; do
+    trap "STOP_THE_LOOP=1" INT
+    STOP_THE_LOOP=0
+    while [[ $STOP_THE_LOOP != 1 ]]; do
         $CLICKHOUSE_CLIENT --multiquery --query "
         BEGIN TRANSACTION;
         -- no duplicates

--- a/tests/queries/0_stateless/01171_mv_select_insert_isolation_long.sh
+++ b/tests/queries/0_stateless/01171_mv_select_insert_isolation_long.sh
@@ -50,8 +50,9 @@ function thread_insert_rollback()
 function thread_optimize()
 {
     set -e
-    trap "exit 0" INT
-    while true; do
+    trap "STOP_THE_LOOP=1" INT
+    STOP_THE_LOOP=0
+    while [[ $STOP_THE_LOOP != 1 ]]; do
         optimize_query="OPTIMIZE TABLE src"
         partition_id=$(( RANDOM % 2 ))
         if (( RANDOM % 2 )); then
@@ -102,8 +103,9 @@ function thread_select()
 function thread_select_insert()
 {
     set -e
-    trap "exit 0" INT
-    while true; do
+    trap "STOP_THE_LOOP=1" INT
+    STOP_THE_LOOP=0
+    while [[ $STOP_THE_LOOP != 1 ]]; do
         $CLICKHOUSE_CLIENT --multiquery --query "
         BEGIN TRANSACTION;
         SELECT throwIf((SELECT count() FROM tmp) != 0) FORMAT Null;

--- a/tests/queries/0_stateless/01174_select_insert_isolation.sh
+++ b/tests/queries/0_stateless/01174_select_insert_isolation.sh
@@ -35,8 +35,9 @@ function thread_insert_rollback()
 
 function thread_select()
 {
-    trap "exit 0" INT
-    while true; do
+    trap "STOP_THE_LOOP=1" INT
+    STOP_THE_LOOP=0
+    while [[ $STOP_THE_LOOP != 1 ]]; do
         # Result of `uniq | wc -l` must be 1 if the first and the last queries got the same result
         $CLICKHOUSE_CLIENT --multiquery --query "
         BEGIN TRANSACTION;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix failures like this:
https://s3.amazonaws.com/clickhouse-test-reports/36493/88f37ef34f89670b0c7a6d4333f5a5c9a99422a3/stateless_tests__release__actions_.html
```
2022-04-21 12:33:59 01174_select_insert_isolation:                                          [ FAIL ] 3.70 sec. - having stderror: 
2022-04-21 12:33:59 Error on processing query: Code: 75. DB::ErrnoException: Cannot write to file (fd = 1), errno: 32, strerror: Broken pipe. (CANNOT_WRITE_TO_FILE_DESCRIPTOR) (version 22.4.1.2311)
2022-04-21 12:33:59 (query: SELECT arraySort(groupArray(n)), arraySort(groupArray(m)), arraySort(groupArray(_part)) FROM mt;)
```
Also fixes #36381


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
