### PR TITLE
Hotfix for minio in functional tests 2

### DIFF
--- a/docker/test/stateful/setup_minio.sh
+++ b/docker/test/stateful/setup_minio.sh
@@ -9,7 +9,7 @@
 
 set -e -x -a -u
 
-rpm2cpio ./minio-20220103182258.0.0.x86_64.rpm | cpio -i --make-directories
+rpm2cpio ./minio-20220103182258.0.0.*.rpm | cpio -i --make-directories
 find / -name minio
 cp ./usr/local/bin/minio ./
 

--- a/docker/test/stateless/setup_minio.sh
+++ b/docker/test/stateless/setup_minio.sh
@@ -7,7 +7,7 @@
 
 set -e -x -a -u
 
-rpm2cpio ./minio-20220103182258.0.0.x86_64.rpm | cpio -i --make-directories
+rpm2cpio ./minio-20220103182258.0.0.*.rpm | cpio -i --make-directories
 find / -name minio
 cp ./usr/local/bin/minio ./
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Continuation of  #37845
This is supposed to fix tests on ARM

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
