### PR TITLE
fix a word error in docs/zh/getting-started/tutorial.md

### DIFF
--- a/docs/zh/getting-started/tutorial.md
+++ b/docs/zh/getting-started/tutorial.md
@@ -644,7 +644,7 @@ ZooKeeper位置在配置文件中指定:
 
 ``` sql
 CREATE TABLE tutorial.hits_replica (...)
-ENGINE = ReplcatedMergeTree(
+ENGINE = ReplicatedMergeTree(
     '/clickhouse_perftest/tables/{shard}/hits',
     '{replica}'
 )


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)