### PR TITLE
Enable -Wc++98-compat-extra-semi

### DIFF
--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -345,7 +345,7 @@ HedgedConnections::ReplicaLocation HedgedConnections::getReadyReplicaLocation(As
         else
             throw Exception("Unknown event from epoll", ErrorCodes::LOGICAL_ERROR);
     }
-};
+}
 
 bool HedgedConnections::resumePacketReceiver(const HedgedConnections::ReplicaLocation & location)
 {

--- a/src/Common/tests/gtest_lru_file_cache.cpp
+++ b/src/Common/tests/gtest_lru_file_cache.cpp
@@ -32,7 +32,7 @@ void assertRange(
     ASSERT_EQ(range.left, expected_range.left);
     ASSERT_EQ(range.right, expected_range.right);
     ASSERT_EQ(file_segment->state(), expected_state);
-};
+}
 
 void printRanges(const auto & segments)
 {

--- a/src/Common/tests/gtest_sensitive_data_masker.cpp
+++ b/src/Common/tests/gtest_sensitive_data_masker.cpp
@@ -22,7 +22,7 @@ extern const int CANNOT_COMPILE_REGEXP;
 extern const int NO_ELEMENTS_IN_CONFIG;
 extern const int INVALID_CONFIG_PARAMETER;
 }
-};
+}
 
 
 TEST(Common, SensitiveDataMasker)

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -790,7 +790,7 @@ std::vector<CodecTestSequence> generatePyramidOfSequences(const size_t sequences
     }
 
     return sequences;
-};
+}
 
 // helper macro to produce human-friendly sequence name from generator
 #define G(generator) generator, #generator

--- a/src/DataTypes/tests/gtest_data_type_get_common_type.cpp
+++ b/src/DataTypes/tests/gtest_data_type_get_common_type.cpp
@@ -22,7 +22,7 @@ static auto typeFromString(const std::string & str)
 {
     auto & data_type_factory = DataTypeFactory::instance();
     return data_type_factory.get(str);
-};
+}
 
 static auto typesFromString(const std::string & str)
 {
@@ -33,7 +33,7 @@ static auto typesFromString(const std::string & str)
         data_types.push_back(typeFromString(data_type));
 
     return data_types;
-};
+}
 
 struct TypesTestCase
 {

--- a/src/Disks/IDiskRemote.cpp
+++ b/src/Disks/IDiskRemote.cpp
@@ -23,7 +23,7 @@ namespace ErrorCodes
     extern const int INCORRECT_DISK_INDEX;
     extern const int UNKNOWN_FORMAT;
     extern const int FILE_ALREADY_EXISTS;
-    extern const int PATH_ACCESS_DENIED;;
+    extern const int PATH_ACCESS_DENIED;
     extern const int FILE_DOESNT_EXIST;
     extern const int BAD_FILE_TYPE;
 }

--- a/src/Functions/SubtractSubSeconds.cpp
+++ b/src/Functions/SubtractSubSeconds.cpp
@@ -9,19 +9,19 @@ using FunctionSubtractNanoseconds = FunctionDateOrDateTimeAddInterval<SubtractNa
 void registerFunctionSubtractNanoseconds(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionSubtractNanoseconds>();
-};
+}
 
 using FunctionSubtractMicroseconds = FunctionDateOrDateTimeAddInterval<SubtractMicrosecondsImpl>;
 void registerFunctionSubtractMicroseconds(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionSubtractMicroseconds>();
-};
+}
 
 using FunctionSubtractMilliseconds = FunctionDateOrDateTimeAddInterval<SubtractMillisecondsImpl>;
 void registerFunctionSubtractMilliseconds(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionSubtractMilliseconds>();
-};
+}
 
 }
 

--- a/src/Interpreters/SessionLog.cpp
+++ b/src/Interpreters/SessionLog.cpp
@@ -61,7 +61,7 @@ void fillColumnArray(const Strings & data, IColumn & column)
     }
     auto & offsets = array.getOffsets();
     offsets.push_back(offsets.back() + size);
-};
+}
 
 }
 

--- a/src/Storages/ExecutableSettings.cpp
+++ b/src/Storages/ExecutableSettings.cpp
@@ -14,7 +14,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_SETTING;
 }
 
-IMPLEMENT_SETTINGS_TRAITS(ExecutableSettingsTraits, LIST_OF_EXECUTABLE_SETTINGS);
+IMPLEMENT_SETTINGS_TRAITS(ExecutableSettingsTraits, LIST_OF_EXECUTABLE_SETTINGS)
 
 void ExecutableSettings::loadFromQuery(ASTStorage & storage_def)
 {

--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -19,7 +19,7 @@ namespace ErrorCodes
 {
     extern const int INCORRECT_QUERY;
     extern const int LOGICAL_ERROR;
-};
+}
 
 IndexDescription::IndexDescription(const IndexDescription & other)
     : definition_ast(other.definition_ast ? other.definition_ast->clone() : nullptr)

--- a/src/Storages/MeiliSearch/MeiliSearchColumnDescriptionFetcher.cpp
+++ b/src/Storages/MeiliSearch/MeiliSearchColumnDescriptionFetcher.cpp
@@ -84,4 +84,4 @@ ColumnsDescription MeiliSearchColumnDescriptionFetcher::fetchColumnsDescription(
     return ColumnsDescription(list);
 }
 
-};
+}

--- a/src/Storages/MeiliSearch/MeiliSearchColumnDescriptionFetcher.h
+++ b/src/Storages/MeiliSearch/MeiliSearchColumnDescriptionFetcher.h
@@ -21,4 +21,4 @@ private:
     MeiliSearchConnection connection;
 };
 
-};
+}

--- a/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -660,7 +660,7 @@ MergeTreeIndexConditionPtr MergeTreeIndexFullText::createIndexCondition(
         const SelectQueryInfo & query, ContextPtr context) const
 {
     return std::make_shared<MergeTreeConditionFullText>(query, context, index.sample_block, params, token_extractor.get());
-};
+}
 
 bool MergeTreeIndexFullText::mayBenefitFromIndexForIn(const ASTPtr & node) const
 {

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -484,7 +484,7 @@ MergeTreeIndexConditionPtr MergeTreeIndexSet::createIndexCondition(
     const SelectQueryInfo & query, ContextPtr context) const
 {
     return std::make_shared<MergeTreeIndexConditionSet>(index.name, index.sample_block, max_rows, query, context);
-};
+}
 
 bool MergeTreeIndexSet::mayBenefitFromIndexForIn(const ASTPtr &) const
 {

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -123,14 +123,14 @@ static const ASTFunction * getAsTuple(const ASTPtr & node)
     if (const auto * func = node->as<ASTFunction>(); func && func->name == "tuple")
         return func;
     return {};
-};
+}
 
 static bool getAsTupleLiteral(const ASTPtr & node, Tuple & tuple)
 {
     if (const auto * value_tuple = node->as<ASTLiteral>())
         return value_tuple && value_tuple->value.tryGet<Tuple>(tuple);
     return false;
-};
+}
 
 bool MergeTreeWhereOptimizer::tryAnalyzeTuple(Conditions & res, const ASTFunction * func, bool is_final) const
 {

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -29,7 +29,7 @@ namespace ErrorCodes
     extern const int ILLEGAL_PROJECTION;
     extern const int NOT_IMPLEMENTED;
     extern const int LOGICAL_ERROR;
-};
+}
 
 bool ProjectionDescription::isPrimaryKeyColumnPossiblyWrappedInFunctions(const ASTPtr & node) const
 {


### PR DESCRIPTION
In PR https://github.com/ClickHouse/ClickHouse/pull/37300, Alexej asked
why the compiler does not warn about unnecessary semicolons, e.g.

```
  f()
  {
  }; // <-- here
```

The answer is surprising: In C++98, above syntax was disallowed but
most compilers accepted it regardless. C++>11 introduced "empty
declarations" which made the syntax legal.

The previous behavior can be restored using flag
-Wc++98-compat-extra-semi. This finds many useless semicolons which were
removed in this change. Unfortunately, there are also false positives
which would require #pragma-s and HAS_* logic (--> check_flags.cmake) to
suppress. In the end, -Wc++98-compat-extra-semi comes with extra effort
for little benefit. Therefore, this change only fixes some semicolons
but does not enable the flag.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)