### PR TITLE
Better cache config for local cache

### DIFF
--- a/src/Common/FileCacheSettings.cpp
+++ b/src/Common/FileCacheSettings.cpp
@@ -5,13 +5,18 @@
 namespace DB
 {
 
-void FileCacheSettings::loadFromConfig(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
+void FileCacheSettings::loadFromConfig(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix, const std::string & default_cache_base_path)
 {
+    cache_base_path = config.getString(config_prefix + ".cache_base_path", default_cache_base_path);
+
     max_size = config.getUInt64(config_prefix + ".data_cache_max_size", REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_CACHE_SIZE);
     max_elements = config.getUInt64(config_prefix + ".data_cache_max_elements", REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_ELEMENTS);
-    max_file_segment_size = config.getUInt64(config_prefix + ".max_file_segment_size", REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_FILE_SEGMENT_SIZE);
+    max_file_segment_size
+        = config.getUInt64(config_prefix + ".max_file_segment_size", REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_FILE_SEGMENT_SIZE);
     cache_on_write_operations = config.getUInt64(config_prefix + ".cache_on_write_operations", false);
-    enable_cache_hits_threshold = config.getUInt64(config_prefix + ".enable_cache_hits_threshold", REMOTE_FS_OBJECTS_CACHE_ENABLE_HITS_THRESHOLD);
+    
+    enable_cache_hits_threshold
+        = config.getUInt64(config_prefix + ".enable_cache_hits_threshold", REMOTE_FS_OBJECTS_CACHE_ENABLE_HITS_THRESHOLD);
 }
 
 }

--- a/src/Common/FileCacheSettings.h
+++ b/src/Common/FileCacheSettings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/FileCache_fwd.h>
+#include <string>
 
 namespace Poco { namespace Util { class AbstractConfiguration; } }
 
@@ -9,6 +10,8 @@ namespace DB
 
 struct FileCacheSettings
 {
+    std::string cache_base_path;
+
     size_t max_size = 0;
     size_t max_elements = REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_ELEMENTS;
     size_t max_file_segment_size = REMOTE_FS_OBJECTS_CACHE_DEFAULT_MAX_FILE_SEGMENT_SIZE;
@@ -16,7 +19,7 @@ struct FileCacheSettings
 
     size_t enable_cache_hits_threshold = REMOTE_FS_OBJECTS_CACHE_ENABLE_HITS_THRESHOLD;
 
-    void loadFromConfig(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
+    void loadFromConfig(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix, const std::string & default_cache_base_path);
 };
 
 }

--- a/src/Disks/ObjectStorages/DiskObjectStorageCommon.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageCommon.cpp
@@ -79,7 +79,6 @@ FileCachePtr getCachePtrForDisk(
     cache->initialize();
 
     auto * log = &Poco::Logger::get("Disk(" + name + ")");
-    LOG_INFO(log, "Disk registered with prefix [{}], cache_prefix [{}]", config_prefix, cache_config_prefix);
 
     LOG_INFO(log, "Disk registered with cache path: {}. Cache size: {}, max cache elements size: {}, max_file_segment_size: {}, enable_cache_hits_threshold: {}",
              file_cache_settings.cache_base_path,

--- a/tests/config/config.d/s3_storage_policy_by_default.xml
+++ b/tests/config/config.d/s3_storage_policy_by_default.xml
@@ -1,13 +1,17 @@
 <clickhouse>
     <storage_configuration>
+        <cache>
+            <s3_cache>
+                <data_cache_max_size>22548578304</data_cache_max_size>
+            </s3_cache>
+        </cache>
         <disks>
             <s3>
                 <type>s3</type>
                 <endpoint>http://localhost:11111/test/test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
-                <data_cache_enabled>1</data_cache_enabled>
-                <data_cache_max_size>22548578304</data_cache_max_size>
+                <cache>s3_cache</cache>
             </s3>
         </disks>
         <policies>

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -1,39 +1,50 @@
 <clickhouse>
     <storage_configuration>
+        <!-- cache setting -->
+        <cache>
+            <cache_1>
+                <data_cache_max_size>22548578304</data_cache_max_size>
+                <cache_on_write_operations>1</cache_on_write_operations>
+                <data_cache_path>./s3_cache/</data_cache_path>
+            </cache_1>
+            <cache_2>
+                <data_cache_max_size>22548578304</data_cache_max_size>
+                <cache_on_write_operations>0</cache_on_write_operations>
+            </cache_2>
+            <cache_3>
+                <data_cache_max_size>22548578304</data_cache_max_size>
+                <cache_on_write_operations>1</cache_on_write_operations>
+                <enable_cache_hits_threshold>1</enable_cache_hits_threshold>
+            </cache_3>
+        <cache>
+        <!-- disk -->
         <disks>
             <s3_cache>
                 <type>s3</type>
                 <endpoint>http://localhost:11111/test/00170_test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
-                <data_cache_enabled>1</data_cache_enabled>
                 <cache_enabled>0</cache_enabled>
-                <data_cache_max_size>22548578304</data_cache_max_size>
-                <cache_on_write_operations>1</cache_on_write_operations>
-                <data_cache_path>./s3_cache/</data_cache_path>
+                <cache>cache_1</cache>
             </s3_cache>
             <s3_cache_2>
                 <type>s3</type>
                 <endpoint>http://localhost:11111/test/00170_test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
-                <data_cache_enabled>1</data_cache_enabled>
                 <cache_enabled>0</cache_enabled>
-                <data_cache_max_size>22548578304</data_cache_max_size>
-                <cache_on_write_operations>0</cache_on_write_operations>
+                <cache>cache_2</cache>
             </s3_cache_2>
             <s3_cache_3>
                 <type>s3</type>
                 <endpoint>http://localhost:11111/test/00170_test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
-                <data_cache_enabled>1</data_cache_enabled>
                 <cache_enabled>0</cache_enabled>
-                <data_cache_max_size>22548578304</data_cache_max_size>
-                <cache_on_write_operations>1</cache_on_write_operations>
-                <enable_cache_hits_threshold>1</enable_cache_hits_threshold>
+                <cache>cache_3</cache>
             </s3_cache_3>
         </disks>
+        <!-- storage policies -->
         <policies>
             <s3_cache>
                 <volumes>


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The current configuration for the cache is to put all parameters in `<disk>`, which may result in poor configuration readability. If the parameters of the cache are added later, the internal configuration of the disk may appear very chaotic. In addition, if two disks use the same cache, it may cause configuration redundancy. Therefore, I separated the configuration of the cache. When the disk selects the cache, it can directly refer to the configuration of a cache through `<cache>.`

**Before:**
<img width="646" alt="image" src="https://user-images.githubusercontent.com/10573698/170812415-e451bbf3-3588-4522-8401-3d5a2c7e96c6.png">

**Now:**
We can refer to the same cache configuration for different disks to avoid redundant configuration.
<img width="654" alt="image" src="https://user-images.githubusercontent.com/10573698/170812432-64c312a2-77c1-4106-992e-5acc5064af5b.png">

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
