### PR TITLE
Disable `log_query_threads` by default

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -379,7 +379,7 @@ static constexpr UInt64 operator""_Gb(unsigned long long value)
     \
     M(Bool, log_profile_events, true, "Log query performance statistics into the query_log, query_thread_log and query_views_log.", 0) \
     M(Bool, log_query_settings, true, "Log query settings into the query_log.", 0) \
-    M(Bool, log_query_threads, true, "Log query threads into system.query_thread_log table. This setting have effect only when 'log_queries' is true.", 0) \
+    M(Bool, log_query_threads, false, "Log query threads into system.query_thread_log table. This setting have effect only when 'log_queries' is true.", 0) \
     M(Bool, log_query_views, true, "Log query dependent views into system.query_views_log table. This setting have effect only when 'log_queries' is true.", 0) \
     M(String, log_comment, "", "Log comment into system.query_log table and server log. It can be set to arbitrary string no longer than max_query_size.", 0) \
     M(LogsLevel, send_logs_level, LogsLevel::fatal, "Send server text logs with specified minimum level to client. Valid values: 'trace', 'debug', 'information', 'warning', 'error', 'fatal', 'none'", 0) \

--- a/tests/queries/0_stateless/01461_query_start_time_microseconds.sql
+++ b/tests/queries/0_stateless/01461_query_start_time_microseconds.sql
@@ -23,6 +23,7 @@ WITH (
       ) AS t)
 SELECT if(dateDiff('second', toDateTime(time_with_microseconds), toDateTime(t)) = 0, 'ok', 'fail'); --
 
+SET log_query_threads = 1;
 SELECT '01461_query_thread_log_query_start_time_milliseconds_test';
 SYSTEM FLUSH LOGS;
 -- assumes that the query_start_time field is already accurate.

--- a/tests/queries/0_stateless/01473_event_time_microseconds.sql
+++ b/tests/queries/0_stateless/01473_event_time_microseconds.sql
@@ -6,6 +6,7 @@
 -- Refer: tests/integration/test_asynchronous_metric_log_table.
 
 SET log_queries = 1;
+SET log_query_threads = 1;
 SET query_profiler_real_time_period_ns = 100000000;
 -- a long enough query to trigger the query profiler and to record trace log
 SELECT sleep(2) FORMAT Null;
@@ -41,7 +42,6 @@ WITH (
     ) AS time
 SELECT if(dateDiff('second', toDateTime(time.1), toDateTime(time.2)) = 0, 'ok', toString(time));
 
-SET log_query_threads = 1;
 SELECT '01473_query_thread_log_table_event_start_time_microseconds_test';
 WITH (
         SELECT event_time_microseconds, event_time

--- a/tests/queries/0_stateless/01473_event_time_microseconds.sql
+++ b/tests/queries/0_stateless/01473_event_time_microseconds.sql
@@ -41,6 +41,7 @@ WITH (
     ) AS time
 SELECT if(dateDiff('second', toDateTime(time.1), toDateTime(time.2)) = 0, 'ok', toString(time));
 
+SET log_query_threads = 1;
 SELECT '01473_query_thread_log_table_event_start_time_microseconds_test';
 WITH (
         SELECT event_time_microseconds, event_time


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable `log_query_threads` setting by default. It controls the logging of statistics about every thread participating in query execution. After supporting asynchronous reads, the total number of distinct thread ids became too large, and logging into the `query_thread_log` has become too heavy.

===

After the introduction of async reads from remote FS and the `pread_threadpool` read method, every query can generate 100s of entries in query_thread_log for legitimate reasons. It can slow down operations in some cases. Example: https://github.com/ClickHouse/ClickHouse/pull/33653 (here it slowed down significantly in Debug build and under TSan)

As query_thread_log is rarely used, maybe disable it by default? (see log_query_threads)

Another option is to make sure that the same query will more likely get the recently used threads from ThreadPool, so the number of unique thread ids will be lower, but it looks like an overkill.
