### PR TITLE
Less flaky jbod rebalancer test

### DIFF
--- a/tests/integration/test_jbod_balancer/test.py
+++ b/tests/integration/test_jbod_balancer/test.py
@@ -161,11 +161,13 @@ def test_replicated_balanced_merge_fetch(start_cluster):
         p = Pool(20)
 
         def task(i):
-            print("Processing insert {}/{}".format(i, 200))
+            print("Processing insert {}/{}".format(i, 80))
             # around 1k per block
             node1.query(
                 "insert into tbl select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
             )
+
+            # Fill jbod disks with garbage data
             node1.query(
                 "insert into tmp1 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
             )
@@ -179,7 +181,7 @@ def test_replicated_balanced_merge_fetch(start_cluster):
                 "insert into tmp2 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
             )
 
-        p.map(task, range(200))
+        p.map(task, range(80))
 
         node2.query("SYSTEM SYNC REPLICA tbl", timeout=10)
 

--- a/tests/integration/test_jbod_balancer/test.py
+++ b/tests/integration/test_jbod_balancer/test.py
@@ -158,10 +158,10 @@ def test_replicated_balanced_merge_fetch(start_cluster):
             node.query("create table tmp2 as tmp1")
 
         node2.query("alter table tbl modify setting always_fetch_merged_part = 1")
-        p = Pool(20)
+        p = Pool(5)
 
         def task(i):
-            print("Processing insert {}/{}".format(i, 80))
+            print("Processing insert {}/{}".format(i, 200))
             # around 1k per block
             node1.query(
                 "insert into tbl select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
@@ -181,7 +181,7 @@ def test_replicated_balanced_merge_fetch(start_cluster):
                 "insert into tmp2 select randConstant() % 2, randomPrintableASCII(16) from numbers(50)"
             )
 
-        p.map(task, range(80))
+        p.map(task, range(200))
 
         node2.query("SYSTEM SYNC REPLICA tbl", timeout=10)
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Lower the amount of insertion to avoid possible `ZooKeeperClient: Code: 999. Coordination::Exception: Operation timeout (deadline already expired)` . This is for https://github.com/ClickHouse/ClickHouse/pull/37491#issuecomment-1137743438


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
