### PR TITLE
Disable real-time digest in Keeper by default

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -111,7 +111,7 @@ KeeperServer::KeeperServer(
           configuration_and_settings_->snapshot_storage_path,
           coordination_settings,
           checkAndGetSuperdigest(configuration_and_settings_->super_digest),
-          config.getBool("keeper_server.digest_enabled", true)))
+          config.getBool("keeper_server.digest_enabled", false)))
     , state_manager(nuraft::cs_new<KeeperStateManager>(
           server_id, "keeper_server", configuration_and_settings_->log_storage_path, configuration_and_settings_->state_file_path, config, coordination_settings))
     , log(&Poco::Logger::get("KeeperServer"))


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
