### PR TITLE
SQLUserDefinedFunctionsLoader allow symlinks in user_defined directory

### DIFF
--- a/src/Interpreters/UserDefinedSQLObjectsLoader.cpp
+++ b/src/Interpreters/UserDefinedSQLObjectsLoader.cpp
@@ -86,28 +86,33 @@ void UserDefinedSQLObjectsLoader::loadObjects(ContextPtr context)
     if (unlikely(!enable_persistence))
         return;
 
-    LOG_DEBUG(log, "loading user defined objects");
+    LOG_DEBUG(log, "Loading user defined objects");
 
     String dir_path = context->getUserDefinedPath();
     Poco::DirectoryIterator dir_end;
     for (Poco::DirectoryIterator it(dir_path); it != dir_end; ++it)
     {
-        if (it->isLink())
+        if (it->isDirectory())
             continue;
 
-        const auto & file_name = it.name();
+        const std::string & file_name = it.name();
 
         /// For '.svn', '.gitignore' directory and similar.
         if (file_name.at(0) == '.')
             continue;
 
-        if (!it->isDirectory() && endsWith(file_name, ".sql"))
-        {
-            std::string_view object_name = file_name;
-            object_name.remove_suffix(strlen(".sql"));
-            object_name.remove_prefix(strlen("function_"));
-            loadUserDefinedObject(context, UserDefinedSQLObjectType::Function, object_name, dir_path + it.name());
-        }
+        if (!startsWith(file_name, "function_") || !endsWith(file_name, ".sql"))
+            continue;
+
+        std::string_view object_name = file_name;
+
+        object_name.remove_prefix(strlen("function_"));
+        object_name.remove_suffix(strlen(".sql"));
+
+        if (object_name.empty())
+            continue;
+
+        loadUserDefinedObject(context, UserDefinedSQLObjectType::Function, object_name, dir_path + it.name());
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not skip symlinks in `user_defined` directory during SQL user defined functions loading. Closes #38042.