### PR TITLE
Moved `ClientConfigurationPerRequest` to ClickHouse

### DIFF
--- a/src/Disks/ObjectStorages/S3/ProxyConfiguration.h
+++ b/src/Disks/ObjectStorages/S3/ProxyConfiguration.h
@@ -6,7 +6,7 @@
 
 #include <utility>
 #include <base/types.h>
-#include <aws/core/client/ClientConfiguration.h>
+#include <IO/S3/PocoHTTPClient.h>
 #include <Poco/URI.h>
 
 namespace DB::S3
@@ -16,8 +16,8 @@ class ProxyConfiguration
 public:
     virtual ~ProxyConfiguration() = default;
     /// Returns proxy configuration on each HTTP request.
-    virtual Aws::Client::ClientConfigurationPerRequest getConfiguration(const Aws::Http::HttpRequest & request) = 0;
-    virtual void errorReport(const Aws::Client::ClientConfigurationPerRequest & config) = 0;
+    virtual ClientConfigurationPerRequest getConfiguration(const Aws::Http::HttpRequest & request) = 0;
+    virtual void errorReport(const ClientConfigurationPerRequest & config) = 0;
 };
 
 }

--- a/src/Disks/ObjectStorages/S3/ProxyListConfiguration.cpp
+++ b/src/Disks/ObjectStorages/S3/ProxyListConfiguration.cpp
@@ -12,15 +12,15 @@ ProxyListConfiguration::ProxyListConfiguration(std::vector<Poco::URI> proxies_) 
 }
 
 
-Aws::Client::ClientConfigurationPerRequest ProxyListConfiguration::getConfiguration(const Aws::Http::HttpRequest &)
+ClientConfigurationPerRequest ProxyListConfiguration::getConfiguration(const Aws::Http::HttpRequest &)
 {
     /// Avoid atomic increment if number of proxies is 1.
     size_t index = proxies.size() > 1 ? (access_counter++) % proxies.size() : 0;
 
-    Aws::Client::ClientConfigurationPerRequest cfg;
-    cfg.proxyScheme = Aws::Http::SchemeMapper::FromString(proxies[index].getScheme().c_str());
-    cfg.proxyHost = proxies[index].getHost();
-    cfg.proxyPort = proxies[index].getPort();
+    ClientConfigurationPerRequest cfg;
+    cfg.proxy_scheme = Aws::Http::SchemeMapper::FromString(proxies[index].getScheme().c_str());
+    cfg.proxy_host = proxies[index].getHost();
+    cfg.proxy_port = proxies[index].getPort();
 
     LOG_DEBUG(&Poco::Logger::get("AWSClient"), "Use proxy: {}", proxies[index].toString());
 

--- a/src/Disks/ObjectStorages/S3/ProxyListConfiguration.h
+++ b/src/Disks/ObjectStorages/S3/ProxyListConfiguration.h
@@ -17,8 +17,8 @@ class ProxyListConfiguration : public ProxyConfiguration
 {
 public:
     explicit ProxyListConfiguration(std::vector<Poco::URI> proxies_);
-    Aws::Client::ClientConfigurationPerRequest getConfiguration(const Aws::Http::HttpRequest & request) override;
-    void errorReport(const Aws::Client::ClientConfigurationPerRequest &) override {}
+    ClientConfigurationPerRequest getConfiguration(const Aws::Http::HttpRequest & request) override;
+    void errorReport(const ClientConfigurationPerRequest &) override {}
 
 private:
     /// List of configured proxies.

--- a/src/Disks/ObjectStorages/S3/ProxyResolverConfiguration.cpp
+++ b/src/Disks/ObjectStorages/S3/ProxyResolverConfiguration.cpp
@@ -24,7 +24,7 @@ ProxyResolverConfiguration::ProxyResolverConfiguration(const Poco::URI & endpoin
 {
 }
 
-Aws::Client::ClientConfigurationPerRequest ProxyResolverConfiguration::getConfiguration(const Aws::Http::HttpRequest &)
+ClientConfigurationPerRequest ProxyResolverConfiguration::getConfiguration(const Aws::Http::HttpRequest &)
 {
     LOG_DEBUG(&Poco::Logger::get("AWSClient"), "Obtain proxy using resolver: {}", endpoint.toString());
 
@@ -34,7 +34,7 @@ Aws::Client::ClientConfigurationPerRequest ProxyResolverConfiguration::getConfig
 
     if (cache_ttl.count() && cache_valid && now <= cache_timestamp + cache_ttl && now >= cache_timestamp)
     {
-        LOG_DEBUG(&Poco::Logger::get("AWSClient"), "Use cached proxy: {}://{}:{}", Aws::Http::SchemeMapper::ToString(cached_config.proxyScheme), cached_config.proxyHost, cached_config.proxyPort);
+        LOG_DEBUG(&Poco::Logger::get("AWSClient"), "Use cached proxy: {}://{}:{}", Aws::Http::SchemeMapper::ToString(cached_config.proxy_scheme), cached_config.proxy_host, cached_config.proxy_port);
         return cached_config;
     }
 
@@ -88,9 +88,9 @@ Aws::Client::ClientConfigurationPerRequest ProxyResolverConfiguration::getConfig
 
         LOG_DEBUG(&Poco::Logger::get("AWSClient"), "Use proxy: {}://{}:{}", proxy_scheme, proxy_host, proxy_port);
 
-        cached_config.proxyScheme = Aws::Http::SchemeMapper::FromString(proxy_scheme.c_str());
-        cached_config.proxyHost = proxy_host;
-        cached_config.proxyPort = proxy_port;
+        cached_config.proxy_scheme = Aws::Http::SchemeMapper::FromString(proxy_scheme.c_str());
+        cached_config.proxy_host = proxy_host;
+        cached_config.proxy_port = proxy_port;
         cache_timestamp = std::chrono::system_clock::now();
         cache_valid = true;
 
@@ -100,14 +100,14 @@ Aws::Client::ClientConfigurationPerRequest ProxyResolverConfiguration::getConfig
     {
         tryLogCurrentException("AWSClient", "Failed to obtain proxy");
         /// Don't use proxy if it can't be obtained.
-        Aws::Client::ClientConfigurationPerRequest cfg;
+        ClientConfigurationPerRequest cfg;
         return cfg;
     }
 }
 
-void ProxyResolverConfiguration::errorReport(const Aws::Client::ClientConfigurationPerRequest & config)
+void ProxyResolverConfiguration::errorReport(const ClientConfigurationPerRequest & config)
 {
-    if (config.proxyHost.empty())
+    if (config.proxy_host.empty())
         return;
 
     std::unique_lock lock(cache_mutex);
@@ -115,8 +115,8 @@ void ProxyResolverConfiguration::errorReport(const Aws::Client::ClientConfigurat
     if (!cache_ttl.count() || !cache_valid)
         return;
 
-    if (cached_config.proxyScheme != config.proxyScheme || cached_config.proxyHost != config.proxyHost
-            || cached_config.proxyPort != config.proxyPort)
+    if (std::tie(cached_config.proxy_scheme, cached_config.proxy_host, cached_config.proxy_port)
+            != std::tie(config.proxy_scheme, config.proxy_host, config.proxy_port))
         return;
 
     /// Invalidate cached proxy when got error with this proxy

--- a/src/Disks/ObjectStorages/S3/ProxyResolverConfiguration.h
+++ b/src/Disks/ObjectStorages/S3/ProxyResolverConfiguration.h
@@ -19,8 +19,8 @@ class ProxyResolverConfiguration : public ProxyConfiguration
 {
 public:
     ProxyResolverConfiguration(const Poco::URI & endpoint_, String proxy_scheme_, unsigned proxy_port_, unsigned cache_ttl_);
-    Aws::Client::ClientConfigurationPerRequest getConfiguration(const Aws::Http::HttpRequest & request) override;
-    void errorReport(const Aws::Client::ClientConfigurationPerRequest & config) override;
+    ClientConfigurationPerRequest getConfiguration(const Aws::Http::HttpRequest & request) override;
+    void errorReport(const ClientConfigurationPerRequest & config) override;
 
 private:
     /// Endpoint to obtain a proxy host.
@@ -34,7 +34,7 @@ private:
     bool cache_valid = false;
     std::chrono::time_point<std::chrono::system_clock> cache_timestamp;
     const std::chrono::seconds cache_ttl{0};
-    Aws::Client::ClientConfigurationPerRequest cached_config;
+    ClientConfigurationPerRequest cached_config;
 };
 
 }

--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<Aws::S3::S3Client> getClient(const Poco::Util::AbstractConfigura
     auto proxy_config = getProxyConfiguration(config_prefix, config);
     if (proxy_config)
     {
-        client_configuration.perRequestConfiguration
+        client_configuration.per_request_configuration
             = [proxy_config](const auto & request) { return proxy_config->getConfiguration(request); };
         client_configuration.error_report
             = [proxy_config](const auto & request_config) { proxy_config->errorReport(request_config); };

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -95,7 +95,7 @@ void PocoHTTPClientConfiguration::updateSchemeAndRegion()
 
 
 PocoHTTPClient::PocoHTTPClient(const PocoHTTPClientConfiguration & client_configuration)
-    : per_request_configuration(client_configuration.perRequestConfiguration)
+    : per_request_configuration(client_configuration.per_request_configuration)
     , error_report(client_configuration.error_report)
     , timeouts(ConnectionTimeouts(
           Poco::Timespan(client_configuration.connectTimeoutMs * 1000), /// connection timeout.
@@ -179,17 +179,17 @@ void PocoHTTPClient::makeRequestInternal(
             HTTPSessionPtr session;
             auto request_configuration = per_request_configuration(request);
 
-            if (!request_configuration.proxyHost.empty())
+            if (!request_configuration.proxy_host.empty())
             {
                 /// Reverse proxy can replace host header with resolved ip address instead of host name.
                 /// This can lead to request signature difference on S3 side.
                 session = makeHTTPSession(target_uri, timeouts, /* resolve_host = */ false);
-                bool use_tunnel = request_configuration.proxyScheme == Aws::Http::Scheme::HTTP && target_uri.getScheme() == "https";
+                bool use_tunnel = request_configuration.proxy_scheme == Aws::Http::Scheme::HTTP && target_uri.getScheme() == "https";
 
                 session->setProxy(
-                    request_configuration.proxyHost,
-                    request_configuration.proxyPort,
-                    Aws::Http::SchemeMapper::ToString(request_configuration.proxyScheme),
+                    request_configuration.proxy_host,
+                    request_configuration.proxy_port,
+                    Aws::Http::SchemeMapper::ToString(request_configuration.proxy_scheme),
                     use_tunnel
                 );
             }

--- a/src/IO/S3/PocoHTTPClient.h
+++ b/src/IO/S3/PocoHTTPClient.h
@@ -27,8 +27,16 @@ namespace DB::S3
 {
 class ClientFactory;
 
+struct ClientConfigurationPerRequest
+{
+    Aws::Http::Scheme proxy_scheme = Aws::Http::Scheme::HTTPS;
+    String proxy_host;
+    unsigned proxy_port = 0;
+};
+
 struct PocoHTTPClientConfiguration : public Aws::Client::ClientConfiguration
 {
+    std::function<ClientConfigurationPerRequest(const Aws::Http::HttpRequest &)> per_request_configuration = [] (const Aws::Http::HttpRequest &) { return ClientConfigurationPerRequest(); };
     String force_region;
     const RemoteHostFilter & remote_host_filter;
     unsigned int s3_max_redirects;
@@ -36,10 +44,15 @@ struct PocoHTTPClientConfiguration : public Aws::Client::ClientConfiguration
 
     void updateSchemeAndRegion();
 
-    std::function<void(const Aws::Client::ClientConfigurationPerRequest &)> error_report;
+    std::function<void(const ClientConfigurationPerRequest &)> error_report;
 
 private:
-    PocoHTTPClientConfiguration(const String & force_region_, const RemoteHostFilter & remote_host_filter_, unsigned int s3_max_redirects_, bool enable_s3_requests_logging_);
+    PocoHTTPClientConfiguration(
+        const String & force_region_,
+        const RemoteHostFilter & remote_host_filter_,
+        unsigned int s3_max_redirects_,
+        bool enable_s3_requests_logging_
+    );
 
     /// Constructor of Aws::Client::ClientConfiguration must be called after AWS SDK initialization.
     friend ClientFactory;
@@ -95,8 +108,8 @@ private:
         Aws::Utils::RateLimits::RateLimiterInterface * readLimiter,
         Aws::Utils::RateLimits::RateLimiterInterface * writeLimiter) const;
 
-    std::function<Aws::Client::ClientConfigurationPerRequest(const Aws::Http::HttpRequest &)> per_request_configuration;
-    std::function<void(const Aws::Client::ClientConfigurationPerRequest &)> error_report;
+    std::function<ClientConfigurationPerRequest(const Aws::Http::HttpRequest &)> per_request_configuration;
+    std::function<void(const ClientConfigurationPerRequest &)> error_report;
     ConnectionTimeouts timeouts;
     const RemoteHostFilter & remote_host_filter;
     unsigned int s3_max_redirects;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There is no need to store this changes in ClickHouse/aws-sdk-cpp. ClickHouse/aws-sdk-cpp#1, ClickHouse/aws-sdk-cpp#2

FYI @Jokser 