### PR TITLE
Auto set test name in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -243,8 +243,8 @@ def extract_test_name(base_path):
     """
     name = p.basename(base_path)
     name = p.splitext(name)[0]
-    name = name.removeprefix('test')
-    name = name.strip('-_')
+    name = name.removeprefix("test")
+    name = name.strip("-_")
     return name
 
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -245,7 +245,7 @@ def extract_test_name(base_path):
     if name == "test.py":
         name = ""
     elif name.startswith("test_") and name.endswith(".py"):
-        name = name[len("test_"):(len(name)-len(".py"))]
+        name = name[len("test_") : (len(name) - len(".py"))]
     return name
 
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -242,9 +242,10 @@ def extract_test_name(base_path):
     Must be unique in each test directory (because it's used to make instances dir and to stop docker containers from previous run)
     """
     name = p.basename(base_path)
-    name = p.splitext(name)[0]
-    name = name.removeprefix("test")
-    name = name.strip("-_")
+    if name == "test.py":
+        name = ""
+    elif name.startswith("test_") and name.endswith(".py"):
+        name = name[len("test_"):(len(name)-len(".py"))]
     return name
 
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -237,6 +237,18 @@ def enable_consistent_hash_plugin(rabbitmq_id):
     return p.returncode == 0
 
 
+def extract_test_name(base_path):
+    """Extracts the name of the test based to a path to its test*.py file
+    Must be unique in each test directory (because it's used to make instances dir and to stop docker containers from previous run)
+    """
+    name = p.basename(base_path)
+    if name == "test.py":
+        name = ""
+    elif name.startswith("test_") and name.endswith(".py"):
+        name = name[len("test_"):(len(name)-len(".py"))]
+    return name
+
+
 def get_instances_dir():
     if (
         "INTEGRATION_TESTS_RUN_ID" in os.environ
@@ -274,7 +286,7 @@ class ClickHouseCluster:
             logging.debug("ENV %40s %s" % (param, os.environ[param]))
         self.base_path = base_path
         self.base_dir = p.dirname(base_path)
-        self.name = name if name is not None else ""
+        self.name = name if name is not None else extract_test_name(base_path)
 
         self.base_config_dir = base_config_dir or os.environ.get(
             "CLICKHOUSE_TESTS_BASE_CONFIG_DIR", "/etc/clickhouse-server/"

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -242,10 +242,9 @@ def extract_test_name(base_path):
     Must be unique in each test directory (because it's used to make instances dir and to stop docker containers from previous run)
     """
     name = p.basename(base_path)
-    if name == "test.py":
-        name = ""
-    elif name.startswith("test_") and name.endswith(".py"):
-        name = name[len("test_"):(len(name)-len(".py"))]
+    name = p.splitext(name)[0]
+    name = name.removeprefix('test')
+    name = name.strip('-_')
     return name
 
 

--- a/tests/integration/test_backward_compatibility/test_aggregate_fixed_key.py
+++ b/tests/integration/test_backward_compatibility/test_aggregate_fixed_key.py
@@ -2,7 +2,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="aggregate_fixed_key")
+cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
     with_zookeeper=True,

--- a/tests/integration/test_backward_compatibility/test_aggregate_function_state_avg.py
+++ b/tests/integration/test_backward_compatibility/test_aggregate_function_state_avg.py
@@ -2,7 +2,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="aggregate_state")
+cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
     with_zookeeper=False,

--- a/tests/integration/test_backward_compatibility/test_convert_ordinary.py
+++ b/tests/integration/test_backward_compatibility/test_convert_ordinary.py
@@ -1,7 +1,7 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="convert_ordinary")
+cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
     image="yandex/clickhouse-server",

--- a/tests/integration/test_backward_compatibility/test_cte_distributed.py
+++ b/tests/integration/test_backward_compatibility/test_cte_distributed.py
@@ -2,7 +2,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="cte_distributed")
+cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance("node1", with_zookeeper=False)
 node2 = cluster.add_instance(
     "node2",

--- a/tests/integration/test_backward_compatibility/test_data_skipping_indices.py
+++ b/tests/integration/test_backward_compatibility/test_data_skipping_indices.py
@@ -5,7 +5,7 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="skipping_indices")
+cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
     image="yandex/clickhouse-server",

--- a/tests/integration/test_backward_compatibility/test_detach_part_wrong_partition_id.py
+++ b/tests/integration/test_backward_compatibility/test_detach_part_wrong_partition_id.py
@@ -2,7 +2,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="detach")
+cluster = ClickHouseCluster(__file__)
 # Version 21.6.3.14 has incompatible partition id for tables with UUID in partition key.
 node_21_6 = cluster.add_instance(
     "node_21_6",

--- a/tests/integration/test_backward_compatibility/test_insert_profile_events.py
+++ b/tests/integration/test_backward_compatibility/test_insert_profile_events.py
@@ -6,7 +6,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="insert_profile_events")
+cluster = ClickHouseCluster(__file__)
 upstream_node = cluster.add_instance("upstream_node")
 old_node = cluster.add_instance(
     "old_node",

--- a/tests/integration/test_backward_compatibility/test_select_aggregate_alias_column.py
+++ b/tests/integration/test_backward_compatibility/test_select_aggregate_alias_column.py
@@ -2,7 +2,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="aggregate_alias_column")
+cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance("node1", with_zookeeper=False)
 node2 = cluster.add_instance(
     "node2",

--- a/tests/integration/test_backward_compatibility/test_short_strings_aggregation.py
+++ b/tests/integration/test_backward_compatibility/test_short_strings_aggregation.py
@@ -2,7 +2,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="short_strings")
+cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
     with_zookeeper=False,

--- a/tests/integration/test_cluster_copier/test.py
+++ b/tests/integration/test_cluster_copier/test.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))
 COPYING_FAIL_PROBABILITY = 0.2
 MOVING_FAIL_PROBABILITY = 0.2
 
-cluster = ClickHouseCluster(__file__, name="copier_test")
+cluster = ClickHouseCluster(__file__)
 
 
 def generateRandomString(count):

--- a/tests/integration/test_cluster_copier/test_three_nodes.py
+++ b/tests/integration/test_cluster_copier/test_three_nodes.py
@@ -12,7 +12,7 @@ import docker
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))
 
-cluster = ClickHouseCluster(__file__, name="copier_test_three_nodes")
+cluster = ClickHouseCluster(__file__)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_cluster_copier/test_trivial.py
+++ b/tests/integration/test_cluster_copier/test_trivial.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))
 COPYING_FAIL_PROBABILITY = 0.1
 MOVING_FAIL_PROBABILITY = 0.1
 
-cluster = ClickHouseCluster(__file__, name="copier_test_trivial")
+cluster = ClickHouseCluster(__file__)
 
 
 def generateRandomString(count):

--- a/tests/integration/test_cluster_copier/test_two_nodes.py
+++ b/tests/integration/test_cluster_copier/test_two_nodes.py
@@ -12,7 +12,7 @@ import docker
 CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(CURRENT_TEST_DIR))
 
-cluster = ClickHouseCluster(__file__, name="copier_test_two_nodes")
+cluster = ClickHouseCluster(__file__)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_cassandra.py
@@ -24,7 +24,7 @@ def setup_module(module):
     global complex_tester
     global ranged_tester
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     SOURCE = SourceCassandra(
         "Cassandra",

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_local.py
@@ -38,7 +38,7 @@ def setup_module(module):
     ranged_tester.create_dictionaries(SOURCE)
     # Since that all .xml configs were created
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     main_configs = []
     main_configs.append(os.path.join("configs", "disable_ssl_verification.xml"))

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_clickhouse_remote.py
@@ -38,7 +38,7 @@ def setup_module(module):
     ranged_tester.create_dictionaries(SOURCE)
     # Since that all .xml configs were created
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     main_configs = []
     main_configs.append(os.path.join("configs", "disable_ssl_verification.xml"))

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_cache.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_cache.py
@@ -38,7 +38,7 @@ def setup_module(module):
     ranged_tester.create_dictionaries(SOURCE)
     # Since that all .xml configs were created
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     main_configs = []
     main_configs.append(os.path.join("configs", "disable_ssl_verification.xml"))

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_executable_hashed.py
@@ -38,7 +38,7 @@ def setup_module(module):
     ranged_tester.create_dictionaries(SOURCE)
     # Since that all .xml configs were created
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     main_configs = []
     main_configs.append(os.path.join("configs", "disable_ssl_verification.xml"))

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_file.py
@@ -36,7 +36,7 @@ def setup_module(module):
     ranged_tester.create_dictionaries(SOURCE)
     # Since that all .xml configs were created
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     main_configs = []
     main_configs.append(os.path.join("configs", "disable_ssl_verification.xml"))

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_http.py
@@ -36,7 +36,7 @@ def setup_module(module):
     ranged_tester.create_dictionaries(SOURCE)
     # Since that all .xml configs were created
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     main_configs = []
     main_configs.append(os.path.join("configs", "disable_ssl_verification.xml"))

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_https.py
@@ -38,7 +38,7 @@ def setup_module(module):
     ranged_tester.create_dictionaries(SOURCE)
     # Since that all .xml configs were created
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     main_configs = []
     main_configs.append(os.path.join("configs", "disable_ssl_verification.xml"))

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo.py
@@ -24,7 +24,7 @@ def setup_module(module):
     global complex_tester
     global ranged_tester
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
     SOURCE = SourceMongo(
         "MongoDB",
         "localhost",

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo_uri.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mongo_uri.py
@@ -24,7 +24,7 @@ def setup_module(module):
     global complex_tester
     global ranged_tester
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     SOURCE = SourceMongoURI(
         "MongoDB",

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/test_mysql.py
@@ -24,7 +24,7 @@ def setup_module(module):
     global complex_tester
     global ranged_tester
 
-    cluster = ClickHouseCluster(__file__, name=test_name)
+    cluster = ClickHouseCluster(__file__)
 
     SOURCE = SourceMySQL(
         "MySQL",

--- a/tests/integration/test_dictionaries_redis/test_long.py
+++ b/tests/integration/test_dictionaries_redis/test_long.py
@@ -2,7 +2,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 import redis
 
-cluster = ClickHouseCluster(__file__, name="long")
+cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance("node", with_redis=True)
 

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_default_reading.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_default_reading.py
@@ -5,7 +5,7 @@ from helpers.cluster import ClickHouseCluster
 from helpers.cluster import ClickHouseKiller
 from helpers.network import PartitionManager
 
-cluster = ClickHouseCluster(__file__, name="reading")
+cluster = ClickHouseCluster(__file__)
 
 dictionary_node = cluster.add_instance("dictionary_node", stay_alive=True)
 main_node = cluster.add_instance(

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_default_string.py
@@ -7,7 +7,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__, name="string")
+cluster = ClickHouseCluster(__file__)
 
 dictionary_node = cluster.add_instance("dictionary_node", stay_alive=True)
 main_node = cluster.add_instance(

--- a/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get_or_default.py
+++ b/tests/integration/test_dictionary_allow_read_expired_keys/test_dict_get_or_default.py
@@ -5,7 +5,7 @@ from helpers.cluster import ClickHouseCluster
 from helpers.cluster import ClickHouseKiller
 from helpers.network import PartitionManager
 
-cluster = ClickHouseCluster(__file__, name="default")
+cluster = ClickHouseCluster(__file__)
 
 dictionary_node = cluster.add_instance("dictionary_node", stay_alive=True)
 main_node = cluster.add_instance(

--- a/tests/integration/test_disabled_access_control_improvements/test_row_policy.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_row_policy.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__, name="row_policy")
+cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
     main_configs=["configs/config.d/disable_access_control_improvements.xml"],

--- a/tests/integration/test_disabled_access_control_improvements/test_row_policy.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_row_policy.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(__file__, name="row_policy")
 node = cluster.add_instance(
     "node",
     main_configs=["configs/config.d/disable_access_control_improvements.xml"],

--- a/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(__file__, name="select_from_system_tables")
 node = cluster.add_instance(
     "node",
     main_configs=["configs/config.d/disable_access_control_improvements.xml"],

--- a/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
+++ b/tests/integration/test_disabled_access_control_improvements/test_select_from_system_tables.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__, name="select_from_system_tables")
+cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
     main_configs=["configs/config.d/disable_access_control_improvements.xml"],

--- a/tests/integration/test_distributed_respect_user_timeouts/test.py
+++ b/tests/integration/test_distributed_respect_user_timeouts/test.py
@@ -8,8 +8,6 @@ from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__)
-
 NODES = {"node" + str(i): None for i in (1, 2)}
 
 IS_DEBUG = False

--- a/tests/integration/test_keeper_four_word_command/test_allow_list.py
+++ b/tests/integration/test_keeper_four_word_command/test_allow_list.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 import time
 
-cluster = ClickHouseCluster(__file__, name="test_keeper_4lw_allow_list")
+cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1", main_configs=["configs/keeper_config_with_allow_list.xml"], stay_alive=True
 )

--- a/tests/integration/test_log_levels_update/test.py
+++ b/tests/integration/test_log_levels_update/test.py
@@ -3,7 +3,7 @@ import re
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="log_quries_probability")
+cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", with_zookeeper=False)
 
 config = """<clickhouse>

--- a/tests/integration/test_log_query_probability/test.py
+++ b/tests/integration/test_log_query_probability/test.py
@@ -2,7 +2,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="log_quries_probability")
+cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance("node1", with_zookeeper=False)
 node2 = cluster.add_instance("node2", with_zookeeper=False)
 

--- a/tests/integration/test_select_access_rights/test_from_system_tables.py
+++ b/tests/integration/test_select_access_rights/test_from_system_tables.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__, name="from_system_tables")
+cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
     "node",
     user_configs=[

--- a/tests/integration/test_select_access_rights/test_from_system_tables.py
+++ b/tests/integration/test_select_access_rights/test_from_system_tables.py
@@ -3,7 +3,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
-cluster = ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(__file__, name="from_system_tables")
 node = cluster.add_instance(
     "node",
     user_configs=[

--- a/tests/integration/test_select_access_rights/test_main.py
+++ b/tests/integration/test_select_access_rights/test_main.py
@@ -3,7 +3,7 @@ from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance("instance", name="main")
+instance = cluster.add_instance("instance")
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/integration/test_select_access_rights/test_main.py
+++ b/tests/integration/test_select_access_rights/test_main.py
@@ -3,7 +3,7 @@ from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance("instance")
+instance = cluster.add_instance("instance", name="main")
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/integration/test_zookeeper_config/test_password.py
+++ b/tests/integration/test_zookeeper_config/test_password.py
@@ -2,7 +2,7 @@ import time
 import pytest
 from helpers.cluster import ClickHouseCluster
 
-cluster = ClickHouseCluster(__file__, name="password")
+cluster = ClickHouseCluster(__file__)
 
 # TODO ACL not implemented in Keeper.
 node1 = cluster.add_instance(

--- a/tests/integration/test_zookeeper_config/test_secure.py
+++ b/tests/integration/test_zookeeper_config/test_secure.py
@@ -9,7 +9,6 @@ TEST_DIR = os.path.dirname(__file__)
 
 cluster = ClickHouseCluster(
     __file__,
-    name="secure",
     zookeeper_certfile=os.path.join(TEST_DIR, "configs_secure", "client.crt"),
     zookeeper_keyfile=os.path.join(TEST_DIR, "configs_secure", "client.key"),
 )


### PR DESCRIPTION
### Changelog category:
- Not for changelog (changelog entry is not required)

Auto set test name in integration tests to make situations like https://github.com/ClickHouse/ClickHouse/pull/39320 not happen again.