### PR TITLE
Use correct version in `DiskObjectStorageMetadata`

### DIFF
--- a/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageMetadata.cpp
@@ -72,7 +72,7 @@ void DiskObjectStorageMetadata::deserializeFromString(const std::string & data)
 
 void DiskObjectStorageMetadata::serialize(WriteBuffer & buf, bool sync) const
 {
-    writeIntText(VERSION_RELATIVE_PATHS, buf);
+    writeIntText(VERSION_READ_ONLY_FLAG, buf);
     writeChar('\n', buf);
 
     writeIntText(remote_fs_objects.size(), buf);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Use correct version in `DiskObjectStorageMetadata`. `read_only` is never read from the file because incorrect version is set.
cc: @alesapin 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
