### PR TITLE
Move username and password from URL parameters to Basic Authentication

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -501,7 +501,8 @@
 
         const server_address = document.getElementById('url').value;
 
-        const url = server_address +
+        
+        var url = server_address +
             (server_address.indexOf('?') >= 0 ? '&' : '?') +
             /// Ask server to allow cross-domain requests.
             'add_http_cors_header=1' +
@@ -509,11 +510,19 @@
             /// Safety settings to prevent results that browser cannot display.
             '&max_result_rows=1000&max_result_bytes=10000000&result_overflow_mode=break';
 
+        // If play.html is opened locally, append username and password to the URL parameter to avoid CORS issue.
+        if (document.location.href.startsWith("file://")) {
+            url += '&user=' + encodeURIComponent(user) +
+            '&password=' + encodeURIComponent(password)
+        }
+
         const xhr = new XMLHttpRequest;
 
         xhr.open('POST', url, true);
-        xhr.setRequestHeader("Authorization", "Basic " + btoa(user+":"+password));
-
+        // If play.html is open normally, use Basic auth to prevent username and password being exposed in URL parameters
+        if (!document.location.href.startsWith("file://")) {
+            xhr.setRequestHeader("Authorization", "Basic " + btoa(user+":"+password));
+        }
         xhr.onreadystatechange = function()
         {
             if (posted_request_num != request_num) {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -505,8 +505,6 @@
             (server_address.indexOf('?') >= 0 ? '&' : '?') +
             /// Ask server to allow cross-domain requests.
             'add_http_cors_header=1' +
-            '&user=' + encodeURIComponent(user) +
-            '&password=' + encodeURIComponent(password) +
             '&default_format=JSONCompact' +
             /// Safety settings to prevent results that browser cannot display.
             '&max_result_rows=1000&max_result_bytes=10000000&result_overflow_mode=break';
@@ -514,6 +512,7 @@
         const xhr = new XMLHttpRequest;
 
         xhr.open('POST', url, true);
+        xhr.setRequestHeader("Authorization", "Basic " + btoa(user+":"+password));
 
         xhr.onreadystatechange = function()
         {


### PR DESCRIPTION
A small update for play ui to move the credentials, currently being submited in url parameter of the  POST request to basic authentication header.

This improvement should reduce the risk of credentials being exposed and cached in web proxy log and in ClickHouse server log when trace level log is enabled as shown below.

```
<Trace> DynamicQueryHandler: Request URI: /?add_http_cors_header=1&user=san&password=supersecretpassword&default_format=JSONCompact&max_result_rows=1000&max_result_bytes=10000000&result_overflow_mode=break
```

```
<Trace> DynamicQueryHandler: Request URI: /?add_http_cors_header=1&default_format=JSONCompact&max_result_rows=1000&max_result_bytes=10000000&result_overflow_mode=break
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
