### PR TITLE
Fixing coverity-errors

### DIFF
--- a/src/Common/Dwarf.cpp
+++ b/src/Common/Dwarf.cpp
@@ -696,14 +696,13 @@ Dwarf::Die Dwarf::getDieAtOffset(const CompilationUnit & cu, uint64_t offset) co
     die.is64Bit = cu.is64Bit;
     auto code = readULEB(sp);
     die.code = code;
+    die.attr_offset = sp.data() - info_.data() - offset;
+    die.abbr = !cu.abbr_cache.empty() && die.code < kMaxAbbreviationEntries ? cu.abbr_cache[die.code - 1]
+                                                                            : getAbbreviation(die.code, cu.abbrev_offset);
     if (code == 0)
     {
         return die;
     }
-    die.attr_offset = sp.data() - info_.data() - offset;
-    die.abbr = !cu.abbr_cache.empty() && die.code < kMaxAbbreviationEntries ? cu.abbr_cache[die.code - 1]
-                                                                            : getAbbreviation(die.code, cu.abbrev_offset);
-
     return die;
 }
 

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -255,7 +255,7 @@ StorageS3Source::StorageS3Source(
     String name_,
     const Block & sample_block_,
     ContextPtr context_,
-    std::optional<FormatSettings> format_settings_,
+    std::optional<FormatSettings> & format_settings_,
     const ColumnsDescription & columns_,
     UInt64 max_block_size_,
     UInt64 max_single_read_retries_,
@@ -438,7 +438,7 @@ public:
         const String & format,
         const Block & sample_block_,
         ContextPtr context,
-        std::optional<FormatSettings> format_settings_,
+        std::optional<FormatSettings> & format_settings_,
         const CompressionMethod compression_method,
         const StorageS3::S3Configuration & s3_configuration_,
         const String & bucket,
@@ -492,7 +492,7 @@ public:
 
 private:
     Block sample_block;
-    std::optional<FormatSettings> format_settings;
+    std::optional<FormatSettings> & format_settings;
     std::unique_ptr<WriteBuffer> write_buf;
     OutputFormatPtr writer;
 };
@@ -506,7 +506,7 @@ public:
         const String & format_,
         const Block & sample_block_,
         ContextPtr context_,
-        std::optional<FormatSettings> format_settings_,
+        std::optional<FormatSettings> & format_settings_,
         const CompressionMethod compression_method_,
         const StorageS3::S3Configuration & s3_configuration_,
         const String & bucket_,
@@ -594,7 +594,7 @@ StorageS3::StorageS3(
     const ConstraintsDescription & constraints_,
     const String & comment,
     ContextPtr context_,
-    std::optional<FormatSettings> format_settings_,
+    std::optional<FormatSettings> & format_settings_,
     const String & compression_method_,
     bool distributed_processing_,
     ASTPtr partition_by_)

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -77,7 +77,7 @@ public:
         String name_,
         const Block & sample_block,
         ContextPtr context_,
-        std::optional<FormatSettings> format_settings_,
+        std::optional<FormatSettings> & format_settings_,
         const ColumnsDescription & columns_,
         UInt64 max_block_size_,
         UInt64 max_single_read_retries_,
@@ -106,7 +106,7 @@ private:
     String compression_hint;
     std::shared_ptr<Aws::S3::S3Client> client;
     Block sample_block;
-    std::optional<FormatSettings> format_settings;
+    std::optional<FormatSettings> & format_settings;
 
 
     std::unique_ptr<ReadBuffer> read_buf;
@@ -145,7 +145,7 @@ public:
         const ConstraintsDescription & constraints_,
         const String & comment,
         ContextPtr context_,
-        std::optional<FormatSettings> format_settings_,
+        std::optional<FormatSettings> & format_settings_,
         const String & compression_method_ = "",
         bool distributed_processing_ = false,
         ASTPtr partition_by_ = nullptr);
@@ -208,7 +208,7 @@ private:
     String compression_method;
     String name;
     const bool distributed_processing;
-    std::optional<FormatSettings> format_settings;
+    std::optional<FormatSettings> & format_settings;
     ASTPtr partition_by;
     bool is_key_with_globs = false;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This PR fixes the Coverity Errors:

  CID 392767:  Performance inefficiencies  (PASS_BY_VALUE)
  CID 392762:  Performance inefficiencies  (PASS_BY_VALUE)
  CID 392759:  Performance inefficiencies  (PASS_BY_VALUE)
  CID 382100:  Uninitialized variables  (UNINIT)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
