### PR TITLE
Fix post-build script for building utils/self-extracting-executable/compressor

### DIFF
--- a/utils/self-extracting-executable/post_build.sh
+++ b/utils/self-extracting-executable/post_build.sh
@@ -1,3 +1,7 @@
 padding="               "
-sz="$(stat -c %s 'decompressor')"
+if [[ $OSTYPE == 'darwin'* ]]; then
+    sz="$(stat -f %z 'decompressor')"
+else
+    sz="$(stat -c %s 'decompressor')"
+fi
 printf "%s%s" "${padding:${#sz}}" $sz


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

MacOS stat util has different parameters.

Closes #39824
