### PR TITLE
fix bug for local cache

### DIFF
--- a/src/Common/FileCache.cpp
+++ b/src/Common/FileCache.cpp
@@ -625,7 +625,7 @@ void LRUFileCache::remove(
     }
 }
 
-void LRUFileCache::loadCacheInfoIntoMemory(std::lock_guard<std::mutex> &cache_lock)
+void LRUFileCache::loadCacheInfoIntoMemory(std::lock_guard<std::mutex> & cache_lock)
 {
     Key key;
     UInt64 offset = 0;

--- a/src/Common/FileCache.cpp
+++ b/src/Common/FileCache.cpp
@@ -78,12 +78,15 @@ LRUFileCache::LRUFileCache(const String & cache_base_path_, const FileCacheSetti
 
 void LRUFileCache::initialize()
 {
-    if (fs::exists(cache_base_path))
-        loadCacheInfoIntoMemory();
-    else
-        fs::create_directories(cache_base_path);
-
-    is_initialized = true;
+    std::lock_guard cache_lock(mutex);
+    if (!is_initialized)
+    {
+        if (fs::exists(cache_base_path))
+            loadCacheInfoIntoMemory();
+        else
+            fs::create_directories(cache_base_path);
+        is_initialized = true;
+    }
 }
 
 void LRUFileCache::useCell(
@@ -624,8 +627,6 @@ void LRUFileCache::remove(
 
 void LRUFileCache::loadCacheInfoIntoMemory()
 {
-    std::lock_guard cache_lock(mutex);
-
     Key key;
     UInt64 offset = 0;
     size_t size = 0;

--- a/src/Common/FileCache.cpp
+++ b/src/Common/FileCache.cpp
@@ -82,7 +82,7 @@ void LRUFileCache::initialize()
     if (!is_initialized)
     {
         if (fs::exists(cache_base_path))
-            loadCacheInfoIntoMemory();
+            loadCacheInfoIntoMemory(cache_lock);
         else
             fs::create_directories(cache_base_path);
         is_initialized = true;
@@ -625,7 +625,7 @@ void LRUFileCache::remove(
     }
 }
 
-void LRUFileCache::loadCacheInfoIntoMemory()
+void LRUFileCache::loadCacheInfoIntoMemory(std::lock_guard<std::mutex> &cache_lock)
 {
     Key key;
     UInt64 offset = 0;

--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -219,7 +219,7 @@ private:
 
     size_t availableSize() const { return max_size - current_size; }
 
-    void loadCacheInfoIntoMemory(std::lock_guard<std::mutex> &cache_lock);
+    void loadCacheInfoIntoMemory(std::lock_guard<std::mutex> & cache_lock);
 
     FileSegments splitRangeIntoCells(
         const Key & key, size_t offset, size_t size, FileSegment::State state, std::lock_guard<std::mutex> & cache_lock);

--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -219,7 +219,7 @@ private:
 
     size_t availableSize() const { return max_size - current_size; }
 
-    void loadCacheInfoIntoMemory();
+    void loadCacheInfoIntoMemory(std::lock_guard<std::mutex> &cache_lock);
 
     FileSegments splitRangeIntoCells(
         const Key & key, size_t offset, size_t size, FileSegment::State state, std::lock_guard<std::mutex> & cache_lock);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
During the [test](https://s3.amazonaws.com/clickhouse-test-reports/36376/1cb1c7275cb53769ab826772db9b71361bb3e413/stress_test__thread__actions_/clickhouse-server.clean.log) in [PR](https://github.com/ClickHouse/ClickHouse/pull/36376), I found that the one cache class was initialized twice, it throws a exception. Although the cause of this problem is not clear, there should be code logic of repeatedly loading disk in ClickHouse, so we need to make special judgment for this situation.

As follows, in this code, an old initialized cache instance may be obtained from **getOrCreate()**, and  it is initialized directly without judgement.

```

1. FileCachePtr getCachePtrForDisk(
2.     const String & name,
3.     const Poco::Util::AbstractConfiguration & config,
4.     const String & config_prefix,
5.     ContextPtr context)
6. {
7.       ...
8.     auto cache = FileCacheFactory::instance().getOrCreate(cache_base_path, file_cache_settings);
9.     cache->initialize();
10.     ...
11. }

```