### PR TITLE
Fix for column declaration in CREATE TABLE

### DIFF
--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -16,8 +16,8 @@ By default, tables are created only on the current server. Distributed DDL queri
 ``` sql
 CREATE TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 (
-    name1 [type1] [NULL|NOT NULL] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr1] [compression_codec] [TTL expr1],
-    name2 [type2] [NULL|NOT NULL] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr2] [compression_codec] [TTL expr2],
+    name1 [type1] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr1] [NULL|NOT NULL] [compression_codec] [TTL expr1],
+    name2 [type2] [DEFAULT|MATERIALIZED|EPHEMERAL|ALIAS expr2] [NULL|NOT NULL] [compression_codec] [TTL expr2],
     ...
 ) ENGINE = engine
 ```


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

In current implementation, `CREATE TABLE` query will return an error if `Nullable` modifier will be provided before `Default value` modifier 
For example,
```
CREATE TABLE t
(
     `c1` int NOT NULL DEFAULT 1 COMMENT '1'
)
ENGINE = MergeTree
ORDER BY tuple()
```
will return 
```
Syntax error: failed at position 41 ('DEFAULT') (line 3, col 24)
```

Interestingly, if I provide a valid query like this:
```
create table t (c1 int(11) DEFAULT 1 NOT NULL COMMENT '1') engine=MergeTree order by tuple()
```
in parsed query, `NOT NULL` and `DEFAULT 1` will exchange their places, i.e. ClickHouse will return:
```
CREATE TABLE t
(
     `c1` int NOT NULL DEFAULT 1 COMMENT '1'
)
ENGINE = MergeTree
ORDER BY tuple()
```



