### PR TITLE
Remove prompt($) from bash scripts

### DIFF
--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -19,7 +19,7 @@ The following tutorial is based on the Ubuntu Linux system. With appropriate cha
 ### Install Git, CMake, Python and Ninja {#install-git-cmake-python-and-ninja}
 
 ``` bash
-$ sudo apt-get install git cmake python ninja-build
+sudo apt-get install git cmake python ninja-build
 ```
 
 Or cmake3 instead of cmake on older systems.
@@ -37,8 +37,8 @@ For other Linux distribution - check the availability of the [prebuild packages]
 #### Use the latest clang for Builds
 
 ``` bash
-$ export CC=clang-14
-$ export CXX=clang++-14
+export CC=clang-14
+export CXX=clang++-14
 ```
 
 In this example we use version 14 that is the latest as of Feb 2022.
@@ -48,23 +48,23 @@ Gcc can also be used though it is discouraged.
 ### Checkout ClickHouse Sources {#checkout-clickhouse-sources}
 
 ``` bash
-$ git clone --recursive git@github.com:ClickHouse/ClickHouse.git
+git clone --recursive git@github.com:ClickHouse/ClickHouse.git
 ```
 
 or
 
 ``` bash
-$ git clone --recursive https://github.com/ClickHouse/ClickHouse.git
+git clone --recursive https://github.com/ClickHouse/ClickHouse.git
 ```
 
 ### Build ClickHouse {#build-clickhouse}
 
 ``` bash
-$ cd ClickHouse
-$ mkdir build
-$ cd build
-$ cmake ..
-$ ninja
+cd ClickHouse
+mkdir build
+cd build
+cmake ..
+ninja
 ```
 
 To create an executable, run `ninja clickhouse`.
@@ -114,13 +114,13 @@ make -j $(nproc)
 Here is an example of how to build `clang` and all the llvm infrastructure from sources:
 
 ```
- git clone git@github.com:llvm/llvm-project.git
- mkdir llvm-build && cd llvm-build
- cmake -DCMAKE_BUILD_TYPE:STRING=Release -DLLVM_ENABLE_PROJECTS=all ../llvm-project/llvm/
- make -j16
- sudo make install
- hash clang
- clang --version
+git clone git@github.com:llvm/llvm-project.git
+mkdir llvm-build && cd llvm-build
+cmake -DCMAKE_BUILD_TYPE:STRING=Release -DLLVM_ENABLE_PROJECTS=all ../llvm-project/llvm/
+make -j16
+sudo make install
+hash clang
+clang --version
 ```
 
 You can install the older clang like clang-11 from packages and then use it to build the new clang from sources.
@@ -140,21 +140,21 @@ hash cmake
 ### Install Git {#install-git}
 
 ``` bash
-$ sudo apt-get update
-$ sudo apt-get install git python debhelper lsb-release fakeroot sudo debian-archive-keyring debian-keyring
+sudo apt-get update
+sudo apt-get install git python debhelper lsb-release fakeroot sudo debian-archive-keyring debian-keyring
 ```
 
 ### Checkout ClickHouse Sources {#checkout-clickhouse-sources-1}
 
 ``` bash
-$ git clone --recursive --branch master https://github.com/ClickHouse/ClickHouse.git
-$ cd ClickHouse
+git clone --recursive --branch master https://github.com/ClickHouse/ClickHouse.git
+cd ClickHouse
 ```
 
 ### Run Release Script {#run-release-script}
 
 ``` bash
-$ ./release
+./release
 ```
 
 ## You Don’t Have to Build ClickHouse {#you-dont-have-to-build-clickhouse}


### PR DESCRIPTION
Copy bash script. Paste it into terminal. Some bash scripts fail to execute due to bash prompt in documentation. So, I just removed the prompt(s)

### Changelog category (leave one):
- Documentation (changelog entry is not required)