### PR TITLE
Fix universal installation script for FreeBSD

### DIFF
--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -7,31 +7,31 @@ DIR=
 
 if [ "${OS}" = "Linux" ]
 then
-    if [ "${ARCH}" = "x86_64" ]
+    if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
     then
         DIR="amd64"
-    elif [ "${ARCH}" = "aarch64" ]
+    elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
     then
         DIR="aarch64"
-    elif [ "${ARCH}" = "powerpc64le" ] || [ "${ARCH}" = "ppc64le" ]
+    elif [ "${ARCH}" = "powerpc64le" -o "${ARCH}" = "ppc64le" ]
     then
         DIR="powerpc64le"
     fi
 elif [ "${OS}" = "FreeBSD" ]
 then
-    if [ "${ARCH}" = "x86_64" ]
+    if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
     then
         DIR="freebsd"
-    elif [ "${ARCH}" = "aarch64" ]
+    elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
     then
         DIR="freebsd-aarch64"
-    elif [ "${ARCH}" = "powerpc64le" ] || [ "${ARCH}" = "ppc64le" ]
+    elif [ "${ARCH}" = "powerpc64le" -o "${ARCH}" = "ppc64le" ]
     then
         DIR="freebsd-powerpc64le"
     fi
 elif [ "${OS}" = "Darwin" ]
 then
-    if [ "${ARCH}" = "x86_64" ]
+    if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
     then
         DIR="macos"
     elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Adapt universal installation script for FreeBSD.