### PR TITLE
Fix postgres engine not using pg schema when retrieving array dimension size

### DIFF
--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -300,10 +300,11 @@ PostgreSQLTableStructure fetchPostgreSQLTableStructure(
             "and a.attnum = ANY(ix.indkey) "
             "and t.relkind in ('r', 'p') " /// simple tables
             "and t.relname = {} " /// Connection is already done to a needed database, only table name is needed.
-            "and t.relnamespace = {} "
+            "{}"
             "and ix.indisreplident = 't' " /// index is is replica identity index
-            "ORDER BY a.attname", /// column names
-        quoteString(postgres_table), quoteString(postgres_schema.empty() ? "public" : postgres_schema));
+            "ORDER BY a.attname", /// column name
+            (postgres_schema.empty() ? "" : "and t.relnamespace = " + quoteString(postgres_schema)) + " ",
+            quoteString(postgres_table));
 
         table.replica_identity_columns = readNamesAndTypesList(tx, postgres_table_with_schema, query, use_nulls, true);
     }

--- a/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
+++ b/src/Databases/PostgreSQL/fetchPostgreSQLTableStructure.cpp
@@ -263,10 +263,11 @@ PostgreSQLTableStructure fetchPostgreSQLTableStructure(
            "WHERE attrelid = (SELECT oid FROM pg_class WHERE {}) "
            "AND NOT attisdropped AND attnum > 0", where);
 
-    table.physical_columns = readNamesAndTypesList(tx, postgres_table, query, use_nulls, false);
+    auto postgres_table_with_schema = postgres_schema.empty() ? postgres_table : doubleQuoteString(postgres_schema) + '.' + doubleQuoteString(postgres_table);
+    table.physical_columns = readNamesAndTypesList(tx, postgres_table_with_schema, query, use_nulls, false);
 
     if (!table.physical_columns)
-        throw Exception(ErrorCodes::UNKNOWN_TABLE, "PostgreSQL table {} does not exist", postgres_table);
+        throw Exception(ErrorCodes::UNKNOWN_TABLE, "PostgreSQL table {} does not exist", postgres_table_with_schema);
 
     if (with_primary_key)
     {
@@ -278,7 +279,7 @@ PostgreSQLTableStructure fetchPostgreSQLTableStructure(
                 "AND a.attnum = ANY(i.indkey) "
                 "WHERE attrelid = (SELECT oid FROM pg_class WHERE {}) AND i.indisprimary", where);
 
-        table.primary_key_columns = readNamesAndTypesList(tx, postgres_table, query, use_nulls, true);
+        table.primary_key_columns = readNamesAndTypesList(tx, postgres_table_with_schema, query, use_nulls, true);
     }
 
     if (with_replica_identity_index && !table.primary_key_columns)
@@ -299,11 +300,12 @@ PostgreSQLTableStructure fetchPostgreSQLTableStructure(
             "and a.attnum = ANY(ix.indkey) "
             "and t.relkind in ('r', 'p') " /// simple tables
             "and t.relname = {} " /// Connection is already done to a needed database, only table name is needed.
+            "and t.relnamespace = {} "
             "and ix.indisreplident = 't' " /// index is is replica identity index
             "ORDER BY a.attname", /// column names
-        quoteString(postgres_table));
+        quoteString(postgres_table), quoteString(postgres_schema.empty() ? "public" : postgres_schema));
 
-        table.replica_identity_columns = readNamesAndTypesList(tx, postgres_table, query, use_nulls, true);
+        table.replica_identity_columns = readNamesAndTypesList(tx, postgres_table_with_schema, query, use_nulls, true);
     }
 
     return table;

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -433,6 +433,7 @@ def test_datetime_with_timezone(started_cluster):
 
 def test_postgres_ndim(started_cluster):
     cursor = started_cluster.postgres_conn.cursor()
+
     cursor.execute("DROP TABLE IF EXISTS arr1, arr2")
 
     cursor.execute("CREATE TABLE arr1 (a Integer[])")
@@ -451,6 +452,20 @@ def test_postgres_ndim(started_cluster):
     )
     assert result.strip() == "Array(Array(Nullable(Int32)))"
     cursor.execute("DROP TABLE arr1, arr2")
+
+    cursor.execute("DROP SCHEMA IF EXISTS ndim_schema CASCADE")
+    cursor.execute("CREATE SCHEMA ndim_schema")
+    cursor.execute("CREATE TABLE ndim_schema.arr1 (a integer[])")
+    cursor.execute("INSERT INTO ndim_schema.arr1 SELECT '{{1}, {2}}'")
+    # The point is in creating a table via 'as select *', in postgres att_ndim will not be correct in this case.
+    cursor.execute("CREATE TABLE ndim_schema.arr2 AS SELECT * FROM ndim_schema.arr1")
+    result = node1.query(
+        """SELECT toTypeName(a) FROM postgresql(postgres1, schema='ndim_schema', table='arr2')"""
+    )
+    assert result.strip() == "Array(Array(Nullable(Int32)))"
+
+    cursor.execute("DROP TABLE ndim_schema.arr1, ndim_schema.arr2")
+    cursor.execute("DROP SCHEMA ndim_schema CASCADE")
 
 
 def test_postgres_on_conflict(started_cluster):


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix PostgreSQL engine not using PostgreSQL schema when retrieving array dimension size. Closes https://github.com/ClickHouse/ClickHouse/issues/36755. Closes https://github.com/ClickHouse/ClickHouse/issues/36772.