### PR TITLE
Fixes for clickhouse/clickhouse-keeper docker image

### DIFF
--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -67,7 +67,7 @@ RUN arch=${TARGETARCH:-amd64} \
     && chmod ugo+Xrw -R /var/lib/clickhouse /var/log/clickhouse-keeper /etc/clickhouse-keeper
 
 
-EXPOSE 2181 10181 44444
+EXPOSE 2181 10181 44444 9181
 
 VOLUME /var/lib/clickhouse /var/log/clickhouse-keeper /etc/clickhouse-keeper
 

--- a/docker/keeper/entrypoint.sh
+++ b/docker/keeper/entrypoint.sh
@@ -31,7 +31,7 @@ else
     DO_CHOWN=0
 fi
 
-KEEPER_CONFIG="${KEEPER_CONFIG:-/etc/clickhouse-keeper/config.yaml}"
+KEEPER_CONFIG="${KEEPER_CONFIG:-/etc/clickhouse-keeper/keeper_config.xml}"
 
 if [ -f "$KEEPER_CONFIG" ] && ! $gosu test -f "$KEEPER_CONFIG" -a -r "$KEEPER_CONFIG"; then
     echo "Configuration file '$KEEPER_CONFIG' isn't readable by user with id '$USER'"


### PR DESCRIPTION
There is a problem when starting official docker image (clickhouse/clickhouse-keeper) as it is. It uses wrong keeper_config file which leads to logs entries:
```
Processing configuration file 'keeper_config.xml'.
There is no file 'keeper_config.xml', will use embedded config.
```

After fix all is fine.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix: expose new CH keeper port in Dockerfile clickhouse/clickhouse-keeper
fix: use correct KEEPER_CONFIG filename in clickhouse/clickhouse-keeper docker image


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
