### PR TITLE
Print stacks if we cannot terminate server in stress tests

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -101,7 +101,11 @@ EOL
 
 function stop()
 {
-    clickhouse stop
+    clickhouse stop --do-not-kill && return
+    # We failed to stop the server with SIGTERM. Maybe it hang, let's collect stacktraces.
+    kill -TERM $(pidof gdb) ||:
+    gdb -batch -ex 'thread apply all backtrace' -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" ||:
+    clickhouse stop --force
 }
 
 function start()

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -103,7 +103,8 @@ function stop()
 {
     clickhouse stop --do-not-kill && return
     # We failed to stop the server with SIGTERM. Maybe it hang, let's collect stacktraces.
-    kill -TERM $(pidof gdb) ||:
+    kill -TERM "$(pidof gdb)" ||:
+    sleep 5
     gdb -batch -ex 'thread apply all backtrace' -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" ||:
     clickhouse stop --force
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Sometimes we fail to terminate server with SIGTERM after stress tests, so we send SIGKILL, watchdog prints "Child process was terminated by signal 9" to log and stress test fail with "OOM killer (or signal 9) in clickhouse-server.log". But server logs look like it hang on shutdown:
https://s3.amazonaws.com/clickhouse-test-reports/36977/222277f4f0aafdd32224d5cdd85a3671e7255595/stress_test__address__actions_.html