### PR TITLE
Fix settings profile with seconds unit

### DIFF
--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -192,7 +192,8 @@ namespace
 }
 
 template <>
-SettingFieldSeconds::SettingFieldTimespan(const Field & f) : SettingFieldTimespan(float64AsSecondsToTimespan(fieldToNumber<Float64>(f)))
+SettingFieldSeconds::SettingFieldTimespan(const Field & f)
+    : SettingFieldTimespan(Poco::Timespan{float64AsSecondsToTimespan(fieldToNumber<Float64>(f))})
 {
 }
 

--- a/tests/queries/0_stateless/02294_fp_seconds_profile.reference
+++ b/tests/queries/0_stateless/02294_fp_seconds_profile.reference
@@ -1,0 +1,2 @@
+CREATE SETTINGS PROFILE `02294_profile1` SETTINGS timeout_before_checking_execution_speed = 3. TO default
+CREATE SETTINGS PROFILE `02294_profile2` SETTINGS max_execution_time = 0.5 TO default

--- a/tests/queries/0_stateless/02294_fp_seconds_profile.sql
+++ b/tests/queries/0_stateless/02294_fp_seconds_profile.sql
@@ -1,0 +1,12 @@
+-- Tags: no-parallel
+-- Bug: https://github.com/ClickHouse/ClickHouse/issues/38863
+
+DROP SETTINGS PROFILE IF EXISTS 02294_profile1, 02294_profile2;
+
+CREATE SETTINGS PROFILE 02294_profile1 SETTINGS timeout_before_checking_execution_speed = 3 TO default;
+SHOW CREATE SETTINGS PROFILE 02294_profile1;
+
+CREATE SETTINGS PROFILE 02294_profile2 SETTINGS max_execution_time = 0.5 TO default;
+SHOW CREATE SETTINGS PROFILE 02294_profile2;
+
+DROP SETTINGS PROFILE IF EXISTS 02294_profile1, 02294_profile2;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix settings profile with seconds unit


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Closes https://github.com/ClickHouse/ClickHouse/issues/38863
Should be backported to 22.6