### PR TITLE
Preserve filling step plan position on sorting optimization

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
+++ b/src/Processors/QueryPlan/Optimizations/liftUpFunctions.cpp
@@ -1,5 +1,6 @@
 #include <Interpreters/ActionsDAG.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
+#include <Processors/QueryPlan/FillingStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/SortingStep.h>
 #include <Common/Exception.h>
@@ -41,6 +42,11 @@ size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan:
 
     if (!sorting_step || !expression_step)
         return 0;
+
+    // Filling step position should be preserved
+    if (!child_node->children.empty())
+        if (typeid_cast<FillingStep *>(child_node->children.front()->step.get()))
+            return 0;
 
     NameSet sort_columns;
     for (const auto & col : sorting_step->getSortDescription())

--- a/tests/queries/0_stateless/02336_sort_optimization_with_fill.reference
+++ b/tests/queries/0_stateless/02336_sort_optimization_with_fill.reference
@@ -1,0 +1,9 @@
+1	A
+2	AA
+3	AAA
+4	AAAA
+5	Hello
+6	HelloA
+7	HelloAA
+8	HelloAAA
+9	HelloAAAA

--- a/tests/queries/0_stateless/02336_sort_optimization_with_fill.sql
+++ b/tests/queries/0_stateless/02336_sort_optimization_with_fill.sql
@@ -1,0 +1,4 @@
+SELECT x, s FROM (
+        SELECT 5 AS x, 'Hello' AS s ORDER BY x WITH FILL FROM 1 TO 10 INTERPOLATE (s AS s||'A')
+) ORDER BY s;
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible incorrect result of `SELECT ... WITH FILL` in the case when `ORDER BY` should be applied after `WITH FILL` result (e.g. for outer query). Incorrect result was caused by optimization for `ORDER BY` expressions (#35623). Closes #37904