### PR TITLE
Fix extra column after ARRAY JOIN optimization.

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -1513,8 +1513,7 @@ ActionsDAG::SplitResult ActionsDAG::splitActionsBeforeArrayJoin(const NameSet & 
     }
 
     auto res = split(split_nodes);
-    /// Do not remove array joined columns if they are not used.
-    /// res.first->project_input = false;
+    res.second->project_input = project_input;
     return res;
 }
 

--- a/tests/queries/0_stateless/01881_union_header_mismatch_bug.sql
+++ b/tests/queries/0_stateless/01881_union_header_mismatch_bug.sql
@@ -28,3 +28,8 @@ WHERE number IN
     SELECT number
     FROM numbers(5)
 ) order by label, number;
+
+SELECT NULL FROM
+(SELECT [1048575, NULL] AS ax, 2147483648 AS c) t1 ARRAY JOIN ax
+INNER JOIN (SELECT NULL AS c) t2 USING (c);
+


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error `Invalid number of columns in chunk pushed to OutputPort` which was cause by ARRAY JOIN optimization. Fixes #39164
