### PR TITLE
fix `-DENABLE_EXAMPLES=1` in master

### DIFF
--- a/src/Common/ZooKeeper/examples/zkutil_test_commands_new_lib.cpp
+++ b/src/Common/ZooKeeper/examples/zkutil_test_commands_new_lib.cpp
@@ -99,6 +99,7 @@ try
     std::cout << "list\n";
 
     zk.list("/",
+        Coordination::ListRequestType::ALL,
         [&](const ListResponse & response)
         {
             if (response.error != Coordination::Error::ZOK)

--- a/src/Common/examples/small_table.cpp
+++ b/src/Common/examples/small_table.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <iomanip>
 
 #include <Interpreters/AggregationCommon.h>
 
@@ -26,22 +25,6 @@ int main(int, char **)
 
         for (auto x : cont)
             std::cerr << x.getValue() << std::endl;
-
-        DB::WriteBufferFromOwnString wb;
-        cont.writeText(wb);
-
-        std::cerr << "dump: " << wb.str() << std::endl;
-    }
-
-    {
-        using Cont = SmallMap<int, std::string, 16>;
-        Cont cont;
-
-        cont.insert(Cont::value_type(1, "Hello, world!"));
-        cont[1] = "Goodbye.";
-
-        for (auto x : cont)
-            std::cerr << x.getKey() << " -> " << x.getMapped() << std::endl;
 
         DB::WriteBufferFromOwnString wb;
         cont.writeText(wb);

--- a/src/Interpreters/examples/hash_map_string.cpp
+++ b/src/Interpreters/examples/hash_map_string.cpp
@@ -30,11 +30,14 @@ struct CompactStringRef
     union
     {
         const char * data_mixed = nullptr;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnested-anon-types"
         struct
         {
             char dummy[6];
             UInt16 size;
         };
+#pragma clang diagnostic pop
     };
 
     CompactStringRef(const char * data_, size_t size_)

--- a/src/Storages/examples/async_read_buffer_from_hdfs.cpp
+++ b/src/Storages/examples/async_read_buffer_from_hdfs.cpp
@@ -23,7 +23,8 @@ int main()
 
     String hdfs_namenode_url = "hdfs://namenode:port/";
     String path = "/path/to/hdfs/file";
-    auto in = std::make_unique<ReadBufferFromHDFS>(hdfs_namenode_url, path, *config);
+    ReadSettings settings = {};
+    auto in = std::make_unique<ReadBufferFromHDFS>(hdfs_namenode_url, path, *config, settings);
     auto reader = IObjectStorage::getThreadPoolReader();
     AsynchronousReadBufferFromHDFS buf(reader, {}, std::move(in));
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Examples are broken since recent pushes in `master` nobody runs `BuilderBinClangTidy`? Or maybe they don't wait for it to finish...