### PR TITLE
Clang -Tidy Fixes

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -410,7 +410,7 @@ Packet LocalConnection::receivePacket()
         {
             if (state->profile_info)
             {
-                packet.profile_info = std::move(*state->profile_info);
+                packet.profile_info = *state->profile_info;
                 state->profile_info.reset();
             }
             next_packet_type.reset();

--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -170,9 +170,9 @@ private:
 
         FileSegmentCell(FileSegmentPtr file_segment_, LRUQueue & queue_);
 
-        FileSegmentCell(FileSegmentCell && other)
+        FileSegmentCell(FileSegmentCell && other) noexcept
             : file_segment(std::move(other.file_segment))
-            , queue_iterator(std::move(other.queue_iterator)) {}
+            , queue_iterator(other.queue_iterator) {}
 
         std::pair<Key, size_t> getKeyAndOffset() const { return std::make_pair(file_segment->key(), file_segment->range().left); }
     };

--- a/src/Common/FileSegment.h
+++ b/src/Common/FileSegment.h
@@ -219,7 +219,7 @@ private:
 struct FileSegmentsHolder : private boost::noncopyable
 {
     explicit FileSegmentsHolder(FileSegments && file_segments_) : file_segments(std::move(file_segments_)) {}
-    FileSegmentsHolder(FileSegmentsHolder && other) : file_segments(std::move(other.file_segments)) {}
+    FileSegmentsHolder(FileSegmentsHolder && other) noexcept : file_segments(std::move(other.file_segments)) {}
 
     ~FileSegmentsHolder();
 

--- a/src/Disks/S3/registerDiskS3.cpp
+++ b/src/Disks/S3/registerDiskS3.cpp
@@ -161,7 +161,7 @@ std::unique_ptr<DiskS3Settings> getSettings(const Poco::Util::AbstractConfigurat
 
     return std::make_unique<DiskS3Settings>(
         getClient(config, config_prefix, context),
-        std::move(rw_settings),
+        rw_settings,
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),
         config.getBool(config_prefix + ".send_metadata", false),
         config.getInt(config_prefix + ".thread_pool_size", 16),

--- a/src/QueryPipeline/BlockIO.cpp
+++ b/src/QueryPipeline/BlockIO.cpp
@@ -37,7 +37,7 @@ BlockIO & BlockIO::operator= (BlockIO && rhs) noexcept
     finish_callback         = std::move(rhs.finish_callback);
     exception_callback      = std::move(rhs.exception_callback);
 
-    null_format             = std::move(rhs.null_format);
+    null_format             = rhs.null_format;
 
     return *this;
 }


### PR DESCRIPTION
# Changelog category 
- Not for changelog

# Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This PR fixed Clang-Tidy issues from recent PRs.
- [ performance-move-const-arg](https://clang.llvm.org/extra/clang-tidy/checks/performance-move-const-arg.html)
- [performance-noexcept-move-constructor](https://clang.llvm.org/extra/clang-tidy/checks/performance-noexcept-move-constructor.html)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
