### PR TITLE
s3 cluster support `IN` clause

### DIFF
--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -405,7 +405,7 @@ void ASTSelectQuery::addTableFunction(ASTPtr & table_function_ptr)
     table_expression->table_function = table_function_ptr->clone();
     table_expression->database_and_table_name = nullptr;
 
-    if (table_alias.empty())
+    if (!table_alias.empty())
         table_expression->table_function->setAlias(table_alias);
 }
 

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -207,6 +207,7 @@ public:
 private:
     friend class StorageS3Cluster;
     friend class TableFunctionS3Cluster;
+    friend class TableFunctionS3ClusterLocalShard;
 
     S3Configuration s3_configuration;
     std::vector<String> keys;

--- a/src/Storages/StorageS3Cluster.h
+++ b/src/Storages/StorageS3Cluster.h
@@ -34,6 +34,8 @@ public:
 
     std::string getName() const override { return "S3Cluster"; }
 
+    bool isRemote() const override { return true; }
+
     Pipe read(const Names &, const StorageSnapshotPtr &, SelectQueryInfo &,
         ContextPtr, QueryProcessingStage::Enum, size_t /*max_block_size*/, unsigned /*num_streams*/) override;
 
@@ -51,6 +53,8 @@ private:
     String compression_method;
     NamesAndTypesList virtual_columns;
     Block virtual_block;
+
+    ASTPtr rewriteQuery(const ASTPtr & query);
 };
 
 

--- a/src/TableFunctions/TableFunctionS3.h
+++ b/src/TableFunctions/TableFunctionS3.h
@@ -32,6 +32,7 @@ public:
 
 protected:
     friend class TableFunctionS3Cluster;
+    friend class TableFunctionS3ClusterLocalShard;
 
     StoragePtr executeImpl(
         const ASTPtr & ast_function,

--- a/src/TableFunctions/TableFunctionS3Cluster.h
+++ b/src/TableFunctions/TableFunctionS3Cluster.h
@@ -54,6 +54,39 @@ protected:
     ColumnsDescription structure_hint;
 };
 
+class TableFunctionS3ClusterLocalShard : public ITableFunction
+{
+public:
+    static constexpr auto name = "s3ClusterLocalShard";
+    std::string getName() const override
+    {
+        return name;
+    }
+
+    bool hasStaticStructure() const override { return configuration.structure != "auto"; }
+
+    bool needStructureHint() const override { return configuration.structure == "auto"; }
+
+    void setStructureHint(const ColumnsDescription & structure_hint_) override { structure_hint = structure_hint_; }
+
+protected:
+    StoragePtr executeImpl(
+        const ASTPtr & ast_function,
+        ContextPtr context,
+        const std::string & table_name,
+        ColumnsDescription cached_columns) const override;
+
+    const char * getStorageTypeName() const override { return "S3Cluster"; }
+
+    AccessType getSourceAccessType() const override { return AccessType::S3; }
+
+    ColumnsDescription getActualTableStructure(ContextPtr) const override;
+    void parseArguments(const ASTPtr &, ContextPtr) override;
+
+    StorageS3ClusterConfiguration configuration;
+    ColumnsDescription structure_hint;
+};
+
 }
 
 #endif


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
support the following query for s3 cluster
```SQL
SELECT * FROM s3Cluster(...) AS t1 WHERE id IN (SELECT id FROM s3Cluster(...) as t2)  
```

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
