### PR TITLE
Fix flaky 01154_move_partition_long

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -501,6 +501,10 @@ public:
     /// This predicate is checked for the first part of each range.
     bool canMergeSinglePart(const MergeTreeData::DataPartPtr & part, String * out_reason) const;
 
+    /// Returns true if part is needed for some REPLACE_RANGE entry.
+    /// We should not drop part in this case, because replication queue may stuck without that part.
+    bool partParticipatesInReplaceRange(const MergeTreeData::DataPartPtr & part, String * out_reason) const;
+
     /// Return nonempty optional of desired mutation version and alter version.
     /// If we have no alter (modify/drop) mutations in mutations queue, than we return biggest possible
     /// mutation version (and -1 as alter version). In other case, we return biggest mutation version with

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7128,6 +7128,13 @@ bool StorageReplicatedMergeTree::dropPartImpl(
             return false;
         }
 
+        if (merge_pred.partParticipatesInReplaceRange(part, &out_reason))
+        {
+            if (throw_if_noop)
+                throw Exception(ErrorCodes::PART_IS_TEMPORARILY_LOCKED, out_reason);
+            return false;
+        }
+
         if (partIsLastQuorumPart(part->info))
         {
             if (throw_if_noop)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes #37739

```
2022-05-30 10:25:56 sync failed, queue:	default	src_10	r1_1340819367	1	queue-0000000354	REPLACE_RANGE	2022-05-30 10:18:37	0	r1_3691680433		[]	0	0	698	Code: 234. DB::Exception: Not found part 0_36_36_1 (or part covering it) neither source table neither remote replicas. (NO_REPLICA_HAS_PART) (version 22.6.1.1)	2022-05-30 10:25:52	22	Not executing log entry queue-0000000354 for part 0_37_37_1 because it is covered by part 0_37_42_2 that is currently executing.	2022-05-30 10:18:48	
2022-05-30 10:25:56 sync failed, queue:	default	src_10	r1_1340819367	0	queue-0000000355	DROP_RANGE	2022-05-30 10:18:37	0	r1_3691680433	0_36_36_1	[]	0	0	0		1969-12-31 18:00:00	1910	Not executing log entry queue-0000000355 of type DROP_RANGE for part 0_36_36_1 because another DROP_RANGE or REPLACE_RANGE entry are currently executing.	2022-05-30 10:25:52	


2022.05.30 10:25:39.159028 [ 500 ] {} <Debug> test_8r9vin.src_10 (9e000aca-17ed-4ac9-ba47-28468bcf5a58): Executing log entry queue-0000000354 to replace parts range 0_0_35_999999999_999999999 with 5 parts from test_8r9vin.src_1
2022.05.30 10:25:39.169862 [ 500 ] {} <Debug> test_8r9vin.src_10 (9e000aca-17ed-4ac9-ba47-28468bcf5a58): Will check part 0_36_36_1 required for queue-0000000354, because no replicas have it (including replicas of source table)


2022.05.30 10:25:53.963975 [ 506 ] {} <Warning> test_8r9vin.src_13 (434057b5-5e94-4aef-97b9-439c39674883): Do not enqueue part 0_36_36_1 for check because it's covered by DROP_RANGE 0_36_36_1 and going to be removed

```
