### PR TITLE
optimize select query from cluster table function

### DIFF
--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -126,10 +126,11 @@ ColumnsDescription getStructureOfRemoteTable(
     // use local shard as first priority, as it needs no network communication
     for (const auto & shard_info : shards_info)
     {
-        if(shard_info.isLocal()){
+        if(shard_info.isLocal())
+        {
             const auto & res = getStructureOfRemoteTableInShard(cluster, shard_info, table_id, context, table_func_ptr);
             if (res.empty())
-                continue;
+                break;
 
             return res;
         }

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -122,6 +122,18 @@ ColumnsDescription getStructureOfRemoteTable(
     const auto & shards_info = cluster.getShardsInfo();
 
     std::string fail_messages;
+    
+    // use local shard as first priority, as it needs no network communication
+    for (const auto & shard_info : shards_info)
+    {
+        if(shard_info.isLocal()){
+            const auto & res = getStructureOfRemoteTableInShard(cluster, shard_info, table_id, context, table_func_ptr);
+            if (res.empty())
+                continue;
+
+            return res;
+        }
+    }
 
     for (const auto & shard_info : shards_info)
     {

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -122,7 +122,7 @@ ColumnsDescription getStructureOfRemoteTable(
     const auto & shards_info = cluster.getShardsInfo();
 
     std::string fail_messages;
-    
+
     /// Use local shard as first priority, as it needs no network communication
     for (const auto & shard_info : shards_info)
     {

--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -123,15 +123,13 @@ ColumnsDescription getStructureOfRemoteTable(
 
     std::string fail_messages;
     
-    // use local shard as first priority, as it needs no network communication
+    /// Use local shard as first priority, as it needs no network communication
     for (const auto & shard_info : shards_info)
     {
-        if(shard_info.isLocal())
+        if (shard_info.isLocal())
         {
             const auto & res = getStructureOfRemoteTableInShard(cluster, shard_info, table_id, context, table_func_ptr);
-            if (res.empty())
-                break;
-
+            chassert(!res.empty());
             return res;
         }
     }

--- a/tests/integration/test_distributed_respect_user_timeouts/test.py
+++ b/tests/integration/test_distributed_respect_user_timeouts/test.py
@@ -129,15 +129,7 @@ def started_cluster(request):
 def _check_timeout_and_exception(node, user, query_base, query):
     repeats = EXPECTED_BEHAVIOR[user]["times"]
 
-    extra_repeats = 1
-    # Table function remote() are executed two times.
-    # It tries to get table structure from remote shards.
-    # On 'node2' it will firstly try to get structure from 'node1' (which is not available),
-    # so there are 1 extra connection attempts for 'node2' and 'remote'
-    if node.name == "node2" and query_base == "remote":
-        extra_repeats = 2
-
-    expected_timeout = EXPECTED_BEHAVIOR[user]["timeout"] * repeats * extra_repeats
+    expected_timeout = EXPECTED_BEHAVIOR[user]["timeout"] * repeats
 
     start = timeit.default_timer()
     exception = node.query_and_get_error(query, user=user)


### PR DESCRIPTION
Use local node as first priority to get Structure Of Remote Table.
we have many distributed queries( like   select xx from cluster('xx',view  (xxxx)   ) on a clickhouse cluster.  we found that the first node (shard_num=1)  have 2 times of query number compared to other shards.
The reason is that  the getStructureOfRemoteTableInShard func always take the first shard to execute  "DESC TABLE xx" query.
The better way is to  use local node as first priority which save the network rpc and reduce the pressure of first shard .

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use local node as first priority to get structure of remote table when executing `cluster` and similar table functions.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
