### PR TITLE
Fix strange backport titles issues

### DIFF
--- a/tests/ci/cherry_pick_utils/cherrypick.py
+++ b/tests/ci/cherry_pick_utils/cherrypick.py
@@ -165,7 +165,7 @@ class CherryPick:
             "user.name=robot-clickhouse",
         ]
 
-        title = (self._pr["title"].replace('"', r"\""),)
+        title = self._pr["title"].replace('"', r"\"")
         pr_title = f"Backport #{self._pr['number']} to {self.target_branch}: {title}"
 
         self._run(git_prefix + ["checkout", "-f", self.backport_branch])


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Backport titles were spoiled a bit in #38137, fixing it