### PR TITLE
Fix FillingTransform

### DIFF
--- a/src/Processors/Transforms/FillingTransform.cpp
+++ b/src/Processors/Transforms/FillingTransform.cpp
@@ -215,6 +215,13 @@ IProcessor::Status FillingTransform::prepare()
 
         if (first || filling_row < next_row)
         {
+            /// Output if has data.
+            if (has_output)
+            {
+                output.pushData(std::move(output_data));
+                has_output = false;
+            }
+
             generate_suffix = true;
             return Status::Ready;
         }

--- a/tests/queries/0_stateless/02112_with_fill_interval.sql
+++ b/tests/queries/0_stateless/02112_with_fill_interval.sql
@@ -1,5 +1,3 @@
-SET max_threads = 1;
-
 DROP TABLE IF EXISTS with_fill_date;
 CREATE TABLE with_fill_date (d Date, d32 Date32) ENGINE = Memory;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We push data to subsequent transforms lazily in [ISimpleTransform::prepare()](https://github.com/ClickHouse/ClickHouse/blob/master/src/Processors/ISimpleTransform.cpp#L31-L40), so if we override `transform(...)` method, we should not forget to push currently "buffered" data.