### PR TITLE
Deduce `UInt8` type for bools from json instead of `UInt64`

### DIFF
--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -154,6 +154,12 @@ public:
             type_indexes.insert(TypeIndex::Int64);
     }
 
+    void operator()(const bool &)
+    {
+        field_types.insert(FieldType::UInt64);
+        type_indexes.insert(TypeIndex::UInt8);
+    }
+
     void operator()(const Null &)
     {
         have_nulls = true;

--- a/tests/queries/0_stateless/01825_type_json_bools.reference
+++ b/tests/queries/0_stateless/01825_type_json_bools.reference
@@ -1,0 +1,1 @@
+(1,0)	Tuple(k1 UInt8, k2 UInt8)

--- a/tests/queries/0_stateless/01825_type_json_bools.sql
+++ b/tests/queries/0_stateless/01825_type_json_bools.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 DROP TABLE IF EXISTS t_json_bools;
 SET allow_experimental_object_type = 1;
 

--- a/tests/queries/0_stateless/01825_type_json_bools.sql
+++ b/tests/queries/0_stateless/01825_type_json_bools.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS t_json_bools;
+SET allow_experimental_object_type = 1;
+
+CREATE TABLE t_json_bools (data JSON) ENGINE = Memory;
+INSERT INTO t_json_bools VALUES ('{"k1": true, "k2": false}');
+SELECT data, toTypeName(data) FROM t_json_bools;
+
+DROP TABLE t_json_bools;

--- a/tests/queries/0_stateless/01825_type_json_btc.reference
+++ b/tests/queries/0_stateless/01825_type_json_btc.reference
@@ -1,5 +1,5 @@
 100
-data	Tuple(double_spend UInt64, fee Int32, hash String, inputs Nested(index Int8, prev_out Tuple(addr String, n Int16, script String, spending_outpoints Nested(n Int8, tx_index Int64), spent UInt64, tx_index Int64, type Int8, value Int64), script String, sequence Int64, witness String), lock_time Int32, out Nested(addr String, n Int8, script String, spending_outpoints Nested(n Int8, tx_index Int64), spent UInt64, tx_index Int64, type Int8, value Int64), rbf UInt64, relayed_by String, size Int16, time Int32, tx_index Int64, ver Int8, vin_sz Int8, vout_sz Int8, weight Int16)					
+data	Tuple(double_spend UInt8, fee Int32, hash String, inputs Nested(index Int8, prev_out Tuple(addr String, n Int16, script String, spending_outpoints Nested(n Int8, tx_index Int64), spent UInt8, tx_index Int64, type Int8, value Int64), script String, sequence Int64, witness String), lock_time Int32, out Nested(addr String, n Int8, script String, spending_outpoints Nested(n Int8, tx_index Int64), spent UInt8, tx_index Int64, type Int8, value Int64), rbf UInt8, relayed_by String, size Int16, time Int32, tx_index Int64, ver Int8, vin_sz Int8, vout_sz Int8, weight Int16)					
 8174.56	2680
 2.32	1
 [[],[(0,359661801933760)]]

--- a/tests/queries/0_stateless/01825_type_json_ghdata.reference
+++ b/tests/queries/0_stateless/01825_type_json_ghdata.reference
@@ -2,10 +2,11 @@
 839
 String	562
 Array	134
-UInt64	63
+UInt8	54
 Int32	47
 Int8	17
 Int16	15
+UInt64	9
 Int64	1
 leonardomso/33-js-concepts	3
 ytdl-org/youtube-dl	3

--- a/tests/queries/0_stateless/01825_type_json_nbagames.reference
+++ b/tests/queries/0_stateless/01825_type_json_nbagames.reference
@@ -1,5 +1,5 @@
 1000
-data	Tuple(_id Tuple(`$oid` String), date Tuple(`$date` String), teams Nested(abbreviation String, city String, home UInt64, name String, players Nested(ast Int8, blk Int8, drb Int8, fg Int8, fg3 Int8, fg3_pct String, fg3a Int8, fg_pct String, fga Int8, ft Int8, ft_pct String, fta Int8, mp String, orb Int8, pf Int8, player String, pts Int8, stl Int8, tov Int8, trb Int8), results Tuple(ast Int8, blk Int8, drb Int8, fg Int8, fg3 Int8, fg3_pct String, fg3a Int8, fg_pct String, fga Int8, ft Int8, ft_pct String, fta Int8, mp Int16, orb Int8, pf Int8, pts Int16, stl Int8, tov Int8, trb Int8), score Int16, won Int8))					
+data	Tuple(_id Tuple(`$oid` String), date Tuple(`$date` String), teams Nested(abbreviation String, city String, home UInt8, name String, players Nested(ast Int8, blk Int8, drb Int8, fg Int8, fg3 Int8, fg3_pct String, fg3a Int8, fg_pct String, fga Int8, ft Int8, ft_pct String, fta Int8, mp String, orb Int8, pf Int8, player String, pts Int8, stl Int8, tov Int8, trb Int8), results Tuple(ast Int8, blk Int8, drb Int8, fg Int8, fg3 Int8, fg3_pct String, fg3a Int8, fg_pct String, fga Int8, ft Int8, ft_pct String, fta Int8, mp Int16, orb Int8, pf Int8, pts Int16, stl Int8, tov Int8, trb Int8), score Int16, won Int8))					
 Boston Celtics	70
 Los Angeles Lakers	64
 Milwaukee Bucks	61


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)