### PR TITLE
Apply input_format_max_rows_to_read_for_schema_inference for all files in globs in total

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -660,7 +660,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(Char, input_format_hive_text_map_keys_delimiter, '\x03', "Delimiter between a pair of map key/values in Hive Text File", 0) \
     M(UInt64, input_format_msgpack_number_of_columns, 0, "The number of columns in inserted MsgPack data. Used for automatic schema inference from data.", 0) \
     M(MsgPackUUIDRepresentation, output_format_msgpack_uuid_representation, FormatSettings::MsgPackUUIDRepresentation::EXT, "The way how to output UUID in MsgPack format.", 0) \
-    M(UInt64, input_format_max_rows_to_read_for_schema_inference, 100, "The maximum rows of data to read for automatic schema inference", 0) \
+    M(UInt64, input_format_max_rows_to_read_for_schema_inference, 25000, "The maximum rows of data to read for automatic schema inference", 0) \
     M(Bool, input_format_csv_use_best_effort_in_schema_inference, true, "Use some tweaks and heuristics to infer schema in CSV format", 0) \
     M(Bool, input_format_tsv_use_best_effort_in_schema_inference, true, "Use some tweaks and heuristics to infer schema in TSV format", 0) \
     M(Bool, input_format_parquet_skip_columns_with_unsupported_types_in_schema_inference, false, "Allow to skip columns with unsupported types while schema inference for format Parquet", 0) \

--- a/src/Formats/ReadSchemaUtils.cpp
+++ b/src/Formats/ReadSchemaUtils.cpp
@@ -73,11 +73,15 @@ ColumnsDescription readSchemaFromFormat(
     {
         std::string exception_messages;
         SchemaReaderPtr schema_reader;
+        size_t max_rows_to_read = format_settings ? format_settings->max_rows_to_read_for_schema_inference : context->getSettingsRef().input_format_max_rows_to_read_for_schema_inference;
+        size_t iterations = 0;
         while ((buf = read_buffer_iterator()))
         {
+            ++iterations;
+
             if (buf->eof())
             {
-                auto exception_message = fmt::format("Cannot extract table structure from {} format file, file is emptyg", format_name);
+                auto exception_message = fmt::format("Cannot extract table structure from {} format file, file is empty", format_name);
 
                 if (!retry)
                     throw Exception(ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE, exception_message);
@@ -89,12 +93,26 @@ ColumnsDescription readSchemaFromFormat(
             try
             {
                 schema_reader = FormatFactory::instance().getSchemaReader(format_name, *buf, context, format_settings);
+                schema_reader->setMaxRowsToRead(max_rows_to_read);
                 names_and_types = schema_reader->readSchema();
                 break;
             }
             catch (...)
             {
                 auto exception_message = getCurrentExceptionMessage(false);
+                size_t rows_read = schema_reader->getNumRowsRead();
+                assert(rows_read <= max_rows_to_read);
+                max_rows_to_read -= schema_reader->getNumRowsRead();
+                if (rows_read != 0 && max_rows_to_read == 0)
+                {
+                    exception_message += "\nTo increase the maximum number of rows to read for structure determination, use setting input_format_max_rows_to_read_for_schema_inference";
+                    if (iterations > 1)
+                    {
+                        exception_messages += "\n" + exception_message;
+                        break;
+                    }
+                    retry = false;
+                }
 
                 if (!retry || !isRetryableSchemaInferenceError(getCurrentExceptionCode()))
                     throw Exception(ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE, "Cannot extract table structure from {} format file. Error: {}", format_name, exception_message);

--- a/src/Processors/Formats/ISchemaReader.cpp
+++ b/src/Processors/Formats/ISchemaReader.cpp
@@ -12,6 +12,7 @@ namespace ErrorCodes
     extern const int TYPE_MISMATCH;
     extern const int INCORRECT_DATA;
     extern const int EMPTY_DATA_PASSED;
+    extern const int BAD_ARGUMENTS;
 }
 
 static void chooseResultType(
@@ -48,16 +49,14 @@ static void chooseResultType(
     }
 }
 
-static void checkTypeAndAppend(NamesAndTypesList & result, DataTypePtr & type, const String & name, const DataTypePtr & default_type, size_t max_rows_to_read)
+static void checkTypeAndAppend(NamesAndTypesList & result, DataTypePtr & type, const String & name, const DataTypePtr & default_type, size_t rows_read)
 {
     if (!type)
     {
         if (!default_type)
             throw Exception(
                 ErrorCodes::ONLY_NULLS_WHILE_READING_SCHEMA,
-                "Cannot determine table structure by first {} rows of data, because some columns contain only Nulls. To increase the maximum "
-                "number of rows to read for structure determination, use setting input_format_max_rows_to_read_for_schema_inference",
-                max_rows_to_read);
+                "Cannot determine table structure by first {} rows of data, because some columns contain only Nulls", rows_read);
 
         type = default_type;
     }
@@ -65,7 +64,7 @@ static void checkTypeAndAppend(NamesAndTypesList & result, DataTypePtr & type, c
 }
 
 IRowSchemaReader::IRowSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings)
-    : ISchemaReader(in_), max_rows_to_read(format_settings.max_rows_to_read_for_schema_inference)
+    : ISchemaReader(in_)
 {
     if (!format_settings.column_names_for_schema_inference.empty())
     {
@@ -94,8 +93,14 @@ IRowSchemaReader::IRowSchemaReader(ReadBuffer & in_, const FormatSettings & form
 
 NamesAndTypesList IRowSchemaReader::readSchema()
 {
+    if (max_rows_to_read == 0)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Cannot read rows to determine the schema, the maximum number of rows to read is set to 0. "
+            "Most likely setting input_format_max_rows_to_read_for_schema_inference is set to 0");
+
     DataTypes data_types = readRowAndGetDataTypes();
-    for (size_t row = 1; row < max_rows_to_read; ++row)
+    for (rows_read = 1; rows_read < max_rows_to_read; ++rows_read)
     {
         DataTypes new_data_types = readRowAndGetDataTypes();
         if (new_data_types.empty())
@@ -111,7 +116,7 @@ NamesAndTypesList IRowSchemaReader::readSchema()
             if (!new_data_types[i])
                 continue;
 
-            chooseResultType(data_types[i], new_data_types[i], common_type_checker, getDefaultType(i), std::to_string(i + 1), row);
+            chooseResultType(data_types[i], new_data_types[i], common_type_checker, getDefaultType(i), std::to_string(i + 1), rows_read);
         }
     }
 
@@ -136,7 +141,7 @@ NamesAndTypesList IRowSchemaReader::readSchema()
     for (size_t i = 0; i != data_types.size(); ++i)
     {
         /// Check that we could determine the type of this column.
-        checkTypeAndAppend(result, data_types[i], column_names[i], getDefaultType(i), max_rows_to_read);
+        checkTypeAndAppend(result, data_types[i], column_names[i], getDefaultType(i), rows_read);
     }
 
     return result;
@@ -151,13 +156,19 @@ DataTypePtr IRowSchemaReader::getDefaultType(size_t column) const
     return nullptr;
 }
 
-IRowWithNamesSchemaReader::IRowWithNamesSchemaReader(ReadBuffer & in_, size_t max_rows_to_read_, DataTypePtr default_type_)
-    : ISchemaReader(in_), max_rows_to_read(max_rows_to_read_), default_type(default_type_)
+IRowWithNamesSchemaReader::IRowWithNamesSchemaReader(ReadBuffer & in_, DataTypePtr default_type_)
+    : ISchemaReader(in_), default_type(default_type_)
 {
 }
 
 NamesAndTypesList IRowWithNamesSchemaReader::readSchema()
 {
+    if (max_rows_to_read == 0)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Cannot read rows to determine the schema, the maximum number of rows to read is set to 0. "
+            "Most likely setting input_format_max_rows_to_read_for_schema_inference is set to 0");
+
     bool eof = false;
     auto names_and_types = readRowAndGetNamesAndDataTypes(eof);
     std::unordered_map<String, DataTypePtr> names_to_types;
@@ -170,7 +181,7 @@ NamesAndTypesList IRowWithNamesSchemaReader::readSchema()
         names_order.push_back(name);
     }
 
-    for (size_t row = 1; row < max_rows_to_read; ++row)
+    for (rows_read = 1; rows_read < max_rows_to_read; ++rows_read)
     {
         auto new_names_and_types = readRowAndGetNamesAndDataTypes(eof);
         if (eof)
@@ -189,7 +200,7 @@ NamesAndTypesList IRowWithNamesSchemaReader::readSchema()
             }
 
             auto & type = it->second;
-            chooseResultType(type, new_type, common_type_checker, default_type, name, row);
+            chooseResultType(type, new_type, common_type_checker, default_type, name, rows_read);
         }
     }
 
@@ -202,7 +213,7 @@ NamesAndTypesList IRowWithNamesSchemaReader::readSchema()
     {
         auto & type = names_to_types[name];
         /// Check that we could determine the type of this column.
-        checkTypeAndAppend(result, type, name, default_type, max_rows_to_read);
+        checkTypeAndAppend(result, type, name, default_type, rows_read);
     }
 
     return result;

--- a/src/Processors/Formats/ISchemaReader.h
+++ b/src/Processors/Formats/ISchemaReader.h
@@ -26,6 +26,9 @@ public:
     virtual bool needContext() const { return false; }
     virtual void setContext(ContextPtr &) {}
 
+    virtual void setMaxRowsToRead(size_t) {}
+    virtual size_t getNumRowsRead() const { return 0; }
+
     virtual ~ISchemaReader() = default;
 
 protected:
@@ -61,10 +64,14 @@ protected:
 
     void setColumnNames(const std::vector<String> & names) { column_names = names; }
 
+    void setMaxRowsToRead(size_t max_rows) override { max_rows_to_read = max_rows; }
+    size_t getNumRowsRead() const override { return rows_read; }
+
 private:
 
     DataTypePtr getDefaultType(size_t column) const;
     size_t max_rows_to_read;
+    size_t rows_read = 0;
     DataTypePtr default_type;
     DataTypes default_types;
     CommonDataTypeChecker common_type_checker;
@@ -79,7 +86,7 @@ private:
 class IRowWithNamesSchemaReader : public ISchemaReader
 {
 public:
-    IRowWithNamesSchemaReader(ReadBuffer & in_, size_t max_rows_to_read_, DataTypePtr default_type_ = nullptr);
+    IRowWithNamesSchemaReader(ReadBuffer & in_, DataTypePtr default_type_ = nullptr);
     NamesAndTypesList readSchema() override;
     bool hasStrictOrderOfColumns() const override { return false; }
 
@@ -92,8 +99,12 @@ protected:
     /// Set eof = true if can't read more data.
     virtual NamesAndTypesList readRowAndGetNamesAndDataTypes(bool & eof) = 0;
 
+    void setMaxRowsToRead(size_t max_rows) override { max_rows_to_read = max_rows; }
+    size_t getNumRowsRead() const override { return rows_read; }
+
 private:
     size_t max_rows_to_read;
+    size_t rows_read = 0;
     DataTypePtr default_type;
     CommonDataTypeChecker common_type_checker;
 };

--- a/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
@@ -307,7 +307,7 @@ void JSONEachRowRowInputFormat::readSuffix()
 }
 
 JSONEachRowSchemaReader::JSONEachRowSchemaReader(ReadBuffer & in_, bool json_strings_, const FormatSettings & format_settings)
-    : IRowWithNamesSchemaReader(in_, format_settings.max_rows_to_read_for_schema_inference)
+    : IRowWithNamesSchemaReader(in_)
     , json_strings(json_strings_)
 {
     bool allow_bools_as_numbers = format_settings.json.read_bools_as_numbers;

--- a/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -214,10 +214,7 @@ void TSKVRowInputFormat::resetParser()
 }
 
 TSKVSchemaReader::TSKVSchemaReader(ReadBuffer & in_, const FormatSettings & format_settings_)
-    : IRowWithNamesSchemaReader(
-        in_,
-        format_settings_.max_rows_to_read_for_schema_inference,
-        getDefaultDataTypeForEscapingRule(FormatSettings::EscapingRule::Escaped))
+    : IRowWithNamesSchemaReader(in_, getDefaultDataTypeForEscapingRule(FormatSettings::EscapingRule::Escaped))
     , format_settings(format_settings_)
 {
 }

--- a/tests/queries/0_stateless/02305_schema_inference_with_globs.reference
+++ b/tests/queries/0_stateless/02305_schema_inference_with_globs.reference
@@ -1,0 +1,6 @@
+2
+4
+6
+8
+x	Nullable(String)					
+x	Nullable(String)					

--- a/tests/queries/0_stateless/02305_schema_inference_with_globs.sh
+++ b/tests/queries/0_stateless/02305_schema_inference_with_globs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02305_schema_inference_with_globs.sh
+++ b/tests/queries/0_stateless/02305_schema_inference_with_globs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "insert into function file(data1.jsonl) select NULL as x from numbers(10) settings engine_file_truncate_on_insert=1"
+$CLICKHOUSE_CLIENT -q "insert into function file(data2.jsonl) select NULL as x from numbers(10) settings engine_file_truncate_on_insert=1"
+$CLICKHOUSE_CLIENT -q "insert into function file(data3.jsonl) select NULL as x from numbers(10) settings engine_file_truncate_on_insert=1"
+$CLICKHOUSE_CLIENT -q "insert into function file(data4.jsonl) select number % 2 ? number : NULL as x from numbers(10) settings engine_file_truncate_on_insert=1"
+
+$CLICKHOUSE_CLIENT -q "desc file('data*.jsonl') settings input_format_max_rows_to_read_for_schema_inference=8" 2>&1 | grep -c 'ONLY_NULLS_WHILE_READING_SCHEMA';
+$CLICKHOUSE_CLIENT -q "desc file('data*.jsonl') settings input_format_max_rows_to_read_for_schema_inference=16" 2>&1 | grep -c 'ONLY_NULLS_WHILE_READING_SCHEMA';
+$CLICKHOUSE_CLIENT -q "desc file('data*.jsonl') settings input_format_max_rows_to_read_for_schema_inference=24" 2>&1 | grep -c 'ONLY_NULLS_WHILE_READING_SCHEMA';
+$CLICKHOUSE_CLIENT -q "desc file('data*.jsonl') settings input_format_max_rows_to_read_for_schema_inference=31" 2>&1 | grep -c 'ONLY_NULLS_WHILE_READING_SCHEMA';
+$CLICKHOUSE_CLIENT -q "desc file('data*.jsonl') settings input_format_max_rows_to_read_for_schema_inference=32"
+$CLICKHOUSE_CLIENT -q "desc file('data*.jsonl') settings input_format_max_rows_to_read_for_schema_inference=100"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Apply setting `input_format_max_rows_to_read_for_schema_inference` for all read rows in total from all files in globs. Previously setting `input_format_max_rows_to_read_for_schema_inference` was applied for each file in glob separately and in case of huge number of nulls we could read first `input_format_max_rows_to_read_for_schema_inference` rows from each file and get nothing. Also increase default value for this setting to 25000.
 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
