### PR TITLE
Do not fail CI if events clickhouse is down

### DIFF
--- a/tests/ci/ast_fuzzer_check.py
+++ b/tests/ci/ast_fuzzer_check.py
@@ -169,6 +169,8 @@ if __name__ == "__main__":
         check_name,
     )
 
+    ch_helper.insert_events_into(db="default", table="checks", events=prepared_events)
+
     logging.info("Result: '%s', '%s', '%s'", status, description, report_url)
     print(f"::notice ::Report url: {report_url}")
     post_commit_status(gh, pr_info.sha, check_name, description, status, report_url)

--- a/tests/ci/clickhouse_helper.py
+++ b/tests/ci/clickhouse_helper.py
@@ -26,7 +26,7 @@ class ClickHouseHelper:
     def _insert_json_str_info_impl(url, auth, db, table, json_str):
         params = {
             "database": db,
-            "query": "INSERT INTO {table} FORMAT JSONEachRow".format(table=table),
+            "query": f"INSERT INTO {table} FORMAT JSONEachRow",
             "date_time_input_format": "best_effort",
             "send_logs_level": "warning",
         }
@@ -185,17 +185,14 @@ def prepare_tests_results_for_clickhouse(
 
 def mark_flaky_tests(clickhouse_helper, check_name, test_results):
     try:
-        query = """
-        SELECT DISTINCT test_name
-        FROM checks
-        WHERE
-            check_start_time BETWEEN now() - INTERVAL 3 DAY AND now()
-            AND check_name = '{check_name}'
-            AND (test_status = 'FAIL' OR test_status = 'FLAKY')
-            AND pull_request_number = 0
-        """.format(
-            check_name=check_name
-        )
+        query = f"""SELECT DISTINCT test_name
+FROM checks
+WHERE
+    check_start_time BETWEEN now() - INTERVAL 3 DAY AND now()
+    AND check_name = '{check_name}'
+    AND (test_status = 'FAIL' OR test_status = 'FLAKY')
+    AND pull_request_number = 0
+"""
 
         tests_data = clickhouse_helper.select_json_each_row("default", query)
         master_failed_tests = {row["test_name"] for row in tests_data}

--- a/tests/ci/clickhouse_helper.py
+++ b/tests/ci/clickhouse_helper.py
@@ -32,9 +32,7 @@ class ClickHouseHelper:
         }
 
         for i in range(5):
-            response = requests.post(
-                url, params=params, data=json_str, headers=auth, verify=False
-            )
+            response = requests.post(url, params=params, data=json_str, headers=auth)
 
             logging.info("Response content '%s'", response.content)
 
@@ -103,9 +101,7 @@ class ClickHouseHelper:
         for i in range(5):
             response = None
             try:
-                response = requests.get(
-                    self.url, params=params, headers=self.auth, verify=False
-                )
+                response = requests.get(self.url, params=params, headers=self.auth)
                 response.raise_for_status()
                 return response.text
             except Exception as ex:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not fail CI if the events DB is down