### PR TITLE
Add cloudflare DNS as a fallback

### DIFF
--- a/tests/ci/worker/dockerhub_proxy_template.sh
+++ b/tests/ci/worker/dockerhub_proxy_template.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+# Add cloudflare DNS as a fallback
+# Get default gateway interface
+IFACE=$(ip --json route list | jq '.[]|select(.dst == "default").dev' --raw-output)
+# `Link 2 (eth0): 172.31.0.2`
+ETH_DNS=$(resolvectl dns "$IFACE") || :
+CLOUDFLARE_NS=1.1.1.1
+if [[ "$ETH_DNS" ]] && [[ "${ETH_DNS#*: }" != *"$CLOUDFLARE_NS"* ]]; then
+  # Cut the leading legend
+  ETH_DNS=${ETH_DNS#*: }
+  # shellcheck disable=SC2206
+  new_dns=(${ETH_DNS} "$CLOUDFLARE_NS")
+  resolvectl dns "$IFACE" "${new_dns[@]}"
+fi
+
 mkdir /home/ubuntu/registrystorage
 
 sed -i 's/preserve_hostname: false/preserve_hostname: true/g' /etc/cloud/cloud.cfg

--- a/tests/ci/worker/init_runner.sh
+++ b/tests/ci/worker/init_runner.sh
@@ -17,6 +17,20 @@ export RUNNER_URL="https://github.com/ClickHouse"
 INSTANCE_ID=$(ec2metadata --instance-id)
 export INSTANCE_ID
 
+# Add cloudflare DNS as a fallback
+# Get default gateway interface
+IFACE=$(ip -j route l | jq '.[]|select(.dst == "default").dev' -r)
+# `Link 2 (eth0): 172.31.0.2`
+ETH_DNS=$(resolvectl dns "$IFACE") || :
+CLOUDFRONT_NS=1.1.1.1
+if [[ "$ETH_DNS" ]] && [[ "${ETH_DNS#*: }" != *"$CLOUDFRONT_NS"* ]]; then
+  # Cut the leading legend
+  ETH_DNS=${ETH_DNS#*: }
+  # shellcheck disable=SC2206
+  new_dns=(${ETH_DNS} "$CLOUDFRONT_NS")
+  resolvectl dns "$IFACE" "${new_dns[@]}"
+fi
+
 # combine labels
 RUNNER_TYPE=$(/usr/local/bin/aws ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE_ID" --query "Tags[?Key=='github:runner-type'].Value" --output text)
 LABELS="self-hosted,Linux,$(uname -m),$RUNNER_TYPE"

--- a/tests/ci/worker/init_runner.sh
+++ b/tests/ci/worker/init_runner.sh
@@ -19,7 +19,7 @@ export INSTANCE_ID
 
 # Add cloudflare DNS as a fallback
 # Get default gateway interface
-IFACE=$(ip -j route l | jq '.[]|select(.dst == "default").dev' -r)
+IFACE=$(ip --json route list | jq '.[]|select(.dst == "default").dev' --raw-output)
 # `Link 2 (eth0): 172.31.0.2`
 ETH_DNS=$(resolvectl dns "$IFACE") || :
 CLOUDFRONT_NS=1.1.1.1

--- a/tests/ci/worker/init_runner.sh
+++ b/tests/ci/worker/init_runner.sh
@@ -22,12 +22,12 @@ export INSTANCE_ID
 IFACE=$(ip --json route list | jq '.[]|select(.dst == "default").dev' --raw-output)
 # `Link 2 (eth0): 172.31.0.2`
 ETH_DNS=$(resolvectl dns "$IFACE") || :
-CLOUDFRONT_NS=1.1.1.1
-if [[ "$ETH_DNS" ]] && [[ "${ETH_DNS#*: }" != *"$CLOUDFRONT_NS"* ]]; then
+CLOUDFLARE_NS=1.1.1.1
+if [[ "$ETH_DNS" ]] && [[ "${ETH_DNS#*: }" != *"$CLOUDFLARE_NS"* ]]; then
   # Cut the leading legend
   ETH_DNS=${ETH_DNS#*: }
   # shellcheck disable=SC2206
-  new_dns=(${ETH_DNS} "$CLOUDFRONT_NS")
+  new_dns=(${ETH_DNS} "$CLOUDFLARE_NS")
   resolvectl dns "$IFACE" "${new_dns[@]}"
 fi
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
We have failing infrastructure from time to time, and it causes a lot of DOS. Here we add 1.1.1.1 as a fallback for our ubuntu EC2 runners.