### PR TITLE
Fix interactive client with older server

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -125,9 +125,9 @@ void Client::showWarnings()
 std::vector<String> Client::loadWarningMessages()
 {
     /// Older server versions cannot execute the query loading warnings.
-    constexpr UInt64 MIN_SERVER_REVISION_TO_LOAD_WARNINGS = DBMS_MIN_PROTOCOL_VERSION_WITH_VIEW_IF_PERMITTED;
+    constexpr UInt64 min_server_revision_to_load_warnings = DBMS_MIN_PROTOCOL_VERSION_WITH_VIEW_IF_PERMITTED;
 
-    if (server_revision < MIN_SERVER_REVISION_TO_LOAD_WARNINGS)
+    if (server_revision < min_server_revision_to_load_warnings)
         return {};
 
     std::vector<String> messages;

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -102,9 +102,34 @@ void Client::processError(const String & query) const
 }
 
 
+void Client::showWarnings()
+{
+    try
+    {
+        std::vector<String> messages = loadWarningMessages();
+        if (!messages.empty())
+        {
+            std::cout << "Warnings:" << std::endl;
+            for (const auto & message : messages)
+                std::cout << " * " << message << std::endl;
+            std::cout << std::endl;
+        }
+    }
+    catch (...)
+    {
+        /// Ignore exception
+    }
+}
+
 /// Make query to get all server warnings
 std::vector<String> Client::loadWarningMessages()
 {
+    /// Older server versions cannot execute the query loading warnings.
+    constexpr UInt64 MIN_SERVER_REVISION_TO_LOAD_WARNINGS = DBMS_MIN_PROTOCOL_VERSION_WITH_VIEW_IF_PERMITTED;
+
+    if (server_revision < MIN_SERVER_REVISION_TO_LOAD_WARNINGS)
+        return {};
+
     std::vector<String> messages;
     connection->sendQuery(connection_parameters.timeouts,
                           "SELECT * FROM viewIfPermitted(SELECT message FROM system.warnings ELSE null('message String'))",
@@ -226,25 +251,9 @@ try
 
     connect();
 
-    /// Load Warnings at the beginning of connection
+    /// Show warnings at the beginning of connection.
     if (is_interactive && !config().has("no-warnings"))
-    {
-        try
-        {
-            std::vector<String> messages = loadWarningMessages();
-            if (!messages.empty())
-            {
-                std::cout << "Warnings:" << std::endl;
-                for (const auto & message : messages)
-                    std::cout << " * " << message << std::endl;
-                std::cout << std::endl;
-            }
-        }
-        catch (...)
-        {
-            /// Ignore exception
-        }
-    }
+        showWarnings();
 
     if (is_interactive && !delayed_interactive)
     {
@@ -370,7 +379,7 @@ void Client::connect()
     }
 
     server_version = toString(server_version_major) + "." + toString(server_version_minor) + "." + toString(server_version_patch);
-    load_suggestions = is_interactive && (server_revision >= Suggest::MIN_SERVER_REVISION && !config().getBool("disable_suggestion", false));
+    load_suggestions = is_interactive && (server_revision >= Suggest::MIN_SERVER_REVISION) && !config().getBool("disable_suggestion", false);
 
     if (server_display_name = connection->getServerDisplayName(connection_parameters.timeouts); server_display_name.empty())
         server_display_name = config().getString("host", "localhost");

--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -45,6 +45,7 @@ protected:
 
 private:
     void printChangedSettings() const;
+    void showWarnings();
     std::vector<String> loadWarningMessages();
 };
 }

--- a/src/Client/Suggest.h
+++ b/src/Client/Suggest.h
@@ -28,8 +28,8 @@ public:
     template <typename ConnectionType>
     void load(ContextPtr context, const ConnectionParameters & connection_parameters, Int32 suggestion_limit);
 
-    /// Older server versions cannot execute the query above.
-    static constexpr int MIN_SERVER_REVISION = 54406;
+    /// Older server versions cannot execute the query loading suggestions.
+    static constexpr int MIN_SERVER_REVISION = DBMS_MIN_PROTOCOL_VERSION_WITH_VIEW_IF_PERMITTED;
 
 private:
     void fetch(IServerConnection & connection, const ConnectionTimeouts & timeouts, const std::string & query);

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -52,8 +52,10 @@
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-#define DBMS_TCP_PROTOCOL_VERSION 54456
+#define DBMS_TCP_PROTOCOL_VERSION 54457
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME 54449
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_PROFILE_EVENTS_IN_INSERT 54456
+
+#define DBMS_MIN_PROTOCOL_VERSION_WITH_VIEW_IF_PERMITTED 54457


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Fix interactive client with older server after https://github.com/ClickHouse/ClickHouse/pull/38970
The problem was that older servers don't know the function `viewIfPermitted()` and thus can't make a suggest for a newer client.