### PR TITLE
Don't spoil return code of integration tests runner with redundant tee

### DIFF
--- a/tests/ci/integration_test_check.py
+++ b/tests/ci/integration_test_check.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
     output_path_log = os.path.join(result_path, "main_script_log.txt")
 
     runner_path = os.path.join(repo_path, "tests/integration", "ci-runner.py")
-    run_command = f"sudo -E {runner_path} | tee {output_path_log}"
+    run_command = f"sudo -E {runner_path}"
     logging.info("Going to run command: `%s`", run_command)
     logging.info(
         "ENV parameters for runner:\n%s",


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

Testing CI reported fail when integration tests fail with error while collecting tests (https://github.com/ClickHouse/ClickHouse/runs/7101668300?check_suite_focus=true):

```
Exception: There is something wrong with getting all tests list: file '/home/ubuntu/actions-runner/_work/_temp/integration_tests_tsan/ClickHouse/tests/integration/all_tests.txt' is empty or does not exist.
INFO:root:Run tests successfully
```