### PR TITLE
Fix build on mac osx

### DIFF
--- a/src/Common/waitForPid.cpp
+++ b/src/Common/waitForPid.cpp
@@ -92,6 +92,8 @@ static int pollPid(pid_t pid, int timeout_in_ms)
 }
 #elif defined(OS_DARWIN) || defined(OS_FREEBSD)
 
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+
 #include <sys/event.h>
 #include <err.h>
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix build error:
```
[ 69%] Building CXX object src/CMakeFiles/clickhouse_common_io.dir/Common/waitForPid.cpp.o
/CLionProjects/clickhouse-yandex/src/Common/waitForPid.cpp:112:5: error: identifier '__kevp__' is reserved because it starts with '__' [-Werror,-Wreserved-identifier]
    EV_SET(&change, pid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, NULL);
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/event.h:108:17: note: expanded from macro 'EV_SET'
        struct kevent *__kevp__ = (kevp);       \
                       ^
```