### PR TITLE
Try random container name in integration tests runner

### DIFF
--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -9,11 +9,21 @@ import logging
 import signal
 import subprocess
 import sys
+import string
+import random
+
+
+def random_str(length=6):
+    alphabet = string.ascii_lowercase + string.digits
+    return "".join(
+        random.SystemRandom().choice(alphabet) for _ in range(length)
+    )
+
 
 CUR_FILE_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_CLICKHOUSE_ROOT = os.path.abspath(os.path.join(CUR_FILE_DIR, "../../"))
 CURRENT_WORK_DIR = os.getcwd()
-CONTAINER_NAME = "clickhouse_integration_tests"
+CONTAINER_NAME = f"clickhouse_integration_tests_{random_str()}"
 
 CONFIG_DIR_IN_REPO = "programs/server"
 INTERGATION_DIR_IN_REPO = "tests/integration"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


I hope it will fix failures like this:
```
2022-06-14 18:06:22,850 [ 811394 ] INFO : Unknown image clickhouse/integration-helper (runner:246, <module>)
Error response from daemon: Cannot kill container: 6f3d71a319b8: tried to kill container, but did not receive an exit event
docker: Error response from daemon: Conflict. The container name "/clickhouse_integration_tests" is already in use by container "6f3d71a319b8435af3c1b198f0bbc785da5f3895f54f4cdbaa8753d7ed538890". You have to remove (or rename) that container to be able to reuse that name.
See 'docker run --help'.
Traceback (most recent call last):
  File "./runner", line 316, in <module>
    subprocess.check_call(cmd, shell=True)
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
```
