### PR TITLE
Fix flaky test test_login_as_dropped_user_xml.

### DIFF
--- a/tests/integration/test_create_user_and_login/test.py
+++ b/tests/integration/test_create_user_and_login/test.py
@@ -81,18 +81,23 @@ EOF""",
             ["bash", "-c", "rm /etc/clickhouse-server/users.d/user_c.xml"]
         )
 
-        expected_error = "no user with such name"
+        expected_errors = ["no user with such name", "not found in user directories"]
         while True:
             out, err = instance.query_and_get_answer_with_error("SELECT 1", user="C")
-            if expected_error in err:
-                logging.debug(f"Got error '{expected_error}' just as expected")
+            found_error = [
+                expected_error
+                for expected_error in expected_errors
+                if (expected_error in err)
+            ]
+            if found_error:
+                logging.debug(f"Got error '{found_error}' just as expected")
                 break
             if out == "1\n":
                 logging.debug(f"Got output '1', retrying...")
                 time.sleep(0.5)
                 continue
             raise Exception(
-                f"Expected either output '1' or error '{expected_error}', got output={out} and error={err}"
+                f"Expected either output '1' or one of errors '{expected_errors}', got output={out} and error={err}"
             )
 
         assert instance.query("SELECT name FROM system.users WHERE name='C'") == ""


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Fix flaky `test_create_user_and_login/test.py::test_login_as_dropped_user_xml` ([failure](https://s3.amazonaws.com/clickhouse-test-reports/39359/43b939d50d80cc6bd88d3bc94744268eacc0261b/integration_tests__thread__actions__[2/4]/integration_run_parallel0_0.log))