### PR TITLE
Fix strings in dictionary in Arrow format

### DIFF
--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -47,7 +47,8 @@
         M(INT64, arrow::Int64Type) \
         M(FLOAT, arrow::FloatType) \
         M(DOUBLE, arrow::DoubleType) \
-        M(BINARY, arrow::BinaryType)
+        M(BINARY, arrow::BinaryType) \
+        M(STRING, arrow::StringType)
 
 namespace DB
 {

--- a/tests/queries/0_stateless/02376_arrow_dict_with_string.reference
+++ b/tests/queries/0_stateless/02376_arrow_dict_with_string.reference
@@ -1,0 +1,11 @@
+x	LowCardinality(Nullable(String))					
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9

--- a/tests/queries/0_stateless/02376_arrow_dict_with_string.sql
+++ b/tests/queries/0_stateless/02376_arrow_dict_with_string.sql
@@ -1,0 +1,4 @@
+-- Tags: no-parallel
+insert into function file(02376_data.arrow) select toLowCardinality(toString(number)) as x from numbers(10) settings output_format_arrow_string_as_string=1, output_format_arrow_low_cardinality_as_dictionary=1, engine_file_truncate_on_insert=1;
+desc file (02376_data.arrow);
+select * from file(02376_data.arrow);

--- a/tests/queries/0_stateless/02376_arrow_dict_with_string.sql
+++ b/tests/queries/0_stateless/02376_arrow_dict_with_string.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-fasttest
 insert into function file(02376_data.arrow) select toLowCardinality(toString(number)) as x from numbers(10) settings output_format_arrow_string_as_string=1, output_format_arrow_low_cardinality_as_dictionary=1, engine_file_truncate_on_insert=1;
 desc file (02376_data.arrow);
 select * from file(02376_data.arrow);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix settings `output_format_arrow_string_as_string` and `output_format_arrow_low_cardinality_as_dictionary` work in combination. Closes https://github.com/ClickHouse/ClickHouse/issues/39624


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
