### PR TITLE
Validate that function had been passed in CREATE FUNCTION

### DIFF
--- a/src/Interpreters/InterpreterCreateFunctionQuery.cpp
+++ b/src/Interpreters/InterpreterCreateFunctionQuery.cpp
@@ -61,8 +61,12 @@ BlockIO InterpreterCreateFunctionQuery::execute()
 
 void InterpreterCreateFunctionQuery::validateFunction(ASTPtr function, const String & name)
 {
-    auto & lambda_function = function->as<ASTFunction &>();
-    auto & lambda_function_expression_list = lambda_function.arguments->children;
+    ASTFunction * lambda_function = function->as<ASTFunction>();
+
+    if (!lambda_function)
+        throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Expected function, got: {}", function->formatForErrorMessage());
+
+    auto & lambda_function_expression_list = lambda_function->arguments->children;
 
     if (lambda_function_expression_list.size() != 2)
         throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "Lambda must have arguments and body");

--- a/tests/queries/0_stateless/02292_create_function_validate.sql
+++ b/tests/queries/0_stateless/02292_create_function_validate.sql
@@ -1,0 +1,1 @@
+create function foo as x -- { serverError UNSUPPORTED_METHOD }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Otherwise right now it leads to LOGICAL_ERROR, due to bad cast.