### PR TITLE
Fix googletest contrib compilation (due to GTEST_HAS_POSIX_RE=0)

### DIFF
--- a/contrib/googletest-cmake/CMakeLists.txt
+++ b/contrib/googletest-cmake/CMakeLists.txt
@@ -2,7 +2,7 @@ set (SRC_DIR "${ClickHouse_SOURCE_DIR}/contrib/googletest/googletest")
 
 add_library(_gtest "${SRC_DIR}/src/gtest-all.cc")
 set_target_properties(_gtest PROPERTIES VERSION "1.0.0")
-target_compile_definitions (_gtest INTERFACE GTEST_HAS_POSIX_RE=0)
+target_compile_definitions (_gtest PUBLIC GTEST_HAS_POSIX_RE=0)
 target_include_directories(_gtest SYSTEM PUBLIC "${SRC_DIR}/include")
 target_include_directories(_gtest PRIVATE "${SRC_DIR}")
 


### PR DESCRIPTION
By some reason cmake rules for googletest sets GTEST_HAS_POSIX_RE=0
(Compatibilty? But which platform that does support ClickHouse does not
have it?)

But everything will be okay, if these macros was set PUBLIC (i.e. for
compiling googletest library itself and it's users), however it was
added as INTERFACE only (so library itself does not know about
GTEST_HAS_POSIX_RE=0), and this leads to UB, here ASan report (while I
was trying to use ASSERT_EXIT()).

<details>

<summary>ASan report</summary>

    [ RUN      ] Common.LSan
    =================================================================
    ==7566==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6030005b2388 at pc 0x00000d00924c bp 0x7ffcd3b7cfb0 sp 0x7ffcd3b7c770
    WRITE of size 64 at 0x6030005b2388 thread T0
        0 0xd00924b in regcomp (/bld/src/unit_tests_dbms+0xd00924b) (BuildId: 40d3fa83125f9047)
        1 0x29ca243b in testing::internal::RE::Init(char const*) /bld/./contrib/googletest/googletest/src/gtest-port.cc:750:15
        2 0xd4d92b3 in testing::internal::RE::RE(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /bld/./contrib/googletest/googletest/include/gtest/internal/gtest-port.h:896:36
        3 0xd4d92b3 in testing::PolymorphicMatcher<testing::internal::MatchesRegexMatcher> testing::ContainsRegex<char const*>(char const* const&) /bld/./contrib/googletest/googletest/include/gtest/gtest-matchers.h:868:28
        4 0xd4d813a in testing::internal::MakeDeathTestMatcher(char const*) /bld/./contrib/googletest/googletest/include/gtest/internal/gtest-death-test-internal.h:173:10
        5 0xd4d813a in Common_LSan_Test::TestBody() /bld/./src/Common/tests/gtest_lsan.cpp:11:5

    0x6030005b2388 is located 0 bytes to the right of 24-byte region [0x6030005b2370,0x6030005b2388)
    allocated by thread T0 here:
        0 0xd066fbd in operator new(unsigned long) (/bld/src/unit_tests_dbms+0xd066fbd) (BuildId: 40d3fa83125f9047)
        1 0xd4d913d in testing::PolymorphicMatcher<testing::internal::MatchesRegexMatcher> testing::ContainsRegex<char const*>(char const* const&) /bld/./contrib/googletest/googletest/include/gtest/gtest-matchers.h:868:24
        2 0xd4d813a in testing::internal::MakeDeathTestMatcher(char const*) /bld/./contrib/googletest/googletest/include/gtest/internal/gtest-death-test-internal.h:173:10
        3 0xd4d813a in Common_LSan_Test::TestBody() /bld/./src/Common/tests/gtest_lsan.cpp:11:5

</details>

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
