### PR TITLE
tests: avoid "_csv.Error: field larger than field limit (131072)" error

### DIFF
--- a/docker/test/util/process_functional_tests_result.py
+++ b/docker/test/util/process_functional_tests_result.py
@@ -113,7 +113,7 @@ def process_result(result_path):
             test_results,
         ) = process_test_log(result_path)
         is_flacky_check = 1 < int(os.environ.get("NUM_TRIES", 1))
-        logging.info("Is flacky check: %s", is_flacky_check)
+        logging.info("Is flaky check: %s", is_flacky_check)
         # If no tests were run (success == 0) it indicates an error (e.g. server did not start or crashed immediately)
         # But it's Ok for "flaky checks" - they can contain just one test for check which is marked as skipped.
         if failed != 0 or unknown != 0 or (success == 0 and (not is_flacky_check)):

--- a/docker/test/util/process_functional_tests_result.py
+++ b/docker/test/util/process_functional_tests_result.py
@@ -11,6 +11,7 @@ TIMEOUT_SIGN = "[ Timeout! "
 UNKNOWN_SIGN = "[ UNKNOWN "
 SKIPPED_SIGN = "[ SKIPPED "
 HUNG_SIGN = "Found hung queries in processlist"
+DATABASE_SIGN = "Database: "
 
 SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]
 
@@ -27,14 +28,19 @@ def process_test_log(log_path):
     retries = False
     success_finish = False
     test_results = []
+    test_end = True
     with open(log_path, "r") as test_file:
         for line in test_file:
             original_line = line
             line = line.strip()
+
             if any(s in line for s in SUCCESS_FINISH_SIGNS):
                 success_finish = True
+            # Ignore hung check report, since it may be quite large.
+            # (and may break python parser which has limit of 128KiB for each row).
             if HUNG_SIGN in line:
                 hung = True
+                break
             if RETRIES_SIGN in line:
                 retries = True
             if any(
@@ -67,8 +73,17 @@ def process_test_log(log_path):
                 else:
                     success += int(OK_SIGN in line)
                     test_results.append((test_name, "OK", test_time, []))
-            elif len(test_results) > 0 and test_results[-1][1] == "FAIL":
+                test_end = False
+            elif (
+                len(test_results) > 0 and test_results[-1][1] == "FAIL" and not test_end
+            ):
                 test_results[-1][3].append(original_line)
+            # Database printed after everything else in case of failures,
+            # so this is a stop marker for capturing test output.
+            #
+            # And it is handled after everything else to include line with database into the report.
+            if DATABASE_SIGN in line:
+                test_end = True
 
     test_results = [
         (test[0], test[1], test[2], "".join(test[3])) for test in test_results


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Ignores tests stdout (and hence hung check stdout) to avoid too long lines in csv.