### PR TITLE
Disable 02360_send_logs_level_colors for ubsan

### DIFF
--- a/tests/queries/0_stateless/02360_send_logs_level_colors.sh
+++ b/tests/queries/0_stateless/02360_send_logs_level_colors.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Tags: no-ubsan
+
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It has a timeout 3 sec, but for ubsan it's not enough ([checks](https://play.clickhouse.com/play?user=play#CiAgICBTRUxFQ1QKICAgICAgICByZXBvcnRfdXJsLAogICAgICAgIHN1YnN0cmluZyhjaGVja19uYW1lLCAxLCAxNSkgfHwgJy4uLicgfHwgc3Vic3RyaW5nKGNoZWNrX25hbWUsIC0xNSkgYXMgY2hlY2ssCiAgICAgICAgc3Vic3RyaW5nKHRlc3RfbmFtZSwgLTUwKSBhcyB0ZXN0LAogICAgICAgIGNoZWNrX3N0YXJ0X3RpbWUsCiAgICAgICAgdGVzdF9zdGF0dXMsCiAgICAgICAgc3Vic3RyaW5nKGNvbW1pdF9zaGEsIDEsIDEwKSBhcyBjb21taXRfc2hvcnQsCiAgICAgICAgcHVsbF9yZXF1ZXN0X251bWJlciBhcyBwcm51bSwKICAgICAgICBtdWx0aUlmKAogICAgICAgICAgICBub3coKSAtIElOVEVSVkFMICcxJyBkYXkgPD0gY2hlY2tfc3RhcnRfdGltZSwgJzwxZCcsCiAgICAgICAgICAgIG5vdygpIC0gSU5URVJWQUwgJzcnIGRheSA8PSBjaGVja19zdGFydF90aW1lLCAnPDF3JywKICAgICAgICAgICAgJycpIGFzIGxhc3QKICAgIEZST00gY2hlY2tzCiAgICBXSEVSRSB0ZXN0X3N0YXR1cyBub3QgaW4gKCdPSycsICdTS0lQUEVEJykKICAgICAgICBBTkQgdGVzdF9uYW1lIGxpa2UgJyUwMjM2MF9zZW5kX2xvZ3NfbGV2ZWxfY29sb3JzJScKICAgICAgICBBTkQgbm93KCkgLSBJTlRFUlZBTCAnMTAnIGRheSA8PSBjaGVja19zdGFydF90aW1lCiAgICBPUkRFUiBCWQogICAgICAgIGNoZWNrX3N0YXJ0X3RpbWUgREVTQwoK)). It doesn't run complex query, just `SELECT 1` and grep logs, so I suppose we can do not run it for sanitizer builds

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
