### PR TITLE
ThreadPool fixes

### DIFF
--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -165,7 +165,9 @@ public:
         : state(std::make_shared<Poco::Event>())
         , thread_id(std::make_shared<std::thread::id>())
     {
-        /// NOTE: If this will throw an exception, the destructor won't be called.
+        /// NOTE:
+        /// - If this will throw an exception, the destructor won't be called
+        /// - this pointer cannot be passed in the lambda, since after detach() it will not be valid
         GlobalThreadPool::instance().scheduleOrThrow([
             thread_id = thread_id,
             state = state,

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -162,22 +162,19 @@ public:
 
     template <typename Function, typename... Args>
     explicit ThreadFromGlobalPool(Function && func, Args &&... args)
-        : state(std::make_shared<Poco::Event>())
-        , thread_id(std::make_shared<ThreadIdHolder>())
+        : state(std::make_shared<State>())
     {
         /// NOTE:
         /// - If this will throw an exception, the destructor won't be called
         /// - this pointer cannot be passed in the lambda, since after detach() it will not be valid
         GlobalThreadPool::instance().scheduleOrThrow([
-            thread_id = thread_id,
             state = state,
             func = std::forward<Function>(func),
             args = std::make_tuple(std::forward<Args>(args)...)]() mutable /// mutable is needed to destroy capture
         {
-            auto event = std::move(state);
-            SCOPE_EXIT(event->set());
+            SCOPE_EXIT(state->event.set());
 
-            thread_id->id = std::this_thread::get_id();
+            state->thread_id = std::this_thread::get_id();
 
             /// This moves are needed to destroy function and arguments before exit.
             /// It will guarantee that after ThreadFromGlobalPool::join all captured params are destroyed.
@@ -201,7 +198,6 @@ public:
         if (initialized())
             abort();
         state = std::move(rhs.state);
-        thread_id = std::move(rhs.thread_id);
         return *this;
     }
 
@@ -216,7 +212,7 @@ public:
         if (!initialized())
             abort();
 
-        state->wait();
+        state->event.wait();
         state.reset();
     }
 
@@ -232,22 +228,22 @@ public:
         if (!state)
             return false;
         /// Thread cannot join itself.
-        if (thread_id->id == std::this_thread::get_id())
+        if (state->thread_id == std::this_thread::get_id())
             return false;
         return true;
     }
 
 private:
-    /// The state used in this object and inside the thread job.
-    std::shared_ptr<Poco::Event> state;
-
-    struct ThreadIdHolder
+    struct State
     {
         /// Should be atomic() because of possible concurrent access between
         /// assignment and joinable() check.
-        std::atomic<std::thread::id> id;
+        std::atomic<std::thread::id> thread_id;
+
+        /// The state used in this object and inside the thread job.
+        Poco::Event event;
     };
-    std::shared_ptr<ThreadIdHolder> thread_id;
+    std::shared_ptr<State> state;
 
     /// Internally initialized() should be used over joinable(),
     /// since it is enough to know that the thread is initialized,

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -198,7 +198,7 @@ public:
 
     ThreadFromGlobalPool & operator=(ThreadFromGlobalPool && rhs) noexcept
     {
-        if (joinable())
+        if (initialized())
             abort();
         state = std::move(rhs.state);
         thread_id = std::move(rhs.thread_id);
@@ -207,13 +207,13 @@ public:
 
     ~ThreadFromGlobalPool()
     {
-        if (joinable())
+        if (initialized())
             abort();
     }
 
     void join()
     {
-        if (!joinable())
+        if (!initialized())
             abort();
 
         state->wait();
@@ -222,7 +222,7 @@ public:
 
     void detach()
     {
-        if (!joinable())
+        if (!initialized())
             abort();
         state.reset();
     }
@@ -241,6 +241,14 @@ private:
     /// The state used in this object and inside the thread job.
     std::shared_ptr<Poco::Event> state;
     std::shared_ptr<std::thread::id> thread_id;
+
+    /// Internally initialized() should be used over joinable(),
+    /// since it is enough to know that the thread is initialized,
+    /// and ignore that fact that thread cannot join itself.
+    bool initialized() const
+    {
+        return static_cast<bool>(state);
+    }
 };
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- ThreadPool: fix thread_id assignment
- ThreadPool: do not use joinable() internally
- ThreadPool: add some clarification comments

As found by @KochetovNicolai before this patch, lambda in
ThreadFromGlobalPool() ctor assigns value only to a copy of the
thread_id value, and so check in joinable() had been working
incorrectly, fix this by changing the value not the shared_ptr itself.

Also it is not safe to assign thread_id w/o atomics, since this can be
racy, so wrap id with std::atomic<>

Fixes: #28431