### PR TITLE
Fix wrong regexp replace

### DIFF
--- a/src/Functions/replaceAll.cpp
+++ b/src/Functions/replaceAll.cpp
@@ -21,7 +21,6 @@ void registerFunctionReplaceAll(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionReplaceAll>();
     factory.registerAlias("replace", NameReplaceAll::name, FunctionFactory::CaseInsensitive);
-    factory.registerAlias("REGEXP_REPLACE", NameReplaceAll::name, FunctionFactory::CaseInsensitive);
 }
 
 }

--- a/src/Functions/replaceRegexpAll.cpp
+++ b/src/Functions/replaceRegexpAll.cpp
@@ -20,6 +20,7 @@ using FunctionReplaceRegexpAll = FunctionStringReplace<ReplaceRegexpImpl<false>,
 void registerFunctionReplaceRegexpAll(FunctionFactory & factory)
 {
     factory.registerFunction<FunctionReplaceRegexpAll>();
+    factory.registerAlias("REGEXP_REPLACE", NameReplaceRegexpAll::name, FunctionFactory::CaseInsensitive);
 }
 
 }

--- a/tests/queries/0_stateless/02374_regexp_replace.reference
+++ b/tests/queries/0_stateless/02374_regexp_replace.reference
@@ -1,0 +1,1 @@
+https://www.clickhouse.com/	clickhouse.com

--- a/tests/queries/0_stateless/02374_regexp_replace.sql
+++ b/tests/queries/0_stateless/02374_regexp_replace.sql
@@ -1,0 +1,1 @@
+SELECT 'https://www.clickhouse.com/' AS s, REGEXP_REPLACE(s, '^https?://(?:www\.)?([^/]+)/.*$', '\1');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the wrong `REGEXP_REPLACE` alias. This fixes https://github.com/ClickHouse/ClickBench/issues/9