### PR TITLE
Possible fix for flaky `test_keeper_force_recovery`

### DIFF
--- a/tests/integration/test_keeper_force_recovery/test.py
+++ b/tests/integration/test_keeper_force_recovery/test.py
@@ -5,7 +5,7 @@ from helpers.cluster import ClickHouseCluster
 import time
 
 
-from kazoo.client import KazooClient
+from kazoo.client import KazooClient, KazooRetry
 
 CLUSTER_SIZE = 5
 QUORUM_SIZE = CLUSTER_SIZE // 2 + 1
@@ -52,8 +52,10 @@ def started_cluster():
 
 def get_fake_zk(nodename, timeout=30.0):
     _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout
+        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout,
+        command_retry=KazooRetry(max_tries=10)
     )
+
     _fake_zk_instance.start()
     return _fake_zk_instance
 
@@ -117,7 +119,7 @@ def test_cluster_recovery(started_cluster):
         data_in_cluster = []
 
         def add_data(zk, path, data):
-            zk.create(path, data.encode())
+            zk.retry(zk.create, path, data.encode())
             data_in_cluster.append((path, data))
 
         def assert_all_data(zk):

--- a/tests/integration/test_keeper_force_recovery/test.py
+++ b/tests/integration/test_keeper_force_recovery/test.py
@@ -52,8 +52,9 @@ def started_cluster():
 
 def get_fake_zk(nodename, timeout=30.0):
     _fake_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(nodename) + ":9181", timeout=timeout,
-        command_retry=KazooRetry(max_tries=10)
+        hosts=cluster.get_instance_ip(nodename) + ":9181",
+        timeout=timeout,
+        command_retry=KazooRetry(max_tries=10),
     )
 
     _fake_zk_instance.start()


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)




> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
