### PR TITLE
Fix postgres database engine possible incompatibility on upgrade

### DIFF
--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -335,7 +335,13 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
             configuration.password = safeGetLiteralValue<String>(engine_args[3], engine_name);
 
             if (engine_args.size() >= 5)
-                configuration.schema = safeGetLiteralValue<String>(engine_args[4], engine_name);
+            {
+                auto arg_value = engine_args[4]->as<ASTLiteral>()->value;
+                if (arg_value.getType() == Field::Types::Which::String)
+                    configuration.schema = safeGetLiteralValue<String>(engine_args[4], engine_name);
+                else
+                    use_table_cache = safeGetLiteralValue<UInt8>(engine_args[4], engine_name);
+            }
         }
 
         if (engine_args.size() >= 6)

--- a/tests/integration/test_postgresql_database_engine/test.py
+++ b/tests/integration/test_postgresql_database_engine/test.py
@@ -320,6 +320,20 @@ def test_predefined_connection_configuration(started_cluster):
     cursor.execute("DROP SCHEMA IF EXISTS test_schema CASCADE")
 
 
+def test_postgres_database_old_syntax(started_cluster):
+    conn = get_postgres_conn(started_cluster, True)
+    cursor = conn.cursor()
+
+    node1.query(
+        """
+        DROP DATABASE IF EXISTS test_database;
+        CREATE DATABASE test_database ENGINE = PostgreSQL('postgres1:5432', 'test_database', 'postgres', 'mysecretpassword', 1);
+        """
+    )
+    create_postgres_table(cursor, "test_table")
+    assert "test_table" in node1.query("SHOW TABLES FROM test_database")
+
+
 if __name__ == "__main__":
     cluster.start()
     input("Cluster created, press any key to destroy...")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix PostgreSQL database engine incompatibility on upgrade from 21.3 to 22.3. Closes https://github.com/ClickHouse/ClickHouse/issues/36659.


