### PR TITLE
tests: increase random string in database for tests

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -503,7 +503,7 @@ class TestCase:
         else:
             # If --database is not specified, we will create temporary database with
             # unique name and we will recreate and drop it for each test
-            def random_str(length=6):
+            def random_str(length=8):
                 alphabet = string.ascii_lowercase + string.digits
                 # NOTE: it is important not to use default random generator, since it shares state.
                 return "".join(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
tests: increase random string in database for tests

Recently I saw that some database overlaps [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/38728/e4b81e6de9b5efb8ec8aa079741aaa05ece6719c/stateless_tests_flaky_check__address__actions_.html

And even I've tested `SystemRandom` before (back in #32163), and had
pretty good results, it still fails. One issue that came to my mind is
lack of entropy on VMs.

I've also tried test from #32163 with 8 threads (like CI uses by
default), and on my laptop it fails within 5s, while with 2 threads it
takes 1m30s.

But using 8 threads and 8 prefix length, I stopped waiting after 15
minutes.

Note, 8 bytes for random prefix with alphabet (0-9a-z) is
`36**8`=2'821'109'907'456 unique words, which is `6**4` greater then `36**6`

