### PR TITLE
Fix redirecting of logs to stdout in clickhouse-client

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -583,9 +583,14 @@ try
         if (has_vertical_output_suffix)
             current_format = "Vertical";
 
-        /// It is not clear how to write progress intermixed with data with parallel formatting.
+        bool logs_into_stdout = server_logs_file == "-";
+        bool extras_into_stdout = need_render_progress || logs_into_stdout;
+        bool select_only_into_file = select_into_file && !select_into_file_and_stdout;
+
+        /// It is not clear how to write progress and logs
+        /// intermixed with data with parallel formatting.
         /// It may increase code complexity significantly.
-        if (!need_render_progress || (select_into_file && !select_into_file_and_stdout))
+        if (!extras_into_stdout || select_only_into_file)
             output_format = global_context->getOutputFormatParallelIfPossible(
                 current_format, out_file_buf ? *out_file_buf : *out_buf, block);
         else

--- a/tests/queries/0_stateless/02360_send_logs_level_colors.reference
+++ b/tests/queries/0_stateless/02360_send_logs_level_colors.reference
@@ -1,2 +1,3 @@
 ASCII text
 ASCII text
+ASCII text

--- a/tests/queries/0_stateless/02360_send_logs_level_colors.sh
+++ b/tests/queries/0_stateless/02360_send_logs_level_colors.sh
@@ -26,8 +26,6 @@ EOF
 
 run "$CLICKHOUSE_CLIENT -q 'SELECT 1' 2>$file_name"
 run "$CLICKHOUSE_CLIENT -q 'SELECT 1' --server_logs_file=$file_name"
-
-# This query may fail due to bug in clickhouse-client.
-# run "$CLICKHOUSE_CLIENT -q 'SELECT 1' --server_logs_file=- >$file_name"
+run "$CLICKHOUSE_CLIENT -q 'SELECT 1' --server_logs_file=- >$file_name"
 
 rm -f "$file_name"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes #39719.
