### PR TITLE
Add majority_insert_quorum setting

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1196,6 +1196,16 @@ See also:
 -   [insert_quorum_parallel](#settings-insert_quorum_parallel)
 -   [select_sequential_consistency](#settings-select_sequential_consistency)
 
+## majority_insert_quorum {#settings-majority_insert_quorum}
+
+Use majority number as quorum number. Majority is defined as (number_of_replicas/2) + 1. If insert_quorum and majority_insert_quorum both are specified, max(insert_quorum , majority number) will be used as quorum.
+
+Default value: false
+
+See also:
+
+-   [insert_quorum](#settings-insert_quorum)
+
 ## insert_quorum_timeout {#settings-insert_quorum_timeout}
 
 Write to a quorum timeout in milliseconds. If the timeout has passed and no write has taken place yet, ClickHouse will generate an exception and the client must repeat the query to write the same block to the same or any other replica.

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1176,8 +1176,9 @@ Enables the quorum writes.
 
 -   If `insert_quorum < 2`, the quorum writes are disabled.
 -   If `insert_quorum >= 2`, the quorum writes are enabled.
+-   If `insert_quorum = 'auto'`, use majority number (`number_of_replicas / 2 + 1`) as quorum number.
 
-Default value: 0.
+Default value: 0 - disabled.
 
 Quorum writes
 
@@ -1195,16 +1196,6 @@ See also:
 -   [insert_quorum_timeout](#settings-insert_quorum_timeout)
 -   [insert_quorum_parallel](#settings-insert_quorum_parallel)
 -   [select_sequential_consistency](#settings-select_sequential_consistency)
-
-## majority_insert_quorum {#settings-majority_insert_quorum}
-
-Use majority number as quorum number. Majority is defined as (number_of_replicas/2) + 1. If insert_quorum and majority_insert_quorum both are specified, max(insert_quorum , majority number) will be used as quorum.
-
-Default value: false
-
-See also:
-
--   [insert_quorum](#settings-insert_quorum)
 
 ## insert_quorum_timeout {#settings-insert_quorum_timeout}
 
@@ -1269,7 +1260,7 @@ Possible values:
 
 Default value: 1.
 
-By default, blocks inserted into replicated tables by the `INSERT` statement are deduplicated (see [Data Replication](../../engines/table-engines/mergetree-family/replication.md)). 
+By default, blocks inserted into replicated tables by the `INSERT` statement are deduplicated (see [Data Replication](../../engines/table-engines/mergetree-family/replication.md)).
 For the replicated tables by default the only 100 of the most recent blocks for each partition are deduplicated (see [replicated_deduplication_window](merge-tree-settings.md#replicated-deduplication-window), [replicated_deduplication_window_seconds](merge-tree-settings.md/#replicated-deduplication-window-seconds)).
 For not replicated tables see [non_replicated_deduplication_window](merge-tree-settings.md/#non-replicated-deduplication-window).
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -213,7 +213,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     \
     M(Bool, insert_deduplicate, true, "For INSERT queries in the replicated table, specifies that deduplication of insertings blocks should be performed", 0) \
     \
-    M(UInt64Auto, insert_quorum, 0, "For INSERT queries in the replicated table, wait writing for the specified number of replicas and linearize the addition of the data. 0 - disabled.", 0) \
+    M(UInt64Auto, insert_quorum, 0, "For INSERT queries in the replicated table, wait writing for the specified number of replicas and linearize the addition of the data. 0 - disabled, 'auto' - use majority", 0) \
     M(Milliseconds, insert_quorum_timeout, 600000, "If the quorum of replicas did not meet in specified time (in milliseconds), exception will be thrown and insertion is aborted.", 0) \
     M(Bool, insert_quorum_parallel, true, "For quorum INSERT queries - enable to make parallel inserts without linearizability", 0) \
     M(UInt64, select_sequential_consistency, 0, "For SELECT queries from the replicated table, throw an exception if the replica does not have a chunk written with the quorum; do not read the parts that have not yet been written with the quorum.", 0) \

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -41,41 +41,44 @@ struct ReplicatedMergeTreeSink::DelayedChunk
         String block_id;
     };
 
+    DelayedChunk() = default;
+    explicit DelayedChunk(size_t replicas_num_) : replicas_num(replicas_num_) {}
+
+    size_t replicas_num = 0;
+
     std::vector<Partition> partitions;
 };
 
 ReplicatedMergeTreeSink::ReplicatedMergeTreeSink(
     StorageReplicatedMergeTree & storage_,
     const StorageMetadataPtr & metadata_snapshot_,
-    size_t quorum_,
+    size_t quorum_size,
     size_t quorum_timeout_ms_,
     size_t max_parts_per_block_,
     bool quorum_parallel_,
     bool deduplicate_,
-    bool majority_quorum_,
+    bool majority_quorum,
     ContextPtr context_,
     bool is_attach_)
     : SinkToStorage(metadata_snapshot_->getSampleBlock())
     , storage(storage_)
     , metadata_snapshot(metadata_snapshot_)
-    , quorum(quorum_)
+    , required_quorum_size(majority_quorum ? std::nullopt : std::make_optional<size_t>(quorum_size))
     , quorum_timeout_ms(quorum_timeout_ms_)
     , max_parts_per_block(max_parts_per_block_)
     , is_attach(is_attach_)
     , quorum_parallel(quorum_parallel_)
     , deduplicate(deduplicate_)
-    , majority_quorum(majority_quorum_)
     , log(&Poco::Logger::get(storage.getLogName() + " (Replicated OutputStream)"))
     , context(context_)
     , storage_snapshot(storage.getStorageSnapshot(metadata_snapshot, context))
 {
     /// The quorum value `1` has the same meaning as if it is disabled.
-    if (quorum == 1)
-        quorum = 0;
+    if (required_quorum_size == 1)
+        required_quorum_size = 0;
 }
 
 ReplicatedMergeTreeSink::~ReplicatedMergeTreeSink() = default;
-
 
 /// Allow to verify that the session in ZooKeeper is still alive.
 static void assertSessionIsNotExpired(zkutil::ZooKeeperPtr & zookeeper)
@@ -87,9 +90,11 @@ static void assertSessionIsNotExpired(zkutil::ZooKeeperPtr & zookeeper)
         throw Exception("ZooKeeper session has been expired.", ErrorCodes::NO_ZOOKEEPER);
 }
 
-
-void ReplicatedMergeTreeSink::setMajorityQuorumAndCheckQuorum(zkutil::ZooKeeperPtr & zookeeper)
+size_t ReplicatedMergeTreeSink::checkQuorumPrecondition(zkutil::ZooKeeperPtr & zookeeper)
 {
+    if (!isQuorumEnabled())
+        return 0;
+
     quorum_info.status_path = storage.zookeeper_path + "/quorum/status";
 
     Strings replicas = zookeeper->getChildren(fs::path(storage.zookeeper_path) / "replicas");
@@ -107,12 +112,12 @@ void ReplicatedMergeTreeSink::setMajorityQuorumAndCheckQuorum(zkutil::ZooKeeperP
         if (status.get().error == Coordination::Error::ZOK)
             ++active_replicas;
 
-    if (majority_quorum)
-        quorum = std::max(quorum, replicas.size() / 2 + 1);
+    size_t replicas_number = replicas.size();
+    size_t quorum_size = getQuorumSize(replicas_number);
 
-    if (active_replicas < quorum)
-        throw Exception(ErrorCodes::TOO_FEW_LIVE_REPLICAS, "Number of alive replicas ({}) is less than requested quorum ({}).",
-                        active_replicas, quorum);
+    if (active_replicas < quorum_size)
+        throw Exception(ErrorCodes::TOO_FEW_LIVE_REPLICAS, "Number of alive replicas ({}) is less than requested quorum ({}/{}).",
+                        active_replicas, quorum_size, replicas_number);
 
     /** Is there a quorum for the last part for which a quorum is needed?
         * Write of all the parts with the included quorum is linearly ordered.
@@ -138,8 +143,9 @@ void ReplicatedMergeTreeSink::setMajorityQuorumAndCheckQuorum(zkutil::ZooKeeperP
     quorum_info.is_active_node_value = is_active.data;
     quorum_info.is_active_node_version = is_active.stat.version;
     quorum_info.host_node_version = host.stat.version;
-}
 
+    return replicas_number;
+}
 
 void ReplicatedMergeTreeSink::consume(Chunk chunk)
 {
@@ -153,8 +159,7 @@ void ReplicatedMergeTreeSink::consume(Chunk chunk)
       * And also check that during the insertion, the replica was not reinitialized or disabled (by the value of `is_active` node).
       * TODO Too complex logic, you can do better.
       */
-    if (quorumEnabled())
-        setMajorityQuorumAndCheckQuorum(zookeeper);
+    size_t replicas_num = checkQuorumPrecondition(zookeeper);
 
     storage.writer.deduceTypesOfObjectColumns(storage_snapshot, block);
     auto part_blocks = storage.writer.splitBlockIntoParts(block, max_parts_per_block, metadata_snapshot, context);
@@ -198,11 +203,11 @@ void ReplicatedMergeTreeSink::consume(Chunk chunk)
             }
 
             block_id = temp_part.part->getZeroLevelPartBlockID(block_dedup_token);
-            LOG_DEBUG(log, "Wrote block with ID '{}', {} rows", block_id, current_block.block.rows());
+            LOG_DEBUG(log, "Wrote block with ID '{}', {} rows on {} replicas", block_id, current_block.block.rows(), replicas_num);
         }
         else
         {
-            LOG_DEBUG(log, "Wrote block with {} rows", current_block.block.rows());
+            LOG_DEBUG(log, "Wrote block with {} rows on {} replicas", current_block.block.rows(), replicas_num);
         }
 
         UInt64 elapsed_ns = watch.elapsed();
@@ -216,7 +221,7 @@ void ReplicatedMergeTreeSink::consume(Chunk chunk)
         if (streams > max_insert_delayed_streams_for_parallel_write)
         {
             finishDelayedChunk(zookeeper);
-            delayed_chunk = std::make_unique<ReplicatedMergeTreeSink::DelayedChunk>();
+            delayed_chunk = std::make_unique<ReplicatedMergeTreeSink::DelayedChunk>(replicas_num);
             delayed_chunk->partitions = std::move(partitions);
             finishDelayedChunk(zookeeper);
 
@@ -259,7 +264,7 @@ void ReplicatedMergeTreeSink::finishDelayedChunk(zkutil::ZooKeeperPtr & zookeepe
 
         try
         {
-            commitPart(zookeeper, part, partition.block_id, partition.temp_part.builder);
+            commitPart(zookeeper, part, partition.block_id, partition.temp_part.builder, delayed_chunk->replicas_num);
 
             last_block_is_duplicate = last_block_is_duplicate || part->is_duplicate;
 
@@ -278,7 +283,6 @@ void ReplicatedMergeTreeSink::finishDelayedChunk(zkutil::ZooKeeperPtr & zookeepe
     delayed_chunk.reset();
 }
 
-
 void ReplicatedMergeTreeSink::writeExistingPart(MergeTreeData::MutableDataPartPtr & part)
 {
     /// NOTE: No delay in this case. That's Ok.
@@ -286,15 +290,14 @@ void ReplicatedMergeTreeSink::writeExistingPart(MergeTreeData::MutableDataPartPt
     auto zookeeper = storage.getZooKeeper();
     assertSessionIsNotExpired(zookeeper);
 
-    if (quorumEnabled())
-        setMajorityQuorumAndCheckQuorum(zookeeper);
+    size_t replicas_num = checkQuorumPrecondition(zookeeper);
 
     Stopwatch watch;
 
     try
     {
         part->version.setCreationTID(Tx::PrehistoricTID, nullptr);
-        commitPart(zookeeper, part, "", part->data_part_storage->getBuilder());
+        commitPart(zookeeper, part, "", part->data_part_storage->getBuilder(), replicas_num);
         PartLog::addNewPart(storage.getContext(), part, watch.elapsed());
     }
     catch (...)
@@ -304,12 +307,12 @@ void ReplicatedMergeTreeSink::writeExistingPart(MergeTreeData::MutableDataPartPt
     }
 }
 
-
 void ReplicatedMergeTreeSink::commitPart(
     zkutil::ZooKeeperPtr & zookeeper,
     MergeTreeData::MutableDataPartPtr & part,
     const String & block_id,
-    DataPartStorageBuilderPtr builder)
+    DataPartStorageBuilderPtr builder,
+    size_t replicas_num)
 {
     metadata_snapshot->check(part->getColumns());
     assertSessionIsNotExpired(zookeeper);
@@ -372,7 +375,7 @@ void ReplicatedMergeTreeSink::commitPart(
             log_entry.source_replica = storage.replica_name;
             log_entry.new_part_name = part->name;
             /// TODO maybe add UUID here as well?
-            log_entry.quorum = quorum;
+            log_entry.quorum = getQuorumSize(replicas_num);
             log_entry.block_id = block_id;
             log_entry.new_part_type = part->getType();
 
@@ -389,11 +392,11 @@ void ReplicatedMergeTreeSink::commitPart(
               *  but for it the quorum has not yet been reached.
               *  You can not do the next quorum record at this time.)
               */
-            if (quorumEnabled())
+            if (isQuorumEnabled())
             {
                 ReplicatedMergeTreeQuorumEntry quorum_entry;
                 quorum_entry.part_name = part->name;
-                quorum_entry.required_number_of_replicas = quorum;
+                quorum_entry.required_number_of_replicas = getQuorumSize(replicas_num);
                 quorum_entry.replicas.insert(storage.replica_name);
 
                 /** At this point, this node will contain information that the current replica received a part.
@@ -441,7 +444,7 @@ void ReplicatedMergeTreeSink::commitPart(
             {
                 part->is_duplicate = true;
                 ProfileEvents::increment(ProfileEvents::DuplicatedInsertedBlocks);
-                if (quorumEnabled())
+                if (isQuorumEnabled())
                 {
                     LOG_INFO(log, "Block with ID {} already exists locally as part {}; ignoring it, but checking quorum.", block_id, existing_part_name);
 
@@ -451,7 +454,7 @@ void ReplicatedMergeTreeSink::commitPart(
                     else
                         quorum_path = storage.zookeeper_path + "/quorum/status";
 
-                    waitForQuorum(zookeeper, existing_part_name, quorum_path, quorum_info.is_active_node_value);
+                    waitForQuorum(zookeeper, existing_part_name, quorum_path, quorum_info.is_active_node_value, replicas_num);
                 }
                 else
                 {
@@ -598,7 +601,7 @@ void ReplicatedMergeTreeSink::commitPart(
         break;
     }
 
-    if (quorumEnabled())
+    if (isQuorumEnabled())
     {
         if (is_already_existing_part)
         {
@@ -610,7 +613,7 @@ void ReplicatedMergeTreeSink::commitPart(
                 storage.updateQuorum(part->name, false);
         }
 
-        waitForQuorum(zookeeper, part->name, quorum_info.status_path, quorum_info.is_active_node_value);
+        waitForQuorum(zookeeper, part->name, quorum_info.status_path, quorum_info.is_active_node_value, replicas_num);
     }
 }
 
@@ -632,10 +635,11 @@ void ReplicatedMergeTreeSink::waitForQuorum(
     zkutil::ZooKeeperPtr & zookeeper,
     const std::string & part_name,
     const std::string & quorum_path,
-    const std::string & is_active_node_value) const
+    const std::string & is_active_node_value,
+    size_t replicas_num) const
 {
     /// We are waiting for quorum to be satisfied.
-    LOG_TRACE(log, "Waiting for quorum");
+    LOG_TRACE(log, "Waiting for quorum '{}' for part {} on {} replicas", quorum_path, part_name, replicas_num);
 
     try
     {
@@ -659,7 +663,7 @@ void ReplicatedMergeTreeSink::waitForQuorum(
             if (!event->tryWait(quorum_timeout_ms))
                 throw Exception("Timeout while waiting for quorum", ErrorCodes::TIMEOUT_EXCEEDED);
 
-            LOG_TRACE(log, "Quorum {} updated, will check quorum node still exists", quorum_path);
+            LOG_TRACE(log, "Quorum {} for part {} updated, will check quorum node still exists", quorum_path, part_name);
         }
 
         /// And what if it is possible that the current replica at this time has ceased to be active
@@ -677,8 +681,23 @@ void ReplicatedMergeTreeSink::waitForQuorum(
             ErrorCodes::UNKNOWN_STATUS_OF_INSERT);
     }
 
-    LOG_TRACE(log, "Quorum satisfied");
+    LOG_TRACE(log, "Quorum '{}' for part {} satisfied", quorum_path, part_name);
 }
 
+size_t ReplicatedMergeTreeSink::getQuorumSize(size_t replicas_num) const
+{
+    if (!isQuorumEnabled())
+        return 0;
+
+    if (required_quorum_size)
+        return required_quorum_size.value();
+
+    return replicas_num / 2 + 1;
+}
+
+bool ReplicatedMergeTreeSink::isQuorumEnabled() const
+{
+    return !required_quorum_size.has_value() || required_quorum_size.value() > 1;
+}
 
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
@@ -32,6 +32,7 @@ public:
         size_t max_parts_per_block_,
         bool quorum_parallel_,
         bool deduplicate_,
+        bool majority_quorum_,
         ContextPtr context_,
         // special flag to determine the ALTER TABLE ATTACH PART without the query context,
         // needed to set the special LogEntryType::ATTACH_PART
@@ -68,7 +69,8 @@ private:
     };
 
     QuorumInfo quorum_info;
-    void checkQuorumPrecondition(zkutil::ZooKeeperPtr & zookeeper);
+    /// set quorum if majority_quorum is true and checks active replicas
+    void setMajorityQuorumAndCheckQuorum(zkutil::ZooKeeperPtr & zookeeper);
 
     /// Rename temporary part and commit to ZooKeeper.
     void commitPart(
@@ -93,6 +95,7 @@ private:
     bool quorum_parallel = false;
     const bool deduplicate = true;
     bool last_block_is_duplicate = false;
+    bool majority_quorum = false;
 
     using Logger = Poco::Logger;
     Poco::Logger * log;
@@ -107,6 +110,10 @@ private:
     std::unique_ptr<DelayedChunk> delayed_chunk;
 
     void finishDelayedChunk(zkutil::ZooKeeperPtr & zookeeper);
+    bool quorumEnabled() const
+    {
+        return majority_quorum || quorum != 0;
+    }
 };
 
 }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4437,6 +4437,7 @@ SinkToStoragePtr StorageReplicatedMergeTree::write(const ASTPtr & /*query*/, con
         query_settings.max_partitions_per_insert_block,
         query_settings.insert_quorum_parallel,
         deduplicate,
+        query_settings.majority_insert_quorum,
         local_context);
 }
 
@@ -5125,7 +5126,7 @@ PartitionCommandsResultInfo StorageReplicatedMergeTree::attachPartition(
     MutableDataPartsVector loaded_parts = tryLoadPartsToAttach(partition, attach_part, query_context, renamed_parts);
 
     /// TODO Allow to use quorum here.
-    ReplicatedMergeTreeSink output(*this, metadata_snapshot, 0, 0, 0, false, false, query_context,
+    ReplicatedMergeTreeSink output(*this, metadata_snapshot, 0, 0, 0, false, false, false, query_context,
         /*is_attach*/true);
 
     for (size_t i = 0; i < loaded_parts.size(); ++i)
@@ -8394,7 +8395,7 @@ void StorageReplicatedMergeTree::restoreDataFromBackup(RestorerFromBackup & rest
 void StorageReplicatedMergeTree::attachRestoredParts(MutableDataPartsVector && parts)
 {
     auto metadata_snapshot = getInMemoryMetadataPtr();
-    auto sink = std::make_shared<ReplicatedMergeTreeSink>(*this, metadata_snapshot, 0, 0, 0, false, false, getContext(), /*is_attach*/true);
+    auto sink = std::make_shared<ReplicatedMergeTreeSink>(*this, metadata_snapshot, 0, 0, 0, false, false, false,  getContext(), /*is_attach*/true);
     for (auto part : parts)
         sink->writeExistingPart(part);
 }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4430,14 +4430,13 @@ SinkToStoragePtr StorageReplicatedMergeTree::write(const ASTPtr & /*query*/, con
     bool deduplicate = storage_settings_ptr->replicated_deduplication_window != 0 && query_settings.insert_deduplicate;
 
     // TODO: should we also somehow pass list of columns to deduplicate on to the ReplicatedMergeTreeSink?
-    // TODO: insert_quorum = 'auto' would be supported in https://github.com/ClickHouse/ClickHouse/pull/39970, now it's same as 0.
     return std::make_shared<ReplicatedMergeTreeSink>(
         *this, metadata_snapshot, query_settings.insert_quorum.valueOr(0),
         query_settings.insert_quorum_timeout.totalMilliseconds(),
         query_settings.max_partitions_per_insert_block,
         query_settings.insert_quorum_parallel,
         deduplicate,
-        query_settings.majority_insert_quorum,
+        query_settings.insert_quorum.is_auto,
         local_context);
 }
 

--- a/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.reference
+++ b/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.reference
@@ -1,0 +1,39 @@
+1
+2
+3
+1
+2
+3
+majority_insert_quorum	1	1	Choose number_of_replicas/2 + 1 as insert_quorum. Note if insert_quorum and majority_insert_quorum both are specified max(insert_quorum, number_of_replicas/2+1) will be used	\N	\N	0	Bool
+majority_insert_quorum	0	1	Choose number_of_replicas/2 + 1 as insert_quorum. Note if insert_quorum and majority_insert_quorum both are specified max(insert_quorum, number_of_replicas/2+1) will be used	\N	\N	0	Bool
+majority_insert_quorum	1	1	Choose number_of_replicas/2 + 1 as insert_quorum. Note if insert_quorum and majority_insert_quorum both are specified max(insert_quorum, number_of_replicas/2+1) will be used	\N	\N	0	Bool
+1
+1
+1
+1
+1
+1
+1
+2
+3
+1
+2
+3
+1
+2
+3
+11
+11
+11
+11
+11
+11
+11
+12
+13
+11
+12
+13
+11
+12
+13

--- a/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.reference
+++ b/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.reference
@@ -4,9 +4,6 @@
 1
 2
 3
-majority_insert_quorum	1	1	Choose number_of_replicas/2 + 1 as insert_quorum. Note if insert_quorum and majority_insert_quorum both are specified max(insert_quorum, number_of_replicas/2+1) will be used	\N	\N	0	Bool
-majority_insert_quorum	0	1	Choose number_of_replicas/2 + 1 as insert_quorum. Note if insert_quorum and majority_insert_quorum both are specified max(insert_quorum, number_of_replicas/2+1) will be used	\N	\N	0	Bool
-majority_insert_quorum	1	1	Choose number_of_replicas/2 + 1 as insert_quorum. Note if insert_quorum and majority_insert_quorum both are specified max(insert_quorum, number_of_replicas/2+1) will be used	\N	\N	0	Bool
 1
 1
 1
@@ -22,18 +19,3 @@ majority_insert_quorum	1	1	Choose number_of_replicas/2 + 1 as insert_quorum. Not
 1
 2
 3
-11
-11
-11
-11
-11
-11
-11
-12
-13
-11
-12
-13
-11
-12
-13

--- a/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.sql
+++ b/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.sql
@@ -1,0 +1,122 @@
+-- Tags: long, zookeeper
+
+SET send_logs_level = 'fatal';
+SET insert_quorum_parallel = false;
+SET select_sequential_consistency=1;
+
+DROP TABLE IF EXISTS quorum1;
+DROP TABLE IF EXISTS quorum2;
+DROP TABLE IF EXISTS quorum3;
+
+CREATE TABLE quorum1(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum', '1') ORDER BY x PARTITION BY y;
+CREATE TABLE quorum2(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum', '2') ORDER BY x PARTITION BY y;
+
+-- majority_insert_quorum = n/2 + 1 , so insert will be written to both replica
+SET majority_insert_quorum = true;
+
+INSERT INTO quorum1 VALUES (1, '2018-11-15');
+INSERT INTO quorum1 VALUES (2, '2018-11-15');
+INSERT INTO quorum1 VALUES (3, '2018-12-16');
+
+SELECT x FROM quorum1 ORDER BY x;
+SELECT x FROM quorum2 ORDER BY x;
+
+DROP TABLE quorum1;
+DROP TABLE quorum2;
+
+-- check majority_insert_quorum valid values
+SET majority_insert_quorum = TrUe;
+select * from system.settings where name like 'majority_insert_quorum';
+SET majority_insert_quorum = FalSE;
+select * from system.settings where name like 'majority_insert_quorum';
+-- this is also allowed
+SET majority_insert_quorum = 10;
+select * from system.settings where name like 'majority_insert_quorum';
+
+-- Create 3 replicas and stop sync 2 replicas
+CREATE TABLE quorum1(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum1', '1') ORDER BY x PARTITION BY y;
+CREATE TABLE quorum2(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum1', '2') ORDER BY x PARTITION BY y;
+CREATE TABLE quorum3(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum1', '3') ORDER BY x PARTITION BY y;
+
+SET majority_insert_quorum = true;
+
+-- Insert should be successful
+-- stop replica 3
+SYSTEM STOP FETCHES quorum3;
+INSERT INTO quorum1 VALUES (1, '2018-11-15');
+SELECT x FROM quorum1 ORDER BY x;
+SELECT x FROM quorum2 ORDER BY x;
+SELECT x FROM quorum3 ORDER BY x; -- {serverError 289}
+
+-- Sync replica 3
+SYSTEM START FETCHES quorum3;
+SYSTEM SYNC REPLICA quorum3;
+SELECT x FROM quorum3 ORDER BY x;
+
+-- Stop 2 replicas , so insert wont be successful
+SYSTEM STOP FETCHES quorum2;
+SYSTEM STOP FETCHES quorum3;
+SET insert_quorum_timeout = 5000;
+INSERT INTO quorum1 VALUES (2, '2018-11-15'); -- { serverError 319 }
+SELECT x FROM quorum1 ORDER BY x;
+SELECT x FROM quorum2 ORDER BY x;
+SELECT x FROM quorum3 ORDER BY x;
+
+-- Sync replica 2 and 3
+SYSTEM START FETCHES quorum2;
+SYSTEM SYNC REPLICA quorum2;
+SYSTEM START FETCHES quorum3;
+SYSTEM SYNC REPLICA quorum3;
+
+INSERT INTO quorum1 VALUES (3, '2018-11-15');
+SELECT x FROM quorum1 ORDER BY x;
+SYSTEM SYNC REPLICA quorum2;
+SYSTEM SYNC REPLICA quorum3;
+SELECT x FROM quorum2 ORDER BY x;
+SELECT x FROM quorum3 ORDER BY x;
+
+DROP TABLE quorum1;
+DROP TABLE quorum2;
+DROP TABLE quorum3;
+
+-- both insert_quorum and majority_insert_quorum are on, in that case max of both will be used as insert quorum
+-- insert_quorum < n/2 +1
+SET majority_insert_quorum = true;
+set insert_quorum = 1;
+CREATE TABLE quorum1(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum2', '1') ORDER BY x PARTITION BY y;
+CREATE TABLE quorum2(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum2', '2') ORDER BY x PARTITION BY y;
+CREATE TABLE quorum3(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum2', '3') ORDER BY x PARTITION BY y;
+
+-- Insert should be successful
+-- stop replica 3
+SYSTEM STOP FETCHES quorum3;
+INSERT INTO quorum1 VALUES (11, '2018-11-15');
+SELECT x FROM quorum1 ORDER BY x;
+SELECT x FROM quorum2 ORDER BY x;
+SELECT x FROM quorum3 ORDER BY x; -- {serverError 289}
+
+-- Sync replica 3
+SYSTEM START FETCHES quorum3;
+SYSTEM SYNC REPLICA quorum3;
+SELECT x FROM quorum3 ORDER BY x;
+
+-- insert_quorum > n/2 +1
+set insert_quorum = 3;
+SET majority_insert_quorum = false;
+SYSTEM STOP FETCHES quorum3;
+INSERT INTO quorum1 VALUES (12, '2018-11-15'); -- { serverError 319 }
+SELECT x FROM quorum1 ORDER BY x;
+SELECT x FROM quorum2 ORDER BY x;
+SELECT x FROM quorum3 ORDER BY x;
+
+-- Sync replica 3
+SYSTEM START FETCHES quorum3;
+SYSTEM SYNC REPLICA quorum3;
+INSERT INTO quorum1 VALUES (13, '2018-11-15');
+SELECT x FROM quorum1 ORDER BY x;
+SELECT x FROM quorum2 ORDER BY x;
+SELECT x FROM quorum3 ORDER BY x;
+
+DROP TABLE quorum1;
+DROP TABLE quorum2;
+DROP TABLE quorum3;

--- a/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.sql
+++ b/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.sql
@@ -1,8 +1,11 @@
--- Tags: long, zookeeper
+-- Tags: long, zookeeper, no-replicated-database
 
-SET send_logs_level = 'fatal';
+-- no-replicated-database:
+--   The number of replicas is doubled, so `SYSTEM STOP FETCHES` stop not enough replicas.
+
 SET insert_quorum_parallel = false;
-SET select_sequential_consistency=1;
+
+SET select_sequential_consistency = 1;
 
 DROP TABLE IF EXISTS quorum1;
 DROP TABLE IF EXISTS quorum2;

--- a/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.sql
+++ b/tests/queries/0_stateless/02377_majority_insert_quorum_zookeeper_long.sql
@@ -11,8 +11,8 @@ DROP TABLE IF EXISTS quorum3;
 CREATE TABLE quorum1(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum', '1') ORDER BY x PARTITION BY y;
 CREATE TABLE quorum2(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum', '2') ORDER BY x PARTITION BY y;
 
--- majority_insert_quorum = n/2 + 1 , so insert will be written to both replica
-SET majority_insert_quorum = true;
+-- insert_quorum = n/2 + 1 , so insert will be written to both replica
+SET insert_quorum = 'auto';
 
 INSERT INTO quorum1 VALUES (1, '2018-11-15');
 INSERT INTO quorum1 VALUES (2, '2018-11-15');
@@ -24,21 +24,10 @@ SELECT x FROM quorum2 ORDER BY x;
 DROP TABLE quorum1;
 DROP TABLE quorum2;
 
--- check majority_insert_quorum valid values
-SET majority_insert_quorum = TrUe;
-select * from system.settings where name like 'majority_insert_quorum';
-SET majority_insert_quorum = FalSE;
-select * from system.settings where name like 'majority_insert_quorum';
--- this is also allowed
-SET majority_insert_quorum = 10;
-select * from system.settings where name like 'majority_insert_quorum';
-
 -- Create 3 replicas and stop sync 2 replicas
 CREATE TABLE quorum1(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum1', '1') ORDER BY x PARTITION BY y;
 CREATE TABLE quorum2(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum1', '2') ORDER BY x PARTITION BY y;
 CREATE TABLE quorum3(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum1', '3') ORDER BY x PARTITION BY y;
-
-SET majority_insert_quorum = true;
 
 -- Insert should be successful
 -- stop replica 3
@@ -72,48 +61,6 @@ INSERT INTO quorum1 VALUES (3, '2018-11-15');
 SELECT x FROM quorum1 ORDER BY x;
 SYSTEM SYNC REPLICA quorum2;
 SYSTEM SYNC REPLICA quorum3;
-SELECT x FROM quorum2 ORDER BY x;
-SELECT x FROM quorum3 ORDER BY x;
-
-DROP TABLE quorum1;
-DROP TABLE quorum2;
-DROP TABLE quorum3;
-
--- both insert_quorum and majority_insert_quorum are on, in that case max of both will be used as insert quorum
--- insert_quorum < n/2 +1
-SET majority_insert_quorum = true;
-set insert_quorum = 1;
-CREATE TABLE quorum1(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum2', '1') ORDER BY x PARTITION BY y;
-CREATE TABLE quorum2(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum2', '2') ORDER BY x PARTITION BY y;
-CREATE TABLE quorum3(x UInt32, y Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/{database}/test_02377/quorum2', '3') ORDER BY x PARTITION BY y;
-
--- Insert should be successful
--- stop replica 3
-SYSTEM STOP FETCHES quorum3;
-INSERT INTO quorum1 VALUES (11, '2018-11-15');
-SELECT x FROM quorum1 ORDER BY x;
-SELECT x FROM quorum2 ORDER BY x;
-SELECT x FROM quorum3 ORDER BY x; -- {serverError 289}
-
--- Sync replica 3
-SYSTEM START FETCHES quorum3;
-SYSTEM SYNC REPLICA quorum3;
-SELECT x FROM quorum3 ORDER BY x;
-
--- insert_quorum > n/2 +1
-set insert_quorum = 3;
-SET majority_insert_quorum = false;
-SYSTEM STOP FETCHES quorum3;
-INSERT INTO quorum1 VALUES (12, '2018-11-15'); -- { serverError 319 }
-SELECT x FROM quorum1 ORDER BY x;
-SELECT x FROM quorum2 ORDER BY x;
-SELECT x FROM quorum3 ORDER BY x;
-
--- Sync replica 3
-SYSTEM START FETCHES quorum3;
-SYSTEM SYNC REPLICA quorum3;
-INSERT INTO quorum1 VALUES (13, '2018-11-15');
-SELECT x FROM quorum1 ORDER BY x;
 SELECT x FROM quorum2 ORDER BY x;
 SELECT x FROM quorum3 ORDER BY x;
 


### PR DESCRIPTION
majority_insert_quorum is defined as (number_of_replicas/2)+1. Insert
will be successful only if majority of quorum have applied it. If
insert_quorum and majority_insert_quorum both are specified, max of
both will be used.


### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Support `insert_quorum = 'auto'` to use majority number


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
