### PR TITLE
Suppression for BC check (`Cannot parse string 'Hello' as UInt64`)

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -353,6 +353,7 @@ else
 
     # Error messages (we should ignore some errors)
     # FIXME https://github.com/ClickHouse/ClickHouse/issues/38643 ("Unknown index: idx.")
+    # FIXME https://github.com/ClickHouse/ClickHouse/issues/39174 ("Cannot parse string 'Hello' as UInt64")
     echo "Check for Error messages in server log:"
     zgrep -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
                -e "Code: 236. DB::Exception: Cancelled mutating parts" \
@@ -376,6 +377,7 @@ else
                -e "found in queue and some source parts for it was lost" \
                -e "is lost forever." \
                -e "Unknown index: idx." \
+               -e "Cannot parse string 'Hello' as UInt64" \
         /var/log/clickhouse-server/clickhouse-server.backward.clean.log | zgrep -Fa "<Error>" > /test_output/bc_check_error_messages.txt \
         && echo -e 'Backward compatibility check: Error message in clickhouse-server.log (see bc_check_error_messages.txt)\tFAIL' >> /test_output/test_results.tsv \
         || echo -e 'Backward compatibility check: No Error messages in clickhouse-server.log\tOK' >> /test_output/test_results.tsv


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



https://s3.amazonaws.com/clickhouse-test-reports/0/334b3f3c730053eb282491de12864239aa23ded2/stress_test__undefined__actions_.html