### PR TITLE
Improve system.backups table

### DIFF
--- a/src/Backups/BackupIO.h
+++ b/src/Backups/BackupIO.h
@@ -8,21 +8,22 @@ class SeekableReadBuffer;
 class WriteBuffer;
 
 /// Represents operations of loading from disk or downloading for reading a backup.
-class IBackupReader /// BackupReaderFile, BackupReaderDisk, BackupReaderS3
+class IBackupReader /// BackupReaderFile, BackupReaderDisk
 {
 public:
     virtual ~IBackupReader() = default;
     virtual bool fileExists(const String & file_name) = 0;
-    virtual size_t getFileSize(const String & file_name) = 0;
+    virtual UInt64 getFileSize(const String & file_name) = 0;
     virtual std::unique_ptr<SeekableReadBuffer> readFile(const String & file_name) = 0;
 };
 
 /// Represents operations of storing to disk or uploading for writing a backup.
-class IBackupWriter /// BackupWriterFile, BackupWriterDisk, BackupWriterS3
+class IBackupWriter /// BackupWriterFile, BackupWriterDisk
 {
 public:
     virtual ~IBackupWriter() = default;
     virtual bool fileExists(const String & file_name) = 0;
+    virtual UInt64 getFileSize(const String & file_name) = 0;
     virtual bool fileContentsEqual(const String & file_name, const String & expected_file_contents) = 0;
     virtual std::unique_ptr<WriteBuffer> writeFile(const String & file_name) = 0;
     virtual void removeFiles(const Strings & file_names) = 0;

--- a/src/Backups/BackupIO_Disk.cpp
+++ b/src/Backups/BackupIO_Disk.cpp
@@ -17,7 +17,7 @@ bool BackupReaderDisk::fileExists(const String & file_name)
     return disk->exists(path / file_name);
 }
 
-size_t BackupReaderDisk::getFileSize(const String & file_name)
+UInt64 BackupReaderDisk::getFileSize(const String & file_name)
 {
     return disk->getFileSize(path / file_name);
 }
@@ -36,6 +36,11 @@ BackupWriterDisk::~BackupWriterDisk() = default;
 bool BackupWriterDisk::fileExists(const String & file_name)
 {
     return disk->exists(path / file_name);
+}
+
+UInt64 BackupWriterDisk::getFileSize(const String & file_name)
+{
+    return disk->getFileSize(path / file_name);
 }
 
 bool BackupWriterDisk::fileContentsEqual(const String & file_name, const String & expected_file_contents)

--- a/src/Backups/BackupIO_Disk.h
+++ b/src/Backups/BackupIO_Disk.h
@@ -15,7 +15,7 @@ public:
     ~BackupReaderDisk() override;
 
     bool fileExists(const String & file_name) override;
-    size_t getFileSize(const String & file_name) override;
+    UInt64 getFileSize(const String & file_name) override;
     std::unique_ptr<SeekableReadBuffer> readFile(const String & file_name) override;
 
 private:
@@ -30,6 +30,7 @@ public:
     ~BackupWriterDisk() override;
 
     bool fileExists(const String & file_name) override;
+    UInt64 getFileSize(const String & file_name) override;
     bool fileContentsEqual(const String & file_name, const String & expected_file_contents) override;
     std::unique_ptr<WriteBuffer> writeFile(const String & file_name) override;
     void removeFiles(const Strings & file_names) override;

--- a/src/Backups/BackupIO_File.cpp
+++ b/src/Backups/BackupIO_File.cpp
@@ -18,7 +18,7 @@ bool BackupReaderFile::fileExists(const String & file_name)
     return fs::exists(path / file_name);
 }
 
-size_t BackupReaderFile::getFileSize(const String & file_name)
+UInt64 BackupReaderFile::getFileSize(const String & file_name)
 {
     return fs::file_size(path / file_name);
 }
@@ -37,6 +37,11 @@ BackupWriterFile::~BackupWriterFile() = default;
 bool BackupWriterFile::fileExists(const String & file_name)
 {
     return fs::exists(path / file_name);
+}
+
+UInt64 BackupWriterFile::getFileSize(const String & file_name)
+{
+    return fs::file_size(path / file_name);
 }
 
 bool BackupWriterFile::fileContentsEqual(const String & file_name, const String & expected_file_contents)

--- a/src/Backups/BackupIO_File.h
+++ b/src/Backups/BackupIO_File.h
@@ -13,7 +13,7 @@ public:
     ~BackupReaderFile() override;
 
     bool fileExists(const String & file_name) override;
-    size_t getFileSize(const String & file_name) override;
+    UInt64 getFileSize(const String & file_name) override;
     std::unique_ptr<SeekableReadBuffer> readFile(const String & file_name) override;
 
 private:
@@ -27,6 +27,7 @@ public:
     ~BackupWriterFile() override;
 
     bool fileExists(const String & file_name) override;
+    UInt64 getFileSize(const String & file_name) override;
     bool fileContentsEqual(const String & file_name, const String & expected_file_contents) override;
     std::unique_ptr<WriteBuffer> writeFile(const String & file_name) override;
     void removeFiles(const Strings & file_names) override;

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -232,12 +232,6 @@ void BackupImpl::close()
     coordination.reset();
 }
 
-time_t BackupImpl::getTimestamp() const
-{
-    std::lock_guard lock{mutex};
-    return timestamp;
-}
-
 void BackupImpl::writeBackupMetadata()
 {
     assert(!is_internal_backup);

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -57,6 +57,8 @@ public:
     OpenMode getOpenMode() const override { return open_mode; }
     time_t getTimestamp() const override { return timestamp; }
     UUID getUUID() const override { return *uuid; }
+    UInt64 getTotalSize() const override;
+    size_t getTotalNumFiles() const override;
     Strings listFiles(const String & directory, bool recursive) const override;
     bool hasFiles(const String & directory) const override;
     bool fileExists(const String & file_name) const override;
@@ -96,6 +98,10 @@ private:
     std::shared_ptr<IArchiveReader> getArchiveReader(const String & suffix) const;
     std::shared_ptr<IArchiveWriter> getArchiveWriter(const String & suffix);
 
+    /// Updates `total_num_files` and `total_size`.
+    void updateTotals(UInt64 file_size);
+    void updateTotals(const FileInfo & info);
+
     const String backup_name;
     const ArchiveParams archive_params;
     const bool use_archives;
@@ -108,6 +114,8 @@ private:
     mutable std::mutex mutex;
     std::optional<UUID> uuid;
     time_t timestamp = 0;
+    size_t total_num_files = 0;
+    UInt64 total_size = 0;
     UInt64 version;
     std::optional<BackupInfo> base_backup_info;
     std::shared_ptr<const IBackup> base_backup;

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -57,8 +57,9 @@ public:
     OpenMode getOpenMode() const override { return open_mode; }
     time_t getTimestamp() const override { return timestamp; }
     UUID getUUID() const override { return *uuid; }
-    UInt64 getTotalSize() const override;
-    size_t getTotalNumFiles() const override;
+    size_t getNumFiles() const override;
+    UInt64 getUncompressedSize() const override;
+    UInt64 getCompressedSize() const override;
     Strings listFiles(const String & directory, bool recursive) const override;
     bool hasFiles(const String & directory) const override;
     bool fileExists(const String & file_name) const override;
@@ -78,6 +79,7 @@ private:
 
     void open(const ContextPtr & context);
     void close();
+    void closeArchives();
 
     /// Writes the file ".backup" containing backup's metadata.
     void writeBackupMetadata();
@@ -98,9 +100,12 @@ private:
     std::shared_ptr<IArchiveReader> getArchiveReader(const String & suffix) const;
     std::shared_ptr<IArchiveWriter> getArchiveWriter(const String & suffix);
 
-    /// Updates `total_num_files` and `total_size`.
-    void updateTotals(UInt64 file_size);
-    void updateTotals(const FileInfo & info);
+    /// Increases `uncompressed_size` by a specific value and `num_files` by 1.
+    void increaseUncompressedSize(UInt64 file_size);
+    void increaseUncompressedSize(const FileInfo & info);
+
+    /// Calculates and sets `compressed_size`.
+    void setCompressedSize();
 
     const String backup_name;
     const ArchiveParams archive_params;
@@ -114,8 +119,9 @@ private:
     mutable std::mutex mutex;
     std::optional<UUID> uuid;
     time_t timestamp = 0;
-    size_t total_num_files = 0;
-    UInt64 total_size = 0;
+    size_t num_files = 0;
+    UInt64 uncompressed_size = 0;
+    UInt64 compressed_size = 0;
     UInt64 version;
     std::optional<BackupInfo> base_backup_info;
     std::shared_ptr<const IBackup> base_backup;

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -55,7 +55,7 @@ public:
 
     const String & getName() const override { return backup_name; }
     OpenMode getOpenMode() const override { return open_mode; }
-    time_t getTimestamp() const override;
+    time_t getTimestamp() const override { return timestamp; }
     UUID getUUID() const override { return *uuid; }
     Strings listFiles(const String & directory, bool recursive) const override;
     bool hasFiles(const String & directory) const override;

--- a/src/Backups/BackupSettings.cpp
+++ b/src/Backups/BackupSettings.cpp
@@ -60,6 +60,7 @@ namespace
 
 /// List of backup settings except base_backup_name and cluster_host_ids.
 #define LIST_OF_BACKUP_SETTINGS(M) \
+    M(String, id) \
     M(String, compression_method) \
     M(Int64, compression_level) \
     M(String, password) \

--- a/src/Backups/BackupSettings.h
+++ b/src/Backups/BackupSettings.h
@@ -11,6 +11,9 @@ class ASTBackupQuery;
 /// Settings specified in the "SETTINGS" clause of a BACKUP query.
 struct BackupSettings
 {
+    /// ID of the backup operation, to identify it in the system.backups table. Auto-generated if not set.
+    String id;
+
     /// Base backup, if it's set an incremental backup will be built. That means only differences made after the base backup will be put
     /// into a new backup.
     std::optional<BackupInfo> base_backup_info;

--- a/src/Backups/BackupStatus.cpp
+++ b/src/Backups/BackupStatus.cpp
@@ -15,18 +15,18 @@ std::string_view toString(BackupStatus backup_status)
 {
     switch (backup_status)
     {
-        case BackupStatus::MAKING_BACKUP:
-            return "MAKING_BACKUP";
-        case BackupStatus::BACKUP_COMPLETE:
-            return "BACKUP_COMPLETE";
-        case BackupStatus::FAILED_TO_BACKUP:
-            return "FAILED_TO_BACKUP";
+        case BackupStatus::CREATING_BACKUP:
+            return "CREATING_BACKUP";
+        case BackupStatus::BACKUP_CREATED:
+            return "BACKUP_CREATED";
+        case BackupStatus::BACKUP_FAILED:
+            return "BACKUP_FAILED";
         case BackupStatus::RESTORING:
             return "RESTORING";
         case BackupStatus::RESTORED:
             return "RESTORED";
-        case BackupStatus::FAILED_TO_RESTORE:
-            return "FAILED_TO_RESTORE";
+        case BackupStatus::RESTORE_FAILED:
+            return "RESTORE_FAILED";
         default:
             break;
     }

--- a/src/Backups/BackupStatus.h
+++ b/src/Backups/BackupStatus.h
@@ -9,14 +9,14 @@ namespace DB
 enum class BackupStatus
 {
     /// Statuses of making backups
-    MAKING_BACKUP,
-    BACKUP_COMPLETE,
-    FAILED_TO_BACKUP,
+    CREATING_BACKUP,
+    BACKUP_CREATED,
+    BACKUP_FAILED,
 
     /// Status of restoring
     RESTORING,
     RESTORED,
-    FAILED_TO_RESTORE,
+    RESTORE_FAILED,
 
     MAX,
 };

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -28,6 +28,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int LOGICAL_ERROR;
 }
 
 using OperationID = BackupsWorker::OperationID;
@@ -589,7 +590,7 @@ void BackupsWorker::addInfo(const OperationID & id, const String & name, BackupS
     }
 
     infos[id] = std::move(info);
-    
+
     num_active_backups += getNumActiveBackupsChange(status);
     num_active_restores += getNumActiveRestoresChange(status);
 }

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -559,7 +559,10 @@ void BackupsWorker::addInfo(const OperationID & id, const String & name, BackupS
     info.id = id;
     info.name = name;
     info.status = status;
-    info.status_changed_time = time(nullptr);
+    info.start_time = std::chrono::system_clock::now();
+
+    if (isFinalStatus(status))
+        info.end_time = info.start_time;
 
     std::lock_guard lock{infos_mutex};
 
@@ -590,7 +593,9 @@ void BackupsWorker::setStatus(const String & id, BackupStatus status)
     auto old_status = info.status;
 
     info.status = status;
-    info.status_changed_time = time(nullptr);
+
+    if (isFinalStatus(status))
+        info.end_time = std::chrono::system_clock::now();
 
     if (isErrorStatus(status))
     {

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -529,11 +529,11 @@ void BackupsWorker::doRestore(
 }
 
 
-void BackupsWorker::addInfo(const UUID & uuid, const String & backup_name, BackupStatus status)
+void BackupsWorker::addInfo(const UUID & uuid, const String & name, BackupStatus status)
 {
     Info info;
     info.uuid = uuid;
-    info.backup_name = backup_name;
+    info.name = name;
     info.status = status;
     info.status_changed_time = time(nullptr);
 

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -69,13 +69,13 @@ public:
 
 private:
     OperationID startMakingBackup(const ASTPtr & query, const ContextPtr & context);
-    
+
     void doBackup(const std::shared_ptr<ASTBackupQuery> & backup_query, const OperationID & backup_id, BackupSettings backup_settings,
                   const BackupInfo & backup_info, std::shared_ptr<IBackupCoordination> backup_coordination, const ContextPtr & context,
                   ContextMutablePtr mutable_context, bool called_async);
 
     OperationID startRestoring(const ASTPtr & query, ContextMutablePtr context);
-    
+
     void doRestore(const std::shared_ptr<ASTBackupQuery> & restore_query, const OperationID & restore_id, const UUID & restore_uuid,
                    RestoreSettings restore_settings, const BackupInfo & backup_info,
                    std::shared_ptr<IRestoreCoordination> restore_coordination, ContextMutablePtr context, bool called_async);

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -47,6 +47,9 @@ public:
         /// Backup's name, a string like "Disk('backups', 'my_backup')"
         String name;
 
+        /// This operation is internal and should not be shown in system.backups
+        bool internal = false;
+
         /// Status of backup or restore operation.
         BackupStatus status;
 
@@ -79,12 +82,12 @@ private:
 
     OperationID startRestoring(const ASTPtr & query, ContextMutablePtr context);
 
-    void doRestore(const std::shared_ptr<ASTBackupQuery> & restore_query, const OperationID & restore_id, const UUID & restore_uuid,
-                   RestoreSettings restore_settings, const BackupInfo & backup_info,
+    void doRestore(const std::shared_ptr<ASTBackupQuery> & restore_query, const OperationID & restore_id, RestoreSettings restore_settings, const BackupInfo & backup_info,
                    std::shared_ptr<IRestoreCoordination> restore_coordination, ContextMutablePtr context, bool called_async);
 
-    void addInfo(const OperationID & id, const String & name, BackupStatus status);
-    void setStatus(const OperationID & id, BackupStatus status);
+    void addInfo(const OperationID & id, const String & name, bool internal, BackupStatus status);
+    void setStatus(const OperationID & id, BackupStatus status, bool throw_if_error = true);
+    void setStatusSafe(const String & id, BackupStatus status) { setStatus(id, status, false); }
     void setNumFilesAndSize(const OperationID & id, size_t num_files, UInt64 uncompressed_size, UInt64 compressed_size);
 
     ThreadPool backups_thread_pool;

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -50,6 +50,12 @@ public:
         /// Status of backup or restore operation.
         BackupStatus status;
 
+        /// Number of files in the backup (including backup's metadata; only unique files are counted).
+        size_t num_files = 0;
+
+        /// Total size of files in the backup (including backup's metadata; only unique files are counted).
+        UInt64 total_size = 0;
+
         /// Set only if there was an error.
         std::exception_ptr exception;
         String error_message;
@@ -76,6 +82,7 @@ private:
 
     void addInfo(const OperationID & id, const String & name, BackupStatus status);
     void setStatus(const OperationID & id, BackupStatus status);
+    void setNumFilesAndTotalSize(const OperationID & id, size_t num_files, UInt64 total_size);
 
     ThreadPool backups_thread_pool;
     ThreadPool restores_thread_pool;

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -53,8 +53,11 @@ public:
         /// Number of files in the backup (including backup's metadata; only unique files are counted).
         size_t num_files = 0;
 
-        /// Total size of files in the backup (including backup's metadata; only unique files are counted).
-        UInt64 total_size = 0;
+        /// Size of all files in the backup (including backup's metadata; only unique files are counted).
+        UInt64 uncompressed_size = 0;
+
+        /// Size of the backup if it's stored as an archive; or the same as `uncompressed_size` if the backup is stored as a folder.
+        UInt64 compressed_size = 0;
 
         /// Set only if there was an error.
         std::exception_ptr exception;
@@ -82,7 +85,7 @@ private:
 
     void addInfo(const OperationID & id, const String & name, BackupStatus status);
     void setStatus(const OperationID & id, BackupStatus status);
-    void setNumFilesAndTotalSize(const OperationID & id, size_t num_files, UInt64 total_size);
+    void setNumFilesAndSize(const OperationID & id, size_t num_files, UInt64 uncompressed_size, UInt64 compressed_size);
 
     ThreadPool backups_thread_pool;
     ThreadPool restores_thread_pool;

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -38,10 +38,10 @@ public:
     /// Information about executing a BACKUP or RESTORE query started by calling start().
     struct Info
     {
-        UUID uuid;
-
         /// Backup's name, a string like "Disk('backups', 'my_backup')"
-        String backup_name;
+        String name;
+
+        UUID uuid;
 
         BackupStatus status;
         time_t status_changed_time;
@@ -66,7 +66,7 @@ private:
                    const BackupInfo & backup_info, std::shared_ptr<IRestoreCoordination> restore_coordination, ContextMutablePtr context,
                    bool called_async);
 
-    void addInfo(const UUID & uuid, const String & backup_name, BackupStatus status);
+    void addInfo(const UUID & uuid, const String & name, BackupStatus status);
     void setStatus(const UUID & uuid, BackupStatus status);
 
     ThreadPool backups_thread_pool;

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -49,11 +49,13 @@ public:
 
         /// Status of backup or restore operation.
         BackupStatus status;
-        time_t status_changed_time;
 
         /// Set only if there was an error.
         std::exception_ptr exception;
         String error_message;
+
+        std::chrono::system_clock::time_point start_time;
+        std::chrono::system_clock::time_point end_time;
     };
 
     Info getInfo(const OperationID & id) const;

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -29,11 +29,11 @@ public:
     void shutdown();
 
     /// Starts executing a BACKUP or RESTORE query. Returns UUID of the operation.
-    std::pair<UUID, bool> start(const ASTPtr & backup_or_restore_query, ContextMutablePtr context);
+    UUID start(const ASTPtr & backup_or_restore_query, ContextMutablePtr context);
 
     /// Waits until a BACKUP or RESTORE query started by start() is finished.
     /// The function returns immediately if the operation is already finished.
-    void wait(const UUID & backup_or_restore_uuid, bool internal, bool rethrow_exception = true);
+    void wait(const UUID & backup_or_restore_uuid, bool rethrow_exception = true);
 
     /// Information about executing a BACKUP or RESTORE query started by calling start().
     struct Info
@@ -48,35 +48,31 @@ public:
 
         String error_message;
         std::exception_ptr exception;
-
-        /// Whether this operation is internal, i.e. caused by another BACKUP or RESTORE operation.
-        /// For example BACKUP ON CLUSTER executes an internal BACKUP commands per each node.
-        bool internal = false;
     };
 
-    Info getInfo(const UUID & backup_or_restore_uuid, bool internal) const;
+    Info getInfo(const UUID & backup_or_restore_uuid) const;
     std::vector<Info> getAllInfos() const;
 
 private:
-    std::pair<UUID, bool> startMakingBackup(const ASTPtr & query, const ContextPtr & context);
+    UUID startMakingBackup(const ASTPtr & query, const ContextPtr & context);
 
     void doBackup(const UUID & backup_uuid, const std::shared_ptr<ASTBackupQuery> & backup_query, BackupSettings backup_settings,
                   const BackupInfo & backup_info, std::shared_ptr<IBackupCoordination> backup_coordination, const ContextPtr & context,
                   ContextMutablePtr mutable_context, bool called_async);
 
-    std::pair<UUID, bool> startRestoring(const ASTPtr & query, ContextMutablePtr context);
+    UUID startRestoring(const ASTPtr & query, ContextMutablePtr context);
 
     void doRestore(const UUID & restore_uuid, const std::shared_ptr<ASTBackupQuery> & restore_query, RestoreSettings restore_settings,
                    const BackupInfo & backup_info, std::shared_ptr<IRestoreCoordination> restore_coordination, ContextMutablePtr context,
                    bool called_async);
 
-    void addInfo(const UUID & uuid, bool internal, const String & backup_name, BackupStatus status);
-    void setStatus(const UUID & uuid, bool internal, BackupStatus status);
+    void addInfo(const UUID & uuid, const String & backup_name, BackupStatus status);
+    void setStatus(const UUID & uuid, BackupStatus status);
 
     ThreadPool backups_thread_pool;
     ThreadPool restores_thread_pool;
 
-    std::map<std::pair<UUID, bool>, Info> infos;
+    std::unordered_map<UUID, Info> infos;
     std::condition_variable status_changed;
     std::atomic<size_t> num_active_backups = 0;
     std::atomic<size_t> num_active_restores = 0;

--- a/src/Backups/IBackup.h
+++ b/src/Backups/IBackup.h
@@ -36,11 +36,14 @@ public:
     /// Returns UUID of the backup.
     virtual UUID getUUID() const = 0;
 
-    /// Returns the total size of unique files in the backup.
-    virtual UInt64 getTotalSize() const = 0;
-
     /// Returns the number of unique files in the backup.
-    virtual size_t getTotalNumFiles() const = 0;
+    virtual size_t getNumFiles() const = 0;
+
+    /// Returns the total size of unique files in the backup.
+    virtual UInt64 getUncompressedSize() const = 0;
+
+    /// Returns the compressed size of the backup. If the backup is not stored as an archive it returns the same as getUncompressedSize().
+    virtual UInt64 getCompressedSize() const = 0;
 
     /// Returns names of entries stored in a specified directory in the backup.
     /// If `directory` is empty or '/' the functions returns entries in the backup's root.

--- a/src/Backups/IBackup.h
+++ b/src/Backups/IBackup.h
@@ -36,6 +36,12 @@ public:
     /// Returns UUID of the backup.
     virtual UUID getUUID() const = 0;
 
+    /// Returns the total size of unique files in the backup.
+    virtual UInt64 getTotalSize() const = 0;
+
+    /// Returns the number of unique files in the backup.
+    virtual size_t getTotalNumFiles() const = 0;
+
     /// Returns names of entries stored in a specified directory in the backup.
     /// If `directory` is empty or '/' the functions returns entries in the backup's root.
     virtual Strings listFiles(const String & directory, bool recursive = false) const = 0;

--- a/src/Backups/RestoreSettings.cpp
+++ b/src/Backups/RestoreSettings.cpp
@@ -143,6 +143,7 @@ namespace
 
 /// List of restore settings except base_backup_name and cluster_host_ids.
 #define LIST_OF_RESTORE_SETTINGS(M) \
+    M(String, id) \
     M(String, password) \
     M(Bool, structure_only) \
     M(RestoreTableCreationMode, create_table) \

--- a/src/Backups/RestoreSettings.h
+++ b/src/Backups/RestoreSettings.h
@@ -41,6 +41,9 @@ using RestoreUDFCreationMode = RestoreAccessCreationMode;
 /// Settings specified in the "SETTINGS" clause of a RESTORE query.
 struct RestoreSettings
 {
+    /// ID of the restore operation, to identify it in the system.backups table. Auto-generated if not set.
+    String id;
+
     /// Base backup, with this setting we can override the location of the base backup while restoring.
     /// Any incremental backup keeps inside the information about its base backup, so using this setting is optional.
     std::optional<BackupInfo> base_backup_info;

--- a/src/Interpreters/InterpreterBackupQuery.cpp
+++ b/src/Interpreters/InterpreterBackupQuery.cpp
@@ -20,17 +20,14 @@ namespace
     Block getResultRow(const BackupsWorker::Info & info)
     {
         auto column_uuid = ColumnUUID::create();
-        auto column_backup_name = ColumnString::create();
         auto column_status = ColumnInt8::create();
 
         column_uuid->insert(info.uuid);
-        column_backup_name->insert(info.backup_name);
         column_status->insert(static_cast<Int8>(info.status));
 
         Block res_columns;
         res_columns.insert(0, {std::move(column_uuid), std::make_shared<DataTypeUUID>(), "uuid"});
-        res_columns.insert(1, {std::move(column_backup_name), std::make_shared<DataTypeString>(), "backup_name"});
-        res_columns.insert(2, {std::move(column_status), std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues()), "status"});
+        res_columns.insert(1, {std::move(column_status), std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues()), "status"});
 
         return res_columns;
     }
@@ -40,8 +37,13 @@ BlockIO InterpreterBackupQuery::execute()
 {
     auto & backups_worker = context->getBackupsWorker();
     auto uuid = backups_worker.start(query_ptr, context);
+
+    auto info = backups_worker.getInfo(uuid);
+    if (info.exception)
+        std::rethrow_exception(info.exception);
+
     BlockIO res_io;
-    res_io.pipeline = QueryPipeline(std::make_shared<SourceFromSingleChunk>(getResultRow(backups_worker.getInfo(uuid))));
+    res_io.pipeline = QueryPipeline(std::make_shared<SourceFromSingleChunk>(getResultRow(info)));
     return res_io;
 }
 

--- a/src/Interpreters/InterpreterBackupQuery.cpp
+++ b/src/Interpreters/InterpreterBackupQuery.cpp
@@ -19,14 +19,14 @@ namespace
 {
     Block getResultRow(const BackupsWorker::Info & info)
     {
-        auto column_uuid = ColumnUUID::create();
+        auto column_id = ColumnString::create();
         auto column_status = ColumnInt8::create();
 
-        column_uuid->insert(info.uuid);
+        column_id->insert(info.id);
         column_status->insert(static_cast<Int8>(info.status));
 
         Block res_columns;
-        res_columns.insert(0, {std::move(column_uuid), std::make_shared<DataTypeUUID>(), "uuid"});
+        res_columns.insert(0, {std::move(column_id), std::make_shared<DataTypeString>(), "id"});
         res_columns.insert(1, {std::move(column_status), std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues()), "status"});
 
         return res_columns;
@@ -36,9 +36,9 @@ namespace
 BlockIO InterpreterBackupQuery::execute()
 {
     auto & backups_worker = context->getBackupsWorker();
-    auto uuid = backups_worker.start(query_ptr, context);
+    auto id = backups_worker.start(query_ptr, context);
 
-    auto info = backups_worker.getInfo(uuid);
+    auto info = backups_worker.getInfo(id);
     if (info.exception)
         std::rethrow_exception(info.exception);
 

--- a/src/Interpreters/InterpreterBackupQuery.cpp
+++ b/src/Interpreters/InterpreterBackupQuery.cpp
@@ -39,9 +39,9 @@ namespace
 BlockIO InterpreterBackupQuery::execute()
 {
     auto & backups_worker = context->getBackupsWorker();
-    auto [uuid, internal] = backups_worker.start(query_ptr, context);
+    auto uuid = backups_worker.start(query_ptr, context);
     BlockIO res_io;
-    res_io.pipeline = QueryPipeline(std::make_shared<SourceFromSingleChunk>(getResultRow(backups_worker.getInfo(uuid, internal))));
+    res_io.pipeline = QueryPipeline(std::make_shared<SourceFromSingleChunk>(getResultRow(backups_worker.getInfo(uuid))));
     return res_io;
 }
 

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -34,8 +34,8 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
     auto & column_id = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
-    auto & column_num_files = assert_cast<ColumnInt64 &>(*res_columns[column_index++]);
-    auto & column_total_size = assert_cast<ColumnInt64 &>(*res_columns[column_index++]);
+    auto & column_num_files = assert_cast<ColumnUInt64 &>(*res_columns[column_index++]);
+    auto & column_total_size = assert_cast<ColumnUInt64 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_start_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
     auto & column_end_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -15,8 +15,8 @@ namespace DB
 NamesAndTypesList StorageSystemBackups::getNamesAndTypes()
 {
     NamesAndTypesList names_and_types{
+        {"name", std::make_shared<DataTypeString>()},
         {"uuid", std::make_shared<DataTypeUUID>()},
-        {"backup_name", std::make_shared<DataTypeString>()},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues())},
         {"status_changed_time", std::make_shared<DataTypeDateTime>()},
         {"error", std::make_shared<DataTypeString>()},
@@ -28,16 +28,16 @@ NamesAndTypesList StorageSystemBackups::getNamesAndTypes()
 void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo &) const
 {
     size_t column_index = 0;
+    auto & column_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_uuid = assert_cast<ColumnUUID &>(*res_columns[column_index++]);
-    auto & column_backup_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
     auto & column_status_changed_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
 
     auto add_row = [&](const BackupsWorker::Info & info)
     {
+        column_name.insertData(info.name.data(), info.name.size());
         column_uuid.insertValue(info.uuid);
-        column_backup_name.insertData(info.backup_name.data(), info.backup_name.size());
         column_status.insertValue(static_cast<Int8>(info.status));
         column_status_changed_time.insertValue(info.status_changed_time);
         column_error.insertData(info.error_message.data(), info.error_message.size());

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -19,7 +19,8 @@ NamesAndTypesList StorageSystemBackups::getNamesAndTypes()
         {"name", std::make_shared<DataTypeString>()},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues())},
         {"num_files", std::make_shared<DataTypeUInt64>()},
-        {"total_size", std::make_shared<DataTypeUInt64>()},
+        {"uncompressed_size", std::make_shared<DataTypeUInt64>()},
+        {"compressed_size", std::make_shared<DataTypeUInt64>()},
         {"error", std::make_shared<DataTypeString>()},
         {"start_time", std::make_shared<DataTypeDateTime>()},
         {"end_time", std::make_shared<DataTypeDateTime>()},
@@ -35,7 +36,8 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
     auto & column_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
     auto & column_num_files = assert_cast<ColumnUInt64 &>(*res_columns[column_index++]);
-    auto & column_total_size = assert_cast<ColumnUInt64 &>(*res_columns[column_index++]);
+    auto & column_uncompressed_size = assert_cast<ColumnUInt64 &>(*res_columns[column_index++]);
+    auto & column_compressed_size = assert_cast<ColumnUInt64 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_start_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
     auto & column_end_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
@@ -46,7 +48,8 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
         column_name.insertData(info.name.data(), info.name.size());
         column_status.insertValue(static_cast<Int8>(info.status));
         column_num_files.insertValue(info.num_files);
-        column_total_size.insertValue(info.total_size);
+        column_uncompressed_size.insertValue(info.uncompressed_size);
+        column_compressed_size.insertValue(info.compressed_size);
         column_error.insertData(info.error_message.data(), info.error_message.size());
         column_start_time.insertValue(std::chrono::system_clock::to_time_t(info.start_time));
         column_end_time.insertValue(std::chrono::system_clock::to_time_t(info.end_time));

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -18,6 +18,8 @@ NamesAndTypesList StorageSystemBackups::getNamesAndTypes()
         {"id", std::make_shared<DataTypeString>()},
         {"name", std::make_shared<DataTypeString>()},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues())},
+        {"num_files", std::make_shared<DataTypeUInt64>()},
+        {"total_size", std::make_shared<DataTypeUInt64>()},
         {"error", std::make_shared<DataTypeString>()},
         {"start_time", std::make_shared<DataTypeDateTime>()},
         {"end_time", std::make_shared<DataTypeDateTime>()},
@@ -32,6 +34,8 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
     auto & column_id = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
+    auto & column_num_files = assert_cast<ColumnInt64 &>(*res_columns[column_index++]);
+    auto & column_total_size = assert_cast<ColumnInt64 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_start_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
     auto & column_end_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
@@ -41,6 +45,8 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
         column_id.insertData(info.id.data(), info.id.size());
         column_name.insertData(info.name.data(), info.name.size());
         column_status.insertValue(static_cast<Int8>(info.status));
+        column_num_files.insertValue(info.num_files);
+        column_total_size.insertValue(info.total_size);
         column_error.insertData(info.error_message.data(), info.error_message.size());
         column_start_time.insertValue(std::chrono::system_clock::to_time_t(info.start_time));
         column_end_time.insertValue(std::chrono::system_clock::to_time_t(info.end_time));

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -15,8 +15,8 @@ namespace DB
 NamesAndTypesList StorageSystemBackups::getNamesAndTypes()
 {
     NamesAndTypesList names_and_types{
+        {"id", std::make_shared<DataTypeString>()},
         {"name", std::make_shared<DataTypeString>()},
-        {"uuid", std::make_shared<DataTypeUUID>()},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues())},
         {"status_changed_time", std::make_shared<DataTypeDateTime>()},
         {"error", std::make_shared<DataTypeString>()},
@@ -28,16 +28,16 @@ NamesAndTypesList StorageSystemBackups::getNamesAndTypes()
 void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo &) const
 {
     size_t column_index = 0;
+    auto & column_id = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
-    auto & column_uuid = assert_cast<ColumnUUID &>(*res_columns[column_index++]);
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
     auto & column_status_changed_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
 
     auto add_row = [&](const BackupsWorker::Info & info)
     {
+        column_id.insertData(info.id.data(), info.id.size());
         column_name.insertData(info.name.data(), info.name.size());
-        column_uuid.insertValue(info.uuid);
         column_status.insertValue(static_cast<Int8>(info.status));
         column_status_changed_time.insertValue(info.status_changed_time);
         column_error.insertData(info.error_message.data(), info.error_message.size());

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -18,8 +18,9 @@ NamesAndTypesList StorageSystemBackups::getNamesAndTypes()
         {"id", std::make_shared<DataTypeString>()},
         {"name", std::make_shared<DataTypeString>()},
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues())},
-        {"status_changed_time", std::make_shared<DataTypeDateTime>()},
         {"error", std::make_shared<DataTypeString>()},
+        {"start_time", std::make_shared<DataTypeDateTime>()},
+        {"end_time", std::make_shared<DataTypeDateTime>()},
     };
     return names_and_types;
 }
@@ -31,16 +32,18 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
     auto & column_id = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_name = assert_cast<ColumnString &>(*res_columns[column_index++]);
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
-    auto & column_status_changed_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
+    auto & column_start_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
+    auto & column_end_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
 
     auto add_row = [&](const BackupsWorker::Info & info)
     {
         column_id.insertData(info.id.data(), info.id.size());
         column_name.insertData(info.name.data(), info.name.size());
         column_status.insertValue(static_cast<Int8>(info.status));
-        column_status_changed_time.insertValue(info.status_changed_time);
         column_error.insertData(info.error_message.data(), info.error_message.size());
+        column_start_time.insertValue(std::chrono::system_clock::to_time_t(info.start_time));
+        column_end_time.insertValue(std::chrono::system_clock::to_time_t(info.end_time));
     };
 
     for (const auto & entry : context->getBackupsWorker().getAllInfos())

--- a/src/Storages/System/StorageSystemBackups.cpp
+++ b/src/Storages/System/StorageSystemBackups.cpp
@@ -20,7 +20,6 @@ NamesAndTypesList StorageSystemBackups::getNamesAndTypes()
         {"status", std::make_shared<DataTypeEnum8>(getBackupStatusEnumValues())},
         {"status_changed_time", std::make_shared<DataTypeDateTime>()},
         {"error", std::make_shared<DataTypeString>()},
-        {"internal", std::make_shared<DataTypeUInt8>()},
     };
     return names_and_types;
 }
@@ -34,7 +33,6 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
     auto & column_status = assert_cast<ColumnInt8 &>(*res_columns[column_index++]);
     auto & column_status_changed_time = assert_cast<ColumnUInt32 &>(*res_columns[column_index++]);
     auto & column_error = assert_cast<ColumnString &>(*res_columns[column_index++]);
-    auto & column_internal = assert_cast<ColumnUInt8 &>(*res_columns[column_index++]);
 
     auto add_row = [&](const BackupsWorker::Info & info)
     {
@@ -43,7 +41,6 @@ void StorageSystemBackups::fillData(MutableColumns & res_columns, ContextPtr con
         column_status.insertValue(static_cast<Int8>(info.status));
         column_status_changed_time.insertValue(info.status_changed_time);
         column_error.insertData(info.error_message.data(), info.error_message.size());
-        column_internal.insertValue(info.internal);
     };
 
     for (const auto & entry : context->getBackupsWorker().getAllInfos())

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -305,12 +305,12 @@ def test_async():
         f"BACKUP TABLE test.table TO {backup_name} ASYNC"
     ).split("\t")
 
-    assert status == "MAKING_BACKUP\n" or status == "BACKUP_COMPLETE\n"
+    assert status == "CREATING_BACKUP\n" or status == "BACKUP_CREATED\n"
 
     assert_eq_with_retry(
         instance,
         f"SELECT status, error FROM system.backups WHERE id='{id}'",
-        TSV([["BACKUP_COMPLETE", ""]]),
+        TSV([["BACKUP_CREATED", ""]]),
     )
 
     instance.query("DROP TABLE test.table")
@@ -347,17 +347,17 @@ def test_async_backups_to_same_destination(interface):
 
     assert_eq_with_retry(
         instance,
-        f"SELECT status FROM system.backups WHERE id IN ['{id1}', '{id2}'] AND status == 'MAKING_BACKUP'",
+        f"SELECT status FROM system.backups WHERE id IN ['{id1}', '{id2}'] AND status == 'CREATING_BACKUP'",
         "",
     )
 
     assert instance.query(
         f"SELECT status, error FROM system.backups WHERE id='{id1}'"
-    ) == TSV([["BACKUP_COMPLETE", ""]])
+    ) == TSV([["BACKUP_CREATED", ""]])
 
     assert (
         instance.query(f"SELECT status FROM system.backups WHERE id='{id2}'")
-        == "FAILED_TO_BACKUP\n"
+        == "BACKUP_FAILED\n"
     )
 
     instance.query("DROP TABLE test.table")
@@ -759,7 +759,7 @@ def test_system_users_async():
     assert_eq_with_retry(
         instance,
         f"SELECT status, error FROM system.backups WHERE id='{id}'",
-        TSV([["BACKUP_COMPLETE", ""]]),
+        TSV([["BACKUP_CREATED", ""]]),
     )
 
     instance.query("DROP USER u1")
@@ -894,12 +894,12 @@ def test_operation_id():
     ).split("\t")
     
     assert id == "first"
-    assert status == "MAKING_BACKUP\n" or status == "BACKUP_COMPLETE\n"
+    assert status == "CREATING_BACKUP\n" or status == "BACKUP_CREATED\n"
 
     assert_eq_with_retry(
         instance,
         f"SELECT status, error FROM system.backups WHERE id='first'",
-        TSV([["BACKUP_COMPLETE", ""]]),
+        TSV([["BACKUP_CREATED", ""]]),
     )
 
     instance.query("DROP TABLE test.table")

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -301,7 +301,7 @@ def test_async():
     assert instance.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
 
     backup_name = new_backup_name()
-    [id, _, status] = instance.query(
+    [id, status] = instance.query(
         f"BACKUP TABLE test.table TO {backup_name} ASYNC"
     ).split("\t")
 
@@ -315,7 +315,7 @@ def test_async():
 
     instance.query("DROP TABLE test.table")
 
-    [id, _, status] = instance.query(
+    [id, status] = instance.query(
         f"RESTORE TABLE test.table FROM {backup_name} ASYNC"
     ).split("\t")
 

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -400,12 +400,12 @@ def test_replicated_database_async():
         f"BACKUP DATABASE mydb ON CLUSTER 'cluster' TO {backup_name} ASYNC"
     ).split("\t")
 
-    assert status == "MAKING_BACKUP\n" or status == "BACKUP_COMPLETE\n"
+    assert status == "CREATING_BACKUP\n" or status == "BACKUP_CREATED\n"
 
     assert_eq_with_retry(
         node1,
         f"SELECT status, error FROM system.backups WHERE id='{id}'",
-        TSV([["BACKUP_COMPLETE", ""]]),
+        TSV([["BACKUP_CREATED", ""]]),
     )
 
     node1.query("DROP DATABASE mydb ON CLUSTER 'cluster' NO DELAY")
@@ -462,7 +462,7 @@ def test_async_backups_to_same_destination(interface, on_cluster):
     for i in range(len(nodes)):
         assert_eq_with_retry(
             nodes[i],
-            f"SELECT status FROM system.backups WHERE id='{ids[i]}' AND status == 'MAKING_BACKUP'",
+            f"SELECT status FROM system.backups WHERE id='{ids[i]}' AND status == 'CREATING_BACKUP'",
             "",
         )
 
@@ -471,7 +471,7 @@ def test_async_backups_to_same_destination(interface, on_cluster):
             int(
                 nodes[i]
                 .query(
-                    f"SELECT count() FROM system.backups WHERE id='{ids[i]}' AND status == 'BACKUP_COMPLETE'"
+                    f"SELECT count() FROM system.backups WHERE id='{ids[i]}' AND status == 'BACKUP_CREATED'"
                 )
                 .strip()
             )
@@ -817,7 +817,7 @@ def test_stop_other_host_during_backup(kill):
 
     assert_eq_with_retry(
         node1,
-        f"SELECT status FROM system.backups WHERE id='{id}' AND status == 'MAKING_BACKUP'",
+        f"SELECT status FROM system.backups WHERE id='{id}' AND status == 'CREATING_BACKUP'",
         "",
         retry_count=100,
     )
@@ -825,17 +825,17 @@ def test_stop_other_host_during_backup(kill):
     status = node1.query(f"SELECT status FROM system.backups WHERE id='{id}'").strip()
 
     if kill:
-        assert status in ["BACKUP_COMPLETE", "FAILED_TO_BACKUP"]
+        assert status in ["BACKUP_CREATED", "BACKUP_FAILED"]
     else:
-        assert status == "BACKUP_COMPLETE"
+        assert status == "BACKUP_CREATED"
 
     node2.start_clickhouse()
 
-    if status == "BACKUP_COMPLETE":
+    if status == "BACKUP_CREATED":
         node1.query("DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY")
         node1.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
         assert node1.query("SELECT * FROM tbl ORDER BY x") == TSV([3, 5])
-    elif status == "FAILED_TO_BACKUP":
+    elif status == "BACKUP_FAILED":
         assert not os.path.exists(
             os.path.join(get_path_to_backup(backup_name), ".backup")
         )

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -404,7 +404,7 @@ def test_replicated_database_async():
 
     assert_eq_with_retry(
         node1,
-        f"SELECT status, error FROM system.backups WHERE uuid='{id}'",
+        f"SELECT status, error FROM system.backups WHERE id='{id}'",
         TSV([["BACKUP_COMPLETE", ""]]),
     )
 
@@ -418,7 +418,7 @@ def test_replicated_database_async():
 
     assert_eq_with_retry(
         node1,
-        f"SELECT status, error FROM system.backups WHERE uuid='{id}'",
+        f"SELECT status, error FROM system.backups WHERE id='{id}'",
         TSV([["RESTORED", ""]]),
     )
 
@@ -462,7 +462,7 @@ def test_async_backups_to_same_destination(interface, on_cluster):
     for i in range(len(nodes)):
         assert_eq_with_retry(
             nodes[i],
-            f"SELECT status FROM system.backups WHERE uuid='{ids[i]}' AND status == 'MAKING_BACKUP'",
+            f"SELECT status FROM system.backups WHERE id='{ids[i]}' AND status == 'MAKING_BACKUP'",
             "",
         )
 
@@ -471,7 +471,7 @@ def test_async_backups_to_same_destination(interface, on_cluster):
             int(
                 nodes[i]
                 .query(
-                    f"SELECT count() FROM system.backups WHERE uuid='{ids[i]}' AND status == 'BACKUP_COMPLETE'"
+                    f"SELECT count() FROM system.backups WHERE id='{ids[i]}' AND status == 'BACKUP_COMPLETE'"
                 )
                 .strip()
             )
@@ -483,7 +483,7 @@ def test_async_backups_to_same_destination(interface, on_cluster):
         for i in range(len(nodes)):
             print(
                 nodes[i].query(
-                    f"SELECT status, error FROM system.backups WHERE uuid='{ids[i]}'"
+                    f"SELECT status, error FROM system.backups WHERE id='{ids[i]}'"
                 )
             )
 
@@ -817,12 +817,12 @@ def test_stop_other_host_during_backup(kill):
 
     assert_eq_with_retry(
         node1,
-        f"SELECT status FROM system.backups WHERE uuid='{id}' AND status == 'MAKING_BACKUP'",
+        f"SELECT status FROM system.backups WHERE id='{id}' AND status == 'MAKING_BACKUP'",
         "",
         retry_count=100,
     )
 
-    status = node1.query(f"SELECT status FROM system.backups WHERE uuid='{id}'").strip()
+    status = node1.query(f"SELECT status FROM system.backups WHERE id='{id}'").strip()
 
     if kill:
         assert status in ["BACKUP_COMPLETE", "FAILED_TO_BACKUP"]

--- a/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
@@ -122,13 +122,13 @@ def test_concurrent_backups_on_same_node():
 
     assert_eq_with_retry(
         node0,
-        f"SELECT status FROM system.backups WHERE status == 'MAKING_BACKUP' AND id IN {ids_list}",
+        f"SELECT status FROM system.backups WHERE status == 'CREATING_BACKUP' AND id IN {ids_list}",
         "",
     )
 
     assert node0.query(
         f"SELECT status, error FROM system.backups WHERE id IN {ids_list}"
-    ) == TSV([["BACKUP_COMPLETE", ""]] * num_concurrent_backups)
+    ) == TSV([["BACKUP_CREATED", ""]] * num_concurrent_backups)
 
     for backup_name in backup_names:
         node0.query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY")
@@ -156,14 +156,14 @@ def test_concurrent_backups_on_different_nodes():
     for i in range(num_concurrent_backups):
         assert_eq_with_retry(
             nodes[i],
-            f"SELECT status FROM system.backups WHERE status == 'MAKING_BACKUP' AND id = '{ids[i]}'",
+            f"SELECT status FROM system.backups WHERE status == 'CREATING_BACKUP' AND id = '{ids[i]}'",
             "",
         )
 
     for i in range(num_concurrent_backups):
         assert nodes[i].query(
             f"SELECT status, error FROM system.backups WHERE id = '{ids[i]}'"
-        ) == TSV([["BACKUP_COMPLETE", ""]])
+        ) == TSV([["BACKUP_CREATED", ""]])
 
     for i in range(num_concurrent_backups):
         nodes[i].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY")
@@ -244,14 +244,14 @@ def test_create_or_drop_tables_during_backup(db_engine, table_engine):
     for node in nodes:
         assert_eq_with_retry(
             node,
-            f"SELECT status from system.backups WHERE id IN {ids_list} AND (status == 'MAKING_BACKUP')",
+            f"SELECT status from system.backups WHERE id IN {ids_list} AND (status == 'CREATING_BACKUP')",
             "",
         )
 
     for node in nodes:
         assert_eq_with_retry(
             node,
-            f"SELECT status, error from system.backups WHERE id IN {ids_list} AND (status == 'FAILED_TO_BACKUP')",
+            f"SELECT status, error from system.backups WHERE id IN {ids_list} AND (status == 'BACKUP_FAILED')",
             "",
         )
 

--- a/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
@@ -122,12 +122,12 @@ def test_concurrent_backups_on_same_node():
 
     assert_eq_with_retry(
         node0,
-        f"SELECT status FROM system.backups WHERE status == 'MAKING_BACKUP' AND uuid IN {ids_list}",
+        f"SELECT status FROM system.backups WHERE status == 'MAKING_BACKUP' AND id IN {ids_list}",
         "",
     )
 
     assert node0.query(
-        f"SELECT status, error FROM system.backups WHERE uuid IN {ids_list}"
+        f"SELECT status, error FROM system.backups WHERE id IN {ids_list}"
     ) == TSV([["BACKUP_COMPLETE", ""]] * num_concurrent_backups)
 
     for backup_name in backup_names:
@@ -156,13 +156,13 @@ def test_concurrent_backups_on_different_nodes():
     for i in range(num_concurrent_backups):
         assert_eq_with_retry(
             nodes[i],
-            f"SELECT status FROM system.backups WHERE status == 'MAKING_BACKUP' AND uuid = '{ids[i]}'",
+            f"SELECT status FROM system.backups WHERE status == 'MAKING_BACKUP' AND id = '{ids[i]}'",
             "",
         )
 
     for i in range(num_concurrent_backups):
         assert nodes[i].query(
-            f"SELECT status, error FROM system.backups WHERE uuid = '{ids[i]}'"
+            f"SELECT status, error FROM system.backups WHERE id = '{ids[i]}'"
         ) == TSV([["BACKUP_COMPLETE", ""]])
 
     for i in range(num_concurrent_backups):
@@ -244,14 +244,14 @@ def test_create_or_drop_tables_during_backup(db_engine, table_engine):
     for node in nodes:
         assert_eq_with_retry(
             node,
-            f"SELECT status from system.backups WHERE uuid IN {ids_list} AND (status == 'MAKING_BACKUP')",
+            f"SELECT status from system.backups WHERE id IN {ids_list} AND (status == 'MAKING_BACKUP')",
             "",
         )
 
     for node in nodes:
         assert_eq_with_retry(
             node,
-            f"SELECT status, error from system.backups WHERE uuid IN {ids_list} AND (status == 'FAILED_TO_BACKUP')",
+            f"SELECT status, error from system.backups WHERE id IN {ids_list} AND (status == 'FAILED_TO_BACKUP')",
             "",
         )
 
@@ -259,7 +259,7 @@ def test_create_or_drop_tables_during_backup(db_engine, table_engine):
     for node in nodes:
         for id in ids:
             backup_name = node.query(
-                f"SELECT name FROM system.backups WHERE uuid='{id}' FORMAT RawBLOB"
+                f"SELECT name FROM system.backups WHERE id='{id}' FORMAT RawBLOB"
             ).strip()
             if backup_name:
                 backup_names[id] = backup_name

--- a/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
@@ -127,7 +127,7 @@ def test_concurrent_backups_on_same_node():
     )
 
     assert node0.query(
-        f"SELECT status, error FROM system.backups WHERE uuid IN {ids_list} AND NOT internal"
+        f"SELECT status, error FROM system.backups WHERE uuid IN {ids_list}"
     ) == TSV([["BACKUP_COMPLETE", ""]] * num_concurrent_backups)
 
     for backup_name in backup_names:
@@ -162,7 +162,7 @@ def test_concurrent_backups_on_different_nodes():
 
     for i in range(num_concurrent_backups):
         assert nodes[i].query(
-            f"SELECT status, error FROM system.backups WHERE uuid = '{ids[i]}' AND NOT internal"
+            f"SELECT status, error FROM system.backups WHERE uuid = '{ids[i]}'"
         ) == TSV([["BACKUP_COMPLETE", ""]])
 
     for i in range(num_concurrent_backups):
@@ -259,7 +259,7 @@ def test_create_or_drop_tables_during_backup(db_engine, table_engine):
     for node in nodes:
         for id in ids:
             backup_name = node.query(
-                f"SELECT backup_name FROM system.backups WHERE uuid='{id}' FORMAT RawBLOB"
+                f"SELECT name FROM system.backups WHERE uuid='{id}' FORMAT RawBLOB"
             ).strip()
             if backup_name:
                 backup_names[id] = backup_name

--- a/tests/integration/test_concurrent_backups_s3/test.py
+++ b/tests/integration/test_concurrent_backups_s3/test.py
@@ -45,7 +45,7 @@ def test_concurrent_backups(start_cluster):
 
     assert_eq_with_retry(
         node,
-        "SELECT count() FROM system.backups WHERE status != 'BACKUP_COMPLETE' and status != 'FAILED_TO_BACKUP'",
+        "SELECT count() FROM system.backups WHERE status != 'BACKUP_CREATED' and status != 'BACKUP_FAILED'",
         "0",
         retry_count=100,
     )


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
Rework and simplify the `system.backups` table, remove the `internal` column, allow user to set ID of operation, add columns `num_files`, `uncompressed_size`, `compressed_size`, `start_time`, `end_time`.

Example:

```
> backup table test.table to Disk('backups', '1.zip') settings id='my-cool-backup'

┌─id─────────────┬─status─────────┐
│ my-cool-backup │ BACKUP_CREATED │
└────────────────┴────────────────┘

> select * from system.backups

┌─id───────────────────────────────────┬─name──────────────────────┬─status─────────┬─num_files─┬─uncompressed_size─┬─compressed_size─┬─error─┬──────────start_time─┬────────────end_time─┐
│ my-cool-backup                       │ Disk('backups', '1.zip')  │ BACKUP_CREATED │         8 │              1534 │            2248 │       │ 2022-07-27 12:36:21 │ 2022-07-27 12:36:21 │
└──────────────────────────────────────┴───────────────────────────┴────────────────┴───────────┴───────────────────┴─────────────────┴───────┴─────────────────────┴─────────────────────┘
```