### PR TITLE
Revert "Fix WriteBuffer finalize in destructor when cacnel query"

### DIFF
--- a/src/Processors/Formats/IOutputFormat.cpp
+++ b/src/Processors/Formats/IOutputFormat.cpp
@@ -73,6 +73,7 @@ void IOutputFormat::work()
             setRowsBeforeLimit(rows_before_limit_counter->get());
 
         finalize();
+        finalized = true;
         return;
     }
 
@@ -119,12 +120,9 @@ void IOutputFormat::write(const Block & block)
 
 void IOutputFormat::finalize()
 {
-    if (finalized)
-        return;
     writePrefixIfNot();
     writeSuffixIfNot();
     finalizeImpl();
-    finalized = true;
 }
 
 }

--- a/src/Storages/HDFS/StorageHDFS.cpp
+++ b/src/Storages/HDFS/StorageHDFS.cpp
@@ -430,13 +430,6 @@ public:
         writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
     }
 
-    void onCancel() override
-    {
-        if (!writer)
-            return;
-        onFinish();
-    }
-
     void onException() override
     {
         if (!writer)

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -813,13 +813,6 @@ public:
         writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
     }
 
-    void onCancel() override
-    {
-        if (!writer)
-            return;
-        onFinish();
-    }
-
     void onException() override
     {
         if (!writer)

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -602,13 +602,6 @@ public:
         writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
     }
 
-    void onCancel() override
-    {
-        if (!writer)
-            return;
-        onFinish();
-    }
-
     void onException() override
     {
         if (!writer)

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -450,13 +450,6 @@ void StorageURLSink::consume(Chunk chunk)
     writer->write(getHeader().cloneWithColumns(chunk.detachColumns()));
 }
 
-void StorageURLSink::onCancel()
-{
-    if (!writer)
-        return;
-    onFinish();
-}
-
 void StorageURLSink::onException()
 {
     if (!writer)

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -114,7 +114,6 @@ public:
 
     std::string getName() const override { return "StorageURLSink"; }
     void consume(Chunk chunk) override;
-    void onCancel() override;
     void onException() override;
     void onFinish() override;
 


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#39396

It caused possible data race https://s3.amazonaws.com/clickhouse-test-reports/39391/85e55977988fff18bf08d1f2346ffc07a5de79e5/stress_test__thread__actions_/stderr.log
And possible logical error `'Cannot write to finalized buffer'.`. I will create a new PR with proper fix when debug it