### PR TITLE
fixed: crash caused by IHiveFile be shared among threads

### DIFF
--- a/src/Storages/Hive/HiveFile.cpp
+++ b/src/Storages/Hive/HiveFile.cpp
@@ -88,7 +88,6 @@ std::optional<size_t> IHiveFile::getRows()
             has_init_rows = true;
         }
     }
-
     return rows;
 }
 

--- a/src/Storages/Hive/HiveFile.cpp
+++ b/src/Storages/Hive/HiveFile.cpp
@@ -82,6 +82,8 @@ std::optional<size_t> IHiveFile::getRows()
     if (!has_init_rows)
     {
         std::lock_guard lock(mutex);
+        if (has_init_rows)
+            return rows;
         rows = getRowsImpl();
         has_init_rows = true;
     }
@@ -93,6 +95,8 @@ void IHiveFile::loadFileMinMaxIndex()
     if (file_minmax_idx_loaded)
         return;
     std::lock_guard lock(mutex);
+    if (file_minmax_idx_loaded)
+        return;
     loadFileMinMaxIndexImpl();
     file_minmax_idx_loaded = true;
 }
@@ -102,6 +106,8 @@ void IHiveFile::loadSplitMinMaxIndexes()
     if (split_minmax_idxes_loaded)
         return;
     std::lock_guard lock(mutex);
+    if (split_minmax_idxes_loaded)
+        return;
     loadSplitMinMaxIndexesImpl();
     split_minmax_idxes_loaded = true;
 }

--- a/src/Storages/Hive/HiveFile.cpp
+++ b/src/Storages/Hive/HiveFile.cpp
@@ -79,8 +79,12 @@ Range createRangeFromParquetStatistics(std::shared_ptr<parquet::ByteArrayStatist
 
 std::optional<size_t> IHiveFile::getRows()
 {
-    if (!rows)
+    if (!has_init_rows)
+    {
+        std::lock_guard lock(mutex);
         rows = getRowsImpl();
+        has_init_rows = true;
+    }
     return rows;
 }
 
@@ -88,6 +92,7 @@ void IHiveFile::loadFileMinMaxIndex()
 {
     if (file_minmax_idx_loaded)
         return;
+    std::lock_guard lock(mutex);
     loadFileMinMaxIndexImpl();
     file_minmax_idx_loaded = true;
 }
@@ -96,6 +101,7 @@ void IHiveFile::loadSplitMinMaxIndexes()
 {
     if (split_minmax_idxes_loaded)
         return;
+    std::lock_guard lock(mutex);
     loadSplitMinMaxIndexesImpl();
     split_minmax_idxes_loaded = true;
 }

--- a/src/Storages/Hive/HiveFile.cpp
+++ b/src/Storages/Hive/HiveFile.cpp
@@ -82,10 +82,11 @@ std::optional<size_t> IHiveFile::getRows()
     if (!has_init_rows)
     {
         std::lock_guard lock(mutex);
-        if (has_init_rows)
-            return rows;
-        rows = getRowsImpl();
-        has_init_rows = true;
+        if (!has_init_rows)
+        {
+            rows = getRowsImpl();
+            has_init_rows = true;
+        }
     }
     return rows;
 }

--- a/src/Storages/Hive/HiveFile.cpp
+++ b/src/Storages/Hive/HiveFile.cpp
@@ -88,6 +88,7 @@ std::optional<size_t> IHiveFile::getRows()
             has_init_rows = true;
         }
     }
+
     return rows;
 }
 

--- a/src/Storages/Hive/HiveFile.h
+++ b/src/Storages/Hive/HiveFile.h
@@ -149,6 +149,7 @@ protected:
     String path;
     UInt64 last_modify_time;
     size_t size;
+    std::atomic<bool> has_init_rows = false;
     std::optional<size_t> rows;
 
     NamesAndTypesList index_names_and_types;
@@ -162,6 +163,9 @@ protected:
     /// Skip splits for this file after applying minmax index (if any)
     std::unordered_set<int> skip_splits;
     std::shared_ptr<HiveSettings> storage_settings;
+
+    /// IHiveFile would be shared among multi threads, need lock's protection to update min/max indexes.
+    std::mutex mutex;
 };
 
 using HiveFilePtr = std::shared_ptr<IHiveFile>;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Bug Fix



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Fixed crash caused by IHiveFile be shared among threads

IHiveFile would be shared among threads which cause a crash without lock protection to update min/max indexes.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
