### PR TITLE
Fix flaky test `02360_send_logs_level_colors`

### DIFF
--- a/tests/queries/0_stateless/02360_send_logs_level_colors.sh
+++ b/tests/queries/0_stateless/02360_send_logs_level_colors.sh
@@ -13,7 +13,7 @@ function run()
     command=$1
     expect << EOF
 log_user 0
-set timeout 3
+set timeout 60
 match_max 100000
 
 spawn bash -c "$command"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

