### PR TITLE
Fix flaky `test_system_merges/test.py::test_mutation_simple`

### DIFF
--- a/tests/integration/test_system_merges/test.py
+++ b/tests/integration/test_system_merges/test.py
@@ -225,7 +225,7 @@ def test_mutation_simple(started_cluster, replicated):
 
         assert (
             node_check.query(
-                "SELECT * FROM system.merges WHERE table = '{name}'".format(
+                "SELECT * FROM system.merges WHERE table = '{name}' and progress < 1".format(
                     name=table_name
                 )
             )


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/7593560dd0f1eea4e7c08432d065f3174ca9c2f1/integration_tests__release__actions__[2/2].html
```
>           assert (
                node_check.query(
                    "SELECT * FROM system.merges WHERE table = '{name}'".format(
                        name=table_name
                    )
                )
                == ""
            )
E           assert ("test\tmutation_simple\t3.982245838\t0\t1\t['all_0_0_0']\tall_0_0_0_1\t"\n "['/var/lib/clickhouse/data/test/mutation_simple/all_0_0_0/']\t"\n '/var/lib/clickhouse/data/test/mutation_simple/all_0_0_0_1/\tall\t1\t83\t2\t'\n '0\t0\t0\t0\t0\t0\t34\t\t\n') == ''
E             + test	mutation_simple	3.982245838	0	1	['all_0_0_0']	all_0_0_0_1	['/var/lib/clickhouse/data/test/mutation_simple/all_0_0_0/']	/var/lib/clickhouse/data/test/mutation_simple/all_0_0_0_1/	all	1	83	2	0	0	0	0	0	0	34

```
Follow-up to #36004

cc: @excitoon 