### PR TITLE
fix nats-io TLS support

### DIFF
--- a/contrib/nats-io-cmake/CMakeLists.txt
+++ b/contrib/nats-io-cmake/CMakeLists.txt
@@ -18,6 +18,8 @@ elseif(WIN32)
     set(NATS_PLATFORM_INCLUDE "apple")
 endif()
 
+add_definitions(-DNATS_HAS_TLS)
+
 file(GLOB PS_SOURCES "${NATS_IO_SOURCE_DIR}/${NATS_PLATFORM_INCLUDE}/*.c")
 set(SRCS
     "${NATS_IO_SOURCE_DIR}/asynccb.c"

--- a/docker/test/integration/runner/compose/docker_compose_nats.yml
+++ b/docker/test/integration/runner/compose/docker_compose_nats.yml
@@ -4,4 +4,8 @@ services:
     image: nats
     ports:
       - "${NATS_EXTERNAL_PORT}:${NATS_INTERNAL_PORT}"
-    command: "-p 4444 --user click --pass house"
+    command: "-p 4444 --user click --pass house --tls --tlscert=/etc/certs/server-cert.pem --tlskey=/etc/certs/server-key.pem"
+    volumes:
+      - type: bind
+        source: "${NATS_CERT_DIR}/nats"
+        target: /etc/certs

--- a/src/Storages/NATS/NATSConnection.cpp
+++ b/src/Storages/NATS/NATSConnection.cpp
@@ -9,7 +9,6 @@
 namespace DB
 {
 
-//static const auto CONNECT_SLEEP = 200;
 static const auto RETRIES_MAX = 20;
 static const auto CONNECTED_TO_BUFFER_SIZE = 256;
 
@@ -19,6 +18,10 @@ NATSConnectionManager::NATSConnectionManager(const NATSConfiguration & configura
     , log(log_)
     , event_handler(loop.getLoop(), log)
 {
+    const char * val = std::getenv("CLICKHOUSE_NATS_TLS_SECURE");
+    std::string tls_secure = val == nullptr ? std::string("1") : std::string(val);
+    if (tls_secure == "0")
+        skip_verification = true;
 }
 
 
@@ -92,6 +95,9 @@ void NATSConnectionManager::connectImpl()
     if (configuration.secure)
     {
         natsOptions_SetSecure(options, true);
+    }
+    if (skip_verification)
+    {
         natsOptions_SkipServerVerification(options, true);
     }
     if (!configuration.url.empty())

--- a/src/Storages/NATS/NATSConnection.h
+++ b/src/Storages/NATS/NATSConnection.h
@@ -65,6 +65,9 @@ private:
     // true if at any point successfully connected to NATS
     bool has_connection = false;
 
+    // use CLICKHOUSE_NATS_TLS_SECURE=0 env var to skip TLS verification of server cert
+    bool skip_verification = false;
+
     std::mutex mutex;
 };
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -30,6 +30,7 @@ try:
     import pymongo
     import pymysql
     import nats
+    import ssl
     import meilisearch
     from confluent_kafka.avro.cached_schema_registry_client import (
         CachedSchemaRegistryClient,
@@ -215,9 +216,27 @@ def check_rabbitmq_is_available(rabbitmq_id):
     return p.returncode == 0
 
 
-async def check_nats_is_available(nats_ip):
-    nc = await nats.connect("{}:4444".format(nats_ip), user="click", password="house")
-    return nc.is_connected
+async def check_nats_is_available(nats_port, ssl_ctx=None):
+    nc = await nats_connect_ssl(
+        nats_port, user="click", password="house", ssl_ctx=ssl_ctx
+    )
+    available = nc.is_connected
+    await nc.close()
+    return available
+
+
+async def nats_connect_ssl(nats_port, user, password, ssl_ctx=None):
+    if not ssl_ctx:
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+    nc = await nats.connect(
+        "tls://localhost:{}".format(nats_port),
+        user=user,
+        password=password,
+        tls=ssl_ctx,
+    )
+    return nc
 
 
 def enable_consistent_hash_plugin(rabbitmq_id):
@@ -336,6 +355,7 @@ class ClickHouseCluster:
         self.env_variables = {}
         self.env_variables["TSAN_OPTIONS"] = "second_deadlock_stack=1"
         self.env_variables["CLICKHOUSE_WATCHDOG_ENABLE"] = "0"
+        self.env_variables["CLICKHOUSE_NATS_TLS_SECURE"] = "0"
         self.up_called = False
 
         custom_dockerd_host = custom_dockerd_host or os.environ.get(
@@ -464,9 +484,11 @@ class ClickHouseCluster:
         self.rabbitmq_logs_dir = os.path.join(self.rabbitmq_dir, "logs")
 
         self.nats_host = "nats1"
-        self.nats_ip = None
         self.nats_port = 4444
         self.nats_docker_id = None
+        self.nats_dir = p.abspath(p.join(self.instances_dir, "nats"))
+        self.nats_cert_dir = os.path.join(self.nats_dir, "cert")
+        self.nats_ssl_context = None
 
         # available when with_nginx == True
         self.nginx_host = "nginx"
@@ -1046,6 +1068,7 @@ class ClickHouseCluster:
         env_variables["NATS_HOST"] = self.nats_host
         env_variables["NATS_INTERNAL_PORT"] = "4444"
         env_variables["NATS_EXTERNAL_PORT"] = str(self.nats_port)
+        env_variables["NATS_CERT_DIR"] = self.nats_cert_dir
 
         self.base_cmd.extend(
             ["--file", p.join(docker_compose_yml_dir, "docker_compose_nats.yml")]
@@ -1967,10 +1990,12 @@ class ClickHouseCluster:
             raise Exception("Cannot wait RabbitMQ container")
         return False
 
-    def wait_nats_is_available(self, nats_ip, max_retries=5):
+    def wait_nats_is_available(self, max_retries=5):
         retries = 0
         while True:
-            if asyncio.run(check_nats_is_available(nats_ip)):
+            if asyncio.run(
+                check_nats_is_available(self.nats_port, ssl_ctx=self.nats_ssl_context)
+            ):
                 break
             else:
                 retries += 1
@@ -2453,11 +2478,24 @@ class ClickHouseCluster:
 
             if self.with_nats and self.base_nats_cmd:
                 logging.debug("Setup NATS")
+                os.makedirs(self.nats_cert_dir)
+                env = os.environ.copy()
+                env["NATS_CERT_DIR"] = self.nats_cert_dir
+                run_and_check(
+                    p.join(self.base_dir, "nats_certs.sh"),
+                    env=env,
+                    detach=False,
+                    nothrow=False,
+                )
+
+                self.nats_ssl_context = ssl.create_default_context()
+                self.nats_ssl_context.load_verify_locations(
+                    p.join(self.nats_cert_dir, "ca", "ca-cert.pem")
+                )
                 subprocess_check_call(self.base_nats_cmd + common_opts)
                 self.nats_docker_id = self.get_instance_docker_id("nats1")
                 self.up_called = True
-                self.nats_ip = self.get_instance_ip("nats1")
-                self.wait_nats_is_available(self.nats_ip)
+                self.wait_nats_is_available()
 
             if self.with_hdfs and self.base_hdfs_cmd:
                 logging.debug("Setup HDFS")

--- a/tests/integration/test_storage_nats/nats_certs.sh
+++ b/tests/integration/test_storage_nats/nats_certs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euxo pipefail
+
+mkdir -p "${NATS_CERT_DIR}/ca"
+mkdir -p "${NATS_CERT_DIR}/nats"
+openssl req -newkey rsa:4096 -x509 -days 365 -nodes -batch -keyout "${NATS_CERT_DIR}/ca/ca-key.pem" -out "${NATS_CERT_DIR}/ca/ca-cert.pem" -subj "/C=RU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=ca"
+openssl req -newkey rsa:4096 -nodes -batch -keyout "${NATS_CERT_DIR}/nats/server-key.pem" -out "${NATS_CERT_DIR}/nats/server-req.pem" -subj "/C=RU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=server"
+openssl x509 -req -days 365 -in "${NATS_CERT_DIR}/nats/server-req.pem" -CA "${NATS_CERT_DIR}/ca/ca-cert.pem" -CAkey "${NATS_CERT_DIR}/ca/ca-key.pem" -CAcreateserial -out "${NATS_CERT_DIR}/nats/server-cert.pem" -extfile <(
+cat <<-EOF
+subjectAltName = DNS:localhost, DNS:nats1
+EOF
+)
+rm -f "${NATS_CERT_DIR}/nats/server-req.pem"


### PR DESCRIPTION
nats-io library needs `NATS_HAS_TLS` define to correctly compile-in TLS
support

fixes #39525

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for TLS connections to NATS. Implements #39525.
