### PR TITLE
BackgroundSchedulePoolTaskInfo: Deactivation should not hold exec_mutex

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -54,7 +54,6 @@ bool BackgroundSchedulePoolTaskInfo::scheduleAfter(size_t ms, bool overwrite)
 
 void BackgroundSchedulePoolTaskInfo::deactivate()
 {
-    std::lock_guard lock_exec(exec_mutex);
     std::lock_guard lock_schedule(schedule_mutex);
 
     if (deactivated)


### PR DESCRIPTION
BackgroundSchedulePoolTaskInfo: Deactivation should not hold execution mutex

Since deactivated and scheduled are protected by schedule_mutex,
BackgroundSchedulePool has its own mutex.
Why BackgroundSchedulePoolTaskInfo::deactivate() holds exec_mutex?

From the past, there was one recursive mutex which was replaced by execution and schedule ones.

Proposing to remove locking of exec_mutex in BackgroundSchedulePoolTaskInfo::deactivate()
since some tasks can be quite slow and exec_mutex is held.
And deactivation takes too much time to finish, and there is no reason to wait before execution of the task is finished.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Removed holding execution mutex in BackgroundSchedulePoolTaskInfo::deactivate()
