### PR TITLE
fix incorrect format for functions with settings

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -14,6 +14,7 @@
 #include <Parsers/ASTSubquery.h>
 #include <Parsers/ASTWithAlias.h>
 #include <Parsers/queryToString.h>
+#include <Parsers/ASTSetQuery.h>
 
 using namespace std::literals;
 
@@ -549,6 +550,8 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
                     {
                         if (i != 0)
                             settings.ostr << (settings.hilite ? hilite_operator : "") << func[1] << (settings.hilite ? hilite_none : "");
+                        if (arguments->children[i]->as<ASTSetQuery>())
+                            settings.ostr << "SETTINGS ";
                         arguments->children[i]->formatImpl(settings, state, nested_need_parens);
                     }
                     if (frame.need_parens)
@@ -565,6 +568,8 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
             {
                 if (i != 0)
                     settings.ostr << ", ";
+                if (arguments->children[i]->as<ASTSetQuery>())
+                    settings.ostr << "SETTINGS ";
                 arguments->children[i]->formatImpl(settings, state, nested_dont_need_parens);
             }
             settings.ostr << (settings.hilite ? hilite_operator : "") << ']' << (settings.hilite ? hilite_none : "");
@@ -578,6 +583,8 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
             {
                 if (i != 0)
                     settings.ostr << ", ";
+                if (arguments->children[i]->as<ASTSetQuery>())
+                    settings.ostr << "SETTINGS ";
                 arguments->children[i]->formatImpl(settings, state, nested_dont_need_parens);
             }
             settings.ostr << (settings.hilite ? hilite_operator : "") << ')' << (settings.hilite ? hilite_none : "");
@@ -591,6 +598,8 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
             {
                 if (i != 0)
                     settings.ostr << ", ";
+                if (arguments->children[i]->as<ASTSetQuery>())
+                    settings.ostr << "SETTINGS ";
                 arguments->children[i]->formatImpl(settings, state, nested_dont_need_parens);
             }
             settings.ostr << (settings.hilite ? hilite_operator : "") << ')' << (settings.hilite ? hilite_none : "");
@@ -625,6 +634,8 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
         {
             if (i != 0)
                 settings.ostr << ", ";
+            if (arguments->children[i]->as<ASTSetQuery>())
+                settings.ostr << "SETTINGS ";
 
             bool special_hilite = false;
             if (i == 1 && special_hilite_regexp)

--- a/tests/queries/0_stateless/02377_executable_function_settings.reference
+++ b/tests/queries/0_stateless/02377_executable_function_settings.reference
@@ -1,0 +1,8 @@
+SELECT data
+FROM executable(\'\', \'JSON\', \'data String\')
+--------------------
+SELECT data
+FROM executable(\'\', \'JSON\', \'data String\', SETTINGS max_command_execution_time = 100)
+--------------------
+SELECT data
+FROM executable(\'\', \'JSON\', \'data String\', SETTINGS max_command_execution_time = 100, command_read_timeout = 1)

--- a/tests/queries/0_stateless/02377_executable_function_settings.sql
+++ b/tests/queries/0_stateless/02377_executable_function_settings.sql
@@ -1,0 +1,5 @@
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String');
+SELECT '--------------------';
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String', SETTINGS max_command_execution_time=100);
+SELECT '--------------------';
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String', SETTINGS max_command_execution_time=100, command_read_timeout=1);


### PR DESCRIPTION
when support for settings was added in #39681
the formatting was not altered to support settings

now it's supported

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
