### PR TITLE
use utility methods to access x509 struct fields.

### DIFF
--- a/src/Functions/FunctionShowCertificate.h
+++ b/src/Functions/FunctionShowCertificate.h
@@ -74,7 +74,7 @@ public:
 
                 {
                     char buf[1024] = {0};
-                    const ASN1_INTEGER * sn = cert->cert_info->serialNumber;
+                    const ASN1_INTEGER * sn = X509_get0_serialNumber(cert);
                     BIGNUM * bnsn = ASN1_INTEGER_to_BN(sn, nullptr);
                     SCOPE_EXIT(
                     {
@@ -101,7 +101,7 @@ public:
                     }
                 }
 
-                char * issuer = X509_NAME_oneline(cert->cert_info->issuer, nullptr, 0);
+                char * issuer = X509_NAME_oneline(X509_get_issuer_name(cert), nullptr, 0);
                 if (issuer)
                 {
                     SCOPE_EXIT(
@@ -130,7 +130,7 @@ public:
                     }
                 }
 
-                char * subject = X509_NAME_oneline(cert->cert_info->subject, nullptr, 0);
+                char * subject = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
                 if (subject)
                 {
                     SCOPE_EXIT(

--- a/src/Storages/System/StorageSystemCertificates.cpp
+++ b/src/Storages/System/StorageSystemCertificates.cpp
@@ -55,7 +55,7 @@ static void populateTable(const X509 * cert, MutableColumns & res_columns, const
 
     {
         char buf[1024] = {0};
-        const ASN1_INTEGER * sn = cert->cert_info->serialNumber;
+        const ASN1_INTEGER * sn = X509_get0_serialNumber(cert);
         BIGNUM * bnsn = ASN1_INTEGER_to_BN(sn, nullptr);
         SCOPE_EXIT(
         {
@@ -83,7 +83,7 @@ static void populateTable(const X509 * cert, MutableColumns & res_columns, const
     }
     ++col;
 
-    char * issuer = X509_NAME_oneline(cert->cert_info->issuer, nullptr, 0);
+    char * issuer = X509_NAME_oneline(X509_get_issuer_name(cert), nullptr, 0);
     if (issuer)
     {
         SCOPE_EXIT(
@@ -114,7 +114,7 @@ static void populateTable(const X509 * cert, MutableColumns & res_columns, const
     }
     ++col;
 
-    char * subject = X509_NAME_oneline(cert->cert_info->subject, nullptr, 0);
+    char * subject = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
     if (subject)
     {
         SCOPE_EXIT(


### PR DESCRIPTION
<!---
Fixing build error by using utility methods to access x509 struct fields.
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
