### PR TITLE
fix output error in LabelsCheck

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -220,7 +220,7 @@ class PRInfo:
         else:
             diff_object = PatchSet(response.text)
             self.changed_files = {f.path for f in diff_object}
-        print("Fetched info about %d changed files", len(self.changed_files))
+        print("Fetched info about %d changed files" % len(self.changed_files))
 
     def get_dict(self):
         return {


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
