### PR TITLE
Added zookeeper multi-read support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ website/package-lock.json
 /programs/server/metadata
 /programs/server/store
 
+# direnv config
+/.envrc
+/.direnv

--- a/src/Common/ZooKeeper/IKeeper.cpp
+++ b/src/Common/ZooKeeper/IKeeper.cpp
@@ -140,6 +140,7 @@ void RemoveRequest::addRootPath(const String & root_path) { Coordination::addRoo
 void ExistsRequest::addRootPath(const String & root_path) { Coordination::addRootPath(path, root_path); }
 void GetRequest::addRootPath(const String & root_path) { Coordination::addRootPath(path, root_path); }
 void SetRequest::addRootPath(const String & root_path) { Coordination::addRootPath(path, root_path); }
+void SimpleListRequest::addRootPath(const String & root_path) { Coordination::addRootPath(path, root_path); }
 void ListRequest::addRootPath(const String & root_path) { Coordination::addRootPath(path, root_path); }
 void CheckRequest::addRootPath(const String & root_path) { Coordination::addRootPath(path, root_path); }
 void SetACLRequest::addRootPath(const String & root_path) { Coordination::addRootPath(path, root_path); }

--- a/src/Common/ZooKeeper/IKeeper.h
+++ b/src/Common/ZooKeeper/IKeeper.h
@@ -275,6 +275,29 @@ struct SetResponse : virtual Response
     size_t bytesSize() const override { return sizeof(stat); }
 };
 
+struct SimpleListRequest : virtual Request
+{
+    String path;
+
+    void addRootPath(const String & root_path) override;
+    String getPath() const override { return path; }
+
+    size_t bytesSize() const override { return path.size(); }
+};
+
+struct SimpleListResponse : virtual Response
+{
+    std::vector<String> names;
+
+    size_t bytesSize() const override
+    {
+        size_t size = 0;
+        for (const auto & name : names)
+            size += name.size();
+        return size;
+    }
+};
+
 struct ListRequest : virtual Request
 {
     String path;

--- a/src/Common/ZooKeeper/TestKeeper.cpp
+++ b/src/Common/ZooKeeper/TestKeeper.cpp
@@ -180,7 +180,8 @@ struct TestKeeperMultiRequest final : MultiRequest, TestKeeperRequest
             dynamic_cast<const TestKeeperRequest &>(*generic_request).processWatches(node_watches, list_watches);
     }
 
-    void checkOpKindOrThrow(bool is_write) {
+    void checkOpKindOrThrow(bool is_write)
+    {
         if (op_kind.has_value() && op_kind.value() != is_write)
         {
             throw Exception("Illegal mixing of read and write operations in multi request", Error::ZBADARGUMENTS);

--- a/src/Common/ZooKeeper/TestKeeper.cpp
+++ b/src/Common/ZooKeeper/TestKeeper.cpp
@@ -181,9 +181,12 @@ struct TestKeeperMultiRequest final : MultiRequest, TestKeeperRequest
     }
 
     void checkOpKindOrThrow(bool is_write) {
-        if (op_kind.has_value() && op_kind.value() != is_write) {
+        if (op_kind.has_value() && op_kind.value() != is_write)
+        {
             throw Exception("Illegal mixing of read and write operations in multi request", Error::ZBADARGUMENTS);
-        } else {
+        }
+        else
+        {
             op_kind = is_write;
         }
     }

--- a/src/Common/ZooKeeper/Types.h
+++ b/src/Common/ZooKeeper/Types.h
@@ -31,6 +31,7 @@ using AsyncResponses = std::vector<std::pair<std::string, std::future<R>>>;
 
 Coordination::RequestPtr makeCreateRequest(const std::string & path, const std::string & data, int create_mode);
 Coordination::RequestPtr makeRemoveRequest(const std::string & path, int version);
+Coordination::RequestPtr makeGetRequest(const std::string & path);
 Coordination::RequestPtr makeSetRequest(const std::string & path, const std::string & data, int version);
 Coordination::RequestPtr makeCheckRequest(const std::string & path, int version);
 

--- a/src/Common/ZooKeeper/Types.h
+++ b/src/Common/ZooKeeper/Types.h
@@ -32,6 +32,7 @@ using AsyncResponses = std::vector<std::pair<std::string, std::future<R>>>;
 Coordination::RequestPtr makeCreateRequest(const std::string & path, const std::string & data, int create_mode);
 Coordination::RequestPtr makeRemoveRequest(const std::string & path, int version);
 Coordination::RequestPtr makeGetRequest(const std::string & path);
+Coordination::RequestPtr makeSimpleListRequest(const std::string & path);
 Coordination::RequestPtr makeSetRequest(const std::string & path, const std::string & data, int version);
 Coordination::RequestPtr makeCheckRequest(const std::string & path, int version);
 

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -715,7 +715,6 @@ Coordination::Error ZooKeeper::tryMultiReadNoThrow(const Coordination::Requests 
 }
 
 
-
 void ZooKeeper::removeChildren(const std::string & path)
 {
     Strings children = getChildren(path);

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -1245,6 +1245,13 @@ Coordination::RequestPtr makeGetRequest(const std::string & path)
     return request;
 }
 
+Coordination::RequestPtr makeSimpleListRequest(const std::string & path)
+{
+    auto request = std::make_shared<Coordination::SimpleListRequest>();
+    request->path = path;
+    return request;
+}
+
 Coordination::RequestPtr makeSetRequest(const std::string & path, const std::string & data, int version)
 {
     auto request = std::make_shared<Coordination::SetRequest>();

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -209,6 +209,15 @@ public:
     /// Throws nothing (even session expired errors)
     Coordination::Error tryMultiNoThrow(const Coordination::Requests & requests, Coordination::Responses & responses);
 
+    /// Performs several operations in a transaction.
+    /// Throws on every error.
+    Coordination::Responses multiRead(const Coordination::Requests & requests);
+    /// Throws only if some operation has returned an "unexpected" error
+    /// - an error that would cause the corresponding try- method to throw.
+    Coordination::Error tryMultiRead(const Coordination::Requests & requests, Coordination::Responses & responses);
+    /// Throws nothing (even session expired errors)
+    Coordination::Error tryMultiReadNoThrow(const Coordination::Requests & requests, Coordination::Responses & responses);
+
     Int64 getClientID();
 
     /// Remove the node with the subtree. If someone concurrently adds or removes a node
@@ -324,6 +333,7 @@ private:
     Coordination::Error getChildrenImpl(
         const std::string & path, Strings & res, Coordination::Stat * stat, Coordination::WatchCallback watch_callback);
     Coordination::Error multiImpl(const Coordination::Requests & requests, Coordination::Responses & responses);
+    Coordination::Error multiReadImpl(const Coordination::Requests & requests, Coordination::Responses & responses);
     Coordination::Error existsImpl(const std::string & path, Coordination::Stat * stat_, Coordination::WatchCallback watch_callback);
 
     std::unique_ptr<Coordination::IKeeper> impl;

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -443,6 +443,11 @@ void ZooKeeperMultiRequest::readImpl(ReadBuffer & in)
         ZooKeeperRequestPtr request = ZooKeeperRequestFactory::instance().get(op_num);
         request->readImpl(in);
         requests.push_back(request);
+        if (request->isReadRequest()) {
+            checkOpKindOrThrow(OpKind::Read);
+        } else {
+            checkOpKindOrThrow(OpKind::Transaction);
+        }
 
         if (in.eof())
             throw Exception("Not enough results received for multi transaction", Error::ZMARSHALLINGERROR);

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -355,10 +355,14 @@ ZooKeeperMultiRequest::ZooKeeperMultiRequest(const Requests & generic_requests, 
     }
 }
 
-OpNum ZooKeeperMultiRequest::getOpNum() const {
-    if (isReadRequest()) {
+OpNum ZooKeeperMultiRequest::getOpNum() const
+{
+    if (isReadRequest())
+    {
         return OpNum::MultiRead;
-    } else {
+    }
+    else
+    {
         return OpNum::Multi;
     }
 }
@@ -423,10 +427,14 @@ bool ZooKeeperMultiRequest::isReadRequest() const
     return op_kind == OpKind::Read;
 }
 
-void ZooKeeperMultiRequest::checkOpKindOrThrow(OpKind kind) {
-    if (op_kind.has_value() && op_kind.value() != kind) {
+void ZooKeeperMultiRequest::checkOpKindOrThrow(OpKind kind)
+{
+    if (op_kind.has_value() && op_kind.value() != kind)
+    {
         throw Exception("Illegal mixing of read and write operations in multi request", Error::ZBADARGUMENTS);
-    } else {
+    }
+    else
+    {
         op_kind = kind;
     }
 }

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -833,6 +833,7 @@ ZooKeeperRequestFactory::ZooKeeperRequestFactory()
     registerZooKeeperRequest<OpNum::List, ZooKeeperListRequest>(*this);
     registerZooKeeperRequest<OpNum::Check, ZooKeeperCheckRequest>(*this);
     registerZooKeeperRequest<OpNum::Multi, ZooKeeperMultiRequest>(*this);
+    registerZooKeeperRequest<OpNum::MultiRead, ZooKeeperMultiRequest>(*this);
     registerZooKeeperRequest<OpNum::SessionID, ZooKeeperSessionIDRequest>(*this);
     registerZooKeeperRequest<OpNum::GetACL, ZooKeeperGetACLRequest>(*this);
     registerZooKeeperRequest<OpNum::SetACL, ZooKeeperSetACLRequest>(*this);

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -337,9 +337,18 @@ struct ZooKeeperListRequest : ListRequest, ZooKeeperRequest
     size_t bytesSize() const override { return ListRequest::bytesSize() + sizeof(xid) + sizeof(has_watch); }
 };
 
-struct ZooKeeperSimpleListRequest final : ZooKeeperListRequest
+struct ZooKeeperSimpleListRequest final : SimpleListRequest, ZooKeeperRequest
 {
+    ZooKeeperSimpleListRequest() = default;
+    explicit ZooKeeperSimpleListRequest(const SimpleListRequest & base) : SimpleListRequest(base) {}
+
     OpNum getOpNum() const override { return OpNum::SimpleList; }
+    void writeImpl(WriteBuffer & out) const override;
+    void readImpl(ReadBuffer & in) override;
+    ZooKeeperResponsePtr makeResponse() const override;
+    bool isReadRequest() const override { return true; }
+
+    size_t bytesSize() const override { return SimpleListRequest::bytesSize() + sizeof(xid) + sizeof(has_watch); }
 };
 
 struct ZooKeeperListResponse : ListResponse, ZooKeeperResponse
@@ -353,9 +362,15 @@ struct ZooKeeperListResponse : ListResponse, ZooKeeperResponse
     void fillLogElements(LogElements & elems, size_t idx) const override;
 };
 
-struct ZooKeeperSimpleListResponse final : ZooKeeperListResponse
+struct ZooKeeperSimpleListResponse final : SimpleListResponse, ZooKeeperResponse
 {
-    OpNum getOpNum() const override { return OpNum::SimpleList; }
+    void readImpl(ReadBuffer & in) override;
+    void writeImpl(WriteBuffer & out) const override;
+    OpNum getOpNum() const override { return OpNum::List; }
+
+    size_t bytesSize() const override { return SimpleListResponse::bytesSize() + sizeof(xid) + sizeof(zxid); }
+
+    void fillLogElements(LogElements & elems, size_t idx) const override;
 };
 
 struct ZooKeeperCheckRequest final : CheckRequest, ZooKeeperRequest

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -275,6 +275,9 @@ struct ZooKeeperExistsResponse final : ExistsResponse, ZooKeeperResponse
 
 struct ZooKeeperGetRequest final : GetRequest, ZooKeeperRequest
 {
+    ZooKeeperGetRequest() = default;
+    explicit ZooKeeperGetRequest(const GetRequest & base) : GetRequest(base) {}
+
     OpNum getOpNum() const override { return OpNum::Get; }
     void writeImpl(WriteBuffer & out) const override;
     void readImpl(ReadBuffer & in) override;
@@ -434,7 +437,7 @@ struct ZooKeeperGetACLResponse final : GetACLResponse, ZooKeeperResponse
 
 struct ZooKeeperMultiRequest final : MultiRequest, ZooKeeperRequest
 {
-    OpNum getOpNum() const override { return OpNum::Multi; }
+    OpNum getOpNum() const override;
     ZooKeeperMultiRequest() = default;
 
     ZooKeeperMultiRequest(const Requests & generic_requests, const ACLs & default_acls);
@@ -448,6 +451,10 @@ struct ZooKeeperMultiRequest final : MultiRequest, ZooKeeperRequest
     size_t bytesSize() const override { return MultiRequest::bytesSize() + sizeof(xid) + sizeof(has_watch); }
 
     void createLogElements(LogElements & elems) const override;
+
+    void checkOpKindOrThrow(OpKind kind);
+
+    std::optional<OpKind> op_kind;
 };
 
 struct ZooKeeperMultiResponse final : MultiResponse, ZooKeeperResponse

--- a/src/Common/ZooKeeper/ZooKeeperConstants.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperConstants.cpp
@@ -20,6 +20,7 @@ static const std::unordered_set<int32_t> VALID_OPERATIONS =
     static_cast<int32_t>(OpNum::List),
     static_cast<int32_t>(OpNum::Check),
     static_cast<int32_t>(OpNum::Multi),
+    static_cast<int32_t>(OpNum::MultiRead),
     static_cast<int32_t>(OpNum::Auth),
     static_cast<int32_t>(OpNum::SessionID),
     static_cast<int32_t>(OpNum::SetACL),
@@ -52,6 +53,8 @@ std::string toString(OpNum op_num)
             return "Check";
         case OpNum::Multi:
             return "Multi";
+        case OpNum::MultiRead:
+            return "MultiRead";
         case OpNum::Sync:
             return "Sync";
         case OpNum::Heartbeat:

--- a/src/Common/ZooKeeper/ZooKeeperConstants.h
+++ b/src/Common/ZooKeeper/ZooKeeperConstants.h
@@ -14,6 +14,11 @@ static constexpr XID PING_XID  = -2;
 static constexpr XID AUTH_XID  = -4;
 static constexpr XID CLOSE_XID = 0x7FFFFFFF;
 
+enum class OpKind : int32_t {
+    Read = 1,
+    Transaction = 2,
+};
+
 enum class OpNum : int32_t
 {
     Close = -11,
@@ -31,6 +36,7 @@ enum class OpNum : int32_t
     List = 12,
     Check = 13,
     Multi = 14,
+    MultiRead = 22,
     Auth = 100,
     SessionID = 997, /// Special internal request
 };
@@ -51,6 +57,6 @@ static constexpr int32_t MAX_STRING_OR_ARRAY_SIZE = 1 << 28;  /// 256 MiB
 static constexpr int32_t DEFAULT_SESSION_TIMEOUT_MS = 30000;
 static constexpr int32_t DEFAULT_MIN_SESSION_TIMEOUT_MS = 10000;
 static constexpr int32_t DEFAULT_MAX_SESSION_TIMEOUT_MS = 100000;
-static constexpr int32_t DEFAULT_OPERATION_TIMEOUT_MS = 10000;
+static constexpr int32_t DEFAULT_OPERATION_TIMEOUT_MS = 100000;
 
 }

--- a/src/Common/ZooKeeper/ZooKeeperConstants.h
+++ b/src/Common/ZooKeeper/ZooKeeperConstants.h
@@ -14,7 +14,8 @@ static constexpr XID PING_XID  = -2;
 static constexpr XID AUTH_XID  = -4;
 static constexpr XID CLOSE_XID = 0x7FFFFFFF;
 
-enum class OpKind : int32_t {
+enum class OpKind : int32_t
+{
     Read = 1,
     Transaction = 2,
 };

--- a/src/Common/ZooKeeper/ZooKeeperConstants.h
+++ b/src/Common/ZooKeeper/ZooKeeperConstants.h
@@ -14,10 +14,10 @@ static constexpr XID PING_XID  = -2;
 static constexpr XID AUTH_XID  = -4;
 static constexpr XID CLOSE_XID = 0x7FFFFFFF;
 
-enum class OpKind : int32_t
+enum class OpKind : uint8_t
 {
     Read = 1,
-    Transaction = 2,
+    Write = 2,
 };
 
 enum class OpNum : int32_t
@@ -58,6 +58,6 @@ static constexpr int32_t MAX_STRING_OR_ARRAY_SIZE = 1 << 28;  /// 256 MiB
 static constexpr int32_t DEFAULT_SESSION_TIMEOUT_MS = 30000;
 static constexpr int32_t DEFAULT_MIN_SESSION_TIMEOUT_MS = 10000;
 static constexpr int32_t DEFAULT_MAX_SESSION_TIMEOUT_MS = 100000;
-static constexpr int32_t DEFAULT_OPERATION_TIMEOUT_MS = 100000;
+static constexpr int32_t DEFAULT_OPERATION_TIMEOUT_MS = 10000;
 
 }

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -1134,6 +1134,7 @@ KeeperStorageRequestProcessorsFactory::KeeperStorageRequestProcessorsFactory()
     registerKeeperRequestProcessor<Coordination::OpNum::SimpleList, KeeperStorageListRequestProcessor>(*this);
     registerKeeperRequestProcessor<Coordination::OpNum::Check, KeeperStorageCheckRequestProcessor>(*this);
     registerKeeperRequestProcessor<Coordination::OpNum::Multi, KeeperStorageMultiRequestProcessor>(*this);
+    registerKeeperRequestProcessor<Coordination::OpNum::MultiRead, KeeperStorageMultiRequestProcessor>(*this);
     registerKeeperRequestProcessor<Coordination::OpNum::SetACL, KeeperStorageSetACLRequestProcessor>(*this);
     registerKeeperRequestProcessor<Coordination::OpNum::GetACL, KeeperStorageGetACLRequestProcessor>(*this);
 }

--- a/utils/zookeeper-test/main.cpp
+++ b/utils/zookeeper-test/main.cpp
@@ -72,16 +72,20 @@ void testCreateList(zkutil::ZooKeeper & zk)
 }
 
 template<typename T, typename U>
-void assert_eq(const T& left, const U& right) {
-    if (left != right) {
+void assert_eq(const T& left, const U& right)
+{
+    if (left != right)
+    {
         throw std::runtime_error("assert_eq failed");
     }
 }
 
 template<typename T, typename U>
-T* assert_dynamic_cast(U* ptr) {
+T* assert_dynamic_cast(U* ptr)
+{
     T* result = dynamic_cast<T*>(ptr);
-    if (result == nullptr) {
+    if (result == nullptr)
+    {
         throw std::runtime_error("dynamic cast failed");
     }
     return result;

--- a/utils/zookeeper-test/main.cpp
+++ b/utils/zookeeper-test/main.cpp
@@ -100,13 +100,20 @@ void testMultiRead(zkutil::ZooKeeper & zk)
     Coordination::Requests requests{
         zkutil::makeGetRequest("/data/multiread/d2"),
         zkutil::makeGetRequest("/data/multiread/d1"),
+        zkutil::makeSimpleListRequest("/data/multiread"),
         zkutil::makeGetRequest("/data/multiread/d3"),
     };
     auto resp = zk.multiRead(requests);
-    assert_eq(resp.size(), 3u);
+    assert_eq(resp.size(), 4u);
     assert_eq(assert_dynamic_cast<Coordination::GetResponse>(resp[0].get())->data, "b");
     assert_eq(assert_dynamic_cast<Coordination::GetResponse>(resp[1].get())->data, "a");
     assert_eq(assert_dynamic_cast<Coordination::GetResponse>(resp[3].get())->data, "c");
+
+    const auto * list_resp = assert_dynamic_cast<Coordination::SimpleListResponse>(resp[2].get());
+    assert_eq(list_resp->names.size(), 3u);
+    assert_eq(list_resp->names[0], "d1");
+    assert_eq(list_resp->names[1], "d2");
+    assert_eq(list_resp->names[2], "d3");
 }
 
 void testCreateSetVersionRequest(zkutil::ZooKeeper & zk)
@@ -383,19 +390,19 @@ int main(int argc, char *argv[])
         zk.createIfNotExists("/data", "");
         std::cerr << "Created\n";
 
-        Stopwatch watch;
-        createConcurrent(zk, argv[1], 1, 1005000, 10);
-        std::cerr << "Finished in: " << watch.elapsedMilliseconds() << "ms" << std::endl;
+        //Stopwatch watch;
+        //createConcurrent(zk, argv[1], 1, 1005000, 10);
+        //std::cerr << "Finished in: " << watch.elapsedMilliseconds() << "ms" << std::endl;
 
         //testCreateGetExistsNode(zk);
-        //testCreateSetNode(zk);
-        //testCreateList(zk);
-        //testCreateSetVersionRequest(zk);
-        //testMultiRequest(zk);
-        //testMultiRead(zk);
-        //testCreateSetWatchEvent(zk);
-        //testCreateListWatchEvent(zk);
-        //tryConcurrentWatches(zk);
+        testCreateSetNode(zk);
+        testCreateList(zk);
+        testCreateSetVersionRequest(zk);
+        testMultiRequest(zk);
+        testMultiRead(zk);
+        testCreateSetWatchEvent(zk);
+        testCreateListWatchEvent(zk);
+        tryConcurrentWatches(zk);
     }
     catch (...)
     {

--- a/utils/zookeeper-test/main.cpp
+++ b/utils/zookeeper-test/main.cpp
@@ -62,6 +62,7 @@ void testCreateList(zkutil::ZooKeeper & zk)
     auto children = zk.getChildren("/data/lst");
     if (children.size() != 3)
         throw std::runtime_error("Children of /data/lst doesn't equal to three");
+    std::sort(children.begin(), children.end());
     for (size_t i = 0; i < children.size(); ++i)
     {
         std::cerr << "children:" << children[i] << std::endl;

--- a/utils/zookeeper-test/main.cpp
+++ b/utils/zookeeper-test/main.cpp
@@ -94,6 +94,7 @@ T* assert_dynamic_cast(U* ptr)
 
 void testMultiRead(zkutil::ZooKeeper & zk)
 {
+    std::cerr << "Testing multi read request" << std::endl;
     zk.create("/data/multiread", "", zkutil::CreateMode::Persistent);
     zk.create("/data/multiread/d1", "a", zkutil::CreateMode::Persistent);
     zk.create("/data/multiread/d2", "b", zkutil::CreateMode::Persistent);
@@ -110,7 +111,8 @@ void testMultiRead(zkutil::ZooKeeper & zk)
     assert_eq(assert_dynamic_cast<Coordination::GetResponse>(resp[1].get())->data, "a");
     assert_eq(assert_dynamic_cast<Coordination::GetResponse>(resp[3].get())->data, "c");
 
-    const auto * list_resp = assert_dynamic_cast<Coordination::SimpleListResponse>(resp[2].get());
+    auto * list_resp = assert_dynamic_cast<Coordination::SimpleListResponse>(resp[2].get());
+    std::sort(list_resp->names.begin(), list_resp->names.end());
     assert_eq(list_resp->names.size(), 3u);
     assert_eq(list_resp->names[0], "d1");
     assert_eq(list_resp->names[1], "d2");


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

- [x] Implemented multi-read support for get operation
- [x] Implemented multi-read support for simple list operation
- [ ] Implemented server version check and fallback to loop-retry solution for old servers
- [x] Added multi-read support in ClickHouse Keeper