### PR TITLE
[bug-fix] root_dir is not set in copyThroughBuffers

### DIFF
--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -437,7 +437,7 @@ void DiskLocal::copy(const String & from_path, const std::shared_ptr<IDisk> & to
         fs::copy(from, to, fs::copy_options::recursive | fs::copy_options::overwrite_existing); /// Use more optimal way.
     }
     else
-        copyThroughBuffers(from_path, to_disk, to_path, true); /// Base implementation.
+        copyThroughBuffers(from_path, to_disk, to_path, /* copy_root_dir */ true); /// Base implementation.
 }
 
 void DiskLocal::copyDirectoryContent(const String & from_dir, const std::shared_ptr<IDisk> & to_disk, const String & to_dir)

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -445,7 +445,7 @@ void DiskLocal::copyDirectoryContent(const String & from_dir, const std::shared_
     if (isSameDiskType(*this, *to_disk))
         fs::copy(from_dir, to_dir, fs::copy_options::recursive | fs::copy_options::overwrite_existing); /// Use more optimal way.
     else
-        copyThroughBuffers(from_dir, to_disk, to_dir, false); /// Base implementation.
+        copyThroughBuffers(from_dir, to_disk, to_dir, /* copy_root_dir */ false); /// Base implementation.
 }
 
 SyncGuardPtr DiskLocal::getDirectorySyncGuard(const String & path) const

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -437,7 +437,7 @@ void DiskLocal::copy(const String & from_path, const std::shared_ptr<IDisk> & to
         fs::copy(from, to, fs::copy_options::recursive | fs::copy_options::overwrite_existing); /// Use more optimal way.
     }
     else
-        copyThroughBuffers(from_path, to_disk, to_path); /// Base implementation.
+        copyThroughBuffers(from_path, to_disk, to_path, true); /// Base implementation.
 }
 
 void DiskLocal::copyDirectoryContent(const String & from_dir, const std::shared_ptr<IDisk> & to_disk, const String & to_dir)
@@ -445,7 +445,7 @@ void DiskLocal::copyDirectoryContent(const String & from_dir, const std::shared_
     if (isSameDiskType(*this, *to_disk))
         fs::copy(from_dir, to_dir, fs::copy_options::recursive | fs::copy_options::overwrite_existing); /// Use more optimal way.
     else
-        copyThroughBuffers(from_dir, to_disk, to_dir); /// Base implementation.
+        copyThroughBuffers(from_dir, to_disk, to_dir, false); /// Base implementation.
 }
 
 SyncGuardPtr DiskLocal::getDirectorySyncGuard(const String & path) const


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)




root_dir is not set in copyThrouahBuffers function in DiskLocal.cpp. In this case, when calling DiskLocal::copyDIrectoryContent function, it will also copy parent dir name of from path, it is not expected.
ex. if we want to copy aa.cpp,bb.cpp from  /store1/xxx/xxx/111 to /store2/xxx/xxx/tmp_111, the final path will be /store2/xxx/xxx/tmp_111/111/{aa.cpp,bb.cpp}
the correct one shold be /store2/xxx/xxx/tmp_111/{aa.cpp,bb.cpp}
