### PR TITLE
add avx512 support for mergetree reader

### DIFF
--- a/src/Common/CpuId.h
+++ b/src/Common/CpuId.h
@@ -221,7 +221,7 @@ bool haveAVX512F() noexcept
            && (our_xgetbv(0) & 6u) == 6u              // XMM state and YMM state are enabled by OS
            && ((our_xgetbv(0) >> 5) & 7u) == 7u       // ZMM state is enabled by OS
            && CpuInfo(0x0).registers.eax >= 0x7          // leaf 7 is present
-           && ((CpuInfo(0x7).registers.ebx >> 16) & 1u); // AVX512F bit
+           && ((CpuInfo(0x7, 0).registers.ebx >> 16) & 1u); // AVX512F bit
 #else
     return false;
 #endif

--- a/src/Common/TargetSpecific.cpp
+++ b/src/Common/TargetSpecific.cpp
@@ -17,7 +17,7 @@ UInt32 getSupportedArchs()
     if (Cpu::CpuFlagsCache::have_AVX512F)
         result |= static_cast<UInt32>(TargetArch::AVX512F);
     if (Cpu::CpuFlagsCache::have_AVX512BW)
-        result |= static_cast<UInt32>(TargetArch::AVX512BW);        
+        result |= static_cast<UInt32>(TargetArch::AVX512BW);
     return result;
 }
 

--- a/src/Common/TargetSpecific.cpp
+++ b/src/Common/TargetSpecific.cpp
@@ -16,6 +16,8 @@ UInt32 getSupportedArchs()
         result |= static_cast<UInt32>(TargetArch::AVX2);
     if (Cpu::CpuFlagsCache::have_AVX512F)
         result |= static_cast<UInt32>(TargetArch::AVX512F);
+    if (Cpu::CpuFlagsCache::have_AVX512BW)
+        result |= static_cast<UInt32>(TargetArch::AVX512BW);        
     return result;
 }
 
@@ -34,6 +36,7 @@ String toString(TargetArch arch)
         case TargetArch::AVX:     return "avx";
         case TargetArch::AVX2:    return "avx2";
         case TargetArch::AVX512F: return "avx512f";
+        case TargetArch::AVX512BW: return "avx512bw";
     }
 
     __builtin_unreachable();

--- a/src/Common/TargetSpecific.h
+++ b/src/Common/TargetSpecific.h
@@ -80,6 +80,7 @@ enum class TargetArch : UInt32
     AVX      = (1 << 1),
     AVX2     = (1 << 2),
     AVX512F  = (1 << 3),
+    AVX512BW  = (1 << 4),
 };
 
 /// Runtime detection.

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -452,7 +452,8 @@ size_t MergeTreeRangeReader::ReadResult::numZerosInTail(const UInt8 * begin, con
     size_t count = 0;
 
 #if defined(__AVX512F__) && defined(__AVX512BW__) /// check if avx512 instructions are compiled
-    if (isArchSupported(TargetArch::AVX512BW)) {
+    if (isArchSupported(TargetArch::AVX512BW))
+    {
         /// check if cpu support avx512 dynamically, haveAVX512BW contains check of haveAVX512F
         const __m512i zero64 = _mm512_setzero_epi32();
         while (end - begin >= 64)
@@ -461,10 +462,9 @@ size_t MergeTreeRangeReader::ReadResult::numZerosInTail(const UInt8 * begin, con
             const auto * pos = end;
             UInt64 val = static_cast<UInt64>(_mm512_cmp_epi8_mask(_mm512_loadu_si512(reinterpret_cast<const __m512i *>(pos)), zero64, _MM_CMPINT_EQ));
             val = ~val;
-            if (val == 0) 
-            {
+            if (val == 0)
                 count += 64;
-            } else 
+            else
             {
                 count += __builtin_clzll(val);
                 return count;

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -2,6 +2,7 @@
 #include <Columns/FilterDescription.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnsCommon.h>
+#include <Common/TargetSpecific.h>
 #include <base/range.h>
 #include <Interpreters/castColumn.h>
 #include <DataTypes/DataTypeNothing.h>
@@ -9,6 +10,7 @@
 #ifdef __SSE2__
 #include <emmintrin.h>
 #endif
+
 
 namespace DB
 {
@@ -448,6 +450,33 @@ void MergeTreeRangeReader::ReadResult::collapseZeroTails(const IColumn::Filter &
 size_t MergeTreeRangeReader::ReadResult::numZerosInTail(const UInt8 * begin, const UInt8 * end)
 {
     size_t count = 0;
+
+#if defined(__AVX512F__) && defined(__AVX512BW__) /// check if avx512 instructions are compiled
+    if (isArchSupported(TargetArch::AVX512BW)) {
+        /// check if cpu support avx512 dynamically, haveAVX512BW contains check of haveAVX512F
+        const __m512i zero64 = _mm512_setzero_epi32();
+        while (end - begin >= 64)
+        {
+            end -= 64;
+            const auto * pos = end;
+            UInt64 val = static_cast<UInt64>(_mm512_cmp_epi8_mask(_mm512_loadu_si512(reinterpret_cast<const __m512i *>(pos)), zero64, _MM_CMPINT_EQ));
+            val = ~val;
+            if (val == 0) 
+            {
+                count += 64;
+            } else 
+            {
+                count += __builtin_clzll(val);
+                return count;
+            }
+        }
+        while (end > begin && *(--end) == 0)
+        {
+            ++count;
+        }
+        return count;
+    }
+#endif
 
 #if defined(__SSE2__) && defined(__POPCNT__)
     const __m128i zero16 = _mm_setzero_si128();


### PR DESCRIPTION
 Changelog category (leave one):
- Performance Improvement

 Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve filter bitmask generator function all in one with avx512 instructions

Detailed description / Documentation draft:
It will optimize IO and shrink columns in where clause when there are zero in column tails.

We suppose a 30% improvement approximately in instruction level  and 0~10% improvement approximately in QPS on Intel platforms that support AVX512. The QPS improvement depend on how much zero values in filter column.

On Intel platform such as IceLake that support AVX512, you can generate data with ssb-dbgen(git@github.com:vadimtk/ssb-dbgen.git) that the Start Schema Benchmark use. Then compare query a table with where clauses, for example:
SELECT count(LO_SHIPPRIORITY)  FROM lineorder_flat  WHERE toYYYYMM(LO_ORDERDATE) = 199401 and LO_SHIPPRIORITY <0;





> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
