### PR TITLE
Fix cmake warning text

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,7 +515,7 @@ endif ()
 add_subdirectory (contrib EXCLUDE_FROM_ALL)
 
 if (NOT ENABLE_JEMALLOC)
-    message (WARNING "Non default allocator is disabled. This is not recommended for production builds.")
+    message (WARNING "Non default allocator is enabled. This is not recommended for production builds.")
 endif ()
 
 macro (clickhouse_add_executable target)


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
