### PR TITLE
Fix WriteBuffer finalize in destructor when cancel query

### DIFF
--- a/src/Processors/Formats/IOutputFormat.cpp
+++ b/src/Processors/Formats/IOutputFormat.cpp
@@ -73,7 +73,6 @@ void IOutputFormat::work()
             setRowsBeforeLimit(rows_before_limit_counter->get());
 
         finalize();
-        finalized = true;
         return;
     }
 
@@ -120,9 +119,12 @@ void IOutputFormat::write(const Block & block)
 
 void IOutputFormat::finalize()
 {
+    if (finalized)
+        return;
     writePrefixIfNot();
     writeSuffixIfNot();
     finalizeImpl();
+    finalized = true;
 }
 
 }

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -430,6 +430,13 @@ public:
         writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
     }
 
+    void onCancel() override
+    {
+        if (!writer)
+            return;
+        onFinish();
+    }
+
     void onException() override
     {
         if (!writer)

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -813,6 +813,13 @@ public:
         writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
     }
 
+    void onCancel() override
+    {
+        if (!writer)
+            return;
+        onFinish();
+    }
+
     void onException() override
     {
         if (!writer)

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -602,6 +602,13 @@ public:
         writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
     }
 
+    void onCancel() override
+    {
+        if (!writer)
+            return;
+        onFinish();
+    }
+
     void onException() override
     {
         if (!writer)

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -450,6 +450,13 @@ void StorageURLSink::consume(Chunk chunk)
     writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
 }
 
+void StorageURLSink::onCancel()
+{
+    if (!writer)
+        return;
+    onFinish();
+}
+
 void StorageURLSink::onException()
 {
     if (!writer)

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -114,6 +114,7 @@ public:
 
     std::string getName() const override { return "StorageURLSink"; }
     void consume(Chunk chunk) override;
+    void onCancel() override;
     void onException() override;
     void onFinish() override;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix WriteBuffer finalize in destructor when cacnel query that could lead to stuck query or even terminate. Closes https://github.com/ClickHouse/ClickHouse/issues/38199

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
