### PR TITLE
free compression and decompression contexts

### DIFF
--- a/utils/self-extracting-executable/compressor.cpp
+++ b/utils/self-extracting-executable/compressor.cpp
@@ -103,12 +103,14 @@ int compress(int in_fd, int out_fd, int level, off_t & pointer, const struct sta
     if (ZSTD_isError(check_result))
     {
         std::cerr << "Error (ZSTD): " << check_result << " " << ZSTD_getErrorName(check_result) << std::endl;
+        ZSTD_freeCCtx(cctx);
         return 1;
     }
     check_result = ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 1);
     if (ZSTD_isError(check_result))
     {
         std::cerr << "Error (ZSTD): " << check_result << " " << ZSTD_getErrorName(check_result) << std::endl;
+        ZSTD_freeCCtx(cctx);
         return 1;
     }
 
@@ -129,11 +131,13 @@ int compress(int in_fd, int out_fd, int level, off_t & pointer, const struct sta
     if (output == MAP_FAILED)
     {
         perror(nullptr);
+        ZSTD_freeCCtx(cctx);
         return 1;
     }
     if (-1 == lseek(out_fd, 0, SEEK_END))
     {
         perror(nullptr);
+        ZSTD_freeCCtx(cctx);
         return 1;
     }
 
@@ -154,6 +158,7 @@ int compress(int in_fd, int out_fd, int level, off_t & pointer, const struct sta
                 perror(nullptr);
             if (0 != munmap(output, 2 * max_block_size))
                 perror(nullptr);
+            ZSTD_freeCCtx(cctx);
             return 1;
         }
 
@@ -161,6 +166,7 @@ int compress(int in_fd, int out_fd, int level, off_t & pointer, const struct sta
         if (current_block_size != write_data(out_fd, output, current_block_size))
         {
             perror(nullptr);
+            ZSTD_freeCCtx(cctx);
             return 1;
         }
         pointer += current_block_size;
@@ -172,8 +178,11 @@ int compress(int in_fd, int out_fd, int level, off_t & pointer, const struct sta
         0 != munmap(output, 2 * max_block_size))
     {
         perror(nullptr);
+        ZSTD_freeCCtx(cctx);
         return 1;
     }
+
+    ZSTD_freeCCtx(cctx);
     return 0;
 }
 

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -151,6 +151,8 @@ int decompress(char * input, char * output, off_t start, off_t end, size_t max_n
         --number_of_forks;
     }
 
+    ZSTD_freeDCtx(dctx);
+
     /// If error happen end of processed part will not reach end
     if (in_pointer < end || error_happened)
         return 1;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes memory leaks in compressor and decompressor.
Closes #39572
