### PR TITLE
Fix Endian issue in BitHelpers for s390x

### DIFF
--- a/src/IO/BitHelpers.h
+++ b/src/IO/BitHelpers.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bit>
 #include <base/types.h>
 #include <Common/BitHelpers.h>
 #include <Common/Exception.h>
@@ -140,7 +141,8 @@ private:
         memcpy(&tmp_buffer, source_current, bytes_to_read);
         source_current += bytes_to_read;
 
-        tmp_buffer = __builtin_bswap64(tmp_buffer);
+        if constexpr (std::endian::native == std::endian::little)
+            tmp_buffer = __builtin_bswap64(tmp_buffer);
 
         bits_buffer |= BufferType(tmp_buffer) << ((sizeof(BufferType) - sizeof(tmp_buffer)) * 8 - bits_count);
         bits_count += static_cast<UInt8>(bytes_to_read) * 8;
@@ -223,8 +225,11 @@ private:
                 "Can not write past end of buffer. Space available {} bytes, required to write {} bytes.",
                 available, to_write);
         }
-
-        const auto tmp_buffer = __builtin_bswap64(static_cast<UInt64>(bits_buffer >> (sizeof(bits_buffer) - sizeof(UInt64)) * 8));
+        UInt64 tmp_buffer = 0;
+        if constexpr (std::endian::native == std::endian::little)
+            tmp_buffer = __builtin_bswap64(static_cast<UInt64>(bits_buffer >> (sizeof(bits_buffer) - sizeof(UInt64)) * 8));
+        else
+            tmp_buffer = static_cast<UInt64>(bits_buffer >> (sizeof(bits_buffer) - sizeof(UInt64)) * 8);
         memcpy(dest_current, &tmp_buffer, to_write);
         dest_current += to_write;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
There is an endian issue in IO/BitHepers.h which causes unit test failure in IO/tests/gtest_bit_io.cpp:

`[  FAILED  ] Simple/BitIO.WriteAndRead/0, where GetParam() = 48-byte object <00-00 00-00 1C-B3 D3-80 00-00 00-00 1C-B3 D3-D0 00-00 00-00 1C-B3 D3-D0 00-00 00-00 1C-FB 79-F0 00-00 00-00 00-00 00-36 00-00 00-00 00-00 00-41> (0 ms)
`

The reason is that in IO/BitHelpers.cpp, there is code for converting the byte order of bits buffer, which is only necessary for Little-Endian machine.

The fix disables the byte order conversion for Big-Endian machine.

### Changelog category (leave one):
- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed Endian issue in BitHelpers for s390x.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
