### PR TITLE
Add check for empty proccessors in AggregatingTransform::expandPipeline

### DIFF
--- a/src/Processors/Transforms/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/AggregatingTransform.cpp
@@ -501,6 +501,8 @@ void AggregatingTransform::work()
 
 Processors AggregatingTransform::expandPipeline()
 {
+    if (processors.empty())
+        throw Exception("Can not expandPipeline in AggregatingTransform. This is a bug.", ErrorCodes::LOGICAL_ERROR);
     auto & out = processors.back()->getOutputs().front();
     inputs.emplace_back(out.getHeader(), this);
     connect(out, inputs.back());


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prevent very rare segfault from AggregatingTransform::expandPipeline (by throwing LOGICAL_ERROR instead).

No reproducible scenario, so no tests.

Examples of stack traces:

```
2022.06.09 07:53:56.106837 [ 48395 ] {} <Fatal> BaseDaemon: ########################################
2022.06.09 07:53:56.151326 [ 48395 ] {} <Fatal> BaseDaemon: (version 21.1.9.41 (official build), build id: 15058D7F7CDE734632FBFD572BFA1F6325CDD929) (from thread 37242) (no query) Received signal Segmentation fault (11)
2022.06.09 07:53:56.161327 [ 48395 ] {} <Fatal> BaseDaemon: Address: 0xfffffffffffffff0 Access: read. Address not mapped to object.
2022.06.09 07:53:56.161376 [ 48395 ] {} <Fatal> BaseDaemon: Stack trace: 0xfa6b403 0xf900a41 0xf905884 0xf90a445 0x862e3fd 0x8631fb3 0x7fd5177ceea5 0x7fd5172f3b0d
2022.06.09 07:53:56.188965 [ 48395 ] {} <Fatal> BaseDaemon: 2. DB::AggregatingTransform::expandPipeline() @ 0xfa6b403 in /usr/bin/clickhouse
2022.06.09 07:53:56.195191 [ 48395 ] {} <Fatal> BaseDaemon: 3. DB::PipelineExecutor::expandPipeline(std::__1::stack<unsigned long, std::__1::deque<unsigned long, std::__1::allocator<unsigned long> > >&, unsigned long) @ 0xf900a41 in /usr/bin/clickhouse
2022.06.09 07:53:56.195281 [ 48395 ] {} <Fatal> BaseDaemon: 4. DB::PipelineExecutor::executeStepImpl(unsigned long, unsigned long, std::__1::atomic<bool>*) @ 0xf905884 in /usr/bin/clickhouse
2022.06.09 07:53:56.195296 [ 48395 ] {} <Fatal> BaseDaemon: 5. ? @ 0xf90a445 in /usr/bin/clickhouse
2022.06.09 07:53:56.221804 [ 48395 ] {} <Fatal> BaseDaemon: 6. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x862e3fd in /usr/bin/clickhouse
2022.06.09 07:53:56.221855 [ 48395 ] {} <Fatal> BaseDaemon: 7. ? @ 0x8631fb3 in /usr/bin/clickhouse
2022.06.09 07:53:56.221964 [ 48395 ] {} <Fatal> BaseDaemon: 8. start_thread @ 0x7ea5 in /usr/lib64/libpthread-2.17.so
2022.06.09 07:53:56.224405 [ 23580 ] {53146bbb-f637-44c9-b4ca-067f5d839c94} <Error> executeQuery: Code: 241, e.displayText() = DB::Exception: Memory limit (for user) exceeded: would use 59.61 GiB (attempt to allocate chunk of 4709664 bytes), maximum: 59.60 GiB: (avg_value_size_hint = 27.77294921875, avg_chars_size = 23.7275390625, limit = 14607): (while reading column 


2022.02.16 11:40:09.590895 [ 3956 ] {} <Fatal> BaseDaemon: (version 21.1.9.41 (official build), build id: 15058D7F7CDE734632FBFD572BFA1F6325CDD929) (from thread 61579) (no query) Received signal Segmentation fault (11)
2022.02.16 11:40:09.591339 [ 3956 ] {} <Fatal> BaseDaemon: Address: 0xfffffffffffffff0 Access: read. Address not mapped to object.
2022.02.16 11:40:09.591377 [ 3956 ] {} <Fatal> BaseDaemon: Stack trace: 0xfa6b403 0xf900a41 0xf905884 0xf90a445 0x862e3fd 0x8631fb3 0x7f73c37c2ea5 0x7f73c32e7b0d
2022.02.16 11:40:09.632424 [ 3956 ] {} <Fatal> BaseDaemon: 2. DB::AggregatingTransform::expandPipeline() @ 0xfa6b403 in /usr/bin/clickhouse
2022.02.16 11:40:09.648552 [ 3956 ] {} <Fatal> BaseDaemon: 3. DB::PipelineExecutor::expandPipeline(std::__1::stack<unsigned long, std::__1::deque<unsigned long, std::__1::allocator<unsigned long> > >&, unsigned long) @ 0xf900a41 in /usr/bin/clickhouse
2022.02.16 11:40:09.648627 [ 3956 ] {} <Fatal> BaseDaemon: 4. DB::PipelineExecutor::executeStepImpl(unsigned long, unsigned long, std::__1::atomic<bool>*) @ 0xf905884 in /usr/bin/clickhouse
2022.02.16 11:40:09.648651 [ 3956 ] {} <Fatal> BaseDaemon: 5. ? @ 0xf90a445 in /usr/bin/clickhouse
2022.02.16 11:40:09.648683 [ 3956 ] {} <Fatal> BaseDaemon: 6. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x862e3fd in /usr/bin/clickhouse
2022.02.16 11:40:09.648704 [ 3956 ] {} <Fatal> BaseDaemon: 7. ? @ 0x8631fb3 in /usr/bin/clickhouse
2022.02.16 11:40:09.665098 [ 3956 ] {} <Fatal> BaseDaemon: 8. start_thread @ 0x7ea5 in /usr/lib64/libpthread-2.17.so
2022.02.16 11:40:09.679986 [ 3956 ] {} <Fatal> BaseDaemon: 9. __clone @ 0xfeb0d in /usr/lib64/libc-2.17.so
2022.02.16 11:40:10.800914 [ 3956 ] {} <Fatal> BaseDaemon: Checksum of the binary: 8FA8B553D71EEEA3AC39596231B6F345, integrity check passed.
```

It looks like (from the coredump) that it happens when processors are empty

```
(lldb) bt
* thread #1, name = 'clickhouse-serv', stop reason = signal SIGSEGV
  * frame #0: 0x000000000fa6b403 clickhouse`DB::AggregatingTransform::expandPipeline() [inlined] std::__1::shared_ptr<DB::IProcessor>::operator->(this=0xfffffffffffffff0) const at memory:3826:56
    frame #1: 0x000000000fa6b403 clickhouse`DB::AggregatingTransform::expandPipeline(this=0x00007f352c8c4f98) at AggregatingTransform.cpp:502:18
    frame #2: 0x000000000f900a41 clickhouse`DB::PipelineExecutor::expandPipeline(this=0x00007f352d3c9818, stack=0x00007f17cebf0950, pid=<unavailable>) at PipelineExecutor.cpp:117:46
    frame #3: 0x000000000f905884 clickhouse`DB::PipelineExecutor::executeStepImpl(unsigned long, unsigned long, std::__1::atomic<bool>*) [inlined] DB::PipelineExecutor::doExpandPipeline(this=0x00007f352d3c9818, task=<unavailable>, processing=true) at PipelineExecutor.cpp:349:18
    frame #4: 0x000000000f905760 clickhouse`DB::PipelineExecutor::executeStepImpl(this=0x00007f352d3c9818, thread_num=<unavailable>, num_threads=32, yield_flag=0x0000000000000000) at PipelineExecutor.cpp:609:21
    frame #5: 0x000000000f90a445 clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator()() [inlined] DB::PipelineExecutor::executeSingleThread(this=0x00007f352d3c9818, thread_num=<unavailable>, num_threads=<unavailable>) at PipelineExecutor.cpp:473:5
    frame #6: 0x000000000f90a43b clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator()() [inlined] DB::PipelineExecutor::executeImpl(this=0x00007f315d1f5ba0)::$_4::operator()() const at PipelineExecutor.cpp:776:21
    frame #7: 0x000000000f90a42c clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator()() [inlined] decltype(__f=0x00007f315d1f5ba0)::$_4&>(fp)()) std::__1::__invoke_constexpr<DB::PipelineExecutor::executeImpl(unsigned long)::$_4&>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&) at type_traits:3525:1
    frame #8: 0x000000000f90a42c clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator()() [inlined] decltype(__f=0x00007f315d1f5ba0, __t=<unavailable>, (null)=<unavailable>) std::__1::__apply_tuple_impl<DB::PipelineExecutor::executeImpl(unsigned long)::$_4&, std::__1::tuple<>&>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&, std::__1::tuple<>&, std::__1::__tuple_indices<>) at tuple:1415:1
    frame #9: 0x000000000f90a42c clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator()() [inlined] decltype(__f=0x00007f315d1f5ba0, __t=<unavailable>) std::__1::apply<DB::PipelineExecutor::executeImpl(unsigned long)::$_4&, std::__1::tuple<>&>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&, std::__1::tuple<>&) at tuple:1424:1
    frame #10: 0x000000000f90a42c clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator()() [inlined] ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(this=<unavailable>)::$_4&&)::'lambda'()::operator()() at ThreadPool.h:178:13
    frame #11: 0x000000000f90a3b0 clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator()() [inlined] decltype(__f=<unavailable>)::$_4>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()&>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&) at type_traits:3519:1
    frame #12: 0x000000000f90a3b0 clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator()() [inlined] void std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(__args=<unavailable>)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()&>(ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()&) at __functional_base:348:9
    frame #13: 0x000000000f90a3b0 clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator()() [inlined] std::__1::__function::__alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator(this=<unavailable>)() at functional:1540:16
    frame #14: 0x000000000f90a3b0 clickhouse`std::__1::__function::__func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'(), std::__1::allocator<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::$_4>(DB::PipelineExecutor::executeImpl(unsigned long)::$_4&&)::'lambda'()>, void ()>::operator(this=<unavailable>)() at functional:1714:12
    frame #15: 0x000000000862e3fd clickhouse`ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) [inlined] std::__1::__function::__value_func<void ()>::operator(this=0x00007f315d1f5e50)() const at functional:1867:16
    frame #16: 0x000000000862e3e9 clickhouse`ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) [inlined] std::__1::function<void ()>::operator(this=0x00007f315d1f5e50)() const at functional:2473:12
    frame #17: 0x000000000862e3e9 clickhouse`ThreadPoolImpl<std::__1::thread>::worker(this=0x00007f44a5c5c000, thread_it=std::__1::list<std::__1::thread, std::__1::allocator<std::__1::thread> >::iterator @ 0x00007f315d1f5ec8) at ThreadPool.cpp:243:17


(lldb) f 2
frame #2: 0x000000000f900a41 clickhouse`DB::PipelineExecutor::expandPipeline(this=0x00007f352d3c9818, stack=0x00007f17cebf0950, pid=<unavailable>) at PipelineExecutor.cpp:117:46
(lldb) p processors
(DB::Processors) $4 = {
  std::__1::__vector_base<std::__1::shared_ptr<DB::IProcessor>, std::__1::allocator<std::__1::shared_ptr<DB::IProcessor> > > = {
    __begin_ = nullptr
    __end_ = nullptr
    __end_cap_ = {
      std::__1::__compressed_pair_elem<std::__1::shared_ptr<DB::IProcessor> *, 0, false> = {
        __value_ = nullptr
      }
    }
  }
}
```

How exactly `processors` can be empty - is not clear, but that crash often happens after ' Memory limit (for user) exceeded' so maybe somehow the exception happens in initGenerate and gets caught somewhere else, keeping the processor in the dirty state?

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
