### PR TITLE
Better binary serialization of `ColumnObject`

### DIFF
--- a/src/Common/COW.h
+++ b/src/Common/COW.h
@@ -219,7 +219,7 @@ protected:
         /// Get internal immutable ptr. Does not change internal use counter.
         immutable_ptr<T> detach() && { return std::move(value); }
 
-        operator bool() const { return value != nullptr; } /// NOLINT
+        explicit operator bool() const { return value != nullptr; }
         bool operator! () const { return value == nullptr; }
 
         bool operator== (const chameleon_ptr & rhs) const { return value == rhs.value; }

--- a/src/DataTypes/ObjectUtils.cpp
+++ b/src/DataTypes/ObjectUtils.cpp
@@ -143,29 +143,16 @@ void convertObjectsToTuples(Block & block, const NamesAndTypesList & extended_st
             continue;
 
         const auto & column_object = assert_cast<const ColumnObject &>(*column.column);
-        const auto & subcolumns = column_object.getSubcolumns();
-
         if (!column_object.isFinalized())
             throw Exception(ErrorCodes::LOGICAL_ERROR,
                 "Cannot convert to tuple column '{}' from type {}. Column should be finalized first",
                 column.name, column.type->getName());
 
-        PathsInData tuple_paths;
-        DataTypes tuple_types;
-        Columns tuple_columns;
-
-        for (const auto & entry : subcolumns)
-        {
-            tuple_paths.emplace_back(entry->path);
-            tuple_types.emplace_back(entry->data.getLeastCommonType());
-            tuple_columns.emplace_back(entry->data.getFinalizedColumnPtr());
-        }
+        std::tie(column.column, column.type) = unflattenObjectToTuple(column_object);
 
         auto it = storage_columns_map.find(column.name);
         if (it == storage_columns_map.end())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Column '{}' not found in storage", column.name);
-
-        std::tie(column.column, column.type) = unflattenTuple(tuple_paths, tuple_types, tuple_columns);
 
         /// Check that constructed Tuple type and type in storage are compatible.
         getLeastCommonTypeForObject({column.type, it->second}, true);
@@ -583,6 +570,28 @@ DataTypePtr unflattenTuple(const PathsInData & paths, const DataTypes & tuple_ty
         tuple_columns.emplace_back(type->createColumn());
 
     return unflattenTuple(paths, tuple_types, tuple_columns).second;
+}
+
+std::pair<ColumnPtr, DataTypePtr> unflattenObjectToTuple(const ColumnObject & column)
+{
+    const auto & subcolumns = column.getSubcolumns();
+
+    PathsInData paths;
+    DataTypes types;
+    Columns columns;
+
+    paths.reserve(subcolumns.size());
+    types.reserve(subcolumns.size());
+    columns.reserve(subcolumns.size());
+
+    for (const auto & entry : subcolumns)
+    {
+        paths.emplace_back(entry->path);
+        types.emplace_back(entry->data.getLeastCommonType());
+        columns.emplace_back(entry->data.getFinalizedColumnPtr());
+    }
+
+    return unflattenTuple(paths, types, columns);
 }
 
 std::pair<ColumnPtr, DataTypePtr> unflattenTuple(

--- a/src/DataTypes/ObjectUtils.h
+++ b/src/DataTypes/ObjectUtils.h
@@ -73,10 +73,13 @@ DataTypePtr unflattenTuple(
     const PathsInData & paths,
     const DataTypes & tuple_types);
 
+std::pair<ColumnPtr, DataTypePtr> unflattenObjectToTuple(const ColumnObject & column);
+
 std::pair<ColumnPtr, DataTypePtr> unflattenTuple(
     const PathsInData & paths,
     const DataTypes & tuple_types,
     const Columns & tuple_columns);
+
 
 /// For all columns which exist in @expected_columns and
 /// don't exist in @available_columns adds to WITH clause

--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -172,10 +172,6 @@ String getNameForSubstreamPath(
             else
                 stream_name += "." + it->tuple_element_name;
         }
-        else if (it->type == Substream::ObjectElement)
-        {
-            stream_name += escapeForFileName(".") + escapeForFileName(it->object_key_name);
-        }
     }
 
     return stream_name;

--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -126,7 +126,7 @@ public:
             SparseOffsets,
 
             ObjectStructure,
-            ObjectElement,
+            ObjectData,
 
             Regular,
         };
@@ -135,9 +135,6 @@ public:
 
         /// Index of tuple element, starting at 1 or name.
         String tuple_element_name;
-
-        /// Name of subcolumn of object column.
-        String object_key_name;
 
         /// Do we need to escape a dot in filenames for tuple elements.
         bool escape_tuple_delimiter = true;

--- a/src/DataTypes/Serializations/PathInData.h
+++ b/src/DataTypes/Serializations/PathInData.h
@@ -7,9 +7,6 @@
 namespace DB
 {
 
-class ReadBuffer;
-class WriteBuffer;
-
 /// Class that represents path in document, e.g. JSON.
 class PathInData
 {
@@ -56,9 +53,6 @@ public:
 
     bool isNested(size_t i) const { return parts[i].is_nested; }
     bool hasNested() const { return has_nested; }
-
-    void writeBinary(WriteBuffer & out) const;
-    void readBinary(ReadBuffer & in);
 
     bool operator==(const PathInData & other) const { return parts == other.parts; }
     struct Hash { size_t operator()(const PathInData & value) const; };

--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -1,5 +1,6 @@
 #include <DataTypes/Serializations/SerializationObject.h>
 #include <DataTypes/Serializations/JSONDataParser.h>
+#include <DataTypes/Serializations/SerializationString.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/ObjectUtils.h>
@@ -9,12 +10,17 @@
 #include <Common/JSONParsers/RapidJSONParser.h>
 #include <Common/HashTable/HashSet.h>
 #include <Columns/ColumnObject.h>
+#include <Columns/ColumnString.h>
+#include <Functions/FunctionsConversion.h>
 
 #include <Common/FieldVisitorToString.h>
 
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <IO/VarInt.h>
+#include <magic_enum.hpp>
+#include <memory>
+#include <string>
 
 namespace DB
 {
@@ -193,24 +199,51 @@ void SerializationObject<Parser>::deserializeTextCSV(IColumn & column, ReadBuffe
 }
 
 template <typename Parser>
-template <typename TSettings, typename TStatePtr>
-void SerializationObject<Parser>::checkSerializationIsSupported(const TSettings & settings, const TStatePtr & state) const
+template <typename TSettings>
+void SerializationObject<Parser>::checkSerializationIsSupported(const TSettings & settings) const
 {
     if (settings.position_independent_encoding)
         throw Exception(ErrorCodes::NOT_IMPLEMENTED,
             "DataTypeObject doesn't support serialization with position independent encoding");
-
-    if (state)
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-            "DataTypeObject doesn't support serialization with non-trivial state");
 }
+
+template <typename Parser>
+struct SerializationObject<Parser>::SerializeStateObject : public ISerialization::SerializeBinaryBulkState
+{
+    bool is_first = true;
+    DataTypePtr nested_type;
+    SerializationPtr nested_serialization;
+    SerializeBinaryBulkStatePtr nested_state;
+};
+
+template <typename Parser>
+struct SerializationObject<Parser>::DeserializeStateObject : public ISerialization::DeserializeBinaryBulkState
+{
+    BinarySerializationKind kind;
+    DataTypePtr nested_type;
+    SerializationPtr nested_serialization;
+    DeserializeBinaryBulkStatePtr nested_state;
+};
 
 template <typename Parser>
 void SerializationObject<Parser>::serializeBinaryBulkStatePrefix(
     SerializeBinaryBulkSettings & settings,
     SerializeBinaryBulkStatePtr & state) const
 {
-    checkSerializationIsSupported(settings, state);
+    checkSerializationIsSupported(settings);
+    if (state)
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+            "DataTypeObject doesn't support serialization with non-trivial state");
+
+    settings.path.push_back(Substream::ObjectStructure);
+    auto * stream = settings.getter(settings.path);
+    settings.path.pop_back();
+
+    if (!stream)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Missing stream for kind of binary serialization");
+
+    writeIntBinary(static_cast<UInt8>(BinarySerializationKind::TUPLE), *stream);
+    state = std::make_shared<SerializeStateObject>();
 }
 
 template <typename Parser>
@@ -218,7 +251,12 @@ void SerializationObject<Parser>::serializeBinaryBulkStateSuffix(
     SerializeBinaryBulkSettings & settings,
     SerializeBinaryBulkStatePtr & state) const
 {
-    checkSerializationIsSupported(settings, state);
+    checkSerializationIsSupported(settings);
+    auto * state_object = checkAndGetState<SerializeStateObject>(state);
+
+    settings.path.push_back(Substream::ObjectData);
+    state_object->nested_serialization->serializeBinaryBulkStateSuffix(settings, state_object->nested_state);
+    settings.path.pop_back();
 }
 
 template <typename Parser>
@@ -226,7 +264,56 @@ void SerializationObject<Parser>::deserializeBinaryBulkStatePrefix(
     DeserializeBinaryBulkSettings & settings,
     DeserializeBinaryBulkStatePtr & state) const
 {
-    checkSerializationIsSupported(settings, state);
+    checkSerializationIsSupported(settings);
+    if (state)
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+            "DataTypeObject doesn't support serialization with non-trivial state");
+
+    settings.path.push_back(Substream::ObjectStructure);
+    auto * stream = settings.getter(settings.path);
+    settings.path.pop_back();
+
+    if (!stream)
+        throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
+            "Cannot read kind of binary serialization of DataTypeObject, because its stream is missing");
+
+    UInt8 kind_raw;
+    readIntBinary(kind_raw, *stream);
+    auto kind = magic_enum::enum_cast<BinarySerializationKind>(kind_raw);
+    if (!kind)
+        throw Exception(ErrorCodes::INCORRECT_DATA,
+            "Unknown binary serialization kind of Object: " + std::to_string(kind_raw));
+
+    auto state_object = std::make_shared<DeserializeStateObject>();
+    state_object->kind = *kind;
+
+    if (state_object->kind == BinarySerializationKind::TUPLE)
+    {
+        String data_type_name;
+        readStringBinary(data_type_name, *stream);
+        state_object->nested_type = DataTypeFactory::instance().get(data_type_name);
+        state_object->nested_serialization = state_object->nested_type->getDefaultSerialization();
+
+        if (!isTuple(state_object->nested_type))
+            throw Exception(ErrorCodes::INCORRECT_DATA,
+                "Data of type Object should be written as Tuple, got: {}", data_type_name);
+    }
+    else if (state_object->kind == BinarySerializationKind::STRING)
+    {
+        state_object->nested_type = std::make_shared<DataTypeString>();
+        state_object->nested_serialization = std::make_shared<SerializationString>();
+    }
+    else
+    {
+        throw Exception(ErrorCodes::INCORRECT_DATA,
+            "Unknown binary serialization kind of Object: " + std::to_string(kind_raw));
+    }
+
+    settings.path.push_back(Substream::ObjectData);
+    state_object->nested_serialization->deserializeBinaryBulkStatePrefix(settings, state_object->nested_state);
+    settings.path.pop_back();
+
+    state = std::move(state_object);
 }
 
 template <typename Parser>
@@ -237,36 +324,45 @@ void SerializationObject<Parser>::serializeBinaryBulkWithMultipleStreams(
     SerializeBinaryBulkSettings & settings,
     SerializeBinaryBulkStatePtr & state) const
 {
-    checkSerializationIsSupported(settings, state);
+    checkSerializationIsSupported(settings);
     const auto & column_object = assert_cast<const ColumnObject &>(column);
+    auto * state_object = checkAndGetState<SerializeStateObject>(state);
 
     if (!column_object.isFinalized())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot write non-finalized ColumnObject");
 
-    settings.path.push_back(Substream::ObjectStructure);
-    if (auto * stream = settings.getter(settings.path))
-        writeVarUInt(column_object.getSubcolumns().size(), *stream);
+    auto [tuple_column, tuple_type] = unflattenObjectToTuple(column_object);
 
-    const auto & subcolumns = column_object.getSubcolumns();
-    for (const auto & entry : subcolumns)
+    if (state_object->is_first)
     {
-        settings.path.back() = Substream::ObjectStructure;
-        settings.path.back().object_key_name = entry->path.getPath();
+        /// Actually it's a part of serializeBinaryBulkStatePrefix,
+        /// but it cannot be done there, because we have to know the
+        /// structure of column.
 
-        const auto & type = entry->data.getLeastCommonType();
+        settings.path.push_back(Substream::ObjectStructure);
         if (auto * stream = settings.getter(settings.path))
-        {
-            entry->path.writeBinary(*stream);
-            writeStringBinary(type->getName(), *stream);
-        }
+            writeStringBinary(tuple_type->getName(), *stream);
 
-        settings.path.back() = Substream::ObjectElement;
-        if (auto * stream = settings.getter(settings.path))
-        {
-            auto serialization = type->getDefaultSerialization();
-            serialization->serializeBinaryBulkWithMultipleStreams(
-                entry->data.getFinalizedColumn(), offset, limit, settings, state);
-        }
+        state_object->nested_type = tuple_type;
+        state_object->nested_serialization = tuple_type->getDefaultSerialization();
+        state_object->is_first = false;
+
+        settings.path.back() = Substream::ObjectData;
+        state_object->nested_serialization->serializeBinaryBulkStatePrefix(settings, state_object->nested_state);
+        settings.path.pop_back();
+    }
+    else if (state_object->nested_type->equals(*tuple_type))
+    {
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Types of internal column of Object mismatched. Expected: {}, Got: {}",
+            state_object->nested_type->getName(), tuple_type->getName());
+    }
+
+    settings.path.push_back(Substream::ObjectData);
+    if (auto * stream = settings.getter(settings.path))
+    {
+        state_object->nested_serialization->serializeBinaryBulkWithMultipleStreams(
+            *tuple_column, offset, limit, settings, state_object->nested_state);
     }
 
     settings.path.pop_back();
@@ -280,59 +376,68 @@ void SerializationObject<Parser>::deserializeBinaryBulkWithMultipleStreams(
     DeserializeBinaryBulkStatePtr & state,
     SubstreamsCache * cache) const
 {
-    checkSerializationIsSupported(settings, state);
+    checkSerializationIsSupported(settings);
     if (!column->empty())
         throw Exception(ErrorCodes::NOT_IMPLEMENTED,
             "DataTypeObject cannot be deserialized to non-empty column");
 
     auto mutable_column = column->assumeMutable();
-    auto & column_object = typeid_cast<ColumnObject &>(*mutable_column);
+    auto & column_object = assert_cast<ColumnObject &>(*mutable_column);
+    auto * state_object = checkAndGetState<DeserializeStateObject>(state);
 
-    size_t num_subcolumns = 0;
-    settings.path.push_back(Substream::ObjectStructure);
-    if (auto * stream = settings.getter(settings.path))
-        readVarUInt(num_subcolumns, *stream);
-
-    settings.path.back() = Substream::ObjectElement;
-    for (size_t i = 0; i < num_subcolumns; ++i)
-    {
-        PathInData key;
-        String type_name;
-
-        settings.path.back() = Substream::ObjectStructure;
-        if (auto * stream = settings.getter(settings.path))
-        {
-            key.readBinary(*stream);
-            readStringBinary(type_name, *stream);
-        }
-        else
-        {
-            throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
-                "Cannot read structure of DataTypeObject, because its stream is missing");
-        }
-
-        settings.path.back() = Substream::ObjectElement;
-        settings.path.back().object_key_name = key.getPath();
-
-        if (auto * stream = settings.getter(settings.path))
-        {
-            auto type = DataTypeFactory::instance().get(type_name);
-            auto serialization = type->getDefaultSerialization();
-            ColumnPtr subcolumn_data = type->createColumn();
-            serialization->deserializeBinaryBulkWithMultipleStreams(subcolumn_data, limit, settings, state, cache);
-            column_object.addSubcolumn(key, subcolumn_data->assumeMutable());
-        }
-        else
-        {
-            throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
-                "Cannot read subcolumn '{}' of DataTypeObject, because its stream is missing", key.getPath());
-        }
-    }
+    settings.path.push_back(Substream::ObjectData);
+    if (state_object->kind == BinarySerializationKind::STRING)
+        deserializeBinaryBulkFromString(column_object, limit, settings, *state_object, cache);
+    else
+        deserializeBinaryBulkFromTuple(column_object, limit, settings, *state_object, cache);
 
     settings.path.pop_back();
     column_object.checkConsistency();
     column_object.finalize();
     column = std::move(mutable_column);
+}
+
+template <typename Parser>
+void SerializationObject<Parser>::deserializeBinaryBulkFromString(
+    ColumnObject & column_object,
+    size_t limit,
+    DeserializeBinaryBulkSettings & settings,
+    DeserializeStateObject & state,
+    SubstreamsCache * cache) const
+{
+    ColumnPtr column_string = state.nested_type->createColumn();
+    state.nested_serialization->deserializeBinaryBulkWithMultipleStreams(
+        column_string, limit, settings, state.nested_state, cache);
+
+    ConvertImplGenericFromString<ColumnString>::executeImpl(*column_string, column_object, *this, column_string->size());
+}
+
+template <typename Parser>
+void SerializationObject<Parser>::deserializeBinaryBulkFromTuple(
+    ColumnObject & column_object,
+    size_t limit,
+    DeserializeBinaryBulkSettings & settings,
+    DeserializeStateObject & state,
+    SubstreamsCache * cache) const
+{
+    ColumnPtr column_tuple = state.nested_type->createColumn();
+    state.nested_serialization->deserializeBinaryBulkWithMultipleStreams(
+        column_tuple, limit, settings, state.nested_state, cache);
+
+    auto [tuple_paths, tuple_types] = flattenTuple(state.nested_type);
+    auto flattened_tuple = flattenTuple(column_tuple);
+    const auto & tuple_columns = assert_cast<const ColumnTuple &>(*flattened_tuple).getColumns();
+
+    assert(tuple_paths.size() == tuple_types.size());
+    size_t num_subcolumns = tuple_paths.size();
+
+    if (tuple_columns.size() != num_subcolumns)
+        throw Exception(ErrorCodes::INCORRECT_DATA,
+            "Inconsistent type ({}) and column ({}) while reading column of type Object",
+            state.nested_type->getName(), column_tuple->getName());
+
+    for (size_t i = 0; i < num_subcolumns; ++i)
+        column_object.addSubcolumn(tuple_paths[i], tuple_columns[i]->assumeMutable());
 }
 
 template <typename Parser>

--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -351,7 +351,7 @@ void SerializationObject<Parser>::serializeBinaryBulkWithMultipleStreams(
         state_object->nested_serialization->serializeBinaryBulkStatePrefix(settings, state_object->nested_state);
         settings.path.pop_back();
     }
-    else if (state_object->nested_type->equals(*tuple_type))
+    else if (!state_object->nested_type->equals(*tuple_type))
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR,
             "Types of internal column of Object mismatched. Expected: {}, Got: {}",

--- a/src/DataTypes/Serializations/SerializationObject.h
+++ b/src/DataTypes/Serializations/SerializationObject.h
@@ -1,19 +1,35 @@
 #pragma once
 
+#include <Columns/ColumnObject.h>
 #include <DataTypes/Serializations/SimpleTextSerialization.h>
 #include <Common/ObjectPool.h>
 
 namespace DB
 {
 
-/// Serialization for data type Object.
-/// Supported only test serialization/deserialization.
-/// and binary bulk serialization/deserialization without position independent
-/// encoding, i.e. serialization/deserialization into Native format.
+/** Serialization for data type Object.
+  * Supported only test serialization/deserialization.
+  * and binary bulk serialization/deserialization without position independent
+  * encoding, i.e. serialization/deserialization into Native format.
+  */
 template <typename Parser>
 class SerializationObject : public ISerialization
 {
 public:
+    /** In Native format ColumnObject can be serialized
+      * in two formats: as Tuple or as String.
+      * The format is the following:
+      *
+      * <serialization_kind> 1 byte -- 0 if Tuple, 1 if String.
+      * [type_name] -- Only for tuple serialization.
+      * ... data of internal column ...
+      *
+      * ClickHouse client serializazes objects as tuples.
+      * String serialization exists for clients, which cannot
+      * do parsing by themselves and they can send raw data as
+      * string. It will be parsed on the server side.
+      */
+
     void serializeBinaryBulkStatePrefix(
         SerializeBinaryBulkSettings & settings,
         SerializeBinaryBulkStatePtr & state) const override;
@@ -58,8 +74,31 @@ public:
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
 
 private:
-    template <typename TSettings, typename TStatePtr>
-    void checkSerializationIsSupported(const TSettings & settings, const TStatePtr & state) const;
+    enum class BinarySerializationKind : UInt8
+    {
+        TUPLE = 0,
+        STRING = 1,
+    };
+
+    struct SerializeStateObject;
+    struct DeserializeStateObject;
+
+    void deserializeBinaryBulkFromString(
+        ColumnObject & column_object,
+        size_t limit,
+        DeserializeBinaryBulkSettings & settings,
+        DeserializeStateObject & state,
+        SubstreamsCache * cache) const;
+
+    void deserializeBinaryBulkFromTuple(
+        ColumnObject & column_object,
+        size_t limit,
+        DeserializeBinaryBulkSettings & settings,
+        DeserializeStateObject & state,
+        SubstreamsCache * cache) const;
+
+    template <typename TSettings>
+    void checkSerializationIsSupported(const TSettings & settings) const;
 
     template <typename Reader>
     void deserializeTextImpl(IColumn & column, Reader && reader) const;

--- a/src/DataTypes/Serializations/tests/gtest_object_serialization.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_object_serialization.cpp
@@ -1,0 +1,80 @@
+#include <DataTypes/Serializations/SerializationString.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
+#include <IO/WriteHelpers.h>
+#include <DataTypes/DataTypeObject.h>
+#include <DataTypes/Serializations/SerializationObject.h>
+#include <Columns/ColumnObject.h>
+#include <Columns/ColumnString.h>
+#include <Common/FieldVisitorToString.h>
+
+#include <gtest/gtest.h>
+
+#if USE_SIMDJSON
+
+using namespace DB;
+
+TEST(SerializationObject, FromString)
+{
+    WriteBufferFromOwnString out;
+
+    auto column_string = ColumnString::create();
+    column_string->insert(R"({"k1" : 1, "k2" : [{"k3" : "aa", "k4" : 2}, {"k3": "bb", "k4": 3}]})");
+    column_string->insert(R"({"k1" : 2, "k2" : [{"k3" : "cc", "k5" : 4}, {"k4": 5}, {"k4": 6}]})");
+
+    {
+        auto serialization = std::make_shared<SerializationString>();
+
+        ISerialization::SerializeBinaryBulkSettings settings;
+        ISerialization::SerializeBinaryBulkStatePtr state;
+        settings.position_independent_encoding = false;
+        settings.getter = [&out](const auto &) { return &out; };
+
+        writeIntBinary(static_cast<UInt8>(1), out);
+        serialization->serializeBinaryBulkStatePrefix(settings, state);
+        serialization->serializeBinaryBulkWithMultipleStreams(*column_string, 0, column_string->size(), settings, state);
+        serialization->serializeBinaryBulkStateSuffix(settings, state);
+    }
+
+    auto type_object = std::make_shared<DataTypeObject>("json", false);
+    ColumnPtr result_column = type_object->createColumn();
+
+    ReadBufferFromOwnString in(out.str());
+
+    {
+        auto serialization = type_object->getDefaultSerialization();
+
+        ISerialization::DeserializeBinaryBulkSettings settings;
+        ISerialization::DeserializeBinaryBulkStatePtr state;
+        settings.position_independent_encoding = false;
+        settings.getter = [&in](const auto &) { return &in; };
+
+        serialization->deserializeBinaryBulkStatePrefix(settings, state);
+        serialization->deserializeBinaryBulkWithMultipleStreams(result_column, column_string->size(), settings, state, nullptr);
+    }
+
+    auto & column_object = assert_cast<ColumnObject &>(*result_column->assumeMutable());
+    column_object.finalize();
+
+    ASSERT_TRUE(column_object.size() == 2);
+    ASSERT_TRUE(column_object.getSubcolumns().size() == 4);
+
+    auto check_subcolumn = [&](const auto & name, const auto & type_name, const std::vector<Field> & expected)
+    {
+        const auto & subcolumn = column_object.getSubcolumn(PathInData{name});
+        ASSERT_EQ(subcolumn.getLeastCommonType()->getName(), type_name);
+
+        const auto & data = subcolumn.getFinalizedColumn();
+        for (size_t i = 0; i < expected.size(); ++i)
+            ASSERT_EQ(
+                applyVisitor(FieldVisitorToString(), data[i]),
+                applyVisitor(FieldVisitorToString(), expected[i]));
+    };
+
+    check_subcolumn("k1", "Int8", {1, 2});
+    check_subcolumn("k2.k3", "Array(String)", {Array{"aa", "bb"}, Array{"cc", "", ""}});
+    check_subcolumn("k2.k4", "Array(Int8)", {Array{2, 3}, Array{0, 5, 6}});
+    check_subcolumn("k2.k5", "Array(Int8)", {Array{0, 0}, Array{4, 0, 0}});
+}
+
+#endif

--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Common/Exception.h"
 #include <cstddef>
 #include <type_traits>
 
@@ -1046,13 +1047,11 @@ inline bool tryParseImpl<DataTypeUUID>(DataTypeUUID::FieldType & x, ReadBuffer &
 
 /** Throw exception with verbose message when string value is not parsed completely.
   */
-[[noreturn]] inline void throwExceptionForIncompletelyParsedValue(ReadBuffer & read_buffer, const DataTypePtr result_type)
+[[noreturn]] inline void throwExceptionForIncompletelyParsedValue(ReadBuffer & read_buffer, const IDataType & result_type)
 {
-    const IDataType & to_type = *result_type;
-
     WriteBufferFromOwnString message_buf;
     message_buf << "Cannot parse string " << quote << String(read_buffer.buffer().begin(), read_buffer.buffer().size())
-                << " as " << to_type.getName()
+                << " as " << result_type.getName()
                 << ": syntax error";
 
     if (read_buffer.offset())
@@ -1062,8 +1061,8 @@ inline bool tryParseImpl<DataTypeUUID>(DataTypeUUID::FieldType & x, ReadBuffer &
         message_buf << " at begin of string";
 
     // Currently there are no functions toIPv{4,6}Or{Null,Zero}
-    if (isNativeNumber(to_type) && !(to_type.getName() == "IPv4" || to_type.getName() == "IPv6"))
-        message_buf << ". Note: there are to" << to_type.getName() << "OrZero and to" << to_type.getName() << "OrNull functions, which returns zero/NULL instead of throwing exception.";
+    if (isNativeNumber(result_type) && !(result_type.getName() == "IPv4" || result_type.getName() == "IPv6"))
+        message_buf << ". Note: there are to" << result_type.getName() << "OrZero and to" << result_type.getName() << "OrNull functions, which returns zero/NULL instead of throwing exception.";
 
     throw Exception(message_buf.str(), ErrorCodes::CANNOT_PARSE_TEXT);
 }
@@ -1253,7 +1252,7 @@ struct ConvertThroughParsing
                 }
 
                 if (!isAllRead(read_buffer))
-                    throwExceptionForIncompletelyParsedValue(read_buffer, res_type);
+                    throwExceptionForIncompletelyParsedValue(read_buffer, *res_type);
             }
             else
             {
@@ -1354,18 +1353,32 @@ struct ConvertImplGenericFromString
         static_assert(std::is_same_v<StringColumnType, ColumnString> || std::is_same_v<StringColumnType, ColumnFixedString>,
                 "Can be used only to parse from ColumnString or ColumnFixedString");
 
-        const IColumn & col_from = *arguments[0].column;
+        const IColumn & column_from = *arguments[0].column;
         const IDataType & data_type_to = *result_type;
-        if (const StringColumnType * col_from_string = checkAndGetColumn<StringColumnType>(&col_from))
-        {
-            auto res = data_type_to.createColumn();
+        auto res = data_type_to.createColumn();
+        auto serialization = data_type_to.getDefaultSerialization();
+        const auto * null_map = column_nullable ? &column_nullable->getNullMapData() : nullptr;
 
-            IColumn & column_to = *res;
+        executeImpl(column_from, *res, *serialization, input_rows_count, null_map, result_type.get());
+        return res;
+    }
+
+    static void executeImpl(
+        const IColumn & column_from,
+        IColumn & column_to,
+        const ISerialization & serialization_from,
+        size_t input_rows_count,
+        const PaddedPODArray<UInt8> * null_map = nullptr,
+        const IDataType * result_type = nullptr)
+    {
+        static_assert(std::is_same_v<StringColumnType, ColumnString> || std::is_same_v<StringColumnType, ColumnFixedString>,
+                "Can be used only to parse from ColumnString or ColumnFixedString");
+
+        if (const StringColumnType * col_from_string = checkAndGetColumn<StringColumnType>(&column_from))
+        {
             column_to.reserve(input_rows_count);
 
             FormatSettings format_settings;
-            auto serialization = data_type_to.getDefaultSerialization();
-            const auto * null_map = column_nullable ? &column_nullable->getNullMapData() : nullptr;
             for (size_t i = 0; i < input_rows_count; ++i)
             {
                 if (null_map && (*null_map)[i])
@@ -1376,20 +1389,24 @@ struct ConvertImplGenericFromString
 
                 const auto & val = col_from_string->getDataAt(i);
                 ReadBufferFromMemory read_buffer(val.data, val.size);
-
-                serialization->deserializeWholeText(column_to, read_buffer, format_settings);
+                serialization_from.deserializeWholeText(column_to, read_buffer, format_settings);
 
                 if (!read_buffer.eof())
-                    throwExceptionForIncompletelyParsedValue(read_buffer, result_type);
+                {
+                    if (result_type)
+                        throwExceptionForIncompletelyParsedValue(read_buffer, *result_type);
+                    else
+                        throw Exception(ErrorCodes::CANNOT_PARSE_TEXT,
+                            "Cannot parse string to column {}. Expected eof", column_to.getName());
+                }
             }
-
-            return res;
         }
         else
-            throw Exception("Illegal column " + arguments[0].column->getName()
-                    + " of first argument of conversion function from string",
-                ErrorCodes::ILLEGAL_COLUMN);
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN,
+                "Illegal column {} of first argument of conversion function from string",
+                column_from.getName());
     }
+
 };
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Changed format of binary serialization of columns of experimental type `Object`. New format is more convenient to implement by third-party clients. 

