### PR TITLE
tests: make aggregate_state_exception_memory_leak deterministic

### DIFF
--- a/tests/queries/0_stateless/01301_aggregate_state_exception_memory_leak.sh
+++ b/tests/queries/0_stateless/01301_aggregate_state_exception_memory_leak.sh
@@ -5,15 +5,16 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-function test()
-{
-    for _ in {1..1000}; do
-        $CLICKHOUSE_CLIENT --max_memory_usage 1G <<< "SELECT uniqExactState(number) FROM system.numbers_mt GROUP BY number % 10";
-    done
-}
-
-export -f test;
-
+start=$SECONDS
 # If the memory leak exists, it will lead to OOM fairly quickly.
-timeout 30 bash -c test 2>&1 | grep -o -F 'Memory limit (for query) exceeded' | uniq
+for _ in {1..1000}; do
+    $CLICKHOUSE_CLIENT --max_memory_usage 1G <<< "SELECT uniqExactState(number) FROM system.numbers_mt GROUP BY number % 10";
+
+    # NOTE: we cannot use timeout here since this will not guarantee that the query will be executed at least once.
+    # (since graceful wait of clickhouse-client had been reverted)
+    elapsed=$((SECONDS - start))
+    if [[ $elapsed -gt 30 ]]; then
+        break
+    fi
+done 2>&1 | grep -o -F 'Memory limit (for query) exceeded' | uniq
 echo 'Ok'

--- a/tests/queries/0_stateless/01302_aggregate_state_exception_memory_leak.sh
+++ b/tests/queries/0_stateless/01302_aggregate_state_exception_memory_leak.sh
@@ -5,14 +5,14 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-function test()
-{
-    for _ in {1..250}; do
-        $CLICKHOUSE_CLIENT --query "SELECT groupArrayIfState(('Hello, world' AS s) || s || s || s || s || s || s || s || s || s, NOT throwIf(number > 10000000, 'Ok')) FROM system.numbers_mt GROUP BY number % 10";
-    done
-}
+start=$SECONDS
+for _ in {1..250}; do
+    $CLICKHOUSE_CLIENT --query "SELECT groupArrayIfState(('Hello, world' AS s) || s || s || s || s || s || s || s || s || s, NOT throwIf(number > 10000000, 'Ok')) FROM system.numbers_mt GROUP BY number % 10";
 
-export -f test;
-
-# If the memory leak exists, it will lead to OOM fairly quickly.
-timeout 30 bash -c test 2>&1 | grep -o -F 'Ok' | uniq
+    # NOTE: we cannot use timeout here since this will not guarantee that the query will be executed at least once.
+    # (since graceful wait of clickhouse-client had been reverted)
+    elapsed=$((SECONDS - start))
+    if [[ $elapsed -gt 30 ]]; then
+        break
+    fi
+done 2>&1 | grep -o -F 'Ok' | uniq


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Sometimes if the 30 seconds is not enough for the query to fail (i.e. under [TSan](https://s3.amazonaws.com/clickhouse-test-reports/38748/d863f6ce1ece810c66ddf8bd89575825d3f2595f/stateless_tests__thread__actions__%5B2/3%5D.html)),
the error will be ignored and the test will fail.

Drop that loops away, since the query fails everytime and convert it to simple `.sql` test.

Follow-up for: #11496 (cc @alexey-milovidov )