### PR TITLE
tests: cleanup tmp data in 02335_column_ttl_expired_column_optimization

### DIFF
--- a/tests/queries/0_stateless/02335_column_ttl_expired_column_optimization.sh
+++ b/tests/queries/0_stateless/02335_column_ttl_expired_column_optimization.sh
@@ -4,7 +4,9 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-$CLICKHOUSE_LOCAL --path "$CLICKHOUSE_TEST_UNIQUE_NAME" -nm -q "
+data_path="$CLICKHOUSE_TMP/local"
+
+$CLICKHOUSE_LOCAL --path "$data_path" -nm -q "
     create table ttl_02335 (
         date Date,
         key Int,
@@ -25,5 +27,5 @@ $CLICKHOUSE_LOCAL --path "$CLICKHOUSE_TEST_UNIQUE_NAME" -nm -q "
     optimize table ttl_02335 final;
 "
 
-test -f "$CLICKHOUSE_TEST_UNIQUE_NAME"/data/_local/ttl_02335/all_1_1_3/value.bin && echo "[FAIL] value column should not exist"
-exit 0
+test -f "$data_path"/data/_local/ttl_02335/all_1_1_3/value.bin && echo "[FAIL] value column should not exist"
+rm -fr "${data_path:?}"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)