### PR TITLE
tests: disable 01646_system_restart_replicas_smoke under stress tests

### DIFF
--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -18,8 +18,10 @@ def get_options(i, backward_compatibility_check):
         options.append("--db-engine=Ordinary")
 
     if i % 3 == 2 and not backward_compatibility_check:
-        options.append('''--db-engine="Replicated('/test/db/test_{}', 's1', 'r1')"'''.format(i))
-        client_options.append('allow_experimental_database_replicated=1')
+        options.append(
+            '''--db-engine="Replicated('/test/db/test_{}', 's1', 'r1')"'''.format(i)
+        )
+        client_options.append("allow_experimental_database_replicated=1")
 
     # If database name is not specified, new database is created for each functional test.
     # Run some threads with one database for all tests.
@@ -37,37 +39,57 @@ def get_options(i, backward_compatibility_check):
 
     if i % 15 == 11:
         client_options.append("join_algorithm='auto'")
-        client_options.append('max_rows_in_join=1000')
+        client_options.append("max_rows_in_join=1000")
 
     if i == 13:
-        client_options.append('memory_tracker_fault_probability=0.001')
+        client_options.append("memory_tracker_fault_probability=0.001")
 
     if client_options:
-        options.append(" --client-option " + ' '.join(client_options))
+        options.append(" --client-option " + " ".join(client_options))
 
-    return ' '.join(options)
+    return " ".join(options)
 
 
-def run_func_test(cmd, output_prefix, num_processes, skip_tests_option, global_time_limit, backward_compatibility_check):
-    backward_compatibility_check_option = '--backward-compatibility-check' if backward_compatibility_check else ''
-    global_time_limit_option = ''
+def run_func_test(
+    cmd,
+    output_prefix,
+    num_processes,
+    skip_tests_option,
+    global_time_limit,
+    backward_compatibility_check,
+):
+    backward_compatibility_check_option = (
+        "--backward-compatibility-check" if backward_compatibility_check else ""
+    )
+    global_time_limit_option = ""
     if global_time_limit:
         global_time_limit_option = "--global_time_limit={}".format(global_time_limit)
 
-    output_paths = [os.path.join(output_prefix, "stress_test_run_{}.txt".format(i)) for i in range(num_processes)]
+    output_paths = [
+        os.path.join(output_prefix, "stress_test_run_{}.txt".format(i))
+        for i in range(num_processes)
+    ]
     pipes = []
     for i in range(0, len(output_paths)):
-        f = open(output_paths[i], 'w')
-        full_command = "{} {} {} {} {}".format(cmd, get_options(i, backward_compatibility_check), global_time_limit_option, skip_tests_option, backward_compatibility_check_option)
+        f = open(output_paths[i], "w")
+        full_command = "{} {} {} {} {}".format(
+            cmd,
+            get_options(i, backward_compatibility_check),
+            global_time_limit_option,
+            skip_tests_option,
+            backward_compatibility_check_option,
+        )
         logging.info("Run func tests '%s'", full_command)
         p = Popen(full_command, shell=True, stdout=f, stderr=f)
         pipes.append(p)
         time.sleep(0.5)
     return pipes
 
+
 def compress_stress_logs(output_path, files_prefix):
     cmd = f"cd {output_path} && tar -zcf stress_run_logs.tar.gz {files_prefix}* && rm {files_prefix}*"
     check_output(cmd, shell=True)
+
 
 def call_with_retry(query, timeout=30, retry_count=5):
     for i in range(retry_count):
@@ -76,6 +98,7 @@ def call_with_retry(query, timeout=30, retry_count=5):
             time.sleep(i)
         else:
             break
+
 
 def make_query_command(query):
     return f"""clickhouse client -q "{query}" --max_untracked_memory=1Gi --memory_profiler_step=1Gi --max_memory_usage_for_user=0"""
@@ -93,28 +116,34 @@ def prepare_for_hung_check(drop_databases):
     # ThreadFuzzer significantly slows down server and causes false-positive hung check failures
     call_with_retry("clickhouse client -q 'SYSTEM STOP THREAD FUZZER'")
 
-    call_with_retry(make_query_command('SELECT 1 FORMAT Null'))
+    call_with_retry(make_query_command("SELECT 1 FORMAT Null"))
 
     # Some tests execute SYSTEM STOP MERGES or similar queries.
     # It may cause some ALTERs to hang.
     # Possibly we should fix tests and forbid to use such queries without specifying table.
-    call_with_retry(make_query_command('SYSTEM START MERGES'))
-    call_with_retry(make_query_command('SYSTEM START DISTRIBUTED SENDS'))
-    call_with_retry(make_query_command('SYSTEM START TTL MERGES'))
-    call_with_retry(make_query_command('SYSTEM START MOVES'))
-    call_with_retry(make_query_command('SYSTEM START FETCHES'))
-    call_with_retry(make_query_command('SYSTEM START REPLICATED SENDS'))
-    call_with_retry(make_query_command('SYSTEM START REPLICATION QUEUES'))
-    call_with_retry(make_query_command('SYSTEM DROP MARK CACHE'))
+    call_with_retry(make_query_command("SYSTEM START MERGES"))
+    call_with_retry(make_query_command("SYSTEM START DISTRIBUTED SENDS"))
+    call_with_retry(make_query_command("SYSTEM START TTL MERGES"))
+    call_with_retry(make_query_command("SYSTEM START MOVES"))
+    call_with_retry(make_query_command("SYSTEM START FETCHES"))
+    call_with_retry(make_query_command("SYSTEM START REPLICATED SENDS"))
+    call_with_retry(make_query_command("SYSTEM START REPLICATION QUEUES"))
+    call_with_retry(make_query_command("SYSTEM DROP MARK CACHE"))
 
     # Issue #21004, live views are experimental, so let's just suppress it
     call_with_retry(make_query_command("KILL QUERY WHERE upper(query) LIKE 'WATCH %'"))
 
     # Kill other queries which known to be slow
     # It's query from 01232_preparing_sets_race_condition_long, it may take up to 1000 seconds in slow builds
-    call_with_retry(make_query_command("KILL QUERY WHERE query LIKE 'insert into tableB select %'"))
+    call_with_retry(
+        make_query_command("KILL QUERY WHERE query LIKE 'insert into tableB select %'")
+    )
     # Long query from 00084_external_agregation
-    call_with_retry(make_query_command("KILL QUERY WHERE query LIKE 'SELECT URL, uniq(SearchPhrase) AS u FROM test.hits GROUP BY URL ORDER BY u %'"))
+    call_with_retry(
+        make_query_command(
+            "KILL QUERY WHERE query LIKE 'SELECT URL, uniq(SearchPhrase) AS u FROM test.hits GROUP BY URL ORDER BY u %'"
+        )
+    )
 
     if drop_databases:
         for i in range(5):
@@ -123,23 +152,35 @@ def prepare_for_hung_check(drop_databases):
                 # Otherwise we will get rid of queries which wait for background pool. It can take a long time on slow builds (more than 900 seconds).
                 #
                 # Also specify max_untracked_memory to allow 1GiB of memory to overcommit.
-                databases = check_output(make_query_command('SHOW DATABASES'), shell=True, timeout=30).decode('utf-8').strip().split()
+                databases = (
+                    check_output(
+                        make_query_command("SHOW DATABASES"), shell=True, timeout=30
+                    )
+                    .decode("utf-8")
+                    .strip()
+                    .split()
+                )
                 for db in databases:
                     if db == "system":
                         continue
-                    command = make_query_command(f'DROP DATABASE {db}')
+                    command = make_query_command(f"DROP DATABASE {db}")
                     # we don't wait for drop
                     Popen(command, shell=True)
                 break
             except Exception as ex:
-                logging.error("Failed to SHOW or DROP databasese, will retry %s", str(ex))
+                logging.error(
+                    "Failed to SHOW or DROP databasese, will retry %s", str(ex)
+                )
                 time.sleep(i)
         else:
-            raise Exception("Cannot drop databases after stress tests. Probably server consumed too much memory and cannot execute simple queries")
-
+            raise Exception(
+                "Cannot drop databases after stress tests. Probably server consumed too much memory and cannot execute simple queries"
+            )
 
     # Wait for last queries to finish if any, not longer than 300 seconds
-    call(make_query_command("""
+    call(
+        make_query_command(
+            """
     select sleepEachRow((
         select maxOrDefault(300 - elapsed) + 1
         from system.processes
@@ -147,39 +188,58 @@ def prepare_for_hung_check(drop_databases):
     ) / 300)
     from numbers(300)
     format Null
-    """), shell=True, stderr=STDOUT, timeout=330)
+    """
+        ),
+        shell=True,
+        stderr=STDOUT,
+        timeout=330,
+    )
 
     # Even if all clickhouse-test processes are finished, there are probably some sh scripts,
     # which still run some new queries. Let's ignore them.
     try:
         query = """clickhouse client -q "SELECT count() FROM system.processes where where elapsed > 300" """
-        output = check_output(query, shell=True, stderr=STDOUT, timeout=30).decode('utf-8').strip()
+        output = (
+            check_output(query, shell=True, stderr=STDOUT, timeout=30)
+            .decode("utf-8")
+            .strip()
+        )
         if int(output) == 0:
             return False
     except:
         pass
     return True
 
+
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
-    parser = argparse.ArgumentParser(description="ClickHouse script for running stresstest")
-    parser.add_argument("--test-cmd", default='/usr/bin/clickhouse-test')
-    parser.add_argument("--skip-func-tests", default='')
-    parser.add_argument("--client-cmd", default='clickhouse-client')
-    parser.add_argument("--server-log-folder", default='/var/log/clickhouse-server')
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    parser = argparse.ArgumentParser(
+        description="ClickHouse script for running stresstest"
+    )
+    parser.add_argument("--test-cmd", default="/usr/bin/clickhouse-test")
+    parser.add_argument("--skip-func-tests", default="")
+    parser.add_argument("--client-cmd", default="clickhouse-client")
+    parser.add_argument("--server-log-folder", default="/var/log/clickhouse-server")
     parser.add_argument("--output-folder")
     parser.add_argument("--global-time-limit", type=int, default=1800)
     parser.add_argument("--num-parallel", type=int, default=cpu_count())
-    parser.add_argument('--backward-compatibility-check', action='store_true')
-    parser.add_argument('--hung-check', action='store_true', default=False)
+    parser.add_argument("--backward-compatibility-check", action="store_true")
+    parser.add_argument("--hung-check", action="store_true", default=False)
     # make sense only for hung check
-    parser.add_argument('--drop-databases', action='store_true', default=False)
+    parser.add_argument("--drop-databases", action="store_true", default=False)
 
     args = parser.parse_args()
     if args.drop_databases and not args.hung_check:
         raise Exception("--drop-databases only used in hung check (--hung-check)")
     func_pipes = []
-    func_pipes = run_func_test(args.test_cmd, args.output_folder, args.num_parallel, args.skip_func_tests, args.global_time_limit, args.backward_compatibility_check)
+    func_pipes = run_func_test(
+        args.test_cmd,
+        args.output_folder,
+        args.num_parallel,
+        args.skip_func_tests,
+        args.global_time_limit,
+        args.backward_compatibility_check,
+    )
 
     logging.info("Will wait functests to finish")
     while True:
@@ -205,32 +265,40 @@ if __name__ == "__main__":
             have_long_running_queries = True
             logging.error("Failed to prepare for hung check %s", str(ex))
         logging.info("Checking if some queries hung")
-        cmd = ' '.join([args.test_cmd,
-            # Do not track memory allocations up to 1Gi,
-            # this will allow to ignore server memory limit (max_server_memory_usage) for this query.
-            #
-            # NOTE: memory_profiler_step should be also adjusted, because:
-            #
-            #     untracked_memory_limit = min(settings.max_untracked_memory, settings.memory_profiler_step)
-            #
-            # NOTE: that if there will be queries with GROUP BY, this trick
-            # will not work due to CurrentMemoryTracker::check() from
-            # Aggregator code.
-            # But right now it should work, since neither hung check, nor 00001_select_1 has GROUP BY.
-            "--client-option", "max_untracked_memory=1Gi",
-            "--client-option", "max_memory_usage_for_user=0",
-            "--client-option", "memory_profiler_step=1Gi",
-            # Use system database to avoid CREATE/DROP DATABASE queries
-            "--database=system",
-            "--hung-check",
-            "00001_select_1"
-        ])
+        cmd = " ".join(
+            [
+                args.test_cmd,
+                # Do not track memory allocations up to 1Gi,
+                # this will allow to ignore server memory limit (max_server_memory_usage) for this query.
+                #
+                # NOTE: memory_profiler_step should be also adjusted, because:
+                #
+                #     untracked_memory_limit = min(settings.max_untracked_memory, settings.memory_profiler_step)
+                #
+                # NOTE: that if there will be queries with GROUP BY, this trick
+                # will not work due to CurrentMemoryTracker::check() from
+                # Aggregator code.
+                # But right now it should work, since neither hung check, nor 00001_select_1 has GROUP BY.
+                "--client-option",
+                "max_untracked_memory=1Gi",
+                "--client-option",
+                "max_memory_usage_for_user=0",
+                "--client-option",
+                "memory_profiler_step=1Gi",
+                # Use system database to avoid CREATE/DROP DATABASE queries
+                "--database=system",
+                "--hung-check",
+                "00001_select_1",
+            ]
+        )
         res = call(cmd, shell=True, stderr=STDOUT)
         hung_check_status = "No queries hung\tOK\n"
         if res != 0 and have_long_running_queries:
             logging.info("Hung check failed with exit code {}".format(res))
             hung_check_status = "Hung check failed\tFAIL\n"
-        with open(os.path.join(args.output_folder, "test_results.tsv"), 'w+') as results:
+        with open(
+            os.path.join(args.output_folder, "test_results.tsv"), "w+"
+        ) as results:
             results.write(hung_check_status)
 
     logging.info("Stress test finished")

--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -288,6 +288,7 @@ if __name__ == "__main__":
                 # Use system database to avoid CREATE/DROP DATABASE queries
                 "--database=system",
                 "--hung-check",
+                "--stress",
                 "00001_select_1",
             ]
         )

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -883,7 +883,7 @@ class TestCase:
             "test": self.case_file,
             "stdout": self.stdout_file,
             "stderr": self.stderr_file,
-            "secure": "--secure" if args.secure else ""
+            "secure": "--secure" if args.secure else "",
         }
 
         # >> append to stderr (but not stdout since it is not used there),
@@ -1218,7 +1218,9 @@ class TestSuite:
             try:
                 return int(clickhouse_execute(args, "EXISTS TABLE test.hits"))
             except Exception as e:
-                print("Cannot check if dataset is available, assuming it's not: ", str(e))
+                print(
+                    "Cannot check if dataset is available, assuming it's not: ", str(e)
+                )
                 return False
 
         base_dir = os.path.abspath(args.queries)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -385,6 +385,7 @@ class FailureReason(enum.Enum):
     NO_LONG = "not running long tests"
     REPLICATED_DB = "replicated-database"
     S3_STORAGE = "s3-storage"
+    STRESS = "stress"
     BUILD = "not running for current build"
     BACKWARD_INCOMPATIBLE = "test is backward incompatible"
 
@@ -682,6 +683,9 @@ class TestCase:
 
         elif tags and ("no-s3-storage" in tags) and args.s3_storage:
             return FailureReason.S3_STORAGE
+
+        elif tags and ("no-stress" in tags) and args.stress:
+            return FailureReason.STRESS
 
         elif tags:
             for build_flag in args.build_flags:
@@ -1960,6 +1964,12 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Run tests over s3 storage",
+    )
+    parser.add_argument(
+        "--stress",
+        action="store_true",
+        default=False,
+        help="Run stress tests",
     )
     parser.add_argument(
         "--no-random-settings",

--- a/tests/queries/0_stateless/01414_mutations_and_errors_zookeeper.sh
+++ b/tests/queries/0_stateless/01414_mutations_and_errors_zookeeper.sh
@@ -76,4 +76,4 @@ $CLICKHOUSE_CLIENT --query "ALTER TABLE replicated_mutation_table MODIFY COLUMN 
 
 $CLICKHOUSE_CLIENT --query "SELECT distinct(value) FROM replicated_mutation_table ORDER BY value"
 
-$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS replicated_mutation_table"
+$CLICKHOUSE_CLIENT --query "DROP TABLE replicated_mutation_table"

--- a/tests/queries/0_stateless/01646_system_restart_replicas_smoke.sql
+++ b/tests/queries/0_stateless/01646_system_restart_replicas_smoke.sql
@@ -1,5 +1,9 @@
--- Tags: replica, no-tsan, no-parallel
+-- Tags: replica, no-tsan, no-parallel, no-stress
 -- Tag no-tsan: RESTART REPLICAS can acquire too much locks, while only 64 is possible from one thread under TSan
+-- Tag no-stress: RESTART REPLICAS can leave some tables,
+--                that may pollute error log,
+--                like in 01414_mutations_and_errors_zookeeper.
+--                no-stress is like worked no-parallel for stress testing
 
 DROP TABLE IF EXISTS data_01646;
 CREATE TABLE data_01646 (x Date, s String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test_01646/data_01646', 'r') ORDER BY s PARTITION BY x;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
tests: disable `01646_system_restart_replicas_smoke` under stress tests (should fix one reason of `Backward compatibility check: Error message in clickhouse-server.log (see bc_check_error_messages.txt)`)

This test executes SYSTEM RESTART REPLICAS, that may leave some tables
in some tests, and the problem test is
01414_mutations_and_errors_zookeeper, that has invalid values in the
table that produces the following error:

    2022.06.19 19:02:07.165320 [ 1242562 ] {} <Error> MutateFromLogEntryTask: virtual bool DB::ReplicatedMergeMutateTaskBase::executeStep(): Code: 6. DB::Exception: Cannot parse string 'Hello' as UInt64: syntax error at begin of string. Note: there are toUInt64OrZero and toUInt64OrNull functions, which returns zero/NULL instead of throwing exception.: while executing 'FUNCTION _CAST(value :: 2, 'UInt64' :: 3) -> _CAST(value, 'UInt64') UInt64 : 4': (while reading from part /var/lib/clickhouse/store/700/70043200-eae1-44da-8554-0d43b7e936d7/20191002_1_1_0/): While executing MergeTreeInOrder. (CANNOT_PARSE_TEXT), Stack trace (when copying this message, always include the lines below):

Here is part of the server log that relevant for the test:

<details>

    ...
    2022.06.19 18:33:22.495867 [ 391343 ] {e0332447-5473-4653-ba8b-b976acb304a1} <Trace> InterpreterSystemQuery: Restarting replica on test_9.replicated_mutation_table
    2022.06.19 18:33:22.503462 [ 390869 ] {} <Information> test_9.replicated_mutation_table (70043200-eae1-44da-8554-0d43b7e936d7): Stopped being leader
    ...
    2022.06.19 18:33:23.396760 [ 395825 ] {09ee374d-a8d9-47db-bdca-611d605b40c6} <Error> executeQuery: Code: 341. DB::Exception: Mutation is not finished because table shutdown was called. It will be done after table restart. (UNFINISHED) (version 22.6.1.1985 (official build)) (from [::1]:40558) (comment: '01414_mutations_and_errors_zookeeper.sh') (in query: ALTER TABLE replicated_mutation_table MODIFY COLUMN value UInt64 SETTINGS replication_alter_partitions_sync = 2), Stack trace (when copying this message, always include the lines below):
    ...
    2022.06.19 18:33:23.467115 [ 390869 ] {} <Debug> test_9.replicated_mutation_table (70043200-eae1-44da-8554-0d43b7e936d7): Loading data parts
    2022.06.19 18:33:23.471062 [ 390869 ] {} <Debug> test_9.replicated_mutation_table (70043200-eae1-44da-8554-0d43b7e936d7): Loaded data parts (3 items)
    ...
    2022.06.19 18:33:23.515997 [ 390869 ] {} <Trace> test_9.replicated_mutation_table (ReplicatedMergeTreeRestartingThread): Restarting thread finished
    ...
    2022.06.19 18:33:23.522475 [ 390869 ] {} <Trace> test_9.replicated_mutation_table (PartMovesBetweenShardsOrchestrator): PartMovesBetweenShardsOrchestrator thread finished
    ...
    2022.06.19 18:33:24.960630 [ 391343 ] {e0332447-5473-4653-ba8b-b976acb304a1} <Error> executeQuery: Code: 57. DB::Exception: Cannot attach table with UUID 9b62c1d4-cf4a-4e41-bd11-bafb1446495c, because it was detached but still used by some query. Retry later. (TABLE_ALREADY_EXISTS) (version 22.6.1.1985 (official build)) (from [::1]:47448) (comment: 01646_system_restart_replicas_smoke.sql) (in query: SYSTEM RESTART REPLICAS;), Stack trace (when copying this message, always include the lines below):
    ...
    2022.06.19 18:33:24.490940 [ 400623 ] {00c29852-e786-4e53-a44a-5f1c5f23c698} <Debug> executeQuery: (from [::1]:48804) (comment: '01414_mutations_and_errors_zookeeper.sh') SELECT distinct(value) FROM replicated_mutation_table ORDER BY value (stage: Complete)
    2022.06.19 18:33:24.502168 [ 400623 ] {00c29852-e786-4e53-a44a-5f1c5f23c698} <Error> executeQuery: Code: 60. DB::Exception: Table test_9.replicated_mutation_table doesn't exist. (UNKNOWN_TABLE) (version 22.6.1.1985 (official build)) (from [::1]:48804) (comment: '01414_mutations_and_errors_zookeeper.sh') (in query: SELECT distinct(value) FROM replicated_mutation_table ORDER BY value), Stack trace (when copying this message, always include the lines below):
    ...
    2022.06.19 18:33:25.048152 [ 395940 ] {bb31a17f-aca1-411a-ab30-c6b7598c59e5} <Debug> executeQuery: (from [::1]:49236) (comment: '01414_mutations_and_errors_zookeeper.sh') DROP TABLE IF EXISTS replicated_mutation_table (stage: Complete)

</details>

And if this table will be left, then checking error messages in
/var/log/clickhouse-server/clickhouse-server.backward.clean.log will
fail, like in [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/38205/90b57e7445d5167ea2170bfe03af29faffc195cf/stress_test__undefined__actions_.html