### PR TITLE
Introduce BackgroundSchedulePoolTaskInfo::cancelDelayed()

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -52,6 +52,17 @@ bool BackgroundSchedulePoolTaskInfo::scheduleAfter(size_t ms, bool overwrite)
     return true;
 }
 
+bool BackgroundSchedulePoolTaskInfo::cancelDelayed()
+{
+    std::lock_guard lock_schedule(schedule_mutex);
+
+    if (deactivated || !delayed)
+        return false;
+
+    pool.cancelDelayedTask(shared_from_this(), lock_schedule);
+    return true;
+}
+
 void BackgroundSchedulePoolTaskInfo::deactivate()
 {
     std::lock_guard lock_exec(exec_mutex);

--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -104,6 +104,9 @@ public:
     /// If overwrite is set then the task will be re-scheduled (if it was already scheduled, i.e. delayed == true).
     bool scheduleAfter(size_t ms, bool overwrite = true);
 
+    /// Cancel delayed task if any.
+    bool cancelDelayed();
+
     /// Further attempts to schedule become no-op. Will wait till the end of the current execution of the task.
     void deactivate();
 


### PR DESCRIPTION
It is possible to schedule a delayed task by scheduleAfter().
But there is only one way to cancel it, by calling deactivate().
Which waits till the end of the current execution of the task.

But we just would like to cancel current delayed task without deactivation.
And reschedule it when we are ready.

Proposing to introduce BackgroundSchedulePoolTaskInfo::cancelDelayed()
which should just cancel recently delayed task if any.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Introduced BackgroundSchedulePoolTaskInfo::cancelDelayed()


