### PR TITLE
Prefix overridden add_executable() command with "clickhouse_"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,14 +507,14 @@ if (NOT ENABLE_JEMALLOC)
     message (WARNING "Non default allocator is disabled. This is not recommended for production builds.")
 endif ()
 
-macro (add_executable target)
+macro (clickhouse_add_executable target)
     # invoke built-in add_executable
     # explicitly acquire and interpose malloc symbols by clickhouse_malloc
     # if GLIBC_COMPATIBILITY is ON and ENABLE_THINLTO is on than provide memcpy symbol explicitly to neutrialize thinlto's libcall generation.
     if (ARCH_AMD64 AND GLIBC_COMPATIBILITY AND ENABLE_THINLTO)
-        _add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc> $<TARGET_OBJECTS:memcpy>)
+        add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc> $<TARGET_OBJECTS:memcpy>)
     else ()
-        _add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc>)
+        add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc>)
     endif ()
 
     get_target_property (type ${target} TYPE)

--- a/base/base/tests/CMakeLists.txt
+++ b/base/base/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (dump_variable dump_variable.cpp)
+clickhouse_add_executable (dump_variable dump_variable.cpp)
 target_link_libraries (dump_variable PRIVATE clickhouse_common_io)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -235,7 +235,7 @@ endmacro()
 
 macro(clickhouse_program_add_executable name)
     if(CLICKHOUSE_SPLIT_BINARY)
-        add_executable(clickhouse-${name} clickhouse-${name}.cpp)
+        clickhouse_add_executable(clickhouse-${name} clickhouse-${name}.cpp)
         clickhouse_program_link_split_binary(${name})
         install(TARGETS clickhouse-${name} ${CLICKHOUSE_ALL_TARGETS} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT clickhouse)
     endif()
@@ -374,7 +374,7 @@ if (CLICKHOUSE_SPLIT_BINARY)
 
     install(PROGRAMS clickhouse-split-helper DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME clickhouse COMPONENT clickhouse)
 else ()
-    add_executable (clickhouse main.cpp)
+    clickhouse_add_executable (clickhouse main.cpp)
 
     # A library that prevent usage of several functions from libc.
     if (ARCH_AMD64 AND OS_LINUX AND NOT OS_ANDROID)

--- a/programs/keeper/CMakeLists.txt
+++ b/programs/keeper/CMakeLists.txt
@@ -99,7 +99,7 @@ if (BUILD_STANDALONE_KEEPER)
 
     )
 
-    add_executable(clickhouse-keeper ${CLICKHOUSE_KEEPER_STANDALONE_SOURCES})
+    clickhouse_add_executable(clickhouse-keeper ${CLICKHOUSE_KEEPER_STANDALONE_SOURCES})
 
     # Remove some redundant dependencies
     target_compile_definitions (clickhouse-keeper PRIVATE -DKEEPER_STANDALONE_BUILD)

--- a/programs/library-bridge/CMakeLists.txt
+++ b/programs/library-bridge/CMakeLists.txt
@@ -14,7 +14,7 @@ if (OS_LINUX)
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-export-dynamic")
 endif ()
 
-add_executable(clickhouse-library-bridge ${CLICKHOUSE_LIBRARY_BRIDGE_SOURCES})
+clickhouse_add_executable(clickhouse-library-bridge ${CLICKHOUSE_LIBRARY_BRIDGE_SOURCES})
 
 target_link_libraries(clickhouse-library-bridge PRIVATE
     daemon

--- a/programs/odbc-bridge/CMakeLists.txt
+++ b/programs/odbc-bridge/CMakeLists.txt
@@ -21,7 +21,7 @@ if (OS_LINUX)
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-export-dynamic")
 endif ()
 
-add_executable(clickhouse-odbc-bridge ${CLICKHOUSE_ODBC_BRIDGE_SOURCES})
+clickhouse_add_executable(clickhouse-odbc-bridge ${CLICKHOUSE_ODBC_BRIDGE_SOURCES})
 
 target_link_libraries(clickhouse-odbc-bridge PRIVATE
     daemon

--- a/programs/odbc-bridge/tests/CMakeLists.txt
+++ b/programs/odbc-bridge/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (validate-odbc-connection-string validate-odbc-connection-string.cpp ../validateODBCConnectionString.cpp)
+clickhouse_add_executable (validate-odbc-connection-string validate-odbc-connection-string.cpp ../validateODBCConnectionString.cpp)
 target_link_libraries (validate-odbc-connection-string PRIVATE clickhouse_common_io)

--- a/src/Access/examples/CMakeLists.txt
+++ b/src/Access/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
 if (TARGET ch_contrib::krb5)
-    add_executable (kerberos_init kerberos_init.cpp)
+    clickhouse_add_executable (kerberos_init kerberos_init.cpp)
     target_link_libraries (kerberos_init PRIVATE dbms ch_contrib::krb5)
 endif()

--- a/src/AggregateFunctions/examples/CMakeLists.txt
+++ b/src/AggregateFunctions/examples/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (quantile-t-digest quantile-t-digest.cpp)
+clickhouse_add_executable (quantile-t-digest quantile-t-digest.cpp)
 target_link_libraries (quantile-t-digest PRIVATE dbms clickhouse_aggregate_functions)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -564,7 +564,7 @@ if (ENABLE_TESTS)
 
     # attach all dbms gtest sources
     grep_gtest_sources("${ClickHouse_SOURCE_DIR}/src" dbms_gtest_sources)
-    add_executable(unit_tests_dbms ${dbms_gtest_sources})
+    clickhouse_add_executable(unit_tests_dbms ${dbms_gtest_sources})
 
     # gtest framework has substandard code
     target_compile_options(unit_tests_dbms PRIVATE

--- a/src/Client/examples/CMakeLists.txt
+++ b/src/Client/examples/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(test-connect test_connect.cpp)
+clickhouse_add_executable(test-connect test_connect.cpp)
 target_link_libraries (test-connect PRIVATE dbms)

--- a/src/Common/ZooKeeper/examples/CMakeLists.txt
+++ b/src/Common/ZooKeeper/examples/CMakeLists.txt
@@ -1,11 +1,11 @@
-add_executable(zkutil_test_commands zkutil_test_commands.cpp)
+clickhouse_add_executable(zkutil_test_commands zkutil_test_commands.cpp)
 target_link_libraries(zkutil_test_commands PRIVATE clickhouse_common_zookeeper_no_log)
 
-add_executable(zkutil_test_commands_new_lib zkutil_test_commands_new_lib.cpp)
+clickhouse_add_executable(zkutil_test_commands_new_lib zkutil_test_commands_new_lib.cpp)
 target_link_libraries(zkutil_test_commands_new_lib PRIVATE clickhouse_common_zookeeper_no_log string_utils)
 
-add_executable(zkutil_test_async zkutil_test_async.cpp)
+clickhouse_add_executable(zkutil_test_async zkutil_test_async.cpp)
 target_link_libraries(zkutil_test_async PRIVATE clickhouse_common_zookeeper_no_log)
 
-add_executable (zookeeper_impl zookeeper_impl.cpp)
+clickhouse_add_executable (zookeeper_impl zookeeper_impl.cpp)
 target_link_libraries (zookeeper_impl PRIVATE clickhouse_common_zookeeper_no_log)

--- a/src/Common/examples/CMakeLists.txt
+++ b/src/Common/examples/CMakeLists.txt
@@ -1,87 +1,87 @@
-add_executable (hashes_test hashes_test.cpp)
+clickhouse_add_executable (hashes_test hashes_test.cpp)
 target_link_libraries (hashes_test PRIVATE clickhouse_common_io ch_contrib::cityhash)
 if (TARGET OpenSSL::Crypto)
     target_link_libraries (hashes_test PRIVATE OpenSSL::Crypto)
 endif()
 
-add_executable (sip_hash_perf sip_hash_perf.cpp)
+clickhouse_add_executable (sip_hash_perf sip_hash_perf.cpp)
 target_link_libraries (sip_hash_perf PRIVATE clickhouse_common_io)
 
-add_executable (small_table small_table.cpp)
+clickhouse_add_executable (small_table small_table.cpp)
 target_link_libraries (small_table PRIVATE clickhouse_common_io)
 
-add_executable (parallel_aggregation parallel_aggregation.cpp)
+clickhouse_add_executable (parallel_aggregation parallel_aggregation.cpp)
 target_link_libraries (parallel_aggregation PRIVATE dbms)
 
-add_executable (parallel_aggregation2 parallel_aggregation2.cpp)
+clickhouse_add_executable (parallel_aggregation2 parallel_aggregation2.cpp)
 target_link_libraries (parallel_aggregation2 PRIVATE dbms)
 
-add_executable (int_hashes_perf int_hashes_perf.cpp)
+clickhouse_add_executable (int_hashes_perf int_hashes_perf.cpp)
 target_link_libraries (int_hashes_perf PRIVATE clickhouse_common_io)
 
-add_executable (compact_array compact_array.cpp)
+clickhouse_add_executable (compact_array compact_array.cpp)
 target_link_libraries (compact_array PRIVATE clickhouse_common_io)
 
-add_executable (radix_sort radix_sort.cpp)
+clickhouse_add_executable (radix_sort radix_sort.cpp)
 target_link_libraries (radix_sort PRIVATE clickhouse_common_io ch_contrib::pdqsort)
 
-add_executable (arena_with_free_lists arena_with_free_lists.cpp)
+clickhouse_add_executable (arena_with_free_lists arena_with_free_lists.cpp)
 target_link_libraries (arena_with_free_lists PRIVATE dbms)
 
-add_executable (lru_hash_map_perf lru_hash_map_perf.cpp)
+clickhouse_add_executable (lru_hash_map_perf lru_hash_map_perf.cpp)
 target_link_libraries (lru_hash_map_perf PRIVATE dbms)
 
-add_executable (thread_creation_latency thread_creation_latency.cpp)
+clickhouse_add_executable (thread_creation_latency thread_creation_latency.cpp)
 target_link_libraries (thread_creation_latency PRIVATE clickhouse_common_io)
 
-add_executable (array_cache array_cache.cpp)
+clickhouse_add_executable (array_cache array_cache.cpp)
 target_link_libraries (array_cache PRIVATE clickhouse_common_io)
 
-add_executable (space_saving space_saving.cpp)
+clickhouse_add_executable (space_saving space_saving.cpp)
 target_link_libraries (space_saving PRIVATE clickhouse_common_io)
 
-add_executable (integer_hash_tables_and_hashes integer_hash_tables_and_hashes.cpp)
+clickhouse_add_executable (integer_hash_tables_and_hashes integer_hash_tables_and_hashes.cpp)
 target_link_libraries (integer_hash_tables_and_hashes PRIVATE dbms ch_contrib::abseil_swiss_tables ch_contrib::sparsehash)
 
-add_executable (integer_hash_tables_benchmark integer_hash_tables_benchmark.cpp)
+clickhouse_add_executable (integer_hash_tables_benchmark integer_hash_tables_benchmark.cpp)
 target_link_libraries (integer_hash_tables_benchmark PRIVATE dbms ch_contrib::abseil_swiss_tables ch_contrib::sparsehash)
 
-add_executable (cow_columns cow_columns.cpp)
+clickhouse_add_executable (cow_columns cow_columns.cpp)
 target_link_libraries (cow_columns PRIVATE clickhouse_common_io)
 
-add_executable (cow_compositions cow_compositions.cpp)
+clickhouse_add_executable (cow_compositions cow_compositions.cpp)
 target_link_libraries (cow_compositions PRIVATE clickhouse_common_io)
 
-add_executable (stopwatch stopwatch.cpp)
+clickhouse_add_executable (stopwatch stopwatch.cpp)
 target_link_libraries (stopwatch PRIVATE clickhouse_common_io)
 
-add_executable (symbol_index symbol_index.cpp)
+clickhouse_add_executable (symbol_index symbol_index.cpp)
 target_link_libraries (symbol_index PRIVATE clickhouse_common_io)
 
-add_executable (chaos_sanitizer chaos_sanitizer.cpp)
+clickhouse_add_executable (chaos_sanitizer chaos_sanitizer.cpp)
 target_link_libraries (chaos_sanitizer PRIVATE clickhouse_common_io)
 
 if (OS_LINUX)
-    add_executable (memory_statistics_os_perf memory_statistics_os_perf.cpp)
+    clickhouse_add_executable (memory_statistics_os_perf memory_statistics_os_perf.cpp)
     target_link_libraries (memory_statistics_os_perf PRIVATE clickhouse_common_io)
 endif()
 
-add_executable (procfs_metrics_provider_perf procfs_metrics_provider_perf.cpp)
+clickhouse_add_executable (procfs_metrics_provider_perf procfs_metrics_provider_perf.cpp)
 target_link_libraries (procfs_metrics_provider_perf PRIVATE clickhouse_common_io)
 
-add_executable (average average.cpp)
+clickhouse_add_executable (average average.cpp)
 target_link_libraries (average PRIVATE clickhouse_common_io)
 
-add_executable (shell_command_inout shell_command_inout.cpp)
+clickhouse_add_executable (shell_command_inout shell_command_inout.cpp)
 target_link_libraries (shell_command_inout PRIVATE clickhouse_common_io)
 
-add_executable (executable_udf executable_udf.cpp)
+clickhouse_add_executable (executable_udf executable_udf.cpp)
 target_link_libraries (executable_udf PRIVATE dbms)
 
 if (ENABLE_HIVE)
-    add_executable (hive_metastore_client hive_metastore_client.cpp)
+    clickhouse_add_executable (hive_metastore_client hive_metastore_client.cpp)
     target_link_libraries (hive_metastore_client PUBLIC ch_contrib::hivemetastore ch_contrib::thrift)
 endif()
 
-add_executable (interval_tree interval_tree.cpp)
+clickhouse_add_executable (interval_tree interval_tree.cpp)
 target_link_libraries (interval_tree PRIVATE dbms)

--- a/src/Common/mysqlxx/tests/CMakeLists.txt
+++ b/src/Common/mysqlxx/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (mysqlxx_pool_test mysqlxx_pool_test.cpp)
+clickhouse_add_executable (mysqlxx_pool_test mysqlxx_pool_test.cpp)
 target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx)

--- a/src/Compression/examples/CMakeLists.txt
+++ b/src/Compression/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_executable (compressed_buffer compressed_buffer.cpp)
+clickhouse_add_executable (compressed_buffer compressed_buffer.cpp)
 target_link_libraries (compressed_buffer PRIVATE dbms)
 
-add_executable (cached_compressed_read_buffer cached_compressed_read_buffer.cpp)
+clickhouse_add_executable (cached_compressed_read_buffer cached_compressed_read_buffer.cpp)
 target_link_libraries (cached_compressed_read_buffer PRIVATE dbms)

--- a/src/Compression/fuzzers/CMakeLists.txt
+++ b/src/Compression/fuzzers/CMakeLists.txt
@@ -4,17 +4,17 @@
 # So, some symbols will be declared, but not defined. Unfortunately, this trick doesn't work with UBSan.
 # If you want really small size of the resulted binary, just link with fuzz_compression and clickhouse_common_io
 
-add_executable (compressed_buffer_fuzzer compressed_buffer_fuzzer.cpp)
+clickhouse_add_executable (compressed_buffer_fuzzer compressed_buffer_fuzzer.cpp)
 target_link_libraries (compressed_buffer_fuzzer PRIVATE dbms ${LIB_FUZZING_ENGINE})
 
-add_executable (lz4_decompress_fuzzer lz4_decompress_fuzzer.cpp)
+clickhouse_add_executable (lz4_decompress_fuzzer lz4_decompress_fuzzer.cpp)
 target_link_libraries (lz4_decompress_fuzzer PUBLIC dbms ch_contrib::lz4 ${LIB_FUZZING_ENGINE})
 
-add_executable (delta_decompress_fuzzer delta_decompress_fuzzer.cpp)
+clickhouse_add_executable (delta_decompress_fuzzer delta_decompress_fuzzer.cpp)
 target_link_libraries (delta_decompress_fuzzer PRIVATE dbms ${LIB_FUZZING_ENGINE})
 
-add_executable (double_delta_decompress_fuzzer double_delta_decompress_fuzzer.cpp)
+clickhouse_add_executable (double_delta_decompress_fuzzer double_delta_decompress_fuzzer.cpp)
 target_link_libraries (double_delta_decompress_fuzzer PRIVATE dbms ${LIB_FUZZING_ENGINE})
 
-add_executable (encrypted_decompress_fuzzer encrypted_decompress_fuzzer.cpp)
+clickhouse_add_executable (encrypted_decompress_fuzzer encrypted_decompress_fuzzer.cpp)
 target_link_libraries (encrypted_decompress_fuzzer PRIVATE dbms ${LIB_FUZZING_ENGINE})

--- a/src/Core/examples/CMakeLists.txt
+++ b/src/Core/examples/CMakeLists.txt
@@ -1,14 +1,14 @@
-add_executable (string_pool string_pool.cpp)
+clickhouse_add_executable (string_pool string_pool.cpp)
 target_link_libraries (string_pool PRIVATE clickhouse_common_io ch_contrib::sparsehash)
 
-add_executable (field field.cpp)
+clickhouse_add_executable (field field.cpp)
 target_link_libraries (field PRIVATE dbms)
 
-add_executable (string_ref_hash string_ref_hash.cpp)
+clickhouse_add_executable (string_ref_hash string_ref_hash.cpp)
 target_link_libraries (string_ref_hash PRIVATE clickhouse_common_io)
 
-add_executable (mysql_protocol mysql_protocol.cpp)
+clickhouse_add_executable (mysql_protocol mysql_protocol.cpp)
 target_link_libraries (mysql_protocol PRIVATE dbms)
 
-add_executable (coro coro.cpp)
+clickhouse_add_executable (coro coro.cpp)
 target_link_libraries (coro PRIVATE clickhouse_common_io)

--- a/src/Core/fuzzers/CMakeLists.txt
+++ b/src/Core/fuzzers/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (names_and_types_fuzzer names_and_types_fuzzer.cpp)
+clickhouse_add_executable (names_and_types_fuzzer names_and_types_fuzzer.cpp)
 target_link_libraries (names_and_types_fuzzer PRIVATE dbms ${LIB_FUZZING_ENGINE})

--- a/src/IO/examples/CMakeLists.txt
+++ b/src/IO/examples/CMakeLists.txt
@@ -1,81 +1,81 @@
-add_executable (read_buffer read_buffer.cpp)
+clickhouse_add_executable (read_buffer read_buffer.cpp)
 target_link_libraries (read_buffer PRIVATE clickhouse_common_io)
 
-add_executable (read_buffer_perf read_buffer_perf.cpp)
+clickhouse_add_executable (read_buffer_perf read_buffer_perf.cpp)
 target_link_libraries (read_buffer_perf PRIVATE clickhouse_common_io)
 
-add_executable (read_float_perf read_float_perf.cpp)
+clickhouse_add_executable (read_float_perf read_float_perf.cpp)
 target_link_libraries (read_float_perf PRIVATE clickhouse_common_io)
 
-add_executable (write_buffer write_buffer.cpp)
+clickhouse_add_executable (write_buffer write_buffer.cpp)
 target_link_libraries (write_buffer PRIVATE clickhouse_common_io)
 
-add_executable (write_buffer_perf write_buffer_perf.cpp)
+clickhouse_add_executable (write_buffer_perf write_buffer_perf.cpp)
 target_link_libraries (write_buffer_perf PRIVATE clickhouse_common_io)
 
-add_executable (valid_utf8_perf valid_utf8_perf.cpp)
+clickhouse_add_executable (valid_utf8_perf valid_utf8_perf.cpp)
 target_link_libraries (valid_utf8_perf PRIVATE clickhouse_common_io)
 
-add_executable (valid_utf8 valid_utf8.cpp)
+clickhouse_add_executable (valid_utf8 valid_utf8.cpp)
 target_link_libraries (valid_utf8 PRIVATE clickhouse_common_io)
 
-add_executable (var_uint var_uint.cpp)
+clickhouse_add_executable (var_uint var_uint.cpp)
 target_link_libraries (var_uint PRIVATE clickhouse_common_io)
 
-add_executable (read_escaped_string read_escaped_string.cpp)
+clickhouse_add_executable (read_escaped_string read_escaped_string.cpp)
 target_link_libraries (read_escaped_string PRIVATE clickhouse_common_io)
 
-add_executable (parse_int_perf parse_int_perf.cpp)
+clickhouse_add_executable (parse_int_perf parse_int_perf.cpp)
 target_link_libraries (parse_int_perf PRIVATE clickhouse_common_io)
 
-add_executable (parse_int_perf2 parse_int_perf2.cpp)
+clickhouse_add_executable (parse_int_perf2 parse_int_perf2.cpp)
 target_link_libraries (parse_int_perf2 PRIVATE clickhouse_common_io)
 
-add_executable (read_write_int read_write_int.cpp)
+clickhouse_add_executable (read_write_int read_write_int.cpp)
 target_link_libraries (read_write_int PRIVATE clickhouse_common_io)
 
-add_executable (o_direct_and_dirty_pages o_direct_and_dirty_pages.cpp)
+clickhouse_add_executable (o_direct_and_dirty_pages o_direct_and_dirty_pages.cpp)
 target_link_libraries (o_direct_and_dirty_pages PRIVATE clickhouse_common_io)
 
-add_executable (hashing_write_buffer hashing_write_buffer.cpp)
+clickhouse_add_executable (hashing_write_buffer hashing_write_buffer.cpp)
 target_link_libraries (hashing_write_buffer PRIVATE clickhouse_common_io)
 
-add_executable (hashing_read_buffer hashing_read_buffer.cpp)
+clickhouse_add_executable (hashing_read_buffer hashing_read_buffer.cpp)
 target_link_libraries (hashing_read_buffer PRIVATE clickhouse_common_io)
 
-add_executable (io_operators io_operators.cpp)
+clickhouse_add_executable (io_operators io_operators.cpp)
 target_link_libraries (io_operators PRIVATE clickhouse_common_io)
 
-add_executable (write_int write_int.cpp)
+clickhouse_add_executable (write_int write_int.cpp)
 target_link_libraries (write_int PRIVATE clickhouse_common_io)
 
-add_executable (zlib_buffers zlib_buffers.cpp)
+clickhouse_add_executable (zlib_buffers zlib_buffers.cpp)
 target_link_libraries (zlib_buffers PRIVATE clickhouse_common_io)
 
-add_executable (lzma_buffers lzma_buffers.cpp)
+clickhouse_add_executable (lzma_buffers lzma_buffers.cpp)
 target_link_libraries (lzma_buffers PRIVATE clickhouse_common_io)
 
-add_executable (limit_read_buffer limit_read_buffer.cpp)
+clickhouse_add_executable (limit_read_buffer limit_read_buffer.cpp)
 target_link_libraries (limit_read_buffer PRIVATE clickhouse_common_io)
 
-add_executable (limit_read_buffer2 limit_read_buffer2.cpp)
+clickhouse_add_executable (limit_read_buffer2 limit_read_buffer2.cpp)
 target_link_libraries (limit_read_buffer2 PRIVATE clickhouse_common_io)
 
-add_executable (parse_date_time_best_effort parse_date_time_best_effort.cpp)
+clickhouse_add_executable (parse_date_time_best_effort parse_date_time_best_effort.cpp)
 target_link_libraries (parse_date_time_best_effort PRIVATE clickhouse_common_io)
 
-add_executable (zlib_ng_bug zlib_ng_bug.cpp)
+clickhouse_add_executable (zlib_ng_bug zlib_ng_bug.cpp)
 target_link_libraries (zlib_ng_bug PRIVATE ch_contrib::zlib)
 
-add_executable (dragonbox_test dragonbox_test.cpp)
+clickhouse_add_executable (dragonbox_test dragonbox_test.cpp)
 target_link_libraries (dragonbox_test PRIVATE ch_contrib::dragonbox_to_chars)
 
-add_executable (zstd_buffers zstd_buffers.cpp)
+clickhouse_add_executable (zstd_buffers zstd_buffers.cpp)
 target_link_libraries (zstd_buffers PRIVATE clickhouse_common_io)
 
-add_executable (snappy_read_buffer snappy_read_buffer.cpp)
+clickhouse_add_executable (snappy_read_buffer snappy_read_buffer.cpp)
 target_link_libraries (snappy_read_buffer PRIVATE clickhouse_common_io)
 
-add_executable (hadoop_snappy_read_buffer hadoop_snappy_read_buffer.cpp)
+clickhouse_add_executable (hadoop_snappy_read_buffer hadoop_snappy_read_buffer.cpp)
 target_link_libraries (hadoop_snappy_read_buffer PRIVATE clickhouse_common_io)
 

--- a/src/Interpreters/examples/CMakeLists.txt
+++ b/src/Interpreters/examples/CMakeLists.txt
@@ -1,35 +1,35 @@
-add_executable (hash_map hash_map.cpp)
+clickhouse_add_executable (hash_map hash_map.cpp)
 target_link_libraries (hash_map PRIVATE dbms ch_contrib::sparsehash)
 
-add_executable (hash_map_lookup hash_map_lookup.cpp)
+clickhouse_add_executable (hash_map_lookup hash_map_lookup.cpp)
 target_link_libraries (hash_map_lookup PRIVATE dbms)
 
-add_executable (hash_map3 hash_map3.cpp)
+clickhouse_add_executable (hash_map3 hash_map3.cpp)
 target_link_libraries (hash_map3 PRIVATE dbms ch_contrib::farmhash ch_contrib::metrohash)
 
-add_executable (hash_map_string hash_map_string.cpp)
+clickhouse_add_executable (hash_map_string hash_map_string.cpp)
 target_link_libraries (hash_map_string PRIVATE dbms ch_contrib::sparsehash)
 
-add_executable (hash_map_string_2 hash_map_string_2.cpp)
+clickhouse_add_executable (hash_map_string_2 hash_map_string_2.cpp)
 target_link_libraries (hash_map_string_2 PRIVATE dbms)
 
-add_executable (hash_map_string_3 hash_map_string_3.cpp)
+clickhouse_add_executable (hash_map_string_3 hash_map_string_3.cpp)
 target_link_libraries (hash_map_string_3 PRIVATE dbms ch_contrib::farmhash ch_contrib::metrohash)
 
-add_executable (hash_map_string_small hash_map_string_small.cpp)
+clickhouse_add_executable (hash_map_string_small hash_map_string_small.cpp)
 target_link_libraries (hash_map_string_small PRIVATE dbms ch_contrib::sparsehash)
 
-add_executable (string_hash_map string_hash_map.cpp)
+clickhouse_add_executable (string_hash_map string_hash_map.cpp)
 target_link_libraries (string_hash_map PRIVATE dbms ch_contrib::sparsehash)
 
-add_executable (string_hash_map_aggregation string_hash_map.cpp)
+clickhouse_add_executable (string_hash_map_aggregation string_hash_map.cpp)
 target_link_libraries (string_hash_map_aggregation PRIVATE dbms)
 
-add_executable (string_hash_set string_hash_set.cpp)
+clickhouse_add_executable (string_hash_set string_hash_set.cpp)
 target_link_libraries (string_hash_set PRIVATE dbms)
 
-add_executable (two_level_hash_map two_level_hash_map.cpp)
+clickhouse_add_executable (two_level_hash_map two_level_hash_map.cpp)
 target_link_libraries (two_level_hash_map PRIVATE dbms ch_contrib::sparsehash)
 
-add_executable (jit_example jit_example.cpp)
+clickhouse_add_executable (jit_example jit_example.cpp)
 target_link_libraries (jit_example PRIVATE dbms)

--- a/src/Interpreters/fuzzers/CMakeLists.txt
+++ b/src/Interpreters/fuzzers/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(execute_query_fuzzer execute_query_fuzzer.cpp)
+clickhouse_add_executable(execute_query_fuzzer execute_query_fuzzer.cpp)
 target_link_libraries(execute_query_fuzzer PRIVATE
     dbms
     clickhouse_functions

--- a/src/Parsers/examples/CMakeLists.txt
+++ b/src/Parsers/examples/CMakeLists.txt
@@ -1,10 +1,10 @@
 set(SRCS)
 
-add_executable(lexer lexer.cpp ${SRCS})
+clickhouse_add_executable(lexer lexer.cpp ${SRCS})
 target_link_libraries(lexer PRIVATE clickhouse_parsers)
 
-add_executable(select_parser select_parser.cpp ${SRCS})
+clickhouse_add_executable(select_parser select_parser.cpp ${SRCS})
 target_link_libraries(select_parser PRIVATE clickhouse_parsers)
 
-add_executable(create_parser create_parser.cpp ${SRCS})
+clickhouse_add_executable(create_parser create_parser.cpp ${SRCS})
 target_link_libraries(create_parser PRIVATE clickhouse_parsers)

--- a/src/Parsers/fuzzers/CMakeLists.txt
+++ b/src/Parsers/fuzzers/CMakeLists.txt
@@ -1,10 +1,10 @@
-add_executable(lexer_fuzzer lexer_fuzzer.cpp ${SRCS})
+clickhouse_add_executable(lexer_fuzzer lexer_fuzzer.cpp ${SRCS})
 target_link_libraries(lexer_fuzzer PRIVATE clickhouse_parsers ${LIB_FUZZING_ENGINE})
 
-add_executable(select_parser_fuzzer select_parser_fuzzer.cpp ${SRCS})
+clickhouse_add_executable(select_parser_fuzzer select_parser_fuzzer.cpp ${SRCS})
 target_link_libraries(select_parser_fuzzer PRIVATE clickhouse_parsers ${LIB_FUZZING_ENGINE})
 
-add_executable(create_parser_fuzzer create_parser_fuzzer.cpp ${SRCS})
+clickhouse_add_executable(create_parser_fuzzer create_parser_fuzzer.cpp ${SRCS})
 target_link_libraries(create_parser_fuzzer PRIVATE clickhouse_parsers ${LIB_FUZZING_ENGINE})
 
 add_subdirectory(codegen_fuzzer)

--- a/src/Parsers/fuzzers/codegen_fuzzer/CMakeLists.txt
+++ b/src/Parsers/fuzzers/codegen_fuzzer/CMakeLists.txt
@@ -37,7 +37,7 @@ set(FUZZER_SRCS codegen_select_fuzzer.cpp "${CURRENT_DIR_IN_BINARY}/out.cpp" ${P
 
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
-add_executable(codegen_select_fuzzer ${FUZZER_SRCS})
+clickhouse_add_executable(codegen_select_fuzzer ${FUZZER_SRCS})
 
 set_source_files_properties("${PROTO_SRCS}" "out.cpp" PROPERTIES COMPILE_FLAGS "-Wno-reserved-identifier")
 

--- a/src/Processors/examples/CMakeLists.txt
+++ b/src/Processors/examples/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (comma_separated_streams comma_separated_streams.cpp)
+clickhouse_add_executable (comma_separated_streams comma_separated_streams.cpp)
 target_link_libraries (comma_separated_streams PRIVATE dbms)

--- a/src/Storages/MergeTree/examples/CMakeLists.txt
+++ b/src/Storages/MergeTree/examples/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (wal_action_metadata wal_action_metadata.cpp)
+clickhouse_add_executable (wal_action_metadata wal_action_metadata.cpp)
 target_link_libraries (wal_action_metadata PRIVATE dbms)

--- a/src/Storages/examples/CMakeLists.txt
+++ b/src/Storages/examples/CMakeLists.txt
@@ -1,16 +1,16 @@
-add_executable (merge_selector merge_selector.cpp)
+clickhouse_add_executable (merge_selector merge_selector.cpp)
 target_link_libraries (merge_selector PRIVATE dbms)
 
-add_executable (merge_selector2 merge_selector2.cpp)
+clickhouse_add_executable (merge_selector2 merge_selector2.cpp)
 target_link_libraries (merge_selector2 PRIVATE dbms)
 
-add_executable (get_current_inserts_in_replicated get_current_inserts_in_replicated.cpp)
+clickhouse_add_executable (get_current_inserts_in_replicated get_current_inserts_in_replicated.cpp)
 target_link_libraries (get_current_inserts_in_replicated PRIVATE dbms clickhouse_common_config clickhouse_common_zookeeper string_utils)
 
-add_executable (get_abandonable_lock_in_all_partitions get_abandonable_lock_in_all_partitions.cpp)
+clickhouse_add_executable (get_abandonable_lock_in_all_partitions get_abandonable_lock_in_all_partitions.cpp)
 target_link_libraries (get_abandonable_lock_in_all_partitions PRIVATE dbms clickhouse_common_config clickhouse_common_zookeeper)
 
 if (TARGET ch_contrib::hdfs)
-    add_executable (async_read_buffer_from_hdfs async_read_buffer_from_hdfs.cpp)
+    clickhouse_add_executable (async_read_buffer_from_hdfs async_read_buffer_from_hdfs.cpp)
     target_link_libraries (async_read_buffer_from_hdfs PRIVATE dbms ch_contrib::hdfs)
 endif ()

--- a/src/Storages/fuzzers/CMakeLists.txt
+++ b/src/Storages/fuzzers/CMakeLists.txt
@@ -1,7 +1,7 @@
 
-add_executable (mergetree_checksum_fuzzer mergetree_checksum_fuzzer.cpp)
+clickhouse_add_executable (mergetree_checksum_fuzzer mergetree_checksum_fuzzer.cpp)
 # Look at comment around fuzz_compression target declaration
 target_link_libraries (mergetree_checksum_fuzzer PRIVATE dbms ${LIB_FUZZING_ENGINE})
 
-add_executable (columns_description_fuzzer columns_description_fuzzer.cpp)
+clickhouse_add_executable (columns_description_fuzzer columns_description_fuzzer.cpp)
 target_link_libraries (columns_description_fuzzer PRIVATE dbms ${LIB_FUZZING_ENGINE})

--- a/utils/check-marks/CMakeLists.txt
+++ b/utils/check-marks/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (check-marks main.cpp)
+clickhouse_add_executable (check-marks main.cpp)
 target_link_libraries(check-marks PRIVATE dbms boost::program_options)

--- a/utils/check-mysql-binlog/CMakeLists.txt
+++ b/utils/check-mysql-binlog/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(check-mysql-binlog main.cpp)
+clickhouse_add_executable(check-mysql-binlog main.cpp)
 target_link_libraries(check-mysql-binlog PRIVATE dbms boost::program_options)

--- a/utils/checksum-for-compressed-block/CMakeLists.txt
+++ b/utils/checksum-for-compressed-block/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (checksum-for-compressed-block-find-bit-flips main.cpp)
+clickhouse_add_executable (checksum-for-compressed-block-find-bit-flips main.cpp)
 target_link_libraries(checksum-for-compressed-block-find-bit-flips PRIVATE dbms)

--- a/utils/compressor/CMakeLists.txt
+++ b/utils/compressor/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (decompress_perf decompress_perf.cpp)
+clickhouse_add_executable (decompress_perf decompress_perf.cpp)
 target_link_libraries(decompress_perf PRIVATE dbms ch_contrib::lz4)

--- a/utils/config-processor/CMakeLists.txt
+++ b/utils/config-processor/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (config-processor config-processor.cpp)
+clickhouse_add_executable (config-processor config-processor.cpp)
 target_link_libraries(config-processor PRIVATE clickhouse_common_config_no_zookeeper_log)

--- a/utils/corrector_utf8/CMakeLists.txt
+++ b/utils/corrector_utf8/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(corrector_utf8 corrector_utf8.cpp)
+clickhouse_add_executable(corrector_utf8 corrector_utf8.cpp)
 target_link_libraries(corrector_utf8 PRIVATE clickhouse_common_io)

--- a/utils/db-generator/CMakeLists.txt
+++ b/utils/db-generator/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (query_db_generator query_db_generator.cpp)
+clickhouse_add_executable (query_db_generator query_db_generator.cpp)
 target_link_libraries(query_db_generator PRIVATE clickhouse_parsers boost::program_options)

--- a/utils/graphite-rollup/CMakeLists.txt
+++ b/utils/graphite-rollup/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(graphite-rollup-bench graphite-rollup-bench.cpp)
+clickhouse_add_executable(graphite-rollup-bench graphite-rollup-bench.cpp)
 target_link_libraries(
     graphite-rollup-bench
     PRIVATE

--- a/utils/iotest/CMakeLists.txt
+++ b/utils/iotest/CMakeLists.txt
@@ -1,9 +1,9 @@
 
-add_executable (iotest iotest.cpp ${SRCS})
+clickhouse_add_executable (iotest iotest.cpp ${SRCS})
 target_link_libraries (iotest PRIVATE clickhouse_common_io)
 
-add_executable (iotest_nonblock iotest_nonblock.cpp ${SRCS})
+clickhouse_add_executable (iotest_nonblock iotest_nonblock.cpp ${SRCS})
 target_link_libraries (iotest_nonblock PRIVATE clickhouse_common_io)
 
-add_executable (iotest_aio iotest_aio.cpp ${SRCS})
+clickhouse_add_executable (iotest_aio iotest_aio.cpp ${SRCS})
 target_link_libraries (iotest_aio PRIVATE clickhouse_common_io)

--- a/utils/keeper-bench/CMakeLists.txt
+++ b/utils/keeper-bench/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(keeper-bench Generator.cpp Runner.cpp Stats.cpp main.cpp)
+clickhouse_add_executable(keeper-bench Generator.cpp Runner.cpp Stats.cpp main.cpp)
 target_link_libraries(keeper-bench PRIVATE clickhouse_common_zookeeper_no_log)

--- a/utils/keeper-data-dumper/CMakeLists.txt
+++ b/utils/keeper-data-dumper/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(keeper-data-dumper main.cpp)
+clickhouse_add_executable(keeper-data-dumper main.cpp)
 target_link_libraries(keeper-data-dumper PRIVATE dbms)

--- a/utils/memcpy-bench/CMakeLists.txt
+++ b/utils/memcpy-bench/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_language(ASM)
 
-add_executable (memcpy-bench
+clickhouse_add_executable (memcpy-bench
     memcpy-bench.cpp
     FastMemcpy.cpp
     FastMemcpy_Avx.cpp

--- a/utils/self-extracting-executable/CMakeLists.txt
+++ b/utils/self-extracting-executable/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_executable (pre_compressor compressor.cpp)
+clickhouse_add_executable (pre_compressor compressor.cpp)
 target_link_libraries(pre_compressor PUBLIC ch_contrib::zstd)
 
-add_executable (decompressor decompressor.cpp)
+clickhouse_add_executable (decompressor decompressor.cpp)
 target_link_libraries(decompressor PUBLIC ch_contrib::zstd)
 
 add_custom_target (compressor)

--- a/utils/self-extracting-executable/CMakeLists.txt
+++ b/utils/self-extracting-executable/CMakeLists.txt
@@ -1,7 +1,7 @@
-clickhouse_add_executable (pre_compressor compressor.cpp)
+add_executable (pre_compressor compressor.cpp)
 target_link_libraries(pre_compressor PUBLIC ch_contrib::zstd)
 
-clickhouse_add_executable (decompressor decompressor.cpp)
+add_executable (decompressor decompressor.cpp)
 target_link_libraries(decompressor PUBLIC ch_contrib::zstd)
 
 add_custom_target (compressor)

--- a/utils/wal-dump/CMakeLists.txt
+++ b/utils/wal-dump/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (wal-dump main.cpp)
+clickhouse_add_executable (wal-dump main.cpp)
 target_link_libraries(wal-dump PRIVATE dbms boost::program_options)

--- a/utils/wikistat-loader/CMakeLists.txt
+++ b/utils/wikistat-loader/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (wikistat-loader main.cpp ${SRCS})
+clickhouse_add_executable (wikistat-loader main.cpp ${SRCS})
 target_link_libraries (wikistat-loader PRIVATE clickhouse_common_io boost::program_options)

--- a/utils/zookeeper-adjust-block-numbers-to-parts/CMakeLists.txt
+++ b/utils/zookeeper-adjust-block-numbers-to-parts/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable (zookeeper-adjust-block-numbers-to-parts main.cpp ${SRCS})
+clickhouse_add_executable (zookeeper-adjust-block-numbers-to-parts main.cpp ${SRCS})
 target_compile_options(zookeeper-adjust-block-numbers-to-parts PRIVATE -Wno-format)
 target_link_libraries (zookeeper-adjust-block-numbers-to-parts PRIVATE clickhouse_aggregate_functions dbms clickhouse_common_zookeeper boost::program_options)

--- a/utils/zookeeper-cli/CMakeLists.txt
+++ b/utils/zookeeper-cli/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(clickhouse-zookeeper-cli zookeeper-cli.cpp)
+clickhouse_add_executable(clickhouse-zookeeper-cli zookeeper-cli.cpp)
 target_link_libraries(clickhouse-zookeeper-cli PRIVATE clickhouse_common_zookeeper_no_log)

--- a/utils/zookeeper-create-entry-to-download-part/CMakeLists.txt
+++ b/utils/zookeeper-create-entry-to-download-part/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (zookeeper-create-entry-to-download-part main.cpp ${SRCS})
+clickhouse_add_executable (zookeeper-create-entry-to-download-part main.cpp ${SRCS})
 target_link_libraries (zookeeper-create-entry-to-download-part PRIVATE dbms clickhouse_common_zookeeper boost::program_options)

--- a/utils/zookeeper-dump-tree/CMakeLists.txt
+++ b/utils/zookeeper-dump-tree/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (zookeeper-dump-tree main.cpp ${SRCS})
+clickhouse_add_executable (zookeeper-dump-tree main.cpp ${SRCS})
 target_link_libraries(zookeeper-dump-tree PRIVATE clickhouse_common_zookeeper_no_log clickhouse_common_io boost::program_options)

--- a/utils/zookeeper-remove-by-list/CMakeLists.txt
+++ b/utils/zookeeper-remove-by-list/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable (zookeeper-remove-by-list main.cpp ${SRCS})
+clickhouse_add_executable (zookeeper-remove-by-list main.cpp ${SRCS})
 target_link_libraries(zookeeper-remove-by-list PRIVATE clickhouse_common_zookeeper_no_log boost::program_options)

--- a/utils/zookeeper-test/CMakeLists.txt
+++ b/utils/zookeeper-test/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(zk-test main.cpp)
+clickhouse_add_executable(zk-test main.cpp)
 target_link_libraries(zk-test PRIVATE clickhouse_common_zookeeper_no_log)


### PR DESCRIPTION
A simple HelloWorld program with zero includes except iostream triggers
a build of ca. 2000 source files. The reason is that ClickHouse's
top-level CMakeLists.txt overrides "add_executable()" to link all
binaries against "clickhouse_new_delete". This links against
"clickhouse_common_io", which in turn has lots of 3rd party library
dependencies ... Without linking "clickhouse_new_delete", the number of
compiled files for "HelloWorld" goes down to ca. 70.

As an example, the self-extracting-executable needs none of its current
dependencies. Other programs may also benefit.

In order to restore access to the original "add_executable()", the
overriding version is now prefixed. There is precedence for a
"clickhouse_" prefix (as opposed to "ch_"), for example
"clickhouse_split_debug_symbols". In general prefixing makes sense also
because overriding CMake commands relies on undocumented behavior and is
considered not-so-great practice (*).

(*) https://crascit.com/2018/09/14/do-not-redefine-cmake-commands/

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)