### PR TITLE
Fix for BC check

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -335,7 +335,7 @@ else
         || echo -e 'Backward compatibility check: Test script failed\tFAIL' >> /test_output/test_results.tsv
     rm -rf tmp_stress_output
 
-    clickhouse-client --query="SELECT 'Tables count:', count() FROM system.tables"
+    clickhouse-client --query="SELECT 'Tables count:', count() FROM system.tables" ||:
 
     stop
     mv /var/log/clickhouse-server/clickhouse-server.log /var/log/clickhouse-server/clickhouse-server.backward.stress.log


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


```
2022-07-22 06:16:37,746 Finished 33 from 36 processes
2022-07-22 06:16:42,750 Finished 34 from 36 processes
2022-07-22 06:16:47,754 All processes finished
2022-07-22 06:16:47,755 Compressing stress logs
2022-07-22 06:16:47,893 Logs compressed
2022-07-22 06:16:47,894 Stress test finished
+ echo -e 'Backward compatibility check: Test script exit code\tOK'
+ rm -rf tmp_stress_output
+ clickhouse-client '--query=SELECT '\''Tables count:'\'', count() FROM system.tables'
Timeout exceeded while receiving data from server. Waited for 300 seconds, timeout is 300 seconds.
```
https://s3.amazonaws.com/clickhouse-test-reports/39460/a8da5d96fce7e72859dca8b83c8b1d509b926c69/stress_test__memory__actions_.html
