### PR TITLE
Fix concurrent integration tests runs

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -274,7 +274,11 @@ class ClickHouseCluster:
             logging.debug("ENV %40s %s" % (param, os.environ[param]))
         self.base_path = base_path
         self.base_dir = p.dirname(base_path)
-        self.name = name if name is not None else ""
+        self.name = (
+            name
+            if name is not None
+            else p.splitext(p.basename(base_path))[0].replace("test", "").strip("_-")
+        )
 
         self.base_config_dir = base_config_dir or os.environ.get(
             "CLICKHOUSE_TESTS_BASE_CONFIG_DIR", "/etc/clickhouse-server/"


### PR DESCRIPTION
Right now it is possible for one test module from the same directory
will try to remove data for other test, this is because right now test
name does not included into the instance dir.

Here is an example [1]:

<details>

    2022-07-17 16:46:32 [ 475 ] INFO : Running tests in /ClickHouse/tests/integration/test_select_access_rights/test_select_from_system_tables.py (cluster.py:2204, start)
    2022-07-17 16:46:32 [ 475 ] DEBUG : Removing instances dir /ClickHouse/tests/integration/test_select_access_rights/_instances_0 (cluster.py:2225, start)
    2022-07-17 16:46:32 [ 475 ] DEBUG : Failed to start cluster:  (cluster.py:2540, start)
    2022-07-17 16:46:32 [ 475 ] DEBUG : [Errno 2] No such file or directory: 'macros.xml' (cluster.py:2541, start)
    ...
    _______________________ ERROR at setup of test_system_db _______________________
    [gw1] linux -- Python 3.8.10 /usr/bin/python3

        @pytest.fixture(scope="module", autouse=True)
        def started_cluster():
            try:
    >           cluster.start()

    test_select_access_rights/test_select_from_system_tables.py:18:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    helpers/cluster.py:2226: in start
        shutil.rmtree(self.instances_dir)
    /usr/lib/python3.8/shutil.py:718: in rmtree
        _rmtree_safe_fd(fd, path, onerror)
    /usr/lib/python3.8/shutil.py:655: in _rmtree_safe_fd
        _rmtree_safe_fd(dirfd, fullname, onerror)
    /usr/lib/python3.8/shutil.py:655: in _rmtree_safe_fd
        _rmtree_safe_fd(dirfd, fullname, onerror)
    /usr/lib/python3.8/shutil.py:655: in _rmtree_safe_fd
        _rmtree_safe_fd(dirfd, fullname, onerror)
    /usr/lib/python3.8/shutil.py:675: in _rmtree_safe_fd
        onerror(os.unlink, fullname, sys.exc_info())
    ...
    >                   os.unlink(entry.name, dir_fd=topfd)
    E                   FileNotFoundError: [Errno 2] No such file or directory: 'macros.xml'

</details>

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/39298/d99851bcbed183f7949a0d34e811a81e6ed97667/integration_tests__thread__actions__[3/4].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)