### PR TITLE
Proper wait of the clickhouse-server in tests

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -37,38 +37,13 @@ export FASTTEST_DATA
 export FASTTEST_OUT
 export PATH
 
-server_pid=none
-
-function stop_server
-{
-    if ! kill -0 -- "$server_pid"
-    then
-        echo "ClickHouse server pid '$server_pid' is not running"
-        return 0
-    fi
-
-    for _ in {1..60}
-    do
-        if ! pkill -f "clickhouse-server" && ! kill -- "$server_pid" ; then break ; fi
-        sleep 1
-    done
-
-    if kill -0 -- "$server_pid"
-    then
-        pstree -apgT
-        jobs
-        echo "Failed to kill the ClickHouse server pid '$server_pid'"
-        return 1
-    fi
-
-    server_pid=none
-}
-
 function start_server
 {
     set -m # Spawn server in its own process groups
+
     local opts=(
         --config-file "$FASTTEST_DATA/config.xml"
+        --pid-file "$FASTTEST_DATA/clickhouse-server.pid"
         --
         --path "$FASTTEST_DATA"
         --user_files_path "$FASTTEST_DATA/user_files"
@@ -76,40 +51,22 @@ function start_server
         --keeper_server.storage_path "$FASTTEST_DATA/coordination"
     )
     clickhouse-server "${opts[@]}" &>> "$FASTTEST_OUTPUT/server.log" &
-    server_pid=$!
     set +m
 
-    if [ "$server_pid" == "0" ]
-    then
-        echo "Failed to start ClickHouse server"
-        # Avoid zero PID because `kill` treats it as our process group PID.
-        server_pid="none"
-        return 1
-    fi
-
-    for _ in {1..60}
-    do
-        if clickhouse-client --query "select 1" || ! kill -0 -- "$server_pid"
-        then
+    for _ in {1..60}; do
+        if clickhouse-client --query "select 1"; then
             break
         fi
         sleep 1
     done
 
-    if ! clickhouse-client --query "select 1"
-    then
+    if ! clickhouse-client --query "select 1"; then
         echo "Failed to wait until ClickHouse server starts."
-        server_pid="none"
         return 1
     fi
 
-    if ! kill -0 -- "$server_pid"
-    then
-        echo "Wrong clickhouse server started: PID '$server_pid' we started is not running, but '$(pgrep -f clickhouse-server)' is running"
-        server_pid="none"
-        return 1
-    fi
-
+    local server_pid
+    server_pid="$(cat "$FASTTEST_DATA/clickhouse-server.pid")"
     echo "ClickHouse server pid '$server_pid' started and responded"
 }
 
@@ -254,9 +211,6 @@ function run_tests
     clickhouse-server --version
     clickhouse-test --help
 
-    # Kill the server in case we are running locally and not in docker
-    stop_server ||:
-
     start_server
 
     set +e
@@ -284,6 +238,8 @@ function run_tests
         | ts '%Y-%m-%d %H:%M:%S' \
         | tee "$FASTTEST_OUTPUT/test_result.txt"
     set -e
+
+    clickhouse stop --pid-path "$FASTTEST_DATA"
 }
 
 case "$stage" in

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -125,16 +125,7 @@ function filter_exists_and_template
 function stop_server
 {
     clickhouse-client --query "select elapsed, query from system.processes" ||:
-    killall clickhouse-server ||:
-    for _ in {1..10}
-    do
-        if ! pgrep -f clickhouse-server
-        then
-            break
-        fi
-        sleep 1
-    done
-    killall -9 clickhouse-server ||:
+    clickhouse stop
 
     # Debug.
     date
@@ -159,10 +150,12 @@ function fuzz
         NEW_TESTS_OPT="${NEW_TESTS_OPT:-}"
     fi
 
+    mkdir -p /var/run/clickhouse-server
+
     # interferes with gdb
     export CLICKHOUSE_WATCHDOG_ENABLE=0
     # NOTE: we use process substitution here to preserve keep $! as a pid of clickhouse-server
-    clickhouse-server --config-file db/config.xml -- --path db > >(tail -100000 > server.log) 2>&1 &
+    clickhouse-server --config-file db/config.xml --pid-file /var/run/clickhouse-server/clickhouse-server.pid -- --path db > >(tail -100000 > server.log) 2>&1 &
     server_pid=$!
 
     kill -0 $server_pid

--- a/docker/test/sqlancer/run.sh
+++ b/docker/test/sqlancer/run.sh
@@ -21,7 +21,7 @@ export NUM_QUERIES=1000
 ( java -jar target/sqlancer-*.jar --num-threads 10 --timeout-seconds $TIMEOUT --num-queries $NUM_QUERIES  --username default --password "" clickhouse --oracle TLPDistinct | tee /test_output/TLPDistinct.out )  3>&1 1>&2 2>&3 | tee /test_output/TLPDistinct.err
 ( java -jar target/sqlancer-*.jar --num-threads 10 --timeout-seconds $TIMEOUT --num-queries $NUM_QUERIES  --username default --password "" clickhouse --oracle TLPAggregate | tee /test_output/TLPAggregate.out )  3>&1 1>&2 2>&3 | tee /test_output/TLPAggregate.err
 
-service clickhouse-server stop && sleep 10
+service clickhouse stop
 
 ls /var/log/clickhouse-server/
 tar czf /test_output/logs.tar.gz -C /var/log/clickhouse-server/ .

--- a/docker/test/stateful/run.sh
+++ b/docker/test/stateful/run.sh
@@ -22,17 +22,23 @@ ln -s /usr/share/clickhouse-test/clickhouse-test /usr/bin/clickhouse-test
 function start()
 {
     if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then
+        mkdir -p /var/run/clickhouse-server1
+        sudo chown clickhouse:clickhouse /var/run/clickhouse-server1
         # NOTE We run "clickhouse server" instead of "clickhouse-server"
         # to make "pidof clickhouse-server" return single pid of the main instance.
         # We wil run main instance using "service clickhouse-server start"
         sudo -E -u clickhouse /usr/bin/clickhouse server --config /etc/clickhouse-server1/config.xml --daemon \
+        --pid-file /var/run/clickhouse-server1/clickhouse-server.pid \
         -- --path /var/lib/clickhouse1/ --logger.stderr /var/log/clickhouse-server/stderr1.log \
         --logger.log /var/log/clickhouse-server/clickhouse-server1.log --logger.errorlog /var/log/clickhouse-server/clickhouse-server1.err.log \
         --tcp_port 19000 --tcp_port_secure 19440 --http_port 18123 --https_port 18443 --interserver_http_port 19009 --tcp_with_proxy_port 19010 \
         --mysql_port 19004 --postgresql_port 19005 \
         --keeper_server.tcp_port 19181 --keeper_server.server_id 2
 
+        mkdir -p /var/run/clickhouse-server2
+        sudo chown clickhouse:clickhouse /var/run/clickhouse-server2
         sudo -E -u clickhouse /usr/bin/clickhouse server --config /etc/clickhouse-server2/config.xml --daemon \
+        --pid-file /var/run/clickhouse-server2/clickhouse-server.pid \
         -- --path /var/lib/clickhouse2/ --logger.stderr /var/log/clickhouse-server/stderr2.log \
         --logger.log /var/log/clickhouse-server/clickhouse-server2.log --logger.errorlog /var/log/clickhouse-server/clickhouse-server2.err.log \
         --tcp_port 29000 --tcp_port_secure 29440 --http_port 28123 --https_port 28443 --interserver_http_port 29009 --tcp_with_proxy_port 29010 \
@@ -134,6 +140,12 @@ echo "Files in root directory"
 ls -la /
 
 /process_functional_tests_result.py || echo -e "failure\tCannot parse results" > /test_output/check_status.tsv
+
+sudo clickhouse stop ||:
+if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then
+    sudo clickhouse stop --pid-path /var/run/clickhouse-server1 ||:
+    sudo clickhouse stop --pid-path /var/run/clickhouse-server2 ||:
+fi
 
 grep -Fa "Fatal" /var/log/clickhouse-server/clickhouse-server.log ||:
 

--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -40,15 +40,18 @@ if [ "$NUM_TRIES" -gt "1" ]; then
     export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_TIME_US=10000
     export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_TIME_US=10000
 
+    mkdir -p /var/run/clickhouse-server
     # simpliest way to forward env variables to server
-    sudo -E -u clickhouse /usr/bin/clickhouse-server --config /etc/clickhouse-server/config.xml --daemon
+    sudo -E -u clickhouse /usr/bin/clickhouse-server --config /etc/clickhouse-server/config.xml --daemon --pid-file /var/run/clickhouse-server/clickhouse-server.pid
 else
     sudo clickhouse start
 fi
 
 if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then
-
+    mkdir -p /var/run/clickhouse-server1
+    sudo chown clickhouse:clickhouse /var/run/clickhouse-server1
     sudo -E -u clickhouse /usr/bin/clickhouse server --config /etc/clickhouse-server1/config.xml --daemon \
+    --pid-file /var/run/clickhouse-server1/clickhouse-server.pid \
     -- --path /var/lib/clickhouse1/ --logger.stderr /var/log/clickhouse-server/stderr1.log \
     --logger.log /var/log/clickhouse-server/clickhouse-server1.log --logger.errorlog /var/log/clickhouse-server/clickhouse-server1.err.log \
     --tcp_port 19000 --tcp_port_secure 19440 --http_port 18123 --https_port 18443 --interserver_http_port 19009 --tcp_with_proxy_port 19010 \
@@ -56,7 +59,10 @@ if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]
     --keeper_server.tcp_port 19181 --keeper_server.server_id 2 \
     --macros.replica r2   # It doesn't work :(
 
+    mkdir -p /var/run/clickhouse-server2
+    sudo chown clickhouse:clickhouse /var/run/clickhouse-server2
     sudo -E -u clickhouse /usr/bin/clickhouse server --config /etc/clickhouse-server2/config.xml --daemon \
+    --pid-file /var/run/clickhouse-server2/clickhouse-server.pid \
     -- --path /var/lib/clickhouse2/ --logger.stderr /var/log/clickhouse-server/stderr2.log \
     --logger.log /var/log/clickhouse-server/clickhouse-server2.log --logger.errorlog /var/log/clickhouse-server/clickhouse-server2.err.log \
     --tcp_port 29000 --tcp_port_secure 29440 --http_port 28123 --https_port 28443 --interserver_http_port 29009 --tcp_with_proxy_port 29010 \
@@ -134,18 +140,10 @@ clickhouse-client -q "system flush logs" ||:
 # Stop server so we can safely read data with clickhouse-local.
 # Why do we read data with clickhouse-local?
 # Because it's the simplest way to read it when server has crashed.
-if [ "$NUM_TRIES" -gt "1" ]; then
-    clickhouse-client -q "system shutdown" ||:
-    sleep 10
-else
-    sudo clickhouse stop ||:
-fi
-
-
+sudo clickhouse stop ||:
 if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then
-    clickhouse-client --port 19000 -q "system shutdown" ||:
-    clickhouse-client --port 29000 -q "system shutdown" ||:
-    sleep 10
+    sudo clickhouse stop --pid-path /var/run/clickhouse-server1 ||:
+    sudo clickhouse stop --pid-path /var/run/clickhouse-server2 ||:
 fi
 
 grep -Fa "Fatal" /var/log/clickhouse-server/clickhouse-server.log ||:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- tests/fasttest: simplify waiting of the server
- tests/sqlancer: remove superior wait of the server stop
- tests/stateful: properly wait the server
- tests/fuzzer: use "clickhouse stop" to stop the server
- tests/stateless: properly wait for server (fixes #36885, cc @tavplubix )