### PR TITLE
tests/stress: fix TSan detection

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -10,7 +10,7 @@ set -x
 #
 # But under thread fuzzer, TSan build is too slow and this produces some flaky
 # tests, so for now, as a temporary solution it had been disabled.
-if ! test -f package_folder/*tsan*.deb; then
+if ! test -f package_folder/clickhouse-server*tsan*.deb; then
     export THREAD_FUZZER_CPU_TIME_PERIOD_US=1000
     export THREAD_FUZZER_SLEEP_PROBABILITY=0.1
     export THREAD_FUZZER_SLEEP_TIME_US=100000


### PR DESCRIPTION
    + test -f package_folder/clickhouse-client_22.7.1.1+tsan_all.deb package_folder/clickhouse-common-static-dbg_22.7.1.1+tsan_amd64.deb package_folder/clickhouse-common-static_22.7.1.1+tsan_amd64.deb package_folder/clickhouse-keeper_22.7.1.1+tsan_amd64.deb package_folder/clickhouse-server_22.7.1.1+tsan_all.deb
    /run.sh: line 13: test: too many arguments

Follow-up for: #38207 (cc @tavplubix)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

*Note: will mark as `Draft` for now, want to make sure that everything will works correctly (waiting for stress tests)*