### PR TITLE
 Fixed a stack overflow issue that would cause compilation to fail

### DIFF
--- a/utils/self-extr-exec/compressor.cpp
+++ b/utils/self-extr-exec/compressor.cpp
@@ -297,7 +297,7 @@ int copy_decompressor(const char *self, int output_fd)
         return 1;
     }
 
-    char * buf = (char *)malloc(1ul<<19);
+    char *buf = reinterpret_cast<char*>(malloc(1ul<<19));
     ssize_t n = 0;
     do
     {

--- a/utils/self-extr-exec/compressor.cpp
+++ b/utils/self-extr-exec/compressor.cpp
@@ -297,7 +297,7 @@ int copy_decompressor(const char *self, int output_fd)
         return 1;
     }
 
-    char * buf = new char[1ul<<19];
+    char * buf = (char *)malloc(1ul<<19);
     ssize_t n = 0;
     do
     {
@@ -327,7 +327,7 @@ int copy_decompressor(const char *self, int output_fd)
     } while (true);
 
     close(input_fd);
-    delete []buf;
+    free(buf);
     return 0;
 }
 

--- a/utils/self-extr-exec/compressor.cpp
+++ b/utils/self-extr-exec/compressor.cpp
@@ -297,7 +297,7 @@ int copy_decompressor(const char *self, int output_fd)
         return 1;
     }
 
-    char *buf = new char[1ul<<19];
+    char * buf = new char[1ul<<19];
     ssize_t n = 0;
     do
     {

--- a/utils/self-extr-exec/compressor.cpp
+++ b/utils/self-extr-exec/compressor.cpp
@@ -297,7 +297,7 @@ int copy_decompressor(const char *self, int output_fd)
         return 1;
     }
 
-    char buf[1ul<<19];
+    char *buf = new char[1ul<<19];
     ssize_t n = 0;
     do
     {
@@ -327,7 +327,7 @@ int copy_decompressor(const char *self, int output_fd)
     } while (true);
 
     close(input_fd);
-
+    delete []buf;
     return 0;
 }
 

--- a/utils/self-extr-exec/compressor.cpp
+++ b/utils/self-extr-exec/compressor.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <memory>
 
 #include "types.h"
 
@@ -297,7 +298,8 @@ int copy_decompressor(const char *self, int output_fd)
         return 1;
     }
 
-    char * buf = reinterpret_cast<char *>(malloc(1ul<<19));
+    auto buf_memory = std::make_unique<char[]>(1ul<<19);
+    char * buf = buf_memory.get();
     ssize_t n = 0;
     do
     {
@@ -327,7 +329,6 @@ int copy_decompressor(const char *self, int output_fd)
     } while (true);
 
     close(input_fd);
-    free(buf);
     return 0;
 }
 

--- a/utils/self-extr-exec/compressor.cpp
+++ b/utils/self-extr-exec/compressor.cpp
@@ -297,7 +297,7 @@ int copy_decompressor(const char *self, int output_fd)
         return 1;
     }
 
-    char *buf = reinterpret_cast<char*>(malloc(1ul<<19));
+    char * buf = reinterpret_cast<char *>(malloc(1ul<<19));
     ssize_t n = 0;
     do
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed a stack overflow issue that would cause compilation to fail

```
error: stack frame size (524344) exceeds limit (65536) in 'copy_decompressor(char const*, int)' [-Werror,-Wframe-larger-than]
int copy_decompressor(const char *self, int output_fd)
    ^
1 error generated.
```


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
