### PR TITLE
Chown all directories for multidisk setup

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -38,6 +38,7 @@ FORMAT_SCHEMA_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_
 
 # There could be many disks declared in config
 readarray -t FILESYSTEM_CACHE_PATHS < <(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='storage_configuration.disks.*.data_cache_path' || true)
+readarray -t DISKS_PATHS < <(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key='storage_configuration.disks.*.path' || true)
 
 CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
 CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-}"
@@ -50,7 +51,8 @@ for dir in "$DATA_DIR" \
   "$TMP_DIR" \
   "$USER_PATH" \
   "$FORMAT_SCHEMA_PATH" \
-  "${FILESYSTEM_CACHE_PATHS[@]}"
+  "${FILESYSTEM_CACHE_PATHS[@]}" \
+  "${DISKS_PATHS[@]}"
 do
     # check if variable not empty
     [ -z "$dir" ] && continue


### PR DESCRIPTION

### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now entrypoint.sh in docker image creates and executes chown for all folders it found in config for multidisk setup  #17717


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
