### PR TITLE
Delete default constructor for Exception

### DIFF
--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -534,7 +534,6 @@ ExecutionStatus ExecutionStatus::fromText(const std::string & data)
     return status;
 }
 
-ParsingException::ParsingException() = default;
 ParsingException::ParsingException(const std::string & msg, int code)
     : Exception(msg, code)
 {

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -27,7 +27,6 @@ class Exception : public Poco::Exception
 public:
     using FramePointers = std::vector<void *>;
 
-    Exception() = default;
     Exception(const std::string & msg, int code, bool remote_ = false);
 
     Exception(int code, const std::string & message)
@@ -112,7 +111,6 @@ private:
 class ParsingException : public Exception
 {
 public:
-    ParsingException();
     ParsingException(const std::string & msg, int code);
     ParsingException(int code, const std::string & message);
 


### PR DESCRIPTION
... to avoid Exception with code OK

Once I stumble on such case  [here](https://github.com/ClickHouse/ClickHouse/pull/37178/files#diff-da014867807d23b4f33a776259af48f88e03f9683f334cceed5773b51af54edbL573)

Changelog category (leave one):
- Not for changelog (changelog entry is not required)
