### PR TITLE
Fix Endian issue in SipHash for s390x

### DIFF
--- a/base/base/unaligned.h
+++ b/base/base/unaligned.h
@@ -10,13 +10,13 @@ inline void reverseMemcpy(void * dst, const void * src, size_t size)
     uint8_t * uint_dst = reinterpret_cast<uint8_t *>(dst);
     const uint8_t * uint_src = reinterpret_cast<const uint8_t *>(src);
 
-    uint_dst += length;
+    uint_dst += size;
     while (length)
     {
         --uint_dst;
         *uint_dst = *uint_src;
         ++uint_src;
-        --length;
+        --size;
     }
 }
 

--- a/base/base/unaligned.h
+++ b/base/base/unaligned.h
@@ -11,7 +11,7 @@ inline void reverseMemcpy(void * dst, const void * src, size_t size)
     const uint8_t * uint_src = reinterpret_cast<const uint8_t *>(src);
 
     uint_dst += size;
-    while (length)
+    while (size)
     {
         --uint_dst;
         *uint_dst = *uint_src;

--- a/base/base/unaligned.h
+++ b/base/base/unaligned.h
@@ -2,7 +2,39 @@
 
 #include <cstring>
 #include <type_traits>
+#include <bit>
 
+inline void reverseMemcpy(void *dst, const void *src, int length)
+{
+    uint8_t *d = reinterpret_cast<uint8_t*>(dst);
+    const uint8_t *s = reinterpret_cast<const uint8_t*>(src);
+
+    d += length;
+    while (length--)
+        *--d = *s++;
+}
+
+template <typename T>
+inline T unalignedLoadLE(const void * address)
+{
+    T res {};
+    if constexpr (std::endian::native == std::endian::little)
+        memcpy(&res, address, sizeof(res));
+    else
+        reverseMemcpy(&res, address, sizeof(res));
+    return res;
+}
+
+template <typename T>
+inline void unalignedStoreLE(void * address,
+                           const typename std::enable_if<true, T>::type & src)
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+    if constexpr (std::endian::native == std::endian::little)
+        memcpy(address, &src, sizeof(src));
+    else
+        reverseMemcpy(address, &src, sizeof(src));
+}
 
 template <typename T>
 inline T unalignedLoad(const void * address)

--- a/base/base/unaligned.h
+++ b/base/base/unaligned.h
@@ -4,14 +4,20 @@
 #include <type_traits>
 #include <bit>
 
-inline void reverseMemcpy(void *dst, const void *src, int length)
-{
-    uint8_t *d = reinterpret_cast<uint8_t*>(dst);
-    const uint8_t *s = reinterpret_cast<const uint8_t*>(src);
 
-    d += length;
-    while (length--)
-        *--d = *s++;
+inline void reverseMemcpy(void * dst, const void * src, size_t size)
+{
+    uint8_t * uint_dst = reinterpret_cast<uint8_t *>(dst);
+    const uint8_t * uint_src = reinterpret_cast<const uint8_t *>(src);
+
+    uint_dst += length;
+    while (length)
+    {
+        --uint_dst;
+        *uint_dst = *uint_src;
+        ++uint_src;
+        --length;
+    }
 }
 
 template <typename T>
@@ -24,6 +30,7 @@ inline T unalignedLoadLE(const void * address)
         reverseMemcpy(&res, address, sizeof(res));
     return res;
 }
+
 
 template <typename T>
 inline void unalignedStoreLE(void * address,

--- a/src/Common/SipHash.h
+++ b/src/Common/SipHash.h
@@ -111,7 +111,7 @@ public:
 
         while (data + 8 <= end)
         {
-            current_word = unalignedLoad<UInt64>(data);
+            current_word = unalignedLoadLE<UInt64>(data);
 
             v3 ^= current_word;
             SIPROUND;
@@ -157,8 +157,8 @@ public:
     void get128(char * out)
     {
         finalize();
-        unalignedStore<UInt64>(out, v0 ^ v1);
-        unalignedStore<UInt64>(out + 8, v2 ^ v3);
+        unalignedStoreLE<UInt64>(out, v0 ^ v1);
+        unalignedStoreLE<UInt64>(out + 8, v2 ^ v3);
     }
 
     template <typename T>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
There is an Endian issue in SipHash algorithm which uses Endian dependent code, and this caused SipHash failure in Big-Endian machine like s390x. For example, the following unit test failure is caused by the issue:

`[  FAILED  ] HadoopSnappyDecoder.repeatNeedMoreInput (1 ms)`

The fix is to add unaligned Load/Store function for Little Endian which works on both Endian machines and use them in SipHash algorithm. 



### Changelog category (leave one):
- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implement a piece of code related to SipHash for s390x architecture (which is not supported by ClickHouse).


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
