### PR TITLE
Stabilize hierarchical_dictionaries perf test

### DIFF
--- a/tests/performance/hierarchical_dictionaries.xml
+++ b/tests/performance/hierarchical_dictionaries.xml
@@ -40,7 +40,7 @@
 
     <fill_query>
         INSERT INTO hierarchical_dictionary_source_table
-        SELECT number, rand64() % 250000
+        SELECT number, sipHash64(number) % 250000
         FROM system.numbers
         LIMIT 500000;
     </fill_query>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)