### PR TITLE
Build thread sanitizer binaries with clang-13

### DIFF
--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -118,5 +118,20 @@ ENV GOCACHE=/workdir/
 RUN mkdir /workdir && chmod 777 /workdir
 WORKDIR /workdir
 
+# FIXME: thread sanitizer is broken in clang-14, we have to build it with clang-13
+# https://github.com/ClickHouse/ClickHouse/pull/39450
+# https://github.com/google/sanitizers/issues/1540
+# https://github.com/google/sanitizers/issues/1552
+
+RUN export CODENAME="$(lsb_release --codename --short | tr 'A-Z' 'a-z')" \
+    && echo "deb [trusted=yes] https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-13 main" >> \
+        /etc/apt/sources.list.d/clang.list \
+    && apt-get update \
+    && apt-get install \
+        clang-13 \
+        clang-tidy-13 \
+        --yes --no-install-recommends \
+    && apt-get clean
+
 COPY build.sh /
 CMD ["bash", "-c", "/build.sh 2>&1"]

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -323,6 +323,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--compiler",
         choices=(
+            "clang-13",  # For TSAN builds, see #39450
             "clang-14",
             "clang-14-darwin",
             "clang-14-darwin-aarch64",

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -7,29 +7,26 @@ set -x
 
 # Thread Fuzzer allows to check more permutations of possible thread scheduling
 # and find more potential issues.
-#
-# But under thread fuzzer, TSan build is too slow and this produces some flaky
-# tests, so for now, as a temporary solution it had been disabled.
-if ! test -f package_folder/clickhouse-server*tsan*.deb; then
-    export THREAD_FUZZER_CPU_TIME_PERIOD_US=1000
-    export THREAD_FUZZER_SLEEP_PROBABILITY=0.1
-    export THREAD_FUZZER_SLEEP_TIME_US=100000
 
-    export THREAD_FUZZER_pthread_mutex_lock_BEFORE_MIGRATE_PROBABILITY=1
-    export THREAD_FUZZER_pthread_mutex_lock_AFTER_MIGRATE_PROBABILITY=1
-    export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_MIGRATE_PROBABILITY=1
-    export THREAD_FUZZER_pthread_mutex_unlock_AFTER_MIGRATE_PROBABILITY=1
+export THREAD_FUZZER_CPU_TIME_PERIOD_US=1000
+export THREAD_FUZZER_SLEEP_PROBABILITY=0.1
+export THREAD_FUZZER_SLEEP_TIME_US=100000
 
-    export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_PROBABILITY=0.001
-    export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_PROBABILITY=0.001
-    export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_PROBABILITY=0.001
-    export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_PROBABILITY=0.001
-    export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_TIME_US=10000
+export THREAD_FUZZER_pthread_mutex_lock_BEFORE_MIGRATE_PROBABILITY=1
+export THREAD_FUZZER_pthread_mutex_lock_AFTER_MIGRATE_PROBABILITY=1
+export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_MIGRATE_PROBABILITY=1
+export THREAD_FUZZER_pthread_mutex_unlock_AFTER_MIGRATE_PROBABILITY=1
 
-    export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_TIME_US=10000
-    export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_TIME_US=10000
-    export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_TIME_US=10000
-fi
+export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_PROBABILITY=0.001
+export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_PROBABILITY=0.001
+export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_PROBABILITY=0.001
+export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_PROBABILITY=0.001
+export THREAD_FUZZER_pthread_mutex_lock_BEFORE_SLEEP_TIME_US=10000
+
+export THREAD_FUZZER_pthread_mutex_lock_AFTER_SLEEP_TIME_US=10000
+export THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_TIME_US=10000
+export THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_TIME_US=10000
+
 
 function install_packages()
 {

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -63,7 +63,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "package_tsan": {
-            "compiler": "clang-14",
+            "compiler": "clang-13",
             "build_type": "",
             "sanitizer": "thread",
             "package_type": "deb",

--- a/tests/queries/0_stateless/00984_parser_stack_overflow.sh
+++ b/tests/queries/0_stateless/00984_parser_stack_overflow.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-tsan
-# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 # Such a huge timeout mostly for debug build.
 CLICKHOUSE_CURL_TIMEOUT=60

--- a/tests/queries/0_stateless/01172_transaction_counters.sql
+++ b/tests/queries/0_stateless/01172_transaction_counters.sql
@@ -1,6 +1,5 @@
--- Tags: no-s3-storage, no-tsan, no-ordinary-database
+-- Tags: no-s3-storage, no-ordinary-database
 -- FIXME this test fails with S3 due to a bug in DiskCacheWrapper
--- FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 drop table if exists txn_counters;
 
 create table txn_counters (n Int64, creation_tid DEFAULT transactionID()) engine=MergeTree order by n;

--- a/tests/queries/0_stateless/01183_custom_separated_format_http.sh
+++ b/tests/queries/0_stateless/01183_custom_separated_format_http.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-tsan
-# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01184_long_insert_values_huge_strings.sh
+++ b/tests/queries/0_stateless/01184_long_insert_values_huge_strings.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-tsan
-# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
+# Tags: long
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01651_lc_insert_tiny_log.sql
+++ b/tests/queries/0_stateless/01651_lc_insert_tiny_log.sql
@@ -1,6 +1,3 @@
--- Tags: no-tsan
--- FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
-
 drop table if exists perf_lc_num;
 
 CREATE TABLE perf_lc_num(　        num UInt8,　        arr Array(LowCardinality(Int64)) default [num]　        ) ENGINE = TinyLog;

--- a/tests/queries/0_stateless/01746_long_zstd_http_compression_json_format.sh
+++ b/tests/queries/0_stateless/01746_long_zstd_http_compression_json_format.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-fasttest, no-tsan
-# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
+# Tags: long, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01926_order_by_desc_limit.sql
+++ b/tests/queries/0_stateless/01926_order_by_desc_limit.sql
@@ -1,5 +1,4 @@
--- Tags: no-random-settings, no-tsan
--- FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
+-- Tags: no-random-settings
 
 DROP TABLE IF EXISTS order_by_desc;
 

--- a/tests/queries/1_stateful/00159_parallel_formatting_http.sh
+++ b/tests/queries/1_stateful/00159_parallel_formatting_http.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-tsan
-# FIXME It became flaky after upgrading to llvm-14 due to obscure freezes in tsan
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
TSAN has issues with clang-14 (https://github.com/google/sanitizers/issues/1552, https://github.com/google/sanitizers/issues/1540), so here we temporary build the TSAN binaries with clang-13.