### PR TITLE
Update run-check.py to match PR template, add comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!---
+A technical comment, you are free to remove or leave it as it is when PR is created
+The following categories are used in the next scripts, update them accordingly
+utils/changelog/changelog.py
+tests/ci/run_check.py
+-->
 ### Changelog category (leave one):
 - New Feature
 - Improvement

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -25,11 +25,14 @@ CAN_BE_TESTED_LABEL = "can be tested"
 DO_NOT_TEST_LABEL = "do not test"
 SUBMODULE_CHANGED_LABEL = "submodule changed"
 
+# They are used in .github/PULL_REQUEST_TEMPLATE.md, keep comments there
+# updated accordingly
 LABELS = {
     "pr-backward-incompatible": ["Backward Incompatible Change"],
     "pr-bugfix": [
         "Bug Fix",
         "Bug Fix (user-visible misbehaviour in official stable or prestable release)",
+        "Bug Fix (user-visible misbehavior in official stable or prestable release)",
     ],
     "pr-build": [
         "Build/Testing/Packaging Improvement",

--- a/utils/changelog/changelog.py
+++ b/utils/changelog/changelog.py
@@ -19,6 +19,8 @@ from git_helper import is_shallow, git_runner as runner
 
 # This array gives the preferred category order, and is also used to
 # normalize category names.
+# Categories are used in .github/PULL_REQUEST_TEMPLATE.md, keep comments there
+# updated accordingly
 categories_preferred_order = (
     "Backward Incompatible Change",
     "New Feature",


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix unmatched template categories, add cross-comments to the template and scripts where it processed