### PR TITLE
Add support of !/* (exclamation/asterisk) in custom TLDs

### DIFF
--- a/src/Common/TLDListsHolder.cpp
+++ b/src/Common/TLDListsHolder.cpp
@@ -15,20 +15,31 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+constexpr size_t StringHashTablePadRequirement = 8;
+
 /// TLDList
 TLDList::TLDList(size_t size)
     : tld_container(size)
-    , pool(std::make_unique<Arena>(10 << 20))
-{}
-bool TLDList::insert(StringRef host)
+    , memory_pool(std::make_unique<Arena>())
 {
-    bool inserted;
-    tld_container.emplace(DB::ArenaKeyHolder{host, *pool}, inserted);
-    return inserted;
+    /// StringHashTable requires padded to 8 bytes key,
+    /// and Arena (memory_pool here) does satisfies this,
+    /// since it has padding with 15 bytes at the right.
+    ///
+    /// However, StringHashTable may reference -1 byte of the key,
+    /// so left padding is also required:
+    memory_pool->alignedAlloc(StringHashTablePadRequirement, StringHashTablePadRequirement);
 }
-bool TLDList::has(StringRef host) const
+void TLDList::insert(const String & host, TLDType type)
 {
-    return tld_container.has(host);
+    StringRef owned_host{memory_pool->insert(host.data(), host.size()), host.size()};
+    tld_container[owned_host] = type;
+}
+TLDType TLDList::lookup(StringRef host) const
+{
+    if (auto it = tld_container.find(host); it != nullptr)
+        return it->getMapped();
+    return TLDType::TLD_NONE;
 }
 
 /// TLDListsHolder
@@ -57,32 +68,44 @@ void TLDListsHolder::parseConfig(const std::string & top_level_domains_path, con
 
 size_t TLDListsHolder::parseAndAddTldList(const std::string & name, const std::string & path)
 {
-    std::unordered_set<std::string> tld_list_tmp;
+    std::unordered_map<std::string, TLDType> tld_list_tmp;
 
     ReadBufferFromFile in(path);
-    String line;
+    String buffer;
     while (!in.eof())
     {
-        readEscapedStringUntilEOL(line, in);
+        readEscapedStringUntilEOL(buffer, in);
         if (!in.eof())
             ++in.position();
+        std::string_view line(buffer);
         /// Skip comments
-        if (line.size() > 2 && line[0] == '/' && line[1] == '/')
+        if (line.starts_with("//"))
             continue;
-        line = trim(line, [](char c) { return std::isspace(c); });
+        line = line.substr(0, line.rend() - std::find_if_not(line.rbegin(), line.rend(), ::isspace));
         /// Skip empty line
         if (line.empty())
             continue;
-        tld_list_tmp.emplace(line);
+        /// Validate special symbols.
+        if (line.starts_with("*."))
+        {
+            line = line.substr(2);
+            tld_list_tmp.emplace(line, TLDType::TLD_ANY);
+        }
+        else if (line[0] == '!')
+        {
+            line = line.substr(1);
+            tld_list_tmp.emplace(line, TLDType::TLD_EXCLUDE);
+        }
+        else
+            tld_list_tmp.emplace(line, TLDType::TLD_REGULAR);
     }
     if (!in.eof())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Not all list had been read", name);
 
     TLDList tld_list(tld_list_tmp.size());
-    for (const auto & host : tld_list_tmp)
+    for (const auto & [host, type] : tld_list_tmp)
     {
-        StringRef host_ref{host.data(), host.size()};
-        tld_list.insert(host_ref);
+        tld_list.insert(host, type);
     }
 
     size_t tld_list_size = tld_list.size();

--- a/src/Common/TLDListsHolder.h
+++ b/src/Common/TLDListsHolder.h
@@ -2,7 +2,7 @@
 
 #include <base/defines.h>
 #include <base/StringRef.h>
-#include <Common/HashTable/StringHashSet.h>
+#include <Common/HashTable/StringHashMap.h>
 #include <Common/Arena.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <mutex>
@@ -12,25 +12,35 @@
 namespace DB
 {
 
+enum TLDType
+{
+    /// Does not exist marker
+    TLD_NONE,
+    /// For regular lines
+    TLD_REGULAR,
+    /// For asterisk (*)
+    TLD_ANY,
+    /// For exclamation mark (!)
+    TLD_EXCLUDE,
+};
+
 /// Custom TLD List
 ///
-/// Unlike tldLookup (which uses gperf) this one uses plain StringHashSet.
+/// Unlike tldLookup (which uses gperf) this one uses plain StringHashMap.
 class TLDList
 {
 public:
-    using Container = StringHashSet<>;
+    using Container = StringHashMap<TLDType>;
 
     explicit TLDList(size_t size);
 
-    /// Return true if the tld_container does not contains such element.
-    bool insert(StringRef host);
-    /// Check is there such TLD
-    bool has(StringRef host) const;
+    void insert(const String & host, TLDType type);
+    TLDType lookup(StringRef host) const;
     size_t size() const { return tld_container.size(); }
 
 private:
     Container tld_container;
-    std::unique_ptr<Arena> pool;
+    std::unique_ptr<Arena> memory_pool;
 };
 
 class TLDListsHolder
@@ -48,6 +58,11 @@ public:
     /// - "//" -- comment,
     /// - empty lines will be ignored.
     ///
+    /// Treats the following special symbols:
+    /// - "*"
+    /// - "!"
+    ///
+    /// Format : https://github.com/publicsuffix/list/wiki/Format
     /// Example: https://publicsuffix.org/list/public_suffix_list.dat
     ///
     /// Return size of the list.

--- a/src/Functions/URL/ExtractFirstSignificantSubdomain.h
+++ b/src/Functions/URL/ExtractFirstSignificantSubdomain.h
@@ -3,15 +3,16 @@
 #include <base/find_symbols.h>
 #include "domain.h"
 #include "tldLookup.h"
+#include <Common/TLDListsHolder.h> /// TLDType
 
 namespace DB
 {
 
 struct FirstSignificantSubdomainDefaultLookup
 {
-    bool operator()(const char *src, size_t len) const
+    bool operator()(StringRef host) const
     {
-        return tldLookup::isValid(src, len);
+        return tldLookup::isValid(host.data, host.size);
     }
 };
 
@@ -51,44 +52,46 @@ struct ExtractFirstSignificantSubdomain
 
         const auto * begin = tmp;
         const auto * end = begin + domain_length;
-        const char * last_3_periods[3]{};
+        std::array<const char *, 3> last_periods{};
 
         const auto * pos = find_first_symbols<'.'>(begin, end);
         while (pos < end)
         {
-            last_3_periods[2] = last_3_periods[1];
-            last_3_periods[1] = last_3_periods[0];
-            last_3_periods[0] = pos;
+            last_periods[2] = last_periods[1];
+            last_periods[1] = last_periods[0];
+            last_periods[0] = pos;
             pos = find_first_symbols<'.'>(pos + 1, end);
         }
 
-        if (!last_3_periods[0])
+        if (!last_periods[0])
             return;
 
-        if (!last_3_periods[1])
+        if (!last_periods[1])
         {
-            res_size = last_3_periods[0] - begin;
+            res_size = last_periods[0] - begin;
             return;
         }
 
-        if (!last_3_periods[2])
-            last_3_periods[2] = begin - 1;
+        if (!last_periods[2])
+            last_periods[2] = begin - 1;
 
-        const auto * end_of_level_domain = find_first_symbols<'/'>(last_3_periods[0], end);
+        const auto * end_of_level_domain = find_first_symbols<'/'>(last_periods[0], end);
         if (!end_of_level_domain)
         {
             end_of_level_domain = end;
         }
 
-        if (lookup(last_3_periods[1] + 1, end_of_level_domain - last_3_periods[1] - 1))
+        size_t host_len = static_cast<size_t>(end_of_level_domain - last_periods[1] - 1);
+        StringRef host{last_periods[1] + 1, host_len};
+        if (lookup(host))
         {
-            res_data += last_3_periods[2] + 1 - begin;
-            res_size = last_3_periods[1] - last_3_periods[2] - 1;
+            res_data += last_periods[2] + 1 - begin;
+            res_size = last_periods[1] - last_periods[2] - 1;
         }
         else
         {
-            res_data += last_3_periods[1] + 1 - begin;
-            res_size = last_3_periods[0] - last_3_periods[1] - 1;
+            res_data += last_periods[1] + 1 - begin;
+            res_size = last_periods[0] - last_periods[1] - 1;
         }
     }
 
@@ -119,40 +122,63 @@ struct ExtractFirstSignificantSubdomain
 
         const auto * begin = tmp;
         const auto * end = begin + domain_length;
-        const char * last_2_periods[2]{};
-        const char * prev = begin - 1;
+        std::array<const char *, 2> last_periods{};
+        last_periods[0] = begin - 1;
+        StringRef excluded_host{};
 
         const auto * pos = find_first_symbols<'.'>(begin, end);
         while (pos < end)
         {
-            if (lookup(pos + 1, end - pos - 1))
+            size_t host_len = static_cast<size_t>(end - pos - 1);
+            StringRef host{pos + 1, host_len};
+            TLDType tld_type = lookup(host);
+            switch (tld_type)
             {
-                res_data += prev + 1 - begin;
-                res_size = end - 1 - prev;
-                return;
+                case TLDType::TLD_NONE:
+                    break;
+                case TLDType::TLD_REGULAR:
+                    res_data += last_periods[0] + 1 - begin;
+                    res_size = end - 1 - last_periods[0];
+                    return;
+                case TLDType::TLD_ANY:
+                {
+                    StringRef regular_host{last_periods[0] + 1, static_cast<size_t>(end - 1 - last_periods[0])};
+                    if (last_periods[1] && excluded_host != regular_host)
+                    {
+                        /// Return TLD_REGULAR + 1
+                        res_data += last_periods[1] + 1 - begin;
+                        res_size = end - 1 - last_periods[1];
+                    }
+                    else
+                    {
+                        /// Same as TLD_REGULAR
+                        res_data += last_periods[0] + 1 - begin;
+                        res_size = end - 1 - last_periods[0];
+                    }
+                    return;
+                }
+                case TLDType::TLD_EXCLUDE:
+                    excluded_host = host;
+                    break;
             }
 
-            last_2_periods[1] = last_2_periods[0];
-            last_2_periods[0] = pos;
-            prev = pos;
+            last_periods[1] = last_periods[0];
+            last_periods[0] = pos;
             pos = find_first_symbols<'.'>(pos + 1, end);
         }
 
-        /// if there is domain of the first level (i.e. no dots in the hostname) -> return nothing
-        if (!last_2_periods[0])
+        /// - if there is domain of the first level (i.e. no dots in the hostname) ->
+        ///   return nothing
+        if (last_periods[0] == begin - 1)
             return;
 
-        /// if there is domain of the second level -> always return itself
-        if (!last_2_periods[1])
-        {
-            res_size = last_2_periods[0] - begin;
-            return;
-        }
-
-        /// if there is domain of the 3+ level, and zero records in TLD list ->
-        /// fallback to domain of the second level
-        res_data += last_2_periods[1] + 1 - begin;
-        res_size = last_2_periods[0] - last_2_periods[1] - 1;
+        /// - if there is domain of the second level ->
+        ///   always return itself
+        ///
+        /// - if there is domain of the 3+ level, and zero records in TLD list ->
+        ///   fallback to domain of the second level
+        res_data += last_periods[1] + 1 - begin;
+        res_size = last_periods[0] - last_periods[1] - 1;
     }
 };
 

--- a/src/Functions/URL/FirstSignificantSubdomainCustomImpl.h
+++ b/src/Functions/URL/FirstSignificantSubdomainCustomImpl.h
@@ -25,9 +25,9 @@ struct FirstSignificantSubdomainCustomLookup
     {
     }
 
-    bool operator()(const char *pos, size_t len) const
+    TLDType operator()(StringRef host) const
     {
-        return tld_list.has(StringRef{pos, len});
+        return tld_list.lookup(host);
     }
 };
 

--- a/tests/queries/0_stateless/01601_custom_tld.reference
+++ b/tests/queries/0_stateless/01601_custom_tld.reference
@@ -1,34 +1,73 @@
+-- { echo }
+
+select '-- no-tld';
 -- no-tld
+-- even if there is no TLD, 2-nd level by default anyway
+-- FIXME: make this behavior optional (so that TLD for host never changed, either empty or something real)
+select cutToFirstSignificantSubdomain('there-is-no-such-domain');
 
+select cutToFirstSignificantSubdomain('foo.there-is-no-such-domain');
 foo.there-is-no-such-domain
+select cutToFirstSignificantSubdomain('bar.foo.there-is-no-such-domain');
 foo.there-is-no-such-domain
+select cutToFirstSignificantSubdomainCustom('there-is-no-such-domain', 'public_suffix_list');
 
+select cutToFirstSignificantSubdomainCustom('foo.there-is-no-such-domain', 'public_suffix_list');
 foo.there-is-no-such-domain
+select cutToFirstSignificantSubdomainCustom('bar.foo.there-is-no-such-domain', 'public_suffix_list');
 foo.there-is-no-such-domain
+select firstSignificantSubdomainCustom('bar.foo.there-is-no-such-domain', 'public_suffix_list');
 foo
+select '-- generic';
 -- generic
+select firstSignificantSubdomainCustom('foo.kernel.biz.ss', 'public_suffix_list'); -- kernel
 kernel
+select cutToFirstSignificantSubdomainCustom('foo.kernel.biz.ss', 'public_suffix_list'); -- kernel.biz.ss
 kernel.biz.ss
+select '-- difference';
 -- difference
+-- biz.ss is not in the default TLD list, hence:
+select cutToFirstSignificantSubdomain('foo.kernel.biz.ss'); -- biz.ss
 biz.ss
+select cutToFirstSignificantSubdomainCustom('foo.kernel.biz.ss', 'public_suffix_list'); -- kernel.biz.ss
 kernel.biz.ss
+select '-- 3+level';
 -- 3+level
+select cutToFirstSignificantSubdomainCustom('xx.blogspot.co.at', 'public_suffix_list'); -- xx.blogspot.co.at
 xx.blogspot.co.at
+select firstSignificantSubdomainCustom('xx.blogspot.co.at', 'public_suffix_list'); -- blogspot
 blogspot
+select cutToFirstSignificantSubdomainCustom('foo.bar.xx.blogspot.co.at', 'public_suffix_list'); -- xx.blogspot.co.at
 xx.blogspot.co.at
+select firstSignificantSubdomainCustom('foo.bar.xx.blogspot.co.at', 'public_suffix_list'); -- blogspot
 blogspot
+select '-- url';
 -- url
+select cutToFirstSignificantSubdomainCustom('http://foobar.com', 'public_suffix_list');
 foobar.com
+select cutToFirstSignificantSubdomainCustom('http://foobar.com/foo', 'public_suffix_list');
 foobar.com
+select cutToFirstSignificantSubdomainCustom('http://bar.foobar.com/foo', 'public_suffix_list');
 foobar.com
+select cutToFirstSignificantSubdomainCustom('http://xx.blogspot.co.at', 'public_suffix_list');
 xx.blogspot.co.at
+select '-- www';
 -- www
+select cutToFirstSignificantSubdomainCustomWithWWW('http://www.foo', 'public_suffix_list');
 www.foo
+select cutToFirstSignificantSubdomainCustom('http://www.foo', 'public_suffix_list');
 foo
+select '-- vector';
 -- vector
+select cutToFirstSignificantSubdomainCustom('http://xx.blogspot.co.at/' || toString(number), 'public_suffix_list') from numbers(1);
 xx.blogspot.co.at
+select cutToFirstSignificantSubdomainCustom('there-is-no-such-domain' || toString(number), 'public_suffix_list') from numbers(1);
 
+select '-- no new line';
 -- no new line
+select cutToFirstSignificantSubdomainCustom('foo.bar', 'no_new_line_list');
 foo.bar
+select cutToFirstSignificantSubdomainCustom('a.foo.bar', 'no_new_line_list');
 a.foo.bar
+select cutToFirstSignificantSubdomainCustom('a.foo.baz', 'no_new_line_list');
 foo.baz

--- a/tests/queries/0_stateless/01601_custom_tld.reference
+++ b/tests/queries/0_stateless/01601_custom_tld.reference
@@ -71,3 +71,21 @@ select cutToFirstSignificantSubdomainCustom('a.foo.bar', 'no_new_line_list');
 a.foo.bar
 select cutToFirstSignificantSubdomainCustom('a.foo.baz', 'no_new_line_list');
 foo.baz
+select '-- asterisk';
+-- asterisk
+select cutToFirstSignificantSubdomainCustom('foo.something.sheffield.sch.uk', 'public_suffix_list');
+something.sheffield.sch.uk
+select cutToFirstSignificantSubdomainCustom('something.sheffield.sch.uk', 'public_suffix_list');
+something.sheffield.sch.uk
+select cutToFirstSignificantSubdomainCustom('sheffield.sch.uk', 'public_suffix_list');
+sheffield.sch.uk
+select '-- exclamation mark';
+-- exclamation mark
+select cutToFirstSignificantSubdomainCustom('foo.kawasaki.jp', 'public_suffix_list');
+foo.kawasaki.jp
+select cutToFirstSignificantSubdomainCustom('foo.foo.kawasaki.jp', 'public_suffix_list');
+foo.foo.kawasaki.jp
+select cutToFirstSignificantSubdomainCustom('city.kawasaki.jp', 'public_suffix_list');
+city.kawasaki.jp
+select cutToFirstSignificantSubdomainCustom('some.city.kawasaki.jp', 'public_suffix_list');
+city.kawasaki.jp

--- a/tests/queries/0_stateless/01601_custom_tld.sql
+++ b/tests/queries/0_stateless/01601_custom_tld.sql
@@ -1,3 +1,5 @@
+-- { echo }
+
 select '-- no-tld';
 -- even if there is no TLD, 2-nd level by default anyway
 -- FIXME: make this behavior optional (so that TLD for host never changed, either empty or something real)

--- a/tests/queries/0_stateless/01601_custom_tld.sql
+++ b/tests/queries/0_stateless/01601_custom_tld.sql
@@ -44,3 +44,14 @@ select '-- no new line';
 select cutToFirstSignificantSubdomainCustom('foo.bar', 'no_new_line_list');
 select cutToFirstSignificantSubdomainCustom('a.foo.bar', 'no_new_line_list');
 select cutToFirstSignificantSubdomainCustom('a.foo.baz', 'no_new_line_list');
+
+select '-- asterisk';
+select cutToFirstSignificantSubdomainCustom('foo.something.sheffield.sch.uk', 'public_suffix_list');
+select cutToFirstSignificantSubdomainCustom('something.sheffield.sch.uk', 'public_suffix_list');
+select cutToFirstSignificantSubdomainCustom('sheffield.sch.uk', 'public_suffix_list');
+
+select '-- exclamation mark';
+select cutToFirstSignificantSubdomainCustom('foo.kawasaki.jp', 'public_suffix_list');
+select cutToFirstSignificantSubdomainCustom('foo.foo.kawasaki.jp', 'public_suffix_list');
+select cutToFirstSignificantSubdomainCustom('city.kawasaki.jp', 'public_suffix_list');
+select cutToFirstSignificantSubdomainCustom('some.city.kawasaki.jp', 'public_suffix_list');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support of `!`/`*` (exclamation/asterisk) in custom TLDs (`cutToFirstSignificantSubdomainCustom()`/`cutToFirstSignificantSubdomainCustomWithWWW()`/`firstSignificantSubdomainCustom()`)

Public suffix list may contain special characters (you may find format
here - [1]):
- asterisk (`*`)
- exclamation mark (`!`)

  [1]: https://github.com/publicsuffix/list/wiki/Format

It is easier to describe how it should be interpreted with an examples.

Consider the following part of the list:

    *.sch.uk
    *.kawasaki.jp
    !city.kawasaki.jp

And here are the results for `cutToFirstSignificantSubdomainCustom()`:

If you have only asterisk (*):

    foo.something.sheffield.sch.uk -> something.sheffield.sch.uk
    sheffield.sch.uk               -> sheffield.sch.uk

If you have exclamation mark (!) too:

    foo.kawasaki.jp                -> foo.kawasaki.jp
    foo.foo.kawasaki.jp            -> foo.foo.kawasaki.jp
    city.kawasaki.jp               -> city.kawasaki.jp
    some.city.kawasaki.jp          -> city.kawasaki.jp

TLDs had been verified wit the following script [2], to match with
python publicsuffix2 module.

  [2]: https://gist.github.com/azat/c1a7a9f1e3519793134ef4b1df5461a6

Fixes: #39468 (cc @filimonov)
Follow-up for: #17748