### PR TITLE
Remove unused class member

### DIFF
--- a/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -257,7 +257,6 @@ SelectStreamFactory::ShardPlans SelectStreamFactory::createForShardWithParallelR
             std::move(scalars),
             std::move(external_tables),
             &Poco::Logger::get("ReadFromParallelRemoteReplicasStep"),
-            shard_count,
             storage_limits);
 
         remote_plan->addStep(std::move(read_from_remote));

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -239,7 +239,6 @@ ReadFromParallelRemoteReplicasStep::ReadFromParallelRemoteReplicasStep(
     Scalars scalars_,
     Tables external_tables_,
     Poco::Logger * log_,
-    UInt32 shard_count_,
     std::shared_ptr<const StorageLimitsList> storage_limits_)
     : ISourceStep(DataStream{.header = std::move(header_)})
     , coordinator(std::move(coordinator_))
@@ -253,7 +252,6 @@ ReadFromParallelRemoteReplicasStep::ReadFromParallelRemoteReplicasStep(
     , external_tables{external_tables_}
     , storage_limits(std::move(storage_limits_))
     , log(log_)
-    , shard_count(shard_count_)
 {
     std::vector<String> description;
 

--- a/src/Processors/QueryPlan/ReadFromRemote.h
+++ b/src/Processors/QueryPlan/ReadFromRemote.h
@@ -83,7 +83,6 @@ public:
         Scalars scalars_,
         Tables external_tables_,
         Poco::Logger * log_,
-        UInt32 shard_count_,
         std::shared_ptr<const StorageLimitsList> storage_limits_);
 
     String getName() const override { return "ReadFromRemoteParallelReplicas"; }
@@ -110,8 +109,6 @@ private:
     std::shared_ptr<const StorageLimitsList> storage_limits;
 
     Poco::Logger * log;
-
-    UInt32 shard_count{0};
 };
 
 }


### PR DESCRIPTION
when using clang12 compile, the unused file shard_count will cause a compile error.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

