### PR TITLE
More consts for disks

### DIFF
--- a/src/Disks/DiskDecorator.cpp
+++ b/src/Disks/DiskDecorator.cpp
@@ -83,7 +83,7 @@ void DiskDecorator::moveDirectory(const String & from_path, const String & to_pa
     delegate->moveDirectory(from_path, to_path);
 }
 
-DirectoryIteratorPtr DiskDecorator::iterateDirectory(const String & path)
+DirectoryIteratorPtr DiskDecorator::iterateDirectory(const String & path) const
 {
     return delegate->iterateDirectory(path);
 }
@@ -113,7 +113,7 @@ void DiskDecorator::copyDirectoryContent(const String & from_dir, const std::sha
     delegate->copyDirectoryContent(from_dir, to_disk, to_dir);
 }
 
-void DiskDecorator::listFiles(const String & path, std::vector<String> & file_names)
+void DiskDecorator::listFiles(const String & path, std::vector<String> & file_names) const
 {
     delegate->listFiles(path, file_names);
 }
@@ -171,7 +171,7 @@ void DiskDecorator::setLastModified(const String & path, const Poco::Timestamp &
     delegate->setLastModified(path, timestamp);
 }
 
-Poco::Timestamp DiskDecorator::getLastModified(const String & path)
+Poco::Timestamp DiskDecorator::getLastModified(const String & path) const
 {
     return delegate->getLastModified(path);
 }

--- a/src/Disks/DiskDecorator.h
+++ b/src/Disks/DiskDecorator.h
@@ -28,13 +28,13 @@ public:
     void createDirectories(const String & path) override;
     void clearDirectory(const String & path) override;
     void moveDirectory(const String & from_path, const String & to_path) override;
-    DirectoryIteratorPtr iterateDirectory(const String & path) override;
+    DirectoryIteratorPtr iterateDirectory(const String & path) const override;
     void createFile(const String & path) override;
     void moveFile(const String & from_path, const String & to_path) override;
     void replaceFile(const String & from_path, const String & to_path) override;
     void copy(const String & from_path, const std::shared_ptr<IDisk> & to_disk, const String & to_path) override;
     void copyDirectoryContent(const String & from_dir, const std::shared_ptr<IDisk> & to_disk, const String & to_dir) override;
-    void listFiles(const String & path, std::vector<String> & file_names) override;
+    void listFiles(const String & path, std::vector<String> & file_names) const override;
 
     std::unique_ptr<ReadBufferFromFileBase> readFile(
         const String & path,
@@ -56,7 +56,7 @@ public:
     void removeSharedRecursive(const String & path, bool keep_all_batch_data, const NameSet & file_names_remove_metadata_only) override;
     void removeSharedFiles(const RemoveBatchRequest & files, bool keep_all_batch_data, const NameSet & file_names_remove_metadata_only) override;
     void setLastModified(const String & path, const Poco::Timestamp & timestamp) override;
-    Poco::Timestamp getLastModified(const String & path) override;
+    Poco::Timestamp getLastModified(const String & path) const override;
     void setReadOnly(const String & path) override;
     void createHardLink(const String & src_path, const String & dst_path) override;
     void truncateFile(const String & path, size_t size) override;

--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -83,7 +83,7 @@ public:
         delegate->moveDirectory(wrapped_from_path, wrapped_to_path);
     }
 
-    DirectoryIteratorPtr iterateDirectory(const String & path) override
+    DirectoryIteratorPtr iterateDirectory(const String & path) const override
     {
         auto wrapped_path = wrappedPath(path);
         return delegate->iterateDirectory(wrapped_path);
@@ -109,7 +109,7 @@ public:
         delegate->replaceFile(wrapped_from_path, wrapped_to_path);
     }
 
-    void listFiles(const String & path, std::vector<String> & file_names) override
+    void listFiles(const String & path, std::vector<String> & file_names) const override
     {
         auto wrapped_path = wrappedPath(path);
         delegate->listFiles(wrapped_path, file_names);
@@ -192,7 +192,7 @@ public:
         delegate->setLastModified(wrapped_path, timestamp);
     }
 
-    Poco::Timestamp getLastModified(const String & path) override
+    Poco::Timestamp getLastModified(const String & path) const override
     {
         auto wrapped_path = wrappedPath(path);
         return delegate->getLastModified(wrapped_path);

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -325,7 +325,7 @@ void DiskLocal::moveDirectory(const String & from_path, const String & to_path)
     fs::rename(fs::path(disk_path) / from_path, fs::path(disk_path) / to_path);
 }
 
-DirectoryIteratorPtr DiskLocal::iterateDirectory(const String & path)
+DirectoryIteratorPtr DiskLocal::iterateDirectory(const String & path) const
 {
     fs::path meta_path = fs::path(disk_path) / path;
     if (!broken && fs::exists(meta_path) && fs::is_directory(meta_path))
@@ -387,7 +387,7 @@ void DiskLocal::removeRecursive(const String & path)
     fs::remove_all(fs::path(disk_path) / path);
 }
 
-void DiskLocal::listFiles(const String & path, std::vector<String> & file_names)
+void DiskLocal::listFiles(const String & path, std::vector<String> & file_names) const
 {
     file_names.clear();
     for (const auto & entry : fs::directory_iterator(fs::path(disk_path) / path))
@@ -399,7 +399,7 @@ void DiskLocal::setLastModified(const String & path, const Poco::Timestamp & tim
     FS::setModificationTime(fs::path(disk_path) / path, timestamp.epochTime());
 }
 
-Poco::Timestamp DiskLocal::getLastModified(const String & path)
+Poco::Timestamp DiskLocal::getLastModified(const String & path) const
 {
     return FS::getModificationTimestamp(fs::path(disk_path) / path);
 }

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -58,7 +58,7 @@ public:
 
     void moveDirectory(const String & from_path, const String & to_path) override;
 
-    DirectoryIteratorPtr iterateDirectory(const String & path) override;
+    DirectoryIteratorPtr iterateDirectory(const String & path) const override;
 
     void createFile(const String & path) override;
 
@@ -70,7 +70,7 @@ public:
 
     void copyDirectoryContent(const String & from_dir, const std::shared_ptr<IDisk> & to_disk, const String & to_dir) override;
 
-    void listFiles(const String & path, std::vector<String> & file_names) override;
+    void listFiles(const String & path, std::vector<String> & file_names) const override;
 
     std::unique_ptr<ReadBufferFromFileBase> readFile(
         const String & path,
@@ -91,7 +91,7 @@ public:
 
     void setLastModified(const String & path, const Poco::Timestamp & timestamp) override;
 
-    Poco::Timestamp getLastModified(const String & path) override;
+    Poco::Timestamp getLastModified(const String & path) const override;
 
     void setReadOnly(const String & path) override;
 

--- a/src/Disks/DiskMemory.cpp
+++ b/src/Disks/DiskMemory.cpp
@@ -262,7 +262,7 @@ void DiskMemory::moveDirectory(const String & /*from_path*/, const String & /*to
     throw Exception("Method moveDirectory is not implemented for memory disks", ErrorCodes::NOT_IMPLEMENTED);
 }
 
-DirectoryIteratorPtr DiskMemory::iterateDirectory(const String & path)
+DirectoryIteratorPtr DiskMemory::iterateDirectory(const String & path) const
 {
     std::lock_guard lock(mutex);
 
@@ -409,7 +409,7 @@ void DiskMemory::removeRecursive(const String & path)
     }
 }
 
-void DiskMemory::listFiles(const String & path, std::vector<String> & file_names)
+void DiskMemory::listFiles(const String & path, std::vector<String> & file_names) const
 {
     std::lock_guard lock(mutex);
 

--- a/src/Disks/DiskMemory.h
+++ b/src/Disks/DiskMemory.h
@@ -52,7 +52,7 @@ public:
 
     void moveDirectory(const String & from_path, const String & to_path) override;
 
-    DirectoryIteratorPtr iterateDirectory(const String & path) override;
+    DirectoryIteratorPtr iterateDirectory(const String & path) const override;
 
     void createFile(const String & path) override;
 
@@ -60,7 +60,7 @@ public:
 
     void replaceFile(const String & from_path, const String & to_path) override;
 
-    void listFiles(const String & path, std::vector<String> & file_names) override;
+    void listFiles(const String & path, std::vector<String> & file_names) const override;
 
     std::unique_ptr<ReadBufferFromFileBase> readFile(
         const String & path,
@@ -81,7 +81,7 @@ public:
 
     void setLastModified(const String &, const Poco::Timestamp &) override {}
 
-    Poco::Timestamp getLastModified(const String &) override { return Poco::Timestamp(); }
+    Poco::Timestamp getLastModified(const String &) const override { return Poco::Timestamp(); }
 
     void setReadOnly(const String & path) override;
 

--- a/src/Disks/DiskRestartProxy.cpp
+++ b/src/Disks/DiskRestartProxy.cpp
@@ -171,7 +171,7 @@ void DiskRestartProxy::moveDirectory(const String & from_path, const String & to
     DiskDecorator::moveDirectory(from_path, to_path);
 }
 
-DirectoryIteratorPtr DiskRestartProxy::iterateDirectory(const String & path)
+DirectoryIteratorPtr DiskRestartProxy::iterateDirectory(const String & path) const
 {
     ReadLock lock (mutex);
     return DiskDecorator::iterateDirectory(path);
@@ -207,7 +207,7 @@ void DiskRestartProxy::copyDirectoryContent(const String & from_dir, const std::
     DiskDecorator::copyDirectoryContent(from_dir, to_disk, to_dir);
 }
 
-void DiskRestartProxy::listFiles(const String & path, std::vector<String> & file_names)
+void DiskRestartProxy::listFiles(const String & path, std::vector<String> & file_names) const
 {
     ReadLock lock (mutex);
     DiskDecorator::listFiles(path, file_names);
@@ -276,7 +276,7 @@ void DiskRestartProxy::setLastModified(const String & path, const Poco::Timestam
     DiskDecorator::setLastModified(path, timestamp);
 }
 
-Poco::Timestamp DiskRestartProxy::getLastModified(const String & path)
+Poco::Timestamp DiskRestartProxy::getLastModified(const String & path) const
 {
     ReadLock lock (mutex);
     return DiskDecorator::getLastModified(path);

--- a/src/Disks/DiskRestartProxy.h
+++ b/src/Disks/DiskRestartProxy.h
@@ -37,13 +37,13 @@ public:
     void createDirectories(const String & path) override;
     void clearDirectory(const String & path) override;
     void moveDirectory(const String & from_path, const String & to_path) override;
-    DirectoryIteratorPtr iterateDirectory(const String & path) override;
+    DirectoryIteratorPtr iterateDirectory(const String & path) const override;
     void createFile(const String & path) override;
     void moveFile(const String & from_path, const String & to_path) override;
     void replaceFile(const String & from_path, const String & to_path) override;
     void copy(const String & from_path, const DiskPtr & to_disk, const String & to_path) override;
     void copyDirectoryContent(const String & from_dir, const std::shared_ptr<IDisk> & to_disk, const String & to_dir) override;
-    void listFiles(const String & path, std::vector<String> & file_names) override;
+    void listFiles(const String & path, std::vector<String> & file_names) const override;
     std::unique_ptr<ReadBufferFromFileBase> readFile(
         const String & path,
         const ReadSettings & settings,
@@ -58,7 +58,7 @@ public:
     void removeSharedFiles(const RemoveBatchRequest & files, bool keep_all_batch_data, const NameSet & file_names_remove_metadata_only) override;
     void removeSharedRecursive(const String & path, bool keep_all_batch_data, const NameSet & file_names_remove_metadata_only) override;
     void setLastModified(const String & path, const Poco::Timestamp & timestamp) override;
-    Poco::Timestamp getLastModified(const String & path) override;
+    Poco::Timestamp getLastModified(const String & path) const override;
     void setReadOnly(const String & path) override;
     void createHardLink(const String & src_path, const String & dst_path) override;
     void truncateFile(const String & path, size_t size) override;

--- a/src/Disks/DiskWebServer.cpp
+++ b/src/Disks/DiskWebServer.cpp
@@ -188,7 +188,7 @@ std::unique_ptr<ReadBufferFromFileBase> DiskWebServer::readFile(const String & p
 }
 
 
-DirectoryIteratorPtr DiskWebServer::iterateDirectory(const String & path)
+DirectoryIteratorPtr DiskWebServer::iterateDirectory(const String & path) const
 {
     std::vector<fs::path> dir_file_paths;
     if (files.find(path) == files.end())

--- a/src/Disks/DiskWebServer.h
+++ b/src/Disks/DiskWebServer.h
@@ -90,15 +90,15 @@ public:
 
     size_t getFileSize(const String & path) const override;
 
-    void listFiles(const String & /* path */, std::vector<String> & /* file_names */) override { }
+    void listFiles(const String & /* path */, std::vector<String> & /* file_names */) const override { }
 
     void setReadOnly(const String & /* path */) override {}
 
     bool isDirectory(const String & path) const override;
 
-    DirectoryIteratorPtr iterateDirectory(const String & /* path */) override;
+    DirectoryIteratorPtr iterateDirectory(const String & /* path */) const override;
 
-    Poco::Timestamp getLastModified(const String &) override { return Poco::Timestamp{}; }
+    Poco::Timestamp getLastModified(const String &) const override { return Poco::Timestamp{}; }
 
     /// Write and modification part
 

--- a/src/Disks/IDisk.cpp
+++ b/src/Disks/IDisk.cpp
@@ -16,7 +16,7 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
 }
 
-bool IDisk::isDirectoryEmpty(const String & path)
+bool IDisk::isDirectoryEmpty(const String & path) const
 {
     return !iterateDirectory(path)->isValid();
 }

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -138,10 +138,10 @@ public:
     virtual void moveDirectory(const String & from_path, const String & to_path) = 0;
 
     /// Return iterator to the contents of the specified directory.
-    virtual DirectoryIteratorPtr iterateDirectory(const String & path) = 0;
+    virtual DirectoryIteratorPtr iterateDirectory(const String & path) const = 0;
 
     /// Return `true` if the specified directory is empty.
-    bool isDirectoryEmpty(const String & path);
+    bool isDirectoryEmpty(const String & path) const;
 
     /// Create empty file at `path`.
     virtual void createFile(const String & path) = 0;
@@ -164,7 +164,7 @@ public:
     virtual void copyFile(const String & from_file_path, IDisk & to_disk, const String & to_file_path);
 
     /// List files at `path` and add their names to `file_names`
-    virtual void listFiles(const String & path, std::vector<String> & file_names) = 0;
+    virtual void listFiles(const String & path, std::vector<String> & file_names) const = 0;
 
     /// Open the file for read and return ReadBufferFromFileBase object.
     virtual std::unique_ptr<ReadBufferFromFileBase> readFile( /// NOLINT
@@ -259,7 +259,7 @@ public:
     virtual void setLastModified(const String & path, const Poco::Timestamp & timestamp) = 0;
 
     /// Get last modified time of file or directory at `path`.
-    virtual Poco::Timestamp getLastModified(const String & path) = 0;
+    virtual Poco::Timestamp getLastModified(const String & path) const = 0;
 
     /// Set file at `path` as read-only.
     virtual void setReadOnly(const String & path) = 0;

--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -350,13 +350,13 @@ void DiskObjectStorage::removeDirectory(const String & path)
 }
 
 
-DirectoryIteratorPtr DiskObjectStorage::iterateDirectory(const String & path)
+DirectoryIteratorPtr DiskObjectStorage::iterateDirectory(const String & path) const
 {
     return metadata_storage->iterateDirectory(path);
 }
 
 
-void DiskObjectStorage::listFiles(const String & path, std::vector<String> & file_names)
+void DiskObjectStorage::listFiles(const String & path, std::vector<String> & file_names) const
 {
     for (auto it = iterateDirectory(path); it->isValid(); it->next())
         file_names.push_back(it->name());
@@ -371,7 +371,7 @@ void DiskObjectStorage::setLastModified(const String & path, const Poco::Timesta
 }
 
 
-Poco::Timestamp DiskObjectStorage::getLastModified(const String & path)
+Poco::Timestamp DiskObjectStorage::getLastModified(const String & path) const
 {
     return metadata_storage->getLastModified(path);
 }

--- a/src/Disks/ObjectStorages/DiskObjectStorage.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.h
@@ -108,7 +108,7 @@ public:
     void createHardLink(const String & src_path, const String & dst_path) override;
     void createHardLink(const String & src_path, const String & dst_path, bool should_send_metadata);
 
-    void listFiles(const String & path, std::vector<String> & file_names) override;
+    void listFiles(const String & path, std::vector<String> & file_names) const override;
 
     void setReadOnly(const String & path) override;
 
@@ -124,11 +124,11 @@ public:
 
     void removeDirectory(const String & path) override;
 
-    DirectoryIteratorPtr iterateDirectory(const String & path) override;
+    DirectoryIteratorPtr iterateDirectory(const String & path) const override;
 
     void setLastModified(const String & path, const Poco::Timestamp & timestamp) override;
 
-    Poco::Timestamp getLastModified(const String & path) override;
+    Poco::Timestamp getLastModified(const String & path) const override;
 
     bool isRemote() const override { return true; }
 

--- a/src/Disks/ObjectStorages/IMetadataStorage.h
+++ b/src/Disks/ObjectStorages/IMetadataStorage.h
@@ -15,16 +15,6 @@
 namespace DB
 {
 
-struct IMetadataOperation
-{
-    virtual void execute() = 0;
-    virtual void undo() = 0;
-    virtual void finalize() {}
-    virtual ~IMetadataOperation() = default;
-};
-
-using MetadataOperationPtr = std::unique_ptr<IMetadataOperation>;
-
 class IMetadataStorage;
 
 /// Tries to provide some "transactions" interface, which allow
@@ -113,7 +103,7 @@ public:
 
     virtual std::vector<std::string> listDirectory(const std::string & path) const = 0;
 
-    virtual DirectoryIteratorPtr iterateDirectory(const std::string & path) = 0;
+    virtual DirectoryIteratorPtr iterateDirectory(const std::string & path) const = 0;
 
     virtual uint32_t getHardlinkCount(const std::string & path) const = 0;
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
@@ -484,7 +484,7 @@ std::vector<std::string> MetadataStorageFromDisk::listDirectory(const std::strin
     return result_files;
 }
 
-DirectoryIteratorPtr MetadataStorageFromDisk::iterateDirectory(const std::string & path)
+DirectoryIteratorPtr MetadataStorageFromDisk::iterateDirectory(const std::string & path) const
 {
     return disk->iterateDirectory(path);
 }

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
@@ -8,6 +8,17 @@
 namespace DB
 {
 
+
+struct IMetadataOperation
+{
+    virtual void execute() = 0;
+    virtual void undo() = 0;
+    virtual void finalize() {}
+    virtual ~IMetadataOperation() = default;
+};
+
+using MetadataOperationPtr = std::unique_ptr<IMetadataOperation>;
+
 enum class MetadataFromDiskTransactionState
 {
     PREPARING,
@@ -50,7 +61,7 @@ public:
 
     std::vector<std::string> listDirectory(const std::string & path) const override;
 
-    DirectoryIteratorPtr iterateDirectory(const std::string & path) override;
+    DirectoryIteratorPtr iterateDirectory(const std::string & path) const override;
 
     std::string readFileToString(const std::string & path) const override;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):