### PR TITLE
Better error message for failed odbc query

### DIFF
--- a/programs/odbc-bridge/ODBCPooledConnectionFactory.h
+++ b/programs/odbc-bridge/ODBCPooledConnectionFactory.h
@@ -91,7 +91,11 @@ T execute(nanodbc::ConnectionHolderPtr connection_holder, std::function<T(nanodb
     }
     catch (const nanodbc::database_error & e)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        LOG_ERROR(
+            &Poco::Logger::get("ODBCConnection"),
+            "ODBC query failed with error: {}, state: {}, native code: {}",
+            e.what(), e.state(), e.native());
+
         /// SQLState, connection related errors start with 08 (main: 08S01), cursor invalid state is 24000.
         /// Invalid cursor state is a retriable error.
         /// Invalid transaction state 25000. Truncate to 2 letters on purpose.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


