### PR TITLE
Fix for empty function name on FreeBSD build

### DIFF
--- a/src/Functions/array/arrayDistance.cpp
+++ b/src/Functions/array/arrayDistance.cpp
@@ -22,7 +22,7 @@ namespace ErrorCodes
 
 struct L1Distance
 {
-    static inline String name = "L1";
+    static constexpr auto name = "L1";
 
     struct ConstParams {};
 
@@ -53,7 +53,7 @@ struct L1Distance
 
 struct L2Distance
 {
-    static inline String name = "L2";
+    static constexpr auto name = "L2";
 
     struct ConstParams {};
 
@@ -84,7 +84,7 @@ struct L2Distance
 
 struct L2SquaredDistance : L2Distance
 {
-    static inline String name = "L2Squared";
+    static constexpr auto name = "L2Squared";
 
     template <typename ResultType>
     static ResultType finalize(const State<ResultType> & state, const ConstParams &)
@@ -95,7 +95,7 @@ struct L2SquaredDistance : L2Distance
 
 struct LpDistance
 {
-    static inline String name = "Lp";
+    static constexpr auto name = "Lp";
 
     struct ConstParams
     {
@@ -130,7 +130,7 @@ struct LpDistance
 
 struct LinfDistance
 {
-    static inline String name = "Linf";
+    static constexpr auto name = "Linf";
 
     struct ConstParams {};
 
@@ -161,7 +161,7 @@ struct LinfDistance
 
 struct CosineDistance
 {
-    static inline String name = "Cosine";
+    static constexpr auto name = "Cosine";
 
     struct ConstParams {};
 
@@ -200,8 +200,7 @@ template <class Kernel>
 class FunctionArrayDistance : public IFunction
 {
 public:
-    static inline auto name = "array" + Kernel::name + "Distance";
-    String getName() const override { return name; }
+    String getName() const override { static auto name = String("array") + Kernel::name + "Distance"; return name; }
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionArrayDistance<Kernel>>(); }
     size_t getNumberOfArguments() const override { return 2; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {}; }

--- a/src/Functions/array/arrayNorm.cpp
+++ b/src/Functions/array/arrayNorm.cpp
@@ -21,7 +21,7 @@ namespace ErrorCodes
 
 struct L1Norm
 {
-    static inline String name = "L1";
+    static constexpr auto name = "L1";
 
     struct ConstParams {};
 
@@ -46,7 +46,7 @@ struct L1Norm
 
 struct L2Norm
 {
-    static inline String name = "L2";
+    static constexpr auto name = "L2";
 
     struct ConstParams {};
 
@@ -71,7 +71,7 @@ struct L2Norm
 
 struct L2SquaredNorm : L2Norm
 {
-    static inline String name = "L2Squared";
+    static constexpr auto name = "L2Squared";
 
     template <typename ResultType>
     inline static ResultType finalize(ResultType result, const ConstParams &)
@@ -83,7 +83,7 @@ struct L2SquaredNorm : L2Norm
 
 struct LpNorm
 {
-    static inline String name = "Lp";
+    static constexpr auto name = "Lp";
 
     struct ConstParams
     {
@@ -112,7 +112,7 @@ struct LpNorm
 
 struct LinfNorm
 {
-    static inline String name = "Linf";
+    static constexpr auto name = "Linf";
 
     struct ConstParams {};
 
@@ -140,8 +140,7 @@ template <class Kernel>
 class FunctionArrayNorm : public IFunction
 {
 public:
-    static inline auto name = "array" + Kernel::name + "Norm";
-    String getName() const override { return name; }
+    String getName() const override { static auto name = String("array") + Kernel::name + "Norm"; return name; }
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionArrayNorm<Kernel>>(); }
     size_t getNumberOfArguments() const override { return 1; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {}; }

--- a/src/Functions/vectorFunctions.cpp
+++ b/src/Functions/vectorFunctions.cpp
@@ -1124,7 +1124,7 @@ template <class Traits>
 class TupleOrArrayFunction : public IFunction
 {
 public:
-    static inline String name = Traits::name;
+    static constexpr auto name = Traits::name;
 
     explicit TupleOrArrayFunction(ContextPtr context_)
         : IFunction()
@@ -1173,7 +1173,7 @@ extern FunctionPtr createFunctionArrayCosineDistance(ContextPtr context_);
 
 struct L1NormTraits
 {
-    static inline String name = "L1Norm";
+    static constexpr auto name = "L1Norm";
 
     static constexpr auto CreateTupleFunction = FunctionL1Norm::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayL1Norm;
@@ -1181,7 +1181,7 @@ struct L1NormTraits
 
 struct L2NormTraits
 {
-    static inline String name = "L2Norm";
+    static constexpr auto name = "L2Norm";
 
     static constexpr auto CreateTupleFunction = FunctionL2Norm::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayL2Norm;
@@ -1189,7 +1189,7 @@ struct L2NormTraits
 
 struct L2SquaredNormTraits
 {
-    static inline String name = "L2SquaredNorm";
+    static constexpr auto name = "L2SquaredNorm";
 
     static constexpr auto CreateTupleFunction = FunctionL2SquaredNorm::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayL2SquaredNorm;
@@ -1197,7 +1197,7 @@ struct L2SquaredNormTraits
 
 struct LpNormTraits
 {
-    static inline String name = "LpNorm";
+    static constexpr auto name = "LpNorm";
 
     static constexpr auto CreateTupleFunction = FunctionLpNorm::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayLpNorm;
@@ -1205,7 +1205,7 @@ struct LpNormTraits
 
 struct LinfNormTraits
 {
-    static inline String name = "LinfNorm";
+    static constexpr auto name = "LinfNorm";
 
     static constexpr auto CreateTupleFunction = FunctionLinfNorm::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayLinfNorm;
@@ -1213,7 +1213,7 @@ struct LinfNormTraits
 
 struct L1DistanceTraits
 {
-    static inline String name = "L1Distance";
+    static constexpr auto name = "L1Distance";
 
     static constexpr auto CreateTupleFunction = FunctionL1Distance::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayL1Distance;
@@ -1221,7 +1221,7 @@ struct L1DistanceTraits
 
 struct L2DistanceTraits
 {
-    static inline String name = "L2Distance";
+    static constexpr auto name = "L2Distance";
 
     static constexpr auto CreateTupleFunction = FunctionL2Distance::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayL2Distance;
@@ -1229,7 +1229,7 @@ struct L2DistanceTraits
 
 struct L2SquaredDistanceTraits
 {
-    static inline String name = "L2SquaredDistance";
+    static constexpr auto name = "L2SquaredDistance";
 
     static constexpr auto CreateTupleFunction = FunctionL2SquaredDistance::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayL2SquaredDistance;
@@ -1237,7 +1237,7 @@ struct L2SquaredDistanceTraits
 
 struct LpDistanceTraits
 {
-    static inline String name = "LpDistance";
+    static constexpr auto name = "LpDistance";
 
     static constexpr auto CreateTupleFunction = FunctionLpDistance::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayLpDistance;
@@ -1245,7 +1245,7 @@ struct LpDistanceTraits
 
 struct LinfDistanceTraits
 {
-    static inline String name = "LinfDistance";
+    static constexpr auto name = "LinfDistance";
 
     static constexpr auto CreateTupleFunction = FunctionLinfDistance::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayLinfDistance;
@@ -1253,7 +1253,7 @@ struct LinfDistanceTraits
 
 struct CosineDistanceTraits
 {
-    static inline String name = "cosineDistance";
+    static constexpr auto name = "cosineDistance";
 
     static constexpr auto CreateTupleFunction = FunctionCosineDistance::create;
     static constexpr auto CreateArrayFunction = createFunctionArrayCosineDistance;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes "Code: 49. DB::Exception: FunctionFactory: the function name '' is not unique. (LOGICAL_ERROR)" observed on FreeBSD when starting clickhouse

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
