### PR TITLE
Avoid false positive red sanitizer asserts check in stress test

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -228,7 +228,7 @@ clickhouse-client --query "SELECT 'Server successfully started', 'OK'" >> /test_
 # Sanitizer asserts
 grep -Fa "==================" /var/log/clickhouse-server/stderr.log | grep -v "in query:" >> /test_output/tmp
 grep -Fa "WARNING" /var/log/clickhouse-server/stderr.log >> /test_output/tmp
-zgrep -Fav "ASan doesn't fully support makecontext/swapcontext functions" /test_output/tmp > /dev/null \
+zgrep -Fav -e "ASan doesn't fully support makecontext/swapcontext functions" -e "DB::Exception" /test_output/tmp > /dev/null \
     && echo -e 'Sanitizer assert (in stderr.log)\tFAIL' >> /test_output/test_results.tsv \
     || echo -e 'No sanitizer asserts\tOK' >> /test_output/test_results.tsv
 rm -f /test_output/tmp
@@ -368,7 +368,7 @@ then
     # Sanitizer asserts
     zgrep -Fa "==================" /var/log/clickhouse-server/stderr.log >> /test_output/tmp
     zgrep -Fa "WARNING" /var/log/clickhouse-server/stderr.log >> /test_output/tmp
-    zgrep -Fav "ASan doesn't fully support makecontext/swapcontext functions" /test_output/tmp > /dev/null \
+    zgrep -Fav -e "ASan doesn't fully support makecontext/swapcontext functions" -e "DB::Exception" /test_output/tmp > /dev/null \
         && echo -e 'Backward compatibility check: Sanitizer assert (in stderr.log)\tFAIL' >> /test_output/test_results.tsv \
         || echo -e 'Backward compatibility check: No sanitizer asserts\tOK' >> /test_output/test_results.tsv
     rm -f /test_output/tmp


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Example of false positive: https://s3.amazonaws.com/clickhouse-test-reports/38816/46cfe419d229a235c0d3abd983d7f4394b526bce/stress_test__memory__actions_.html

It's because of  an error in stderr that contains `===========`:
```
Cannot add message to the log: Code: 60. DB::Exception: Table test_w65oiw.custom_separated doesn't exist. (UNKNOWN_TABLE) (version 22.7.1.1) (from [::1]:46718) (comment: 01014_format_custom_separated.sh) (in query: SELECT * FROM custom_separated ORDER BY n FORMAT CustomSeparated SETTINGS format_custom_escaping_rule = 'CSV', format_custom_field_delimiter = '\t|\t', format_custom_row_before_delimiter = '||', format_custom_row_after_delimiter = '\t||', format_custom_row_between_delimiter = '\n', format_custom_result_before_delimiter = '========== result ==========\n', format_custom_result_after_delimiter = '\n============================\n'), Stack trace (when copying this message, always include the lines below):

```