### PR TITLE
tests/stress: fix TSan detection (enables thread fuzzer for non-TSan builds)

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -7,8 +7,10 @@ set -x
 
 # Thread Fuzzer allows to check more permutations of possible thread scheduling
 # and find more potential issues.
-is_tsan_build=$(clickhouse local -q "select value like '% -fsanitize=thread %' from system.build_options where name='CXX_FLAGS'")
-if [ "$is_tsan_build" -eq "0" ]; then
+#
+# But under thread fuzzer, TSan build is too slow and this produces some flaky
+# tests, so for now, as a temporary solution it had been disabled.
+if ! test -f package_folder/*tsan*.deb; then
     export THREAD_FUZZER_CPU_TIME_PERIOD_US=1000
     export THREAD_FUZZER_SLEEP_PROBABILITY=0.1
     export THREAD_FUZZER_SLEEP_TIME_US=100000


### PR DESCRIPTION
Right now check does not work:

```
++ clickhouse local -q 'select value like '\''% -fsanitize=thread %'\'' from system.build_options where name='\''CXX_FLAGS'\'''
/run.sh: line 10: clickhouse: command not found
+ is_tsan_build=
+ '[' '' -eq 0 ']'
/run.sh: line 11: [: : integer expression expected
```

Follow-up for: #38106 (cc @tavplubix @alesapin)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)