### PR TITLE
Docs: clarify processing of DateTime64 values

### DIFF
--- a/docs/en/sql-reference/data-types/datetime64.md
+++ b/docs/en/sql-reference/data-types/datetime64.md
@@ -7,7 +7,7 @@ sidebar_label: DateTime64
 
 Allows to store an instant in time, that can be expressed as a calendar date and a time of a day, with defined sub-second precision
 
-Tick size (precision): 10<sup>-precision</sup> seconds. Valid range: [ 0 : 9 ]. 
+Tick size (precision): 10<sup>-precision</sup> seconds. Valid range: [ 0 : 9 ].
 Typically are used - 3 (milliseconds), 6 (microseconds), 9 (nanoseconds).
 
 **Syntax:**
@@ -34,7 +34,7 @@ ENGINE = TinyLog;
 ```
 
 ``` sql
-INSERT INTO dt Values (1546300800000, 1), ('2019-01-01 00:00:00', 2);
+INSERT INTO dt Values (1546300800123, 1), (1546300800.123, 2), ('2019-01-01 00:00:00', 3);
 ```
 
 ``` sql
@@ -43,12 +43,13 @@ SELECT * FROM dt;
 
 ``` text
 ┌───────────────timestamp─┬─event_id─┐
-│ 2019-01-01 03:00:00.000 │        1 │
-│ 2019-01-01 00:00:00.000 │        2 │
+│ 2019-01-01 03:00:00.123 │        1 │
+│ 2019-01-01 03:00:00.123 │        2 │
+│ 2019-01-01 00:00:00.000 │        3 │
 └─────────────────────────┴──────────┘
 ```
 
--   When inserting datetime as an integer, it is treated as an appropriately scaled Unix Timestamp (UTC). `1546300800000` (with precision 3) represents `'2019-01-01 00:00:00'` UTC. However, as `timestamp` column has `Asia/Istanbul` (UTC+3) timezone specified, when outputting as a string the value will be shown as `'2019-01-01 03:00:00'`.
+-   When inserting datetime as an integer, it is treated as an appropriately scaled Unix Timestamp (UTC). `1546300800000` (with precision 3) represents `'2019-01-01 00:00:00'` UTC. However, as `timestamp` column has `Asia/Istanbul` (UTC+3) timezone specified, when outputting as a string the value will be shown as `'2019-01-01 03:00:00'`. Inserting datetime as a decimal will treat it similarly as an integer, except the value before the decimal point is the Unix Timestamp up to and including the seconds, and after the decimal point will be treated as the precision.
 -   When inserting string value as datetime, it is treated as being in column timezone. `'2019-01-01 00:00:00'` will be treated as being in `Asia/Istanbul` timezone and stored as `1546290000000`.
 
 2. Filtering on `DateTime64` values
@@ -64,6 +65,20 @@ SELECT * FROM dt WHERE timestamp = toDateTime64('2019-01-01 00:00:00', 3, 'Asia/
 ```
 
 Unlike `DateTime`, `DateTime64` values are not converted from `String` automatically.
+
+``` sql
+SELECT * FROM dt WHERE timestamp = toDateTime64(1546300800.123, 3);
+```
+
+``` text
+┌───────────────timestamp─┬─event_id─┐
+│ 2019-01-01 00:00:00.123 │        1 │
+│ 2019-01-01 00:00:00.123 │        2 │
+└─────────────────────────┴──────────┘
+```
+
+Contrary to inserting, the `toDateTime64` function will treat all values as the decimal variant, so precision needs to
+be given after the decimal point.
 
 3. Getting a time zone for a `DateTime64`-type value:
 

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -301,6 +301,80 @@ Result:
 └─────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────┘
 ```
 
+## toDateTime64
+
+Converts the argument to the [DateTime64](../../sql-reference/data-types/datetime64.md) data type.
+
+**Syntax**
+
+``` sql
+toDateTime64(expr, scale, [timezone])
+```
+
+**Arguments**
+
+-   `expr` — The value. [String](../../sql-reference/data-types/string.md), [UInt32](../../sql-reference/data-types/int-uint.md), [Float](../../sql-reference/data-types/float.md) or [DateTime](../../sql-reference/data-types/datetime.md).
+-   `scale` - Tick size (precision): 10<sup>-precision</sup> seconds. Valid range: [ 0 : 9 ].
+-   `timezone` - Time zone of the specified datetime64 object.
+
+**Returned value**
+
+-   A calendar date and time of day, with sub-second precision.
+
+Type: [DateTime64](../../sql-reference/data-types/datetime64.md).
+
+**Example**
+
+1. The value is within the range:
+
+``` sql
+SELECT toDateTime64('1955-01-01 00:00:00.000', 3) AS value, toTypeName(value);
+```
+
+``` text
+┌───────────────────value─┬─toTypeName(toDateTime64('1955-01-01 00:00:00.000', 3))─┐
+│ 1955-01-01 00:00:00.000 │ DateTime64(3)                                          │
+└─────────────────────────┴────────────────────────────────────────────────────────┘
+```
+
+2. As decimal with precision:
+
+``` sql
+SELECT toDateTime64(1546300800.000, 3) AS value, toTypeName(value);
+```
+
+``` text
+┌───────────────────value─┬─toTypeName(toDateTime64(1546300800., 3))─┐
+│ 2019-01-01 00:00:00.000 │ DateTime64(3)                            │
+└─────────────────────────┴──────────────────────────────────────────┘
+```
+
+Without the decimal point the value is still treated as Unix Timestamp in seconds:
+
+``` sql
+SELECT toDateTime64(1546300800000, 3) AS value, toTypeName(value);
+```
+
+``` text
+┌───────────────────value─┬─toTypeName(toDateTime64(1546300800000, 3))─┐
+│ 2282-12-31 00:00:00.000 │ DateTime64(3)                              │
+└─────────────────────────┴────────────────────────────────────────────┘
+```
+
+
+3. With `timezone`:
+
+``` sql
+SELECT toDateTime64('2019-01-01 00:00:00', 3, 'Asia/Istanbul') AS value, toTypeName(value);
+```
+
+``` text
+┌───────────────────value─┬─toTypeName(toDateTime64('2019-01-01 00:00:00', 3, 'Asia/Istanbul'))─┐
+│ 2019-01-01 00:00:00.000 │ DateTime64(3, 'Asia/Istanbul')                                      │
+└─────────────────────────┴─────────────────────────────────────────────────────────────────────┘
+```
+
+
 ## toDecimal(32\|64\|128\|256)
 
 Converts `value` to the [Decimal](../../sql-reference/data-types/decimal.md) data type with precision of `S`. The `value` can be a number or a string. The `S` (scale) parameter specifies the number of decimal places.


### PR DESCRIPTION
`DateTime64` objects are not treated consistently between inserting values (as `DateTime64`) or using the `toDateTime64()` conversion function. Especially integers without decimal point.
Therefore add some description to the docs to clarify use-cases, to prevent unexpected outcomes.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
