### PR TITLE
Use correct nodes in test_keeper_znode_time

### DIFF
--- a/tests/integration/test_keeper_znode_time/test.py
+++ b/tests/integration/test_keeper_znode_time/test.py
@@ -134,9 +134,9 @@ def test_server_restart(started_cluster):
         node2_zk = get_fake_zk("node2")
         node3_zk = get_fake_zk("node3")
         for child_node in range(1000):
-            stats1 = node1_zk.exists("/test_between_servers/" + str(child_node))
-            stats2 = node2_zk.exists("/test_between_servers/" + str(child_node))
-            stats3 = node3_zk.exists("/test_between_servers/" + str(child_node))
+            stats1 = node1_zk.exists("/test_server_restart/" + str(child_node))
+            stats2 = node2_zk.exists("/test_server_restart/" + str(child_node))
+            stats3 = node3_zk.exists("/test_server_restart/" + str(child_node))
             assert_eq_stats(stats1, stats2)
             assert_eq_stats(stats2, stats3)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
