### PR TITLE
Fix exception in AsynchronousMetrics for s390x

### DIFF
--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -989,9 +989,15 @@ void AsynchronousMetrics::update(std::chrono::system_clock::time_point update_ti
 
                 if (s.rfind("processor", 0) == 0)
                 {
+                    /// s390x example: processor 0: version = FF, identification = 039C88, machine = 3906
+                    /// non s390x example: processor : 0
                     if (auto colon = s.find_first_of(':'))
                     {
+#ifdef __s390x__
+                        core_id = std::stoi(s.substr(10)); /// 10: length of "processor" plus 1
+#else
                         core_id = std::stoi(s.substr(colon + 2));
+#endif
                     }
                 }
                 else if (s.rfind("cpu MHz", 0) == 0)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
This PR is to address a bug in s390x build (Z mainframe): ClickHouse Server keeps throwing exceptions:

`<Error> void DB::AsynchronousMetrics::update(std::chrono::system_clock::time_point): std::exception. Code: 1001, type: std::invalid_argument, e.what() = stoi: no conversion...`

The root of cause is that s390x has different cpuinfo format, for example:

`processor 0: version = FF,  identification = 039C88,  machine = 3906`
which is different from other platforms, like:
`processor	: 0`

In AsynchronousMetrics:cpp, the call to "stoi()" throws exceptions in s390x.

This PR fixed the issue by using corrected code when parsing core_id in s390x.

### Changelog category (leave one):
- Not for changelog.

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the "stoi() exception issue in AsynchronousMetrics in s390x platform.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
