### PR TITLE
Display entires for failed tests at the top of report by default

### DIFF
--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -165,6 +165,11 @@ def create_test_html_report(
         num_fails = 0
         has_test_time = False
         has_test_logs = False
+
+        if with_raw_logs:
+            # Display entires with logs at the top (they correspond to failed tests)
+            test_result.sort(key=lambda result: len(result) <= 3)
+
         for result in test_result:
             test_name = result[0]
             test_status = result[1]


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
