### PR TITLE
Fix `clickhouse-keeper` force recovery for single node cluster

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -466,20 +466,23 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
 {
     if (is_recovering)
     {
+        const auto finish_recovering = [&]
+        {
+            auto new_params = raft_instance->get_current_params();
+            new_params.custom_commit_quorum_size_ = 0;
+            new_params.custom_election_quorum_size_ = 0;
+            raft_instance->update_params(new_params);
+
+            LOG_INFO(log, "Recovery is done. You can continue using cluster normally.");
+            is_recovering = false;
+        };
+
         switch (type)
         {
             case nuraft::cb_func::HeartBeat:
             {
                 if (raft_instance->isClusterHealthy())
-                {
-                    auto new_params = raft_instance->get_current_params();
-                    new_params.custom_commit_quorum_size_ = 0;
-                    new_params.custom_election_quorum_size_ = 0;
-                    raft_instance->update_params(new_params);
-
-                    LOG_INFO(log, "Recovery is done. You can continue using cluster normally.");
-                    is_recovering = false;
-                }
+                    finish_recovering();
                 break;
             }
             case nuraft::cb_func::NewConfig:
@@ -490,8 +493,19 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
                 // Because we manually set the config to commit
                 // we need to call the reconfigure also
                 uint64_t log_idx = *static_cast<uint64_t *>(param->ctx);
-                if (log_idx == state_manager->load_config()->get_log_idx())
-                    raft_instance->forceReconfigure(state_manager->load_config());
+
+                auto config = state_manager->load_config();
+                if (log_idx == config->get_log_idx())
+                {
+                    raft_instance->forceReconfigure(config);
+
+                    // Single node cluster doesn't need to wait for any other nodes
+                    // so we can finish recovering immediatelly after applying
+                    // new configuration
+                    if (config->get_servers().size() == 1)
+                        finish_recovering();
+                }
+
                 break;
             }
             case nuraft::cb_func::ProcessReq:

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -500,7 +500,7 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
                     raft_instance->forceReconfigure(config);
 
                     // Single node cluster doesn't need to wait for any other nodes
-                    // so we can finish recovering immediatelly after applying
+                    // so we can finish recovering immediately after applying
                     // new configuration
                     if (config->get_servers().size() == 1)
                         finish_recovering();

--- a/tests/integration/test_keeper_force_recovery_single_node/__init__.py
+++ b/tests/integration/test_keeper_force_recovery_single_node/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/tests/integration/test_keeper_force_recovery_single_node/configs/enable_keeper1.xml
+++ b/tests/integration/test_keeper_force_recovery_single_node/configs/enable_keeper1.xml
@@ -1,0 +1,33 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <snapshot_distance>75</snapshot_distance>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node1</hostname>
+                <port>9234</port>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>node2</hostname>
+                <port>9234</port>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>node3</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_force_recovery_single_node/configs/enable_keeper1_solo.xml
+++ b/tests/integration/test_keeper_force_recovery_single_node/configs/enable_keeper1_solo.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <keeper_server>
+        <force_recovery>1</force_recovery>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <snapshot_distance>75</snapshot_distance>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node1</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_force_recovery_single_node/configs/enable_keeper2.xml
+++ b/tests/integration/test_keeper_force_recovery_single_node/configs/enable_keeper2.xml
@@ -1,0 +1,33 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>2</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <snapshot_distance>75</snapshot_distance>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node1</hostname>
+                <port>9234</port>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>node2</hostname>
+                <port>9234</port>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>node3</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_force_recovery_single_node/configs/enable_keeper3.xml
+++ b/tests/integration/test_keeper_force_recovery_single_node/configs/enable_keeper3.xml
@@ -1,0 +1,33 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>3</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <snapshot_distance>75</snapshot_distance>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node1</hostname>
+                <port>9234</port>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>node2</hostname>
+                <port>9234</port>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>node3</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_force_recovery_single_node/configs/use_keeper.xml
+++ b/tests/integration/test_keeper_force_recovery_single_node/configs/use_keeper.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <zookeeper>
+        <node index="1">
+            <host>node1</host>
+            <port>9181</port>
+        </node>
+        <node index="2">
+            <host>node2</host>
+            <port>9181</port>
+        </node>
+        <node index="3">
+            <host>node3</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_keeper_force_recovery_single_node/test.py
+++ b/tests/integration/test_keeper_force_recovery_single_node/test.py
@@ -1,0 +1,157 @@
+import os
+import pytest
+import socket
+from helpers.cluster import ClickHouseCluster
+import time
+
+
+from kazoo.client import KazooClient
+
+CLUSTER_SIZE = 3
+
+cluster = ClickHouseCluster(__file__)
+CONFIG_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs")
+
+
+def get_nodes():
+    nodes = []
+    for i in range(CLUSTER_SIZE):
+        nodes.append(
+            cluster.add_instance(
+                f"node{i+1}",
+                main_configs=[
+                    f"configs/enable_keeper{i+1}.xml",
+                    f"configs/use_keeper.xml"
+                ],
+                stay_alive=True,
+            )
+        )
+
+    return nodes
+
+
+nodes = get_nodes()
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def get_fake_zk(nodename, timeout=30.0):
+    _fake_zk_instance = KazooClient(
+        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
+    )
+    _fake_zk_instance.start()
+    return _fake_zk_instance
+
+
+def get_keeper_socket(node_name):
+    hosts = cluster.get_instance_ip(node_name)
+    client = socket.socket()
+    client.settimeout(10)
+    client.connect((hosts, 9181))
+    return client
+
+
+def send_4lw_cmd(node_name, cmd="ruok"):
+    client = None
+    try:
+        client = get_keeper_socket(node_name)
+        client.send(cmd.encode())
+        data = client.recv(100_000)
+        data = data.decode()
+        return data
+    finally:
+        if client is not None:
+            client.close()
+
+
+def wait_until_connected(node_name):
+    while send_4lw_cmd(node_name, "mntr") == NOT_SERVING_REQUESTS_ERROR_MSG:
+        time.sleep(0.1)
+
+
+def wait_nodes(nodes):
+    for node in nodes:
+        wait_until_connected(node.name)
+
+
+def wait_and_assert_data(zk, path, data):
+    while zk.exists(path) is None:
+        time.sleep(0.1)
+    assert zk.get(path)[0] == data.encode()
+
+
+def close_zk(zk):
+    zk.stop()
+    zk.close()
+
+
+NOT_SERVING_REQUESTS_ERROR_MSG = "This instance is not currently serving requests"
+
+
+def test_cluster_recovery(started_cluster):
+    node_zks = []
+    try:
+        wait_nodes(nodes)
+
+        node_zks = [get_fake_zk(node.name) for node in nodes]
+
+        data_in_cluster = []
+
+        def add_data(zk, path, data):
+            zk.create(path, data.encode())
+            data_in_cluster.append((path, data))
+
+        def assert_all_data(zk):
+            for path, data in data_in_cluster:
+                wait_and_assert_data(zk, path, data)
+
+        for i, zk in enumerate(node_zks):
+            add_data(zk, f"/test_force_recovery_node{i+1}", f"somedata{i+1}")
+
+        for zk in node_zks:
+            assert_all_data(zk)
+
+        nodes[0].stop_clickhouse()
+
+        add_data(node_zks[1], "/test_force_recovery_extra", "somedataextra")
+
+        for node_zk in node_zks[2:CLUSTER_SIZE]:
+            wait_and_assert_data(node_zk, "/test_force_recovery_extra", "somedataextra")
+
+        nodes[0].start_clickhouse()
+        wait_until_connected(nodes[0].name)
+
+        node_zks[0] = get_fake_zk(nodes[0].name)
+        wait_and_assert_data(node_zks[0], "/test_force_recovery_extra", "somedataextra")
+
+        # stop all nodes
+        for node_zk in node_zks:
+            close_zk(node_zk)
+        node_zks = []
+
+        for node in nodes:
+            node.stop_clickhouse()
+
+        nodes[0].copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper1_solo.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+        )
+
+        nodes[0].start_clickhouse()
+        wait_until_connected(nodes[0].name)
+
+        assert_all_data(get_fake_zk(nodes[0].name))
+    finally:
+        try:
+            for zk_conn in node_zks:
+                close_zk(zk_conn)
+        except:
+            pass

--- a/tests/integration/test_keeper_force_recovery_single_node/test.py
+++ b/tests/integration/test_keeper_force_recovery_single_node/test.py
@@ -21,7 +21,7 @@ def get_nodes():
                 f"node{i+1}",
                 main_configs=[
                     f"configs/enable_keeper{i+1}.xml",
-                    f"configs/use_keeper.xml"
+                    f"configs/use_keeper.xml",
                 ],
                 stay_alive=True,
             )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
clickhouse-keeper bugfix: fix force recovery for single node cluster.

Fix [#37434](https://github.com/ClickHouse/ClickHouse/issues/37434)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
