### PR TITLE
Add PowerPC binary to universal install script

### DIFF
--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -13,7 +13,7 @@ then
     elif [ "${ARCH}" = "aarch64" ]
     then
         DIR="aarch64"
-    elif [ "${ARCH}" = "powerpc64le" ]
+    elif [ "${ARCH}" = "powerpc64le" ] || [ "${ARCH}" = "ppc64le" ]
     then
         DIR="powerpc64le"
     fi
@@ -25,7 +25,7 @@ then
     elif [ "${ARCH}" = "aarch64" ]
     then
         DIR="freebsd-aarch64"
-    elif [ "${ARCH}" = "powerpc64le" ]
+    elif [ "${ARCH}" = "powerpc64le" ] || [ "${ARCH}" = "ppc64le" ]
     then
         DIR="freebsd-powerpc64le"
     fi

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -191,6 +191,7 @@ CI_CONFIG = {
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",
+            "static_binary_name": "powerpc64le",
             "bundled": "bundled",
             "splitted": "unsplitted",
             "tidy": "disable",


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ClickHouse builds for `PowerPC64LE` architecture are now available in universal installation script `curl https://clickhouse.com/ | sh` and by direct link `https://builds.clickhouse.com/master/powerpc64le/clickhouse`.


See also #36025
