### PR TITLE
Don't try to kill empty list of containers in `integration/runner`

### DIFF
--- a/docker/test/integration/runner/dockerd-entrypoint.sh
+++ b/docker/test/integration/runner/dockerd-entrypoint.sh
@@ -30,8 +30,8 @@ set -e
 # cleanup for retry run if volume is not recreated
 # shellcheck disable=SC2046
 {
-  docker kill $(docker ps -aq) || true
-  docker rm $(docker ps -aq) || true
+    docker ps -aq | xargs -r docker kill
+    docker ps -aq | xargs -r docker rm
 }
 
 echo "Start tests"

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -310,8 +310,6 @@ if __name__ == "__main__":
         print(f"Trying to kill container name={CONTAINER_NAME} ids={containers}")
         subprocess.check_call(f"docker kill {' '.join(containers)}", shell=True)
         print("Container killed")
-    else:
-        print("Nothing to kill")
 
     print(("Running pytest container as: '" + cmd + "'."))
     subprocess.check_call(cmd, shell=True)

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -16,7 +16,7 @@ CURRENT_WORK_DIR = os.getcwd()
 CONTAINER_NAME = "clickhouse_integration_tests"
 
 CONFIG_DIR_IN_REPO = "programs/server"
-INTERGATION_DIR_IN_REPO = "tests/integration"
+INTEGRATION_DIR_IN_REPO = "tests/integration"
 SRC_DIR_IN_REPO = "src"
 
 DIND_INTEGRATION_TESTS_IMAGE_NAME = "clickhouse/integration-tests-runner"
@@ -55,7 +55,7 @@ def check_args_and_update_paths(args):
         if not os.path.isabs(args.cases_dir):
             args.cases_dir = os.path.abspath(os.path.join(CURRENT_WORK_DIR, args.cases_dir))
     else:
-        args.cases_dir = os.path.abspath(os.path.join(CLICKHOUSE_ROOT, INTERGATION_DIR_IN_REPO))
+        args.cases_dir = os.path.abspath(os.path.join(CLICKHOUSE_ROOT, INTEGRATION_DIR_IN_REPO))
         logging.info("Cases dir is not set. Will use %s" % (args.cases_dir))
 
     if args.src_dir:

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -307,9 +307,9 @@ if __name__ == "__main__":
 
     containers = subprocess.check_output(f"docker ps -a -q --filter name={CONTAINER_NAME} --format={{{{.ID}}}}", shell=True, universal_newlines=True).splitlines()
     if containers:
-        print(f"Trying to kill container name={CONTAINER_NAME} ids={containers}")
+        print(f"Trying to kill containers name={CONTAINER_NAME} ids={containers}")
         subprocess.check_call(f"docker kill {' '.join(containers)}", shell=True)
-        print("Container killed")
+        print(f"Containers {containers} killed")
 
     print(("Running pytest container as: '" + cmd + "'."))
     subprocess.check_call(cmd, shell=True)

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -305,11 +305,12 @@ if __name__ == "__main__":
         command=args.command
     )
 
-    try:
-        print("Trying to kill container", CONTAINER_NAME, "if it's already running")
-        subprocess.check_call(f'docker kill $(docker ps -a -q --filter name={CONTAINER_NAME} --format="{{{{.ID}}}}")', shell=True)
+    containers = subprocess.check_output(f"docker ps -a -q --filter name={CONTAINER_NAME} --format={{{{.ID}}}}", shell=True, universal_newlines=True).splitlines()
+    if containers:
+        print(f"Trying to kill container name={CONTAINER_NAME} ids={containers}")
+        subprocess.check_call(f"docker kill {' '.join(containers)}", shell=True)
         print("Container killed")
-    except:
+    else:
         print("Nothing to kill")
 
     print(("Running pytest container as: '" + cmd + "'."))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Before:
```
Trying to kill container clickhouse_integration_tests if it's already running
"docker kill" requires at least 1 argument.
See 'docker kill --help'.

Usage:  docker kill [OPTIONS] CONTAINER [CONTAINER...]

Kill one or more running containers
Nothing to kill
```

After:
```
Trying to kill containers name=clickhouse_integration_tests ids=['c1ecddcbd73a']
c1ecddcbd73a
Containers ['c1ecddcbd73a'] killed
```