### PR TITLE
Disable thread fuzzer after server restart

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -203,6 +203,10 @@ clickhouse-client --query "SHOW TABLES FROM test"
 stop
 mv /var/log/clickhouse-server/clickhouse-server.log /var/log/clickhouse-server/clickhouse-server.stress.log
 
+# NOTE Disable thread fuzzer before server start with data after stress test.
+# In debug build it can take a lot of time.
+unset "${!THREAD_@}"
+
 start
 
 clickhouse-client --query "SELECT 'Server successfully started', 'OK'" >> /test_output/test_results.tsv \


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Disable it, because looks like sometimes it gives unacceptable startup time.