### PR TITLE
Fix some clang-tidy warnings in headers

### DIFF
--- a/base/base/argsToConfig.h
+++ b/base/base/argsToConfig.h
@@ -4,7 +4,7 @@
 
 namespace Poco::Util
 {
-class LayeredConfiguration;
+class LayeredConfiguration; // NOLINT(cppcoreguidelines-virtual-class-destructor)
 }
 
 /// Import extra command line arguments to configuration. These are command line arguments after --.

--- a/base/base/demangle.h
+++ b/base/base/demangle.h
@@ -27,6 +27,6 @@ struct FreeingDeleter
     }
 };
 
-typedef std::unique_ptr<char, FreeingDeleter> DemangleResult;
+using DemangleResult = std::unique_ptr<char, FreeingDeleter>;
 
 DemangleResult tryDemangle(const char * name);

--- a/base/base/iostream_debug_helpers.h
+++ b/base/base/iostream_debug_helpers.h
@@ -120,7 +120,7 @@ Out & dumpDispatchPriorities(Out & out, T && x, std::decay_t<decltype(dumpImpl<p
     return dumpImpl<priority>(out, x);
 }
 
-struct LowPriority { explicit LowPriority(void *) {} };
+struct LowPriority { LowPriority(void *) {} };
 
 template <int priority, typename Out, typename T>
 Out & dumpDispatchPriorities(Out & out, T && x, LowPriority)

--- a/base/base/iostream_debug_helpers.h
+++ b/base/base/iostream_debug_helpers.h
@@ -120,7 +120,7 @@ Out & dumpDispatchPriorities(Out & out, T && x, std::decay_t<decltype(dumpImpl<p
     return dumpImpl<priority>(out, x);
 }
 
-struct LowPriority { LowPriority(void *) {} };
+struct LowPriority { explicit LowPriority(void *) {} };
 
 template <int priority, typename Out, typename T>
 Out & dumpDispatchPriorities(Out & out, T && x, LowPriority)

--- a/base/base/strong_typedef.h
+++ b/base/base/strong_typedef.h
@@ -23,10 +23,10 @@ public:
     constexpr StrongTypedef(): t() {}
 
     constexpr StrongTypedef(const Self &) = default;
-    constexpr StrongTypedef(Self &&) = default;
+    constexpr StrongTypedef(Self &&) noexcept(std::is_nothrow_move_constructible_v<T>) = default;
 
     Self & operator=(const Self &) = default;
-    Self & operator=(Self &&) = default;
+    Self & operator=(Self &&) noexcept(std::is_nothrow_move_assignable_v<T>)= default;
 
     template <class Enable = typename std::is_copy_assignable<T>::type>
     Self & operator=(const T & rhs) { t = rhs; return *this;}

--- a/base/base/time.h
+++ b/base/base/time.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <time.h>
+#include <ctime>
 
 #if defined (OS_DARWIN) || defined (OS_SUNOS)
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC

--- a/base/base/unaligned.h
+++ b/base/base/unaligned.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string.h>
+#include <cstring>
 #include <type_traits>
 
 

--- a/base/base/wide_integer.h
+++ b/base/base/wide_integer.h
@@ -27,6 +27,8 @@
 #include <type_traits>
 #include <initializer_list>
 
+// NOLINTBEGIN(*)
+
 namespace wide
 {
 template <size_t Bits, typename Signed>
@@ -257,4 +259,7 @@ struct hash<wide::integer<Bits, Signed>>;
 
 }
 
+// NOLINTEND(*)
+
 #include "wide_integer_impl.h"
+

--- a/base/base/wide_integer_impl.h
+++ b/base/base/wide_integer_impl.h
@@ -15,6 +15,8 @@
 #include <boost/multiprecision/cpp_bin_float.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
+// NOLINTBEGIN(*)
+
 /// Use same extended double for all platforms
 #if (LDBL_MANT_DIG == 64)
 #define CONSTEXPR_FROM_DOUBLE constexpr
@@ -1478,3 +1480,5 @@ struct hash<wide::integer<Bits, Signed>>
 };
 
 }
+
+// NOLINTEND(*)

--- a/base/pcg-random/pcg_extras.hpp
+++ b/base/pcg-random/pcg_extras.hpp
@@ -1,5 +1,3 @@
-// NOLINTBEGIN(*)
-
 /*
  * PCG Random Number Generation for C++
  *
@@ -92,6 +90,7 @@
     #define PCG_EMULATED_128BIT_MATH 1
 #endif
 
+// NOLINTBEGIN(*)
 
 namespace pcg_extras {
 
@@ -554,6 +553,6 @@ std::ostream& operator<<(std::ostream& out, printable_typename<T>) {
 
 } // namespace pcg_extras
 
-#endif // PCG_EXTRAS_HPP_INCLUDED
-
 // NOLINTEND(*)
+
+#endif // PCG_EXTRAS_HPP_INCLUDED

--- a/base/pcg-random/pcg_extras.hpp
+++ b/base/pcg-random/pcg_extras.hpp
@@ -1,3 +1,5 @@
+// NOLINTBEGIN(*)
+
 /*
  * PCG Random Number Generation for C++
  *
@@ -553,3 +555,5 @@ std::ostream& operator<<(std::ostream& out, printable_typename<T>) {
 } // namespace pcg_extras
 
 #endif // PCG_EXTRAS_HPP_INCLUDED
+
+// NOLINTEND(*)

--- a/base/pcg-random/pcg_random.hpp
+++ b/base/pcg-random/pcg_random.hpp
@@ -1,5 +1,3 @@
-// NOLINTBEGIN(*)
-
 /*
  * PCG Random Number Generation for C++
  *
@@ -114,6 +112,8 @@
  */
 
 #include "pcg_extras.hpp"
+
+// NOLINTBEGIN(*)
 
 namespace DB
 {
@@ -1779,6 +1779,6 @@ typedef pcg_engines::ext_oneseq_xsh_rs_64_32<14,32,true>    pcg32_k16384_fast;
     #pragma warning(default:4146)
 #endif
 
-#endif // PCG_RAND_HPP_INCLUDED
-
 // NOLINTEND(*)
+
+#endif // PCG_RAND_HPP_INCLUDED

--- a/base/pcg-random/pcg_random.hpp
+++ b/base/pcg-random/pcg_random.hpp
@@ -1,3 +1,5 @@
+// NOLINTBEGIN(*)
+
 /*
  * PCG Random Number Generation for C++
  *
@@ -1778,3 +1780,5 @@ typedef pcg_engines::ext_oneseq_xsh_rs_64_32<14,32,true>    pcg32_k16384_fast;
 #endif
 
 #endif // PCG_RAND_HPP_INCLUDED
+
+// NOLINTEND(*)

--- a/base/widechar_width/widechar_width.h
+++ b/base/widechar_width/widechar_width.h
@@ -16,6 +16,8 @@
 #include <cstddef>
 #include <cstdint>
 
+// NOLINTBEGIN(*)
+
 /* Special width values */
 enum {
   widechar_nonprint = -1,     // The character is not printable.
@@ -517,5 +519,7 @@ inline int widechar_wcwidth(wchar_t c) {
         return widechar_widened_in_9;
     return 1;
 }
+
+// NOLINTEND(*)
 
 #endif // WIDECHAR_WIDTH_H

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string.h>
+#include <cstring>
 
 #ifdef NDEBUG
     #define ALLOCATOR_ASLR 0

--- a/src/Common/Arena.h
+++ b/src/Common/Arena.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string.h>
+#include <cstring>
 #include <memory>
 #include <vector>
 #include <boost/noncopyable.hpp>

--- a/src/Common/CurrentMetrics.h
+++ b/src/Common/CurrentMetrics.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <cstdint>
 #include <utility>
 #include <atomic>

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -130,7 +130,7 @@ public:
     int getLineNumber() const { return line_number; }
     void setLineNumber(int line_number_) { line_number = line_number_;}
 
-    const String getFileName() const { return file_name; }
+    String getFileName() const { return file_name; }
     void setFileName(const String & file_name_) { file_name = file_name_; }
 
     Exception * clone() const override { return new ParsingException(*this); }

--- a/src/Common/FileCacheSettings.h
+++ b/src/Common/FileCacheSettings.h
@@ -2,7 +2,7 @@
 
 #include <Common/FileCache_fwd.h>
 
-namespace Poco { namespace Util { class AbstractConfiguration; } }
+namespace Poco { namespace Util { class AbstractConfiguration; } } // NOLINT(cppcoreguidelines-virtual-class-destructor)
 
 namespace DB
 {

--- a/src/Common/IFactoryWithAliases.h
+++ b/src/Common/IFactoryWithAliases.h
@@ -27,9 +27,9 @@ protected:
 
     String getAliasToOrName(const String & name) const
     {
-        if (aliases.count(name))
+        if (aliases.contains(name))
             return aliases.at(name);
-        else if (String name_lowercase = Poco::toLower(name); case_insensitive_aliases.count(name_lowercase))
+        else if (String name_lowercase = Poco::toLower(name); case_insensitive_aliases.contains(name_lowercase))
             return case_insensitive_aliases.at(name_lowercase);
         else
             return name;
@@ -108,7 +108,7 @@ public:
 
     bool isAlias(const String & name) const
     {
-        return aliases.count(name) || case_insensitive_aliases.count(name);
+        return aliases.count(name) || case_insensitive_aliases.contains(name);
     }
 
     bool hasNameOrAlias(const String & name) const
@@ -125,7 +125,7 @@ public:
         return name;
     }
 
-    virtual ~IFactoryWithAliases() override = default;
+    ~IFactoryWithAliases() override = default;
 
 private:
     using InnerMap = std::unordered_map<String, Value>; // name -> creator

--- a/src/Common/LocalDate.h
+++ b/src/Common/LocalDate.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string.h>
+#include <cstring>
 #include <string>
 #include <exception>
 #include <Common/DateLUT.h>

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string.h>
+#include <cstring>
 #include <cstddef>
 #include <cassert>
 #include <algorithm>

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -4,7 +4,7 @@
 #include "base/types.h"
 #include <atomic>
 #include <memory>
-#include <stddef.h>
+#include <cstddef>
 
 /** Implements global counters for various events happening in the application
   *  - for high level profiling.

--- a/src/Common/StackTrace.h
+++ b/src/Common/StackTrace.h
@@ -7,7 +7,7 @@
 #include <array>
 #include <optional>
 #include <functional>
-#include <signal.h>
+#include <csignal>
 
 #ifdef OS_DARWIN
 // ucontext is not available without _XOPEN_SOURCE

--- a/src/Common/StringSearcher.h
+++ b/src/Common/StringSearcher.h
@@ -7,8 +7,8 @@
 #include <Core/Defines.h>
 #include <base/range.h>
 #include <Poco/Unicode.h>
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #ifdef __SSE2__
     #include <emmintrin.h>

--- a/src/Common/formatIPv6.h
+++ b/src/Common/formatIPv6.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <base/types.h>
-#include <string.h>
+#include <cstring>
 #include <algorithm>
 #include <utility>
 #include <base/range.h>

--- a/src/Common/memcpySmall.h
+++ b/src/Common/memcpySmall.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string.h>
+#include <cstring>
 
 #ifdef __SSE2__
 #    include <emmintrin.h>

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -54,7 +54,7 @@ DEFINE_FIELD_VECTOR(Map); /// TODO: use map instead of vector.
 
 #undef DEFINE_FIELD_VECTOR
 
-using FieldMap = std::map<String, Field, std::less<String>, AllocatorWithMemoryTracking<std::pair<const String, Field>>>;
+using FieldMap = std::map<String, Field, std::less<>, AllocatorWithMemoryTracking<std::pair<const String, Field>>>;
 
 #define DEFINE_FIELD_MAP(X) \
 struct X : public FieldMap \

--- a/src/Databases/TablesLoader.h
+++ b/src/Databases/TablesLoader.h
@@ -12,7 +12,7 @@
 
 namespace Poco
 {
-    class Logger;
+    class Logger; // NOLINT(cppcoreguidelines-virtual-class-destructor)
 }
 
 class AtomicStopwatch;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -36,7 +36,7 @@ struct FormatSettings
     bool seekable_read = true;
     UInt64 max_rows_to_read_for_schema_inference = 100;
 
-    String column_names_for_schema_inference = "";
+    String column_names_for_schema_inference;
 
     enum class DateTimeInputFormat
     {

--- a/src/IO/BufferWithOwnMemory.h
+++ b/src/IO/BufferWithOwnMemory.h
@@ -181,7 +181,7 @@ public:
     }
 
 private:
-    void nextImpl() override final
+    void nextImpl() final
     {
         const size_t prev_size = Base::position() - memory.data();
         memory.resize(2 * prev_size + 1);

--- a/src/IO/WriteBuffer.h
+++ b/src/IO/WriteBuffer.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <iostream>
 #include <cassert>
-#include <string.h>
+#include <cstring>
 
 #include <Common/Exception.h>
 #include <Common/LockMemoryExceptionInThread.h>

--- a/src/IO/WriteBuffer.h
+++ b/src/IO/WriteBuffer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <cstring>
 #include <memory>
 #include <iostream>
 #include <cassert>

--- a/src/IO/WriteBufferFromVector.h
+++ b/src/IO/WriteBufferFromVector.h
@@ -64,7 +64,7 @@ public:
     }
 
 private:
-    void finalizeImpl() override final
+    void finalizeImpl() override
     {
         vector.resize(
             ((position() - reinterpret_cast<Position>(vector.data())) /// NOLINT

--- a/src/Interpreters/StorageID.h
+++ b/src/Interpreters/StorageID.h
@@ -10,7 +10,7 @@ namespace Poco
 {
 namespace Util
 {
-class AbstractConfiguration;
+class AbstractConfiguration; // NOLINT(cppcoreguidelines-virtual-class-destructor)
 }
 }
 

--- a/utils/iotest/iotest_aio.cpp
+++ b/utils/iotest/iotest_aio.cpp
@@ -4,8 +4,8 @@ int main(int, char **) { return 0; }
 
 #include <fcntl.h>
 #include <unistd.h>
-#include <stdlib.h>
-#include <time.h>
+#include <cstdlib>
+#include <ctime>
 #include <iostream>
 #include <iomanip>
 #include <vector>
@@ -18,7 +18,7 @@ int main(int, char **) { return 0; }
 #include <pcg_random.hpp>
 #include <IO/BufferWithOwnMemory.h>
 #include <IO/ReadHelpers.h>
-#include <stdio.h>
+#include <cstdio>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <IO/AIO.h>

--- a/utils/self-extracting-executable/compressor.cpp
+++ b/utils/self-extracting-executable/compressor.cpp
@@ -3,10 +3,10 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
 #include <memory>
 #include <iostream>
 

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -8,9 +8,9 @@
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 
 #include "types.h"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)