### PR TITLE
Docs: Mention Spark ClickHouse Connector in thrid party

### DIFF
--- a/docs/en/interfaces/third-party/integrations.md
+++ b/docs/en/interfaces/third-party/integrations.md
@@ -28,6 +28,9 @@ ClickHouse, Inc. does **not** maintain the tools and libraries listed below and 
     -   [Kafka](https://kafka.apache.org)
         -   [clickhouse_sinker](https://github.com/housepower/clickhouse_sinker) (uses [Go client](https://github.com/ClickHouse/clickhouse-go/))
         -   [stream-loader-clickhouse](https://github.com/adform/stream-loader)
+-   Batch processing
+    -   [Spark](https://spark.apache.org)
+        -   [spark-clickhouse-connector](https://github.com/housepower/spark-clickhouse-connector)
 -   Stream processing
     -   [Flink](https://flink.apache.org)
         -   [flink-clickhouse-sink](https://github.com/ivi-ru/flink-clickhouse-sink)


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required) 

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The [Spark ClickHouse Connector](https://github.com/housepower/spark-clickhouse-connector) builds on Spark DataSourceV2 API and gRPC protocol.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
