### PR TITLE
Fix trivial count with empty set

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1933,6 +1933,7 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
         syntax_analyzer_result->optimize_trivial_count
         && (settings.max_parallel_replicas <= 1)
         && !settings.allow_experimental_query_deduplication
+        && !settings.empty_result_for_aggregation_by_empty_set
         && storage
         && storage->getName() != "MaterializedMySQL"
         && !row_policy_filter

--- a/tests/queries/0_stateless/02356_trivial_count_with_empty_set.sql
+++ b/tests/queries/0_stateless/02356_trivial_count_with_empty_set.sql
@@ -1,0 +1,9 @@
+drop table if exists test;
+
+create table test(a Int64) Engine=MergeTree order by tuple();
+
+set optimize_trivial_count_query=1, empty_result_for_aggregation_by_empty_set=1;
+
+select count() from test;
+
+drop table test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix unexpected query result when both `optimize_trivial_count_query` and `empty_result_for_aggregation_by_empty_set` are set to true. This fixes https://github.com/ClickHouse/ClickHouse/issues/39140

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
