### PR TITLE
Allow trailing comma in columns list

### DIFF
--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -467,6 +467,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     ParserKeyword s_from("FROM");
     ParserKeyword s_on("ON");
     ParserToken s_dot(TokenType::Dot);
+    ParserToken s_comma(TokenType::Comma);
     ParserToken s_lparen(TokenType::OpeningRoundBracket);
     ParserToken s_rparen(TokenType::ClosingRoundBracket);
     ParserStorage storage_p;
@@ -572,6 +573,9 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     if (s_lparen.ignore(pos, expected))
     {
         if (!table_properties_p.parse(pos, columns_list, expected))
+            return false;
+
+        if (s_comma.checkWithoutMoving(pos, expected) && !s_comma.ignore(pos, expected))
             return false;
 
         if (!s_rparen.ignore(pos, expected))

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -575,8 +575,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         if (!table_properties_p.parse(pos, columns_list, expected))
             return false;
 
-        if (s_comma.checkWithoutMoving(pos, expected) && !s_comma.ignore(pos, expected))
-            return false;
+        s_comma.ignore(pos, expected);
 
         if (!s_rparen.ignore(pos, expected))
             return false;

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -575,6 +575,8 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         if (!table_properties_p.parse(pos, columns_list, expected))
             return false;
 
+        /// We allow a trailing comma in the columns list for user convenience.
+        /// Although it diverges from the SQL standard slightly.
         s_comma.ignore(pos, expected);
 
         if (!s_rparen.ignore(pos, expected))

--- a/tests/queries/0_stateless/02345_create_table_allow_trailing_comma.reference
+++ b/tests/queries/0_stateless/02345_create_table_allow_trailing_comma.reference
@@ -1,0 +1,4 @@
+id	Int32	DEFAULT	1			
+id	Int32	DEFAULT	1			
+x	UInt8					
+y	UInt8					

--- a/tests/queries/0_stateless/02345_create_table_allow_trailing_comma.sql
+++ b/tests/queries/0_stateless/02345_create_table_allow_trailing_comma.sql
@@ -1,11 +1,14 @@
 DROP TABLE IF EXISTS trailing_comma_1 SYNC;
 CREATE TABLE trailing_comma_1 (id INT NOT NULL DEFAULT 1,) ENGINE=MergeTree() ORDER BY tuple();
 DESCRIBE TABLE trailing_comma_1;
+DROP TABLE trailing_comma_1;
 
 DROP TABLE IF EXISTS trailing_comma_2 SYNC;
 CREATE TABLE trailing_comma_2 (id INT DEFAULT 1,) ENGINE=MergeTree() ORDER BY tuple();
 DESCRIBE TABLE trailing_comma_2;
+DROP TABLE trailing_comma_2;
 
 DROP TABLE IF EXISTS trailing_comma_3 SYNC;
 CREATE TABLE trailing_comma_3 (x UInt8, y UInt8,) ENGINE=MergeTree() ORDER BY tuple();
 DESCRIBE TABLE trailing_comma_3;
+DROP TABLE trailing_comma_3;

--- a/tests/queries/0_stateless/02345_create_table_allow_trailing_comma.sql
+++ b/tests/queries/0_stateless/02345_create_table_allow_trailing_comma.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS trailing_comma_1 SYNC;
+CREATE TABLE trailing_comma_1 (id INT NOT NULL DEFAULT 1,) ENGINE=MergeTree() ORDER BY tuple();
+DESCRIBE TABLE trailing_comma_1;
+
+DROP TABLE IF EXISTS trailing_comma_2 SYNC;
+CREATE TABLE trailing_comma_2 (id INT DEFAULT 1,) ENGINE=MergeTree() ORDER BY tuple();
+DESCRIBE TABLE trailing_comma_2;
+
+DROP TABLE IF EXISTS trailing_comma_3 SYNC;
+CREATE TABLE trailing_comma_3 (x UInt8, y UInt8,) ENGINE=MergeTree() ORDER BY tuple();
+DESCRIBE TABLE trailing_comma_3;


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow trailing comma in columns list. closes #38425


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
