### PR TITLE
Print stacktraces if test queue is full

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1594,6 +1594,8 @@ def do_run_tests(jobs, test_suite: TestSuite, parallel):
 
                 queue.close()
         except Full:
+            print("Couldn't put test to the queue within timeout. Server probably hung.")
+            print_stacktraces()
             queue.close()
 
         pool.join()


### PR DESCRIPTION
### Changelog category (leave one):

- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Always print stacktraces if test queue is full. Follow up #38490
cc @tavplubix 