### PR TITLE
Escape credentials for diagnostics tool

### DIFF
--- a/programs/diagnostics/internal/platform/database/native.go
+++ b/programs/diagnostics/internal/platform/database/native.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/ClickHouse/ClickHouse/programs/diagnostics/internal/platform/data"
@@ -17,7 +18,7 @@ type ClickhouseNativeClient struct {
 
 func NewNativeClient(host string, port uint16, username string, password string) (*ClickhouseNativeClient, error) {
 	// debug output ?debug=true
-	connection, err := sql.Open("clickhouse", fmt.Sprintf("clickhouse://%s:%s@%s:%d/", username, password, host, port))
+	connection, err := sql.Open("clickhouse", fmt.Sprintf("clickhouse://%s:%s@%s:%d/", url.QueryEscape(username), url.QueryEscape(password), host, port))
 	if err != nil {
 		return &ClickhouseNativeClient{}, err
 	}


### PR DESCRIPTION
Diagnostics tool doesn't escape usernames and passwords - causes issues with passwords like `#wLeRzc@sMVdg9cK`