### PR TITLE
Don't try to kill empty list of containers in `integration/runner` II

### DIFF
--- a/docker/test/integration/runner/dockerd-entrypoint.sh
+++ b/docker/test/integration/runner/dockerd-entrypoint.sh
@@ -30,8 +30,8 @@ set -e
 # cleanup for retry run if volume is not recreated
 # shellcheck disable=SC2046
 {
-  docker kill $(docker ps -aq) || true
-  docker rm $(docker ps -aq) || true
+    docker ps -aq | xargs -r docker kill
+    docker ps -aq | xargs -r docker rm
 }
 
 echo "Start tests"

--- a/docker/test/integration/runner/dockerd-entrypoint.sh
+++ b/docker/test/integration/runner/dockerd-entrypoint.sh
@@ -30,8 +30,8 @@ set -e
 # cleanup for retry run if volume is not recreated
 # shellcheck disable=SC2046
 {
-    docker ps -aq | xargs -r docker kill
-    docker ps -aq | xargs -r docker rm
+    docker ps -aq | xargs -r docker kill || true
+    docker ps -aq | xargs -r docker rm || true
 }
 
 echo "Start tests"

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -25,7 +25,7 @@ VOLUME_NAME = "clickhouse_integration_tests"
 CONTAINER_NAME = f"{VOLUME_NAME}_{random_str()}"
 
 CONFIG_DIR_IN_REPO = "programs/server"
-INTERGATION_DIR_IN_REPO = "tests/integration"
+INTEGRATION_DIR_IN_REPO = "tests/integration"
 SRC_DIR_IN_REPO = "src"
 
 DIND_INTEGRATION_TESTS_IMAGE_NAME = "clickhouse/integration-tests-runner"
@@ -84,7 +84,7 @@ def check_args_and_update_paths(args):
             )
     else:
         args.cases_dir = os.path.abspath(
-            os.path.join(CLICKHOUSE_ROOT, INTERGATION_DIR_IN_REPO)
+            os.path.join(CLICKHOUSE_ROOT, INTEGRATION_DIR_IN_REPO)
         )
         logging.info("Cases dir is not set. Will use %s" % (args.cases_dir))
 
@@ -392,6 +392,7 @@ if __name__ == "__main__":
         command=args.command,
     )
 
+<<<<<<< HEAD
     try:
         print("Trying to kill container", CONTAINER_NAME, "if it's already running")
         subprocess.check_call(
@@ -401,6 +402,13 @@ if __name__ == "__main__":
         print("Container killed")
     except:
         print("Nothing to kill")
+=======
+    containers = subprocess.check_output(f"docker ps -a -q --filter name={CONTAINER_NAME} --format={{{{.ID}}}}", shell=True, universal_newlines=True).splitlines()
+    if containers:
+        print(f"Trying to kill containers name={CONTAINER_NAME} ids={containers}")
+        subprocess.check_call(f"docker kill {' '.join(containers)}", shell=True)
+        print(f"Containers {containers} killed")
+>>>>>>> 0fd25d1e46... Don't try to kill empty list of containers in `integration/runner`.
 
     print(("Running pytest container as: '" + cmd + "'."))
     subprocess.check_call(cmd, shell=True)

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -392,23 +392,11 @@ if __name__ == "__main__":
         command=args.command,
     )
 
-<<<<<<< HEAD
-    try:
-        print("Trying to kill container", CONTAINER_NAME, "if it's already running")
-        subprocess.check_call(
-            f'docker kill $(docker ps -a -q --filter name={CONTAINER_NAME} --format="{{{{.ID}}}}")',
-            shell=True,
-        )
-        print("Container killed")
-    except:
-        print("Nothing to kill")
-=======
     containers = subprocess.check_output(f"docker ps -a -q --filter name={CONTAINER_NAME} --format={{{{.ID}}}}", shell=True, universal_newlines=True).splitlines()
     if containers:
         print(f"Trying to kill containers name={CONTAINER_NAME} ids={containers}")
         subprocess.check_call(f"docker kill {' '.join(containers)}", shell=True)
         print(f"Containers {containers} killed")
->>>>>>> 0fd25d1e46... Don't try to kill empty list of containers in `integration/runner`.
 
     print(("Running pytest container as: '" + cmd + "'."))
     subprocess.check_call(cmd, shell=True)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Also fixed an issue appeared in #37854 

@tavplubix 