### PR TITLE
Introduce a dependency to libuv when building NATS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -376,7 +376,7 @@ if (TARGET ch_contrib::rdkafka)
 endif()
 
 if (TARGET ch_contrib::nats_io)
-    dbms_target_link_libraries(PRIVATE ch_contrib::nats_io)
+    dbms_target_link_libraries(PRIVATE ch_contrib::nats_io ch_contrib::uv)
 endif()
 
 if (TARGET ch_contrib::sasl2)


### PR DESCRIPTION
The following compilation error occurs:
```
In file included from /root/projects/github/ltrk2/ClickHouse/src/Storages/NATS/NATSConnection.cpp:1:
In file included from /root/projects/github/ltrk2/ClickHouse/src/Storages/NATS/NATSConnection.h:4:
/root/projects/github/ltrk2/ClickHouse/src/Storages/NATS/NATSHandler.h:3:10: fatal error: 'uv.h' file not found
#include <uv.h>
         ^~~~~~
1 error generated.
```

The build is configured as follows, then built using `ninja`.
```
cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
-DWITH_OPTIM=ON \
-DGLIBC_COMPATIBILITY=ON \
-DCMAKE_INSTALL_PREFIX:PATH=/opt/clickhouse \
-DENABLE_RDKAFKA=ON \
-DBUILD_SHARED_LIBS=OFF \
-DITK_DYNAMIC_LOADING=OFF \
-DENABLE_AMQPCPP=OFF \
-DENABLE_AVRO=ON \
-DENABLE_CAPNP=OFF \
-DENABLE_CASSANDRA=OFF \
-DENABLE_H3=OFF \
-DENABLE_HDFS=OFF \
-DENABLE_MSGPACK=OFF \
-DENABLE_MYSQL=OFF \
-DENABLE_NLP=OFF \
-DENABLE_ODBC=OFF \
-DENABLE_ORC=OFF \
-DENABLE_PARQUET=OFF \
-DENABLE_ROCKSDB=OFF \
-DENABLE_SQLITE=OFF \
-DENABLE_SHELL_COMMANDS=0 \
-DENABLE_PLAY=0 \
-DADD_GDB_INDEX_FOR_GOLD=1 \
 ..
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Introduce a dependency to libuv when building NATS.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
