### PR TITLE
Fix fsync_part_directory for fetches

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -796,7 +796,7 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
 
     SyncGuardPtr sync_guard;
     if (data.getSettings()->fsync_part_directory)
-        sync_guard = disk->getDirectorySyncGuard(data_part_storage->getPartDirectory());
+        sync_guard = disk->getDirectorySyncGuard(data_part_storage->getRelativePath());
 
     CurrentMetrics::Increment metric_increment{CurrentMetrics::ReplicatedFetch};
 

--- a/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.reference
+++ b/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.reference
@@ -1,0 +1,15 @@
+default
+1
+compact fsync_after_insert
+1
+compact fsync_after_insert,fsync_part_directory
+1
+wide fsync_after_insert
+1
+wide fsync_after_insert,fsync_part_directory
+1
+memory in_memory_parts_insert_sync
+1
+wide fsync_part_directory,vertical
+1
+2

--- a/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.sql
+++ b/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.sql
@@ -1,6 +1,8 @@
 -- Tags: no-parallel
 -- no-parallel -- for flaky check and to avoid "Removing leftovers from table" (for other tables)
 
+-- Temporarily skip warning 'table was created by another server at the same moment, will retry'
+set send_logs_level='error';
 set database_atomic_wait_for_drop_and_detach_synchronously=1;
 
 drop table if exists rep_fsync_r1;

--- a/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.sql
+++ b/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.sql
@@ -1,0 +1,86 @@
+-- Tags: no-parallel
+-- no-parallel -- for flaky check and to avoid "Removing leftovers from table" (for other tables)
+
+set database_atomic_wait_for_drop_and_detach_synchronously=1;
+
+drop table if exists rep_fsync_r1;
+drop table if exists rep_fsync_r2;
+
+select 'default';
+create table rep_fsync_r1 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r1') order by key;
+create table rep_fsync_r2 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r2') order by key;
+insert into rep_fsync_r1 values (1);
+system sync replica rep_fsync_r2;
+select * from rep_fsync_r2;
+optimize table rep_fsync_r1 final;
+system sync replica rep_fsync_r2;
+drop table rep_fsync_r1;
+drop table rep_fsync_r2;
+
+select 'compact fsync_after_insert';
+create table rep_fsync_r1 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r1') order by key settings min_rows_for_wide_part=2, fsync_after_insert=1;
+create table rep_fsync_r2 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r2') order by key settings min_rows_for_wide_part=2, fsync_after_insert=1;
+insert into rep_fsync_r1 values (1);
+system sync replica rep_fsync_r2;
+select * from rep_fsync_r2;
+optimize table rep_fsync_r1 final;
+system sync replica rep_fsync_r2;
+drop table rep_fsync_r1;
+drop table rep_fsync_r2;
+
+select 'compact fsync_after_insert,fsync_part_directory';
+create table rep_fsync_r1 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r1') order by key settings min_rows_for_wide_part=2, fsync_after_insert=1, fsync_part_directory=1;
+create table rep_fsync_r2 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r2') order by key settings min_rows_for_wide_part=2, fsync_after_insert=1, fsync_part_directory=1;
+insert into rep_fsync_r1 values (1);
+system sync replica rep_fsync_r2;
+select * from rep_fsync_r2;
+optimize table rep_fsync_r1 final;
+system sync replica rep_fsync_r2;
+drop table rep_fsync_r1;
+drop table rep_fsync_r2;
+
+select 'wide fsync_after_insert';
+create table rep_fsync_r1 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r1') order by key settings min_bytes_for_wide_part=0, fsync_after_insert=1;
+create table rep_fsync_r2 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r2') order by key settings min_bytes_for_wide_part=0, fsync_after_insert=1;
+insert into rep_fsync_r1 values (1);
+system sync replica rep_fsync_r2;
+select * from rep_fsync_r2;
+optimize table rep_fsync_r1 final;
+system sync replica rep_fsync_r2;
+drop table rep_fsync_r1;
+drop table rep_fsync_r2;
+
+select 'wide fsync_after_insert,fsync_part_directory';
+create table rep_fsync_r1 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r1') order by key settings min_bytes_for_wide_part=0, fsync_after_insert=1, fsync_part_directory=1;
+create table rep_fsync_r2 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r2') order by key settings min_bytes_for_wide_part=0, fsync_after_insert=1, fsync_part_directory=1;
+insert into rep_fsync_r1 values (1);
+system sync replica rep_fsync_r2;
+select * from rep_fsync_r2;
+optimize table rep_fsync_r1 final;
+system sync replica rep_fsync_r2;
+drop table rep_fsync_r1;
+drop table rep_fsync_r2;
+
+select 'memory in_memory_parts_insert_sync';
+create table rep_fsync_r1 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r1') order by key settings min_rows_for_compact_part=2, in_memory_parts_insert_sync=1, fsync_after_insert=1, fsync_part_directory=1;
+create table rep_fsync_r2 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r2') order by key settings min_rows_for_compact_part=2, in_memory_parts_insert_sync=1, fsync_after_insert=1, fsync_part_directory=1;
+insert into rep_fsync_r1 values (1);
+system sync replica rep_fsync_r2;
+select * from rep_fsync_r2;
+optimize table rep_fsync_r1 final;
+system sync replica rep_fsync_r2;
+drop table rep_fsync_r1;
+drop table rep_fsync_r2;
+
+select 'wide fsync_part_directory,vertical';
+create table rep_fsync_r1 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r1') order by key settings min_bytes_for_wide_part=0, fsync_part_directory=1, enable_vertical_merge_algorithm=1, vertical_merge_algorithm_min_rows_to_activate=0, vertical_merge_algorithm_min_columns_to_activate=0;
+create table rep_fsync_r2 (key Int) engine=ReplicatedMergeTree('/clickhouse/tables/{database}/rep_fsync', 'r2') order by key settings min_bytes_for_wide_part=0, fsync_part_directory=1, enable_vertical_merge_algorithm=1, vertical_merge_algorithm_min_rows_to_activate=0, vertical_merge_algorithm_min_columns_to_activate=0;
+insert into rep_fsync_r1 values (1);
+insert into rep_fsync_r2 values (2);
+system sync replica rep_fsync_r2;
+select * from rep_fsync_r2 order by key;
+-- vertical merge does not supports deduplicate, hence no FINAL
+optimize table rep_fsync_r1;
+system sync replica rep_fsync_r2;
+drop table rep_fsync_r1;
+drop table rep_fsync_r2;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix fsync_part_directory for fetches

Before it produces the following error:

    2022.07.07 23:40:03.131044 [ 44869 ] {} <Error> default.rep_data: auto DB::StorageReplicatedMergeTree::processQueueEntry(ReplicatedMergeTreeQueue::SelectedEntryPtr)::(anonymous class)::operator()(DB::StorageReplicatedMergeTree::LogEntryPtr &) const: Code: 107. DB::ErrnoException: Cannot open file /var/lib/clickhouse/data/tmp-fetch_36_25458_25458_0, errno: 2, strerror: No such file or directory. (FILE_DOESNT_EXIST), Stack trace (when copying this message, always include the lines below):

    0. Poco::Exception::Exception() @ 0x1764634c in /usr/bin/clickhouse
    1. DB::Exception::Exception() @ 0xb42caba in /usr/bin/clickhouse
    2. DB::throwFromErrnoWithPath() @ 0xb42d79b in /usr/bin/clickhouse
    3. DB::LocalDirectorySyncGuard::LocalDirectorySyncGuard() @ 0x1404bbd4 in /usr/bin/clickhouse
    4. DB::DiskLocal::getDirectorySyncGuard() const @ 0x140466a4 in /usr/bin/clickhouse
    5. DB::DataPartsExchange::Fetcher::downloadPartToDisk() @ 0x15122af1 in /usr/bin/clickhouse
    6. DB::DataPartsExchange::Fetcher::fetchPart() @ 0x1511de39 in /usr/bin/clickhouse

Fixes: #36555 (cc @KochetovNicolai )