### PR TITLE
Stop reporting Zookeeper "Node exists" exceptions in system.errors when they are expected

### DIFF
--- a/src/Common/ZooKeeper/KeeperException.h
+++ b/src/Common/ZooKeeper/KeeperException.h
@@ -24,9 +24,7 @@ public:
     static void check(Coordination::Error code, const Coordination::Requests & requests, const Coordination::Responses & responses);
 
     KeeperMultiException(Coordination::Error code, const Coordination::Requests & requests, const Coordination::Responses & responses);
-
-private:
-    static size_t getFailedOpIndex(Coordination::Error code, const Coordination::Responses & responses);
 };
 
+size_t getFailedOpIndex(Coordination::Error code, const Coordination::Responses & responses);
 }

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -1227,7 +1227,7 @@ void ZooKeeper::setZooKeeperLog(std::shared_ptr<DB::ZooKeeperLog> zk_log_)
 }
 
 
-size_t KeeperMultiException::getFailedOpIndex(Coordination::Error exception_code, const Coordination::Responses & responses)
+size_t getFailedOpIndex(Coordination::Error exception_code, const Coordination::Responses & responses)
 {
     if (responses.empty())
         throw DB::Exception("Responses for multi transaction is empty", DB::ErrorCodes::LOGICAL_ERROR);

--- a/src/Storages/MergeTree/EphemeralLockInZooKeeper.cpp
+++ b/src/Storages/MergeTree/EphemeralLockInZooKeeper.cpp
@@ -12,30 +12,53 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-EphemeralLockInZooKeeper::EphemeralLockInZooKeeper(
-    const String & path_prefix_, const String & temp_path, zkutil::ZooKeeper & zookeeper_, Coordination::Requests * precheck_ops)
-    : zookeeper(&zookeeper_), path_prefix(path_prefix_)
+EphemeralLockInZooKeeper::EphemeralLockInZooKeeper(const String & path_prefix_, zkutil::ZooKeeper & zookeeper_, const String & holder_path_)
+    : zookeeper(&zookeeper_), path_prefix(path_prefix_), holder_path(holder_path_)
+{
+    /// Write the path to the secondary node in the main node.
+    path = zookeeper->create(path_prefix, holder_path, zkutil::CreateMode::EphemeralSequential);
+    if (path.size() <= path_prefix.size())
+        throw Exception("Logical error: name of the main node is shorter than prefix.", ErrorCodes::LOGICAL_ERROR);
+}
+
+std::optional<EphemeralLockInZooKeeper> createEphemeralLockInZooKeeper(
+    const String & path_prefix_, const String & temp_path, zkutil::ZooKeeper & zookeeper_, const String & deduplication_path)
 {
     /// The /abandonable_lock- name is for backward compatibility.
     String holder_path_prefix = temp_path + "/abandonable_lock-";
+    String holder_path;
 
     /// Let's create an secondary ephemeral node.
-    if (!precheck_ops || precheck_ops->empty())
+    if (deduplication_path.empty())
     {
-        holder_path = zookeeper->create(holder_path_prefix, "", zkutil::CreateMode::EphemeralSequential);
+        holder_path = zookeeper_.create(holder_path_prefix, "", zkutil::CreateMode::EphemeralSequential);
     }
     else
     {
-        precheck_ops->emplace_back(zkutil::makeCreateRequest(holder_path_prefix, "", zkutil::CreateMode::EphemeralSequential));
-        Coordination::Responses op_results = zookeeper->multi(*precheck_ops);
-        holder_path = dynamic_cast<const Coordination::CreateResponse &>(*op_results.back()).path_created;
+        /// Check for duplicates in advance, to avoid superfluous block numbers allocation
+        Coordination::Requests ops;
+        ops.emplace_back(zkutil::makeCreateRequest(deduplication_path, "", zkutil::CreateMode::Persistent));
+        ops.emplace_back(zkutil::makeRemoveRequest(deduplication_path, -1));
+        ops.emplace_back(zkutil::makeCreateRequest(holder_path_prefix, "", zkutil::CreateMode::EphemeralSequential));
+        Coordination::Responses responses;
+        Coordination::Error e = zookeeper_.tryMulti(ops, responses);
+        if (e != Coordination::Error::ZOK)
+        {
+            if (responses[0]->error == Coordination::Error::ZNODEEXISTS)
+            {
+                return {};
+            }
+            else
+            {
+                zkutil::KeeperMultiException::check(e, ops, responses); // This should always throw the proper exception
+                throw Exception("Unable to handle error {} when acquiring ephemeral lock in ZK", ErrorCodes::LOGICAL_ERROR);
+            }
+        }
+
+        holder_path = dynamic_cast<const Coordination::CreateResponse *>(responses.back().get())->path_created;
     }
 
-    /// Write the path to the secondary node in the main node.
-    path = zookeeper->create(path_prefix, holder_path, zkutil::CreateMode::EphemeralSequential);
-
-    if (path.size() <= path_prefix.size())
-        throw Exception("Logical error: name of the main node is shorter than prefix.", ErrorCodes::LOGICAL_ERROR);
+    return EphemeralLockInZooKeeper{path_prefix_, zookeeper_, holder_path};
 }
 
 void EphemeralLockInZooKeeper::unlock()

--- a/src/Storages/MergeTree/EphemeralLockInZooKeeper.h
+++ b/src/Storages/MergeTree/EphemeralLockInZooKeeper.h
@@ -24,12 +24,14 @@ namespace ErrorCodes
 /// it would be simpler to allocate block numbers for all partitions in one ZK directory).
 class EphemeralLockInZooKeeper : public boost::noncopyable
 {
+    friend std::optional<EphemeralLockInZooKeeper> createEphemeralLockInZooKeeper(
+        const String & path_prefix_, const String & temp_path, zkutil::ZooKeeper & zookeeper_, const String & deduplication_path);
+
+protected:
+    EphemeralLockInZooKeeper() = delete;
+    EphemeralLockInZooKeeper(const String & path_prefix_, zkutil::ZooKeeper & zookeeper_, const String & holder_path_);
+
 public:
-    EphemeralLockInZooKeeper(
-        const String & path_prefix_, const String & temp_path, zkutil::ZooKeeper & zookeeper_, Coordination::Requests * precheck_ops = nullptr);
-
-    EphemeralLockInZooKeeper() = default;
-
     EphemeralLockInZooKeeper(EphemeralLockInZooKeeper && rhs) noexcept
     {
         *this = std::move(rhs);
@@ -89,6 +91,9 @@ private:
     String path;
     String holder_path;
 };
+
+std::optional<EphemeralLockInZooKeeper> createEphemeralLockInZooKeeper(
+    const String & path_prefix_, const String & temp_path, zkutil::ZooKeeper & zookeeper_, const String & deduplication_path);
 
 
 /// Acquires block number locks in all partitions.

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -146,7 +146,6 @@ namespace ErrorCodes
     extern const int RECEIVED_ERROR_TOO_MANY_REQUESTS;
     extern const int PART_IS_TEMPORARILY_LOCKED;
     extern const int CANNOT_ASSIGN_OPTIMIZE;
-    extern const int KEEPER_EXCEPTION;
     extern const int ALL_REPLICAS_LOST;
     extern const int REPLICA_STATUS_CHANGED;
     extern const int CANNOT_ASSIGN_ALTER;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Stop reporting Zookeeper "Node exists" exceptions in system.errors when they are expected


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/


Background: While monitoring a live system with multiple replicas, if you check system.errors, you see thousands or millions of ZK errors that aren't such. For example:
```
SELECT *
FROM clusterAllReplicas('CLUSTERNAME', 'system.errors')
WHERE name = 'KEEPER_EXCEPTION'

┌─name─────────────┬─code─┬──value─┬─────last_error_time─┬─last_error_message───────────────┐
│ KEEPER_EXCEPTION │  999 │ 256690 │ 2022-07-07 14:12:31 │ Transaction failed (Node exists) │
└──────────────────┴──────┴────────┴─────────────────────┴──────────────────────────────────┘
┌─name─────────────┬─code─┬──value─┬─────last_error_time─┬─last_error_message───────────────┐
│ KEEPER_EXCEPTION │  999 │ 372941 │ 2022-07-07 14:12:33 │ Transaction failed (Node exists) │
└──────────────────┴──────┴────────┴─────────────────────┴──────────────────────────────────┘
┌─name─────────────┬─code─┬──value─┬─────last_error_time─┬─last_error_message─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ KEEPER_EXCEPTION │  999 │ 231948 │ 2022-07-07 14:12:33 │ Transaction failed (Node exists)                                                                                                                                                                                                                           │
│ KEEPER_EXCEPTION │  999 │      1 │ 2022-07-01 08:46:00 │ Received from 10.156.15.202:9000. DB::Exception: Cannot allocate block number in ZooKeeper: Coordination::Exception: Connection loss. Stack trace:

0. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x93a6a9a in /usr/bin/clickhouse
1. DB::StorageReplicatedMergeTree::allocateBlockNumber(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<zkutil::ZooKeeper> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const @ 0x11277457 in /usr/bin/clickhouse
2. DB::ReplicatedMergeTreeSink::commitPart(std::__1::shared_ptr<zkutil::ZooKeeper>&, std::__1::shared_ptr<DB::IMergeTreeDataPart>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x116a8942 in /usr/bin/clickhouse
3. DB::ReplicatedMergeTreeSink::consume(DB::Chunk) @ 0x116a7e4d in /usr/bin/clickhouse
4. DB::ISink::work() @ 0x11832501 in /usr/bin/clickhouse
5. DB::PushingToSinkBlockOutputStream::write(DB::Block const&) @ 0x10b31347 in /usr/bin/clickhouse
6. DB::PushingToViewsBlockOutputStream::write(DB::Block const&) @ 0x10b36aaf in /usr/bin/clickhouse
7. DB::AddingDefaultBlockOutputStream::write(DB::Block const&) @ 0x10b43bab in /usr/bin/clickhouse
8. DB::SquashingBlockOutputStream::finalize() @ 0x10b4422c in /usr/bin/clickhouse
9. DB::SquashingBlockOutputStream::writeSuffix() @ 0x10b442c9 in /usr/bin/clickhouse
10. DB::TCPHandler::processInsertQuery() @ 0x117f6d5a in /usr/bin/clickhouse
11. DB::TCPHandler::runImpl() @ 0x117f0103 in /usr/bin/clickhouse
12. DB::TCPHandler::run() @ 0x11803039 in /usr/bin/clickhouse
13. Poco::Net::TCPServerConnection::start() @ 0x143c2dcf in /usr/bin/clickhouse
14. Poco::Net::TCPServerDispatcher::run() @ 0x143c485a in /usr/bin/clickhouse
15. Poco::PooledThread::run() @ 0x144f6ad9 in /usr/bin/clickhouse
16. Poco::ThreadImpl::runnableEntry(void*) @ 0x144f2d6a in /usr/bin/clickhouse
17. start_thread @ 0x76db in /lib/x86_64-linux-gnu/libpthread-2.27.so
18. clone @ 0x12161f in /lib/x86_64-linux-gnu/libc-2.27.so
 │
└──────────────────┴──────┴────────┴─────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

In all likelihood, 99.9999% of the errors reported here, except the last one aren't errors but simple notices about a ZK node already existing (`ZNODEEXISTS`). In my local tests with master I've only seen 2 occurrences so far, `checkPartChecksumsAndCommit` and in `EphemeralLocksInAllPartitions`, and in both cases the server already has logic to deal with this. The idea is to stop reporting those expected conflicts in system.errors so it's easier to notice the rest of the `KEEPER_EXCEPTION`.

I've refactored this 2 functions to follow similar patterns in other parts of the code (using tryMulti instead of multi to only throw on unexpected exceptions). The 2 commits can be reviewed separately (not directly related to one another). 

References https://github.com/ClickHouse/ClickHouse/issues/38600#issuecomment-1171196174
cc @tavplubix 