### PR TITLE
Added --recursive to clickhouse-disks list

### DIFF
--- a/programs/disks/CommandList.cpp
+++ b/programs/disks/CommandList.cpp
@@ -16,6 +16,7 @@ public:
     CommandList()
     {
         command_name = "list";
+        command_option_description.emplace(createOptionsDescription("Allowed options", getTerminalWidth()));
         description = "List files (the default disk is used by default)\nPath should be in format './' or './path' or 'path'";
         usage = "list [OPTION]... <PATH>...";
         command_option_description->add_options()

--- a/programs/disks/CommandList.cpp
+++ b/programs/disks/CommandList.cpp
@@ -18,11 +18,18 @@ public:
         command_name = "list";
         description = "List files (the default disk is used by default)\nPath should be in format './' or './path' or 'path'";
         usage = "list [OPTION]... <PATH>...";
+        command_option_description->add_options()
+            ("recursive", "recursively list all directories")
+            ;
     }
 
     void processOptions(
-        Poco::Util::LayeredConfiguration &,
-        po::variables_map &) const override{}
+        Poco::Util::LayeredConfiguration & config,
+        po::variables_map & options) const override
+    {
+        if (options.count("recursive"))
+            config.setBool("recursive", true);
+    }
 
     void execute(
         const std::vector<String> & command_arguments,
@@ -39,15 +46,44 @@ public:
 
         String path =  command_arguments[0];
 
-        std::vector<String> file_names;
         DiskPtr disk = global_context->getDisk(disk_name);
 
         String full_path = fullPathWithValidate(disk, path);
 
+        bool recursive = config.getBool("recursive", false);
+
+        if (recursive)
+            listRecursive(disk, full_path);
+        else
+            list(disk, full_path);
+    }
+
+private:
+    static void list(const DiskPtr & disk, const std::string & full_path)
+    {
+        std::vector<String> file_names;
         disk->listFiles(full_path, file_names);
 
         for (const auto & file_name : file_names)
             std::cout << file_name << '\n';
+    }
+
+    static void listRecursive(const DiskPtr & disk, const std::string & full_path)
+    {
+        std::vector<String> file_names;
+        disk->listFiles(full_path, file_names);
+
+        std::cout << full_path << ":\n";
+        for (const auto & file_name : file_names)
+            std::cout << file_name << '\n';
+        std::cout << "\n";
+
+        for (const auto & file_name : file_names)
+        {
+            auto path = full_path + "/" + file_name;
+            if (disk->isDirectory(path))
+                listRecursive(disk, path);
+        }
     }
 };
 }

--- a/tests/integration/test_disks_app_func/test.py
+++ b/tests/integration/test_disks_app_func/test.py
@@ -58,6 +58,22 @@ def test_disks_app_func_ls(started_cluster):
 
     assert files[0] == "store"
 
+    out = source.exec_in_container(
+        [
+            "/usr/bin/clickhouse",
+            "disks",
+            "--send-logs",
+            "--disk",
+            "test1",
+            "list",
+            ".",
+            "--recursive",
+        ]
+    )
+
+    assert ".:\nstore\n" in out
+    assert "\n./store:\n" in out
+
 
 def test_disks_app_func_cp(started_cluster):
     source = cluster.instances["disks_app_test"]


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
