### PR TITLE
[WIP] Add functions to extract data from HTML with CSS selectors

### DIFF
--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -103,6 +103,9 @@ endif()
 add_subdirectory(JSONPath)
 list (APPEND PRIVATE_LIBS clickhouse_functions_jsonpath)
 
+add_subdirectory(selectors)
+target_link_libraries(clickhouse_functions PRIVATE clickhouse_functions_selectors)
+
 # Signed integer overflow on user-provided data inside boost::geometry - ignore.
 set_source_files_properties("pointInPolygon.cpp" PROPERTIES COMPILE_FLAGS -fno-sanitize=signed-integer-overflow)
 

--- a/src/Functions/extractHTML.cpp
+++ b/src/Functions/extractHTML.cpp
@@ -59,7 +59,6 @@ size_t extract(const char * __restrict src, size_t size, char * __restrict dst, 
 
         if (next == end)
         {
-            std::cout << __FILE_NAME__ << ":" << __LINE__ << " got end while scanning\n";
             if (cur_match_result == MatchResult::MATCH && match_start != nullptr)
             {
                 size_t bytes_to_copy = end - match_start;
@@ -80,13 +79,8 @@ size_t extract(const char * __restrict src, size_t size, char * __restrict dst, 
         switch (cur_match_result)
         {
             case MatchResult::MATCH:
-                if (tag_preview.is_closing)
+                if (!tag_preview.is_closing)
                 {
-                    std::cout << __FILE_NAME__ << ":" << __LINE__ << " match on closing tag " << tag_preview.name.value << "\n";
-                }
-                else
-                {
-                    std::cout << __FILE_NAME__ << ":" << __LINE__ << " match on opening tag " << tag_preview.name.value << "\n";
                     if (prev_match_result == MatchResult::NOT_MATCH)
                         match_start = tag_scanner.last_tag_start;
                 }
@@ -94,7 +88,6 @@ size_t extract(const char * __restrict src, size_t size, char * __restrict dst, 
             case MatchResult::NOT_MATCH:
                 if (tag_preview.is_closing)
                 {
-                    std::cout << __FILE_NAME__ << ":" << __LINE__ << " not_match on closing tag " << tag_preview.name.value << "\n";
                     if (prev_match_result == MatchResult::MATCH && match_start != nullptr)
                     {
                         if (dst != dst_begin)
@@ -107,13 +100,8 @@ size_t extract(const char * __restrict src, size_t size, char * __restrict dst, 
                             return dst - dst_begin;
                     }
                 }
-                else
-                {
-                    std::cout << __FILE_NAME__ << ":" << __LINE__ << " not_match on opening tag " << tag_preview.name.value << "\n";
-                }
                 break;
             case MatchResult::NEED_ATTRIBUTES:
-                std::cout << __FILE_NAME__ << ":" << __LINE__ << "NEVER: need_attrs on opening tag " << tag_preview.name.value << "\n";
                 break;
         }
         prev_match_result = cur_match_result;

--- a/src/Functions/extractHTML.cpp
+++ b/src/Functions/extractHTML.cpp
@@ -1,4 +1,6 @@
 #include <Columns/ColumnString.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeString.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
@@ -39,10 +41,14 @@ std::pair<const char *, MatchResult> feedAttributes(const char * begin, const ch
     return {end, MatchResult::NOT_MATCH};
 }
 
-template <bool only_first_match>
-size_t extract(const char * __restrict src, size_t size, char * __restrict dst, SelectorMatchingVM & vm)
+template <bool only_first_match, typename F>
+size_t extract(
+    const char * __restrict src,
+    size_t size,
+    char * __restrict dst,
+    SelectorMatchingVM & vm,
+    F && copy_match)
 {
-    vm.reset();
     TagScanner tag_scanner;
 
     const char * end = src + size;
@@ -61,9 +67,8 @@ size_t extract(const char * __restrict src, size_t size, char * __restrict dst, 
         {
             if (cur_match_result == MatchResult::MATCH && match_start != nullptr)
             {
-                size_t bytes_to_copy = end - match_start;
-                memcpy(dst, match_start, bytes_to_copy);
-                dst += bytes_to_copy;
+                dst = copy_match(dst, match_start, end - match_start);
+                return dst - dst_begin;
             }
             break;
         }
@@ -90,12 +95,7 @@ size_t extract(const char * __restrict src, size_t size, char * __restrict dst, 
                 {
                     if (prev_match_result == MatchResult::MATCH && match_start != nullptr)
                     {
-                        if (dst != dst_begin)
-                            *dst++ = '\n';
-
-                        size_t bytes_to_copy = next - match_start + 1;
-                        memcpy(dst, match_start, bytes_to_copy);
-                        dst += bytes_to_copy;
+                        dst = copy_match(dst, match_start, next - match_start + 1);
                         if constexpr (only_first_match)
                             return dst - dst_begin;
                     }
@@ -125,17 +125,105 @@ public:
     bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
 
-    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        if (!isString(arguments[0]))
-            throw Exception(
-                "Illegal type " + arguments[0]->getName() + " of argument of function " + getName(), ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+        FunctionArgumentDescriptors args{
+            {"document", &isStringOrFixedString<IDataType>, nullptr, "const String or const FixedString"},
+            {"selector", &isStringOrFixedString<IDataType>, isColumnConst, "const String or const FixedString"},
+        };
+        validateFunctionArgumentTypes(*this, arguments, args);
 
-        if (!isStringOrFixedString(arguments[1]))
-            throw Exception(
-                "Illegal type " + arguments[1]->getName() + " of argument of function " + getName(), ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+        if constexpr (only_first_match)
+            return std::make_shared<DataTypeString>();
+        return std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());
+    }
 
-        return arguments[0];
+    ColumnPtr executeOne(const ColumnString * src_column, size_t rows, SelectorMatchingVM & vm) const
+    {
+        const ColumnString::Chars & src_chars = src_column->getChars();
+        const ColumnString::Offsets & src_offsets = src_column->getOffsets();
+
+        auto res = ColumnString::create();
+
+        ColumnString::Chars & res_chars = res->getChars();
+        ColumnString::Offsets & res_offsets = res->getOffsets();
+
+        res_chars.resize(src_chars.size());
+        res_offsets.resize(src_offsets.size());
+
+        ColumnString::Offset src_offset = 0;
+        ColumnString::Offset res_offset = 0;
+
+        for (size_t i = 0; i < rows; ++i)
+        {
+            vm.reset();
+            auto next_src_offset = src_offsets[i];
+
+            res_offset += extract<only_first_match>(
+                reinterpret_cast<const char *>(&src_chars[src_offset]),
+                next_src_offset - src_offset - 1,
+                reinterpret_cast<char *>(&res_chars[res_offset]),
+                vm,
+                [](char * dst, const char * src, size_t n){
+                    memcpy(dst, src, n);
+                    return dst + n;
+                });
+
+            res_chars[res_offset] = 0;
+            ++res_offset;
+            res_offsets[i] = res_offset;
+
+            src_offset = next_src_offset;
+        }
+
+        res_chars.resize(res_offset);
+        return res;
+    }
+
+    ColumnPtr executeAll(const ColumnString * src_column, size_t rows, SelectorMatchingVM & vm) const
+    {
+        const ColumnString::Chars & src_chars = src_column->getChars();
+        const ColumnString::Offsets & src_offsets = src_column->getOffsets();
+
+        auto res = ColumnArray::create(ColumnString::create());
+        ColumnString & res_strings = typeid_cast<ColumnString &>(res->getData());
+
+        ColumnArray::Offsets & res_offsets = res->getOffsets();
+        ColumnString::Chars & res_strings_chars = res_strings.getChars();
+        ColumnString::Offsets & res_strings_offsets = res_strings.getOffsets();
+
+        ColumnString::Offset src_offset = 0;
+        ColumnString::Offset res_offset = 0;
+
+        res_strings_chars.resize(src_chars.size());
+        res_offsets.resize(rows);
+        for (size_t i = 0; i < rows; ++i)
+        {
+            vm.reset();
+            auto next_src_offset = src_offsets[i];
+
+            res_offset += extract<only_first_match>(
+                reinterpret_cast<const char *>(&src_chars[src_offset]),
+                next_src_offset - src_offset - 1,
+                reinterpret_cast<char *>(&res_strings_chars[res_offset]),
+                vm,
+                [&res_strings_offsets, &res_strings_chars, offset = 0ul](char * dst, const char * src, size_t n) mutable
+                {
+                    memcpy(dst, src, n);
+                    offset += n;
+                    res_strings_chars[offset] = 0;
+                    ++offset;
+                    res_strings_offsets.push_back(offset);
+                    return dst + n + 1;
+                });
+
+            ++res_offset;
+            res_offsets[i] = res_strings_offsets.size();
+
+            src_offset = next_src_offset;
+        }
+
+        return res;
     }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t rows) const override
@@ -151,39 +239,7 @@ public:
         String selector = selector_column->getValue<String>();
         SelectorMatchingVM vm = SelectorMatchingVM::parseSelector(selector.data(), selector.data() + selector.size());
 
-        const ColumnString::Chars & src_chars = src->getChars();
-        const ColumnString::Offsets & src_offsets = src->getOffsets();
-
-        auto res = ColumnString::create();
-
-        ColumnString::Chars & res_chars = res->getChars();
-        ColumnString::Offsets & res_offsets = res->getOffsets();
-
-        res_chars.resize(src_chars.size());
-        res_offsets.resize(src_offsets.size());
-
-        ColumnString::Offset src_offset = 0;
-        ColumnString::Offset res_offset = 0;
-
-        for (size_t i = 0; i < rows; ++i)
-        {
-            auto next_src_offset = src_offsets[i];
-
-            res_offset += extract<only_first_match>(
-                reinterpret_cast<const char *>(&src_chars[src_offset]),
-                next_src_offset - src_offset - 1,
-                reinterpret_cast<char *>(&res_chars[res_offset]),
-                vm);
-
-            res_chars[res_offset] = 0;
-            ++res_offset;
-            res_offsets[i] = res_offset;
-
-            src_offset = next_src_offset;
-        }
-
-        res_chars.resize(res_offset);
-        return res;
+        return only_first_match ? executeOne(src, rows, vm) : executeAll(src, rows, vm);
     }
 };
 

--- a/src/Functions/extractHTML.cpp
+++ b/src/Functions/extractHTML.cpp
@@ -1,0 +1,212 @@
+#include <Columns/ColumnString.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Functions/selectors/SelectorMatchingVM.h>
+#include <Functions/selectors/TagScanner.h>
+#include <Functions/selectors/parseNextAttribute.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_COLUMN;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+namespace
+{
+
+std::pair<const char *, MatchResult> feedAttributes(const char * begin, const char * end, SelectorMatchingVM & vm) {
+    while (begin != end) {
+        Attribute attribute;
+        begin = parseNextAttribute(begin, end, attribute);
+        if (!attribute.key.value.empty()) {
+            auto match_result = vm.handleAttribute(attribute);
+            switch (match_result)
+            {
+                case MatchResult::MATCH:
+                case MatchResult::NOT_MATCH:
+                    return {begin, match_result};
+                case MatchResult::NEED_ATTRIBUTES:
+                    continue;
+            }
+        }
+
+        return {begin, MatchResult::NOT_MATCH};
+    }
+    return {end, MatchResult::NOT_MATCH};
+}
+
+template <bool only_first_match>
+size_t extract(const char * __restrict src, size_t size, char * __restrict dst, SelectorMatchingVM & vm)
+{
+    vm.reset();
+    TagScanner tag_scanner;
+
+    const char * end = src + size;
+    char * dst_begin = dst;
+    const char * match_start = nullptr;
+
+    MatchResult cur_match_result = MatchResult::NOT_MATCH;
+    MatchResult prev_match_result = MatchResult::NOT_MATCH;
+
+    while (src != end)
+    {
+        TagPreview tag_preview;
+        const char * next = tag_scanner.scan(src, end, tag_preview);
+
+        if (next == end)
+        {
+            std::cout << __FILE_NAME__ << ":" << __LINE__ << " got end while scanning\n";
+            if (cur_match_result == MatchResult::MATCH && match_start != nullptr)
+            {
+                size_t bytes_to_copy = end - match_start;
+                memcpy(dst, match_start, bytes_to_copy);
+                dst += bytes_to_copy;
+            }
+            break;
+        }
+
+        if (tag_preview.is_closing)
+            cur_match_result = vm.handleClosingTag(tag_preview.name);
+        else
+            cur_match_result = vm.handleOpeningTag(tag_preview.name);
+
+        if (cur_match_result == MatchResult::NEED_ATTRIBUTES)
+            std::tie(next, cur_match_result) = feedAttributes(next, end, vm);
+
+        switch (cur_match_result)
+        {
+            case MatchResult::MATCH:
+                if (tag_preview.is_closing)
+                {
+                    std::cout << __FILE_NAME__ << ":" << __LINE__ << " match on closing tag " << tag_preview.name.value << "\n";
+                }
+                else
+                {
+                    std::cout << __FILE_NAME__ << ":" << __LINE__ << " match on opening tag " << tag_preview.name.value << "\n";
+                    if (prev_match_result == MatchResult::NOT_MATCH)
+                        match_start = tag_scanner.last_tag_start;
+                }
+                break;
+            case MatchResult::NOT_MATCH:
+                if (tag_preview.is_closing)
+                {
+                    std::cout << __FILE_NAME__ << ":" << __LINE__ << " not_match on closing tag " << tag_preview.name.value << "\n";
+                    if (prev_match_result == MatchResult::MATCH && match_start != nullptr)
+                    {
+                        if (dst != dst_begin)
+                            *dst++ = '\n';
+
+                        size_t bytes_to_copy = next - match_start + 1;
+                        memcpy(dst, match_start, bytes_to_copy);
+                        dst += bytes_to_copy;
+                        if constexpr (only_first_match)
+                            return dst - dst_begin;
+                    }
+                }
+                else
+                {
+                    std::cout << __FILE_NAME__ << ":" << __LINE__ << " not_match on opening tag " << tag_preview.name.value << "\n";
+                }
+                break;
+            case MatchResult::NEED_ATTRIBUTES:
+                std::cout << __FILE_NAME__ << ":" << __LINE__ << "NEVER: need_attrs on opening tag " << tag_preview.name.value << "\n";
+                break;
+        }
+        prev_match_result = cur_match_result;
+        src = next;
+    }
+
+    return dst - dst_begin;
+}
+
+}
+
+template <bool only_first_match>
+class FunctionExtractHTML : public IFunction
+{
+public:
+    static constexpr auto name = only_first_match ? "extractHTMLOne" : "extractHTMLAll";
+
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionExtractHTML<only_first_match>>(); }
+    String getName() const override { return name; }
+    size_t getNumberOfArguments() const override { return 2; }
+    bool useDefaultImplementationForConstants() const override { return true; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    {
+        if (!isString(arguments[0]))
+            throw Exception(
+                "Illegal type " + arguments[0]->getName() + " of argument of function " + getName(), ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
+        if (!isStringOrFixedString(arguments[1]))
+            throw Exception(
+                "Illegal type " + arguments[1]->getName() + " of argument of function " + getName(), ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+
+        return arguments[0];
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t rows) const override
+    {
+        const ColumnString * src = checkAndGetColumn<ColumnString>(arguments[0].column.get());
+        if (!src)
+            throw Exception("First argument for function " + getName() + " must be string.", ErrorCodes::ILLEGAL_COLUMN);
+
+        const ColumnConst * selector_column = checkAndGetColumn<ColumnConst>(arguments[1].column.get());
+        if (!selector_column)
+            throw Exception("Second argument for function " + getName() + " must be constant.", ErrorCodes::ILLEGAL_COLUMN);
+
+        String selector = selector_column->getValue<String>();
+        SelectorMatchingVM vm = SelectorMatchingVM::parseSelector(selector.data(), selector.data() + selector.size());
+
+        const ColumnString::Chars & src_chars = src->getChars();
+        const ColumnString::Offsets & src_offsets = src->getOffsets();
+
+        auto res = ColumnString::create();
+
+        ColumnString::Chars & res_chars = res->getChars();
+        ColumnString::Offsets & res_offsets = res->getOffsets();
+
+        res_chars.resize(src_chars.size());
+        res_offsets.resize(src_offsets.size());
+
+        ColumnString::Offset src_offset = 0;
+        ColumnString::Offset res_offset = 0;
+
+        for (size_t i = 0; i < rows; ++i)
+        {
+            auto next_src_offset = src_offsets[i];
+
+            res_offset += extract<only_first_match>(
+                reinterpret_cast<const char *>(&src_chars[src_offset]),
+                next_src_offset - src_offset - 1,
+                reinterpret_cast<char *>(&res_chars[res_offset]),
+                vm);
+
+            res_chars[res_offset] = 0;
+            ++res_offset;
+            res_offsets[i] = res_offset;
+
+            src_offset = next_src_offset;
+        }
+
+        res_chars.resize(res_offset);
+        return res;
+    }
+};
+
+void registerFunctionExtractHTMLAll(FunctionFactory & factory)
+{
+    factory.registerFunction<FunctionExtractHTML<false>>();
+}
+
+void registerFunctionExtractHTMLOne(FunctionFactory & factory)
+{
+    factory.registerFunction<FunctionExtractHTML<true>>();
+}
+
+}

--- a/src/Functions/selectors/CMakeLists.txt
+++ b/src/Functions/selectors/CMakeLists.txt
@@ -1,0 +1,5 @@
+include("${ClickHouse_SOURCE_DIR}/cmake/dbms_glob_sources.cmake")
+add_headers_and_sources(clickhouse_functions_selectors .)
+add_library(clickhouse_functions_selectors ${clickhouse_functions_selectors_sources} ${clickhouse_functions_selectors_headers})
+
+target_link_libraries(clickhouse_functions_selectors PRIVATE dbms)

--- a/src/Functions/selectors/SelectorMatchingVM.h
+++ b/src/Functions/selectors/SelectorMatchingVM.h
@@ -1,0 +1,403 @@
+#pragma once
+
+#include "Types.h"
+
+#include <base/find_symbols.h>
+
+#include <string>
+#include <sstream>
+#include <vector>
+
+namespace DB
+{
+
+struct AttributeInfo
+{
+    AttributeMatcher matcher;
+    bool matched = false;
+};
+
+inline const char * fillAttributes(std::vector<AttributeInfo> & attributes, const char * begin, const char * end)
+{
+    assert(*begin == '[');
+    ++begin;
+    while (true)
+    {
+        AttributeMatcher attribute;
+        begin = find_first_not_symbols<' '>(begin, end);
+        if (begin == end)
+            return end;
+
+        if (*begin == ']')
+        {
+            ++begin;
+            if (begin == end || *begin != '[')
+                return begin;
+
+            ++begin;
+        }
+
+        const char * key_end = find_first_symbols<' ', '='>(begin, end);
+        if (key_end == end)
+            return end;
+
+        attribute.key = std::string_view(begin, key_end - begin);
+
+        begin = key_end;
+
+        const char * eq_pos = find_first_symbols<'='>(begin, end);
+        if (eq_pos + 1 < end)
+            begin = eq_pos + 1;
+        else
+            return end;
+
+        begin = find_first_not_symbols<' '>(begin, end);
+        if (begin == end || *begin == ']')
+            return end;
+
+        const char * value_end = end;
+        if (*begin == '\'')
+        {
+            ++begin;
+            value_end = find_first_symbols<'\''>(begin, value_end);
+        }
+        else if (*begin == '"')
+        {
+            ++begin;
+            value_end = find_first_symbols<'"'>(begin, value_end);
+        }
+        else
+        {
+            value_end = find_first_symbols<' ', ']'>(begin, value_end);
+        }
+
+        if (value_end == end)
+            return end;
+
+        attribute.value_matcher = std::make_unique<ExactValueMatcher>(std::string_view(begin, value_end - begin));
+        attributes.push_back({.matcher = std::move(attribute)});
+
+        begin = value_end;
+
+        if (*begin == '\'' || *begin == '"')
+            ++begin;
+    }
+}
+
+enum class MatchResult
+{
+    MATCH = 0,
+    NOT_MATCH = 1,
+    NEED_ATTRIBUTES = 2,
+};
+
+struct StackItem
+{
+    CaseInsensitiveStringView tag_name;
+    size_t next = 0;
+    int64_t jump = -1;
+};
+
+struct Instruction
+{
+    CaseInsensitiveStringView expected_tag;
+    std::vector<AttributeInfo> attributes;
+    bool need_jump_to_next_instruction = false;
+
+    std::string ToString() const
+    {
+        std::ostringstream ss;
+        ss << "<" << expected_tag.value << ">";
+        for (const auto & attr: attributes) {
+            ss << "[" << attr.matched << ", " << attr.matcher.key.value << "=" << attr.matcher.value_matcher->pattern()
+               << "]";
+        }
+        ss << "need_jmp=" << need_jump_to_next_instruction;
+        return ss.str();
+    }
+
+    MatchResult match(CaseInsensitiveStringView tag_name) const
+    {
+        std::cout << "try match <" << tag_name.value << ">" << " [" << ToString() << "]\n";
+        if (expected_tag.value == "*" || expected_tag == tag_name)
+        {
+            if (!attributes.empty()) {
+                std::cout << "match result: need attributes\n";
+                return MatchResult::NEED_ATTRIBUTES;
+            }
+
+            std::cout << "match result: match\n";
+            return MatchResult::MATCH;
+        }
+        std::cout << "match result: not_match\n";
+        return MatchResult::NOT_MATCH;
+    }
+
+    MatchResult handleAttribute(const Attribute & attribute)
+    {
+        std::cout << "handle attribute: " << attribute.key.value << '=' << attribute.value << " [" << ToString() << "]\n";
+        for (auto & attr : attributes)
+        {
+            if (!attr.matched && attr.matcher.key == attribute.key)
+            {
+                if (attr.matcher.match(attribute.value))
+                {
+                    attr.matched = true;
+                }
+                else
+                {
+                    reset();
+                    std::cout << "handleAttribute result: not_match\n";
+                    return MatchResult::NOT_MATCH;
+                }
+            }
+        }
+
+        if (isAllAttributesMatched()) {
+            reset();
+            std::cout << "handleAttribute result: match\n";
+            return MatchResult::MATCH;
+        }
+        std::cout << "handleAttribute result: need_attrs\n";
+        return MatchResult::NEED_ATTRIBUTES;
+    }
+
+    bool isAllAttributesMatched() const
+    {
+        for (const auto & attr : attributes)
+        {
+            if (!attr.matched)
+                return false;
+        }
+        return true;
+    }
+
+    void reset() {
+        for (auto & attr : attributes)
+            attr.matched = false;
+    }
+};
+
+
+struct SelectorMatchingVM
+{
+    std::vector<Instruction> instructions;
+    std::vector<StackItem> stack;
+    size_t current_instruction_index = 0;
+    int last_stack_jump_index = -1;
+    CaseInsensitiveStringView last_tag_name;
+    bool matched = false;
+    CaseInsensitiveStringView last_matched_tag;
+    int last_matched_tag_count = 0;
+
+    void reset()
+    {
+        stack.clear();
+        current_instruction_index = 0;
+        for (auto & instruction : instructions)
+            instruction.reset();
+    }
+
+    MatchResult handleOpeningTag(CaseInsensitiveStringView tag_name)
+    {
+        std::cout << "got opening tag " << tag_name.value << '\n';
+        for (auto && entry: stack)
+            std::cout << "<" << entry.tag_name.value << "> jump=" << entry.jump << ", next=" << entry.next << std::endl;
+        if (matched) {
+            if (tag_name == last_matched_tag)
+                ++last_matched_tag_count;
+            return MatchResult::MATCH;
+        }
+
+        last_tag_name = tag_name;
+        last_stack_jump_index = stack.size() - 1;
+        stack.push_back(StackItem{.tag_name = tag_name});
+
+        auto match_result = instructions[current_instruction_index].match(tag_name);
+        switch (match_result)
+        {
+            case MatchResult::MATCH:
+                if (instructions[current_instruction_index].need_jump_to_next_instruction) {
+                    stack.back().jump = current_instruction_index + 1;
+                }
+                ++current_instruction_index;
+                if (current_instruction_index == instructions.size())
+                {
+                    current_instruction_index = 0;
+                    matched = true;
+                    last_matched_tag = tag_name;
+                    last_matched_tag_count = 1;
+                    return MatchResult::MATCH;
+                }
+                stack.back().next = current_instruction_index;
+                return MatchResult::NOT_MATCH;
+            case MatchResult::NOT_MATCH:
+                // TODO: store index of last item with jump in every stack item
+                for (; last_stack_jump_index >= 0; --last_stack_jump_index)
+                {
+                    auto ind = stack[last_stack_jump_index].jump;
+                    if (ind != -1)
+                    {
+                        std::cout << "found jump, executing, ind on stack = " << last_stack_jump_index <<  "\n";
+                        auto mr = instructions[ind].match(tag_name);
+                        switch (mr)
+                        {
+                            case MatchResult::MATCH:
+                                current_instruction_index = ind + 1;
+                                if (current_instruction_index == instructions.size())
+                                {
+                                    current_instruction_index = 0;
+                                    matched = true;
+                                    last_matched_tag = last_tag_name;
+                                    last_matched_tag_count = 1;
+                                    return MatchResult::MATCH;
+                                }
+                                stack.back().next = current_instruction_index;
+                                if (instructions[ind].need_jump_to_next_instruction) {
+                                    stack.back().jump = current_instruction_index;
+                                }
+                                return MatchResult::NOT_MATCH;
+                            case MatchResult::NOT_MATCH:
+                                continue;
+                            case MatchResult::NEED_ATTRIBUTES:
+                                current_instruction_index = ind;
+                                --last_stack_jump_index;
+                                return MatchResult::NEED_ATTRIBUTES;
+                        }
+                    }
+                }
+
+                current_instruction_index = 0;
+                return MatchResult::NOT_MATCH;
+            case MatchResult::NEED_ATTRIBUTES:
+                return MatchResult::NEED_ATTRIBUTES;
+        }
+    }
+
+    MatchResult handleClosingTag(CaseInsensitiveStringView tag_name)
+    {
+        std::cout << "got closing tag " << tag_name.value << '\n';
+        for (auto && entry: stack)
+            std::cout << "<" << entry.tag_name.value << "> jump=" << entry.jump << ", next=" << entry.next << std::endl;
+
+        if (matched) {
+            if (tag_name == last_matched_tag)
+                --last_matched_tag_count;
+            if (last_matched_tag_count == 0) {
+                matched = false;
+                stack.pop_back();
+                return MatchResult::NOT_MATCH;
+            } else {
+                return MatchResult::MATCH;
+            }
+        }
+
+        // remove self-closing tags
+        while (!stack.empty() && tag_name != stack.back().tag_name)
+            stack.pop_back();
+
+        // TODO: ??? assert(!stack.empty() && tag_name == stack.back().tag_name);
+        if (!stack.empty())
+            stack.pop_back();
+
+        if (!stack.empty())
+            current_instruction_index = stack.back().next;
+        else
+            current_instruction_index = 0;
+
+        return MatchResult::NOT_MATCH;
+    }
+
+    MatchResult handleAttribute(const Attribute & attribute) {
+        auto match_result = instructions[current_instruction_index].handleAttribute(attribute);
+        switch (match_result)
+        {
+            case MatchResult::MATCH:
+                ++current_instruction_index;
+                if (current_instruction_index == instructions.size())
+                {
+                    current_instruction_index = 0;
+                    matched = true;
+                    last_matched_tag = last_tag_name;
+                    last_matched_tag_count = 1;
+                    return MatchResult::MATCH;
+                }
+                stack.back().next = current_instruction_index;
+                return MatchResult::NOT_MATCH;
+            case MatchResult::NOT_MATCH:
+                for (; last_stack_jump_index >= 0; --last_stack_jump_index)
+                {
+                    auto ind = stack[last_stack_jump_index].jump;
+                    if (ind != -1)
+                    {
+                        auto mr = instructions[ind].match(last_tag_name);
+                        switch (mr)
+                        {
+                            case MatchResult::MATCH:
+                                current_instruction_index = ind + 1;
+                                if (current_instruction_index == instructions.size())
+                                {
+                                    current_instruction_index = 0;
+                                    return MatchResult::MATCH;
+                                }
+                                stack.back().next = current_instruction_index;
+                                return MatchResult::NOT_MATCH;
+                            case MatchResult::NOT_MATCH:
+                                continue;
+                            case MatchResult::NEED_ATTRIBUTES:
+                                current_instruction_index = ind;
+                                --last_stack_jump_index;
+                                return MatchResult::NEED_ATTRIBUTES;
+                        }
+                    }
+                }
+
+                current_instruction_index = 0;
+                return MatchResult::NOT_MATCH;
+            case MatchResult::NEED_ATTRIBUTES:
+                return MatchResult::NEED_ATTRIBUTES;
+        }
+    }
+
+    static SelectorMatchingVM parseSelector(const char * begin, const char * end)
+    {
+        SelectorMatchingVM vm;
+        while (begin != end)
+        {
+            bool need_jump = !vm.instructions.empty();
+            begin = find_first_not_symbols<' '>(begin, end);
+
+            if (begin == end)
+                break;
+
+            if (*begin == '>')
+            {
+                need_jump = false;
+
+                ++begin;
+                begin = find_first_not_symbols<' '>(begin, end);
+                if (begin == end)
+                    break;
+            }
+
+            const char * next = find_first_symbols<' ', '['>(begin, end);
+
+            Instruction instruction;
+
+            instruction.expected_tag = std::string_view(begin, next - begin);
+
+            if (next != end && *next == '[')
+                begin = fillAttributes(instruction.attributes, next, end);
+            else
+                begin = next;
+
+            if (need_jump)
+                vm.instructions.back().need_jump_to_next_instruction = true;
+
+            vm.instructions.push_back(std::move(instruction));
+        }
+        return vm;
+    }
+};
+
+}

--- a/src/Functions/selectors/TagScanner.h
+++ b/src/Functions/selectors/TagScanner.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "Types.h"
+
+#include <base/find_symbols.h>
+#include <Common/StringUtils/StringUtils.h>
+
+#include <string_view>
+
+namespace DB
+{
+
+struct TagScanner
+{
+    const char * last_tag_start = nullptr;
+
+    /// @returns position of the symbol after a tag name or end if no tag is found
+    const char * scan(const char * begin, const char * end, TagPreview & result)
+    {
+        while (begin != end)
+        {
+            begin = find_first_symbols<'<'>(begin, end);
+            if (begin + 1 >= end)
+                return end;
+
+            ++begin;
+
+            // if (*begin == '!')
+            //{
+            //    TODO: properly skip comment, DOCTYPE, etc.
+            // }
+
+            if (*begin == '/')
+            {
+                const char * gt = find_first_symbols<'>'>(begin, end);
+                if (gt == end)
+                    return end;
+
+                result.name = std::string_view(begin + 1, gt - begin - 1);
+                result.is_closing = true;
+                return gt;
+            }
+
+            if (!isAlphaASCII(*begin))
+                continue;
+
+            last_tag_start = begin - 1;
+
+            const char * after_tag_name = find_first_symbols<'>', ' ', '\t', '\n', '\r', '\f', '\v'>(begin, end);
+            if (after_tag_name == end)
+                return end;
+
+            result.name = std::string_view(begin, after_tag_name - begin);
+            result.is_closing = false;
+            return after_tag_name;
+            // TODO: skip <style>, <script> ???
+        }
+
+        return end;
+    }
+};
+
+}

--- a/src/Functions/selectors/Types.h
+++ b/src/Functions/selectors/Types.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <base/find_symbols.h>
+#include <Common/StringUtils/StringUtils.h>
+
+#include <string>
+#include <vector>
+
+namespace DB
+{
+
+struct CaseInsensitiveStringView
+{
+    std::string_view value;
+
+    CaseInsensitiveStringView() = default;
+    CaseInsensitiveStringView(std::string_view value_) : value(value_) { }
+
+    bool operator==(const CaseInsensitiveStringView & other) const
+    {
+        if (value.size() != other.value.size())
+            return false;
+        for (size_t i = 0; i < value.size(); ++i)
+        {
+            if (!equalsCaseInsensitive(value[i], other.value[i]))
+                return false;
+        }
+
+        return true;
+    }
+};
+
+struct TagPreview
+{
+    CaseInsensitiveStringView name;
+    bool is_closing = false;
+
+    bool operator==(const TagPreview & other) const = default;
+};
+
+struct Attribute
+{
+    CaseInsensitiveStringView key;
+    std::string_view value;
+
+    bool operator==(const Attribute & other) const = default;
+};
+
+class IValueMatcher
+{
+public:
+    virtual bool match(std::string_view value) const = 0;
+    virtual std::string_view pattern() const = 0;
+    virtual ~IValueMatcher() = default;
+};
+
+using ValuePatternPtr = std::unique_ptr<IValueMatcher>;
+
+struct AttributeMatcher
+{
+    CaseInsensitiveStringView key;
+    ValuePatternPtr value_matcher;
+
+    bool match(std::string_view value) const { return value_matcher->match(value); }
+};
+
+class ExactValueMatcher : public IValueMatcher
+{
+private:
+    std::string_view pattern_;
+
+public:
+    explicit ExactValueMatcher(std::string_view pattern) : pattern_(pattern) { }
+    bool match(std::string_view value) const override { return pattern_ == value; }
+    std::string_view pattern() const override { return pattern_; }
+};
+
+}

--- a/src/Functions/selectors/Types.h
+++ b/src/Functions/selectors/Types.h
@@ -50,29 +50,18 @@ class IValueMatcher
 {
 public:
     virtual bool match(std::string_view value) const = 0;
-    virtual std::string_view pattern() const = 0;
+    virtual std::string_view getPattern() const = 0;
     virtual ~IValueMatcher() = default;
 };
 
-using ValuePatternPtr = std::unique_ptr<IValueMatcher>;
+using ValueMatcherPtr = std::unique_ptr<IValueMatcher>;
 
-struct AttributeMatcher
+struct AttributeSelector
 {
     CaseInsensitiveStringView key;
-    ValuePatternPtr value_matcher;
+    ValueMatcherPtr value_matcher;
 
     bool match(std::string_view value) const { return value_matcher->match(value); }
-};
-
-class ExactValueMatcher : public IValueMatcher
-{
-private:
-    std::string_view pattern_;
-
-public:
-    explicit ExactValueMatcher(std::string_view pattern) : pattern_(pattern) { }
-    bool match(std::string_view value) const override { return pattern_ == value; }
-    std::string_view pattern() const override { return pattern_; }
 };
 
 }

--- a/src/Functions/selectors/ValueMatchers.cpp
+++ b/src/Functions/selectors/ValueMatchers.cpp
@@ -1,0 +1,123 @@
+#include "Types.h"
+#include "ValueMatchers.h"
+
+#include <Common/StringUtils/StringUtils.h>
+
+namespace DB
+{
+
+namespace
+{
+
+class AlwaysTrueMatcher : public IValueMatcher
+{
+private:
+    std::string_view pattern;
+
+public:
+    bool match(std::string_view) const override { return true; }
+    std::string_view getPattern() const override { return ""; }
+};
+
+class ExactMatcher : public IValueMatcher
+{
+private:
+    std::string_view pattern;
+
+public:
+    explicit ExactMatcher(std::string_view pattern_) : pattern(pattern_) { }
+    bool match(std::string_view value) const override { return value == pattern; }
+    std::string_view getPattern() const override { return pattern; }
+};
+
+class StartsWithMatcher : public IValueMatcher
+{
+private:
+    std::string_view pattern;
+
+public:
+    explicit StartsWithMatcher(std::string_view pattern_) : pattern(pattern_) { }
+    bool match(std::string_view value) const override { return value.starts_with(pattern); }
+    std::string_view getPattern() const override { return pattern; }
+};
+
+class EndsWithMatcher : public IValueMatcher
+{
+private:
+    std::string_view pattern;
+
+public:
+    explicit EndsWithMatcher(std::string_view pattern_) : pattern(pattern_) { }
+    bool match(std::string_view value) const override { return value.ends_with(pattern); }
+    std::string_view getPattern() const override { return pattern; }
+};
+
+class ContainsWordMatcher : public IValueMatcher
+{
+private:
+    std::string_view pattern;
+
+public:
+    explicit ContainsWordMatcher(std::string_view pattern_) : pattern(pattern_) { }
+    bool match(std::string_view value) const override
+    {
+        const char * end = value.end();
+        const char * word_start = find_first_not_symbols<' ', '\t'>(value.begin(), end);
+        while (word_start != end)
+        {
+            const char * word_end = find_first_symbols<' ', '\t'>(word_start, end);
+
+            if (std::string_view(word_start, word_end - word_start) == pattern)
+                return true;
+
+            word_start = find_first_not_symbols<' ', '\t'>(word_end, end);
+        }
+        return false;
+    }
+    std::string_view getPattern() const override { return pattern; }
+};
+
+class SubstringMatcher : public IValueMatcher
+{
+private:
+    std::string_view pattern;
+
+public:
+    explicit SubstringMatcher(std::string_view pattern_) : pattern(pattern_) { }
+    bool match(std::string_view value) const override { return value.find(pattern) != std::string::npos; }
+    std::string_view getPattern() const override { return pattern; }
+};
+
+}
+
+ValueMatcherPtr MakeAlwaysTrueMatcher()
+{
+    return std::make_unique<AlwaysTrueMatcher>();
+}
+
+ValueMatcherPtr MakeExactMatcher(std::string_view pattern)
+{
+    return std::make_unique<ExactMatcher>(pattern);
+}
+
+ValueMatcherPtr MakeStartsWithMatcher(std::string_view pattern)
+{
+    return std::make_unique<StartsWithMatcher>(pattern);
+}
+
+ValueMatcherPtr MakeEndsWithMatcher(std::string_view pattern)
+{
+    return std::make_unique<EndsWithMatcher>(pattern);
+}
+
+ValueMatcherPtr MakeContainsWordMatcher(std::string_view pattern)
+{
+    return std::make_unique<ContainsWordMatcher>(pattern);
+}
+
+ValueMatcherPtr MakeSubstringMatcher(std::string_view pattern)
+{
+    return std::make_unique<SubstringMatcher>(pattern);
+}
+
+}

--- a/src/Functions/selectors/ValueMatchers.h
+++ b/src/Functions/selectors/ValueMatchers.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Types.h"
+
+namespace DB
+{
+
+ValueMatcherPtr MakeAlwaysTrueMatcher();
+ValueMatcherPtr MakeExactMatcher(std::string_view pattern);
+ValueMatcherPtr MakeStartsWithMatcher(std::string_view pattern);
+ValueMatcherPtr MakeEndsWithMatcher(std::string_view pattern);
+ValueMatcherPtr MakeContainsWordMatcher(std::string_view pattern);
+ValueMatcherPtr MakeSubstringMatcher(std::string_view pattern);
+
+}

--- a/src/Functions/selectors/parseNextAttribute.h
+++ b/src/Functions/selectors/parseNextAttribute.h
@@ -18,7 +18,7 @@ inline const char * parseNextAttribute(const char * begin, const char * end, Att
     if (*begin == '>')
         return begin;
 
-    const char * key_end = find_first_symbols<'=', ' ', '\t', '\n', '\r', '\f', '\v'>(begin, end);
+    const char * key_end = find_first_symbols<'>', '=', ' ', '\t', '\n', '\r', '\f', '\v'>(begin, end);
     if (key_end == end)
         return end;
 

--- a/src/Functions/selectors/parseNextAttribute.h
+++ b/src/Functions/selectors/parseNextAttribute.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "Types.h"
+
+#include <base/find_symbols.h>
+#include <Common/StringUtils/StringUtils.h>
+
+#include <string_view>
+
+namespace DB
+{
+
+inline const char * parseNextAttribute(const char * begin, const char * end, Attribute & result)
+{
+    begin = find_first_not_symbols<' ', '\t', '\n', '\r', '\f', '\v'>(begin, end);
+    if (begin == end)
+        return end;
+    if (*begin == '>')
+        return begin;
+
+    const char * key_end = find_first_symbols<'=', ' ', '\t', '\n', '\r', '\f', '\v'>(begin, end);
+    if (key_end == end)
+        return end;
+
+    result.key = std::string_view(begin, key_end - begin);
+
+    begin = key_end;
+
+    const char * eq_pos = find_first_symbols<'='>(begin, end);
+
+    if (eq_pos + 1 >= end)
+        return end;
+
+    begin = eq_pos + 1;
+
+    begin = find_first_not_symbols<' ', '\t', '\n', '\r', '\f', '\v'>(begin, end);
+    if (begin == end || *begin == '>')
+        return begin;
+
+    const char * value_end = end;
+    bool has_quotes = false;
+    if (*begin == '\'')
+    {
+        ++begin;
+        value_end = find_first_symbols<'\''>(begin, value_end);
+        has_quotes = true;
+    }
+    else if (*begin == '"')
+    {
+        ++begin;
+        value_end = find_first_symbols<'"'>(begin, value_end);
+        has_quotes = true;
+    }
+    else
+    {
+        value_end = find_first_symbols<'>', ' ', '\t', '\n', '\r', '\f', '\v'>(begin, value_end);
+    }
+
+    if (value_end == end) {
+        return end;
+    }
+
+    result.value = std::string_view(begin, value_end - begin);
+
+    return has_quotes ? value_end + 1 : value_end;
+}
+
+}

--- a/src/Functions/selectors/tests/gtest_SelectorMatchingVM.cpp
+++ b/src/Functions/selectors/tests/gtest_SelectorMatchingVM.cpp
@@ -1,0 +1,175 @@
+#include <Functions/selectors/SelectorMatchingVM.h>
+#include <gtest/gtest.h>
+
+using namespace DB;
+using namespace std::string_view_literals;
+
+TEST(SelectorMatchingVM, SingleTag)
+{
+    std::string selector = "body";
+    const char * begin = selector.data();
+    const char * end = selector.data() + selector.size();
+    auto vm = SelectorMatchingVM::parseSelector(begin, end);
+
+    ASSERT_EQ(vm.instructions.size(), 1);
+    EXPECT_EQ(vm.instructions[0].expected_tag, "body"sv);
+    EXPECT_TRUE(vm.instructions[0].attributes.empty());
+    EXPECT_FALSE(vm.instructions[0].need_jump_to_next_instruction);
+
+    EXPECT_EQ(vm.handleOpeningTag("a"sv), MatchResult::NOT_MATCH);
+    EXPECT_EQ(vm.handleOpeningTag("bOdY"sv), MatchResult::MATCH);
+}
+
+TEST(SelectorMatchingVM, SingleTagWithAttributes)
+{
+    std::string selector = "body[key1='value1'][key2 = \"value2\"]";
+    const char * begin = selector.data();
+    const char * end = selector.data() + selector.size();
+    auto vm = SelectorMatchingVM::parseSelector(begin, end);
+
+    ASSERT_EQ(vm.instructions.size(), 1);
+    EXPECT_EQ(vm.instructions[0].expected_tag, "body"sv);
+
+    const auto & attrs = vm.instructions[0].attributes;
+    ASSERT_EQ(attrs.size(), 2);
+
+    EXPECT_EQ(attrs[0].matcher.key, "key1"sv);
+    EXPECT_EQ(attrs[0].matcher.value_matcher->pattern(), "value1");
+    EXPECT_FALSE(attrs[0].matched);
+
+    EXPECT_EQ(attrs[1].matcher.key, "key2"sv);
+    EXPECT_EQ(attrs[1].matcher.value_matcher->pattern(), "value2");
+    EXPECT_FALSE(attrs[1].matched);
+
+    EXPECT_FALSE(vm.instructions[0].need_jump_to_next_instruction);
+
+    EXPECT_EQ(vm.handleOpeningTag("a"sv), MatchResult::NOT_MATCH);
+    EXPECT_EQ(vm.handleOpeningTag("body"sv), MatchResult::NEED_ATTRIBUTES);
+    EXPECT_EQ(vm.handleAttribute(Attribute{"key1"sv, "value1"}), MatchResult::NEED_ATTRIBUTES);
+    EXPECT_EQ(vm.handleAttribute(Attribute{"unknown_key"sv, "value2"}), MatchResult::NEED_ATTRIBUTES);
+    EXPECT_EQ(vm.handleAttribute(Attribute{"key2"sv, "value2"}), MatchResult::MATCH);
+
+    vm.reset();
+
+    EXPECT_EQ(vm.handleOpeningTag("body"sv), MatchResult::NEED_ATTRIBUTES);
+    EXPECT_EQ(vm.handleAttribute(Attribute{"key1"sv, "value1"}), MatchResult::NEED_ATTRIBUTES);
+    EXPECT_EQ(vm.handleAttribute(Attribute{"key2"sv, "unknown_value"}), MatchResult::NOT_MATCH);
+}
+
+TEST(SelectorMatchingVM, Combinators)
+{
+    std::string selector = "body > div span";
+    const char * begin = selector.data();
+    const char * end = selector.data() + selector.size();
+    auto vm = SelectorMatchingVM::parseSelector(begin, end);
+
+    ASSERT_EQ(vm.instructions.size(), 3);
+    EXPECT_EQ(vm.instructions[0].expected_tag, "body"sv);
+    EXPECT_TRUE(vm.instructions[0].attributes.empty());
+    EXPECT_FALSE(vm.instructions[0].need_jump_to_next_instruction);
+    EXPECT_EQ(vm.instructions[1].expected_tag, "div"sv);
+    EXPECT_TRUE(vm.instructions[1].attributes.empty());
+    EXPECT_TRUE(vm.instructions[1].need_jump_to_next_instruction);
+    EXPECT_EQ(vm.instructions[2].expected_tag, "span"sv);
+    EXPECT_TRUE(vm.instructions[2].attributes.empty());
+    EXPECT_FALSE(vm.instructions[2].need_jump_to_next_instruction);
+
+    EXPECT_EQ(vm.handleOpeningTag("body"sv), MatchResult::NOT_MATCH);
+    EXPECT_EQ(vm.current_instruction_index, 1);
+
+    EXPECT_EQ(vm.handleOpeningTag("div"sv), MatchResult::NOT_MATCH);
+    EXPECT_EQ(vm.current_instruction_index, 2);
+
+    EXPECT_EQ(vm.handleOpeningTag("a"sv), MatchResult::NOT_MATCH);
+    EXPECT_EQ(vm.current_instruction_index, 0);
+
+    EXPECT_EQ(vm.handleOpeningTag("div"sv), MatchResult::NOT_MATCH);
+    EXPECT_EQ(vm.current_instruction_index, 0);
+
+    EXPECT_EQ(vm.handleOpeningTag("span"sv), MatchResult::MATCH);
+    EXPECT_EQ(vm.current_instruction_index, 0);
+
+    EXPECT_EQ(vm.handleOpeningTag("span"sv), MatchResult::MATCH);
+    EXPECT_EQ(vm.current_instruction_index, 0);
+
+    vm.handleClosingTag("span"sv);
+    vm.handleClosingTag("span"sv);
+    vm.handleClosingTag("div"sv);
+    vm.handleClosingTag("a"sv);
+    vm.handleClosingTag("div"sv);
+    EXPECT_EQ(vm.current_instruction_index, 1);
+
+    vm.handleClosingTag("body"sv);
+    EXPECT_EQ(vm.current_instruction_index, 0);
+}
+
+void expectKeyValue(const Instruction& instruction) {
+    const auto & attrs = instruction.attributes;
+    ASSERT_EQ(attrs.size(), 2);
+
+    EXPECT_EQ(attrs[0].matcher.key, "key1"sv);
+    EXPECT_EQ(attrs[0].matcher.value_matcher->pattern(), "value1");
+    EXPECT_FALSE(attrs[0].matched);
+
+    EXPECT_EQ(attrs[1].matcher.key, "key2"sv);
+    EXPECT_EQ(attrs[1].matcher.value_matcher->pattern(), "value2");
+    EXPECT_FALSE(attrs[1].matched);
+}
+
+TEST(SelectorMatchingVM, CombinatorsWithAttributes)
+{
+    std::string selector
+        = R"(body[key1='value1'][key2 = "value2"] > div[key1=value1][key2 = value2] span[key1='value1'][key2 = "value2"])";
+    const char * begin = selector.data();
+    const char * end = selector.data() + selector.size();
+    auto vm = SelectorMatchingVM::parseSelector(begin, end);
+
+    ASSERT_EQ(vm.instructions.size(), 3);
+
+    EXPECT_EQ(vm.instructions[0].expected_tag, "body"sv);
+    EXPECT_FALSE(vm.instructions[0].need_jump_to_next_instruction);
+
+    EXPECT_EQ(vm.instructions[1].expected_tag, "div"sv);
+    EXPECT_TRUE(vm.instructions[1].need_jump_to_next_instruction);
+
+    EXPECT_EQ(vm.instructions[2].expected_tag, "span"sv);
+    EXPECT_FALSE(vm.instructions[2].need_jump_to_next_instruction);
+
+    expectKeyValue(vm.instructions[0]);
+    expectKeyValue(vm.instructions[1]);
+    expectKeyValue(vm.instructions[2]);
+
+//    EXPECT_EQ(vm.handleOpeningTag("body"sv), MatchResult::NEED_ATTRIBUTES);
+//    EXPECT_EQ(vm.handleAttribute(Attribute{"key1"sv, "value1"}), MatchResult::NEED_ATTRIBUTES);
+//    EXPECT_EQ(vm.handleAttribute(Attribute{"unknown_key"sv, "value2"}), MatchResult::NEED_ATTRIBUTES);
+//    EXPECT_EQ(vm.handleAttribute(Attribute{"key2"sv, "value2"}), MatchResult::MATCH);
+//    EXPECT_EQ(vm.current_instruction_index, 1);
+//
+//    EXPECT_EQ(vm.handleOpeningTag("div"sv), MatchResult::NOT_MATCH);
+//    EXPECT_EQ(vm.handleAttribute(Attribute{"key1"sv, "value1"}), MatchResult::NEED_ATTRIBUTES);
+//    EXPECT_EQ(vm.handleAttribute(Attribute{"unknown_key"sv, "value2"}), MatchResult::NEED_ATTRIBUTES);
+//    EXPECT_EQ(vm.handleAttribute(Attribute{"key2"sv, "value2"}), MatchResult::MATCH);
+//    EXPECT_EQ(vm.current_instruction_index, 2);
+//
+//    EXPECT_EQ(vm.handleOpeningTag("span"sv), MatchResult::NOT_MATCH);
+//    EXPECT_EQ(vm.current_instruction_index, 0);
+//
+//    EXPECT_EQ(vm.handleOpeningTag("div"sv), MatchResult::NOT_MATCH);
+//    EXPECT_EQ(vm.current_instruction_index, 0);
+//
+//    EXPECT_EQ(vm.handleOpeningTag("span"sv), MatchResult::MATCH);
+//    EXPECT_EQ(vm.current_instruction_index, 0);
+//
+//    EXPECT_EQ(vm.handleOpeningTag("span"sv), MatchResult::MATCH);
+//    EXPECT_EQ(vm.current_instruction_index, 0);
+//
+//    vm.handleClosingTag("span"sv);
+//    vm.handleClosingTag("span"sv);
+//    vm.handleClosingTag("div"sv);
+//    vm.handleClosingTag("a"sv);
+//    vm.handleClosingTag("div"sv);
+//    EXPECT_EQ(vm.current_instruction_index, 1);
+//
+//    vm.handleClosingTag("body"sv);
+//    EXPECT_EQ(vm.current_instruction_index, 0);
+}

--- a/src/Functions/selectors/tests/gtest_TagScanner.cpp
+++ b/src/Functions/selectors/tests/gtest_TagScanner.cpp
@@ -1,0 +1,38 @@
+#include <Functions/selectors/TagScanner.h>
+#include <gtest/gtest.h>
+
+using namespace DB;
+using namespace std::literals::string_view_literals;
+
+TEST(TagScanner, Scan)
+{
+    std::string s = R"(
+<div class="code-example">
+<span class="token property">color</span>
+        blue
+    <span class="token punctuation">;</span>
+</div>
+)";
+    const char * begin = s.data();
+    const char * end = s.data() + s.size();
+
+    std::vector<TagPreview> expected_tags = {
+        TagPreview{"div"sv, .is_closing = false},
+        TagPreview{"span"sv, .is_closing = false},
+        TagPreview{"span"sv, .is_closing = true},
+        TagPreview{"span"sv, .is_closing = false},
+        TagPreview{"span"sv, .is_closing = true},
+        TagPreview{"div"sv, .is_closing = true},
+    };
+
+    TagScanner tag_scanner;
+    size_t ind = 0;
+    TagPreview tag;
+    begin = tag_scanner.scan(begin, end, tag);
+    for (; begin != end; begin = tag_scanner.scan(begin, end, tag))
+    {
+        EXPECT_EQ(tag, expected_tags[ind++]);
+    }
+
+    EXPECT_EQ(ind, expected_tags.size());
+}

--- a/src/Functions/selectors/tests/gtest_parseNextAttribute.cpp
+++ b/src/Functions/selectors/tests/gtest_parseNextAttribute.cpp
@@ -1,0 +1,59 @@
+#include <Functions/selectors/parseNextAttribute.h>
+#include <gtest/gtest.h>
+
+using namespace DB;
+using namespace std::literals::string_view_literals;
+
+void checkAttributes(const char * begin, const char * end, const std::vector<Attribute> & expected)
+{
+    size_t ind = 0;
+    Attribute attr;
+    begin = parseNextAttribute(begin, end, attr);
+    for (; begin != end; begin = parseNextAttribute(begin, end, attr))
+    {
+        EXPECT_EQ(attr, expected[ind++]);
+        if (*begin == '>') {
+            break;
+        }
+    }
+
+    EXPECT_EQ(ind, expected.size());
+}
+
+TEST(parseNextAttribute, Unquoted)
+{
+    std::string s = R"( key1 = value1    key2=value2>)";
+
+    std::vector<Attribute> expected = {
+        {"key1"sv, "value1"},
+        {"key2"sv, "value2"},
+    };
+
+    checkAttributes(s.data(), s.data() + s.size(), expected);
+}
+
+TEST(parseNextAttribute, SingleQuoted)
+{
+    std::string s = R"( key1 = 'va"<>lue1' key2='va"lue2' >)";
+
+    std::vector<Attribute> expected = {
+        {"key1"sv, "va\"<>lue1"},
+        {"key2"sv, "va\"lue2"},
+    };
+
+    checkAttributes(s.data(), s.data() + s.size(), expected);
+}
+
+TEST(parseNextAttribute, DoubleQuoted)
+{
+    std::string s = R"( key1 = "va'lue1"
+                        key2="va'<>lue2"
+                        >)";
+
+    std::vector<Attribute> expected = {
+        {"key1"sv, "va'lue1"},
+        {"key2"sv, "va'<>lue2"},
+    };
+
+    checkAttributes(s.data(), s.data() + s.size(), expected);
+}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- add functions `extractHTMLAll`, `extractHTMLAll`
Usage
```
SELECT extractHTMLOne('<html><div><h1>heading</h1> div content</div></html>', 'h1')
<h1>heading</h1>
```


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
