### PR TITLE
Mark new codec DEFLATE_QPL as experimental + cosmetics

### DIFF
--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -250,10 +250,12 @@ High compression levels are useful for asymmetric scenarios, like compress once,
 
 #### DEFLATE_QPL
 
-`DEFLATE_QPL` — [Deflate compression algorithm](https://github.com/intel/qpl) implemented by Intel® Query Processing Library, which has dependency on Intel Hardware:
+`DEFLATE_QPL` — [Deflate compression algorithm](https://github.com/intel/qpl) implemented by Intel® Query Processing Library. Some limitations apply:
 
--   DEFLATE_QPL is only supported on systems with AVX2/AVX512/IAA.
--   DEFLATE_QPL-compressed data can only be transferred between nodes with AVX2/AVX512/IAA.
+-   DEFLATE_QPL is experimental and can only be used after setting configuration parameter `allow_experimental_codecs=1`.
+-   DEFLATE_QPL only works if ClickHouse was compiled with support for AVX2 or AVX512 instructions
+-   DEFLATE_QPL works best if the system has a Intel® IAA (In-Memory Analytics Accelerator) offloading device
+-   DEFLATE_QPL-compressed data can only be transferred between ClickHouse nodes compiled with support for AVX2/AVX512
 
 ### Specialized Codecs
 

--- a/src/Compression/CompressionCodecDeflateQpl.cpp
+++ b/src/Compression/CompressionCodecDeflateQpl.cpp
@@ -28,8 +28,8 @@ DeflateQplJobHWPool & DeflateQplJobHWPool::instance()
 }
 
 DeflateQplJobHWPool::DeflateQplJobHWPool()
-    :random_engine(std::random_device()())
-    ,distribution(0, MAX_HW_JOB_NUMBER-1)
+    : random_engine(std::random_device()())
+    , distribution(0, MAX_HW_JOB_NUMBER - 1)
 {
     Poco::Logger * log = &Poco::Logger::get("DeflateQplJobHWPool");
     UInt32 job_size = 0;
@@ -73,7 +73,7 @@ DeflateQplJobHWPool::~DeflateQplJobHWPool()
     job_pool_ready = false;
 }
 
-qpl_job * DeflateQplJobHWPool::acquireJob(UInt32 &job_id)
+qpl_job * DeflateQplJobHWPool::acquireJob(UInt32 & job_id)
 {
     if (isJobPoolReady())
     {
@@ -141,7 +141,7 @@ HardwareCodecDeflateQpl::~HardwareCodecDeflateQpl()
 Int32 HardwareCodecDeflateQpl::doCompressData(const char * source, UInt32 source_size, char * dest, UInt32 dest_size) const
 {
     UInt32 job_id = 0;
-    qpl_job* job_ptr = nullptr;
+    qpl_job * job_ptr = nullptr;
     UInt32 compressed_size = 0;
     if (!(job_ptr = DeflateQplJobHWPool::instance().acquireJob(job_id)))
     {
@@ -330,10 +330,9 @@ void SoftwareCodecDeflateQpl::doDecompressData(const char * source, UInt32 sourc
             "Execution of DeflateQpl software fallback codec failed. (Details: qpl_execute_job with error code: {} - please refer to qpl_status in ./contrib/qpl/include/qpl/c_api/status.h)", status);
 }
 
-//CompressionCodecDeflateQpl
 CompressionCodecDeflateQpl::CompressionCodecDeflateQpl()
-    :hw_codec(std::make_unique<HardwareCodecDeflateQpl>())
-    ,sw_codec(std::make_unique<SoftwareCodecDeflateQpl>())
+    : hw_codec(std::make_unique<HardwareCodecDeflateQpl>())
+    , sw_codec(std::make_unique<SoftwareCodecDeflateQpl>())
 {
     setCodecDescription("DEFLATE_QPL");
 }

--- a/src/Compression/CompressionCodecDeflateQpl.h
+++ b/src/Compression/CompressionCodecDeflateQpl.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <Compression/ICompressionCodec.h>
-#include <qpl/qpl.h>
+#include <map>
 #include <random>
+#include <qpl/qpl.h>
 
 namespace Poco
 {
@@ -18,20 +19,16 @@ class DeflateQplJobHWPool
 {
 public:
     DeflateQplJobHWPool();
-
     ~DeflateQplJobHWPool();
-
-    qpl_job * acquireJob(UInt32 &job_id);
-
-    static void releaseJob(UInt32 job_id);
-
-    static const bool & isJobPoolReady() { return job_pool_ready; }
 
     static DeflateQplJobHWPool & instance();
 
+    qpl_job * acquireJob(UInt32 & job_id);
+    static void releaseJob(UInt32 job_id);
+    static const bool & isJobPoolReady() { return job_pool_ready; }
+
 private:
     static bool tryLockJob(UInt32 index);
-
     static void unLockJob(UInt32 index);
 
     /// Maximum jobs running in parallel supported by IAA hardware
@@ -39,9 +36,9 @@ private:
     /// Entire buffer for storing all job objects
     static std::unique_ptr<uint8_t[]> hw_jobs_buffer;
     /// Job pool for storing all job object pointers
-    static std::array<qpl_job *, DeflateQplJobHWPool::MAX_HW_JOB_NUMBER> hw_job_ptr_pool;
+    static std::array<qpl_job *, MAX_HW_JOB_NUMBER> hw_job_ptr_pool;
     /// Locks for accessing each job object pointers
-    static std::array<std::atomic_bool, DeflateQplJobHWPool::MAX_HW_JOB_NUMBER> hw_job_ptr_locks;
+    static std::array<std::atomic_bool, MAX_HW_JOB_NUMBER> hw_job_ptr_locks;
     static bool job_pool_ready;
     std::mt19937 random_engine;
     std::uniform_int_distribution<int> distribution;
@@ -57,23 +54,25 @@ public:
 private:
     qpl_job * sw_job = nullptr;
     std::unique_ptr<uint8_t[]> sw_buffer;
+
     qpl_job * getJobCodecPtr();
 };
 
 class HardwareCodecDeflateQpl
 {
 public:
-    /// RET_ERROR stands for hardware codec fail,need fallback to software codec.
+    /// RET_ERROR stands for hardware codec fail, needs fallback to software codec.
     static constexpr Int32 RET_ERROR = -1;
 
     HardwareCodecDeflateQpl();
     ~HardwareCodecDeflateQpl();
+
     Int32 doCompressData(const char * source, UInt32 source_size, char * dest, UInt32 dest_size) const;
 
-    ///Submit job request to the IAA hardware and then busy waiting till it complete.
+    /// Submit job request to the IAA hardware and then busy waiting till it complete.
     Int32 doDecompressDataSynchronous(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size);
 
-    ///Submit job request to the IAA hardware and return immediately. IAA hardware will process decompression jobs automatically.
+    /// Submit job request to the IAA hardware and return immediately. IAA hardware will process decompression jobs automatically.
     Int32 doDecompressDataAsynchronous(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size);
 
     /// Flush result for all previous requests which means busy waiting till all the jobs in "decomp_async_job_map" are finished.
@@ -96,23 +95,19 @@ public:
     void updateHash(SipHash & hash) const override;
 
 protected:
-    bool isCompression() const override
-    {
-        return true;
-    }
-
-    bool isGenericCompression() const override
-    {
-        return true;
-    }
+    bool isCompression() const override { return true; }
+    bool isGenericCompression() const override { return true; }
+    bool isExperimental() const override { return true; }
 
     UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
     void doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const override;
-    ///Flush result for previous asynchronous decompression requests on asynchronous mode.
+
+    /// Flush result for previous asynchronous decompression requests on asynchronous mode.
     void flushAsynchronousDecompressRequests() override;
 
 private:
     UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const override;
+
     std::unique_ptr<HardwareCodecDeflateQpl> hw_codec;
     std::unique_ptr<SoftwareCodecDeflateQpl> sw_codec;
 };

--- a/tests/queries/0_stateless/02372_qpl_is_experimental.sql
+++ b/tests/queries/0_stateless/02372_qpl_is_experimental.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS qpl_codec;
+
+CREATE TABLE qpl_codec (id Int32 CODEC(DEFLATE_QPL)) ENGINE = MergeTree() ORDER BY id; -- { serverError 36 }
+
+SET allow_experimental_codecs = 1;
+CREATE TABLE qpl_codec (id Int32 CODEC(DEFLATE_QPL)) ENGINE = MergeTree() ORDER BY id;
+
+DROP TABLE IF EXISTS qpl_codec;
+

--- a/tests/queries/0_stateless/02372_qpl_is_experimental.sql
+++ b/tests/queries/0_stateless/02372_qpl_is_experimental.sql
@@ -1,9 +1,0 @@
-DROP TABLE IF EXISTS qpl_codec;
-
-CREATE TABLE qpl_codec (id Int32 CODEC(DEFLATE_QPL)) ENGINE = MergeTree() ORDER BY id; -- { serverError 36 }
-
-SET allow_experimental_codecs = 1;
-CREATE TABLE qpl_codec (id Int32 CODEC(DEFLATE_QPL)) ENGINE = MergeTree() ORDER BY id;
-
-DROP TABLE IF EXISTS qpl_codec;
-


### PR DESCRIPTION
Introduced with https://github.com/ClickHouse/ClickHouse/pull/39494. The codec can only be used if AVX2 or AVX512 is enabled but we should still put it behind an 'experimental' switch, at least for a while.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)