### PR TITLE
Tiny updates for tests.

### DIFF
--- a/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.sql
+++ b/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.sql
@@ -1,5 +1,6 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-s3-storage
 -- no-parallel -- for flaky check and to avoid "Removing leftovers from table" (for other tables)
+-- no-s3-storage -- hangs now, need investigation
 
 -- Temporarily skip warning 'table was created by another server at the same moment, will retry'
 set send_logs_level='error';

--- a/tests/queries/0_stateless/01710_projection_fetch_long.sql
+++ b/tests/queries/0_stateless/01710_projection_fetch_long.sql
@@ -1,4 +1,4 @@
--- Tags: long, no-s3-storage, no-backward-compatibility-check
+-- Tags: long, no-s3-storage
 
 drop table if exists tp_1;
 drop table if exists tp_2;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Enable backward_compatibility for 01710_projection_fetch_long, disable s3 for 01643_replicated_merge_tree_fsync_smoke.
