### PR TITLE
Use Jepsen worklow directly in PR workflow

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -7,11 +7,8 @@ concurrency:
 on: # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 */6 * * *'
-  workflow_run:
-    workflows: ["PullRequestCI"]
-    types:
-      - completed
   workflow_dispatch:
+  workflow_call:
 jobs:
   KeeperJepsenRelease:
     runs-on: [self-hosted, style-checker]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -298,7 +298,7 @@ jobs:
           docker rm -f $(docker ps -a -q) ||:
           sudo rm -fr "$TEMP_PATH"
   BuilderBinRelease:
-    needs: [DockerHubPush]
+    needs: [DockerHubPush, FastTest]
     runs-on: [self-hosted, builder]
     steps:
       - name: Set envs
@@ -3276,8 +3276,8 @@ jobs:
 ###################################### JEPSEN TESTS #########################################
 #############################################################################################
   Jepsen:
-      needs: [BuilderBinRelease]
-      uses: ./.github/workflows/jepsen.yml
+    needs: [BuilderBinRelease]
+    uses: ./.github/workflows/jepsen.yml  # yamllint disable-line
 
   FinishCheck:
     needs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3272,6 +3272,13 @@ jobs:
           # shellcheck disable=SC2046
           docker rm -f $(docker ps -a -q) ||:
           sudo rm -fr "$TEMP_PATH"
+#############################################################################################
+###################################### JEPSEN TESTS #########################################
+#############################################################################################
+  Jepsen:
+      needs: [BuilderBinRelease]
+      uses: ./.github/workflows/jepsen.yml
+
   FinishCheck:
     needs:
       - StyleCheck
@@ -3336,6 +3343,7 @@ jobs:
       - SplitBuildSmokeTest
       - CompatibilityCheck
       - IntegrationTestsFlakyCheck
+      - Jepsen
     runs-on: [self-hosted, style-checker]
     steps:
       - name: Clear repository

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -298,7 +298,7 @@ jobs:
           docker rm -f $(docker ps -a -q) ||:
           sudo rm -fr "$TEMP_PATH"
   BuilderBinRelease:
-    needs: [DockerHubPush, FastTest]
+    needs: [DockerHubPush]
     runs-on: [self-hosted, builder]
     steps:
       - name: Set envs

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3277,7 +3277,7 @@ jobs:
 #############################################################################################
   Jepsen:
     needs: [BuilderBinRelease]
-    uses: ./.github/workflows/jepsen.yml  # yamllint disable-line
+    uses: ./.github/workflows/jepsen.yml
 
   FinishCheck:
     needs:

--- a/utils/check-style/check-workflows
+++ b/utils/check-style/check-workflows
@@ -6,4 +6,4 @@ GIT_ROOT=$(git rev-parse --show-cdup)
 GIT_ROOT=${GIT_ROOT:-.}
 act --list --directory="$GIT_ROOT" 1>/dev/null 2>&1 || act --list --directory="$GIT_ROOT" 2>&1
 
-actionlint || :
+actionlint -ignore 'reusable workflow call.+' || :


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Call Jepsen workflow instantly after the binaries are built instead of waiting for the entire PRCI to finish.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
