### PR TITLE
Avoid loading toolchain file multiple times to avoid confusing ccache

### DIFF
--- a/cmake/linux/toolchain-x86_64.cmake
+++ b/cmake/linux/toolchain-x86_64.cmake
@@ -1,3 +1,19 @@
+if (_CLICKHOUSE_TOOLCHAIN_FILE_LOADED)
+    # During first run of cmake the toolchain file will be loaded twice,
+    # - /usr/share/cmake-3.23/Modules/CMakeDetermineSystem.cmake
+    # - /bld/CMakeFiles/3.23.2/CMakeSystem.cmake
+    #
+    # But once you already have non-empty cmake cache it will be loaded only
+    # once:
+    # - /bld/CMakeFiles/3.23.2/CMakeSystem.cmake
+    #
+    # This has no harm except for double load of toolchain will add
+    # --gcc-toolchain multiple times that will not allow ccache to reuse the
+    # cache.
+    return()
+endif()
+set (_CLICKHOUSE_TOOLCHAIN_FILE_LOADED ON)
+
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set (CMAKE_SYSTEM_NAME "Linux")


### PR DESCRIPTION
During first run of cmake the toolchain file will be loaded twice,
- /usr/share/cmake-3.23/Modules/CMakeDetermineSystem.cmake
- /bld/CMakeFiles/3.23.2/CMakeSystem.cmake

But once you already have non-empty cmake cache it will be loaded only
once:
- /bld/CMakeFiles/3.23.2/CMakeSystem.cmake

This has no harm except for double load of toolchain will add
--gcc-toolchain multiple times that will not allow ccache to reuse the
cache.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)