### PR TITLE
Pass SubqueryForSets into the child interpreter

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.h
+++ b/src/Interpreters/InterpreterSelectQuery.h
@@ -54,13 +54,17 @@ public:
         const ASTPtr & query_ptr_,
         const ContextPtr & context_,
         const SelectQueryOptions &,
-        const Names & required_result_column_names_ = Names{});
+        const Names & required_result_column_names_ = Names{},
+        SubqueriesForSets subquery_for_sets_ = {},
+        PreparedSets prepared_sets_ = {});
 
     InterpreterSelectQuery(
         const ASTPtr & query_ptr_,
         const ContextMutablePtr & context_,
         const SelectQueryOptions &,
-        const Names & required_result_column_names_ = Names{});
+        const Names & required_result_column_names_ = Names{},
+        SubqueriesForSets subquery_for_sets_ = {},
+        PreparedSets prepared_sets_ = {});
 
     /// Read data not from the table specified in the query, but from the prepared pipe `input`.
     InterpreterSelectQuery(

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -154,8 +154,12 @@ InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery(
             buildCurrentChildInterpreter(
                 ast->list_of_selects->children.at(query_num),
                 require_full_header ? Names() : current_required_result_column_names,
-                std::move(subqueries_for_sets_), std::move(prepared_sets_))
+                std::move(subqueries_for_sets_), prepared_sets_)
         );
+
+        /// We will pass subqueries_for_sets_ only to the first subquery
+        /// It one will own subqueries_for_sets and query plan to build set, other will just share prepared_sets
+        subqueries_for_sets_ = SubqueriesForSets();
 
         // We need to propagate the uses_view_source flag from children to the (self) parent since, if one of the children uses
         // a view source that means that the parent uses it too and can be cached globally

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.h
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.h
@@ -2,6 +2,8 @@
 
 #include <Core/QueryProcessingStage.h>
 #include <Interpreters/IInterpreterUnionOrSelectQuery.h>
+#include <Interpreters/PreparedSets.h>
+#include <Interpreters/SubqueryForSet.h>
 
 namespace DB
 {
@@ -20,13 +22,17 @@ public:
         const ASTPtr & query_ptr_,
         ContextPtr context_,
         const SelectQueryOptions &,
-        const Names & required_result_column_names = {});
+        const Names & required_result_column_names = {},
+        SubqueriesForSets subqueries_for_sets_ = {},
+        PreparedSets prepared_sets_ = {});
 
     InterpreterSelectWithUnionQuery(
         const ASTPtr & query_ptr_,
         ContextMutablePtr context_,
         const SelectQueryOptions &,
-        const Names & required_result_column_names = {});
+        const Names & required_result_column_names = {},
+        SubqueriesForSets subqueries_for_sets_ = {},
+        PreparedSets prepared_sets_ = {});
 
     ~InterpreterSelectWithUnionQuery() override;
 
@@ -55,7 +61,9 @@ private:
     Block getCurrentChildResultHeader(const ASTPtr & ast_ptr_, const Names & required_result_column_names);
 
     std::unique_ptr<IInterpreterUnionOrSelectQuery>
-    buildCurrentChildInterpreter(const ASTPtr & ast_ptr_, const Names & current_required_result_column_names);
+    buildCurrentChildInterpreter(
+        const ASTPtr & ast_ptr_, const Names & current_required_result_column_names,
+        SubqueriesForSets subqueries_for_sets_, PreparedSets prepared_sets_);
 };
 
 }

--- a/src/Interpreters/SubqueryForSet.cpp
+++ b/src/Interpreters/SubqueryForSet.cpp
@@ -10,4 +10,16 @@ SubqueryForSet::~SubqueryForSet() = default;
 SubqueryForSet::SubqueryForSet(SubqueryForSet &&) noexcept = default;
 SubqueryForSet & SubqueryForSet::operator= (SubqueryForSet &&) noexcept = default;
 
+SubqueryForSet::SubqueryForSet(const SubqueryForSet & rhs) noexcept
+{
+    /*
+     * Sometimes, we must pass SubqueryFroSet to child interpreters to reuse sets.
+     * But we can't copy the source because it is a unique pointer to QueryPlan.
+     * So, copy sets so that they can be reused.
+     * Parent SubqueryForSet will execute the query plan, and it works because we need to execute it just once.
+     */
+    this->set = rhs.set;
+    this->table = rhs.table;
+}
+
 }

--- a/src/Interpreters/SubqueryForSet.h
+++ b/src/Interpreters/SubqueryForSet.h
@@ -20,6 +20,8 @@ struct SubqueryForSet
     SubqueryForSet(SubqueryForSet &&) noexcept;
     SubqueryForSet & operator=(SubqueryForSet &&) noexcept;
 
+    SubqueryForSet(const SubqueryForSet & rhs) noexcept;
+
     /// The source is obtained using the InterpreterSelectQuery subquery.
     std::unique_ptr<QueryPlan> source;
 

--- a/tests/performance/set.xml
+++ b/tests/performance/set.xml
@@ -49,4 +49,11 @@
             GROUP BY bitAnd(number, 17)
         ))
     </query>
+
+    <!-- Set is not calculated twice for subquery -->
+    <query>
+    SELECT sum(x)
+    FROM ( SELECT number * 2 AS x FROM numbers({size_large}) ) AS t1
+    WHERE x NOT IN ( SELECT number * 3 AS y FROM numbers({size_large}) )
+    </query>
 </test>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix redundant set calculation in a sub-query, close https://github.com/ClickHouse/ClickHouse/issues/37982


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
