### PR TITLE
Fix protobuf-mutator build

### DIFF
--- a/contrib/libprotobuf-mutator-cmake/CMakeLists.txt
+++ b/contrib/libprotobuf-mutator-cmake/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(_protobuf-mutator
     ${LIBRARY_DIR}/src/utf8_fix.cc)
 
 target_include_directories(_protobuf-mutator BEFORE INTERFACE "${LIBRARY_DIR}")
-target_include_directories(_protobuf-mutator BEFORE INTERFACE "${ClickHouse_SOURCE_DIR}/contrib/protobuf/src")
+target_include_directories(_protobuf-mutator BEFORE PUBLIC "${ClickHouse_SOURCE_DIR}/contrib/protobuf/src")
 
 target_link_libraries(_protobuf-mutator ch_contrib::protobuf)
 


### PR DESCRIPTION
Fixes below error when building

    cmake -DENABLE_FUZZING=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build

```
[1/2417] Building CXX object contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/binary_format.cc.o
FAILED: contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/binary_format.cc.o
/usr/bin/ccache /usr/bin/clang++ --target=x86_64-linux-gnu --sysroot=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -DHAS_RESERVED_IDENTIFI
ER -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUNALIGNED_OK -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -I/home/ubuntu/repo/ClickHouse1/contrib/protobuf -isystem /home/ubuntu/repo/ClickHouse1/contrib/libc
xx/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxx/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxxabi/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libunwind/
include -isystem /home/ubuntu/repo/ClickHouse1/contrib/protobuf/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/zlib-ng -isystem /home/ubuntu/repo/ClickHouse1/build/contrib/zlib-ng-cmake -
-gcc-toolchain=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64 -std=c++20 -nostdlib++  -fsanitize=fuzzer-no-link -fdiagnostics-color=always -Xclang -fuse-ctor-hom
ing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/home/ubuntu/repo/ClickHouse1=. -falign-functions=32
 -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fexperimental-new-pass-manager -w -O2 -g -DNDEBUG -O3 -g -gdwarf-4  -fno-pie   -D OS_LINUX -Werror -nostdinc++ -std=gnu++20 -MD -MT con
trib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/binary_format.cc.o -MF contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprot
obuf-mutator/src/binary_format.cc.o.d -o contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/binary_format.cc.o -c /home/ubuntu/repo/ClickHouse1/cont
rib/libprotobuf-mutator/src/binary_format.cc
/home/ubuntu/repo/ClickHouse1/contrib/libprotobuf-mutator/src/binary_format.cc:15:10: fatal error: 'src/binary_format.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
[2/2417] Building CXX object contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/text_format.cc.o
FAILED: contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/text_format.cc.o
/usr/bin/ccache /usr/bin/clang++ --target=x86_64-linux-gnu --sysroot=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -DHAS_RESERVED_IDENTIFI
ER -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUNALIGNED_OK -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -I/home/ubuntu/repo/ClickHouse1/contrib/protobuf -isystem /home/ubuntu/repo/ClickHouse1/contrib/libc
xx/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxx/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxxabi/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libunwind/
include -isystem /home/ubuntu/repo/ClickHouse1/contrib/protobuf/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/zlib-ng -isystem /home/ubuntu/repo/ClickHouse1/build/contrib/zlib-ng-cmake -
-gcc-toolchain=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64 -std=c++20 -nostdlib++  -fsanitize=fuzzer-no-link -fdiagnostics-color=always -Xclang -fuse-ctor-hom
ing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/home/ubuntu/repo/ClickHouse1=. -falign-functions=32
 -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fexperimental-new-pass-manager -w -O2 -g -DNDEBUG -O3 -g -gdwarf-4  -fno-pie   -D OS_LINUX -Werror -nostdinc++ -std=gnu++20 -MD -MT con
trib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/text_format.cc.o -MF contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotob
uf-mutator/src/text_format.cc.o.d -o contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/text_format.cc.o -c /home/ubuntu/repo/ClickHouse1/contrib/li
bprotobuf-mutator/src/text_format.cc
/home/ubuntu/repo/ClickHouse1/contrib/libprotobuf-mutator/src/text_format.cc:15:10: fatal error: 'src/text_format.h' file not found
         ^~~~~~~~~~~~~~~~~~~
1 error generated.
[6/2417] Building CXX object contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/utf8_fix.cc.o
FAILED: contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/utf8_fix.cc.o
/usr/bin/ccache /usr/bin/clang++ --target=x86_64-linux-gnu --sysroot=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -DHAS_RESERVED_IDENTIFI
ER -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUNALIGNED_OK -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -I/home/ubuntu/repo/ClickHouse1/contrib/protobuf -isystem /home/ubuntu/repo/ClickHouse1/contrib/libc
xx/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxx/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxxabi/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libunwind/
include -isystem /home/ubuntu/repo/ClickHouse1/contrib/protobuf/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/zlib-ng -isystem /home/ubuntu/repo/ClickHouse1/build/contrib/zlib-ng-cmake -
-gcc-toolchain=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64 -std=c++20 -nostdlib++  -fsanitize=fuzzer-no-link -fdiagnostics-color=always -Xclang -fuse-ctor-hom
ing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/home/ubuntu/repo/ClickHouse1=. -falign-functions=32
 -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fexperimental-new-pass-manager -w -O2 -g -DNDEBUG -O3 -g -gdwarf-4  -fno-pie   -D OS_LINUX -Werror -nostdinc++ -std=gnu++20 -MD -MT con
trib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/utf8_fix.cc.o -MF contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-
mutator/src/utf8_fix.cc.o.d -o contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/utf8_fix.cc.o -c /home/ubuntu/repo/ClickHouse1/contrib/libprotobuf
-mutator/src/utf8_fix.cc
/home/ubuntu/repo/ClickHouse1/contrib/libprotobuf-mutator/src/utf8_fix.cc:15:10: fatal error: 'src/utf8_fix.h' file not found
         ^~~~~~~~~~~~~~~~
1 error generated.
[7/2417] Building CXX object contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.cc.o
FAILED: contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.cc.o
/usr/bin/ccache /usr/bin/clang++ --target=x86_64-linux-gnu --sysroot=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -DHAS_RESERVED_IDENTIFI
ER -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUNALIGNED_OK -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -I/home/ubuntu/repo/ClickHouse1/contrib/protobuf -isystem /home/ubuntu/repo/ClickHouse1/contrib/libc
xx/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxx/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxxabi/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libunwind/
include -isystem /home/ubuntu/repo/ClickHouse1/contrib/protobuf/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/zlib-ng -isystem /home/ubuntu/repo/ClickHouse1/build/contrib/zlib-ng-cmake -
-gcc-toolchain=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64 -std=c++20 -nostdlib++  -fsanitize=fuzzer-no-link -fdiagnostics-color=always -Xclang -fuse-ctor-hom
ing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/home/ubuntu/repo/ClickHouse1=. -falign-functions=32
 -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fexperimental-new-pass-manager -w -O2 -g -DNDEBUG -O3 -g -gdwarf-4  -fno-pie   -D OS_LINUX -Werror -nostdinc++ -std=gnu++20 -MD -MT con
trib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.cc.o -MF contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.di
r/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.cc.o.d -o contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.cc.o -
c /home/ubuntu/repo/ClickHouse1/contrib/libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.cc
/home/ubuntu/repo/ClickHouse1/contrib/libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.cc:15:10: fatal error: 'src/libfuzzer/libfuzzer_macro.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[8/2417] Building CXX object contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_mutator.cc.o
FAILED: contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_mutator.cc.o
/usr/bin/ccache /usr/bin/clang++ --target=x86_64-linux-gnu --sysroot=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -DHAS_RESERVED_IDENTIFI
ER -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUNALIGNED_OK -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -I/home/ubuntu/repo/ClickHouse1/contrib/protobuf -isystem /home/ubuntu/repo/ClickHouse1/contrib/libc
xx/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxx/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxxabi/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libunwind/
include -isystem /home/ubuntu/repo/ClickHouse1/contrib/protobuf/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/zlib-ng -isystem /home/ubuntu/repo/ClickHouse1/build/contrib/zlib-ng-cmake -
-gcc-toolchain=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64 -std=c++20 -nostdlib++  -fsanitize=fuzzer-no-link -fdiagnostics-color=always -Xclang -fuse-ctor-hom
ing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/home/ubuntu/repo/ClickHouse1=. -falign-functions=32
 -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fexperimental-new-pass-manager -w -O2 -g -DNDEBUG -O3 -g -gdwarf-4  -fno-pie   -D OS_LINUX -Werror -nostdinc++ -std=gnu++20 -MD -MT con
trib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_mutator.cc.o -MF contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.
dir/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_mutator.cc.o.d -o contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/libfuzzer/libfuzzer_mutator.
cc.o -c /home/ubuntu/repo/ClickHouse1/contrib/libprotobuf-mutator/src/libfuzzer/libfuzzer_mutator.cc
/home/ubuntu/repo/ClickHouse1/contrib/libprotobuf-mutator/src/libfuzzer/libfuzzer_mutator.cc:15:10: fatal error: 'src/libfuzzer/libfuzzer_mutator.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[10/2417] Building CXX object contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/mutator.cc.o
FAILED: contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/mutator.cc.o
/usr/bin/ccache /usr/bin/clang++ --target=x86_64-linux-gnu --sysroot=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc -DHAS_RESERVED_IDENTIFI
ER -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUNALIGNED_OK -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -I/home/ubuntu/repo/ClickHouse1/contrib/protobuf -isystem /home/ubuntu/repo/ClickHouse1/contrib/libc
xx/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxx/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/libcxxabi/include -isystem /home/ubuntu/repo/ClickHouse1/contrib/libunwind/
include -isystem /home/ubuntu/repo/ClickHouse1/contrib/protobuf/src -isystem /home/ubuntu/repo/ClickHouse1/contrib/zlib-ng -isystem /home/ubuntu/repo/ClickHouse1/build/contrib/zlib-ng-cmake -
-gcc-toolchain=/home/ubuntu/repo/ClickHouse1/cmake/linux/../../contrib/sysroot/linux-x86_64 -std=c++20 -nostdlib++  -fsanitize=fuzzer-no-link -fdiagnostics-color=always -Xclang -fuse-ctor-hom
ing -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/home/ubuntu/repo/ClickHouse1=. -falign-functions=32
 -fdiagnostics-absolute-paths -fstrict-vtable-pointers -fexperimental-new-pass-manager -w -O2 -g -DNDEBUG -O3 -g -gdwarf-4  -fno-pie   -D OS_LINUX -Werror -nostdinc++ -std=gnu++20 -MD -MT con
trib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/mutator.cc.o -MF contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-m
utator/src/mutator.cc.o.d -o contrib/libprotobuf-mutator-cmake/CMakeFiles/_protobuf-mutator.dir/__/libprotobuf-mutator/src/mutator.cc.o -c /home/ubuntu/repo/ClickHouse1/contrib/libprotobuf-mu
tator/src/mutator.cc
/home/ubuntu/repo/ClickHouse1/contrib/libprotobuf-mutator/src/mutator.cc:15:10: fatal error: 'src/mutator.h' file not found
1 error generated.
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)