### PR TITLE
Don't use std::unique_lock unless we need to

### DIFF
--- a/base/base/BorrowedObjectPool.h
+++ b/base/base/BorrowedObjectPool.h
@@ -89,7 +89,7 @@ public:
     inline void returnObject(T && object_to_return)
     {
         {
-            std::lock_guard<std::mutex> lock(objects_mutex);
+            std::lock_guard lock(objects_mutex);
 
             objects.emplace_back(std::move(object_to_return));
             --borrowed_objects_size;
@@ -107,14 +107,14 @@ public:
     /// Allocated objects size by the pool. If allocatedObjectsSize == maxSize then pool is full.
     inline size_t allocatedObjectsSize() const
     {
-        std::unique_lock<std::mutex> lock(objects_mutex);
+        std::lock_guard lock(objects_mutex);
         return allocated_objects_size;
     }
 
     /// Returns allocatedObjectsSize == maxSize
     inline bool isFull() const
     {
-        std::unique_lock<std::mutex> lock(objects_mutex);
+        std::lock_guard lock(objects_mutex);
         return allocated_objects_size == max_size;
     }
 
@@ -122,7 +122,7 @@ public:
     /// Then client will wait during borrowObject function call.
     inline size_t borrowedObjectsSize() const
     {
-        std::unique_lock<std::mutex> lock(objects_mutex);
+        std::lock_guard lock(objects_mutex);
         return borrowed_objects_size;
     }
 

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -223,7 +223,7 @@ void kerberosInit(const String & keytab_file, const String & principal, const St
 {
     // Using mutex to prevent cache file corruptions
     static std::mutex kinit_mtx;
-    std::unique_lock<std::mutex> lck(kinit_mtx);
+    std::lock_guard lck(kinit_mtx);
     KerberosInit k_init;
     k_init.init(keytab_file, principal, cache_name);
 }

--- a/src/Common/OvercommitTracker.cpp
+++ b/src/Common/OvercommitTracker.cpp
@@ -137,7 +137,7 @@ void OvercommitTracker::onQueryStop(MemoryTracker * tracker)
 {
     DENY_ALLOCATIONS_IN_SCOPE;
 
-    std::unique_lock<std::mutex> lk(overcommit_m);
+    std::lock_guard lk(overcommit_m);
     if (picked_tracker == tracker)
     {
         LOG_DEBUG_SAFE(getLogger(), "Picked query stopped");

--- a/src/Common/PoolBase.h
+++ b/src/Common/PoolBase.h
@@ -55,7 +55,7 @@ private:
         explicit PoolEntryHelper(PooledObject & data_) : data(data_) { data.in_use = true; }
         ~PoolEntryHelper()
         {
-            std::unique_lock lock(data.pool.mutex);
+            std::lock_guard lock(data.pool.mutex);
             data.in_use = false;
             data.pool.available.notify_one();
         }
@@ -163,7 +163,7 @@ public:
 
     inline size_t size()
     {
-        std::unique_lock lock(mutex);
+        std::lock_guard lock(mutex);
         return items.size();
     }
 

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -139,7 +139,7 @@ void SystemLogBase<LogElement>::flush(bool force)
     uint64_t this_thread_requested_offset;
 
     {
-        std::unique_lock lock(mutex);
+        std::lock_guard lock(mutex);
 
         if (is_shutdown)
             return;

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -209,7 +209,7 @@ template <typename Thread>
 void ThreadPoolImpl<Thread>::finalize()
 {
     {
-        std::unique_lock lock(mutex);
+        std::lock_guard lock(mutex);
         shutdown = true;
     }
 
@@ -224,14 +224,14 @@ void ThreadPoolImpl<Thread>::finalize()
 template <typename Thread>
 size_t ThreadPoolImpl<Thread>::active() const
 {
-    std::unique_lock lock(mutex);
+    std::lock_guard lock(mutex);
     return scheduled_jobs;
 }
 
 template <typename Thread>
 bool ThreadPoolImpl<Thread>::finished() const
 {
-    std::unique_lock lock(mutex);
+    std::lock_guard lock(mutex);
     return shutdown;
 }
 
@@ -290,7 +290,7 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
                 job = {};
 
                 {
-                    std::unique_lock lock(mutex);
+                    std::lock_guard lock(mutex);
                     if (!first_exception)
                         first_exception = std::current_exception(); // NOLINT
                     if (shutdown_on_exception)
@@ -305,7 +305,7 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
         }
 
         {
-            std::unique_lock lock(mutex);
+            std::lock_guard lock(mutex);
             --scheduled_jobs;
 
             if (threads.size() > scheduled_jobs + max_free_threads)

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -576,7 +576,7 @@ nuraft::cb_func::ReturnCode KeeperServer::callbackFunc(nuraft::cb_func::Type typ
 
     auto set_initialized = [this]()
     {
-        std::unique_lock lock(initialized_mutex);
+        std::lock_guard lock(initialized_mutex);
         initialized_flag = true;
         initialized_cv.notify_all();
     };

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -925,7 +925,7 @@ void BaseDaemon::handleSignal(int signal_id)
         signal_id == SIGQUIT ||
         signal_id == SIGTERM)
     {
-        std::unique_lock<std::mutex> lock(signal_handler_mutex);
+        std::lock_guard lock(signal_handler_mutex);
         {
             ++terminate_signals_counter;
             sigint_signals_counter += signal_id == SIGINT;

--- a/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMaterializedMySQL.cpp
@@ -39,7 +39,7 @@ DatabaseMaterializedMySQL::DatabaseMaterializedMySQL(
 
 void DatabaseMaterializedMySQL::rethrowExceptionIfNeeded() const
 {
-    std::unique_lock<std::mutex> lock(mutex);
+    std::lock_guard lock(mutex);
 
     if (!settings->allows_query_when_mysql_lost && exception)
     {
@@ -59,7 +59,7 @@ void DatabaseMaterializedMySQL::rethrowExceptionIfNeeded() const
 
 void DatabaseMaterializedMySQL::setException(const std::exception_ptr & exception_)
 {
-    std::unique_lock<std::mutex> lock(mutex);
+    std::lock_guard lock(mutex);
     exception = exception_;
 }
 

--- a/src/Dictionaries/CacheDictionaryUpdateQueue.cpp
+++ b/src/Dictionaries/CacheDictionaryUpdateQueue.cpp
@@ -135,14 +135,14 @@ void CacheDictionaryUpdateQueue<dictionary_key_type>::updateThreadFunction()
 
             /// Notify thread about finished updating the bunch of ids
             /// where their own ids were included.
-            std::unique_lock<std::mutex> lock(update_mutex);
+            std::lock_guard lock(update_mutex);
 
             unit_to_update->is_done = true;
             is_update_finished.notify_all();
         }
         catch (...)
         {
-            std::unique_lock<std::mutex> lock(update_mutex);
+            std::lock_guard lock(update_mutex);
 
             unit_to_update->current_exception = std::current_exception(); // NOLINT(bugprone-throw-keyword-missing)
             is_update_finished.notify_all();

--- a/src/Disks/DiskCacheWrapper.cpp
+++ b/src/Disks/DiskCacheWrapper.cpp
@@ -90,7 +90,7 @@ DiskCacheWrapper::DiskCacheWrapper(
 
 std::shared_ptr<FileDownloadMetadata> DiskCacheWrapper::acquireDownloadMetadata(const String & path) const
 {
-    std::unique_lock<std::mutex> lock{mutex};
+    std::lock_guard lock{mutex};
 
     auto it = file_downloads.find(path);
     if (it != file_downloads.end())
@@ -101,7 +101,7 @@ std::shared_ptr<FileDownloadMetadata> DiskCacheWrapper::acquireDownloadMetadata(
         new FileDownloadMetadata,
         [this, path] (FileDownloadMetadata * p)
         {
-            std::unique_lock<std::mutex> erase_lock{mutex};
+            std::lock_guard erase_lock{mutex};
             file_downloads.erase(path);
             delete p;
         });

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
@@ -56,7 +56,7 @@ void MetadataStorageFromDiskTransaction::commit()
                         toString(state), toString(MetadataFromDiskTransactionState::PREPARING));
 
     {
-        std::unique_lock lock(metadata_storage.metadata_mutex);
+        std::lock_guard lock(metadata_storage.metadata_mutex);
         for (size_t i = 0; i < operations.size(); ++i)
         {
             try

--- a/src/Disks/ObjectStorages/S3/ProxyResolverConfiguration.cpp
+++ b/src/Disks/ObjectStorages/S3/ProxyResolverConfiguration.cpp
@@ -28,7 +28,7 @@ ClientConfigurationPerRequest ProxyResolverConfiguration::getConfiguration(const
 {
     LOG_DEBUG(&Poco::Logger::get("AWSClient"), "Obtain proxy using resolver: {}", endpoint.toString());
 
-    std::unique_lock lock(cache_mutex);
+    std::lock_guard lock(cache_mutex);
 
     std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
 
@@ -110,7 +110,7 @@ void ProxyResolverConfiguration::errorReport(const ClientConfigurationPerRequest
     if (config.proxy_host.empty())
         return;
 
-    std::unique_lock lock(cache_mutex);
+    std::lock_guard lock(cache_mutex);
 
     if (!cache_ttl.count() || !cache_valid)
         return;

--- a/src/IO/HTTPCommon.cpp
+++ b/src/IO/HTTPCommon.cpp
@@ -212,7 +212,7 @@ namespace
             size_t max_connections_per_endpoint,
             bool resolve_host = true)
         {
-            std::unique_lock lock(mutex);
+            std::lock_guard lock(mutex);
             const std::string & host = uri.getHost();
             UInt16 port = uri.getPort();
             bool https = isHTTPS(uri);

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -148,7 +148,7 @@ public:
     {
         String credentials_string;
         {
-            std::unique_lock<std::recursive_mutex> locker(token_mutex);
+            std::lock_guard locker(token_mutex);
 
             LOG_TRACE(logger, "Getting default credentials for EC2 instance.");
             auto result = GetResourceWithAWSWebServiceResult(endpoint.c_str(), EC2_SECURITY_CREDENTIALS_RESOURCE, nullptr);
@@ -194,7 +194,7 @@ public:
         String new_token;
 
         {
-            std::unique_lock<std::recursive_mutex> locker(token_mutex);
+            std::lock_guard locker(token_mutex);
 
             Aws::StringStream ss;
             ss << endpoint << EC2_IMDS_TOKEN_RESOURCE;

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -215,7 +215,7 @@ void AsynchronousInsertQueue::push(ASTPtr query, ContextPtr query_context)
         }
     }
 
-    std::unique_lock write_lock(rwlock);
+    std::lock_guard write_lock(rwlock);
     auto it = queue.emplace(key, std::make_shared<Container>()).first;
     pushImpl(std::move(entry), it);
 }
@@ -343,7 +343,7 @@ void AsynchronousInsertQueue::cleanup()
 
         if (!keys_to_remove.empty())
         {
-            std::unique_lock write_lock(rwlock);
+            std::lock_guard write_lock(rwlock);
             size_t total_removed = 0;
 
             for (const auto & key : keys_to_remove)

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -698,7 +698,7 @@ std::unique_lock<std::shared_mutex> DatabaseCatalog::getExclusiveDDLGuardForData
 {
     DDLGuards::iterator db_guard_iter;
     {
-        std::unique_lock lock(ddl_guards_mutex);
+        std::lock_guard lock(ddl_guards_mutex);
         db_guard_iter = ddl_guards.try_emplace(database).first;
         assert(db_guard_iter->second.first.contains(""));
     }

--- a/src/Interpreters/EmbeddedDictionaries.cpp
+++ b/src/Interpreters/EmbeddedDictionaries.cpp
@@ -60,7 +60,7 @@ bool EmbeddedDictionaries::reloadDictionary(
 
 bool EmbeddedDictionaries::reloadImpl(const bool throw_on_error, const bool force_reload)
 {
-    std::unique_lock lock(mutex);
+    std::lock_guard lock(mutex);
 
     /** If you can not update the directories, then despite this, do not throw an exception (use the old directories).
       * If there are no old correct directories, then when using functions that depend on them,

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -580,7 +580,7 @@ void MergeJoin::mergeRightBlocks()
 
 void MergeJoin::mergeInMemoryRightBlocks()
 {
-    std::unique_lock lock(rwlock);
+    std::lock_guard lock(rwlock);
 
     if (right_blocks.empty())
         return;
@@ -613,7 +613,7 @@ void MergeJoin::mergeInMemoryRightBlocks()
 
 void MergeJoin::mergeFlushedRightBlocks()
 {
-    std::unique_lock lock(rwlock);
+    std::lock_guard lock(rwlock);
 
     auto callback = [&](const Block & block)
     {
@@ -638,7 +638,7 @@ bool MergeJoin::saveRightBlock(Block && block)
 {
     if (is_in_memory)
     {
-        std::unique_lock lock(rwlock);
+        std::lock_guard lock(rwlock);
 
         if (!is_in_memory)
         {

--- a/src/Interpreters/Set.cpp
+++ b/src/Interpreters/Set.cpp
@@ -103,7 +103,7 @@ void NO_INLINE Set::insertFromBlockImplCase(
 
 void Set::setHeader(const ColumnsWithTypeAndName & header)
 {
-    std::unique_lock lock(rwlock);
+    std::lock_guard lock(rwlock);
 
     if (!data.empty())
         return;

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
@@ -20,7 +20,7 @@ namespace DB
         }
 
         {
-            std::unique_lock<std::mutex> lock(mutex);
+            std::lock_guard lock(mutex);
 
             if (background_exception)
                 std::rethrow_exception(background_exception);
@@ -30,7 +30,7 @@ namespace DB
     void ParallelFormattingOutputFormat::addChunk(Chunk chunk, ProcessingUnitType type, bool can_throw_exception)
     {
         {
-            std::unique_lock<std::mutex> lock(mutex);
+            std::lock_guard lock(mutex);
             if (background_exception && can_throw_exception)
                 std::rethrow_exception(background_exception);
         }

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.h
@@ -236,7 +236,7 @@ private:
 
     void onBackgroundException()
     {
-        std::unique_lock<std::mutex> lock(mutex);
+        std::lock_guard lock(mutex);
         if (!background_exception)
         {
             background_exception = std::current_exception();

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
@@ -121,7 +121,7 @@ void ParallelParsingInputFormat::parserThreadFunction(ThreadGroupStatusPtr threa
 
 void ParallelParsingInputFormat::onBackgroundException(size_t offset)
 {
-    std::unique_lock<std::mutex> lock(mutex);
+    std::lock_guard lock(mutex);
     if (!background_exception)
     {
         background_exception = std::current_exception();
@@ -233,7 +233,7 @@ Chunk ParallelParsingInputFormat::generate()
         else
         {
             // Pass the unit back to the segmentator.
-            std::unique_lock<std::mutex> lock(mutex);
+            std::lock_guard lock(mutex);
             unit.status = READY_TO_INSERT;
             segmentator_condvar.notify_all();
         }

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -26,7 +26,7 @@ void HTTPServerConnection::run()
     {
         try
         {
-            std::unique_lock<std::mutex> lock(mutex);
+            std::lock_guard lock(mutex);
             if (!stopped && tcp_server.isOpen() && session.connected())
             {
                 HTTPServerResponse response(session);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -189,7 +189,7 @@ bool ReplicatedMergeTreeRestartingThread::tryStartup()
         }
         catch (...)
         {
-            std::unique_lock lock(storage.last_queue_update_exception_lock);
+            std::lock_guard lock(storage.last_queue_update_exception_lock);
             storage.last_queue_update_exception = getCurrentExceptionMessage(false);
             throw;
         }

--- a/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
+++ b/src/Storages/RocksDB/StorageEmbeddedRocksDB.cpp
@@ -336,7 +336,7 @@ StorageEmbeddedRocksDB::StorageEmbeddedRocksDB(const StorageID & table_id_,
 
 void StorageEmbeddedRocksDB::truncate(const ASTPtr &, const StorageMetadataPtr & , ContextPtr, TableExclusiveLockHolder &)
 {
-    std::unique_lock<std::shared_mutex> lock(rocksdb_ptr_mx);
+    std::lock_guard lock(rocksdb_ptr_mx);
     rocksdb_ptr->Close();
     rocksdb_ptr = nullptr;
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2969,7 +2969,7 @@ void StorageReplicatedMergeTree::cloneReplicaIfNeeded(zkutil::ZooKeeperPtr zooke
 
 String StorageReplicatedMergeTree::getLastQueueUpdateException() const
 {
-    std::unique_lock lock(last_queue_update_exception_lock);
+    std::lock_guard lock(last_queue_update_exception_lock);
     return last_queue_update_exception;
 }
 
@@ -2991,7 +2991,7 @@ void StorageReplicatedMergeTree::queueUpdatingTask()
     {
         tryLogCurrentException(log, __PRETTY_FUNCTION__);
 
-        std::unique_lock lock(last_queue_update_exception_lock);
+        std::lock_guard lock(last_queue_update_exception_lock);
         last_queue_update_exception = getCurrentExceptionMessage(false);
 
         if (e.code == Coordination::Error::ZSESSIONEXPIRED)
@@ -3006,7 +3006,7 @@ void StorageReplicatedMergeTree::queueUpdatingTask()
     {
         tryLogCurrentException(log, __PRETTY_FUNCTION__);
 
-        std::unique_lock lock(last_queue_update_exception_lock);
+        std::lock_guard lock(last_queue_update_exception_lock);
         last_queue_update_exception = getCurrentExceptionMessage(false);
 
         queue_updating_task->scheduleAfter(QUEUE_UPDATE_ERROR_SLEEP_MS);
@@ -4340,7 +4340,7 @@ void StorageReplicatedMergeTree::shutdown()
         /// Ask all parts exchange handlers to finish asap. New ones will fail to start
         data_parts_exchange_ptr->blocker.cancelForever();
         /// Wait for all of them
-        std::unique_lock lock(data_parts_exchange_ptr->rwlock);
+        std::lock_guard lock(data_parts_exchange_ptr->rwlock);
     }
 }
 
@@ -7399,7 +7399,7 @@ void StorageReplicatedMergeTree::checkBrokenDisks()
         if (disk_ptr->isBroken())
         {
             {
-                std::unique_lock lock(last_broken_disks_mutex);
+                std::lock_guard lock(last_broken_disks_mutex);
                 if (!last_broken_disks.insert(disk_ptr->getName()).second)
                     continue;
             }
@@ -7419,7 +7419,7 @@ void StorageReplicatedMergeTree::checkBrokenDisks()
         else
         {
             {
-                std::unique_lock lock(last_broken_disks_mutex);
+                std::lock_guard lock(last_broken_disks_mutex);
                 if (last_broken_disks.erase(disk_ptr->getName()) > 0)
                     LOG_INFO(
                         log,

--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -1017,7 +1017,7 @@ void StorageWindowView::threadFuncFireProc()
     if (shutdown_called)
         return;
 
-    std::unique_lock lock(fire_signal_mutex);
+    std::lock_guard lock(fire_signal_mutex);
     UInt32 timestamp_now = std::time(nullptr);
 
     while (next_fire_signal <= timestamp_now)
@@ -1049,7 +1049,7 @@ void StorageWindowView::threadFuncFireProc()
 
 void StorageWindowView::threadFuncFireEvent()
 {
-    std::unique_lock lock(fire_signal_mutex);
+    std::lock_guard lock(fire_signal_mutex);
 
     LOG_TRACE(log, "Fire events: {}", fire_signal.size());
 


### PR DESCRIPTION
Replace where possible by std::lock_guard which is more light-weight.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)