### PR TITLE
Mark all `operator bool()` as explicit

### DIFF
--- a/src/Common/COW.h
+++ b/src/Common/COW.h
@@ -219,7 +219,7 @@ protected:
         /// Get internal immutable ptr. Does not change internal use counter.
         immutable_ptr<T> detach() && { return std::move(value); }
 
-        operator bool() const { return value != nullptr; } /// NOLINT
+        explicit operator bool() const { return value != nullptr; }
         bool operator! () const { return value == nullptr; }
 
         bool operator== (const chameleon_ptr & rhs) const { return value == rhs.value; }

--- a/src/Common/HashTable/StringHashTable.h
+++ b/src/Common/HashTable/StringHashTable.h
@@ -169,7 +169,7 @@ struct StringHashTableLookupResult
     auto & operator*() const { return *this; }
     auto * operator->() { return this; }
     auto * operator->() const { return this; }
-    operator bool() const { return mapped_ptr; } /// NOLINT
+    explicit operator bool() const { return mapped_ptr; }
     friend bool operator==(const StringHashTableLookupResult & a, const std::nullptr_t &) { return !a.mapped_ptr; }
     friend bool operator==(const std::nullptr_t &, const StringHashTableLookupResult & b) { return !b.mapped_ptr; }
     friend bool operator!=(const StringHashTableLookupResult & a, const std::nullptr_t &) { return a.mapped_ptr; }

--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -161,7 +161,7 @@ public:
             task_info->deactivate();
     }
 
-    operator bool() const { return task_info != nullptr; } /// NOLINT
+    explicit operator bool() const { return task_info != nullptr; }
 
     BackgroundSchedulePoolTaskInfo * operator->() { return task_info.get(); }
     const BackgroundSchedulePoolTaskInfo * operator->() const { return task_info.get(); }

--- a/src/Core/Block.h
+++ b/src/Core/Block.h
@@ -108,7 +108,7 @@ public:
     /// Approximate number of allocated bytes in memory - for profiling and limits.
     size_t allocatedBytes() const;
 
-    operator bool() const { return !!columns(); } /// NOLINT
+    explicit operator bool() const { return !!columns(); }
     bool operator!() const { return !this->operator bool(); } /// NOLINT
 
     /** Get a list of column names separated by commas. */

--- a/src/Processors/Chunk.h
+++ b/src/Processors/Chunk.h
@@ -90,7 +90,7 @@ public:
     bool hasRows() const { return num_rows > 0; }
     bool hasColumns() const { return !columns.empty(); }
     bool empty() const { return !hasRows() && !hasColumns(); }
-    operator bool() const { return !empty(); } /// NOLINT
+    explicit operator bool() const { return !empty(); }
 
     void addColumn(ColumnPtr column);
     void addColumn(size_t position, ColumnPtr column);

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
@@ -88,7 +88,7 @@ void ParallelParsingInputFormat::parserThreadFunction(ThreadGroupStatusPtr threa
         // We don't know how many blocks will be. So we have to read them all
         // until an empty block occurred.
         Chunk chunk;
-        while (!parsing_finished && (chunk = parser.getChunk()) != Chunk())
+        while (!parsing_finished && (chunk = parser.getChunk()))
         {
             /// Variable chunk is moved, but it is not really used in the next iteration.
             /// NOLINTNEXTLINE(bugprone-use-after-move, hicpp-invalid-access-moved)

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1480,7 +1480,7 @@ bool TCPHandler::receiveUnexpectedData(bool throw_exception)
         maybe_compressed_in = in;
 
     auto skip_block_in = std::make_shared<NativeReader>(*maybe_compressed_in, client_tcp_protocol_version);
-    bool read_ok = skip_block_in->read();
+    bool read_ok = !!skip_block_in->read();
 
     if (!read_ok)
         state.read_all_data = true;

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -29,7 +29,7 @@ struct MergeTreeIndexFormat
     MergeTreeIndexVersion version;
     const char* extension;
 
-    operator bool() const { return version != 0; } /// NOLINT
+    explicit operator bool() const { return version != 0; }
 };
 
 /// Stores some info about a single block of data.

--- a/src/Storages/System/StorageSystemPartsBase.h
+++ b/src/Storages/System/StorageSystemPartsBase.h
@@ -22,7 +22,7 @@ struct StoragesInfo
     bool need_inactive_parts = false;
     MergeTreeData * data = nullptr;
 
-    operator bool() const { return storage != nullptr; } /// NOLINT
+    explicit operator bool() const { return storage != nullptr; }
     MergeTreeData::DataPartsVector
     getParts(MergeTreeData::DataPartStateVector & state, bool has_state_column, bool require_projection_parts = false) const;
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

With explicit bool operators classes still can be contextually converted in places where it's expected (like it's stated in [cppreference](https://en.cppreference.com/w/cpp/language/implicit_conversion)), but explicit operator will prevent implicit conversions to other numeric types, which could lead to calling of wrong functions' overloads and obscure bugs.

E.g. this code will successfully compile: https://godbolt.org/z/P173Ph1Wf.