### PR TITLE
Use different root path for Jepsen Counter test

### DIFF
--- a/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/counter.clj
+++ b/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/counter.clj
@@ -9,6 +9,7 @@
    [zookeeper :as zk])
   (:import (org.apache.zookeeper ZooKeeper KeeperException KeeperException$BadVersionException)))
 
+(def root-path "/counter")
 (defn r   [_ _] {:type :invoke, :f :read})
 (defn add [_ _] {:type :invoke, :f :add, :value (rand-int 5)})
 
@@ -20,17 +21,19 @@
             :conn (zk-connect node 9181 30000))
      :nodename node))
 
-  (setup! [this test])
+  (setup! [this test]
+    (exec-with-retries 30 (fn []
+      (zk-create-if-not-exists conn root-path ""))))
 
   (invoke! [this test op]
     (case (:f op)
       :read (exec-with-retries 30 (fn []
                                     (assoc op
                                            :type :ok
-                                           :value (count (zk-list conn "/")))))
+                                           :value (count (zk-list conn root-path)))))
       :add (try
              (do
-               (zk-multi-create-many-seq-nodes conn "/seq-" (:value op))
+               (zk-multi-create-many-seq-nodes conn (concat-path root-path "seq-") (:value op))
                (assoc op :type :ok))
              (catch Exception _ (assoc op :type :info, :error :connect-error)))))
 


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Same reasoning as for #39738 
Other tests don't use list request, so this should be the last test affected by `/keeper` addition.

Fix #39989 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
