### PR TITLE
tests/stress: add dmesg output (to see OOM details)

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -456,3 +456,5 @@ for core in core.*; do
     pigz $core
     mv $core.gz /test_output/
 done
+
+dmesg -T > /test_output/dmesg.log


### PR DESCRIPTION
max_server_memory_usage already set to 75%, so OOM should not happen,
the reason is that because RSS does not match with memory tracker
statistics:

    2022.08.05 12:36:57.869896 [ 82524 ] {} <Trace> AsynchronousMetrics: MemoryTracking: was 64.69 GiB, peak 65.26 GiB, will set to 62.80 GiB (RSS), difference: -1.89 GiB
    ...
    2022.08.05 12:37:00.213440 [ 82334 ] {} <Error> void DB::MergeTreeBackgroundExecutor<DB::MergeMutateRuntimeQueue>::routine(DB::TaskRuntimeDataPtr) [Queue = DB::MergeMutateRuntimeQueue]: Code: 241. DB::Exception: Memory limit (total) exceeded: would use 64.68 GiB (attempt to allocate chunk of 1298794 bytes), maximum: 51.44 GiB. OvercommitTracker decision: Memory overcommit isn't used. Waiting time or orvercommit denominator are set to zero.. (MEMORY_LIMIT_EXCEEDED), Stack trace (when copying this message, always include the lines below):

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)