### PR TITLE
[RFC] Fix NOEXCEPT_SCOPE (before it calls std::terminate and looses the exception)

### DIFF
--- a/src/Common/noexcept_scope.h
+++ b/src/Common/noexcept_scope.h
@@ -1,36 +1,28 @@
 #pragma once
-#include <base/scope_guard.h>
 #include <Common/Exception.h>
 #include <Common/LockMemoryExceptionInThread.h>
-
-
-#define NOEXCEPT_SCOPE_IMPL_CONCAT(n, expected) \
-    LockMemoryExceptionInThread lock_memory_tracker##n(VariableContext::Global);   \
-    SCOPE_EXIT(                                                                    \
-        {                                                                          \
-            const auto uncaught = std::uncaught_exceptions();                      \
-            assert((expected) == uncaught || (expected) + 1 == uncaught);          \
-            if ((expected) < uncaught)                                             \
-            {                                                                      \
-                tryLogCurrentException("NOEXCEPT_SCOPE");                          \
-                abort();                                                           \
-            }                                                                      \
-        }                                                                          \
-    )
-
-#define NOEXCEPT_SCOPE_IMPL(n, expected) NOEXCEPT_SCOPE_IMPL_CONCAT(n, expected)
-
-#define NOEXCEPT_SCOPE_CONCAT(n)                                                   \
-    const auto num_curr_exceptions##n = std::uncaught_exceptions();                \
-    NOEXCEPT_SCOPE_IMPL(n, num_curr_exceptions##n)
-
-#define NOEXCEPT_SCOPE_FWD(n) NOEXCEPT_SCOPE_CONCAT(n)
-
 
 /// It can be used in critical places to exit on unexpected exceptions.
 /// SIGABRT is usually better that broken in-memory state with unpredictable consequences.
 /// It also temporarily disables exception from memory tracker in current thread.
 /// Strict version does not take into account nested exception (i.e. it aborts even when we're in catch block).
 
-#define NOEXCEPT_SCOPE_STRICT NOEXCEPT_SCOPE_IMPL(__LINE__, 0)
-#define NOEXCEPT_SCOPE NOEXCEPT_SCOPE_FWD(__LINE__)
+#define NOEXCEPT_SCOPE_IMPL(...) do {                          \
+    LockMemoryExceptionInThread                                \
+        noexcept_lock_memory_tracker(VariableContext::Global); \
+    try                                                        \
+    {                                                          \
+        __VA_ARGS__;                                           \
+    }                                                          \
+    catch (...)                                                \
+    {                                                          \
+        DB::tryLogCurrentException(__PRETTY_FUNCTION__);       \
+        std::terminate();                                      \
+    }                                                          \
+} while (0) /* to allow leading semi-colon */
+
+#define NOEXCEPT_SCOPE_STRICT(...)                    \
+    if (std::uncaught_exceptions()) std::terminate(); \
+    NOEXCEPT_SCOPE_IMPL(__VA_ARGS__)
+
+#define NOEXCEPT_SCOPE(...) NOEXCEPT_SCOPE_IMPL(__VA_ARGS__)

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -403,10 +403,11 @@ void DatabaseCatalog::attachDatabase(const String & database_name, const Databas
     std::lock_guard lock{databases_mutex};
     assertDatabaseDoesntExistUnlocked(database_name);
     databases.emplace(database_name, database);
-    NOEXCEPT_SCOPE;
-    UUID db_uuid = database->getUUID();
-    if (db_uuid != UUIDHelpers::Nil)
-        addUUIDMapping(db_uuid, database, nullptr);
+    NOEXCEPT_SCOPE({
+        UUID db_uuid = database->getUUID();
+        if (db_uuid != UUIDHelpers::Nil)
+            addUUIDMapping(db_uuid, database, nullptr);
+    });
 }
 
 

--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -149,11 +149,12 @@ void MergeTreeTransaction::removeOldPart(const StoragePtr & storage, const DataP
         checkIsNotCancelled();
 
         part_to_remove->version.lockRemovalTID(tid, context);
-        NOEXCEPT_SCOPE;
-        storages.insert(storage);
-        if (maybe_lock)
-            table_read_locks_for_ordinary_db.emplace_back(std::move(maybe_lock));
-        removing_parts.push_back(part_to_remove);
+        NOEXCEPT_SCOPE({
+            storages.insert(storage);
+            if (maybe_lock)
+                table_read_locks_for_ordinary_db.emplace_back(std::move(maybe_lock));
+            removing_parts.push_back(part_to_remove);
+        });
     }
 
     part_to_remove->appendRemovalTIDToVersionMetadata();

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -343,7 +343,7 @@ void ThreadStatus::finalizeQueryProfiler()
 
 void ThreadStatus::detachQuery(bool exit_if_already_detached, bool thread_exits)
 {
-    NOEXCEPT_SCOPE;
+    LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
 
     if (exit_if_already_detached && thread_state == ThreadState::DetachedFromQuery)
     {

--- a/src/Interpreters/TransactionLog.cpp
+++ b/src/Interpreters/TransactionLog.cpp
@@ -140,8 +140,7 @@ void TransactionLog::loadEntries(Strings::const_iterator beg, Strings::const_ite
     }
     futures.clear();
 
-    NOEXCEPT_SCOPE_STRICT;
-    {
+    NOEXCEPT_SCOPE_STRICT({
         std::lock_guard lock{mutex};
         for (const auto & entry : loaded)
         {
@@ -151,7 +150,8 @@ void TransactionLog::loadEntries(Strings::const_iterator beg, Strings::const_ite
             tid_to_csn.emplace(entry.first, entry.second);
         }
         last_loaded_entry = last_entry;
-    }
+    });
+
     {
         std::lock_guard lock{running_list_mutex};
         latest_snapshot = loaded.back().second.csn;
@@ -445,10 +445,11 @@ CSN TransactionLog::commitTransaction(const MergeTreeTransactionPtr & txn, bool 
 
         /// Do not allow exceptions between commit point and the and of transaction finalization
         /// (otherwise it may stuck in COMMITTING state holding snapshot).
-        NOEXCEPT_SCOPE_STRICT;
-        /// FIXME Transactions: Sequential node numbers in ZooKeeper are Int32, but 31 bit is not enough for production use
-        /// (overflow is possible in a several weeks/months of active usage)
-        allocated_csn = deserializeCSN(csn_path_created.substr(zookeeper_path_log.size() + 1));
+        NOEXCEPT_SCOPE_STRICT({
+            /// FIXME Transactions: Sequential node numbers in ZooKeeper are Int32, but 31 bit is not enough for production use
+            /// (overflow is possible in a several weeks/months of active usage)
+            allocated_csn = deserializeCSN(csn_path_created.substr(zookeeper_path_log.size() + 1));
+        });
     }
 
     return finalizeCommittedTransaction(txn.get(), allocated_csn, state_guard);

--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -138,18 +138,20 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
     }
     catch (const Exception & e)
     {
-        NOEXCEPT_SCOPE;
-        ALLOW_ALLOCATIONS_IN_SCOPE;
-        if (e.code() == ErrorCodes::ABORTED)    /// Cancelled merging parts is not an error - log as info.
-            LOG_INFO(log, fmt::runtime(getCurrentExceptionMessage(false)));
-        else
-            tryLogCurrentException(__PRETTY_FUNCTION__);
+        NOEXCEPT_SCOPE({
+            ALLOW_ALLOCATIONS_IN_SCOPE;
+            if (e.code() == ErrorCodes::ABORTED)    /// Cancelled merging parts is not an error - log as info.
+                LOG_INFO(log, fmt::runtime(getCurrentExceptionMessage(false)));
+            else
+                tryLogCurrentException(__PRETTY_FUNCTION__);
+        });
     }
     catch (...)
     {
-        NOEXCEPT_SCOPE;
-        ALLOW_ALLOCATIONS_IN_SCOPE;
-        tryLogCurrentException(__PRETTY_FUNCTION__);
+        NOEXCEPT_SCOPE({
+            ALLOW_ALLOCATIONS_IN_SCOPE;
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        });
     }
 
     if (need_execute_again)
@@ -162,9 +164,10 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
 
             /// This is significant to order the destructors.
             {
-                NOEXCEPT_SCOPE;
-                ALLOW_ALLOCATIONS_IN_SCOPE;
-                item->task.reset();
+                NOEXCEPT_SCOPE({
+                    ALLOW_ALLOCATIONS_IN_SCOPE;
+                    item->task.reset();
+                });
             }
             item->is_done.set();
             item = nullptr;
@@ -197,18 +200,20 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         }
         catch (const Exception & e)
         {
-            NOEXCEPT_SCOPE;
-            ALLOW_ALLOCATIONS_IN_SCOPE;
-            if (e.code() == ErrorCodes::ABORTED)    /// Cancelled merging parts is not an error - log as info.
-                LOG_INFO(log, fmt::runtime(getCurrentExceptionMessage(false)));
-            else
-                tryLogCurrentException(__PRETTY_FUNCTION__);
+            NOEXCEPT_SCOPE({
+                ALLOW_ALLOCATIONS_IN_SCOPE;
+                if (e.code() == ErrorCodes::ABORTED)    /// Cancelled merging parts is not an error - log as info.
+                    LOG_INFO(log, fmt::runtime(getCurrentExceptionMessage(false)));
+                else
+                    tryLogCurrentException(__PRETTY_FUNCTION__);
+            });
         }
         catch (...)
         {
-            NOEXCEPT_SCOPE;
-            ALLOW_ALLOCATIONS_IN_SCOPE;
-            tryLogCurrentException(__PRETTY_FUNCTION__);
+            NOEXCEPT_SCOPE({
+                ALLOW_ALLOCATIONS_IN_SCOPE;
+                tryLogCurrentException(__PRETTY_FUNCTION__);
+            });
         }
 
 
@@ -218,9 +223,10 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
         /// The thread that shutdowns storage will scan queues in order to find some tasks to wait for, but will find nothing.
         /// So, the destructor of a task and the destructor of a storage will be executed concurrently.
         {
-            NOEXCEPT_SCOPE;
-            ALLOW_ALLOCATIONS_IN_SCOPE;
-            item->task.reset();
+            NOEXCEPT_SCOPE({
+                ALLOW_ALLOCATIONS_IN_SCOPE;
+                item->task.reset();
+            });
         }
 
         item->is_done.set();
@@ -256,9 +262,10 @@ void MergeTreeBackgroundExecutor<Queue>::threadFunction()
         }
         catch (...)
         {
-            NOEXCEPT_SCOPE;
-            ALLOW_ALLOCATIONS_IN_SCOPE;
-            tryLogCurrentException(__PRETTY_FUNCTION__);
+            NOEXCEPT_SCOPE({
+                ALLOW_ALLOCATIONS_IN_SCOPE;
+                tryLogCurrentException(__PRETTY_FUNCTION__);
+            });
         }
     }
 }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4942,78 +4942,78 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(MergeTreeData:
             }
         }
 
-        NOEXCEPT_SCOPE;
+        NOEXCEPT_SCOPE({
+            auto current_time = time(nullptr);
 
-        auto current_time = time(nullptr);
+            size_t add_bytes = 0;
+            size_t add_rows = 0;
+            size_t add_parts = 0;
 
-        size_t add_bytes = 0;
-        size_t add_rows = 0;
-        size_t add_parts = 0;
+            size_t reduce_bytes = 0;
+            size_t reduce_rows = 0;
+            size_t reduce_parts = 0;
 
-        size_t reduce_bytes = 0;
-        size_t reduce_rows = 0;
-        size_t reduce_parts = 0;
-
-        for (const DataPartPtr & part : precommitted_parts)
-        {
-            auto part_in_memory = asInMemoryPart(part);
-            if (part_in_memory && settings->in_memory_parts_enable_wal)
+            for (const DataPartPtr & part : precommitted_parts)
             {
-                if (!wal)
-                    wal = data.getWriteAheadLog();
-
-                wal->addPart(part_in_memory);
-            }
-
-            DataPartPtr covering_part;
-            DataPartsVector covered_parts = data.getActivePartsToReplace(part->info, part->name, covering_part, *owing_parts_lock);
-            if (covering_part)
-            {
-                LOG_WARNING(data.log, "Tried to commit obsolete part {} covered by {}", part->name, covering_part->getNameWithState());
-
-                part->remove_time.store(0, std::memory_order_relaxed); /// The part will be removed without waiting for old_parts_lifetime seconds.
-                data.modifyPartState(part, DataPartState::Outdated);
-            }
-            else
-            {
-                if (!txn)
-                    MergeTreeTransaction::addNewPartAndRemoveCovered(data.shared_from_this(), part, covered_parts, NO_TRANSACTION_RAW);
-
-                total_covered_parts.insert(total_covered_parts.end(), covered_parts.begin(), covered_parts.end());
-                for (const auto & covered_part : covered_parts)
+                auto part_in_memory = asInMemoryPart(part);
+                if (part_in_memory && settings->in_memory_parts_enable_wal)
                 {
-                    covered_part->remove_time.store(current_time, std::memory_order_relaxed);
+                    if (!wal)
+                        wal = data.getWriteAheadLog();
 
-                    reduce_bytes += covered_part->getBytesOnDisk();
-                    reduce_rows += covered_part->rows_count;
-
-                    data.modifyPartState(covered_part, DataPartState::Outdated);
-                    data.removePartContributionToColumnAndSecondaryIndexSizes(covered_part);
+                    wal->addPart(part_in_memory);
                 }
 
-                reduce_parts += covered_parts.size();
+                DataPartPtr covering_part;
+                DataPartsVector covered_parts = data.getActivePartsToReplace(part->info, part->name, covering_part, *owing_parts_lock);
+                if (covering_part)
+                {
+                    LOG_WARNING(data.log, "Tried to commit obsolete part {} covered by {}", part->name, covering_part->getNameWithState());
 
-                add_bytes += part->getBytesOnDisk();
-                add_rows += part->rows_count;
-                ++add_parts;
+                    part->remove_time.store(0, std::memory_order_relaxed); /// The part will be removed without waiting for old_parts_lifetime seconds.
+                    data.modifyPartState(part, DataPartState::Outdated);
+                }
+                else
+                {
+                    if (!txn)
+                        MergeTreeTransaction::addNewPartAndRemoveCovered(data.shared_from_this(), part, covered_parts, NO_TRANSACTION_RAW);
 
-                data.modifyPartState(part, DataPartState::Active);
-                data.addPartContributionToColumnAndSecondaryIndexSizes(part);
+                    total_covered_parts.insert(total_covered_parts.end(), covered_parts.begin(), covered_parts.end());
+                    for (const auto & covered_part : covered_parts)
+                    {
+                        covered_part->remove_time.store(current_time, std::memory_order_relaxed);
+
+                        reduce_bytes += covered_part->getBytesOnDisk();
+                        reduce_rows += covered_part->rows_count;
+
+                        data.modifyPartState(covered_part, DataPartState::Outdated);
+                        data.removePartContributionToColumnAndSecondaryIndexSizes(covered_part);
+                    }
+
+                    reduce_parts += covered_parts.size();
+
+                    add_bytes += part->getBytesOnDisk();
+                    add_rows += part->rows_count;
+                    ++add_parts;
+
+                    data.modifyPartState(part, DataPartState::Active);
+                    data.addPartContributionToColumnAndSecondaryIndexSizes(part);
+                }
             }
-        }
 
-        if (reduce_parts == 0)
-        {
-            for (const auto & part : precommitted_parts)
-                data.updateObjectColumns(part, parts_lock);
-        }
-        else
-            data.resetObjectColumnsFromActiveParts(parts_lock);
+            if (reduce_parts == 0)
+            {
+                for (const auto & part : precommitted_parts)
+                    data.updateObjectColumns(part, parts_lock);
+            }
+            else
+                data.resetObjectColumnsFromActiveParts(parts_lock);
 
-        ssize_t diff_bytes = add_bytes - reduce_bytes;
-        ssize_t diff_rows = add_rows - reduce_rows;
-        ssize_t diff_parts  = add_parts - reduce_parts;
-        data.increaseDataVolume(diff_bytes, diff_rows, diff_parts);
+            ssize_t diff_bytes = add_bytes - reduce_bytes;
+            ssize_t diff_rows = add_rows - reduce_rows;
+            ssize_t diff_parts  = add_parts - reduce_parts;
+            data.increaseDataVolume(diff_bytes, diff_rows, diff_parts);
+        });
     }
 
     clear();


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix NOEXCEPT_SCOPE (before it calls std::terminate and looses the exception)

Current implementation of NOEXCEPT_SCOPE will not work, you cannot
rethrow exception outside the catch block, this will simply terminate
(via std::terminate) the program.
In other words NOEXCEPT_SCOPE macro will simply call std::terminate on
exception and will lost original exception.

But if NOEXCEPT_SCOPE will accept the code that should be runned w/o
exceptions, then it can catch exception and log it, rewrite it in this
way.

Cc: @tavplubix 