### PR TITLE
Sync workflows paths for PR and DocsCheck

### DIFF
--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -13,9 +13,9 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
     paths:
+      - 'docker/docs/**'
       - 'docs/**'
       - 'website/**'
-      - 'docker/docs/**'
 jobs:
   CheckLabels:
     runs-on: [self-hosted, style-checker]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,6 +13,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - master
     paths-ignore:
+      - 'docker/docs/**'
       - 'docs/**'
       - 'website/**'
 ##########################################################################################

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -253,16 +253,7 @@ if __name__ == "__main__":
         )
         sys.exit(1)
     else:
-        if "pr-documentation" in pr_info.labels or "pr-doc-fix" in pr_info.labels:
-            commit.create_status(
-                context=NAME,
-                description="Skipping checks for documentation",
-                state="success",
-                target_url=url,
-            )
-            print("::notice ::Can run, but it's documentation PR, skipping")
-        else:
-            print("::notice ::Can run")
-            commit.create_status(
-                context=NAME, description=description, state="pending", target_url=url
-            )
+        print("::notice ::Can run")
+        commit.create_status(
+            context=NAME, description=description, state="pending", target_url=url
+        )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove redundant if branch in check_labels, sync paths in DocsCheck and PullRequestCI