### PR TITLE
Do not move predicates from HAVING to WHERE

### DIFF
--- a/src/Interpreters/PredicateExpressionsOptimizer.h
+++ b/src/Interpreters/PredicateExpressionsOptimizer.h
@@ -34,8 +34,6 @@ private:
 
     bool tryRewritePredicatesToTable(
         ASTPtr & table_element, const ASTs & table_predicates, const TableWithColumnNamesAndTypes & table_columns) const;
-
-    bool tryMovePredicatesFromHavingToWhere(ASTSelectQuery & select_query);
 };
 
 }

--- a/tests/queries/0_stateless/02293_having_to_where.sql
+++ b/tests/queries/0_stateless/02293_having_to_where.sql
@@ -1,0 +1,21 @@
+select a, max(b) max_b, min(b) min_b from
+(
+	select 1 as a, 10 as b
+	union all
+	select 1 as a, 20 as b
+	union all
+	select 1 as a, 30 as b
+)
+group by a
+having b = 10 or max(b) = 30; -- { serverError 215 }
+
+select a, max(b) max_b, min(b) min_b from
+(
+	select 1 as a, 10 as b
+	union all
+	select 1 as a, 20 as b
+	union all
+	select 1 as a, 30 as b
+)
+group by a
+having b = 10; -- { serverError 215 }


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehaviour in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ClickHouse may miss errors like `Column x is not under an aggregate function` because it may move predicates that depends not only on the columns available after GROUP BY from HAVING clause to WHERE clause. The resulting query may be correct, but not the same as the original. This fixes #36895


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
