### PR TITLE
Cleanup: local clang-tidy warnings founded during review

### DIFF
--- a/src/Core/PostgreSQL/Connection.h
+++ b/src/Core/PostgreSQL/Connection.h
@@ -32,7 +32,7 @@ struct ConnectionInfo
 class Connection : private boost::noncopyable
 {
 public:
-    Connection(const ConnectionInfo & connection_info_, bool replication_ = false, size_t num_tries = 3);
+    explicit Connection(const ConnectionInfo & connection_info_, bool replication_ = false, size_t num_tries = 3);
 
     void execWithRetry(const std::function<void(pqxx::nontransaction &)> & exec);
 

--- a/src/Core/PostgreSQL/PoolWithFailover.h
+++ b/src/Core/PostgreSQL/PoolWithFailover.h
@@ -25,13 +25,13 @@ public:
     static constexpr inline auto POSTGRESQL_POOL_WAIT_TIMEOUT = 5000;
     static constexpr inline auto POSTGRESQL_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES = 5;
 
-    PoolWithFailover(
+    explicit PoolWithFailover(
         const DB::ExternalDataSourcesConfigurationByPriority & configurations_by_priority,
         size_t pool_size = POSTGRESQL_POOL_DEFAULT_SIZE,
         size_t pool_wait_timeout = POSTGRESQL_POOL_WAIT_TIMEOUT,
         size_t max_tries_ = POSTGRESQL_POOL_WITH_FAILOVER_DEFAULT_MAX_TRIES);
 
-    PoolWithFailover(
+    explicit PoolWithFailover(
         const DB::StoragePostgreSQLConfiguration & configuration,
         size_t pool_size = POSTGRESQL_POOL_DEFAULT_SIZE,
         size_t pool_wait_timeout = POSTGRESQL_POOL_WAIT_TIMEOUT,

--- a/src/Dictionaries/RedisDictionarySource.h
+++ b/src/Dictionaries/RedisDictionarySource.h
@@ -8,11 +8,6 @@
 
 namespace Poco
 {
-    namespace Util
-    {
-        class AbstractConfiguration;
-    }
-
     namespace Redis
     {
         class Client;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)