### PR TITLE
Avoid recursive destruction of AST.

### DIFF
--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <set>
+#include <list>
 
 
 class SipHash;
@@ -34,7 +35,7 @@ class IAST : public std::enable_shared_from_this<IAST>, public TypePromotion<IAS
 public:
     ASTs children;
 
-    virtual ~IAST() = default;
+    virtual ~IAST();
     IAST() = default;
     IAST(const IAST &) = default;
     IAST & operator=(const IAST &) = default;
@@ -273,6 +274,9 @@ public:
 
 private:
     size_t checkDepthImpl(size_t max_depth, size_t level) const;
+
+    /// This deleter is used in ~IAST to avoid possible stack overflow in destructor.
+    std::list<ASTs> * deleter = nullptr;
 };
 
 template <typename AstArray>

--- a/src/Parsers/tests/gtest_ast_deleter.cpp
+++ b/src/Parsers/tests/gtest_ast_deleter.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+#include <Parsers/IAST.h>
+#include <Common/StackTrace.h>
+
+namespace DB::ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+struct StackDecrementer
+{
+    size_t & depth;
+
+    explicit StackDecrementer(size_t & depth_) : depth(depth_) {}
+
+    virtual ~StackDecrementer()
+    {
+        --depth;
+    }
+};
+
+struct ASTCounting : public StackDecrementer, public DB::IAST
+{
+    explicit ASTCounting(size_t & depth_) : StackDecrementer(depth_) {}
+
+    String getID(char) const override { return ""; }
+    DB::ASTPtr clone() const override { return nullptr; }
+};
+
+class ASTWithMembers : public ASTCounting
+{
+public:
+    explicit ASTWithMembers(DB::ASTs members_, size_t & depth_) : ASTCounting(depth_), members(std::move(members_))
+    {
+        children = members;
+    }
+
+    DB::ASTs members;
+};
+
+class ASTWithDecrementer : public ASTWithMembers
+{
+public:
+    ASTWithDecrementer(DB::ASTs members_, size_t & depth_, size_t max_depth_)
+        : ASTWithMembers(std::move(members_), depth_), max_depth(max_depth_)
+    {
+    }
+
+    size_t max_depth;
+
+    ~ASTWithDecrementer() override
+    {
+        ++depth;
+        if (depth == max_depth)
+            std::cout << StackTrace().toString() << std::endl;
+        if (depth > max_depth)
+            EXPECT_LE(depth, max_depth);
+    }
+};
+
+
+TEST(ASTDeleter, SimpleChain)
+{
+    size_t depth = 0;
+    size_t max_depth = 5;
+    size_t chain_lenght = 10;
+
+    {
+        DB::ASTPtr ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
+
+        for (size_t i = 0; i < chain_lenght; ++i)
+            ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast)}, depth, max_depth);
+    }
+}
+
+TEST(ASTDeleter, SimpleChainLong)
+{
+    size_t depth = 0;
+    size_t max_depth = 5;
+    size_t chain_lenght = 100000;
+
+    {
+        DB::ASTPtr ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
+
+        for (size_t i = 0; i < chain_lenght; ++i)
+            ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast)}, depth, max_depth);
+    }
+}
+
+TEST(ASTDeleter, ChainWithExtraMember)
+{
+    size_t depth = 0;
+    size_t max_depth = 5;
+    size_t member_depth = 10;
+    size_t chain_lenght = 100;
+
+    {
+        DB::ASTPtr ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
+
+        for (size_t i = 0; i < chain_lenght; ++i)
+        {
+            ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast)}, depth, max_depth);
+            if (i > member_depth)
+            {
+                DB::ASTPtr member = ast;
+                for (size_t j = 0; j < member_depth; ++j)
+                    member = member->children.front();
+                ast->as<ASTWithDecrementer>()->members.push_back(std::move(member));
+            }
+        }
+    }
+}
+
+TEST(ASTDeleter, DoubleChain)
+{
+    size_t depth = 0;
+    size_t max_depth = 5;
+    size_t chain_lenght = 10;
+
+    {
+        DB::ASTPtr ast1 = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
+        DB::ASTPtr ast2 = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
+
+        for (size_t i = 0; i < chain_lenght; ++i)
+        {
+            ast1 = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast1)}, depth, max_depth);
+            ast2 = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast2)}, depth, max_depth);
+            ast1->as<ASTWithDecrementer>()->members.push_back(ast2->children.front());
+            ast2->as<ASTWithDecrementer>()->members.push_back(ast1->children.front());
+        }
+    }
+}
+
+TEST(ASTDeleter, DoubleChainLong)
+{
+    size_t depth = 0;
+    size_t max_depth = 5;
+    size_t chain_lenght = 100000;
+
+    {
+        DB::ASTPtr ast1 = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
+        DB::ASTPtr ast2 = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
+
+        for (size_t i = 0; i < chain_lenght; ++i)
+        {
+            ast1 = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast1)}, depth, max_depth);
+            ast2 = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast2)}, depth, max_depth);
+            ast1->as<ASTWithDecrementer>()->members.push_back(ast2->children.front());
+            ast2->as<ASTWithDecrementer>()->members.push_back(ast1->children.front());
+        }
+    }
+}

--- a/src/Parsers/tests/gtest_ast_deleter.cpp
+++ b/src/Parsers/tests/gtest_ast_deleter.cpp
@@ -2,11 +2,6 @@
 #include <Parsers/IAST.h>
 #include <Common/StackTrace.h>
 
-namespace DB::ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
-
 struct StackDecrementer
 {
     size_t & depth;

--- a/src/Parsers/tests/gtest_ast_deleter.cpp
+++ b/src/Parsers/tests/gtest_ast_deleter.cpp
@@ -58,12 +58,12 @@ TEST(ASTDeleter, SimpleChain)
 {
     size_t depth = 0;
     size_t max_depth = 5;
-    size_t chain_lenght = 10;
+    size_t chain_length = 10;
 
     {
         DB::ASTPtr ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
 
-        for (size_t i = 0; i < chain_lenght; ++i)
+        for (size_t i = 0; i < chain_length; ++i)
             ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast)}, depth, max_depth);
     }
 }
@@ -72,12 +72,12 @@ TEST(ASTDeleter, SimpleChainLong)
 {
     size_t depth = 0;
     size_t max_depth = 5;
-    size_t chain_lenght = 100000;
+    size_t chain_length = 100000;
 
     {
         DB::ASTPtr ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
 
-        for (size_t i = 0; i < chain_lenght; ++i)
+        for (size_t i = 0; i < chain_length; ++i)
             ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast)}, depth, max_depth);
     }
 }
@@ -87,12 +87,12 @@ TEST(ASTDeleter, ChainWithExtraMember)
     size_t depth = 0;
     size_t max_depth = 5;
     size_t member_depth = 10;
-    size_t chain_lenght = 100;
+    size_t chain_length = 100;
 
     {
         DB::ASTPtr ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
 
-        for (size_t i = 0; i < chain_lenght; ++i)
+        for (size_t i = 0; i < chain_length; ++i)
         {
             ast = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast)}, depth, max_depth);
             if (i > member_depth)
@@ -110,13 +110,13 @@ TEST(ASTDeleter, DoubleChain)
 {
     size_t depth = 0;
     size_t max_depth = 5;
-    size_t chain_lenght = 10;
+    size_t chain_length = 10;
 
     {
         DB::ASTPtr ast1 = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
         DB::ASTPtr ast2 = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
 
-        for (size_t i = 0; i < chain_lenght; ++i)
+        for (size_t i = 0; i < chain_length; ++i)
         {
             ast1 = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast1)}, depth, max_depth);
             ast2 = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast2)}, depth, max_depth);
@@ -130,13 +130,13 @@ TEST(ASTDeleter, DoubleChainLong)
 {
     size_t depth = 0;
     size_t max_depth = 5;
-    size_t chain_lenght = 100000;
+    size_t chain_length = 100000;
 
     {
         DB::ASTPtr ast1 = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
         DB::ASTPtr ast2 = std::make_shared<ASTWithDecrementer>(DB::ASTs{}, depth, max_depth);
 
-        for (size_t i = 0; i < chain_lenght; ++i)
+        for (size_t i = 0; i < chain_length; ++i)
         {
             ast1 = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast1)}, depth, max_depth);
             ast2 = std::make_shared<ASTWithDecrementer>(DB::ASTs{std::move(ast2)}, depth, max_depth);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

