### PR TITLE
Continue server start-up if dictionaries with broken metadata are present

### DIFF
--- a/src/Databases/DatabaseDictionary.cpp
+++ b/src/Databases/DatabaseDictionary.cpp
@@ -62,6 +62,9 @@ Tables DatabaseDictionary::listTables(const FilterByNameFunction & filter_by_nam
     String db_name = getDatabaseName();
     for (auto & load_result : load_results)
     {
+        if (load_result.status == ExternalLoaderStatus::FAILED)
+            continue;
+
         auto storage = createStorageDictionary(db_name, load_result, getContext());
         if (storage)
             tables.emplace(storage->getStorageID().table_name, storage);

--- a/tests/integration/test_dictionaries_broken_config/configs/config.xml
+++ b/tests/integration/test_dictionaries_broken_config/configs/config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<clickhouse>
+<dictionaries_lazy_load>False</dictionaries_lazy_load>
+    <logger>
+        <!-- Possible levels [1]:
+
+          - none (turns off logging)
+          - fatal
+          - critical
+          - error
+          - warning
+          - notice
+          - information
+          - debug
+          - trace
+          - test (not for production usage)
+
+            [1]: https://github.com/pocoproject/poco/blob/poco-1.9.4-release/Foundation/include/Poco/Logger.h#L105-L114
+        -->
+        <level>trace</level>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+        <size>1000M</size>
+        <count>10</count>
+    </logger>
+</clickhouse>

--- a/tests/integration/test_dictionaries_broken_config/configs/dictionaries/broken_metadata.xml
+++ b/tests/integration/test_dictionaries_broken_config/configs/dictionaries/broken_metadata.xml
@@ -1,0 +1,39 @@
+<dictionaries>
+  <dictionary>
+    <name>broken_metadata</name>
+    <source>
+      <executable>
+        <command>echo "1,2,b,c"</command>
+        <format>CSV</format>
+      </executable>
+    </source>
+    <lifetime>
+      <min>86400</min>
+      <max>90000</max>
+    </lifetime>
+    <layout>
+      <flat />
+    </layout>
+    <structure>
+      <id>
+        <name>prefix_id</name>
+      </id>
+      <attribute>
+        <name>first</name>
+        <type>UInt32</type>
+        <!-- OOPS! null value incompatible with type -->
+        <null_value>UNKNOWN</null_value>
+      </attribute>
+      <attribute>
+        <name>second</name>
+        <type>String</type>
+        <null_value>UNKNOWN</null_value>
+      </attribute>
+      <attribute>
+        <name>third</name>
+        <type>String</type>
+        <null_value>UNKNOWN</null_value>
+      </attribute>
+    </structure>
+  </dictionary>
+</dictionaries>

--- a/tests/integration/test_dictionaries_broken_config/configs/dictionaries/good_dict.xml
+++ b/tests/integration/test_dictionaries_broken_config/configs/dictionaries/good_dict.xml
@@ -1,0 +1,38 @@
+<dictionaries>
+  <dictionary>
+    <name>good_dict</name>
+    <source>
+      <executable>
+        <command>echo "1,2,b,c"</command>
+        <format>CSV</format>
+      </executable>
+    </source>
+    <lifetime>
+      <min>86400</min>
+      <max>90000</max>
+    </lifetime>
+    <layout>
+      <flat />
+    </layout>
+    <structure>
+      <id>
+        <name>prefix_id</name>
+      </id>
+      <attribute>
+        <name>first</name>
+        <type>UInt32</type>
+        <null_value>0</null_value>
+      </attribute>
+      <attribute>
+        <name>second</name>
+        <type>String</type>
+        <null_value>UNKNOWN</null_value>
+      </attribute>
+      <attribute>
+        <name>third</name>
+        <type>String</type>
+        <null_value>UNKNOWN</null_value>
+      </attribute>
+    </structure>
+  </dictionary>
+</dictionaries>

--- a/tests/integration/test_dictionaries_broken_config/test.py
+++ b/tests/integration/test_dictionaries_broken_config/test.py
@@ -1,0 +1,60 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+
+@pytest.fixture(scope="module", params=["broken_metadata"])
+def started_cluster_instance(request):
+    cluster = ClickHouseCluster(__file__)
+    try:
+        instance = cluster.add_instance(
+            request.param,
+            main_configs=["configs/config.xml"],
+            dictionaries=[
+                "configs/dictionaries/good_dict.xml",
+                "configs/dictionaries/{}.xml".format(request.param),
+            ],
+            stay_alive=True,
+        )
+        cluster.start()
+
+        # Load some data so that the restart is not "empty"
+        instance.query(
+            """
+            CREATE DATABASE IF NOT EXISTS dict ENGINE=Dictionary;
+            CREATE DATABASE IF NOT EXISTS test;
+            DROP TABLE IF EXISTS test.elements;
+            CREATE TABLE test.elements (id UInt64, a String, b Int32, c Float64) ENGINE=Log;
+            INSERT INTO test.elements VALUES (0, 'water', 10, 1), (1, 'air', 40, 0.01), (2, 'earth', 100, 1.7);
+            """
+        )
+        yield (request.param, instance)
+
+    finally:
+        cluster.shutdown()
+
+
+def get_status(instance, dictionary_name):
+    return instance.query(
+        "SELECT status FROM system.dictionaries WHERE name='" + dictionary_name + "'"
+    ).rstrip("\n")
+
+
+def get_exception(instance, dictionary_name):
+    return instance.query(
+        "SELECT last_exception FROM system.dictionaries WHERE name='"
+        + dictionary_name
+        + "'"
+    ).rstrip("\n")
+
+
+def test_broken_dict(started_cluster_instance):
+    error_type, instance = started_cluster_instance
+    instance.restart_clickhouse()
+    assert get_status(instance, "good_dict") == "LOADED"
+    assert instance.query("select dictGet('good_dict', 'first', toUInt64(1))") == "2\n"
+
+    assert get_status(instance, error_type) == "FAILED"
+    assert "DB::Exception" in get_exception(instance, error_type)
+    assert "DB::Exception" in instance.query_and_get_error(
+        "select dictGet('{}', 'first', toUInt32(1))".format(error_type)
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not crash the server when a dictionary with invalid metadata is present.

Since 21.9 (approx.) having invalid metadata in dictionaries (e.g. when the default value is of wrong type) causes an exception. This change makes sure the server starts up successfully when one of the dictionaries is broken. Additionally, with this fix system.dictionaries reports the correct status (FAILED) and error message.

 Fixes #37571.