### PR TITLE
Add logging in Epoll and TimerDescriptor in case of EINTR

### DIFF
--- a/src/Common/Epoll.cpp
+++ b/src/Common/Epoll.cpp
@@ -72,7 +72,7 @@ size_t Epoll::getManyReady(int max_events, epoll_event * events_out, bool blocki
             throwFromErrno("Error in epoll_wait", DB::ErrorCodes::EPOLL_ERROR);
         
         if (errno == EINTR)
-            LOG_DEBUG(&Poco::Logger::get("Epoll"), "EINTR");
+            LOG_TEST(&Poco::Logger::get("Epoll"), "EINTR");
     }
     while (ready_size <= 0 && (ready_size != 0 || blocking));
 

--- a/src/Common/Epoll.cpp
+++ b/src/Common/Epoll.cpp
@@ -70,7 +70,7 @@ size_t Epoll::getManyReady(int max_events, epoll_event * events_out, bool blocki
 
         if (ready_size == -1 && errno != EINTR)
             throwFromErrno("Error in epoll_wait", DB::ErrorCodes::EPOLL_ERROR);
-        
+
         if (errno == EINTR)
             LOG_TEST(&Poco::Logger::get("Epoll"), "EINTR");
     }

--- a/src/Common/Epoll.cpp
+++ b/src/Common/Epoll.cpp
@@ -70,6 +70,9 @@ size_t Epoll::getManyReady(int max_events, epoll_event * events_out, bool blocki
 
         if (ready_size == -1 && errno != EINTR)
             throwFromErrno("Error in epoll_wait", DB::ErrorCodes::EPOLL_ERROR);
+        
+        if (errno == EINTR)
+            LOG_DEBUG(&Poco::Logger::get("Epoll"), "EINTR");
     }
     while (ready_size <= 0 && (ready_size != 0 || blocking));
 

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -6,6 +6,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <Common/logger_useful.h>
+
 namespace DB
 {
 
@@ -70,6 +72,8 @@ void TimerDescriptor::drain() const
 
             if (errno != EINTR)
                 throwFromErrno("Cannot drain timer_fd", ErrorCodes::CANNOT_READ_FROM_SOCKET);
+            else
+                LOG_DEBUG(&Poco::Logger::get("TimerDescriptor"), "EINTR");
         }
     }
 }

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -73,7 +73,7 @@ void TimerDescriptor::drain() const
             if (errno != EINTR)
                 throwFromErrno("Cannot drain timer_fd", ErrorCodes::CANNOT_READ_FROM_SOCKET);
             else
-                LOG_DEBUG(&Poco::Logger::get("TimerDescriptor"), "EINTR");
+                LOG_TEST(&Poco::Logger::get("TimerDescriptor"), "EINTR");
         }
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Test if hungs in Epoll and TimerDescriptor related to EINTR.