### PR TITLE
Fix `CANNOT_READ_ALL_DATA` with `pread_threadpool`.

### DIFF
--- a/src/Disks/IO/ThreadPoolReader.cpp
+++ b/src/Disks/IO/ThreadPoolReader.cpp
@@ -76,10 +76,11 @@ namespace ErrorCodes
 #if defined(OS_LINUX)
 /// According to man, Linux 5.9 and 5.10 have a bug in preadv2() with the RWF_NOWAIT.
 /// https://manpages.debian.org/testing/manpages-dev/preadv2.2.en.html#BUGS
+/// We also disable it for older Linux kernels, because according to user's reports, RedHat-patched kernels might be also affected.
 static bool hasBugInPreadV2()
 {
     VersionNumber linux_version(Poco::Environment::osVersion());
-    return linux_version >= VersionNumber{5, 9, 0} && linux_version < VersionNumber{5, 11, 0};
+    return linux_version < VersionNumber{5, 11, 0};
 }
 #endif
 

--- a/src/Disks/IO/ThreadPoolReader.cpp
+++ b/src/Disks/IO/ThreadPoolReader.cpp
@@ -73,6 +73,7 @@ namespace ErrorCodes
 
 }
 
+#if defined(OS_LINUX)
 /// According to man, Linux 5.9 and 5.10 have a bug in preadv2() with the RWF_NOWAIT.
 /// https://manpages.debian.org/testing/manpages-dev/preadv2.2.en.html#BUGS
 static bool hasBugInPreadV2()
@@ -80,6 +81,7 @@ static bool hasBugInPreadV2()
     VersionNumber linux_version(Poco::Environment::osVersion());
     return linux_version >= VersionNumber{5, 9, 0} && linux_version < VersionNumber{5, 11, 0};
 }
+#endif
 
 ThreadPoolReader::ThreadPoolReader(size_t pool_size, size_t queue_size_)
     : pool(pool_size, pool_size, queue_size_)

--- a/src/Disks/IO/ThreadPoolReader.cpp
+++ b/src/Disks/IO/ThreadPoolReader.cpp
@@ -1,4 +1,5 @@
 #include "ThreadPoolReader.h"
+#include <Common/VersionNumber.h>
 #include <Common/assert_cast.h>
 #include <Common/Exception.h>
 #include <Common/ProfileEvents.h>
@@ -7,6 +8,7 @@
 #include <Common/setThreadName.h>
 #include <Common/MemorySanitizer.h>
 #include <Common/CurrentThread.h>
+#include <Poco/Environment.h>
 #include <base/errnoToString.h>
 #include <Poco/Event.h>
 #include <future>
@@ -71,6 +73,13 @@ namespace ErrorCodes
 
 }
 
+/// According to man, Linux 5.9 and 5.10 have a bug in preadv2() with the RWF_NOWAIT.
+/// https://manpages.debian.org/testing/manpages-dev/preadv2.2.en.html#BUGS
+static bool hasBugInPreadV2()
+{
+    VersionNumber linux_version(Poco::Environment::osVersion());
+    return linux_version >= VersionNumber{5, 9, 0} && linux_version < VersionNumber{5, 11, 0};
+}
 
 ThreadPoolReader::ThreadPoolReader(size_t pool_size, size_t queue_size_)
     : pool(pool_size, pool_size, queue_size_)
@@ -88,7 +97,11 @@ std::future<IAsynchronousReader::Result> ThreadPoolReader::submit(Request reques
     /// Check if data is already in page cache with preadv2 syscall.
 
     /// We don't want to depend on new Linux kernel.
-    static std::atomic<bool> has_pread_nowait_support{true};
+    /// But kernels 5.9 and 5.10 have a bug where preadv2() with the
+    /// RWF_NOWAIT flag may return 0 even when not at end of file.
+    /// It can't be distinguished from the real eof, so we have to
+    /// disable pread with nowait.
+    static std::atomic<bool> has_pread_nowait_support = !hasBugInPreadV2();
 
     if (has_pread_nowait_support.load(std::memory_order_relaxed))
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `CANNOT_READ_ALL_DATA` exception with `local_filesystem_read_method=pread_threadpool`. This bug affected only Linux kernel version 5.9 and 5.10 according to [man](https://manpages.debian.org/testing/manpages-dev/preadv2.2.en.html#BUGS)

Fixes #39753