### PR TITLE
Fix some wrong titles and links in alter docs

### DIFF
--- a/docs/en/sql-reference/statements/alter/column.md
+++ b/docs/en/sql-reference/statements/alter/column.md
@@ -18,12 +18,12 @@ Each action is an operation on a column.
 
 The following actions are supported:
 
--   [ADD COLUMN](#alter_add-column) — Adds a new column to the table.
--   [DROP COLUMN](#alter_drop-column) — Deletes the column.
--   [RENAME COLUMN](#alter_rename-column) — Renames an existing column.
--   [CLEAR COLUMN](#alter_clear-column) — Resets column values.
--   [COMMENT COLUMN](#alter_comment-column) — Adds a text comment to the column.
--   [MODIFY COLUMN](#alter_modify-column) — Changes column’s type, default expression and TTL.
+-   [ADD COLUMN](#add-column) — Adds a new column to the table.
+-   [DROP COLUMN](#drop-column) — Deletes the column.
+-   [RENAME COLUMN](#rename-column) — Renames an existing column.
+-   [CLEAR COLUMN](#clear-column) — Resets column values.
+-   [COMMENT COLUMN](#comment-column) — Adds a text comment to the column.
+-   [MODIFY COLUMN](#modify-column) — Changes column’s type, default expression and TTL.
 -   [MODIFY COLUMN REMOVE](#modify-remove) — Removes one of the column properties.
 -   [MATERIALIZE COLUMN](#materialize-column) — Materializes the column in the parts where the column is missing.
 

--- a/docs/en/sql-reference/statements/alter/partition.md
+++ b/docs/en/sql-reference/statements/alter/partition.md
@@ -7,18 +7,18 @@ sidebar_label: PARTITION
 
 The following operations with [partitions](../../../engines/table-engines/mergetree-family/custom-partitioning-key.md) are available:
 
--   [DETACH PARTITION](#alter_detach-partition) — Moves a partition to the `detached` directory and forget it.
--   [DROP PARTITION](#alter_drop-partition) — Deletes a partition.
--   [ATTACH PART\|PARTITION](#alter_attach-partition) — Adds a part or partition from the `detached` directory to the table.
--   [ATTACH PARTITION FROM](#alter_attach-partition-from) — Copies the data partition from one table to another and adds.
--   [REPLACE PARTITION](#alter_replace-partition) — Copies the data partition from one table to another and replaces.
--   [MOVE PARTITION TO TABLE](#alter_move_to_table-partition) — Moves the data partition from one table to another.
--   [CLEAR COLUMN IN PARTITION](#alter_clear-column-partition) — Resets the value of a specified column in a partition.
--   [CLEAR INDEX IN PARTITION](#alter_clear-index-partition) — Resets the specified secondary index in a partition.
--   [FREEZE PARTITION](#alter_freeze-partition) — Creates a backup of a partition.
--   [UNFREEZE PARTITION](#alter_unfreeze-partition) — Removes a backup of a partition.
--   [FETCH PARTITION\|PART](#alter_fetch-partition) — Downloads a part or partition from another server.
--   [MOVE PARTITION\|PART](#alter_move-partition) — Move partition/data part to another disk or volume.
+-   [DETACH PARTITION\|Part](#detach-partitionpart) — Moves a partition or part to the `detached` directory and forget it.
+-   [DROP PARTITION\|Part](#drop-partitionpart) — Deletes a partition or part.
+-   [ATTACH PARTITION\|Part](#attach-partitionpart) — Adds a partition or part from the `detached` directory to the table.
+-   [ATTACH PARTITION FROM](#attach-partition-from) — Copies the data partition from one table to another and adds.
+-   [REPLACE PARTITION](#replace-partition) — Copies the data partition from one table to another and replaces.
+-   [MOVE PARTITION TO TABLE](#move_to_table-partition) — Moves the data partition from one table to another.
+-   [CLEAR COLUMN IN PARTITION](#clear-column-partition) — Resets the value of a specified column in a partition.
+-   [CLEAR INDEX IN PARTITION](#clear-index-partition) — Resets the specified secondary index in a partition.
+-   [FREEZE PARTITION](#freeze-partition) — Creates a backup of a partition.
+-   [UNFREEZE PARTITION](#unfreeze-partition) — Removes a backup of a partition.
+-   [FETCH PARTITION\|PART](#fetch-partition) — Downloads a part or partition from another server.
+-   [MOVE PARTITION\|PART](#move-partition) — Move partition/data part to another disk or volume.
 -   [UPDATE IN PARTITION](#update-in-partition) — Update data inside the partition by condition.
 -   [DELETE IN PARTITION](#delete-in-partition) — Delete data inside the partition by condition.
 

--- a/docs/en/sql-reference/statements/alter/partition.md
+++ b/docs/en/sql-reference/statements/alter/partition.md
@@ -7,9 +7,9 @@ sidebar_label: PARTITION
 
 The following operations with [partitions](../../../engines/table-engines/mergetree-family/custom-partitioning-key.md) are available:
 
--   [DETACH PARTITION\|Part](#detach-partitionpart) — Moves a partition or part to the `detached` directory and forget it.
--   [DROP PARTITION\|Part](#drop-partitionpart) — Deletes a partition or part.
--   [ATTACH PARTITION\|Part](#attach-partitionpart) — Adds a partition or part from the `detached` directory to the table.
+-   [DETACH PARTITION\|PART](#detach-partitionpart) — Moves a partition or part to the `detached` directory and forget it.
+-   [DROP PARTITION\|PART](#drop-partitionpart) — Deletes a partition or part.
+-   [ATTACH PARTITION\|PART](#attach-partitionpart) — Adds a partition or part from the `detached` directory to the table.
 -   [ATTACH PARTITION FROM](#attach-partition-from) — Copies the data partition from one table to another and adds.
 -   [REPLACE PARTITION](#replace-partition) — Copies the data partition from one table to another and replaces.
 -   [MOVE PARTITION TO TABLE](#move_to_table-partition) — Moves the data partition from one table to another.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
Fix some wrong titles and links in alter column and partition docs

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
