### PR TITLE
[RFC] Disable watchdog under init/systemd (watchdog by itself)

### DIFF
--- a/packages/clickhouse-server.init
+++ b/packages/clickhouse-server.init
@@ -44,6 +44,9 @@ CLICKHOUSE_PIDDIR=/var/run/$PROGRAM
 CLICKHOUSE_PIDFILE="$CLICKHOUSE_PIDDIR/$PROGRAM.pid"
 # CLICKHOUSE_STOP_TIMEOUT=60 # Disabled by default. Place to /etc/default/clickhouse if you need.
 
+# init is watchdog by itself
+CLICKHOUSE_WATCHDOG_ENABLE=0
+
 # Some systems lack "flock"
 command -v flock >/dev/null && FLOCK=flock
 

--- a/packages/clickhouse-server.service
+++ b/packages/clickhouse-server.service
@@ -18,6 +18,8 @@ RuntimeDirectory=clickhouse-server
 ExecStart=/usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml --pid-file=/run/clickhouse-server/clickhouse-server.pid
 # Minus means that this file is optional.
 EnvironmentFile=-/etc/default/clickhouse
+# systemd is watchdog by itself
+Environment=CLICKHOUSE_WATCHDOG_ENABLE=0
 LimitCORE=infinity
 LimitNOFILE=500000
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_IPC_LOCK CAP_SYS_NICE CAP_NET_BIND_SERVICE


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Disable watchdog under init/systemd (watchdog by itself)

There is no need in using watchdog under init (sys-v-init/systemd), and
in case of later and Type=simple (which is used by ClickHouse systemd
service), while it should be Type=fork (i.e. for correctly detect
MainPID, detecting deactivating and so on).

Cc: @alexey-milovidov 
Refs: #13516