### PR TITLE
Allow Ordinary database in Stress Tests

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -42,6 +42,7 @@ function install_packages()
 function configure()
 {
     # install test configs
+    export USE_DATABASE_ORDINARY=1
     /usr/share/clickhouse-test/config/install.sh
 
     # we mount tests folder from repo to /usr/share


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Stress Tests use all database engines:
https://github.com/ClickHouse/ClickHouse/blob/e307a728caaa36c9d603422152c71850a602bacf/docker/test/stress/stress#L17-L22
But it was accidentally broken in #38335:
```
00052_group_by_in:                                                      [ FAIL ] - return code: 81
Received exception from server (version 22.7.1):
Code: 81. DB::Exception: Received from localhost:9000. DB::Exception: Database test_1 doesn't exist. (UNKNOWN_DATABASE)
(query: select StartDate, TraficSourceID in (0) ? 'type_in' : 'other' as traf_type, sum(Sign) 
from test.visits 
where CounterID = 842440
group by StartDate, traf_type ORDER BY StartDate, traf_type
)
, result:



stdout:


Settings used in the test: --max_insert_threads=12 --group_by_two_level_threshold=100000 --group_by_two_level_threshold_bytes=50000000 --distributed_aggregation_memory_efficient=0 --fsync_metadata=0 --output_format_parallel_formatting=1 --input_format_parallel_parsing=0 --min_chunk_bytes_for_parallel_parsing=10852191 --max_read_buffer_size=995523 --prefer_localhost_replica=1 --max_block_size=57772 --max_threads=48 --optimize_or_like_chain=0 --optimize_read_in_order=0 --read_in_order_two_level_merge_threshold=52 --optimize_aggregation_in_order=0 --aggregation_in_order_max_block_bytes=13660351

Database: test_1
00081_group_by_without_key_and_totals:                                  [ FAIL ] - return code: 81
Received exception from server (version 22.7.1):
Code: 81. DB::Exception: Received from localhost:9000. DB::Exception: Database test_1 doesn't exist. (UNKNOWN_DATABASE)
(query: SELECT count() AS c FROM test.hits WHERE CounterID = 1704509 WITH TOTALS SETTINGS totals_mode = 'before_having',          max_rows_to_group_by = 100000, group_by_overflow_mode = 'any';)
, result:



stdout:


Settings used in the test: --max_insert_threads=0 --group_by_two_level_threshold=1 --group_by_two_level_threshold_bytes=1152921504606846976 --distributed_aggregation_memory_efficient=0 --fsync_metadata=0 --output_format_parallel_formatting=1 --input_format_parallel_parsing=0 --min_chunk_bytes_for_parallel_parsing=10716242 --max_read_buffer_size=704077 --prefer_localhost_replica=1 --max_block_size=50041 --max_threads=49 --optimize_or_like_chain=1 --optimize_read_in_order=1 --read_in_order_two_level_merge_threshold=9 --optimize_aggregation_in_order=1 --aggregation_in_order_max_block_bytes=33958456

Database: test_1
```

