### PR TITLE
Use hashMap instead of unordered map to find fs cache keys

### DIFF
--- a/src/Common/FileCache.cpp
+++ b/src/Common/FileCache.cpp
@@ -116,11 +116,11 @@ void LRUFileCache::useCell(
 LRUFileCache::FileSegmentCell * LRUFileCache::getCell(
     const Key & key, size_t offset, std::lock_guard<std::mutex> & /* cache_lock */)
 {
-    auto it = files.find(key);
-    if (it == files.end())
+    auto * it = files.find(key);
+    if (!it)
         return nullptr;
 
-    auto & offsets = it->second;
+    auto & offsets = it->getMapped();
     auto cell_it = offsets.find(offset);
     if (cell_it == offsets.end())
         return nullptr;
@@ -134,11 +134,11 @@ FileSegments LRUFileCache::getImpl(
     /// Given range = [left, right] and non-overlapping ordered set of file segments,
     /// find list [segment1, ..., segmentN] of segments which intersect with given range.
 
-    auto it = files.find(key);
-    if (it == files.end())
+    auto * it = files.find(key);
+    if (!it)
         return {};
 
-    const auto & file_segments = it->second;
+    const auto & file_segments = it->getMapped();
     if (file_segments.empty())
     {
         auto key_path = getPathInLocalCache(key);
@@ -569,11 +569,11 @@ void LRUFileCache::remove(const Key & key)
 
     std::lock_guard cache_lock(mutex);
 
-    auto it = files.find(key);
-    if (it == files.end())
+    auto * it = files.find(key);
+    if (!it)
         return;
 
-    auto & offsets = it->second;
+    auto & offsets = it->getMapped();
 
     std::vector<FileSegmentCell *> to_remove;
     to_remove.reserve(offsets.size());

--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -13,6 +13,7 @@
 #include "FileCache_fwd.h"
 #include <Common/logger_useful.h>
 #include <Common/FileSegment.h>
+#include <Common/HashTable/HashMap.h>
 #include <Core/Types.h>
 
 
@@ -221,7 +222,7 @@ private:
     };
 
     using FileSegmentsByOffset = std::map<size_t, FileSegmentCell>;
-    using CachedFiles = std::unordered_map<Key, FileSegmentsByOffset>;
+    using CachedFiles = HashMap<Key, FileSegmentsByOffset, HashCRC32<Key>>;
 
     CachedFiles files;
     LRUQueue queue;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

