### PR TITLE
Send profile events for INSERT queries (previously only SELECT was supported)

### DIFF
--- a/programs/local/LocalServer.h
+++ b/programs/local/LocalServer.h
@@ -3,7 +3,6 @@
 #include <Client/ClientBase.h>
 #include <Client/LocalConnection.h>
 
-#include <Common/ProgressIndication.h>
 #include <Common/StatusFile.h>
 #include <Common/InterruptListener.h>
 #include <Loggers/Loggers.h>

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1275,7 +1275,7 @@ try
         }
 
         /// Check if server send Log packet
-        receiveLogs(parsed_query);
+        receiveLogsAndProfileEvents(parsed_query);
 
         /// Check if server send Exception packet
         auto packet_type = connection->checkPacket(0);
@@ -1328,11 +1328,11 @@ void ClientBase::sendDataFromStdin(Block & sample, const ColumnsDescription & co
 
 
 /// Process Log packets, used when inserting data by blocks
-void ClientBase::receiveLogs(ASTPtr parsed_query)
+void ClientBase::receiveLogsAndProfileEvents(ASTPtr parsed_query)
 {
     auto packet_type = connection->checkPacket(0);
 
-    while (packet_type && *packet_type == Protocol::Server::Log)
+    while (packet_type && (*packet_type == Protocol::Server::Log || *packet_type == Protocol::Server::ProfileEvents))
     {
         receiveAndProcessPacket(parsed_query, false);
         packet_type = connection->checkPacket(0);

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -117,7 +117,7 @@ protected:
 private:
     void receiveResult(ASTPtr parsed_query);
     bool receiveAndProcessPacket(ASTPtr parsed_query, bool cancelled_);
-    void receiveLogs(ASTPtr parsed_query);
+    void receiveLogsAndProfileEvents(ASTPtr parsed_query);
     bool receiveSampleBlock(Block & out, ColumnsDescription & columns_description, ASTPtr parsed_query);
     bool receiveEndOfQuery();
     void cancelQuery();

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -18,6 +18,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_PACKET_FROM_SERVER;
     extern const int UNKNOWN_EXCEPTION;
     extern const int NOT_IMPLEMENTED;
+    extern const int LOGICAL_ERROR;
 }
 
 LocalConnection::LocalConnection(ContextPtr context_, bool send_progress_, bool send_profile_events_, const String & server_display_name_)
@@ -62,9 +63,13 @@ void LocalConnection::updateProgress(const Progress & value)
     state->progress.incrementPiecewiseAtomically(value);
 }
 
-void LocalConnection::getProfileEvents(Block & block)
+void LocalConnection::sendProfileEvents()
 {
-    ProfileEvents::getProfileEvents(server_display_name, state->profile_queue, block, last_sent_snapshots);
+    Block profile_block;
+    state->after_send_profile_events.restart();
+    next_packet_type = Protocol::Server::ProfileEvents;
+    ProfileEvents::getProfileEvents(server_display_name, state->profile_queue, profile_block, last_sent_snapshots);
+    state->block.emplace(std::move(profile_block));
 }
 
 void LocalConnection::sendQuery(
@@ -192,13 +197,14 @@ void LocalConnection::sendData(const Block & block, const String &, bool)
         return;
 
     if (state->pushing_async_executor)
-    {
         state->pushing_async_executor->push(block);
-    }
     else if (state->pushing_executor)
-    {
         state->pushing_executor->push(block);
-    }
+    else
+        throw Exception("Unknown executor", ErrorCodes::LOGICAL_ERROR);
+
+    if (send_profile_events)
+        sendProfileEvents();
 }
 
 void LocalConnection::sendCancel()
@@ -264,11 +270,7 @@ bool LocalConnection::poll(size_t)
 
         if (send_profile_events && (state->after_send_profile_events.elapsedMicroseconds() >= query_context->getSettingsRef().interactive_delay))
         {
-            Block block;
-            state->after_send_profile_events.restart();
-            next_packet_type = Protocol::Server::ProfileEvents;
-            getProfileEvents(block);
-            state->block.emplace(std::move(block));
+            sendProfileEvents();
             return true;
         }
 
@@ -349,11 +351,7 @@ bool LocalConnection::poll(size_t)
 
         if (send_profile_events && state->executor)
         {
-            Block block;
-            state->after_send_profile_events.restart();
-            next_packet_type = Protocol::Server::ProfileEvents;
-            getProfileEvents(block);
-            state->block.emplace(std::move(block));
+            sendProfileEvents();
             return true;
         }
     }

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -142,7 +142,7 @@ private:
 
     void updateProgress(const Progress & value);
 
-    void getProfileEvents(Block & block);
+    void sendProfileEvents();
 
     bool pollImpl();
 

--- a/src/Common/ProgressIndication.cpp
+++ b/src/Common/ProgressIndication.cpp
@@ -53,8 +53,11 @@ void ProgressIndication::resetProgress()
     show_progress_bar = false;
     written_progress_chars = 0;
     write_progress_on_update = false;
-    host_cpu_usage.clear();
-    thread_data.clear();
+    {
+        std::lock_guard lock(profile_events_mutex);
+        host_cpu_usage.clear();
+        thread_data.clear();
+    }
 }
 
 void ProgressIndication::setFileProgressCallback(ContextMutablePtr context, bool write_progress_on_update_)
@@ -71,6 +74,8 @@ void ProgressIndication::setFileProgressCallback(ContextMutablePtr context, bool
 
 void ProgressIndication::addThreadIdToList(String const & host, UInt64 thread_id)
 {
+    std::lock_guard lock(profile_events_mutex);
+
     auto & thread_to_times = thread_data[host];
     if (thread_to_times.contains(thread_id))
         return;
@@ -79,6 +84,8 @@ void ProgressIndication::addThreadIdToList(String const & host, UInt64 thread_id
 
 void ProgressIndication::updateThreadEventData(HostToThreadTimesMap & new_thread_data, UInt64 elapsed_time)
 {
+    std::lock_guard lock(profile_events_mutex);
+
     for (auto & new_host_map : new_thread_data)
     {
         host_cpu_usage[new_host_map.first] = calculateCPUUsage(new_host_map.second, elapsed_time);
@@ -88,6 +95,8 @@ void ProgressIndication::updateThreadEventData(HostToThreadTimesMap & new_thread
 
 size_t ProgressIndication::getUsedThreadsCount() const
 {
+    std::lock_guard lock(profile_events_mutex);
+
     return std::accumulate(thread_data.cbegin(), thread_data.cend(), 0,
         [] (size_t acc, auto const & threads)
         {
@@ -97,6 +106,8 @@ size_t ProgressIndication::getUsedThreadsCount() const
 
 double ProgressIndication::getCPUUsage() const
 {
+    std::lock_guard lock(profile_events_mutex);
+
     double res = 0;
     for (const auto & elem : host_cpu_usage)
         res += elem.second;
@@ -105,6 +116,8 @@ double ProgressIndication::getCPUUsage() const
 
 ProgressIndication::MemoryUsage ProgressIndication::getMemoryUsage() const
 {
+    std::lock_guard lock(profile_events_mutex);
+
     return std::accumulate(thread_data.cbegin(), thread_data.cend(), MemoryUsage{},
         [](MemoryUsage const & acc, auto const & host_data)
         {
@@ -137,6 +150,8 @@ void ProgressIndication::writeFinalProgress()
 
 void ProgressIndication::writeProgress()
 {
+    std::lock_guard lock(progress_mutex);
+
     /// Output all progress bar commands to stderr at once to avoid flicker.
     WriteBufferFromFileDescriptor message(STDERR_FILENO, 1024);
 

--- a/src/Common/ProgressIndication.h
+++ b/src/Common/ProgressIndication.h
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include <mutex>
 #include <IO/Progress.h>
 #include <Interpreters/Context.h>
 #include <base/types.h>
@@ -92,6 +93,16 @@ private:
 
     std::unordered_map<String, double> host_cpu_usage;
     HostToThreadTimesMap thread_data;
+    /// In case of all of the above:
+    /// - clickhouse-local
+    /// - input_format_parallel_parsing=true
+    /// - write_progress_on_update=true
+    ///
+    /// It is possible concurrent access to the following:
+    /// - writeProgress() (class properties) (guarded with progress_mutex)
+    /// - thread_data/host_cpu_usage (guarded with profile_events_mutex)
+    mutable std::mutex profile_events_mutex;
+    mutable std::mutex progress_mutex;
 };
 
 }

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -52,6 +52,8 @@
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-#define DBMS_TCP_PROTOCOL_VERSION 54455
+#define DBMS_TCP_PROTOCOL_VERSION 54456
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME 54449
+
+#define DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS_IN_INSERT 54456

--- a/src/QueryPipeline/RemoteInserter.cpp
+++ b/src/QueryPipeline/RemoteInserter.cpp
@@ -72,6 +72,10 @@ RemoteInserter::RemoteInserter(
             if (auto log_queue = CurrentThread::getInternalTextLogsQueue())
                 log_queue->pushBlock(std::move(packet.block));
         }
+        else if (Protocol::Server::ProfileEvents == packet.type)
+        {
+            // Do nothing
+        }
         else if (Protocol::Server::TableColumns == packet.type)
         {
             /// Server could attach ColumnsDescription in front of stream for column defaults. There's no need to pass it through cause
@@ -129,6 +133,10 @@ void RemoteInserter::onFinish()
         else if (Protocol::Server::Exception == packet.type)
             packet.exception->rethrow();
         else if (Protocol::Server::Log == packet.type)
+        {
+            // Do nothing
+        }
+        else if (Protocol::Server::ProfileEvents == packet.type)
         {
             // Do nothing
         }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -357,7 +357,7 @@ void TCPHandler::runImpl()
                             return true;
 
                         sendProgress();
-                        sendProfileEvents();
+                        sendSelectProfileEvents();
                         sendLogs();
 
                         return false;
@@ -586,7 +586,10 @@ bool TCPHandler::readDataNext()
     }
 
     if (read_ok)
+    {
         sendLogs();
+        sendInsertProfileEvents();
+    }
     else
         state.read_all_data = true;
 
@@ -659,6 +662,8 @@ void TCPHandler::processInsertQuery()
         PushingPipelineExecutor executor(state.io.pipeline);
         run_executor(executor);
     }
+
+    sendInsertProfileEvents();
 }
 
 
@@ -701,7 +706,7 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
                 /// Some time passed and there is a progress.
                 after_send_progress.restart();
                 sendProgress();
-                sendProfileEvents();
+                sendSelectProfileEvents();
             }
 
             sendLogs();
@@ -727,7 +732,7 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
             sendProfileInfo(executor.getProfileInfo());
             sendProgress();
             sendLogs();
-            sendProfileEvents();
+            sendSelectProfileEvents();
         }
 
         if (state.is_connection_closed)
@@ -861,9 +866,6 @@ void TCPHandler::sendExtremes(const Block & extremes)
 
 void TCPHandler::sendProfileEvents()
 {
-    if (client_tcp_protocol_version < DBMS_MIN_PROTOCOL_VERSION_WITH_INCREMENTAL_PROFILE_EVENTS)
-        return;
-
     Block block;
     ProfileEvents::getProfileEvents(server_display_name, state.profile_queue, block, last_sent_snapshots);
     if (block.rows() != 0)
@@ -878,6 +880,21 @@ void TCPHandler::sendProfileEvents()
     }
 }
 
+void TCPHandler::sendSelectProfileEvents()
+{
+    if (client_tcp_protocol_version < DBMS_MIN_PROTOCOL_VERSION_WITH_INCREMENTAL_PROFILE_EVENTS)
+        return;
+
+    sendProfileEvents();
+}
+
+void TCPHandler::sendInsertProfileEvents()
+{
+    if (client_tcp_protocol_version < DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS_IN_INSERT)
+        return;
+
+    sendProfileEvents();
+}
 
 bool TCPHandler::receiveProxyHeader()
 {

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -251,6 +251,8 @@ private:
     void sendTotals(const Block & totals);
     void sendExtremes(const Block & extremes);
     void sendProfileEvents();
+    void sendSelectProfileEvents();
+    void sendInsertProfileEvents();
 
     /// Creates state.block_in/block_out for blocks read/write, depending on whether compression is enabled.
     void initBlockInput();

--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -25,6 +25,7 @@ class Client:
         user=None,
         password=None,
         database=None,
+        host=None,
         ignore_error=False,
         query_id=None,
     ):
@@ -36,6 +37,7 @@ class Client:
             user=user,
             password=password,
             database=database,
+            host=host,
             ignore_error=ignore_error,
             query_id=query_id,
         ).get_answer()
@@ -49,6 +51,7 @@ class Client:
         user=None,
         password=None,
         database=None,
+        host=None,
         ignore_error=False,
         query_id=None,
     ):
@@ -66,13 +69,12 @@ class Client:
 
         if user is not None:
             command += ["--user", user]
-
         if password is not None:
             command += ["--password", password]
-
         if database is not None:
             command += ["--database", database]
-
+        if host is not None:
+            command += ["--host", host]
         if query_id is not None:
             command += ["--query_id", query_id]
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2876,6 +2876,7 @@ class ClickHouseInstance:
         user=None,
         password=None,
         database=None,
+        host=None,
         ignore_error=False,
         query_id=None,
     ):
@@ -2890,6 +2891,7 @@ class ClickHouseInstance:
             database=database,
             ignore_error=ignore_error,
             query_id=query_id,
+            host=host,
         )
 
     def query_with_retry(
@@ -2901,6 +2903,7 @@ class ClickHouseInstance:
         user=None,
         password=None,
         database=None,
+        host=None,
         ignore_error=False,
         retry_count=20,
         sleep_time=0.5,
@@ -2918,6 +2921,7 @@ class ClickHouseInstance:
                     user=user,
                     password=password,
                     database=database,
+                    host=host,
                     ignore_error=ignore_error,
                 )
                 if check_callback(result):

--- a/tests/integration/test_backward_compatibility/test_insert_profile_events.py
+++ b/tests/integration/test_backward_compatibility/test_insert_profile_events.py
@@ -1,0 +1,42 @@
+# pylint: disable=line-too-long
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__, name="insert_profile_events")
+upstream_node = cluster.add_instance("upstream_node")
+old_node = cluster.add_instance(
+    "old_node",
+    image="clickhouse/clickhouse-server",
+    tag="22.5.1.2079",
+    with_installed_binary=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_old_client_compatible(start_cluster):
+    old_node.query("INSERT INTO FUNCTION null('foo String') VALUES ('foo')('bar')")
+    old_node.query(
+        "INSERT INTO FUNCTION null('foo String') VALUES ('foo')('bar')",
+        host=upstream_node.ip_address,
+    )
+
+
+def test_new_client_compatible(start_cluster):
+    upstream_node.query(
+        "INSERT INTO FUNCTION null('foo String') VALUES ('foo')('bar')",
+        host=old_node.ip_address,
+    )
+    upstream_node.query("INSERT INTO FUNCTION null('foo String') VALUES ('foo')('bar')")

--- a/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.reference
+++ b/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.reference
@@ -1,0 +1,2 @@
+0
+--progress produce some rows

--- a/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.sh
+++ b/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Tags: long
+
+# This is the regression for the concurrent access in ProgressIndication,
+# so it is important to read enough rows here (10e6).
+#
+# Initially there was 100e6, but under thread fuzzer 10min may be not enough sometimes,
+# but I believe that CI will catch possible issues even with less rows anyway.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+tmp_file_progress="$(mktemp "$CUR_DIR/$CLICKHOUSE_TEST_UNIQUE_NAME.XXXXXX.progress")"
+trap 'rm $tmp_file_progress' EXIT
+
+yes | head -n10000000 | $CLICKHOUSE_CLIENT -q "insert into function null('foo String') format TSV" --progress 2> "$tmp_file_progress"
+echo $?
+test -s "$tmp_file_progress" && echo "--progress produce some rows" || echo "FAIL: no rows with --progress"

--- a/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.reference
+++ b/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.reference
@@ -1,0 +1,2 @@
+0
+--progress produce some rows

--- a/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.sh
+++ b/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Tags: long
+
+# This is the regression for the concurrent access in ProgressIndication,
+# so it is important to read enough rows here (10e6).
+#
+# Initially there was 100e6, but under thread fuzzer 10min may be not enough sometimes,
+# but I believe that CI will catch possible issues even with less rows anyway.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+tmp_file_progress="$(mktemp "$CUR_DIR/$CLICKHOUSE_TEST_UNIQUE_NAME.XXXXXX.progress")"
+trap 'rm $tmp_file_progress' EXIT
+
+yes | head -n10000000 | $CLICKHOUSE_LOCAL -q "insert into function null('foo String') format TSV" --progress 2> "$tmp_file_progress"
+echo $?
+test -s "$tmp_file_progress" && echo "--progress produce some rows" || echo "FAIL: no rows with --progress"

--- a/tests/queries/0_stateless/02310_profile_events_insert.reference
+++ b/tests/queries/0_stateless/02310_profile_events_insert.reference
@@ -1,0 +1,4 @@
+client
+InsertedRows: 1 (increment)
+local
+InsertedRows: 1 (increment)

--- a/tests/queries/0_stateless/02310_profile_events_insert.sh
+++ b/tests/queries/0_stateless/02310_profile_events_insert.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo client
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -q "insert into function null('foo Int') values (1)" |& grep -o 'InsertedRows: .*'
+
+echo local
+$CLICKHOUSE_LOCAL  --print-profile-events --profile-events-delay-ms=-1 -q "insert into function null('foo Int') values (1)" |& grep -o 'InsertedRows: .*'
+
+exit 0


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Send profile events for INSERT queries (previously only SELECT was supported)

Reproducer:

    echo "1" | clickhouse-client --query="insert into function null('foo String') format TSV" --print-profile-events --profile-events-delay-ms=-1

But note, that in case of `clickhouse-local` they were implicitly supported, but only if query was long enough, i.e.:

    # yes | head -n100000 | clickhouse-local --query="insert into function null('foo String') format TSV" --print-profile-events --profile-events-delay-ms=-1
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] ContextLock: 10 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] DiskReadElapsedMicroseconds: 29 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] IOBufferAllocBytes: 200000 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] IOBufferAllocs: 1 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] InsertQuery: 1 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] InsertedBytes: 1000000 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] InsertedRows: 100000 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] MemoryTrackerUsage: 1521975 (gauge)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] OSCPUVirtualTimeMicroseconds: 102148 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] OSReadChars: 135700 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] OSWriteChars: 8 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] Query: 1 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] RWLockAcquiredReadLocks: 2 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] ReadBufferFromFileDescriptorRead: 5 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] ReadBufferFromFileDescriptorReadBytes: 134464 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] RealTimeMicroseconds: 293747 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] SoftPageFaults: 382 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] TableFunctionExecute: 1 (increment)
    [s1.ch] 2022.05.20 15:20:27 [ 0 ] UserTimeMicroseconds: 102148 (increment)


Fixes: #37241 (cc @alexey-milovidov @zhicwu )