### PR TITLE
Do not write expired columns by TTL after subsequent merges

### DIFF
--- a/src/Processors/TTL/TTLAggregationAlgorithm.cpp
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.cpp
@@ -39,7 +39,7 @@ TTLAggregationAlgorithm::TTLAggregationAlgorithm(
     aggregator = std::make_unique<Aggregator>(params);
 
     if (isMaxTTLExpired())
-        new_ttl_info.finished = true;
+        new_ttl_info.ttl_finished = true;
 }
 
 void TTLAggregationAlgorithm::execute(Block & block)

--- a/src/Processors/TTL/TTLColumnAlgorithm.cpp
+++ b/src/Processors/TTL/TTLColumnAlgorithm.cpp
@@ -25,7 +25,7 @@ TTLColumnAlgorithm::TTLColumnAlgorithm(
     }
 
     if (isMaxTTLExpired())
-        new_ttl_info.finished = true;
+        new_ttl_info.ttl_finished = true;
 }
 
 void TTLColumnAlgorithm::execute(Block & block)

--- a/src/Processors/TTL/TTLDeleteAlgorithm.cpp
+++ b/src/Processors/TTL/TTLDeleteAlgorithm.cpp
@@ -11,7 +11,7 @@ TTLDeleteAlgorithm::TTLDeleteAlgorithm(
         new_ttl_info = old_ttl_info;
 
     if (isMaxTTLExpired())
-        new_ttl_info.finished = true;
+        new_ttl_info.ttl_finished = true;
 }
 
 void TTLDeleteAlgorithm::execute(Block & block)

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
@@ -34,20 +34,7 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
     SerializationInfoByName & serialization_infos,
     MergeTreeData::DataPart::Checksums & checksums)
 {
-    NameSet empty_columns = data_part->expired_columns;
-
-    /// Skip fully expired columns manually, since TTLTransform not always applied.
-    /// (and only it, via TTLColumnAlgorithm, fills expired_columns)
-    for (auto & [column, ttl] : data_part->ttl_infos.columns_ttl)
-    {
-        if (empty_columns.contains(column))
-            continue;
-        if (!ttl.finished())
-            continue;
-
-        empty_columns.insert(column);
-        LOG_TRACE(storage.log, "Adding expired column {} for {} (from column TTL)", column, data_part->name);
-    }
+    const NameSet & empty_columns = data_part->expired_columns;
 
     /// For compact part we have to override whole file with data, it's not
     /// worth it

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
@@ -34,7 +34,20 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
     SerializationInfoByName & serialization_infos,
     MergeTreeData::DataPart::Checksums & checksums)
 {
-    const NameSet & empty_columns = data_part->expired_columns;
+    NameSet empty_columns = data_part->expired_columns;
+
+    /// Skip fully expired columns manually, since TTLTransform not always applied.
+    /// (and only it, via TTLColumnAlgorithm, fills expired_columns)
+    for (auto & [column, ttl] : data_part->ttl_infos.columns_ttl)
+    {
+        if (empty_columns.contains(column))
+            continue;
+        if (!ttl.finished())
+            continue;
+
+        empty_columns.insert(column);
+        LOG_TRACE(storage.log, "Adding expired column {} for {} (from column TTL)", column, data_part->name);
+    }
 
     /// For compact part we have to override whole file with data, it's not
     /// worth it

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
@@ -42,7 +42,7 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
         return {};
 
     for (const auto & column : empty_columns)
-        LOG_TRACE(storage.log, "Skipping expired/empty column {} for {}", column, data_part->name);
+        LOG_TRACE(storage.log, "Skipping expired/empty column {} for part {}", column, data_part->name);
 
     /// Collect counts for shared streams of different columns. As an example, Nested columns have shared stream with array sizes.
     std::map<String, size_t> stream_counts;

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
@@ -41,6 +41,9 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
     if (empty_columns.empty() || isCompactPart(data_part))
         return {};
 
+    for (const auto & column : empty_columns)
+        LOG_TRACE(storage.log, "Skipping expired/empty column {} for {}", column, data_part->name);
+
     /// Collect counts for shared streams of different columns. As an example, Nested columns have shared stream with array sizes.
     std::map<String, size_t> stream_counts;
     for (const auto & column : columns)

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.h
@@ -35,7 +35,7 @@ protected:
 
     /// Remove all columns marked expired in data_part. Also, clears checksums
     /// and columns array. Return set of removed files names.
-    static NameSet removeEmptyColumnsFromPart(
+    NameSet removeEmptyColumnsFromPart(
         const MergeTreeDataPartPtr & data_part,
         NamesAndTypesList & columns,
         SerializationInfoByName & serialization_infos,

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -274,7 +274,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare()
             if (ttl.finished())
             {
                 global_ctx->new_data_part->expired_columns.insert(column_name);
-                LOG_TRACE(ctx->log, "Adding expired column {} for {}", column_name, global_ctx->new_data_part->name);
+                LOG_TRACE(ctx->log, "Adding expired column {} for part {}", column_name, global_ctx->new_data_part->name);
                 std::erase(global_ctx->gathering_column_names, column_name);
                 std::erase(global_ctx->merging_column_names, column_name);
                 ++expired_columns;

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -248,11 +248,45 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare()
             throw Exception("Merge algorithm must be chosen", ErrorCodes::LOGICAL_ERROR);
     }
 
+    assert(global_ctx->gathering_columns.size() == global_ctx->gathering_column_names.size());
+    assert(global_ctx->merging_columns.size() == global_ctx->merging_column_names.size());
+
     /// If merge is vertical we cannot calculate it
     ctx->blocks_are_granules_size = (global_ctx->chosen_merge_algorithm == MergeAlgorithm::Vertical);
 
     /// Merged stream will be created and available as merged_stream variable
     createMergedStream();
+
+    /// Skip fully expired columns manually, since in case of
+    /// need_remove_expired_values is not set, TTLTransform will not be used,
+    /// and columns that had been removed by TTL (via TTLColumnAlgorithm) will
+    /// be added again with default values.
+    ///
+    /// Also note, that it is better to do this here, since in other places it
+    /// will be too late (i.e. they will be written, and we will burn CPU/disk
+    /// resources for this).
+    if (!ctx->need_remove_expired_values)
+    {
+        size_t expired_columns = 0;
+
+        for (auto & [column_name, ttl] : global_ctx->new_data_part->ttl_infos.columns_ttl)
+        {
+            if (ttl.finished())
+            {
+                global_ctx->new_data_part->expired_columns.insert(column_name);
+                LOG_TRACE(ctx->log, "Adding expired column {} for {}", column_name, global_ctx->new_data_part->name);
+                std::erase(global_ctx->gathering_column_names, column_name);
+                std::erase(global_ctx->merging_column_names, column_name);
+                ++expired_columns;
+            }
+        }
+
+        if (expired_columns)
+        {
+            global_ctx->gathering_columns = global_ctx->gathering_columns.filter(global_ctx->gathering_column_names);
+            global_ctx->merging_columns = global_ctx->merging_columns.filter(global_ctx->merging_column_names);
+        }
+    }
 
     global_ctx->to = std::make_shared<MergedBlockOutputStream>(
         global_ctx->new_data_part,

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -200,20 +200,6 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare()
         ctx->need_remove_expired_values = false;
     }
 
-    /// Skip fully expired columns manually, since in case of need_remove_expired_values is not set,
-    /// TTLTransform will not be used, and columns that had been removed by TTL will be added again with default values.
-    if (!ctx->need_remove_expired_values)
-    {
-        for (auto & [column_name, ttl] : global_ctx->new_data_part->ttl_infos.columns_ttl)
-        {
-            if (ttl.finished())
-            {
-                global_ctx->new_data_part->expired_columns.insert(column_name);
-                LOG_TRACE(ctx->log, "Adding expired column {} for {}", column_name, global_ctx->new_data_part->name);
-            }
-        }
-    }
-
     ctx->sum_input_rows_upper_bound = global_ctx->merge_list_element_ptr->total_rows_count;
     ctx->sum_compressed_bytes_upper_bound = global_ctx->merge_list_element_ptr->total_size_bytes_compressed;
     global_ctx->chosen_merge_algorithm = chooseMergeAlgorithm();

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -996,6 +996,7 @@ protected:
     friend class MergeTreeDataWriter;
     friend class MergeTask;
     friend class IPartMetadataManager;
+    friend class IMergedBlockOutputStream; // for access to log
 
     bool require_part_metadata;
 

--- a/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.cpp
@@ -9,6 +9,26 @@
 namespace DB
 {
 
+void MergeTreeDataPartTTLInfo::update(time_t time)
+{
+    if (time && (!min || time < min))
+        min = time;
+
+    max = std::max(time, max);
+}
+
+void MergeTreeDataPartTTLInfo::update(const MergeTreeDataPartTTLInfo & other_info)
+{
+    if (other_info.min && (!min || other_info.min < min))
+        min = other_info.min;
+
+    max = std::max(other_info.max, max);
+    if (ttl_finished.has_value())
+        ttl_finished = ttl_finished.value() & other_info.finished();
+    else
+        ttl_finished = other_info.finished();
+}
+
 void MergeTreeDataPartTTLInfos::update(const MergeTreeDataPartTTLInfos & other_infos)
 {
     for (const auto & [name, ttl_info] : other_infos.columns_ttl)
@@ -57,7 +77,7 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
             ttl_info.max = col["max"].getUInt();
 
             if (col.has("finished"))
-                ttl_info.finished = col["finished"].getUInt();
+                ttl_info.ttl_finished = col["finished"].getUInt();
 
             String name = col["name"].getString();
             columns_ttl.emplace(name, ttl_info);
@@ -72,7 +92,7 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
         table_ttl.max = table["max"].getUInt();
 
         if (table.has("finished"))
-            table_ttl.finished = table["finished"].getUInt();
+            table_ttl.ttl_finished = table["finished"].getUInt();
 
         updatePartMinMaxTTL(table_ttl.min, table_ttl.max);
     }
@@ -86,7 +106,7 @@ void MergeTreeDataPartTTLInfos::read(ReadBuffer & in)
             ttl_info.max = elem["max"].getUInt();
 
             if (elem.has("finished"))
-                ttl_info.finished = elem["finished"].getUInt();
+                ttl_info.ttl_finished = elem["finished"].getUInt();
 
             String expression = elem["expression"].getString();
             ttl_info_map.emplace(expression, ttl_info);
@@ -138,7 +158,7 @@ void MergeTreeDataPartTTLInfos::write(WriteBuffer & out) const
             writeString(",\"max\":", out);
             writeIntText(it->second.max, out);
             writeString(R"(,"finished":)", out);
-            writeIntText(static_cast<uint8_t>(it->second.finished), out);
+            writeIntText(static_cast<uint8_t>(it->second.finished()), out);
             writeString("}", out);
         }
         writeString("]", out);
@@ -152,7 +172,7 @@ void MergeTreeDataPartTTLInfos::write(WriteBuffer & out) const
         writeString(R"(,"max":)", out);
         writeIntText(table_ttl.max, out);
         writeString(R"(,"finished":)", out);
-        writeIntText(static_cast<uint8_t>(table_ttl.finished), out);
+        writeIntText(static_cast<uint8_t>(table_ttl.finished()), out);
         writeString("}", out);
     }
 
@@ -175,7 +195,7 @@ void MergeTreeDataPartTTLInfos::write(WriteBuffer & out) const
             writeString(R"(,"max":)", out);
             writeIntText(it->second.max, out);
             writeString(R"(,"finished":)", out);
-            writeIntText(static_cast<uint8_t>(it->second.finished), out);
+            writeIntText(static_cast<uint8_t>(it->second.finished()), out);
             writeString("}", out);
         }
         writeString("]", out);
@@ -225,13 +245,13 @@ bool MergeTreeDataPartTTLInfos::hasAnyNonFinishedTTLs() const
     {
         for (const auto & [name, info] : map)
         {
-            if (!info.finished)
+            if (!info.finished())
                 return true;
         }
         return false;
     };
 
-    if (!table_ttl.finished)
+    if (!table_ttl.finished())
         return true;
 
     if (has_non_finished_ttl(columns_ttl))

--- a/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartTTLInfo.h
@@ -4,6 +4,7 @@
 #include <Storages/TTLDescription.h>
 
 #include <map>
+#include <optional>
 
 namespace DB
 {
@@ -17,24 +18,11 @@ struct MergeTreeDataPartTTLInfo
     /// This TTL was computed on completely expired part. It doesn't make sense
     /// to select such parts for TTL again. But make sense to recalcuate TTL
     /// again for merge with multiple parts.
-    bool finished = false;
+    std::optional<bool> ttl_finished;
+    bool finished() const { return ttl_finished.value_or(false); }
 
-    void update(time_t time)
-    {
-        if (time && (!min || time < min))
-            min = time;
-
-        max = std::max(time, max);
-    }
-
-    void update(const MergeTreeDataPartTTLInfo & other_info)
-    {
-        if (other_info.min && (!min || other_info.min < min))
-            min = other_info.min;
-
-        max = std::max(other_info.max, max);
-        finished &= other_info.finished;
-    }
+    void update(time_t time);
+    void update(const MergeTreeDataPartTTLInfo & other_info);
 };
 
 /// Order is important as it would be serialized and hashed for checksums

--- a/tests/queries/0_stateless/02335_column_ttl_expired_column_optimization.sh
+++ b/tests/queries/0_stateless/02335_column_ttl_expired_column_optimization.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_LOCAL --path "$CLICKHOUSE_TEST_UNIQUE_NAME" -nm -q "
+    create table ttl_02335 (
+        date Date,
+        key Int,
+        value String TTL date + interval 1 month
+    )
+    engine=MergeTree
+    order by key
+    settings
+        min_bytes_for_wide_part=0,
+        min_rows_for_wide_part=0;
+
+    -- all_1_1_0
+    -- all_1_1_1
+    insert into ttl_02335 values ('2010-01-01', 2010, 'foo');
+    -- all_1_1_2
+    optimize table ttl_02335 final;
+    -- all_1_1_3
+    optimize table ttl_02335 final;
+"
+
+test -f "$CLICKHOUSE_TEST_UNIQUE_NAME"/data/_local/ttl_02335/all_1_1_3/value.bin && echo "[FAIL] value column should not exist"
+exit 0


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not write expired columns by TTL after subsequent merges (before only first merge/optimize of the part will not write expired by TTL columns, all other will do)

Usually second merge do not perform TTL, since everything is up to date,
however in this case TTLTransform is not used, and hence expired_columns
will not be filled for new part, and so those columns will be written
with default values.

You will find reproducer in `details` (and in the test):

<details>

```sql
create table ttl_02262 (date Date, key Int, value String TTL date + interval 1 month) engine=MergeTree order by key settings min_bytes_for_wide_part=0, min_rows_for_wide_part=0;
insert into ttl_02262 values ('2010-01-01', 2010, 'foo');
```

```sh
# ls -l .server/data/default/ttl_02262/all_*
.server/data/default/ttl_02262/all_1_1_0:
total 48
-rw-r----- 1 root root 335 May 26 14:19 checksums.txt
-rw-r----- 1 root root  76 May 26 14:19 columns.txt
-rw-r----- 1 root root   1 May 26 14:19 count.txt
-rw-r----- 1 root root  28 May 26 14:19 date.bin
-rw-r----- 1 root root  48 May 26 14:19 date.mrk2
-rw-r----- 1 root root  10 May 26 14:19 default_compression_codec.txt
-rw-r----- 1 root root  30 May 26 14:19 key.bin
-rw-r----- 1 root root  48 May 26 14:19 key.mrk2
-rw-r----- 1 root root   8 May 26 14:19 primary.idx
-rw-r----- 1 root root  99 May 26 14:19 ttl.txt
-rw-r----- 1 root root  30 May 26 14:19 value.bin
-rw-r----- 1 root root  48 May 26 14:19 value.mrk2
```

```sql
optimize table ttl_02262 final;
```

```sh
.server/data/default/ttl_02262/all_1_1_1:
total 40
-rw-r----- 1 root root 279 May 26 14:19 checksums.txt
-rw-r----- 1 root root  61 May 26 14:19 columns.txt
-rw-r----- 1 root root   1 May 26 14:19 count.txt
-rw-r----- 1 root root  28 May 26 14:19 date.bin
-rw-r----- 1 root root  48 May 26 14:19 date.mrk2
-rw-r----- 1 root root  10 May 26 14:19 default_compression_codec.txt
-rw-r----- 1 root root  30 May 26 14:19 key.bin
-rw-r----- 1 root root  48 May 26 14:19 key.mrk2
-rw-r----- 1 root root   8 May 26 14:19 primary.idx
-rw-r----- 1 root root  81 May 26 14:19 ttl.txt
```

```sql
optimize table ttl_02262 final;
```

```sh
.server/data/default/ttl_02262/all_1_1_2:
total 48
-rw-r----- 1 root root 349 May 26 14:20 checksums.txt
-rw-r----- 1 root root  76 May 26 14:20 columns.txt
-rw-r----- 1 root root   1 May 26 14:20 count.txt
-rw-r----- 1 root root  28 May 26 14:20 date.bin
-rw-r----- 1 root root  48 May 26 14:20 date.mrk2
-rw-r----- 1 root root  10 May 26 14:20 default_compression_codec.txt
-rw-r----- 1 root root  30 May 26 14:20 key.bin
-rw-r----- 1 root root  48 May 26 14:20 key.mrk2
-rw-r----- 1 root root   8 May 26 14:20 primary.idx
-rw-r----- 1 root root  81 May 26 14:20 ttl.txt
-rw-r----- 1 root root  27 May 26 14:20 value.bin
-rw-r----- 1 root root  48 May 26 14:20 value.mrk2
```

And now we have `value.*` for all_1_1_2, this should not happen.

</details>

Cc: @CurtizJ 