### PR TITLE
Fix setting cast_ipv4_ipv6_default_on_conversion_error for internal cast

### DIFF
--- a/src/Functions/CastOverloadResolver.h
+++ b/src/Functions/CastOverloadResolver.h
@@ -45,7 +45,7 @@ public:
         const auto & settings_ref = context->getSettingsRef();
 
         if constexpr (internal)
-            return createImpl({}, false /*keep_nullable*/, false /*cast_ipv4_ipv6_default_on_conversion_error*/);
+            return createImpl({}, false /*keep_nullable*/, settings_ref.cast_ipv4_ipv6_default_on_conversion_error);
 
         return createImpl({}, settings_ref.cast_keep_nullable, settings_ref.cast_ipv4_ipv6_default_on_conversion_error);
     }

--- a/tests/queries/0_stateless/02316_cast_to_ip_address_default_column.sql
+++ b/tests/queries/0_stateless/02316_cast_to_ip_address_default_column.sql
@@ -1,0 +1,24 @@
+SET cast_ipv4_ipv6_default_on_conversion_error = 1;
+
+DROP TABLE IF EXISTS ipv4_test;
+CREATE TABLE ipv4_test
+(
+    id UInt64,
+    value String
+) ENGINE=MergeTree ORDER BY id;
+
+ALTER TABLE ipv4_test MODIFY COLUMN value IPv4 DEFAULT '';
+
+DROP TABLE ipv4_test;
+
+DROP TABLE IF EXISTS ipv6_test;
+CREATE TABLE ipv6_test
+(
+    id UInt64,
+    value String
+) ENGINE=MergeTree ORDER BY id;
+
+ALTER TABLE ipv6_test MODIFY COLUMN value IPv4 DEFAULT '';
+SELECT * FROM ipv6_test;
+
+DROP TABLE ipv6_test;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix setting cast_ipv4_ipv6_default_on_conversion_error for internal cast function. Closes #35156.
