### PR TITLE
Allow a user to inspect grants from granted roles

### DIFF
--- a/src/Interpreters/Access/InterpreterShowGrantsQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowGrantsQuery.cpp
@@ -6,6 +6,7 @@
 #include <Access/AccessControl.h>
 #include <Access/CachedAccessChecking.h>
 #include <Access/ContextAccess.h>
+#include <Access/EnabledRolesInfo.h>
 #include <Access/Role.h>
 #include <Access/RolesOrUsersSet.h>
 #include <Access/User.h>
@@ -147,13 +148,22 @@ std::vector<AccessEntityPtr> InterpreterShowGrantsQuery::getEntities() const
     CachedAccessChecking show_roles(access, AccessType::SHOW_ROLES);
     bool throw_if_access_denied = !show_query.for_roles->all;
 
+    auto current_user = access->getUser();
+    auto roles_info = access->getRolesInfo();
+
     std::vector<AccessEntityPtr> entities;
     for (const auto & id : ids)
     {
         auto entity = access_control.tryRead(id);
         if (!entity)
             continue;
-        if ((id == access->getUserID() /* Any user can see his own grants */)
+
+        bool is_current_user = (id == access->getUserID());
+        bool is_enabled_or_granted_role = entity->isTypeOf<Role>()
+            && ((current_user && current_user->granted_roles.isGranted(id)) || roles_info->enabled_roles.contains(id));
+
+        if ((is_current_user /* Any user can see his own grants */)
+            || (is_enabled_or_granted_role /* and grants from the granted roles */)
             || (entity->isTypeOf<User>() && show_users.checkAccess(throw_if_access_denied))
             || (entity->isTypeOf<Role>() && show_roles.checkAccess(throw_if_access_denied)))
             entities.push_back(entity);

--- a/tests/integration/test_role/test.py
+++ b/tests/integration/test_role/test.py
@@ -1,4 +1,5 @@
 import pytest
+from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
@@ -260,6 +261,11 @@ def test_introspection():
     assert instance.query("SHOW GRANTS", user="A") == TSV(
         ["GRANT SELECT ON test.table TO A", "GRANT R1 TO A"]
     )
+
+    assert instance.query("SHOW GRANTS FOR R1", user="A") == TSV([])
+    with pytest.raises(QueryRuntimeException, match="Not enough privileges"):
+        assert instance.query("SHOW GRANTS FOR R2", user="A")
+
     assert instance.query("SHOW GRANTS", user="B") == TSV(
         [
             "GRANT CREATE ON *.* TO B WITH GRANT OPTION",


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow a user to inspect grants from granted roles

cc @vitlibar 