### PR TITLE
Proper fix for ipv4/ipv6 conversion error

### DIFF
--- a/src/Databases/TablesLoader.h
+++ b/src/Databases/TablesLoader.h
@@ -104,7 +104,7 @@ private:
 
     DependenciesInfosIter removeResolvedDependency(const DependenciesInfosIter & info_it, TableNames & independent_database_objects);
 
-    void startLoadingIndependentTables(ThreadPool & pool, size_t level);
+    void startLoadingIndependentTables(ThreadPool & pool, size_t level, ContextMutablePtr load_context);
 
     void checkCyclicDependencies() const;
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -996,6 +996,11 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
         throw Exception("Temporary tables cannot be inside a database. You should not specify a database for a temporary table.",
             ErrorCodes::BAD_DATABASE_FOR_TEMPORARY_TABLE);
 
+    /// Compatibility setting which should be enabled by default on attach
+    /// Otherwise server will be unable to start for some old-format of IPv6/IPv4 types
+    if (create.attach)
+        getContext()->setSetting("cast_ipv4_ipv6_default_on_conversion_error", 1);
+
     String current_database = getContext()->getCurrentDatabase();
     auto database_name = create.database ? create.getDatabase() : current_database;
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -996,11 +996,6 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
         throw Exception("Temporary tables cannot be inside a database. You should not specify a database for a temporary table.",
             ErrorCodes::BAD_DATABASE_FOR_TEMPORARY_TABLE);
 
-    /// Compatibility setting which should be enabled by default on attach
-    /// Otherwise server will be unable to start for some old-format of IPv6/IPv4 types
-    if (create.attach)
-        getContext()->setSetting("cast_ipv4_ipv6_default_on_conversion_error", 1);
-
     String current_database = getContext()->getCurrentDatabase();
     auto database_name = create.database ? create.getDatabase() : current_database;
 
@@ -1043,6 +1038,10 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
         create.attach = true;
         create.attach_short_syntax = true;
         create.if_not_exists = if_not_exists;
+
+        /// Compatibility setting which should be enabled by default on attach
+        /// Otherwise server will be unable to start for some old-format of IPv6/IPv4 types
+        getContext()->setSetting("cast_ipv4_ipv6_default_on_conversion_error", 1);
     }
 
     /// TODO throw exception if !create.attach_short_syntax && !create.attach_from_path && !internal

--- a/tests/integration/test_server_start_and_ip_conversions/__init__.py
+++ b/tests/integration/test_server_start_and_ip_conversions/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/tests/integration/test_server_start_and_ip_conversions/test.py
+++ b/tests/integration/test_server_start_and_ip_conversions/test.py
@@ -15,7 +15,7 @@ def start_cluster():
         cluster.shutdown()
 
 
-def test_restart_success():
+def test_restart_success_ipv4():
     node.query("""
         CREATE TABLE ipv4_test
         (
@@ -25,6 +25,22 @@ def test_restart_success():
         settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
 
     node.query("ALTER TABLE ipv4_test MODIFY COLUMN value IPv4 DEFAULT ''", settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
+
+    node.restart_clickhouse()
+
+    assert node.query("SELECT 1") == "1\n"
+
+
+def test_restart_success_ipv6():
+    node.query("""
+        CREATE TABLE ipv6_test
+        (
+            id UInt64,
+            value String
+        ) ENGINE=MergeTree ORDER BY id""",
+        settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
+
+    node.query("ALTER TABLE ipv6_test MODIFY COLUMN value IPv6 DEFAULT ''", settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
 
     node.restart_clickhouse()
 

--- a/tests/integration/test_server_start_and_ip_conversions/test.py
+++ b/tests/integration/test_server_start_and_ip_conversions/test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import logging
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", stay_alive=True)
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_restart_success():
+    node.query("""
+        CREATE TABLE ipv4_test
+        (
+            id UInt64,
+            value String
+        ) ENGINE=MergeTree ORDER BY id""",
+        settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
+
+    node.query("ALTER TABLE ipv4_test MODIFY COLUMN value IPv4 DEFAULT ''", settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
+
+    node.restart_clickhouse()
+
+    assert node.query("SELECT 1") == "1\n"

--- a/tests/integration/test_server_start_and_ip_conversions/test.py
+++ b/tests/integration/test_server_start_and_ip_conversions/test.py
@@ -6,6 +6,7 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", stay_alive=True)
 
+
 @pytest.fixture(scope="module", autouse=True)
 def start_cluster():
     try:
@@ -16,15 +17,20 @@ def start_cluster():
 
 
 def test_restart_success_ipv4():
-    node.query("""
+    node.query(
+        """
         CREATE TABLE ipv4_test
         (
             id UInt64,
             value String
         ) ENGINE=MergeTree ORDER BY id""",
-        settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
+        settings={"cast_ipv4_ipv6_default_on_conversion_error": 1},
+    )
 
-    node.query("ALTER TABLE ipv4_test MODIFY COLUMN value IPv4 DEFAULT ''", settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
+    node.query(
+        "ALTER TABLE ipv4_test MODIFY COLUMN value IPv4 DEFAULT ''",
+        settings={"cast_ipv4_ipv6_default_on_conversion_error": 1},
+    )
 
     node.restart_clickhouse()
 
@@ -32,15 +38,20 @@ def test_restart_success_ipv4():
 
 
 def test_restart_success_ipv6():
-    node.query("""
+    node.query(
+        """
         CREATE TABLE ipv6_test
         (
             id UInt64,
             value String
         ) ENGINE=MergeTree ORDER BY id""",
-        settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
+        settings={"cast_ipv4_ipv6_default_on_conversion_error": 1},
+    )
 
-    node.query("ALTER TABLE ipv6_test MODIFY COLUMN value IPv6 DEFAULT ''", settings={"cast_ipv4_ipv6_default_on_conversion_error": 1})
+    node.query(
+        "ALTER TABLE ipv6_test MODIFY COLUMN value IPv6 DEFAULT ''",
+        settings={"cast_ipv4_ipv6_default_on_conversion_error": 1},
+    )
 
     node.restart_clickhouse()
 

--- a/tests/queries/0_stateless/02316_cast_to_ip_address_default_column.sql
+++ b/tests/queries/0_stateless/02316_cast_to_ip_address_default_column.sql
@@ -1,5 +1,5 @@
 -- Tags: no-backward-compatibility-check
--- TODO: remove after new 22.6 release
+-- TODO: remove no-backward-compatibility-check after new 22.6 release
 
 SET cast_ipv4_ipv6_default_on_conversion_error = 1;
 

--- a/tests/queries/0_stateless/02316_cast_to_ip_address_default_column.sql
+++ b/tests/queries/0_stateless/02316_cast_to_ip_address_default_column.sql
@@ -11,6 +11,13 @@ CREATE TABLE ipv4_test
 
 ALTER TABLE ipv4_test MODIFY COLUMN value IPv4 DEFAULT '';
 
+SET cast_ipv4_ipv6_default_on_conversion_error = 0;
+
+DETACH TABLE ipv4_test;
+ATTACH TABLE ipv4_test;
+
+SET cast_ipv4_ipv6_default_on_conversion_error = 1;
+
 DROP TABLE ipv4_test;
 
 DROP TABLE IF EXISTS ipv6_test;
@@ -20,7 +27,15 @@ CREATE TABLE ipv6_test
     value String
 ) ENGINE=MergeTree ORDER BY id;
 
-ALTER TABLE ipv6_test MODIFY COLUMN value IPv4 DEFAULT '';
+ALTER TABLE ipv6_test MODIFY COLUMN value IPv6 DEFAULT '';
+
+SET cast_ipv4_ipv6_default_on_conversion_error = 0;
+
+DETACH TABLE ipv6_test;
+ATTACH TABLE ipv6_test;
+
+SET cast_ipv4_ipv6_default_on_conversion_error = 1;
+
 SELECT * FROM ipv6_test;
 
 DROP TABLE ipv6_test;

--- a/tests/queries/0_stateless/02316_cast_to_ip_address_default_column.sql
+++ b/tests/queries/0_stateless/02316_cast_to_ip_address_default_column.sql
@@ -1,4 +1,5 @@
 -- Tags: no-backward-compatibility-check
+-- TODO: remove after new 22.6 release
 
 SET cast_ipv4_ipv6_default_on_conversion_error = 1;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now it's possible to start a clickhouse-server and attach/detach tables even for tables with the incorrect values of IPv4/IPv6 representation. Proper fix for issue #35156.
