### PR TITLE
remove useless code

### DIFF
--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -170,8 +170,6 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
     }
     else
     {
-        pipeline.resize(1);
-
         pipeline.addSimpleTransform([&](const Block & header)
         {
             return std::make_shared<AggregatingTransform>(header, transform_params);


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
If streams size is 1,  looks like`pipeline.resize(1)` did nothing.