### PR TITLE
Improve perf of queries with DISTINCT

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -48,15 +48,22 @@ size_t tryPushDownFilter(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes
 /// May split ExpressionStep and lift up only a part of it.
 size_t tryExecuteFunctionsAfterSorting(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes);
 
+/// Usually we have two DistinctStep-s in the plan.
+/// One is meant to be executed on multiple threads (so called pre-distinct) and may be helpful if it reduce the amount of data coming to e.g. SortingStep.
+/// The second one returns the final result and executed in one thread.
+/// But it may happen that there will be no other steps between these two DistinctStep-s and we will just do useless computations.
+size_t tryRemoveDuplicateDistincts(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes);
+
 inline const auto & getOptimizations()
 {
-    static const std::array<Optimization, 6> optimizations = {{
+    static const std::array<Optimization, 7> optimizations = {{
         {tryLiftUpArrayJoin, "liftUpArrayJoin", &QueryPlanOptimizationSettings::optimize_plan},
         {tryPushDownLimit, "pushDownLimit", &QueryPlanOptimizationSettings::optimize_plan},
         {trySplitFilter, "splitFilter", &QueryPlanOptimizationSettings::optimize_plan},
         {tryMergeExpressions, "mergeExpressions", &QueryPlanOptimizationSettings::optimize_plan},
         {tryPushDownFilter, "pushDownFilter", &QueryPlanOptimizationSettings::filter_push_down},
         {tryExecuteFunctionsAfterSorting, "liftUpFunctions", &QueryPlanOptimizationSettings::optimize_plan},
+        {tryRemoveDuplicateDistincts, "removeDuplicateDistincts", &QueryPlanOptimizationSettings::optimize_plan},
     }};
 
     return optimizations;

--- a/src/Processors/QueryPlan/Optimizations/removeDuplicateDistincts.cpp
+++ b/src/Processors/QueryPlan/Optimizations/removeDuplicateDistincts.cpp
@@ -1,0 +1,27 @@
+#include <Processors/QueryPlan/DistinctStep.h>
+#include <Processors/QueryPlan/Optimizations/Optimizations.h>
+
+namespace DB::QueryPlanOptimizations
+{
+
+size_t tryRemoveDuplicateDistincts(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes)
+{
+    if (parent_node->children.size() != 1)
+        return 0;
+
+    QueryPlan::Node * child_node = parent_node->children.front();
+
+    auto * distinct_step = typeid_cast<DistinctStep *>(parent_node->step.get());
+    auto * predistinct_step = typeid_cast<DistinctStep *>(child_node->step.get());
+
+    if (!distinct_step || !predistinct_step)
+        return 0;
+
+    // We will keep only the "final" single-threaded distinct.
+    std::swap(parent_node->children, child_node->children);
+    const auto it = std::find_if(nodes.begin(), nodes.end(), [&](const auto & node) { return &node == child_node; });
+    nodes.erase(it);
+
+    return 2;
+}
+}

--- a/tests/performance/distinct.xml
+++ b/tests/performance/distinct.xml
@@ -1,0 +1,5 @@
+<test>
+  <query>select distinct number from numbers_mt(1e7) settings max_threads=2 format Null</query>
+  <query>select distinct number from numbers_mt(5e7) settings max_threads=2 format Null</query>
+  <query>select distinct number from numbers_mt(1e7) group by number format Null</query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed performance of queries with Distinct. It may happen that there will be no other steps between two DistinctStep-s (multithreaded pre-distinct and single-threaded final distinct) and we will just do useless computations.

It is sort of a quick-fix. The right approach here IMO is to always add only one DistinctStep to query plan and then during plan optimization check that we have a DistinctStep, a SortingStep (maybe it is useful also for some others) and statistics (!) tells us that it makes sense to do pre-distinct. Only in that case add another DistinctStep into query plan. I will make an issue for that.