### PR TITLE
Better diagnostics in ReplicatedMergeTreeQueue

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1103,7 +1103,9 @@ bool ReplicatedMergeTreeQueue::isCoveredByFuturePartsImpl(const LogEntry & entry
             continue;
 
         /// Parts are not disjoint, so new_part_name either contains or covers future_part.
-        chassert(future_part.contains(result_part) || result_part.contains(future_part));
+        if (!(future_part.contains(result_part) || result_part.contains(future_part)))
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Got unexpected non-disjoint parts: {} and {}", future_part_elem.first, new_part_name);
+
         /// We cannot execute `entry` (or upgrade its actual_part_name to `new_part_name`)
         /// while any covered or covering parts are processed.
         /// But we also cannot simply return true and postpone entry processing, because it may lead to kind of livelock.


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI caught something interesting, but it's not clear what exactly happened:
https://s3.amazonaws.com/clickhouse-test-reports/0/bd4a208428c8f17c4c3148886e6bf008bb064f58/stateless_tests__ubsan__actions_.html
```
2022.06.30 02:32:30.494369 [ 786 ] {} <Fatal> : Logical error: 'future_part.contains(result_part) || result_part.contains(future_part)'.
2022.06.30 02:32:30.495062 [ 245068 ] {} <Fatal> BaseDaemon: ########################################
2022.06.30 02:32:30.495134 [ 245068 ] {} <Fatal> BaseDaemon: (version 22.7.1.1 (official build), build id: BBC2342294CA8EC9) (from thread 786) (no query) Received signal Aborted (6)
2022.06.30 02:32:30.495163 [ 245068 ] {} <Fatal> BaseDaemon: 
2022.06.30 02:32:30.495254 [ 245068 ] {} <Fatal> BaseDaemon: Stack trace: 0x7f81fad9100b 0x7f81fad70859 0xfe6ae0b 0x24e4d860 0x24e4f61e 0x24e54a24 0x247f2ffe 0x247f3427 0x24a7bf53 0x22b15c97 0x22b1835d 0x22b18d1f 0xff45161 0xff47d62 0x7f81faf48609 0x7f81fae6d133
2022.06.30 02:32:30.495343 [ 245068 ] {} <Fatal> BaseDaemon: 3. raise @ 0x7f81fad9100b in ?
2022.06.30 02:32:30.495371 [ 245068 ] {} <Fatal> BaseDaemon: 4. abort @ 0x7f81fad70859 in ?
2022.06.30 02:32:30.518026 [ 245068 ] {} <Fatal> BaseDaemon: 5. ./build_docker/../src/Common/Exception.cpp:47: DB::abortOnFailedAssertion(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0xfe6ae0b in /usr/bin/clickhouse
2022.06.30 02:32:30.617729 [ 245068 ] {} <Fatal> BaseDaemon: 6.1. inlined from ./build_docker/../contrib/libcxx/include/string:1445: std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__is_long() const
2022.06.30 02:32:30.617763 [ 245068 ] {} <Fatal> BaseDaemon: 6.2. inlined from ../contrib/libcxx/include/string:2231: ~basic_string
2022.06.30 02:32:30.617778 [ 245068 ] {} <Fatal> BaseDaemon: 6. ../src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp:1106: DB::ReplicatedMergeTreeQueue::isCoveredByFuturePartsImpl(DB::ReplicatedMergeTreeLogEntry const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::unique_lock<std::__1::mutex>&, std::__1::vector<std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry>, std::__1::allocator<std::__1::shared_ptr<DB::ReplicatedMergeTreeLogEntry> > >*) const @ 0x24e4d860 in /usr/bin/clickhouse
2022.06.30 02:32:30.717324 [ 245068 ] {} <Fatal> BaseDaemon: 7. ./build_docker/../src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp:0: DB::ReplicatedMergeTreeQueue::shouldExecuteLogEntry(DB::ReplicatedMergeTreeLogEntry const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, DB::MergeTreeDataMergerMutator&, DB::MergeTreeData&, std::__1::unique_lock<std::__1::mutex>&) const @ 0x24e4f61e in /usr/bin/clickhouse
2022.06.30 02:32:30.913012 [ 245068 ] {} <Fatal> BaseDaemon: 8. ./build_docker/../src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp:1540: DB::ReplicatedMergeTreeQueue::selectEntryToProcess(DB::MergeTreeDataMergerMutator&, DB::MergeTreeData&) @ 0x24e54a24 in /usr/bin/clickhouse
2022.06.30 02:32:31.102431 [ 245068 ] {} <Fatal> BaseDaemon: 9. ./build_docker/../src/Storages/StorageReplicatedMergeTree.cpp:3057: DB::StorageReplicatedMergeTree::selectQueueEntry() @ 0x247f2ffe in /usr/bin/clickhouse
2022.06.30 02:32:31.225179 [ 245068 ] {} <Fatal> BaseDaemon: 10. ./build_docker/../src/Storages/StorageReplicatedMergeTree.cpp:3111: DB::StorageReplicatedMergeTree::scheduleDataProcessingJob(DB::BackgroundJobsAssignee&) @ 0x247f3427 in /usr/bin/clickhouse
2022.06.30 02:32:31.271931 [ 245068 ] {} <Fatal> BaseDaemon: 11. ./build_docker/../src/Storages/MergeTree/BackgroundJobsAssignee.cpp:0: DB::BackgroundJobsAssignee::threadFunc() @ 0x24a7bf53 in /usr/bin/clickhouse
2022.06.30 02:32:31.281616 [ 245068 ] {} <Fatal> BaseDaemon: 12.1. inlined from ./build_docker/../src/Common/Stopwatch.h:49: Stopwatch::elapsedNanoseconds() const
2022.06.30 02:32:31.281641 [ 245068 ] {} <Fatal> BaseDaemon: 12.2. inlined from ../src/Common/Stopwatch.h:51: Stopwatch::elapsedMilliseconds() const
2022.06.30 02:32:31.281655 [ 245068 ] {} <Fatal> BaseDaemon: 12. ../src/Core/BackgroundSchedulePool.cpp:94: DB::BackgroundSchedulePoolTaskInfo::execute() @ 0x22b15c97 in /usr/bin/clickhouse
2022.06.30 02:32:31.295111 [ 245068 ] {} <Fatal> BaseDaemon: 13. ./build_docker/../src/Core/BackgroundSchedulePool.cpp:0: DB::BackgroundSchedulePool::threadFunction() @ 0x22b1835d in /usr/bin/clickhouse
2022.06.30 02:32:31.312953 [ 245068 ] {} <Fatal> BaseDaemon: 14.1. inlined from ./build_docker/../src/Core/BackgroundSchedulePool.cpp:0: operator()
2022.06.30 02:32:31.312983 [ 245068 ] {} <Fatal> BaseDaemon: 14. ../contrib/libcxx/include/type_traits:3640: decltype(static_cast<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_1>(fp)()) std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_1&&)::'lambda'()&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_1&&) @ 0x22b18d1f in /usr/bin/clickhouse
2022.06.30 02:32:31.324473 [ 245068 ] {} <Fatal> BaseDaemon: 15.1. inlined from ./build_docker/../contrib/libcxx/include/__functional/function.h:1157: std::__1::function<void ()>::operator=(std::nullptr_t)
2022.06.30 02:32:31.324495 [ 245068 ] {} <Fatal> BaseDaemon: 15. ../src/Common/ThreadPool.cpp:284: ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0xff45161 in /usr/bin/clickhouse
2022.06.30 02:32:31.335981 [ 245068 ] {} <Fatal> BaseDaemon: 16. ./build_docker/../src/Common/ThreadPool.cpp:0: void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()> >(void*) @ 0xff47d62 in /usr/bin/clickhouse
2022.06.30 02:32:31.336021 [ 245068 ] {} <Fatal> BaseDaemon: 17. ? @ 0x7f81faf48609 in ?
2022.06.30 02:32:31.336034 [ 245068 ] {} <Fatal> BaseDaemon: 18. __clone @ 0x7f81fae6d133 in ?
2022.06.30 02:32:31.644733 [ 245068 ] {} <Fatal> BaseDaemon: Integrity check of the executable successfully passed (checksum: 80A447046E8216D461FDEF7536A0EF19)
2022.06.30 02:32:51.650230 [ 598 ] {} <Fatal> Application: Child process was terminated by signal 6.
+ pigz
```

May be related to #37608
