### PR TITLE
Fix segfault with mysql db + show create table + named collections

### DIFF
--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -26,6 +26,7 @@
 #    include <Common/setThreadName.h>
 #    include <filesystem>
 #    include <Common/filesystemHelpers.h>
+#    include <Parsers/ASTIdentifier.h>
 
 namespace fs = std::filesystem;
 
@@ -148,8 +149,16 @@ ASTPtr DatabaseMySQL::getCreateTableQueryImpl(const String & table_name, Context
         auto storage_engine_arguments = ast_storage->engine->arguments;
 
         /// Add table_name to engine arguments
-        auto mysql_table_name = std::make_shared<ASTLiteral>(table_name);
-        storage_engine_arguments->children.insert(storage_engine_arguments->children.begin() + 2, mysql_table_name);
+        if (typeid_cast<ASTIdentifier *>(storage_engine_arguments->children[0].get()))
+        {
+            storage_engine_arguments->children.push_back(
+                makeASTFunction("equals", std::make_shared<ASTIdentifier>("table"), std::make_shared<ASTLiteral>(table_name)));
+        }
+        else
+        {
+            auto mysql_table_name = std::make_shared<ASTLiteral>(table_name);
+            storage_engine_arguments->children.insert(storage_engine_arguments->children.begin() + 2, mysql_table_name);
+        }
 
         /// Unset settings
         std::erase_if(storage_children, [&](const ASTPtr & element) { return element.get() == ast_storage->settings; });

--- a/tests/integration/test_mysql_database_engine/test.py
+++ b/tests/integration/test_mysql_database_engine/test.py
@@ -930,6 +930,10 @@ def test_predefined_connection_configuration(started_cluster):
             == "100"
         )
 
+        result = clickhouse_node.query("show create table test_database.test_table")
+        print(result)
+        assert(result.strip() == "CREATE TABLE test_database.test_table\\n(\\n    `id` Int32\\n)\\nENGINE = MySQL(mysql1, table = \\'test_table\\')")
+
         clickhouse_node.query("DROP DATABASE test_database")
         clickhouse_node.query_and_get_error(
             "CREATE DATABASE test_database ENGINE = MySQL(mysql2)"

--- a/tests/integration/test_mysql_database_engine/test.py
+++ b/tests/integration/test_mysql_database_engine/test.py
@@ -931,8 +931,10 @@ def test_predefined_connection_configuration(started_cluster):
         )
 
         result = clickhouse_node.query("show create table test_database.test_table")
-        print(result)
-        assert(result.strip() == "CREATE TABLE test_database.test_table\\n(\\n    `id` Int32\\n)\\nENGINE = MySQL(mysql1, table = \\'test_table\\')")
+        assert (
+            result.strip()
+            == "CREATE TABLE test_database.test_table\\n(\\n    `id` Int32\\n)\\nENGINE = MySQL(mysql1, table = \\'test_table\\')"
+        )
 
         clickhouse_node.query("DROP DATABASE test_database")
         clickhouse_node.query_and_get_error(


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix segmentation fault in `show create table` from mysql database when it is configured with named collections. Closes https://github.com/ClickHouse/ClickHouse/issues/37683.