### PR TITLE
Docs: move UK Property and Taxi datasets up

### DIFF
--- a/docs/en/getting-started/example-datasets/nyc-taxi.md
+++ b/docs/en/getting-started/example-datasets/nyc-taxi.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: New York Taxi Data
+sidebar_position: 2
 description: Data for billions of taxi and for-hire vehicle (Uber, Lyft, etc.) trips originating in New York City since 2009
 ---
 

--- a/docs/en/getting-started/example-datasets/uk-price-paid.md
+++ b/docs/en/getting-started/example-datasets/uk-price-paid.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: UK Property Price Paid
+sidebar_position: 1
 ---
 
 # UK Property Price Paid


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

                             
The PR moves the UK Property price paid dataset to the top of the list, and the NY Taxi data to second.