### PR TITLE
Fix LOGICAL_ERROR in getMaxSourcePartsSizeForMerge during merges

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1395,8 +1395,11 @@ int Server::main(const std::vector<std::string> & /*args*/)
     fs::create_directories(format_schema_path);
 
     /// Check sanity of MergeTreeSettings on server startup
-    global_context->getMergeTreeSettings().sanityCheck(settings);
-    global_context->getReplicatedMergeTreeSettings().sanityCheck(settings);
+    {
+        size_t background_pool_tasks = global_context->getMergeMutateExecutor()->getMaxTasksCount();
+        global_context->getMergeTreeSettings().sanityCheck(background_pool_tasks);
+        global_context->getReplicatedMergeTreeSettings().sanityCheck(background_pool_tasks);
+    }
 
     /// try set up encryption. There are some errors in config, error will be printed and server wouldn't start.
     CompressionCodecEncrypted::Configuration::instance().load(config(), "encryption_codecs");

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -62,6 +62,12 @@ void MergeTreeBackgroundExecutor<Queue>::increaseThreadsAndMaxTasksCount(size_t 
     threads_count = new_threads_count;
 }
 
+template <class Queue>
+size_t MergeTreeBackgroundExecutor<Queue>::getMaxTasksCount() const
+{
+    std::lock_guard lock(mutex);
+    return max_tasks_count;
+}
 
 template <class Queue>
 bool MergeTreeBackgroundExecutor<Queue>::trySchedule(ExecutableTaskPtr task)

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -192,6 +192,7 @@ public:
     /// Supports only increasing the number of threads and tasks, because
     /// implementing tasks eviction will definitely be too error-prone and buggy.
     void increaseThreadsAndMaxTasksCount(size_t new_threads_count, size_t new_max_tasks_count);
+    size_t getMaxTasksCount() const;
 
     bool trySchedule(ExecutableTaskPtr task);
     void removeTasksCorrespondingToStorage(StorageID id);
@@ -209,7 +210,7 @@ private:
     /// Initially it will be empty
     Queue pending{};
     boost::circular_buffer<TaskRuntimeDataPtr> active{0};
-    std::mutex mutex;
+    mutable std::mutex mutex;
     std::condition_variable has_tasks;
     std::atomic_bool shutdown{false};
     ThreadPool pool;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -226,7 +226,7 @@ MergeTreeData::MergeTreeData(
 
     /// Check sanity of MergeTreeSettings. Only when table is created.
     if (!attach)
-        settings->sanityCheck(getContext()->getSettingsRef());
+        settings->sanityCheck(getContext()->getMergeMutateExecutor()->getMaxTasksCount());
 
     MergeTreeDataFormatVersion min_format_version(0);
     if (!date_column_name.empty())
@@ -2569,7 +2569,7 @@ void MergeTreeData::changeSettings(
         /// Reset to default settings before applying existing.
         auto copy = getDefaultSettings();
         copy->applyChanges(new_changes);
-        copy->sanityCheck(getContext()->getSettingsRef());
+        copy->sanityCheck(getContext()->getMergeMutateExecutor()->getMaxTasksCount());
 
         storage_settings.set(std::move(copy));
         StorageInMemoryMetadata new_metadata = getInMemoryMetadata();

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -83,8 +83,11 @@ UInt64 MergeTreeDataMergerMutator::getMaxSourcePartsSizeForMerge() const
 UInt64 MergeTreeDataMergerMutator::getMaxSourcePartsSizeForMerge(size_t max_count, size_t scheduled_tasks_count) const
 {
     if (scheduled_tasks_count > max_count)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical error: invalid argument passed to \
-            getMaxSourcePartsSize: scheduled_tasks_count = {} > max_count = {}", scheduled_tasks_count, max_count);
+    {
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Logical error: invalid argument passed to getMaxSourcePartsSize: scheduled_tasks_count = {} > max_count = {}",
+            scheduled_tasks_count, max_count);
+    }
 
     size_t free_entries = max_count - scheduled_tasks_count;
     const auto data_settings = data.getSettings();

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -73,10 +73,9 @@ void MergeTreeSettings::loadFromQuery(ASTStorage & storage_def)
 #undef ADD_IF_ABSENT
 }
 
-void MergeTreeSettings::sanityCheck(const Settings & query_settings) const
+void MergeTreeSettings::sanityCheck(size_t background_pool_tasks) const
 {
-    if (number_of_free_entries_in_pool_to_execute_mutation >
-        query_settings.background_pool_size * query_settings.background_merges_mutations_concurrency_ratio)
+    if (number_of_free_entries_in_pool_to_execute_mutation > background_pool_tasks)
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "The value of 'number_of_free_entries_in_pool_to_execute_mutation' setting"
             " ({}) (default values are defined in <merge_tree> section of config.xml"
@@ -85,11 +84,10 @@ void MergeTreeSettings::sanityCheck(const Settings & query_settings) const
             " ({}) (the value is defined in users.xml for default profile)."
             " This indicates incorrect configuration because mutations cannot work with these settings.",
             number_of_free_entries_in_pool_to_execute_mutation,
-            query_settings.background_pool_size * query_settings.background_merges_mutations_concurrency_ratio);
+            background_pool_tasks);
     }
 
-    if (number_of_free_entries_in_pool_to_lower_max_size_of_merge >
-        query_settings.background_pool_size * query_settings.background_merges_mutations_concurrency_ratio)
+    if (number_of_free_entries_in_pool_to_lower_max_size_of_merge > background_pool_tasks)
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "The value of 'number_of_free_entries_in_pool_to_lower_max_size_of_merge' setting"
             " ({}) (default values are defined in <merge_tree> section of config.xml"
@@ -98,7 +96,7 @@ void MergeTreeSettings::sanityCheck(const Settings & query_settings) const
             " ({}) (the value is defined in users.xml for default profile)."
             " This indicates incorrect configuration because the maximum size of merge will be always lowered.",
             number_of_free_entries_in_pool_to_lower_max_size_of_merge,
-            query_settings.background_pool_size * query_settings.background_merges_mutations_concurrency_ratio);
+            background_pool_tasks);
     }
 
     // The min_index_granularity_bytes value is 1024 b and index_granularity_bytes is 10 mb by default.

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -183,7 +183,7 @@ struct MergeTreeSettings : public BaseSettings<MergeTreeSettingsTraits>
     }
 
     /// Check that the values are sane taking also query-level settings into account.
-    void sanityCheck(const Settings & query_settings) const;
+    void sanityCheck(size_t background_pool_tasks) const;
 };
 
 using MergeTreeSettingsPtr = std::shared_ptr<const MergeTreeSettings>;

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -100,9 +100,7 @@ StorageMergeTree::StorageMergeTree(
         attach)
     , reader(*this)
     , writer(*this)
-    , merger_mutator(*this,
-        getContext()->getSettingsRef().background_merges_mutations_concurrency_ratio *
-        getContext()->getSettingsRef().background_pool_size)
+    , merger_mutator(*this, getContext()->getMergeMutateExecutor()->getMaxTasksCount())
 {
     loadDataParts(has_force_restore_data_flag);
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -263,9 +263,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
     , replica_path(fs::path(zookeeper_path) / "replicas" / replica_name_)
     , reader(*this)
     , writer(*this)
-    , merger_mutator(*this,
-        getContext()->getSettingsRef().background_merges_mutations_concurrency_ratio *
-        getContext()->getSettingsRef().background_pool_size)
+    , merger_mutator(*this, getContext()->getMergeMutateExecutor()->getMaxTasksCount())
     , merge_strategy_picker(*this)
     , queue(*this, merge_strategy_picker)
     , fetcher(*this)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix LOGICAL_ERROR in getMaxSourcePartsSizeForMerge during merges (in case of non standard, greater, values of `background_pool_size`/`background_merges_mutations_concurrency_ratio` has been specified in `config.xml` (new way) not in `users.xml` (deprecated way))

In #36425 some pool sizes, has been converted from settings to config
directives.

And after this conversion, it is possible to get LOGICAL_ERROR during
merges if you use non-standard, greater value of,
background_pool_size/background_merges_mutations_concurrency_ratio
settings in config.xml i.e. config directives (and this is the prefered
way of specifying them), but not in users.xml i.e. settings (obsolete
since referenced PR), since some existing code was still using those
values from settings.

Here is an example of a stacktrace:

    0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x17b3be2c in /usr/bin/clickhouse
    1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0xb0272fa in /usr/bin/clickhouse
    2. DB::Exception::Exception<unsigned long&, unsigned long&>(int, fmt::v8::basic_format_string<char, fmt::v8::type_identity<unsigned long&>::type, fmt::v8::type_identity<unsigned long&>::type>, unsigned long&, unsigned long&) @ 0x10f8fcac in /usr/bin/clickhouse
    3. DB::MergeTreeDataMergerMutator::getMaxSourcePartsSizeForMerge(unsigned long, unsigned long) const @ 0x1461eeea in /usr/bin/clickhouse
    4. DB::ReplicatedMergeTreeQueue::shouldExecuteLogEntry(DB::ReplicatedMergeTreeLogEntry const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::MergeTreeDataMergerMutator&, DB::MergeTreeData&, std::__1::lock_guard<std::__1::mutex>&) const @ 0x1475d217 in /usr/bin/clickhouse
    5. DB::ReplicatedMergeTreeQueue::selectEntryToProcess(DB::MergeTreeDataMergerMutator&, DB::MergeTreeData&) @ 0x1475f560 in /usr/bin/clickhouse
    6. DB::StorageReplicatedMergeTree::selectQueueEntry() @ 0x1439d51e in /usr/bin/clickhouse
    7. DB::StorageReplicatedMergeTree::scheduleDataProcessingJob(DB::BackgroundJobsAssignee&) @ 0x1439d7a1 in /usr/bin/clickhouse
    8. DB::BackgroundJobsAssignee::threadFunc() @ 0x14533c07 in /usr/bin/clickhouse
    9. DB::BackgroundSchedulePoolTaskInfo::execute() @ 0x1319815d in /usr/bin/clickhouse
    10. DB::BackgroundSchedulePool::threadFunction() @ 0x1319a086 in /usr/bin/clickhouse
    11. ? @ 0x1319a678 in /usr/bin/clickhouse

Fixes: #36425 (cc @nikitamikhaylov @KochetovNicolai )