### PR TITLE
LZ4_decompress_faster.cpp: remove endianness-dependent code

### DIFF
--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -24,13 +24,11 @@
 #include <arm_neon.h>
 #endif
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 static inline UInt16 LZ4_readLE16(const void* mem_ptr)
 {
         const UInt8* p = reinterpret_cast<const UInt8*>(mem_ptr);
         return static_cast<UInt16>(p[0]) + (p[1] << 8);
 }
-#endif
 
 namespace LZ4
 {
@@ -569,11 +567,7 @@ bool NO_INLINE decompressImpl(
 
         /// Get match offset.
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
         size_t offset = LZ4_readLE16(ip);
-#else
-        size_t offset = unalignedLoad<UInt16>(ip);
-#endif
         ip += 2;
         const UInt8 * match = op - offset;
 


### PR DESCRIPTION
Little-endian is little-endian no matter what the native endianness is.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
