### PR TITLE
Fix rabbitmq restart with empty settings

### DIFF
--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -1154,7 +1154,8 @@ void registerStorageRabbitMQ(StorageFactory & factory)
         if (!with_named_collection && !args.storage_def->settings)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "RabbitMQ engine must have settings");
 
-        rabbitmq_settings->loadFromQuery(*args.storage_def);
+        if (args.storage_def->settings)
+            rabbitmq_settings->loadFromQuery(*args.storage_def);
 
         if (!rabbitmq_settings->rabbitmq_host_port.changed
            && !rabbitmq_settings->rabbitmq_address.changed)

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -27,6 +27,7 @@ instance = cluster.add_instance(
     ],
     user_configs=["configs/users.xml"],
     with_rabbitmq=True,
+    stay_alive=True,
 )
 
 
@@ -2723,6 +2724,16 @@ def test_rabbitmq_predefined_configuration(rabbitmq_cluster):
             ENGINE = RabbitMQ(rabbit1, rabbitmq_vhost = '/') """
     )
 
+    channel.basic_publish(
+        exchange="named", routing_key="", body=json.dumps({"key": 1, "value": 2})
+    )
+    while True:
+        result = instance.query(
+            "SELECT * FROM test.rabbitmq ORDER BY key", ignore_error=True
+        )
+        if result == "1\t2\n":
+            break
+    instance.restart_clickhouse()
     channel.basic_publish(
         exchange="named", routing_key="", body=json.dumps({"key": 1, "value": 2})
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix RabbitMQ Storage not being able to startup on server restart if storage was create without SETTINGS clause. Closes https://github.com/ClickHouse/ClickHouse/issues/37463