### PR TITLE
Avoid possible abort() in CapnProto on exception descruction

### DIFF
--- a/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
@@ -267,13 +267,7 @@ bool CapnProtoRowInputFormat::readRow(MutableColumns & columns, RowReadExtension
     try
     {
         auto array = readMessage();
-
-#if CAPNP_VERSION >= 7000 && CAPNP_VERSION < 8000
-        capnp::UnalignedFlatArrayMessageReader msg(array);
-#else
         capnp::FlatArrayMessageReader msg(array);
-#endif
-
         auto root_reader = msg.getRoot<capnp::DynamicStruct>(root);
         for (size_t i = 0; i != columns.size(); ++i)
         {

--- a/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/CapnProtoRowInputFormat.cpp
@@ -30,6 +30,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int INCORRECT_DATA;
 }
 
 CapnProtoRowInputFormat::CapnProtoRowInputFormat(ReadBuffer & in_, Block header, Params params_, const FormatSchemaInfo & info, const FormatSettings & format_settings_)


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Avoid possible abort() in CapnProto on exception descruction. Closes https://github.com/ClickHouse/ClickHouse/issues/30706


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
