### PR TITLE
Remove log message on client reconnects (reverts #36587)

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1430,15 +1430,7 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
             apply_query_settings(*with_output->settings_ast);
 
         if (!connection->checkConnected())
-        {
-            auto poco_logs_level = Poco::Logger::parseLevel(config().getString("send_logs_level", "none"));
-            /// Print under WARNING also because it is used by clickhouse-test.
-            if (poco_logs_level >= Poco::Message::PRIO_WARNING)
-            {
-                fmt::print(stderr, "Connection lost. Reconnecting.\n");
-            }
             connect();
-        }
 
         ASTPtr input_function;
         if (insert && insert->select)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Before tests can fail if there was implicit reconnect, with queries
left, and without referenced PR, it requires manual debugging to know
that the reason was reconnect.

But the problem is, that the server does send EndOfStream but hanged
after, but before removing this query from the system.processes.
But after adding is_all_data_sent (#36816, #36767, #36649),
clickhouse-test can check queries left only for which server did not
sent EndOfStream/Exception.

In other words after adding is_all_data_sent, it should not be possible
to have queries left in such cases.

Reverts: 53be9c5d0c510a93a3db64f4a7a083610af46bd1
Reverts: #36587
Cc: @tavplubix 
Cc: @alexey-milovidov 

_P.S. I've also looked through those failures, and the problem is indeed query profiler._