### PR TITLE
Deactivate mutations_finalizing_task during shutdown

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4229,6 +4229,7 @@ void StorageReplicatedMergeTree::shutdown()
     fetcher.blocker.cancelForever();
     merger_mutator.merges_blocker.cancelForever();
     parts_mover.moves_blocker.cancelForever();
+    mutations_finalizing_task->deactivate();
     stopBeingLeader();
 
     restarting_thread.shutdown();


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Deactivate `mutations_finalizing_task` before shutdown to avoid `TABLE_IS_READ_ONLY` errors.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Closes https://github.com/ClickHouse/ClickHouse/issues/38681

 The error itself is not important since it was ignored, but it'd fill the logs and make monitoring harder.

To test this I reduced `MUTATIONS_FINALIZING_SLEEP_MS` and ` MUTATIONS_FINALIZING_IDLE_SLEEP_MS` to 1ms and created and dropped a replicated table in a loop. Before the change it would throw `TABLE_IS_READ_ONLY` almost always, and after the change they are gone:

```bash
#!/bin/bash

__query()
{
    clickhouse client -h clickhouse-01 --port 49000 --query "$1"
}


__query "DROP DATABASE IF EXISTS test ON CLUSTER tinybird SYNC;"
__query "CREATE DATABASE test ON CLUSTER tinybird;"

for i in {1..100};
do
    echo $i
    __query "
        CREATE TABLE test.test$i ON CLUSTER tinybird (date DateTime('UTC'), city String)
                        ENGINE = ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard}/test.test$i', '{replica}')
                        PARTITION BY toYear(date)
                        ORDER BY (date, city) TTL date + toIntervalDay(1)" || break;
    __query "DROP TABLE test.test$i SYNC";
    __query "SELECT throwIf(count()) FROM clusterAllReplicas('tinybird', 'system.errors') WHERE name = 'TABLE_IS_READ_ONLY'" || exit 1
done
```
