### PR TITLE
Disable WITH ROLLUP/CUBE for GROUPING SETS

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1093,7 +1093,10 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
     bool use_grouping_set_key = expressions.use_grouping_set_key;
 
     if (query.group_by_with_grouping_sets && query.group_by_with_totals)
-       throw Exception("WITH TOTALS and GROUPING SETS are not supported together", ErrorCodes::NOT_IMPLEMENTED);
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "WITH TOTALS and GROUPING SETS are not supported together");
+
+    if (query.group_by_with_grouping_sets && (query.group_by_with_rollup || query.group_by_with_cube))
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "GROUPING SETS are not supported together with ROLLUP and CUBE");
 
     if (query_info.projection && query_info.projection->desc->type == ProjectionDescription::Type::Aggregate)
     {

--- a/tests/queries/0_stateless/02304_grouping_sets_with_rollup_cube.sql
+++ b/tests/queries/0_stateless/02304_grouping_sets_with_rollup_cube.sql
@@ -1,0 +1,23 @@
+SELECT
+    number
+FROM
+    numbers(10)
+GROUP BY
+    GROUPING SETS
+    (
+        number,
+        number % 2
+    )
+    WITH ROLLUP; -- { serverError NOT_IMPLEMENTED }
+
+SELECT
+    number
+FROM
+    numbers(10)
+GROUP BY
+    GROUPING SETS
+    (
+        number,
+        number % 2
+    )
+    WITH CUBE; -- { serverError NOT_IMPLEMENTED }

--- a/tests/queries/0_stateless/02304_grouping_sets_with_rollup_cube.sql
+++ b/tests/queries/0_stateless/02304_grouping_sets_with_rollup_cube.sql
@@ -1,4 +1,4 @@
--- Tags: no-backward-compatibility-check:22.4
+-- Tags: no-backward-compatibility-check:22.5.1
 
 SELECT
     number

--- a/tests/queries/0_stateless/02304_grouping_sets_with_rollup_cube.sql
+++ b/tests/queries/0_stateless/02304_grouping_sets_with_rollup_cube.sql
@@ -1,3 +1,5 @@
+-- Tags: no-backward-compatibility-check:22.4
+
 SELECT
     number
 FROM


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Throw an exception when GROUPING SETS used with ROLLUP or CUBE.