### PR TITLE
Fix typo in string search functions docs page

### DIFF
--- a/docs/en/sql-reference/functions/string-search-functions.md
+++ b/docs/en/sql-reference/functions/string-search-functions.md
@@ -374,7 +374,7 @@ The same as `multiMatchAny`, but returns any index that matches the haystack.
 
 ## multiMatchAllIndices(haystack, \[pattern<sub>1</sub>, pattern<sub>2</sub>, …, pattern<sub>n</sub>\])
 
-The same as `multiMatchAny`, but returns the array of all indicies that match the haystack in any order.
+The same as `multiMatchAny`, but returns the array of all indices that match the haystack in any order.
 
 ## multiFuzzyMatchAny(haystack, distance, \[pattern<sub>1</sub>, pattern<sub>2</sub>, …, pattern<sub>n</sub>\])
 


### PR DESCRIPTION
Replace "indicies" by "indices"


### Changelog category (leave one):
- Documentation (changelog entry is not required)



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
No CI checks needed, just a typo fix