### PR TITLE
Create metadata directory on CREATE for FileLog engine

### DIFF
--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -37,6 +37,7 @@ namespace ErrorCodes
     extern const int CANNOT_READ_ALL_DATA;
     extern const int LOGICAL_ERROR;
     extern const int TABLE_METADATA_ALREADY_EXISTS;
+    extern const int DIRECTORY_DOESNT_EXIST;
     extern const int CANNOT_SELECT;
     extern const int QUERY_NOT_ALLOWED;
 }
@@ -72,6 +73,25 @@ StorageFileLog::StorageFileLog(
 
     try
     {
+        if (!attach)
+        {
+            std::error_code ec;
+            std::filesystem::create_directories(metadata_base_path, ec);
+
+            if (ec)
+            {
+                if (ec == std::make_error_code(std::errc::file_exists))
+                {
+                    throw Exception(ErrorCodes::TABLE_METADATA_ALREADY_EXISTS,
+                        "Metadata files already exist by path: {}, remove them manually if it is intended",
+                        metadata_base_path);
+                }
+                else
+                    throw Exception(ErrorCodes::DIRECTORY_DOESNT_EXIST,
+                        "Could not create directory {}, reason: {}", metadata_base_path, ec.message());
+            }
+        }
+
         loadMetaFiles(attach);
         loadFiles();
 
@@ -116,19 +136,6 @@ void StorageFileLog::loadMetaFiles(bool attach)
         }
         /// Load all meta info to file_infos;
         deserialize();
-    }
-    /// Create table, just create meta data directory
-    else
-    {
-        if (std::filesystem::exists(metadata_base_path))
-        {
-            throw Exception(
-                ErrorCodes::TABLE_METADATA_ALREADY_EXISTS,
-                "Metadata files already exist by path: {}, remove them manually if it is intended",
-                metadata_base_path);
-        }
-        /// We do not create the metadata_base_path directory at creation time, create it at the moment of serializing
-        /// meta files, such that can avoid unnecessarily create this directory if create table failed.
     }
 }
 
@@ -218,10 +225,6 @@ void StorageFileLog::loadFiles()
 
 void StorageFileLog::serialize() const
 {
-    if (!std::filesystem::exists(metadata_base_path))
-    {
-        std::filesystem::create_directories(metadata_base_path);
-    }
     for (const auto & [inode, meta] : file_infos.meta_by_inode)
     {
         auto full_name = getFullMetaPath(meta.file_name);
@@ -242,10 +245,6 @@ void StorageFileLog::serialize() const
 
 void StorageFileLog::serialize(UInt64 inode, const FileMeta & file_meta) const
 {
-    if (!std::filesystem::exists(metadata_base_path))
-    {
-        std::filesystem::create_directories(metadata_base_path);
-    }
     auto full_name = getFullMetaPath(file_meta.file_name);
     if (!std::filesystem::exists(full_name))
     {
@@ -379,8 +378,7 @@ void StorageFileLog::drop()
 {
     try
     {
-        if (std::filesystem::exists(metadata_base_path))
-            std::filesystem::remove_all(metadata_base_path);
+        std::filesystem::remove_all(metadata_base_path);
     }
     catch (...)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Create metadata directory on CREATE for FileLog engine

This will allow to distinguish really corrupted data, since right now if
you will CREATE/DETACH/ATTACH such engine you will have the following
error [1]:

    2022.08.05 20:02:20.726398 [ 696405 ] {} <Error> StorageFileLog (file_log): Metadata files of table file_log are lost.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/39926/72961328f68b1ec05300d6dc4411a87618a2f46b/stress_test__debug_.html

Likely that previously it was not created to avoid creating empty
directories, however this should be a problem I guess.

Refs: #25969 (@ucasfl)