### PR TITLE
Use pdqsort instead of standard sort

### DIFF
--- a/src/Backups/BackupCoordinationDistributed.cpp
+++ b/src/Backups/BackupCoordinationDistributed.cpp
@@ -326,7 +326,7 @@ Strings BackupCoordinationDistributed::listFiles(const String & prefix, const St
         elements.push_back(String{new_element});
     }
 
-    std::sort(elements.begin(), elements.end());
+    ::sort(elements.begin(), elements.end());
     return elements;
 }
 

--- a/src/Backups/RestoreUtils.cpp
+++ b/src/Backups/RestoreUtils.cpp
@@ -84,7 +84,7 @@ namespace
                     return true;
                 });
 
-            std::sort(res.begin(), res.end());
+            ::sort(res.begin(), res.end());
             res.erase(std::unique(res.begin(), res.end()), res.end());
             return res;
         }
@@ -113,7 +113,7 @@ namespace
                     return true;
                 });
 
-            std::sort(res.begin(), res.end());
+            ::sort(res.begin(), res.end());
             res.erase(std::unique(res.begin(), res.end()), res.end());
             return res;
         }

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 
 #include <base/find_symbols.h>
+#include <base/sort.h>
 #include <base/getFQDNOrHostName.h>
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/Exception.h>
@@ -169,7 +170,7 @@ std::vector<ShuffleHost> ZooKeeper::shuffleHosts() const
         shuffle_hosts.emplace_back(shuffle_host);
     }
 
-    std::sort(
+    ::sort(
         shuffle_hosts.begin(), shuffle_hosts.end(),
         [](const ShuffleHost & lhs, const ShuffleHost & rhs)
         {

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -153,7 +153,7 @@ void KeeperStorageSnapshot::serialize(const KeeperStorageSnapshot & snapshot, Wr
 
     /// Better to sort before serialization, otherwise snapshots can be different on different replicas
     std::vector<std::pair<int64_t, Coordination::ACLs>> sorted_acl_map(snapshot.acl_map.begin(), snapshot.acl_map.end());
-    std::sort(sorted_acl_map.begin(), sorted_acl_map.end());
+    ::sort(sorted_acl_map.begin(), sorted_acl_map.end());
     /// Serialize ACLs map
     writeBinary(sorted_acl_map.size(), out);
     for (const auto & [acl_id, acls] : sorted_acl_map)
@@ -195,7 +195,7 @@ void KeeperStorageSnapshot::serialize(const KeeperStorageSnapshot & snapshot, Wr
     /// Session must be saved in a sorted order,
     /// otherwise snapshots will be different
     std::vector<std::pair<int64_t, int64_t>> sorted_session_and_timeout(snapshot.session_and_timeout.begin(), snapshot.session_and_timeout.end());
-    std::sort(sorted_session_and_timeout.begin(), sorted_session_and_timeout.end());
+    ::sort(sorted_session_and_timeout.begin(), sorted_session_and_timeout.end());
 
     /// Serialize sessions
     size_t size = sorted_session_and_timeout.size();

--- a/src/DataTypes/ObjectUtils.cpp
+++ b/src/DataTypes/ObjectUtils.cpp
@@ -455,7 +455,7 @@ ColumnWithTypeAndDimensions createTypeFromNode(const Node * node)
         }
 
         /// Sort to always create the same type for the same set of subcolumns.
-        std::sort(tuple_elements.begin(), tuple_elements.end(),
+        ::sort(tuple_elements.begin(), tuple_elements.end(),
             [](const auto & lhs, const auto & rhs) { return std::get<0>(lhs) < std::get<0>(rhs); });
 
         auto tuple_names = extractVector<0>(tuple_elements);
@@ -692,7 +692,7 @@ void replaceMissedSubcolumnsByConstants(
                 res.emplace_back(full_name, types[i]);
             }
 
-            std::sort(res.begin(), res.end());
+            ::sort(res.begin(), res.end());
             return res;
         };
 

--- a/src/Interpreters/TransactionLog.cpp
+++ b/src/Interpreters/TransactionLog.cpp
@@ -201,7 +201,7 @@ void TransactionLog::loadLogFromZooKeeper()
     /// 3. support 64-bit CSNs on top of Apache ZooKeeper (it uses Int32 for sequential numbers)
     Strings entries_list = zookeeper->getChildren(zookeeper_path_log, nullptr, log_updated_event);
     chassert(!entries_list.empty());
-    std::sort(entries_list.begin(), entries_list.end());
+    ::sort(entries_list.begin(), entries_list.end());
     loadEntries(entries_list.begin(), entries_list.end());
     chassert(!last_loaded_entry.empty());
     chassert(latest_snapshot == deserializeCSN(last_loaded_entry));
@@ -262,7 +262,7 @@ void TransactionLog::loadNewEntries()
 {
     Strings entries_list = zookeeper->getChildren(zookeeper_path_log, nullptr, log_updated_event);
     chassert(!entries_list.empty());
-    std::sort(entries_list.begin(), entries_list.end());
+    ::sort(entries_list.begin(), entries_list.end());
     auto it = std::upper_bound(entries_list.begin(), entries_list.end(), last_loaded_entry);
     loadEntries(it, entries_list.end());
     chassert(last_loaded_entry == entries_list.back());
@@ -602,7 +602,7 @@ void TransactionLog::sync() const
 {
     Strings entries_list = zookeeper->getChildren(zookeeper_path_log);
     chassert(!entries_list.empty());
-    std::sort(entries_list.begin(), entries_list.end());
+    ::sort(entries_list.begin(), entries_list.end());
     CSN newest_csn = deserializeCSN(entries_list.back());
     waitForCSNLoaded(newest_csn);
 }

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -469,7 +469,7 @@ void removeUnneededColumnsFromSelectClause(ASTSelectQuery * select_query, const 
             for (const auto & name : required_result_columns)
                 name_pos[name] = pos++;
         }
-        std::sort(elements.begin(), elements.end(), [&](const auto & lhs, const auto & rhs)
+        ::sort(elements.begin(), elements.end(), [&](const auto & lhs, const auto & rhs)
         {
             String lhs_name = lhs->getAliasOrColumnName();
             String rhs_name = rhs->getAliasOrColumnName();

--- a/src/Storages/Cache/ExternalDataSourceCache.cpp
+++ b/src/Storages/Cache/ExternalDataSourceCache.cpp
@@ -7,6 +7,7 @@
 #include <Storages/Cache/ExternalDataSourceCache.h>
 #include <Storages/Cache/RemoteFileMetadataFactory.h>
 #include <base/errnoToString.h>
+#include <base/sort.h>
 #include <Common/logger_useful.h>
 #include <base/sleep.h>
 #include <Poco/Logger.h>
@@ -229,7 +230,7 @@ void ExternalDataSourceCache::initOnce(ContextPtr context, const String & root_d
     LOG_INFO(
         log, "Initializing local cache for remote data sources. Local cache root path: {}, cache size limit: {}", root_dir_, limit_size_);
     splitInto<','>(root_dirs, root_dir_);
-    std::sort(root_dirs.begin(), root_dirs.end());
+    ::sort(root_dirs.begin(), root_dirs.end());
     local_cache_bytes_read_before_flush = bytes_read_before_flush_;
     lru_caches = std::make_unique<RemoteFileCacheType>(limit_size_);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`pdqsort` is faster and we also have our own wrappers around it to check iterators safety.