### PR TITLE
Fix macosx compilation due to endian.h

### DIFF
--- a/utils/self-extracting-executable/compressor.cpp
+++ b/utils/self-extracting-executable/compressor.cpp
@@ -9,7 +9,18 @@
 #include <cerrno>
 #include <memory>
 #include <iostream>
+#if defined __APPLE__
+
+// dependencies
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+
+// define 64 bit macros
+#define htole64(x) OSSwapHostToLittleInt64(x)
+
+#else
 #include <endian.h>
+#endif
 
 #include "types.h"
 

--- a/utils/self-extracting-executable/compressor.cpp
+++ b/utils/self-extracting-executable/compressor.cpp
@@ -9,7 +9,7 @@
 #include <cerrno>
 #include <memory>
 #include <iostream>
-#if defined __APPLE__
+#if defined OS_DARWIN
 
 // dependencies
 #include <machine/endian.h>

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -1,6 +1,6 @@
 #include <zstd.h>
 #include <sys/mman.h>
-#if defined __APPLE__
+#if defined OS_DARWIN
 #include <sys/mount.h>
 #else
 #include <sys/statfs.h>
@@ -12,7 +12,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
-#if defined __APPLE__
+#if defined OS_DARWIN
 
 // dependencies
 #include <machine/endian.h>

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -12,7 +12,18 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#if defined __APPLE__
+
+// dependencies
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+
+// define 64 bit macros
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#else
 #include <endian.h>
+#endif
 
 #include "types.h"
 


### PR DESCRIPTION
### Changelog category (leave one):
Not for changelog (changelog entry is not required)

- Fix MacOS compilation due to <endian.h> being located in <machine/endian.h>

Closes #39219 