### PR TITLE
Remove useless codec from `system.asynchronous_metric_log`

### DIFF
--- a/src/Interpreters/AsynchronousMetricLog.h
+++ b/src/Interpreters/AsynchronousMetricLog.h
@@ -40,7 +40,7 @@ struct AsynchronousMetricLogElement
         return "event_date Date CODEC(Delta(2), ZSTD(1)), "
                "event_time DateTime CODEC(Delta(4), ZSTD(1)), "
                "metric LowCardinality(String) CODEC(ZSTD(1)), "
-               "value Float64 CODEC(Gorilla, ZSTD(3))";
+               "value Float64 CODEC(ZSTD(3))";
     }
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The table `system.asynchronous_metric_log` is further optimized for storage space. This closes #38134. See the [YouTube video](https://www.youtube.com/watch?v=0fSp9SF8N8A).