### PR TITLE
Fix `Intersect` with constant strings

### DIFF
--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -6,9 +6,11 @@
 #include <Common/Arena.h>
 #include <Common/LRUCache.h>
 #include <Common/assert_cast.h>
+#include "Columns/IColumn.h"
 #include <base/unaligned.h>
 
 #include <Columns/ColumnString.h>
+#include <Columns/ColumnConst.h>
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnLowCardinality.h>
 
@@ -83,8 +85,11 @@ struct HashMethodString
 
     HashMethodString(const ColumnRawPtrs & key_columns, const Sizes & /*key_sizes*/, const HashMethodContextPtr &)
     {
-        const IColumn & column = *key_columns[0];
-        const ColumnString & column_string = assert_cast<const ColumnString &>(column);
+        const IColumn * column = key_columns[0];
+        if (isColumnConst(*column))
+            column = &assert_cast<const ColumnConst &>(*column).getDataColumn();
+
+        const ColumnString & column_string = assert_cast<const ColumnString &>(*column);
         offsets = column_string.getOffsets().data();
         chars = column_string.getChars().data();
     }

--- a/tests/queries/0_stateless/02316_const_string_intersact.reference
+++ b/tests/queries/0_stateless/02316_const_string_intersact.reference
@@ -1,0 +1,1 @@
+Play ClickHouse

--- a/tests/queries/0_stateless/02316_const_string_intersact.sql
+++ b/tests/queries/0_stateless/02316_const_string_intersact.sql
@@ -1,0 +1,1 @@
+SELECT 'Play ClickHouse' InterSect SELECT 'Play ClickHouse'


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `SELECT ... INTERSECT` and `EXCEPT SELECT` statements with constant string types.

Fix #37727 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
