### PR TITLE
Remove excessive logging from S3

### DIFF
--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -483,7 +483,7 @@ protected:
         Aws::Internal::STSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{session_name, role_arn, token};
 
         auto result = client->GetAssumeRoleWithWebIdentityCredentials(request);
-        LOG_TRACE(logger, "Successfully retrieved credentials with AWS_ACCESS_KEY: {}", result.creds.GetAWSAccessKeyId());
+        LOG_TRACE(logger, "Successfully retrieved credentials.", result.creds.GetAWSAccessKeyId());
         credentials = result.creds;
     }
 

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -285,7 +285,7 @@ protected:
 
         auto credentials_view = credentials_doc.View();
         access_key = credentials_view.GetString("AccessKeyId");
-        LOG_TRACE(logger, "Successfully pulled credentials from EC2MetadataService with access key {}.", access_key);
+        LOG_TRACE(logger, "Successfully pulled credentials from EC2MetadataService with access key.");
 
         secret_key = credentials_view.GetString("SecretAccessKey");
         token = credentials_view.GetString("Token");
@@ -483,7 +483,7 @@ protected:
         Aws::Internal::STSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{session_name, role_arn, token};
 
         auto result = client->GetAssumeRoleWithWebIdentityCredentials(request);
-        LOG_TRACE(logger, "Successfully retrieved credentials.", result.creds.GetAWSAccessKeyId());
+        LOG_TRACE(logger, "Successfully retrieved credentials.");
         credentials = result.creds;
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


AWS Access Key not neccessarily to be hidden, but its presense in logs maybe annoying to some people.