### PR TITLE
Improve docs_check to be used in clickhouse-docs

### DIFF
--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -1,10 +1,11 @@
+---
 name: DocsCheck
 
 env:
   # Force the stdout and stderr streams to be unbuffered
   PYTHONUNBUFFERED: 1
 
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   pull_request:
     types:
       - synchronize
@@ -15,6 +16,7 @@ on: # yamllint disable-line rule:truthy
     paths:
       - 'docs/**'
       - 'website/**'
+      - 'docker/docs/**'
 jobs:
   CheckLabels:
     runs-on: [self-hosted, style-checker]

--- a/docker/docs/builder/run.sh
+++ b/docker/docs/builder/run.sh
@@ -2,8 +2,10 @@
 
 set -ex
 
-if [ "$GIT_DOCS_BRANCH" ]; then
-  git fetch origin --depth=1 "$GIT_DOCS_BRANCH:$GIT_DOCS_BRANCH"
+GIT_BRANCH=$(git branch --show-current)
+
+if [ "$GIT_DOCS_BRANCH" ] && ! [ "$GIT_DOCS_BRANCH" == "$GIT_BRANCH" ]; then
+  git fetch origin --depth=1 -- "$GIT_DOCS_BRANCH:$GIT_DOCS_BRANCH"
   git checkout "$GIT_DOCS_BRANCH"
 else
   # Update docs repo

--- a/tests/ci/docs_check.py
+++ b/tests/ci/docs_check.py
@@ -31,6 +31,11 @@ if __name__ == "__main__":
         default="",
         help="a branch to get from docs repository",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="check the docs even if there no changes",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
@@ -49,7 +54,7 @@ if __name__ == "__main__":
         logging.info("Check is already finished according to github status, exiting")
         sys.exit(0)
 
-    if not pr_info.has_changes_in_documentation():
+    if not pr_info.has_changes_in_documentation() and not args.force:
         logging.info("No changes in documentation")
         commit = get_commit(gh, pr_info.sha)
         commit.create_status(
@@ -57,7 +62,10 @@ if __name__ == "__main__":
         )
         sys.exit(0)
 
-    logging.info("Has changes in docs")
+    if pr_info.has_changes_in_documentation():
+        logging.info("Has changes in docs")
+    elif args.force:
+        logging.info("Check the docs because of force flag")
 
     if not os.path.exists(temp_path):
         os.makedirs(temp_path)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `--force` key to ignore unchanged docs.

Fix issue with GIT_DOCS_BRANCH env in docs-builder