### PR TITLE
Fix create/drop index on cluster

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -7,6 +7,8 @@
 #include <Parsers/ASTOptimizeQuery.h>
 #include <Parsers/ASTQueryWithOnCluster.h>
 #include <Parsers/ASTQueryWithTableAndOutput.h>
+#include <Parsers/ASTCreateIndexQuery.h>
+#include <Parsers/ASTDropIndexQuery.h>
 #include <Parsers/ParserQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/queryToString.h>
@@ -652,7 +654,11 @@ bool DDLWorker::taskShouldBeExecutedOnLeader(const ASTPtr & ast_ddl, const Stora
     if (auto * query = ast_ddl->as<ASTDropQuery>(); query && query->kind != ASTDropQuery::Kind::Truncate)
         return false;
 
-    if (!ast_ddl->as<ASTAlterQuery>() && !ast_ddl->as<ASTOptimizeQuery>() && !ast_ddl->as<ASTDropQuery>())
+    if (!ast_ddl->as<ASTAlterQuery>() &&
+        !ast_ddl->as<ASTOptimizeQuery>() &&
+        !ast_ddl->as<ASTDropQuery>() &&
+        !ast_ddl->as<ASTCreateIndexQuery>() &&
+        !ast_ddl->as<ASTDropIndexQuery>())
         return false;
 
     if (auto * alter = ast_ddl->as<ASTAlterQuery>())

--- a/tests/queries/0_stateless/02319_sql_standard_create_drop_index.reference
+++ b/tests/queries/0_stateless/02319_sql_standard_create_drop_index.reference
@@ -2,8 +2,8 @@ CREATE TABLE default.t_index\n(\n    `a` Int32,\n    `b` String,\n    INDEX i_a 
 t_index	i_a	minmax	a	4
 t_index	i_b	bloom_filter	b	2
 t_index	i_b	bloom_filter	b	2
-CREATE TABLE default.t_index\n(\n    `a` Int32,\n    `b` String,\n    INDEX i_a a TYPE minmax GRANULARITY 4,\n    INDEX i_b b TYPE bloom_filter GRANULARITY 2\n)\nENGINE = ReplicatedMergeTree(\'/test/2319/default/\', \'1\')\nORDER BY a\nSETTINGS index_granularity = 8192
-CREATE TABLE default.t_index_replica\n(\n    `a` Int32,\n    `b` String,\n    INDEX i_a a TYPE minmax GRANULARITY 4,\n    INDEX i_b b TYPE bloom_filter GRANULARITY 2\n)\nENGINE = ReplicatedMergeTree(\'/test/2319/default/\', \'2\')\nORDER BY a\nSETTINGS index_granularity = 8192
+CREATE TABLE default.t_index\n(\n    `a` Int32,\n    `b` String,\n    INDEX i_a a TYPE minmax GRANULARITY 4,\n    INDEX i_b b TYPE bloom_filter GRANULARITY 2\n)\nENGINE = ReplicatedMergeTree(\'/test/2319/default\', \'1\')\nORDER BY a\nSETTINGS index_granularity = 8192
+CREATE TABLE default.t_index_replica\n(\n    `a` Int32,\n    `b` String,\n    INDEX i_a a TYPE minmax GRANULARITY 4,\n    INDEX i_b b TYPE bloom_filter GRANULARITY 2\n)\nENGINE = ReplicatedMergeTree(\'/test/2319/default\', \'2\')\nORDER BY a\nSETTINGS index_granularity = 8192
 t_index	i_a	minmax	a	4
 t_index	i_b	bloom_filter	b	2
 t_index	i_b	bloom_filter	b	2

--- a/tests/queries/0_stateless/02319_sql_standard_create_drop_index.reference
+++ b/tests/queries/0_stateless/02319_sql_standard_create_drop_index.reference
@@ -2,3 +2,9 @@ CREATE TABLE default.t_index\n(\n    `a` Int32,\n    `b` String,\n    INDEX i_a 
 t_index	i_a	minmax	a	4
 t_index	i_b	bloom_filter	b	2
 t_index	i_b	bloom_filter	b	2
+CREATE TABLE default.t_index\n(\n    `a` Int32,\n    `b` String,\n    INDEX i_a a TYPE minmax GRANULARITY 4,\n    INDEX i_b b TYPE bloom_filter GRANULARITY 2\n)\nENGINE = ReplicatedMergeTree(\'/test/2319/default/\', \'1\')\nORDER BY a\nSETTINGS index_granularity = 8192
+CREATE TABLE default.t_index_replica\n(\n    `a` Int32,\n    `b` String,\n    INDEX i_a a TYPE minmax GRANULARITY 4,\n    INDEX i_b b TYPE bloom_filter GRANULARITY 2\n)\nENGINE = ReplicatedMergeTree(\'/test/2319/default/\', \'2\')\nORDER BY a\nSETTINGS index_granularity = 8192
+t_index	i_a	minmax	a	4
+t_index	i_b	bloom_filter	b	2
+t_index	i_b	bloom_filter	b	2
+t_index_replica	i_b	bloom_filter	b	2

--- a/tests/queries/0_stateless/02319_sql_standard_create_drop_index.sql
+++ b/tests/queries/0_stateless/02319_sql_standard_create_drop_index.sql
@@ -16,8 +16,8 @@ select table, name, type, expr, granularity from system.data_skipping_indices wh
 
 drop table t_index;
 
-create table t_index(a int, b String) engine=ReplicatedMergeTree('/test/2319/{database}/', '1') order by a;
-create table t_index_replica(a int, b String) engine=ReplicatedMergeTree('/test/2319/{database}/', '2') order by a;
+create table t_index(a int, b String) engine=ReplicatedMergeTree('/test/2319/{database}', '1') order by a;
+create table t_index_replica(a int, b String) engine=ReplicatedMergeTree('/test/2319/{database}', '2') order by a;
 
 create index i_a on t_index(a) TYPE minmax GRANULARITY 4;
 create index if not exists i_a on t_index(a) TYPE minmax GRANULARITY 2;

--- a/tests/queries/0_stateless/02319_sql_standard_create_drop_index.sql
+++ b/tests/queries/0_stateless/02319_sql_standard_create_drop_index.sql
@@ -15,3 +15,25 @@ drop index if exists i_a on t_index;
 select table, name, type, expr, granularity from system.data_skipping_indices where database = currentDatabase() and table = 't_index'; 
 
 drop table t_index;
+
+create table t_index(a int, b String) engine=ReplicatedMergeTree('/test/2319/{database}/', '1') order by a;
+create table t_index_replica(a int, b String) engine=ReplicatedMergeTree('/test/2319/{database}/', '2') order by a;
+
+create index i_a on t_index(a) TYPE minmax GRANULARITY 4;
+create index if not exists i_a on t_index(a) TYPE minmax GRANULARITY 2;
+
+create index i_b on t_index(b) TYPE bloom_filter GRANULARITY 2;
+
+show create table t_index;
+system sync replica t_index_replica;
+show create table t_index_replica;
+select table, name, type, expr, granularity from system.data_skipping_indices where database = currentDatabase() and table = 't_index';
+
+drop index i_a on t_index;
+drop index if exists i_a on t_index;
+
+select table, name, type, expr, granularity from system.data_skipping_indices where database = currentDatabase() and table = 't_index';
+system sync replica t_index_replica;
+select table, name, type, expr, granularity from system.data_skipping_indices where database = currentDatabase() and table = 't_index_replica';
+
+drop table t_index;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `CREATE/DROP INDEX` query with `ON CLUSTER` or `Replicated` database and `ReplicatedMergeTree`. It used to be executed on all replicas (causing error or DDL queue stuck). Fixes #39511