### PR TITLE
tests: disable 02260_alter_compact_part_drop_nested_column for <=22.4

### DIFF
--- a/tests/queries/0_stateless/02260_alter_compact_part_drop_nested_column.sql.j2
+++ b/tests/queries/0_stateless/02260_alter_compact_part_drop_nested_column.sql.j2
@@ -1,3 +1,5 @@
+-- Tags: no-backward-compatibility-check:22.4
+
 {# force compact parts and wide #}
 {% for min_bytes_for_wide_part in [100000, 0] %}
 DROP TABLE IF EXISTS compact_alter_{{ min_bytes_for_wide_part }};


### PR DESCRIPTION
This should fix backward compatibility check in stress tests, like here [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/36836/9dde147529979ed9cc4d68036de5fd93e0fc2c42/stress_test__address__actions_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)