### PR TITLE
Replace `multiIf` to `if` in case of one condition

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -458,6 +458,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(Bool, optimize_duplicate_order_by_and_distinct, true, "Remove duplicate ORDER BY and DISTINCT if it's possible", 0) \
     M(Bool, optimize_redundant_functions_in_order_by, true, "Remove functions from ORDER BY if its argument is also in ORDER BY", 0) \
     M(Bool, optimize_if_chain_to_multiif, false, "Replace if(cond1, then1, if(cond2, ...)) chains to multiIf. Currently it's not beneficial for numeric types.", 0) \
+    M(Bool, optimize_multiif_to_if, true, "Replace 'multiIf' with only one condition to 'if'.", 0) \
     M(Bool, optimize_if_transform_strings_to_enum, false, "Replaces string-type arguments in If and Transform to enum. Disabled by default cause it could make inconsistent change in distributed query that would lead to its fail.", 0) \
     M(Bool, optimize_monotonous_functions_in_order_by, true, "Replace monotonous function with its argument in ORDER BY", 0) \
     M(Bool, optimize_functions_to_subcolumns, false, "Transform functions to subcolumns, if possible, to reduce amount of read data. E.g. 'length(arr)' -> 'arr.size0', 'col IS NULL' -> 'col.null' ", 0) \

--- a/src/Interpreters/OptimizeIfChains.h
+++ b/src/Interpreters/OptimizeIfChains.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Parsers/IAST.h>
+#include <Parsers/ASTFunction.h>
+#include <Interpreters/InDepthNodeVisitor.h>
 
 namespace DB
 {
@@ -15,5 +17,23 @@ public:
 private:
     ASTs ifChain(const ASTPtr & child);
 };
+
+/// Replaces multiIf with one condition to if,
+/// because it's more efficient.
+class OptimizeMultiIfToIfData
+{
+public:
+    using TypeToVisit = ASTFunction;
+
+    void visit(ASTFunction & function, ASTPtr &)
+    {
+        /// 3 args: condition, then branch, else branch.
+        if (function.name == "multiIf" && (function.arguments && function.arguments->children.size() == 3))
+            function.name = "if";
+    }
+};
+
+using OptimizeMultiIfToIfMatcher = OneTypeMatcher<OptimizeMultiIfToIfData>;
+using OptimizeMultiIfToIfVisitor = InDepthNodeVisitor<OptimizeMultiIfToIfMatcher, true>;
 
 }

--- a/src/Interpreters/TreeOptimizer.cpp
+++ b/src/Interpreters/TreeOptimizer.cpp
@@ -674,6 +674,12 @@ void optimizeSumIfFunctions(ASTPtr & query)
     RewriteSumIfFunctionVisitor(data).visit(query);
 }
 
+void optimizeMultiIfToIf(ASTPtr & query)
+{
+    OptimizeMultiIfToIfVisitor::Data data;
+    OptimizeMultiIfToIfVisitor(data).visit(query);
+}
+
 void optimizeInjectiveFunctionsInsideUniq(ASTPtr & query, ContextPtr context)
 {
     RemoveInjectiveFunctionsVisitor::Data data(context);
@@ -819,6 +825,9 @@ void TreeOptimizer::apply(ASTPtr & query, TreeRewriterResult & result,
 
     if (settings.optimize_rewrite_sum_if_to_count_if)
         optimizeSumIfFunctions(query);
+
+    if (settings.optimize_multiif_to_if)
+        optimizeMultiIfToIf(query);
 
     /// Remove injective functions inside uniq
     if (settings.optimize_injective_functions_inside_uniq)

--- a/tests/queries/0_stateless/01355_if_fixed_string.sql
+++ b/tests/queries/0_stateless/01355_if_fixed_string.sql
@@ -1,3 +1,5 @@
+SET optimize_multiif_to_if = 0;
+
 SELECT if(number % 2, toFixedString(toString(number), 2), toFixedString(toString(-number), 5)) AS x, toTypeName(x) FROM system.numbers LIMIT 10;
 SELECT if(number % 2, toFixedString(toString(number), 2), toFixedString(toString(-number), 2)) AS x, toTypeName(x) FROM system.numbers LIMIT 10;
 

--- a/tests/queries/0_stateless/02315_replace_multiif_to_if.reference
+++ b/tests/queries/0_stateless/02315_replace_multiif_to_if.reference
@@ -1,0 +1,4 @@
+SELECT if(number = 0, NULL, toNullable(number))
+FROM numbers(10000)
+SELECT if(number = 0, NULL, toNullable(number))
+FROM numbers(10000)

--- a/tests/queries/0_stateless/02315_replace_multiif_to_if.sql
+++ b/tests/queries/0_stateless/02315_replace_multiif_to_if.sql
@@ -1,0 +1,2 @@
+EXPLAIN SYNTAX SELECT multiIf(number = 0, NULL, toNullable(number)) FROM numbers(10000);
+EXPLAIN SYNTAX SELECT CASE WHEN number = 0 THEN NULL ELSE toNullable(number) END FROM numbers(10000);


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Replace `multiIf` to `if` in case when `multiIf` has only one condition, because function `if` is more performant.

Resolves #37586.
Resolves #29892.

Addition to #37666.
