### PR TITLE
Got rid of `S3AuthSigner`

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -246,10 +246,11 @@ void PocoHTTPClient::makeRequestInternal(
                     break;
             }
 
+            /// Headers coming from SDK are lower-cased.
             for (const auto & [header_name, header_value] : request.GetHeaders())
                 poco_request.set(header_name, header_value);
             for (const auto & [header_name, header_value] : extra_headers)
-                poco_request.set(header_name, header_value);
+                poco_request.set(boost::algorithm::to_lower_copy(header_name), header_value);
 
             Poco::Net::HTTPResponse poco_response;
 

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -5,10 +5,13 @@
 #include "PocoHTTPClient.h"
 
 #include <utility>
+
+#include <Common/logger_useful.h>
+#include <Common/Stopwatch.h>
 #include <IO/HTTPCommon.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
-#include <Common/Stopwatch.h>
+
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/HttpResponse.h>
 #include <aws/core/monitoring/HttpClientMetrics.h>
@@ -16,7 +19,6 @@
 #include "Poco/StreamCopier.h"
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
-#include <Common/logger_useful.h>
 #include <re2/re2.h>
 
 #include <boost/algorithm/string.hpp>
@@ -105,6 +107,7 @@ PocoHTTPClient::PocoHTTPClient(const PocoHTTPClientConfiguration & client_config
     , remote_host_filter(client_configuration.remote_host_filter)
     , s3_max_redirects(client_configuration.s3_max_redirects)
     , enable_s3_requests_logging(client_configuration.enable_s3_requests_logging)
+    , extra_headers(client_configuration.extra_headers)
 {
 }
 
@@ -206,7 +209,7 @@ void PocoHTTPClient::makeRequestInternal(
               * Effectively, `Poco::URI` chooses smaller subset of characters to encode,
               * whereas Amazon S3 and Google Cloud Storage expects another one.
               * In order to successfully execute a request, a path must be exact representation
-              * of decoded path used by `S3AuthSigner`.
+              * of decoded path used by `AWSAuthSigner`.
               * Therefore we shall encode some symbols "manually" to fit the signatures.
               */
 
@@ -244,6 +247,8 @@ void PocoHTTPClient::makeRequestInternal(
             }
 
             for (const auto & [header_name, header_value] : request.GetHeaders())
+                poco_request.set(header_name, header_value);
+            for (const auto & [header_name, header_value] : extra_headers)
                 poco_request.set(header_name, header_value);
 
             Poco::Net::HTTPResponse poco_response;

--- a/src/IO/S3/PocoHTTPClient.h
+++ b/src/IO/S3/PocoHTTPClient.h
@@ -8,10 +8,13 @@
 #include <IO/ConnectionTimeouts.h>
 #include <IO/HTTPCommon.h>
 #include <IO/S3/SessionAwareIOStream.h>
+#include <Storages/StorageS3Settings.h>
+
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
+
 
 namespace Aws::Http::Standard
 {
@@ -41,6 +44,7 @@ struct PocoHTTPClientConfiguration : public Aws::Client::ClientConfiguration
     const RemoteHostFilter & remote_host_filter;
     unsigned int s3_max_redirects;
     bool enable_s3_requests_logging;
+    HeaderCollection extra_headers;
 
     void updateSchemeAndRegion();
 
@@ -114,6 +118,7 @@ private:
     const RemoteHostFilter & remote_host_filter;
     unsigned int s3_max_redirects;
     bool enable_s3_requests_logging;
+    const HeaderCollection extra_headers;
 };
 
 }

--- a/src/IO/S3/tests/TestPocoHTTPServer.h
+++ b/src/IO/S3/tests/TestPocoHTTPServer.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <string>
+
+#include <Poco/Net/HTTPRequestHandler.h>
+#include <Poco/Net/HTTPRequestHandlerFactory.h>
+#include <Poco/Net/HTTPServer.h>
+#include <Poco/Net/HTTPServerParams.h>
+#include <Poco/Net/NetException.h>
+#include <Poco/Net/ServerSocket.h>
+#include <Poco/AutoPtr.h>
+#include <Poco/SharedPtr.h>
+
+
+template <typename RequestHandler>
+class HTTPRequestHandlerFactory : public Poco::Net::HTTPRequestHandlerFactory
+{
+    virtual Poco::Net::HTTPRequestHandler * createRequestHandler(const Poco::Net::HTTPServerRequest &) override
+    {
+        return new RequestHandler();
+    }
+
+public:
+    virtual ~HTTPRequestHandlerFactory() override
+    {
+    }
+};
+
+template <typename RequestHandler>
+class TestPocoHTTPServer
+{
+    std::unique_ptr<Poco::Net::ServerSocket> server_socket;
+    std::unique_ptr<Poco::Net::HTTPServer> server;
+    Poco::SharedPtr<HTTPRequestHandlerFactory<RequestHandler>> handler_factory;
+    Poco::AutoPtr<Poco::Net::HTTPServerParams> server_params;
+
+public:
+    TestPocoHTTPServer():
+        handler_factory(new HTTPRequestHandlerFactory<RequestHandler>()),
+        server_params(new Poco::Net::HTTPServerParams())
+    {
+        std::random_device device;
+        std::mt19937 generator(device());
+        std::uniform_int_distribution<> distribution(10000, 60000);
+        for (int attempt = 100; attempt >= 0; --attempt)
+        {
+            try
+            {
+                server_socket = std::make_unique<Poco::Net::ServerSocket>(distribution(generator));
+            }
+            catch (Poco::Net::NetException &)
+            {
+                if (!attempt)
+                    throw;
+            }
+        }
+        server = std::make_unique<Poco::Net::HTTPServer>(handler_factory, *server_socket, server_params);
+        server->start();
+    }
+
+    std::string getUrl()
+    {
+        return "http://" + server_socket->address().toString();
+    }
+};

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -1,0 +1,127 @@
+#include <gtest/gtest.h>
+
+#include <Common/config.h>
+
+
+#if USE_AWS_S3
+
+#include <memory>
+#include <ostream>
+
+#include <boost/algorithm/string.hpp>
+
+#include <Poco/Net/HTTPRequestHandler.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+#include <Poco/URI.h>
+
+#include <aws/core/client/AWSError.h>
+#include <aws/core/client/CoreErrors.h>
+#include <aws/core/client/RetryStrategy.h>
+#include <aws/core/http/URI.h>
+#include <aws/s3/S3Client.h>
+
+#include <Common/RemoteHostFilter.h>
+#include <IO/ReadBufferFromS3.h>
+#include <IO/ReadHelpers.h>
+#include <IO/ReadSettings.h>
+#include <IO/S3Common.h>
+#include <Storages/StorageS3Settings.h>
+
+#include "TestPocoHTTPServer.h"
+
+
+class NoRetryStrategy : public Aws::Client::StandardRetryStrategy
+{
+    bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors> &, long) const override { return false; }
+
+public:
+    ~NoRetryStrategy() override {}
+};
+
+
+TEST(IOTestAwsS3Client, AppendExtraSSECHeaders)
+{
+    /// See https://github.com/ClickHouse/ClickHouse/pull/19748
+
+    class MyRequestHandler : public Poco::Net::HTTPRequestHandler
+    {
+    public:
+        virtual void handleRequest(Poco::Net::HTTPServerRequest & request, Poco::Net::HTTPServerResponse & response) override
+        {
+            response.setStatus(Poco::Net::HTTPResponse::HTTP_OK);
+            std::ostream & out = response.send();
+            for (const auto & [header_name, header_value] : request)
+            {
+                if (boost::algorithm::starts_with(header_name, "x-amz-server-side-encryption-customer-"))
+                    out << header_name << ": " << header_value << "\n";
+                if (header_name == "authorization")
+                {
+                    std::vector<String> parts;
+                    boost::split(parts, header_value, [](char c){ return c == ' '; });
+                    for (const auto & part : parts)
+                    {
+                        if (boost::algorithm::starts_with(part, "SignedHeaders="))
+                            out << header_name << ": ... " << part << " ...\n";
+                    }
+                }
+            }
+            out.flush();
+        }
+    };
+
+    TestPocoHTTPServer<MyRequestHandler> http;
+
+    DB::RemoteHostFilter remote_host_filter;
+    unsigned int s3_max_redirects = 100;
+    DB::S3::URI uri(Poco::URI(http.getUrl() + "/IOTestAwsS3ClientAppendExtraHeaders/test.txt"));
+    String access_key_id = "ACCESS_KEY_ID";
+    String secret_access_key = "SECRET_ACCESS_KEY";
+    String region = "us-east-1";
+    String version_id = "";
+    UInt64 max_single_read_retries = 1;
+    bool enable_s3_requests_logging = false;
+    DB::S3::PocoHTTPClientConfiguration client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
+        region,
+        remote_host_filter,
+        s3_max_redirects,
+        enable_s3_requests_logging
+    );
+
+    client_configuration.endpointOverride = uri.endpoint;
+    client_configuration.retryStrategy = std::make_shared<NoRetryStrategy>();
+
+    String server_side_encryption_customer_key_base64 = "Kv/gDqdWVGIT4iDqg+btQvV3lc1idlm4WI+MMOyHOAw=";
+    DB::HeaderCollection headers;
+    bool use_environment_credentials = false;
+    bool use_insecure_imds_request = false;
+
+    std::shared_ptr<Aws::S3::S3Client> client = DB::S3::ClientFactory::instance().create(
+        client_configuration,
+        uri.is_virtual_hosted_style,
+        access_key_id,
+        secret_access_key,
+        server_side_encryption_customer_key_base64,
+        headers,
+        use_environment_credentials,
+        use_insecure_imds_request
+    );
+
+    ASSERT_TRUE(client);
+
+    DB::ReadSettings read_settings;
+    DB::ReadBufferFromS3 read_buffer(
+        client,
+        uri.bucket,
+        uri.key,
+        version_id,
+        max_single_read_retries,
+        read_settings
+    );
+
+    String content;
+    DB::readStringUntilEOF(content, read_buffer);
+    EXPECT_EQ(content, "authorization: ... SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-type;host;x-amz-api-version;x-amz-content-sha256;x-amz-date, ...\nx-amz-server-side-encryption-customer-algorithm: AES256\nx-amz-server-side-encryption-customer-key: Kv/gDqdWVGIT4iDqg+btQvV3lc1idlm4WI+MMOyHOAw=\nx-amz-server-side-encryption-customer-key-md5: fMNuOw6OLU5GG2vc6RTA+g==\n");
+}
+
+#endif

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -54,8 +54,10 @@ TEST(IOTestAwsS3Client, AppendExtraSSECHeaders)
             for (const auto & [header_name, header_value] : request)
             {
                 if (boost::algorithm::starts_with(header_name, "x-amz-server-side-encryption-customer-"))
+                {
                     out << header_name << ": " << header_value << "\n";
-                if (header_name == "authorization")
+                }
+                else if (header_name == "authorization")
                 {
                     std::vector<String> parts;
                     boost::split(parts, header_value, [](char c){ return c == ' '; });

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -33,10 +33,10 @@
 
 class NoRetryStrategy : public Aws::Client::StandardRetryStrategy
 {
-    bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors> &, long) const override { return false; }
+    bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors> &, long /* NOLINT */) const override { return false; }
 
 public:
-    ~NoRetryStrategy() override {}
+    ~NoRetryStrategy() override = default;
 };
 
 
@@ -47,7 +47,7 @@ TEST(IOTestAwsS3Client, AppendExtraSSECHeaders)
     class MyRequestHandler : public Poco::Net::HTTPRequestHandler
     {
     public:
-        virtual void handleRequest(Poco::Net::HTTPServerRequest & request, Poco::Net::HTTPServerResponse & response) override
+        void handleRequest(Poco::Net::HTTPServerRequest & request, Poco::Net::HTTPServerResponse & response) override
         {
             response.setStatus(Poco::Net::HTTPResponse::HTTP_OK);
             std::ostream & out = response.send();
@@ -80,7 +80,7 @@ TEST(IOTestAwsS3Client, AppendExtraSSECHeaders)
     String access_key_id = "ACCESS_KEY_ID";
     String secret_access_key = "SECRET_ACCESS_KEY";
     String region = "us-east-1";
-    String version_id = "";
+    String version_id;
     UInt64 max_single_read_retries = 1;
     bool enable_s3_requests_logging = false;
     DB::S3::PocoHTTPClientConfiguration client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -683,7 +683,7 @@ namespace S3
 
         Aws::Auth::AWSCredentials credentials(access_key_id, secret_access_key);
         auto credentials_provider = std::make_shared<S3CredentialsProviderChain>(
-                static_cast<const DB::S3::PocoHTTPClientConfiguration &>(client_configuration),
+                client_configuration,
                 std::move(credentials),
                 use_environment_credentials,
                 use_insecure_imds_request);

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -689,7 +689,7 @@ namespace S3
                 use_insecure_imds_request);
 
         return std::make_unique<Aws::S3::S3Client>(
-            credentials_provider,
+            std::move(credentials_provider),
             std::move(client_configuration), // Client configuration.
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
             is_virtual_hosted_style || client_configuration.endpointOverride.empty() /// Use virtual addressing if endpoint is not specified.

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -675,7 +675,7 @@ namespace S3
 
             Aws::Utils::ByteBuffer buffer = Aws::Utils::HashingUtils::Base64Decode(server_side_encryption_customer_key_base64);
             String str_buffer(reinterpret_cast<char *>(buffer.GetUnderlyingData()), buffer.GetLength());
-            headers.push_back({boost::algorithm::to_lower_copy(String(Aws::S3::SSEHeaders::SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5)),
+            headers.push_back({Aws::S3::SSEHeaders::SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5,
                 Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::HashingUtils::CalculateMD5(str_buffer))});
         }
 

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -692,7 +692,7 @@ namespace S3
             credentials_provider,
             std::move(client_configuration), // Client configuration.
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-            is_virtual_hosted_style || client_configuration.endpointOverride.empty() /// Use virtual addressing only if endpoint is not specified.
+            is_virtual_hosted_style || client_configuration.endpointOverride.empty() /// Use virtual addressing if endpoint is not specified.
         );
     }
 

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -675,7 +675,7 @@ namespace S3
 
             Aws::Utils::ByteBuffer buffer = Aws::Utils::HashingUtils::Base64Decode(server_side_encryption_customer_key_base64);
             String str_buffer(reinterpret_cast<char *>(buffer.GetUnderlyingData()), buffer.GetLength());
-            headers.push_back({Aws::S3::SSEHeaders::SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5,
+            headers.push_back({boost::algorithm::to_lower_copy(String(Aws::S3::SSEHeaders::SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5)),
                 Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::HashingUtils::CalculateMD5(str_buffer))});
         }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It will allow to remove ClickHouse/aws-sdk-cpp#3.
FYI @Jokser