### PR TITLE
Ignore AUTO_INCREMENT in CREATE TABLE to simplify migration from MySQL

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -588,6 +588,7 @@ static constexpr UInt64 operator""_Gb(unsigned long long value)
     M(Bool, count_distinct_optimization, false, "Rewrite count distinct to subquery of group by", 0) \
     M(Bool, throw_on_unsupported_query_inside_transaction, true, "Throw exception if unsupported query is used inside transaction", 0) \
     M(Bool, throw_if_no_data_to_insert, true, "Enables or disables empty INSERTs, enabled by default", 0) \
+    M(Bool, compatibility_ignore_auto_increment_in_create_table, false, "Ignore AUTO_INCREMENT keyword in column declaration if true, otherwise return error. It simplifies migration from MySQL", 0) \
     // End of COMMON_SETTINGS
     // Please add settings related to formats into the FORMAT_FACTORY_SETTINGS and move obsolete settings to OBSOLETE_SETTINGS.
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -552,6 +552,16 @@ ColumnsDescription InterpreterCreateQuery::getColumnsDescription(
 
         column.name = col_decl.name;
 
+        /// ignore or not other database extensions depending on compatibility settings
+        if (col_decl.default_specifier == "AUTO_INCREMENT"
+            && !context_->getSettingsRef().compatibility_ignore_auto_increment_in_create_table)
+        {
+            throw Exception{
+                "AUTO_INCREMENT is not supported. To ignore the keyword in column declaration set "
+                "`compatibility_ignore_auto_increment_in_create_table` to true",
+                ErrorCodes::SYNTAX_ERROR};
+        }
+
         if (col_decl.default_expression)
         {
             ASTPtr default_expr =

--- a/src/Parsers/CommonParsers.h
+++ b/src/Parsers/CommonParsers.h
@@ -21,9 +21,9 @@ public:
     //NOLINTNEXTLINE Want to be able to init ParserKeyword("literal")
     constexpr ParserKeyword(std::string_view s_): s(s_) { assert(!s.empty()); }
 
-protected:
     constexpr const char * getName() const override { return s.data(); }
 
+protected:
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
 };
 

--- a/src/Parsers/ParserCreateQuery.h
+++ b/src/Parsers/ParserCreateQuery.h
@@ -126,6 +126,7 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
     ParserKeyword s_materialized{"MATERIALIZED"};
     ParserKeyword s_ephemeral{"EPHEMERAL"};
     ParserKeyword s_alias{"ALIAS"};
+    ParserKeyword s_auto_increment{"AUTO_INCREMENT"};
     ParserKeyword s_comment{"COMMENT"};
     ParserKeyword s_codec{"CODEC"};
     ParserKeyword s_ttl{"TTL"};
@@ -175,6 +176,7 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
         && !s_materialized.checkWithoutMoving(pos, expected)
         && !s_ephemeral.checkWithoutMoving(pos, expected)
         && !s_alias.checkWithoutMoving(pos, expected)
+        && !s_auto_increment.checkWithoutMoving(pos, expected)
         && (require_type
             || (!s_comment.checkWithoutMoving(pos, expected)
                 && !s_codec.checkWithoutMoving(pos, expected))))
@@ -196,12 +198,23 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
     }
     else if (s_ephemeral.ignore(pos, expected))
     {
-        default_specifier = "EPHEMERAL";
+        default_specifier = s_ephemeral.getName();
         if (!literal_parser.parse(pos, default_expression, expected) && type)
             default_expression = std::make_shared<ASTLiteral>(Field());
 
         if (!default_expression && !type)
             return false;
+    }
+    else if (s_auto_increment.ignore(pos, expected))
+    {
+        default_specifier = s_auto_increment.getName();
+        if (!type) {
+            const String type_int("INT");
+            Tokens tokens(type_int.data(), type_int.data() + type_int.size());
+            Pos tmp_pos(tokens, 0);
+            Expected tmp_expected;
+            ParserDataType().parse(tmp_pos, type, tmp_expected);
+        }
     }
 
     if (require_type && !type && !default_expression)
@@ -248,9 +261,9 @@ bool IParserColumnDeclaration<NameParser>::parseImpl(Pos & pos, ASTPtr & node, E
 
     column_declaration->null_modifier = null_modifier;
 
+    column_declaration->default_specifier = default_specifier;
     if (default_expression)
     {
-        column_declaration->default_specifier = default_specifier;
         column_declaration->default_expression = default_expression;
         column_declaration->children.push_back(std::move(default_expression));
     }

--- a/tests/queries/0_stateless/02293_compatibility_ignore_auto_increment_in_create_table.reference
+++ b/tests/queries/0_stateless/02293_compatibility_ignore_auto_increment_in_create_table.reference
@@ -1,0 +1,7 @@
+disable AUTO_INCREMENT compatibility mode
+create table with AUTO_INCREMENT, compatibility disabled
+enable AUTO_INCREMENT compatibility mode
+create table with AUTO_INCREMENT
+create table with AUTO_INCREMENT, without column type
+create table with several AUTO_INCREMENT
+disable AUTO_INCREMENT compatibility mode

--- a/tests/queries/0_stateless/02293_compatibility_ignore_auto_increment_in_create_table.sql
+++ b/tests/queries/0_stateless/02293_compatibility_ignore_auto_increment_in_create_table.sql
@@ -1,0 +1,34 @@
+select 'disable AUTO_INCREMENT compatibility mode';
+set compatibility_ignore_auto_increment_in_create_table=false;
+
+select 'create table with AUTO_INCREMENT, compatibility disabled';
+DROP TABLE IF EXISTS ignore_auto_increment SYNC;
+CREATE TABLE ignore_auto_increment (
+    id int AUTO_INCREMENT
+) ENGINE=MergeTree() ORDER BY tuple(); -- {serverError SYNTAX_ERROR}
+
+select 'enable AUTO_INCREMENT compatibility mode';
+set compatibility_ignore_auto_increment_in_create_table=true;
+
+select 'create table with AUTO_INCREMENT';
+DROP TABLE IF EXISTS ignore_auto_increment SYNC;
+CREATE TABLE ignore_auto_increment (
+    id int AUTO_INCREMENT
+) ENGINE=MergeTree() ORDER BY tuple();
+
+select 'create table with AUTO_INCREMENT, without column type';
+DROP TABLE IF EXISTS ignore_auto_increment SYNC;
+CREATE TABLE ignore_auto_increment (
+    id AUTO_INCREMENT
+) ENGINE=MergeTree() ORDER BY tuple();
+
+select 'create table with several AUTO_INCREMENT';
+DROP TABLE IF EXISTS ignore_auto_increment SYNC;
+CREATE TABLE ignore_auto_increment (
+    id int AUTO_INCREMENT, di AUTO_INCREMENT, s String AUTO_INCREMENT
+) ENGINE=MergeTree() ORDER BY tuple();
+
+select 'disable AUTO_INCREMENT compatibility mode';
+set compatibility_ignore_auto_increment_in_create_table=false;
+
+DROP TABLE IF EXISTS ignore_auto_increment SYNC;


### PR DESCRIPTION
Issue #35893

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Option `compatibility_ignore_auto_increment_in_create_table` allows ignoring `AUTO_INCREMENT` keyword in a column declaration to simplify migration from MySQL
