### PR TITLE
Do not try to save corrupt OpenTelemetry spans

### DIFF
--- a/src/Interpreters/InterpreterFactory.cpp
+++ b/src/Interpreters/InterpreterFactory.cpp
@@ -113,6 +113,7 @@ namespace ErrorCodes
 std::unique_ptr<IInterpreter> InterpreterFactory::get(ASTPtr & query, ContextMutablePtr context, const SelectQueryOptions & options)
 {
     OpenTelemetrySpanHolder span("InterpreterFactory::get()");
+    span.ready();
 
     ProfileEvents::increment(ProfileEvents::Query);
 

--- a/src/Interpreters/InterpreterFactory.cpp
+++ b/src/Interpreters/InterpreterFactory.cpp
@@ -113,7 +113,7 @@ namespace ErrorCodes
 std::unique_ptr<IInterpreter> InterpreterFactory::get(ASTPtr & query, ContextMutablePtr context, const SelectQueryOptions & options)
 {
     OpenTelemetrySpanHolder span("InterpreterFactory::get()");
-    span.ready();
+    span.setReady();
 
     ProfileEvents::increment(ProfileEvents::Query);
 

--- a/src/Interpreters/OpenTelemetrySpanLog.cpp
+++ b/src/Interpreters/OpenTelemetrySpanLog.cpp
@@ -101,6 +101,11 @@ OpenTelemetrySpanHolder::~OpenTelemetrySpanHolder()
 {
     try
     {
+        // If span is not ready we don't try to save it.
+        // It may be broken by bad_alloc when filled or similar
+        if (!is_ready)
+            return;
+
         if (trace_id == UUID())
             return;
 

--- a/src/Interpreters/OpenTelemetrySpanLog.cpp
+++ b/src/Interpreters/OpenTelemetrySpanLog.cpp
@@ -104,7 +104,10 @@ OpenTelemetrySpanHolder::~OpenTelemetrySpanHolder()
         // If span is not ready we don't try to save it.
         // It may be broken by bad_alloc when filled or similar
         if (!is_ready)
+        {
+            assert(std::uncaught_exceptions());
             return;
+        }
 
         if (trace_id == UUID())
             return;

--- a/src/Interpreters/OpenTelemetrySpanLog.h
+++ b/src/Interpreters/OpenTelemetrySpanLog.h
@@ -16,7 +16,7 @@ struct OpenTelemetrySpan
     UInt64 start_time_us;
     UInt64 finish_time_us;
     Map attributes;
-    bool is_ready;
+    bool is_ready = false;
     // I don't understand how Links work, namely, which direction should they
     // point to, and how they are related with parent_span_id, so no Links for now.
 };

--- a/src/Interpreters/OpenTelemetrySpanLog.h
+++ b/src/Interpreters/OpenTelemetrySpanLog.h
@@ -49,7 +49,7 @@ struct OpenTelemetrySpanHolder : public OpenTelemetrySpan
     void addAttribute(const std::string& name, const std::string& value);
     void addAttribute(const Exception & e);
     void addAttribute(std::exception_ptr e);
-    void ready() { this->is_ready = true; }
+    void setReady() { this->is_ready = true; }
 
     ~OpenTelemetrySpanHolder();
 };

--- a/src/Interpreters/OpenTelemetrySpanLog.h
+++ b/src/Interpreters/OpenTelemetrySpanLog.h
@@ -16,6 +16,7 @@ struct OpenTelemetrySpan
     UInt64 start_time_us;
     UInt64 finish_time_us;
     Map attributes;
+    bool is_ready;
     // I don't understand how Links work, namely, which direction should they
     // point to, and how they are related with parent_span_id, so no Links for now.
 };
@@ -48,6 +49,7 @@ struct OpenTelemetrySpanHolder : public OpenTelemetrySpan
     void addAttribute(const std::string& name, const std::string& value);
     void addAttribute(const Exception & e);
     void addAttribute(std::exception_ptr e);
+    void ready() { this->is_ready = true; }
 
     ~OpenTelemetrySpanHolder();
 };

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -385,7 +385,7 @@ void ThreadStatus::detachQuery(bool exit_if_already_detached, bool thread_exits)
             std::chrono::duration_cast<std::chrono::microseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count();
         span.attributes.push_back(Tuple{"clickhouse.thread_id", toString(thread_id)});
-
+        span.is_ready = true;
         opentelemetry_span_log->add(span);
     }
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -689,8 +689,8 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                     auto * raw_interpreter_ptr = interpreter.get();
                     std::string class_name(demangle(typeid(*raw_interpreter_ptr).name()));
                     span = std::make_unique<OpenTelemetrySpanHolder>(class_name + "::execute()");
+                    span->ready();
                 }
-                span->ready();
                 res = interpreter->execute();
             }
         }

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -311,7 +311,6 @@ static void onExceptionBeforeStart(const String & query_for_logging, ContextPtr 
         {
             span.attributes.push_back(Tuple{"clickhouse.tracestate", context->query_trace_context.tracestate});
         }
-        span.is_ready = true;
         opentelemetry_span_log->add(span);
     }
 
@@ -952,7 +951,6 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                     {
                     span.attributes.push_back(Tuple{"clickhouse.tracestate", context->query_trace_context.tracestate});
                     }
-                    span.is_ready = true;
                     opentelemetry_span_log->add(span);
                 }
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -311,7 +311,7 @@ static void onExceptionBeforeStart(const String & query_for_logging, ContextPtr 
         {
             span.attributes.push_back(Tuple{"clickhouse.tracestate", context->query_trace_context.tracestate});
         }
-
+        span.is_ready = true;
         opentelemetry_span_log->add(span);
     }
 
@@ -690,6 +690,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                     std::string class_name(demangle(typeid(*raw_interpreter_ptr).name()));
                     span = std::make_unique<OpenTelemetrySpanHolder>(class_name + "::execute()");
                 }
+                span->ready();
                 res = interpreter->execute();
             }
         }
@@ -951,7 +952,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                     {
                     span.attributes.push_back(Tuple{"clickhouse.tracestate", context->query_trace_context.tracestate});
                     }
-
+                    span.is_ready = true;
                     opentelemetry_span_log->add(span);
                 }
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -688,7 +688,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                     auto * raw_interpreter_ptr = interpreter.get();
                     std::string class_name(demangle(typeid(*raw_interpreter_ptr).name()));
                     span = std::make_unique<OpenTelemetrySpanHolder>(class_name + "::execute()");
-                    span->ready();
+                    span->setReady();
                 }
                 res = interpreter->execute();
             }

--- a/src/Processors/Executors/ExecutionThreadContext.cpp
+++ b/src/Processors/Executors/ExecutionThreadContext.cpp
@@ -103,7 +103,7 @@ bool ExecutionThreadContext::executeTask()
 #endif
 
     span.addAttribute("thread_number", thread_number);
-
+    span.setReady();
     return node->exception == nullptr;
 }
 

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -339,7 +339,7 @@ DistributedSink::runWritingJob(JobReplica & job, const Block & current_block, si
         OpenTelemetrySpanHolder span(__PRETTY_FUNCTION__);
         span.addAttribute("clickhouse.shard_num", shard_info.shard_num);
         span.addAttribute("clickhouse.written_rows", rows);
-        span.ready();
+        span.setReady();
 
         if (!job.is_local_job || !settings.prefer_localhost_replica)
         {
@@ -503,10 +503,10 @@ void DistributedSink::writeSync(const Block & block)
     {
         exception.addMessage(getCurrentStateDescription());
         span.addAttribute(exception);
-        span.ready();
+        span.setReady();
         throw;
     }
-    span.ready();
+    span.setReady();
 
     inserted_blocks += 1;
     inserted_rows += block.rows();
@@ -621,7 +621,7 @@ void DistributedSink::writeAsyncImpl(const Block & block, size_t shard_id)
 
     span.addAttribute("clickhouse.shard_num", shard_info.shard_num);
     span.addAttribute("clickhouse.written_rows", block.rows());
-    span.ready();
+    span.setReady();
 
     if (shard_info.hasInternalReplication())
     {
@@ -658,7 +658,7 @@ void DistributedSink::writeToLocal(const Block & block, size_t repeats)
 {
     OpenTelemetrySpanHolder span(__PRETTY_FUNCTION__);
     span.addAttribute("db.statement", this->query_string);
-    span.ready();
+    span.setReady();
 
     InterpreterInsertQuery interp(query_ast, context, allow_materialized);
 
@@ -674,7 +674,7 @@ void DistributedSink::writeToLocal(const Block & block, size_t repeats)
 void DistributedSink::writeToShard(const Block & block, const std::vector<std::string> & dir_names)
 {
     OpenTelemetrySpanHolder span(__PRETTY_FUNCTION__);
-    span.ready();
+    span.setReady();
 
     const auto & settings = context->getSettingsRef();
     const auto & distributed_settings = storage.getDistributedSettingsRef();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

On bad alloc we can have corrupt span that will be added to log in OpenTelemetrySpanHolder destructor.