### PR TITLE
Fix style error in DocsCheck

### DIFF
--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -1,4 +1,3 @@
----
 name: DocsCheck
 
 env:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A style fix, added in #36796