### PR TITLE
Fix misleading error message while s3 schema inference

### DIFF
--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -1151,7 +1151,7 @@ ColumnsDescription StorageS3::getTableStructureFromDataImpl(
     auto file_iterator
         = createFileIterator(s3_configuration, {s3_configuration.uri.key}, is_key_with_globs, distributed_processing, ctx, nullptr, {});
 
-    ReadBufferIterator read_buffer_iterator = [&, first = false]() mutable -> std::unique_ptr<ReadBuffer>
+    ReadBufferIterator read_buffer_iterator = [&, first = true]() mutable -> std::unique_ptr<ReadBuffer>
     {
         auto key = (*file_iterator)();
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/38298