### PR TITLE
fix other wrong links in alter column and partition docs

### DIFF
--- a/docs/en/sql-reference/statements/alter/column.md
+++ b/docs/en/sql-reference/statements/alter/column.md
@@ -24,7 +24,7 @@ The following actions are supported:
 -   [CLEAR COLUMN](#clear-column) — Resets column values.
 -   [COMMENT COLUMN](#comment-column) — Adds a text comment to the column.
 -   [MODIFY COLUMN](#modify-column) — Changes column’s type, default expression and TTL.
--   [MODIFY COLUMN REMOVE](#modify-remove) — Removes one of the column properties.
+-   [MODIFY COLUMN REMOVE](#modify-column-remove) — Removes one of the column properties.
 -   [MATERIALIZE COLUMN](#materialize-column) — Materializes the column in the parts where the column is missing.
 
 These actions are described in detail below.

--- a/docs/en/sql-reference/statements/alter/partition.md
+++ b/docs/en/sql-reference/statements/alter/partition.md
@@ -12,13 +12,13 @@ The following operations with [partitions](../../../engines/table-engines/merget
 -   [ATTACH PARTITION\|PART](#attach-partitionpart) — Adds a partition or part from the `detached` directory to the table.
 -   [ATTACH PARTITION FROM](#attach-partition-from) — Copies the data partition from one table to another and adds.
 -   [REPLACE PARTITION](#replace-partition) — Copies the data partition from one table to another and replaces.
--   [MOVE PARTITION TO TABLE](#move_to_table-partition) — Moves the data partition from one table to another.
--   [CLEAR COLUMN IN PARTITION](#clear-column-partition) — Resets the value of a specified column in a partition.
--   [CLEAR INDEX IN PARTITION](#clear-index-partition) — Resets the specified secondary index in a partition.
+-   [MOVE PARTITION TO TABLE](#move-partition-to-table) — Moves the data partition from one table to another.
+-   [CLEAR COLUMN IN PARTITION](#clear-column-in-partition) — Resets the value of a specified column in a partition.
+-   [CLEAR INDEX IN PARTITION](#clear-index-in-partition) — Resets the specified secondary index in a partition.
 -   [FREEZE PARTITION](#freeze-partition) — Creates a backup of a partition.
 -   [UNFREEZE PARTITION](#unfreeze-partition) — Removes a backup of a partition.
--   [FETCH PARTITION\|PART](#fetch-partition) — Downloads a part or partition from another server.
--   [MOVE PARTITION\|PART](#move-partition) — Move partition/data part to another disk or volume.
+-   [FETCH PARTITION\|PART](#fetch-partitionpart) — Downloads a part or partition from another server.
+-   [MOVE PARTITION\|PART](#move-partitionpart) — Move partition/data part to another disk or volume.
 -   [UPDATE IN PARTITION](#update-in-partition) — Update data inside the partition by condition.
 -   [DELETE IN PARTITION](#delete-in-partition) — Delete data inside the partition by condition.
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Continue with https://github.com/ClickHouse/ClickHouse/pull/38392, find other 6 wrong links in alter column and partition docs, try to fix them  


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
