### PR TITLE
Add perf checkers to all Jepsen tests

### DIFF
--- a/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/counter.clj
+++ b/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/counter.clj
@@ -43,7 +43,9 @@
   "A generator, client, and checker for a set test."
   [opts]
   {:client    (CounterClient. nil nil)
-   :checker   (checker/counter)
+   :checker   (checker/compose
+                {:counter (checker/counter)
+                 :perf    (checker/perf)})
    :generator (->> (range)
                    (map (fn [x]
                           (->> (gen/mix [r add])))))

--- a/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/queue.clj
+++ b/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/queue.clj
@@ -59,7 +59,8 @@
   {:client    (QueueClient. nil nil)
    :checker   (checker/compose
                {:total-queue (checker/total-queue)
-                :timeline (timeline/html)})
+                :perf        (checker/perf)
+                :timeline    (timeline/html)})
    :generator (->> (sorted-str-range 50000)
                    (map (fn [x]
                           (rand-nth [{:type :invoke, :f :enqueue :value x}
@@ -72,6 +73,7 @@
    :checker   (checker/compose
                {:linear   (checker/linearizable {:model     (model/unordered-queue)
                                                  :algorithm :linear})
+                :perf        (checker/perf)
                 :timeline (timeline/html)})
    :generator (->> (sorted-str-range 10000)
                    (map (fn [x]

--- a/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/register.clj
+++ b/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/register.clj
@@ -55,6 +55,7 @@
                (checker/compose
                 {:linear   (checker/linearizable {:model     (model/cas-register)
                                                   :algorithm :linear})
+                 :perf     (checker/perf)
                  :timeline (timeline/html)}))
    :generator (independent/concurrent-generator
                10

--- a/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/set.clj
+++ b/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/set.clj
@@ -44,7 +44,9 @@
   "A generator, client, and checker for a set test."
   [opts]
   {:client    (SetClient. "/a-set" nil nil)
-   :checker   (checker/set)
+   :checker   (checker/compose
+                {:set (checker/set)
+                 :perf (checker/perf)})
    :generator (->> (range)
                    (map (fn [x] {:type :invoke, :f :add, :value x})))
    :final-generator (gen/once {:type :invoke, :f :read, :value nil})})

--- a/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/unique.clj
+++ b/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/unique.clj
@@ -36,7 +36,9 @@
   "A generator, client, and checker for a set test."
   [opts]
   {:client    (UniqueClient. nil nil)
-   :checker   (checker/unique-ids)
+   :checker   (checker/compose
+                {:perf   (checker/perf)
+                 :unique (checker/unique-ids)})
    :generator (->>
                (range)
                (map (fn [_] {:type :invoke, :f :generate})))})


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This will generate latency and rate graphs for all the tests. Let's first see if it has any major impact on the test runtime. 
We should also think about increasing the `time-limit` of the tests.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
