### PR TITLE
Fix distributed table insert error

### DIFF
--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -61,6 +61,7 @@ namespace ErrorCodes
     extern const int TOO_MANY_PARTITIONS;
     extern const int DISTRIBUTED_TOO_MANY_PENDING_BYTES;
     extern const int ARGUMENT_OUT_OF_BOUND;
+    extern const int NO_SUCH_COLUMN_IN_TABLE;
 }
 
 
@@ -240,6 +241,7 @@ namespace
             || code == ErrorCodes::CANNOT_DECOMPRESS
             || code == ErrorCodes::DISTRIBUTED_BROKEN_BATCH_INFO
             || code == ErrorCodes::DISTRIBUTED_BROKEN_BATCH_FILES
+            || code == ErrorCodes::NO_SUCH_COLUMN_IN_TABLE
             || (!remote_error && code == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF);
     }
 

--- a/tests/queries/0_stateless/02234_insert_distributed_no_sunch_column_in_local.sql
+++ b/tests/queries/0_stateless/02234_insert_distributed_no_sunch_column_in_local.sql
@@ -1,0 +1,12 @@
+drop table if exists data;
+drop table if exists dist;
+create table data (key Int) engine=Null();
+create table dist (key Int, value Int) engine=Distributed(test_cluster_two_shards, currentDatabase(), data, 1);
+-- disable send in background to make the test behavior determine
+system stop distributed sends dist;
+set prefer_localhost_replica=0;
+insert into dist values (1, 1);
+-- first try will get an error and mark batch as broken
+system flush distributed dist; -- { serverError NO_SUCH_COLUMN_IN_TABLE }
+-- subsequent sent will not have anything to send
+system flush distributed dist;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix distributed table insert error, close https://github.com/ClickHouse/ClickHouse/issues/37938

1. fix the distributed table and the local table structure are inconsistent, the distributed table retry insert error indefinitely
2. add NO_SUCH_COLUMN_IN_TABLE to BrokenErrorCode