### PR TITLE
Remove height restrictions from the query div in play web tool.

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -129,8 +129,8 @@
 
         #query_div
         {
-            /* Make enough space for even huge queries. */
-            height: 20%;
+            /* Make enough space for medium/large queries but allowing query textarea to grow. */
+            min-height: 20%;
         }
 
         #query


### PR DESCRIPTION
### Changelog category:
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Modify query div in play.html to be extendable beyond 200px height. In case of very long queries it is helpful to extend the textarea element, only today, since the div is fixed height, the extended textarea hides the data div underneath. With this fix, extending the textarea element will push the data div down/up such the extended textarea won't hide it. 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
