### PR TITLE
Add setting type to support special 'auto' value

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -212,7 +212,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     \
     M(Bool, insert_deduplicate, true, "For INSERT queries in the replicated table, specifies that deduplication of insertings blocks should be performed", 0) \
     \
-    M(UInt64, insert_quorum, 0, "For INSERT queries in the replicated table, wait writing for the specified number of replicas and linearize the addition of the data. 0 - disabled.", 0) \
+    M(UInt64WithAuto, insert_quorum, 0, "For INSERT queries in the replicated table, wait writing for the specified number of replicas and linearize the addition of the data. 0 - disabled.", 0) \
     M(Milliseconds, insert_quorum_timeout, 600000, "", 0) \
     M(Bool, insert_quorum_parallel, true, "For quorum INSERT queries - enable to make parallel inserts without linearizability", 0) \
     M(UInt64, select_sequential_consistency, 0, "For SELECT queries from the replicated table, throw an exception if the replica does not have a chunk written with the quorum; do not read the parts that have not yet been written with the quorum.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -212,7 +212,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     \
     M(Bool, insert_deduplicate, true, "For INSERT queries in the replicated table, specifies that deduplication of insertings blocks should be performed", 0) \
     \
-    M(UInt64WithAuto, insert_quorum, 0, "For INSERT queries in the replicated table, wait writing for the specified number of replicas and linearize the addition of the data. 0 - disabled.", 0) \
+    M(UInt64Auto, insert_quorum, 0, "For INSERT queries in the replicated table, wait writing for the specified number of replicas and linearize the addition of the data. 0 - disabled.", 0) \
     M(Milliseconds, insert_quorum_timeout, 600000, "", 0) \
     M(Bool, insert_quorum_parallel, true, "For quorum INSERT queries - enable to make parallel inserts without linearizability", 0) \
     M(UInt64, select_sequential_consistency, 0, "For SELECT queries from the replicated table, throw an exception if the replica does not have a chunk written with the quorum; do not read the parts that have not yet been written with the quorum.", 0) \

--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -153,9 +153,9 @@ template struct SettingFieldNumber<Int64>;
 template struct SettingFieldNumber<float>;
 template struct SettingFieldNumber<bool>;
 
-template struct SettingWithAuto<SettingFieldNumber<UInt64>>;
-template struct SettingWithAuto<SettingFieldNumber<Int64>>;
-template struct SettingWithAuto<SettingFieldNumber<float>>;
+template struct SettingAutoWrapper<SettingFieldNumber<UInt64>>;
+template struct SettingAutoWrapper<SettingFieldNumber<Int64>>;
+template struct SettingAutoWrapper<SettingFieldNumber<float>>;
 
 namespace
 {

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -115,7 +115,7 @@ struct SettingAutoWrapper
             base.writeBinary(out);
     }
 
-    /* 
+    /*
      * That it is fine to reset `is_auto` here and to use default value in case `is_auto`
      * because settings will be serialized only if changed.
      * If they were changed they were requested to use explicit value instead of `auto`.

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4443,8 +4443,9 @@ SinkToStoragePtr StorageReplicatedMergeTree::write(const ASTPtr & /*query*/, con
     bool deduplicate = storage_settings_ptr->replicated_deduplication_window != 0 && query_settings.insert_deduplicate;
 
     // TODO: should we also somehow pass list of columns to deduplicate on to the ReplicatedMergeTreeSink?
+    // TODO: insert_quorum = 'auto' would be supported in https://github.com/ClickHouse/ClickHouse/pull/39970, now it's same as 0.
     return std::make_shared<ReplicatedMergeTreeSink>(
-        *this, metadata_snapshot, query_settings.insert_quorum,
+        *this, metadata_snapshot, query_settings.insert_quorum.valueOr(0),
         query_settings.insert_quorum_timeout.totalMilliseconds(),
         query_settings.max_partitions_per_insert_block,
         query_settings.insert_quorum_parallel,

--- a/tests/queries/0_stateless/02381_setting_value_auto.reference
+++ b/tests/queries/0_stateless/02381_setting_value_auto.reference
@@ -1,4 +1,4 @@
-0	0	UInt64WithAuto
-auto	1	UInt64WithAuto
-0	1	UInt64WithAuto
-1	1	UInt64WithAuto
+0	0	UInt64Auto
+auto	1	UInt64Auto
+0	1	UInt64Auto
+1	1	UInt64Auto

--- a/tests/queries/0_stateless/02381_setting_value_auto.reference
+++ b/tests/queries/0_stateless/02381_setting_value_auto.reference
@@ -1,0 +1,4 @@
+0	0	UInt64WithAuto
+auto	1	UInt64WithAuto
+0	1	UInt64WithAuto
+1	1	UInt64WithAuto

--- a/tests/queries/0_stateless/02381_setting_value_auto.sql
+++ b/tests/queries/0_stateless/02381_setting_value_auto.sql
@@ -1,0 +1,10 @@
+SELECT value, changed, type FROM system.settings WHERE name = 'insert_quorum';
+
+SET insert_quorum = 'auto';
+SELECT value, changed, type FROM system.settings WHERE name = 'insert_quorum';
+
+SET insert_quorum = 0;
+SELECT value, changed, type FROM system.settings WHERE name = 'insert_quorum';
+
+SET insert_quorum = 1;
+SELECT value, changed, type FROM system.settings WHERE name = 'insert_quorum';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We usually use numeric settings, but with special treatment for some values like `0` or `-1`. Using `0` as auto is not always the best solution because it's less explicit, and also, it could mean 'disabled' (let's image setting `some_cache_size`, so 0 means cache size is 0 bytes - don't use it at all, and 'auto' is use cache with automatic size). Now only type `MaxThreads` parses value `auto`.
This PR suggests introducing a type for such settings. 

The only my concern in how to upgrade existing setting (if we realize that we need 'auto' in some future version) without breaking serialization compatibility

Can be used e. g. for https://github.com/ClickHouse/ClickHouse/pull/39970


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
