### PR TITLE
Fix 01961_roaring_memory_tracking test

### DIFF
--- a/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
+++ b/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
@@ -1,4 +1,4 @@
 -- Tags: no-replicated-database
 
 SET max_memory_usage = '100M';
-SELECT cityHash64(rand() % 1000) as n, groupBitmapState(number) FROM numbers_mt(2000000000) GROUP BY n; -- { serverError 241 }
+SELECT cityHash64(rand() % 1000) as n, groupBitmapState(number) FROM numbers_mt(2000000000) GROUP BY n FORMAT Null; -- { serverError 241 }


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Do not print query output in case of failure.
