### PR TITLE
Release without prestable

### DIFF
--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -101,7 +101,7 @@ class Release:
         self.run("gh auth status")
         self.run("git status")
 
-    def do(self, check_dirty: bool, check_branch: bool, with_prestable: bool):
+    def do(self, check_dirty: bool, check_branch: bool, with_release_branch: bool):
         self.check_prerequisites()
 
         if check_dirty:
@@ -120,11 +120,11 @@ class Release:
         with self._checkout(self.release_commit, True):
             if self.release_type in self.BIG:
                 # Checkout to the commit, it will provide the correct current version
-                if with_prestable:
-                    with self.prestable():
+                if with_release_branch:
+                    with self.create_release_branch():
                         logging.info("Prestable part of the releasing is done")
                 else:
-                    logging.info("Skipping prestable stage")
+                    logging.info("Skipping creating release branch stage")
 
                 rollback = self._rollback_stack.copy()
                 try:
@@ -183,16 +183,16 @@ class Release:
             )
 
     @contextmanager
-    def prestable(self):
+    def create_release_branch(self):
         self.check_no_tags_after()
         # Create release branch
         self.read_version()
         with self._create_branch(self.release_branch, self.release_commit):
             with self._checkout(self.release_branch, True):
                 self.read_version()
-                self.version.with_description(VersionType.PRESTABLE)
-                with self._create_gh_release(True):
-                    with self._bump_prestable_version():
+                self.version.with_description(self.get_stable_release_type())
+                with self._create_gh_release(False):
+                    with self._bump_release_branch():
                         # At this point everything will rollback automatically
                         yield
 
@@ -265,11 +265,15 @@ class Release:
         self._release_commit = commit(release_commit)
 
     @contextmanager
-    def _bump_prestable_version(self):
+    def _bump_release_branch(self):
         # Update only git, origal version stays the same
         self._git.update()
         new_version = self.version.patch_update()
-        new_version.with_description("prestable")
+        version_type = self.get_stable_release_type()
+        pr_labels = "--label release"
+        if version_type == VersionType.LTS:
+            pr_labels += " --label release-lts"
+        new_version.with_description(version_type)
         update_cmake_version(new_version)
         update_contributors(raise_error=True)
         self.run(
@@ -287,12 +291,12 @@ class Release:
                     self.run(
                         f"gh pr create --repo {self.repo} --title "
                         f"'Release pull request for branch {self.release_branch}' "
-                        f"--head {self.release_branch}  --label release "
+                        f"--head {self.release_branch} {pr_labels} "
                         "--body 'This PullRequest is a part of ClickHouse release "
                         "cycle. It is used by CI system only. Do not perform any "
                         "changes with it.'"
                     )
-                    # Here the prestable part is done
+                    # Here the release branch part is done
                     yield
 
     @contextmanager
@@ -449,14 +453,13 @@ def parse_args() -> argparse.Namespace:
         dest="release_type",
         help="a release type, new branch is created only for 'major' and 'minor'",
     )
-    parser.add_argument("--with-prestable", default=True, help=argparse.SUPPRESS)
+    parser.add_argument("--with-release-branch", default=True, help=argparse.SUPPRESS)
     parser.add_argument(
-        "--no-prestable",
-        dest="with_prestable",
+        "--no-release-branch",
+        dest="with_release_branch",
         action="store_false",
         default=argparse.SUPPRESS,
-        help=f"if set, for release types in {Release.BIG} skip creating prestable "
-        "release and  release branch",
+        help=f"if set, for release types in {Release.BIG} skip creating release branch",
     )
     parser.add_argument("--check-dirty", default=True, help=argparse.SUPPRESS)
     parser.add_argument(
@@ -487,7 +490,7 @@ def main():
     repo = Repo(args.repo, args.remote_protocol)
     release = Release(repo, args.commit, args.release_type)
 
-    release.do(args.check_dirty, args.check_branch, args.with_prestable)
+    release.do(args.check_dirty, args.check_branch, args.with_release_branch)
 
 
 if __name__ == "__main__":

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -374,7 +374,7 @@ class Release:
             if as_prerelease:
                 prerelease = "--prerelease"
             self.run(
-                f"gh release create {prerelease} --draft --repo {self.repo} "
+                f"gh release create {prerelease} --repo {self.repo} "
                 f"--title 'Release {tag}' '{tag}'"
             )
             rollback_cmd = f"gh release delete --yes --repo {self.repo} '{tag}'"

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -121,8 +121,16 @@ class Release:
                 else:
                     logging.info("Skipping prestable stage")
 
-                with self.testing():
-                    logging.info("Testing part of the releasing is done")
+                rollback = self._rollback_stack.copy()
+                try:
+                    with self.testing():
+                        logging.info("Testing part of the releasing is done")
+                except (Exception, KeyboardInterrupt):
+                    logging.fatal("Testing part failed, rollback previous steps")
+                    rollback.reverse()
+                    for cmd in rollback:
+                        self.run(cmd)
+                    raise
 
             elif self.release_type in self.SMALL:
                 with self.stable():

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -314,7 +314,7 @@ class Release:
             rollback_cmd = f"git checkout {orig_ref}"
         try:
             yield
-        except BaseException:
+        except (Exception, KeyboardInterrupt):
             logging.warning("Rolling back checked out %s for %s", ref, orig_ref)
             self.run(f"git reset --hard; git checkout {orig_ref}")
             raise
@@ -329,7 +329,7 @@ class Release:
         self._rollback_stack.append(rollback_cmd)
         try:
             yield
-        except BaseException:
+        except (Exception, KeyboardInterrupt):
             logging.warning("Rolling back created branch %s", name)
             self.run(rollback_cmd)
             raise
@@ -344,7 +344,7 @@ class Release:
         self._rollback_stack.append(rollback_cmd)
         try:
             yield
-        except BaseException:
+        except (Exception, KeyboardInterrupt):
             logging.warning("Rolling back label %s", label)
             self.run(rollback_cmd)
             raise
@@ -365,7 +365,7 @@ class Release:
             self._rollback_stack.append(rollback_cmd)
             try:
                 yield
-            except BaseException:
+            except (Exception, KeyboardInterrupt):
                 logging.warning("Rolling back release publishing")
                 self.run(rollback_cmd)
                 raise
@@ -379,7 +379,7 @@ class Release:
         try:
             with self._push(f"'{tag}'"):
                 yield
-        except BaseException:
+        except (Exception, KeyboardInterrupt):
             logging.warning("Rolling back tag %s", tag)
             self.run(rollback_cmd)
             raise
@@ -396,7 +396,7 @@ class Release:
 
         try:
             yield
-        except BaseException:
+        except (Exception, KeyboardInterrupt):
             if with_rollback_on_fail:
                 logging.warning("Rolling back pushed ref %s", ref)
                 self.run(rollback_cmd)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Do not create prestable release
- to be continued

Relates to #34900