### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ### Table of Contents
-**[ClickHouse release v22.7, 2022-07-21](#226)**<br>
-**[ClickHouse release v22.6, 2022-06-16](#226)**<br>
-**[ClickHouse release v22.5, 2022-05-19](#225)**<br>
-**[ClickHouse release v22.4, 2022-04-20](#224)**<br>
-**[ClickHouse release v22.3-lts, 2022-03-17](#223)**<br>
-**[ClickHouse release v22.2, 2022-02-17](#222)**<br>
-**[ClickHouse release v22.1, 2022-01-18](#221)**<br>
-**[Changelog for 2021](https://clickhouse.com/docs/en/whats-new/changelog/2021/)**<br>
+**[ClickHouse release v22.7, 2022-07-21](#227)**<br/>
+**[ClickHouse release v22.6, 2022-06-16](#226)**<br/>
+**[ClickHouse release v22.5, 2022-05-19](#225)**<br/>
+**[ClickHouse release v22.4, 2022-04-20](#224)**<br/>
+**[ClickHouse release v22.3-lts, 2022-03-17](#223)**<br/>
+**[ClickHouse release v22.2, 2022-02-17](#222)**<br/>
+**[ClickHouse release v22.1, 2022-01-18](#221)**<br/>
+**[Changelog for 2021](https://clickhouse.com/docs/en/whats-new/changelog/2021/)**<br/>
 
 ### <a id="227"></a> ClickHouse release 22.7, 2022-07-21
 


### PR DESCRIPTION
- fix the link to 22.7 log in table of contents
- To allow reuse of the changelog in the docs I need to change the `<br>` to `<br/>`.  With this change we can update the doc build process to
```
cp $PARENT_DIR/CHANGELOG.md $PARENT_DIR/clickhouse-docs/docs/en/whats-new/changelog/index.md
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)

