### PR TITLE
Fix replication after improper merge process

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -599,7 +599,6 @@ void StorageReplicatedMergeTree::createNewZooKeeperNodes()
     auto zookeeper = getZooKeeper();
 
     std::vector<zkutil::ZooKeeper::FutureCreate> futures;
-    futures.push_back(zookeeper->asyncTryCreateNoThrow(zookeeper_path + "/quorum/parallel", String(), zkutil::CreateMode::Persistent));
 
     /// These 4 nodes used to be created in createNewZookeeperNodes() and they were moved to createTable()
     /// This means that if the first replica creating the table metadata has an older version of CH (22.3 or previous)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Related to https://github.com/ClickHouse/ClickHouse/issues/38529#issuecomment-1173070201

This was fixed in https://github.com/ClickHouse/ClickHouse/pull/38541 and https://github.com/ClickHouse/ClickHouse/pull/38627 but a recent pull request reintroduced the buggy lines (now `/quorum/parallel` is duplicated and the first appears before creating `/quorun`).

Tagging as not for changelog since it only affects master. The fixes were backported to 22.4 to 22.6 but in those branches the final code is correct (no duplication due to other PRs being merged afterwards).  