### PR TITLE
Rethrow exception on cache initialisation on server startup, better error message

### DIFF
--- a/src/Common/LRUFileCache.cpp
+++ b/src/Common/LRUFileCache.cpp
@@ -842,7 +842,7 @@ void LRUFileCache::loadCacheInfoIntoMemory(std::lock_guard<std::mutex> & cache_l
 
     if (!files.empty())
         throw Exception(
-            REMOTE_FS_OBJECT_CACHE_ERROR, 
+            ErrorCodes::REMOTE_FS_OBJECT_CACHE_ERROR, 
             "Cache initialization is partially made. "
             "This can be a result of a failed first attempt to initialize cache. "
             "Please, check log for error messages");

--- a/src/Common/LRUFileCache.cpp
+++ b/src/Common/LRUFileCache.cpp
@@ -45,7 +45,7 @@ void LRUFileCache::initialize()
             catch (...)
             {
                 tryLogCurrentException(__PRETTY_FUNCTION__);
-                return;
+                throw;
             }
         }
         else

--- a/src/Common/LRUFileCache.cpp
+++ b/src/Common/LRUFileCache.cpp
@@ -844,7 +844,7 @@ void LRUFileCache::loadCacheInfoIntoMemory(std::lock_guard<std::mutex> & cache_l
         throw Exception(
             REMOTE_FS_OBJECT_CACHE_ERROR, 
             "Cache initialization is partially made. "
-            "This can be a result of a first attempt to initialize cache. "
+            "This can be a result of a failed first attempt to initialize cache. "
             "Please, check log for error messages");
 
     fs::directory_iterator key_prefix_it{cache_base_path};

--- a/src/Common/LRUFileCache.cpp
+++ b/src/Common/LRUFileCache.cpp
@@ -842,7 +842,7 @@ void LRUFileCache::loadCacheInfoIntoMemory(std::lock_guard<std::mutex> & cache_l
 
     if (!files.empty())
         throw Exception(
-            ErrorCodes::REMOTE_FS_OBJECT_CACHE_ERROR, 
+            ErrorCodes::REMOTE_FS_OBJECT_CACHE_ERROR,
             "Cache initialization is partially made. "
             "This can be a result of a failed first attempt to initialize cache. "
             "Please, check log for error messages");

--- a/src/Common/LRUFileCache.cpp
+++ b/src/Common/LRUFileCache.cpp
@@ -841,7 +841,9 @@ void LRUFileCache::loadCacheInfoIntoMemory(std::lock_guard<std::mutex> & cache_l
     /// cache_base_path / key_prefix / key / offset
 
     if (!files.empty())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cache already initialized");
+        throw Exception(
+            REMOTE_FS_OBJECT_CACHE_ERROR, 
+            "Cache already initialized: this can be result of a first attempt during cache initialization. Please, check log for error messages");
 
     fs::directory_iterator key_prefix_it{cache_base_path};
     for (; key_prefix_it != fs::directory_iterator(); ++key_prefix_it)

--- a/src/Common/LRUFileCache.cpp
+++ b/src/Common/LRUFileCache.cpp
@@ -843,7 +843,9 @@ void LRUFileCache::loadCacheInfoIntoMemory(std::lock_guard<std::mutex> & cache_l
     if (!files.empty())
         throw Exception(
             REMOTE_FS_OBJECT_CACHE_ERROR, 
-            "Cache already initialized: this can be result of a first attempt during cache initialization. Please, check log for error messages");
+            "Cache initialization is partially made. "
+            "This can be a result of a first attempt to initialize cache. "
+            "Please, check log for error messages");
 
     fs::directory_iterator key_prefix_it{cache_base_path};
     for (; key_prefix_it != fs::directory_iterator(); ++key_prefix_it)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Rethrow exception on filesystem cache initialisation on server startup, better error message. 

