### PR TITLE
Self-extracting - run resulting executable with execvp

### DIFF
--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -357,19 +357,7 @@ int main(int/* argc*/, char* argv[])
     }
     else
     {
-        const char * const delete_name_fmt = "%s.delete.XXXXXX";
-        int delete_name_len = snprintf(nullptr, 0, delete_name_fmt, argv[0]);
-        char delete_name[delete_name_len + 1];
-        delete_name_len = snprintf(delete_name, delete_name_len + 1, delete_name_fmt, argv[0]);
-        int fd = mkstemp(delete_name);
-        if (fd == -1)
-        {
-            perror(nullptr);
-            return 1;
-        }
-        close(fd);
-
-        if (rename(argv[0], delete_name))
+        if (unlink(argv[0]))
         {
             perror(nullptr);
             return 1;
@@ -394,7 +382,7 @@ int main(int/* argc*/, char* argv[])
             return 1;
         }
 
-        if (unlink(delete_name) || unlink(decompressed_name))
+        if (unlink(decompressed_name))
         {
             perror(nullptr);
             return 1;

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -360,7 +360,7 @@ int main(int/* argc*/, char* argv[])
         const char * const decompressed_name_fmt = "%s.decompressed.%s";
         int decompressed_name_len = snprintf(nullptr, 0, decompressed_name_fmt, argv[0], decompressed_suffix);
         char decompressed_name[decompressed_name_len + 1];
-        decompressed_name_len = snprintf(decompressed_name, decompressed_name_len + 1, decompressed_name_fmt, argv[0], decompressed_suffix);
+        (void)snprintf(decompressed_name, decompressed_name_len + 1, decompressed_name_fmt, argv[0], decompressed_suffix);
 
         std::error_code ec;
         std::filesystem::copy_file(static_cast<char *>(decompressed_name), argv[0], ec);

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -242,7 +242,7 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
         {
             strcat(file_name, ".decompressed.XXXXXX");
             int fd = mkstemp(file_name);
-            if(fd == -1)
+            if (fd == -1)
             {
                 perror(nullptr);
                 return 1;
@@ -362,14 +362,14 @@ int main(int/* argc*/, char* argv[])
         char delete_name[delete_name_len + 1];
         delete_name_len = snprintf(delete_name, delete_name_len + 1, delete_name_fmt, argv[0]);
         int fd = mkstemp(delete_name);
-        if(fd == -1)
+        if (fd == -1)
         {
             perror(nullptr);
             return 1;
         }
         close(fd);
 
-        if(rename(argv[0], delete_name))
+        if (rename(argv[0], delete_name))
         {
             perror(nullptr);
             return 1;
@@ -387,7 +387,7 @@ int main(int/* argc*/, char* argv[])
             std::cerr << ec.message() << std::endl;
             return 1;
         }
-        
+
         if (chmod(argv[0], decompressed_umask))
         {
             perror(nullptr);

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -28,9 +28,6 @@
 
 #include "types.h"
 
-char decompressed_suffix[7] = {0};
-uint64_t decompressed_umask = 0;
-
 /// decompress part
 int doDecompress(char * input, char * output, off_t & in_offset, off_t & out_offset,
                off_t input_size, off_t output_size, ZSTD_DCtx* dctx)
@@ -166,7 +163,7 @@ int decompress(char * input, char * output, off_t start, off_t end, size_t max_n
 
 
 /// Read data about files and decomrpess them.
-int decompressFiles(int input_fd, char * path, char * name, bool & have_compressed_analoge)
+int decompressFiles(int input_fd, char * path, char * name, bool & have_compressed_analoge, char * decompressed_suffix, uint64_t * decompressed_umask)
 {
     /// Read data about output file.
     /// Compressed data will replace data in file
@@ -249,7 +246,7 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
             }
             close(fd);
             strncpy(decompressed_suffix, file_name + strlen(file_name) - 6, 6);
-            decompressed_umask = le64toh(file_info.umask);
+            *decompressed_umask = le64toh(file_info.umask);
             have_compressed_analoge = true;
         }
 
@@ -334,9 +331,11 @@ int main(int/* argc*/, char* argv[])
     }
 
     bool have_compressed_analoge = false;
+    char decompressed_suffix[7] = {0};
+    uint64_t decompressed_umask = 0;
 
     /// Decompress all files
-    if (0 != decompressFiles(input_fd, path, name, have_compressed_analoge))
+    if (0 != decompressFiles(input_fd, path, name, have_compressed_analoge, decompressed_suffix, &decompressed_umask))
     {
         printf("Error happened during decompression.\n");
         if (0 != close(input_fd))

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -385,7 +385,7 @@ int main(int/* argc*/, char* argv[])
         const char * const cmd_fmt = "mv %s %s.delete && cp %s.decompressed %s && rm %s.delete %s.decompressed";
         int cmd_len = snprintf(nullptr, 0, cmd_fmt, argv[0], argv[0], argv[0], argv[0], argv[0], argv[0]);
         char command[cmd_len + 1];
-        snprintf(command, cmd_len + 1, cmd_fmt, argv[0], argv[0], argv[0], argv[0], argv[0], argv[0]);
+        cmd_len = snprintf(command, cmd_len + 1, cmd_fmt, argv[0], argv[0], argv[0], argv[0], argv[0], argv[0]);
         if (do_system(command))
             return 1;
 

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -303,7 +303,7 @@ int do_system(const char * cmd)
 
     if (pid == 0)
     {
-        execlp( "sh" , "sh", "-c", cmd, NULL);
+        execlp("sh" , "sh", "-c", cmd, NULL);
 
         perror(nullptr);
         exit(127);
@@ -313,7 +313,7 @@ int do_system(const char * cmd)
     int status = 0;
     while ((ret = waitpid(pid, &status, 0)) == -1)
     {
-        if ( errno != EINTR)
+        if (errno != EINTR)
         {
             perror(nullptr);
             return 1;

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -347,22 +347,16 @@ int main(int/* argc*/, char* argv[])
     if (0 != close(input_fd))
         perror(nullptr);
 
-    if (!have_compressed_analoge)
+    if (unlink(argv[0]))
     {
-        printf("No target executable - decompression only was performed.\n");
-        /// remove file
-        execlp("rm", "rm", argv[0], NULL);
         perror(nullptr);
         return 1;
     }
+
+    if (!have_compressed_analoge)
+        printf("No target executable - decompression only was performed.\n");
     else
     {
-        if (unlink(argv[0]))
-        {
-            perror(nullptr);
-            return 1;
-        }
-
         const char * const decompressed_name_fmt = "%s.decompressed.%s";
         int decompressed_name_len = snprintf(nullptr, 0, decompressed_name_fmt, argv[0], decompressed_suffix);
         char decompressed_name[decompressed_name_len + 1];


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Running extracted executable with "sh -c" complicates forwarding parameters - using execvp makes it seamless.
Ref. discussion:
https://github.com/ClickHouse/ClickHouse/pull/35775/files#r933707748
Also should eliminate some artifacts found in #39617
Required by #39617
