### PR TITLE
Fix setting name in some integration tests.

### DIFF
--- a/tests/integration/test_disabled_access_control_improvements/test_row_policy.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_row_policy.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(__file__, name="row_policy")
 node = cluster.add_instance(
     "node",
     main_configs=["configs/config.d/disable_access_control_improvements.xml"],

--- a/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(__file__, name="select_from_system_tables")
 node = cluster.add_instance(
     "node",
     main_configs=["configs/config.d/disable_access_control_improvements.xml"],

--- a/tests/integration/test_select_access_rights/test_from_system_tables.py
+++ b/tests/integration/test_select_access_rights/test_from_system_tables.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(__file__, name="from_system_tables")
 node = cluster.add_instance(
     "node",
     user_configs=[

--- a/tests/integration/test_select_access_rights/test_main.py
+++ b/tests/integration/test_select_access_rights/test_main.py
@@ -3,7 +3,7 @@ from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance("instance")
+instance = cluster.add_instance("instance", name="main")
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Fix setting name in some integraton tests
This will fix issues with parallel running of the integration tests `test_disabled_access_control_improvements*` and `test_select_access_rights*`