### PR TITLE
Add SETTING update_allow_materialized_columns

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -2241,6 +2241,10 @@ Default value: `0`.
 -   [Synchronicity of ALTER Queries](../../sql-reference/statements/alter/index.md#synchronicity-of-alter-queries)
 -   [Mutations](../../sql-reference/statements/alter/index.md#mutations)
 
+## update_allow_materialized_columns {#update_allow_materialized_columns}
+
+Allows `ALTER TABLE ... UPDATE` queries to modify [MATERIALIZED](../../sql-reference/statements/create/table.md#materialized) columns.
+
 ## ttl_only_drop_parts {#ttl_only_drop_parts}
 
 Enables or disables complete dropping of data parts where all rows are expired in [MergeTree](../../engines/table-engines/mergetree-family/mergetree.md) tables.

--- a/docs/en/sql-reference/statements/alter/update.md
+++ b/docs/en/sql-reference/statements/alter/update.md
@@ -22,9 +22,14 @@ One query can contain several commands separated by commas.
 
 The synchronicity of the query processing is defined by the [mutations_sync](../../../operations/settings/settings.md#mutations_sync) setting. By default, it is asynchronous.
 
+Columns that are part of a table's primary key or partition key may not be updated.
+[MATERIALIZED](../../statements/create/table.md#materialized) columns may be updated only if the
+[update_allow_materialized_columns](../../../operations/settings/settings.md#update_allow_materialized_columns) setting is 1.
+
 **See also**
 
 -   [Mutations](../../../sql-reference/statements/alter/index.md#mutations)
 -   [Synchronicity of ALTER Queries](../../../sql-reference/statements/alter/index.md#synchronicity-of-alter-queries)
 -   [mutations_sync](../../../operations/settings/settings.md#mutations_sync) setting
+-   [update_allow_materialized_columns](../../../operations/settings/settings.md#update_allow_materialized_columns) setting
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -273,7 +273,8 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     /** Settings for testing connection collector */ \
     M(Milliseconds, sleep_in_receive_cancel_ms, 0, "Time to sleep in receiving cancel in TCPHandler", 0) \
     \
-    M(Bool, insert_allow_materialized_columns, false, "If setting is enabled, Allow materialized columns in INSERT.", 0) \
+    M(Bool, insert_allow_materialized_columns, false, "If setting is enabled, allow materialized columns in INSERT.", 0) \
+    M(Bool, update_allow_materialized_columns, false, "If setting is enabled, allow materialized columns in UPDATE.", 0) \
     M(Seconds, http_connection_timeout, DEFAULT_HTTP_READ_BUFFER_CONNECTION_TIMEOUT, "HTTP connection timeout.", 0) \
     M(Seconds, http_send_timeout, DEFAULT_HTTP_READ_BUFFER_TIMEOUT, "HTTP send timeout", 0) \
     M(Seconds, http_receive_timeout, DEFAULT_HTTP_READ_BUFFER_TIMEOUT, "HTTP receive timeout", 0) \

--- a/src/Interpreters/InterpreterAlterQuery.cpp
+++ b/src/Interpreters/InterpreterAlterQuery.cpp
@@ -143,6 +143,7 @@ BlockIO InterpreterAlterQuery::executeToTable(const ASTAlterQuery & alter)
 
     if (!mutation_commands.empty())
     {
+        mutation_commands.readSettingsFromQuery(getContext(), alter.settings_ast);
         table->checkMutationIsPossible(mutation_commands, getContext()->getSettingsRef());
         MutationsInterpreter(table, metadata_snapshot, mutation_commands, getContext(), false).validate();
         table->mutate(mutation_commands, getContext());
@@ -224,6 +225,8 @@ BlockIO InterpreterAlterQuery::executeToDatabase(const ASTAlterQuery & alter)
 
     return res;
 }
+
+
 AccessRightsElements InterpreterAlterQuery::getRequiredAccess() const
 {
     AccessRightsElements required_access;

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1495,6 +1495,7 @@ bool MutateTask::prepare()
     context_for_reading->setSetting("force_index_by_date", false);
     context_for_reading->setSetting("force_primary_key", false);
 
+    ctx->commands_for_part.settings_changes = ctx->commands->settings_changes;
     for (const auto & command : *ctx->commands)
     {
         if (command.partition == nullptr || ctx->source_part->info.partition_id == ctx->data->getPartitionIDFromQuery(
@@ -1516,6 +1517,8 @@ bool MutateTask::prepare()
         LOG_TRACE(ctx->log, "Mutating part {} to mutation version {}", ctx->source_part->name, ctx->future_part->part_info.mutation);
     }
 
+    ctx->for_interpreter.settings_changes = ctx->commands->settings_changes;
+    ctx->for_file_renames.settings_changes = ctx->commands->settings_changes;
     MutationHelpers::splitMutationCommands(ctx->source_part, ctx->commands_for_part, ctx->for_interpreter, ctx->for_file_renames);
 
     ctx->stage_progress = std::make_unique<MergeStageProgress>(1.0);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeMutationEntry.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeMutationEntry.cpp
@@ -30,6 +30,11 @@ void ReplicatedMergeTreeMutationEntry::writeText(WriteBuffer & out) const
     out << "alter version: ";
     out << alter_version;
 
+    if (!commands.settings_changes.empty())
+    {
+        out << "\nsettings: ";
+        commands.writeSettings(out);
+    }
 }
 
 void ReplicatedMergeTreeMutationEntry::readText(ReadBuffer & in)
@@ -58,6 +63,8 @@ void ReplicatedMergeTreeMutationEntry::readText(ReadBuffer & in)
     commands.readText(in);
     if (checkString("\nalter version: ", in))
         in >> alter_version;
+    if (checkString("\nsettings: ", in))
+        commands.readSettings(in);
 }
 
 String ReplicatedMergeTreeMutationEntry::toString() const

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1710,6 +1710,8 @@ MutationCommands ReplicatedMergeTreeQueue::getMutationCommands(
         ++end;
 
     MutationCommands commands;
+    if (begin != end)
+        commands.settings_changes = begin->second->entry->commands.settings_changes;
     for (auto it = begin; it != end; ++it)
         commands.insert(commands.end(), it->second->entry->commands.begin(), it->second->entry->commands.end());
 

--- a/src/Storages/MutationCommands.cpp
+++ b/src/Storages/MutationCommands.cpp
@@ -3,7 +3,6 @@
 #include <IO/ReadHelpers.h>
 #include <Interpreters/Context.h>
 #include <Parsers/formatAST.h>
-#include <Parsers/formatSettingName.h>
 #include <Parsers/ParserAlterQuery.h>
 #include <Parsers/ParserSetQuery.h>
 #include <Parsers/parseQuery.h>
@@ -14,7 +13,6 @@
 #include <Parsers/ASTSetQuery.h>
 #include <Common/typeid_cast.h>
 #include <Common/quoteString.h>
-#include <Common/FieldVisitorToString.h>
 #include <Core/Defines.h>
 #include <DataTypes/DataTypeFactory.h>
 
@@ -189,14 +187,10 @@ void MutationCommands::readText(ReadBuffer & in)
 
 void MutationCommands::writeSettings(WriteBuffer & out) const
 {
-    for (auto it = settings_changes.begin(); it != settings_changes.end(); ++it)
-    {
-        if (it != settings_changes.begin())
-            out << ", ";
-        formatSettingName(it->name, out);
-        out << " = ";
-        writeEscapedString(applyVisitor(FieldVisitorToString(), it->value), out);
-    }
+    ASTSetQuery ast;
+    ast.is_standalone = false;
+    ast.changes = settings_changes;
+    out << serializeAST(ast);
 }
 
 void MutationCommands::readSettings(ReadBuffer & in)

--- a/src/Storages/MutationCommands.h
+++ b/src/Storages/MutationCommands.h
@@ -8,7 +8,9 @@
 #include <Parsers/ASTAlterQuery.h>
 #include <Storages/IStorage_fwd.h>
 #include <DataTypes/IDataType.h>
+#include <Common/SettingsChanges.h>
 #include <Core/Names.h>
+#include <Interpreters/Context_fwd.h>
 
 namespace DB
 {
@@ -72,10 +74,16 @@ struct MutationCommand
 class MutationCommands : public std::vector<MutationCommand>
 {
 public:
+    /// For ALTER TABLE ... UPDATE ... SETTINGS ...
+    SettingsChanges settings_changes;
+
     std::shared_ptr<ASTExpressionList> ast() const;
 
     void writeText(WriteBuffer & out) const;
     void readText(ReadBuffer & in);
+    void writeSettings(WriteBuffer & out) const;
+    void readSettings(ReadBuffer & in);
+    void readSettingsFromQuery(ContextPtr context, const ASTPtr & settings_ast);
 };
 
 using MutationCommandsConstPtr = std::shared_ptr<MutationCommands>;

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1052,6 +1052,7 @@ std::shared_ptr<MergeMutateSelectedEntry> StorageMergeTree::selectPartsToMutate(
 
             size_t commands_size = 0;
             MutationCommands commands_for_size_validation;
+            commands_for_size_validation.settings_changes = it->second.commands.settings_changes;
             for (const auto & command : it->second.commands)
             {
                 if (command.type != MutationCommand::Type::DROP_COLUMN
@@ -1094,6 +1095,7 @@ std::shared_ptr<MergeMutateSelectedEntry> StorageMergeTree::selectPartsToMutate(
 
             current_ast_elements += commands_size;
             commands->insert(commands->end(), it->second.commands.begin(), it->second.commands.end());
+            commands->settings_changes = it->second.commands.settings_changes;
             last_mutation_to_apply = it;
         }
 

--- a/tests/queries/0_stateless/00652_mutations_alter_update.reference
+++ b/tests/queries/0_stateless/00652_mutations_alter_update.reference
@@ -22,3 +22,16 @@ Updating column that MATERIALIZED key column depends on should fail
 27	materialized_34
 30	materialized_37
 40	materialized_47
+*** Test materialized primary key or partitioning key columns cannot be updated even with SETTINGS update_allow_materialized_columns=1 ***
+Updating primary key should fail
+Updating partition key should fail
+*** Test materialized column can be updated with SETTINGS update_allow_materialized_columns=1 ***
+** alter_update rows[setting from query]:
+123	updated_10
+234	updated_20
+** alter_update rows[setting from session]:
+123	updated_123
+234	updated_234
+** alter_update_repl rows:
+123	repl_updated_123
+234	repl_updated_234

--- a/tests/queries/0_stateless/00652_mutations_alter_update.reference
+++ b/tests/queries/0_stateless/00652_mutations_alter_update.reference
@@ -32,6 +32,3 @@ Updating partition key should fail
 ** alter_update rows[setting from session]:
 123	updated_123
 234	updated_234
-** alter_update_repl rows:
-123	repl_updated_123
-234	repl_updated_234

--- a/tests/queries/0_stateless/00652_replicated_mutations_zookeeper.reference
+++ b/tests/queries/0_stateless/00652_replicated_mutations_zookeeper.reference
@@ -12,3 +12,6 @@ Query should fail 2
 0000000001	DELETE WHERE x = 2	1
 0000000002	DELETE WHERE x = 3	1
 0000000003	DELETE WHERE x = 4	0
+** alter_update_repl rows:
+123	repl_updated_123
+234	repl_updated_234


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

 * Allow updating MATERIALIZED columns by setting `update_allow_materialized_columns=1`.  Add `ALTER UPDATE MATERIALIZED COLUMN` permission (inherits from SYSTEM) to protect this setting.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
