### PR TITLE
Fix running cmake with predefined cache (for development only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,15 +74,10 @@ message (STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 string (TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UC)
 
 option(USE_STATIC_LIBRARIES "Disable to use shared libraries" ON)
-
-if (NOT USE_STATIC_LIBRARIES)
-    # DEVELOPER ONLY.
-    # Faster linking if turned on.
-    option(SPLIT_SHARED_LIBRARIES "Keep all internal libraries as separate .so files")
-
-    option(CLICKHOUSE_SPLIT_BINARY
-        "Make several binaries (clickhouse-server, clickhouse-client etc.) instead of one bundled")
-endif ()
+# DEVELOPER ONLY.
+# Faster linking if turned on.
+option(SPLIT_SHARED_LIBRARIES "Keep all internal libraries as separate .so files" OFF)
+option(CLICKHOUSE_SPLIT_BINARY "Make several binaries (clickhouse-server, clickhouse-client etc.) instead of one bundled" OFF)
 
 if (USE_STATIC_LIBRARIES AND SPLIT_SHARED_LIBRARIES)
     message(FATAL_ERROR "Defining SPLIT_SHARED_LIBRARIES=1 without USE_STATIC_LIBRARIES=0 has no effect.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,8 @@ option(USE_STATIC_LIBRARIES "Disable to use shared libraries" ON)
 option(SPLIT_SHARED_LIBRARIES "Keep all internal libraries as separate .so files" OFF)
 option(CLICKHOUSE_SPLIT_BINARY "Make several binaries (clickhouse-server, clickhouse-client etc.) instead of one bundled" OFF)
 
-if (USE_STATIC_LIBRARIES AND SPLIT_SHARED_LIBRARIES)
-    message(FATAL_ERROR "Defining SPLIT_SHARED_LIBRARIES=1 without USE_STATIC_LIBRARIES=0 has no effect.")
+if (USE_STATIC_LIBRARIES AND (SPLIT_SHARED_LIBRARIES OR CLICKHOUSE_SPLIT_BINARY))
+    message(FATAL_ERROR "SPLIT_SHARED_LIBRARIES=1 or CLICKHOUSE_SPLIT_BINARY=1 must not be used together with USE_STATIC_LIBRARIES=1")
 endif()
 
 if (NOT USE_STATIC_LIBRARIES AND SPLIT_SHARED_LIBRARIES)


### PR DESCRIPTION
Right now cmake add the following options only if USE_STATIC_LIBRARIES
is OFF:
- SPLIT_SHARED_LIBRARIES
- CLICKHOUSE_SPLIT_BINARY

And this breaks the following usage:

    $ cmake ..
    $ cat > debug-build-cache.cmake
    set(USE_STATIC_LIBRARIES              OFF CACHE BOOL "")
    set(SPLIT_SHARED_LIBRARIES            ON  CACHE BOOL "")
    set(CLICKHOUSE_SPLIT_BINARY           ON  CACHE BOOL "")
    ^D
    $ cmake -C debug-build-cache.cmake ..
    CMake Error at CMakeLists.txt:83 (message):
      Defining SPLIT_SHARED_LIBRARIES=1 without USE_STATIC_LIBRARIES=0 has no
      effect.

Since with this initial cache we have the following:

- USE_STATIC_LIBRARIES=OFF (because it was already set)
- SPLIT_SHARED_LIBRARIES=ON (was not set before, so new value)
- CLICKHOUSE_SPLIT_BINARY (was not set before, also new value)

Yes this is not the common usage, but it seems that it is pretty easy to
avoid.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)