### PR TITLE
Fix flaky test `test_ddl_worker_non_leader`

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -47,6 +47,7 @@ namespace ErrorCodes
     extern const int TIMEOUT_EXCEEDED;
     extern const int UNFINISHED;
     extern const int NOT_A_LEADER;
+    extern const int TABLE_IS_READ_ONLY;
     extern const int KEEPER_EXCEPTION;
     extern const int CANNOT_ASSIGN_ALTER;
     extern const int CANNOT_ALLOCATE_MEMORY;
@@ -459,6 +460,7 @@ bool DDLWorker::tryExecuteQuery(const String & query, DDLTaskBase & task, const 
         /// and consider query as executed with status "failed" and return true in other cases.
         bool no_sense_to_retry = e.code() != ErrorCodes::KEEPER_EXCEPTION &&
                                  e.code() != ErrorCodes::NOT_A_LEADER &&
+                                 e.code() != ErrorCodes::TABLE_IS_READ_ONLY &&
                                  e.code() != ErrorCodes::CANNOT_ASSIGN_ALTER &&
                                  e.code() != ErrorCodes::CANNOT_ALLOCATE_MEMORY &&
                                  e.code() != ErrorCodes::MEMORY_LIMIT_EXCEEDED;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/36613/afd82a68f981e2244d481ff039996ff6b122b0a4/integration_tests__thread__actions__[4/4].html

It was race condition between `DDLWorker` and `ReplicatedMergeTreeRestartingThread`:
```
2022.04.27 04:23:21.042776 [ 218 ] {5974f779-828f-4493-94a2-78b29b438dcf} <Error> executeQuery: Code: 242. DB::Exception: Table is in readonly mode (replica path: /clickhouse/tables/0/sometable/replicas/1). (TABLE_IS_READ_ONLY) (version 22.5.1.1) (from 0.0.0.0:0) (in query: /* ddl_entry=query-0000000000 */ ALTER TABLE default.sometable MODIFY COLUMN `value` UInt64), Stack trace (when copying this message, always include the lines below):
```