### PR TITLE
Do not override compiler if it had been already set

### DIFF
--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -62,9 +62,10 @@ execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCH)
 # By default, prefer clang on Linux
 # But note, that you still may change the compiler with -DCMAKE_C_COMPILER/-DCMAKE_CXX_COMPILER.
 if (OS MATCHES "Linux"
-    # some build systems may use CC/CXX env variables
     AND "$ENV{CC}" STREQUAL ""
-    AND "$ENV{CXX}" STREQUAL "")
+    AND "$ENV{CXX}" STREQUAL ""
+    AND NOT DEFINED CMAKE_C_COMPILER
+    AND NOT DEFINED CMAKE_CXX_COMPILER)
     find_program(CLANG_PATH clang)
     if (CLANG_PATH)
         set(CMAKE_C_COMPILER "clang" CACHE INTERNAL "")

--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -87,8 +87,7 @@ if (OS MATCHES "Linux"
         set (CMAKE_TOOLCHAIN_FILE "cmake/linux/toolchain-aarch64.cmake" CACHE INTERNAL "")
     elseif (ARCH MATCHES "^(ppc64le.*|PPC64LE.*)")
         set (CMAKE_TOOLCHAIN_FILE "cmake/linux/toolchain-ppc64le.cmake" CACHE INTERNAL "")
-else ()
+    else ()
         message (FATAL_ERROR "Unsupported architecture: ${ARCH}")
     endif ()
-
 endif()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not override compiler if it had been already set

Before this patch:

    cmake -DCMAKE_C_COMPILER=foo .. # will use foo
    cmake .. # will use clang

After:

    cmake -DCMAKE_C_COMPILER=foo .. # will use foo
    cmake .. # will use foo

Follow-up for: #37796 (@rschu1ze)