### PR TITLE
Fix redundant memory reservation for output block in MergeSorter

### DIFF
--- a/src/Processors/Transforms/SortingTransform.cpp
+++ b/src/Processors/Transforms/SortingTransform.cpp
@@ -82,8 +82,9 @@ Chunk MergeSorter::mergeImpl(TSortingHeap & queue)
     /// Reserve
     if (queue.isValid())
     {
-        /// The expected size of output block is the same as input block
-        size_t size_to_reserve = chunks[0].getNumRows();
+        /// The size of output block will not be larger than the `max_merged_block_size`.
+        /// If redundant memory space is reserved, `MemoryTracker` will count more memory usage than actual usage.
+        size_t size_to_reserve = std::min(chunks[0].getNumRows(), max_merged_block_size);
         for (auto & column : merged_columns)
             column->reserve(size_to_reserve);
     }

--- a/src/Processors/Transforms/SortingTransform.cpp
+++ b/src/Processors/Transforms/SortingTransform.cpp
@@ -84,7 +84,7 @@ Chunk MergeSorter::mergeImpl(TSortingHeap & queue)
     {
         /// The size of output block will not be larger than the `max_merged_block_size`.
         /// If redundant memory space is reserved, `MemoryTracker` will count more memory usage than actual usage.
-        size_t size_to_reserve = std::min(chunks[0].getNumRows(), max_merged_block_size);
+        size_t size_to_reserve = std::min(static_cast<size_t>(chunks[0].getNumRows()), max_merged_block_size);
         for (auto & column : merged_columns)
             column->reserve(size_to_reserve);
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
Hello, we found this issue when we run TPC-H queries against 1 TB data scale, using HDFS table engine for data in Parquet  format.

We enabled the `partial_merge` join algorithm due to the high memory usage in `hash` join.
ClickHouse configurations:
```
<join_algorithm>prefer_partial_merge</join_algorithm>
<default_max_bytes_in_join>214748364800</default_max_bytes_in_join> <!-- 200 GB -->
```

When running Q3 of TPC-H, the client side prints like this:

`Progress: 7.68 billion rows, 193.54 GB (5.36 million rows/s., 134.95 MB/s.)        (0.0 CPU, `**`3.28 TB RAM)`**

Logs at server side:
`AsynchronousMetrics: MemoryTracking: was 187.96 GiB, `**`peak 192.09 GiB,`**` will set to 185.46 GiB (RSS), difference: -2.50 GiB`
`MemoryTracker: Current memory usage (for query): 3.00 TiB.`


We can see more than 3 TB memory usage was tracked for query, which is much larger than the actual utilization.

This issue may make a query get aborted too early when `max_memory_usage` is configured.

We try to fix above issue with this pull request.


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix redundant memory reservation for output block during `ORDER BY`.
