### PR TITLE
clearOldLogs: Don't report KEEPER_EXCEPTION on concurrent deletes

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
@@ -248,17 +248,17 @@ void ReplicatedMergeTreeCleanupThread::clearOldLogs()
             /// Simultaneously with clearing the log, we check to see if replica was added since we received replicas list.
             ops.emplace_back(zkutil::makeCheckRequest(storage.zookeeper_path + "/replicas", stat.version));
 
-            try
-            {
-                zookeeper->multi(ops);
-            }
-            catch (const zkutil::KeeperMultiException & e)
+            Coordination::Responses responses;
+            Coordination::Error e = zookeeper->tryMulti(ops, responses);
+
+            if (e == Coordination::Error::ZNONODE)
             {
                 /// Another replica already deleted the same node concurrently.
-                if (e.code == Coordination::Error::ZNONODE)
-                    break;
-
-                throw;
+                break;
+            }
+            else
+            {
+                zkutil::KeeperMultiException::check(e, ops, responses);
             }
             ops.clear();
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- clearOldLogs: Don't report KEEPER_EXCEPTION on concurrent deletes


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

From system.errors of master:

```
│            1 │ 22.7.1.1644 │ KEEPER_EXCEPTION                  │  999 │     3 │ 2022-07-08 10:18:14 │ Transaction failed (No node)                                                                                                                                                                                                                               │ [195041146,397820021,397820854,397919748,388503748,388484582,388478914,362844312,362857302,362861006,195744535,195757885,140126854297097,140126853398835]                                                                                                  │      0 │
```

```sql
WITH arrayMap(x -> demangle(addressToSymbol(x)), [195041146, 397820021, 397820854, 397919748, 388503748, 388484582, 388478914, 362844312, 362857302, 362861006, 195744535, 195757885, 140358804010505, 140358803112243]) AS `all`
SELECT arrayStringConcat(`all`, '\n') AS res
SETTINGS allow_introspection_functions = 1

Query id: e877481d-ed3a-42eb-82fd-1aab7c9d18ff

Row 1:
──────
res: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool)
Coordination::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, Coordination::Error, int)
Coordination::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, Coordination::Error)
zkutil::KeeperMultiException::KeeperMultiException(Coordination::Error, std::__1::vector<std::__1::shared_ptr<Coordination::Request>, std::__1::allocator<std::__1::shared_ptr<Coordination::Request> > > const&, std::__1::vector<std::__1::shared_ptr<Coordination::Response>, std::__1::allocator<std::__1::shared_ptr<Coordination::Response> > > const&)
DB::ReplicatedMergeTreeCleanupThread::clearOldLogs()
DB::ReplicatedMergeTreeCleanupThread::iterate()
DB::ReplicatedMergeTreeCleanupThread::run()
DB::BackgroundSchedulePoolTaskInfo::execute()
DB::BackgroundSchedulePool::threadFunction()
void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_1&&)::'lambda'(), void ()> >(std::__1::__function::__policy_storage const*)
ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>)
void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()> >(void*)
```


Similar to https://github.com/ClickHouse/ClickHouse/pull/38961, don't report this in system.errors since it's a known / expected behaviour on a cluster.
