### PR TITLE
Use a separate mutex for query_factories_info in Context.

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1079,7 +1079,7 @@ void Context::addQueryFactoriesInfo(QueryLogFactories factory_type, const String
     if (isGlobalContext())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Global context cannot have query factories info");
 
-    std::lock_guard lock(query_factories_info_mutex);
+    std::lock_guard lock(query_factories_info.mutex);
 
     switch (factory_type)
     {

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1079,7 +1079,7 @@ void Context::addQueryFactoriesInfo(QueryLogFactories factory_type, const String
     if (isGlobalContext())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Global context cannot have query factories info");
 
-    auto lock = getLock();
+    std::lock_guard lock(query_factories_info_mutex);
 
     switch (factory_type)
     {

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -291,6 +291,43 @@ private:
     /// Record names of created objects of factories (for testing, etc)
     struct QueryFactoriesInfo
     {
+        QueryFactoriesInfo() = default;
+
+        QueryFactoriesInfo(const QueryFactoriesInfo & rhs)
+        {
+            std::lock_guard<std::mutex> lock(rhs.mutex);
+            aggregate_functions = rhs.aggregate_functions;
+            aggregate_function_combinators = rhs.aggregate_function_combinators;
+            database_engines = rhs.database_engines;
+            data_type_families = rhs.data_type_families;
+            dictionaries = rhs.dictionaries;
+            formats = rhs.formats;
+            functions = rhs.functions;
+            storages = rhs.storages;
+            table_functions = rhs.table_functions;
+        }
+
+        QueryFactoriesInfo(QueryFactoriesInfo && rhs) = delete;
+
+        QueryFactoriesInfo & operator=(QueryFactoriesInfo rhs)
+        {
+            swap(rhs);
+            return *this;
+        }
+
+        void swap(QueryFactoriesInfo & rhs)
+        {
+            std::swap(aggregate_functions, rhs.aggregate_functions);
+            std::swap(aggregate_function_combinators, rhs.aggregate_function_combinators);
+            std::swap(database_engines, rhs.database_engines);
+            std::swap(data_type_families, rhs.data_type_families);
+            std::swap(dictionaries, rhs.dictionaries);
+            std::swap(formats, rhs.formats);
+            std::swap(functions, rhs.functions);
+            std::swap(storages, rhs.storages);
+            std::swap(table_functions, rhs.table_functions);
+        }
+
         std::unordered_set<std::string> aggregate_functions;
         std::unordered_set<std::string> aggregate_function_combinators;
         std::unordered_set<std::string> database_engines;
@@ -300,11 +337,12 @@ private:
         std::unordered_set<std::string> functions;
         std::unordered_set<std::string> storages;
         std::unordered_set<std::string> table_functions;
+
+        std::mutex mutex;
     };
 
     /// Needs to be changed while having const context in factories methods
     mutable QueryFactoriesInfo query_factories_info;
-    mutable std::mutex query_factories_info_mutex;
 
     /// TODO: maybe replace with temporary tables?
     StoragePtr view_source;                 /// Temporary StorageValues used to generate alias columns for materialized views

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -338,7 +338,7 @@ private:
         std::unordered_set<std::string> storages;
         std::unordered_set<std::string> table_functions;
 
-        std::mutex mutex;
+        mutable std::mutex mutex;
     };
 
     /// Needs to be changed while having const context in factories methods

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -302,8 +302,9 @@ private:
         std::unordered_set<std::string> table_functions;
     };
 
-    /// Needs to be chandged while having const context in factories methods
+    /// Needs to be changed while having const context in factories methods
     mutable QueryFactoriesInfo query_factories_info;
+    mutable std::mutex query_factories_info_mutex;
 
     /// TODO: maybe replace with temporary tables?
     StoragePtr view_source;                 /// Temporary StorageValues used to generate alias columns for materialized views


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not for changelog (changelog entry is not required)
Fixes #37329
