### PR TITLE
DO NOT REVIEW - Investigate why Split and Tidy builds omit utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,8 @@ include_directories(${ConfigIncludePath})
 include (cmake/warnings.cmake)
 include (cmake/print_flags.cmake)
 
+message (WARNING "DEBUG 0 ${ENABLE_UTILS}")
+
 add_subdirectory (base)
 add_subdirectory (src)
 add_subdirectory (programs)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -17,6 +17,8 @@ endif ()
 add_subdirectory (config-processor)
 add_subdirectory (report)
 
+message (WARNING "DEBUG 1 ${ENABLE_UTILS}")
+
 # Not used in package
 if (NOT DEFINED ENABLE_UTILS OR ENABLE_UTILS)
     add_subdirectory (compressor)

--- a/utils/keeper-data-dumper/CMakeLists.txt
+++ b/utils/keeper-data-dumper/CMakeLists.txt
@@ -1,2 +1,3 @@
+message (WARNING "DEBUG 3 ${ENABLE_UTILS}")
 clickhouse_add_executable(keeper-data-dumper main.cpp)
 target_link_libraries(keeper-data-dumper PRIVATE dbms)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)