### PR TITLE
Disable flaky tests with MaterializedPostgreSQL

### DIFF
--- a/tests/integration/test_postgresql_replica_database_engine_1/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_1/test.py
@@ -766,6 +766,7 @@ def test_concurrent_transactions(started_cluster):
 
 
 def test_abrupt_connection_loss_while_heavy_replication(started_cluster):
+    pytest.skip("Temporary disabled (FIXME)")
     def transaction(thread_id):
         if thread_id % 2:
             conn = get_postgres_conn(
@@ -841,6 +842,7 @@ def test_restart_server_while_replication_startup_not_finished(started_cluster):
 
 
 def test_abrupt_server_restart_while_heavy_replication(started_cluster):
+    pytest.skip("Temporary disabled (FIXME)")
     def transaction(thread_id):
         if thread_id % 2:
             conn = get_postgres_conn(

--- a/tests/integration/test_postgresql_replica_database_engine_1/test.py
+++ b/tests/integration/test_postgresql_replica_database_engine_1/test.py
@@ -767,6 +767,7 @@ def test_concurrent_transactions(started_cluster):
 
 def test_abrupt_connection_loss_while_heavy_replication(started_cluster):
     pytest.skip("Temporary disabled (FIXME)")
+
     def transaction(thread_id):
         if thread_id % 2:
             conn = get_postgres_conn(
@@ -843,6 +844,7 @@ def test_restart_server_while_replication_startup_not_finished(started_cluster):
 
 def test_abrupt_server_restart_while_heavy_replication(started_cluster):
     pytest.skip("Temporary disabled (FIXME)")
+
     def transaction(thread_id):
         if thread_id % 2:
             conn = get_postgres_conn(

--- a/tests/integration/test_storage_postgresql_replica/test.py
+++ b/tests/integration/test_storage_postgresql_replica/test.py
@@ -545,6 +545,7 @@ def test_connection_loss(started_cluster):
 
 @pytest.mark.timeout(320)
 def test_clickhouse_restart(started_cluster):
+    pytest.skip("Temporary disabled (FIXME)")
     conn = get_postgres_conn(
         ip=started_cluster.postgres_ip,
         port=started_cluster.postgres_port,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

These tests are broken for a long time and the feature is experimental, so I'd prefer to disable them. And some tests for MaterializedPostgreSQL are already disabled (see #36631 and #36898)

https://play.clickhouse.com/play?user=play#c2VsZWN0IApjb3VudCgpIGFzIGMsIHRlc3RfbmFtZSwgYW55KHJlcG9ydF91cmwpCmZyb20gY2hlY2tzIHdoZXJlICcyMDIyLTA2LTAxJyA8PSBjaGVja19zdGFydF90aW1lIGFuZCB0ZXN0X3N0YXR1cyBpbiAoJ0ZBSUwnLCAnRkxBS1knKSBhbmQgcHVsbF9yZXF1ZXN0X251bWJlcj0wIGdyb3VwIGJ5IHRlc3RfbmFtZSBvcmRlciBieSBjIGRlc2M=

https://play.clickhouse.com/play?user=play#c2VsZWN0IAp0b1N0YXJ0T2ZEYXkoY2hlY2tfc3RhcnRfdGltZSkgYXMgZCwKY291bnQoKSwgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlciksIGFueShyZXBvcnRfdXJsKQpmcm9tIGNoZWNrcyB3aGVyZSAnMjAyMi0wMS0wMScgPD0gY2hlY2tfc3RhcnRfdGltZSBhbmQgdGVzdF9uYW1lIGxpa2UgJyVfcG9zdGdyZXNxbF9yZXBsaWNhXyUnIGFuZCB0ZXN0X3N0YXR1cyBpbiAoJ0ZBSUwnLCAnRkxBS1knKSBncm91cCBieSBkIG9yZGVyIGJ5IGQgZGVzYw==