### PR TITLE
Fix Clang-Tidy:  remove std::move() from trivially-copyable object

### DIFF
--- a/src/Dictionaries/FlatDictionary.cpp
+++ b/src/Dictionaries/FlatDictionary.cpp
@@ -643,7 +643,7 @@ void registerDictionaryFlat(DictionaryFactory & factory)
 
         const auto dict_id = StorageID::fromDictionaryConfig(config, config_prefix);
 
-        return std::make_unique<FlatDictionary>(dict_id, dict_struct, std::move(source_ptr), std::move(configuration));
+        return std::make_unique<FlatDictionary>(dict_id, dict_struct, std::move(source_ptr), configuration);
     };
 
     factory.registerLayout("flat", create_layout, false);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This PR fixed the medium severity Clang-Tidy error "std::move of the variable 'configuration' of the trivially-copyable type 'FlatDictionary::Configuration' has no effect; remove std::move()"

Refer: https://clang.llvm.org/extra/clang-tidy/checks/performance-move-const-arg.html


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
