### PR TITLE
Add an extra check for RAFT config change

### DIFF
--- a/src/Coordination/KeeperStateManager.cpp
+++ b/src/Coordination/KeeperStateManager.cpp
@@ -284,10 +284,25 @@ ConfigUpdateActions KeeperStateManager::getConfigurationDiff(const Poco::Util::A
     ConfigUpdateActions result;
 
     /// First of all add new servers
-    for (auto [new_id, server_config] : new_ids)
+    for (const auto & [new_id, server_config] : new_ids)
     {
-        if (!old_ids.contains(new_id))
+        auto old_server_it = old_ids.find(new_id);
+        if (old_server_it == old_ids.end())
             result.emplace_back(ConfigUpdateAction{ConfigUpdateActionType::AddServer, server_config});
+        else
+        {
+            const auto & old_endpoint = old_server_it->second->get_endpoint();
+            if (old_endpoint != server_config->get_endpoint())
+            {
+                LOG_WARNING(
+                    &Poco::Logger::get("RaftConfiguration"),
+                    "Config will be ignored because a server with ID {} is already present in the cluster on a different endpoint ({}). "
+                    "The endpoint of the current servers should not be changed. For servers on a new endpoint, please use a new ID.",
+                    new_id,
+                    old_endpoint);
+                return {};
+            }
+        }
     }
 
     /// After that remove old ones

--- a/tests/integration/test_keeper_nodes_add/test.py
+++ b/tests/integration/test_keeper_nodes_add/test.py
@@ -98,3 +98,16 @@ def test_nodes_add(started_cluster):
 
     for i in range(100):
         assert zk_conn3.exists("/test_three_" + str(i)) is not None
+
+    # configs which change endpoints of server should not be allowed
+    node1.replace_in_config(
+        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+        "node3",
+        "non_existing_node",
+    )
+
+    node1.query("SYSTEM RELOAD CONFIG")
+    time.sleep(2)
+    assert node1.contains_in_log(
+        "Config will be ignored because a server with ID 3 is already present in the cluster"
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add extra checks for RAFT configuration changes


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
