### PR TITLE
Pass const std::string_view by value, not by reference

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -101,7 +101,7 @@ public:
         registered_prefixes = prefixes_;
     }
 
-    bool isSettingNameAllowed(const std::string_view & setting_name) const
+    bool isSettingNameAllowed(std::string_view setting_name) const
     {
         if (Settings::hasBuiltin(setting_name))
             return true;
@@ -116,7 +116,7 @@ public:
         return false;
     }
 
-    void checkSettingNameIsAllowed(const std::string_view & setting_name) const
+    void checkSettingNameIsAllowed(std::string_view setting_name) const
     {
         if (isSettingNameAllowed(setting_name))
             return;

--- a/src/Access/AccessRights.cpp
+++ b/src/Access/AccessRights.cpp
@@ -252,7 +252,7 @@ public:
     }
 
     template <typename ... Args>
-    void grant(const AccessFlags & flags_, const std::string_view & name, const Args &... subnames)
+    void grant(const AccessFlags & flags_, std::string_view name, const Args &... subnames)
     {
         auto & child = getChild(name);
         child.grant(flags_, subnames...);
@@ -279,7 +279,7 @@ public:
     }
 
     template <typename... Args>
-    void revoke(const AccessFlags & flags_, const std::string_view & name, const Args &... subnames)
+    void revoke(const AccessFlags & flags_, std::string_view name, const Args &... subnames)
     {
         auto & child = getChild(name);
 
@@ -306,7 +306,7 @@ public:
     }
 
     template <typename... Args>
-    bool isGranted(const AccessFlags & flags_, const std::string_view & name, const Args &... subnames) const
+    bool isGranted(const AccessFlags & flags_, std::string_view name, const Args &... subnames) const
     {
         AccessFlags flags_to_check = flags_ - min_flags_with_children;
         if (!flags_to_check)
@@ -415,7 +415,7 @@ private:
     AccessFlags getAllGrantableFlags() const { return ::DB::getAllGrantableFlags(level); }
     AccessFlags getChildAllGrantableFlags() const { return ::DB::getAllGrantableFlags(static_cast<Level>(level + 1)); }
 
-    Node * tryGetChild(const std::string_view & name) const
+    Node * tryGetChild(std::string_view name) const
     {
         if (!children)
             return nullptr;
@@ -425,7 +425,7 @@ private:
         return &it->second;
     }
 
-    Node & getChild(const std::string_view & name)
+    Node & getChild(std::string_view name)
     {
         auto * child = tryGetChild(name);
         if (child)
@@ -819,20 +819,20 @@ void AccessRights::grantImpl(const AccessRightsElements & elements)
 }
 
 void AccessRights::grant(const AccessFlags & flags) { grantImpl<false>(flags); }
-void AccessRights::grant(const AccessFlags & flags, const std::string_view & database) { grantImpl<false>(flags, database); }
-void AccessRights::grant(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) { grantImpl<false>(flags, database, table); }
-void AccessRights::grant(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) { grantImpl<false>(flags, database, table, column); }
-void AccessRights::grant(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) { grantImpl<false>(flags, database, table, columns); }
-void AccessRights::grant(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) { grantImpl<false>(flags, database, table, columns); }
+void AccessRights::grant(const AccessFlags & flags, std::string_view database) { grantImpl<false>(flags, database); }
+void AccessRights::grant(const AccessFlags & flags, std::string_view database, std::string_view table) { grantImpl<false>(flags, database, table); }
+void AccessRights::grant(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) { grantImpl<false>(flags, database, table, column); }
+void AccessRights::grant(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) { grantImpl<false>(flags, database, table, columns); }
+void AccessRights::grant(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) { grantImpl<false>(flags, database, table, columns); }
 void AccessRights::grant(const AccessRightsElement & element) { grantImpl<false>(element); }
 void AccessRights::grant(const AccessRightsElements & elements) { grantImpl<false>(elements); }
 
 void AccessRights::grantWithGrantOption(const AccessFlags & flags) { grantImpl<true>(flags); }
-void AccessRights::grantWithGrantOption(const AccessFlags & flags, const std::string_view & database) { grantImpl<true>(flags, database); }
-void AccessRights::grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) { grantImpl<true>(flags, database, table); }
-void AccessRights::grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) { grantImpl<true>(flags, database, table, column); }
-void AccessRights::grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) { grantImpl<true>(flags, database, table, columns); }
-void AccessRights::grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) { grantImpl<true>(flags, database, table, columns); }
+void AccessRights::grantWithGrantOption(const AccessFlags & flags, std::string_view database) { grantImpl<true>(flags, database); }
+void AccessRights::grantWithGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table) { grantImpl<true>(flags, database, table); }
+void AccessRights::grantWithGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) { grantImpl<true>(flags, database, table, column); }
+void AccessRights::grantWithGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) { grantImpl<true>(flags, database, table, columns); }
+void AccessRights::grantWithGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) { grantImpl<true>(flags, database, table, columns); }
 void AccessRights::grantWithGrantOption(const AccessRightsElement & element) { grantImpl<true>(element); }
 void AccessRights::grantWithGrantOption(const AccessRightsElements & elements) { grantImpl<true>(elements); }
 
@@ -892,20 +892,20 @@ void AccessRights::revokeImpl(const AccessRightsElements & elements)
 }
 
 void AccessRights::revoke(const AccessFlags & flags) { revokeImpl<false>(flags); }
-void AccessRights::revoke(const AccessFlags & flags, const std::string_view & database) { revokeImpl<false>(flags, database); }
-void AccessRights::revoke(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) { revokeImpl<false>(flags, database, table); }
-void AccessRights::revoke(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) { revokeImpl<false>(flags, database, table, column); }
-void AccessRights::revoke(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) { revokeImpl<false>(flags, database, table, columns); }
-void AccessRights::revoke(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) { revokeImpl<false>(flags, database, table, columns); }
+void AccessRights::revoke(const AccessFlags & flags, std::string_view database) { revokeImpl<false>(flags, database); }
+void AccessRights::revoke(const AccessFlags & flags, std::string_view database, std::string_view table) { revokeImpl<false>(flags, database, table); }
+void AccessRights::revoke(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) { revokeImpl<false>(flags, database, table, column); }
+void AccessRights::revoke(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) { revokeImpl<false>(flags, database, table, columns); }
+void AccessRights::revoke(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) { revokeImpl<false>(flags, database, table, columns); }
 void AccessRights::revoke(const AccessRightsElement & element) { revokeImpl<false>(element); }
 void AccessRights::revoke(const AccessRightsElements & elements) { revokeImpl<false>(elements); }
 
 void AccessRights::revokeGrantOption(const AccessFlags & flags) { revokeImpl<true>(flags); }
-void AccessRights::revokeGrantOption(const AccessFlags & flags, const std::string_view & database) { revokeImpl<true>(flags, database); }
-void AccessRights::revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) { revokeImpl<true>(flags, database, table); }
-void AccessRights::revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) { revokeImpl<true>(flags, database, table, column); }
-void AccessRights::revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) { revokeImpl<true>(flags, database, table, columns); }
-void AccessRights::revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) { revokeImpl<true>(flags, database, table, columns); }
+void AccessRights::revokeGrantOption(const AccessFlags & flags, std::string_view database) { revokeImpl<true>(flags, database); }
+void AccessRights::revokeGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table) { revokeImpl<true>(flags, database, table); }
+void AccessRights::revokeGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) { revokeImpl<true>(flags, database, table, column); }
+void AccessRights::revokeGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) { revokeImpl<true>(flags, database, table, columns); }
+void AccessRights::revokeGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) { revokeImpl<true>(flags, database, table, columns); }
 void AccessRights::revokeGrantOption(const AccessRightsElement & element) { revokeImpl<true>(element); }
 void AccessRights::revokeGrantOption(const AccessRightsElements & elements) { revokeImpl<true>(elements); }
 
@@ -984,20 +984,20 @@ bool AccessRights::isGrantedImpl(const AccessRightsElements & elements) const
 }
 
 bool AccessRights::isGranted(const AccessFlags & flags) const { return isGrantedImpl<false>(flags); }
-bool AccessRights::isGranted(const AccessFlags & flags, const std::string_view & database) const { return isGrantedImpl<false>(flags, database); }
-bool AccessRights::isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { return isGrantedImpl<false>(flags, database, table); }
-bool AccessRights::isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const { return isGrantedImpl<false>(flags, database, table, column); }
-bool AccessRights::isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const { return isGrantedImpl<false>(flags, database, table, columns); }
-bool AccessRights::isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { return isGrantedImpl<false>(flags, database, table, columns); }
+bool AccessRights::isGranted(const AccessFlags & flags, std::string_view database) const { return isGrantedImpl<false>(flags, database); }
+bool AccessRights::isGranted(const AccessFlags & flags, std::string_view database, std::string_view table) const { return isGrantedImpl<false>(flags, database, table); }
+bool AccessRights::isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const { return isGrantedImpl<false>(flags, database, table, column); }
+bool AccessRights::isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const { return isGrantedImpl<false>(flags, database, table, columns); }
+bool AccessRights::isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const { return isGrantedImpl<false>(flags, database, table, columns); }
 bool AccessRights::isGranted(const AccessRightsElement & element) const { return isGrantedImpl<false>(element); }
 bool AccessRights::isGranted(const AccessRightsElements & elements) const { return isGrantedImpl<false>(elements); }
 
 bool AccessRights::hasGrantOption(const AccessFlags & flags) const { return isGrantedImpl<true>(flags); }
-bool AccessRights::hasGrantOption(const AccessFlags & flags, const std::string_view & database) const { return isGrantedImpl<true>(flags, database); }
-bool AccessRights::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { return isGrantedImpl<true>(flags, database, table); }
-bool AccessRights::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const { return isGrantedImpl<true>(flags, database, table, column); }
-bool AccessRights::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const { return isGrantedImpl<true>(flags, database, table, columns); }
-bool AccessRights::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { return isGrantedImpl<true>(flags, database, table, columns); }
+bool AccessRights::hasGrantOption(const AccessFlags & flags, std::string_view database) const { return isGrantedImpl<true>(flags, database); }
+bool AccessRights::hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table) const { return isGrantedImpl<true>(flags, database, table); }
+bool AccessRights::hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const { return isGrantedImpl<true>(flags, database, table, column); }
+bool AccessRights::hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const { return isGrantedImpl<true>(flags, database, table, columns); }
+bool AccessRights::hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const { return isGrantedImpl<true>(flags, database, table, columns); }
 bool AccessRights::hasGrantOption(const AccessRightsElement & element) const { return isGrantedImpl<true>(element); }
 bool AccessRights::hasGrantOption(const AccessRightsElements & elements) const { return isGrantedImpl<true>(elements); }
 

--- a/src/Access/AccessRights.h
+++ b/src/Access/AccessRights.h
@@ -39,59 +39,59 @@ public:
     /// Grants access on a specified database/table/column.
     /// Does nothing if the specified access has been already granted.
     void grant(const AccessFlags & flags);
-    void grant(const AccessFlags & flags, const std::string_view & database);
-    void grant(const AccessFlags & flags, const std::string_view & database, const std::string_view & table);
-    void grant(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column);
-    void grant(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns);
-    void grant(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns);
+    void grant(const AccessFlags & flags, std::string_view database);
+    void grant(const AccessFlags & flags, std::string_view database, std::string_view table);
+    void grant(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column);
+    void grant(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns);
+    void grant(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns);
     void grant(const AccessRightsElement & element);
     void grant(const AccessRightsElements & elements);
 
     void grantWithGrantOption(const AccessFlags & flags);
-    void grantWithGrantOption(const AccessFlags & flags, const std::string_view & database);
-    void grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table);
-    void grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column);
-    void grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns);
-    void grantWithGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns);
+    void grantWithGrantOption(const AccessFlags & flags, std::string_view database);
+    void grantWithGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table);
+    void grantWithGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column);
+    void grantWithGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns);
+    void grantWithGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns);
     void grantWithGrantOption(const AccessRightsElement & element);
     void grantWithGrantOption(const AccessRightsElements & elements);
 
     /// Revokes a specified access granted earlier on a specified database/table/column.
     /// For example, revoke(AccessType::ALL) revokes all grants at all, just like clear();
     void revoke(const AccessFlags & flags);
-    void revoke(const AccessFlags & flags, const std::string_view & database);
-    void revoke(const AccessFlags & flags, const std::string_view & database, const std::string_view & table);
-    void revoke(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column);
-    void revoke(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns);
-    void revoke(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns);
+    void revoke(const AccessFlags & flags, std::string_view database);
+    void revoke(const AccessFlags & flags, std::string_view database, std::string_view table);
+    void revoke(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column);
+    void revoke(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns);
+    void revoke(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns);
     void revoke(const AccessRightsElement & element);
     void revoke(const AccessRightsElements & elements);
 
     void revokeGrantOption(const AccessFlags & flags);
-    void revokeGrantOption(const AccessFlags & flags, const std::string_view & database);
-    void revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table);
-    void revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column);
-    void revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns);
-    void revokeGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns);
+    void revokeGrantOption(const AccessFlags & flags, std::string_view database);
+    void revokeGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table);
+    void revokeGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column);
+    void revokeGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns);
+    void revokeGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns);
     void revokeGrantOption(const AccessRightsElement & element);
     void revokeGrantOption(const AccessRightsElements & elements);
 
     /// Whether a specified access granted.
     bool isGranted(const AccessFlags & flags) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database, std::string_view table) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const;
     bool isGranted(const AccessRightsElement & element) const;
     bool isGranted(const AccessRightsElements & elements) const;
 
     bool hasGrantOption(const AccessFlags & flags) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const;
     bool hasGrantOption(const AccessRightsElement & element) const;
     bool hasGrantOption(const AccessRightsElements & elements) const;
 
@@ -107,9 +107,9 @@ public:
         const AccessFlags & flags,
         const AccessFlags & min_flags_with_children,
         const AccessFlags & max_flags_with_children,
-        const std::string_view & database,
-        const std::string_view & table,
-        const std::string_view & column)>;
+        std::string_view database,
+        std::string_view table,
+        std::string_view column)>;
     void modifyFlags(const ModifyFlagsFunction & function);
     void modifyFlagsWithGrantOption(const ModifyFlagsFunction & function);
 

--- a/src/Access/Authentication.cpp
+++ b/src/Access/Authentication.cpp
@@ -26,17 +26,17 @@ namespace
         return (Util::stringToDigest(password) == password_plaintext);
     }
 
-    bool checkPasswordDoubleSHA1(const std::string_view & password, const Digest & password_double_sha1)
+    bool checkPasswordDoubleSHA1(std::string_view password, const Digest & password_double_sha1)
     {
         return (Util::encodeDoubleSHA1(password) == password_double_sha1);
     }
 
-    bool checkPasswordSHA256(const std::string_view & password, const Digest & password_sha256, const String & salt)
+    bool checkPasswordSHA256(std::string_view password, const Digest & password_sha256, const String & salt)
     {
         return Util::encodeSHA256(String(password).append(salt)) == password_sha256;
     }
 
-    bool checkPasswordDoubleSHA1MySQL(const std::string_view & scramble, const std::string_view & scrambled_password, const Digest & password_double_sha1)
+    bool checkPasswordDoubleSHA1MySQL(std::string_view scramble, std::string_view scrambled_password, const Digest & password_double_sha1)
     {
         /// scrambled_password = SHA1(password) XOR SHA1(scramble <concat> SHA1(SHA1(password)))
 
@@ -61,7 +61,7 @@ namespace
         return calculated_password_double_sha1 == password_double_sha1;
     }
 
-    bool checkPasswordPlainTextMySQL(const std::string_view & scramble, const std::string_view & scrambled_password, const Digest & password_plaintext)
+    bool checkPasswordPlainTextMySQL(std::string_view scramble, std::string_view scrambled_password, const Digest & password_plaintext)
     {
         return checkPasswordDoubleSHA1MySQL(scramble, scrambled_password, Util::encodeDoubleSHA1(password_plaintext));
     }

--- a/src/Access/Common/AccessFlags.cpp
+++ b/src/Access/Common/AccessFlags.cpp
@@ -35,7 +35,7 @@ namespace
             return access_type_to_flags_mapping[static_cast<size_t>(type)];
         }
 
-        Flags keywordToFlags(const std::string_view & keyword) const
+        Flags keywordToFlags(std::string_view keyword) const
         {
             auto it = keyword_to_flags_map.find(keyword);
             if (it == keyword_to_flags_map.end())
@@ -142,14 +142,14 @@ namespace
             }
         };
 
-        static String replaceUnderscoreWithSpace(const std::string_view & str)
+        static String replaceUnderscoreWithSpace(std::string_view str)
         {
             String res{str};
             boost::replace_all(res, "_", " ");
             return res;
         }
 
-        static Strings splitAliases(const std::string_view & str)
+        static Strings splitAliases(std::string_view str)
         {
             Strings aliases;
             boost::split(aliases, str, boost::is_any_of(","));
@@ -160,10 +160,10 @@ namespace
 
         static void makeNode(
             AccessType access_type,
-            const std::string_view & name,
-            const std::string_view & aliases,
+            std::string_view name,
+            std::string_view aliases,
             NodeType node_type,
-            const std::string_view & parent_group_name,
+            std::string_view parent_group_name,
             std::unordered_map<std::string_view, Node *> & nodes,
             std::unordered_map<std::string_view, NodePtr> & owned_nodes,
             size_t & next_flag)
@@ -353,7 +353,7 @@ namespace
 
 
 AccessFlags::AccessFlags(AccessType type) : flags(Helper::instance().accessTypeToFlags(type)) {}
-AccessFlags::AccessFlags(const std::string_view & keyword) : flags(Helper::instance().keywordToFlags(keyword)) {}
+AccessFlags::AccessFlags(std::string_view keyword) : flags(Helper::instance().keywordToFlags(keyword)) {}
 AccessFlags::AccessFlags(const std::vector<std::string_view> & keywords) : flags(Helper::instance().keywordsToFlags(keywords)) {}
 AccessFlags::AccessFlags(const Strings & keywords) : flags(Helper::instance().keywordsToFlags(keywords)) {}
 String AccessFlags::toString() const { return Helper::instance().flagsToString(flags); }

--- a/src/Access/Common/AccessFlags.h
+++ b/src/Access/Common/AccessFlags.h
@@ -21,7 +21,7 @@ public:
     AccessFlags() = default;
 
     /// Constructs from a string like "SELECT".
-    AccessFlags(const std::string_view & keyword); /// NOLINT
+    AccessFlags(std::string_view keyword); /// NOLINT
 
     /// Constructs from a list of strings like "SELECT, UPDATE, INSERT".
     AccessFlags(const std::vector<std::string_view> & keywords); /// NOLINT

--- a/src/Access/Common/AccessRightsElement.cpp
+++ b/src/Access/Common/AccessRightsElement.cpp
@@ -81,7 +81,7 @@ namespace
         }
 
         bool need_comma = false;
-        for (const std::string_view & keyword : keywords)
+        for (std::string_view keyword : keywords)
         {
             if (need_comma)
                 result.append(", ");
@@ -145,18 +145,18 @@ namespace
 }
 
 
-AccessRightsElement::AccessRightsElement(AccessFlags access_flags_, const std::string_view & database_)
+AccessRightsElement::AccessRightsElement(AccessFlags access_flags_, std::string_view database_)
     : access_flags(access_flags_), database(database_), any_database(false)
 {
 }
 
-AccessRightsElement::AccessRightsElement(AccessFlags access_flags_, const std::string_view & database_, const std::string_view & table_)
+AccessRightsElement::AccessRightsElement(AccessFlags access_flags_, std::string_view database_, std::string_view table_)
     : access_flags(access_flags_), database(database_), table(table_), any_database(false), any_table(false)
 {
 }
 
 AccessRightsElement::AccessRightsElement(
-    AccessFlags access_flags_, const std::string_view & database_, const std::string_view & table_, const std::string_view & column_)
+    AccessFlags access_flags_, std::string_view database_, std::string_view table_, std::string_view column_)
     : access_flags(access_flags_)
     , database(database_)
     , table(table_)
@@ -169,8 +169,8 @@ AccessRightsElement::AccessRightsElement(
 
 AccessRightsElement::AccessRightsElement(
     AccessFlags access_flags_,
-    const std::string_view & database_,
-    const std::string_view & table_,
+    std::string_view database_,
+    std::string_view table_,
     const std::vector<std::string_view> & columns_)
     : access_flags(access_flags_), database(database_), table(table_), any_database(false), any_table(false), any_column(false)
 {
@@ -180,7 +180,7 @@ AccessRightsElement::AccessRightsElement(
 }
 
 AccessRightsElement::AccessRightsElement(
-    AccessFlags access_flags_, const std::string_view & database_, const std::string_view & table_, const Strings & columns_)
+    AccessFlags access_flags_, std::string_view database_, std::string_view table_, const Strings & columns_)
     : access_flags(access_flags_)
     , database(database_)
     , table(table_)

--- a/src/Access/Common/AccessRightsElement.h
+++ b/src/Access/Common/AccessRightsElement.h
@@ -28,19 +28,19 @@ struct AccessRightsElement
 
     explicit AccessRightsElement(AccessFlags access_flags_) : access_flags(access_flags_) {}
 
-    AccessRightsElement(AccessFlags access_flags_, const std::string_view & database_);
-    AccessRightsElement(AccessFlags access_flags_, const std::string_view & database_, const std::string_view & table_);
+    AccessRightsElement(AccessFlags access_flags_, std::string_view database_);
+    AccessRightsElement(AccessFlags access_flags_, std::string_view database_, std::string_view table_);
     AccessRightsElement(
-        AccessFlags access_flags_, const std::string_view & database_, const std::string_view & table_, const std::string_view & column_);
+        AccessFlags access_flags_, std::string_view database_, std::string_view table_, std::string_view column_);
 
     AccessRightsElement(
         AccessFlags access_flags_,
-        const std::string_view & database_,
-        const std::string_view & table_,
+        std::string_view database_,
+        std::string_view table_,
         const std::vector<std::string_view> & columns_);
 
     AccessRightsElement(
-        AccessFlags access_flags_, const std::string_view & database_, const std::string_view & table_, const Strings & columns_);
+        AccessFlags access_flags_, std::string_view database_, std::string_view table_, const Strings & columns_);
 
     bool empty() const { return !access_flags || (!any_column && columns.empty()); }
 

--- a/src/Access/Common/AccessType.cpp
+++ b/src/Access/Common/AccessType.cpp
@@ -35,7 +35,7 @@ namespace
 #undef ACCESS_TYPE_TO_STRING_CONVERTER_ADD_TO_MAPPING
         }
 
-        void addToMapping(AccessType type, const std::string_view & str)
+        void addToMapping(AccessType type, std::string_view str)
         {
             String str2{str};
             boost::replace_all(str2, "_", " ");

--- a/src/Access/Common/AuthenticationData.cpp
+++ b/src/Access/Common/AuthenticationData.cpp
@@ -71,7 +71,7 @@ const AuthenticationTypeInfo & AuthenticationTypeInfo::get(AuthenticationType ty
 }
 
 
-AuthenticationData::Digest AuthenticationData::Util::encodeSHA256(const std::string_view & text [[maybe_unused]])
+AuthenticationData::Digest AuthenticationData::Util::encodeSHA256(std::string_view text [[maybe_unused]])
 {
 #if USE_SSL
     Digest hash;
@@ -86,7 +86,7 @@ AuthenticationData::Digest AuthenticationData::Util::encodeSHA256(const std::str
 }
 
 
-AuthenticationData::Digest AuthenticationData::Util::encodeSHA1(const std::string_view & text)
+AuthenticationData::Digest AuthenticationData::Util::encodeSHA1(std::string_view text)
 {
     Poco::SHA1Engine engine;
     engine.update(text.data(), text.size());

--- a/src/Access/Common/AuthenticationData.h
+++ b/src/Access/Common/AuthenticationData.h
@@ -96,11 +96,11 @@ public:
 
     struct Util
     {
-        static Digest stringToDigest(const std::string_view & text) { return Digest(text.data(), text.data() + text.size()); }
-        static Digest encodeSHA256(const std::string_view & text);
-        static Digest encodeSHA1(const std::string_view & text);
+        static Digest stringToDigest(std::string_view text) { return Digest(text.data(), text.data() + text.size()); }
+        static Digest encodeSHA256(std::string_view text);
+        static Digest encodeSHA1(std::string_view text);
         static Digest encodeSHA1(const Digest & text) { return encodeSHA1(std::string_view{reinterpret_cast<const char *>(text.data()), text.size()}); }
-        static Digest encodeDoubleSHA1(const std::string_view & text) { return encodeSHA1(encodeSHA1(text)); }
+        static Digest encodeDoubleSHA1(std::string_view text) { return encodeSHA1(encodeSHA1(text)); }
         static Digest encodeDoubleSHA1(const Digest & text) { return encodeSHA1(encodeSHA1(text)); }
     };
 

--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -46,7 +46,7 @@ namespace
 
     AccessRights addImplicitAccessRights(const AccessRights & access)
     {
-        auto modifier = [&](const AccessFlags & flags, const AccessFlags & min_flags_with_children, const AccessFlags & max_flags_with_children, const std::string_view & database, const std::string_view & table, const std::string_view & column) -> AccessFlags
+        auto modifier = [&](const AccessFlags & flags, const AccessFlags & min_flags_with_children, const AccessFlags & max_flags_with_children, std::string_view database, std::string_view table, std::string_view column) -> AccessFlags
         {
             size_t level = !database.empty() + !table.empty() + !column.empty();
             AccessFlags res = flags;
@@ -141,7 +141,7 @@ namespace
     std::string_view getDatabase() { return {}; }
 
     template <typename... OtherArgs>
-    std::string_view getDatabase(const std::string_view & arg1, const OtherArgs &...) { return arg1; }
+    std::string_view getDatabase(std::string_view arg1, const OtherArgs &...) { return arg1; }
 }
 
 
@@ -519,7 +519,7 @@ bool ContextAccess::checkAccessImpl(const AccessFlags & flags) const
 }
 
 template <bool throw_if_denied, bool grant_option, typename... Args>
-bool ContextAccess::checkAccessImpl(const AccessFlags & flags, const std::string_view & database, const Args &... args) const
+bool ContextAccess::checkAccessImpl(const AccessFlags & flags, std::string_view database, const Args &... args) const
 {
     return checkAccessImplHelper<throw_if_denied, grant_option>(flags, database.empty() ? params.current_database : database, args...);
 }
@@ -564,38 +564,38 @@ bool ContextAccess::checkAccessImpl(const AccessRightsElements & elements) const
 }
 
 bool ContextAccess::isGranted(const AccessFlags & flags) const { return checkAccessImpl<false, false>(flags); }
-bool ContextAccess::isGranted(const AccessFlags & flags, const std::string_view & database) const { return checkAccessImpl<false, false>(flags, database); }
-bool ContextAccess::isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { return checkAccessImpl<false, false>(flags, database, table); }
-bool ContextAccess::isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const { return checkAccessImpl<false, false>(flags, database, table, column); }
-bool ContextAccess::isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const { return checkAccessImpl<false, false>(flags, database, table, columns); }
-bool ContextAccess::isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { return checkAccessImpl<false, false>(flags, database, table, columns); }
+bool ContextAccess::isGranted(const AccessFlags & flags, std::string_view database) const { return checkAccessImpl<false, false>(flags, database); }
+bool ContextAccess::isGranted(const AccessFlags & flags, std::string_view database, std::string_view table) const { return checkAccessImpl<false, false>(flags, database, table); }
+bool ContextAccess::isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const { return checkAccessImpl<false, false>(flags, database, table, column); }
+bool ContextAccess::isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const { return checkAccessImpl<false, false>(flags, database, table, columns); }
+bool ContextAccess::isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const { return checkAccessImpl<false, false>(flags, database, table, columns); }
 bool ContextAccess::isGranted(const AccessRightsElement & element) const { return checkAccessImpl<false, false>(element); }
 bool ContextAccess::isGranted(const AccessRightsElements & elements) const { return checkAccessImpl<false, false>(elements); }
 
 bool ContextAccess::hasGrantOption(const AccessFlags & flags) const { return checkAccessImpl<false, true>(flags); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database) const { return checkAccessImpl<false, true>(flags, database); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { return checkAccessImpl<false, true>(flags, database, table); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const { return checkAccessImpl<false, true>(flags, database, table, column); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const { return checkAccessImpl<false, true>(flags, database, table, columns); }
-bool ContextAccess::hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { return checkAccessImpl<false, true>(flags, database, table, columns); }
+bool ContextAccess::hasGrantOption(const AccessFlags & flags, std::string_view database) const { return checkAccessImpl<false, true>(flags, database); }
+bool ContextAccess::hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table) const { return checkAccessImpl<false, true>(flags, database, table); }
+bool ContextAccess::hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const { return checkAccessImpl<false, true>(flags, database, table, column); }
+bool ContextAccess::hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const { return checkAccessImpl<false, true>(flags, database, table, columns); }
+bool ContextAccess::hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const { return checkAccessImpl<false, true>(flags, database, table, columns); }
 bool ContextAccess::hasGrantOption(const AccessRightsElement & element) const { return checkAccessImpl<false, true>(element); }
 bool ContextAccess::hasGrantOption(const AccessRightsElements & elements) const { return checkAccessImpl<false, true>(elements); }
 
 void ContextAccess::checkAccess(const AccessFlags & flags) const { checkAccessImpl<true, false>(flags); }
-void ContextAccess::checkAccess(const AccessFlags & flags, const std::string_view & database) const { checkAccessImpl<true, false>(flags, database); }
-void ContextAccess::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { checkAccessImpl<true, false>(flags, database, table); }
-void ContextAccess::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const { checkAccessImpl<true, false>(flags, database, table, column); }
-void ContextAccess::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const { checkAccessImpl<true, false>(flags, database, table, columns); }
-void ContextAccess::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { checkAccessImpl<true, false>(flags, database, table, columns); }
+void ContextAccess::checkAccess(const AccessFlags & flags, std::string_view database) const { checkAccessImpl<true, false>(flags, database); }
+void ContextAccess::checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table) const { checkAccessImpl<true, false>(flags, database, table); }
+void ContextAccess::checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const { checkAccessImpl<true, false>(flags, database, table, column); }
+void ContextAccess::checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const { checkAccessImpl<true, false>(flags, database, table, columns); }
+void ContextAccess::checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const { checkAccessImpl<true, false>(flags, database, table, columns); }
 void ContextAccess::checkAccess(const AccessRightsElement & element) const { checkAccessImpl<true, false>(element); }
 void ContextAccess::checkAccess(const AccessRightsElements & elements) const { checkAccessImpl<true, false>(elements); }
 
 void ContextAccess::checkGrantOption(const AccessFlags & flags) const { checkAccessImpl<true, true>(flags); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database) const { checkAccessImpl<true, true>(flags, database); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { checkAccessImpl<true, true>(flags, database, table); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const { checkAccessImpl<true, true>(flags, database, table, column); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const { checkAccessImpl<true, true>(flags, database, table, columns); }
-void ContextAccess::checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { checkAccessImpl<true, true>(flags, database, table, columns); }
+void ContextAccess::checkGrantOption(const AccessFlags & flags, std::string_view database) const { checkAccessImpl<true, true>(flags, database); }
+void ContextAccess::checkGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table) const { checkAccessImpl<true, true>(flags, database, table); }
+void ContextAccess::checkGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const { checkAccessImpl<true, true>(flags, database, table, column); }
+void ContextAccess::checkGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const { checkAccessImpl<true, true>(flags, database, table, columns); }
+void ContextAccess::checkGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const { checkAccessImpl<true, true>(flags, database, table, columns); }
 void ContextAccess::checkGrantOption(const AccessRightsElement & element) const { checkAccessImpl<true, true>(element); }
 void ContextAccess::checkGrantOption(const AccessRightsElements & elements) const { checkAccessImpl<true, true>(elements); }
 

--- a/src/Access/ContextAccess.h
+++ b/src/Access/ContextAccess.h
@@ -101,40 +101,40 @@ public:
     /// Checks if a specified access is granted, and throws an exception if not.
     /// Empty database means the current database.
     void checkAccess(const AccessFlags & flags) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const;
     void checkAccess(const AccessRightsElement & element) const;
     void checkAccess(const AccessRightsElements & elements) const;
 
     void checkGrantOption(const AccessFlags & flags) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    void checkGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
+    void checkGrantOption(const AccessFlags & flags, std::string_view database) const;
+    void checkGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table) const;
+    void checkGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const;
+    void checkGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const;
+    void checkGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const;
     void checkGrantOption(const AccessRightsElement & element) const;
     void checkGrantOption(const AccessRightsElements & elements) const;
 
     /// Checks if a specified access is granted, and returns false if not.
     /// Empty database means the current database.
     bool isGranted(const AccessFlags & flags) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    bool isGranted(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database, std::string_view table) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const;
+    bool isGranted(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const;
     bool isGranted(const AccessRightsElement & element) const;
     bool isGranted(const AccessRightsElements & elements) const;
 
     bool hasGrantOption(const AccessFlags & flags) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    bool hasGrantOption(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const;
+    bool hasGrantOption(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const;
     bool hasGrantOption(const AccessRightsElement & element) const;
     bool hasGrantOption(const AccessRightsElements & elements) const;
 
@@ -180,7 +180,7 @@ private:
     bool checkAccessImpl(const AccessFlags & flags) const;
 
     template <bool throw_if_denied, bool grant_option, typename... Args>
-    bool checkAccessImpl(const AccessFlags & flags, const std::string_view & database, const Args &... args) const;
+    bool checkAccessImpl(const AccessFlags & flags, std::string_view database, const Args &... args) const;
 
     template <bool throw_if_denied, bool grant_option>
     bool checkAccessImpl(const AccessRightsElement & element) const;

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -36,12 +36,12 @@ void SettingsConstraints::clear()
 }
 
 
-void SettingsConstraints::setMinValue(const std::string_view & setting_name, const Field & min_value)
+void SettingsConstraints::setMinValue(std::string_view setting_name, const Field & min_value)
 {
     getConstraintRef(setting_name).min_value = Settings::castValueUtil(setting_name, min_value);
 }
 
-Field SettingsConstraints::getMinValue(const std::string_view & setting_name) const
+Field SettingsConstraints::getMinValue(std::string_view setting_name) const
 {
     const auto * ptr = tryGetConstraint(setting_name);
     if (ptr)
@@ -51,12 +51,12 @@ Field SettingsConstraints::getMinValue(const std::string_view & setting_name) co
 }
 
 
-void SettingsConstraints::setMaxValue(const std::string_view & setting_name, const Field & max_value)
+void SettingsConstraints::setMaxValue(std::string_view setting_name, const Field & max_value)
 {
     getConstraintRef(setting_name).max_value = Settings::castValueUtil(setting_name, max_value);
 }
 
-Field SettingsConstraints::getMaxValue(const std::string_view & setting_name) const
+Field SettingsConstraints::getMaxValue(std::string_view setting_name) const
 {
     const auto * ptr = tryGetConstraint(setting_name);
     if (ptr)
@@ -66,12 +66,12 @@ Field SettingsConstraints::getMaxValue(const std::string_view & setting_name) co
 }
 
 
-void SettingsConstraints::setReadOnly(const std::string_view & setting_name, bool read_only)
+void SettingsConstraints::setReadOnly(std::string_view setting_name, bool read_only)
 {
     getConstraintRef(setting_name).read_only = read_only;
 }
 
-bool SettingsConstraints::isReadOnly(const std::string_view & setting_name) const
+bool SettingsConstraints::isReadOnly(std::string_view setting_name) const
 {
     const auto * ptr = tryGetConstraint(setting_name);
     if (ptr)
@@ -81,7 +81,7 @@ bool SettingsConstraints::isReadOnly(const std::string_view & setting_name) cons
 }
 
 
-void SettingsConstraints::set(const std::string_view & setting_name, const Field & min_value, const Field & max_value, bool read_only)
+void SettingsConstraints::set(std::string_view setting_name, const Field & min_value, const Field & max_value, bool read_only)
 {
     auto & ref = getConstraintRef(setting_name);
     ref.min_value = Settings::castValueUtil(setting_name, min_value);
@@ -89,7 +89,7 @@ void SettingsConstraints::set(const std::string_view & setting_name, const Field
     ref.read_only = read_only;
 }
 
-void SettingsConstraints::get(const std::string_view & setting_name, Field & min_value, Field & max_value, bool & read_only) const
+void SettingsConstraints::get(std::string_view setting_name, Field & min_value, Field & max_value, bool & read_only) const
 {
     const auto * ptr = tryGetConstraint(setting_name);
     if (ptr)
@@ -318,7 +318,7 @@ bool SettingsConstraints::checkImpl(const Settings & current_settings, SettingCh
 }
 
 
-SettingsConstraints::Constraint & SettingsConstraints::getConstraintRef(const std::string_view & setting_name)
+SettingsConstraints::Constraint & SettingsConstraints::getConstraintRef(std::string_view setting_name)
 {
     auto it = constraints.find(setting_name);
     if (it == constraints.end())
@@ -331,7 +331,7 @@ SettingsConstraints::Constraint & SettingsConstraints::getConstraintRef(const st
     return it->second;
 }
 
-const SettingsConstraints::Constraint * SettingsConstraints::tryGetConstraint(const std::string_view & setting_name) const
+const SettingsConstraints::Constraint * SettingsConstraints::tryGetConstraint(std::string_view setting_name) const
 {
     auto it = constraints.find(setting_name);
     if (it == constraints.end())

--- a/src/Access/SettingsConstraints.h
+++ b/src/Access/SettingsConstraints.h
@@ -61,17 +61,17 @@ public:
     void clear();
     bool empty() const { return constraints.empty(); }
 
-    void setMinValue(const std::string_view & setting_name, const Field & min_value);
-    Field getMinValue(const std::string_view & setting_name) const;
+    void setMinValue(std::string_view setting_name, const Field & min_value);
+    Field getMinValue(std::string_view setting_name) const;
 
-    void setMaxValue(const std::string_view & setting_name, const Field & max_value);
-    Field getMaxValue(const std::string_view & setting_name) const;
+    void setMaxValue(std::string_view setting_name, const Field & max_value);
+    Field getMaxValue(std::string_view setting_name) const;
 
-    void setReadOnly(const std::string_view & setting_name, bool read_only);
-    bool isReadOnly(const std::string_view & setting_name) const;
+    void setReadOnly(std::string_view setting_name, bool read_only);
+    bool isReadOnly(std::string_view setting_name) const;
 
-    void set(const std::string_view & setting_name, const Field & min_value, const Field & max_value, bool read_only);
-    void get(const std::string_view & setting_name, Field & min_value, Field & max_value, bool & read_only) const;
+    void set(std::string_view setting_name, const Field & min_value, const Field & max_value, bool read_only);
+    void get(std::string_view setting_name, Field & min_value, Field & max_value, bool & read_only) const;
 
     void merge(const SettingsConstraints & other);
 
@@ -105,8 +105,8 @@ private:
     };
     bool checkImpl(const Settings & current_settings, SettingChange & change, ReactionOnViolation reaction) const;
 
-    Constraint & getConstraintRef(const std::string_view & setting_name);
-    const Constraint * tryGetConstraint(const std::string_view & setting_name) const;
+    Constraint & getConstraintRef(std::string_view setting_name);
+    const Constraint * tryGetConstraint(std::string_view setting_name) const;
 
     std::unordered_map<std::string_view, Constraint> constraints;
     const AccessControl * access_control = nullptr;

--- a/src/Common/JSONParsers/DummyJSONParser.h
+++ b/src/Common/JSONParsers/DummyJSONParser.h
@@ -84,7 +84,7 @@ struct DummyJSONParser
         static Iterator begin() { return {}; }
         static Iterator end() { return {}; }
         static size_t size() { return 0; }
-        bool find(const std::string_view &, Element &) const { return false; } /// NOLINT
+        bool find(std::string_view, Element &) const { return false; } /// NOLINT
 
 #if 0
         /// Optional: Provides access to an object's element by index.
@@ -93,7 +93,7 @@ struct DummyJSONParser
     };
 
     /// Parses a JSON document, returns the reference to its root element if succeeded.
-    bool parse(const std::string_view &, Element &) { throw Exception{"Functions JSON* are not supported", ErrorCodes::NOT_IMPLEMENTED}; } /// NOLINT
+    bool parse(std::string_view, Element &) { throw Exception{"Functions JSON* are not supported", ErrorCodes::NOT_IMPLEMENTED}; } /// NOLINT
 
 #if 0
     /// Optional: Allocates memory to parse JSON documents faster.

--- a/src/Common/JSONParsers/RapidJSONParser.h
+++ b/src/Common/JSONParsers/RapidJSONParser.h
@@ -98,7 +98,7 @@ struct RapidJSONParser
         ALWAYS_INLINE Iterator end() const { return ptr->MemberEnd(); }
         ALWAYS_INLINE size_t size() const { return ptr->MemberCount(); }
 
-        bool find(const std::string_view & key, Element & result) const
+        bool find(std::string_view key, Element & result) const
         {
             auto it = ptr->FindMember(rapidjson::StringRef(key.data(), key.length()));
             if (it == ptr->MemberEnd())
@@ -122,7 +122,7 @@ struct RapidJSONParser
     };
 
     /// Parses a JSON document, returns the reference to its root element if succeeded.
-    bool parse(const std::string_view & json, Element & result)
+    bool parse(std::string_view json, Element & result)
     {
         rapidjson::MemoryStream ms(json.data(), json.size());
         rapidjson::EncodedInputStream<rapidjson::UTF8<>, rapidjson::MemoryStream> is(ms);

--- a/src/Common/JSONParsers/SimdJSONParser.h
+++ b/src/Common/JSONParsers/SimdJSONParser.h
@@ -105,7 +105,7 @@ struct SimdJSONParser
         ALWAYS_INLINE Iterator end() const { return object.end(); }
         ALWAYS_INLINE size_t size() const { return object.size(); }
 
-        bool find(const std::string_view & key, Element & result) const
+        bool find(std::string_view key, Element & result) const
         {
             auto x = object.at_key(key);
             if (x.error())
@@ -131,7 +131,7 @@ struct SimdJSONParser
     };
 
     /// Parses a JSON document, returns the reference to its root element if succeeded.
-    bool parse(const std::string_view & json, Element & result)
+    bool parse(std::string_view json, Element & result)
     {
         auto document = parser.parse(json.data(), json.size());
         if (document.error())

--- a/src/Common/OpenSSLHelpers.cpp
+++ b/src/Common/OpenSSLHelpers.cpp
@@ -10,7 +10,7 @@ namespace DB
 {
 #pragma GCC diagnostic warning "-Wold-style-cast"
 
-std::string encodeSHA256(const std::string_view & text)
+std::string encodeSHA256(std::string_view text)
 {
     return encodeSHA256(text.data(), text.size());
 }
@@ -21,7 +21,7 @@ std::string encodeSHA256(const void * text, size_t size)
     encodeSHA256(text, size, reinterpret_cast<unsigned char *>(out.data()));
     return out;
 }
-void encodeSHA256(const std::string_view & text, unsigned char * out)
+void encodeSHA256(std::string_view text, unsigned char * out)
 {
     encodeSHA256(text.data(), text.size(), out);
 }

--- a/src/Common/OpenSSLHelpers.h
+++ b/src/Common/OpenSSLHelpers.h
@@ -10,10 +10,10 @@ namespace DB
 {
 
 /// Encodes `text` and returns it.
-std::string encodeSHA256(const std::string_view & text);
+std::string encodeSHA256(std::string_view text);
 std::string encodeSHA256(const void * text, size_t size);
 /// `out` must be at least 32 bytes long.
-void encodeSHA256(const std::string_view & text, unsigned char * out);
+void encodeSHA256(std::string_view text, unsigned char * out);
 void encodeSHA256(const void * text, size_t size, unsigned char * out);
 
 /// Returns concatenation of error strings for all errors that OpenSSL has recorded, emptying the error queue.

--- a/src/Common/SettingsChanges.cpp
+++ b/src/Common/SettingsChanges.cpp
@@ -4,7 +4,7 @@ namespace DB
 {
 namespace
 {
-    SettingChange * find(SettingsChanges & changes, const std::string_view & name)
+    SettingChange * find(SettingsChanges & changes, std::string_view name)
     {
         auto it = std::find_if(changes.begin(), changes.end(), [&name](const SettingChange & change) { return change.name == name; });
         if (it == changes.end())
@@ -12,7 +12,7 @@ namespace
         return &*it;
     }
 
-    const SettingChange * find(const SettingsChanges & changes, const std::string_view & name)
+    const SettingChange * find(const SettingsChanges & changes, std::string_view name)
     {
         auto it = std::find_if(changes.begin(), changes.end(), [&name](const SettingChange & change) { return change.name == name; });
         if (it == changes.end())
@@ -21,7 +21,7 @@ namespace
     }
 }
 
-bool SettingsChanges::tryGet(const std::string_view & name, Field & out_value) const
+bool SettingsChanges::tryGet(std::string_view name, Field & out_value) const
 {
     const auto * change = find(*this, name);
     if (!change)
@@ -30,7 +30,7 @@ bool SettingsChanges::tryGet(const std::string_view & name, Field & out_value) c
     return true;
 }
 
-const Field * SettingsChanges::tryGet(const std::string_view & name) const
+const Field * SettingsChanges::tryGet(std::string_view name) const
 {
     const auto * change = find(*this, name);
     if (!change)
@@ -38,7 +38,7 @@ const Field * SettingsChanges::tryGet(const std::string_view & name) const
     return &change->value;
 }
 
-Field * SettingsChanges::tryGet(const std::string_view & name)
+Field * SettingsChanges::tryGet(std::string_view name)
 {
     auto * change = find(*this, name);
     if (!change)

--- a/src/Common/SettingsChanges.h
+++ b/src/Common/SettingsChanges.h
@@ -14,8 +14,8 @@ struct SettingChange
     Field value;
 
     SettingChange() = default;
-    SettingChange(const std::string_view & name_, const Field & value_) : name(name_), value(value_) {}
-    SettingChange(const std::string_view & name_, Field && value_) : name(name_), value(std::move(value_)) {}
+    SettingChange(std::string_view name_, const Field & value_) : name(name_), value(value_) {}
+    SettingChange(std::string_view name_, Field && value_) : name(name_), value(std::move(value_)) {}
 
     friend bool operator ==(const SettingChange & lhs, const SettingChange & rhs) { return (lhs.name == rhs.name) && (lhs.value == rhs.value); }
     friend bool operator !=(const SettingChange & lhs, const SettingChange & rhs) { return !(lhs == rhs); }
@@ -27,9 +27,9 @@ class SettingsChanges : public std::vector<SettingChange>
 public:
     using std::vector<SettingChange>::vector;
 
-    bool tryGet(const std::string_view & name, Field & out_value) const;
-    const Field * tryGet(const std::string_view & name) const;
-    Field * tryGet(const std::string_view & name);
+    bool tryGet(std::string_view name, Field & out_value) const;
+    const Field * tryGet(std::string_view name) const;
+    Field * tryGet(std::string_view name);
 };
 
 }

--- a/src/Common/StringUtils/StringUtils.h
+++ b/src/Common/StringUtils/StringUtils.h
@@ -147,7 +147,7 @@ inline bool isPunctuationASCII(char c)
 }
 
 
-inline bool isValidIdentifier(const std::string_view & str)
+inline bool isValidIdentifier(std::string_view str)
 {
     return !str.empty()
         && isValidIdentifierBegin(str[0])

--- a/src/Compression/CompressionCodecEncrypted.cpp
+++ b/src/Compression/CompressionCodecEncrypted.cpp
@@ -131,7 +131,7 @@ std::string lastErrorString()
 /// This function get key and nonce and encrypt text with their help.
 /// If something went wrong (can't init context or can't encrypt data) it throws exception.
 /// It returns length of encrypted text.
-size_t encrypt(const std::string_view & plaintext, char * ciphertext_and_tag, EncryptionMethod method, const String & key, const String & nonce)
+size_t encrypt(std::string_view plaintext, char * ciphertext_and_tag, EncryptionMethod method, const String & key, const String & nonce)
 {
     /// Init context for encryption, using key.
     EVP_AEAD_CTX encrypt_ctx;
@@ -160,7 +160,7 @@ size_t encrypt(const std::string_view & plaintext, char * ciphertext_and_tag, En
 /// This function get key and nonce and encrypt text with their help.
 /// If something went wrong (can't init context or can't encrypt data) it throws exception.
 /// It returns length of encrypted text.
-size_t decrypt(const std::string_view & ciphertext, char * plaintext, EncryptionMethod method, const String & key, const String & nonce)
+size_t decrypt(std::string_view ciphertext, char * plaintext, EncryptionMethod method, const String & key, const String & nonce)
 {
     /// Init context for decryption with given key.
     EVP_AEAD_CTX decrypt_ctx;

--- a/src/Core/BaseSettings.cpp
+++ b/src/Core/BaseSettings.cpp
@@ -11,7 +11,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_SETTING;
 }
 
-void BaseSettingsHelpers::writeString(const std::string_view & str, WriteBuffer & out)
+void BaseSettingsHelpers::writeString(std::string_view str, WriteBuffer & out)
 {
     writeStringBinary(str, out);
 }
@@ -39,13 +39,13 @@ BaseSettingsHelpers::Flags BaseSettingsHelpers::readFlags(ReadBuffer & in)
 }
 
 
-void BaseSettingsHelpers::throwSettingNotFound(const std::string_view & name)
+void BaseSettingsHelpers::throwSettingNotFound(std::string_view name)
 {
     throw Exception("Unknown setting " + String{name}, ErrorCodes::UNKNOWN_SETTING);
 }
 
 
-void BaseSettingsHelpers::warningSettingNotFound(const std::string_view & name)
+void BaseSettingsHelpers::warningSettingNotFound(std::string_view name)
 {
     static auto * log = &Poco::Logger::get("Settings");
     LOG_WARNING(log, "Unknown setting {}, skipping", name);

--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -45,16 +45,16 @@ class BaseSettings : public TTraits::Data
 public:
     using Traits = TTraits;
 
-    void set(const std::string_view & name, const Field & value);
-    Field get(const std::string_view & name) const;
+    void set(std::string_view name, const Field & value);
+    Field get(std::string_view name) const;
 
-    void setString(const std::string_view & name, const String & value);
-    String getString(const std::string_view & name) const;
+    void setString(std::string_view name, const String & value);
+    String getString(std::string_view name) const;
 
-    bool tryGet(const std::string_view & name, Field & value) const;
-    bool tryGetString(const std::string_view & name, String & value) const;
+    bool tryGet(std::string_view name, Field & value) const;
+    bool tryGetString(std::string_view name, String & value) const;
 
-    bool isChanged(const std::string_view & name) const;
+    bool isChanged(std::string_view name) const;
     SettingsChanges changes() const;
     void applyChange(const SettingChange & change);
     void applyChanges(const SettingsChanges & changes);
@@ -63,22 +63,22 @@ public:
     /// Resets all the settings to their default values.
     void resetToDefault();
 
-    bool has(const std::string_view & name) const { return hasBuiltin(name) || hasCustom(name); }
-    static bool hasBuiltin(const std::string_view & name);
-    bool hasCustom(const std::string_view & name) const;
+    bool has(std::string_view name) const { return hasBuiltin(name) || hasCustom(name); }
+    static bool hasBuiltin(std::string_view name);
+    bool hasCustom(std::string_view name) const;
 
-    const char * getTypeName(const std::string_view & name) const;
-    const char * getDescription(const std::string_view & name) const;
+    const char * getTypeName(std::string_view name) const;
+    const char * getDescription(std::string_view name) const;
 
     /// Checks if it's possible to assign a field to a specified value and throws an exception if not.
     /// This function doesn't change the fields, it performs check only.
-    static void checkCanSet(const std::string_view & name, const Field & value);
-    static void checkCanSetString(const std::string_view & name, const String & str);
+    static void checkCanSet(std::string_view name, const Field & value);
+    static void checkCanSetString(std::string_view name, const String & str);
 
     /// Conversions without changing the fields.
-    static Field castValueUtil(const std::string_view & name, const Field & value);
-    static String valueToStringUtil(const std::string_view & name, const Field & value);
-    static Field stringToValueUtil(const std::string_view & name, const String & str);
+    static Field castValueUtil(std::string_view name, const Field & value);
+    static String valueToStringUtil(std::string_view name, const Field & value);
+    static Field stringToValueUtil(std::string_view name, const String & str);
 
     void write(WriteBuffer & out, SettingsWriteFormat format = SettingsWriteFormat::DEFAULT) const;
     void read(ReadBuffer & in, SettingsWriteFormat format = SettingsWriteFormat::DEFAULT);
@@ -164,19 +164,19 @@ public:
     Iterator end() const { return allChanged().end(); }
 
 private:
-    SettingFieldCustom & getCustomSetting(const std::string_view & name);
-    const SettingFieldCustom & getCustomSetting(const std::string_view & name) const;
-    const SettingFieldCustom * tryGetCustomSetting(const std::string_view & name) const;
+    SettingFieldCustom & getCustomSetting(std::string_view name);
+    const SettingFieldCustom & getCustomSetting(std::string_view name) const;
+    const SettingFieldCustom * tryGetCustomSetting(std::string_view name) const;
 
     std::conditional_t<Traits::allow_custom_settings, CustomSettingMap, boost::blank> custom_settings_map;
 };
 
 struct BaseSettingsHelpers
 {
-    [[noreturn]] static void throwSettingNotFound(const std::string_view & name);
-    static void warningSettingNotFound(const std::string_view & name);
+    [[noreturn]] static void throwSettingNotFound(std::string_view name);
+    static void warningSettingNotFound(std::string_view name);
 
-    static void writeString(const std::string_view & str, WriteBuffer & out);
+    static void writeString(std::string_view str, WriteBuffer & out);
     static String readString(ReadBuffer & in);
 
     enum Flags : UInt64
@@ -190,7 +190,7 @@ struct BaseSettingsHelpers
 };
 
 template <typename TTraits>
-void BaseSettings<TTraits>::set(const std::string_view & name, const Field & value)
+void BaseSettings<TTraits>::set(std::string_view name, const Field & value)
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -200,7 +200,7 @@ void BaseSettings<TTraits>::set(const std::string_view & name, const Field & val
 }
 
 template <typename TTraits>
-Field BaseSettings<TTraits>::get(const std::string_view & name) const
+Field BaseSettings<TTraits>::get(std::string_view name) const
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -210,7 +210,7 @@ Field BaseSettings<TTraits>::get(const std::string_view & name) const
 }
 
 template <typename TTraits>
-void BaseSettings<TTraits>::setString(const std::string_view & name, const String & value)
+void BaseSettings<TTraits>::setString(std::string_view name, const String & value)
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -220,7 +220,7 @@ void BaseSettings<TTraits>::setString(const std::string_view & name, const Strin
 }
 
 template <typename TTraits>
-String BaseSettings<TTraits>::getString(const std::string_view & name) const
+String BaseSettings<TTraits>::getString(std::string_view name) const
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -230,7 +230,7 @@ String BaseSettings<TTraits>::getString(const std::string_view & name) const
 }
 
 template <typename TTraits>
-bool BaseSettings<TTraits>::tryGet(const std::string_view & name, Field & value) const
+bool BaseSettings<TTraits>::tryGet(std::string_view name, Field & value) const
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -247,7 +247,7 @@ bool BaseSettings<TTraits>::tryGet(const std::string_view & name, Field & value)
 }
 
 template <typename TTraits>
-bool BaseSettings<TTraits>::tryGetString(const std::string_view & name, String & value) const
+bool BaseSettings<TTraits>::tryGetString(std::string_view name, String & value) const
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -264,7 +264,7 @@ bool BaseSettings<TTraits>::tryGetString(const std::string_view & name, String &
 }
 
 template <typename TTraits>
-bool BaseSettings<TTraits>::isChanged(const std::string_view & name) const
+bool BaseSettings<TTraits>::isChanged(std::string_view name) const
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -316,20 +316,20 @@ void BaseSettings<TTraits>::resetToDefault()
 }
 
 template <typename TTraits>
-bool BaseSettings<TTraits>::hasBuiltin(const std::string_view & name)
+bool BaseSettings<TTraits>::hasBuiltin(std::string_view name)
 {
     const auto & accessor = Traits::Accessor::instance();
     return (accessor.find(name) != static_cast<size_t>(-1));
 }
 
 template <typename TTraits>
-bool BaseSettings<TTraits>::hasCustom(const std::string_view & name) const
+bool BaseSettings<TTraits>::hasCustom(std::string_view name) const
 {
     return tryGetCustomSetting(name);
 }
 
 template <typename TTraits>
-const char * BaseSettings<TTraits>::getTypeName(const std::string_view & name) const
+const char * BaseSettings<TTraits>::getTypeName(std::string_view name) const
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -341,7 +341,7 @@ const char * BaseSettings<TTraits>::getTypeName(const std::string_view & name) c
 }
 
 template <typename TTraits>
-const char * BaseSettings<TTraits>::getDescription(const std::string_view & name) const
+const char * BaseSettings<TTraits>::getDescription(std::string_view name) const
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -353,19 +353,19 @@ const char * BaseSettings<TTraits>::getDescription(const std::string_view & name
 }
 
 template <typename TTraits>
-void BaseSettings<TTraits>::checkCanSet(const std::string_view & name, const Field & value)
+void BaseSettings<TTraits>::checkCanSet(std::string_view name, const Field & value)
 {
     castValueUtil(name, value);
 }
 
 template <typename TTraits>
-void BaseSettings<TTraits>::checkCanSetString(const std::string_view & name, const String & str)
+void BaseSettings<TTraits>::checkCanSetString(std::string_view name, const String & str)
 {
     stringToValueUtil(name, str);
 }
 
 template <typename TTraits>
-Field BaseSettings<TTraits>::castValueUtil(const std::string_view & name, const Field & value)
+Field BaseSettings<TTraits>::castValueUtil(std::string_view name, const Field & value)
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -377,7 +377,7 @@ Field BaseSettings<TTraits>::castValueUtil(const std::string_view & name, const 
 }
 
 template <typename TTraits>
-String BaseSettings<TTraits>::valueToStringUtil(const std::string_view & name, const Field & value)
+String BaseSettings<TTraits>::valueToStringUtil(std::string_view name, const Field & value)
 {
     const auto & accessor = Traits::Accessor::instance();
     if (size_t index = accessor.find(name); index != static_cast<size_t>(-1))
@@ -389,7 +389,7 @@ String BaseSettings<TTraits>::valueToStringUtil(const std::string_view & name, c
 }
 
 template <typename TTraits>
-Field BaseSettings<TTraits>::stringToValueUtil(const std::string_view & name, const String & str)
+Field BaseSettings<TTraits>::stringToValueUtil(std::string_view name, const String & str)
 {
     try
     {
@@ -521,7 +521,7 @@ bool operator!=(const BaseSettings<TTraits> & left, const BaseSettings<TTraits> 
 }
 
 template <typename TTraits>
-SettingFieldCustom & BaseSettings<TTraits>::getCustomSetting(const std::string_view & name)
+SettingFieldCustom & BaseSettings<TTraits>::getCustomSetting(std::string_view name)
 {
     if constexpr (Traits::allow_custom_settings)
     {
@@ -537,7 +537,7 @@ SettingFieldCustom & BaseSettings<TTraits>::getCustomSetting(const std::string_v
 }
 
 template <typename TTraits>
-const SettingFieldCustom & BaseSettings<TTraits>::getCustomSetting(const std::string_view & name) const
+const SettingFieldCustom & BaseSettings<TTraits>::getCustomSetting(std::string_view name) const
 {
     if constexpr (Traits::allow_custom_settings)
     {
@@ -549,7 +549,7 @@ const SettingFieldCustom & BaseSettings<TTraits>::getCustomSetting(const std::st
 }
 
 template <typename TTraits>
-const SettingFieldCustom * BaseSettings<TTraits>::tryGetCustomSetting(const std::string_view & name) const
+const SettingFieldCustom * BaseSettings<TTraits>::tryGetCustomSetting(std::string_view name) const
 {
     if constexpr (Traits::allow_custom_settings)
     {
@@ -780,7 +780,7 @@ bool BaseSettings<TTraits>::SettingFieldRef::isObsolete() const
         public: \
             static const Accessor & instance(); \
             size_t size() const { return field_infos.size(); } \
-            size_t find(const std::string_view & name) const; \
+            size_t find(std::string_view name) const; \
             const String & getName(size_t index) const { return field_infos[index].name; } \
             const char * getTypeName(size_t index) const { return field_infos[index].type; } \
             const char * getDescription(size_t index) const { return field_infos[index].description; } \
@@ -851,7 +851,7 @@ bool BaseSettings<TTraits>::SettingFieldRef::isObsolete() const
     \
     SETTINGS_TRAITS_NAME::Accessor::Accessor() {} \
     \
-    size_t SETTINGS_TRAITS_NAME::Accessor::find(const std::string_view & name) const \
+    size_t SETTINGS_TRAITS_NAME::Accessor::find(std::string_view name) const \
     { \
         auto it = name_to_index_map.find(name); \
         if (it != name_to_index_map.end()) \

--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -286,7 +286,7 @@ String Field::dump() const
     return applyVisitor(FieldVisitorDump(), *this);
 }
 
-Field Field::restoreFromDump(const std::string_view & dump_)
+Field Field::restoreFromDump(std::string_view dump_)
 {
     auto show_error = [&dump_]
     {

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -346,7 +346,7 @@ public:
     }
 
     /// Create a string inplace.
-    Field(const std::string_view & str) { create(str.data(), str.size()); } /// NOLINT
+    Field(std::string_view str) { create(str.data(), str.size()); } /// NOLINT
     Field(const String & str) { create(std::string_view{str}); } /// NOLINT
     Field(String && str) { create(std::move(str)); } /// NOLINT
     Field(const char * str) { create(std::string_view{str}); } /// NOLINT
@@ -403,7 +403,7 @@ public:
         return *this;
     }
 
-    Field & operator= (const std::string_view & str);
+    Field & operator= (std::string_view str);
     Field & operator= (const String & str) { return *this = std::string_view{str}; }
     Field & operator= (String && str);
     Field & operator= (const char * str) { return *this = std::string_view{str}; }
@@ -631,7 +631,7 @@ public:
     }
 
     String dump() const;
-    static Field restoreFromDump(const std::string_view & dump_);
+    static Field restoreFromDump(std::string_view dump_);
 
 private:
     std::aligned_union_t<DBMS_MIN_FIELD_SIZE - sizeof(Types::Which),
@@ -929,7 +929,7 @@ Field::operator=(T && rhs)
     return *this;
 }
 
-inline Field & Field::operator=(const std::string_view & str)
+inline Field & Field::operator=(std::string_view str)
 {
     if (which != Types::String)
     {

--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -350,7 +350,7 @@ void SettingFieldURI::readBinary(ReadBuffer & in)
 }
 
 
-void SettingFieldEnumHelpers::writeBinary(const std::string_view & str, WriteBuffer & out)
+void SettingFieldEnumHelpers::writeBinary(std::string_view str, WriteBuffer & out)
 {
     writeStringBinary(str, out);
 }

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -146,13 +146,13 @@ struct SettingFieldString
     String value;
     bool changed = false;
 
-    explicit SettingFieldString(const std::string_view & str = {}) : value(str) {}
+    explicit SettingFieldString(std::string_view str = {}) : value(str) {}
     explicit SettingFieldString(const String & str) : SettingFieldString(std::string_view{str}) {}
     explicit SettingFieldString(String && str) : value(std::move(str)) {}
     explicit SettingFieldString(const char * str) : SettingFieldString(std::string_view{str}) {}
     explicit SettingFieldString(const Field & f) : SettingFieldString(f.safeGet<const String &>()) {}
 
-    SettingFieldString & operator =(const std::string_view & str) { value = str; changed = true; return *this; }
+    SettingFieldString & operator =(std::string_view str) { value = str; changed = true; return *this; }
     SettingFieldString & operator =(const String & str) { *this = std::string_view{str}; return *this; }
     SettingFieldString & operator =(String && str) { value = std::move(str); changed = true; return *this; }
     SettingFieldString & operator =(const char * str) { *this = std::string_view{str}; return *this; }
@@ -256,7 +256,7 @@ struct SettingFieldEnum
 
 struct SettingFieldEnumHelpers
 {
-    static void writeBinary(const std::string_view & str, WriteBuffer & out);
+    static void writeBinary(std::string_view str, WriteBuffer & out);
     static String readBinary(ReadBuffer & in);
 };
 
@@ -286,7 +286,7 @@ void SettingFieldEnum<EnumT, Traits>::readBinary(ReadBuffer & in)
     { \
         using EnumType = ENUM_TYPE; \
         static const String & toString(EnumType value); \
-        static EnumType fromString(const std::string_view & str); \
+        static EnumType fromString(std::string_view str); \
     }; \
     \
     using SettingField##NEW_NAME = SettingFieldEnum<ENUM_TYPE, SettingField##NEW_NAME##Traits>;
@@ -310,7 +310,7 @@ void SettingFieldEnum<EnumT, Traits>::readBinary(ReadBuffer & in)
             ERROR_CODE_FOR_UNEXPECTED_NAME); \
     } \
     \
-    typename SettingField##NEW_NAME::EnumType SettingField##NEW_NAME##Traits::fromString(const std::string_view & str) \
+    typename SettingField##NEW_NAME::EnumType SettingField##NEW_NAME##Traits::fromString(std::string_view str) \
     { \
         static const std::unordered_map<std::string_view, EnumType> map = [] { \
             std::unordered_map<std::string_view, EnumType> res; \
@@ -430,7 +430,7 @@ void SettingFieldMultiEnum<EnumT, Traits>::readBinary(ReadBuffer & in)
         using EnumType = ENUM_TYPE; \
         static size_t getEnumSize(); \
         static const String & toString(EnumType value); \
-        static EnumType fromString(const std::string_view & str); \
+        static EnumType fromString(std::string_view str); \
     }; \
     \
     using SettingField##NEW_NAME = SettingFieldMultiEnum<ENUM_TYPE, SettingField##NEW_NAME##Traits>;

--- a/src/DataTypes/NestedUtils.cpp
+++ b/src/DataTypes/NestedUtils.cpp
@@ -54,7 +54,7 @@ std::pair<std::string, std::string> splitName(const std::string & name, bool rev
     return {name.substr(0, idx), name.substr(idx + 1)};
 }
 
-std::pair<std::string_view, std::string_view> splitName(const std::string_view & name, bool reverse)
+std::pair<std::string_view, std::string_view> splitName(std::string_view name, bool reverse)
 {
     auto idx = (reverse ? name.find_last_of('.') : name.find_first_of('.'));
     if (idx == std::string::npos || idx == 0 || idx + 1 == name.size())

--- a/src/DataTypes/NestedUtils.h
+++ b/src/DataTypes/NestedUtils.h
@@ -13,7 +13,7 @@ namespace Nested
 
     /// Splits name of compound identifier by first/last dot (depending on 'reverse' parameter).
     std::pair<std::string, std::string> splitName(const std::string & name, bool reverse = false);
-    std::pair<std::string_view, std::string_view> splitName(const std::string_view & name, bool reverse = false);
+    std::pair<std::string_view, std::string_view> splitName(std::string_view name, bool reverse = false);
 
     /// Returns the prefix of the name to the first '.'. Or the name is unchanged if there is no dot.
     std::string extractTableName(const std::string & nested_name);

--- a/src/Formats/ProtobufSerializer.cpp
+++ b/src/Formats/ProtobufSerializer.cpp
@@ -77,18 +77,18 @@ namespace
             return convertChar(c1) == convertChar(c2);
         }
 
-        static bool equals(const std::string_view & s1, const std::string_view & s2)
+        static bool equals(std::string_view s1, std::string_view s2)
         {
             return (s1.length() == s2.length())
                 && std::equal(s1.begin(), s1.end(), s2.begin(), [](char c1, char c2) { return convertChar(c1) == convertChar(c2); });
         }
 
-        static bool less(const std::string_view & s1, const std::string_view & s2)
+        static bool less(std::string_view s1, std::string_view s2)
         {
             return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(), [](char c1, char c2) { return convertChar(c1) < convertChar(c2); });
         }
 
-        static bool startsWith(const std::string_view & s1, const std::string_view & s2)
+        static bool startsWith(std::string_view s1, std::string_view s2)
         {
             return (s1.length() >= s2.length()) && equals(s1.substr(0, s2.length()), s2);
         }
@@ -195,7 +195,7 @@ namespace
     {
     protected:
         ProtobufSerializerSingleValue(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const FieldDescriptor & field_descriptor_,
             const ProtobufReaderOrWriter & reader_or_writer_)
             : column_name(column_name_)
@@ -264,7 +264,7 @@ namespace
             return reader->readFixed<FieldType>();
         }
 
-        void writeStr(const std::string_view & str)
+        void writeStr(std::string_view str)
         {
             if (!str.empty() || !skip_zero_or_empty)
                 writer->writeString(field_tag, str);
@@ -274,7 +274,7 @@ namespace
         void readStrAndAppend(PaddedPODArray<UInt8> & str) { reader->readStringAndAppend(str); }
 
         template <typename DestType>
-        DestType parseFromStr(const std::string_view & str) const
+        DestType parseFromStr(std::string_view str) const
         {
             try
             {
@@ -307,7 +307,7 @@ namespace
             return result;
         }
 
-        [[noreturn]] void incompatibleColumnType(const std::string_view & column_type) const
+        [[noreturn]] void incompatibleColumnType(std::string_view column_type) const
         {
             throw Exception(
                 ErrorCodes::DATA_TYPE_INCOMPATIBLE_WITH_PROTOBUF_FIELD,
@@ -318,7 +318,7 @@ namespace
                 field_descriptor.type_name());
         }
 
-        [[noreturn]] void cannotConvertValue(const std::string_view & src_value, const std::string_view & src_type_name, const std::string_view & dest_type_name) const
+        [[noreturn]] void cannotConvertValue(std::string_view src_value, std::string_view src_type_name, std::string_view dest_type_name) const
         {
             throw Exception(
                 "Could not convert value '" + String{src_value} + "' from type " + String{src_type_name} + " to type "
@@ -351,7 +351,7 @@ namespace
     public:
         using ColumnType = ColumnVector<NumberType>;
 
-        ProtobufSerializerNumber(const std::string_view & column_name_, const FieldDescriptor & field_descriptor_, const ProtobufReaderOrWriter & reader_or_writer_)
+        ProtobufSerializerNumber(std::string_view column_name_, const FieldDescriptor & field_descriptor_, const ProtobufReaderOrWriter & reader_or_writer_)
             : ProtobufSerializerSingleValue(column_name_, field_descriptor_, reader_or_writer_)
         {
             setFunctions();
@@ -590,7 +590,7 @@ namespace
         using ColumnType = std::conditional_t<is_fixed_string, ColumnFixedString, ColumnString>;
 
         ProtobufSerializerString(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const std::shared_ptr<const DataTypeFixedString> & fixed_string_data_type_,
             const google::protobuf::FieldDescriptor & field_descriptor_,
             const ProtobufReaderOrWriter & reader_or_writer_)
@@ -604,7 +604,7 @@ namespace
         }
 
         ProtobufSerializerString(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const google::protobuf::FieldDescriptor & field_descriptor_,
             const ProtobufReaderOrWriter & reader_or_writer_)
             : ProtobufSerializerSingleValue(column_name_, field_descriptor_, reader_or_writer_)
@@ -727,7 +727,7 @@ namespace
             {
                 case FieldTypeId::TYPE_INT32:
                 {
-                    write_function = [this](const std::string_view & str) { writeInt(parseFromStr<Int32>(str)); };
+                    write_function = [this](std::string_view str) { writeInt(parseFromStr<Int32>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readInt(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_int32()); };
                     break;
@@ -735,7 +735,7 @@ namespace
 
                 case FieldTypeId::TYPE_SINT32:
                 {
-                    write_function = [this](const std::string_view & str) { writeSInt(parseFromStr<Int32>(str)); };
+                    write_function = [this](std::string_view str) { writeSInt(parseFromStr<Int32>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readSInt(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_int32()); };
                     break;
@@ -743,7 +743,7 @@ namespace
 
                 case FieldTypeId::TYPE_UINT32:
                 {
-                    write_function = [this](const std::string_view & str) { writeUInt(parseFromStr<UInt32>(str)); };
+                    write_function = [this](std::string_view str) { writeUInt(parseFromStr<UInt32>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readUInt(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_uint32()); };
                     break;
@@ -751,7 +751,7 @@ namespace
 
                 case FieldTypeId::TYPE_INT64:
                 {
-                    write_function = [this](const std::string_view & str) { writeInt(parseFromStr<Int64>(str)); };
+                    write_function = [this](std::string_view str) { writeInt(parseFromStr<Int64>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readInt(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_int64()); };
                     break;
@@ -759,7 +759,7 @@ namespace
 
                 case FieldTypeId::TYPE_SINT64:
                 {
-                    write_function = [this](const std::string_view & str) { writeSInt(parseFromStr<Int64>(str)); };
+                    write_function = [this](std::string_view str) { writeSInt(parseFromStr<Int64>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readSInt(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_int64()); };
                     break;
@@ -767,7 +767,7 @@ namespace
 
                 case FieldTypeId::TYPE_UINT64:
                 {
-                    write_function = [this](const std::string_view & str) { writeUInt(parseFromStr<UInt64>(str)); };
+                    write_function = [this](std::string_view str) { writeUInt(parseFromStr<UInt64>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readUInt(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_uint64()); };
                     break;
@@ -775,7 +775,7 @@ namespace
 
                 case FieldTypeId::TYPE_FIXED32:
                 {
-                    write_function = [this](const std::string_view & str) { writeFixed<UInt32>(parseFromStr<UInt32>(str)); };
+                    write_function = [this](std::string_view str) { writeFixed<UInt32>(parseFromStr<UInt32>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readFixed<UInt32>(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_uint32()); };
                     break;
@@ -783,7 +783,7 @@ namespace
 
                 case FieldTypeId::TYPE_SFIXED32:
                 {
-                    write_function = [this](const std::string_view & str) { writeFixed<Int32>(parseFromStr<Int32>(str)); };
+                    write_function = [this](std::string_view str) { writeFixed<Int32>(parseFromStr<Int32>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readFixed<Int32>(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_int32()); };
                     break;
@@ -791,7 +791,7 @@ namespace
 
                 case FieldTypeId::TYPE_FIXED64:
                 {
-                    write_function = [this](const std::string_view & str) { writeFixed<UInt64>(parseFromStr<UInt64>(str)); };
+                    write_function = [this](std::string_view str) { writeFixed<UInt64>(parseFromStr<UInt64>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readFixed<UInt64>(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_uint64()); };
                     break;
@@ -799,7 +799,7 @@ namespace
 
                 case FieldTypeId::TYPE_SFIXED64:
                 {
-                    write_function = [this](const std::string_view & str) { writeFixed<Int64>(parseFromStr<Int64>(str)); };
+                    write_function = [this](std::string_view str) { writeFixed<Int64>(parseFromStr<Int64>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readFixed<Int64>(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_int64()); };
                     break;
@@ -807,7 +807,7 @@ namespace
 
                 case FieldTypeId::TYPE_FLOAT:
                 {
-                    write_function = [this](const std::string_view & str) { writeFixed<Float32>(parseFromStr<Float32>(str)); };
+                    write_function = [this](std::string_view str) { writeFixed<Float32>(parseFromStr<Float32>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readFixed<Float32>(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_float()); };
                     break;
@@ -815,7 +815,7 @@ namespace
 
                 case FieldTypeId::TYPE_DOUBLE:
                 {
-                    write_function = [this](const std::string_view & str) { writeFixed<Float64>(parseFromStr<Float64>(str)); };
+                    write_function = [this](std::string_view str) { writeFixed<Float64>(parseFromStr<Float64>(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { toStringAppend(readFixed<Float64>(), str); };
                     default_function = [this]() -> String { return toString(field_descriptor.default_value_double()); };
                     break;
@@ -823,7 +823,7 @@ namespace
 
                 case FieldTypeId::TYPE_BOOL:
                 {
-                    write_function = [this](const std::string_view & str)
+                    write_function = [this](std::string_view str)
                     {
                         if (str == "true")
                             writeUInt(1);
@@ -855,7 +855,7 @@ namespace
                 case FieldTypeId::TYPE_STRING:
                 case FieldTypeId::TYPE_BYTES:
                 {
-                    write_function = [this](const std::string_view & str) { writeStr(str); };
+                    write_function = [this](std::string_view str) { writeStr(str); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { readStrAndAppend(str); };
                     default_function = [this]() -> String { return field_descriptor.default_value_string(); };
                     break;
@@ -863,7 +863,7 @@ namespace
 
                 case FieldTypeId::TYPE_ENUM:
                 {
-                    write_function = [this](const std::string_view & str) { writeInt(stringToProtobufEnumValue(str)); };
+                    write_function = [this](std::string_view str) { writeInt(stringToProtobufEnumValue(str)); };
                     read_function = [this](PaddedPODArray<UInt8> & str) { protobufEnumValueToStringAppend(readInt(), str); };
                     default_function = [this]() -> String { return field_descriptor.default_value_enum()->name(); };
                     break;
@@ -908,7 +908,7 @@ namespace
             }
         }
 
-        int stringToProtobufEnumValue(const std::string_view & str) const
+        int stringToProtobufEnumValue(std::string_view str) const
         {
             auto it = string_to_protobuf_enum_value_map.find(str);
             if (it == string_to_protobuf_enum_value_map.end())
@@ -932,7 +932,7 @@ namespace
 
         const std::shared_ptr<const DataTypeFixedString> fixed_string_data_type;
         const size_t n = 0;
-        std::function<void(const std::string_view &)> write_function;
+        std::function<void(std::string_view)> write_function;
         std::function<void(PaddedPODArray<UInt8> &)> read_function;
         std::function<String()> default_function;
         std::unordered_map<std::string_view, int> string_to_protobuf_enum_value_map;
@@ -953,7 +953,7 @@ namespace
         using BaseClass = ProtobufSerializerNumber<NumberType>;
 
         ProtobufSerializerEnum(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const std::shared_ptr<const EnumDataType> & enum_data_type_,
             const FieldDescriptor & field_descriptor_,
             const ProtobufReaderOrWriter & reader_or_writer_)
@@ -1067,7 +1067,7 @@ namespace
                     protobuf_enum_value_to_enum_data_type_value_map.emplace(protobuf_enum_value, enum_data_type_value);
             };
 
-            auto iless = [](const std::string_view & s1, const std::string_view & s2) { return ColumnNameWithProtobufFieldNameComparator::less(s1, s2); };
+            auto iless = [](std::string_view s1, std::string_view s2) { return ColumnNameWithProtobufFieldNameComparator::less(s1, s2); };
             boost::container::flat_map<std::string_view, int, decltype(iless)> string_to_protobuf_enum_value_map;
             typename decltype(string_to_protobuf_enum_value_map)::sequence_type string_to_protobuf_enum_value_seq;
             for (int i : collections::range(enum_descriptor.value_count()))
@@ -1133,9 +1133,9 @@ namespace
 
         Int64 readInt() { return ProtobufSerializerSingleValue::readInt(); }
         void writeInt(Int64 value) { ProtobufSerializerSingleValue::writeInt(value); }
-        void writeStr(const std::string_view & str) { ProtobufSerializerSingleValue::writeStr(str); }
+        void writeStr(std::string_view str) { ProtobufSerializerSingleValue::writeStr(str); }
         void readStr(String & str) { ProtobufSerializerSingleValue::readStr(str); }
-        [[noreturn]] void cannotConvertValue(const std::string_view & src_value, const std::string_view & src_type_name, const std::string_view & dest_type_name) const { ProtobufSerializerSingleValue::cannotConvertValue(src_value, src_type_name, dest_type_name); }
+        [[noreturn]] void cannotConvertValue(std::string_view src_value, std::string_view src_type_name, std::string_view dest_type_name) const { ProtobufSerializerSingleValue::cannotConvertValue(src_value, src_type_name, dest_type_name); }
 
         const std::shared_ptr<const EnumDataType> enum_data_type;
         std::unordered_map<NumberType, int> enum_data_type_value_to_protobuf_enum_value_map;
@@ -1152,7 +1152,7 @@ namespace
         using ColumnType = ColumnDecimal<DecimalType>;
 
         ProtobufSerializerDecimal(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const DataTypeDecimalBase<DecimalType> & decimal_data_type_,
             const FieldDescriptor & field_descriptor_,
             const ProtobufReaderOrWriter & reader_or_writer_)
@@ -1412,7 +1412,7 @@ namespace
     {
     public:
         ProtobufSerializerDate(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const FieldDescriptor & field_descriptor_,
             const ProtobufReaderOrWriter & reader_or_writer_)
             : ProtobufSerializerNumber<UInt16>(column_name_, field_descriptor_, reader_or_writer_)
@@ -1490,7 +1490,7 @@ namespace
     {
     public:
         ProtobufSerializerDateTime(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const DataTypeDateTime & type,
             const FieldDescriptor & field_descriptor_,
             const ProtobufReaderOrWriter & reader_or_writer_)
@@ -1574,7 +1574,7 @@ namespace
     {
     public:
         ProtobufSerializerUUID(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const google::protobuf::FieldDescriptor & field_descriptor_,
             const ProtobufReaderOrWriter & reader_or_writer_)
             : ProtobufSerializerSingleValue(column_name_, field_descriptor_, reader_or_writer_)
@@ -1654,7 +1654,7 @@ namespace
     {
     public:
         ProtobufSerializerAggregateFunction(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const std::shared_ptr<const DataTypeAggregateFunction> & aggregate_function_data_type_,
             const google::protobuf::FieldDescriptor & field_descriptor_,
             const ProtobufReaderOrWriter & reader_or_writer_)
@@ -2061,7 +2061,7 @@ namespace
     {
     public:
         ProtobufSerializerTupleAsArray(
-            const std::string_view & column_name_,
+            std::string_view column_name_,
             const std::shared_ptr<const DataTypeTuple> & tuple_data_type_,
             const FieldDescriptor & field_descriptor_,
             std::vector<std::unique_ptr<ProtobufSerializer>> element_serializers_)
@@ -2833,7 +2833,7 @@ namespace
             return field_names;
         }
 
-        static bool columnNameEqualsToFieldName(const std::string_view & column_name, const FieldDescriptor & field_descriptor)
+        static bool columnNameEqualsToFieldName(std::string_view column_name, const FieldDescriptor & field_descriptor)
         {
             std::string_view suffix;
             return columnNameStartsWithFieldName(column_name, field_descriptor, suffix) && suffix.empty();
@@ -2844,7 +2844,7 @@ namespace
         /// which doesn't match to the field's name.
         /// The function requires that rest part of the column's name to be started with a dot '.' or underline '_',
         /// but doesn't include those '.' or '_' characters into `suffix`.
-        static bool columnNameStartsWithFieldName(const std::string_view & column_name, const FieldDescriptor & field_descriptor, std::string_view & suffix)
+        static bool columnNameStartsWithFieldName(std::string_view column_name, const FieldDescriptor & field_descriptor, std::string_view & suffix)
         {
             size_t matching_length = 0;
             const MessageDescriptor & containing_type = *field_descriptor.containing_type();
@@ -2887,7 +2887,7 @@ namespace
         /// for that case suffixes are also returned.
         /// This is only the first filter, buildMessageSerializerImpl() does other checks after calling this function.
         static bool findFieldsByColumnName(
-            const std::string_view & column_name,
+            std::string_view column_name,
             const MessageDescriptor & message_descriptor,
             std::vector<std::pair<const FieldDescriptor *, std::string_view /* suffix */>> & out_field_descriptors_with_suffixes,
             bool google_wrappers_special_treatment)
@@ -3030,7 +3030,7 @@ namespace
             used_column_indices_sorted.reserve(num_columns);
             size_t sequential_column_index = 0;
 
-            auto add_field_serializer = [&](const std::string_view & column_name_,
+            auto add_field_serializer = [&](std::string_view column_name_,
                                             std::vector<size_t> && column_indices_,
                                             const FieldDescriptor & field_descriptor_,
                                             std::unique_ptr<ProtobufSerializer> field_serializer_)
@@ -3243,7 +3243,7 @@ namespace
         /// Builds a serializer for one-to-one match:
         /// one column is serialized as one field in the protobuf message.
         std::unique_ptr<ProtobufSerializer> buildFieldSerializer(
-            const std::string_view & column_name,
+            std::string_view column_name,
             const DataTypePtr & data_type,
             const FieldDescriptor & field_descriptor,
             bool allow_repeat,
@@ -3395,7 +3395,7 @@ namespace
             }
         }
 
-        [[noreturn]] static void throwFieldNotRepeated(const FieldDescriptor & field_descriptor, const std::string_view & column_name)
+        [[noreturn]] static void throwFieldNotRepeated(const FieldDescriptor & field_descriptor, std::string_view column_name)
         {
             if (!field_descriptor.is_repeated())
                 throw Exception(

--- a/src/Formats/ProtobufWriter.cpp
+++ b/src/Formats/ProtobufWriter.cpp
@@ -196,7 +196,7 @@ template void ProtobufWriter::writeFixed<UInt64>(int field_number, UInt64 value)
 template void ProtobufWriter::writeFixed<Float32>(int field_number, Float32 value);
 template void ProtobufWriter::writeFixed<Float64>(int field_number, Float64 value);
 
-void ProtobufWriter::writeString(int field_number, const std::string_view & str)
+void ProtobufWriter::writeString(int field_number, std::string_view str)
 {
     size_t length = str.length();
     size_t old_size = buffer.size();

--- a/src/Formats/ProtobufWriter.h
+++ b/src/Formats/ProtobufWriter.h
@@ -30,7 +30,7 @@ public:
     void writeSInt(int field_number, Int64 value);
     template <typename T>
     void writeFixed(int field_number, T value);
-    void writeString(int field_number, const std::string_view & str);
+    void writeString(int field_number, std::string_view str);
 
     void startRepeatedPack();
     void endRepeatedPack(int field_number, bool skip_if_empty);

--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -304,7 +304,7 @@ private:
 
     /// Performs moves of types MoveType::Key and MoveType::ConstKey.
     template <typename JSONParser>
-    static bool moveToElementByKey(typename JSONParser::Element & element, const std::string_view & key)
+    static bool moveToElementByKey(typename JSONParser::Element & element, std::string_view key)
     {
         if (!element.isObject())
             return false;
@@ -504,7 +504,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element &, const std::string_view &)
+    static bool insertResultToColumn(IColumn & dest, const Element &, std::string_view)
     {
         ColumnVector<UInt8> & col_vec = assert_cast<ColumnVector<UInt8> &>(dest);
         col_vec.insertValue(1);
@@ -532,7 +532,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName &) { return 0; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element &, const std::string_view &)
+    static bool insertResultToColumn(IColumn & dest, const Element &, std::string_view)
     {
         /// This function is called only if JSON is valid.
         /// If JSON isn't valid then `FunctionJSON::Executor::run()` adds default value (=zero) to `dest` without calling this function.
@@ -556,7 +556,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    static bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         size_t size;
         if (element.isArray())
@@ -586,7 +586,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element &, const std::string_view & last_key)
+    static bool insertResultToColumn(IColumn & dest, const Element &, std::string_view last_key)
     {
         if (last_key.empty())
             return false;
@@ -620,7 +620,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    static bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         UInt8 type;
         if (element.isInt64())
@@ -662,7 +662,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    static bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         NumberType value;
 
@@ -737,7 +737,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    static bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         if (!element.isBool())
             return false;
@@ -764,7 +764,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    static bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         if (element.isNull())
             return false;
@@ -1164,7 +1164,7 @@ public:
         extract_tree = JSONExtractTree<JSONParser>::build(function_name, result_type);
     }
 
-    bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         return extract_tree->insertResultToColumn(dest, element);
     }
@@ -1207,7 +1207,7 @@ public:
         extract_tree = JSONExtractTree<JSONParser>::build(function_name, value_type);
     }
 
-    bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         if (!element.isObject())
             return false;
@@ -1251,7 +1251,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    static bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         ColumnString & col_str = assert_cast<ColumnString &>(dest);
         auto & chars = col_str.getChars();
@@ -1355,7 +1355,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    static bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    static bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         if (!element.isArray())
             return false;
@@ -1387,7 +1387,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         if (!element.isObject())
             return false;
@@ -1423,7 +1423,7 @@ public:
 
     static size_t getNumberOfIndexArguments(const ColumnsWithTypeAndName & arguments) { return arguments.size() - 1; }
 
-    bool insertResultToColumn(IColumn & dest, const Element & element, const std::string_view &)
+    bool insertResultToColumn(IColumn & dest, const Element & element, std::string_view)
     {
         if (!element.isObject())
             return false;

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -836,7 +836,7 @@ template <typename T>
 inline T parse(const char * data, size_t size);
 
 template <typename T>
-inline T parseFromString(const std::string_view & str)
+inline T parseFromString(std::string_view str)
 {
     return parse<T>(str.data(), str.size());
 }
@@ -1338,7 +1338,7 @@ inline T parseWithSizeSuffix(const char * data, size_t size)
 }
 
 template <typename T>
-inline T parseWithSizeSuffix(const std::string_view & s)
+inline T parseWithSizeSuffix(std::string_view s)
 {
     return parseWithSizeSuffix<T>(s.data(), s.size());
 }

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -113,7 +113,7 @@ inline void writeStringBinary(const char * s, WriteBuffer & buf)
     writeStringBinary(StringRef{s}, buf);
 }
 
-inline void writeStringBinary(const std::string_view & s, WriteBuffer & buf)
+inline void writeStringBinary(std::string_view s, WriteBuffer & buf)
 {
     writeStringBinary(StringRef{s}, buf);
 }
@@ -365,7 +365,7 @@ inline void writeJSONString(const StringRef & s, WriteBuffer & buf, const Format
     writeJSONString(s.data, s.data + s.size, buf, settings);
 }
 
-inline void writeJSONString(const std::string_view & s, WriteBuffer & buf, const FormatSettings & settings)
+inline void writeJSONString(std::string_view s, WriteBuffer & buf, const FormatSettings & settings)
 {
     writeJSONString(StringRef{s}, buf, settings);
 }
@@ -440,7 +440,7 @@ inline void writeEscapedString(const StringRef & ref, WriteBuffer & buf)
     writeEscapedString(ref.data, ref.size, buf);
 }
 
-inline void writeEscapedString(const std::string_view & ref, WriteBuffer & buf)
+inline void writeEscapedString(std::string_view ref, WriteBuffer & buf)
 {
     writeEscapedString(ref.data(), ref.size(), buf);
 }
@@ -478,7 +478,7 @@ inline void writeQuotedString(const StringRef & ref, WriteBuffer & buf)
     writeAnyQuotedString<'\''>(ref, buf);
 }
 
-inline void writeQuotedString(const std::string_view & ref, WriteBuffer & buf)
+inline void writeQuotedString(std::string_view ref, WriteBuffer & buf)
 {
     writeAnyQuotedString<'\''>(ref.data(), ref.data() + ref.size(), buf);
 }
@@ -493,7 +493,7 @@ inline void writeDoubleQuotedString(const StringRef & s, WriteBuffer & buf)
     writeAnyQuotedString<'"'>(s, buf);
 }
 
-inline void writeDoubleQuotedString(const std::string_view & s, WriteBuffer & buf)
+inline void writeDoubleQuotedString(std::string_view s, WriteBuffer & buf)
 {
     writeAnyQuotedString<'"'>(s.data(), s.data() + s.size(), buf);
 }
@@ -891,7 +891,7 @@ inline void writeBinary(const T & x, WriteBuffer & buf) { writePODBinary(x, buf)
 
 inline void writeBinary(const String & x, WriteBuffer & buf) { writeStringBinary(x, buf); }
 inline void writeBinary(const StringRef & x, WriteBuffer & buf) { writeStringBinary(x, buf); }
-inline void writeBinary(const std::string_view & x, WriteBuffer & buf) { writeStringBinary(x, buf); }
+inline void writeBinary(std::string_view x, WriteBuffer & buf) { writeStringBinary(x, buf); }
 inline void writeBinary(const Decimal32 & x, WriteBuffer & buf) { writePODBinary(x, buf); }
 inline void writeBinary(const Decimal64 & x, WriteBuffer & buf) { writePODBinary(x, buf); }
 inline void writeBinary(const Decimal128 & x, WriteBuffer & buf) { writePODBinary(x, buf); }
@@ -1015,7 +1015,7 @@ inline void writeQuoted(const T & x, WriteBuffer & buf) { writeText(x, buf); }
 
 inline void writeQuoted(const String & x, WriteBuffer & buf) { writeQuotedString(x, buf); }
 
-inline void writeQuoted(const std::string_view & x, WriteBuffer & buf) { writeQuotedString(x, buf); }
+inline void writeQuoted(std::string_view x, WriteBuffer & buf) { writeQuotedString(x, buf); }
 
 inline void writeQuoted(const StringRef & x, WriteBuffer & buf) { writeQuotedString(x, buf); }
 
@@ -1048,7 +1048,7 @@ inline void writeDoubleQuoted(const T & x, WriteBuffer & buf) { writeText(x, buf
 
 inline void writeDoubleQuoted(const String & x, WriteBuffer & buf) { writeDoubleQuotedString(x, buf); }
 
-inline void writeDoubleQuoted(const std::string_view & x, WriteBuffer & buf) { writeDoubleQuotedString(x, buf); }
+inline void writeDoubleQuoted(std::string_view x, WriteBuffer & buf) { writeDoubleQuotedString(x, buf); }
 
 inline void writeDoubleQuoted(const StringRef & x, WriteBuffer & buf) { writeDoubleQuotedString(x, buf); }
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -854,13 +854,13 @@ void Context::checkAccessImpl(const Args &... args) const
 }
 
 void Context::checkAccess(const AccessFlags & flags) const { return checkAccessImpl(flags); }
-void Context::checkAccess(const AccessFlags & flags, const std::string_view & database) const { return checkAccessImpl(flags, database); }
-void Context::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const { return checkAccessImpl(flags, database, table); }
-void Context::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const { return checkAccessImpl(flags, database, table, column); }
-void Context::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const { return checkAccessImpl(flags, database, table, columns); }
-void Context::checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const { return checkAccessImpl(flags, database, table, columns); }
+void Context::checkAccess(const AccessFlags & flags, std::string_view database) const { return checkAccessImpl(flags, database); }
+void Context::checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table) const { return checkAccessImpl(flags, database, table); }
+void Context::checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const { return checkAccessImpl(flags, database, table, column); }
+void Context::checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const { return checkAccessImpl(flags, database, table, columns); }
+void Context::checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const { return checkAccessImpl(flags, database, table, columns); }
 void Context::checkAccess(const AccessFlags & flags, const StorageID & table_id) const { checkAccessImpl(flags, table_id.getDatabaseName(), table_id.getTableName()); }
-void Context::checkAccess(const AccessFlags & flags, const StorageID & table_id, const std::string_view & column) const { checkAccessImpl(flags, table_id.getDatabaseName(), table_id.getTableName(), column); }
+void Context::checkAccess(const AccessFlags & flags, const StorageID & table_id, std::string_view column) const { checkAccessImpl(flags, table_id.getDatabaseName(), table_id.getTableName(), column); }
 void Context::checkAccess(const AccessFlags & flags, const StorageID & table_id, const std::vector<std::string_view> & columns) const { checkAccessImpl(flags, table_id.getDatabaseName(), table_id.getTableName(), columns); }
 void Context::checkAccess(const AccessFlags & flags, const StorageID & table_id, const Strings & columns) const { checkAccessImpl(flags, table_id.getDatabaseName(), table_id.getTableName(), columns); }
 void Context::checkAccess(const AccessRightsElement & element) const { return checkAccessImpl(element); }

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -474,13 +474,13 @@ public:
     /// Checks access rights.
     /// Empty database means the current database.
     void checkAccess(const AccessFlags & flags) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::string_view & column) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const std::vector<std::string_view> & columns) const;
-    void checkAccess(const AccessFlags & flags, const std::string_view & database, const std::string_view & table, const Strings & columns) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, std::string_view column) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, const std::vector<std::string_view> & columns) const;
+    void checkAccess(const AccessFlags & flags, std::string_view database, std::string_view table, const Strings & columns) const;
     void checkAccess(const AccessFlags & flags, const StorageID & table_id) const;
-    void checkAccess(const AccessFlags & flags, const StorageID & table_id, const std::string_view & column) const;
+    void checkAccess(const AccessFlags & flags, const StorageID & table_id, std::string_view column) const;
     void checkAccess(const AccessFlags & flags, const StorageID & table_id, const std::vector<std::string_view> & columns) const;
     void checkAccess(const AccessFlags & flags, const StorageID & table_id, const Strings & columns) const;
     void checkAccess(const AccessRightsElement & element) const;

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -234,7 +234,7 @@ void DatabaseCatalog::shutdownImpl()
     view_dependencies.clear();
 }
 
-bool DatabaseCatalog::isPredefinedDatabase(const std::string_view & database_name)
+bool DatabaseCatalog::isPredefinedDatabase(std::string_view database_name)
 {
     return database_name == TEMPORARY_DATABASE || database_name == SYSTEM_DATABASE || database_name == INFORMATION_SCHEMA
         || database_name == INFORMATION_SCHEMA_UPPERCASE;

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -131,7 +131,7 @@ public:
     static constexpr const char * INFORMATION_SCHEMA_UPPERCASE = "INFORMATION_SCHEMA";
 
     /// Returns true if a passed name is one of the predefined databases' names.
-    static bool isPredefinedDatabase(const std::string_view & database_name);
+    static bool isPredefinedDatabase(std::string_view database_name);
 
     static DatabaseCatalog & init(ContextMutablePtr global_context_);
     static DatabaseCatalog & instance();

--- a/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
+++ b/src/Interpreters/TranslateQualifiedNamesVisitor.cpp
@@ -31,7 +31,7 @@ namespace ErrorCodes
     extern const int UNSUPPORTED_JOIN_KEYS;
     extern const int LOGICAL_ERROR;
 }
-bool TranslateQualifiedNamesMatcher::Data::matchColumnName(const std::string_view & name, const String & column_name, DataTypePtr column_type)
+bool TranslateQualifiedNamesMatcher::Data::matchColumnName(std::string_view name, const String & column_name, DataTypePtr column_type)
 {
     if (name.size() < column_name.size())
         return false;

--- a/src/Interpreters/TranslateQualifiedNamesVisitor.h
+++ b/src/Interpreters/TranslateQualifiedNamesVisitor.h
@@ -39,7 +39,7 @@ public:
         bool hasTable() const { return !tables.empty(); }
         bool processAsterisks() const { return hasTable() && has_columns; }
         bool unknownColumn(size_t table_pos, const ASTIdentifier & identifier) const;
-        static bool matchColumnName(const std::string_view & name, const String & column_name, DataTypePtr column_type);
+        static bool matchColumnName(std::string_view name, const String & column_name, DataTypePtr column_type);
     };
 
     static void visit(ASTPtr & ast, Data & data);

--- a/src/Interpreters/UserDefinedSQLObjectsLoader.cpp
+++ b/src/Interpreters/UserDefinedSQLObjectsLoader.cpp
@@ -43,7 +43,7 @@ UserDefinedSQLObjectsLoader::UserDefinedSQLObjectsLoader()
     : log(&Poco::Logger::get("UserDefinedSQLObjectsLoader"))
 {}
 
-void UserDefinedSQLObjectsLoader::loadUserDefinedObject(ContextPtr context, UserDefinedSQLObjectType object_type, const std::string_view & name, const String & path)
+void UserDefinedSQLObjectsLoader::loadUserDefinedObject(ContextPtr context, UserDefinedSQLObjectType object_type, std::string_view name, const String & path)
 {
     auto name_ref = StringRef(name.data(), name.size());
     LOG_DEBUG(log, "Loading user defined object {} from file {}", backQuote(name_ref), path);

--- a/src/Interpreters/UserDefinedSQLObjectsLoader.h
+++ b/src/Interpreters/UserDefinedSQLObjectsLoader.h
@@ -29,7 +29,7 @@ public:
 
 private:
 
-    void loadUserDefinedObject(ContextPtr context, UserDefinedSQLObjectType object_type, const std::string_view & object_name, const String & file_path);
+    void loadUserDefinedObject(ContextPtr context, UserDefinedSQLObjectType object_type, std::string_view object_name, const String & file_path);
     Poco::Logger * log;
     bool enable_persistence = true;
 };

--- a/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRowPolicyQuery.cpp
@@ -75,7 +75,7 @@ namespace
     {
         for (auto filter_type : collections::range(RowPolicyFilterType::MAX))
         {
-            const std::string_view & command = RowPolicyFilterTypeInfo::get(filter_type).command;
+            std::string_view command = RowPolicyFilterTypeInfo::get(filter_type).command;
             commands.emplace(command);
         }
     }
@@ -96,7 +96,7 @@ namespace
 
             for (auto filter_type : collections::range(RowPolicyFilterType::MAX))
             {
-                const std::string_view & command = RowPolicyFilterTypeInfo::get(filter_type).command;
+                std::string_view command = RowPolicyFilterTypeInfo::get(filter_type).command;
                 if (ParserKeyword{command.data()}.ignore(pos, expected))
                 {
                     res_commands.emplace(command);

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2050,7 +2050,7 @@ bool KeyCondition::mayBeTrueInRange(
 }
 
 String KeyCondition::RPNElement::toString() const { return toString("column " + std::to_string(key_column), false); }
-String KeyCondition::RPNElement::toString(const std::string_view & column_name, bool print_constants) const
+String KeyCondition::RPNElement::toString(std::string_view column_name, bool print_constants) const
 {
     auto print_wrapped_column = [this, &column_name, print_constants](WriteBuffer & buf)
     {

--- a/src/Storages/MergeTree/KeyCondition.h
+++ b/src/Storages/MergeTree/KeyCondition.h
@@ -320,7 +320,7 @@ private:
             : function(function_), range(range_), key_column(key_column_) {}
 
         String toString() const;
-        String toString(const std::string_view & column_name, bool print_constants) const;
+        String toString(std::string_view column_name, bool print_constants) const;
 
         Function function = FUNCTION_UNKNOWN;
 

--- a/src/Storages/System/StorageSystemPrivileges.cpp
+++ b/src/Storages/System/StorageSystemPrivileges.cpp
@@ -85,7 +85,7 @@ void StorageSystemPrivileges::fillData(MutableColumns & res_columns, ContextPtr,
     auto & column_parent_group = assert_cast<ColumnInt16 &>(assert_cast<ColumnNullable &>(*res_columns[column_index]).getNestedColumn()).getData();
     auto & column_parent_group_null_map = assert_cast<ColumnNullable &>(*res_columns[column_index++]).getNullMapData();
 
-    auto add_row = [&](AccessType access_type, const std::string_view & aliases, Level max_level, AccessType parent_group)
+    auto add_row = [&](AccessType access_type, std::string_view aliases, Level max_level, AccessType parent_group)
     {
         column_access_type.push_back(static_cast<Int16>(access_type));
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Was inspired by @antonio2368 in https://github.com/ClickHouse/ClickHouse/pull/38957#discussion_r921097507
See https://quuxplusone.github.io/blog/2021/11/09/pass-string-view-by-value/