### PR TITLE
More precise result of the `dumpColumnStructure` and `byteSize` miscellaneous functions

### DIFF
--- a/src/Functions/byteSize.cpp
+++ b/src/Functions/byteSize.cpp
@@ -24,7 +24,9 @@ public:
 
     String getName() const override { return name; }
     bool useDefaultImplementationForNulls() const override { return false; }
+    bool useDefaultImplementationForNothing() const override { return false; }
     bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
+    bool useDefaultImplementationForSparseColumns() const override { return false; }
     bool isVariadic() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
     size_t getNumberOfArguments() const override { return 0; }

--- a/src/Functions/dumpColumnStructure.cpp
+++ b/src/Functions/dumpColumnStructure.cpp
@@ -25,6 +25,9 @@ public:
     }
 
     bool useDefaultImplementationForNulls() const override { return false; }
+    bool useDefaultImplementationForNothing() const override { return false; }
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
+    bool useDefaultImplementationForSparseColumns() const override { return false; }
 
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 

--- a/tests/queries/0_stateless/02313_dump_column_structure_low_cardinality.reference
+++ b/tests/queries/0_stateless/02313_dump_column_structure_low_cardinality.reference
@@ -1,0 +1,1 @@
+Array(LowCardinality(String)), Const(size = 1, Array(size = 1, UInt64(size = 1), ColumnLowCardinality(size = 2, UInt8(size = 2), ColumnUnique(size = 3, String(size = 3)))))

--- a/tests/queries/0_stateless/02313_dump_column_structure_low_cardinality.sql
+++ b/tests/queries/0_stateless/02313_dump_column_structure_low_cardinality.sql
@@ -1,0 +1,1 @@
+SELECT dumpColumnStructure(['Hello', 'World']::Array(LowCardinality(String)));


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
More precise result of the `dumpColumnStructure` miscellaneous function in presence of LowCardinality or Sparse columns. In previous versions, these functions were converting the argument to a full column before returning the result. This is needed to provide an answer in #6935.


Note: `byteSize` function is unaffected but looks like the code is more correct.