### PR TITLE
reload ddl worker config without restart server

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1205,6 +1205,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
             global_context->updateStorageConfiguration(*config);
             global_context->updateInterserverCredentials(*config);
 
+            global_context->reloadDDLWorker(config);
+
             CompressionCodecEncrypted::Configuration::instance().tryLoad(*config, "encryption_codecs");
 #if USE_SSL
             CertificateReloader::instance().tryLoad(*config);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1527,6 +1527,17 @@ void Context::loadOrReloadModels(const Poco::Util::AbstractConfiguration & confi
     shared->models_repository_guard = external_models_loader.addConfigRepository(std::move(repository));
 }
 
+void Context::reloadDDLWorker(const Poco::Util::AbstractConfiguration * config)
+{
+    auto lock = getLock();
+    if (shared->ddl_worker)
+    {
+        shared->ddl_worker->loadOrReloadWorkerConfig(config);
+    }
+
+    return;
+}
+
 EmbeddedDictionaries & Context::getEmbeddedDictionariesImpl(const bool throw_on_error) const
 {
     std::lock_guard lock(shared->embedded_dictionaries_mutex);

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -636,6 +636,7 @@ public:
     void loadOrReloadDictionaries(const Poco::Util::AbstractConfiguration & config);
     void loadOrReloadUserDefinedExecutableFunctions(const Poco::Util::AbstractConfiguration & config);
     void loadOrReloadModels(const Poco::Util::AbstractConfiguration & config);
+    void reloadDDLWorker(const Poco::Util::AbstractConfiguration * config);
 
 #if USE_NLP
     SynonymsExtensions & getSynonymsExtensions() const;

--- a/src/Interpreters/DDLWorker.h
+++ b/src/Interpreters/DDLWorker.h
@@ -66,6 +66,8 @@ public:
 
     bool isCurrentlyActive() const { return initialized && !stop_flag; }
 
+    void loadOrReloadWorkerConfig(const Poco::Util::AbstractConfiguration * config);
+
 protected:
 
     /// Returns cached ZooKeeper session (possibly expired).
@@ -153,6 +155,9 @@ protected:
     Int64 task_max_lifetime = 7 * 24 * 60 * 60; // week (in seconds)
     /// How many tasks could be in the queue
     size_t max_tasks_in_queue = 1000;
+    /// ddl profile name
+    String profile_name = "default";
+    String prefix;
 
     std::atomic<UInt64> max_id = 0;
     const CurrentMetrics::Metric * max_entry_metric;


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Auto reload distributed_ddl config without restart 

Fix #32861
Support auto load some distributed_ddl config except `zk_root_dir` and `pool_size`, it also can auto load profile config.




> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
