### PR TITLE
Fix possible deadlock in OvercommitTracker during logging

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -310,8 +310,11 @@ void MemoryTracker::free(Int64 size)
             accounted_size += new_amount;
         }
     }
-    if (auto * overcommit_tracker_ptr = overcommit_tracker.load(std::memory_order_relaxed); overcommit_tracker_ptr)
-        overcommit_tracker_ptr->tryContinueQueryExecutionAfterFree(accounted_size);
+    if (!OvercommitTrackerBlockerInThread::isBlocked())
+    {
+        if (auto * overcommit_tracker_ptr = overcommit_tracker.load(std::memory_order_relaxed); overcommit_tracker_ptr)
+            overcommit_tracker_ptr->tryContinueQueryExecutionAfterFree(accounted_size);
+    }
 
     if (auto * loaded_next = parent.load(std::memory_order_relaxed))
         loaded_next->free(size);

--- a/src/Common/OvercommitTracker.cpp
+++ b/src/Common/OvercommitTracker.cpp
@@ -192,3 +192,5 @@ void GlobalOvercommitTracker::pickQueryToExcludeImpl()
         current_ratio.committed, current_ratio.soft_limit);
     picked_tracker = query_tracker;
 }
+
+thread_local size_t OvercommitTrackerBlockerInThread::counter = 0;

--- a/src/Common/OvercommitTracker.h
+++ b/src/Common/OvercommitTracker.h
@@ -154,3 +154,14 @@ private:
     DB::ProcessList * process_list;
     Poco::Logger * logger = &Poco::Logger::get("GlobalOvercommitTracker");
 };
+
+struct OvercommitTrackerBlockerInThread
+{
+    OvercommitTrackerBlockerInThread() { ++counter; }
+    ~OvercommitTrackerBlockerInThread() { --counter; }
+
+    static bool isBlocked() { return counter > 0; }
+
+private:
+    static thread_local size_t counter;
+};

--- a/src/Common/OvercommitTracker.h
+++ b/src/Common/OvercommitTracker.h
@@ -155,10 +155,14 @@ private:
     Poco::Logger * logger = &Poco::Logger::get("GlobalOvercommitTracker");
 };
 
+// This class is used to disallow tracking during logging to avoid deadlocks.
 struct OvercommitTrackerBlockerInThread
 {
     OvercommitTrackerBlockerInThread() { ++counter; }
     ~OvercommitTrackerBlockerInThread() { --counter; }
+
+    OvercommitTrackerBlockerInThread(OvercommitTrackerBlockerInThread const &) = delete;
+    OvercommitTrackerBlockerInThread & operator=(OvercommitTrackerBlockerInThread const &) = delete;
 
     static bool isBlocked() { return counter > 0; }
 

--- a/src/Interpreters/InternalTextLogsQueue.cpp
+++ b/src/Interpreters/InternalTextLogsQueue.cpp
@@ -3,7 +3,6 @@
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/DataTypesNumber.h>
-#include "Common/OvercommitTracker.h"
 #include <Common/logger_useful.h>
 
 #include <Poco/Message.h>

--- a/src/Interpreters/InternalTextLogsQueue.cpp
+++ b/src/Interpreters/InternalTextLogsQueue.cpp
@@ -3,6 +3,7 @@
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/DataTypesNumber.h>
+#include "Common/OvercommitTracker.h"
 #include <Common/logger_useful.h>
 
 #include <Poco/Message.h>
@@ -38,6 +39,7 @@ MutableColumns InternalTextLogsQueue::getSampleColumns()
 
 void InternalTextLogsQueue::pushBlock(Block && log_block)
 {
+    OvercommitTrackerBlockerInThread blocker;
     static Block sample_block = getSampleBlock();
 
     if (blocksHaveEqualStructure(sample_block, log_block))

--- a/src/Interpreters/InternalTextLogsQueue.h
+++ b/src/Interpreters/InternalTextLogsQueue.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Common/ConcurrentBoundedQueue.h>
+#include <Common/OvercommitTracker.h>
 #include <Core/Block.h>
 
 
@@ -16,6 +17,62 @@ public:
 
     static Block getSampleBlock();
     static MutableColumns getSampleColumns();
+
+    template <typename... Args>
+    bool push(Args &&... args)
+    {
+        OvercommitTrackerBlockerInThread blocker;
+        return ConcurrentBoundedQueue::push(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    bool emplace(Args &&... args)
+    {
+        OvercommitTrackerBlockerInThread blocker;
+        return ConcurrentBoundedQueue::emplace(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    bool pop(Args &&... args)
+    {
+        OvercommitTrackerBlockerInThread blocker;
+        return ConcurrentBoundedQueue::pop(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    bool tryPush(Args &&... args)
+    {
+        OvercommitTrackerBlockerInThread blocker;
+        return ConcurrentBoundedQueue::tryPush(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    bool tryEmplace(Args &&... args)
+    {
+        OvercommitTrackerBlockerInThread blocker;
+        return ConcurrentBoundedQueue::tryEmplace(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    bool tryPop(Args &&... args)
+    {
+        OvercommitTrackerBlockerInThread blocker;
+        return ConcurrentBoundedQueue::tryPop(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    void clear(Args &&... args)
+    {
+        OvercommitTrackerBlockerInThread blocker;
+        return ConcurrentBoundedQueue::clear(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    void clearAndFinish(Args &&... args)
+    {
+        OvercommitTrackerBlockerInThread blocker;
+        return ConcurrentBoundedQueue::clearAndFinish(std::forward<Args>(args)...);
+    }
 
     /// Is used to pass block from remote server to the client
     void pushBlock(Block && log_block);


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix possible deadlock in OvercommitTracker during logging. cc @alesapin @tavplubix
Fixes #37272