### PR TITLE
Optimize accesses to system.stack_trace (filter by name before sending signal)

### DIFF
--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -206,10 +206,12 @@ namespace
             filtered_thread_names.emplace(thread_name);
         }
 
-        for (const auto & [tid, name] : tid_to_name)
+        for (auto it = tid_to_name.begin(); it != tid_to_name.end();)
         {
-            if (!filtered_thread_names.contains(name))
-                tid_to_name.erase(tid);
+            if (!filtered_thread_names.contains(it->second))
+                it = tid_to_name.erase(it);
+            else
+                ++it;
         }
 
         return tid_to_name;
@@ -302,8 +304,13 @@ Pipe StorageSystemStackTrace::read(
         size_t res_index = 0;
 
         String thread_name;
-        if (auto it = thread_names.find(tid); it != thread_names.end())
-            thread_name = it->second;
+        if (read_thread_names)
+        {
+            if (auto it = thread_names.find(tid); it != thread_names.end())
+                thread_name = it->second;
+            else
+                continue; /// was filtered out by "thread_name" condition
+        }
 
         if (!send_signal)
         {

--- a/tests/queries/0_stateless/01051_system_stack_trace.reference
+++ b/tests/queries/0_stateless/01051_system_stack_trace.reference
@@ -13,3 +13,6 @@ SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' LIMIT 1
 -- optimization for thread_name
 SELECT length(thread_name) > 0 FROM system.stack_trace WHERE thread_name != '' LIMIT 1;
 1
+-- enough rows (optimizations works "correctly")
+SELECT count() > 100 FROM system.stack_trace;
+1

--- a/tests/queries/0_stateless/01051_system_stack_trace.sql
+++ b/tests/queries/0_stateless/01051_system_stack_trace.sql
@@ -10,3 +10,5 @@ SELECT length(trace) > 0 FROM system.stack_trace LIMIT 1;
 SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' LIMIT 1;
 -- optimization for thread_name
 SELECT length(thread_name) > 0 FROM system.stack_trace WHERE thread_name != '' LIMIT 1;
+-- enough rows (optimizations works "correctly")
+SELECT count() > 100 FROM system.stack_trace;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Optimize accesses to system.stack_trace (filter by name before sending signal)

Because of failed rebase/push this part of the patch was lost, so
resending separatelly (sigh).

Follow-up for: #39177 (cc @yakov-olkhovskiy)