### PR TITLE
WIP limit concurrency by memory usage

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1099,6 +1099,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
             total_memory_tracker.setHardLimit(max_server_memory_usage);
             total_memory_tracker.setDescription("(total)");
             total_memory_tracker.setMetric(CurrentMetrics::MemoryTracking);
+            global_context->getProcessList().setMaxAvailableMemory(max_server_memory_usage);
 
             auto * global_overcommit_tracker = global_context->getGlobalOvercommitTracker();
             total_memory_tracker.setOvercommitTracker(global_overcommit_tracker);

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -374,6 +374,9 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, memory_profiler_step, (4 * 1024 * 1024), "Whenever query memory usage becomes larger than every next step in number of bytes the memory profiler will collect the allocating stack trace. Zero means disabled memory profiler. Values lower than a few megabytes will slow down query processing.", 0) \
     M(Float, memory_profiler_sample_probability, 0., "Collect random allocations and deallocations and write them into system.trace_log with 'MemorySample' trace_type. The probability is for every alloc/free regardless to the size of the allocation. Note that sampling happens only when the amount of untracked memory exceeds 'max_untracked_memory'. You may want to set 'max_untracked_memory' to 0 for extra fine grained sampling.", 0) \
     \
+    M(UInt64, guaranteed_memory_usage, 1_GiB, "", 0) \
+    M(UInt64, max_guaranteed_memory_usage_for_user, 1_GiB, "", 0) \
+    \
     M(UInt64, memory_usage_overcommit_max_wait_microseconds, 5'000'000, "Maximum time thread will wait for memory to be freed in the case of memory overcommit. If timeout is reached and memory is not freed, exception is thrown.", 0) \
     \
     M(UInt64, max_network_bandwidth, 0, "The maximum speed of data exchange over the network in bytes per second for a query. Zero means unlimited.", 0) \


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Introduce settings for guaranteed memory usage and use them to limit the number of concurrent queries.

cc @qoega @serxa  