### PR TITLE
Fix Endian issue in KeeperSnapshotManager for s390x

### DIFF
--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -635,7 +635,11 @@ nuraft::ptr<nuraft::buffer> KeeperSnapshotManager::serializeSnapshotToBuffer(con
 
 bool KeeperSnapshotManager::isZstdCompressed(nuraft::ptr<nuraft::buffer> buffer)
 {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    static constexpr uint32_t ZSTD_COMPRESSED_MAGIC = 0x28B52FFD;
+#else
     static constexpr uint32_t ZSTD_COMPRESSED_MAGIC = 0xFD2FB528;
+#endif
     ReadBufferFromNuraftBuffer reader(buffer);
     uint32_t magic_from_buffer;
     reader.readStrict(reinterpret_cast<char *>(&magic_from_buffer), sizeof(magic_from_buffer));

--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -635,16 +635,13 @@ nuraft::ptr<nuraft::buffer> KeeperSnapshotManager::serializeSnapshotToBuffer(con
 
 bool KeeperSnapshotManager::isZstdCompressed(nuraft::ptr<nuraft::buffer> buffer)
 {
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    static constexpr uint32_t ZSTD_COMPRESSED_MAGIC = 0x28B52FFD;
-#else
-    static constexpr uint32_t ZSTD_COMPRESSED_MAGIC = 0xFD2FB528;
-#endif
+    static constexpr unsigned char ZSTD_COMPRESSED_MAGIC[4] = {0x28, 0xB5, 0x2F, 0xFD};
+
     ReadBufferFromNuraftBuffer reader(buffer);
-    uint32_t magic_from_buffer;
+    unsigned char magic_from_buffer[4]{};
     reader.readStrict(reinterpret_cast<char *>(&magic_from_buffer), sizeof(magic_from_buffer));
     buffer->pos(0);
-    return magic_from_buffer == ZSTD_COMPRESSED_MAGIC;
+    return memcmp(magic_from_buffer, ZSTD_COMPRESSED_MAGIC, 4) == 0;
 }
 
 SnapshotDeserializationResult KeeperSnapshotManager::deserializeSnapshotFromBuffer(nuraft::ptr<nuraft::buffer> buffer) const


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
There is an Endian issue in KeeperSnapshotManager's method  isZstdCompressed(), which uses hardcoded magic number. This magic number is read into memory in big endian on s390x platform.The following unit test failure is caused by the issue:

`[  FAILED  ] CoordinationTestSuite/CoordinationTest.TestStorageSnapshotSimple/0, where GetParam() = 32-byte object <01-00 00-00 1D-B9 46-27 2E-7A 73-74 64-00 00-00 6E-2F 74-65 73-74 73-2F 00-00 00-00 00-00 00-0A> (21 ms)`

The fix is to add magic number for Big Endian machines.

### Changelog category (leave one):
- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed an Endian issue in Coordination snapshot code for s390x architecture (which is not supported by ClickHouse).

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
