### PR TITLE
Try to speedup readCSVStringInto

### DIFF
--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -595,6 +595,12 @@ template <typename Vector>
 void readCSVStringInto(Vector & s, ReadBuffer & buf, const FormatSettings::CSV & settings);
 
 template <typename Vector>
+void readCSVStringIntoSSE2(Vector & s, ReadBuffer & buf, const FormatSettings::CSV & settings);
+
+template <typename Vector>
+void readCSVStringIntoSSE2Opt(Vector & s, ReadBuffer & buf, const FormatSettings::CSV & settings);
+
+template <typename Vector>
 void readCSVStringIntoAVX2(Vector & s, ReadBuffer & buf, const FormatSettings::CSV & settings);
 
 template <typename Vector>

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -594,6 +594,12 @@ void readStringUntilEOFInto(Vector & s, ReadBuffer & buf);
 template <typename Vector>
 void readCSVStringInto(Vector & s, ReadBuffer & buf, const FormatSettings::CSV & settings);
 
+template <typename Vector>
+void readCSVStringIntoAVX2(Vector & s, ReadBuffer & buf, const FormatSettings::CSV & settings);
+
+template <typename Vector>
+void readCSVStringIntoAVX512(Vector & s, ReadBuffer & buf, const FormatSettings::CSV & settings);
+
 /// ReturnType is either bool or void. If bool, the function will return false instead of throwing an exception.
 template <typename Vector, typename ReturnType = void>
 ReturnType readJSONStringInto(Vector & s, ReadBuffer & buf);

--- a/src/IO/examples/CMakeLists.txt
+++ b/src/IO/examples/CMakeLists.txt
@@ -79,3 +79,6 @@ target_link_libraries (snappy_read_buffer PRIVATE clickhouse_common_io)
 add_executable (hadoop_snappy_read_buffer hadoop_snappy_read_buffer.cpp)
 target_link_libraries (hadoop_snappy_read_buffer PRIVATE clickhouse_common_io)
 
+add_executable (perf_read_csv_string_into perf_read_csv_string_into.cpp)
+target_link_libraries (perf_read_csv_string_into PRIVATE clickhouse_common_io)
+

--- a/src/IO/examples/perf_read_csv_string_into.cpp
+++ b/src/IO/examples/perf_read_csv_string_into.cpp
@@ -50,16 +50,29 @@ static void benchmark(int retries, int threads, const String & path, ReadFunc re
 int main()
 {
 #if defined(__AVX512F__) && defined(__AVX512BW__)
-    std::cout << "use avx512" << std::endl;
-#elif defined(__AVX__) && defined(__AVX2__)
-    std::cout << "use avx2" << std::endl;
-#elif defined(__SSE2__)
-    std::cout << "use sse2" << std::endl;
+    std::cout << "support avx512" << std::endl;
+#else
+    std::cout << "do not support avx512" << std::endl;
+#endif
+
+#if defined(__AVX__) && defined(__AVX2__)
+    std::cout << "support avx2" << std::endl;
+#else
+    std::cout << "do not support avx2" << std::endl;
+#endif
+
+#if defined(__SSE2__)
+    std::cout << "support sse2" << std::endl;
+#else
+    std::cout << "do not support sse2" << std::endl;
 #endif
 
     std::map<String, String> paths = {
+        /// echo "SELECT randomPrintableASCII(10), randomPrintableASCII(10) , randomPrintableASCII(10)  from system.numbers limit 10000000  FORMAT CSV settings format_csv_delimiter = '\x01'"  | clickhouse-client >  short.csv
         {"short.csv", "short-string"},
+        /// echo "SELECT randomPrintableASCII(100), randomPrintableASCII(100) , randomPrintableASCII(100)  from system.numbers limit 1000000  FORMAT CSV settings format_csv_delimiter = '\x01'"  | clickhouse-client >  medium.csv
         {"medium.csv", "medium-string"},
+        /// echo "SELECT randomPrintableASCII(1000), randomPrintableASCII(1000) , randomPrintableASCII(1000)  from system.numbers limit 100000  FORMAT CSV settings format_csv_delimiter = '\x01'"  | client-client >  long.csv
         {"long.csv", "long-string"},
     };
     std::map<ReadFunc, String> read_funcs

--- a/src/IO/examples/perf_read_csv_string_into.cpp
+++ b/src/IO/examples/perf_read_csv_string_into.cpp
@@ -1,0 +1,74 @@
+#include <IO/ReadHelpers.h>
+#include <IO/ReadBufferFromFile.h>
+
+using namespace DB;
+using ReadFunc =  void (*)(NullOutput &, ReadBuffer &, const FormatSettings::CSV &);
+
+static inline void skipDelimiters(ReadBuffer & in)
+{
+    while (!in.eof() && (*in.position() == '\x01' || *in.position() == '\r' || *in.position() == '\n'))
+        ++in.position();
+}
+
+void readCSVFile(ReadBuffer & buf, const FormatSettings::CSV & settings, ReadFunc read_func)
+{
+    while (!buf.eof())
+    {
+        NullOutput s;
+        read_func(s, buf, settings);
+        skipDelimiters(buf);
+    }
+}
+
+static void benchmark(int retries, int threads, const String & path, ReadFunc read_func, const String & tag = "")
+{
+    FormatSettings::CSV csv_settings;
+    csv_settings.delimiter = '\x01';
+    csv_settings.allow_single_quotes = false;
+    csv_settings.allow_double_quotes = false;
+
+    UInt64 sum_cost = 0;
+    for (int retry = 0; retry < retries; ++retry)
+    {
+        std::vector<ReadBufferPtr> read_buffers{static_cast<size_t>(threads)};
+        for (int i = 0; i < threads; ++i)
+            read_buffers[i] = std::make_shared<ReadBufferFromFile>(path);
+
+        Stopwatch watch;
+        std::vector<std::thread> group{static_cast<size_t>(threads)};
+        for (int i = 0; i < threads; ++i)
+            group[i]
+                = std::thread([i, read_func, &read_buffers, &csv_settings] { readCSVFile(*(read_buffers[i]), csv_settings, read_func); });
+
+        for (int i = 0; i < threads; ++i)
+            group[i].join();
+        sum_cost += watch.elapsedMilliseconds();
+    }
+    std::cout << tag << "\t" << static_cast<double>(sum_cost)/retries << std::endl;
+}
+
+int main()
+{
+#if defined(__AVX512F__) && defined(__AVX512BW__)
+    std::cout << "use avx512" << std::endl;
+#elif defined(__AVX__) && defined(__AVX2__)
+    std::cout << "use avx2" << std::endl;
+#elif defined(__SSE2__)
+    std::cout << "use sse2" << std::endl;
+#endif
+
+    std::map<String, String> paths = {
+        {"short.csv", "short-string"},
+        {"medium.csv", "medium-string"},
+        {"long.csv", "long-string"},
+    };
+    std::map<ReadFunc, String> read_funcs
+        = {{readCSVStringInto<NullOutput>, "sse2"},
+           {readCSVStringIntoAVX2<NullOutput>, "avx2"},
+           {readCSVStringIntoAVX512<NullOutput>, "avx512"}};
+
+    for (const auto & [path, path_tag] : paths)
+        for (const auto & [read_func, func_tag] : read_funcs)
+            benchmark(40, 1, path, read_func, path_tag + ":" + func_tag);
+    return 0;
+}

--- a/src/IO/examples/perf_read_csv_string_into.cpp
+++ b/src/IO/examples/perf_read_csv_string_into.cpp
@@ -10,7 +10,7 @@ static inline void skipDelimiters(ReadBuffer & in)
         ++in.position();
 }
 
-void readCSVFile(ReadBuffer & buf, const FormatSettings::CSV & settings, ReadFunc read_func)
+static inline void readCSVFile(ReadBuffer & buf, const FormatSettings::CSV & settings, ReadFunc read_func)
 {
     while (!buf.eof())
     {
@@ -76,9 +76,12 @@ int main()
         {"long.csv", "long-string"},
     };
     std::map<ReadFunc, String> read_funcs
-        = {{readCSVStringInto<NullOutput>, "sse2"},
-           {readCSVStringIntoAVX2<NullOutput>, "avx2"},
-           {readCSVStringIntoAVX512<NullOutput>, "avx512"}};
+        = {{readCSVStringInto<NullOutput>, "none"},
+           {readCSVStringIntoSSE2<NullOutput>, "sse2"},
+           {readCSVStringIntoSSE2Opt<NullOutput>, "sse2-opt"},
+        //    {readCSVStringIntoAVX2<NullOutput>, "avx2"},
+        //    {readCSVStringIntoAVX512<NullOutput>, "avx512"}
+           };
 
     for (const auto & [path, path_tag] : paths)
         for (const auto & [read_func, func_tag] : read_funcs)


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Try to speed up function readCSVStringInto by apply AVX2 or AVX512 to it. 

Here is the result `src/IO/examples/perf_read_csv_string_into.cpp` prints out:  

```
long-string:sse2	100.175
long-string:avx2	92.125
long-string:avx512	86.025
medium-string:sse2	142.075
medium-string:avx2	143.275
medium-string:avx512	139.075
short-string:sse2	563.175
short-string:avx2	567.325
short-string:avx512	606.8
```

```
long-string:sse2	103.575
long-string:avx2	90.2
long-string:avx512	85.4
medium-string:sse2	142.275
medium-string:avx2	141.475
medium-string:avx512	147.35
short-string:sse2	563.825
short-string:avx2	566.275
short-string:avx512	606.175
``` 

```
long-string:sse2	103.025
long-string:avx2	94.975
long-string:avx512	91.1
medium-string:sse2	146.625
medium-string:avx2	139.275
medium-string:avx512	138.75
short-string:sse2	560.875
short-string:avx2	561.925
short-string:avx512	592.5
```

We get conclusions: 
- For long csv field strings with size about 1000, avx512 version is the best, and is at most 20% faster than sse2
- For medium csv field strings with size about 100,  avx512, avx2, sse2 cost nearly the same time. 
- For short csv field strings with size about 10,  sse2 is the best.  

I doubt if it is worth using avx512 other than sse2 by judging the length of csv field string? But the string length is unpredictable, it can only be guessed by history cases. 
