### PR TITLE
Always disable --color-diagnostics for LLVM

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -77,6 +77,7 @@ if (OS_LINUX AND NOT LINKER_NAME)
 
     if (NOT LINKER_NAME)
         if (GOLD_PATH)
+            message (WARNING "Linking with gold is not recommended. Please use lld.")
             if (COMPILER_GCC)
                 set (LINKER_NAME "gold")
             else ()

--- a/contrib/llvm-cmake/CMakeLists.txt
+++ b/contrib/llvm-cmake/CMakeLists.txt
@@ -76,9 +76,7 @@ message (STATUS "LLVM library Directory: ${LLVM_LIBRARY_DIRS}")
 message (STATUS "LLVM C++ compiler flags: ${LLVM_CXXFLAGS}")
 
 # ld: unknown option: --color-diagnostics
-if (APPLE)
-    set (LINKER_SUPPORTS_COLOR_DIAGNOSTICS 0 CACHE INTERNAL "")
-endif ()
+set (LINKER_SUPPORTS_COLOR_DIAGNOSTICS 0 CACHE INTERNAL "")
 
 # Do not adjust RPATH in llvm, since then it will not be able to find libcxx/libcxxabi/libunwind
 set (CMAKE_INSTALL_RPATH "ON")


### PR DESCRIPTION
The flag is not only not recognized on MacOS, it is not recognized by
the gold linker in general.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)