### PR TITLE
Revert "Merge pull request #38212 from azat/no-stress"

### DIFF
--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -294,7 +294,6 @@ if __name__ == "__main__":
                 # Use system database to avoid CREATE/DROP DATABASE queries
                 "--database=system",
                 "--hung-check",
-                "--stress",
                 "--report-logs-stats",
                 "00001_select_1",
             ]

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -449,7 +449,6 @@ class FailureReason(enum.Enum):
     NO_LONG = "not running long tests"
     REPLICATED_DB = "replicated-database"
     S3_STORAGE = "s3-storage"
-    STRESS = "stress"
     BUILD = "not running for current build"
     BACKWARD_INCOMPATIBLE = "test is backward incompatible"
     NO_PARALLEL_REPLICAS = "smth in not supported with parallel replicas"
@@ -860,9 +859,6 @@ class TestCase:
 
         elif tags and ("no-s3-storage" in tags) and args.s3_storage:
             return FailureReason.S3_STORAGE
-
-        elif tags and ("no-stress" in tags) and args.stress:
-            return FailureReason.STRESS
 
         elif tags:
             for build_flag in args.build_flags:
@@ -2416,12 +2412,6 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Run tests over s3 storage",
-    )
-    parser.add_argument(
-        "--stress",
-        action="store_true",
-        default=False,
-        help="Run stress tests",
     )
     parser.add_argument(
         "--no-random-settings",

--- a/tests/queries/0_stateless/01646_system_restart_replicas_smoke.sql
+++ b/tests/queries/0_stateless/01646_system_restart_replicas_smoke.sql
@@ -1,9 +1,5 @@
--- Tags: replica, no-tsan, no-parallel, no-stress
+-- Tags: replica, no-tsan, no-parallel
 -- Tag no-tsan: RESTART REPLICAS can acquire too much locks, while only 64 is possible from one thread under TSan
--- Tag no-stress: RESTART REPLICAS can leave some tables,
---                that may pollute error log,
---                like in 01414_mutations_and_errors_zookeeper.
---                no-stress is like worked no-parallel for stress testing
 
 DROP TABLE IF EXISTS data_01646;
 CREATE TABLE data_01646 (x Date, s String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test_01646/data_01646', 'r') ORDER BY s PARTITION BY x;


### PR DESCRIPTION
This reverts commit 24d5be1669fb6b7479acf55e26158f837b118421, reversing
changes made to a756b4be27de0ce07d443f05733310275f84a8d1.

After #38717 there is no need in --no-stress, since there will be no
such checks for previous releases that fails.

Reverts: #38212 (cc @qoega @tavplubix )
Requires: #38717

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)