### PR TITLE
Remove processor description from span attributes - it is not working

### DIFF
--- a/src/Processors/Executors/ExecutionThreadContext.cpp
+++ b/src/Processors/Executors/ExecutionThreadContext.cpp
@@ -103,7 +103,6 @@ bool ExecutionThreadContext::executeTask()
 #endif
 
     span.addAttribute("thread_number", thread_number);
-    span.addAttribute("processor.description", node->processor->getDescription());
 
     return node->exception == nullptr;
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

May be related #38032, but could not reproduce locally yet

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
