### PR TITLE
Get files changed in master since release is branched

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -152,6 +152,13 @@ class PRInfo:
                     self.user_orgs = set(org["id"] for org in response_json)
 
             self.diff_urls.append(github_event["pull_request"]["diff_url"])
+            if "release" in self.labels:
+                # For release PRs we must get not only files changed in the PR
+                # itself, but as well files changed since we branched out
+                self.diff_urls.append(
+                    f"https://github.com/{GITHUB_REPOSITORY}/"
+                    f"compare/{self.head_ref}...master.diff"
+                )
         elif "commits" in github_event:
             self.sha = github_event["after"]
             pull_request = get_pr_for_commit(self.sha, github_event["ref"])

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -152,13 +152,6 @@ class PRInfo:
                     self.user_orgs = set(org["id"] for org in response_json)
 
             self.diff_urls.append(github_event["pull_request"]["diff_url"])
-            if "release" in self.labels:
-                # For release PRs we must get not only files changed in the PR
-                # itself, but as well files changed since we branched out
-                self.diff_urls.append(
-                    f"https://github.com/{GITHUB_REPOSITORY}/"
-                    f"compare/{self.head_ref}...master.diff"
-                )
         elif "commits" in github_event:
             self.sha = github_event["after"]
             pull_request = get_pr_for_commit(self.sha, github_event["ref"])
@@ -207,6 +200,13 @@ class PRInfo:
                     ]
                 else:
                     self.diff_urls.append(pull_request["diff_url"])
+                if "release" in self.labels:
+                    # For release PRs we must get not only files changed in the PR
+                    # itself, but as well files changed since we branched out
+                    self.diff_urls.append(
+                        f"https://github.com/{GITHUB_REPOSITORY}/"
+                        f"compare/{self.head_ref}...master.diff"
+                    )
         else:
             print("event.json does not match pull_request or push:")
             print(json.dumps(github_event, sort_keys=True, indent=4))


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Get files changed in master since a release is branched out. Necessary for quick docker rebuilds in backports