### PR TITLE
Flamegraph Link update

### DIFF
--- a/docs/en/operations/optimizing-performance/sampling-query-profiler.md
+++ b/docs/en/operations/optimizing-performance/sampling-query-profiler.md
@@ -29,7 +29,7 @@ To analyze the `trace_log` system table:
 
 -   Use the `addressToLine`, `addressToLineWithInlines`, `addressToSymbol` and `demangle` [introspection functions](../../sql-reference/functions/introspection.md) to get function names and their positions in ClickHouse code. To get a profile for some query, you need to aggregate data from the `trace_log` table. You can aggregate data by individual functions or by the whole stack traces.
 
-If you need to visualize `trace_log` info, try [flamegraph](../../interfaces/third-party/gui/#clickhouse-flamegraph) and [speedscope](https://github.com/laplab/clickhouse-speedscope).
+If you need to visualize `trace_log` info, try [flamegraph](../../interfaces/third-party/gui.md#clickhouse-flamegraph-clickhouse-flamegraph) and [speedscope](https://github.com/laplab/clickhouse-speedscope).
 
 ## Example {#example}
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)
### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Updated  broken link for flamegraph

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
