### PR TITLE
fix `groupBitmapAndState` function on distributed table

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionState.h
+++ b/src/AggregateFunctions/AggregateFunctionState.h
@@ -52,6 +52,8 @@ public:
         return nested_func->getDefaultVersion();
     }
 
+    size_t getVersionFromRevision(size_t revision) const override { return nested_func->getVersionFromRevision(revision); }
+
     void create(AggregateDataPtr __restrict place) const override
     {
         nested_func->create(place);

--- a/tests/integration/test_groupBitmapAnd_on_distributed/test_groupBitmapAndState_on_distributed_table.py
+++ b/tests/integration/test_groupBitmapAnd_on_distributed/test_groupBitmapAndState_on_distributed_table.py
@@ -1,0 +1,137 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1", main_configs=["configs/clusters.xml"], with_zookeeper=True
+)
+node2 = cluster.add_instance(
+    "node2", main_configs=["configs/clusters.xml"], with_zookeeper=True
+)
+node3 = cluster.add_instance(
+    "node3", main_configs=["configs/clusters.xml"], with_zookeeper=True
+)
+node4 = cluster.add_instance(
+    "node4",
+    main_configs=["configs/clusters.xml"],
+    image="yandex/clickhouse-server",
+    tag="21.6",
+    with_installed_binary=True,
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_groupBitmapAndState_on_distributed_table(start_cluster):
+    local_table_name = "test_group_bitmap_state"
+    distributed_table_name = "test_group_bitmap_state_dst"
+    cluster_name = "awesome_cluster"
+
+    for node in (node1, node2):
+        node.query(
+            """CREATE TABLE {}
+        (
+            z AggregateFunction(groupBitmap, UInt32)
+        )
+        ENGINE = MergeTree()
+        ORDER BY tuple()""".format(
+                local_table_name
+            )
+        )
+
+        node.query(
+            """CREATE TABLE {}
+        (
+            z AggregateFunction(groupBitmap, UInt32)
+        )
+        ENGINE = Distributed('{}', 'default', '{}')""".format(
+                distributed_table_name, cluster_name, local_table_name
+            )
+        )
+
+    node1.query(
+        """INSERT INTO {} VALUES
+                (bitmapBuild(cast([1,2,3,4,5,6,7,8,9,10] as Array(UInt32))));""".format(
+            local_table_name
+        )
+    )
+
+    node2.query(
+        """INSERT INTO {} VALUES
+                (bitmapBuild(cast([0] as Array(UInt32))));""".format(
+            local_table_name
+        )
+    )
+
+    expected = "0"
+    for node in (node1, node2):
+        result = node.query(
+            "select bitmapCardinality(groupBitmapAndState(z)) FROM {};".format(
+                distributed_table_name)
+        ).strip()
+        assert result == expected
+
+
+def test_groupBitmapAndState_on_different_version_nodes(start_cluster):
+    local_table_name = "test_group_bitmap_state_versioned"
+    distributed_table_name = "test_group_bitmap_state_versioned_dst"
+    cluster_name = "test_version_cluster"
+
+    for node in (node3, node4):
+        node.query(
+            """CREATE TABLE {}
+        (
+            z AggregateFunction(groupBitmap, UInt32)
+        )
+        ENGINE = MergeTree()
+        ORDER BY tuple()""".format(
+                local_table_name
+            )
+        )
+
+        node.query(
+            """CREATE TABLE {}
+        (
+            z AggregateFunction(groupBitmap, UInt32)
+        )
+        ENGINE = Distributed('{}', 'default', '{}')""".format(
+                distributed_table_name, cluster_name, local_table_name
+            )
+        )
+
+    node3.query(
+        """INSERT INTO {} VALUES
+                (bitmapBuild(cast([1,2,3,4,5,6,7,8,9,10] as Array(UInt32))));""".format(
+            local_table_name
+        )
+    )
+
+    node4.query(
+        """INSERT INTO {} VALUES
+                (bitmapBuild(cast([0] as Array(UInt32))));""".format(
+            local_table_name
+        )
+    )
+
+    # We will get wrong result when query distribute table if the cluster contains old version server
+    result = node3.query(
+        "select bitmapCardinality(groupBitmapAndState(z)) FROM {};".format(
+            distributed_table_name)
+    ).strip()
+    assert result == "10"
+
+    result = node4.query(
+        "select bitmapCardinality(groupBitmapAndState(z)) FROM {};".format(
+            distributed_table_name)
+    ).strip()
+    assert result == "1"

--- a/tests/integration/test_groupBitmapAnd_on_distributed/test_groupBitmapAndState_on_distributed_table.py
+++ b/tests/integration/test_groupBitmapAnd_on_distributed/test_groupBitmapAndState_on_distributed_table.py
@@ -77,7 +77,8 @@ def test_groupBitmapAndState_on_distributed_table(start_cluster):
     for node in (node1, node2):
         result = node.query(
             "select bitmapCardinality(groupBitmapAndState(z)) FROM {};".format(
-                distributed_table_name)
+                distributed_table_name
+            )
         ).strip()
         assert result == expected
 
@@ -126,12 +127,14 @@ def test_groupBitmapAndState_on_different_version_nodes(start_cluster):
     # We will get wrong result when query distribute table if the cluster contains old version server
     result = node3.query(
         "select bitmapCardinality(groupBitmapAndState(z)) FROM {};".format(
-            distributed_table_name)
+            distributed_table_name
+        )
     ).strip()
     assert result == "10"
 
     result = node4.query(
         "select bitmapCardinality(groupBitmapAndState(z)) FROM {};".format(
-            distributed_table_name)
+            distributed_table_name
+        )
     ).strip()
     assert result == "1"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a bug of `groupBitmapAndState`/`groupBitmapOrState`/`groupBitmapXorState` on distributed table.

We have fixed `groupBitmapAnd` function on distributed tables in https://github.com/ClickHouse/ClickHouse/pull/32529, -State function has the same issue.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
