### PR TITLE
Set is_all_data_sent on exceptions too

### DIFF
--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -102,7 +102,8 @@ protected:
 
     std::atomic<bool> is_killed { false };
 
-    /// All data to the client already had been sent. Including EndOfStream.
+    /// All data to the client already had been sent.
+    /// Including EndOfStream or Exception.
     std::atomic<bool> is_all_data_sent { false };
 
     void setUserProcessList(ProcessListForUser * user_process_list_);

--- a/src/QueryPipeline/BlockIO.cpp
+++ b/src/QueryPipeline/BlockIO.cpp
@@ -47,5 +47,15 @@ BlockIO::~BlockIO()
     reset();
 }
 
+void BlockIO::setAllDataSent() const
+{
+    /// The following queries does not have process_list_entry:
+    /// - internal
+    /// - SHOW PROCESSLIST
+    if (process_list_entry)
+        (*process_list_entry)->setAllDataSent();
+}
+
+
 }
 

--- a/src/QueryPipeline/BlockIO.h
+++ b/src/QueryPipeline/BlockIO.h
@@ -48,6 +48,9 @@ struct BlockIO
         pipeline.reset();
     }
 
+    /// Set is_all_data_sent in system.processes for this query.
+    void setAllDataSent() const;
+
 private:
     void reset();
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This will avoid clickhouse-test complains about left queries after the
test, like in [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/36258/9646487c093a75dc31e3e818417cfad83580b40f/stateful_tests__memory__actions_.html

Follow-up for: #36649 (cc @alexey-milovidov )