### PR TITLE
Disable 02327_capnproto_protobuf_empty_messages with Ordinary

### DIFF
--- a/tests/queries/0_stateless/02327_capnproto_protobuf_empty_messages.sh
+++ b/tests/queries/0_stateless/02327_capnproto_protobuf_empty_messages.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-parallel, no-replicated-database
+# Tags: no-fasttest, no-parallel, no-replicated-database, no-ordinary-database
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/8e98b7d47dbbcfe88c8d420b35794854e93a6361/stateless_tests__release__databaseordinary_.html
```
2022-07-26 22:32:36 02327_capnproto_protobuf_empty_messages:                                [ FAIL ] 0.00 sec. - Internal query (CREATE/DROP DATABASE) failed:
2022-07-26 22:32:36 HTTPError
2022-07-26 22:32:36 Code: 500. Code: 219. DB::Exception: Cannot drop: filesystem error: in remove: Directory not empty ["/var/lib/clickhouse/data/test_emsjtq/"]. Probably database contain some detached tables or metadata leftovers from Ordinary engine. If you want to remove all data anyway, try to attach database back and drop it again with enabled force_remove_data_recursively_on_drop setting. (DATABASE_NOT_EMPTY) (version 22.8.1.319 (official build))
2022-07-26 22:32:36 
2022-07-26 22:32:36   File "/usr/bin/clickhouse-test", line 1060, in run
2022-07-26 22:32:36     proc, stdout, stderr, debug_log, total_time = self.run_single_test(
2022-07-26 22:32:36 
2022-07-26 22:32:36   File "/usr/bin/clickhouse-test", line 991, in run_single_test
2022-07-26 22:32:36     clickhouse_execute(
2022-07-26 22:32:36 
2022-07-26 22:32:36   File "/usr/bin/clickhouse-test", line 129, in clickhouse_execute
2022-07-26 22:32:36     return clickhouse_execute_http(base_args, query, timeout, settings).strip()
2022-07-26 22:32:36 
2022-07-26 22:32:36   File "/usr/bin/clickhouse-test", line 123, in clickhouse_execute_http
2022-07-26 22:32:36     raise HTTPError(data.decode(), res.status)
2022-07-26 22:32:36 
2022-07-26 22:32:36 Settings used in the test: --max_insert_threads=14 --group_by_two_level_threshold=100000 --group_by_two_level_threshold_bytes=1 --distributed_aggregation_memory_efficient=0 --fsync_metadata=0 --output_format_parallel_formatting=1 --input_format_parallel_parsing=1 --min_chunk_bytes_for_parallel_parsing=13615657 --max_read_buffer_size=624180 --prefer_localhost_replica=0 --max_block_size=28839 --max_threads=7 --optimize_or_like_chain=1 --optimize_read_in_order=0 --read_in_order_two_level_merge_threshold=36 --optimize_aggregation_in_order=0 --aggregation_in_order_max_block_bytes=36521118 --use_uncompressed_cache=0 --min_bytes_to_use_direct_io=0 --min_bytes_to_use_mmap_io=750657254 --local_filesystem_read_method=pread --remote_filesystem_read_method=read --local_filesystem_read_prefetch=1 --remote_filesystem_read_prefetch=1 --compile_expressions=1 --compile_aggregate_expressions=0 --compile_sort_description=1 --merge_tree_coarse_index_granularity=29
2022-07-26 22:32:36 
2022-07-26 22:32:36 Database: test_emsjtq
```