### PR TITLE
Add implicit grants with grant option too

### DIFF
--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -120,6 +120,7 @@ namespace
 
         AccessRights res = access;
         res.modifyFlags(modifier);
+        res.modifyFlagsWithGrantOption(modifier);
 
         /// Anyone has access to the "system" and "information_schema" database.
         res.grant(AccessType::SELECT, DatabaseCatalog::SYSTEM_DATABASE);

--- a/tests/integration/test_grant_and_revoke/test.py
+++ b/tests/integration/test_grant_and_revoke/test.py
@@ -342,6 +342,18 @@ def test_implicit_create_view_grant():
         "CREATE VIEW test.view_1 AS SELECT 1", user="A"
     )
 
+    # check grant option
+    instance.query("CREATE USER B")
+    expected_error = "Not enough privileges"
+    assert expected_error in instance.query_and_get_error(
+        "GRANT CREATE VIEW ON test.* TO B", user="A"
+    )
+
+    instance.query("GRANT CREATE TABLE ON test.* TO A WITH GRANT OPTION")
+    instance.query("GRANT CREATE VIEW ON test.* TO B", user="A")
+    instance.query("CREATE VIEW test.view_2 AS SELECT 1", user="B")
+    assert instance.query("SELECT * FROM test.view_2") == "1\n"
+
 
 def test_implicit_create_temporary_table_grant():
     instance.query("CREATE USER A")


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
Add implicit grants with grant option too. For example `GRANT CREATE TABLE ON test.* TO A WITH GRANT OPTION` now allows `A` to execute `GRANT CREATE VIEW ON test.* TO B`.