### PR TITLE
Sorting step: skip sorting 

### DIFF
--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -44,7 +44,7 @@ void SortColumnDescription::explain(JSONBuilder::JSONMap & map) const
 
 bool SortDescription::hasPrefix(const SortDescription & prefix) const
 {
-    if (prefix.size() <= size())
+    if (prefix.empty() || prefix.size() > size())
         return false;
 
     for (size_t i = 0; i < prefix.size(); ++i)

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -42,6 +42,19 @@ void SortColumnDescription::explain(JSONBuilder::JSONMap & map) const
     map.add("With Fill", with_fill);
 }
 
+bool SortDescription::hasPrefix(const SortDescription & prefix) const
+{
+    if (prefix.size() <= size())
+        return false;
+
+    for (size_t i = 0; i < prefix.size(); ++i)
+    {
+        if ((*this)[i] != prefix[i])
+            return false;
+    }
+    return true;
+}
+
 #if USE_EMBEDDED_COMPILER
 
 static CHJIT & getJITInstance()

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -87,6 +87,13 @@ struct SortColumnDescriptionWithColumnIndex
         : base(std::move(description_)), column_number(column_number_)
     {
     }
+
+    bool operator==(const SortColumnDescriptionWithColumnIndex & other) const
+    {
+        return base == other.base && column_number == other.column_number;
+    }
+
+    bool operator!=(const SortColumnDescriptionWithColumnIndex & other) const { return !(*this == other); }
 };
 
 class CompiledSortDescriptionFunctionHolder;
@@ -102,6 +109,8 @@ public:
     std::shared_ptr<CompiledSortDescriptionFunctionHolder> compiled_sort_description_holder;
     size_t min_count_to_compile_sort_description = 3;
     bool compile_sort_description = false;
+
+    bool hasPrefix(const SortDescription & prefix) const;
 };
 
 /** Compile sort description for header_types.

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -113,6 +113,12 @@ void SortingStep::convertToFinishSorting(SortDescription prefix_description_)
 
 void SortingStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
+    const auto input_sort_mode = input_streams.front().sort_mode;
+    const SortDescription & input_sort_desc = input_streams.front().sort_description;
+
+    if (input_sort_mode == DataStream::SortMode::Stream && input_sort_desc.hasPrefix(result_description))
+        return;
+
     if (type == Type::FinishSorting)
     {
         bool need_finish_sorting = (prefix_description.size() < result_description.size());

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -49,7 +49,7 @@ public:
     /// Add limit or change it to lower value.
     void updateLimit(size_t limit_);
 
-    SortDescription getSortDescription() const { return result_description; }
+    const SortDescription & getSortDescription() const { return result_description; }
 
     void convertToFinishSorting(SortDescription prefix_description);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do nothing in sorting step if result sort description is a prefix of input description
