### PR TITLE
Some fixes for tests with tsan

### DIFF
--- a/base/harmful/harmful.c
+++ b/base/harmful/harmful.c
@@ -260,4 +260,35 @@ TRAP(mq_timedreceive)
 TRAP(wordexp)
 TRAP(wordfree)
 
+/// C11 threading primitives are not supported by ThreadSanitizer.
+/// Also we should avoid using them for compatibility with old libc.
+TRAP(thrd_create)
+TRAP(thrd_equal)
+TRAP(thrd_current)
+TRAP(thrd_sleep)
+TRAP(thrd_yield)
+TRAP(thrd_exit)
+TRAP(thrd_detach)
+TRAP(thrd_join)
+
+TRAP(mtx_init)
+TRAP(mtx_lock)
+TRAP(mtx_timedlock)
+TRAP(mtx_trylock)
+TRAP(mtx_unlock)
+TRAP(mtx_destroy)
+TRAP(call_once)
+
+TRAP(cnd_init)
+TRAP(cnd_signal)
+TRAP(cnd_broadcast)
+TRAP(cnd_wait)
+TRAP(cnd_timedwait)
+TRAP(cnd_destroy)
+
+TRAP(tss_create)
+TRAP(tss_get)
+TRAP(tss_set)
+TRAP(tss_delete)
+
 #endif

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -7,26 +7,27 @@ set -x
 
 # Thread Fuzzer allows to check more permutations of possible thread scheduling
 # and find more potential issues.
+is_tsan_build=$(clickhouse local -q "select value like '% -fsanitize=thread %' from system.build_options where name='CXX_FLAGS'")
+if [ "$is_tsan_build" -eq "0" ]; then
+    export THREAD_FUZZER_CPU_TIME_PERIOD_US=1000
+    export THREAD_FUZZER_SLEEP_PROBABILITY=0.1
+    export THREAD_FUZZER_SLEEP_TIME_US=100000
 
-export THREAD_FUZZER_CPU_TIME_PERIOD_US=1000
-export THREAD_FUZZER_SLEEP_PROBABILITY=0.1
-export THREAD_FUZZER_SLEEP_TIME_US=100000
+    export THREAD_FUZZER_pthread_mutex_lock_BEFORE_MIGRATE_PROBABILITY=1
+    export THREAD_FUZZER_pthread_mutex_lock_AFTER_MIGRATE_PROBABILITY=1
+    export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_MIGRATE_PROBABILITY=1
+    export THREAD_FUZZER_pthread_mutex_unlock_AFTER_MIGRATE_PROBABILITY=1
 
-export THREAD_FUZZER_pthread_mutex_lock_BEFORE_MIGRATE_PROBABILITY=1
-export THREAD_FUZZER_pthread_mutex_lock_AFTER_MIGRATE_PROBABILITY=1
-export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_MIGRATE_PROBABILITY=1
-export THREAD_FUZZER_pthread_mutex_unlock_AFTER_MIGRATE_PROBABILITY=1
+    export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_PROBABILITY=0.001
+    export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_PROBABILITY=0.001
+    export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_PROBABILITY=0.001
+    export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_PROBABILITY=0.001
+    export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_TIME_US=10000
 
-export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_PROBABILITY=0.001
-export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_PROBABILITY=0.001
-export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_PROBABILITY=0.001
-export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_PROBABILITY=0.001
-export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_TIME_US=10000
-
-export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_TIME_US=10000
-export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_TIME_US=10000
-export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_TIME_US=10000
-
+    export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_TIME_US=10000
+    export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_TIME_US=10000
+    export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_TIME_US=10000
+fi
 
 function install_packages()
 {

--- a/tests/queries/0_stateless/00984_parser_stack_overflow.sh
+++ b/tests/queries/0_stateless/00984_parser_stack_overflow.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tags: no-tsan
-# FIXME should work with tsan
+# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 # Such a huge timeout mostly for debug build.
 CLICKHOUSE_CURL_TIMEOUT=60

--- a/tests/queries/0_stateless/00984_parser_stack_overflow.sh
+++ b/tests/queries/0_stateless/00984_parser_stack_overflow.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-tsan
+# FIXME should work with tsan
 
 # Such a huge timeout mostly for debug build.
 CLICKHOUSE_CURL_TIMEOUT=60

--- a/tests/queries/0_stateless/01172_transaction_counters.sql
+++ b/tests/queries/0_stateless/01172_transaction_counters.sql
@@ -1,5 +1,6 @@
--- Tags: no-s3-storage
+-- Tags: no-s3-storage, no-tsan
 -- FIXME this test fails with S3 due to a bug in DiskCacheWrapper
+-- FIXME should work with tsan
 drop table if exists txn_counters;
 
 create table txn_counters (n Int64, creation_tid DEFAULT transactionID()) engine=MergeTree order by n;

--- a/tests/queries/0_stateless/01172_transaction_counters.sql
+++ b/tests/queries/0_stateless/01172_transaction_counters.sql
@@ -1,6 +1,6 @@
 -- Tags: no-s3-storage, no-tsan
 -- FIXME this test fails with S3 due to a bug in DiskCacheWrapper
--- FIXME should work with tsan
+-- FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 drop table if exists txn_counters;
 
 create table txn_counters (n Int64, creation_tid DEFAULT transactionID()) engine=MergeTree order by n;

--- a/tests/queries/0_stateless/01183_custom_separated_format_http.sh
+++ b/tests/queries/0_stateless/01183_custom_separated_format_http.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tags: no-tsan
-# FIXME should work with tsan
+# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01183_custom_separated_format_http.sh
+++ b/tests/queries/0_stateless/01183_custom_separated_format_http.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-tsan
+# FIXME should work with tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01184_long_insert_values_huge_strings.sh
+++ b/tests/queries/0_stateless/01184_long_insert_values_huge_strings.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tags: long, no-tsan
-# FIXME should work with tsan
+# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01184_long_insert_values_huge_strings.sh
+++ b/tests/queries/0_stateless/01184_long_insert_values_huge_strings.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-tsan
+# FIXME should work with tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01651_lc_insert_tiny_log.sql
+++ b/tests/queries/0_stateless/01651_lc_insert_tiny_log.sql
@@ -1,3 +1,6 @@
+-- Tags: no-tsan
+-- FIXME should work with tsan
+
 drop table if exists perf_lc_num;
 
 CREATE TABLE perf_lc_num(　        num UInt8,　        arr Array(LowCardinality(Int64)) default [num]　        ) ENGINE = TinyLog;

--- a/tests/queries/0_stateless/01651_lc_insert_tiny_log.sql
+++ b/tests/queries/0_stateless/01651_lc_insert_tiny_log.sql
@@ -1,5 +1,5 @@
 -- Tags: no-tsan
--- FIXME should work with tsan
+-- FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 drop table if exists perf_lc_num;
 

--- a/tests/queries/0_stateless/01746_long_zstd_http_compression_json_format.sh
+++ b/tests/queries/0_stateless/01746_long_zstd_http_compression_json_format.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest
+# Tags: long, no-fasttest, no-tsan
+# FIXME should work with tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01746_long_zstd_http_compression_json_format.sh
+++ b/tests/queries/0_stateless/01746_long_zstd_http_compression_json_format.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tags: long, no-fasttest, no-tsan
-# FIXME should work with tsan
+# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01926_order_by_desc_limit.sql
+++ b/tests/queries/0_stateless/01926_order_by_desc_limit.sql
@@ -1,4 +1,5 @@
--- Tags: no-random-settings
+-- Tags: no-random-settings, no-tsan
+-- FIXME should work with tsan
 
 DROP TABLE IF EXISTS order_by_desc;
 

--- a/tests/queries/0_stateless/01926_order_by_desc_limit.sql
+++ b/tests/queries/0_stateless/01926_order_by_desc_limit.sql
@@ -1,5 +1,5 @@
 -- Tags: no-random-settings, no-tsan
--- FIXME should work with tsan
+-- FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 DROP TABLE IF EXISTS order_by_desc;
 

--- a/tests/queries/1_stateful/00159_parallel_formatting_http.sh
+++ b/tests/queries/1_stateful/00159_parallel_formatting_http.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Tags: no-tsan
-# FIXME should work with tsan
+# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/1_stateful/00159_parallel_formatting_http.sh
+++ b/tests/queries/1_stateful/00159_parallel_formatting_http.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-tsan
+# FIXME should work with tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Changes:
- Temporarily disable [the most flaky](https://play.clickhouse.com/play?user=play&url=https%3A%2F%2Fplay.clickhouse.com%2F#U0VMRUNUIGNoZWNrX25hbWUsIHRlc3RfbmFtZSBBUyBuYW1lLCBjb3VudCgpIEFTIGMsIGNvdW50RGlzdGluY3QocHVsbF9yZXF1ZXN0X251bWJlcikgYXMgY2QsIGFyZ01heChyZXBvcnRfdXJsLCBjaGVja19zdGFydF90aW1lKQpGUk9NIGNoZWNrcwpXSEVSRQogICAgY2hlY2tfbmFtZSBMSUtFICclU3RhdGUldGhyZWFkJScKICAgIEFORCAodGVzdF9zdGF0dXMgTElLRSAnRiUnIE9SIHRlc3Rfc3RhdHVzIExJS0UgJ0UlJykKICAgIEFORCBjaGVja19zdGFydF90aW1lID49IHRvZGF5KCkgLSA3CkdST1VQIEJZIGNoZWNrX25hbWUsIG5hbWUKSEFWSU5HIG1heChjaGVja19zdGFydF90aW1lKSA+PSBub3coKSAtIElOVEVSVkFMIDI0MCBIT1VSCk9SREVSIEJZIGMgREVTQw==) functional tests
- Temporarily disable ThreadFuzzer with ThreadSanitizer (#38019)
- Add C11 threading primitives to the list of harmful functions, rename confusing functions in librdkafka (#36547)

**It does not fix random timeouts in checks with tsan, the reason of these failures is still unknown.**
