### PR TITLE
Small improvement of the error message to hint at possible issue

### DIFF
--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -205,7 +205,7 @@ struct ConvertImpl
 
                 if constexpr (std::is_same_v<FromDataType, DataTypeUUID> != std::is_same_v<ToDataType, DataTypeUUID>)
                 {
-                    throw Exception("Conversion between numeric types and UUID is not supported", ErrorCodes::NOT_IMPLEMENTED);
+                    throw Exception("Conversion between numeric types and UUID is not supported. Probably the passed UUID is unquoted", ErrorCodes::NOT_IMPLEMENTED);
                 }
                 else
                 {


### PR DESCRIPTION
When trying to insert a UUID but this is not quoted, the message is a bit misleading:

```
cc8abf7db4fd :) insert into uuid Values (00000000-0000-0000-0000-000000000000, 1)

INSERT INTO uuid FORMAT Values

Query id: c9e8346f-55e2-4b7f-bb1b-0f6aae08d63d

Exception on client:
Code: 48. DB::Exception: Conversion between numeric types and UUID is not supported: while executing 'FUNCTION if(isNull(minus(minus(minus(minus(_dummy_0, _dummy_1), _dummy_2), _dummy_3), _dummy_4)) : 7, defaultValueOfTypeName('UUID') :: 6, _CAST(minus(minus(minus(minus(_dummy_0, _dummy_1), _dummy_2), _dummy_3), _dummy_4), 'UUID') :: 9) -> if(isNull(minus(minus(minus(minus(_dummy_0, _dummy_1), _dummy_2), _dummy_3), _dummy_4)), defaultValueOfTypeName('UUID'), _CAST(minus(minus(minus(minus(_dummy_0, _dummy_1), _dummy_2), _dummy_3), _dummy_4), 'UUID')) UUID : 5': While executing ValuesBlockInputFormat: data for INSERT was parsed from query. (NOT_IMPLEMENTED)
```

As for date conversion a helpful message is presented (unquoted argument):
```
cc8abf7db4fd :) SELECT toDate(2019-01-01);
Exception on client:
Code: 62. DB::Exception: Argument of function toDate is unquoted: toDate(2019-01-01), must be: toDate('2019-01-01'). (SYNTAX_ERROR)
```

Wanted to do something similar. But at the point where the exception above is thrown, the value is already split into separate numbers as split by the minus sign (`-`). So checking if the original would have parsed as a UUID is no longer possible.

Therefore just slightly changing the message since ending up at this exception is very likely due to the UUID not being quoted _and_ consisting of full numeric values anyhow.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
