### PR TITLE
move title to frontmatter for access control docs

### DIFF
--- a/docs/en/operations/access-rights.md
+++ b/docs/en/operations/access-rights.md
@@ -1,9 +1,8 @@
 ---
 sidebar_position: 48
 sidebar_label: Access Control and Account Management
+title: Access Control and Account Management
 ---
-
-# Access Control and Account Management
 
 ClickHouse supports access control management based on [RBAC](https://en.wikipedia.org/wiki/Role-based_access_control) approach.
 


### PR DESCRIPTION
In order to present the content from ClickHouse/ClickHouse and ClickHouse/clickhouse-docs in a more reader friendly configuration we need to be able to include docs from multiple repos into a single folder structure.  Docusaurus supports this, and the only change necessary is to move the H1 header from the body of the Markdown into the front matter.  For example:

Current:
```
---
sidebar_position: 48
sidebar_label: Access Control and Account Management
---

# Access Control and Account Management

ClickHouse supports access control management based on [RBAC]
```

proposed:

```
---
sidebar_position: 48
sidebar_label: Access Control and Account Management
title: Access Control and Account Management
---

ClickHouse supports access control management based on [RBAC]
```

This then allows us to include content from different location like so:
```
---
sidebar_label: Access Control and Account Management
title: Access Control and Account Management
---

import AccessRights from '@site/docs/en/operations/access-rights.md';

<AccessRights />;
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)
