### PR TITLE
Disable amqp-cpp and cassandra build if libuv is disabled

### DIFF
--- a/contrib/amqpcpp-cmake/CMakeLists.txt
+++ b/contrib/amqpcpp-cmake/CMakeLists.txt
@@ -5,6 +5,11 @@ if (NOT ENABLE_AMQPCPP)
     return()
 endif()
 
+if (NOT TARGET ch_contrib::uv)
+    message(STATUS "Not using AMQP-CPP because libuv is disabled")
+    return()
+endif()
+
 set (LIBRARY_DIR "${ClickHouse_SOURCE_DIR}/contrib/AMQP-CPP")
 
 set (SRCS

--- a/contrib/cassandra-cmake/CMakeLists.txt
+++ b/contrib/cassandra-cmake/CMakeLists.txt
@@ -5,6 +5,11 @@ if (NOT ENABLE_CASSANDRA)
     return()
 endif()
 
+if (NOT TARGET ch_contrib::uv)
+    message(STATUS "Not using cassandra because libuv is disabled")
+    return()
+endif()
+
 if (APPLE)
     set(CMAKE_MACOSX_RPATH ON)
 endif()


### PR DESCRIPTION
On MacOS/GCC, "libuv" disabled due to a compiler bug. This appears as a (non-fatal) warning in the CMake log and later on, the configuration of dependent libraries "amqp-cpp and "cassandra" fails due to to unfulfilled link dependencies. The behavior exists since at least Jan 2022.

This PR adds an additional check to both libs and we will now simply skip them. The prior behavior was not really wrong, just unfriendly.

The bigger picture is that there is currently zero "dependency management" between the dozens of configure-time switches (https://clickhouse.com/docs/en/development/cmake-in-clickhouse/) and the same problem may appear in another form whenever not using the global switch "-DENABLE_LIBRARIES=0/1". Perhaps it is worth to add similar checks in other places - not sure, will discuss internally.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)