### PR TITLE
Possibility to run S3 tests on external endpoint

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2674,11 +2674,11 @@ services:
             - {env_file}
         security_opt:
             - label:disable
-        {dns_opt}
-            {dns_opt_attempts}
-            {dns_opt_timeout}
-            {dns_opt_inet6}
-            {dns_opt_rotate}
+        dns_opt:
+            - attempts:2
+            - timeout:1
+            - inet6
+            - rotate
         {networks}
             {app_net}
                 {ipv4_address}
@@ -3815,14 +3815,6 @@ class ClickHouseInstance:
                 net_aliases = "aliases:"
                 net_alias1 = "- " + self.hostname
 
-        dns_opt = dns_opt_attempts = dns_opt_timeout = dns_opt_inet6 = dns_opt_rotate = ""
-        if not os.environ.get('SKIP_DNS_OPTS'):
-            dns_opt = "dns_opt:"
-            dns_opt_attempts = "- attempts:2"
-            dns_opt_timeout = "- timeout:1"
-            dns_opt_inet6 = "- inet6"
-            dns_opt_rotate = "- rotate"
-
         if not self.with_installed_binary:
             binary_volume = "- " + self.server_bin_path + ":/usr/bin/clickhouse"
             odbc_bridge_volume = (
@@ -3887,11 +3879,6 @@ class ClickHouseInstance:
                     ipv6_address=ipv6_address,
                     net_aliases=net_aliases,
                     net_alias1=net_alias1,
-                    dns_opt=dns_opt,
-                    dns_opt_attempts=dns_opt_attempts,
-                    dns_opt_timeout=dns_opt_timeout,
-                    dns_opt_inet6=dns_opt_inet6,
-                    dns_opt_rotate=dns_opt_rotate,
                 )
             )
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2674,11 +2674,11 @@ services:
             - {env_file}
         security_opt:
             - label:disable
-        dns_opt:
-            - attempts:2
-            - timeout:1
-            - inet6
-            - rotate
+        {dns_opt}
+            {dns_opt_attempts}
+            {dns_opt_timeout}
+            {dns_opt_inet6}
+            {dns_opt_rotate}
         {networks}
             {app_net}
                 {ipv4_address}
@@ -3815,6 +3815,14 @@ class ClickHouseInstance:
                 net_aliases = "aliases:"
                 net_alias1 = "- " + self.hostname
 
+        dns_opt = dns_opt_attempts = dns_opt_timeout = dns_opt_inet6 = dns_opt_rotate = ""
+        if not os.environ.get('SKIP_DNS_OPTS'):
+            dns_opt = "dns_opt:"
+            dns_opt_attempts = "- attempts:2"
+            dns_opt_timeout = "- timeout:1"
+            dns_opt_inet6 = "- inet6"
+            dns_opt_rotate = "- rotate"
+
         if not self.with_installed_binary:
             binary_volume = "- " + self.server_bin_path + ":/usr/bin/clickhouse"
             odbc_bridge_volume = (
@@ -3879,6 +3887,11 @@ class ClickHouseInstance:
                     ipv6_address=ipv6_address,
                     net_aliases=net_aliases,
                     net_alias1=net_alias1,
+                    dns_opt=dns_opt,
+                    dns_opt_attempts=dns_opt_attempts,
+                    dns_opt_timeout=dns_opt_timeout,
+                    dns_opt_inet6=dns_opt_inet6,
+                    dns_opt_rotate=dns_opt_rotate,
                 )
             )
 

--- a/tests/integration/helpers/utility.py
+++ b/tests/integration/helpers/utility.py
@@ -39,11 +39,15 @@ def generate_values(date_str, count, sign=1):
 def replace_xml_by_xpath(input_path, output_path, replace_text={}, remove_node=[]):
     tree = xml.etree.ElementTree.parse(input_path)
     for xpath, value in replace_text.items():
-        for node in tree.findall(xpath):
+        nodes = tree.findall(xpath)
+        assert nodes, f"{repr(xpath)} could not be found in {input_path}"
+        for node in nodes:
             node.text = value
     if remove_node:
         parent_map = {c: p for p in tree.iter() for c in p}
         for xpath in remove_node:
-            for node in tree.findall(xpath):
+            nodes = tree.findall(xpath)
+            assert nodes, f"{repr(xpath)} could not be found in {input_path}"
+            for node in nodes:
                 parent_map[node].remove(node)
     tree.write(output_path)

--- a/tests/integration/helpers/utility.py
+++ b/tests/integration/helpers/utility.py
@@ -37,16 +37,21 @@ def generate_values(date_str, count, sign=1):
 
 
 def replace_xml_by_xpath(input_path, output_path, replace_text={}, remove_node=[]):
+    def no_warn(xpath):
+        if xpath.startswith("//"):
+            return f".{xpath}"
+        else:
+            return xpath
     tree = xml.etree.ElementTree.parse(input_path)
     for xpath, value in replace_text.items():
-        nodes = tree.findall(xpath)
+        nodes = tree.findall(no_warn(xpath))
         assert nodes, f"{repr(xpath)} could not be found in {input_path}"
         for node in nodes:
             node.text = value
     if remove_node:
         parent_map = {c: p for p in tree.iter() for c in p}
         for xpath in remove_node:
-            nodes = tree.findall(xpath)
+            nodes = tree.findall(no_warn(xpath))
             assert nodes, f"{repr(xpath)} could not be found in {input_path}"
             for node in nodes:
                 parent_map[node].remove(node)

--- a/tests/integration/helpers/utility.py
+++ b/tests/integration/helpers/utility.py
@@ -1,6 +1,7 @@
-import string
 import random
+import string
 import threading
+import xml.etree.ElementTree
 
 
 # By default the exceptions that was throwed in threads will be ignored
@@ -35,11 +36,14 @@ def generate_values(date_str, count, sign=1):
     return ",".join(["('{}',{},'{}')".format(x, y, z) for x, y, z in data])
 
 
-def replace_config(config_path, old, new):
-    config = open(config_path, "r")
-    config_lines = config.readlines()
-    config.close()
-    config_lines = [line.replace(old, new) for line in config_lines]
-    config = open(config_path, "w")
-    config.writelines(config_lines)
-    config.close()
+def replace_xml_by_xpath(input_path, output_path, replace_text={}, remove_node=[]):
+    tree = xml.etree.ElementTree.parse(input_path)
+    for xpath, value in replace_test.items():
+        for node in tree.findall(xpath):
+            node.text = value
+    if remove_node:
+        parent_map = {c: p for p in tree.iter() for c in p}
+        for xpath in remove_node:
+            for node in tree.findall(xpath):
+                parent_map[node].remove(node)
+    tree.write(output_path)

--- a/tests/integration/helpers/utility.py
+++ b/tests/integration/helpers/utility.py
@@ -38,7 +38,7 @@ def generate_values(date_str, count, sign=1):
 
 def replace_xml_by_xpath(input_path, output_path, replace_text={}, remove_node=[]):
     tree = xml.etree.ElementTree.parse(input_path)
-    for xpath, value in replace_test.items():
+    for xpath, value in replace_text.items():
         for node in tree.findall(xpath):
             node.text = value
     if remove_node:

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -224,6 +224,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--no-dns-opts",
+        action='store_true',
+        default=False,
+        dest="no_dns_opts",
+        help="Don't use `--dns-opt` for ClickHouse nodes. It allows internal Docker DNS to work properly")
+
+    parser.add_argument(
         "--network",
         help="Set network driver for runnner container (defaults to `host`)",
     )
@@ -379,6 +386,9 @@ if __name__ == "__main__":
     # If enabled we kill and remove containers before pytest session run.
     if args.cleanup_containers:
         env["PYTEST_CLEANUP_CONTAINERS"] = "1"
+
+    if args.no_dns_opts:
+        env["SKIP_DNS_OPTS"] = "1"
 
     for var in args.env:
         env[var] = os.environ[var]

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -6,6 +6,7 @@ import getpass
 import glob
 import argparse
 import logging
+import shlex
 import signal
 import subprocess
 import sys
@@ -16,6 +17,7 @@ import random
 def random_str(length=6):
     alphabet = string.ascii_lowercase + string.digits
     return "".join(random.SystemRandom().choice(alphabet) for _ in range(length))
+
 
 
 CUR_FILE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -283,6 +285,13 @@ if __name__ == "__main__":
         help="Bind volume to this dir to use for dockerd files",
     )
 
+    parser.add_argument(
+        "-e", "--env",
+        action="append",
+        default=[],
+        dest="env",
+        help="Pass environment variable")
+
     parser.add_argument("pytest_args", nargs="*", help="args for pytest command")
 
     args = parser.parse_args()
@@ -348,10 +357,6 @@ if __name__ == "__main__":
             print("Volume creationg failed, probably it already exists, exception", ex)
         dockerd_internal_volume = f"--volume={VOLUME_NAME}_volume:/var/lib/docker"
 
-    # If enabled we kill and remove containers before pytest session run.
-    env_cleanup = ""
-    if args.cleanup_containers:
-        env_cleanup = "-e PYTEST_CLEANUP_CONTAINERS=1"
     # enable tty mode & interactive for docker if we have real tty
     tty = ""
     if sys.stdout.isatty() and sys.stdin.isatty():
@@ -364,15 +369,30 @@ if __name__ == "__main__":
     if args.keyword_expression:
         args.pytest_args += ["-k", args.keyword_expression]
 
+    env = {
+        "DOCKER_CLIENT_TIMEOUT": "300",
+        "COMPOSE_HTTP_TIMEOUT": "600",
+        "XTABLES_LOCKFILE": "/run/host/xtables.lock",
+        "PYTEST_OPTS": f"{parallel_args} {' '.join((shlex.quote(x) for x in args.pytest_args + args.tests_list))} -vvv",
+    }
+
+    # If enabled we kill and remove containers before pytest session run.
+    if args.cleanup_containers:
+        env["PYTEST_CLEANUP_CONTAINERS"] = "1"
+
+    for var in args.env:
+        env[var] = os.environ[var]
+
+    env_escaped = " ".join((f"-e {k}={shlex.quote(v)}" for k, v in env.items()))
+
     cmd = "docker run {net} {tty} --rm --name {name} --privileged \
         --volume={odbc_bridge_bin}:/clickhouse-odbc-bridge --volume={bin}:/clickhouse \
         --volume={library_bridge_bin}:/clickhouse-library-bridge \
         --volume={base_cfg}:/clickhouse-config --volume={cases_dir}:/ClickHouse/tests/integration \
         --volume={src_dir}/Server/grpc_protos:/ClickHouse/src/Server/grpc_protos \
         --volume=/run:/run/host:ro \
-        {dockerd_internal_volume} -e DOCKER_CLIENT_TIMEOUT=300 -e COMPOSE_HTTP_TIMEOUT=600 \
-        -e XTABLES_LOCKFILE=/run/host/xtables.lock \
-        {env_tags} {env_cleanup} -e PYTEST_OPTS='{parallel} {opts} {tests_list} -vvv' {img} {command}".format(
+        {dockerd_internal_volume} \
+        {env_tags} {env_escaped} {img} {command}".format(
         net=net,
         tty=tty,
         bin=args.binary,
@@ -386,6 +406,7 @@ if __name__ == "__main__":
         parallel=parallel_args,
         opts=" ".join(args.pytest_args).replace("'", "\\'"),
         tests_list=" ".join(args.tests_list),
+        env_escaped=env_escaped,
         dockerd_internal_volume=dockerd_internal_volume,
         img=DIND_INTEGRATION_TESTS_IMAGE_NAME + ":" + args.docker_image_version,
         name=CONTAINER_NAME,

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -298,10 +298,10 @@ if __name__ == "__main__":
 
     check_args_and_update_paths(args)
 
-    parallel_args = ""
+    parallel_args = []
     if args.parallel:
-        parallel_args += "--dist=loadfile"
-        parallel_args += " -n {}".format(args.parallel)
+        parallel_args.append("--dist=loadfile")
+        parallel_args.append(f"-n {args.parallel}")
 
     net = ""
     if args.network:
@@ -373,7 +373,7 @@ if __name__ == "__main__":
         "DOCKER_CLIENT_TIMEOUT": "300",
         "COMPOSE_HTTP_TIMEOUT": "600",
         "XTABLES_LOCKFILE": "/run/host/xtables.lock",
-        "PYTEST_OPTS": f"{parallel_args} {' '.join((shlex.quote(x) for x in args.pytest_args + args.tests_list))} -vvv",
+        "PYTEST_OPTS": " ".join((shlex.quote(x) for x in parallel_args + args.pytest_args + args.tests_list + ["-vvv"])),
     }
 
     # If enabled we kill and remove containers before pytest session run.

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -228,7 +228,7 @@ if __name__ == "__main__":
         action='store_true',
         default=False,
         dest="no_dns_opts",
-        help="Don't use `--dns-opt` for ClickHouse nodes. It allows internal Docker DNS to work properly")
+        help="Don't use `--dns-opt` for ClickHouse nodes. It allows Docker internal DNS to work properly")
 
     parser.add_argument(
         "--network",

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -224,13 +224,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--no-dns-opts",
-        action='store_true',
-        default=False,
-        dest="no_dns_opts",
-        help="Don't use `--dns-opt` for ClickHouse nodes. It allows Docker internal DNS to work properly")
-
-    parser.add_argument(
         "--network",
         help="Set network driver for runnner container (defaults to `host`)",
     )
@@ -386,9 +379,6 @@ if __name__ == "__main__":
     # If enabled we kill and remove containers before pytest session run.
     if args.cleanup_containers:
         env["PYTEST_CLEANUP_CONTAINERS"] = "1"
-
-    if args.no_dns_opts:
-        env["SKIP_DNS_OPTS"] = "1"
 
     for var in args.env:
         env[var] = os.environ[var]

--- a/tests/integration/test_merge_tree_azure_blob_storage/test.py
+++ b/tests/integration/test_merge_tree_azure_blob_storage/test.py
@@ -509,7 +509,7 @@ def test_apply_new_settings(cluster):
     helpers.utility.replace_xml_by_xpath(
         CONFIG_PATH, CONFIG_PATH,
         replace_text={
-            "/clickhouse/storage_configuration/disks/blob_storage_disk/max_single_part_upload_size": "4096",
+            "//storage_configuration/disks/blob_storage_disk/max_single_part_upload_size": "4096",
         }
     )
 
@@ -529,7 +529,7 @@ def test_restart_during_load(cluster):
     helpers.utility.replace_xml_by_xpath(
         CONFIG_PATH, CONFIG_PATH,
         remove_node=[
-            "/clickhouse/storage_configuration/disks/blob_storage_disk/container_already_exists",
+            "//storage_configuration/disks/blob_storage_disk/container_already_exists",
         ]
     )
 

--- a/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
@@ -4,6 +4,7 @@
             <s3>
                 <type>s3</type>
                 <endpoint>http://minio1:9001/root/data/</endpoint>
+                <region></region>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
                 <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>
@@ -11,6 +12,7 @@
             <unstable_s3>
                 <type>s3</type>
                 <endpoint>http://resolver:8081/root/data/</endpoint>
+                <region></region>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
                 <s3_max_single_read_retries>10</s3_max_single_read_retries>
@@ -22,6 +24,7 @@
             <s3_with_cache>
                 <type>s3</type>
                 <endpoint>http://minio1:9001/root/data/</endpoint>
+                <region></region>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
                 <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>

--- a/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
@@ -1,3 +1,4 @@
+import argparse
 import http.client
 import http.server
 import random
@@ -6,7 +7,11 @@ import sys
 import urllib.parse
 
 
-UPSTREAM_HOST = "minio1:9001"
+parser = argparse.ArgumentParser()
+parser.add_argument('port', type=int, help='port to listen')
+parser.add_argument('upstream', type=str, help='upstream to redirect requests to')
+args = parser.parse_args()
+
 random.seed("Unstable proxy/1.0")
 
 
@@ -53,7 +58,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         data = self.rfile.read(int(content_length)) if content_length else None
         r = request(
             self.command,
-            f"http://{UPSTREAM_HOST}{self.path}",
+            f"http://{args.upstream}{self.path}",
             headers=self.headers,
             data=data,
         )
@@ -71,5 +76,5 @@ class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     """Handle requests in a separate thread."""
 
 
-httpd = ThreadedHTTPServer(("0.0.0.0", int(sys.argv[1])), RequestHandler)
+httpd = ThreadedHTTPServer(("0.0.0.0", args.port, RequestHandler)
 httpd.serve_forever()

--- a/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
@@ -8,8 +8,8 @@ import urllib.parse
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('port', type=int, help='port to listen')
-parser.add_argument('upstream', type=str, help='upstream to redirect requests to')
+parser.add_argument("port", type=int, help="port to listen")
+parser.add_argument("upstream", type=str, help="upstream to redirect requests to")
 args = parser.parse_args()
 
 random.seed("Unstable proxy/1.0")
@@ -76,5 +76,5 @@ class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     """Handle requests in a separate thread."""
 
 
-httpd = ThreadedHTTPServer(("0.0.0.0", args.port, RequestHandler)
+httpd = ThreadedHTTPServer(("0.0.0.0", args.port), RequestHandler)
 httpd.serve_forever()

--- a/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/unstable_proxy.py
@@ -1,4 +1,6 @@
 import argparse
+import hashlib
+import hmac
 import http.client
 import http.server
 import random
@@ -13,9 +15,10 @@ parser.add_argument("upstream", type=str, help="upstream to redirect requests to
 args = parser.parse_args()
 
 random.seed("Unstable proxy/1.0")
+key = None
 
 
-def request(command, url, headers={}, data=None):
+def request(command, url, headers={}, data=b""):
     """Mini-requests."""
 
     class Dummy:
@@ -39,11 +42,16 @@ def request(command, url, headers={}, data=None):
 
 class RequestHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
-        if self.path == "/":
+        global key
+        parts = urllib.parse.urlparse(self.path)
+        if self.path == "/" or parts.path == "/":
             self.send_response(200)
             self.send_header("Content-Type", "text/plain")
             self.end_headers()
             self.wfile.write(b"OK")
+            params = urllib.parse.parse_qs(parts.query)
+            if "key" in params:
+                key, = params["key"]
         else:
             self.do_HEAD()
 
@@ -53,14 +61,67 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
         self.do_HEAD()
 
+    def sign(self, key, msg):
+        return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+    def get_signing_key(self, key, date, region, service):
+        k_date = self.sign(("AWS4" + key).encode("utf-8"), date)
+        k_region = self.sign(k_date, region)
+        k_service = self.sign(k_region, service)
+        return self.sign(k_service, "aws4_request")
+
+    def replace_authorization(self, authorization):
+        method, credential, signed_headers, signature = authorization.split(" ")
+        assert method == "AWS4-HMAC-SHA256"
+        assert credential.startswith("Credential=")
+        assert signed_headers.startswith("SignedHeaders=")
+        assert signature.startswith("Signature=")
+        _, credential = credential.split("=")
+        credential, _ = credential.split(",")
+        _, signature = signature.split("=")
+        _, signed_headers = signed_headers.split("=")
+        signed_headers, _ = signed_headers.split(",")
+        key_id, date, region, service, aws4_request = credential.split("/")
+        assert service == "s3"
+        assert aws4_request == "aws4_request"
+        signing_key = self.get_signing_key(key, date, region, service)
+        amz_date = self.headers["x-amz-date"]
+        parts = urllib.parse.urlparse(self.path)
+        canonical_uri = parts.path
+        canonical_querystring = urllib.parse.urlencode(dict(sorted(((k, v) for k, (v,) in urllib.parse.parse_qs(parts.query, keep_blank_values=True).items()))))
+        canonical_headers = "\n".join((f"{h}:{self.headers[h]}" for h in signed_headers.split(";"))) + "\n"
+        payload_hash = hashlib.sha256(self.data).hexdigest()
+        canonical_request = "\n".join([self.command, canonical_uri, canonical_querystring, canonical_headers, signed_headers, payload_hash])
+        credential_scope = "/".join([date, region, service, aws4_request])
+        string_to_sign = "\n".join([method, amz_date, credential_scope, hashlib.sha256(canonical_request.encode("utf-8")).hexdigest()])
+        expect_signature = hmac.new(signing_key, string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
+        assert signature == expect_signature, f"Signatures are different: '{signature}' != '{expect_signature}'"
+        canonical_headers = "\n".join((f"{h}:{self.headers[h] if h != 'host' else args.upstream}" for h in signed_headers.split(";"))) + "\n"
+        canonical_request = "\n".join([self.command, canonical_uri, canonical_querystring, canonical_headers, signed_headers, payload_hash])
+        string_to_sign = "\n".join([method, amz_date, credential_scope, hashlib.sha256(canonical_request.encode("utf-8")).hexdigest()])
+        signature = hmac.new(signing_key, string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
+        new_authorization = f"{method} Credential={key_id}/{date}/{region}/s3/aws4_request, SignedHeaders={signed_headers}, Signature={signature}"
+        return new_authorization
+
+    def replace_headers(self, headers):
+        result = {}
+        for k, v in headers.items():
+            if k.lower() == "host":
+                result[k] = args.upstream
+            elif k.lower() == "authorization":
+                result[k] = self.replace_authorization(v) if key else v
+            else:
+                result[k] = v
+        return result
+
     def do_HEAD(self):
         content_length = self.headers.get("Content-Length")
-        data = self.rfile.read(int(content_length)) if content_length else None
+        self.data = self.rfile.read(int(content_length)) if content_length else b""
         r = request(
             self.command,
             f"http://{args.upstream}{self.path}",
-            headers=self.headers,
-            data=data,
+            headers=self.replace_headers(self.headers),
+            data=self.data,
         )
         self.send_response(r.status_code)
         for k, v in r.headers.items():
@@ -69,7 +130,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
         if random.random() < 0.25 and len(r.content) > 1024 * 1024:
             r.content = r.content[: len(r.content) // 2]
         self.wfile.write(r.content)
-        self.wfile.close()
+        self.wfile.flush()
 
 
 class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -18,6 +18,7 @@ CONFIG_PATH = os.path.join(
     "./{}/node/configs/config.d/storage_conf.xml".format(get_instances_dir()),
 )
 MINIO_ENDPOINT = "minio1:9001"
+UNSTABLE_PROXY_ENDPOINT = "resolver:8081"
 
 
 @pytest.fixture(scope="module")
@@ -45,7 +46,7 @@ def cluster():
                         "//storage_configuration/disks/s3_with_cache/access_key_id": os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
                         "//storage_configuration/disks/s3_with_cache/secret_access_key": os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
                         "//storage_configuration/disks/s3_with_cache/region": os.environ["CLICKHOUSE_AWS_REGION"],
-                        "//storage_configuration/disks/unstable_s3/endpoint": "http://resolver:8081/" + os.environ["CLICKHOUSE_AWS_BUCKET"] + "/data/",
+                        "//storage_configuration/disks/unstable_s3/endpoint": f"http://{UNSTABLE_PROXY_ENDPOINT}/" + os.environ["CLICKHOUSE_AWS_BUCKET"] + "/data/",
                         "//storage_configuration/disks/unstable_s3/access_key_id": os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
                         "//storage_configuration/disks/unstable_s3/secret_access_key": os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
                         "//storage_configuration/disks/unstable_s3/region": os.environ["CLICKHOUSE_AWS_REGION"],
@@ -116,7 +117,7 @@ def create_table(node, table_name, **additional_settings):
 
 def run_s3_mocks(cluster):
     logging.info("Starting s3 mocks")
-    mocks = (("unstable_proxy.py", "resolver", "8081", MINIO_ENDPOINT),)
+    mocks = (("unstable_proxy.py", *UNSTABLE_PROXY_ENDPOINT.split(":", maxsplit=1), MINIO_ENDPOINT),)
     for mock_filename, container, *params in mocks:
         container_id = cluster.get_container_id(container)
         current_dir = os.path.dirname(__file__)

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -59,7 +59,7 @@ def cluster():
             cluster.add_instance(
                 "node",
                 main_configs=main_configs,
-                with_minio=True,
+                with_minio=True
             )
             logging.info("Starting cluster...")
             cluster.start()
@@ -71,13 +71,14 @@ def cluster():
                     os.environ["CLICKHOUSE_AWS_HOST_NAME"],
                     access_key=os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
                     secret_key=os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
-                    region=os.environ["CLICKHOUSE_AWS_REGION"]
+                    region=os.environ["CLICKHOUSE_AWS_REGION"],
+                    secure=False
                 )
                 cluster.minio_bucket = os.environ["CLICKHOUSE_AWS_BUCKET"]
                 cluster.exec_in_container(
                     cluster.get_container_id("resolver"),
                     ["curl", "-s", f"http://localhost:8081/?key={urllib.parse.quote(os.environ['CLICKHOUSE_AWS_SECRET_ACCESS_KEY'])}"],
-                    nothrow=True,
+                    nothrow=True
                 )
 
             yield cluster

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -72,7 +72,7 @@ def cluster():
                     ["curl", "-s", f"http://{UNSTABLE_PROXY_ENDPOINT}/?key={urllib.parse.quote(storage_configurator.secret_key)}"],
                     nothrow=True,
                 )
-                cluster.instances["node"].restart_clickhouse() # ClickHouse depends on the disk mock.
+                cluster.instances["node"].restart_clickhouse(kill=True) # ClickHouse depends on the disk mock.
 
             yield cluster
     finally:

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -2,6 +2,7 @@ import logging
 import os
 import tempfile
 import time
+import urllib.parse
 
 import minio
 
@@ -44,6 +45,7 @@ def cluster():
                         "//storage_configuration/disks/s3_with_cache/access_key_id": os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
                         "//storage_configuration/disks/s3_with_cache/secret_access_key": os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
                         "//storage_configuration/disks/s3_with_cache/region": os.environ["CLICKHOUSE_AWS_REGION"],
+                        "//storage_configuration/disks/unstable_s3/endpoint": "http://resolver:8081/" + os.environ["CLICKHOUSE_AWS_BUCKET"] + "/data/",
                         "//storage_configuration/disks/unstable_s3/access_key_id": os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
                         "//storage_configuration/disks/unstable_s3/secret_access_key": os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
                         "//storage_configuration/disks/unstable_s3/region": os.environ["CLICKHOUSE_AWS_REGION"],
@@ -72,6 +74,11 @@ def cluster():
                     region=os.environ["CLICKHOUSE_AWS_REGION"]
                 )
                 cluster.minio_bucket = os.environ["CLICKHOUSE_AWS_BUCKET"]
+                cluster.exec_in_container(
+                    cluster.get_container_id("resolver"),
+                    ["curl", "-s", f"http://localhost:8081/?key={urllib.parse.quote(os.environ['CLICKHOUSE_AWS_SECRET_ACCESS_KEY'])}"],
+                    nothrow=True,
+                )
 
             yield cluster
     finally:

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -5,7 +5,6 @@ import time
 import urllib.parse
 
 import minio
-
 import pytest
 
 from helpers.cluster import ClickHouseCluster, get_instances_dir
@@ -25,6 +24,7 @@ MINIO_ENDPOINT = "minio1:9001"
 def cluster():
     try:
         with tempfile.TemporaryDirectory() as d:
+            cluster = ClickHouseCluster(__file__)
             main_configs = [
                 "configs/config.d/storage_conf.xml",
                 "configs/config.d/bg_processing_pool_conf.xml",
@@ -55,7 +55,6 @@ def cluster():
                 global MINIO_ENDPOINT
                 MINIO_ENDPOINT = os.environ["CLICKHOUSE_AWS_HOST_NAME"]
 
-            cluster = ClickHouseCluster(__file__)
             cluster.add_instance(
                 "node",
                 main_configs=main_configs,

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -1,10 +1,8 @@
 import logging
 import os
-import tempfile
 import time
 import urllib.parse
 
-import minio
 import pytest
 
 from helpers.cluster import ClickHouseCluster, get_instances_dir
@@ -23,63 +21,58 @@ UNSTABLE_PROXY_ENDPOINT = "resolver:8081"
 
 @pytest.fixture(scope="module")
 def cluster():
+    global MINIO_ENDPOINT
     try:
-        with tempfile.TemporaryDirectory() as d:
+        with helpers.utility.StorageConfigurator() as storage_configurator:
             cluster = ClickHouseCluster(__file__)
             main_configs = [
                 "configs/config.d/storage_conf.xml",
                 "configs/config.d/bg_processing_pool_conf.xml",
             ]
 
-            if os.environ.get("CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE"):
-                assert os.environ["CLICKHOUSE_AWS_HOST_NAME"] + "/" + os.environ["CLICKHOUSE_AWS_BUCKET"] in os.environ["CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE"]
-                new_config_name = os.path.join(d, "storage_conf.xml")
+            if storage_configurator.shall_override_storage:
+                new_config_name = storage_configurator.new_file_name("storage_conf.xml")
                 helpers.utility.replace_xml_by_xpath(
                     os.path.join(SCRIPT_DIR, main_configs[0]),
                     new_config_name,
                     replace_text={
-                        "//storage_configuration/disks/s3/endpoint": os.environ["CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE"],
-                        "//storage_configuration/disks/s3/access_key_id": os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
-                        "//storage_configuration/disks/s3/secret_access_key": os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
-                        "//storage_configuration/disks/s3/region": os.environ["CLICKHOUSE_AWS_REGION"],
-                        "//storage_configuration/disks/s3_with_cache/endpoint": os.environ["CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE"],
-                        "//storage_configuration/disks/s3_with_cache/access_key_id": os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
-                        "//storage_configuration/disks/s3_with_cache/secret_access_key": os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
-                        "//storage_configuration/disks/s3_with_cache/region": os.environ["CLICKHOUSE_AWS_REGION"],
-                        "//storage_configuration/disks/unstable_s3/endpoint": f"http://{UNSTABLE_PROXY_ENDPOINT}/" + os.environ["CLICKHOUSE_AWS_BUCKET"] + "/data/",
-                        "//storage_configuration/disks/unstable_s3/access_key_id": os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
-                        "//storage_configuration/disks/unstable_s3/secret_access_key": os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
-                        "//storage_configuration/disks/unstable_s3/region": os.environ["CLICKHOUSE_AWS_REGION"],
+                        "//storage_configuration/disks/s3/endpoint": storage_configurator.url,
+                        "//storage_configuration/disks/s3/access_key_id": storage_configurator.key_id,
+                        "//storage_configuration/disks/s3/secret_access_key": storage_configurator.secret_key,
+                        "//storage_configuration/disks/s3/region": storage_configurator.region,
+                        "//storage_configuration/disks/s3_with_cache/endpoint": storage_configurator.url,
+                        "//storage_configuration/disks/s3_with_cache/access_key_id": storage_configurator.key_id,
+                        "//storage_configuration/disks/s3_with_cache/secret_access_key": storage_configurator.secret_key,
+                        "//storage_configuration/disks/s3_with_cache/region": storage_configurator.region,
+                        "//storage_configuration/disks/unstable_s3/endpoint": f"http://{UNSTABLE_PROXY_ENDPOINT}{storage_configurator.path}",
+                        "//storage_configuration/disks/unstable_s3/access_key_id": storage_configurator.key_id,
+                        "//storage_configuration/disks/unstable_s3/secret_access_key": storage_configurator.secret_key,
+                        "//storage_configuration/disks/unstable_s3/region": storage_configurator.region,
                     }
                 )
                 main_configs[0] = new_config_name
-                global MINIO_ENDPOINT
-                MINIO_ENDPOINT = os.environ["CLICKHOUSE_AWS_HOST_NAME"]
+                MINIO_ENDPOINT = storage_configurator.host_name
 
             cluster.add_instance(
                 "node",
                 main_configs=main_configs,
-                with_minio=True
+                with_minio=True,
+                stay_alive=True,
             )
             logging.info("Starting cluster...")
             cluster.start()
             logging.info("Cluster started")
             run_s3_mocks(cluster)
 
-            if os.environ.get("CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE"):
-                cluster.minio_client = minio.Minio(
-                    os.environ["CLICKHOUSE_AWS_HOST_NAME"],
-                    access_key=os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
-                    secret_key=os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
-                    region=os.environ["CLICKHOUSE_AWS_REGION"],
-                    secure=False
-                )
-                cluster.minio_bucket = os.environ["CLICKHOUSE_AWS_BUCKET"]
+            if storage_configurator.shall_override_storage:
+                cluster.minio_client = storage_configurator.minio_client
+                cluster.minio_bucket = storage_configurator.bucket
                 cluster.exec_in_container(
                     cluster.get_container_id("resolver"),
-                    ["curl", "-s", f"http://localhost:8081/?key={urllib.parse.quote(os.environ['CLICKHOUSE_AWS_SECRET_ACCESS_KEY'])}"],
-                    nothrow=True
+                    ["curl", "-s", f"http://{UNSTABLE_PROXY_ENDPOINT}/?key={urllib.parse.quote(storage_configurator.secret_key)}"],
+                    nothrow=True,
                 )
+                cluster.instances["node"].restart_clickhouse() # ClickHouse depends on the disk mock.
 
             yield cluster
     finally:

--- a/tests/integration/test_merge_tree_s3_restore/test.py
+++ b/tests/integration/test_merge_tree_s3_restore/test.py
@@ -517,7 +517,7 @@ def test_migrate_to_restorable_schema(cluster):
     helpers.utility.replace_xml_by_xpath(
         NOT_RESTORABLE_CONFIG_PATH, NOT_RESTORABLE_CONFIG_PATH,
         replace_text={
-            "/clickhouse/storage_configuration/disks/s3/send_metadata": "true",
+            "//storage_configuration/disks/s3/send_metadata": "true",
         }
     )
     node.restart_clickhouse()

--- a/tests/integration/test_replicated_merge_tree_s3/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_replicated_merge_tree_s3/configs/config.d/storage_conf.xml
@@ -6,6 +6,7 @@
                 <endpoint>http://minio1:9001/root/data/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
+                <region></region>
             </s3>
         </disks>
         <policies>

--- a/tests/integration/test_replicated_merge_tree_s3/test.py
+++ b/tests/integration/test_replicated_merge_tree_s3/test.py
@@ -1,41 +1,76 @@
 import logging
+import os
 import random
 import string
+import tempfile
 
+import minio
 import pytest
-from helpers.cluster import ClickHouseCluster
+
+import helpers.cluster
+import helpers.utility
+
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 @pytest.fixture(scope="module")
 def cluster():
     try:
-        cluster = ClickHouseCluster(__file__)
+        with tempfile.TemporaryDirectory() as d:
+            cluster = helpers.cluster.ClickHouseCluster(__file__)
+            main_configs = ["configs/config.d/storage_conf.xml"]
 
-        cluster.add_instance(
-            "node1",
-            main_configs=["configs/config.d/storage_conf.xml"],
-            macros={"replica": "1"},
-            with_minio=True,
-            with_zookeeper=True,
-        )
-        cluster.add_instance(
-            "node2",
-            main_configs=["configs/config.d/storage_conf.xml"],
-            macros={"replica": "2"},
-            with_zookeeper=True,
-        )
-        cluster.add_instance(
-            "node3",
-            main_configs=["configs/config.d/storage_conf.xml"],
-            macros={"replica": "3"},
-            with_zookeeper=True,
-        )
+            if os.environ.get("CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE"):
+                assert os.environ["CLICKHOUSE_AWS_HOST_NAME"] + "/" + os.environ["CLICKHOUSE_AWS_BUCKET"] in os.environ["CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE"]
+                new_config_name = os.path.join(d, "storage_conf.xml")
+                helpers.utility.replace_xml_by_xpath(
+                    os.path.join(SCRIPT_DIR, main_configs[0]),
+                    new_config_name,
+                    replace_text={
+                        "//storage_configuration/disks/s3/endpoint": os.environ["CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE"],
+                        "//storage_configuration/disks/s3/access_key_id": os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
+                        "//storage_configuration/disks/s3/secret_access_key": os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
+                        "//storage_configuration/disks/s3/region": os.environ["CLICKHOUSE_AWS_REGION"],
+                    }
+                )
+                main_configs[0] = new_config_name
 
-        logging.info("Starting cluster...")
-        cluster.start()
-        logging.info("Cluster started")
+            cluster.add_instance(
+                "node1",
+                main_configs=main_configs,
+                macros={"replica": "1"},
+                with_minio=True,
+                with_zookeeper=True,
+            )
+            cluster.add_instance(
+                "node2",
+                main_configs=main_configs,
+                macros={"replica": "2"},
+                with_zookeeper=True,
+            )
+            cluster.add_instance(
+                "node3",
+                main_configs=main_configs,
+                macros={"replica": "3"},
+                with_zookeeper=True,
+            )
 
-        yield cluster
+            logging.info("Starting cluster...")
+            cluster.start()
+            logging.info("Cluster started")
+
+            if os.environ.get("CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE"):
+                cluster.minio_client = minio.Minio(
+                    os.environ["CLICKHOUSE_AWS_HOST_NAME"],
+                    access_key=os.environ["CLICKHOUSE_AWS_ACCESS_KEY_ID"],
+                    secret_key=os.environ["CLICKHOUSE_AWS_SECRET_ACCESS_KEY"],
+                    region=os.environ["CLICKHOUSE_AWS_REGION"],
+                    secure=False
+                )
+                cluster.minio_bucket = os.environ["CLICKHOUSE_AWS_BUCKET"]
+
+            yield cluster
     finally:
         cluster.shutdown()
 

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -754,7 +754,7 @@ def test_custom_auth_headers(started_cluster):
     helpers.utility.replace_xml_by_xpath(
         CONFIG_PATH, CONFIG_PATH,
         replace_text={
-            "/clickhouse/s3/s3_mock/header": "Authorization: Bearer INVALID_TOKEN",
+            "//s3/s3_mock/header": "Authorization: Bearer INVALID_TOKEN",
         }
     )
     instance.query("SYSTEM RELOAD CONFIG")
@@ -763,7 +763,7 @@ def test_custom_auth_headers(started_cluster):
     helpers.utility.replace_xml_by_xpath(
         CONFIG_PATH, CONFIG_PATH,
         replace_text={
-            "/clickhouse/s3/s3_mock/header": "Authorization: Bearer TOKEN",
+            "//s3/s3_mock/header": "Authorization: Bearer TOKEN",
         }
     )
     instance.query("SYSTEM RELOAD CONFIG")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Possibility to run S3 tests on external endpoint.

```
./runner test_merge_tree_s3 test_replicated_merge_tree_s3 -e CLICKHOUSE_AWS_ENDPOINT_URL_OVERRIDE -e CLICKHOUSE_AWS_ACCESS_KEY_ID -e CLICKHOUSE_AWS_SECRET_ACCESS_KEY -e CLICKHOUSE_AWS_HOST_NAME -e CLICKHOUSE_AWS_BUCKET -e CLICKHOUSE_AWS_REGION --no-dns-opts
```

<s>Also, I worked around docker/for-linux#1404 bug with `--no-dns-opts` in this PR.</s>

This is no longer an issue, will be fixed in moby/moby#43705