### PR TITLE
Avoid recreation of system.asynchronous_metric_log (due to difference in codec)

### DIFF
--- a/src/Interpreters/AsynchronousMetricLog.h
+++ b/src/Interpreters/AsynchronousMetricLog.h
@@ -37,9 +37,9 @@ struct AsynchronousMetricLogElement
     /// Otherwise the list will be constructed from LogElement::getNamesAndTypes and LogElement::getNamesAndAliases.
     static const char * getCustomColumnList()
     {
-        return "event_date Date CODEC(Delta(2), ZSTD), "
-               "event_time DateTime CODEC(Delta(4), ZSTD), "
-               "metric LowCardinality(String) CODEC(ZSTD), "
+        return "event_date Date CODEC(Delta(2), ZSTD(1)), "
+               "event_time DateTime CODEC(Delta(4), ZSTD(1)), "
+               "metric LowCardinality(String) CODEC(ZSTD(1)), "
                "value Float64 CODEC(Gorilla, ZSTD(3))";
     }
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

From the log:

    2022.04.29 12:33:40.397528 [ 486 ] {} <Debug> SystemLog (system.asynchronous_metric_log): Existing table system.asynchronous_metric_log for system log has obsolete or different structure. Renaming it to asynchronous_metric_log_352.
    Old: CREATE TABLE system.asynchronous_metric_log (`event_date` Date CODEC(Delta(2), ZSTD(1)), `event_time` DateTime CODEC(Delta(4), ZSTD(1)), `metric` LowCardinality(String) CODEC(ZSTD(1)), `value` Float64 CODEC(Gorilla, ZSTD(3))) ENGINE = MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (metric, event_date, event_time) SETTINGS index_granularity = 8192
    New: CREATE TABLE system.asynchronous_metric_log (`event_date` Date CODEC(Delta(2), ZSTD), `event_time` DateTime CODEC(Delta(4), ZSTD), `metric` LowCardinality(String) CODEC(ZSTD), `value` Float64 CODEC(Gorilla, ZSTD(3))) ENGINE = MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (metric, event_date, event_time) SETTINGS index_granularity = 8192

As you can see the difference in default ZSTD level.

P.S. I decided not to fix the printer, since this may introduce changes
in metadata, that may lead to changes in metadata between ZooKeeper and
clickhouse server.

Fixes: #36360 (cc @alexey-milovidov )
_NOTE: Marked as not for changelog since original PR had not been included into any stable release yet_