### PR TITLE
Fix CLICKHOUSE_TMP in tests (fixes broken CI)

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -526,7 +526,7 @@ class TestCase:
             # collisions.
             testcase_args.test_tmp_dir = os.path.join(suite_tmp_dir, database)
             os.mkdir(testcase_args.test_tmp_dir)
-            os.environ.setdefault("CLICKHOUSE_TMP", testcase_args.test_tmp_dir)
+            os.environ["CLICKHOUSE_TMP"] = testcase_args.test_tmp_dir
 
         testcase_args.testcase_database = database
 


### PR DESCRIPTION
Previous it was not updated, and always uses the first CLICKHOUSE_TMP
for all tests (that was run from one thread).

Thanks to #38728, that shows the problem.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alexey-milovidov 