### PR TITLE
Fix possible heap-use-after-free error when reading system.projection_parts and system.projection_parts_columns

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4381,10 +4381,7 @@ std::set<String> MergeTreeData::getPartitionIdsAffectedByCommands(
 
 
 MergeTreeData::DataPartsVector MergeTreeData::getDataPartsVectorForInternalUsage(
-    const DataPartStates & affordable_states,
-    const DataPartsLock & /*lock*/,
-    DataPartStateVector * out_states,
-    bool require_projection_parts) const
+    const DataPartStates & affordable_states, const DataPartsLock & /*lock*/, DataPartStateVector * out_states) const
 {
     DataPartsVector res;
     DataPartsVector buf;
@@ -4392,83 +4389,86 @@ MergeTreeData::DataPartsVector MergeTreeData::getDataPartsVectorForInternalUsage
     for (auto state : affordable_states)
     {
         auto range = getDataPartsStateRange(state);
-
-        if (require_projection_parts)
-        {
-            for (const auto & part : range)
-            {
-                for (const auto & [_, projection_part] : part->getProjectionParts())
-                    res.push_back(projection_part);
-            }
-        }
-        else
-        {
-            std::swap(buf, res);
-            res.clear();
-            std::merge(range.begin(), range.end(), buf.begin(), buf.end(), std::back_inserter(res), LessDataPart()); //-V783
-        }
+        std::swap(buf, res);
+        res.clear();
+        std::merge(range.begin(), range.end(), buf.begin(), buf.end(), std::back_inserter(res), LessDataPart()); //-V783
     }
 
     if (out_states != nullptr)
     {
         out_states->resize(res.size());
-        if (require_projection_parts)
-        {
-            for (size_t i = 0; i < res.size(); ++i)
-                (*out_states)[i] = res[i]->getParentPart()->getState();
-        }
-        else
-        {
-            for (size_t i = 0; i < res.size(); ++i)
-                (*out_states)[i] = res[i]->getState();
-        }
+        for (size_t i = 0; i < res.size(); ++i)
+            (*out_states)[i] = res[i]->getState();
     }
 
     return res;
 }
 
-MergeTreeData::DataPartsVector MergeTreeData::getDataPartsVectorForInternalUsage(
-    const DataPartStates & affordable_states,
-    DataPartStateVector * out_states,
-    bool require_projection_parts) const
+MergeTreeData::DataPartsVector
+MergeTreeData::getDataPartsVectorForInternalUsage(const DataPartStates & affordable_states, DataPartStateVector * out_states) const
 {
     auto lock = lockParts();
-    return getDataPartsVectorForInternalUsage(affordable_states, lock, out_states, require_projection_parts);
+    return getDataPartsVectorForInternalUsage(affordable_states, lock, out_states);
 }
 
-MergeTreeData::DataPartsVector
-MergeTreeData::getAllDataPartsVector(MergeTreeData::DataPartStateVector * out_states, bool require_projection_parts) const
+MergeTreeData::ProjectionPartsVector
+MergeTreeData::getProjectionPartsVectorForInternalUsage(const DataPartStates & affordable_states, DataPartStateVector * out_states) const
+{
+    auto lock = lockParts();
+    ProjectionPartsVector res;
+    for (auto state : affordable_states)
+    {
+        auto range = getDataPartsStateRange(state);
+        for (const auto & part : range)
+        {
+            res.data_parts.push_back(part);
+            for (const auto & [_, projection_part] : part->getProjectionParts())
+                res.projection_parts.push_back(projection_part);
+        }
+    }
+
+    if (out_states != nullptr)
+    {
+        out_states->resize(res.projection_parts.size());
+        for (size_t i = 0; i < res.projection_parts.size(); ++i)
+            (*out_states)[i] = res.projection_parts[i]->getParentPart()->getState();
+    }
+
+    return res;
+}
+
+MergeTreeData::DataPartsVector MergeTreeData::getAllDataPartsVector(MergeTreeData::DataPartStateVector * out_states) const
 {
     DataPartsVector res;
-    if (require_projection_parts)
+    auto lock = lockParts();
+    res.assign(data_parts_by_info.begin(), data_parts_by_info.end());
+    if (out_states != nullptr)
     {
-        auto lock = lockParts();
-        for (const auto & part : data_parts_by_info)
-        {
-            for (const auto & [p_name, projection_part] : part->getProjectionParts())
-                res.push_back(projection_part);
-        }
-
-        if (out_states != nullptr)
-        {
-            out_states->resize(res.size());
-            for (size_t i = 0; i < res.size(); ++i)
-                (*out_states)[i] = res[i]->getParentPart()->getState();
-        }
-    }
-    else
-    {
-        auto lock = lockParts();
-        res.assign(data_parts_by_info.begin(), data_parts_by_info.end());
-
-        if (out_states != nullptr)
-        {
-            out_states->resize(res.size());
-            for (size_t i = 0; i < res.size(); ++i)
-                (*out_states)[i] = res[i]->getState();
-        }
+        out_states->resize(res.size());
+        for (size_t i = 0; i < res.size(); ++i)
+            (*out_states)[i] = res[i]->getState();
     }
 
+    return res;
+}
+
+MergeTreeData::ProjectionPartsVector MergeTreeData::getAllProjectionPartsVector(MergeTreeData::DataPartStateVector * out_states) const
+{
+    ProjectionPartsVector res;
+    auto lock = lockParts();
+    for (const auto & part : data_parts_by_info)
+    {
+        res.data_parts.push_back(part);
+        for (const auto & [p_name, projection_part] : part->getProjectionParts())
+            res.projection_parts.push_back(projection_part);
+    }
+
+    if (out_states != nullptr)
+    {
+        out_states->resize(res.projection_parts.size());
+        for (size_t i = 0; i < res.projection_parts.size(); ++i)
+            (*out_states)[i] = res.projection_parts[i]->getParentPart()->getState();
+    }
     return res;
 }
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -449,26 +449,31 @@ public:
 
     Int64 getMaxBlockNumber() const;
 
+    struct ProjectionPartsVector
+    {
+        DataPartsVector projection_parts;
+        DataPartsVector data_parts;
+    };
 
     /// Returns a copy of the list so that the caller shouldn't worry about locks.
     DataParts getDataParts(const DataPartStates & affordable_states) const;
 
     DataPartsVector getDataPartsVectorForInternalUsage(
-        const DataPartStates & affordable_states,
-        const DataPartsLock & lock,
-        DataPartStateVector * out_states = nullptr,
-        bool require_projection_parts = false) const;
+        const DataPartStates & affordable_states, const DataPartsLock & lock, DataPartStateVector * out_states = nullptr) const;
 
     /// Returns sorted list of the parts with specified states
     ///  out_states will contain snapshot of each part state
     DataPartsVector getDataPartsVectorForInternalUsage(
-        const DataPartStates & affordable_states, DataPartStateVector * out_states = nullptr, bool require_projection_parts = false) const;
+        const DataPartStates & affordable_states, DataPartStateVector * out_states = nullptr) const;
+    /// Same as above but only returns projection parts
+    ProjectionPartsVector getProjectionPartsVectorForInternalUsage(
+        const DataPartStates & affordable_states, DataPartStateVector * out_states = nullptr) const;
 
 
     /// Returns absolutely all parts (and snapshot of their states)
-    DataPartsVector getAllDataPartsVector(
-        DataPartStateVector * out_states = nullptr,
-        bool require_projection_parts = false) const;
+    DataPartsVector getAllDataPartsVector(DataPartStateVector * out_states = nullptr) const;
+    /// Same as above but only returns projection parts
+    ProjectionPartsVector getAllProjectionPartsVector(MergeTreeData::DataPartStateVector * out_states = nullptr) const;
 
     /// Returns parts in Active state
     DataParts getDataPartsForInternalUsage() const;

--- a/src/Storages/System/StorageSystemPartsBase.cpp
+++ b/src/Storages/System/StorageSystemPartsBase.cpp
@@ -48,9 +48,25 @@ bool StorageSystemPartsBase::hasStateColumn(const Names & column_names, const St
 }
 
 MergeTreeData::DataPartsVector
-StoragesInfo::getParts(MergeTreeData::DataPartStateVector & state, bool has_state_column, bool require_projection_parts) const
+StoragesInfo::getParts(MergeTreeData::DataPartStateVector & state, bool has_state_column) const
 {
-    if (require_projection_parts && data->getInMemoryMetadataPtr()->projections.empty())
+    using State = MergeTreeData::DataPartState;
+    if (need_inactive_parts)
+    {
+        /// If has_state_column is requested, return all states.
+        if (!has_state_column)
+            return data->getDataPartsVectorForInternalUsage({State::Active, State::Outdated}, &state);
+
+        return data->getAllDataPartsVector(&state);
+    }
+
+    return data->getDataPartsVectorForInternalUsage({State::Active}, &state);
+}
+
+MergeTreeData::ProjectionPartsVector
+StoragesInfo::getProjectionParts(MergeTreeData::DataPartStateVector & state, bool has_state_column) const
+{
+    if (data->getInMemoryMetadataPtr()->projections.empty())
         return {};
 
     using State = MergeTreeData::DataPartState;
@@ -58,12 +74,12 @@ StoragesInfo::getParts(MergeTreeData::DataPartStateVector & state, bool has_stat
     {
         /// If has_state_column is requested, return all states.
         if (!has_state_column)
-            return data->getDataPartsVectorForInternalUsage({State::Active, State::Outdated}, &state, require_projection_parts);
+            return data->getProjectionPartsVectorForInternalUsage({State::Active, State::Outdated}, &state);
 
-        return data->getAllDataPartsVector(&state, require_projection_parts);
+        return data->getAllProjectionPartsVector(&state);
     }
 
-    return data->getDataPartsVectorForInternalUsage({State::Active}, &state, require_projection_parts);
+    return data->getProjectionPartsVectorForInternalUsage({State::Active}, &state);
 }
 
 StoragesInfoStream::StoragesInfoStream(const SelectQueryInfo & query_info, ContextPtr context)

--- a/src/Storages/System/StorageSystemPartsBase.h
+++ b/src/Storages/System/StorageSystemPartsBase.h
@@ -23,8 +23,9 @@ struct StoragesInfo
     MergeTreeData * data = nullptr;
 
     explicit operator bool() const { return storage != nullptr; }
-    MergeTreeData::DataPartsVector
-    getParts(MergeTreeData::DataPartStateVector & state, bool has_state_column, bool require_projection_parts = false) const;
+
+    MergeTreeData::DataPartsVector getParts(MergeTreeData::DataPartStateVector & state, bool has_state_column) const;
+    MergeTreeData::ProjectionPartsVector getProjectionParts(MergeTreeData::DataPartStateVector & state, bool has_state_column) const;
 };
 
 /** A helper class that enumerates the storages that match given query. */

--- a/src/Storages/System/StorageSystemProjectionParts.cpp
+++ b/src/Storages/System/StorageSystemProjectionParts.cpp
@@ -94,14 +94,13 @@ void StorageSystemProjectionParts::processNextStorage(
 {
     using State = IMergeTreeDataPart::State;
     MergeTreeData::DataPartStateVector all_parts_state;
-    MergeTreeData::DataPartsVector all_parts;
-
-    all_parts = info.getParts(all_parts_state, has_state_column, true /* require_projection_parts */);
-
-    for (size_t part_number = 0; part_number < all_parts.size(); ++part_number)
+    MergeTreeData::ProjectionPartsVector all_parts = info.getProjectionParts(all_parts_state, has_state_column);
+    for (size_t part_number = 0; part_number < all_parts.projection_parts.size(); ++part_number)
     {
-        const auto & part = all_parts[part_number];
+        const auto & part = all_parts.projection_parts[part_number];
         const auto * parent_part = part->getParentPart();
+        chassert(parent_part);
+
         auto part_state = all_parts_state[part_number];
 
         ColumnSize columns_size = part->getTotalColumnsSize();

--- a/src/Storages/System/StorageSystemProjectionPartsColumns.cpp
+++ b/src/Storages/System/StorageSystemProjectionPartsColumns.cpp
@@ -100,14 +100,15 @@ void StorageSystemProjectionPartsColumns::processNextStorage(
         }
     }
 
-    /// Go through the list of parts.
+    /// Go through the list of projection parts.
     MergeTreeData::DataPartStateVector all_parts_state;
-    MergeTreeData::DataPartsVector all_parts;
-    all_parts = info.getParts(all_parts_state, has_state_column, true /* require_projection_parts */);
-    for (size_t part_number = 0; part_number < all_parts.size(); ++part_number)
+    MergeTreeData::ProjectionPartsVector all_parts = info.getProjectionParts(all_parts_state, has_state_column);
+    for (size_t part_number = 0; part_number < all_parts.projection_parts.size(); ++part_number)
     {
-        const auto & part = all_parts[part_number];
+        const auto & part = all_parts.projection_parts[part_number];
         const auto * parent_part = part->getParentPart();
+        chassert(parent_part);
+
         auto part_state = all_parts_state[part_number];
         auto columns_size = part->getTotalColumnsSize();
         auto parent_columns_size = parent_part->getTotalColumnsSize();


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible heap-use-after-free error when reading system.projection_parts and system.projection_parts_columns . This fixes https://github.com/ClickHouse/ClickHouse/issues/37184


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
