### PR TITLE
Fixes for objects removal in `S3ObjectStorage`

### DIFF
--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -228,32 +228,12 @@ void S3ObjectStorage::removeObjectImpl(const std::string & path, bool if_exists)
 {
     auto client_ptr = client.get();
 
-    // If chunk size is 0, only use single delete request
-    // This allows us to work with GCS, which doesn't support DeleteObjects
-    if (!s3_capabilities.support_batch_delete)
-    {
-        Aws::S3::Model::DeleteObjectRequest request;
-        request.SetBucket(bucket);
-        request.SetKey(path);
-        auto outcome = client_ptr->DeleteObject(request);
+    Aws::S3::Model::DeleteObjectRequest request;
+    request.SetBucket(bucket);
+    request.SetKey(path);
+    auto outcome = client_ptr->DeleteObject(request);
 
-        throwIfUnexpectedError(outcome, if_exists);
-    }
-    else
-    {
-        /// TODO: For AWS we prefer to use multiobject operation even for single object
-        /// maybe we shouldn't?
-        Aws::S3::Model::ObjectIdentifier obj;
-        obj.SetKey(path);
-        Aws::S3::Model::Delete delkeys;
-        delkeys.SetObjects({obj});
-        Aws::S3::Model::DeleteObjectsRequest request;
-        request.SetBucket(bucket);
-        request.SetDelete(delkeys);
-        auto outcome = client_ptr->DeleteObjects(request);
-
-        throwIfUnexpectedError(outcome, if_exists);
-    }
+    throwIfUnexpectedError(outcome, if_exists);
 }
 
 void S3ObjectStorage::removeObjectsImpl(const PathsWithSize & paths, bool if_exists)

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -83,12 +83,18 @@ public:
     void listPrefix(const std::string & path, RelativePathsWithSize & children) const override;
 
     /// Remove file. Throws exception if file doesn't exist or it's a directory.
+    /// Uses `DeleteObjectRequest`.
     void removeObject(const std::string & path) override;
 
+    /// Uses `DeleteObjectsRequest` if it is allowed by `s3_capabilities`, otherwise `DeleteObjectRequest`.
+    /// `DeleteObjectsRequest` is not supported on GCS, see https://issuetracker.google.com/issues/162653700 .
     void removeObjects(const PathsWithSize & paths) override;
 
+    /// Uses `DeleteObjectRequest`.
     void removeObjectIfExists(const std::string & path) override;
 
+    /// Uses `DeleteObjectsRequest` if it is allowed by `s3_capabilities`, otherwise `DeleteObjectRequest`.
+    /// `DeleteObjectsRequest` does not exist on GCS, see https://issuetracker.google.com/issues/162653700 .
     void removeObjectsIfExist(const PathsWithSize & paths) override;
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
@@ -112,6 +118,8 @@ public:
         const Poco::Util::AbstractConfiguration & config,
         const std::string & config_prefix,
         ContextPtr context) override;
+
+    void setCapabilitiesSupportBatchDelete(bool value) { s3_capabilities.support_batch_delete = value; }
 
     String getObjectsNamespace() const override { return bucket; }
 
@@ -151,7 +159,7 @@ private:
 
     MultiVersion<Aws::S3::S3Client> client;
     MultiVersion<S3ObjectStorageSettings> s3_settings;
-    const S3Capabilities s3_capabilities;
+    S3Capabilities s3_capabilities;
 
     const String version_id;
 };

--- a/src/Disks/ObjectStorages/S3/registerDiskS3.cpp
+++ b/src/Disks/ObjectStorages/S3/registerDiskS3.cpp
@@ -11,12 +11,14 @@
 #include <aws/core/client/DefaultRetryStrategy.h>
 
 #include <base/getFQDNOrHostName.h>
+
 #include <Common/FileCacheFactory.h>
+
+#include <IO/S3Common.h>
 
 #include <Disks/DiskCacheWrapper.h>
 #include <Disks/DiskRestartProxy.h>
 #include <Disks/DiskLocal.h>
-
 #include <Disks/ObjectStorages/DiskObjectStorage.h>
 #include <Disks/ObjectStorages/DiskObjectStorageCommon.h>
 #include <Disks/ObjectStorages/S3/ProxyConfiguration.h>
@@ -26,9 +28,8 @@
 #include <Disks/ObjectStorages/S3/diskSettings.h>
 #include <Disks/ObjectStorages/MetadataStorageFromDisk.h>
 
-#include <IO/S3Common.h>
-
 #include <Storages/StorageS3Settings.h>
+
 
 namespace DB
 {
@@ -65,7 +66,35 @@ void checkReadAccess(const String & disk_name, IDisk & disk)
         throw Exception("No read access to S3 bucket in disk " + disk_name, ErrorCodes::PATH_ACCESS_DENIED);
 }
 
-void checkRemoveAccess(IDisk & disk) { disk.removeFile("test_acl"); }
+void checkRemoveAccess(IDisk & disk)
+{
+    disk.removeFile("test_acl");
+}
+
+bool checkBatchRemoveIsMissing(S3ObjectStorage & storage, const String & key)
+{
+    String path = key + "/test_acl";
+    auto file = storage.writeObject(path, WriteMode::Rewrite);
+    try
+    {
+        file->write("test", 4);
+    }
+    catch (...)
+    {
+        file->finalize();
+        return false; /// We don't have write access, therefore no information about batch remove.
+    }
+    try
+    {
+        /// Uses `DeleteObjects` request (batch delete).
+        storage.removeObjects({{ path, 0 }});
+        return false;
+    }
+    catch (const Exception &)
+    {
+        return true;
+    }
+}
 
 }
 
@@ -91,10 +120,26 @@ void registerDiskS3(DiskFactory & factory)
         FileCachePtr cache = getCachePtrForDisk(name, config, config_prefix, context);
         S3Capabilities s3_capabilities = getCapabilitiesFromConfig(config, config_prefix);
 
-        ObjectStoragePtr s3_storage = std::make_unique<S3ObjectStorage>(
+        auto s3_storage = std::make_unique<S3ObjectStorage>(
             std::move(cache), getClient(config, config_prefix, context),
             getSettings(config, config_prefix, context),
             uri.version_id, s3_capabilities, uri.bucket);
+
+        if (!config.getBool(config_prefix + ".skip_access_check", false))
+        {
+            /// If `support_batch_delete` is turned on (default), check and possibly switch it off.
+            if (s3_capabilities.support_batch_delete && checkBatchRemoveIsMissing(*s3_storage, uri.key))
+            {
+                LOG_WARNING(
+                    &Poco::Logger::get("registerDiskS3"),
+                    "Storage for disk {} does not support batch delete operations, "
+                    "so `s3_capabilities.support_batch_delete` was automatically turned off during the access check. "
+                    "To remove this message set `s3_capabilities.support_batch_delete` for the disk to `false`.",
+                    name
+                );
+                s3_storage->setCapabilitiesSupportBatchDelete(false);
+            }
+        }
 
         bool send_metadata = config.getBool(config_prefix + ".send_metadata", false);
         uint64_t copy_thread_pool_size = config.getUInt(config_prefix + ".thread_pool_size", 16);

--- a/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_s3/configs/config.d/storage_conf.xml
@@ -15,6 +15,13 @@
                 <secret_access_key>minio123</secret_access_key>
                 <s3_max_single_read_retries>10</s3_max_single_read_retries>
             </unstable_s3>
+            <no_delete_objects_s3>
+                <type>s3</type>
+                <endpoint>http://resolver:8082/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+                <s3_max_single_read_retries>10</s3_max_single_read_retries>
+            </no_delete_objects_s3>
             <hdd>
                 <type>local</type>
                 <path>/</path>
@@ -46,6 +53,13 @@
                     </main>
                 </volumes>
             </unstable_s3>
+            <no_delete_objects_s3>
+                <volumes>
+                    <main>
+                        <disk>no_delete_objects_s3</disk>
+                    </main>
+                </volumes>
+            </no_delete_objects_s3>
             <s3_cache>
                 <volumes>
                     <main>

--- a/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
@@ -51,7 +51,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
         query = urllib.parse.urlparse(self.path).query
         params = urllib.parse.parse_qs(query, keep_blank_values=True)
-        if 'delete' in params:
+        if "delete" in params:
             self.send_response(501)
             self.send_header("Content-Type", "application/xml")
             self.end_headers()

--- a/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
@@ -1,0 +1,90 @@
+import http.client
+import http.server
+import random
+import socketserver
+import sys
+import urllib.parse
+
+
+UPSTREAM_HOST = "minio1:9001"
+random.seed("No delete objects/1.0")
+
+
+def request(command, url, headers={}, data=None):
+    """Mini-requests."""
+
+    class Dummy:
+        pass
+
+    parts = urllib.parse.urlparse(url)
+    c = http.client.HTTPConnection(parts.hostname, parts.port)
+    c.request(
+        command,
+        urllib.parse.urlunparse(parts._replace(scheme="", netloc="")),
+        headers=headers,
+        body=data
+    )
+    r = c.getresponse()
+    result = Dummy()
+    result.status_code = r.status
+    result.headers = r.headers
+    result.content = r.read()
+    return result
+
+
+class RequestHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"OK")
+        else:
+            self.do_HEAD()
+
+    def do_PUT(self):
+        self.do_HEAD()
+
+    def do_DELETE(self):
+        self.do_HEAD()
+
+    def do_POST(self):
+        query = urllib.parse.urlparse(self.path).query
+        params = urllib.parse.parse_qs(query, keep_blank_values=True)
+        if 'delete' in params:
+            self.send_response(501)
+            self.send_header("Content-Type", "application/xml")
+            self.end_headers()
+            self.wfile.write(b"""<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+    <Code>NotImplemented</Code>
+    <Message>Ima GCP and I can't do `DeleteObjects` request for ya. See https://issuetracker.google.com/issues/162653700 .</Message>
+    <Resource>RESOURCE</Resource>
+    <RequestId>REQUEST_ID</RequestId>
+</Error>""")
+        else:
+            self.do_HEAD()
+
+    def do_HEAD(self):
+        content_length = self.headers.get("Content-Length")
+        data = self.rfile.read(int(content_length)) if content_length else None
+        r = request(
+            self.command,
+            f"http://{UPSTREAM_HOST}{self.path}",
+            headers=self.headers,
+            data=data
+        )
+        self.send_response(r.status_code)
+        for k, v in r.headers.items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(r.content)
+        self.wfile.close()
+
+
+class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    """Handle requests in a separate thread."""
+
+
+httpd = ThreadedHTTPServer(("0.0.0.0", int(sys.argv[1])), RequestHandler)
+httpd.serve_forever()

--- a/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
+++ b/tests/integration/test_merge_tree_s3/s3_mocks/no_delete_objects.py
@@ -22,7 +22,7 @@ def request(command, url, headers={}, data=None):
         command,
         urllib.parse.urlunparse(parts._replace(scheme="", netloc="")),
         headers=headers,
-        body=data
+        body=data,
     )
     r = c.getresponse()
     result = Dummy()
@@ -55,13 +55,15 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(501)
             self.send_header("Content-Type", "application/xml")
             self.end_headers()
-            self.wfile.write(b"""<?xml version="1.0" encoding="UTF-8"?>
+            self.wfile.write(
+                b"""<?xml version="1.0" encoding="UTF-8"?>
 <Error>
     <Code>NotImplemented</Code>
     <Message>Ima GCP and I can't do `DeleteObjects` request for ya. See https://issuetracker.google.com/issues/162653700 .</Message>
     <Resource>RESOURCE</Resource>
     <RequestId>REQUEST_ID</RequestId>
-</Error>""")
+</Error>"""
+            )
         else:
             self.do_HEAD()
 
@@ -72,7 +74,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             self.command,
             f"http://{UPSTREAM_HOST}{self.path}",
             headers=self.headers,
-            data=data
+            data=data,
         )
         self.send_response(r.status_code)
         for k, v in r.headers.items():

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -67,7 +67,10 @@ def create_table(node, table_name, **additional_settings):
 
 def run_s3_mocks(cluster):
     logging.info("Starting s3 mocks")
-    mocks = (("unstable_proxy.py", "resolver", "8081"),)
+    mocks = (
+        ("unstable_proxy.py", "resolver", "8081"),
+        ("no_delete_objects.py", "resolver", "8082")
+    )
     for mock_filename, container, port in mocks:
         container_id = cluster.get_container_id(container)
         current_dir = os.path.dirname(__file__)
@@ -635,6 +638,15 @@ def test_s3_disk_restart_during_load(cluster, node_name):
 
     for thread in threads:
         thread.join()
+
+
+@pytest.mark.parametrize("node_name", ["node"])
+def test_s3_no_delete_objects(cluster, node_name):
+    node = cluster.instances[node_name]
+    create_table(node, "s3_test_no_delete_objects", storage_policy="no_delete_objects_s3")
+    node.query(
+        "DROP TABLE s3_test_no_delete_objects SYNC"
+    )
 
 
 @pytest.mark.parametrize("node_name", ["node"])

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -69,7 +69,7 @@ def run_s3_mocks(cluster):
     logging.info("Starting s3 mocks")
     mocks = (
         ("unstable_proxy.py", "resolver", "8081"),
-        ("no_delete_objects.py", "resolver", "8082")
+        ("no_delete_objects.py", "resolver", "8082"),
     )
     for mock_filename, container, port in mocks:
         container_id = cluster.get_container_id(container)
@@ -643,10 +643,10 @@ def test_s3_disk_restart_during_load(cluster, node_name):
 @pytest.mark.parametrize("node_name", ["node"])
 def test_s3_no_delete_objects(cluster, node_name):
     node = cluster.instances[node_name]
-    create_table(node, "s3_test_no_delete_objects", storage_policy="no_delete_objects_s3")
-    node.query(
-        "DROP TABLE s3_test_no_delete_objects SYNC"
+    create_table(
+        node, "s3_test_no_delete_objects", storage_policy="no_delete_objects_s3"
     )
+    node.query("DROP TABLE s3_test_no_delete_objects SYNC")
 
 
 @pytest.mark.parametrize("node_name", ["node"])


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
S3 single objects are now removed with `RemoveObjectRequest` (sic). Fixed a bug with `S3ObjectStorage` on GCP which did not allow to use `removeFileIfExists` effectively breaking approximately half of `remove` functionality. Automatic detection for `DeleteObjects` S3 API, that is not supported by GCS. This will allow to use GCS without explicit `support_batch_delete=0` in configuration.