### PR TITLE
Prefetching in aggregation

### DIFF
--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -659,7 +659,6 @@ struct HashMethodSerialized
     HashMethodSerialized(const ColumnRawPtrs & key_columns_, const Sizes & /*key_sizes*/, const HashMethodContextPtr &)
         : key_columns(key_columns_), keys_size(key_columns_.size()) {}
 
-protected:
     friend class columns_hashing_impl::HashMethodBase<Self, Value, Mapped, false>;
 
     ALWAYS_INLINE SerializedKeyHolder getKeyHolder(size_t row, Arena & pool) const

--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -80,7 +80,7 @@ struct HashMethodString
     using Self = HashMethodString<Value, Mapped, place_string_to_arena, use_cache, need_offset>;
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset>;
 
-    static constexpr bool has_cheap_key_calculation = true;
+    static constexpr bool has_cheap_key_calculation = false;
 
     const IColumn::Offset * offsets;
     const UInt8 * chars;
@@ -121,7 +121,7 @@ struct HashMethodFixedString
     using Self = HashMethodFixedString<Value, Mapped, place_string_to_arena, use_cache, need_offset>;
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset>;
 
-    static constexpr bool has_cheap_key_calculation = true;
+    static constexpr bool has_cheap_key_calculation = false;
 
     size_t n;
     const ColumnFixedString::Chars * chars;

--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -487,7 +487,7 @@ struct HashMethodKeysFixed
     static constexpr bool has_nullable_keys = has_nullable_keys_;
     static constexpr bool has_low_cardinality = has_low_cardinality_;
 
-    static constexpr bool has_cheap_key_calculation = false;
+    static constexpr bool has_cheap_key_calculation = true;
 
     LowCardinalityKeys<has_low_cardinality> low_cardinality_keys;
     Sizes key_sizes;

--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -36,6 +36,8 @@ struct HashMethodOneNumber
     using Self = HashMethodOneNumber<Value, Mapped, FieldType, use_cache, need_offset>;
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset>;
 
+    static constexpr bool has_cheap_key_calculation = true;
+
     const char * vec;
 
     /// If the keys of a fixed length then key_sizes contains their lengths, empty otherwise.
@@ -78,6 +80,8 @@ struct HashMethodString
     using Self = HashMethodString<Value, Mapped, place_string_to_arena, use_cache, need_offset>;
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset>;
 
+    static constexpr bool has_cheap_key_calculation = true;
+
     const IColumn::Offset * offsets;
     const UInt8 * chars;
 
@@ -116,6 +120,8 @@ struct HashMethodFixedString
 {
     using Self = HashMethodFixedString<Value, Mapped, place_string_to_arena, use_cache, need_offset>;
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset>;
+
+    static constexpr bool has_cheap_key_calculation = true;
 
     size_t n;
     const ColumnFixedString::Chars * chars;
@@ -209,6 +215,8 @@ struct HashMethodSingleLowCardinalityColumn : public SingleColumnMethod
     static constexpr bool has_mapped = !std::is_same_v<Mapped, void>;
     using EmplaceResult = columns_hashing_impl::EmplaceResultImpl<Mapped>;
     using FindResult = columns_hashing_impl::FindResultImpl<Mapped>;
+
+    static constexpr bool has_cheap_key_calculation = Base::has_cheap_key_calculation;
 
     static HashMethodContextPtr createContext(const HashMethodContext::Settings & settings)
     {
@@ -479,6 +487,8 @@ struct HashMethodKeysFixed
     static constexpr bool has_nullable_keys = has_nullable_keys_;
     static constexpr bool has_low_cardinality = has_low_cardinality_;
 
+    static constexpr bool has_cheap_key_calculation = false;
+
     LowCardinalityKeys<has_low_cardinality> low_cardinality_keys;
     Sizes key_sizes;
     size_t keys_size;
@@ -653,6 +663,8 @@ struct HashMethodSerialized
     using Self = HashMethodSerialized<Value, Mapped>;
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, false>;
 
+    static constexpr bool has_cheap_key_calculation = false;
+
     ColumnRawPtrs key_columns;
     size_t keys_size;
 
@@ -677,6 +689,8 @@ struct HashMethodHashed
     using Key = UInt128;
     using Self = HashMethodHashed<Value, Mapped, use_cache, need_offset>;
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset>;
+
+    static constexpr bool has_cheap_key_calculation = false;
 
     ColumnRawPtrs key_columns;
 

--- a/src/Common/ColumnsHashingImpl.h
+++ b/src/Common/ColumnsHashingImpl.h
@@ -212,9 +212,9 @@ protected:
         if constexpr (has_mapped)
             cached = &it->getMapped();
 
-        if (inserted)
+        if constexpr (has_mapped)
         {
-            if constexpr (has_mapped)
+            if (inserted)
             {
                 new (&it->getMapped()) Mapped();
             }

--- a/src/Common/HashTable/FixedHashMap.h
+++ b/src/Common/HashTable/FixedHashMap.h
@@ -109,7 +109,7 @@ public:
 
     using Base::Base;
 
-    template <typename Func>
+    template <typename Func, bool>
     void ALWAYS_INLINE mergeToViaEmplace(Self & that, Func && func)
     {
         for (auto it = this->begin(), end = this->end(); it != end; ++it)

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -305,8 +305,11 @@ private:
     Iterator advanceIterator(Iterator it, size_t n)
     {
         size_t i = 0;
-        while (i++ < n && it != this->end())
+        while (i < n && it != this->end())
+        {
+            ++i;
             ++it;
+        }
         return it;
     }
 };

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -192,6 +192,8 @@ public:
 
     using Base::Base;
 
+    using Base::prefetch;
+
     /// Merge every cell's value of current map into the destination map via emplace.
     ///  Func should have signature void(Mapped & dst, Mapped & src, bool emplaced).
     ///  Each filled cell in current map will invoke func once. If that map doesn't

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -190,6 +190,7 @@ public:
     using Self = HashMapTable;
     using Base = HashTable<Key, Cell, Hash, Grower, Allocator>;
     using LookupResult = typename Base::LookupResult;
+    using Iterator = typename Base::iterator;
 
     using Base::Base;
     using Base::prefetch;
@@ -301,7 +302,7 @@ public:
     }
 
 private:
-    auto advanceIterator(auto it, size_t n)
+    Iterator advanceIterator(Iterator it, size_t n)
     {
         size_t i = 0;
         while (i++ < n && it != this->end())

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -191,7 +191,6 @@ public:
     using LookupResult = typename Base::LookupResult;
 
     using Base::Base;
-
     using Base::prefetch;
 
     /// Merge every cell's value of current map into the destination map via emplace.

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -219,7 +219,7 @@ public:
                     prefetch_it = advanceIterator(prefetch_it, prefetch_look_ahead - prefetching.getInitialLookAheadValue());
                 }
 
-                if (likely(prefetch_it != end))
+                if (prefetch_it != end)
                 {
                     that.prefetchByHash(prefetch_it.getHash());
                     ++prefetch_it;

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -5,7 +5,6 @@
 #include <math.h>
 
 #include <new>
-#include <type_traits>
 #include <utility>
 
 #include <boost/noncopyable.hpp>
@@ -991,6 +990,12 @@ protected:
         emplaceNonZeroImpl(place_value, key_holder, it, inserted, hash_value);
     }
 
+    void ALWAYS_INLINE prefetchByHash(size_t hash_key) const
+    {
+        const auto place_value = grower.place(hash_key);
+        __builtin_prefetch(&buf[place_value]);
+    }
+
 
 public:
     void reserve(size_t num_elements)
@@ -1032,12 +1037,6 @@ public:
         const auto & key = keyHolderGetKey(key_holder);
         const auto hash_key = hash(key);
         prefetchByHash(hash_key);
-    }
-
-    void ALWAYS_INLINE prefetchByHash(size_t hash_key) const
-    {
-        size_t place_value = grower.place(hash_key);
-        __builtin_prefetch(&buf[place_value]);
     }
 
     /** Insert the key.

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -914,7 +914,7 @@ protected:
         if constexpr (!Cell::need_zero_value_storage)
             return false;
 
-        if unlikely (Cell::isZero(x, *this))
+        if (unlikely(Cell::isZero(x, *this)))
         {
             it = this->zeroValue();
 
@@ -992,10 +992,9 @@ protected:
 
     void ALWAYS_INLINE prefetchByHash(size_t hash_key) const
     {
-        const auto place_value = grower.place(hash_key);
-        __builtin_prefetch(&buf[place_value]);
+        const auto place = grower.place(hash_key);
+        __builtin_prefetch(&buf[place]);
     }
-
 
 public:
     void reserve(size_t num_elements)
@@ -1020,7 +1019,6 @@ public:
         return res;
     }
 
-
     /// Reinsert node pointed to by iterator
     void ALWAYS_INLINE reinsert(iterator & it, size_t hash_value)
     {
@@ -1035,8 +1033,8 @@ public:
     void ALWAYS_INLINE prefetch(KeyHolder && key_holder) const
     {
         const auto & key = keyHolderGetKey(key_holder);
-        const auto hash_key = hash(key);
-        prefetchByHash(hash_key);
+        const auto key_hash = hash(key);
+        prefetchByHash(key_hash);
     }
 
     /** Insert the key.

--- a/src/Common/HashTable/Prefetching.h
+++ b/src/Common/HashTable/Prefetching.h
@@ -7,14 +7,32 @@
 namespace DB
 {
 
+/**
+ * The purpose of this helper class is to provide a good value for prefetch look ahead (how distant row we should prefetch on the given iteration)
+ * based on the latency of a single iteration of the given cycle.
+ *
+ * Assumed usage pattern is the following:
+ *
+ * PrefetchingHelper prefetching; /// When object is created, it starts a watch to measure iteration latency.
+ * size_t prefetch_look_ahead = prefetching.getInitialLookAheadValue(); /// Initially it provides you with some reasonable default value.
+ *
+ * for (size_t i = 0; i < end; ++i)
+ * {
+ *     if (i == prefetching.iterationsToMeasure()) /// When enough iterations passed, we are able to make a fairly accurate estimation of a single iteration latency.
+ *         prefetch_look_ahead = prefetching.calcPrefetchLookAhead(); /// Based on this estimation we can choose a good value for prefetch_look_ahead.
+ *
+ *     ... main loop body ...
+ * }
+ *
+ */
 class PrefetchingHelper
 {
 public:
     size_t calcPrefetchLookAhead()
     {
-        static constexpr size_t assumed_load_latency_ns = 100;
-        static constexpr size_t just_coefficient = 4;
-        const double single_iteration_latency = std::max<double>(1.0 * watch.elapsedNanoseconds() / iterations_to_measure, 1);
+        static constexpr auto assumed_load_latency_ns = 100;
+        static constexpr auto just_coefficient = 4;
+        const auto single_iteration_latency = std::max<double>(1.0L * watch.elapsedNanoseconds() / iterations_to_measure, 1);
         return std::clamp<size_t>(
             just_coefficient * assumed_load_latency_ns / single_iteration_latency, min_look_ahead_value, max_look_ahead_value);
     }

--- a/src/Common/HashTable/Prefetching.h
+++ b/src/Common/HashTable/Prefetching.h
@@ -34,7 +34,7 @@ public:
         static constexpr auto just_coefficient = 4;
         const auto single_iteration_latency = std::max<double>(1.0L * watch.elapsedNanoseconds() / iterations_to_measure, 1);
         return std::clamp<size_t>(
-            just_coefficient * assumed_load_latency_ns / single_iteration_latency, min_look_ahead_value, max_look_ahead_value);
+            ceil(just_coefficient * assumed_load_latency_ns / single_iteration_latency), min_look_ahead_value, max_look_ahead_value);
     }
 
     static constexpr size_t getInitialLookAheadValue() { return min_look_ahead_value; }
@@ -43,7 +43,7 @@ public:
 
 private:
     static constexpr size_t iterations_to_measure = 100;
-    static constexpr size_t min_look_ahead_value = 8;
+    static constexpr size_t min_look_ahead_value = 4;
     static constexpr size_t max_look_ahead_value = 32;
 
     Stopwatch watch;

--- a/src/Common/HashTable/Prefetching.h
+++ b/src/Common/HashTable/Prefetching.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Common/Stopwatch.h>
+
+#include <algorithm>
+
+namespace DB
+{
+
+
+class PrefetchingHelper
+{
+public:
+    size_t calcPrefetchLookAhead()
+    {
+        static constexpr size_t assumed_load_latency_ns = 100;
+        static constexpr size_t just_coefficient = 4;
+        const size_t single_iteration_latency = watch.elapsedNanoseconds() / iterations_to_measure;
+        return std::clamp<size_t>(
+            just_coefficient * assumed_load_latency_ns / single_iteration_latency, min_look_ahead_value, max_look_ahead_value);
+    }
+
+    static constexpr size_t getInitialLookAheadValue() { return min_look_ahead_value; }
+
+    static constexpr size_t iterationsToMeasure() { return iterations_to_measure; }
+
+private:
+    static constexpr size_t iterations_to_measure = 100;
+    static constexpr size_t min_look_ahead_value = 8;
+    static constexpr size_t max_look_ahead_value = 32;
+
+    Stopwatch watch;
+};
+
+
+}

--- a/src/Common/HashTable/Prefetching.h
+++ b/src/Common/HashTable/Prefetching.h
@@ -7,7 +7,6 @@
 namespace DB
 {
 
-
 class PrefetchingHelper
 {
 public:
@@ -15,7 +14,7 @@ public:
     {
         static constexpr size_t assumed_load_latency_ns = 100;
         static constexpr size_t just_coefficient = 4;
-        const size_t single_iteration_latency = watch.elapsedNanoseconds() / iterations_to_measure;
+        const double single_iteration_latency = std::max<double>(1.0 * watch.elapsedNanoseconds() / iterations_to_measure, 1);
         return std::clamp<size_t>(
             just_coefficient * assumed_load_latency_ns / single_iteration_latency, min_look_ahead_value, max_look_ahead_value);
     }
@@ -31,6 +30,5 @@ private:
 
     Stopwatch watch;
 };
-
 
 }

--- a/src/Common/HashTable/StringHashMap.h
+++ b/src/Common/HashTable/StringHashMap.h
@@ -98,7 +98,7 @@ public:
     ///  have a key equals to the given cell, a new cell gets emplaced into that map,
     ///  and func is invoked with the third argument emplaced set to true. Otherwise
     ///  emplaced is set to false.
-    template <typename Func>
+    template <typename Func, bool>
     void ALWAYS_INLINE mergeToViaEmplace(Self & that, Func && func)
     {
         if (this->m0.hasZero() && that.m0.hasZero())

--- a/src/Common/HashTable/TwoLevelHashMap.h
+++ b/src/Common/HashTable/TwoLevelHashMap.h
@@ -21,7 +21,6 @@ public:
     using LookupResult = typename Impl::LookupResult;
 
     using Base::Base;
-
     using Base::prefetch;
 
     template <typename Func>

--- a/src/Common/HashTable/TwoLevelHashMap.h
+++ b/src/Common/HashTable/TwoLevelHashMap.h
@@ -17,9 +17,12 @@ class TwoLevelHashMapTable : public TwoLevelHashTable<Key, Cell, Hash, Grower, A
 {
 public:
     using Impl = ImplTable<Key, Cell, Hash, Grower, Allocator>;
+    using Base = TwoLevelHashTable<Key, Cell, Hash, Grower, Allocator, ImplTable<Key, Cell, Hash, Grower, Allocator>>;
     using LookupResult = typename Impl::LookupResult;
 
-    using TwoLevelHashTable<Key, Cell, Hash, Grower, Allocator, ImplTable<Key, Cell, Hash, Grower, Allocator>>::TwoLevelHashTable;
+    using Base::Base;
+
+    using Base::prefetch;
 
     template <typename Func>
     void ALWAYS_INLINE forEachMapped(Func && func)

--- a/src/Common/HashTable/TwoLevelHashTable.h
+++ b/src/Common/HashTable/TwoLevelHashTable.h
@@ -227,6 +227,15 @@ public:
         return res;
     }
 
+    template <typename KeyHolder>
+    void ALWAYS_INLINE prefetch(KeyHolder && key_holder) const
+    {
+        const auto & key = keyHolderGetKey(key_holder);
+        const auto hash_key = hash(key);
+        size_t buck = getBucketFromHash(hash_key);
+        impls[buck].prefetchByHash(hash_key);
+    }
+
 
     /** Insert the key,
       * return an iterator to a position that can be used for `placement new` of value,

--- a/src/Common/HashTable/TwoLevelHashTable.h
+++ b/src/Common/HashTable/TwoLevelHashTable.h
@@ -231,11 +231,10 @@ public:
     void ALWAYS_INLINE prefetch(KeyHolder && key_holder) const
     {
         const auto & key = keyHolderGetKey(key_holder);
-        const auto hash_key = hash(key);
-        const auto buck = getBucketFromHash(hash_key);
-        impls[buck].prefetchByHash(hash_key);
+        const auto key_hash = hash(key);
+        const auto bucket = getBucketFromHash(key_hash);
+        impls[bucket].prefetchByHash(key_hash);
     }
-
 
     /** Insert the key,
       * return an iterator to a position that can be used for `placement new` of value,

--- a/src/Common/HashTable/TwoLevelHashTable.h
+++ b/src/Common/HashTable/TwoLevelHashTable.h
@@ -232,7 +232,7 @@ public:
     {
         const auto & key = keyHolderGetKey(key_holder);
         const auto hash_key = hash(key);
-        size_t buck = getBucketFromHash(hash_key);
+        const auto buck = getBucketFromHash(hash_key);
         impls[buck].prefetchByHash(hash_key);
     }
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -535,7 +535,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, max_size_to_preallocate_for_aggregation, 10'000'000, "For how many elements it is allowed to preallocate space in all hash tables in total before aggregation", 0) \
     \
     M(Bool, kafka_disable_num_consumers_limit, false, "Disable limit on kafka_num_consumers that depends on the number of available CPU cores", 0) \
-    M(Bool, enable_sortware_prefetch_in_aggregation, true, "Enable use of software prefetch in aggregation", 0) \
+    M(Bool, enable_software_prefetch_in_aggregation, true, "Enable use of software prefetch in aggregation", 0) \
     /** Experimental feature for moving data between shards. */ \
     \
     M(Bool, allow_experimental_query_deduplication, false, "Experimental data deduplication for SELECT queries based on part UUIDs", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -535,6 +535,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, max_size_to_preallocate_for_aggregation, 10'000'000, "For how many elements it is allowed to preallocate space in all hash tables in total before aggregation", 0) \
     \
     M(Bool, kafka_disable_num_consumers_limit, false, "Disable limit on kafka_num_consumers that depends on the number of available CPU cores", 0) \
+    M(Bool, enable_sortware_prefetch_in_aggregation, true, "Enable use of software prefetch in aggregation", 0) \
     /** Experimental feature for moving data between shards. */ \
     \
     M(Bool, allow_experimental_query_deduplication, false, "Experimental data deduplication for SELECT queries based on part UUIDs", 0) \

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -290,7 +290,7 @@ DB::ColumnNumbers calculateKeysPositions(const DB::Block & header, const DB::Agg
 template <typename HashTable, typename KeyHolder>
 concept HasPrefetchMemberFunc = requires
 {
-    {std::declval<HashTable>().prefetch(std::declval<KeyHolder>())} -> std::same_as<void>;
+    {std::declval<HashTable>().prefetch(std::declval<KeyHolder>())};
 };
 
 size_t getL2CacheSize()
@@ -1037,7 +1037,7 @@ void NO_INLINE Aggregator::executeImplBatch(
 {
     using KeyHolder = decltype(state.getKeyHolder(0, std::declval<Arena &>()));
 
-    /// During processing of row #i we will prefetch HashTable cell for row #(row + prefetch_look_ahead).
+    /// During processing of row #i we will prefetch HashTable cell for row #(i + prefetch_look_ahead).
     PrefetchingHelper prefetching;
     size_t prefetch_look_ahead = prefetching.getInitialLookAheadValue();
 

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -995,7 +995,8 @@ void NO_INLINE Aggregator::executeImpl(
     if (!no_more_keys)
     {
         /// Prefetching doesn't make sense for small hash tables, because they fit in caches entirely.
-        const bool prefetch = Method::State::has_cheap_key_calculation && (method.data.getBufferSizeInBytes() > getMinBytesForPrefetch());
+        const bool prefetch = Method::State::has_cheap_key_calculation && params.enable_prefetch
+            && (method.data.getBufferSizeInBytes() > getMinBytesForPrefetch());
 
 #if USE_EMBEDDED_COMPILER
         if (compiled_aggregate_functions_holder && !hasSparseArguments(aggregate_instructions))
@@ -2554,8 +2555,8 @@ void NO_INLINE Aggregator::mergeSingleLevelDataImpl(
     AggregatedDataVariantsPtr & res = non_empty_data[0];
     bool no_more_keys = false;
 
-    const bool prefetch
-        = Method::State::has_cheap_key_calculation && (getDataVariant<Method>(*res).data.getBufferSizeInBytes() > getMinBytesForPrefetch());
+    const bool prefetch = Method::State::has_cheap_key_calculation && params.enable_prefetch
+        && (getDataVariant<Method>(*res).data.getBufferSizeInBytes() > getMinBytesForPrefetch());
 
     /// We merge all aggregation results to the first.
     for (size_t result_num = 1, size = non_empty_data.size(); result_num < size; ++result_num)
@@ -2622,7 +2623,7 @@ void NO_INLINE Aggregator::mergeBucketImpl(
     /// We merge all aggregation results to the first.
     AggregatedDataVariantsPtr & res = data[0];
 
-    const bool prefetch = Method::State::has_cheap_key_calculation
+    const bool prefetch = Method::State::has_cheap_key_calculation && params.enable_prefetch
         && (Method::Data::NUM_BUCKETS * getDataVariant<Method>(*res).data.impls[bucket].getBufferSizeInBytes() > getMinBytesForPrefetch());
 
     for (size_t result_num = 1, size = data.size(); result_num < size; ++result_num)

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -302,8 +302,8 @@ size_t getMinBytesForPrefetch()
         l2_size = ret;
 #endif
 
-    /// 1MB looks like a reasonable estimate of L2 size. 4 is empirical constant.
-    return 4 * std::max<size_t>(l2_size, 1024 * 1024);
+    /// 256KB looks like a reasonable default L2 size. 4 is empirical constant.
+    return 4 * std::max<size_t>(l2_size, 256 * 1024);
 }
 
 }

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1047,7 +1047,7 @@ void NO_INLINE Aggregator::executeImplBatch(
         AggregateDataPtr place = aggregates_pool->alloc(0);
         for (size_t i = row_begin; i < row_end; ++i)
         {
-            if constexpr (prefetch && HasPrefetchMemberFunc<decltype(method.data), KeyHolder>)
+            if constexpr (prefetch && HasPrefetchMemberFunc<decltype(method.data), KeyHolder> && Method::State::has_cheap_key_calculation)
             {
                 if (i == row_begin + prefetching.iterationsToMeasure())
                     prefetch_look_ahead = prefetching.calcPrefetchLookAhead();
@@ -1113,7 +1113,7 @@ void NO_INLINE Aggregator::executeImplBatch(
 
         if constexpr (!no_more_keys)
         {
-            if constexpr (prefetch && HasPrefetchMemberFunc<decltype(method.data), KeyHolder>)
+            if constexpr (prefetch && HasPrefetchMemberFunc<decltype(method.data), KeyHolder> && Method::State::has_cheap_key_calculation)
             {
                 if (i == row_begin + prefetching.iterationsToMeasure())
                     prefetch_look_ahead = prefetching.calcPrefetchLookAhead();

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -3,6 +3,10 @@
 #include <numeric>
 #include <Poco/Util/Application.h>
 
+#ifdef OS_LINUX
+#    include <unistd.h>
+#endif
+
 #include <base/sort.h>
 #include <Common/Stopwatch.h>
 #include <Common/setThreadName.h>
@@ -293,14 +297,14 @@ size_t getL2CacheSize()
 {
     size_t l2_size = 0;
 
-#ifdef OS_LINUX
+#if defined(OS_LINUX) && defined(_SC_LEVEL2_CACHE_SIZE)
     if (auto ret = sysconf(_SC_LEVEL2_CACHE_SIZE); ret != -1)
         l2_size = ret;
 #endif
 
-    /// 1MB looks like a reasonable default.
+    /// 512KB looks like a reasonable default.
     /// max() is needed because sysconf() may return 0 instead of the actual value (at least on ARM).
-    return std::max<size_t>(l2_size, 1 * 1024 * 1024);
+    return std::max<size_t>(l2_size, 512 * 1024);
 }
 
 }

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -302,9 +302,9 @@ size_t getL2CacheSize()
         l2_size = ret;
 #endif
 
-    /// 512KB looks like a reasonable default.
+    /// 4MB looks like a reasonable default.
     /// max() is needed because sysconf() may return 0 instead of the actual value (at least on ARM).
-    return std::max<size_t>(l2_size, 512 * 1024);
+    return std::max<size_t>(l2_size, 4 * 1024 * 1024);
 }
 
 }

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1197,7 +1197,7 @@ void NO_INLINE Aggregator::executeImplBatch(
                 continue;
 
             AggregateFunctionInstruction * inst = aggregate_instructions + i;
-            size_t arguments_size = inst->that->getArgumentTypes().size();
+            size_t arguments_size = inst->that->getArgumentTypes().size(); // NOLINT
 
             for (size_t argument_index = 0; argument_index < arguments_size; ++argument_index)
                 columns_data.emplace_back(getColumnData(inst->batch_arguments[argument_index]));

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1004,7 +1004,7 @@ void NO_INLINE Aggregator::executeImplBatch(
     AggregateDataPtr overflow_row) const
 {
     // During processing of row #i will also prefetch row number #(row + prefetch_indent).
-    static constexpr uint8_t prefetch_indent = 8;
+    static constexpr uint8_t prefetch_look_ahead = 8;
 
     /// Optimization for special case when there are no aggregate functions.
     if (params.aggregates_size == 0)
@@ -1018,10 +1018,10 @@ void NO_INLINE Aggregator::executeImplBatch(
         {
             if constexpr (HasPrefetchMemberFunc<decltype(method.data), decltype(state.getKeyHolder(0, std::declval<Arena &>()))>)
             {
-                if (i + prefetch_indent < row_end)
+                if (i + prefetch_look_ahead < row_end)
                 {
-                    auto key_holder = state.getKeyHolder(i + prefetch_indent, *aggregates_pool);
-                    method.data.prefetch(key_holder);
+                    auto && key_holder = state.getKeyHolder(i + prefetch_look_ahead, *aggregates_pool);
+                    method.data.prefetch(std::move(key_holder));
                 }
             }
 
@@ -1081,10 +1081,10 @@ void NO_INLINE Aggregator::executeImplBatch(
         {
             if constexpr (HasPrefetchMemberFunc<decltype(method.data), decltype(state.getKeyHolder(0, std::declval<Arena &>()))>)
             {
-                if (i + prefetch_indent < row_end)
+                if (i + prefetch_look_ahead < row_end)
                 {
-                    auto key_holder = state.getKeyHolder(i + prefetch_indent, *aggregates_pool);
-                    method.data.prefetch(key_holder);
+                    auto && key_holder = state.getKeyHolder(i + prefetch_look_ahead, *aggregates_pool);
+                    method.data.prefetch(std::move(key_holder));
                 }
             }
 

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1003,7 +1003,7 @@ void NO_INLINE Aggregator::executeImplBatch(
     AggregateFunctionInstruction * aggregate_instructions,
     AggregateDataPtr overflow_row) const
 {
-    // During processing of row #i will also prefetch row number #(row + prefetch_indent).
+    /// During processing of row #i will also prefetch row number #(row + prefetch_look_ahead).
     static constexpr uint8_t prefetch_look_ahead = 8;
 
     /// Optimization for special case when there are no aggregate functions.

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1211,7 +1211,7 @@ private:
         AggregateDataPtr overflow_row) const;
 
     /// Specialization for a particular value no_more_keys.
-    template <bool no_more_keys, bool use_compiled_functions, typename Method>
+    template <bool no_more_keys, bool use_compiled_functions, bool prefetch, typename Method>
     void executeImplBatch(
         Method & method,
         typename Method::State & state,

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -939,6 +939,8 @@ public:
 
         bool only_merge;
 
+        bool enable_prefetch;
+
         struct StatsCollectingParams
         {
             StatsCollectingParams();
@@ -974,6 +976,7 @@ public:
             bool compile_aggregate_expressions_,
             size_t min_count_to_compile_aggregate_expression_,
             size_t max_block_size_,
+            bool enable_prefetch_,
             bool only_merge_ = false, // true for projections
             const StatsCollectingParams & stats_collecting_params_ = {})
             : keys(keys_)
@@ -994,6 +997,7 @@ public:
             , min_count_to_compile_aggregate_expression(min_count_to_compile_aggregate_expression_)
             , max_block_size(max_block_size_)
             , only_merge(only_merge_)
+            , enable_prefetch(enable_prefetch_)
             , stats_collecting_params(stats_collecting_params_)
         {
         }
@@ -1001,7 +1005,7 @@ public:
         /// Only parameters that matter during merge.
         Params(const Names & keys_, const AggregateDescriptions & aggregates_, bool overflow_row_, size_t max_threads_, size_t max_block_size_)
             : Params(
-                keys_, aggregates_, overflow_row_, 0, OverflowMode::THROW, 0, 0, 0, false, nullptr, max_threads_, 0, false, 0, max_block_size_, true, {})
+                keys_, aggregates_, overflow_row_, 0, OverflowMode::THROW, 0, 0, 0, false, nullptr, max_threads_, 0, false, 0, max_block_size_, false, true, {})
         {
         }
 

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -977,7 +977,7 @@ public:
             size_t min_count_to_compile_aggregate_expression_,
             size_t max_block_size_,
             bool enable_prefetch_,
-            bool only_merge_ = false, // true for projections
+            bool only_merge_, // true for projections
             const StatsCollectingParams & stats_collecting_params_ = {})
             : keys(keys_)
             , aggregates(aggregates_)

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1255,11 +1255,8 @@ private:
             Arena * arena) const;
 
     /// Merge data from hash table `src` into `dst`.
-    template <typename Method, bool use_compiled_functions, typename Table>
-    void mergeDataImpl(
-        Table & table_dst,
-        Table & table_src,
-        Arena * arena) const;
+    template <typename Method, bool use_compiled_functions, bool prefetch, typename Table>
+    void mergeDataImpl(Table & table_dst, Table & table_src, Arena * arena) const;
 
     /// Merge data from hash table `src` into `dst`, but only for keys that already exist in dst. In other cases, merge the data into `overflows`.
     template <typename Method, typename Table>

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1150,6 +1150,8 @@ private:
     /// For external aggregation.
     mutable TemporaryFiles temporary_files;
 
+    size_t min_bytes_for_prefetch = 0;
+
 #if USE_EMBEDDED_COMPILER
     std::shared_ptr<CompiledAggregateFunctionsHolder> compiled_aggregate_functions_holder;
 #endif

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2360,6 +2360,7 @@ static Aggregator::Params getAggregatorParams(
         settings.compile_aggregate_expressions,
         settings.min_count_to_compile_aggregate_expression,
         settings.max_block_size,
+        settings.enable_sortware_prefetch_in_aggregation,
         /* only_merge */ false,
         stats_collecting_params
     };

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2360,7 +2360,7 @@ static Aggregator::Params getAggregatorParams(
         settings.compile_aggregate_expressions,
         settings.min_count_to_compile_aggregate_expression,
         settings.max_block_size,
-        settings.enable_sortware_prefetch_in_aggregation,
+        settings.enable_software_prefetch_in_aggregation,
         /* only_merge */ false,
         stats_collecting_params
     };

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -183,6 +183,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
                     transform_params->params.compile_aggregate_expressions,
                     transform_params->params.min_count_to_compile_aggregate_expression,
                     transform_params->params.max_block_size,
+                    transform_params->params.enable_prefetch,
                     /* only_merge */ false,
                     transform_params->params.stats_collecting_params};
                 auto transform_params_for_set = std::make_shared<AggregatingTransformParams>(src_header, std::move(params_for_set), final);

--- a/src/Processors/TTL/TTLAggregationAlgorithm.cpp
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.cpp
@@ -40,7 +40,7 @@ TTLAggregationAlgorithm::TTLAggregationAlgorithm(
         settings.compile_aggregate_expressions,
         settings.min_count_to_compile_aggregate_expression,
         settings.max_block_size,
-        settings.enable_sortware_prefetch_in_aggregation,
+        settings.enable_software_prefetch_in_aggregation,
         false /* only_merge */);
 
     aggregator = std::make_unique<Aggregator>(header, params);

--- a/src/Processors/TTL/TTLAggregationAlgorithm.cpp
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.cpp
@@ -39,7 +39,8 @@ TTLAggregationAlgorithm::TTLAggregationAlgorithm(
         settings.min_free_disk_space_for_temporary_data,
         settings.compile_aggregate_expressions,
         settings.min_count_to_compile_aggregate_expression,
-        settings.max_block_size);
+        settings.max_block_size,
+        false /* enable_prefetch */);
 
     aggregator = std::make_unique<Aggregator>(header, params);
 

--- a/src/Processors/TTL/TTLAggregationAlgorithm.cpp
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.cpp
@@ -40,7 +40,8 @@ TTLAggregationAlgorithm::TTLAggregationAlgorithm(
         settings.compile_aggregate_expressions,
         settings.min_count_to_compile_aggregate_expression,
         settings.max_block_size,
-        false /* enable_prefetch */);
+        settings.enable_sortware_prefetch_in_aggregation,
+        false /* only_merge */);
 
     aggregator = std::make_unique<Aggregator>(header, params);
 

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -314,6 +314,7 @@ QueryPlanPtr MergeTreeDataSelectExecutor::read(
                 settings.compile_aggregate_expressions,
                 settings.min_count_to_compile_aggregate_expression,
                 settings.max_block_size,
+                settings.enable_sortware_prefetch_in_aggregation,
                 only_merge);
 
             return std::make_pair(params, only_merge);

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -314,7 +314,7 @@ QueryPlanPtr MergeTreeDataSelectExecutor::read(
                 settings.compile_aggregate_expressions,
                 settings.min_count_to_compile_aggregate_expression,
                 settings.max_block_size,
-                settings.enable_sortware_prefetch_in_aggregation,
+                settings.enable_software_prefetch_in_aggregation,
                 only_merge);
 
             return std::make_pair(params, only_merge);

--- a/tests/performance/group_by_fixed_keys.xml
+++ b/tests/performance/group_by_fixed_keys.xml
@@ -11,7 +11,7 @@
 
     <create_query>create table group_by_fk(a UInt32, b UInt32, c LowCardinality(UInt32), d Nullable(UInt32), e UInt64, f UInt64, g UInt64, h LowCardinality(UInt64), i Nullable(UInt64)) engine=MergeTree order by tuple()</create_query>
 
-    <fill_query>insert into group_by_fk select number, number, number % 10000, number % 2 == 0 ? number : Null, number, number, number, number % 10000, number % 2 == 0 ? number : Null from numbers_mt(1e7)</fill_query>
+    <fill_query>insert into group_by_fk select number, number, number % 10000, number % 2 == 0 ? number : Null, number, number, number, number % 10000, number % 2 == 0 ? number : Null from numbers_mt(3e7)</fill_query>
 
     <!-- keys64_two_level -->
     <query>select a, b from group_by_fk group by a, b format Null</query>

--- a/tests/performance/group_by_fixed_keys.xml
+++ b/tests/performance/group_by_fixed_keys.xml
@@ -1,8 +1,38 @@
 <test>
-    <!-- -->
+    <settings>
+      <allow_suspicious_low_cardinality_types>1</allow_suspicious_low_cardinality_types>
+    </settings>
+
     <query>WITH toUInt8(number) AS k, toUInt64(k) AS k1, k AS k2 SELECT k1, k2, count() FROM numbers(100000000) GROUP BY k1, k2</query>
     <query>WITH toUInt8(number) AS k, toUInt16(k) AS k1, toUInt32(k) AS k2, k AS k3 SELECT k1, k2, k3, count() FROM numbers(100000000) GROUP BY k1, k2, k3</query>
     <query>WITH toUInt8(number) AS k, k AS k1, k + 1 AS k2 SELECT k1, k2, count() FROM numbers(100000000) GROUP BY k1, k2</query>
     <query>WITH toUInt8(number) AS k, k AS k1, k + 1 AS k2, k + 2 AS k3, k + 3 AS k4 SELECT k1, k2, k3, k4, count() FROM numbers(100000000) GROUP BY k1, k2, k3, k4</query>
     <query>WITH toUInt8(number) AS k, toUInt64(k) AS k1, k1 + 1 AS k2 SELECT k1, k2, count() FROM numbers(100000000) GROUP BY k1, k2</query>
+
+    <create_query>create table group_by_fk(a UInt32, b UInt32, c LowCardinality(UInt32), d Nullable(UInt32), e UInt64, f UInt64, g UInt64, h LowCardinality(UInt64), i Nullable(UInt64)) engine=MergeTree order by tuple()</create_query>
+
+    <fill_query>insert into group_by_fk select number, number, number % 10000, number % 2 == 0 ? number : Null, number, number, number, number % 10000, number % 2 == 0 ? number : Null from numbers_mt(1e7)</fill_query>
+
+    <!-- keys64_two_level -->
+    <query>select a, b from group_by_fk group by a, b format Null</query>
+    <!-- low_cardinality_keys128_two_level -->
+    <query>select a, c from group_by_fk group by a, c format Null</query>
+    <!-- nullable_keys128_two_level -->
+    <query>select a, d from group_by_fk group by a, d format Null</query>
+
+    <!-- keys128_two_level -->
+    <query>select e, f from group_by_fk group by e, f format Null</query>
+    <!-- low_cardinality_keys128_two_level -->
+    <query>select e, h from group_by_fk group by e, h format Null</query>
+    <!-- nullable_keys256_two_level -->
+    <query>select e, i from group_by_fk group by e, i format Null</query>
+
+    <!-- keys256_two_level -->
+    <query>select e, f, g from group_by_fk group by e, f, g format Null</query>
+    <!-- low_cardinality_keys256_two_level -->
+    <query>select e, f, h from group_by_fk group by e, f, h format Null</query>
+    <!-- nullable_keys256_two_level -->
+    <query>select e, f, i from group_by_fk group by e, f, i format Null</query>
+
+    <drop_query>drop table group_by_fk</drop_query>
 </test>

--- a/tests/performance/group_by_fixed_keys.xml
+++ b/tests/performance/group_by_fixed_keys.xml
@@ -1,4 +1,5 @@
 <test>
+    <!-- -->
     <query>WITH toUInt8(number) AS k, toUInt64(k) AS k1, k AS k2 SELECT k1, k2, count() FROM numbers(100000000) GROUP BY k1, k2</query>
     <query>WITH toUInt8(number) AS k, toUInt16(k) AS k1, toUInt32(k) AS k2, k AS k3 SELECT k1, k2, k3, count() FROM numbers(100000000) GROUP BY k1, k2, k3</query>
     <query>WITH toUInt8(number) AS k, k AS k1, k + 1 AS k2 SELECT k1, k2, count() FROM numbers(100000000) GROUP BY k1, k2</query>

--- a/tests/performance/hash_table_sizes_stats.xml
+++ b/tests/performance/hash_table_sizes_stats.xml
@@ -1,4 +1,5 @@
 <test>
+    <!-- -->
     <settings>
         <max_size_to_preallocate_for_aggregation>1000000000</max_size_to_preallocate_for_aggregation>
     </settings>

--- a/tests/performance/prefetch_in_aggregation.xml
+++ b/tests/performance/prefetch_in_aggregation.xml
@@ -7,6 +7,13 @@
         <value>50000000</value>
       </values>
     </substitution>
+    <substitution>
+      <name>table</name>
+      <values>
+        <value>numbers</value>
+        <value>numbers_mt</value>
+      </values>
+    </substitution>
   </substitutions>
 
   <create_query>create table t_str_key_{size}(a String, b FixedString(25)) engine=MergeTree order by tuple()</create_query>
@@ -15,10 +22,10 @@
   <query>select a from t_str_key_{size} group by a format Null</query>
   <query>select b from t_str_key_{size} group by b format Null</query>
 
-  <query>select number from numbers(1e7) group by number format Null</query>
-  <query>select count() from numbers(1e7) group by number format Null</query>
-  <query>select number from numbers_mt(1e7) group by number format Null</query>
-  <query>select count() from numbers_mt(1e7) group by number format Null</query>
+  <query>select number from {table}({size}) group by number format Null</query>
+  <query>select count() from {table}({size}) group by number format Null</query>
+
+  <query>select number from numbers_mt(1e8) group by number format Null</query>
   <query>select count() from numbers_mt(1e8) group by number format Null</query>
 
   <drop_query>drop table t_str_key_{size}</drop_query>

--- a/tests/performance/prefetch_in_aggregation.xml
+++ b/tests/performance/prefetch_in_aggregation.xml
@@ -3,4 +3,5 @@
   <query>select count() from numbers(1e7) group by number format Null</query>
   <query>select number from numbers_mt(1e7) group by number format Null</query>
   <query>select count() from numbers_mt(1e7) group by number format Null</query>
+  <query>select count() from numbers_mt(1e8) group by number format Null</query>
 </test>

--- a/tests/performance/prefetch_in_aggregation.xml
+++ b/tests/performance/prefetch_in_aggregation.xml
@@ -1,7 +1,25 @@
 <test>
+  <substitutions>
+    <substitution>
+      <name>size</name>
+      <values>
+        <value>10000000</value>
+        <value>50000000</value>
+      </values>
+    </substitution>
+  </substitutions>
+
+  <create_query>create table t_str_key_{size}(a String, b FixedString(25)) engine=MergeTree order by tuple()</create_query>
+  <fill_query>insert into t_str_key_{size} select toString(number) as s, toFixedString(s, 25) from numbers_mt({size})</fill_query>
+
+  <query>select a from t_str_key_{size} group by a format Null</query>
+  <query>select b from t_str_key_{size} group by b format Null</query>
+
   <query>select number from numbers(1e7) group by number format Null</query>
   <query>select count() from numbers(1e7) group by number format Null</query>
   <query>select number from numbers_mt(1e7) group by number format Null</query>
   <query>select count() from numbers_mt(1e7) group by number format Null</query>
   <query>select count() from numbers_mt(1e8) group by number format Null</query>
+
+  <drop_query>drop table t_str_key_{size}</drop_query>
 </test>

--- a/tests/performance/prefetch_in_aggregation.xml
+++ b/tests/performance/prefetch_in_aggregation.xml
@@ -1,0 +1,6 @@
+<test>
+  <query>select number from numbers(1e7) group by number format Null</query>
+  <query>select count() from numbers(1e7) group by number format Null</query>
+  <query>select number from numbers_mt(1e7) group by number format Null</query>
+  <query>select count() from numbers_mt(1e7) group by number format Null</query>
+</test>

--- a/tests/performance/single_fixed_string_groupby.xml
+++ b/tests/performance/single_fixed_string_groupby.xml
@@ -1,4 +1,5 @@
 <test>
+    <!-- -->
     <create_query>DROP TABLE IF EXISTS perf_lc_fixed_str_groupby</create_query>
     <create_query>CREATE TABLE perf_lc_fixed_str_groupby(
             a LowCardinality(FixedString(14)),

--- a/tests/performance/synthetic_hardware_benchmark.xml
+++ b/tests/performance/synthetic_hardware_benchmark.xml
@@ -1,4 +1,5 @@
 <test>
+    <!-- -->
     <settings>
         <max_memory_usage>30000000000</max_memory_usage>
     </settings>

--- a/tests/performance/website.xml
+++ b/tests/performance/website.xml
@@ -1,4 +1,5 @@
 <test>
+    <!-- -->
     <settings>
         <max_memory_usage>30000000000</max_memory_usage>
     </settings>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Software prefetching is used in aggregation to speed up operations with hash tables. Controlled by the setting `enable_software_prefetch_in_aggregation`, enabled by default.