### PR TITLE
Fix make clean (due to crosscompile of llvm)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(ClickHouse LANGUAGES C CXX ASM)
 

--- a/contrib/llvm-cmake/CMakeLists.txt
+++ b/contrib/llvm-cmake/CMakeLists.txt
@@ -93,6 +93,18 @@ set (CMAKE_CXX_STANDARD 17)
 set (LLVM_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/llvm/llvm")
 set (LLVM_BINARY_DIR "${ClickHouse_BINARY_DIR}/contrib/llvm/llvm")
 add_subdirectory ("${LLVM_SOURCE_DIR}" "${LLVM_BINARY_DIR}")
+set_directory_properties (PROPERTIES
+   # due to llvm crosscompile cmake does not know how to clean it, and on clean
+   # will lead to the following error:
+   #
+   #   ninja: error: remove(contrib/llvm/llvm/NATIVE): Directory not empty
+   #
+   ADDITIONAL_CLEAN_FILES "${LLVM_BINARY_DIR}"
+   # llvm's cmake configuring this file only when cmake runs,
+   # and after clean cmake will not know that it should re-run,
+   # add explicitly depends from llvm-config.h
+   CMAKE_CONFIGURE_DEPENDS "${LLVM_BINARY_DIR}/include/llvm/Config/llvm-config.h"
+)
 
 add_library (_llvm INTERFACE)
 target_link_libraries (_llvm INTERFACE ${REQUIRED_LLVM_LIBRARIES})

--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -75,7 +75,7 @@ This will create the `programs/clickhouse` executable, which can be used with `c
 The build requires the following components:
 
 -   Git (is used only to checkout the sources, it’s not needed for the build)
--   CMake 3.14 or newer
+-   CMake 3.15 or newer
 -   Ninja
 -   C++ compiler: clang-14 or newer
 -   Linker: lld


### PR DESCRIPTION
Without ADDITIONAL_CLEAN_FILES it reports an error:

    Cleaning... ninja: error: remove(contrib/llvm/llvm/NATIVE): Directory not empty
    ninja: error: remove(/bld/contrib/llvm/llvm/NATIVE): Directory not empty
    0 files.

Note, that ADDITIONAL_CLEAN_FILES had been added since cmake 3.15.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)