### PR TITLE
KeyCondition: optimize applyFunction in multi-thread scenario

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -607,9 +607,9 @@ static FieldRef applyFunction(const FunctionBasePtr & func, const DataTypePtr & 
             result_idx = i;
     }
 
-    ColumnsWithTypeAndName args{(*columns)[field.column_idx]};
     if (result_idx == columns->size())
     {
+        ColumnsWithTypeAndName args{(*columns)[field.column_idx]};
         field.columns->emplace_back(ColumnWithTypeAndName {nullptr, func->getResultType(), result_name});
         (*columns)[result_idx].column = func->execute(args, (*columns)[result_idx].type, columns->front().column->size());
     }


### PR DESCRIPTION
Construct and deconstruct `args` (`ColumnsWithTypeAndName`) will inc/dec
ref_count (actually this is a atomic lock inc/dec operation) to share_ptr,
which may share the same DataTypePtr among different threads. This will
have a lock contention issue in large parallel situation.

The patch try to minimize `args` scope and reduce unnecessary
construct/destory of `args` instances. It will improve the performance in
multi-thread cases.

Performance gain in SSB (SF=100) query (tested on Icelake: Xeon 8380 * 2 socket, 160 logic CPUs):
* 20%+ improvement in `1.1`, `4.2`, `4.3`
* 45%+ improvement in `3.1`, `3.2`, `3.3`

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
KeyCondition: optimize applyFunction in multi-thread scenario

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
