### PR TITLE
Cleanup StorageHDFS (unused variables prevent build with clang 12)

### DIFF
--- a/src/Storages/HDFS/StorageHDFS.h
+++ b/src/Storages/HDFS/StorageHDFS.h
@@ -132,8 +132,6 @@ private:
     Block block_for_format;
     std::vector<NameAndTypePair> requested_virtual_columns;
     UInt64 max_block_size;
-    bool need_path_column;
-    bool need_file_column;
     std::shared_ptr<IteratorWrapper> file_iterator;
     ColumnsDescription columns_description;
 


### PR DESCRIPTION
**Changelog category:**
- Not for changelog (changelog entry is not required)

Unused private variables prevent build with clang 12.
Or use of them planned in future ?
