### PR TITLE
SortDescription compile fix typo

### DIFF
--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -82,7 +82,7 @@ static Poco::Logger * getLogger()
     return &logger;
 }
 
-void compileSortDescriptionIfNeeded(SortDescription & description, const DataTypes & sort_description_types, bool increase_compile_attemps)
+void compileSortDescriptionIfNeeded(SortDescription & description, const DataTypes & sort_description_types, bool increase_compile_attempts)
 {
     static std::unordered_map<UInt128, UInt64, UInt128Hash> counter;
     static std::mutex mutex;
@@ -109,7 +109,7 @@ void compileSortDescriptionIfNeeded(SortDescription & description, const DataTyp
         UInt64 & current_counter = counter[sort_description_hash_key];
         if (current_counter < description.min_count_to_compile_sort_description)
         {
-            current_counter += static_cast<UInt64>(increase_compile_attemps);
+            current_counter += static_cast<UInt64>(increase_compile_attempts);
             return;
         }
     }
@@ -142,11 +142,11 @@ void compileSortDescriptionIfNeeded(SortDescription & description, const DataTyp
 
 #else
 
-void compileSortDescriptionIfNeeded(SortDescription & description, const DataTypes & sort_description_types, bool increase_compile_attemps)
+void compileSortDescriptionIfNeeded(SortDescription & description, const DataTypes & sort_description_types, bool increase_compile_attempts)
 {
     (void)(description);
     (void)(sort_description_types);
-    (void)(increase_compile_attemps);
+    (void)(increase_compile_attempts);
 }
 
 #endif

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -107,7 +107,7 @@ public:
 /** Compile sort description for header_types.
   * Description is compiled only if compilation attempts to compile identical description is more than min_count_to_compile_sort_description.
   */
-void compileSortDescriptionIfNeeded(SortDescription & description, const DataTypes & sort_description_types, bool increase_compile_attemps);
+void compileSortDescriptionIfNeeded(SortDescription & description, const DataTypes & sort_description_types, bool increase_compile_attempts);
 
 /// Outputs user-readable description into `out`.
 void dumpSortDescription(const SortDescription & description, WriteBuffer & out);

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
@@ -40,7 +40,7 @@ MergingSortedAlgorithm::MergingSortedAlgorithm(
 
     queue_variants = SortQueueVariants(sort_description_types, description);
     if (queue_variants.variantSupportJITCompilation())
-        compileSortDescriptionIfNeeded(description, sort_description_types, true /*increase_compile_attemps*/);
+        compileSortDescriptionIfNeeded(description, sort_description_types, true /*increase_compile_attempts*/);
 }
 
 void MergingSortedAlgorithm::addInput()

--- a/src/Processors/Transforms/SortingTransform.cpp
+++ b/src/Processors/Transforms/SortingTransform.cpp
@@ -175,7 +175,7 @@ SortingTransform::SortingTransform(
     description.swap(description_without_constants);
 
     if (SortQueueVariants(sort_description_types, description).variantSupportJITCompilation())
-        compileSortDescriptionIfNeeded(description, sort_description_types, increase_sort_description_compile_attempts /*increase_compile_attemps*/);
+        compileSortDescriptionIfNeeded(description, sort_description_types, increase_sort_description_compile_attempts /*increase_compile_attempts*/);
 }
 
 SortingTransform::~SortingTransform() = default;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
