### PR TITLE
Fix possible segfault in schema inference

### DIFF
--- a/src/Formats/ReadSchemaUtils.cpp
+++ b/src/Formats/ReadSchemaUtils.cpp
@@ -100,18 +100,21 @@ ColumnsDescription readSchemaFromFormat(
             catch (...)
             {
                 auto exception_message = getCurrentExceptionMessage(false);
-                size_t rows_read = schema_reader->getNumRowsRead();
-                assert(rows_read <= max_rows_to_read);
-                max_rows_to_read -= schema_reader->getNumRowsRead();
-                if (rows_read != 0 && max_rows_to_read == 0)
+                if (schema_reader)
                 {
-                    exception_message += "\nTo increase the maximum number of rows to read for structure determination, use setting input_format_max_rows_to_read_for_schema_inference";
-                    if (iterations > 1)
+                    size_t rows_read = schema_reader->getNumRowsRead();
+                    assert(rows_read <= max_rows_to_read);
+                    max_rows_to_read -= schema_reader->getNumRowsRead();
+                    if (rows_read != 0 && max_rows_to_read == 0)
                     {
-                        exception_messages += "\n" + exception_message;
-                        break;
+                        exception_message += "\nTo increase the maximum number of rows to read for structure determination, use setting input_format_max_rows_to_read_for_schema_inference";
+                        if (iterations > 1)
+                        {
+                            exception_messages += "\n" + exception_message;
+                            break;
+                        }
+                        retry = false;
                     }
-                    retry = false;
                 }
 
                 if (!retry || !isRetryableSchemaInferenceError(getCurrentExceptionCode()))

--- a/tests/queries/0_stateless/02318_template_schema_inference_bug.sql
+++ b/tests/queries/0_stateless/02318_template_schema_inference_bug.sql
@@ -1,0 +1,2 @@
+insert into function file(data_02318.tsv) select * from numbers(10);
+desc file('data_02318.tsv', 'Template') SETTINGS format_template_row='nonexist', format_template_resultset='nonexist'; -- {serverError CANNOT_EXTRACT_TABLE_STRUCTURE}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible segfault in schema inference in case of exception in SchemaReader constructor. Closes https://github.com/ClickHouse/ClickHouse/issues/37680

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
