### PR TITLE
Hotfix for minio in functional tests

### DIFF
--- a/docker/test/stateful/Dockerfile
+++ b/docker/test/stateful/Dockerfile
@@ -17,8 +17,7 @@ ENV EXPORT_S3_STORAGE_POLICIES=1
 
 # Download Minio-related binaries
 RUN arch=${TARGETARCH:-amd64} \
-    && wget "https://dl.min.io/server/minio/release/linux-${arch}/minio" \
-    && chmod +x ./minio \
+    && wget "https://dl.min.io/server/minio/release/linux-${arch}/archive/minio-20220103182258.0.0.x86_64.rpm" \
     && wget "https://dl.min.io/client/mc/release/linux-${arch}/mc" \
     && chmod +x ./mc
 ENV MINIO_ROOT_USER="clickhouse"

--- a/docker/test/stateful/Dockerfile
+++ b/docker/test/stateful/Dockerfile
@@ -17,7 +17,7 @@ ENV EXPORT_S3_STORAGE_POLICIES=1
 
 # Download Minio-related binaries
 RUN arch=${TARGETARCH:-amd64} \
-    && wget "https://dl.min.io/server/minio/release/linux-${arch}/archive/minio-20220103182258.0.0.x86_64.rpm" \
+    && if [ "$arch" = "amd64" ] ; then wget "https://dl.min.io/server/minio/release/linux-${arch}/archive/minio-20220103182258.0.0.x86_64.rpm"; else wget "https://dl.min.io/server/minio/release/linux-${arch}/archive/minio-20220103182258.0.0.aarch64.rpm" ; fi \
     && wget "https://dl.min.io/client/mc/release/linux-${arch}/mc" \
     && chmod +x ./mc
 ENV MINIO_ROOT_USER="clickhouse"

--- a/docker/test/stateful/setup_minio.sh
+++ b/docker/test/stateful/setup_minio.sh
@@ -10,7 +10,7 @@
 set -e -x -a -u
 
 rpm2cpio ./minio-20220103182258.0.0.x86_64.rpm | cpio -i --make-directories
-find -name minio
+find -name minio /
 cp ./usr/local/bin/minio ./
 
 ls -lha

--- a/docker/test/stateful/setup_minio.sh
+++ b/docker/test/stateful/setup_minio.sh
@@ -10,7 +10,7 @@
 set -e -x -a -u
 
 rpm2cpio ./minio-20220103182258.0.0.x86_64.rpm | cpio -i --make-directories
-find -name minio /
+find / -name minio
 cp ./usr/local/bin/minio ./
 
 ls -lha

--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -57,7 +57,7 @@ ARG TARGETARCH
 
 # Download Minio-related binaries
 RUN arch=${TARGETARCH:-amd64} \
-    && wget "https://dl.min.io/server/minio/release/linux-${arch}/archive/minio-20220103182258.0.0.x86_64.rpm" \
+    && if [ "$arch" = "amd64" ] ; then wget "https://dl.min.io/server/minio/release/linux-${arch}/archive/minio-20220103182258.0.0.x86_64.rpm"; else wget "https://dl.min.io/server/minio/release/linux-${arch}/archive/minio-20220103182258.0.0.aarch64.rpm" ; fi \
     && wget "https://dl.min.io/client/mc/release/linux-${arch}/mc" \
     && chmod +x ./mc
 

--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -33,7 +33,9 @@ RUN apt-get update -y \
             postgresql-client \
             sqlite3 \
             awscli \
-            openjdk-11-jre-headless
+            openjdk-11-jre-headless \
+            rpm2cpio \
+            cpio
 
 
 RUN pip3 install numpy scipy pandas Jinja2
@@ -55,8 +57,7 @@ ARG TARGETARCH
 
 # Download Minio-related binaries
 RUN arch=${TARGETARCH:-amd64} \
-    && wget "https://dl.min.io/server/minio/release/linux-${arch}/minio" \
-    && chmod +x ./minio \
+    && wget "https://dl.min.io/server/minio/release/linux-${arch}/archive/minio-20220103182258.0.0.x86_64.rpm" \
     && wget "https://dl.min.io/client/mc/release/linux-${arch}/mc" \
     && chmod +x ./mc
 

--- a/docker/test/stateless/setup_minio.sh
+++ b/docker/test/stateless/setup_minio.sh
@@ -8,7 +8,7 @@
 set -e -x -a -u
 
 rpm2cpio ./minio-20220103182258.0.0.x86_64.rpm | cpio -i --make-directories
-find -name minio /
+find / -name minio
 cp ./usr/local/bin/minio ./
 
 ls -lha

--- a/docker/test/stateless/setup_minio.sh
+++ b/docker/test/stateless/setup_minio.sh
@@ -7,6 +7,10 @@
 
 set -e -x -a -u
 
+rpm2cpio ./minio-20220103182258.0.0.x86_64.rpm | cpio -i --make-directories
+find -name minio
+cp ./usr/local/bin/minio ./
+
 ls -lha
 
 mkdir -p ./minio_data
@@ -25,12 +29,19 @@ fi
 MINIO_ROOT_USER=${MINIO_ROOT_USER:-clickhouse}
 MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-clickhouse}
 
+./minio --version
 ./minio server --address ":11111" ./minio_data &
 
+i=0
 while ! curl -v --silent http://localhost:11111 2>&1 | grep AccessDenied
 do
+  if [[ $i == 60 ]]; then
+    echo "Failed to setup minio"
+    exit 0
+  fi
   echo "Trying to connect to minio"
   sleep 1
+  i=$((i + 1))
 done
 
 lsof -i :11111

--- a/docker/test/stateless/setup_minio.sh
+++ b/docker/test/stateless/setup_minio.sh
@@ -8,7 +8,7 @@
 set -e -x -a -u
 
 rpm2cpio ./minio-20220103182258.0.0.x86_64.rpm | cpio -i --make-directories
-find -name minio
+find -name minio /
 cp ./usr/local/bin/minio ./
 
 ls -lha


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It fixes infinite loop like this
```
Trying to connect to minio
+ curl -v --silent http://localhost:11111/
+ grep AccessDenied
Trying to connect to minio
+ echo 'Trying to connect to minio'
+ sleep 1
+ curl -v --silent http://localhost:11111/
+ grep AccessDenied
Trying to connect to minio
+ echo 'Trying to connect to minio'
+ sleep 1
+ curl -v --silent http://localhost:11111/
+ grep AccessDenied
+ echo 'Trying to connect to minio'
+ sleep 1
```

And fixes minio startup
```
Error: Disk `/minio_data` is part of root disk, will not be used (*errors.errorString)
       8: internal/logger/logger.go:278:logger.LogIf()
       7: cmd/erasure-sets.go:1243:cmd.markRootDisksAsDown()
       6: cmd/format-erasure.go:798:cmd.initFormatErasure()
       5: cmd/prepare-storage.go:198:cmd.connectLoadInitFormats()
       4: cmd/prepare-storage.go:282:cmd.waitForFormatErasure()
       3: cmd/erasure-server-pool.go:66:cmd.newErasureServerPools()
       2: cmd/server-main.go:668:cmd.newObjectLayer()
       1: cmd/server-main.go:518:cmd.serverMain()
+ i=2
+ curl -v --silent http://localhost:11111
+ grep AccessDenied
Trying to connect to minio
+ [[ 2 == 100 ]]
+ echo 'Trying to connect to minio'
+ sleep 1
Formatting 1st pool, 1 set(s), 1 drives per set.

API: SYSTEM()
Time: 18:09:25 UTC 06/03/2022
Error: Disk `/minio_data` is part of root disk, will not be used (*errors.errorString)
       8: internal/logger/logger.go:278:logger.LogIf()
       7: cmd/erasure-sets.go:1243:cmd.markRootDisksAsDown()
       6: cmd/format-erasure.go:798:cmd.initFormatErasure()
       5: cmd/prepare-storage.go:198:cmd.connectLoadInitFormats()
       4: cmd/prepare-storage.go:302:cmd.waitForFormatErasure()
       3: cmd/erasure-server-pool.go:66:cmd.newErasureServerPools()
       2: cmd/server-main.go:668:cmd.newObjectLayer()
       1: cmd/server-main.go:518:cmd.serverMain()
ERROR Unable to initialize backend: disk not found
```

And therefore it's supposed to fix functional tests

**However, it breaks functional tests on ARM.**