### PR TITLE
(Window View is an experimental feature) Fix LOGICAL_ERROR for WINDOW VIEW with incorrect structure

### DIFF
--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -459,7 +459,6 @@ void StorageWindowView::alter(
 
     auto inner_query = initInnerQuery(new_select_query->as<ASTSelectQuery &>(), local_context);
 
-    input_header.clear();
     output_header.clear();
 
     InterpreterDropQuery::executeDropQuery(
@@ -1230,7 +1229,6 @@ StorageWindowView::StorageWindowView(
 ASTPtr StorageWindowView::initInnerQuery(ASTSelectQuery query, ContextPtr context_)
 {
     select_query = query.clone();
-    input_header.clear();
     output_header.clear();
 
     String select_database_name = getContext()->getCurrentDatabase();
@@ -1627,15 +1625,10 @@ void StorageWindowView::dropInnerTableIfAny(bool no_delay, ContextPtr local_cont
     }
 }
 
-const Block & StorageWindowView::getInputHeader() const
+Block StorageWindowView::getInputHeader() const
 {
-    std::lock_guard lock(sample_block_lock);
-    if (!input_header)
-    {
-        auto metadata = getSourceTable()->getInMemoryMetadataPtr();
-        input_header = metadata->getSampleBlockNonMaterialized();
-    }
-    return input_header;
+    auto metadata = getSourceTable()->getInMemoryMetadataPtr();
+    return metadata->getSampleBlockNonMaterialized();
 }
 
 const Block & StorageWindowView::getOutputHeader() const

--- a/src/Storages/WindowView/StorageWindowView.h
+++ b/src/Storages/WindowView/StorageWindowView.h
@@ -170,7 +170,7 @@ public:
 
     ASTPtr getSourceTableSelectQuery();
 
-    const Block & getInputHeader() const;
+    Block getInputHeader() const;
 
     const Block & getOutputHeader() const;
 
@@ -193,7 +193,6 @@ private:
     std::atomic<bool> modifying_query{false};
     bool has_inner_table{true};
     bool has_inner_target_table{false};
-    mutable Block input_header;
     mutable Block output_header;
     UInt64 fire_signal_timeout_s;
     UInt64 clean_interval_usec;

--- a/tests/queries/0_stateless/02342_window_view_different_struct.sql
+++ b/tests/queries/0_stateless/02342_window_view_different_struct.sql
@@ -1,0 +1,25 @@
+-- Tags: no-backward-compatibility-check:22.6
+
+SET allow_experimental_window_view = 1;
+
+DROP TABLE IF EXISTS data_02342;
+DROP TABLE IF EXISTS window_view_02342;
+
+-- ALTER
+CREATE TABLE data_02342 (a UInt8) ENGINE=MergeTree ORDER BY a;
+CREATE WINDOW VIEW window_view_02342 ENGINE=Memory AS SELECT count(a), tumbleStart(wid) AS w_start, tumbleEnd(tumble(now(), INTERVAL '3' SECOND)) AS w_end FROM data_02342 GROUP BY tumble(now(), INTERVAL '3' SECOND) AS wid;
+INSERT INTO data_02342 VALUES (42);
+ALTER TABLE data_02342 ADD COLUMN s String;
+INSERT INTO data_02342 VALUES (42, 'data_02342');
+DROP TABLE data_02342;
+DROP TABLE window_view_02342;
+
+-- DROP/CREATE
+CREATE TABLE data_02342 (a UInt8) ENGINE=MergeTree ORDER BY a;
+CREATE WINDOW VIEW window_view_02342 ENGINE=Memory AS SELECT count(a), tumbleStart(wid) AS w_start, tumbleEnd(tumble(now(), INTERVAL '3' SECOND)) AS w_end FROM data_02342 GROUP BY tumble(now(), INTERVAL '3' SECOND) AS wid;
+INSERT INTO data_02342 VALUES (42);
+DROP TABLE data_02342;
+CREATE TABLE data_02342 (a UInt8, s String) ENGINE=MergeTree ORDER BY a;
+INSERT INTO data_02342 VALUES (42, 'data_02342');
+DROP TABLE data_02342;
+DROP TABLE window_view_02342;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
(Window View is a experimental feature) Fix LOGICAL_ERROR for WINDOW VIEW with incorrect structure

Caching header of the source table in the WINDOW VIEW should not be
done, since there is no ability to get notification when it had been
changed (ALTER or CREATE/DROP).

And this fires on [CI], when the following tests had been executed in
order in stress tests:
- 01050_window_view_parser_tumble (leaves wm for mt)
- 01748_partition_id_pruning (cache input_header)
- 01188_attach_table_from_path (insert into mt with wm attached and
  incorrect structure)

  [CI]: https://s3.amazonaws.com/clickhouse-test-reports/38056/109980eb275c064d08bc031bfdc14d95b9a7272b/stress_test__undefined__actions_.html

Follow-up for: #37965 (@Vxider)
Fixes: #37815