### PR TITLE
Remove specialization global lock/unlock from ActionLocksManager

### DIFF
--- a/src/Interpreters/ActionLocksManager.cpp
+++ b/src/Interpreters/ActionLocksManager.cpp
@@ -23,20 +23,6 @@ ActionLocksManager::ActionLocksManager(ContextPtr context_) : WithContext(contex
 {
 }
 
-template <typename F>
-inline void forEachTable(F && f, ContextPtr context)
-{
-    for (auto & elem : DatabaseCatalog::instance().getDatabases())
-        for (auto iterator = elem.second->getTablesIterator(context); iterator->isValid(); iterator->next())
-            if (auto table = iterator->table())
-                f(table);
-}
-
-void ActionLocksManager::add(StorageActionBlockType action_type, ContextPtr context_)
-{
-    forEachTable([&](const StoragePtr & table) { add(table, action_type); }, context_);
-}
-
 void ActionLocksManager::add(const StorageID & table_id, StorageActionBlockType action_type)
 {
     if (auto table = DatabaseCatalog::instance().tryGetTable(table_id, getContext()))
@@ -52,14 +38,6 @@ void ActionLocksManager::add(const StoragePtr & table, StorageActionBlockType ac
         std::lock_guard lock(mutex);
         storage_locks[table.get()][action_type] = std::move(action_lock);
     }
-}
-
-void ActionLocksManager::remove(StorageActionBlockType action_type)
-{
-    std::lock_guard lock(mutex);
-
-    for (auto & storage_elem : storage_locks)
-        storage_elem.second.erase(action_type);
 }
 
 void ActionLocksManager::remove(const StorageID & table_id, StorageActionBlockType action_type)

--- a/src/Interpreters/ActionLocksManager.h
+++ b/src/Interpreters/ActionLocksManager.h
@@ -20,14 +20,10 @@ class ActionLocksManager : WithContext
 public:
     explicit ActionLocksManager(ContextPtr context);
 
-    /// Adds new locks for each table
-    void add(StorageActionBlockType action_type, ContextPtr context);
     /// Add new lock for a table if it has not been already added
     void add(const StorageID & table_id, StorageActionBlockType action_type);
     void add(const StoragePtr & table, StorageActionBlockType action_type);
 
-    /// Remove locks for all tables
-    void remove(StorageActionBlockType action_type);
     /// Removes a lock for a table if it exists
     void remove(const StorageID & table_id, StorageActionBlockType action_type);
     void remove(const StoragePtr & table, StorageActionBlockType action_type);


### PR DESCRIPTION
This had been done in InterpreterSystemQuery explicitly, with grants
checking.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)