### PR TITLE
Fix `test_keeper_force_recovery*` tests

### DIFF
--- a/tests/integration/test_keeper_force_recovery_single_node/test.py
+++ b/tests/integration/test_keeper_force_recovery_single_node/test.py
@@ -121,7 +121,17 @@ def test_cluster_recovery(started_cluster):
 
         nodes[0].stop_clickhouse()
 
-        add_data(node_zks[1], "/test_force_recovery_extra", "somedataextra")
+        # we potentially killed the leader node so we give time for election
+        for _ in range(100):
+            try:
+                node_zks[1] = get_fake_zk(nodes[1].name, timeout=30.0)
+                add_data(node_zks[1], "/test_force_recovery_extra", "somedataextra")
+                break
+            except Exception as ex:
+                time.sleep(0.5)
+                print(f"Retrying create on {nodes[1].name}, exception {ex}")
+        else:
+            raise Exception(f"Failed creating a node on {nodes[1].name}")
 
         for node_zk in node_zks[2:CLUSTER_SIZE]:
             wait_and_assert_data(node_zk, "/test_force_recovery_extra", "somedataextra")


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

If the node is not leader it will try to forward request to the leader. When we kill the leader the request cannot be forwarded and it times out.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
