### PR TITLE
tests/stress: fix dmesg reading

### DIFF
--- a/tests/ci/stress_check.py
+++ b/tests/ci/stress_check.py
@@ -33,6 +33,8 @@ def get_run_command(
         "docker run --cap-add=SYS_PTRACE "
         # a static link, don't use S3_URL or S3_DOWNLOAD
         "-e S3_URL='https://s3.amazonaws.com/clickhouse-datasets' "
+        # For dmesg
+        "--cap-add syslog "
         f"--volume={build_path}:/package_folder "
         f"--volume={result_folder}:/test_output "
         f"--volume={repo_tests_path}:/usr/share/clickhouse-test "


### PR DESCRIPTION
After #39939 there is still an error:

    + dmesg -T
    dmesg: read kernel buffer failed: Operation not permitted

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/39939/a1981f21a153810f072af67bb6007dc1f4367c22/stress_test__debug_.html

Since it is not allowed to access dmesg by default,
one of the following is required:

- `--cap-add syslog`
- `--cap-add cap_sys_admin`
- `--privileged`

I decided to use as little capabilities as possible, even though it is
not that important on CI, but it is a rule of thumb.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #39939 (cc @alexey-milovidov )