### PR TITLE
Cherry pick #33050 to 21.8: Native Out of Bounds Column Index

### DIFF
--- a/src/Formats/NativeReader.cpp
+++ b/src/Formats/NativeReader.cpp
@@ -192,8 +192,8 @@ Block NativeReader::read()
             auto & header_column = header.getByName(column.name);
             if (!header_column.type->equals(*column.type))
             {
-                column.column = recursiveTypeConversion(column.column, column.type, header.getByPosition(i).type);
-                column.type = header.getByPosition(i).type;
+                column.column = recursiveTypeConversion(column.column, column.type, header.safeGetByPosition(i).type);
+                column.type = header.safeGetByPosition(i).type;
             }
         }
 


### PR DESCRIPTION
Original pull-request #33050

This pull-request is a first step of an automated     backporting.
It contains changes like after calling a local command `git cherry-pick`.
If you intend to continue backporting this changes, then resolve all conflicts if any.
Otherwise, if you do not want to backport them, then just close this pull-request.

The check results does not matter at this step - you can safely ignore them.
Also this pull-request will be merged automatically as it reaches the mergeable state,     but you always can merge it manually.
