### PR TITLE
Enable SQL function getOSKernelVersion() on all platforms

### DIFF
--- a/src/Functions/serverConstants.cpp
+++ b/src/Functions/serverConstants.cpp
@@ -8,9 +8,7 @@
 #include <Common/DateLUT.h>
 #include <Common/ClickHouseRevision.h>
 
-#if defined(OS_LINUX)
-#    include <Poco/Environment.h>
-#endif
+#include <Poco/Environment.h>
 
 #include <Common/config_version.h>
 

--- a/src/Functions/serverConstants.cpp
+++ b/src/Functions/serverConstants.cpp
@@ -109,7 +109,6 @@ namespace
         static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionZooKeeperSessionUptime>(context); }
     };
 
-#if defined(OS_LINUX)
     class FunctionGetOSKernelVersion : public FunctionConstantBase<FunctionGetOSKernelVersion, String, DataTypeString>
     {
     public:
@@ -117,7 +116,6 @@ namespace
         explicit FunctionGetOSKernelVersion(ContextPtr context) : FunctionConstantBase(Poco::Environment::osName() + " " + Poco::Environment::osVersion(), context->isDistributed()) {}
         static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionGetOSKernelVersion>(context); }
     };
-#endif
 
 }
 
@@ -171,12 +169,10 @@ REGISTER_FUNCTION(ZooKeeperSessionUptime)
 }
 
 
-#if defined(OS_LINUX)
 REGISTER_FUNCTION(GetOSKernelVersion)
 {
     factory.registerFunction<FunctionGetOSKernelVersion>();
 }
-#endif
 
 
 }


### PR DESCRIPTION
Follow up to PR #38615

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)