### PR TITLE
Fix table creation to avoid replication issues with pre-22.4 replicas

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -598,6 +598,9 @@ void StorageReplicatedMergeTree::createNewZooKeeperNodes()
     auto zookeeper = getZooKeeper();
 
     std::vector<zkutil::ZooKeeper::FutureCreate> futures;
+    /// We need to confirm /quorum exists here although it's called under createTableIfNotExists because in older CH releases (pre 22.4)
+    /// it was created here, so if metadata creation is done by an older replica the node might not exists when reaching this call
+    futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/quorum", String(), zkutil::CreateMode::Persistent));
     futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/quorum/parallel", String(), zkutil::CreateMode::Persistent));
 
     /// Nodes for remote fs zero-copy replication


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix table creation to avoid replication issues with pre-22.4 replicas

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Closes https://github.com/ClickHouse/ClickHouse/issues/38529

This issue only appears when a replicated table is created on a cluster that includes servers running CH22.3 or before and 22.4 or after. Depending on the order of execution of the operations you might get an error like:
```
2022.06.28 11:21:04.617313 [ 542 ] {a10cd1d2-21e2-469f-b9e4-15799499c0a5} <Error> executeQuery: Code: 999. Coordination::Exception: Failed to create new nodes at /clickhouse/tables/01-01/d_fc31c7.t_1dcbb96ee43844bf888d010f18a179b3_quarantine (No node). (KEEPER_EXCEPTION) (version 22.6.1.1985 (official build)) (from 0.0.0.0:0) (in query: /* ddl_entry=query-0000000164 */ CREATE TABLE d_fc31c7.t_1dcbb96ee43844bf888d010f18a179b3_quarantine UUID '6e6781b2-09b9-4f4f-a83f-9d36786d140c' (`c__error_column` Array(String), `c__error` Array(String), `c__import_id` Nullable(String), `number` Nullable(String), `insertion_date` DateTime DEFAULT now()) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard}/d_fc31c7.t_1dcbb96ee43844bf888d010f18a179b3_quarantine', '{replica}') PARTITION BY toYear(insertion_date) ORDER BY insertion_date), Stack trace (when copying this message, always include the lines below):
```

This happens because the creation of `/quorum` was moved to `createTableIfNotExists` so it can happen with something like:
- Replica22.4 starts table creation.
- Replica22.3 starts table creation.
- Replica22.3 is the first replica pushing nodes to ZK. It does not creates `/quorum`
- Replica22.4 sees it's not the first replica so it does not push nodes.
- Replica22.4 reaches createNewZooKeeperNodes() and tries to create `/quorum/parallel`. As `/quorum` doesn't exist if fails.

This is just a matter of bad timing, but it does happen. I've been able to reproduce the issue by running:
```bash
clickhouse client -h clickhouse-01 --port 49000 --query "DROP DATABASE IF EXISTS test2 ON CLUSTER tinybird SYNC;"
clickhouse client -h clickhouse-01 --port 49000 --query "CREATE DATABASE test2 ON CLUSTER tinybird;"
for i in {1..500};
do
echo $i
clickhouse client -h clickhouse-01 --port 49000 --query "
CREATE TABLE test2.test$i ON CLUSTER tinybird (date DateTime('UTC'), city String)
                 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard}/test2.test$i', '{replica}')
                 PARTITION BY toYear(date)
                 ORDER BY (date, city) TTL date + toIntervalDay(1)" || break;
done
```

```bash
$ while true; do sh t.sh || break; done
```

While running other operations (running the internal CI over the cluster). It reproduces, at least, with master, 21.6 and 21.5 (likely 21.4 too) when run alongside 22.3. 

Should be backported to all stable releases including 22.4 to avoid failures when running in a cluster alongside 22.3 or older releases