### PR TITLE
Fix bug for WATCH EVENTS query in WindowView

### DIFF
--- a/src/Storages/WindowView/WindowViewSource.h
+++ b/src/Storages/WindowView/WindowViewSource.h
@@ -51,6 +51,8 @@ protected:
         Block block;
         UInt32 watermark;
         std::tie(block, watermark) = generateImpl();
+        if (!block)
+            return Chunk();
         if (is_events)
         {
             return Chunk(


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now WindowView `WATCH EVENTS` query will not be terminated due to the nonempty Chunk created in `WindowViewSource.h:58`


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
