### PR TITLE
Fix cherry-pick for cases, when assignee is not set for PR

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -206,7 +206,8 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
         )
         self.cherrypick_pr.add_to_labels(Labels.LABEL_CHERRYPICK)
         self.cherrypick_pr.add_to_labels(Labels.LABEL_DO_NOT_TEST)
-        self.cherrypick_pr.add_to_assignees(self.pr.assignee)
+        if self.pr.assignee is not None:
+            self.cherrypick_pr.add_to_assignees(self.pr.assignee)
         self.cherrypick_pr.add_to_assignees(self.pr.user)
 
     def create_backport(self):
@@ -238,7 +239,8 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
             head=self.backport_branch,
         )
         self.backport_pr.add_to_labels(Labels.LABEL_BACKPORT)
-        self.backport_pr.add_to_assignees(self.pr.assignee)
+        if self.pr.assignee is not None:
+            self.cherrypick_pr.add_to_assignees(self.pr.assignee)
         self.backport_pr.add_to_assignees(self.pr.user)
 
     @property


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix some edge cases, when there is no assignee for the original PR. 

See broken https://github.com/ClickHouse/ClickHouse/runs/7583010376?check_suite_focus=true#step:5:35 and fixed https://github.com/ClickHouse/ClickHouse/runs/7583346625