### PR TITLE
Remove height restrictions from the query div in play web tool, and m…

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -131,12 +131,13 @@
         {
             /* Make enough space for medium/large queries but allowing query textarea to grow. */
             min-height: 20%;
+            display: grid;
         }
 
         #query
         {
-            height: 100%;
-            width: 100%;
+            /* Keeps query text-area's width full screen even when user adjusting the width of the query box. */
+            min-width: 100%;
         }
 
         #inputs


### PR DESCRIPTION
Changelog category:
Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Modify query div in play.html to be extendable beyond 20% height. In case of very long queries it is helpful to extend the textarea element, only today, since the div is fixed height, the extended textarea hides the data div underneath. With this fix, extending the textarea element will push the data div down/up such the extended textarea won't hide it.
Also, keeps query box width 100% even when the user adjusting the size of the query textarea