### PR TITLE
Less usage of StringRef

### DIFF
--- a/base/base/JSON.cpp
+++ b/base/base/JSON.cpp
@@ -669,18 +669,18 @@ std::string JSON::getName() const
     return getString();
 }
 
-StringRef JSON::getRawString() const
+std::string_view JSON::getRawString() const
 {
     Pos s = ptr_begin;
     if (*s != '"')
         throw JSONException(std::string("JSON: expected \", got ") + *s);
     while (++s != ptr_end && *s != '"');
     if (s != ptr_end)
-        return StringRef(ptr_begin + 1, s - ptr_begin - 1);
+        return std::string_view(ptr_begin + 1, s - ptr_begin - 1);
     throw JSONException("JSON: incorrect syntax (expected end of string, found end of JSON).");
 }
 
-StringRef JSON::getRawName() const
+std::string_view JSON::getRawName() const
 {
     return getRawString();
 }

--- a/base/base/JSON.h
+++ b/base/base/JSON.h
@@ -136,8 +136,8 @@ public:
     std::string getName() const;    /// Получить имя name-value пары.
     JSON        getValue() const;    /// Получить значение name-value пары.
 
-    StringRef getRawString() const;
-    StringRef getRawName() const;
+    std::string_view getRawString() const;
+    std::string_view getRawName() const;
 
     /// Получить значение элемента; если элемент - строка, то распарсить значение из строки; если не строка или число - то исключение.
     double      toDouble() const;

--- a/src/Common/Config/AbstractConfigurationComparison.cpp
+++ b/src/Common/Config/AbstractConfigurationComparison.cpp
@@ -73,7 +73,7 @@ bool isSameConfiguration(const Poco::Util::AbstractConfiguration & left, const S
         /// Check that the right configuration has the same set of subkeys as the left configuration.
         Poco::Util::AbstractConfiguration::Keys right_subkeys;
         right.keys(right_key, right_subkeys);
-        std::unordered_set<StringRef> left_subkeys{subkeys.begin(), subkeys.end()};
+        std::unordered_set<std::string_view> left_subkeys{subkeys.begin(), subkeys.end()};
         if ((left_subkeys.size() != right_subkeys.size()) || (left_subkeys.size() != subkeys.size()))
             return false;
         for (const auto & right_subkey : right_subkeys)

--- a/src/Common/Volnitsky.h
+++ b/src/Common/Volnitsky.h
@@ -9,7 +9,6 @@
 #include <Common/StringSearcher.h>
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/UTF8Helpers.h>
-#include <base/StringRef.h>
 #include <base/unaligned.h>
 
 /** Search for a substring in a string by Volnitsky's algorithm

--- a/src/IO/WriteBufferFromString.h
+++ b/src/IO/WriteBufferFromString.h
@@ -30,7 +30,7 @@ class WriteBufferFromOwnString : public detail::StringHolder, public WriteBuffer
 public:
     WriteBufferFromOwnString() : WriteBufferFromString(value) {}
 
-    StringRef stringRef() const { return isFinished() ? StringRef(value) : StringRef(value.data(), pos - value.data()); }
+    std::string_view stringView() const { return isFinished() ? std::string_view(value) : std::string_view(value.data(), pos - value.data()); }
 
     std::string & str()
     {

--- a/src/Processors/Formats/Impl/MsgPackRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MsgPackRowOutputFormat.cpp
@@ -178,7 +178,7 @@ void MsgPackRowOutputFormat::serializeField(const IColumn & column, DataTypePtr 
                 {
                     WriteBufferFromOwnString buf;
                     writeBinary(uuid_column.getElement(row_num), buf);
-                    std::string_view uuid_bin = buf.stringRef().toView();
+                    std::string_view uuid_bin = buf.stringView();
                     packer.pack_bin(uuid_bin.size());
                     packer.pack_bin_body(uuid_bin.data(), uuid_bin.size());
                     return;
@@ -187,7 +187,7 @@ void MsgPackRowOutputFormat::serializeField(const IColumn & column, DataTypePtr 
                 {
                     WriteBufferFromOwnString buf;
                     writeText(uuid_column.getElement(row_num), buf);
-                    std::string_view uuid_text = buf.stringRef().toView();
+                    std::string_view uuid_text = buf.stringView();
                     packer.pack_str(uuid_text.size());
                     packer.pack_bin_body(uuid_text.data(), uuid_text.size());
                     return;
@@ -198,7 +198,7 @@ void MsgPackRowOutputFormat::serializeField(const IColumn & column, DataTypePtr 
                     UUID value = uuid_column.getElement(row_num);
                     writeBinaryBigEndian(value.toUnderType().items[0], buf);
                     writeBinaryBigEndian(value.toUnderType().items[1], buf);
-                    std::string_view uuid_ext = buf.stringRef().toView();
+                    std::string_view uuid_ext = buf.stringView();
                     packer.pack_ext(sizeof(UUID), int8_t(MsgPackExtensionTypes::UUIDType));
                     packer.pack_ext_body(uuid_ext.data(), uuid_ext.size());
                     return;

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -764,10 +764,10 @@ void DistributedSink::writeToShard(const Block & block, const std::vector<std::s
             /// And note that it is safe, because we have checksum and size for header.
 
             /// Write the header.
-            const StringRef header = header_buf.stringRef();
+            const std::string_view header = header_buf.stringView();
             writeVarUInt(DBMS_DISTRIBUTED_SIGNATURE_HEADER, out);
-            writeStringBinary(header, out);
-            writePODBinary(CityHash_v1_0_2::CityHash128(header.data, header.size), out);
+            writeStringBinary(StringRef(header), out);
+            writePODBinary(CityHash_v1_0_2::CityHash128(header.data(), header.size()), out);
 
             stream.write(block);
 


### PR DESCRIPTION
... replaced by std::string_view, see #39262

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)