### PR TITLE
Check flaky 00968_live_view_select_format_jsoneachrowwithprogress

### DIFF
--- a/tests/queries/0_stateless/00968_live_view_select_format_jsoneachrowwithprogress.sql
+++ b/tests/queries/0_stateless/00968_live_view_select_format_jsoneachrowwithprogress.sql
@@ -8,7 +8,7 @@ DROP TABLE IF EXISTS mt;
 CREATE TABLE mt (a Int32) Engine=MergeTree order by tuple();
 CREATE LIVE VIEW lv AS SELECT * FROM mt;
 
-INSERT INTO mt VALUES (1),(2),(3);
+INSERT INTO mt VALUES (1), (2), (3);
 
 SELECT * FROM lv FORMAT JSONEachRowWithProgress;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

For some reason `00968_live_view_select_format_jsoneachrowwithprogress` failed flaky check in https://github.com/ClickHouse/ClickHouse/pull/39567 , not reproduced locally and doesn't seem related to changes

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
