### PR TITLE
tests: enable back 02232_dist_insert_send_logs_level_hung

### DIFF
--- a/tests/queries/0_stateless/02232_dist_insert_send_logs_level_hung.sh
+++ b/tests/queries/0_stateless/02232_dist_insert_send_logs_level_hung.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: disabled
+# Tags: long, no-parallel
 # Tag: no-parallel - to heavy
 # Tag: long        - to heavy
 
@@ -33,11 +33,14 @@ $CLICKHOUSE_CLIENT "${client_opts[@]}" -nm -q "
     create materialized view mv_02232 to out_02232 as select * from in_02232;
 "
 
+# 600 is the default timeout of clickhouse-test, and 30 is just a safe padding,
+# to avoid hung query check triggering
+insert_timeout=$((600-30))
+# Increase timeouts to avoid timeout during trying to send Log packet to
+# the remote side, when the socket is full.
 insert_client_opts=(
-    # Increase timeouts to avoid timeout during trying to send Log packet to
-    # the remote side, when the socket is full.
-    --send_timeout 86400
-    --receive_timeout 86400
+    --send_timeout "$insert_timeout"
+    --receive_timeout "$insert_timeout"
 )
 # 250 seconds is enough to trigger the query hung (even in debug build)
 #


### PR DESCRIPTION
The original issue was that log_comment was wrong, and this test relies
on correct log_comment, but this had been fixed already in #37932.

Fixes: #38219 (@tavplubix)

P.S. @tavplubix thanks for the detailed reports

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)