### PR TITLE
Display CPU Usage progress correctly when <= 0

### DIFF
--- a/src/Common/ProgressIndication.cpp
+++ b/src/Common/ProgressIndication.cpp
@@ -190,10 +190,11 @@ void ProgressIndication::writeProgress()
     if (cpu_usage > 0 || memory_usage > 0)
     {
         WriteBufferFromOwnString profiling_msg_builder;
+        profiling_msg_builder << "(";
         if (cpu_usage <= 0)
-            profiling_msg_builder << "(" << fmt::format("{}", 0) << " CPU";
+            profiling_msg_builder << 0 << " CPU";
         else
-            profiling_msg_builder << "(" << fmt::format("{:.1f}", cpu_usage) << " CPU";
+            profiling_msg_builder << fmt::format("{:.1f}", cpu_usage) << " CPU";
         if (memory_usage > 0)
             profiling_msg_builder << ", " << formatReadableSizeWithDecimalSuffix(memory_usage) << " RAM";
         if (max_host_usage < memory_usage)

--- a/src/Common/ProgressIndication.cpp
+++ b/src/Common/ProgressIndication.cpp
@@ -190,9 +190,10 @@ void ProgressIndication::writeProgress()
     if (cpu_usage > 0 || memory_usage > 0)
     {
         WriteBufferFromOwnString profiling_msg_builder;
-
-        profiling_msg_builder << "(" << fmt::format("{:.1f}", cpu_usage) << " CPU";
-
+        if (cpu_usage <= 0)
+            profiling_msg_builder << "(" << fmt::format("{}", 0) << " CPU";
+        else
+            profiling_msg_builder << "(" << fmt::format("{:.1f}", cpu_usage) << " CPU";
         if (memory_usage > 0)
             profiling_msg_builder << ", " << formatReadableSizeWithDecimalSuffix(memory_usage) << " RAM";
         if (max_host_usage < memory_usage)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes #38003. The check has been added to display 0 if CPU_usage is <=0.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
