### PR TITLE
Remove temporary `delete_tmp_` on clickhouse server start

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1501,7 +1501,7 @@ static bool isOldPartDirectory(const DiskPtr & disk, const String & directory_pa
 }
 
 
-size_t MergeTreeData::clearOldTemporaryDirectories(size_t custom_directories_lifetime_seconds)
+size_t MergeTreeData::clearOldTemporaryDirectories(size_t custom_directories_lifetime_seconds, const NameSet & valid_prefixes)
 {
     /// If the method is already called from another thread, then we don't need to do anything.
     std::unique_lock lock(clear_old_temporary_directories_mutex, std::defer_lock);
@@ -1523,10 +1523,19 @@ size_t MergeTreeData::clearOldTemporaryDirectories(size_t custom_directories_lif
         for (auto it = disk->iterateDirectory(relative_data_path); it->isValid(); it->next())
         {
             const std::string & basename = it->name();
-            if (!startsWith(basename, "tmp_"))
+            bool start_with_valid_prefix = false;
+            for (const auto & prefix : valid_prefixes)
             {
-                continue;
+                if (startsWith(basename, prefix))
+                {
+                    start_with_valid_prefix = true;
+                    break;
+                }
             }
+
+            if (!start_with_valid_prefix)
+                continue;
+
             const std::string & full_path = fullPath(disk, it->path());
 
             try

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -624,7 +624,7 @@ public:
 
     /// Delete all directories which names begin with "tmp"
     /// Must be called with locked lockForShare() because it's using relative_data_path.
-    size_t clearOldTemporaryDirectories(size_t custom_directories_lifetime_seconds);
+    size_t clearOldTemporaryDirectories(size_t custom_directories_lifetime_seconds, const NameSet & valid_prefixes = {"tmp_", });
 
     size_t clearEmptyParts();
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -123,7 +123,7 @@ void StorageMergeTree::startup()
 
     /// Temporary directories contain incomplete results of merges (after forced restart)
     ///  and don't allow to reinitialize them, so delete each of them immediately
-    clearOldTemporaryDirectories(0);
+    clearOldTemporaryDirectories(0, {"tmp_", "delete_tmp_"});
 
     /// NOTE background task will also do the above cleanups periodically.
     time_after_previous_cleanup_parts.restart();

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4212,10 +4212,6 @@ void StorageReplicatedMergeTree::startup()
 
     try
     {
-        /// Temporary directories contain incomplete results of merges (after forced restart)
-        ///  and don't allow to reinitialize them, so delete each of them immediately
-        clearOldTemporaryDirectories(0);
-
         InterserverIOEndpointPtr data_parts_exchange_ptr = std::make_shared<DataPartsExchange::Service>(*this);
         [[maybe_unused]] auto prev_ptr = std::atomic_exchange(&data_parts_exchange_endpoint, data_parts_exchange_ptr);
         assert(prev_ptr == nullptr);

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4212,6 +4212,10 @@ void StorageReplicatedMergeTree::startup()
 
     try
     {
+        /// Temporary directories contain incomplete results of merges (after forced restart)
+        ///  and don't allow to reinitialize them, so delete each of them immediately
+        clearOldTemporaryDirectories(0);
+
         InterserverIOEndpointPtr data_parts_exchange_ptr = std::make_shared<DataPartsExchange::Service>(*this);
         [[maybe_unused]] auto prev_ptr = std::atomic_exchange(&data_parts_exchange_endpoint, data_parts_exchange_ptr);
         assert(prev_ptr == nullptr);

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -462,7 +462,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
         }
         /// Temporary directories contain uninitialized results of Merges or Fetches (after forced restart),
         /// don't allow to reinitialize them, delete each of them immediately.
-        clearOldTemporaryDirectories(0);
+        clearOldTemporaryDirectories(0, {"tmp_", "delete_tmp_"});
         clearOldWriteAheadLogs();
     }
 

--- a/tests/integration/test_cleanup_after_start/__init__.py
+++ b/tests/integration/test_cleanup_after_start/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/tests/integration/test_cleanup_after_start/test.py
+++ b/tests/integration/test_cleanup_after_start/test.py
@@ -9,7 +9,6 @@ cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance("node1", with_zookeeper=True, stay_alive=True)
 
 
-
 @pytest.fixture(scope="module")
 def start_cluster():
     try:
@@ -32,6 +31,7 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_old_dirs_cleanup(start_cluster):
     node1.query("INSERT INTO test_table VALUES (toDate('2020-01-01'), 1, 10)")
     assert node1.query("SELECT count() FROM test_table") == "1\n"
@@ -42,7 +42,7 @@ def test_old_dirs_cleanup(start_cluster):
         [
             "bash",
             "-c",
-            'mv /var/lib/clickhouse/data/default/test_table/20200101_0_0_0 /var/lib/clickhouse/data/default/test_table/delete_tmp_20200101_0_0_0',
+            "mv /var/lib/clickhouse/data/default/test_table/20200101_0_0_0 /var/lib/clickhouse/data/default/test_table/delete_tmp_20200101_0_0_0",
         ],
         privileged=True,
     )
@@ -50,11 +50,7 @@ def test_old_dirs_cleanup(start_cluster):
     node1.start_clickhouse()
 
     result = node1.exec_in_container(
-        [
-            "bash",
-            "-c",
-            'ls /var/lib/clickhouse/data/default/test_table/'
-        ],
+        ["bash", "-c", "ls /var/lib/clickhouse/data/default/test_table/"],
         privileged=True,
     )
 

--- a/tests/integration/test_cleanup_after_start/test.py
+++ b/tests/integration/test_cleanup_after_start/test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_logs_contain_with_retry
+import os
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance("node1", with_zookeeper=True, stay_alive=True)
+
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        for i, node in enumerate((node1,)):
+            node_name = "node" + str(i + 1)
+            node.query(
+                """
+                CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test_table', '{}')
+                PARTITION BY date ORDER BY id
+                """.format(
+                    node_name
+                )
+            )
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+def test_old_dirs_cleanup(start_cluster):
+    node1.query("INSERT INTO test_table VALUES (toDate('2020-01-01'), 1, 10)")
+    assert node1.query("SELECT count() FROM test_table") == "1\n"
+
+    node1.stop_clickhouse()
+
+    node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            'mv /var/lib/clickhouse/data/default/test_table/20200101_0_0_0 /var/lib/clickhouse/data/default/test_table/tmp_fetch_20200101_0_0_0',
+        ],
+        privileged=True,
+    )
+
+    node1.start_clickhouse()
+
+    result = node1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            'ls /var/lib/clickhouse/data/default/test_table/'
+        ],
+        privileged=True,
+    )
+
+    # Replaced empty part
+    assert "20200101_0_0_0" in result
+    assert node1.query("SELECT count() FROM test_table") == "0\n"
+
+    assert_logs_contain_with_retry(node1, "Removing temporary directory")
+    assert_logs_contain_with_retry(node1, "tmp_fetch_20200101_0_0_0")

--- a/tests/integration/test_cleanup_after_start/test.py
+++ b/tests/integration/test_cleanup_after_start/test.py
@@ -42,7 +42,7 @@ def test_old_dirs_cleanup(start_cluster):
         [
             "bash",
             "-c",
-            'mv /var/lib/clickhouse/data/default/test_table/20200101_0_0_0 /var/lib/clickhouse/data/default/test_table/tmp_fetch_20200101_0_0_0',
+            'mv /var/lib/clickhouse/data/default/test_table/20200101_0_0_0 /var/lib/clickhouse/data/default/test_table/delete_tmp_20200101_0_0_0',
         ],
         privileged=True,
     )
@@ -63,4 +63,4 @@ def test_old_dirs_cleanup(start_cluster):
     assert node1.query("SELECT count() FROM test_table") == "0\n"
 
     assert_logs_contain_with_retry(node1, "Removing temporary directory")
-    assert_logs_contain_with_retry(node1, "tmp_fetch_20200101_0_0_0")
+    assert_logs_contain_with_retry(node1, "delete_tmp_20200101_0_0_0")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now clickhouse-server removes `delete_tmp` directories on server start. Fixes #26503.