### PR TITLE
Remove unused MergeTreeDataMergerMutator::chooseMergeAlgorithm()

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -154,15 +154,6 @@ public :
     ActionBlocker ttl_merges_blocker;
 
 private:
-
-    MergeAlgorithm chooseMergeAlgorithm(
-        const MergeTreeData::DataPartsVector & parts,
-        size_t rows_upper_bound,
-        const NamesAndTypesList & gathering_columns,
-        bool deduplicate,
-        bool need_remove_expired_values,
-        const MergeTreeData::MergingParams & merging_params) const;
-
     MergeTreeData & data;
     const size_t max_tasks_count;
 


### PR DESCRIPTION
In favor of
`MergeTask::ExecuteAndFinalizeHorizontalPart::chooseMergeAlgorithm()`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #25165 (cc @nikitamikhaylov )