### PR TITLE
Adjustable query div

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -101,14 +101,9 @@
 
         #controls
         {
-            /* Make enough space for even huge queries. */
-            height: 20%;
             /* When a page will be scrolled horizontally due to large table size, keep controls in place. */
             position: sticky;
             left: 0;
-            /* This allows query textarea to occupy the remaining height while other elements have fixed height. */
-            display: flex;
-            flex-direction: column;
         }
 
         /* Otherwise Webkit based browsers will display ugly border on focus. */
@@ -146,15 +141,10 @@
             background-color: var(--element-background-color);
         }
 
-        #query_div
-        {
-            /* Make enough space for medium/large queries but allowing query textarea to grow. */
-            min-height: 20%;
-            display: grid;
-        }
-
         #query
         {
+            /* Make enough space for even big queries. */
+            height: calc(20vh);
             /* Keeps query text-area's width full screen even when user adjusting the width of the query box. */
             min-width: 100%;
         }

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -101,14 +101,9 @@
 
         #controls
         {
-            /* Make enough space for even huge queries. */
-            height: 20%;
             /* When a page will be scrolled horizontally due to large table size, keep controls in place. */
             position: sticky;
             left: 0;
-            /* This allows query textarea to occupy the remaining height while other elements have fixed height. */
-            display: flex;
-            flex-direction: column;
         }
 
         /* Otherwise Webkit based browsers will display ugly border on focus. */
@@ -146,15 +141,10 @@
             background-color: var(--element-background-color);
         }
 
-        #query_div
-        {
-            /* Make enough space for medium/large queries but allowing query textarea to grow. */
-            min-height: 20%;
-            display: grid;
-        }
-
         #query
         {
+            /* Make enough space for even big queries. */
+            height: 20vh;
             /* Keeps query text-area's width full screen even when user adjusting the width of the query box. */
             min-width: 100%;
         }

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -148,13 +148,15 @@
 
         #query_div
         {
-            height: 100%;
+            /* Make enough space for medium/large queries but allowing query textarea to grow. */
+            min-height: 20%;
+            display: grid;
         }
 
         #query
         {
-            height: 100%;
-            width: 100%;
+            /* Keeps query text-area's width full screen even when user adjusting the width of the query box. */
+            min-width: 100%;
         }
 
         #inputs


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Modify query div in play.html to be extendable beyond 20% height. In case of very long queries it is helpful to extend the textarea element, only today, since the div is fixed height, the extended textarea hides the data div underneath. With this fix, extending the textarea element will push the data div down/up such the extended textarea won't hide it.
Also, keeps query box width 100% even when the user adjusting the size of the query textarea