### PR TITLE
Finalize write buffers in case of exception

### DIFF
--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -415,6 +415,11 @@ public:
         writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
     }
 
+    void onException() override
+    {
+        write_buf->finalize();
+    }
+
     void onFinish() override
     {
         try

--- a/src/Storages/PartitionedSink.cpp
+++ b/src/Storages/PartitionedSink.cpp
@@ -111,6 +111,13 @@ void PartitionedSink::consume(Chunk chunk)
     }
 }
 
+void PartitionedSink::onException()
+{
+    for (auto & [_, sink] : partition_id_to_sink)
+    {
+        sink->onException();
+    }
+}
 
 void PartitionedSink::onFinish()
 {

--- a/src/Storages/PartitionedSink.h
+++ b/src/Storages/PartitionedSink.h
@@ -22,6 +22,8 @@ public:
 
     void consume(Chunk chunk) override;
 
+    void onException() override;
+
     void onFinish() override;
 
     virtual SinkPtr createSinkForPartition(const String & partition_id) = 0;

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -782,11 +782,25 @@ public:
         writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
     }
 
+    void onException() override
+    {
+        write_buf->finalize();
+    }
+
     void onFinish() override
     {
-        writer->finalize();
-        writer->flush();
-        write_buf->finalize();
+        try
+        {
+            writer->finalize();
+            writer->flush();
+            write_buf->finalize();
+        }
+        catch (...)
+        {
+            /// Stop ParallelFormattingOutputFormat correctly.
+            writer.reset();
+            throw;
+        }
     }
 
 private:

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -469,6 +469,11 @@ public:
         writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
     }
 
+    void onException() override
+    {
+        write_buf->finalize();
+    }
+
     void onFinish() override
     {
         try

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -442,6 +442,11 @@ void StorageURLSink::consume(Chunk chunk)
     writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
 }
 
+void StorageURLSink::onException()
+{
+    write_buf->finalize();
+}
+
 void StorageURLSink::onFinish()
 {
     writer->finalize();

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -114,6 +114,7 @@ public:
 
     std::string getName() const override { return "StorageURLSink"; }
     void consume(Chunk chunk) override;
+    void onException() override;
     void onFinish() override;
 
 private:


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Finalize write buffers in case of exception to avoid doing it in destructors.
Hope it fixes: https://github.com/ClickHouse/ClickHouse/issues/36907


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
