### PR TITLE
Remove duplicate peak mem log

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -68,7 +68,7 @@ MemoryTracker::MemoryTracker(MemoryTracker * parent_, VariableContext level_) : 
 
 MemoryTracker::~MemoryTracker()
 {
-    if ((level == VariableContext::Process || level == VariableContext::User) && peak)
+    if ((level == VariableContext::Process || level == VariableContext::User) && peak && log_peak_memory_usage_in_destructor)
     {
         try
         {
@@ -82,8 +82,9 @@ MemoryTracker::~MemoryTracker()
 }
 
 
-void MemoryTracker::logPeakMemoryUsage() const
+void MemoryTracker::logPeakMemoryUsage()
 {
+    log_peak_memory_usage_in_destructor = false;
     const auto * description = description_ptr.load(std::memory_order_relaxed);
     LOG_DEBUG(&Poco::Logger::get("MemoryTracker"),
         "Peak memory usage{}: {}.", (description ? " " + std::string(description) : ""), ReadableSize(peak));

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -75,6 +75,8 @@ private:
 
     std::atomic<OvercommitTracker *> overcommit_tracker = nullptr;
 
+    bool log_peak_memory_usage_in_destructor = true;
+
     bool updatePeak(Int64 will_be, bool log_memory_usage);
     void logMemoryUsage(Int64 current) const;
 
@@ -206,7 +208,7 @@ public:
     void set(Int64 to);
 
     /// Prints info about peak memory consumption into log.
-    void logPeakMemoryUsage() const;
+    void logPeakMemoryUsage();
 };
 
 extern MemoryTracker total_memory_tracker;

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -204,6 +204,7 @@ void TCPHandler::runImpl()
          */
         std::unique_ptr<DB::Exception> exception;
         bool network_error = false;
+        bool query_duration_already_logged = false;
 
         try
         {
@@ -381,6 +382,10 @@ void TCPHandler::runImpl()
             /// Do it before sending end of stream, to have a chance to show log message in client.
             query_scope->logPeakMemoryUsage();
 
+            watch.stop();
+            LOG_DEBUG(log, "Processed in {} sec.", watch.elapsedSeconds());
+            query_duration_already_logged = true;
+
             if (state.is_connection_closed)
                 break;
 
@@ -507,9 +512,11 @@ void TCPHandler::runImpl()
              */
         }
 
-        watch.stop();
-
-        LOG_DEBUG(log, "Processed in {} sec.", watch.elapsedSeconds());
+        if (!query_duration_already_logged)
+        {
+            watch.stop();
+            LOG_DEBUG(log, "Processed in {} sec.", watch.elapsedSeconds());
+        }
 
         /// It is important to destroy query context here. We do not want it to live arbitrarily longer than the query.
         query_context.reset();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove duplicated peak mem log. Also log "Processed in {} sec" a little bit earlier so that it's also sent to client and have the log entry related to the query_id.

Now the final resource destruction doesn't contribute to the query duration as logged in TCPHandler in normal cases. It seems more reasonable, since we may have some optimization to do asynchronous resource deallocation.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
