### PR TITLE
Fix deadlock for local cache

### DIFF
--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -467,8 +467,7 @@ void FileSegment::complete(State state)
 
     if (state != State::DOWNLOADED
         && state != State::PARTIALLY_DOWNLOADED
-        && state != State::PARTIALLY_DOWNLOADED_NO_CONTINUATION
-        && state != State::EMPTY)
+        && state != State::PARTIALLY_DOWNLOADED_NO_CONTINUATION)
     {
         cv.notify_all();
         throw Exception(ErrorCodes::REMOTE_FS_OBJECT_CACHE_ERROR,

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -467,7 +467,8 @@ void FileSegment::complete(State state)
 
     if (state != State::DOWNLOADED
         && state != State::PARTIALLY_DOWNLOADED
-        && state != State::PARTIALLY_DOWNLOADED_NO_CONTINUATION)
+        && state != State::PARTIALLY_DOWNLOADED_NO_CONTINUATION
+        && state != State::EMPTY)
     {
         cv.notify_all();
         throw Exception(ErrorCodes::REMOTE_FS_OBJECT_CACHE_ERROR,

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -113,7 +113,7 @@ void WriteBufferFromS3::nextImpl()
             else
             {
                 file_segments.erase(file_segment_it, file_segments.end());
-                file_segment->complete(FileSegment::State::EMPTY);
+                file_segment->complete(FileSegment::State::PARTIALLY_DOWNLOADED_NO_CONTINUATION);
                 break;
             }
         }

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -112,8 +112,11 @@ void WriteBufferFromS3::nextImpl()
             }
             else
             {
+                for (auto reset_segment_it = file_segment_it; reset_segment_it != file_segments.end(); ++reset_segment_it)
+                {
+                    (*reset_segment_it)->complete(FileSegment::State::PARTIALLY_DOWNLOADED_NO_CONTINUATION);
+                }
                 file_segments.erase(file_segment_it, file_segments.end());
-                file_segment->complete(FileSegment::State::PARTIALLY_DOWNLOADED_NO_CONTINUATION);
                 break;
             }
         }

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -113,9 +113,7 @@ void WriteBufferFromS3::nextImpl()
             else
             {
                 for (auto reset_segment_it = file_segment_it; reset_segment_it != file_segments.end(); ++reset_segment_it)
-                {
                     (*reset_segment_it)->complete(FileSegment::State::PARTIALLY_DOWNLOADED_NO_CONTINUATION);
-                }
                 file_segments.erase(file_segment_it, file_segments.end());
                 break;
             }

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -113,6 +113,7 @@ void WriteBufferFromS3::nextImpl()
             else
             {
                 file_segments.erase(file_segment_it, file_segments.end());
+                file_segment->complete(FileSegment::State::EMPTY);
                 break;
             }
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In the previous [PR](https://github.com/ClickHouse/ClickHouse/pull/36376), I found that testing **(stateless tests, flaky check (address, actions))** is timeout. Moreover, testing locally can also trigger unstable system deadlocks. This problem still exists when using the latest source code of master.

The main reasons are as follows:
If data is cached during write operation, the following code is executed. In line 6, it sets the segments to donwloading state. However, in line 23, it may discard some segments without modifying their state.

```
1. void WriteBufferFromS3::nextImpl() {
2.               ...
3.     if (cacheEnabled())
4.     {
5.         auto cache_key = cache->hash(key);
6.         file_segments_holder.emplace(cache->setDownloading(cache_key, current_download_offset, size));
7.         current_download_offset += size;
8. 
9.         size_t remaining_size = size;
10.         auto & file_segments = file_segments_holder->file_segments;
11.         for (auto file_segment_it = file_segments.begin(); file_segment_it != file_segments.end(); ++file_segment_it)
12.         {
13.             auto & file_segment = *file_segment_it;
14.             size_t current_size = std::min(file_segment->range().size(), remaining_size);
15.             remaining_size -= current_size;
16. 
17.             if (file_segment->reserve(current_size))
18.             {
19.                 file_segment->writeInMemory(working_buffer.begin(), current_size);
20.             }
21.             else
22.             {
23.                 file_segments.erase(file_segment_it, file_segments.end());
24.             }
25.       ...
26. }
```

This causes the these segments to still be indexed, but their state are  donwloading, and no thread will set them to downloaded. Therefore, if another thread accesses these segments, it will wait them forever as follows in line 26:

```

1. SeekableReadBufferPtr CachedReadBufferFromRemoteFS::getReadBufferForFileSegment(FileSegmentPtr & file_segment)
2. {
3.              ...
4.             case FileSegment::State::DOWNLOADING:
5.             {
6.                 size_t download_offset = file_segment->getDownloadOffset();
7.                 bool can_start_from_cache = download_offset > file_offset_of_buffer_end;
8. 
9.                 /// If file segment is being downloaded but we can already read from already downloaded part, do that.
10.                 if (can_start_from_cache)
11.                 {
12.                     ///                      segment{k} state: DOWNLOADING
13.                     /// cache:           [______|___________
14.                     ///                         ^
15.                     ///                         download_offset (in progress)
16.                     /// requested_range:    [__________]
17.                     ///                     ^
18.                     ///                     file_offset_of_buffer_end
19. 
20.                     read_type = ReadType::CACHED;
21.                     return getCacheReadBuffer(range.left);
22.                 }
23. 
24.                 if (wait_download_tries++ < wait_download_max_tries)
25.                 {
26.                     download_state = file_segment->wait();
27.                 }
28.                 else
29.                 {
30.                     download_state = FileSegment::State::SKIP_CACHE;
31.                 }
32. 
33.                 continue;
34.             }
35.             ...
36. }

```