### PR TITLE
tests/performance: improve parallel_mv test

### DIFF
--- a/tests/performance/parallel_mv.xml
+++ b/tests/performance/parallel_mv.xml
@@ -3,15 +3,21 @@
         <parallel_view_processing>1</parallel_view_processing>
     </settings>
 
-    <create_query>create table main_table (number UInt64) engine = MergeTree order by tuple();</create_query>
-    <create_query>create materialized view mv_1 engine = MergeTree order by tuple() as
-        select number, toString(number) from main_table where number % 13 != 0;</create_query>
-    <create_query>create materialized view mv_2 engine = MergeTree order by tuple() as
-        select number, toString(number) from main_table where number % 13 != 1;</create_query>
-    <create_query>create materialized view mv_3 engine = MergeTree order by tuple() as
-        select number, toString(number) from main_table where number % 13 != 3;</create_query>
-    <create_query>create materialized view mv_4 engine = MergeTree order by tuple() as
-        select number, toString(number) from main_table where number % 13 != 4;</create_query>
+    <create_query>create table main_table (number UInt64) engine = MergeTree order by tuple()</create_query>
+
+    <create_query>create table mt_1 (n UInt64, s String) engine = MergeTree order by tuple()</create_query>
+    <create_query>create table mt_2 (n UInt64, s String) engine = MergeTree order by tuple()</create_query>
+    <create_query>create table mt_3 (n UInt64, s String) engine = MergeTree order by tuple()</create_query>
+    <create_query>create table mt_4 (n UInt64, s String) engine = MergeTree order by tuple()</create_query>
+
+    <create_query>create materialized view mv_1 to mt_1 as
+        select number, toString(number) from main_table where number % 13 != 0</create_query>
+    <create_query>create materialized view mv_2 to mt_2 as
+        select number, toString(number) from main_table where number % 13 != 1</create_query>
+    <create_query>create materialized view mv_3 to mt_3 as
+        select number, toString(number) from main_table where number % 13 != 3</create_query>
+    <create_query>create materialized view mv_4 to mt_4 as
+        select number, toString(number) from main_table where number % 13 != 4</create_query>
 
     <fill_query>SYSTEM STOP MERGES main_table</fill_query>
     <fill_query>SYSTEM STOP MERGES mt_1</fill_query>
@@ -21,9 +27,15 @@
 
     <query>insert into main_table select number from numbers(10000000)</query>
 
-    <drop_query>drop table if exists main_table;</drop_query>
-    <drop_query>drop table if exists mv_1;</drop_query>
-    <drop_query>drop table if exists mv_2;</drop_query>
-    <drop_query>drop table if exists mv_3;</drop_query>
-    <drop_query>drop table if exists mv_4;</drop_query>
+    <drop_query>drop table if exists mv_1</drop_query>
+    <drop_query>drop table if exists mv_2</drop_query>
+    <drop_query>drop table if exists mv_3</drop_query>
+    <drop_query>drop table if exists mv_4</drop_query>
+
+    <drop_query>drop table if exists main_table</drop_query>
+
+    <drop_query>drop table if exists mt_1</drop_query>
+    <drop_query>drop table if exists mt_2</drop_query>
+    <drop_query>drop table if exists mt_3</drop_query>
+    <drop_query>drop table if exists mt_4</drop_query>
 </test>


### PR DESCRIPTION
Right now it is possible for parallel_mv to fail [1] due to exceeding 15
seconds limit.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/39183/ad6b50b087086fef8aa6f0f72b3a42f014266763/performance_comparison_aarch64_[4/4]/report.html

Let's try to really disable MERGES and see.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)