### PR TITLE
add env var support into executables

### DIFF
--- a/src/Common/ShellCommand.h
+++ b/src/Common/ShellCommand.h
@@ -44,6 +44,17 @@ public:
         size_t wait_for_normal_exit_before_termination_seconds = 0;
     };
 
+
+    struct Environ
+    {
+        explicit Environ(const std::vector<std::string> *env_vars);
+        ~Environ();
+
+        char ** data;
+        size_t orig_number_of_env_vars = 0;
+        size_t current_number_of_env_vars = 0;
+    };
+
     struct Config
     {
         Config(const std::string & command_) /// NOLINT
@@ -57,6 +68,8 @@ public:
         std::string command;
 
         std::vector<std::string> arguments;
+
+        std::vector<std::string> env_vars;
 
         std::vector<int> read_fds;
 
@@ -100,7 +113,7 @@ private:
     static Poco::Logger * getLogger();
 
     /// Print command name and the list of arguments to log. NOTE: No escaping of arguments is performed.
-    static void logCommand(const char * filename, char * const argv[]);
+    static void logCommand(const char * filename, char * const argv[], const std::vector<std::string> *env);
 
     static std::unique_ptr<ShellCommand> executeImpl(const char * filename, char * const argv[], const Config & config);
 };

--- a/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -179,7 +179,7 @@ QueryPipeline ExecutableDictionarySource::getStreamForBlock(const Block & block)
     Pipes shell_input_pipes;
     shell_input_pipes.emplace_back(std::move(shell_input_pipe));
 
-    auto pipe = coordinator->createPipe(command, configuration.command_arguments, std::move(shell_input_pipes), sample_block, context);
+    auto pipe = coordinator->createPipe(command, configuration.command_arguments, {}, std::move(shell_input_pipes), sample_block, context);
 
     if (configuration.implicit_key)
         pipe.addTransform(std::make_shared<TransformWithAdditionalColumns>(block, pipe.getHeader()));

--- a/src/Dictionaries/ExecutablePoolDictionarySource.cpp
+++ b/src/Dictionaries/ExecutablePoolDictionarySource.cpp
@@ -139,6 +139,7 @@ QueryPipeline ExecutablePoolDictionarySource::getStreamForBlock(const Block & bl
     auto pipe = coordinator->createPipe(
         command,
         configuration.command_arguments,
+        {},
         std::move(shell_input_pipes),
         sample_block,
         context,

--- a/src/Interpreters/UserDefinedExecutableFunctionFactory.cpp
+++ b/src/Interpreters/UserDefinedExecutableFunctionFactory.cpp
@@ -194,6 +194,7 @@ public:
         Pipe pipe = coordinator->createPipe(
             command,
             command_arguments_with_parameters,
+            {},
             std::move(shell_input_pipes),
             result_block,
             context,

--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -24,6 +24,11 @@ void ASTSetQuery::formatImpl(const FormatSettings & format, FormatState &, Forma
     if (is_standalone)
         format.ostr << (format.hilite ? hilite_keyword : "") << "SET " << (format.hilite ? hilite_none : "");
 
+    this->formatChanges(format);
+}
+
+void ASTSetQuery::formatChanges(const FormatSettings & format) const
+{
     for (auto it = changes.begin(); it != changes.end(); ++it)
     {
         if (it != changes.begin())
@@ -32,6 +37,13 @@ void ASTSetQuery::formatImpl(const FormatSettings & format, FormatState &, Forma
         formatSettingName(it->name, format.ostr);
         format.ostr << " = " << applyVisitor(FieldVisitorToString(), it->value);
     }
+}
+
+void ASTSettings::formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const
+{
+    format.ostr << (format.hilite ? hilite_keyword : "") << keyword << " " << (format.hilite ? hilite_none : "");
+
+    this->formatChanges(format);
 }
 
 }

--- a/src/Parsers/ASTSetQuery.h
+++ b/src/Parsers/ASTSetQuery.h
@@ -31,6 +31,28 @@ public:
     void formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const override;
 
     void updateTreeHashImpl(SipHash & hash_state) const override;
+
+protected:
+    void formatChanges(const FormatSettings & format) const;
+};
+
+class ASTSettings : public ASTSetQuery
+{
+public:
+    explicit ASTSettings(const char * keyword_)
+    {
+        keyword = String(keyword_);
+    }
+
+    ASTPtr clone() const override { return std::make_shared<ASTSettings>(*this); }
+
+    String getID(char delimiter) const override { return String("Set") + delimiter + keyword; }
+
+    void formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const override;
+
+    String getKeyword() { return keyword; }
+protected:
+    String keyword;
 };
 
 }

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -602,18 +602,26 @@ bool ParserLambdaExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     return elem_parser.parse(pos, node, expected);
 }
 
+bool ParserTableFunctionExpression::parseSettings(std::string_view keyword, Pos & pos, ASTPtr & node, Expected & expected)
+{
+    ParserKeyword p_keyword(keyword);
+    if (p_keyword.ignore(pos, expected))
+    {
+        ParserSettings parser_settings(p_keyword.getName());
+        if (parser_settings.parse(pos, node, expected))
+            return true;
+    }
+    return false;
+}
 
 bool ParserTableFunctionExpression::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     if (ParserTableFunctionView().parse(pos, node, expected))
         return true;
-    ParserKeyword s_settings("SETTINGS");
-    if (s_settings.ignore(pos, expected))
-    {
-        ParserSetQuery parser_settings(true);
-        if (parser_settings.parse(pos, node, expected))
-            return true;
-    }
+    if (parseSettings("ENVIRONMENT", pos, node, expected))
+        return true;
+    if (parseSettings("SETTINGS", pos, node, expected))
+        return true;
     return elem_parser.parse(pos, node, expected);
 }
 

--- a/src/Parsers/ExpressionListParsers.h
+++ b/src/Parsers/ExpressionListParsers.h
@@ -464,6 +464,8 @@ protected:
     const char * getName() const override { return "table function expression"; }
 
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+private:
+    static bool parseSettings(std::string_view keyword, IParser::Pos & pos, ASTPtr & node, Expected & expected);
 };
 
 

--- a/src/Parsers/ParserSetQuery.h
+++ b/src/Parsers/ParserSetQuery.h
@@ -26,4 +26,15 @@ protected:
     bool parse_only_internals;
 };
 
+class ParserSettings : public ParserSetQuery
+{
+public:
+    explicit ParserSettings(const char * keyword_);
+    const char * getName() const override { return name; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+protected:
+    const char * keyword;
+    const char * name;
+};
+
 }

--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -461,6 +461,7 @@ ShellCommandSourceCoordinator::ShellCommandSourceCoordinator(const Configuration
 Pipe ShellCommandSourceCoordinator::createPipe(
     const std::string & command,
     const std::vector<std::string> & arguments,
+    const std::vector<std::string> & env_vars,
     std::vector<Pipe> && input_pipes,
     Block sample_block,
     ContextPtr context,
@@ -468,6 +469,7 @@ Pipe ShellCommandSourceCoordinator::createPipe(
 {
     ShellCommand::Config command_config(command);
     command_config.arguments = arguments;
+    command_config.env_vars = env_vars;
     for (size_t i = 1; i < input_pipes.size(); ++i)
         command_config.write_fds.emplace_back(i + 2);
 

--- a/src/Processors/Sources/ShellCommandSource.h
+++ b/src/Processors/Sources/ShellCommandSource.h
@@ -82,6 +82,7 @@ public:
     Pipe createPipe(
         const std::string & command,
         const std::vector<std::string> & arguments,
+        const std::vector<std::string> & env_vars,
         std::vector<Pipe> && input_pipes,
         Block sample_block,
         ContextPtr context,
@@ -94,7 +95,7 @@ public:
         ContextPtr context,
         const ShellCommandSourceConfiguration & source_configuration = {})
     {
-        return createPipe(command, {}, std::move(input_pipes), std::move(sample_block), std::move(context), source_configuration);
+        return createPipe(command, {}, {}, std::move(input_pipes), std::move(sample_block), std::move(context), source_configuration);
     }
 
     Pipe createPipe(
@@ -103,7 +104,7 @@ public:
         Block sample_block,
         ContextPtr context)
     {
-        return createPipe(command, arguments, {}, std::move(sample_block), std::move(context), {});
+        return createPipe(command, arguments, {}, {}, std::move(sample_block), std::move(context), {});
     }
 
     Pipe createPipe(
@@ -111,7 +112,7 @@ public:
         Block sample_block,
         ContextPtr context)
     {
-        return createPipe(command, {}, {}, std::move(sample_block), std::move(context), {});
+        return createPipe(command, {}, {}, {}, std::move(sample_block), std::move(context), {});
     }
 
 private:

--- a/src/Storages/ExecutableSettings.cpp
+++ b/src/Storages/ExecutableSettings.cpp
@@ -9,9 +9,13 @@
 namespace DB
 {
 
+// limit max custom executable environ size to 4K
+size_t MAX_EXECUTABLE_ENVIRON_SIZE = 4 * 1024;
+
 namespace ErrorCodes
 {
     extern const int UNKNOWN_SETTING;
+    extern const int CANNOT_CREATE_CHILD_PROCESS;
 }
 
 IMPLEMENT_SETTINGS_TRAITS(ExecutableSettingsTraits, LIST_OF_EXECUTABLE_SETTINGS)
@@ -36,6 +40,30 @@ void ExecutableSettings::loadFromQuery(ASTStorage & storage_def)
         auto settings_ast = std::make_shared<ASTSetQuery>();
         settings_ast->is_standalone = false;
         storage_def.set(storage_def.settings, settings_ast);
+    }
+}
+
+void ExecutableSettings::applyEnvVars(const SettingsChanges & changes, const std::vector<String> & allow_list)
+{
+    size_t cur_env_size = 0;
+    for (auto change : changes)
+    {
+        for (const auto & allowed : allow_list)
+        {
+            re2::RE2 matcher(allowed);
+            if (re2::RE2::FullMatch(change.name, matcher))
+            {
+                // env var values are always strings
+                auto value = DB::toString(change.value);
+                // environ is built using an array of pointers to `NAME=VALUE\0` C strings
+                cur_env_size += sizeof(char *) + change.name.size() + sizeof('=') + value.size() + 1;
+                if (cur_env_size > MAX_EXECUTABLE_ENVIRON_SIZE)
+                    throw Exception("Max executable environment size exceeded", ErrorCodes::CANNOT_CREATE_CHILD_PROCESS);
+                env_vars.emplace_back(std::move(change.name));
+                env_vars.emplace_back(std::move(value));
+                break;
+            }
+        }
     }
 }
 

--- a/src/Storages/ExecutableSettings.h
+++ b/src/Storages/ExecutableSettings.h
@@ -2,6 +2,7 @@
 
 #include <Core/Defines.h>
 #include <Core/BaseSettings.h>
+#include <re2/re2.h>
 
 namespace DB
 {
@@ -23,10 +24,12 @@ struct ExecutableSettings : public BaseSettings<ExecutableSettingsTraits>
 {
     std::string script_name;
     std::vector<std::string> script_arguments;
+    std::vector<std::string> env_vars;
 
     bool is_executable_pool = false;
 
     void loadFromQuery(ASTStorage & storage_def);
+    void applyEnvVars(const SettingsChanges & changes, const std::vector<String> & allow_list);
 };
 
 }

--- a/src/Storages/StorageExecutable.cpp
+++ b/src/Storages/StorageExecutable.cpp
@@ -162,7 +162,7 @@ void StorageExecutable::read(
         configuration.read_number_of_rows_from_process_output = true;
     }
 
-    auto pipe = coordinator->createPipe(script_path, settings.script_arguments, std::move(inputs), std::move(sample_block), context, configuration);
+    auto pipe = coordinator->createPipe(script_path, settings.script_arguments, settings.env_vars, std::move(inputs), std::move(sample_block), context, configuration);
     IStorage::readFromPipe(query_plan, std::move(pipe), column_names, storage_snapshot, query_info, context, getName());
     query_plan.addResources(std::move(resources));
 }

--- a/src/TableFunctions/TableFunctionExecutable.h
+++ b/src/TableFunctions/TableFunctionExecutable.h
@@ -6,7 +6,6 @@ namespace DB
 {
 
 class Context;
-class ASTSetQuery;
 
 /* executable(script_name_optional_arguments, format, structure, input_query) - creates a temporary storage from executable file
  *
@@ -34,5 +33,7 @@ private:
     String structure;
     std::vector<ASTPtr> input_queries;
     ASTPtr settings_query = nullptr;
+    ASTPtr env_vars = nullptr;
+    std::vector<String> allowed_env_vars;
 };
 }

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,2 +1,6 @@
 .cache
 _instances*
+.env
+dockerd.log
+pytest.log
+.pytest_cache

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -8,7 +8,7 @@ Prerequisites:
 * Ubuntu 20.04 (Focal) or higher.
 * [docker](https://www.docker.com/community-edition#/download). Minimum required API version: 1.25, check with `docker version`.
 
-You must install latest Docker from
+You must install the latest Docker from
 https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#set-up-the-repository
 Don't use Docker from your system repository.
 
@@ -38,6 +38,8 @@ sudo -H pip install \
     pytz \
     pytest \
     pytest-timeout \
+    pytest-order \
+    pytest-dotenv \
     redis \
     tzlocal==2.1 \
     urllib3 \
@@ -58,7 +60,7 @@ To check, that you have access to Docker, run `docker ps`.
 
 Run the tests with the `pytest` command. To select which tests to run, use: `pytest -k <test_name_pattern>`
 
-By default tests are run with system-wide client binary, server binary and base configs. To change that,
+By default, tests are run with system-wide client binary, server binary and base configs. To change that,
 set the following environment variables:
 * `CLICKHOUSE_TESTS_SERVER_BIN_PATH` to choose the server binary.
 * `CLICKHOUSE_TESTS_CLIENT_BIN_PATH` to choose the client binary.
@@ -119,7 +121,7 @@ test_odbc_interaction/test.py ......                                     [100%]
 ==================== 6 passed, 1 warnings in 96.33 seconds =====================
 ```
 
-You can just open shell inside a container by overwritting the command:
+You can just open shell inside a container by overwriting the command:
 ./runner --command=bash
 
 ### Rebuilding the docker containers

--- a/tests/integration/test_executable_table_function/user_scripts/input_env.py
+++ b/tests/integration/test_executable_table_function/user_scripts/input_env.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+import os
+import sys
+
+if __name__ == "__main__":
+    env_vars = [
+        os.environ.get("FOO_1", "(null)"),
+        os.environ.get("FOO_2", "(null)"),
+        os.environ.get("BAR_1", "(null)"),
+        os.environ.get("BAR_2", "(null)"),
+    ]
+
+    for line in sys.stdin:
+        print("Key " + " ".join(env_vars) + " " + line, end="")
+        sys.stdout.flush()

--- a/tests/queries/0_stateless/02381_executable_function_environment.reference
+++ b/tests/queries/0_stateless/02381_executable_function_environment.reference
@@ -1,0 +1,11 @@
+SELECT data
+FROM executable(\'\', \'JSON\', \'data String\', ENVIRONMENT VAR1 = \'a\')
+--------------------
+SELECT data
+FROM executable(\'\', \'JSON\', \'data String\', ENVIRONMENT VAR1 = \'a\', VAR2 = 1)
+--------------------
+SELECT data
+FROM executable(\'\', \'JSON\', \'data String\', ENVIRONMENT VAR1 = \'a\', SETTINGS max_command_execution_time = 100, command_read_timeout = 1)
+--------------------
+SELECT data
+FROM executable(\'\', \'JSON\', \'data String\', ENVIRONMENT VAR1 = \'a\', VAR2 = 1, SETTINGS max_command_execution_time = 100, command_read_timeout = 1)

--- a/tests/queries/0_stateless/02381_executable_function_environment.sql
+++ b/tests/queries/0_stateless/02381_executable_function_environment.sql
@@ -1,0 +1,7 @@
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String', ENVIRONMENT VAR1 = 'a');
+SELECT '--------------------';
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String', ENVIRONMENT VAR1 = 'a', VAR2 = 1);
+SELECT '--------------------';
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String', ENVIRONMENT VAR1 = 'a', SETTINGS max_command_execution_time=100, command_read_timeout=1);
+SELECT '--------------------';
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String', ENVIRONMENT VAR1 = 'a', VAR2 = 1, SETTINGS max_command_execution_time=100, command_read_timeout=1);


### PR DESCRIPTION
### UPDATED:

- adds a new setting `ENVIRONMENT VAR1 = 'a', VAR2 = 'b'` to table
functions
- improves "set query" handler to work on any settings type, even partial
- adds alow list for env vars to config (with globbing support)

Multiline config:
```xml
    <user_scripts>
        <allow_env_variables>
            <VAR_*/>
            <VAR1/>
        </allow_env_variables>
    </user_scripts>
```
Single pattern config:
```xml
    <user_scripts>
        <allow_env_variables>*</allow_env_variables>
    </user_scripts>
```

Query syntax:

```sql
SELECT * FROM
  executable('<script name>', '<format>', '<columns>',
    (SELECT * FROM table),
    ENVIRONMENT VAR1 = 'test', VAR2 = 1,
    SETTINGS <.....>
  )
```

Note: max additional environment size is limited to 4KB

### DEPRECATED:

Syntax:
```sql
SELECT * FROM
  executable('<script name>', '<format>', '<columns>',
    (SELECT * FROM table),
    SETTINGS env.VAR1 = 'test', env.VAR2 = 1
  )
```
_note: will **not** overwrite existing env vars_

fixes: #39840

### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
environment variable support for executable table functions
