### PR TITLE
Print query in one line on fatal errors

### DIFF
--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -89,6 +89,10 @@ public:
     LogsLevel client_logs_level = LogsLevel::none;
 
     String query;
+    /// Query without new lines (see toOneLineQuery())
+    /// Used to print in case of fatal error
+    /// (to avoid calling extra code in the fatal error handler)
+    String one_line_query;
     UInt64 normalized_query_hash = 0;
 
     std::vector<ProfileEventsCountersAndMemory> finished_threads_counters_memory;

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -302,7 +302,7 @@ private:
 
             if (auto thread_group = thread_ptr->getThreadGroup())
             {
-                query = thread_group->query;
+                query = thread_group->one_line_query;
             }
 
             if (auto logs_queue = thread_ptr->getInternalTextLogsQueue())

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -8,6 +8,7 @@
 #include <Parsers/ASTKillQueryQuery.h>
 #include <Parsers/IAST.h>
 #include <Parsers/queryNormalization.h>
+#include <Parsers/toOneLineQuery.h>
 #include <Processors/Executors/PipelineExecutor.h>
 #include <Common/typeid_cast.h>
 #include <Common/Exception.h>
@@ -208,6 +209,7 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
             thread_group->performance_counters.setParent(&user_process_list.user_performance_counters);
             thread_group->memory_tracker.setParent(&user_process_list.user_memory_tracker);
             thread_group->query = query_;
+            thread_group->one_line_query = toOneLineQuery(query_);
             thread_group->normalized_query_hash = normalizedQueryHash<false>(query_);
 
             /// Set query-level memory trackers

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -33,6 +33,7 @@
 #include <Parsers/queryNormalization.h>
 #include <Parsers/queryToString.h>
 #include <Parsers/formatAST.h>
+#include <Parsers/toOneLineQuery.h>
 
 #include <Formats/FormatFactory.h>
 #include <Storages/StorageInput.h>
@@ -104,38 +105,6 @@ static void checkASTSizeLimits(const IAST & ast, const Settings & settings)
 }
 
 
-static String joinLines(const String & query)
-{
-    /// Care should be taken. We don't join lines inside non-whitespace tokens (e.g. multiline string literals)
-    ///  and we don't join line after comment (because it can be single-line comment).
-    /// All other whitespaces replaced to a single whitespace.
-
-    String res;
-    const char * begin = query.data();
-    const char * end = begin + query.size();
-
-    Lexer lexer(begin, end);
-    Token token = lexer.nextToken();
-    for (; !token.isEnd(); token = lexer.nextToken())
-    {
-        if (token.type == TokenType::Whitespace)
-        {
-            res += ' ';
-        }
-        else if (token.type == TokenType::Comment)
-        {
-            res.append(token.begin, token.end);
-            if (token.end < end && *token.end == '\n')
-                res += '\n';
-        }
-        else
-            res.append(token.begin, token.end);
-    }
-
-    return res;
-}
-
-
 static String prepareQueryForLogging(const String & query, ContextPtr context)
 {
     String res = query;
@@ -162,7 +131,7 @@ static void logQuery(const String & query, ContextPtr context, bool internal, Qu
 {
     if (internal)
     {
-        LOG_DEBUG(&Poco::Logger::get("executeQuery"), "(internal) {} (stage: {})", joinLines(query), QueryProcessingStage::toString(stage));
+        LOG_DEBUG(&Poco::Logger::get("executeQuery"), "(internal) {} (stage: {})", toOneLineQuery(query), QueryProcessingStage::toString(stage));
     }
     else
     {
@@ -191,7 +160,7 @@ static void logQuery(const String & query, ContextPtr context, bool internal, Qu
             (!initial_query_id.empty() && current_query_id != initial_query_id ? ", initial_query_id: " + initial_query_id : std::string()),
             transaction_info,
             comment,
-            joinLines(query),
+            toOneLineQuery(query),
             QueryProcessingStage::toString(stage));
 
         if (client_info.client_trace_context.trace_id != UUID())
@@ -237,7 +206,7 @@ static void logException(ContextPtr context, QueryLogElement & elem)
             elem.exception,
             context->getClientInfo().current_address.toString(),
             comment,
-            joinLines(elem.query));
+            toOneLineQuery(elem.query));
     else
         LOG_ERROR(
             &Poco::Logger::get("executeQuery"),
@@ -246,7 +215,7 @@ static void logException(ContextPtr context, QueryLogElement & elem)
             elem.exception,
             context->getClientInfo().current_address.toString(),
             comment,
-            joinLines(elem.query),
+            toOneLineQuery(elem.query),
             elem.stack_trace);
 }
 

--- a/src/Parsers/toOneLineQuery.cpp
+++ b/src/Parsers/toOneLineQuery.cpp
@@ -1,0 +1,34 @@
+#include <Parsers/toOneLineQuery.h>
+#include <Parsers/Lexer.h>
+
+namespace DB
+{
+
+String toOneLineQuery(const String & query)
+{
+    String res;
+    const char * begin = query.data();
+    const char * end = begin + query.size();
+
+    Lexer lexer(begin, end);
+    Token token = lexer.nextToken();
+    for (; !token.isEnd(); token = lexer.nextToken())
+    {
+        if (token.type == TokenType::Whitespace)
+        {
+            res += ' ';
+        }
+        else if (token.type == TokenType::Comment)
+        {
+            res.append(token.begin, token.end);
+            if (token.end < end && *token.end == '\n')
+                res += '\n';
+        }
+        else
+            res.append(token.begin, token.end);
+    }
+
+    return res;
+}
+
+}

--- a/src/Parsers/toOneLineQuery.h
+++ b/src/Parsers/toOneLineQuery.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <base/types.h>
+
+namespace DB
+{
+
+/// Removes new lines from query.
+///
+/// But with some care:
+/// - don't join lines inside non-whitespace tokens (e.g. multiline string literals)
+/// - don't join line after comment (because it can be single-line comment).
+/// All other whitespaces replaced to a single whitespace.
+String toOneLineQuery(const String & query);
+
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

executeQuery() logging join query to one line, and it is useful, since
you can grep and see the whole query (usually).

So let's use the same in fatal error handler to make CI reports more
informative.