### PR TITLE
Support CREATE ... EMPTY AS SELECT

### DIFF
--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -162,6 +162,7 @@ void cleanupObjectDefinitionFromTemporaryFlags(ASTCreateQuery & query)
     query.as_table.clear();
     query.if_not_exists = false;
     query.is_populate = false;
+    query.is_create_empty = false;
     query.replace_view = false;
     query.replace_table = false;
     query.create_or_replace = false;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1455,7 +1455,7 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
 BlockIO InterpreterCreateQuery::fillTableIfNeeded(const ASTCreateQuery & create)
 {
     /// If the query is a CREATE SELECT, insert the data into the table.
-    if (create.select && !create.attach
+    if (create.select && !create.attach && !create.is_create_empty
         && !create.is_ordinary_view && !create.is_live_view
         && (!(create.is_materialized_view || create.is_window_view) || create.is_populate))
     {

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -428,6 +428,8 @@ void ASTCreateQuery::formatQueryImpl(const FormatSettings & settings, FormatStat
 
     if (is_populate)
         settings.ostr << (settings.hilite ? hilite_keyword : "") << " POPULATE" << (settings.hilite ? hilite_none : "");
+    else if (is_create_empty)
+        settings.ostr << (settings.hilite ? hilite_keyword : "") << " EMPTY" << (settings.hilite ? hilite_none : "");
 
     if (select)
     {

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -70,6 +70,7 @@ public:
     bool is_live_view{false};
     bool is_window_view{false};
     bool is_populate{false};
+    bool is_create_empty{false};    /// CREATE TABLE ... EMPTY AS SELECT ...
     bool replace_view{false}; /// CREATE OR REPLACE VIEW
 
     ASTColumns * columns_list = nullptr;

--- a/tests/queries/0_stateless/02343_create_empty_as_select.reference
+++ b/tests/queries/0_stateless/02343_create_empty_as_select.reference
@@ -1,0 +1,4 @@
+CREATE TABLE default.t\n(\n    `1` UInt8\n)\nENGINE = Memory
+0
+CREATE MATERIALIZED VIEW default.mv\n(\n    `1` UInt8\n)\nENGINE = Memory AS\nSELECT 1
+0

--- a/tests/queries/0_stateless/02343_create_empty_as_select.sql
+++ b/tests/queries/0_stateless/02343_create_empty_as_select.sql
@@ -1,0 +1,18 @@
+
+drop table if exists t;
+drop table if exists mv;
+
+create table t engine=Memory empty; -- { clientError SYNTAX_ERROR }
+create table t engine=Memory empty as; -- { clientError SYNTAX_ERROR }
+create table t engine=Memory as; -- { clientError SYNTAX_ERROR }
+create table t engine=Memory empty as select 1;
+
+show create table t;
+select count() from t;
+
+create materialized view mv engine=Memory empty as select 1;
+show create mv;
+select count() from mv;
+
+drop table t;
+drop table mv;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added `CREATE TABLE ... EMPTY AS SELECT` query. It automatically deduces table structure from the SELECT query, but does not fill the table after creation. Resolves #38049


