### PR TITLE
Fix `_csv.Error: field larger than field limit`

### DIFF
--- a/docker/test/util/process_functional_tests_result.py
+++ b/docker/test/util/process_functional_tests_result.py
@@ -86,7 +86,7 @@ def process_test_log(log_path):
                 test_end = True
 
     test_results = [
-        (test[0], test[1], test[2], "".join(test[3])) for test in test_results
+        (test[0], test[1], test[2], "".join(test[3]))[:4096] for test in test_results
     ]
 
     return (


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Follow-up to #38030
