### PR TITLE
More consistent use of platform macros

### DIFF
--- a/base/base/errnoToString.cpp
+++ b/base/base/errnoToString.cpp
@@ -9,7 +9,7 @@ std::string errnoToString(int code, int the_errno)
     char buf[buf_size];
 #ifndef _GNU_SOURCE
     int rc = strerror_r(the_errno, buf, buf_size);
-#ifdef __APPLE__
+#ifdef OS_DARWIN
     if (rc != 0 && rc != EINVAL)
 #else
     if (rc != 0)

--- a/base/base/getAvailableMemoryAmount.cpp
+++ b/base/base/getAvailableMemoryAmount.cpp
@@ -16,7 +16,7 @@ uint64_t getAvailableMemoryAmountOrZero()
 {
 #if defined(_SC_PHYS_PAGES) // linux
     return getPageSize() * sysconf(_SC_PHYS_PAGES);
-#elif defined(__FreeBSD__)
+#elif defined(OS_FREEBSD)
     struct vmtotal vmt;
     size_t vmt_size = sizeof(vmt);
     if (sysctlbyname("vm.vmtotal", &vmt, &vmt_size, NULL, 0) == 0)

--- a/base/base/phdr_cache.cpp
+++ b/base/base/phdr_cache.cpp
@@ -6,7 +6,7 @@
 
 #include <base/defines.h>
 
-#if defined(__linux__) && !defined(THREAD_SANITIZER) && !defined(USE_MUSL)
+#if defined(OS_LINUX) && !defined(THREAD_SANITIZER) && !defined(USE_MUSL)
     #define USE_PHDR_CACHE 1
 #endif
 

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -5,7 +5,7 @@
 #include <sys/stat.h>
 #include <pwd.h>
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
     #include <syscall.h>
     #include <linux/capability.h>
 #endif
@@ -789,7 +789,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
           *  then attempt to run this file will end up with a cryptic "Operation not permitted" message.
           */
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
         fmt::print("Setting capabilities for clickhouse binary. This is optional.\n");
         std::string command = fmt::format("command -v setcap >/dev/null"
             " && command -v capsh >/dev/null"

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -2,7 +2,7 @@
 #include <csetjmp>
 #include <unistd.h>
 
-#ifdef __linux__
+#ifdef OS_LINUX
 #include <sys/mman.h>
 #endif
 
@@ -339,7 +339,7 @@ struct Checker
         checkRequiredInstructions();
     }
 } checker
-#ifndef __APPLE__
+#ifndef OS_DARWIN
     __attribute__((init_priority(101)))    /// Run before other static initializers.
 #endif
 ;

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -11,7 +11,7 @@
 #include <pcg_random.hpp>
 #include <Common/thread_local_rng.h>
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#if !defined(OS_DARWIN) && !defined(OS_FREEBSD)
 #include <malloc.h>
 #endif
 

--- a/src/Common/Dwarf.cpp
+++ b/src/Common/Dwarf.cpp
@@ -1,4 +1,4 @@
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 /*
  * Copyright 2012-present Facebook, Inc.

--- a/src/Common/Dwarf.h
+++ b/src/Common/Dwarf.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 /*
  * Copyright 2012-present Facebook, Inc.

--- a/src/Common/Elf.cpp
+++ b/src/Common/Elf.cpp
@@ -1,4 +1,4 @@
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 #include <Common/Elf.h>
 #include <Common/Exception.h>

--- a/src/Common/Elf.h
+++ b/src/Common/Elf.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 #include <IO/MMapReadBufferFromFile.h>
 

--- a/src/Common/Exception.cpp
+++ b/src/Common/Exception.cpp
@@ -218,7 +218,7 @@ static void getNoSpaceLeftInfoMessage(std::filesystem::path path, String & msg)
         formatReadableQuantity(fs.f_favail),
         mount_point);
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
     msg += "\nFilesystem: " + getFilesystemName(mount_point);
 #endif
 }
@@ -230,7 +230,7 @@ static void getNoSpaceLeftInfoMessage(std::filesystem::path path, String & msg)
   */
 static void getNotEnoughMemoryMessage(std::string & msg)
 {
-#if defined(__linux__)
+#if defined(OS_LINUX)
     try
     {
         static constexpr size_t buf_size = 1024;

--- a/src/Common/InterruptListener.h
+++ b/src/Common/InterruptListener.h
@@ -16,7 +16,7 @@ namespace ErrorCodes
     extern const int CANNOT_UNBLOCK_SIGNAL;
 }
 
-#ifdef __APPLE__
+#ifdef OS_DARWIN
 // We only need to support timeout = {0, 0} at this moment
 static int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct timespec * /*timeout*/)
 {

--- a/src/Common/PipeFDs.cpp
+++ b/src/Common/PipeFDs.cpp
@@ -27,7 +27,7 @@ void LazyPipeFDs::open()
         if (fd >= 0)
             throw Exception("Pipe is already opened", ErrorCodes::LOGICAL_ERROR);
 
-#ifndef __APPLE__
+#ifndef OS_DARWIN
     if (0 != pipe2(fds_rw, O_CLOEXEC))
         throwFromErrno("Cannot create pipe", ErrorCodes::CANNOT_PIPE);
 #else

--- a/src/Common/ProcfsMetricsProvider.cpp
+++ b/src/Common/ProcfsMetricsProvider.cpp
@@ -1,6 +1,6 @@
 #include "ProcfsMetricsProvider.h"
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 #include <Common/Exception.h>
 #include <IO/ReadBufferFromMemory.h>

--- a/src/Common/ProcfsMetricsProvider.h
+++ b/src/Common/ProcfsMetricsProvider.h
@@ -4,7 +4,7 @@
 #include <boost/noncopyable.hpp>
 
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 struct taskstats;
 
 namespace DB

--- a/src/Common/RadixSort.h
+++ b/src/Common/RadixSort.h
@@ -2,7 +2,7 @@
 
 
 #include <string.h>
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#if !defined(OS_DARWIN) && !defined(OS_FREEBSD)
 #include <malloc.h>
 #endif
 #include <algorithm>

--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -33,7 +33,7 @@ std::string signalToErrorMessage(int sig, const siginfo_t & info, [[maybe_unused
             else
                 error << "Address: " << info.si_addr;
 
-#if defined(__x86_64__) && !defined(__FreeBSD__) && !defined(__APPLE__) && !defined(__arm__) && !defined(__powerpc__)
+#if defined(__x86_64__) && !defined(OS_FREEBSD) && !defined(OS_DARWIN) && !defined(__arm__) && !defined(__powerpc__)
             auto err_mask = context.uc_mcontext.gregs[REG_ERR];
             if ((err_mask & 0x02))
                 error << " Access: write.";
@@ -173,18 +173,18 @@ static void * getCallerAddress(const ucontext_t & context)
 {
 #if defined(__x86_64__)
     /// Get the address at the time the signal was raised from the RIP (x86-64)
-#    if defined(__FreeBSD__)
+#    if defined(OS_FREEBSD)
     return reinterpret_cast<void *>(context.uc_mcontext.mc_rip);
-#    elif defined(__APPLE__)
+#    elif defined(OS_DARWIN)
     return reinterpret_cast<void *>(context.uc_mcontext->__ss.__rip);
 #    else
     return reinterpret_cast<void *>(context.uc_mcontext.gregs[REG_RIP]);
 #    endif
 
-#elif defined(__APPLE__) && defined(__aarch64__)
+#elif defined(OS_DARWIN) && defined(__aarch64__)
     return reinterpret_cast<void *>(context.uc_mcontext->__ss.__pc);
 
-#elif defined(__FreeBSD__) && defined(__aarch64__)
+#elif defined(OS_FREEBSD) && defined(__aarch64__)
     return reinterpret_cast<void *>(context.uc_mcontext.mc_gpregs.gp_elr);
 #elif defined(__aarch64__)
     return reinterpret_cast<void *>(context.uc_mcontext.pc);
@@ -201,7 +201,7 @@ void StackTrace::symbolize(
     const StackTrace::FramePointers & frame_pointers, [[maybe_unused]] size_t offset,
     size_t size, StackTrace::Frames & frames)
 {
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
     auto symbol_index_ptr = DB::SymbolIndex::instance();
     const DB::SymbolIndex & symbol_index = *symbol_index_ptr;
@@ -332,7 +332,7 @@ static void toStringEveryLineImpl(
     if (size == 0)
         return callback("<Empty trace>");
 
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
     auto symbol_index_ptr = DB::SymbolIndex::instance();
     const DB::SymbolIndex & symbol_index = *symbol_index_ptr;
     std::unordered_map<std::string, DB::Dwarf> dwarfs;

--- a/src/Common/StackTrace.h
+++ b/src/Common/StackTrace.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <signal.h>
 
-#ifdef __APPLE__
+#ifdef OS_DARWIN
 // ucontext is not available without _XOPEN_SOURCE
 #   ifdef __clang__
 #       pragma clang diagnostic ignored "-Wreserved-id-macro"

--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -1,4 +1,4 @@
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 #include <Common/SymbolIndex.h>
 #include <Common/hex.h>

--- a/src/Common/SymbolIndex.h
+++ b/src/Common/SymbolIndex.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 #include <vector>
 #include <string>

--- a/src/Common/ThreadProfileEvents.cpp
+++ b/src/Common/ThreadProfileEvents.cpp
@@ -1,6 +1,6 @@
 #include "ThreadProfileEvents.h"
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 #include "TaskStatsInfoGetter.h"
 #include "ProcfsMetricsProvider.h"
@@ -177,7 +177,7 @@ void TasksStatsCounters::incrementProfileEvents(const ::taskstats & prev, const 
 
 #endif
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 namespace DB
 {

--- a/src/Common/ThreadProfileEvents.h
+++ b/src/Common/ThreadProfileEvents.h
@@ -8,7 +8,7 @@
 #include <Common/logger_useful.h>
 
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 #include <linux/taskstats.h>
 #else
 struct taskstats {};
@@ -66,7 +66,7 @@ struct RUsageCounters
     static RUsageCounters current()
     {
         ::rusage rusage {};
-#if !defined(__APPLE__)
+#if !defined(OS_DARWIN)
 #if defined(OS_SUNOS)
         ::getrusage(RUSAGE_LWP, &rusage);
 #else
@@ -102,7 +102,7 @@ private:
     }
 };
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 struct PerfEventInfo
 {
@@ -171,7 +171,7 @@ extern PerfEventsCounters current_thread_counters;
 
 #endif
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 class TasksStatsCounters
 {

--- a/src/Common/ZooKeeper/ZooKeeperIO.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperIO.cpp
@@ -9,7 +9,7 @@ void write(size_t x, WriteBuffer & out)
     writeBinary(x, out);
 }
 
-#ifdef __APPLE__
+#ifdef OS_DARWIN
 void write(uint64_t x, WriteBuffer & out)
 {
     x = __builtin_bswap64(x);
@@ -71,7 +71,7 @@ void write(const Error & x, WriteBuffer & out)
     write(static_cast<int32_t>(x), out);
 }
 
-#ifdef __APPLE__
+#ifdef OS_DARWIN
 void read(uint64_t & x, ReadBuffer & in)
 {
     readBinary(x, in);

--- a/src/Common/ZooKeeper/ZooKeeperIO.h
+++ b/src/Common/ZooKeeper/ZooKeeperIO.h
@@ -16,7 +16,7 @@ using namespace DB;
 void write(size_t x, WriteBuffer & out);
 
 /// uint64_t != size_t on darwin
-#ifdef __APPLE__
+#ifdef OS_DARWIN
 void write(uint64_t x, WriteBuffer & out);
 #endif
 
@@ -45,7 +45,7 @@ void write(const std::vector<T> & arr, WriteBuffer & out)
 }
 
 void read(size_t & x, ReadBuffer & in);
-#ifdef __APPLE__
+#ifdef OS_DARWIN
 void read(uint64_t & x, ReadBuffer & in);
 #endif
 void read(int64_t & x, ReadBuffer & in);

--- a/src/Common/atomicRename.cpp
+++ b/src/Common/atomicRename.cpp
@@ -21,7 +21,7 @@ namespace ErrorCodes
 }
 
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -101,7 +101,7 @@ bool supportsAtomicRename()
 
 }
 
-#elif defined(__APPLE__)
+#elif defined(OS_DARWIN)
 
 // Includes
 #include <dlfcn.h>  // For dlsym

--- a/src/Common/checkStackSize.cpp
+++ b/src/Common/checkStackSize.cpp
@@ -5,7 +5,7 @@
 #include <pthread.h>
 #include <cstdint>
 
-#if defined(__FreeBSD__)
+#if defined(OS_FREEBSD)
 #   include <pthread_np.h>
 #endif
 
@@ -48,7 +48,7 @@ size_t getStackSize(void ** out_address)
     address = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(pthread_get_stackaddr_np(thread)) - size);
 #else
     pthread_attr_t attr;
-#   if defined(__FreeBSD__) || defined(OS_SUNOS)
+#   if defined(OS_FREEBSD) || defined(OS_SUNOS)
     pthread_attr_init(&attr);
     if (0 != pthread_attr_get_np(pthread_self(), &attr))
         throwFromErrno("Cannot pthread_attr_get_np", ErrorCodes::CANNOT_PTHREAD_ATTR);

--- a/src/Common/examples/int_hashes_perf.cpp
+++ b/src/Common/examples/int_hashes_perf.cpp
@@ -16,7 +16,7 @@
 
 static void setAffinity()
 {
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__sun)
+#if !defined(OS_DARWIN) && !defined(OS_FREEBSD) && !defined(__sun)
     cpu_set_t mask;
     CPU_ZERO(&mask);
     CPU_SET(0, &mask);
@@ -283,7 +283,7 @@ int main(int argc, char ** argv)
 
     if (!method || method == 1) test<identity>  (n, data.data(), "0: identity");
     if (!method || method == 2) test<intHash32> (n, data.data(), "1: intHash32");
-#if !defined(__APPLE__) /// The difference in size_t: unsigned long on Linux, unsigned long long on Mac OS.
+#if !defined(OS_DARWIN) /// The difference in size_t: unsigned long on Linux, unsigned long long on Mac OS.
     if (!method || method == 3) test<intHash64> (n, data.data(), "2: intHash64");
 #endif
     if (!method || method == 4) test<hash3>     (n, data.data(), "3: two rounds");

--- a/src/Common/examples/procfs_metrics_provider_perf.cpp
+++ b/src/Common/examples/procfs_metrics_provider_perf.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__)
+#if defined(OS_LINUX)
 #include <Common/ProcfsMetricsProvider.h>
 
 #include <iostream>
@@ -6,7 +6,7 @@
 #endif
 
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 int main(int argc, char ** argv)
 {
     using namespace DB;

--- a/src/Common/examples/symbol_index.cpp
+++ b/src/Common/examples/symbol_index.cpp
@@ -16,7 +16,7 @@ static NO_INLINE const void * getAddress()
 
 int main(int argc, char ** argv)
 {
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
     using namespace DB;
 
     if (argc < 2)

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -1,6 +1,6 @@
 #include "filesystemHelpers.h"
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 #    include <cstdio>
 #    include <mntent.h>
 #    include <sys/sysmacros.h>
@@ -62,12 +62,12 @@ std::unique_ptr<TemporaryFile> createTemporaryFile(const std::string & path)
     return std::make_unique<TemporaryFile>(path);
 }
 
-#if !defined(__linux__)
+#if !defined(OS_LINUX)
 [[noreturn]]
 #endif
 String getBlockDeviceId([[maybe_unused]] const String & path)
 {
-#if defined(__linux__)
+#if defined(OS_LINUX)
     struct stat sb;
     if (lstat(path.c_str(), &sb))
         throwFromErrnoWithPath("Cannot lstat " + path, path, ErrorCodes::CANNOT_STAT);
@@ -79,12 +79,12 @@ String getBlockDeviceId([[maybe_unused]] const String & path)
 #endif
 }
 
-#if !defined(__linux__)
+#if !defined(OS_LINUX)
 [[noreturn]]
 #endif
 BlockDeviceType getBlockDeviceType([[maybe_unused]] const String & device_id)
 {
-#if defined(__linux__)
+#if defined(OS_LINUX)
     try
     {
         ReadBufferFromFile in("/sys/dev/block/" + device_id + "/queue/rotational");
@@ -101,12 +101,12 @@ BlockDeviceType getBlockDeviceType([[maybe_unused]] const String & device_id)
 #endif
 }
 
-#if !defined(__linux__)
+#if !defined(OS_LINUX)
 [[noreturn]]
 #endif
 UInt64 getBlockDeviceReadAheadBytes([[maybe_unused]] const String & device_id)
 {
-#if defined(__linux__)
+#if defined(OS_LINUX)
     try
     {
         ReadBufferFromFile in("/sys/dev/block/" + device_id + "/queue/read_ahead_kb");
@@ -155,12 +155,12 @@ std::filesystem::path getMountPoint(std::filesystem::path absolute_path)
 }
 
 /// Returns name of filesystem mounted to mount_point
-#if !defined(__linux__)
+#if !defined(OS_LINUX)
 [[noreturn]]
 #endif
 String getFilesystemName([[maybe_unused]] const String & mount_point)
 {
-#if defined(__linux__)
+#if defined(OS_LINUX)
     FILE * mounted_filesystems = setmntent("/etc/mtab", "r");
     if (!mounted_filesystems)
         throw DB::Exception("Cannot open /etc/mtab to get name of filesystem", ErrorCodes::SYSTEM_ERROR);

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -19,7 +19,7 @@ bool enoughSpaceInDirectory(const std::string & path, size_t data_size);
 std::unique_ptr<TemporaryFile> createTemporaryFile(const std::string & path);
 
 // Determine what block device is responsible for specified path
-#if !defined(__linux__)
+#if !defined(OS_LINUX)
 [[noreturn]]
 #endif
 String getBlockDeviceId([[maybe_unused]] const String & path);
@@ -32,13 +32,13 @@ enum class BlockDeviceType
 };
 
 // Try to determine block device type
-#if !defined(__linux__)
+#if !defined(OS_LINUX)
 [[noreturn]]
 #endif
 BlockDeviceType getBlockDeviceType([[maybe_unused]] const String & device_id);
 
 // Get size of read-ahead in bytes for specified block device
-#if !defined(__linux__)
+#if !defined(OS_LINUX)
 [[noreturn]]
 #endif
 UInt64 getBlockDeviceReadAheadBytes([[maybe_unused]] const String & device_id);
@@ -47,7 +47,7 @@ UInt64 getBlockDeviceReadAheadBytes([[maybe_unused]] const String & device_id);
 std::filesystem::path getMountPoint(std::filesystem::path absolute_path);
 
 /// Returns name of filesystem mounted to mount_point
-#if !defined(__linux__)
+#if !defined(OS_LINUX)
 [[noreturn]]
 #endif
 String getFilesystemName([[maybe_unused]] const String & mount_point);

--- a/src/Common/getCurrentProcessFDCount.cpp
+++ b/src/Common/getCurrentProcessFDCount.cpp
@@ -11,7 +11,7 @@ int getCurrentProcessFDCount()
 {
     namespace fs = std::filesystem;
     int result = -1;
-#if defined(__linux__)  || defined(__APPLE__)
+#if defined(OS_LINUX)  || defined(OS_DARWIN)
     using namespace DB;
 
     Int32 pid = getpid();

--- a/src/Common/getHashOfLoadedBinary.cpp
+++ b/src/Common/getHashOfLoadedBinary.cpp
@@ -1,6 +1,6 @@
 #include <Common/getHashOfLoadedBinary.h>
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 #include <link.h>
 #include <array>

--- a/src/Common/getMappedArea.cpp
+++ b/src/Common/getMappedArea.cpp
@@ -1,7 +1,7 @@
 #include "getMappedArea.h"
 #include <Common/Exception.h>
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/hex.h>

--- a/src/Common/getMaxFileDescriptorCount.cpp
+++ b/src/Common/getMaxFileDescriptorCount.cpp
@@ -9,7 +9,7 @@ int getMaxFileDescriptorCount()
 {
     namespace fs = std::filesystem;
     int result = -1;
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(OS_LINUX) || defined(OS_DARWIN)
     using namespace DB;
 
     if (fs::exists("/proc/sys/fs/file-max"))

--- a/src/Common/hasLinuxCapability.cpp
+++ b/src/Common/hasLinuxCapability.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 #include "hasLinuxCapability.h"
 

--- a/src/Common/hasLinuxCapability.h
+++ b/src/Common/hasLinuxCapability.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 #include <linux/capability.h>
 

--- a/src/Common/remapExecutable.cpp
+++ b/src/Common/remapExecutable.cpp
@@ -1,6 +1,6 @@
 #include "remapExecutable.h"
 
-#if defined(__linux__) && defined(__amd64__) && defined(__SSE2__) && !defined(SANITIZER) && defined(NDEBUG) && !defined(SPLIT_SHARED_LIBRARIES)
+#if defined(OS_LINUX) && defined(__amd64__) && defined(__SSE2__) && !defined(SANITIZER) && defined(NDEBUG) && !defined(SPLIT_SHARED_LIBRARIES)
 
 #include <sys/mman.h>
 #include <unistd.h>

--- a/src/Common/setThreadName.cpp
+++ b/src/Common/setThreadName.cpp
@@ -1,7 +1,7 @@
 #include <pthread.h>
 
-#if defined(__APPLE__) || defined(OS_SUNOS)
-#elif defined(__FreeBSD__)
+#if defined(OS_DARWIN) || defined(OS_SUNOS)
+#elif defined(OS_FREEBSD)
     #include <pthread_np.h>
 #else
     #include <sys/prctl.h>
@@ -55,10 +55,10 @@ const char * getThreadName()
     if (thread_name[0])
         return thread_name;
 
-#if defined(__APPLE__) || defined(OS_SUNOS)
+#if defined(OS_DARWIN) || defined(OS_SUNOS)
     if (pthread_getname_np(pthread_self(), thread_name, THREAD_NAME_SIZE))
         throw DB::Exception("Cannot get thread name with pthread_getname_np()", DB::ErrorCodes::PTHREAD_ERROR);
-#elif defined(__FreeBSD__)
+#elif defined(OS_FREEBSD)
 // TODO: make test. freebsd will have this function soon https://freshbsd.org/commit/freebsd/r337983
 //    if (pthread_get_name_np(pthread_self(), thread_name, THREAD_NAME_SIZE))
 //        throw DB::Exception("Cannot get thread name with pthread_get_name_np()", DB::ErrorCodes::PTHREAD_ERROR);

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -236,7 +236,7 @@ String MonitorCommand::run()
     print(ret, "key_arena_size", state_machine.getKeyArenaSize());
     print(ret, "latest_snapshot_size", state_machine.getLatestSnapshotBufSize());
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(OS_LINUX) || defined(OS_DARWIN)
     print(ret, "open_file_descriptor_count", getCurrentProcessFDCount());
     print(ret, "max_file_descriptor_count", getMaxFileDescriptorCount());
 #endif

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -10,7 +10,7 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 #include <sys/resource.h>
-#if defined(__linux__)
+#if defined(OS_LINUX)
     #include <sys/prctl.h>
 #endif
 #include <cerrno>
@@ -858,7 +858,7 @@ void BaseDaemon::initializeTerminationAndSignalProcessing()
     signal_listener = std::make_unique<SignalListener>(*this);
     signal_listener_thread.start(*signal_listener);
 
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
     String build_id_hex = DB::SymbolIndex::instance()->getBuildIDHex();
     if (build_id_hex.empty())
         build_id_info = "no build id";
@@ -868,7 +868,7 @@ void BaseDaemon::initializeTerminationAndSignalProcessing()
     build_id_info = "no build id";
 #endif
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
     std::string executable_path = getExecutablePath();
 
     if (!executable_path.empty())
@@ -986,7 +986,7 @@ void BaseDaemon::setupWatchdog()
         if (0 == pid)
         {
             logger().information("Forked a child process to watch");
-#if defined(__linux__)
+#if defined(OS_LINUX)
             if (0 != prctl(PR_SET_PDEATHSIG, SIGKILL))
                 logger().warning("Cannot do prctl to ask termination with parent.");
 #endif

--- a/src/Daemon/SentryWriter.cpp
+++ b/src/Daemon/SentryWriter.cpp
@@ -149,7 +149,7 @@ void SentryWriter::onFault(int sig, const std::string & error_message, const Sta
         sentry_set_tag("signal", strsignal(sig));
         sentry_set_extra("signal_number", sentry_value_new_int32(sig));
 
-        #if defined(__ELF__) && !defined(__FreeBSD__)
+        #if defined(__ELF__) && !defined(OS_FREEBSD)
             const String & build_id_hex = DB::SymbolIndex::instance()->getBuildIDHex();
             sentry_set_tag("build_id", build_id_hex.c_str());
         #endif

--- a/src/Dictionaries/SSDCacheDictionaryStorage.h
+++ b/src/Dictionaries/SSDCacheDictionaryStorage.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
 
 #include <chrono>
 
@@ -507,7 +507,7 @@ public:
         iocb write_request{};
         iocb * write_request_ptr{&write_request};
 
-        #if defined(__FreeBSD__)
+        #if defined(OS_FREEBSD)
         write_request.aio.aio_lio_opcode = LIO_WRITE;
         write_request.aio.aio_fildes = file.fd;
         write_request.aio.aio_buf = reinterpret_cast<volatile void *>(const_cast<char *>(buffer));
@@ -576,7 +576,7 @@ public:
         iocb request{};
         iocb * request_ptr = &request;
 
-        #if defined(__FreeBSD__)
+        #if defined(OS_FREEBSD)
         request.aio.aio_lio_opcode = LIO_READ;
         request.aio.aio_fildes = file.fd;
         request.aio.aio_buf = reinterpret_cast<volatile void *>(reinterpret_cast<UInt64>(read_buffer_memory.data()));
@@ -656,7 +656,7 @@ public:
 
             char * buffer_place = read_buffer.data() + block_size * (block_to_fetch_index % read_from_file_buffer_blocks_size);
 
-            #if defined(__FreeBSD__)
+            #if defined(OS_FREEBSD)
             request.aio.aio_lio_opcode = LIO_READ;
             request.aio.aio_fildes = file.fd;
             request.aio.aio_buf = reinterpret_cast<volatile void *>(reinterpret_cast<UInt64>(buffer_place));
@@ -785,7 +785,7 @@ private:
 
     inline static int preallocateDiskSpace(int fd, size_t offset, size_t len)
     {
-        #if defined(__FreeBSD__)
+        #if defined(OS_FREEBSD)
             return posix_fallocate(fd, offset, len);
         #else
             return fallocate(fd, 0, offset, len);
@@ -796,7 +796,7 @@ private:
     {
         char * result = nullptr;
 
-        #if defined(__FreeBSD__)
+        #if defined(OS_FREEBSD)
             result = reinterpret_cast<char *>(reinterpret_cast<UInt64>(request.aio.aio_buf));
         #else
             result = reinterpret_cast<char *>(request.aio_buf);
@@ -809,7 +809,7 @@ private:
     {
         ssize_t  bytes_written;
 
-        #if defined(__FreeBSD__)
+        #if defined(OS_FREEBSD)
             bytes_written = aio_return(reinterpret_cast<struct aiocb *>(event.udata));
         #else
             bytes_written = event.res;

--- a/src/Dictionaries/registerCacheDictionaries.cpp
+++ b/src/Dictionaries/registerCacheDictionaries.cpp
@@ -41,7 +41,7 @@ CacheDictionaryStorageConfiguration parseCacheStorageConfiguration(
     return storage_configuration;
 }
 
-#if defined(OS_LINUX) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
 
 SSDCacheDictionaryStorageConfiguration parseSSDCacheStorageConfiguration(
     const Poco::Util::AbstractConfiguration & config,
@@ -209,7 +209,7 @@ DictionaryPtr createCacheDictionaryLayout(
         auto storage_configuration = parseCacheStorageConfiguration(config, full_name, layout_type, dictionary_layout_prefix, dict_lifetime);
         storage = std::make_shared<CacheDictionaryStorage<dictionary_key_type>>(dict_struct, storage_configuration);
     }
-#if defined(OS_LINUX) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
     else
     {
         auto storage_configuration = parseSSDCacheStorageConfiguration(config, full_name, layout_type, dictionary_layout_prefix, dict_lifetime);
@@ -261,7 +261,7 @@ void registerDictionaryCache(DictionaryFactory & factory)
 
     factory.registerLayout("complex_key_cache", create_complex_key_cache_layout, true);
 
-#if defined(OS_LINUX) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
 
     auto create_simple_ssd_cache_layout = [=](const std::string & full_name,
                                               const DictionaryStructure & dict_struct,

--- a/src/Dictionaries/tests/gtest_dictionary_ssd_cache_dictionary_storage.cpp
+++ b/src/Dictionaries/tests/gtest_dictionary_ssd_cache_dictionary_storage.cpp
@@ -1,4 +1,4 @@
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
 
 #include <gtest/gtest.h>
 

--- a/src/Disks/IO/ThreadPoolReader.cpp
+++ b/src/Disks/IO/ThreadPoolReader.cpp
@@ -13,7 +13,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
 
 #include <sys/syscall.h>
 #include <sys/uio.h>
@@ -84,7 +84,7 @@ std::future<IAsynchronousReader::Result> ThreadPoolReader::submit(Request reques
 
     int fd = assert_cast<const LocalFileDescriptor &>(*request.descriptor).fd;
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
     /// Check if data is already in page cache with preadv2 syscall.
 
     /// We don't want to depend on new Linux kernel.

--- a/src/Disks/IO/createReadBufferFromFileBase.cpp
+++ b/src/Disks/IO/createReadBufferFromFileBase.cpp
@@ -96,7 +96,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBufferFromFileBase(
     if (flags == -1)
         flags = O_RDONLY | O_CLOEXEC;
 
-#if defined(OS_LINUX) || defined(__FreeBSD__)
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
     if (settings.direct_io_threshold && estimated_size >= settings.direct_io_threshold)
     {
         /** O_DIRECT

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -499,7 +499,7 @@ String FormatFactory::getFormatFromFileDescriptor(int fd)
     if (readlink(proc_path.c_str(), file_path, sizeof(file_path) - 1) != -1)
         return getFormatFromFileName(file_path, false);
     return "";
-#elif defined(__APPLE__)
+#elif defined(OS_DARWIN)
     char file_path[PATH_MAX] = {'\0'};
     if (fcntl(fd, F_GETPATH, file_path) != -1)
         return getFormatFromFileName(file_path, false);

--- a/src/Functions/addressToLine.cpp
+++ b/src/Functions/addressToLine.cpp
@@ -1,4 +1,4 @@
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 #include <Common/Dwarf.h>
 #include <Columns/ColumnString.h>

--- a/src/Functions/addressToLine.h
+++ b/src/Functions/addressToLine.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 #include <Common/Dwarf.h>
 #include <Common/SymbolIndex.h>

--- a/src/Functions/addressToLineWithInlines.cpp
+++ b/src/Functions/addressToLineWithInlines.cpp
@@ -1,4 +1,4 @@
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 #include <Common/Dwarf.h>
 #include <Columns/ColumnString.h>

--- a/src/Functions/addressToSymbol.cpp
+++ b/src/Functions/addressToSymbol.cpp
@@ -1,4 +1,4 @@
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
 
 #include <Common/SymbolIndex.h>
 #include <Columns/ColumnString.h>

--- a/src/Functions/serverConstants.cpp
+++ b/src/Functions/serverConstants.cpp
@@ -19,7 +19,7 @@ namespace DB
 namespace
 {
 
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
     /// buildId() - returns the compiler build id of the running binary.
     class FunctionBuildId : public FunctionConstantBase<FunctionBuildId, String, DataTypeString>
     {
@@ -114,7 +114,7 @@ namespace
 
 void registerFunctionBuildId([[maybe_unused]] FunctionFactory & factory)
 {
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
     factory.registerFunction<FunctionBuildId>();
 #endif
 }

--- a/src/IO/AsynchronousReadBufferFromFile.cpp
+++ b/src/IO/AsynchronousReadBufferFromFile.cpp
@@ -37,7 +37,7 @@ AsynchronousReadBufferFromFile::AsynchronousReadBufferFromFile(
 {
     ProfileEvents::increment(ProfileEvents::FileOpen);
 
-#ifdef __APPLE__
+#ifdef OS_DARWIN
     bool o_direct = (flags != -1) && (flags & O_DIRECT);
     if (o_direct)
         flags = flags & ~O_DIRECT;
@@ -47,7 +47,7 @@ AsynchronousReadBufferFromFile::AsynchronousReadBufferFromFile(
     if (-1 == fd)
         throwFromErrnoWithPath("Cannot open file " + file_name, file_name,
                                errno == ENOENT ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE);
-#ifdef __APPLE__
+#ifdef OS_DARWIN
     if (o_direct)
     {
         if (fcntl(fd, F_NOCACHE, 1) == -1)

--- a/src/IO/ReadBufferFromFile.cpp
+++ b/src/IO/ReadBufferFromFile.cpp
@@ -34,7 +34,7 @@ ReadBufferFromFile::ReadBufferFromFile(
 {
     ProfileEvents::increment(ProfileEvents::FileOpen);
 
-#ifdef __APPLE__
+#ifdef OS_DARWIN
     bool o_direct = (flags != -1) && (flags & O_DIRECT);
     if (o_direct)
         flags = flags & ~O_DIRECT;
@@ -44,7 +44,7 @@ ReadBufferFromFile::ReadBufferFromFile(
     if (-1 == fd)
         throwFromErrnoWithPath("Cannot open file " + file_name, file_name,
                                errno == ENOENT ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE);
-#ifdef __APPLE__
+#ifdef OS_DARWIN
     if (o_direct)
     {
         if (fcntl(fd, F_NOCACHE, 1) == -1)

--- a/src/IO/WriteBufferFromFile.cpp
+++ b/src/IO/WriteBufferFromFile.cpp
@@ -35,7 +35,7 @@ WriteBufferFromFile::WriteBufferFromFile(
 {
     ProfileEvents::increment(ProfileEvents::FileOpen);
 
-#ifdef __APPLE__
+#ifdef OS_DARWIN
     bool o_direct = (flags != -1) && (flags & O_DIRECT);
     if (o_direct)
         flags = flags & ~O_DIRECT;
@@ -47,7 +47,7 @@ WriteBufferFromFile::WriteBufferFromFile(
         throwFromErrnoWithPath("Cannot open file " + file_name, file_name,
                                errno == ENOENT ? ErrorCodes::FILE_DOESNT_EXIST : ErrorCodes::CANNOT_OPEN_FILE);
 
-#ifdef __APPLE__
+#ifdef OS_DARWIN
     if (o_direct)
     {
         if (fcntl(fd, F_NOCACHE, 1) == -1)

--- a/src/Interpreters/CrashLog.cpp
+++ b/src/Interpreters/CrashLog.cpp
@@ -51,7 +51,7 @@ void CrashLogElement::appendToBlock(MutableColumns & columns) const
     columns[i++]->insert(ClickHouseRevision::getVersionRevision());
 
     String build_id_hex;
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
     build_id_hex = SymbolIndex::instance()->getBuildIDHex();
 #endif
     columns[i++]->insert(build_id_hex);

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -384,7 +384,7 @@ BlockIO InterpreterSystemQuery::execute()
             break;
         case Type::RELOAD_SYMBOLS:
         {
-#if defined(__ELF__) && !defined(__FreeBSD__)
+#if defined(__ELF__) && !defined(OS_FREEBSD)
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_SYMBOLS);
             SymbolIndex::reload();
             break;

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -411,7 +411,7 @@ void ThreadStatus::detachQuery(bool exit_if_already_detached, bool thread_exits)
 
     thread_state = thread_exits ? ThreadState::Died : ThreadState::DetachedFromQuery;
 
-#if defined(__linux__)
+#if defined(OS_LINUX)
     if (os_thread_priority)
     {
         LOG_TRACE(log, "Resetting nice");

--- a/utils/iotest/iotest.cpp
+++ b/utils/iotest/iotest.cpp
@@ -138,14 +138,14 @@ int mainImpl(int argc, char ** argv)
 
     ThreadPool pool(threads);
 
-    #ifndef __APPLE__
+    #ifndef OS_DARWIN
     int fd = open(file_name, ((mode & MODE_READ) ? O_RDONLY : O_WRONLY) | ((mode & MODE_DIRECT) ? O_DIRECT : 0) | ((mode & MODE_SYNC) ? O_SYNC : 0));
     #else
     int fd = open(file_name, ((mode & MODE_READ) ? O_RDONLY : O_WRONLY) | ((mode & MODE_SYNC) ? O_SYNC : 0));
     #endif
     if (-1 == fd)
         throwFromErrno("Cannot open file", ErrorCodes::CANNOT_OPEN_FILE);
-    #ifdef __APPLE__
+    #ifdef OS_DARWIN
     if (mode & MODE_DIRECT)
         if (fcntl(fd, F_NOCACHE, 1) == -1)
             throwFromErrno("Cannot open file", ErrorCodes::CANNOT_CLOSE_FILE);


### PR DESCRIPTION
cmake/target.cmake defines macros for the supported platforms, this
commit changes predefined system macros to our own macros.

```
__linux__ --> OS_LINUX
__APPLE__ --> OS_DARWIN
__FreeBSD__ --> OS_FREEBSD
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)