### PR TITLE
optimize fs cache: get rid of cache lock in file segments completion

### DIFF
--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -86,7 +86,7 @@ public:
     /// This applies to read-through cache, not for write-through cache.
     static bool isReadOnly();
 
-    /// Create a snapshot of the current cache state. Returnes a list
+    /// Create a snapshot of the current cache state. Returns a list
     /// of file segments for all keys.
     virtual FileSegments getSnapshot() const = 0;
 
@@ -227,7 +227,7 @@ private:
         FileSegment::State state, std::lock_guard<std::mutex> & cache_lock);
 
     void removeCell(
-        FileSegmentCell * cell,
+        const FileSegmentCell & cell,
         std::lock_guard<std::mutex> & cache_lock);
 
     void useCell(const FileSegmentCell & cell, FileSegments & result, std::lock_guard<std::mutex> & cache_lock);
@@ -262,8 +262,6 @@ private:
     size_t getFileSegmentsNumUnlocked(std::lock_guard<std::mutex> & cache_lock) const;
 
     void assertCacheCellsCorrectness(const CellsByOffset & cells_by_offset, std::lock_guard<std::mutex> & cache_lock);
-
-    void normalize();
 
     void normalize(CellsByOffset & cells, std::lock_guard<std::mutex> & cache_lock);
 

--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -115,6 +115,14 @@ protected:
         std::lock_guard<std::mutex> & cache_lock) = 0;
 
     void assertInitialized() const;
+
+    virtual void remove(
+        const Key & key, size_t offset,
+        std::lock_guard<std::mutex> & cache_lock) = 0;
+
+    virtual size_t getReferencesNum(
+        const Key & key, size_t offset,
+        std::lock_guard<std::mutex> & cache_lock) = 0;
 };
 
 using FileCachePtr = std::shared_ptr<IFileCache>;
@@ -267,6 +275,14 @@ private:
 
     void resizeCellToDownloadedSize(
         FileSegmentCell & cell, std::lock_guard<std::mutex> & cache_lock);
+
+    void remove(
+        const Key & key, size_t offset,
+        std::lock_guard<std::mutex> & cache_lock) override;
+
+    size_t getReferencesNum(
+        const Key & key, size_t offset,
+        std::lock_guard<std::mutex> & cache_lock) override;
 
 public:
     String dumpStructure(const Key & key_) override;

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -528,6 +528,7 @@ void FileSegment::complete()
         /// reference to file segment apart from cache itself?
         /// Cell needs to be manually removed in this case, because in this case it might not have
         /// git into `queue`, so not removing it manually will lead to memory leaks.
+        /// TODO: This needs to be fixed by introducing per key mutex.
         if (downloaded_size == 0 && cache->getReferencesNum(key(), offset(), cache_lock) == 2)
         {
             cache->remove(key(), offset(), cache_lock);

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -521,8 +521,6 @@ void FileSegment::complete()
 {
     std::lock_guard segment_lock(mutex);
 
-    assertNotDetached(segment_lock);
-
     if (download_state == State::SKIP_CACHE || is_detached)
         return;
 
@@ -718,13 +716,7 @@ FileSegmentsHolder::~FileSegmentsHolder()
     {
         try
         {
-            /// If file segment is detached, it is not owned by cache, so it will be destructed
-            /// at this point, therefore no completion required.
-            if ((*file_segment_it)->isDetached() == false)
-            {
-                (*file_segment_it)->complete();
-            }
-
+            (*file_segment_it)->complete();
             file_segment_it = file_segments.erase(file_segment_it);
         }
         catch (...)

--- a/src/Common/FileSegment.h
+++ b/src/Common/FileSegment.h
@@ -155,11 +155,11 @@ public:
         const FileSegmentPtr & file_segment,
         std::lock_guard<std::mutex> & cache_lock);
 
-    void detach(
-        std::lock_guard<std::mutex> & cache_lock,
-        std::lock_guard<std::mutex> & segment_lock);
+    void detach(std::lock_guard<std::mutex> & cache_lock);
 
     [[noreturn]] void throwIfDetached() const;
+
+    bool isDetached() const;
 
 private:
     size_t availableSize() const { return reserved_size - downloaded_size; }
@@ -169,7 +169,6 @@ private:
     void assertCorrectnessImpl(std::lock_guard<std::mutex> & segment_lock) const;
     bool hasFinalizedState() const;
 
-    bool isDetached(std::lock_guard<std::mutex> & /* segment_lock */) const { return is_detached; }
     void markAsDetached(std::lock_guard<std::mutex> & segment_lock);
     [[noreturn]] void throwIfDetachedUnlocked(std::lock_guard<std::mutex> & segment_lock) const;
 
@@ -177,7 +176,7 @@ private:
     void assertNotDetached(std::lock_guard<std::mutex> & segment_lock) const;
 
     void setDownloaded(std::lock_guard<std::mutex> & segment_lock);
-    void setDownloadFailed(std::lock_guard<std::mutex> & segment_lock);
+    void setDownloadFailed(std::lock_guard<std::mutex> & segment_lock, State state = State::PARTIALLY_DOWNLOADED_NO_CONTINUATION);
     bool isDownloaderImpl(std::lock_guard<std::mutex> & segment_lock) const;
 
     void wrapWithCacheInfo(Exception & e, const String & message, std::lock_guard<std::mutex> & segment_lock) const;
@@ -188,12 +187,7 @@ private:
     /// FileSegmentsHolder. complete() might check if the caller of the method
     /// is the last alive holder of the segment. Therefore, complete() and destruction
     /// of the file segment pointer must be done under the same cache mutex.
-    void complete(std::lock_guard<std::mutex> & cache_lock);
-    void completeUnlocked(std::lock_guard<std::mutex> & cache_lock, std::lock_guard<std::mutex> & segment_lock);
-
-    void completeImpl(
-        std::lock_guard<std::mutex> & cache_lock,
-        std::lock_guard<std::mutex> & segment_lock);
+    void complete();
 
     void resetDownloaderImpl(std::lock_guard<std::mutex> & segment_lock);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize filesystem cache implementation by completely getting rid of cache lock in file segment completion.