### PR TITLE
Simplify and update MacOS build instructions

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -10,21 +10,17 @@ description: How to build ClickHouse on Mac OS X
 You can install pre-built ClickHouse as described in [Quick Start](https://clickhouse.com/#quick-start). Follow **macOS (Intel)** or **macOS (Apple silicon)** installation instructions.
 :::
 
-Build should work on x86_64 (Intel) and arm64 (Apple silicon) based macOS 10.15 (Catalina) and higher with Homebrew's vanilla Clang.
-It is always recommended to use vanilla `clang` compiler. 
+The build works on x86_64 (Intel) and arm64 (Apple Silicon) based on macOS 10.15 (Catalina) or higher with Homebrew's vanilla Clang.
 
 :::note
-It is possible to use XCode's `apple-clang` or `gcc`, but it's strongly discouraged.
+It is also possible to compile with Apple's XCode `apple-clang` or Homebrew's `gcc`, but it's strongly discouraged.
 :::
 
 ## Install Homebrew {#install-homebrew}
 
-``` bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-# ...and follow the printed instructions on any additional steps required to complete the installation.
-```
+First install [Homebrew](https://brew.sh/)
 
-## Install Xcode and Command Line Tools {#install-xcode-and-command-line-tools}
+## For Apple's Clang (discouraged): Install Xcode and Command Line Tools {#install-xcode-and-command-line-tools}
 
 Install the latest [Xcode](https://apps.apple.com/am/app/xcode/id497799835?mt=12) from App Store.
 
@@ -57,12 +53,12 @@ To build using Homebrew's vanilla Clang compiler (the only **recommended** way):
 
 ``` bash
 cd ClickHouse
-rm -rf build
 mkdir build
-cd build
-cmake -DCMAKE_C_COMPILER=$(brew --prefix llvm)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ -DCMAKE_AR=$(brew --prefix llvm)/bin/llvm-ar -DCMAKE_RANLIB=$(brew --prefix llvm)/bin/llvm-ranlib -DOBJCOPY_PATH=$(brew --prefix llvm)/bin/llvm-objcopy -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-cmake --build . --config RelWithDebInfo
-# The resulting binary will be created at: ./programs/clickhouse
+export CC=$(brew --prefix llvm)/bin/clang
+export CXX=$(brew --prefix llvm)/bin/clang++
+cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build
+cmake --build build
+# The resulting binary will be created at: build/programs/clickhouse
 ```
 
 To build using Xcode's native AppleClang compiler in Xcode IDE (this option is only for development builds and workflows, and is **not recommended** unless you know what you are doing):
@@ -82,12 +78,12 @@ To build using Homebrew's vanilla GCC compiler (this option is only for developm
 
 ``` bash
 cd ClickHouse
-rm -rf build
 mkdir build
-cd build
-cmake -DCMAKE_C_COMPILER=$(brew --prefix gcc)/bin/gcc-11 -DCMAKE_CXX_COMPILER=$(brew --prefix gcc)/bin/g++-11 -DCMAKE_AR=$(brew --prefix gcc)/bin/gcc-ar-11 -DCMAKE_RANLIB=$(brew --prefix gcc)/bin/gcc-ranlib-11 -DOBJCOPY_PATH=$(brew --prefix binutils)/bin/objcopy -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-cmake --build . --config RelWithDebInfo
-# The resulting binary will be created at: ./programs/clickhouse
+export CC=$(brew --prefix gcc)/bin/gcc-11
+export CXX=$(brew --prefix gcc)/bin/g++-11
+cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build
+cmake --build build
+# The resulting binary will be created at: build/programs/clickhouse
 ```
 
 ## Caveats {#caveats}


### PR DESCRIPTION
- instead of repeating Homebrew's installation steps (which may become
  outdated), just point to their homepage

- Specify CC and CXX env variables instead of internal CMake variables,
  CMake figure out paths to ar, ranlib and objcopy automatically

- use -S and -B parameters available in recent CMake versions to build
  directly from the source directory

### Changelog category (leave one):
- Documentation (changelog entry is not required)