### PR TITLE
Fix throwing exception on error for seekable read from s3

### DIFF
--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -227,7 +227,7 @@ size_t ReadBufferFromS3::getFileSize()
     if (file_size)
         return *file_size;
 
-    auto object_size = S3::getObjectSize(client_ptr, bucket, key, version_id, false);
+    auto object_size = S3::getObjectSize(client_ptr, bucket, key, version_id);
 
     file_size = object_size;
     return *file_size;


### PR DESCRIPTION

Stopped to work correctly after https://github.com/ClickHouse/ClickHouse/pull/38227 because there was an incorrect assumption that getFIleSize method will throw, but it didn't.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix throwing exception for seekable read from s3 (exception was not thrown). 


