### PR TITLE
Don't report system.errors when the disk is not rotational

### DIFF
--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -87,7 +87,10 @@ BlockDeviceType getBlockDeviceType([[maybe_unused]] const String & device_id)
 #if defined(OS_LINUX)
     try
     {
-        ReadBufferFromFile in("/sys/dev/block/" + device_id + "/queue/rotational");
+        const String path = "/sys/dev/block/" + device_id + "/queue/rotational";
+        if (!std::filesystem::exists(path))
+            return BlockDeviceType::UNKNOWN;
+        ReadBufferFromFile in(path);
         int rotational;
         readText(rotational, in);
         return rotational ? BlockDeviceType::ROT : BlockDeviceType::NONROT;

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -87,7 +87,7 @@ BlockDeviceType getBlockDeviceType([[maybe_unused]] const String & device_id)
 #if defined(OS_LINUX)
     try
     {
-        const String path = "/sys/dev/block/" + device_id + "/queue/rotational";
+        const auto path{std::filesystem::path("/sys/dev/block/") / device_id / "queue/rotational"};
         if (!std::filesystem::exists(path))
             return BlockDeviceType::UNKNOWN;
         ReadBufferFromFile in(path);
@@ -112,7 +112,8 @@ UInt64 getBlockDeviceReadAheadBytes([[maybe_unused]] const String & device_id)
 #if defined(OS_LINUX)
     try
     {
-        ReadBufferFromFile in("/sys/dev/block/" + device_id + "/queue/read_ahead_kb");
+        const auto path{std::filesystem::path("/sys/dev/block/") / device_id / "queue/read_ahead_kb"};
+        ReadBufferFromFile in(path);
         int read_ahead_kb;
         readText(read_ahead_kb, in);
         return read_ahead_kb * 1024;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Don't report system.errors when the disk is not rotational


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Another minor tweak to avoid adding errors to system.errors that aren't such. In this case, if the disk isn't rotational under Linux you would get an error like this:

```
│            1 │ 22.7.1.2001 │ FILE_DOESNT_EXIST                 │  107 │     1 │ 2022-07-14 06:44:51 │ Cannot open file /sys/dev/block/0:54/queue/rotational, errno: 2, strerror: No such file or directory                                                                                                                                                       │ [195081178,195085450,195504594,195348095,195707867,440134886,195695604,195685063,195053808,139849509523587,192760302]                                                                                                                                      │      0 │
```

I keep seeing this in both my local machine and in CI and it can mask other errors, so it's better to not report anything.