### PR TITLE
Fix test for system table  count in diag tool

### DIFF
--- a/tools/clickhouse-diagnostics/internal/platform/database/native_test.go
+++ b/tools/clickhouse-diagnostics/internal/platform/database/native_test.go
@@ -67,7 +67,7 @@ func TestReadTableNamesForDatabase(t *testing.T) {
 	t.Run("client can read tables for a database", func(t *testing.T) {
 		tables, err := clickhouseClient.ReadTableNamesForDatabase("system")
 		require.Nil(t, err)
-		require.Greater(t, 70, len(tables))
+		require.GreaterOrEqual(t, len(tables), 70)
 		require.Contains(t, tables, "merge_tree_settings")
 	})
 }

--- a/tools/clickhouse-diagnostics/internal/platform/database/native_test.go
+++ b/tools/clickhouse-diagnostics/internal/platform/database/native_test.go
@@ -67,7 +67,7 @@ func TestReadTableNamesForDatabase(t *testing.T) {
 	t.Run("client can read tables for a database", func(t *testing.T) {
 		tables, err := clickhouseClient.ReadTableNamesForDatabase("system")
 		require.Nil(t, err)
-		require.Equal(t, 70, len(tables))
+		require.Greater(t, 70, len(tables))
 		require.Contains(t, tables, "merge_tree_settings")
 	})
 }

--- a/tools/clickhouse-diagnostics/testdata/logs/var/logs/clickhouse-server.err.log
+++ b/tools/clickhouse-diagnostics/testdata/logs/var/logs/clickhouse-server.err.log
@@ -1,0 +1,10 @@
+2021.12.13 10:12:26.940169 [ 38398 ] {} <Warning> Access(local directory): File /var/lib/clickhouse/access/users.list doesn't exist
+2021.12.13 10:12:26.940204 [ 38398 ] {} <Warning> Access(local directory): Recovering lists in directory /var/lib/clickhouse/access/
+2021.12.13 10:12:40.649453 [ 38445 ] {} <Error> Access(user directories): from: 127.0.0.1, user: default: Authentication failed: Code: 193. DB::Exception: Invalid credentials. (WRONG_PASSWORD), Stack trace (when copying this message, always include the lines below):
+
+0. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x9b722d4 in /usr/bin/clickhouse
+1. DB::IAccessStorage::throwInvalidCredentials() @ 0x119d9b27 in /usr/bin/clickhouse
+2. DB::IAccessStorage::loginImpl(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&) const @ 0x119d98d7 in /usr/bin/clickhouse
+3. DB::IAccessStorage::login(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, bool) const @ 0x119d9084 in /usr/bin/clickhouse
+4. DB::MultipleAccessStorage::loginImpl(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&) const @ 0x119ff93c in /usr/bin/clickhouse
+5. DB::IAccessStorage::login(DB::Credentials const&, Poco::Net::IPAddress const&, DB::ExternalAuthenticators const&, bool) const @ 0x119d9084 in /usr/bin/clickhouse

--- a/tools/clickhouse-diagnostics/testdata/logs/var/logs/clickhouse-server.log
+++ b/tools/clickhouse-diagnostics/testdata/logs/var/logs/clickhouse-server.log
@@ -1,0 +1,10 @@
+2022.02.02 14:49:32.458680 [ 200404 ] {} <Debug> DiskLocal: Reserving 2.47 MiB on disk `default`, having unreserved 1.56 TiB.
+2022.02.02 14:49:32.459086 [ 200359 ] {de87df8b-2250-439c-9e87-df8b2250339c::202202_147058_147550_344} <Debug> MergeTask::PrepareStage: Merging 2 parts: from 202202_147058_147549_343 to 202202_147550_147550_0 into Wide
+2022.02.02 14:49:32.459201 [ 200359 ] {de87df8b-2250-439c-9e87-df8b2250339c::202202_147058_147550_344} <Debug> MergeTask::PrepareStage: Selected MergeAlgorithm: Horizontal
+2022.02.02 14:49:32.459262 [ 200359 ] {de87df8b-2250-439c-9e87-df8b2250339c::202202_147058_147550_344} <Debug> MergeTreeSequentialSource: Reading 159 marks from part 202202_147058_147549_343, total 1289014 rows starting from the beginning of the part
+2022.02.02 14:49:32.459614 [ 200359 ] {de87df8b-2250-439c-9e87-df8b2250339c::202202_147058_147550_344} <Debug> MergeTreeSequentialSource: Reading 2 marks from part 202202_147550_147550_0, total 2618 rows starting from the beginning of the part
+2022.02.02 14:49:32.507755 [ 200359 ] {de87df8b-2250-439c-9e87-df8b2250339c::202202_147058_147550_344} <Debug> MergeTask::MergeProjectionsStage: Merge sorted 1291632 rows, containing 5 columns (5 merged, 0 gathered) in 0.048711404 sec., 26516008.448452853 rows/sec., 639.52 MiB/sec.
+2022.02.02 14:49:32.508332 [ 200359 ] {de87df8b-2250-439c-9e87-df8b2250339c::202202_147058_147550_344} <Trace> system.asynchronous_metric_log (de87df8b-2250-439c-9e87-df8b2250339c): Renaming temporary part tmp_merge_202202_147058_147550_344 to 202202_147058_147550_344.
+2022.02.02 14:49:32.508406 [ 200359 ] {de87df8b-2250-439c-9e87-df8b2250339c::202202_147058_147550_344} <Trace> system.asynchronous_metric_log (de87df8b-2250-439c-9e87-df8b2250339c) (MergerMutator): Merged 2 parts: from 202202_147058_147549_343 to 202202_147550_147550_0
+2022.02.02 14:49:32.508440 [ 200359 ] {} <Debug> MemoryTracker: Peak memory usage Mutate/Merge: 16.31 MiB.
+2022.02.02 14:49:33.000148 [ 200388 ] {} <Trace> AsynchronousMetrics: MemoryTracking: was 774.16 MiB, peak 2.51 GiB, will set to 772.30 MiB (RSS), difference: -1.86 MiB


### PR DESCRIPTION
Fix test which relies on exact count of system tables.

### Changelog category (leave one):
- Not for changelog