### PR TITLE
Fixed GRANT check

### DIFF
--- a/src/Interpreters/Access/InterpreterGrantQuery.cpp
+++ b/src/Interpreters/Access/InterpreterGrantQuery.cpp
@@ -117,7 +117,7 @@ namespace
     void checkGranteeIsAllowed(const ContextAccess & current_user_access, const UUID & grantee_id, const IAccessEntity & grantee)
     {
         auto current_user = current_user_access.getUser();
-        if (current_user && !current_user->grantees.match(grantee_id))
+        if (!current_user || !current_user->grantees.match(grantee_id))
             throw Exception(grantee.formatTypeWithName() + " is not allowed as grantee", ErrorCodes::ACCESS_DENIED);
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In case of a race user can be deleted (and effect of this can be seen) after obtaining a `ContextAccess`. So `ContextAccess::getUser()` may return null.