### PR TITLE
Fix attribute.values alias for OTEL table

### DIFF
--- a/src/Interpreters/OpenTelemetrySpanLog.cpp
+++ b/src/Interpreters/OpenTelemetrySpanLog.cpp
@@ -46,7 +46,7 @@ NamesAndAliases OpenTelemetrySpanLogElement::getNamesAndAliases()
     return
     {
         {"attribute.names", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()), "mapKeys(attribute)"},
-        {"attribute.values", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()), "mapKeys(attribute)"}
+        {"attribute.values", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()), "mapValues(attribute)"}
     };
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix system.opentelemetry_span_log attribute.values alias to values instead of keys


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
