### PR TITLE
Add result_rows and result_bytes to progress reports

### DIFF
--- a/src/IO/Progress.cpp
+++ b/src/IO/Progress.cpp
@@ -61,6 +61,10 @@ void ProgressValues::writeJSON(WriteBuffer & out) const
     writeText(this->written_bytes, out);
     writeCString("\",\"total_rows_to_read\":\"", out);
     writeText(this->total_rows_to_read, out);
+    writeCString("\",\"result_rows\":\"", out);
+    writeText(this->result_rows, out);
+    writeCString("\",\"result_bytes\":\"", out);
+    writeText(this->result_bytes, out);
     writeCString("\"}", out);
 }
 
@@ -75,6 +79,9 @@ bool Progress::incrementPiecewiseAtomically(const Progress & rhs)
     written_rows += rhs.written_rows;
     written_bytes += rhs.written_bytes;
 
+    result_rows += rhs.result_rows;
+    result_bytes += rhs.result_bytes;
+
     return rhs.read_rows || rhs.written_rows;
 }
 
@@ -88,6 +95,9 @@ void Progress::reset()
 
     written_rows = 0;
     written_bytes = 0;
+
+    result_rows = 0;
+    result_bytes = 0;
 }
 
 ProgressValues Progress::getValues() const
@@ -102,6 +112,9 @@ ProgressValues Progress::getValues() const
 
     res.written_rows = written_rows.load(std::memory_order_relaxed);
     res.written_bytes = written_bytes.load(std::memory_order_relaxed);
+
+    res.result_rows = result_rows.load(std::memory_order_relaxed);
+    res.result_bytes = result_bytes.load(std::memory_order_relaxed);
 
     return res;
 }
@@ -119,6 +132,9 @@ ProgressValues Progress::fetchValuesAndResetPiecewiseAtomically()
     res.written_rows = written_rows.fetch_and(0);
     res.written_bytes = written_bytes.fetch_and(0);
 
+    res.result_rows = result_rows.fetch_and(0);
+    res.result_bytes = result_bytes.fetch_and(0);
+
     return res;
 }
 
@@ -135,6 +151,9 @@ Progress Progress::fetchAndResetPiecewiseAtomically()
     res.written_rows = written_rows.fetch_and(0);
     res.written_bytes = written_bytes.fetch_and(0);
 
+    res.result_rows = result_rows.fetch_and(0);
+    res.result_bytes = result_bytes.fetch_and(0);
+
     return res;
 }
 
@@ -148,6 +167,9 @@ Progress & Progress::operator=(Progress && other) noexcept
 
     written_rows = other.written_rows.load(std::memory_order_relaxed);
     written_bytes = other.written_bytes.load(std::memory_order_relaxed);
+
+    result_rows = other.result_rows.load(std::memory_order_relaxed);
+    result_bytes = other.result_bytes.load(std::memory_order_relaxed);
 
     return *this;
 }

--- a/src/IO/Progress.h
+++ b/src/IO/Progress.h
@@ -25,6 +25,9 @@ struct ProgressValues
     size_t written_rows;
     size_t written_bytes;
 
+    size_t result_rows;
+    size_t result_bytes;
+
     void read(ReadBuffer & in, UInt64 server_revision);
     void write(WriteBuffer & out, UInt64 client_revision) const;
     void writeJSON(WriteBuffer & out) const;
@@ -47,6 +50,15 @@ struct WriteProgress
 
     WriteProgress(size_t written_rows_, size_t written_bytes_)
         : written_rows(written_rows_), written_bytes(written_bytes_) {}
+};
+
+struct ResultProgress
+{
+    size_t result_rows;
+    size_t result_bytes;
+
+    ResultProgress(size_t result_rows_, size_t result_bytes_)
+        : result_rows(result_rows_), result_bytes(result_bytes_) {}
 };
 
 struct FileProgress
@@ -77,6 +89,9 @@ struct Progress
     std::atomic<size_t> written_rows {0};
     std::atomic<size_t> written_bytes {0};
 
+    std::atomic<size_t> result_rows {0};
+    std::atomic<size_t> result_bytes {0};
+
     Progress() = default;
 
     Progress(size_t read_rows_, size_t read_bytes_, size_t total_rows_to_read_ = 0)
@@ -86,7 +101,10 @@ struct Progress
         : read_rows(read_progress.read_rows), read_bytes(read_progress.read_bytes), total_rows_to_read(read_progress.total_rows_to_read) {}
 
     explicit Progress(WriteProgress write_progress)
-        : written_rows(write_progress.written_rows), written_bytes(write_progress.written_bytes)  {}
+        : written_rows(write_progress.written_rows), written_bytes(write_progress.written_bytes) {}
+
+    explicit Progress(ResultProgress result_progress)
+        : result_rows(result_progress.result_rows), result_bytes(result_progress.result_bytes) {}
 
     explicit Progress(FileProgress file_progress)
         : read_bytes(file_progress.read_bytes), total_bytes_to_read(file_progress.total_bytes_to_read) {}

--- a/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.reference
+++ b/tests/queries/0_stateless/00416_pocopatch_progress_in_http_headers.reference
@@ -1,9 +1,9 @@
-< X-ClickHouse-Progress: {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"10"}
-< X-ClickHouse-Progress: {"read_rows":"5","read_bytes":"40","written_rows":"0","written_bytes":"0","total_rows_to_read":"10"}
-< X-ClickHouse-Progress: {"read_rows":"10","read_bytes":"80","written_rows":"0","written_bytes":"0","total_rows_to_read":"10"}
+< X-ClickHouse-Progress: {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"10","result_rows":"0","result_bytes":"0"}
+< X-ClickHouse-Progress: {"read_rows":"5","read_bytes":"40","written_rows":"0","written_bytes":"0","total_rows_to_read":"10","result_rows":"0","result_bytes":"0"}
+< X-ClickHouse-Progress: {"read_rows":"10","read_bytes":"80","written_rows":"0","written_bytes":"0","total_rows_to_read":"10","result_rows":"0","result_bytes":"0"}
 9
-< X-ClickHouse-Progress: {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"10"}
-< X-ClickHouse-Progress: {"read_rows":"1","read_bytes":"8","written_rows":"0","written_bytes":"0","total_rows_to_read":"10"}
+< X-ClickHouse-Progress: {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"10","result_rows":"0","result_bytes":"0"}
+< X-ClickHouse-Progress: {"read_rows":"1","read_bytes":"8","written_rows":"0","written_bytes":"0","total_rows_to_read":"10","result_rows":"0","result_bytes":"0"}
 0
 1
 2
@@ -24,4 +24,4 @@
 7
 8
 9
-< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"10","written_bytes":"40","total_rows_to_read":"0"}
+< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"10","written_bytes":"40","total_rows_to_read":"0","result_rows":"10","result_bytes":"40"}

--- a/tests/queries/0_stateless/00968_live_view_select_format_jsoneachrowwithprogress.reference
+++ b/tests/queries/0_stateless/00968_live_view_select_format_jsoneachrowwithprogress.reference
@@ -1,4 +1,4 @@
 {"row":{"a":1}}
 {"row":{"a":2}}
 {"row":{"a":3}}
-{"progress":{"read_rows":"3","read_bytes":"36","written_rows":"0","written_bytes":"0","total_rows_to_read":"0"}}
+{"progress":{"read_rows":"3","read_bytes":"36","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"0","result_bytes":"0"}}

--- a/tests/queries/0_stateless/00969_live_view_watch_format_jsoneachrowwithprogress.reference
+++ b/tests/queries/0_stateless/00969_live_view_watch_format_jsoneachrowwithprogress.reference
@@ -1,6 +1,6 @@
 {"row":{"sum(a)":"0","_version":"1"}}
-{"progress":{"read_rows":"1","read_bytes":"16","written_rows":"0","written_bytes":"0","total_rows_to_read":"0"}}
+{"progress":{"read_rows":"1","read_bytes":"16","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"0","result_bytes":"0"}}
 {"row":{"sum(a)":"6","_version":"2"}}
-{"progress":{"read_rows":"1","read_bytes":"16","written_rows":"0","written_bytes":"0","total_rows_to_read":"0"}}
+{"progress":{"read_rows":"1","read_bytes":"16","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"0","result_bytes":"0"}}
 {"row":{"sum(a)":"21","_version":"3"}}
-{"progress":{"read_rows":"1","read_bytes":"16","written_rows":"0","written_bytes":"0","total_rows_to_read":"0"}}
+{"progress":{"read_rows":"1","read_bytes":"16","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"0","result_bytes":"0"}}

--- a/tests/queries/0_stateless/00970_live_view_watch_events_http_heartbeat.py
+++ b/tests/queries/0_stateless/00970_live_view_watch_events_http_heartbeat.py
@@ -38,17 +38,17 @@ with client(name="client1>", log=log) as client1:
         log=log,
     ) as client2:
         client2.expect(
-            '{"progress":{"read_rows":"1","read_bytes":"8","written_rows":"0","written_bytes":"0","total_rows_to_read":"0"}}\n',
+            '{"progress":{"read_rows":"1","read_bytes":"8","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"0","result_bytes":"0"}}\n',
             escape=True,
         )
         client2.expect('{"row":{"version":"1"}', escape=True)
         client2.expect(
-            '{"progress":{"read_rows":"1","read_bytes":"8","written_rows":"0","written_bytes":"0","total_rows_to_read":"0"}}',
+            '{"progress":{"read_rows":"1","read_bytes":"8","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"0","result_bytes":"0"}}',
             escape=True,
         )
         # heartbeat is provided by progress message
         client2.expect(
-            '{"progress":{"read_rows":"1","read_bytes":"8","written_rows":"0","written_bytes":"0","total_rows_to_read":"0"}}',
+            '{"progress":{"read_rows":"1","read_bytes":"8","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"0","result_bytes":"0"}}',
             escape=True,
         )
 

--- a/tests/queries/0_stateless/02136_scalar_progress.reference
+++ b/tests/queries/0_stateless/02136_scalar_progress.reference
@@ -1,6 +1,6 @@
-< X-ClickHouse-Progress: {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000"}
-< X-ClickHouse-Progress: {"read_rows":"65505","read_bytes":"524040","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000"}
-< X-ClickHouse-Progress: {"read_rows":"131010","read_bytes":"1048080","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000"}
-< X-ClickHouse-Progress: {"read_rows":"131011","read_bytes":"1048081","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000"}
-< X-ClickHouse-Progress: {"read_rows":"131011","read_bytes":"1048081","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000"}
-< X-ClickHouse-Summary: {"read_rows":"131011","read_bytes":"1048081","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000"}
+< X-ClickHouse-Progress: {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000","result_rows":"0","result_bytes":"0"}
+< X-ClickHouse-Progress: {"read_rows":"65505","read_bytes":"524040","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000","result_rows":"0","result_bytes":"0"}
+< X-ClickHouse-Progress: {"read_rows":"131010","read_bytes":"1048080","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000","result_rows":"0","result_bytes":"0"}
+< X-ClickHouse-Progress: {"read_rows":"131011","read_bytes":"1048081","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000","result_rows":"0","result_bytes":"0"}
+< X-ClickHouse-Progress: {"read_rows":"131011","read_bytes":"1048081","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000","result_rows":"1","result_bytes":"80"}
+< X-ClickHouse-Summary: {"read_rows":"131011","read_bytes":"1048081","written_rows":"0","written_bytes":"0","total_rows_to_read":"100000","result_rows":"1","result_bytes":"80"}

--- a/tests/queries/0_stateless/02373_progress_contain_result.reference
+++ b/tests/queries/0_stateless/02373_progress_contain_result.reference
@@ -1,0 +1,1 @@
+< X-ClickHouse-Summary: {"read_rows":"100","read_bytes":"800","written_rows":"0","written_bytes":"0","total_rows_to_read":"100","result_rows":"100","result_bytes":"131"}

--- a/tests/queries/0_stateless/02373_progress_contain_result.sh
+++ b/tests/queries/0_stateless/02373_progress_contain_result.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo 'SELECT 1 FROM numbers(100)' |
+  ${CLICKHOUSE_CURL_COMMAND} -v "${CLICKHOUSE_URL}&wait_end_of_query=1&send_progress_in_http_headers=0" --data-binary @- 2>&1 |
+  grep 'X-ClickHouse-Summary'


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add result_rows and result_bytes to progress reports (`X-ClickHouse-Summary`). 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Basically this enables reporting the final amount of rows and bytes in the result (same value as reported to the query_log) under the `X-ClickHouse-Summary` header if `wait_end_of_query` is set. For example:

```
$ echo 'SELECT * from system.numbers limit 10 format JSON' | curl 'http://clickhouse-01:48123/?wait_end_of_query=1&query=' --data-binary @- -vvv 2>&1 | grep Summary
< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"0","written_bytes":"0","total_rows_to_read":"0","result_rows":"10","result_bytes":"112"}
```

For now it does not send it to the client since that is already able to calculate it easily with the blocks sent, but it could be done if we wanted to (depending on the revision).