### PR TITLE
Add hasJoin method into ASTSelectQuery

### DIFF
--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -344,6 +344,25 @@ const ASTTablesInSelectQueryElement * ASTSelectQuery::join() const
     return getFirstTableJoin(*this);
 }
 
+bool ASTSelectQuery::hasJoin() const
+{
+    if (!tables())
+        return false;
+
+    const auto & tables_in_select_query = tables()->as<ASTTablesInSelectQuery &>();
+    if (tables_in_select_query.children.empty())
+        return false;
+
+    for (const auto & child : tables_in_select_query.children)
+    {
+        const auto & tables_element = child->as<ASTTablesInSelectQueryElement &>();
+        if (tables_element.table_join)
+            return true;
+    }
+
+    return false;
+}
+
 static String getTableExpressionAlias(const ASTTableExpression * table_expression)
 {
     if (table_expression->subquery)

--- a/src/Parsers/ASTSelectQuery.h
+++ b/src/Parsers/ASTSelectQuery.h
@@ -131,6 +131,7 @@ public:
     std::pair<ASTPtr, bool> arrayJoinExpressionList() const;
 
     const ASTTablesInSelectQueryElement * join() const;
+    bool hasJoin() const;
     bool final() const;
     bool withFill() const;
     void replaceDatabaseAndTable(const String & database_name, const String & table_name);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -5489,7 +5489,7 @@ std::optional<ProjectionCandidate> MergeTreeData::getQueryProcessingStageWithAgg
     // In order to properly analyze joins, aliases should be recognized. However, aliases get lost during projection analysis.
     // Let's disable projection if there are any JOIN clauses.
     // TODO: We need a better identifier resolution mechanism for projection analysis.
-    if (select_query->join())
+    if (select_query->hasJoin())
         return std::nullopt;
 
     // INTERPOLATE expressions may include aliases, so aliases should be preserved


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

ASTSelectQuery join method throws exception if there are multiple joins, currently we split multiple joins into subquery and join and we do not trigger it.
Needed in https://github.com/ClickHouse/ClickHouse/pull/31796.