### PR TITLE
Uppercase `ROWS`, `GROUPS`, `RANGE` in queries with windows

### DIFF
--- a/src/Client/QueryFuzzer.cpp
+++ b/src/Client/QueryFuzzer.cpp
@@ -329,9 +329,9 @@ void QueryFuzzer::fuzzWindowFrame(ASTWindowDefinition & def)
         case 0:
         {
             const auto r = fuzz_rand() % 3;
-            def.frame_type = r == 0 ? WindowFrame::FrameType::Rows
-                : r == 1 ? WindowFrame::FrameType::Range
-                    : WindowFrame::FrameType::Groups;
+            def.frame_type = r == 0 ? WindowFrame::FrameType::ROWS
+                : r == 1 ? WindowFrame::FrameType::RANGE
+                    : WindowFrame::FrameType::GROUPS;
             break;
         }
         case 1:
@@ -385,7 +385,7 @@ void QueryFuzzer::fuzzWindowFrame(ASTWindowDefinition & def)
             break;
     }
 
-    if (def.frame_type == WindowFrame::FrameType::Range
+    if (def.frame_type == WindowFrame::FrameType::RANGE
         && def.frame_begin_type == WindowFrame::BoundaryType::Unbounded
         && def.frame_begin_preceding
         && def.frame_end_type == WindowFrame::BoundaryType::Current)

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -824,8 +824,8 @@ void ExpressionAnalyzer::makeWindowDescriptionFromAST(const Context & context_,
     desc.full_sort_description.insert(desc.full_sort_description.end(),
         desc.order_by.begin(), desc.order_by.end());
 
-    if (definition.frame_type != WindowFrame::FrameType::Rows
-        && definition.frame_type != WindowFrame::FrameType::Range)
+    if (definition.frame_type != WindowFrame::FrameType::ROWS
+        && definition.frame_type != WindowFrame::FrameType::RANGE)
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED,
             "Window frame '{}' is not implemented (while processing '{}')",

--- a/src/Interpreters/WindowDescription.cpp
+++ b/src/Interpreters/WindowDescription.cpp
@@ -90,8 +90,8 @@ void WindowFrame::toString(WriteBuffer & buf) const
 void WindowFrame::checkValid() const
 {
     // Check the validity of offsets.
-    if (type == WindowFrame::FrameType::Rows
-        || type == WindowFrame::FrameType::Groups)
+    if (type == WindowFrame::FrameType::ROWS
+        || type == WindowFrame::FrameType::GROUPS)
     {
         if (begin_type == BoundaryType::Offset
             && !((begin_offset.getType() == Field::Types::UInt64
@@ -197,7 +197,7 @@ void WindowDescription::checkValid() const
     frame.checkValid();
 
     // RANGE OFFSET requires exactly one ORDER BY column.
-    if (frame.type == WindowFrame::FrameType::Range
+    if (frame.type == WindowFrame::FrameType::RANGE
         && (frame.begin_type == WindowFrame::BoundaryType::Offset
             || frame.end_type == WindowFrame::BoundaryType::Offset)
         && order_by.size() != 1)

--- a/src/Interpreters/WindowDescription.h
+++ b/src/Interpreters/WindowDescription.h
@@ -28,7 +28,7 @@ struct WindowFunctionDescription
 
 struct WindowFrame
 {
-    enum class FrameType { Rows, Groups, Range };
+    enum class FrameType { ROWS, GROUPS, RANGE };
     enum class BoundaryType { Unbounded, Current, Offset };
 
     // This flag signifies that the frame properties were not set explicitly by
@@ -36,7 +36,7 @@ struct WindowFrame
     // for the default frame of RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW.
     bool is_default = true;
 
-    FrameType type = FrameType::Range;
+    FrameType type = FrameType::RANGE;
 
     // UNBOUNDED FOLLOWING for the frame end is forbidden by the standard, but for
     // uniformity the begin_preceding still has to be set to true for UNBOUNDED

--- a/src/Parsers/ASTWindowDefinition.h
+++ b/src/Parsers/ASTWindowDefinition.h
@@ -17,7 +17,7 @@ struct ASTWindowDefinition : public IAST
     ASTPtr order_by;
 
     bool frame_is_default = true;
-    WindowFrame::FrameType frame_type = WindowFrame::FrameType::Range;
+    WindowFrame::FrameType frame_type = WindowFrame::FrameType::RANGE;
     WindowFrame::BoundaryType frame_begin_type = WindowFrame::BoundaryType::Unbounded;
     ASTPtr frame_begin_offset;
     bool frame_begin_preceding = true;

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1198,15 +1198,15 @@ static bool tryParseFrameDefinition(ASTWindowDefinition * node, IParser::Pos & p
     node->frame_is_default = false;
     if (keyword_rows.ignore(pos, expected))
     {
-        node->frame_type = WindowFrame::FrameType::Rows;
+        node->frame_type = WindowFrame::FrameType::ROWS;
     }
     else if (keyword_groups.ignore(pos, expected))
     {
-        node->frame_type = WindowFrame::FrameType::Groups;
+        node->frame_type = WindowFrame::FrameType::GROUPS;
     }
     else if (keyword_range.ignore(pos, expected))
     {
-        node->frame_type = WindowFrame::FrameType::Range;
+        node->frame_type = WindowFrame::FrameType::RANGE;
     }
     else
     {

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -263,7 +263,7 @@ WindowTransform::WindowTransform(const Block & input_header_,
 
     // Choose a row comparison function for RANGE OFFSET frame based on the
     // type of the ORDER BY column.
-    if (window_description.frame.type == WindowFrame::FrameType::Range
+    if (window_description.frame.type == WindowFrame::FrameType::RANGE
         && (window_description.frame.begin_type
                 == WindowFrame::BoundaryType::Offset
             || window_description.frame.end_type
@@ -612,10 +612,10 @@ void WindowTransform::advanceFrameStart()
         case WindowFrame::BoundaryType::Offset:
             switch (window_description.frame.type)
             {
-                case WindowFrame::FrameType::Rows:
+                case WindowFrame::FrameType::ROWS:
                     advanceFrameStartRowsOffset();
                     break;
-                case WindowFrame::FrameType::Range:
+                case WindowFrame::FrameType::RANGE:
                     advanceFrameStartRangeOffset();
                     break;
                 default:
@@ -659,14 +659,14 @@ bool WindowTransform::arePeers(const RowNumber & x, const RowNumber & y) const
         return true;
     }
 
-    if (window_description.frame.type == WindowFrame::FrameType::Rows)
+    if (window_description.frame.type == WindowFrame::FrameType::ROWS)
     {
         // For ROWS frame, row is only peers with itself (checked above);
         return false;
     }
 
     // For RANGE and GROUPS frames, rows that compare equal w/ORDER BY are peers.
-    assert(window_description.frame.type == WindowFrame::FrameType::Range);
+    assert(window_description.frame.type == WindowFrame::FrameType::RANGE);
     const size_t n = order_by_indices.size();
     if (n == 0)
     {
@@ -844,10 +844,10 @@ void WindowTransform::advanceFrameEnd()
         case WindowFrame::BoundaryType::Offset:
             switch (window_description.frame.type)
             {
-                case WindowFrame::FrameType::Rows:
+                case WindowFrame::FrameType::ROWS:
                     advanceFrameEndRowsOffset();
                     break;
-                case WindowFrame::FrameType::Range:
+                case WindowFrame::FrameType::RANGE:
                     advanceFrameEndRangeOffset();
                     break;
                 default:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Uppercase `ROWS`, `GROUPS`, `RANGE` in queries with windows:
```sql
SELECT
    id,
    f_timestamp AS time,
    exponentialTimeDecayedSum(1)(id, f_timestamp) OVER w,
    sum(id) OVER w
FROM
(
    SELECT *
    FROM datetimes2
    LIMIT 100
)
WINDOW w AS (Rows BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
ORDER BY id ASC
LIMIT 10
```
⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟⮟
```sql
SELECT
    id,
    f_timestamp AS time,
    exponentialTimeDecayedSum(1)(id, f_timestamp) OVER w,
    sum(id) OVER w
FROM
(
    SELECT *
    FROM datetimes2
    LIMIT 100
)
WINDOW w AS (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
ORDER BY id ASC
LIMIT 10
```