### PR TITLE
Hierarchical dictinaries support nullable parent key

### DIFF
--- a/src/Dictionaries/FlatDictionary.cpp
+++ b/src/Dictionaries/FlatDictionary.cpp
@@ -298,6 +298,9 @@ DictionaryHierarchyParentToChildIndexPtr FlatDictionary::getHierarchicalIndex() 
         if (!loaded_keys[child_key])
             continue;
 
+        if (unlikely(hierarchical_attribute.is_nullable_set) && hierarchical_attribute.is_nullable_set->find(child_key))
+            continue;
+
         auto parent_key = parent_keys[child_key];
         parent_to_child[parent_key].emplace_back(child_key);
     }

--- a/src/Dictionaries/HashedArrayDictionary.cpp
+++ b/src/Dictionaries/HashedArrayDictionary.cpp
@@ -331,8 +331,12 @@ DictionaryHierarchicalParentToChildIndexPtr HashedArrayDictionary<dictionary_key
         HashMap<UInt64, PaddedPODArray<UInt64>> parent_to_child;
         parent_to_child.reserve(index_to_key.size());
 
-        for (size_t i = 0; i < parent_keys_container.size(); ++i)
+        size_t parent_keys_container_size = parent_keys_container.size();
+        for (size_t i = 0; i < parent_keys_container_size; ++i)
         {
+            if (unlikely(hierarchical_attribute.is_index_null) && (*hierarchical_attribute.is_index_null)[i])
+                continue;
+
             const auto * it = index_to_key.find(i);
             if (it == index_to_key.end())
                 continue;

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -363,13 +363,13 @@ DictionaryHierarchyParentToChildIndexPtr HashedDictionary<dictionary_key_type, s
 
         size_t hierarchical_attribute_index = *dict_struct.hierarchical_attribute_index;
         const auto & hierarchical_attribute = attributes[hierarchical_attribute_index];
-        const CollectionType<UInt64> & parent_keys = std::get<CollectionType<UInt64>>(hierarchical_attribute.container);
+        const CollectionType<UInt64> & child_key_to_parent_key_map = std::get<CollectionType<UInt64>>(hierarchical_attribute.container);
 
         HashMap<UInt64, PaddedPODArray<UInt64>> parent_to_child;
-        parent_to_child.reserve(parent_keys.size());
+        parent_to_child.reserve(child_key_to_parent_key_map.size());
 
-        for (const auto & [key, value] : parent_keys)
-            parent_to_child[value].emplace_back(key);
+        for (const auto & [child_key, parent_key] : child_key_to_parent_key_map)
+            parent_to_child[parent_key].emplace_back(child_key);
 
         return std::make_shared<DictionaryHierarchicalParentToChildIndex>(parent_to_child);
     }

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -227,6 +227,9 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchy(ColumnPtr 
 {
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
     {
+        if (key_column->isNullable())
+            key_column = assert_cast<const ColumnNullable *>(key_column.get())->getNestedColumnPtr();
+
         PaddedPODArray<UInt64> keys_backup_storage;
         const auto & keys = getColumnVectorData(this, key_column, keys_backup_storage);
 
@@ -235,10 +238,20 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchy(ColumnPtr 
         const auto & dictionary_attribute = dict_struct.attributes[hierarchical_attribute_index];
         const auto & hierarchical_attribute = attributes[hierarchical_attribute_index];
 
-        const UInt64 null_value = dictionary_attribute.null_value.template get<UInt64>();
+        std::optional<UInt64> null_value;
+
+        if (!dictionary_attribute.null_value.isNull())
+            null_value = dictionary_attribute.null_value.get<UInt64>();
+
         const CollectionType<UInt64> & parent_keys_map = std::get<CollectionType<UInt64>>(hierarchical_attribute.container);
 
-        auto is_key_valid_func = [&](auto & key) { return parent_keys_map.find(key) != parent_keys_map.end(); };
+        auto is_key_valid_func = [&](auto & hierarchy_key)
+        {
+            if (unlikely(hierarchical_attribute.is_nullable_set) && hierarchical_attribute.is_nullable_set->find(hierarchy_key))
+                return true;
+
+            return parent_keys_map.find(hierarchy_key) != parent_keys_map.end();
+        };
 
         size_t keys_found = 0;
 
@@ -248,15 +261,23 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchy(ColumnPtr 
 
             auto it = parent_keys_map.find(hierarchy_key);
 
-            if (it != parent_keys_map.end())
-                result = getValueFromCell(it);
+            if (it == parent_keys_map.end())
+                return result;
 
-            keys_found += result.has_value();
+            if (unlikely(hierarchical_attribute.is_nullable_set) && hierarchical_attribute.is_nullable_set->find(hierarchy_key))
+                return result;
+
+            UInt64 parent_key = getValueFromCell(it);
+            if (null_value && *null_value == parent_key)
+                return result;
+
+            result = parent_key;
+            keys_found += 1;
 
             return result;
         };
 
-        auto dictionary_hierarchy_array = getKeysHierarchyArray(keys, null_value, is_key_valid_func, get_parent_func);
+        auto dictionary_hierarchy_array = getKeysHierarchyArray(keys, is_key_valid_func, get_parent_func);
 
         query_count.fetch_add(keys.size(), std::memory_order_relaxed);
         found_count.fetch_add(keys_found, std::memory_order_relaxed);
@@ -264,7 +285,9 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchy(ColumnPtr 
         return dictionary_hierarchy_array;
     }
     else
+    {
         return nullptr;
+    }
 }
 
 template <DictionaryKeyType dictionary_key_type, bool sparse>
@@ -275,6 +298,19 @@ ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::isInHierarchy(
 {
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
     {
+        if (key_column->isNullable())
+            key_column = assert_cast<const ColumnNullable *>(key_column.get())->getNestedColumnPtr();
+
+        const PaddedPODArray<UInt8> * in_key_column_nullable_mask = nullptr;
+
+        if (in_key_column->isNullable())
+        {
+            const auto * in_key_column_typed = assert_cast<const ColumnNullable *>(in_key_column.get());
+
+            in_key_column = in_key_column_typed->getNestedColumnPtr();
+            in_key_column_nullable_mask = &in_key_column_typed->getNullMapColumn().getData();
+        }
+
         PaddedPODArray<UInt64> keys_backup_storage;
         const auto & keys = getColumnVectorData(this, key_column, keys_backup_storage);
 
@@ -286,28 +322,57 @@ ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::isInHierarchy(
         const auto & dictionary_attribute = dict_struct.attributes[hierarchical_attribute_index];
         auto & hierarchical_attribute = attributes[hierarchical_attribute_index];
 
-        const UInt64 null_value = dictionary_attribute.null_value.template get<UInt64>();
+        std::optional<UInt64> null_value;
+
+        if (!dictionary_attribute.null_value.isNull())
+            null_value = dictionary_attribute.null_value.get<UInt64>();
+
         const CollectionType<UInt64> & parent_keys_map = std::get<CollectionType<UInt64>>(hierarchical_attribute.container);
 
-        auto is_key_valid_func = [&](auto & key) { return parent_keys_map.find(key) != parent_keys_map.end(); };
+        auto is_key_valid_func = [&](auto & hierarchy_key)
+        {
+            if (unlikely(hierarchical_attribute.is_nullable_set) && hierarchical_attribute.is_nullable_set->find(hierarchy_key))
+                return true;
+
+            return parent_keys_map.find(hierarchy_key) != parent_keys_map.end();
+        };
 
         size_t keys_found = 0;
 
-        auto get_parent_func = [&](auto & hierarchy_key)
+        auto get_parent_key_func = [&](auto & hierarchy_key)
         {
             std::optional<UInt64> result;
 
             auto it = parent_keys_map.find(hierarchy_key);
 
-            if (it != parent_keys_map.end())
-                result = getValueFromCell(it);
+            if (it == parent_keys_map.end())
+                return result;
 
-            keys_found += result.has_value();
+            if (unlikely(hierarchical_attribute.is_nullable_set) && hierarchical_attribute.is_nullable_set->find(hierarchy_key))
+                return result;
+
+            UInt64 parent_key = getValueFromCell(it);
+            if (null_value && *null_value == parent_key)
+                return result;
+
+            result = parent_key;
+            keys_found += 1;
 
             return result;
         };
 
-        auto result = getKeysIsInHierarchyColumn(keys, keys_in, null_value, is_key_valid_func, get_parent_func);
+        auto result = getKeysIsInHierarchyColumn(keys, keys_in, is_key_valid_func, get_parent_key_func);
+
+        if (unlikely(in_key_column_nullable_mask))
+        {
+            auto mutable_result_ptr = result->assumeMutable();
+            auto & mutable_result = assert_cast<ColumnUInt8 &>(*mutable_result_ptr);
+            auto & mutable_result_data = mutable_result.getData();
+            size_t mutable_result_data_size = mutable_result_data.size();
+
+            for (size_t i = 0; i < mutable_result_data_size; ++i)
+                mutable_result_data[i] &= !(static_cast<bool>((*in_key_column_nullable_mask)[i]));
+        }
 
         query_count.fetch_add(keys.size(), std::memory_order_relaxed);
         found_count.fetch_add(keys_found, std::memory_order_relaxed);

--- a/src/Dictionaries/HierarchyDictionariesUtils.cpp
+++ b/src/Dictionaries/HierarchyDictionariesUtils.cpp
@@ -29,7 +29,8 @@ namespace detail
 
 namespace
 {
-    struct ChildToParentHierarchicalContext {
+    struct ChildToParentHierarchicalContext
+    {
         HashMap<UInt64, UInt64> child_key_to_parent_key;
         std::optional<HashSet<UInt64>> child_key_parent_key_is_null;
     };

--- a/src/Dictionaries/HierarchyDictionariesUtils.cpp
+++ b/src/Dictionaries/HierarchyDictionariesUtils.cpp
@@ -1,5 +1,8 @@
 #include "HierarchyDictionariesUtils.h"
 
+#include <Columns/ColumnNullable.h>
+
+
 namespace DB
 {
 
@@ -26,25 +29,35 @@ namespace detail
 
 namespace
 {
+    struct ChildToParentHierarchicalContext {
+        HashMap<UInt64, UInt64> child_key_to_parent_key;
+        std::optional<HashSet<UInt64>> child_key_parent_key_is_null;
+    };
+
     /** In case of cache or direct dictionary we does not have structure with child to parent representation.
       * This function build such structure calling getColumn for initial keys to request and for next keys in hierarchy,
       * until all keys are requested or result key is null value.
       * To distinguish null value key and key that is not present in dictionary, we use special default value column
       * with max UInt64 value, if result column key has such value we assume that current key is not presented in dictionary storage.
       */
-    HashMap<UInt64, UInt64> getChildToParentHierarchyMapImpl(
+    ChildToParentHierarchicalContext getChildToParentHierarchicalContext(
         const IDictionary * dictionary,
         const DictionaryAttribute & hierarchical_attribute,
         const PaddedPODArray<UInt64> & initial_keys_to_request,
         const DataTypePtr & key_type)
     {
-        UInt64 null_value = hierarchical_attribute.null_value.get<UInt64>();
+        std::optional<UInt64> null_value;
+
+        if (!hierarchical_attribute.null_value.isNull())
+            null_value = hierarchical_attribute.null_value.get<UInt64>();
 
         ColumnPtr key_to_request_column = ColumnVector<UInt64>::create();
         auto * key_to_request_column_typed = static_cast<ColumnVector<UInt64> *>(key_to_request_column->assumeMutable().get());
 
         UInt64 key_not_in_storage_value = std::numeric_limits<UInt64>::max();
         ColumnPtr key_not_in_storage_default_value_column = ColumnVector<UInt64>::create(initial_keys_to_request.size(), key_not_in_storage_value);
+        if (hierarchical_attribute.is_nullable)
+            key_not_in_storage_default_value_column = makeNullable(key_not_in_storage_default_value_column);
 
         PaddedPODArray<UInt64> & keys_to_request = key_to_request_column_typed->getData();
         keys_to_request.assign(initial_keys_to_request);
@@ -52,20 +65,36 @@ namespace
         PaddedPODArray<UInt64> next_keys_to_request;
         HashSet<UInt64> already_requested_keys;
 
-        HashMap<UInt64, UInt64> child_to_parent_key;
+        ChildToParentHierarchicalContext context;
+
+        if (hierarchical_attribute.is_nullable)
+            context.child_key_parent_key_is_null = HashSet<UInt64>();
+
+        HashMap<UInt64, UInt64> & child_key_to_parent_key = context.child_key_to_parent_key;
+        std::optional<HashSet<UInt64>> & child_key_parent_key_is_null = context.child_key_parent_key_is_null;
 
         while (!keys_to_request.empty())
         {
-            child_to_parent_key.reserve(child_to_parent_key.size() + keys_to_request.size());
+            child_key_to_parent_key.reserve(keys_to_request.size());
 
-            auto parent_key_column = dictionary->getColumn(
+            auto hierarchical_attribute_parent_key_column = dictionary->getColumn(
                 hierarchical_attribute.name,
                 hierarchical_attribute.type,
                 {key_to_request_column},
                 {key_type},
                 key_not_in_storage_default_value_column);
 
-            const auto * parent_key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(*parent_key_column);
+            const PaddedPODArray<UInt8> * in_key_column_nullable_mask = nullptr;
+
+            ColumnPtr parent_key_column_non_null = hierarchical_attribute_parent_key_column;
+            if (hierarchical_attribute_parent_key_column->isNullable())
+            {
+                const auto * parent_key_column_typed = assert_cast<const ColumnNullable *>(hierarchical_attribute_parent_key_column.get());
+                in_key_column_nullable_mask = &parent_key_column_typed->getNullMapData();
+                parent_key_column_non_null = parent_key_column_typed->getNestedColumnPtr();
+            }
+
+            const auto * parent_key_column_typed = checkAndGetColumn<ColumnVector<UInt64>>(*parent_key_column_non_null);
             if (!parent_key_column_typed)
                 throw Exception(ErrorCodes::UNSUPPORTED_METHOD,
                     "Parent key column should be UInt64. Actual {}",
@@ -74,17 +103,24 @@ namespace
             const auto & parent_keys = parent_key_column_typed->getData();
             next_keys_to_request.clear();
 
-            for (size_t i = 0; i < keys_to_request.size(); ++i)
+            size_t keys_to_request_size = keys_to_request.size();
+            for (size_t i = 0; i < keys_to_request_size; ++i)
             {
-                auto key = keys_to_request[i];
+                auto child_key = keys_to_request[i];
                 auto parent_key = parent_keys[i];
+
+                if (unlikely(in_key_column_nullable_mask) && (*in_key_column_nullable_mask)[i])
+                {
+                    child_key_parent_key_is_null->insert(child_key);
+                    continue;
+                }
 
                 if (parent_key == key_not_in_storage_value)
                     continue;
 
-                child_to_parent_key[key] = parent_key;
+                child_key_to_parent_key[child_key] = parent_key;
 
-                if (parent_key == null_value ||
+                if ((null_value && parent_key == *null_value) ||
                     already_requested_keys.find(parent_key) != nullptr)
                     continue;
 
@@ -96,7 +132,7 @@ namespace
             keys_to_request.assign(next_keys_to_request);
         }
 
-        return child_to_parent_key;
+        return context;
     }
 }
 
@@ -138,21 +174,33 @@ ColumnPtr getKeysHierarchyDefaultImplementation(
     const auto & hierarchical_attribute = dictionary_structure.attributes[hierarchical_attribute_index];
 
     const PaddedPODArray<UInt64> & requested_keys = key_column_typed->getData();
-    HashMap<UInt64, UInt64> key_to_parent_key = getChildToParentHierarchyMapImpl(dictionary, hierarchical_attribute, requested_keys, key_type);
+    ChildToParentHierarchicalContext child_to_parent_hierarchical_context
+        = getChildToParentHierarchicalContext(dictionary, hierarchical_attribute, requested_keys, key_type);
 
-    auto is_key_valid_func = [&](auto & key) { return key_to_parent_key.find(key) != nullptr; };
+    auto is_key_valid_func = [&](auto & key)
+    {
+        if (unlikely(child_to_parent_hierarchical_context.child_key_parent_key_is_null)
+            && child_to_parent_hierarchical_context.child_key_parent_key_is_null->find(key))
+            return true;
 
-    UInt64 null_value = hierarchical_attribute.null_value.get<UInt64>();
+        return child_to_parent_hierarchical_context.child_key_to_parent_key.find(key) != nullptr;
+    };
+
+    std::optional<UInt64> null_value;
+
+    if (!hierarchical_attribute.null_value.isNull())
+        null_value = hierarchical_attribute.null_value.get<UInt64>();
+
     auto get_parent_key_func = [&](auto & key)
     {
         std::optional<UInt64> result;
-        auto it = key_to_parent_key.find(key);
-        if (it == nullptr) {
+
+        auto it = child_to_parent_hierarchical_context.child_key_to_parent_key.find(key);
+        if (it == nullptr)
             return result;
-        }
 
         UInt64 parent_key = it->getMapped();
-        if (parent_key == null_value)
+        if (null_value && parent_key == *null_value)
             return result;
 
         result = parent_key;
@@ -188,21 +236,33 @@ ColumnUInt8::Ptr getKeysIsInHierarchyDefaultImplementation(
     const auto & hierarchical_attribute = dictionary_structure.attributes[hierarchical_attribute_index];
 
     const PaddedPODArray<UInt64> & requested_keys = key_column_typed->getData();
-    HashMap<UInt64, UInt64> key_to_parent_key = getChildToParentHierarchyMapImpl(dictionary, hierarchical_attribute, requested_keys, key_type);
+    ChildToParentHierarchicalContext child_to_parent_hierarchical_context
+        = getChildToParentHierarchicalContext(dictionary, hierarchical_attribute, requested_keys, key_type);
 
-    auto is_key_valid_func = [&](auto & key) { return key_to_parent_key.find(key) != nullptr; };
+    auto is_key_valid_func = [&](auto & key)
+    {
+        if (unlikely(child_to_parent_hierarchical_context.child_key_parent_key_is_null)
+            && child_to_parent_hierarchical_context.child_key_parent_key_is_null->find(key))
+            return true;
 
-    UInt64 null_value = hierarchical_attribute.null_value.get<UInt64>();
+        return child_to_parent_hierarchical_context.child_key_to_parent_key.find(key) != nullptr;
+    };
+
+    std::optional<UInt64> null_value;
+
+    if (!hierarchical_attribute.null_value.isNull())
+        null_value = hierarchical_attribute.null_value.get<UInt64>();
+
     auto get_parent_key_func = [&](auto & key)
     {
         std::optional<UInt64> result;
-        auto it = key_to_parent_key.find(key);
-        if (it == nullptr) {
+
+        auto it = child_to_parent_hierarchical_context.child_key_to_parent_key.find(key);
+        if (it == nullptr)
             return result;
-        }
 
         UInt64 parent_key = it->getMapped();
-        if (parent_key == null_value)
+        if (null_value && parent_key == *null_value)
             return result;
 
         result = parent_key;

--- a/src/Dictionaries/tests/gtest_hierarchy_dictionaries_utils.cpp
+++ b/src/Dictionaries/tests/gtest_hierarchy_dictionaries_utils.cpp
@@ -17,19 +17,26 @@ TEST(HierarchyDictionariesUtils, getHierarchy)
 
         auto is_key_valid_func = [&](auto key) { return child_to_parent.find(key) != nullptr; };
 
+        UInt64 hierarchy_null_value_key = 0;
         auto get_parent_key_func = [&](auto key)
         {
+            std::optional<UInt64> result;
             auto it = child_to_parent.find(key);
-            std::optional<UInt64> value = (it != nullptr ? std::make_optional(it->getMapped()) : std::nullopt);
-            return value;
+            if (it == nullptr)
+                return result;
+
+            UInt64 parent_key = it->getMapped();
+            if (parent_key == hierarchy_null_value_key)
+                return result;
+
+            result = parent_key;
+            return result;
         };
 
-        UInt64 hierarchy_null_value_key = 0;
         PaddedPODArray<UInt64> keys = {1, 2, 3, 4, 5};
 
         auto result = DB::detail::getHierarchy(
             keys,
-            hierarchy_null_value_key,
             is_key_valid_func,
             get_parent_key_func);
 
@@ -49,19 +56,26 @@ TEST(HierarchyDictionariesUtils, getHierarchy)
 
         auto is_key_valid_func = [&](auto key) { return child_to_parent.find(key) != nullptr; };
 
+        UInt64 hierarchy_null_value_key = 0;
         auto get_parent_key_func = [&](auto key)
         {
+            std::optional<UInt64> result;
             auto it = child_to_parent.find(key);
-            std::optional<UInt64> value = (it != nullptr ? std::make_optional(it->getMapped()) : std::nullopt);
-            return value;
+            if (it == nullptr)
+                return result;
+
+            UInt64 parent_key = it->getMapped();
+            if (parent_key == hierarchy_null_value_key)
+                return result;
+
+            result = parent_key;
+            return result;
         };
 
-        UInt64 hierarchy_null_value_key = 0;
         PaddedPODArray<UInt64> keys = {1, 2, 3};
 
         auto result = DB::detail::getHierarchy(
             keys,
-            hierarchy_null_value_key,
             is_key_valid_func,
             get_parent_key_func);
 
@@ -87,21 +101,28 @@ TEST(HierarchyDictionariesUtils, getIsInHierarchy)
 
         auto is_key_valid_func = [&](auto key) { return child_to_parent.find(key) != nullptr; };
 
+        UInt64 hierarchy_null_value_key = 0;
         auto get_parent_key_func = [&](auto key)
         {
+            std::optional<UInt64> result;
             auto it = child_to_parent.find(key);
-            std::optional<UInt64> value = (it != nullptr ? std::make_optional(it->getMapped()) : std::nullopt);
-            return value;
+            if (it == nullptr)
+                return result;
+
+            UInt64 parent_key = it->getMapped();
+            if (parent_key == hierarchy_null_value_key)
+                return result;
+
+            result = parent_key;
+            return result;
         };
 
-        UInt64 hierarchy_null_value_key = 0;
         PaddedPODArray<UInt64> keys = {1, 2, 3, 4, 5};
         PaddedPODArray<UInt64> keys_in = {1, 1, 1, 2, 5};
 
         PaddedPODArray<UInt8> actual = DB::detail::getIsInHierarchy(
             keys,
             keys_in,
-            hierarchy_null_value_key,
             is_key_valid_func,
             get_parent_key_func);
 
@@ -119,21 +140,28 @@ TEST(HierarchyDictionariesUtils, getIsInHierarchy)
             return child_to_parent.find(key) != nullptr;
         };
 
+        UInt64 hierarchy_null_value_key = 0;
         auto get_parent_key_func = [&](auto key)
         {
+            std::optional<UInt64> result;
             auto it = child_to_parent.find(key);
-            std::optional<UInt64> value = (it != nullptr ? std::make_optional(it->getMapped()) : std::nullopt);
-            return value;
+            if (it == nullptr)
+                return result;
+
+            UInt64 parent_key = it->getMapped();
+            if (parent_key == hierarchy_null_value_key)
+                return result;
+
+            result = parent_key;
+            return result;
         };
 
-        UInt64 hierarchy_null_value_key = 0;
         PaddedPODArray<UInt64> keys = {1, 2, 3};
         PaddedPODArray<UInt64> keys_in = {1, 2, 3};
 
         PaddedPODArray<UInt8> actual = DB::detail::getIsInHierarchy(
             keys,
             keys_in,
-            hierarchy_null_value_key,
             is_key_valid_func,
             get_parent_key_func);
 

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -985,7 +985,7 @@ private:
         const auto & hierarchical_attribute = helper.getDictionaryHierarchicalAttribute(dictionary);
 
         auto key_column = ColumnWithTypeAndName{arguments[1].column, arguments[1].type, arguments[1].name};
-        auto key_column_casted = castColumnAccurate(key_column, hierarchical_attribute.type);
+        auto key_column_casted = castColumnAccurate(key_column, removeNullable(hierarchical_attribute.type));
 
         ColumnPtr result = dictionary->getHierarchy(key_column_casted, hierarchical_attribute.type);
 
@@ -1042,8 +1042,9 @@ private:
         auto key_column = ColumnWithTypeAndName{arguments[1].column->convertToFullColumnIfConst(), arguments[1].type, arguments[2].name};
         auto in_key_column = ColumnWithTypeAndName{arguments[2].column->convertToFullColumnIfConst(), arguments[2].type, arguments[2].name};
 
-        auto key_column_casted = castColumnAccurate(key_column, hierarchical_attribute.type);
-        auto in_key_column_casted = castColumnAccurate(in_key_column, hierarchical_attribute.type);
+        auto hierarchical_attribute_non_nullable = removeNullable(hierarchical_attribute.type);
+        auto key_column_casted = castColumnAccurate(key_column, hierarchical_attribute_non_nullable);
+        auto in_key_column_casted = castColumnAccurate(in_key_column, hierarchical_attribute_non_nullable);
 
         ColumnPtr result = dictionary->isInHierarchy(key_column_casted, in_key_column_casted, hierarchical_attribute.type);
 

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -1083,10 +1083,9 @@ public:
         const auto & hierarchical_attribute = dictionary_helper->getDictionaryHierarchicalAttribute(dictionary);
 
         auto key_column = ColumnWithTypeAndName{arguments[1].column->convertToFullColumnIfConst(), arguments[1].type, arguments[1].name};
-        auto key_column_casted = castColumnAccurate(key_column, hierarchical_attribute.type);
+        auto key_column_casted = castColumnAccurate(key_column, removeNullable(hierarchical_attribute.type));
 
-        ColumnPtr result = dictionary->getDescendants(key_column_casted, hierarchical_attribute.type, level, hierarchical_parent_to_child_index);
-        return result;
+        return dictionary->getDescendants(key_column_casted, removeNullable(hierarchical_attribute.type), level, hierarchical_parent_to_child_index);
     }
 
     String name;
@@ -1235,7 +1234,7 @@ public:
         auto dictionary = dictionary_helper->getDictionary(arguments[0].column);
         const auto & hierarchical_attribute = dictionary_helper->getDictionaryHierarchicalAttribute(dictionary);
 
-        return std::make_shared<DataTypeArray>(hierarchical_attribute.type);
+        return std::make_shared<DataTypeArray>(removeNullable(hierarchical_attribute.type));
     }
 
     std::shared_ptr<FunctionDictHelper> dictionary_helper;

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -973,7 +973,7 @@ private:
         auto dictionary = helper.getDictionary(arguments[0].column);
         const auto & hierarchical_attribute = helper.getDictionaryHierarchicalAttribute(dictionary);
 
-        return std::make_shared<DataTypeArray>(hierarchical_attribute.type);
+        return std::make_shared<DataTypeArray>(removeNullable(hierarchical_attribute.type));
     }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override

--- a/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.reference
+++ b/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.reference
@@ -1,0 +1,45 @@
+Flat dictionary
+Get hierarchy
+[0]
+[1,0]
+[2,1,0]
+[3]
+[4,2,1,0]
+[]
+Get is in hierarchy
+1
+1
+1
+1
+1
+0
+Hashed dictionary
+Get hierarchy
+[0]
+[1,0]
+[2,1,0]
+[3]
+[4,2,1,0]
+[]
+Get is in hierarchy
+1
+1
+1
+1
+1
+0
+HashedArray dictionary
+Get hierarchy
+[0]
+[1,0]
+[2,1,0]
+[3]
+[4,2,1,0]
+[]
+Get is in hierarchy
+1
+1
+1
+1
+1
+0

--- a/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.reference
+++ b/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.reference
@@ -43,3 +43,33 @@ Get is in hierarchy
 1
 1
 0
+Cache dictionary
+Get hierarchy
+[0]
+[1,0]
+[2,1,0]
+[3]
+[4,2,1,0]
+[]
+Get is in hierarchy
+1
+1
+1
+1
+1
+0
+Direct dictionary
+Get hierarchy
+[0]
+[1,0]
+[2,1,0]
+[3]
+[4,2,1,0]
+[]
+Get is in hierarchy
+1
+1
+1
+1
+1
+0

--- a/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.reference
+++ b/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.reference
@@ -13,6 +13,27 @@ Get is in hierarchy
 1
 1
 0
+Get children
+[1]
+[2]
+[4]
+[]
+[]
+[]
+Get all descendants
+[1,2,4]
+[2,4]
+[4]
+[]
+[]
+[]
+Get descendants at first level
+[1]
+[2]
+[4]
+[]
+[]
+[]
 Hashed dictionary
 Get hierarchy
 [0]
@@ -28,6 +49,27 @@ Get is in hierarchy
 1
 1
 0
+Get children
+[1]
+[2]
+[4]
+[]
+[]
+[]
+Get all descendants
+[1,2,4]
+[2,4]
+[4]
+[]
+[]
+[]
+Get descendants at first level
+[1]
+[2]
+[4]
+[]
+[]
+[]
 HashedArray dictionary
 Get hierarchy
 [0]
@@ -43,6 +85,27 @@ Get is in hierarchy
 1
 1
 0
+Get children
+[1]
+[2]
+[4]
+[]
+[]
+[]
+Get all descendants
+[1,2,4]
+[2,4]
+[4]
+[]
+[]
+[]
+Get descendants at first level
+[1]
+[2]
+[4]
+[]
+[]
+[]
 Cache dictionary
 Get hierarchy
 [0]

--- a/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.sql
+++ b/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.sql
@@ -23,6 +23,12 @@ SELECT 'Get hierarchy';
 SELECT dictGetHierarchy('hierachical_flat_dictionary', number) FROM system.numbers LIMIT 6;
 SELECT 'Get is in hierarchy';
 SELECT dictIsIn('hierachical_flat_dictionary', number, number) FROM system.numbers LIMIT 6;
+SELECT 'Get children';
+SELECT dictGetChildren('hierachical_flat_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get all descendants';
+SELECT dictGetDescendants('hierachical_flat_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get descendants at first level';
+SELECT dictGetDescendants('hierachical_flat_dictionary', number, 1) FROM system.numbers LIMIT 6;
 
 DROP DICTIONARY hierachical_flat_dictionary;
 
@@ -42,6 +48,12 @@ SELECT 'Get hierarchy';
 SELECT dictGetHierarchy('hierachical_hashed_dictionary', number) FROM system.numbers LIMIT 6;
 SELECT 'Get is in hierarchy';
 SELECT dictIsIn('hierachical_hashed_dictionary', number, number) FROM system.numbers LIMIT 6;
+SELECT 'Get children';
+SELECT dictGetChildren('hierachical_hashed_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get all descendants';
+SELECT dictGetDescendants('hierachical_hashed_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get descendants at first level';
+SELECT dictGetDescendants('hierachical_hashed_dictionary', number, 1) FROM system.numbers LIMIT 6;
 
 DROP DICTIONARY hierachical_hashed_dictionary;
 
@@ -61,6 +73,12 @@ SELECT 'Get hierarchy';
 SELECT dictGetHierarchy('hierachical_hashed_array_dictionary', number) FROM system.numbers LIMIT 6;
 SELECT 'Get is in hierarchy';
 SELECT dictIsIn('hierachical_hashed_array_dictionary', number, number) FROM system.numbers LIMIT 6;
+SELECT 'Get children';
+SELECT dictGetChildren('hierachical_hashed_array_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get all descendants';
+SELECT dictGetDescendants('hierachical_hashed_array_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get descendants at first level';
+SELECT dictGetDescendants('hierachical_hashed_array_dictionary', number, 1) FROM system.numbers LIMIT 6;
 
 DROP DICTIONARY hierachical_hashed_array_dictionary;
 
@@ -80,6 +98,7 @@ SELECT 'Get hierarchy';
 SELECT dictGetHierarchy('hierachical_cache_dictionary', number) FROM system.numbers LIMIT 6;
 SELECT 'Get is in hierarchy';
 SELECT dictIsIn('hierachical_cache_dictionary', number, number) FROM system.numbers LIMIT 6;
+
 
 DROP DICTIONARY hierachical_cache_dictionary;
 

--- a/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.sql
+++ b/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.sql
@@ -1,0 +1,67 @@
+DROP TABLE IF EXISTS test_hierarhical_table;
+CREATE TABLE test_hierarhical_table
+(
+    id UInt64,
+    parent_id Nullable(UInt64)
+) ENGINE=TinyLog;
+
+INSERT INTO test_hierarhical_table VALUES (0, NULL), (1, 0), (2, 1), (3, NULL), (4, 2);
+
+DROP DICTIONARY IF EXISTS hierachical_flat_dictionary;
+CREATE DICTIONARY hierachical_flat_dictionary
+(
+    id UInt64,
+    parent_id Nullable(UInt64) HIERARCHICAL
+) PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'test_hierarhical_table'))
+LAYOUT(FLAT())
+LIFETIME(0);
+
+SELECT 'Flat dictionary';
+
+SELECT 'Get hierarchy';
+SELECT dictGetHierarchy('hierachical_flat_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get is in hierarchy';
+SELECT dictIsIn('hierachical_flat_dictionary', number, number) FROM system.numbers LIMIT 6;
+
+DROP DICTIONARY hierachical_flat_dictionary;
+
+DROP DICTIONARY IF EXISTS hierachical_hashed_dictionary;
+CREATE DICTIONARY hierachical_hashed_dictionary
+(
+    id UInt64,
+    parent_id Nullable(UInt64) HIERARCHICAL
+) PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'test_hierarhical_table'))
+LAYOUT(HASHED())
+LIFETIME(0);
+
+SELECT 'Hashed dictionary';
+
+SELECT 'Get hierarchy';
+SELECT dictGetHierarchy('hierachical_hashed_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get is in hierarchy';
+SELECT dictIsIn('hierachical_hashed_dictionary', number, number) FROM system.numbers LIMIT 6;
+
+DROP DICTIONARY hierachical_hashed_dictionary;
+
+DROP DICTIONARY IF EXISTS hierachical_hashed_array_dictionary;
+CREATE DICTIONARY hierachical_hashed_array_dictionary
+(
+    id UInt64,
+    parent_id Nullable(UInt64) HIERARCHICAL
+) PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'test_hierarhical_table'))
+LAYOUT(HASHED_ARRAY())
+LIFETIME(0);
+
+SELECT 'HashedArray dictionary';
+
+SELECT 'Get hierarchy';
+SELECT dictGetHierarchy('hierachical_hashed_array_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get is in hierarchy';
+SELECT dictIsIn('hierachical_hashed_array_dictionary', number, number) FROM system.numbers LIMIT 6;
+
+DROP DICTIONARY hierachical_hashed_array_dictionary;
+
+DROP TABLE test_hierarhical_table;

--- a/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.sql
+++ b/tests/queries/0_stateless/02316_hierarchical_dictionaries_nullable_parent_key.sql
@@ -64,4 +64,41 @@ SELECT dictIsIn('hierachical_hashed_array_dictionary', number, number) FROM syst
 
 DROP DICTIONARY hierachical_hashed_array_dictionary;
 
+DROP DICTIONARY IF EXISTS hierachical_cache_dictionary;
+CREATE DICTIONARY hierachical_cache_dictionary
+(
+    id UInt64,
+    parent_id Nullable(UInt64) HIERARCHICAL
+) PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'test_hierarhical_table'))
+LAYOUT(CACHE(SIZE_IN_CELLS 10))
+LIFETIME(0);
+
+SELECT 'Cache dictionary';
+
+SELECT 'Get hierarchy';
+SELECT dictGetHierarchy('hierachical_cache_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get is in hierarchy';
+SELECT dictIsIn('hierachical_cache_dictionary', number, number) FROM system.numbers LIMIT 6;
+
+DROP DICTIONARY hierachical_cache_dictionary;
+
+DROP DICTIONARY IF EXISTS hierachical_direct_dictionary;
+CREATE DICTIONARY hierachical_direct_dictionary
+(
+    id UInt64,
+    parent_id Nullable(UInt64) HIERARCHICAL
+) PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'test_hierarhical_table'))
+LAYOUT(DIRECT());
+
+SELECT 'Direct dictionary';
+
+SELECT 'Get hierarchy';
+SELECT dictGetHierarchy('hierachical_direct_dictionary', number) FROM system.numbers LIMIT 6;
+SELECT 'Get is in hierarchy';
+SELECT dictIsIn('hierachical_direct_dictionary', number, number) FROM system.numbers LIMIT 6;
+
+DROP DICTIONARY hierachical_direct_dictionary;
+
 DROP TABLE test_hierarhical_table;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Functions `dictGetHierarchy`, `dictIsIn`, `dictGetChildren`, `dictGetDescendants` added support nullable `HIERARCHICAL` attribute in dictionaries. Closes #35521.