### PR TITLE
Fix INSERT into Distributed hung due to ProfileEvents

### DIFF
--- a/src/QueryPipeline/RemoteInserter.cpp
+++ b/src/QueryPipeline/RemoteInserter.cpp
@@ -88,10 +88,6 @@ RemoteInserter::RemoteInserter(
             if (auto log_queue = CurrentThread::getInternalTextLogsQueue())
                 log_queue->pushBlock(std::move(packet.block));
         }
-        else if (Protocol::Server::ProfileEvents == packet.type)
-        {
-            // Do nothing
-        }
         else if (Protocol::Server::TableColumns == packet.type)
         {
             /// Server could attach ColumnsDescription in front of stream for column defaults. There's no need to pass it through cause
@@ -149,10 +145,6 @@ void RemoteInserter::onFinish()
         else if (Protocol::Server::Exception == packet.type)
             packet.exception->rethrow();
         else if (Protocol::Server::Log == packet.type)
-        {
-            // Do nothing
-        }
-        else if (Protocol::Server::ProfileEvents == packet.type)
         {
             // Do nothing
         }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -892,6 +892,8 @@ void TCPHandler::sendInsertProfileEvents()
 {
     if (client_tcp_protocol_version < DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS_IN_INSERT)
         return;
+    if (query_kind != ClientInfo::QueryKind::INITIAL_QUERY)
+        return;
 
     sendProfileEvents();
 }
@@ -1357,7 +1359,7 @@ void TCPHandler::receiveQuery()
     /// Settings
     ///
     auto settings_changes = passed_settings.changes();
-    auto query_kind = query_context->getClientInfo().query_kind;
+    query_kind = query_context->getClientInfo().query_kind;
     if (query_kind == ClientInfo::QueryKind::INITIAL_QUERY)
     {
         /// Throw an exception if the passed settings violate the constraints.

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -14,6 +14,7 @@
 #include <QueryPipeline/BlockIO.h>
 #include <Interpreters/InternalTextLogsQueue.h>
 #include <Interpreters/Context_fwd.h>
+#include <Interpreters/ClientInfo.h>
 #include <Interpreters/ProfileEventsExt.h>
 #include <Formats/NativeReader.h>
 #include <Formats/NativeWriter.h>
@@ -169,6 +170,7 @@ private:
 
     std::unique_ptr<Session> session;
     ContextMutablePtr query_context;
+    ClientInfo::QueryKind query_kind = ClientInfo::QueryKind::NO_QUERY;
 
     /// Streams for reading/writing from/to client connection socket.
     std::shared_ptr<ReadBuffer> in;

--- a/tests/queries/0_stateless/02344_insert_profile_events_stress.sql
+++ b/tests/queries/0_stateless/02344_insert_profile_events_stress.sql
@@ -1,0 +1,5 @@
+-- Tags: no-parallel, long, no-debug, no-tsan
+
+create table data_02344 (key Int) engine=Null;
+-- 3e9 rows is enough to fill the socket buffer and cause INSERT hung.
+insert into function remote('127.1', currentDatabase(), data_02344) select number from numbers(3e9) settings prefer_localhost_replica=0;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix INSERT into Distributed hung due to ProfileEvents

Right now RemoteInserter does not read ProfileEvents for INSERT, it
handles them only after sending the query or on finish.

But #37391 sends them for each INSERT block, but sometimes they can be
no ProfileEvents packet, since it sends only non-empty blocks.

And this adds too much complexity, and anyway ProfileEvents are useless
for the server, so let's send them only if the query is initial (i.e.
send by user).

Note, that it is okay to change the logic of sending ProfileEvents w/o
changing DBMS_TCP_PROTOCOL_VERSION, because there were no public
releases with the original patch included yet.

Fixes: #37391 (cc @kssenii )
Refs: #35075