### PR TITLE
optimization for reading hive file  when all columns to read are partition keys

### DIFF
--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -151,12 +151,25 @@ public:
         {
             if (!reader)
             {
+                if (current_file_remained_rows) [[unlikely]]
+                {
+                    return generateChunkByPartitionKeys();
+                }
+
                 current_idx = source_info->next_uri_to_read.fetch_add(1);
                 if (current_idx >= source_info->hive_files.size())
                     return {};
 
-                const auto & current_file = source_info->hive_files[current_idx];
+                current_file = source_info->hive_files[current_idx];
                 current_path = current_file->getPath();
+
+                if (!to_read_block.columns() && current_file->getRows())
+                {
+                    /// this is the case that all columns to read are partition keys. We can construct const columns
+                    /// directly without reading from hive files.
+                    current_file_remained_rows = *(current_file->getRows());
+                    return generateChunkByPartitionKeys();
+                }
 
                 String uri_with_path = hdfs_namenode_url + current_path;
                 auto compression = chooseCompressionMethod(current_path, compression_method);
@@ -260,6 +273,45 @@ public:
         }
     }
 
+    Chunk generateChunkByPartitionKeys()
+    {
+        size_t max_rows = getContext()->getSettings().max_block_size;
+        size_t rows = 0;
+        if (max_rows > current_file_remained_rows)
+        {
+            rows = current_file_remained_rows;
+            current_file_remained_rows = 0;
+        }
+        else
+        {
+            rows = max_rows;
+            current_file_remained_rows -= max_rows;
+        }
+
+        Columns cols;
+        auto types = source_info->partition_name_types.getTypes();
+        auto names = source_info->partition_name_types.getNames();
+        auto fields = current_file->getPartitionValues();
+        for (size_t i = 0, sz = types.size(); i < sz; ++i)
+        {
+            if (!sample_block.has(names[i]))
+                continue;
+            auto col = types[i]->createColumnConst(rows, fields[i]);
+            auto col_idx = sample_block.getPositionByName(names[i]);
+            cols.insert(cols.begin() + col_idx, col);
+        }
+
+        if (source_info->need_file_column)
+        {
+            size_t last_slash_pos = current_file->getPath().find_last_of('/');
+            auto file_name = current_path.substr(last_slash_pos + 1);
+
+            auto col = DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumnConst(rows, std::move(file_name));
+            cols.push_back(col);
+        }
+        return Chunk(std::move(cols), rows);
+    }
+
 private:
     std::unique_ptr<ReadBuffer> read_buf;
     std::unique_ptr<QueryPipeline> pipeline;
@@ -275,8 +327,10 @@ private:
     const Names & text_input_field_names;
     FormatSettings format_settings;
 
+    HiveFilePtr current_file;
     String current_path;
     size_t current_idx = 0;
+    size_t current_file_remained_rows = 0;
 
     Poco::Logger * log = &Poco::Logger::get("StorageHive");
 };
@@ -627,30 +681,6 @@ bool StorageHive::isColumnOriented() const
     return format_name == "Parquet" || format_name == "ORC";
 }
 
-void StorageHive::getActualColumnsToRead(Block & sample_block, const Block & header_block, const NameSet & partition_columns) const
-{
-    if (!isColumnOriented())
-        sample_block = header_block;
-    UInt32 erased_columns = 0;
-    for (const auto & column : partition_columns)
-    {
-        if (sample_block.has(column))
-            erased_columns++;
-    }
-    if (erased_columns == sample_block.columns())
-    {
-        for (size_t i = 0; i < header_block.columns(); ++i)
-        {
-            const auto & col = header_block.getByPosition(i);
-            if (!partition_columns.count(col.name))
-            {
-                sample_block.insert(col);
-                break;
-            }
-        }
-    }
-}
-
 Pipe StorageHive::read(
     const Names & column_names,
     const StorageSnapshotPtr & storage_snapshot,
@@ -689,8 +719,6 @@ Pipe StorageHive::read(
         if (column == "_file")
             sources_info->need_file_column = true;
     }
-
-    getActualColumnsToRead(sample_block, header_block, NameSet{partition_names.begin(), partition_names.end()});
 
     if (num_streams > sources_info->hive_files.size())
         num_streams = sources_info->hive_files.size();

--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -151,7 +151,7 @@ public:
         {
             if (!reader)
             {
-                if (current_file_remained_rows) [[unlikely]]
+                if (current_file_remained_rows)
                 {
                     return generateChunkByPartitionKeys();
                 }
@@ -299,15 +299,6 @@ public:
             auto col = types[i]->createColumnConst(rows, fields[i]);
             auto col_idx = sample_block.getPositionByName(names[i]);
             cols.insert(cols.begin() + col_idx, col);
-        }
-
-        if (source_info->need_file_column)
-        {
-            size_t last_slash_pos = current_file->getPath().find_last_of('/');
-            auto file_name = current_path.substr(last_slash_pos + 1);
-
-            auto col = DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumnConst(rows, std::move(file_name));
-            cols.push_back(col);
         }
         return Chunk(std::move(cols), rows);
     }

--- a/src/Storages/Hive/StorageHive.h
+++ b/src/Storages/Hive/StorageHive.h
@@ -117,8 +117,6 @@ private:
         const ContextPtr & context_,
         PruneLevel prune_level = PruneLevel::Max) const;
 
-    void getActualColumnsToRead(Block & sample_block, const Block & header_block, const NameSet & partition_columns) const;
-
     void lazyInitialize();
 
     std::optional<UInt64>

--- a/tests/integration/test_hive_query/test.py
+++ b/tests/integration/test_hive_query/test.py
@@ -375,7 +375,7 @@ def test_cache_read_bytes(started_cluster):
     for i in range(10):
         result = node.query(
             """
-    SELECT day, count(*) FROM default.demo_parquet_1 group by day order by day settings input_format_parquet_allow_missing_columns = true
+    SELECT * FROM default.demo_parquet_1 settings input_format_parquet_allow_missing_columns = true
             """
         )
         node.query("system flush logs")


### PR DESCRIPTION
### Changelog category (leave one):
- Performance improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

When all the columns to read are partition keys, construct columns by the file's row number without real reading the hive file.

With following test sqls
```SQL
CREATE TABLE test_day_hour
(
    `rip` Nullable(String),
    `rtime` Nullable(String),
    `stattime` Nullable(Int64),
    `msgid` Nullable(String),
    `msgtype` Nullable(Int64),
    `day` String,
    `hour` String
)
ENGINE = Hive('thrift://xxxx', 'db', 'test_table')
PARTITION BY (day, hour);

SELECT
    day,
    count(*)
FROM test_day_hour
WHERE (day = '2022-05-01') AND (hour >= '20')
GROUP BY day

```

we have performance results.
* before optimize
```
1 row in set. Elapsed: 2.202 sec. Processed 99.18 million rows, 2.39 GB (45.04 million rows/s., 1.09 GB/s.)
```
* after optimize
```
1 row in set. Elapsed: 0.899 sec. Processed 99.18 million rows, 73.14 KB (110.33 million rows/s., 81.36 KB/s.)
```


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
