### PR TITLE
Prohibit optimize_aggregation_in_order with GROUPING SETS (fixes LOGICAL_ERROR)

### DIFF
--- a/src/Interpreters/ExpressionAnalyzer.h
+++ b/src/Interpreters/ExpressionAnalyzer.h
@@ -326,7 +326,15 @@ public:
     bool hasGlobalSubqueries() { return has_global_subqueries; }
     bool hasTableJoin() const { return syntax->ast_join; }
 
-    bool useGroupingSetKey() const { return aggregation_keys_list.size() > 1; }
+    /// When there is only one group in GROUPING SETS
+    /// it is a special case that is equal to GROUP BY, i.e.:
+    ///
+    ///     GROUPING SETS ((a, b)) -> GROUP BY a, b
+    ///
+    /// But it is rewritten by GroupingSetsRewriterVisitor to GROUP BY,
+    /// so instead of aggregation_keys_list.size() > 1,
+    /// !aggregation_keys_list.empty() can be used.
+    bool useGroupingSetKey() const { return !aggregation_keys_list.empty(); }
 
     const NamesAndTypesList & aggregationKeys() const { return aggregation_keys; }
     bool hasConstAggregationKeys() const { return has_const_aggregation_keys; }

--- a/src/Interpreters/GroupingSetsRewriterVisitor.cpp
+++ b/src/Interpreters/GroupingSetsRewriterVisitor.cpp
@@ -1,0 +1,22 @@
+#include <Interpreters/GroupingSetsRewriterVisitor.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTExpressionList.h>
+
+
+namespace DB
+{
+
+void GroupingSetsRewriterData::visit(ASTSelectQuery & select_query, ASTPtr &)
+{
+    const ASTPtr group_by = select_query.groupBy();
+    if (!group_by || !select_query.group_by_with_grouping_sets)
+        return;
+
+    if (group_by->children.size() != 1)
+        return;
+
+    select_query.setExpression(ASTSelectQuery::Expression::GROUP_BY, std::move(group_by->children.front()));
+    select_query.group_by_with_grouping_sets = false;
+}
+
+}

--- a/src/Interpreters/GroupingSetsRewriterVisitor.h
+++ b/src/Interpreters/GroupingSetsRewriterVisitor.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Parsers/IAST.h>
+#include <Interpreters/InDepthNodeVisitor.h>
+
+namespace DB
+{
+
+class ASTSelectQuery;
+
+/// Rewrite GROUPING SETS with only one group, to GROUP BY.
+///
+/// Examples:
+/// - GROUPING SETS (foo) -> GROUP BY foo
+/// - GROUPING SETS ((foo, bar)) -> GROUP BY foo, bar
+///
+/// But not the following:
+/// - GROUPING SETS (foo, bar) (since it has two groups (foo) and (bar))
+class GroupingSetsRewriterData
+{
+public:
+    using TypeToVisit = ASTSelectQuery;
+
+    static void visit(ASTSelectQuery & select_query, ASTPtr &);
+};
+
+using GroupingSetsRewriterMatcher = OneTypeMatcher<GroupingSetsRewriterData>;
+using GroupingSetsRewriterVisitor = InDepthNodeVisitor<GroupingSetsRewriterMatcher, true>;
+
+}

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -13,6 +13,7 @@
 #include <Interpreters/FunctionNameNormalizer.h>
 #include <Interpreters/MarkTableIdentifiersVisitor.h>
 #include <Interpreters/QueryNormalizer.h>
+#include <Interpreters/GroupingSetsRewriterVisitor.h>
 #include <Interpreters/ExecuteScalarSubqueriesVisitor.h>
 #include <Interpreters/CollectJoinOnKeysVisitor.h>
 #include <Interpreters/RequiredSourceColumnsVisitor.h>
@@ -64,6 +65,12 @@ namespace
 {
 
 using LogAST = DebugASTLog<false>; /// set to true to enable logs
+
+void optimizeGroupingSets(ASTPtr & query)
+{
+    GroupingSetsRewriterVisitor::Data data;
+    GroupingSetsRewriterVisitor(data).visit(query);
+}
 
 /// Select implementation of a function based on settings.
 /// Important that it is done as query rewrite. It means rewritten query
@@ -1373,6 +1380,8 @@ void TreeRewriter::normalize(
     /// Common subexpression elimination. Rewrite rules.
     QueryNormalizer::Data normalizer_data(aliases, source_columns_set, ignore_alias, settings, allow_self_aliases);
     QueryNormalizer(normalizer_data).visit(query);
+
+    optimizeGroupingSets(query);
 }
 
 }

--- a/tests/queries/0_stateless/01883_grouping_sets_crash.reference
+++ b/tests/queries/0_stateless/01883_grouping_sets_crash.reference
@@ -1,3 +1,14 @@
+-- { echoOn }
+SELECT
+    fact_3_id,
+    fact_4_id
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+        ('wo\0ldworldwo\0ldworld'),
+        (fact_3_id, fact_4_id))
+ORDER BY
+    fact_3_id, fact_4_id;
 0	0
 1	1
 2	2
@@ -9,7 +20,23 @@
 8	8
 9	9
 10	10
+SELECT 'SECOND QUERY:';
 SECOND QUERY:
+SELECT
+    fact_3_id,
+    fact_4_id
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+    (fact_1_id, fact_2_id),
+    ((-9223372036854775808, NULL, (tuple(1.), (tuple(1.), 1048576), 65535))),
+    ((tuple(3.4028234663852886e38), (tuple(1024), -2147483647), NULL)),
+    (fact_3_id, fact_4_id))
+ORDER BY
+    (NULL, ('256', (tuple(NULL), NULL), NULL, NULL), NULL) ASC,
+    fact_1_id DESC NULLS FIRST,
+    fact_2_id DESC NULLS FIRST,
+    fact_4_id ASC;
 0	0
 0	0
 0	0
@@ -32,7 +59,26 @@ SECOND QUERY:
 8	8
 9	9
 10	10
+SELECT 'THIRD QUERY:';
 THIRD QUERY:
+SELECT
+    extractAllGroups(NULL, 'worldworldworldwo\0ldworldworldworldwo\0ld'),
+    fact_2_id,
+    fact_3_id,
+    fact_4_id
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+        (sales_value),
+        (fact_1_id, fact_2_id),
+        ('wo\0ldworldwo\0ldworld'),
+        (fact_3_id, fact_4_id))
+ORDER BY
+    fact_1_id DESC NULLS LAST,
+    fact_1_id DESC NULLS FIRST,
+    fact_2_id ASC,
+    fact_3_id DESC NULLS FIRST,
+    fact_4_id ASC;
 \N	1	0	0
 \N	2	0	0
 \N	3	0	0
@@ -154,6 +200,11 @@ THIRD QUERY:
 \N	0	0	0
 \N	0	0	0
 \N	0	0	0
+SELECT fact_3_id
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS ((fact_3_id, fact_4_id))
+ORDER BY fact_3_id ASC;
 1
 2
 3
@@ -164,6 +215,24 @@ THIRD QUERY:
 8
 9
 10
+-- Following two queries were fuzzed
+SELECT 'w\0\0ldworldwo\0l\0world'
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+    ( fact_4_id),
+    ( NULL),
+    ( fact_3_id, fact_4_id))
+ORDER BY
+    NULL ASC,
+    NULL DESC NULLS FIRST,
+    fact_3_id ASC,
+    fact_3_id ASC NULLS LAST,
+    'wo\0ldworldwo\0ldworld' ASC NULLS LAST,
+    'w\0\0ldworldwo\0l\0world' DESC NULLS FIRST,
+    'wo\0ldworldwo\0ldworld' ASC,
+    NULL ASC NULLS FIRST,
+    fact_4_id DESC NULLS LAST;
 w\0\0ldworldwo\0l\0world
 w\0\0ldworldwo\0l\0world
 w\0\0ldworldwo\0l\0world
@@ -185,6 +254,15 @@ w\0\0ldworldwo\0l\0world
 w\0\0ldworldwo\0l\0world
 w\0\0ldworldwo\0l\0world
 w\0\0ldworldwo\0l\0world
+SELECT fact_3_id
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+    ( 'wo\0ldworldwo\0ldworldwo\0ldworldwo\0ldworldwo\0ldworldwo\0ldworldwo\0ldworldwo\0ldworld'),
+    ( NULL),
+    ( fact_4_id),
+    ( fact_3_id, fact_4_id))
+ORDER BY fact_3_id ASC NULLS FIRST;
 0
 0
 0

--- a/tests/queries/0_stateless/01883_grouping_sets_crash.reference
+++ b/tests/queries/0_stateless/01883_grouping_sets_crash.reference
@@ -285,3 +285,76 @@ ORDER BY fact_3_id ASC NULLS FIRST;
 8
 9
 10
+SELECT fact_3_id, fact_4_id, count()
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+    ( fact_3_id, fact_4_id))
+ORDER BY fact_3_id, fact_4_id
+SETTINGS optimize_aggregation_in_order=1;
+1	1	100
+2	2	100
+3	3	100
+4	4	100
+5	5	100
+6	6	100
+7	7	100
+8	8	100
+9	9	100
+10	10	100
+SELECT fact_3_id, fact_4_id, count()
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+    fact_3_id,
+    fact_4_id)
+ORDER BY fact_3_id, fact_4_id
+SETTINGS optimize_aggregation_in_order=1;
+0	1	100
+0	2	100
+0	3	100
+0	4	100
+0	5	100
+0	6	100
+0	7	100
+0	8	100
+0	9	100
+0	10	100
+1	0	100
+2	0	100
+3	0	100
+4	0	100
+5	0	100
+6	0	100
+7	0	100
+8	0	100
+9	0	100
+10	0	100
+SELECT fact_3_id, fact_4_id, count()
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+    ( fact_3_id ),
+    ( fact_3_id, fact_4_id))
+ORDER BY fact_3_id, fact_4_id
+SETTINGS optimize_aggregation_in_order=1;
+1	0	100
+1	1	100
+2	0	100
+2	2	100
+3	0	100
+3	3	100
+4	0	100
+4	4	100
+5	0	100
+5	5	100
+6	0	100
+6	6	100
+7	0	100
+7	7	100
+8	0	100
+8	8	100
+9	0	100
+9	9	100
+10	0	100
+10	10	100

--- a/tests/queries/0_stateless/01883_grouping_sets_crash.sql
+++ b/tests/queries/0_stateless/01883_grouping_sets_crash.sql
@@ -97,5 +97,31 @@ GROUP BY
     ( fact_3_id, fact_4_id))
 ORDER BY fact_3_id ASC NULLS FIRST;
 
+SELECT fact_3_id, fact_4_id, count()
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+    ( fact_3_id, fact_4_id))
+ORDER BY fact_3_id, fact_4_id
+SETTINGS optimize_aggregation_in_order=1;
+
+SELECT fact_3_id, fact_4_id, count()
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+    fact_3_id,
+    fact_4_id)
+ORDER BY fact_3_id, fact_4_id
+SETTINGS optimize_aggregation_in_order=1;
+
+SELECT fact_3_id, fact_4_id, count()
+FROM grouping_sets
+GROUP BY
+    GROUPING SETS (
+    ( fact_3_id ),
+    ( fact_3_id, fact_4_id))
+ORDER BY fact_3_id, fact_4_id
+SETTINGS optimize_aggregation_in_order=1;
+
 -- { echoOff }
 DROP TABLE IF EXISTS grouping_sets;

--- a/tests/queries/0_stateless/01883_grouping_sets_crash.sql
+++ b/tests/queries/0_stateless/01883_grouping_sets_crash.sql
@@ -11,6 +11,7 @@ SELECT
        number % 100 AS sales_value
 FROM system.numbers limit 1000;
 
+-- { echoOn }
 SELECT
     fact_3_id,
     fact_4_id
@@ -96,4 +97,5 @@ GROUP BY
     ( fact_3_id, fact_4_id))
 ORDER BY fact_3_id ASC NULLS FIRST;
 
+-- { echoOff }
 DROP TABLE IF EXISTS grouping_sets;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prohibit `optimize_aggregation_in_order` with `GROUPING SETS` (fixes `LOGICAL_ERROR`)

AggregatingStep ignores it anyway, and it leads to the following error
in getSortDescriptionFromGroupBy(), like in [1]:

    2022.05.24 04:29:29.279431 [ 3395 ] {26543564-8bc8-4a3a-b984-70a2adf0245d} <Fatal> : Logical error: 'Trying to get name of not a column: ExpressionList'.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/36914/67d3ac72d26ab74d69f03c03422349d4faae9e19/stateless_tests__ubsan__actions_.html

Fixes: #33631 (cc: @novikd )