### PR TITLE
[RFC] Fix possible "Incomplete granules" LOGICAL_ERROR for Vertical merges

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -27,8 +27,6 @@ struct MergeTreeReaderSettings
 
 struct MergeTreeWriterSettings
 {
-    MergeTreeWriterSettings() = default;
-
     MergeTreeWriterSettings(
         const Settings & global_settings,
         const WriteSettings & query_write_settings_,


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible "Incomplete granules" LOGICAL_ERROR for Vertical merges

After https://github.com/ClickHouse/ClickHouse/pull/38022 it is possible to get incomplete granulas for the
Horizontal part of the Veritcal merge, because MergingSortedAlgorithm
may return more then index_granularity rows (usually 4096), but not more
then merge_max_block_size (default to 8192)

Columns from the primary key are merged with Horizontal method, and
during this merge index granularity is calculated, which later will be
passed to the Vertical merge.

And it should be fine to have incomplete granulas for the Horizontal
part of the Vertical merge, since Vertical part of the merge will use
existing granularity.

P.S. I though about fixing MergeTreeDataPartWriterWide/MergedData but it
seems fine to allow incomplete granulas in this case, thoughts?

You will find an example of such situation in `<details>`.

<details>

    (lldb) p granules_written
    (const DB::Granules) $5 = size=2 {
      [0] = {
        start_row = 0
        rows_to_write = 4096
        mark_number = 237
        mark_on_start = true
        is_complete = true
      }
      [1] = {
        start_row = 4096
        rows_to_write = 3
        mark_number = 238
        mark_on_start = true
        is_complete = false
      }
    }

    <Fatal> : Logical error: 'Incomplete granules are not allowed while blocks are granules size. Mark number 238 (rows 4096), rows written in last mark 0, rows to write in last mark from block 3 (from row 4096), total marks currently 239'.
    ...
    0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x171b07ac in /usr/bin/clickhouse
    1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0xb30bd5a in /usr/bin/clickhouse
    2. DB::Exception::Exception<unsigned long&, unsigned long, unsigned long&, unsigned long&, unsigned long&, unsigned long>(int, fmt::v8::basic_format_string<char, fmt::v8::type_identity<unsigned long&>::type, fmt::v8::type_identity<unsigned long>::type, fmt::v8::type_identity<unsigned long&>::type, fmt::v8::type_identity<unsigned long&>::type, fmt::v8::type_identity<unsigned long&>::type, fmt::v8::type_identity<unsigned long>::type>, unsigned long&, unsigned long&&, unsigned long&, unsigned long&, unsigned long&, unsigned long&&) @ 0x14de5516 in /usr/bin/clickhouse
    3. DB::MergeTreeDataPartWriterWide::shiftCurrentMark(std::__1::vector<DB::Granule, std::__1::allocator<DB::Granule> > const&) @ 0x14ddfe7f in /usr/bin/clickhouse
    4. DB::MergeTreeDataPartWriterWide::write(DB::Block const&, DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 15ul, 16ul> const*) @ 0x14de06bc in /usr/bin/clickhouse
    5. DB::MergedBlockOutputStream::write(DB::Block const&) @ 0x14e966b4 in /usr/bin/clickhouse
    6. DB::MergeTask::ExecuteAndFinalizeHorizontalPart::executeImpl() @ 0x14d3c5e2 in /usr/bin/clickhouse
    7. DB::MergeTask::ExecuteAndFinalizeHorizontalPart::execute() @ 0x14d3c50b in /usr/bin/clickhouse
    8. DB::MergeTask::execute() @ 0x14d3fe9a in /usr/bin/clickhouse
    9. DB::MergePlainMergeTreeTask::executeStep() @ 0x14f58a2d in /usr/bin/clickhouse
    10. DB::MergeTreeBackgroundExecutor<DB::MergeMutateRuntimeQueue>::routine(std::__1::shared_ptr<DB::TaskRuntimeData>) @ 0x14d4d68b in /usr/bin/clickhouse
    11. DB::MergeTreeBackgroundExecutor<DB::MergeMutateRuntimeQueue>::threadFunction() @ 0x14d4e3d9 in /usr/bin/clickhouse
    12. ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::__1::__list_iterator<ThreadFromGlobalPool, void*>) @ 0xb399ae9 in /usr/bin/clickhouse
    13. ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(void&&)::'lambda'()::operator()() @ 0xb39b26d in /usr/bin/clickhouse
    14. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0xb39806a in /usr/bin/clickhouse
    15. ? @ 0xb39a46e in /usr/bin/clickhouse
    16. ? @ 0x7f3d7debcd80 in ?
    17. __clone @ 0x7f3d7dde7b6f in ?
     (version 22.7.1.1)

</details>

Cc: @kitaisreal 