### PR TITLE
Fix creation of tables with `flatten_nested = 0`

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -589,7 +589,7 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
         res.add(std::move(column));
     }
 
-    if (context_->getSettingsRef().flatten_nested)
+    if (!attach && context_->getSettingsRef().flatten_nested)
         res.flattenNested();
 
     if (res.getAllPhysical().empty())

--- a/tests/queries/0_stateless/02292_nested_not_flattened_detach.reference
+++ b/tests/queries/0_stateless/02292_nested_not_flattened_detach.reference
@@ -1,0 +1,4 @@
+CREATE TABLE default.t_nested_detach\n(\n    `n` Nested(u UInt32, s String)\n)\nENGINE = Log
+n	Nested(u UInt32, s String)					
+CREATE TABLE default.t_nested_detach\n(\n    `n` Nested(u UInt32, s String)\n)\nENGINE = Log
+n	Nested(u UInt32, s String)					

--- a/tests/queries/0_stateless/02292_nested_not_flattened_detach.sql
+++ b/tests/queries/0_stateless/02292_nested_not_flattened_detach.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS t_nested_detach;
+
+SET flatten_nested = 0;
+CREATE TABLE t_nested_detach (n Nested(u UInt32, s String)) ENGINE = Log;
+
+SHOW CREATE TABLE t_nested_detach;
+DESC TABLE t_nested_detach;
+
+SET flatten_nested = 1;
+
+DETACH TABLE t_nested_detach;
+ATTACH TABLE t_nested_detach;
+
+SHOW CREATE TABLE t_nested_detach;
+DESC TABLE t_nested_detach;
+
+DROP TABLE IF EXISTS t_nested_detach;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix creation of tables with `flatten_nested = 0`. Previously unflattened `Nested` columns could be flattened after server restart.

Fixes #35830.