### PR TITLE
Improve OpenTelemetry spans creation after Processors were implemented

### DIFF
--- a/src/Processors/Executors/CompletedPipelineExecutor.cpp
+++ b/src/Processors/Executors/CompletedPipelineExecutor.cpp
@@ -32,7 +32,7 @@ struct CompletedPipelineExecutor::Data
 
 static void threadFunction(CompletedPipelineExecutor::Data & data, ThreadGroupStatusPtr thread_group, size_t num_threads)
 {
-    setThreadName("QueryPipelineEx");
+    setThreadName("QueryCompPipeEx");
 
     try
     {

--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -9,7 +9,6 @@
 #include <Processors/ISource.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/OpenTelemetrySpanLog.h>
 #include <Common/scope_guard_safe.h>
 
 #ifndef NDEBUG
@@ -269,8 +268,6 @@ void PipelineExecutor::initializeExecution(size_t num_threads)
 
 void PipelineExecutor::executeImpl(size_t num_threads)
 {
-    OpenTelemetrySpanHolder span("PipelineExecutor::executeImpl()");
-
     initializeExecution(num_threads);
 
     using ThreadsData = std::vector<ThreadFromGlobalPool>;

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -68,7 +68,7 @@ const Block & PullingAsyncPipelineExecutor::getHeader() const
 
 static void threadFunction(PullingAsyncPipelineExecutor::Data & data, ThreadGroupStatusPtr thread_group, size_t num_threads)
 {
-    setThreadName("QueryPipelineEx");
+    setThreadName("QueryPullPipeEx");
 
     try
     {

--- a/src/Processors/Executors/PushingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PushingAsyncPipelineExecutor.cpp
@@ -97,7 +97,7 @@ struct PushingAsyncPipelineExecutor::Data
 
 static void threadFunction(PushingAsyncPipelineExecutor::Data & data, ThreadGroupStatusPtr thread_group, size_t num_threads)
 {
-    setThreadName("QueryPipelineEx");
+    setThreadName("QueryPushPipeEx");
 
     try
     {

--- a/src/Processors/IProcessor.h
+++ b/src/Processors/IProcessor.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <Processors/Port.h>
 #include <Common/Stopwatch.h>
+#include <Interpreters/OpenTelemetrySpanLog.h>
 
 
 class EventCounter;
@@ -304,8 +305,13 @@ public:
     uint64_t getInputWaitElapsedUs() const { return input_wait_elapsed_us; }
     uint64_t getOutputWaitElapsedUs() const { return output_wait_elapsed_us; }
 
+    void initOpenTelemetrySpan()
+    {
+        span = std::make_unique<OpenTelemetrySpanHolder>(getName());
+    }
+
 protected:
-    virtual void onCancel() {}
+    virtual void onCancel() { span = nullptr; }
 
 private:
     /// For:
@@ -331,6 +337,8 @@ private:
 
     IQueryPlanStep * query_plan_step = nullptr;
     size_t query_plan_step_group = 0;
+
+    std::unique_ptr<OpenTelemetrySpanHolder> span = nullptr;
 };
 
 

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -532,7 +532,10 @@ QueryPipelineProcessorsCollector::~QueryPipelineProcessorsCollector()
 Processors QueryPipelineProcessorsCollector::detachProcessors(size_t group)
 {
     for (auto & processor : processors)
+    {
+        processor->initOpenTelemetrySpan();
         processor->setQueryPlanStep(step, group);
+    }
 
     Processors res;
     res.swap(processors);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
OpenTelemetry spans now show active time in Processors.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
