### PR TITLE
Control cache downloads to avoid negative optimization of local caches

### DIFF
--- a/src/Common/FileCache.cpp
+++ b/src/Common/FileCache.cpp
@@ -935,7 +935,7 @@ LRUFileCache::LRUQueue::Iterator LRUFileCache::LRUQueue::add(
     const IFileCache::Key & key, size_t offset, size_t size, std::lock_guard<std::mutex> & /* cache_lock */)
 {
 #ifndef NDEBUG
-    for (const auto & [entry_key, entry_offset, _, __] : queue)
+    for (const auto & [entry_key, entry_offset, entry_size, entry_hits] : queue)
     {
         if (entry_key == key && entry_offset == offset)
             throw Exception(

--- a/src/Common/FileCache.cpp
+++ b/src/Common/FileCache.cpp
@@ -935,7 +935,7 @@ LRUFileCache::LRUQueue::Iterator LRUFileCache::LRUQueue::add(
     const IFileCache::Key & key, size_t offset, size_t size, std::lock_guard<std::mutex> & /* cache_lock */)
 {
 #ifndef NDEBUG
-    for (const auto & [entry_key, entry_offset, _, _] : queue)
+    for (const auto & [entry_key, entry_offset, _, __] : queue)
     {
         if (entry_key == key && entry_offset == offset)
             throw Exception(

--- a/src/Common/FileCache.cpp
+++ b/src/Common/FileCache.cpp
@@ -72,6 +72,8 @@ void IFileCache::assertInitialized() const
 
 LRUFileCache::LRUFileCache(const String & cache_base_path_, const FileCacheSettings & cache_settings_)
     : IFileCache(cache_base_path_, cache_settings_)
+    , max_stash_element_size(cache_settings_.max_elements)
+    , enable_cache_hits_threshold(cache_settings_.enable_cache_hits_threshold)
     , log(&Poco::Logger::get("LRUFileCache"))
 {
 }
@@ -404,9 +406,46 @@ LRUFileCache::FileSegmentCell * LRUFileCache::addCell(
             "Cache already exists for key: `{}`, offset: {}, size: {}.\nCurrent cache structure: {}",
             keyToStr(key), offset, size, dumpStructureUnlocked(key, cache_lock));
 
-    auto file_segment = std::make_shared<FileSegment>(offset, size, key, this, state);
-    FileSegmentCell cell(std::move(file_segment), this, cache_lock);
+    auto skip_or_download = [&]() -> FileSegmentPtr
+    {
+        if (state == FileSegment::State::EMPTY)
+        {
+            LOG_TEST(log, "[addCell] FileSegment key:{}, offset:{}, state:{}, enable_cache_hits:{}, current_element_size:{}/{}.",
+                keyToStr(key), offset, FileSegment::stateToString(state), enable_cache_hits_threshold, stash_queue.getElementsNum(cache_lock), max_stash_element_size);
+      
+            auto record = records.find({key, offset});
 
+            if (record == records.end())
+            {
+                auto queue_iter = stash_queue.add(key, offset, 0, cache_lock);
+                records.insert({{key, offset}, queue_iter});
+
+                if (stash_queue.getElementsNum(cache_lock) > max_stash_element_size)
+                {
+                    auto remove_queue_iter = stash_queue.begin();
+                    records.erase({remove_queue_iter->key, remove_queue_iter->offset});
+                    stash_queue.remove(remove_queue_iter, cache_lock);
+                }
+                /// For segments that do not reach the download threshold, we do not download them, but directly read them
+                return std::make_shared<FileSegment>(offset, size, key, this, FileSegment::State::SKIP_CACHE);
+            }
+            else
+            {
+                auto queue_iter = record->second;
+                queue_iter->hits++;
+                stash_queue.moveToEnd(queue_iter, cache_lock);
+                
+                if (queue_iter->hits >= enable_cache_hits_threshold)
+                    return std::make_shared<FileSegment>(offset, size, key, this, FileSegment::State::EMPTY);
+                else
+                    return std::make_shared<FileSegment>(offset, size, key, this, FileSegment::State::SKIP_CACHE);
+            }
+        }
+        else
+            return std::make_shared<FileSegment>(offset, size, key, this, state);
+    };
+
+    FileSegmentCell cell(skip_or_download(), this, cache_lock);
     auto & offsets = files[key];
 
     if (offsets.empty())
@@ -471,7 +510,7 @@ bool LRUFileCache::tryReserve(
     std::vector<FileSegmentCell *> to_evict;
     std::vector<FileSegmentCell *> trash;
 
-    for (const auto & [entry_key, entry_offset, entry_size] : queue)
+    for (const auto & [entry_key, entry_offset, entry_size, entry_hits] : queue)
     {
         if (!is_overflow())
             break;
@@ -619,7 +658,7 @@ void LRUFileCache::remove()
     std::vector<FileSegment *> to_remove;
     for (auto it = queue.begin(); it != queue.end();)
     {
-        const auto & [key, offset, size] = *it++;
+        const auto & [key, offset, size, hits] = *it++;
         auto * cell = getCell(key, offset, cache_lock);
         if (!cell)
             throw Exception(
@@ -882,6 +921,7 @@ LRUFileCache::FileSegmentCell::FileSegmentCell(
             queue_iterator = cache->queue.add(file_segment->key(), file_segment->offset(), file_segment->range().size(), cache_lock);
             break;
         }
+        case FileSegment::State::SKIP_CACHE:
         case FileSegment::State::EMPTY:
         case FileSegment::State::DOWNLOADING:
         {
@@ -934,7 +974,7 @@ bool LRUFileCache::LRUQueue::contains(
 {
     /// This method is used for assertions in debug mode.
     /// So we do not care about complexity here.
-    for (const auto & [entry_key, entry_offset, size] : queue)
+    for (const auto & [entry_key, entry_offset, size, hits] : queue)
     {
         if (key == entry_key && offset == entry_offset)
             return true;
@@ -947,7 +987,7 @@ void LRUFileCache::LRUQueue::assertCorrectness(LRUFileCache * cache, std::lock_g
     [[maybe_unused]] size_t total_size = 0;
     for (auto it = queue.begin(); it != queue.end();)
     {
-        auto & [key, offset, size] = *it++;
+        auto & [key, offset, size, hits] = *it++;
 
         auto * cell = cache->getCell(key, offset, cache_lock);
         if (!cell)
@@ -969,7 +1009,7 @@ void LRUFileCache::LRUQueue::assertCorrectness(LRUFileCache * cache, std::lock_g
 String LRUFileCache::LRUQueue::toString(std::lock_guard<std::mutex> & /* cache_lock */) const
 {
     String result;
-    for (const auto & [key, offset, size] : queue)
+    for (const auto & [key, offset, size, hits] : queue)
     {
         if (!result.empty())
             result += ", ";

--- a/src/Common/FileCache.cpp
+++ b/src/Common/FileCache.cpp
@@ -410,9 +410,6 @@ LRUFileCache::FileSegmentCell * LRUFileCache::addCell(
     {
         if (state == FileSegment::State::EMPTY)
         {
-            LOG_TEST(log, "[addCell] FileSegment key:{}, offset:{}, state:{}, enable_cache_hits:{}, current_element_size:{}/{}.",
-                keyToStr(key), offset, FileSegment::stateToString(state), enable_cache_hits_threshold, stash_queue.getElementsNum(cache_lock), max_stash_element_size);
-      
             auto record = records.find({key, offset});
 
             if (record == records.end())

--- a/src/Common/FileCache.cpp
+++ b/src/Common/FileCache.cpp
@@ -507,7 +507,7 @@ bool LRUFileCache::tryReserve(
     std::vector<FileSegmentCell *> to_evict;
     std::vector<FileSegmentCell *> trash;
 
-    for (const auto & [entry_key, entry_offset, entry_size, entry_hits] : queue)
+    for (const auto & [entry_key, entry_offset, entry_size, _] : queue)
     {
         if (!is_overflow())
             break;
@@ -655,7 +655,7 @@ void LRUFileCache::remove()
     std::vector<FileSegment *> to_remove;
     for (auto it = queue.begin(); it != queue.end();)
     {
-        const auto & [key, offset, size, hits] = *it++;
+        const auto & [key, offset, size, _] = *it++;
         auto * cell = getCell(key, offset, cache_lock);
         if (!cell)
             throw Exception(
@@ -935,7 +935,7 @@ LRUFileCache::LRUQueue::Iterator LRUFileCache::LRUQueue::add(
     const IFileCache::Key & key, size_t offset, size_t size, std::lock_guard<std::mutex> & /* cache_lock */)
 {
 #ifndef NDEBUG
-    for (const auto & [entry_key, entry_offset, _] : queue)
+    for (const auto & [entry_key, entry_offset, _, _] : queue)
     {
         if (entry_key == key && entry_offset == offset)
             throw Exception(
@@ -971,7 +971,7 @@ bool LRUFileCache::LRUQueue::contains(
 {
     /// This method is used for assertions in debug mode.
     /// So we do not care about complexity here.
-    for (const auto & [entry_key, entry_offset, size, hits] : queue)
+    for (const auto & [entry_key, entry_offset, size, _] : queue)
     {
         if (key == entry_key && offset == entry_offset)
             return true;
@@ -984,7 +984,7 @@ void LRUFileCache::LRUQueue::assertCorrectness(LRUFileCache * cache, std::lock_g
     [[maybe_unused]] size_t total_size = 0;
     for (auto it = queue.begin(); it != queue.end();)
     {
-        auto & [key, offset, size, hits] = *it++;
+        auto & [key, offset, size, _] = *it++;
 
         auto * cell = cache->getCell(key, offset, cache_lock);
         if (!cell)
@@ -1006,7 +1006,7 @@ void LRUFileCache::LRUQueue::assertCorrectness(LRUFileCache * cache, std::lock_g
 String LRUFileCache::LRUQueue::toString(std::lock_guard<std::mutex> & /* cache_lock */) const
 {
     String result;
-    for (const auto & [key, offset, size, hits] : queue)
+    for (const auto & [key, offset, size, _] : queue)
     {
         if (!result.empty())
             result += ", ";

--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -196,6 +196,8 @@ private:
 
         Iterator end() { return queue.end(); }
 
+        void removeAll(std::lock_guard<std::mutex> & cache_lock);
+
     private:
         std::list<FileKeyAndOffset> queue;
         size_t cache_size = 0;

--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -234,7 +234,7 @@ private:
     AccessRecord records;
     size_t max_stash_element_size;
     size_t enable_cache_hits_threshold;
-    
+
     Poco::Logger * log;
 
     FileSegments getImpl(

--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
+#include <boost/functional/hash.hpp>
 #include <boost/noncopyable.hpp>
 #include <map>
 
@@ -225,7 +226,16 @@ private:
     using CachedFiles = std::unordered_map<Key, FileSegmentsByOffset>;
 
     using AccessKeyAndOffset = std::pair<Key, size_t>;
-    using AccessRecord = std::map<AccessKeyAndOffset, LRUQueue::Iterator>;
+
+    struct KeyAndOffsetHash
+    {
+        std::size_t operator()(const AccessKeyAndOffset & key) const
+        {
+            return std::hash<UInt128>()(key.first) ^ std::hash<UInt64>()(key.second);
+        }
+    };
+
+    using AccessRecord = std::unordered_map<AccessKeyAndOffset, LRUQueue::Iterator, KeyAndOffsetHash>;
 
     CachedFiles files;
     LRUQueue queue;

--- a/src/Common/FileCache.h
+++ b/src/Common/FileCache.h
@@ -165,6 +165,7 @@ private:
             Key key;
             size_t offset;
             size_t size;
+            size_t hits = 0;
 
             FileKeyAndOffset(const Key & key_, size_t offset_, size_t size_) : key(key_), offset(offset_), size(size_) {}
         };
@@ -223,8 +224,17 @@ private:
     using FileSegmentsByOffset = std::map<size_t, FileSegmentCell>;
     using CachedFiles = std::unordered_map<Key, FileSegmentsByOffset>;
 
+    using AccessKeyAndOffset = std::pair<Key, size_t>;
+    using AccessRecord = std::map<AccessKeyAndOffset, LRUQueue::Iterator>;
+
     CachedFiles files;
     LRUQueue queue;
+
+    LRUQueue stash_queue;
+    AccessRecord records;
+    size_t max_stash_element_size;
+    size_t enable_cache_hits_threshold;
+    
     Poco::Logger * log;
 
     FileSegments getImpl(

--- a/src/Common/FileCacheSettings.cpp
+++ b/src/Common/FileCacheSettings.cpp
@@ -11,6 +11,7 @@ void FileCacheSettings::loadFromConfig(const Poco::Util::AbstractConfiguration &
     max_elements = config.getUInt64(config_prefix + ".data_cache_max_elements", REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_ELEMENTS);
     max_file_segment_size = config.getUInt64(config_prefix + ".max_file_segment_size", REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_FILE_SEGMENT_SIZE);
     cache_on_write_operations = config.getUInt64(config_prefix + ".cache_on_write_operations", false);
+    enable_cache_hits_threshold = config.getUInt64(config_prefix + ".enable_cache_hits_threshold", REMOTE_FS_OBJECTS_CACHE_ENABLE_HITS_THRESHOLD);
 }
 
 }

--- a/src/Common/FileCacheSettings.h
+++ b/src/Common/FileCacheSettings.h
@@ -14,6 +14,8 @@ struct FileCacheSettings
     size_t max_file_segment_size = REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_FILE_SEGMENT_SIZE;
     bool cache_on_write_operations = false;
 
+    size_t enable_cache_hits_threshold = REMOTE_FS_OBJECTS_CACHE_ENABLE_HITS_THRESHOLD;
+
     void loadFromConfig(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
 };
 

--- a/src/Common/FileCache_fwd.h
+++ b/src/Common/FileCache_fwd.h
@@ -7,6 +7,7 @@ namespace DB
 static constexpr int REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_CACHE_SIZE = 1024 * 1024 * 1024;
 static constexpr int REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_FILE_SEGMENT_SIZE = 100 * 1024 * 1024;
 static constexpr int REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_ELEMENTS = 1024 * 1024;
+static constexpr int REMOTE_FS_OBJECTS_CACHE_ENABLE_HITS_THRESHOLD = 0;
 
 class IFileCache;
 using FileCachePtr = std::shared_ptr<IFileCache>;

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -551,8 +551,7 @@ void FileSegment::completeUnlocked(std::lock_guard<std::mutex> & cache_lock, std
         /// Segment state can be changed from DOWNLOADING or EMPTY only if the caller is the
         /// downloader or the only owner of the segment.
 
-        bool can_update_segment_state = isDownloaderImpl(segment_lock)
-            || cache->isLastFileSegmentHolder(key(), offset(), cache_lock, segment_lock);
+        bool can_update_segment_state = isDownloaderImpl(segment_lock) || is_last_holder;
 
         if (can_update_segment_state)
             download_state = State::PARTIALLY_DOWNLOADED;

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -59,6 +59,10 @@ FileSegment::FileSegment(
             downloader_id = getCallerId();
             break;
         }
+        case (State::SKIP_CACHE):
+        {
+            break;
+        }
         default:
         {
             throw Exception(ErrorCodes::REMOTE_FS_OBJECT_CACHE_ERROR, "Can create cell with either EMPTY, DOWNLOADED, DOWNLOADING state");
@@ -525,6 +529,11 @@ void FileSegment::complete(std::lock_guard<std::mutex> & cache_lock)
 
 void FileSegment::completeUnlocked(std::lock_guard<std::mutex> & cache_lock, std::lock_guard<std::mutex> & segment_lock)
 {
+    bool is_last_holder = cache->isLastFileSegmentHolder(key(), offset(), cache_lock, segment_lock);
+
+    if (is_last_holder && download_state == State::SKIP_CACHE)
+        cache->remove(key(), offset(), cache_lock, segment_lock);
+
     if (download_state == State::SKIP_CACHE || is_detached)
         return;
 

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -532,7 +532,10 @@ void FileSegment::completeUnlocked(std::lock_guard<std::mutex> & cache_lock, std
     bool is_last_holder = cache->isLastFileSegmentHolder(key(), offset(), cache_lock, segment_lock);
 
     if (is_last_holder && download_state == State::SKIP_CACHE)
+    {
         cache->remove(key(), offset(), cache_lock, segment_lock);
+        return;
+    }
 
     if (download_state == State::SKIP_CACHE || is_detached)
         return;

--- a/src/Disks/IO/CachedReadBufferFromRemoteFS.cpp
+++ b/src/Disks/IO/CachedReadBufferFromRemoteFS.cpp
@@ -491,7 +491,7 @@ bool CachedReadBufferFromRemoteFS::completeFileSegmentAndGetNext()
 
     /// Do not hold pointer to file segment if it is not needed anymore
     /// so can become releasable and can be evicted from cache.
-    /// If the status of filesegment state is SKIP_CACHE, it will not be deleted. 
+    /// If the status of filesegment state is SKIP_CACHE, it will not be deleted.
     /// It will be deleted from the cache when the holder is destructed.
     if ((*file_segment_it)->state() != FileSegment::State::SKIP_CACHE)
         file_segments_holder->file_segments.erase(file_segment_it);

--- a/src/Disks/IO/CachedReadBufferFromRemoteFS.cpp
+++ b/src/Disks/IO/CachedReadBufferFromRemoteFS.cpp
@@ -491,7 +491,10 @@ bool CachedReadBufferFromRemoteFS::completeFileSegmentAndGetNext()
 
     /// Do not hold pointer to file segment if it is not needed anymore
     /// so can become releasable and can be evicted from cache.
-    file_segments_holder->file_segments.erase(file_segment_it);
+    /// If the status of filesegment state is SKIP_CACHE, it will not be deleted. 
+    /// It will be deleted from the cache when the holder is destructed.
+    if ((*file_segment_it)->state() != FileSegment::State::SKIP_CACHE)
+        file_segments_holder->file_segments.erase(file_segment_it);
 
     if (current_file_segment_it == file_segments_holder->file_segments.end())
         return false;

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -9,6 +9,7 @@
                 <data_cache_enabled>1</data_cache_enabled>
                 <cache_enabled>0</cache_enabled>
                 <data_cache_max_size>22548578304</data_cache_max_size>
+                <cache_on_write_operations>1</cache_on_write_operations>
                 <data_cache_path>./s3_cache/</data_cache_path>
             </s3_cache>
             <s3_cache_2>

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -9,7 +9,6 @@
                 <data_cache_enabled>1</data_cache_enabled>
                 <cache_enabled>0</cache_enabled>
                 <data_cache_max_size>22548578304</data_cache_max_size>
-                <cache_on_write_operations>1</cache_on_write_operations>
                 <data_cache_path>./s3_cache/</data_cache_path>
             </s3_cache>
             <s3_cache_2>
@@ -22,6 +21,18 @@
                 <data_cache_max_size>22548578304</data_cache_max_size>
                 <cache_on_write_operations>0</cache_on_write_operations>
             </s3_cache_2>
+            <s3_cache_3>
+                <type>s3</type>
+                <endpoint>http://localhost:11111/test/00170_test/</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+                <data_cache_enabled>1</data_cache_enabled>
+                <cache_enabled>0</cache_enabled>
+                <data_cache_max_size>22548578304</data_cache_max_size>
+                <cache_on_write_operations>1</cache_on_write_operations>
+                <data_cache_path>./s3_cache/</data_cache_path>
+                <enable_cache_hits_threshold>1</enable_cache_hits_threshold>
+            </s3_cache_3>
         </disks>
         <policies>
             <s3_cache>
@@ -38,6 +49,13 @@
                     </main>
                 </volumes>
             </s3_cache_2>
+            <s3_cache_3>
+                <volumes>
+                    <main>
+                        <disk>s3_cache_3</disk>
+                    </main>
+                </volumes>
+            </s3_cache_3>
         </policies>
     </storage_configuration>
 </clickhouse>

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -31,7 +31,6 @@
                 <cache_enabled>0</cache_enabled>
                 <data_cache_max_size>22548578304</data_cache_max_size>
                 <cache_on_write_operations>1</cache_on_write_operations>
-                <data_cache_path>./s3_cache/</data_cache_path>
                 <enable_cache_hits_threshold>1</enable_cache_hits_threshold>
             </s3_cache_3>
         </disks>

--- a/tests/queries/0_stateless/02240_system_remote_filesystem_cache.reference
+++ b/tests/queries/0_stateless/02240_system_remote_filesystem_cache.reference
@@ -2,7 +2,6 @@
 
 SYSTEM DROP FILESYSTEM CACHE;
 SET enable_filesystem_cache_on_write_operations=0;
-set enable_cache_hits_threshold=0;
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache', min_bytes_for_wide_part = 10485760;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);
@@ -18,7 +17,6 @@ SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesy
 0	745	746
 SYSTEM DROP FILESYSTEM CACHE;
 SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
-set enable_cache_hits_threshold=1;
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache_3', min_bytes_for_wide_part = 10485760;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);

--- a/tests/queries/0_stateless/02240_system_remote_filesystem_cache.reference
+++ b/tests/queries/0_stateless/02240_system_remote_filesystem_cache.reference
@@ -2,6 +2,7 @@
 
 SYSTEM DROP FILESYSTEM CACHE;
 SET enable_filesystem_cache_on_write_operations=0;
+set enable_cache_hits_threshold=0;
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache', min_bytes_for_wide_part = 10485760;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);
@@ -15,5 +16,22 @@ SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesy
 SELECT * FROM test FORMAT Null;
 SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
 0	745	746
+SYSTEM DROP FILESYSTEM CACHE;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+set enable_cache_hits_threshold=1;
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache_3', min_bytes_for_wide_part = 10485760;
+INSERT INTO test SELECT number, toString(number) FROM numbers(100);
+SELECT  * FROM test FORMAT Null;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_end, size;
+0	0	1
+SELECT  * FROM test FORMAT Null;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_end, size;
+0	0	1
+0	745	746
+SYSTEM DROP FILESYSTEM CACHE;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT * FROM test FORMAT Null;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
 SYSTEM DROP FILESYSTEM CACHE;
 SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;

--- a/tests/queries/0_stateless/02240_system_remote_filesystem_cache.sql
+++ b/tests/queries/0_stateless/02240_system_remote_filesystem_cache.sql
@@ -4,7 +4,6 @@
 
 SYSTEM DROP FILESYSTEM CACHE;
 SET enable_filesystem_cache_on_write_operations=0;
-set enable_cache_hits_threshold=0;
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache', min_bytes_for_wide_part = 10485760;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);
@@ -18,7 +17,6 @@ SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesy
 SYSTEM DROP FILESYSTEM CACHE;
 SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
 
-set enable_cache_hits_threshold=1;
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache_3', min_bytes_for_wide_part = 10485760;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);

--- a/tests/queries/0_stateless/02240_system_remote_filesystem_cache.sql
+++ b/tests/queries/0_stateless/02240_system_remote_filesystem_cache.sql
@@ -4,10 +4,27 @@
 
 SYSTEM DROP FILESYSTEM CACHE;
 SET enable_filesystem_cache_on_write_operations=0;
+set enable_cache_hits_threshold=0;
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache', min_bytes_for_wide_part = 10485760;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);
 
+SELECT  * FROM test FORMAT Null;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_end, size;
+SYSTEM DROP FILESYSTEM CACHE;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SELECT * FROM test FORMAT Null;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+SYSTEM DROP FILESYSTEM CACHE;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache;
+
+set enable_cache_hits_threshold=1;
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache_3', min_bytes_for_wide_part = 10485760;
+INSERT INTO test SELECT number, toString(number) FROM numbers(100);
+
+SELECT  * FROM test FORMAT Null;
+SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_end, size;
 SELECT  * FROM test FORMAT Null;
 SELECT file_segment_range_begin, file_segment_range_end, size FROM system.filesystem_cache ORDER BY file_segment_range_end, size;
 SYSTEM DROP FILESYSTEM CACHE;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Currently clickhouse directly downloads all remote files to the local cache (even if they are only read once), which will frequently cause IO of the local hard disk. In some scenarios, these IOs may not be necessary and may easily cause negative optimization. As shown in the figure below, when we run SSB Q1-Q4, the performance of the cache has caused negative optimization.

<img width="678" alt="image" src="https://user-images.githubusercontent.com/10573698/170224827-2c1f2a4b-0db6-402a-be41-8930f249af28.png">

In response to the above problems, we record the data access trend (an LRU queue) within an access frame at the cache layer. Only frequently accessed cache blocks will be saved locally. As shown in the figure, the addition of control will not cause significant negative optimization, but the data with hot spots can still be cached locally.

<img width="868" alt="image" src="https://user-images.githubusercontent.com/10573698/170225347-e81cf190-f87d-45ed-ac0f-9d11e419dcda.png">

The relevant threshold can be set in the configuration file (the threshold indicates how many times a certain piece of data is accessed before being cached, the default value is 0).

<img width="562" alt="image" src="https://user-images.githubusercontent.com/10573698/170225890-5443ca5f-9024-47e2-83e3-6c9436841d88.png">

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
