### PR TITLE
Forbid defining non-default disk with default path from <path>

### DIFF
--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -68,6 +68,8 @@ static void loadDiskLocalConfig(const String & name,
             throw Exception("Disk path can not be empty. Disk " + name, ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG);
         if (path.back() != '/')
             throw Exception("Disk path must end with /. Disk " + name, ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG);
+        if (path == context->getPath())
+            throw Exception(ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG, "Disk path ('{}') cannot be equal to <path>. Use <default> disk instead.", path);
     }
 
     bool has_space_ratio = config.has(config_prefix + ".keep_free_space_ratio");


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Forbid defining non-default disk with default path from <path>

Suppose you have the following configuration:

    <path>/var/lib/clickhouse/</path>
    <storage_configuration>
        <disks>
            <data><path>/var/lib/clickhouse/</path></data>
        </disks>
        <policies>
            <default>
                <volumes>
                    <main>
                        <disk>data</disk>
                    </main>
                </volumes>
            </default>
        </policies>
    </storage_configuration>

In this case disks will have two disks:
- 'data'    disk with path '/var/lib/clickhouse/'
- 'default' disk with path '/var/lib/clickhouse/'

And in this case MergeTree engine will complain on ATTACH for table that
uses 'default' policy:

    2022.06.20 07:49:15.165393 [ 242 ] {e8f50978-218a-426f-babc-637a8d03b1c6} <Error> TCPHandler: Code: 479. DB::Exception: Part `0_0_0_1` was found on disk `default` which is not defined in the storage policy. (UNKNOWN_DISK), Stack trace (when copying this message, always include the lines below):