### PR TITLE
Add kerberosInit function as a replacement for kinit executable calls in Kafka and HDFS

### DIFF
--- a/docs/en/engines/table-engines/integrations/hdfs.md
+++ b/docs/en/engines/table-engines/integrations/hdfs.md
@@ -186,7 +186,6 @@ Similar to GraphiteMergeTree, the HDFS engine supports extended configuration us
 | -                                                     | -                       |
 |hadoop\_kerberos\_keytab                               | ""                      |
 |hadoop\_kerberos\_principal                            | ""                      |
-|hadoop\_kerberos\_kinit\_command                       | kinit                   |
 |libhdfs3\_conf                                         | ""                      |
 
 ### Limitations {#limitations}
@@ -200,8 +199,7 @@ Note that due to libhdfs3 limitations only old-fashioned approach is supported,
 datanode communications are not secured by SASL (`HADOOP_SECURE_DN_USER` is a reliable indicator of such
 security approach). Use `tests/integration/test_storage_kerberized_hdfs/hdfs_configs/bootstrap.sh` for reference.
 
-If `hadoop_kerberos_keytab`, `hadoop_kerberos_principal` or `hadoop_kerberos_kinit_command` is specified, `kinit` will be invoked. `hadoop_kerberos_keytab` and `hadoop_kerberos_principal` are mandatory in this case. `kinit` tool and krb5 configuration files are required.
-
+If `hadoop_kerberos_keytab`, `hadoop_kerberos_principal` or `hadoop_security_kerberos_ticket_cache_path` are specified, Kerberos authentication will be used. `hadoop_kerberos_keytab` and `hadoop_kerberos_principal` are mandatory in this case.
 ## HDFS Namenode HA support {#namenode-ha}
 
 libhdfs3 support HDFS namenode HA.

--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -168,7 +168,7 @@ For a list of possible configuration options, see the [librdkafka configuration 
 ### Kerberos support {#kafka-kerberos-support}
 
 To deal with Kerberos-aware Kafka, add `security_protocol` child element with `sasl_plaintext` value. It is enough if Kerberos ticket-granting ticket is obtained and cached by OS facilities.
-ClickHouse is able to maintain Kerberos credentials using a keytab file. Consider `sasl_kerberos_service_name`, `sasl_kerberos_keytab`, `sasl_kerberos_principal` and `sasl.kerberos.kinit.cmd` child elements.
+ClickHouse is able to maintain Kerberos credentials using a keytab file. Consider `sasl_kerberos_service_name`, `sasl_kerberos_keytab` and `sasl_kerberos_principal` child elements.
 
 Example:
 

--- a/docs/ru/engines/table-engines/integrations/hdfs.md
+++ b/docs/ru/engines/table-engines/integrations/hdfs.md
@@ -183,7 +183,6 @@ CREATE TABLE big_table (name String, value UInt32) ENGINE = HDFS('hdfs://hdfs1:9
 | -                                                     | -                       |
 |hadoop\_kerberos\_keytab                               | ""                      |
 |hadoop\_kerberos\_principal                            | ""                      |
-|hadoop\_kerberos\_kinit\_command                       | kinit                   |
 
 ### Ограничения {#limitations}
   * `hadoop_security_kerberos_ticket_cache_path` и `libhdfs3_conf` могут быть определены только на глобальном, а не на пользовательском уровне
@@ -196,7 +195,7 @@ CREATE TABLE big_table (name String, value UInt32) ENGINE = HDFS('hdfs://hdfs1:9
 коммуникация с узлами данных не защищена SASL (`HADOOP_SECURE_DN_USER` надежный показатель такого
 подхода к безопасности). Используйте `tests/integration/test_storage_kerberized_hdfs/hdfs_configs/bootstrap.sh` для примера настроек.
 
-Если `hadoop_kerberos_keytab`, `hadoop_kerberos_principal` или `hadoop_kerberos_kinit_command` указаны в настройках, `kinit` будет вызван. `hadoop_kerberos_keytab` и `hadoop_kerberos_principal` обязательны в этом случае. Необходимо также будет установить `kinit` и файлы конфигурации krb5.
+Если `hadoop_kerberos_keytab`, `hadoop_kerberos_principal` или `hadoop_security_kerberos_ticket_cache_path` указаны в настройках, будет использоваться аутентификация с помощью Kerberos. `hadoop_kerberos_keytab` и `hadoop_kerberos_principal` обязательны в этом случае.
 
 ## Виртуальные столбцы {#virtual-columns}
 

--- a/docs/ru/engines/table-engines/integrations/kafka.md
+++ b/docs/ru/engines/table-engines/integrations/kafka.md
@@ -167,7 +167,7 @@ Kafka(kafka_broker_list, kafka_topic_list, kafka_group_name, kafka_format
 ### Поддержка Kerberos {#kafka-kerberos-support}
 
 Чтобы начать работу с Kafka с поддержкой Kerberos, добавьте дочерний элемент `security_protocol` со значением `sasl_plaintext`. Этого будет достаточно, если получен тикет на получение тикета (ticket-granting ticket) Kerberos и он кэшируется средствами ОС.
-ClickHouse может поддерживать учетные данные Kerberos с помощью файла keytab. Рассмотрим дочерние элементы `sasl_kerberos_service_name`, `sasl_kerberos_keytab`, `sasl_kerberos_principal` и `sasl.kerberos.kinit.cmd`.
+ClickHouse может поддерживать учетные данные Kerberos с помощью файла keytab. Рассмотрим дочерние элементы `sasl_kerberos_service_name`, `sasl_kerberos_keytab` и `sasl_kerberos_principal`.
 
 Пример:
 

--- a/src/Access/CMakeLists.txt
+++ b/src/Access/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (ENABLE_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -154,7 +154,8 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
         LOG_DEBUG(log,"Stored credentials");
     }
 
-    if (k5.switch_to_cache) {
+    if (k5.switch_to_cache)
+    {
         ret = krb5_cc_switch(k5.ctx, k5.out_cc);
         if (ret)
             throw Exception("Error while switching to new cache", ErrorCodes::KERBEROS_ERROR);

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -9,6 +9,14 @@
 
 using namespace DB;
 
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int KERBEROS_ERROR;
+}
+}
+
 struct k5_data
 {
     krb5_context ctx;
@@ -145,7 +153,7 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
     }
     else
     {
-        LOG_DEBUG(log,"Successfull renewal");
+        LOG_DEBUG(log,"Successful renewal");
         ret = krb5_cc_initialize(k5.ctx, k5.out_cc, k5.me);
         if (ret)
             throw Exception("Error when initializing cache", ErrorCodes::KERBEROS_ERROR);

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -4,6 +4,8 @@
 #include <Poco/Logger.h>
 #include <Loggers/Loggers.h>
 #include <filesystem>
+#include <krb5.h>
+#include <mutex>
 
 using namespace DB;
 

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -1,0 +1,162 @@
+#include <Access/KerberosInit.h>
+#include <Common/Exception.h>
+
+#include <Common/logger_useful.h>
+#include <Poco/Logger.h>
+#include <Loggers/Loggers.h>
+
+
+int KerberosInit::init(const String & keytab_file, const String & principal, const String & cache_name)
+{
+    auto adqm_log = &Poco::Logger::get("ADQM");
+    LOG_DEBUG(adqm_log,"KerberosInit: begin");
+
+    krb5_error_code ret;
+
+    // todo: use deftype
+    //const char *deftype = nullptr;
+    int flags = 0;
+    principal_name = new char[256];
+    std::copy(principal.begin(), principal.end(), principal_name);
+    principal_name[principal.size()] = '\0';
+
+    //memset(&k5, 0, sizeof(k5));
+    memset(&k5d, 0, sizeof(k5d));
+    k5 = &k5d;
+    //memset(k5, 0, sizeof(k5_data));
+    // begin
+    ret = krb5_init_context(&k5->ctx);
+    if (ret)
+        throw DB::Exception(0, "Error while initializing Kerberos 5 library");
+
+    if (!cache_name.empty())
+    {
+        ret = krb5_cc_resolve(k5->ctx, cache_name.c_str(), &k5->out_cc);
+        // todo: analyze return code
+        LOG_DEBUG(adqm_log,"Resolved cache");
+    }
+    else
+    {
+        // Resolve the default ccache and get its type and default principal (if it is initialized).
+        ret = krb5_cc_default(k5->ctx, &defcache);
+        if (ret)
+            throw DB::Exception(0, "Error while getting default ccache");
+        LOG_DEBUG(adqm_log,"Resolved default cache");
+        // todo: deftype
+        /*deftype = */krb5_cc_get_type(k5->ctx, defcache);
+        if (krb5_cc_get_principal(k5->ctx, defcache, &defcache_princ) != 0)
+            defcache_princ = nullptr;
+    }
+
+    // Use the specified principal name.
+    ret = krb5_parse_name_flags(k5->ctx, principal_name, flags, &k5->me);
+    if (ret)
+        throw DB::Exception(0, "Error when parsing principal name " + String(principal_name));
+
+
+    // to-do: add more cache init commands
+
+    ret = krb5_unparse_name(k5->ctx, k5->me, &k5->name);
+    if (ret)
+        throw DB::Exception(0, "Error when unparsing name");
+
+    LOG_DEBUG(adqm_log,"KerberosInit: Using principal: {}", k5->name);
+
+    principal_name = k5->name;
+
+    // init:
+    memset(&my_creds, 0, sizeof(my_creds));
+
+    ret = krb5_get_init_creds_opt_alloc(k5->ctx, &options);
+    if (ret)
+        throw DB::Exception(0, "Error in options allocation");
+
+    // todo
+/*
+#ifndef _WIN32
+    if (strncmp(opts->keytab_name, "KDB:", 4) == 0) {
+        ret = kinit_kdb_init(&k5->ctx, k5->me->realm.data);
+        errctx = k5->ctx;
+        if (ret) {
+            com_err(progname, ret,
+                    _("while setting up KDB keytab for realm %s"),
+                    k5->me->realm.data);
+            goto cleanup;
+        }
+    }
+#endif
+*/
+    // Resolve keytab
+    ret = krb5_kt_resolve(k5->ctx, keytab_file.c_str(), &keytab);
+    if (ret)
+        throw DB::Exception(0, "Error resolving keytab "+keytab_file);
+
+    LOG_DEBUG(adqm_log,"KerberosInit: Using keytab: {}", keytab_file);
+
+    // todo: num_pa_opts
+
+
+    // todo: in_cc / ccache
+
+    // action: init or renew
+    // todo: doing only init action:
+    ret = krb5_get_init_creds_keytab(k5->ctx, &my_creds, k5->me, keytab, 0, nullptr, options);
+    if (ret)
+        LOG_DEBUG(adqm_log,"Getting initial credentials");
+
+    // todo: implement renew action
+
+
+    LOG_DEBUG(adqm_log,"Authenticated to Kerberos v5");
+    LOG_DEBUG(adqm_log,"KerberosInit: end");
+    return 0;
+}
+
+KerberosInit::~KerberosInit()
+{
+    if (k5->ctx)
+    {
+        //begin. cleanup:
+        if (defcache)
+            krb5_cc_close(k5->ctx, defcache);
+        //todo
+        krb5_free_principal(k5->ctx, defcache_princ);
+
+        // init. cleanup:
+        //todo:
+        /*
+    #ifndef _WIN32
+        kinit_kdb_fini();
+    #endif
+        */
+        if (options)
+            krb5_get_init_creds_opt_free(k5->ctx, options);
+        if (my_creds.client == k5->me)
+            my_creds.client = nullptr;
+        /*
+        if (opts->pa_opts) {
+            free(opts->pa_opts);
+            opts->pa_opts = NULL;
+            opts->num_pa_opts = 0;
+        }
+        */
+        krb5_free_cred_contents(k5->ctx, &my_creds);
+        if (keytab)
+            krb5_kt_close(k5->ctx, keytab);
+
+
+        // end:
+        krb5_free_unparsed_name(k5->ctx, k5->name);
+        krb5_free_principal(k5->ctx, k5->me);
+        /*
+        if (k5->in_cc != NULL)
+            krb5_cc_close(k5->ctx, k5->in_cc);
+        if (k5->out_cc != NULL)
+            krb5_cc_close(k5->ctx, k5->out_cc);
+        */
+        krb5_free_context(k5->ctx);
+    }
+    memset(k5, 0, sizeof(*k5));
+
+    delete[] principal_name;
+}

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -9,6 +9,7 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
 {
     auto adqm_log = &Poco::Logger::get("ADQM");
     LOG_DEBUG(adqm_log,"KerberosInit: begin");
+    //LOG_DEBUG(adqm_log,"KerberosInit: do nothing"); return 0;
 
     krb5_error_code ret;
 

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -13,7 +13,6 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
 
     krb5_error_code ret;
 
-    // todo: use deftype
     const char *deftype = nullptr;
     int flags = 0;
 

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -4,6 +4,7 @@
 #include <Poco/Logger.h>
 #include <Loggers/Loggers.h>
 #include <filesystem>
+#if USE_KRB5
 #include <krb5.h>
 #include <mutex>
 
@@ -209,3 +210,4 @@ int kerberosInit(const String & keytab_file, const String & principal, const Str
     KerberosInit k_init;
     return k_init.init(keytab_file, principal, cache_name);
 }
+#endif // USE_KRB5

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -5,11 +5,17 @@
 #include <Loggers/Loggers.h>
 #include <filesystem>
 
+using namespace DB;
+
+std::mutex KerberosInit::kinit_mtx;
+
 int KerberosInit::init(const String & keytab_file, const String & principal, const String & cache_name)
 {
-    auto adqm_log = &Poco::Logger::get("ADQM");
-    LOG_DEBUG(adqm_log,"KerberosInit: begin");
-    //LOG_DEBUG(adqm_log,"KerberosInit: do nothing"); return 0;
+    // Using mutex to prevent cache file corruptions
+    std::unique_lock<std::mutex> lck(kinit_mtx);
+
+    auto log = &Poco::Logger::get("ADQM");
+    LOG_DEBUG(log,"Trying to authenticate to Kerberos v5");
 
     krb5_error_code ret;
 
@@ -17,182 +23,152 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
     int flags = 0;
 
     if (!std::filesystem::exists(keytab_file))
-        throw DB::Exception(0, "Error keytab file does not exist");
+        throw Exception("Error keytab file does not exist", ErrorCodes::KERBEROS_ERROR);
 
-    memset(&k5d, 0, sizeof(k5d));
-    k5 = &k5d;
-    // begin
-    ret = krb5_init_context(&k5->ctx);
+    memset(&k5, 0, sizeof(k5));
+    ret = krb5_init_context(&k5.ctx);
     if (ret)
-        throw DB::Exception(0, "Error while initializing Kerberos 5 library");
+        throw Exception("Error while initializing Kerberos 5 library", ErrorCodes::KERBEROS_ERROR);
 
     if (!cache_name.empty())
     {
-        ret = krb5_cc_resolve(k5->ctx, cache_name.c_str(), &k5->out_cc);
-        // todo: analyze return code
-        LOG_DEBUG(adqm_log,"Resolved cache");
+        ret = krb5_cc_resolve(k5.ctx, cache_name.c_str(), &k5.out_cc);
+        if (ret)
+            throw Exception("Error in resolving cache", ErrorCodes::KERBEROS_ERROR);
+        LOG_DEBUG(log,"Resolved cache");
     }
     else
     {
         // Resolve the default ccache and get its type and default principal (if it is initialized).
-        ret = krb5_cc_default(k5->ctx, &defcache);
+        ret = krb5_cc_default(k5.ctx, &defcache);
         if (ret)
-            throw DB::Exception(0, "Error while getting default ccache");
-        LOG_DEBUG(adqm_log,"Resolved default cache");
-        deftype = krb5_cc_get_type(k5->ctx, defcache);
-        if (krb5_cc_get_principal(k5->ctx, defcache, &defcache_princ) != 0)
+            throw Exception("Error while getting default ccache", ErrorCodes::KERBEROS_ERROR);
+        LOG_DEBUG(log,"Resolved default cache");
+        deftype = krb5_cc_get_type(k5.ctx, defcache);
+        if (krb5_cc_get_principal(k5.ctx, defcache, &defcache_princ) != 0)
             defcache_princ = nullptr;
     }
 
     // Use the specified principal name.
-    ret = krb5_parse_name_flags(k5->ctx, principal.c_str(), flags, &k5->me);
+    ret = krb5_parse_name_flags(k5.ctx, principal.c_str(), flags, &k5.me);
     if (ret)
-        throw DB::Exception(0, "Error when parsing principal name " + principal);
+        throw Exception("Error when parsing principal name " + principal, ErrorCodes::KERBEROS_ERROR);
 
     // Cache related commands
-    if (k5->out_cc == nullptr && krb5_cc_support_switch(k5->ctx, deftype))
+    if (k5.out_cc == nullptr && krb5_cc_support_switch(k5.ctx, deftype))
     {
         // Use an existing cache for the client principal if we can.
-        ret = krb5_cc_cache_match(k5->ctx, k5->me, &k5->out_cc);
+        ret = krb5_cc_cache_match(k5.ctx, k5.me, &k5.out_cc);
         if (ret && ret != KRB5_CC_NOTFOUND)
-            throw DB::Exception(0, "Error while searching for ccache for " + principal);
+            throw Exception("Error while searching for cache for " + principal, ErrorCodes::KERBEROS_ERROR);
         if (!ret)
         {
-            LOG_DEBUG(adqm_log,"Using default cache: {}", krb5_cc_get_name(k5->ctx, k5->out_cc));
-            k5->switch_to_cache = 1;
+            LOG_DEBUG(log,"Using default cache: {}", krb5_cc_get_name(k5.ctx, k5.out_cc));
+            k5.switch_to_cache = 1;
         }
         else if (defcache_princ != nullptr)
         {
             // Create a new cache to avoid overwriting the initialized default cache.
-            ret = krb5_cc_new_unique(k5->ctx, deftype, nullptr, &k5->out_cc);
+            ret = krb5_cc_new_unique(k5.ctx, deftype, nullptr, &k5.out_cc);
             if (ret)
-                throw DB::Exception(0, "Error while generating new ccache");
-            LOG_DEBUG(adqm_log,"Using default cache: {}", krb5_cc_get_name(k5->ctx, k5->out_cc));
-            k5->switch_to_cache = 1;
+                throw Exception("Error while generating new cache", ErrorCodes::KERBEROS_ERROR);
+            LOG_DEBUG(log,"Using default cache: {}", krb5_cc_get_name(k5.ctx, k5.out_cc));
+            k5.switch_to_cache = 1;
         }
     }
 
     // Use the default cache if we haven't picked one yet.
-    if (k5->out_cc == nullptr)
+    if (k5.out_cc == nullptr)
     {
-        k5->out_cc = defcache;
+        k5.out_cc = defcache;
         defcache = nullptr;
-        LOG_DEBUG(adqm_log,"Using default cache: {}", krb5_cc_get_name(k5->ctx, k5->out_cc));
+        LOG_DEBUG(log,"Using default cache: {}", krb5_cc_get_name(k5.ctx, k5.out_cc));
     }
 
-    ret = krb5_unparse_name(k5->ctx, k5->me, &k5->name);
+    ret = krb5_unparse_name(k5.ctx, k5.me, &k5.name);
     if (ret)
-        throw DB::Exception(0, "Error when unparsing name");
+        throw Exception("Error when unparsing name", ErrorCodes::KERBEROS_ERROR);
+    LOG_DEBUG(log,"Using principal: {}", k5.name);
 
-    LOG_DEBUG(adqm_log,"KerberosInit: Using principal: {}", k5->name);
-
-    // init:
     memset(&my_creds, 0, sizeof(my_creds));
-
-    ret = krb5_get_init_creds_opt_alloc(k5->ctx, &options);
+    ret = krb5_get_init_creds_opt_alloc(k5.ctx, &options);
     if (ret)
-        throw DB::Exception(0, "Error in options allocation");
+        throw Exception("Error in options allocation", ErrorCodes::KERBEROS_ERROR);
 
-    // todo
-/*
-#ifndef _WIN32
-    if (strncmp(opts->keytab_name, "KDB:", 4) == 0) {
-        ret = kinit_kdb_init(&k5->ctx, k5->me->realm.data);
-        errctx = k5->ctx;
-        if (ret) {
-            com_err(progname, ret,
-                    _("while setting up KDB keytab for realm %s"),
-                    k5->me->realm.data);
-            goto cleanup;
-        }
-    }
-#endif
-*/
     // Resolve keytab
-    ret = krb5_kt_resolve(k5->ctx, keytab_file.c_str(), &keytab);
+    ret = krb5_kt_resolve(k5.ctx, keytab_file.c_str(), &keytab);
     if (ret)
-        throw DB::Exception(0, "Error resolving keytab "+keytab_file);
+        throw Exception("Error in resolving keytab "+keytab_file, ErrorCodes::KERBEROS_ERROR);
+    LOG_DEBUG(log,"Using keytab: {}", keytab_file);
 
-    LOG_DEBUG(adqm_log,"KerberosInit: Using keytab: {}", keytab_file);
-
-    if (k5->in_cc)
+    if (k5.in_cc)
     {
-        ret = krb5_get_init_creds_opt_set_in_ccache(k5->ctx, options, k5->in_cc);
+        ret = krb5_get_init_creds_opt_set_in_ccache(k5.ctx, options, k5.in_cc);
         if (ret)
-            throw DB::Exception(0, "Error in setting input credential cache");
+            throw Exception("Error in setting input credential cache", ErrorCodes::KERBEROS_ERROR);
     }
-    ret = krb5_get_init_creds_opt_set_out_ccache(k5->ctx, options, k5->out_cc);
+    ret = krb5_get_init_creds_opt_set_out_ccache(k5.ctx, options, k5.out_cc);
     if (ret)
-        throw DB::Exception(0, "Error in setting output credential cache");
+        throw Exception("Error in setting output credential cache", ErrorCodes::KERBEROS_ERROR);
 
-    // action: init or renew
-    LOG_DEBUG(adqm_log,"Trying to renew credentials");
-    ret = krb5_get_renewed_creds(k5->ctx, &my_creds, k5->me, k5->out_cc, nullptr);
+    // Action: init or renew
+    LOG_DEBUG(log,"Trying to renew credentials");
+    ret = krb5_get_renewed_creds(k5.ctx, &my_creds, k5.me, k5.out_cc, nullptr);
     if (ret)
     {
-        LOG_DEBUG(adqm_log,"Renew failed, making init credentials");
-        ret = krb5_get_init_creds_keytab(k5->ctx, &my_creds, k5->me, keytab, 0, nullptr, options);
+        LOG_DEBUG(log,"Renew failed, trying to get initial credentials");
+        ret = krb5_get_init_creds_keytab(k5.ctx, &my_creds, k5.me, keytab, 0, nullptr, options);
         if (ret)
-            throw DB::Exception(0, "Error in init");
+            throw Exception("Error in getting initial credentials", ErrorCodes::KERBEROS_ERROR);
         else
-            LOG_DEBUG(adqm_log,"Getting initial credentials");
+            LOG_DEBUG(log,"Got initial credentials");
     }
     else
     {
-        LOG_DEBUG(adqm_log,"Successfull reviewal");
-        ret = krb5_cc_initialize(k5->ctx, k5->out_cc, k5->me);
+        LOG_DEBUG(log,"Successfull renewal");
+        ret = krb5_cc_initialize(k5.ctx, k5.out_cc, k5.me);
         if (ret)
-            throw DB::Exception(0, "Error when initializing cache");
-        LOG_DEBUG(adqm_log,"Initialized cache");
-        ret = krb5_cc_store_cred(k5->ctx, k5->out_cc, &my_creds);
+            throw Exception("Error when initializing cache", ErrorCodes::KERBEROS_ERROR);
+        LOG_DEBUG(log,"Initialized cache");
+        ret = krb5_cc_store_cred(k5.ctx, k5.out_cc, &my_creds);
         if (ret)
-            LOG_DEBUG(adqm_log,"Error while storing credentials");
-        LOG_DEBUG(adqm_log,"Stored credentials");
+            LOG_DEBUG(log,"Error while storing credentials");
+        LOG_DEBUG(log,"Stored credentials");
     }
 
-    if (k5->switch_to_cache) {
-        ret = krb5_cc_switch(k5->ctx, k5->out_cc);
+    if (k5.switch_to_cache) {
+        ret = krb5_cc_switch(k5.ctx, k5.out_cc);
         if (ret)
-            throw DB::Exception(0, "Error while switching to new ccache");
+            throw Exception("Error while switching to new ccache", ErrorCodes::KERBEROS_ERROR);
     }
 
-    LOG_DEBUG(adqm_log,"Authenticated to Kerberos v5");
-    LOG_DEBUG(adqm_log,"KerberosInit: end");
+    LOG_DEBUG(log,"Authenticated to Kerberos v5");
     return 0;
 }
 
 KerberosInit::~KerberosInit()
 {
-    if (k5->ctx)
+    std::unique_lock<std::mutex> lck(kinit_mtx);
+    if (k5.ctx)
     {
-        //begin. cleanup:
         if (defcache)
-            krb5_cc_close(k5->ctx, defcache);
-        krb5_free_principal(k5->ctx, defcache_princ);
+            krb5_cc_close(k5.ctx, defcache);
+        krb5_free_principal(k5.ctx, defcache_princ);
 
-        // init. cleanup:
-        //todo:
-        /*
-    #ifndef _WIN32
-        kinit_kdb_fini();
-    #endif
-        */
         if (options)
-            krb5_get_init_creds_opt_free(k5->ctx, options);
-        if (my_creds.client == k5->me)
+            krb5_get_init_creds_opt_free(k5.ctx, options);
+        if (my_creds.client == k5.me)
             my_creds.client = nullptr;
-        krb5_free_cred_contents(k5->ctx, &my_creds);
+        krb5_free_cred_contents(k5.ctx, &my_creds);
         if (keytab)
-            krb5_kt_close(k5->ctx, keytab);
+            krb5_kt_close(k5.ctx, keytab);
 
-        // end. cleanup:
-        krb5_free_unparsed_name(k5->ctx, k5->name);
-        krb5_free_principal(k5->ctx, k5->me);
-        if (k5->in_cc != nullptr)
-            krb5_cc_close(k5->ctx, k5->in_cc);
-        if (k5->out_cc != nullptr)
-            krb5_cc_close(k5->ctx, k5->out_cc);
-        krb5_free_context(k5->ctx);
+        krb5_free_unparsed_name(k5.ctx, k5.name);
+        krb5_free_principal(k5.ctx, k5.me);
+        if (k5.in_cc != nullptr)
+            krb5_cc_close(k5.ctx, k5.in_cc);
+        if (k5.out_cc != nullptr)
+            krb5_cc_close(k5.ctx, k5.out_cc);
+        krb5_free_context(k5.ctx);
     }
-    memset(k5, 0, sizeof(*k5));
 }

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -5,6 +5,7 @@
 #include <Loggers/Loggers.h>
 #include <filesystem>
 #include <boost/core/noncopyable.hpp>
+#include <fmt/format.h>
 #if USE_KRB5
 #include <krb5.h>
 #include <mutex>
@@ -36,23 +37,34 @@ struct K5Data
 class KerberosInit : boost::noncopyable
 {
 public:
-    int init(const String & keytab_file, const String & principal, const String & cache_name = "");
+    void init(const String & keytab_file, const String & principal, const String & cache_name = "");
     ~KerberosInit();
 private:
-    struct K5Data k5;
+    struct K5Data k5 {};
     krb5_ccache defcache = nullptr;
     krb5_get_init_creds_opt * options = nullptr;
     // Credentials structure including ticket, session key, and lifetime info.
     krb5_creds my_creds;
     krb5_keytab keytab = nullptr;
     krb5_principal defcache_princ = nullptr;
+    String fmtError(krb5_error_code code);
 };
 }
 
-int KerberosInit::init(const String & keytab_file, const String & principal, const String & cache_name)
+
+String KerberosInit::fmtError(krb5_error_code code)
+{
+    const char *msg;
+    msg = krb5_get_error_message(k5.ctx, code);
+    String fmt_error = fmt::format(" ({}, {})", code, msg);
+    krb5_free_error_message(k5.ctx, msg);
+    return fmt_error;
+}
+
+void KerberosInit::init(const String & keytab_file, const String & principal, const String & cache_name)
 {
     auto * log = &Poco::Logger::get("KerberosInit");
-    LOG_TRACE(log,"Trying to authenticate to Kerberos v5");
+    LOG_TRACE(log,"Trying to authenticate with Kerberos v5");
 
     krb5_error_code ret;
 
@@ -61,16 +73,15 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
     if (!std::filesystem::exists(keytab_file))
         throw Exception("Keytab file does not exist", ErrorCodes::KERBEROS_ERROR);
 
-    memset(&k5, 0, sizeof(k5));
     ret = krb5_init_context(&k5.ctx);
     if (ret)
-        throw Exception("Error while initializing Kerberos 5 library", ErrorCodes::KERBEROS_ERROR);
+        throw Exception(fmt::format("Error while initializing Kerberos 5 library ({})", ret), ErrorCodes::KERBEROS_ERROR);
 
     if (!cache_name.empty())
     {
         ret = krb5_cc_resolve(k5.ctx, cache_name.c_str(), &k5.out_cc);
         if (ret)
-            throw Exception("Error in resolving cache", ErrorCodes::KERBEROS_ERROR);
+            throw Exception("Error in resolving cache" + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
         LOG_TRACE(log,"Resolved cache");
     }
     else
@@ -78,7 +89,7 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
         // Resolve the default cache and get its type and default principal (if it is initialized).
         ret = krb5_cc_default(k5.ctx, &defcache);
         if (ret)
-            throw Exception("Error while getting default cache", ErrorCodes::KERBEROS_ERROR);
+            throw Exception("Error while getting default cache" + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
         LOG_TRACE(log,"Resolved default cache");
         deftype = krb5_cc_get_type(k5.ctx, defcache);
         if (krb5_cc_get_principal(k5.ctx, defcache, &defcache_princ) != 0)
@@ -88,7 +99,7 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
     // Use the specified principal name.
     ret = krb5_parse_name_flags(k5.ctx, principal.c_str(), 0, &k5.me);
     if (ret)
-        throw Exception("Error when parsing principal name " + principal, ErrorCodes::KERBEROS_ERROR);
+        throw Exception("Error when parsing principal name " + principal + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
 
     // Cache related commands
     if (k5.out_cc == nullptr && krb5_cc_support_switch(k5.ctx, deftype))
@@ -96,8 +107,8 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
         // Use an existing cache for the client principal if we can.
         ret = krb5_cc_cache_match(k5.ctx, k5.me, &k5.out_cc);
         if (ret && ret != KRB5_CC_NOTFOUND)
-            throw Exception("Error while searching for cache for " + principal, ErrorCodes::KERBEROS_ERROR);
-        if (!ret)
+            throw Exception("Error while searching for cache for " + principal + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
+        if (0 == ret)
         {
             LOG_TRACE(log,"Using default cache: {}", krb5_cc_get_name(k5.ctx, k5.out_cc));
             k5.switch_to_cache = 1;
@@ -107,7 +118,7 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
             // Create a new cache to avoid overwriting the initialized default cache.
             ret = krb5_cc_new_unique(k5.ctx, deftype, nullptr, &k5.out_cc);
             if (ret)
-                throw Exception("Error while generating new cache", ErrorCodes::KERBEROS_ERROR);
+                throw Exception("Error while generating new cache" + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
             LOG_TRACE(log,"Using default cache: {}", krb5_cc_get_name(k5.ctx, k5.out_cc));
             k5.switch_to_cache = 1;
         }
@@ -123,24 +134,24 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
 
     ret = krb5_unparse_name(k5.ctx, k5.me, &k5.name);
     if (ret)
-        throw Exception("Error when unparsing name", ErrorCodes::KERBEROS_ERROR);
+        throw Exception("Error when unparsing name" + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
     LOG_TRACE(log,"Using principal: {}", k5.name);
 
     // Allocate a new initial credential options structure.
     ret = krb5_get_init_creds_opt_alloc(k5.ctx, &options);
     if (ret)
-        throw Exception("Error in options allocation", ErrorCodes::KERBEROS_ERROR);
+        throw Exception("Error in options allocation" + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
 
     // Resolve keytab
     ret = krb5_kt_resolve(k5.ctx, keytab_file.c_str(), &keytab);
     if (ret)
-        throw Exception("Error in resolving keytab "+keytab_file, ErrorCodes::KERBEROS_ERROR);
+        throw Exception("Error in resolving keytab "+keytab_file + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
     LOG_TRACE(log,"Using keytab: {}", keytab_file);
 
     // Set an output credential cache in initial credential options.
     ret = krb5_get_init_creds_opt_set_out_ccache(k5.ctx, options, k5.out_cc);
     if (ret)
-        throw Exception("Error in setting output credential cache", ErrorCodes::KERBEROS_ERROR);
+        throw Exception("Error in setting output credential cache" + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
 
     // Action: init or renew
     LOG_TRACE(log,"Trying to renew credentials");
@@ -153,7 +164,7 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
         // Request KDC for an initial credentials using keytab.
         ret = krb5_get_init_creds_keytab(k5.ctx, &my_creds, k5.me, keytab, 0, nullptr, options);
         if (ret)
-            throw Exception("Error in getting initial credentials", ErrorCodes::KERBEROS_ERROR);
+            throw Exception("Error in getting initial credentials" + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
         else
             LOG_TRACE(log,"Got initial credentials");
     }
@@ -163,7 +174,7 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
         // Initialize a credential cache. Destroy any existing contents of cache and initialize it for the default principal.
         ret = krb5_cc_initialize(k5.ctx, k5.out_cc, k5.me);
         if (ret)
-            throw Exception("Error when initializing cache", ErrorCodes::KERBEROS_ERROR);
+            throw Exception("Error when initializing cache" + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
         LOG_TRACE(log,"Initialized cache");
         // Store credentials in a credential cache.
         ret = krb5_cc_store_cred(k5.ctx, k5.out_cc, &my_creds);
@@ -177,11 +188,10 @@ int KerberosInit::init(const String & keytab_file, const String & principal, con
         // Make a credential cache the primary cache for its collection.
         ret = krb5_cc_switch(k5.ctx, k5.out_cc);
         if (ret)
-            throw Exception("Error while switching to new cache", ErrorCodes::KERBEROS_ERROR);
+            throw Exception("Error while switching to new cache" + fmtError(ret), ErrorCodes::KERBEROS_ERROR);
     }
 
     LOG_TRACE(log,"Authenticated to Kerberos v5");
-    return 0;
 }
 
 KerberosInit::~KerberosInit()
@@ -208,12 +218,12 @@ KerberosInit::~KerberosInit()
     }
 }
 
-int kerberosInit(const String & keytab_file, const String & principal, const String & cache_name)
+void kerberosInit(const String & keytab_file, const String & principal, const String & cache_name)
 {
     // Using mutex to prevent cache file corruptions
     static std::mutex kinit_mtx;
     std::unique_lock<std::mutex> lck(kinit_mtx);
     KerberosInit k_init;
-    return k_init.init(keytab_file, principal, cache_name);
+    k_init.init(keytab_file, principal, cache_name);
 }
 #endif // USE_KRB5

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -19,7 +19,9 @@ namespace ErrorCodes
 }
 }
 
-struct k5_data
+namespace
+{
+struct K5Data
 {
     krb5_context ctx;
     krb5_ccache in_cc, out_cc;
@@ -37,17 +39,18 @@ public:
     int init(const String & keytab_file, const String & principal, const String & cache_name = "");
     ~KerberosInit();
 private:
-    struct k5_data k5;
+    struct K5Data k5;
     krb5_ccache defcache = nullptr;
     krb5_get_init_creds_opt * options = nullptr;
     krb5_creds my_creds;
     krb5_keytab keytab = nullptr;
     krb5_principal defcache_princ = nullptr;
 };
+}
 
 int KerberosInit::init(const String & keytab_file, const String & principal, const String & cache_name)
 {
-    auto log = &Poco::Logger::get("KerberosInit");
+    auto * log = &Poco::Logger::get("KerberosInit");
     LOG_TRACE(log,"Trying to authenticate to Kerberos v5");
 
     krb5_error_code ret;

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -4,4 +4,8 @@
 
 #include <base/types.h>
 
+#if USE_KRB5
+
 int kerberosInit(const String & keytab_file, const String & principal, const String & cache_name = "");
+
+#endif // USE_KRB5

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "config_core.h"
+
+#include <base/types.h>
+
+//#include <k5-int.h>
+//#include "k5-platform.h"
+#include <krb5.h>
+//#include <extern.h>
+
+struct k5_data
+{
+    krb5_context ctx;
+    krb5_ccache in_cc, out_cc;
+    krb5_principal me;
+    char *name;
+    krb5_boolean switch_to_cache;
+};
+
+class KerberosInit
+{
+public:
+    int init(const String & keytab_file, const String & principal, const String & cache_name = "");
+    ~KerberosInit();
+private:
+    struct k5_data * k5 = nullptr;
+    //struct k5_data k5;
+    struct k5_data k5d;
+    krb5_ccache defcache = nullptr;
+    krb5_get_init_creds_opt *options = nullptr;
+    krb5_creds my_creds;
+    krb5_keytab keytab = nullptr;
+    char * principal_name;
+    krb5_principal defcache_princ = nullptr;
+};
+

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -20,7 +20,7 @@ struct k5_data
     krb5_context ctx;
     krb5_ccache in_cc, out_cc;
     krb5_principal me;
-    char *name;
+    char * name;
     krb5_boolean switch_to_cache;
 };
 
@@ -30,11 +30,9 @@ public:
     int init(const String & keytab_file, const String & principal, const String & cache_name = "");
     ~KerberosInit();
 private:
-    //struct k5_data * k5 = nullptr;
     struct k5_data k5;
-    //struct k5_data k5d;
     krb5_ccache defcache = nullptr;
-    krb5_get_init_creds_opt *options = nullptr;
+    krb5_get_init_creds_opt * options = nullptr;
     krb5_creds my_creds;
     krb5_keytab keytab = nullptr;
     krb5_principal defcache_princ = nullptr;

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -4,9 +4,6 @@
 
 #include <base/types.h>
 
-#include <krb5.h>
-#include <mutex>
-
 namespace DB
 {
 namespace ErrorCodes

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -31,7 +31,6 @@ private:
     krb5_get_init_creds_opt *options = nullptr;
     krb5_creds my_creds;
     krb5_keytab keytab = nullptr;
-    char * principal_name;
     krb5_principal defcache_princ = nullptr;
 };
 

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -15,27 +15,4 @@ namespace ErrorCodes
 }
 }
 
-struct k5_data
-{
-    krb5_context ctx;
-    krb5_ccache in_cc, out_cc;
-    krb5_principal me;
-    char * name;
-    krb5_boolean switch_to_cache;
-};
-
-class KerberosInit
-{
-public:
-    int init(const String & keytab_file, const String & principal, const String & cache_name = "");
-    ~KerberosInit();
-private:
-    struct k5_data k5;
-    krb5_ccache defcache = nullptr;
-    krb5_get_init_creds_opt * options = nullptr;
-    krb5_creds my_creds;
-    krb5_keytab keytab = nullptr;
-    krb5_principal defcache_princ = nullptr;
-    static std::mutex kinit_mtx;
-};
-
+int kerberosInit(const String & keytab_file, const String & principal, const String & cache_name = "");

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -4,12 +4,4 @@
 
 #include <base/types.h>
 
-namespace DB
-{
-namespace ErrorCodes
-{
-    extern const int KERBEROS_ERROR;
-}
-}
-
 int kerberosInit(const String & keytab_file, const String & principal, const String & cache_name = "");

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -4,10 +4,16 @@
 
 #include <base/types.h>
 
-//#include <k5-int.h>
-//#include "k5-platform.h"
 #include <krb5.h>
-//#include <extern.h>
+#include <mutex>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int KERBEROS_ERROR;
+}
+}
 
 struct k5_data
 {
@@ -24,13 +30,14 @@ public:
     int init(const String & keytab_file, const String & principal, const String & cache_name = "");
     ~KerberosInit();
 private:
-    struct k5_data * k5 = nullptr;
-    //struct k5_data k5;
-    struct k5_data k5d;
+    //struct k5_data * k5 = nullptr;
+    struct k5_data k5;
+    //struct k5_data k5d;
     krb5_ccache defcache = nullptr;
     krb5_get_init_creds_opt *options = nullptr;
     krb5_creds my_creds;
     krb5_keytab keytab = nullptr;
     krb5_principal defcache_princ = nullptr;
+    static std::mutex kinit_mtx;
 };
 

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -6,6 +6,6 @@
 
 #if USE_KRB5
 
-int kerberosInit(const String & keytab_file, const String & principal, const String & cache_name = "");
+void kerberosInit(const String & keytab_file, const String & principal, const String & cache_name = "");
 
 #endif // USE_KRB5

--- a/src/Access/examples/CMakeLists.txt
+++ b/src/Access/examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+if (TARGET ch_contrib::krb5)
+    add_executable (kerberos_init kerberos_init.cpp)
+    target_link_libraries (kerberos_init PRIVATE dbms ch_contrib::krb5)
+endif()

--- a/src/Access/examples/kerberos_init.cpp
+++ b/src/Access/examples/kerberos_init.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <Poco/ConsoleChannel.h>
+#include <Poco/Logger.h>
+#include <Poco/AutoPtr.h>
+#include <Common/Exception.h>
+#include <Access/KerberosInit.h>
+
+using namespace DB;
+
+int main(int argc, char ** argv)
+{
+    std::cout << "Kerberos Init" << "\n";
+
+    if (argc < 3)
+    {
+        std::cout << "Usage:" << "\n" << "    kerberos_init keytab principal [cache]" << "\n";
+        return 0;
+    }
+
+    String cache_name = "";
+    if (argc == 4)
+        cache_name = argv[3];
+
+    Poco::AutoPtr<Poco::ConsoleChannel> app_channel(new Poco::ConsoleChannel(std::cerr));
+    Poco::Logger::root().setChannel(app_channel);
+    Poco::Logger::root().setLevel("trace");
+
+    KerberosInit k_init;
+    try {
+        k_init.init(argv[1], argv[2], cache_name);
+    } catch (const Exception & e) {
+         std::cout << "KerberosInit failure: " << getExceptionMessage(e, false) << "\n";
+    }
+    std::cout << "Done" << "\n";
+    return 0;
+}

--- a/src/Access/examples/kerberos_init.cpp
+++ b/src/Access/examples/kerberos_init.cpp
@@ -26,7 +26,8 @@ int main(int argc, char ** argv)
     Poco::Logger::root().setLevel("trace");
 
     KerberosInit k_init;
-    try {
+    try
+    {
         k_init.init(argv[1], argv[2], cache_name);
     } catch (const Exception & e) {
          std::cout << "KerberosInit failure: " << getExceptionMessage(e, false) << "\n";

--- a/src/Access/examples/kerberos_init.cpp
+++ b/src/Access/examples/kerberos_init.cpp
@@ -26,10 +26,9 @@ int main(int argc, char ** argv)
     Poco::Logger::root().setChannel(app_channel);
     Poco::Logger::root().setLevel("trace");
 
-    KerberosInit k_init;
     try
     {
-        k_init.init(argv[1], argv[2], cache_name);
+        kerberosInit(argv[1], argv[2], cache_name);
     } catch (const Exception & e) {
          std::cout << "KerberosInit failure: " << getExceptionMessage(e, false) << "\n";
         return -1;

--- a/src/Access/examples/kerberos_init.cpp
+++ b/src/Access/examples/kerberos_init.cpp
@@ -29,8 +29,10 @@ int main(int argc, char ** argv)
     try
     {
         kerberosInit(argv[1], argv[2], cache_name);
-    } catch (const Exception & e) {
-         std::cout << "KerberosInit failure: " << getExceptionMessage(e, false) << "\n";
+    }
+    catch (const Exception & e)
+    {
+        std::cout << "KerberosInit failure: " << getExceptionMessage(e, false) << "\n";
         return -1;
     }
     std::cout << "Done" << "\n";

--- a/src/Access/examples/kerberos_init.cpp
+++ b/src/Access/examples/kerberos_init.cpp
@@ -13,6 +13,7 @@ int main(int argc, char ** argv)
 
     if (argc < 3)
     {
+        std::cout << "kerberos_init obtains and caches an initial ticket-granting ticket for principal." << "\n\n";
         std::cout << "Usage:" << "\n" << "    kerberos_init keytab principal [cache]" << "\n";
         return 0;
     }
@@ -31,6 +32,7 @@ int main(int argc, char ** argv)
         k_init.init(argv[1], argv[2], cache_name);
     } catch (const Exception & e) {
          std::cout << "KerberosInit failure: " << getExceptionMessage(e, false) << "\n";
+        return -1;
     }
     std::cout << "Done" << "\n";
     return 0;

--- a/src/Access/examples/kerberos_init.cpp
+++ b/src/Access/examples/kerberos_init.cpp
@@ -5,6 +5,13 @@
 #include <Common/Exception.h>
 #include <Access/KerberosInit.h>
 
+/** The example demonstrates using of kerberosInit function to obtain and cache Kerberos ticket-granting ticket.
+  * The first argument specifies keytab file. The second argument specifies principal name.
+  * The third argument is optional. It specifies credentials cache location.
+  * After successful run of kerberos_init it is useful to call klist command to list cached Kerberos tickets.
+  * It is also useful to run kdestroy to destroy Kerberos tickets if needed.
+  */
+
 using namespace DB;
 
 int main(int argc, char ** argv)

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -73,7 +73,7 @@ void HDFSBuilderWrapper::loadFromConfig(const Poco::Util::AbstractConfiguration 
 
 void HDFSBuilderWrapper::runKinit()
 {
-    LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "ADQM: running KerberosInit");
+    LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Running KerberosInit");
     KerberosInit k_init;
     try
     {
@@ -81,7 +81,7 @@ void HDFSBuilderWrapper::runKinit()
     } catch (const DB::Exception & e) {
         throw Exception("KerberosInit failure: "+ getExceptionMessage(e, false), ErrorCodes::KERBEROS_ERROR);
     }
-    LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "ADQM: finished KerberosInit");
+    LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Finished KerberosInit");
 }
 
 HDFSBuilderWrapper createHDFSBuilder(const String & uri_str, const Poco::Util::AbstractConfiguration & config)

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -121,9 +121,7 @@ void HDFSBuilderWrapper::runKinit()
     try {
         k_init.init(hadoop_kerberos_keytab,hadoop_kerberos_principal,hadoop_security_kerberos_ticket_cache_path);
     } catch (const DB::Exception & e) {
-        String msg =  "KerberosInit failure: " + DB::getExceptionMessage(e, false);
-        LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "ADQM: {}",msg);
-        throw Exception(0, msg);
+        throw Exception("KerberosInit failure: "+ DB::getExceptionMessage(e, false), ErrorCodes::BAD_ARGUMENTS);
     }
     LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "ADQM: finished KerberosInit");
 }

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -21,6 +21,7 @@ namespace ErrorCodes
     extern const int NETWORK_ERROR;
     extern const int EXCESSIVE_ELEMENT_IN_CONFIG;
     extern const int NO_ELEMENTS_IN_CONFIG;
+    extern const int KERBEROS_ERROR;
 }
 
 const String HDFSBuilderWrapper::CONFIG_PREFIX = "hdfs";

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -118,7 +118,8 @@ void HDFSBuilderWrapper::runKinit()
     LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "ADQM: running KerberosInit");
     std::unique_lock<std::mutex> lck(kinit_mtx);
     KerberosInit k_init;
-    try {
+    try
+    {
         k_init.init(hadoop_kerberos_keytab,hadoop_kerberos_principal,hadoop_security_kerberos_ticket_cache_path);
     } catch (const DB::Exception & e) {
         throw Exception("KerberosInit failure: "+ DB::getExceptionMessage(e, false), ErrorCodes::BAD_ARGUMENTS);

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -74,10 +74,9 @@ void HDFSBuilderWrapper::loadFromConfig(const Poco::Util::AbstractConfiguration 
 void HDFSBuilderWrapper::runKinit()
 {
     LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Running KerberosInit");
-    KerberosInit k_init;
     try
     {
-        k_init.init(hadoop_kerberos_keytab,hadoop_kerberos_principal,hadoop_security_kerberos_ticket_cache_path);
+        kerberosInit(hadoop_kerberos_keytab,hadoop_kerberos_principal,hadoop_security_kerberos_ticket_cache_path);
     }
     catch (const DB::Exception & e)
     {

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -77,44 +77,8 @@ void HDFSBuilderWrapper::loadFromConfig(const Poco::Util::AbstractConfiguration 
     }
 }
 
-String HDFSBuilderWrapper::getKinitCmd()
-{
-
-    if (hadoop_kerberos_keytab.empty() || hadoop_kerberos_principal.empty())
-    {
-        throw Exception("Not enough parameters to run kinit",
-            ErrorCodes::NO_ELEMENTS_IN_CONFIG);
-    }
-
-    WriteBufferFromOwnString ss;
-
-    String cache_name =  hadoop_security_kerberos_ticket_cache_path.empty() ?
-        String() :
-        (String(" -c \"") + hadoop_security_kerberos_ticket_cache_path + "\"");
-
-    // command to run looks like
-    // kinit -R -t /keytab_dir/clickhouse.keytab -k somebody@TEST.CLICKHOUSE.TECH || ..
-    ss << hadoop_kerberos_kinit_command << cache_name <<
-        " -R -t \"" << hadoop_kerberos_keytab << "\" -k " << hadoop_kerberos_principal <<
-        "|| " << hadoop_kerberos_kinit_command << cache_name << " -t \"" <<
-        hadoop_kerberos_keytab << "\" -k " << hadoop_kerberos_principal;
-    return ss.str();
-}
-
 void HDFSBuilderWrapper::runKinit()
-{   /*
-    String cmd = getKinitCmd();
-    LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "running kinit: {}", cmd);
-
-    std::unique_lock<std::mutex> lck(kinit_mtx);
-
-    auto command = ShellCommand::execute(cmd);
-    auto status = command->tryWait();
-    if (status)
-    {
-        throw Exception("kinit failure: " + cmd, ErrorCodes::BAD_ARGUMENTS);
-    }
-    */
+{
     LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "ADQM: running KerberosInit");
     std::unique_lock<std::mutex> lck(kinit_mtx);
     KerberosInit k_init;

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -119,7 +119,7 @@ void HDFSBuilderWrapper::runKinit()
     std::unique_lock<std::mutex> lck(kinit_mtx);
     KerberosInit k_init;
     try {
-        k_init.init(hadoop_kerberos_keytab,hadoop_kerberos_principal);
+        k_init.init(hadoop_kerberos_keytab,hadoop_kerberos_principal,hadoop_security_kerberos_ticket_cache_path);
     } catch (const DB::Exception & e) {
         String msg =  "KerberosInit failure: " + DB::getExceptionMessage(e, false);
         LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "ADQM: {}",msg);

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -171,10 +171,12 @@ HDFSBuilderWrapper createHDFSBuilder(const String & uri_str, const Poco::Util::A
         }
     }
 
+    #if USE_KRB5
     if (builder.need_kinit)
     {
         builder.runKinit();
     }
+    #endif // USE_KRB5
 
     return builder;
 }

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -78,7 +78,9 @@ void HDFSBuilderWrapper::runKinit()
     try
     {
         k_init.init(hadoop_kerberos_keytab,hadoop_kerberos_principal,hadoop_security_kerberos_ticket_cache_path);
-    } catch (const DB::Exception & e) {
+    }
+    catch (const DB::Exception & e)
+    {
         throw Exception("KerberosInit failure: "+ getExceptionMessage(e, false), ErrorCodes::KERBEROS_ERROR);
     }
     LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Finished KerberosInit");

--- a/src/Storages/HDFS/HDFSCommon.cpp
+++ b/src/Storages/HDFS/HDFSCommon.cpp
@@ -10,8 +10,9 @@
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
 #include <Common/logger_useful.h>
+#if USE_KRB5
 #include <Access/KerberosInit.h>
-
+#endif // USE_KRB5
 
 namespace DB
 {
@@ -74,6 +75,7 @@ void HDFSBuilderWrapper::loadFromConfig(const Poco::Util::AbstractConfiguration 
 
 void HDFSBuilderWrapper::runKinit()
 {
+    #if USE_KRB5
     LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Running KerberosInit");
     try
     {
@@ -84,6 +86,7 @@ void HDFSBuilderWrapper::runKinit()
         throw Exception("KerberosInit failure: "+ getExceptionMessage(e, false), ErrorCodes::KERBEROS_ERROR);
     }
     LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Finished KerberosInit");
+    #endif // USE_KRB5
 }
 
 HDFSBuilderWrapper createHDFSBuilder(const String & uri_str, const Poco::Util::AbstractConfiguration & config)

--- a/src/Storages/HDFS/HDFSCommon.h
+++ b/src/Storages/HDFS/HDFSCommon.h
@@ -69,8 +69,6 @@ public:
 private:
     void loadFromConfig(const Poco::Util::AbstractConfiguration & config, const String & prefix, bool isUser = false);
 
-    String getKinitCmd();
-
     void runKinit();
 
     // hdfs builder relies on an external config data storage

--- a/src/Storages/HDFS/HDFSCommon.h
+++ b/src/Storages/HDFS/HDFSCommon.h
@@ -68,8 +68,6 @@ public:
 private:
     void loadFromConfig(const Poco::Util::AbstractConfiguration & config, const String & prefix, bool isUser = false);
 
-    void runKinit();
-
     // hdfs builder relies on an external config data storage
     std::pair<String, String>& keep(const String & k, const String & v)
     {
@@ -77,12 +75,15 @@ private:
     }
 
     hdfsBuilder * hdfs_builder;
+    std::vector<std::pair<String, String>> config_stor;
+
+    #if USE_KRB5
+    void runKinit();
     String hadoop_kerberos_keytab;
     String hadoop_kerberos_principal;
     String hadoop_security_kerberos_ticket_cache_path;
-
-    std::vector<std::pair<String, String>> config_stor;
     bool need_kinit{false};
+    #endif // USE_KRB5
 };
 
 using HDFSFSPtr = std::unique_ptr<std::remove_pointer_t<hdfsFS>, detail::HDFSFsDeleter>;

--- a/src/Storages/HDFS/HDFSCommon.h
+++ b/src/Storages/HDFS/HDFSCommon.h
@@ -9,7 +9,6 @@
 
 #include <hdfs/hdfs.h>
 #include <base/types.h>
-#include <mutex>
 
 #include <Interpreters/Context.h>
 #include <Poco/Util/AbstractConfiguration.h>
@@ -80,10 +79,8 @@ private:
     hdfsBuilder * hdfs_builder;
     String hadoop_kerberos_keytab;
     String hadoop_kerberos_principal;
-    String hadoop_kerberos_kinit_command = "kinit";
     String hadoop_security_kerberos_ticket_cache_path;
 
-    static std::mutex kinit_mtx;
     std::vector<std::pair<String, String>> config_stor;
     bool need_kinit{false};
 };

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -519,19 +519,17 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
 
     if (conf.has_property("sasl.kerberos.keytab") && conf.has_property("sasl.kerberos.principal"))
     {
-        LOG_DEBUG(log, "ADQM: preparing KerberosInit");
         String keytab = conf.get("sasl.kerberos.keytab");
         String principal = conf.get("sasl.kerberos.principal");
-        LOG_DEBUG(log, "ADQM: keytab: {}, principal: {}", keytab, principal);
-        LOG_DEBUG(log, "ADQM: running KerberosInit");
+        LOG_DEBUG(log, "Running KerberosInit");
         KerberosInit k_init;
         try
         {
             k_init.init(keytab,principal);
         } catch (const Exception & e) {
-            LOG_ERROR(log, "ADQM: KerberosInit failure: {}", getExceptionMessage(e, false));
+            LOG_ERROR(log, "KerberosInit failure: {}", getExceptionMessage(e, false));
         }
-        LOG_DEBUG(log, "ADQM: finished KerberosInit");
+        LOG_DEBUG(log, "Finished KerberosInit");
         conf.set("sasl.kerberos.kinit.cmd","");
         conf.set("sasl.kerberos.min.time.before.relogin","0");
     }

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -517,6 +517,12 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
     if (config.has(config_prefix))
         loadFromConfig(conf, config, config_prefix);
 
+    if (conf.has_property("sasl.kerberos.kinit.cmd"))
+        LOG_WARNING(log, "kinit executable is not allowed.");
+
+    conf.set("sasl.kerberos.kinit.cmd","");
+    conf.set("sasl.kerberos.min.time.before.relogin","0");
+
     if (conf.has_property("sasl.kerberos.keytab") && conf.has_property("sasl.kerberos.principal"))
     {
         String keytab = conf.get("sasl.kerberos.keytab");
@@ -526,12 +532,12 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
         try
         {
             k_init.init(keytab,principal);
-        } catch (const Exception & e) {
+        }
+        catch (const Exception & e)
+        {
             LOG_ERROR(log, "KerberosInit failure: {}", getExceptionMessage(e, false));
         }
         LOG_DEBUG(log, "Finished KerberosInit");
-        conf.set("sasl.kerberos.kinit.cmd","");
-        conf.set("sasl.kerberos.min.time.before.relogin","0");
     }
 
     // Update consumer topic-specific configuration

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -539,6 +539,9 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
         }
         LOG_DEBUG(log, "Finished KerberosInit");
     }
+    #else // USE_KRB5
+    if (conf.has_property("sasl.kerberos.keytab") || conf.has_property("sasl.kerberos.principal"))
+        LOG_WARNING(log, "Kerberos-related parameters are ignored because ClickHouse was built without support of krb5 library.");
     #endif // USE_KRB5
 
     // Update consumer topic-specific configuration

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -518,7 +518,7 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
         loadFromConfig(conf, config, config_prefix);
 
     if (conf.has_property("sasl.kerberos.kinit.cmd"))
-        LOG_WARNING(log, "kinit executable is not allowed.");
+        LOG_WARNING(log, "sasl.kerberos.kinit.cmd configuration parameter is ignored.");
 
     conf.set("sasl.kerberos.kinit.cmd","");
     conf.set("sasl.kerberos.min.time.before.relogin","0");

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -528,10 +528,9 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
         String keytab = conf.get("sasl.kerberos.keytab");
         String principal = conf.get("sasl.kerberos.principal");
         LOG_DEBUG(log, "Running KerberosInit");
-        KerberosInit k_init;
         try
         {
-            k_init.init(keytab,principal);
+            kerberosInit(keytab,principal);
         }
         catch (const Exception & e)
         {

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -43,9 +43,9 @@
 
 #include <Common/CurrentMetrics.h>
 #include <Common/ProfileEvents.h>
-
+#if USE_KRB5
 #include <Access/KerberosInit.h>
-
+#endif // USE_KRB5
 
 namespace CurrentMetrics
 {
@@ -517,6 +517,7 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
     if (config.has(config_prefix))
         loadFromConfig(conf, config, config_prefix);
 
+    #if USE_KRB5
     if (conf.has_property("sasl.kerberos.kinit.cmd"))
         LOG_WARNING(log, "sasl.kerberos.kinit.cmd configuration parameter is ignored.");
 
@@ -538,6 +539,7 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
         }
         LOG_DEBUG(log, "Finished KerberosInit");
     }
+    #endif // USE_KRB5
 
     // Update consumer topic-specific configuration
     for (const auto & topic : topics)

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -528,8 +528,8 @@ void StorageKafka::updateConfiguration(cppkafka::Configuration & conf)
         try
         {
             k_init.init(keytab,principal);
-        } catch (const DB::Exception & e) {
-            LOG_ERROR(log, "ADQM: KerberosInit failure: {}", DB::getExceptionMessage(e, false));
+        } catch (const Exception & e) {
+            LOG_ERROR(log, "ADQM: KerberosInit failure: {}", getExceptionMessage(e, false));
         }
         LOG_DEBUG(log, "ADQM: finished KerberosInit");
         conf.set("sasl.kerberos.kinit.cmd","");

--- a/tests/integration/test_storage_kerberized_hdfs/test.py
+++ b/tests/integration/test_storage_kerberized_hdfs/test.py
@@ -113,7 +113,7 @@ def test_read_table_expired(started_cluster):
         )
         assert False, "Exception have to be thrown"
     except Exception as ex:
-        assert "DB::Exception: kinit failure:" in str(ex)
+        assert "DB::Exception: KerberosInit failure:" in str(ex)
 
     started_cluster.unpause_container("hdfskerberos")
 

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -122,12 +122,51 @@ def test_kafka_json_as_string(kafka_cluster):
 {"t": 124, "e": {"x": "test"} }
 {"F1":"V1","F2":{"F21":"V21","F22":{},"F23":"V23","F24":"2019-12-24T16:28:04"},"F3":"V3"}
 """
-    logging.debug("ADQM: logs: %s", instance.grep_in_log("ADQM"))
     assert TSV(result) == TSV(expected)
     assert instance.contains_in_log(
         "Parsing of message (topic: kafka_json_as_string, partition: 0, offset: 1) return no rows"
     )
 
+def test_kafka_json_as_string_request_new_ticket_after_expiration(kafka_cluster):
+    # Ticket should be expired after the wait time
+    # On run of SELECT query new ticket should be requested and SELECT query should run fine.
+
+    kafka_produce(
+        kafka_cluster,
+        "kafka_json_as_string",
+        [
+            '{"t": 123, "e": {"x": "woof"} }',
+            "",
+            '{"t": 124, "e": {"x": "test"} }',
+            '{"F1":"V1","F2":{"F21":"V21","F22":{},"F23":"V23","F24":"2019-12-24T16:28:04"},"F3":"V3"}',
+        ],
+    )
+
+    instance.query(
+        """
+        CREATE TABLE test.kafka (field String)
+            ENGINE = Kafka
+            SETTINGS kafka_broker_list = 'kerberized_kafka1:19092',
+                     kafka_topic_list = 'kafka_json_as_string',
+                     kafka_commit_on_select = 1,
+                     kafka_group_name = 'kafka_json_as_string',
+                     kafka_format = 'JSONAsString',
+                     kafka_flush_interval_ms=1000;
+        """
+    )
+
+    time.sleep(45) # wait for ticket expiration
+
+    result = instance.query("SELECT * FROM test.kafka;")
+    expected = """\
+{"t": 123, "e": {"x": "woof"} }
+{"t": 124, "e": {"x": "test"} }
+{"F1":"V1","F2":{"F21":"V21","F22":{},"F23":"V23","F24":"2019-12-24T16:28:04"},"F3":"V3"}
+"""
+    assert TSV(result) == TSV(expected)
+    assert instance.contains_in_log(
+        "Parsing of message (topic: kafka_json_as_string, partition: 0, offset: 1) return no rows"
+    )
 
 def test_kafka_json_as_string_no_kdc(kafka_cluster):
     # When the test is run alone (not preceded by any other kerberized kafka test),

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -127,6 +127,7 @@ def test_kafka_json_as_string(kafka_cluster):
         "Parsing of message (topic: kafka_json_as_string, partition: 0, offset: 1) return no rows"
     )
 
+
 def test_kafka_json_as_string_request_new_ticket_after_expiration(kafka_cluster):
     # Ticket should be expired after the wait time
     # On run of SELECT query new ticket should be requested and SELECT query should run fine.
@@ -155,7 +156,7 @@ def test_kafka_json_as_string_request_new_ticket_after_expiration(kafka_cluster)
         """
     )
 
-    time.sleep(45) # wait for ticket expiration
+    time.sleep(45)  # wait for ticket expiration
 
     result = instance.query("SELECT * FROM test.kafka;")
     expected = """\
@@ -167,6 +168,7 @@ def test_kafka_json_as_string_request_new_ticket_after_expiration(kafka_cluster)
     assert instance.contains_in_log(
         "Parsing of message (topic: kafka_json_as_string, partition: 0, offset: 1) return no rows"
     )
+
 
 def test_kafka_json_as_string_no_kdc(kafka_cluster):
     # When the test is run alone (not preceded by any other kerberized kafka test),
@@ -222,7 +224,6 @@ def test_kafka_json_as_string_no_kdc(kafka_cluster):
     assert TSV(result) == TSV(expected)
     assert instance.contains_in_log("StorageKafka (kafka_no_kdc): Nothing to commit")
     assert instance.contains_in_log("Ticket expired")
-    #~ assert instance.contains_in_log("Kerberos ticket refresh failed")
     assert instance.contains_in_log("KerberosInit failure:")
 
 

--- a/tests/integration/test_storage_kerberized_kafka/test.py
+++ b/tests/integration/test_storage_kerberized_kafka/test.py
@@ -122,6 +122,7 @@ def test_kafka_json_as_string(kafka_cluster):
 {"t": 124, "e": {"x": "test"} }
 {"F1":"V1","F2":{"F21":"V21","F22":{},"F23":"V23","F24":"2019-12-24T16:28:04"},"F3":"V3"}
 """
+    logging.debug("ADQM: logs: %s", instance.grep_in_log("ADQM"))
     assert TSV(result) == TSV(expected)
     assert instance.contains_in_log(
         "Parsing of message (topic: kafka_json_as_string, partition: 0, offset: 1) return no rows"
@@ -182,7 +183,8 @@ def test_kafka_json_as_string_no_kdc(kafka_cluster):
     assert TSV(result) == TSV(expected)
     assert instance.contains_in_log("StorageKafka (kafka_no_kdc): Nothing to commit")
     assert instance.contains_in_log("Ticket expired")
-    assert instance.contains_in_log("Kerberos ticket refresh failed")
+    #~ assert instance.contains_in_log("Kerberos ticket refresh failed")
+    assert instance.contains_in_log("KerberosInit failure:")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added  kerberosInit function and corresponding KerberosInit class as a replacement for kinit executable. Replaced all calls of kinit in Kafka and HDFS code by call of kerberosInit function. Added new integration test.
Closes  #27651
