### PR TITLE
Add docs for undocumented allow_nondeterministic_mutations

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -5,30 +5,6 @@ sidebar_label: Server Settings
 
 # Server Settings {#server-settings}
 
-## allow_nondeterministic_mutations {#allow_nondeterministic_mutations}
-
-User-level setting that allows mutations on replicated tables to make use of non-deterministic functions such as `dictGet`.
-
-Given that, for example, dictionaries, can be out of sync across nodes, mutations that pull values from them are disallowed on replicated tables by default. Enabling this setting allows this behavior, making it the user's responsibility to ensure that the data used is in sync across all nodes.
-
-Default value: 0.
-
-**Example**
-
-``` xml
-<profiles>
-    <default>
-        <allow_nondeterministic_mutations>1</allow_nondeterministic_mutations>
-        
-        <!-- ... -->
-    </default>
-
-    <!-- ... -->
-
-</profiles>
-```
-
-
 ## builtin_dictionaries_reload_interval {#builtin-dictionaries-reload-interval}
 
 The interval in seconds before reloading built-in dictionaries.

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -5,6 +5,30 @@ sidebar_label: Server Settings
 
 # Server Settings {#server-settings}
 
+## allow_nondeterministic_mutations {#allow_nondeterministic_mutations}
+
+User-level setting that allows mutations on replicated tables to make use of non-deterministic functions such as `dictGet`.
+
+Given that, for example, dictionaries, can be out of sync across nodes, mutations that pull values from them are disallowed on replicated tables by default. Enabling this setting allows this behavior, making it the user's responsibility to ensure that the data used is in sync across all nodes.
+
+Default value: 0.
+
+**Example**
+
+``` xml
+<profiles>
+    <default>
+        <allow_nondeterministic_mutations>1</allow_nondeterministic_mutations>
+        
+        <!-- ... -->
+    </default>
+
+    <!-- ... -->
+
+</profiles>
+```
+
+
 ## builtin_dictionaries_reload_interval {#builtin-dictionaries-reload-interval}
 
 The interval in seconds before reloading built-in dictionaries.

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -6,6 +6,29 @@ slug: /en/operations/settings/settings
 
 # Settings {#settings}
 
+## allow_nondeterministic_mutations {#allow_nondeterministic_mutations}
+
+User-level setting that allows mutations on replicated tables to make use of non-deterministic functions such as `dictGet`.
+
+Given that, for example, dictionaries, can be out of sync across nodes, mutations that pull values from them are disallowed on replicated tables by default. Enabling this setting allows this behavior, making it the user's responsibility to ensure that the data used is in sync across all nodes.
+
+Default value: 0.
+
+**Example**
+
+``` xml
+<profiles>
+    <default>
+        <allow_nondeterministic_mutations>1</allow_nondeterministic_mutations>
+        
+        <!-- ... -->
+    </default>
+
+    <!-- ... -->
+
+</profiles>
+```
+
 ## distributed_product_mode {#distributed-product-mode}
 
 Changes the behaviour of [distributed subqueries](../../sql-reference/operators/in.md).


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)


Setting was added in https://github.com/ClickHouse/ClickHouse/pull/10186 and featured in the 2020 changelog but nowhere else