### PR TITLE
Handling SIGTERM signals from k8s

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -155,7 +155,7 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
     # so the container can't be finished by ctrl+c
     CLICKHOUSE_WATCHDOG_ENABLE=${CLICKHOUSE_WATCHDOG_ENABLE:-0}
     export CLICKHOUSE_WATCHDOG_ENABLE
-    /usr/bin/clickhouse su "${USER}:${GROUP}" /usr/bin/clickhouse-server --config-file="$CLICKHOUSE_CONFIG" "$@"
+    exec /usr/bin/clickhouse su "${USER}:${GROUP}" /usr/bin/clickhouse-server --config-file="$CLICKHOUSE_CONFIG" "$@"
 fi
 
 # Otherwise, we assume the user want to run his own process, for example a `bash` shell to explore this image


### PR DESCRIPTION

### Changelog category:
- Improvement

### Changelog entry:
Handling SIGTERM signals from k8s. 


Without patch ps output:
```
root@c-camel-js-27-server-1:/# ps axf
  PID TTY      STAT   TIME COMMAND
  388 pts/0    Ss     0:00 bash
  400 pts/0    R+     0:00  \_ ps axf
    1 ?        Ss     0:00 /bin/bash /entrypoint.sh
   43 ?        S      0:00 clickhouse-watchdog        --config-file=/etc/clickhouse-server/config.xml
   44 ?        Sl     0:02  \_ /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
```

SIGTERM is sent to PID 1 and it's not sent to 43/44

With exec in entrypoint.sh:
```
root@c-camel-js-27-server-1:/# ps axf
  PID TTY      STAT   TIME COMMAND
  386 pts/0    Ss     0:00 bash
  398 pts/0    R+     0:00  \_ ps axf
    1 ?        Ss     0:00 clickhouse-watchdog        --config-file=/etc/clickhouse-server/config.xml
   45 ?        Sl     0:01 /usr/bin/clickhouse-server --config-file=/etc/clickhouse-server/config.xml
```
and if you send SIGINT to PID 1, PID 45 revives it as well:
Timurs-MBP:remote-storage-adapter tsolodovnikov$ k logs -f c-camel-js-27-server-0 -c c-camel-js-27-server | grep term
2022.07.11 22:26:11.473547 [ 47 ] {} <Information> Application: Received termination signal (Terminated)
2022.07.11 22:26:11.473607 [ 45 ] {} <Debug> Application: Received termination signal.