### PR TITLE
Fix path retrieval for Keeper's state

### DIFF
--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -225,6 +225,15 @@ String KeeperConfigurationAndSettings::getSnapshotsPathFromConfig(const Poco::Ut
 
 String KeeperConfigurationAndSettings::getStateFilePathFromConfig(const Poco::Util::AbstractConfiguration & config, bool standalone_keeper_)
 {
+    if (config.has("keeper_server.storage_path"))
+        return std::filesystem::path{config.getString("keeper_server.storage_path")} / "state";
+
+    if (config.has("keeper_server.snapshot_storage_path"))
+        return std::filesystem::path(config.getString("keeper_server.snapshot_storage_path")).parent_path() / "state";
+
+    if (config.has("keeper_server.log_storage_path"))
+        return std::filesystem::path(config.getString("keeper_server.log_storage_path")).parent_path() / "state";
+
     if (standalone_keeper_)
         return std::filesystem::path{config.getString("path", KEEPER_DEFAULT_PATH)} / "state";
     else


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Default path `/var/lib/clickhouse-keeper` may not exist while log_storage_path or snapshot_storage_path could be present in config. Better to use them. References: #39069


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
