### PR TITLE
Fix adding dependency when MaterializedView is dropped

### DIFF
--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -69,6 +69,7 @@ public:
 
     void renameInMemory(const StorageID & new_table_id) override;
 
+    void startup() override;
     void shutdown() override;
 
     QueryProcessingStage::Enum


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This PR moving `addDependency` from constructor to `startup()` to avoid adding dependency to a **dropped** table, fix #37237


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
