### PR TITLE
Fix hashId crash and salt parameter not being used

### DIFF
--- a/src/Functions/FunctionHashID.h
+++ b/src/Functions/FunctionHashID.h
@@ -52,6 +52,7 @@ public:
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
     bool useDefaultImplementationForConstants() const override { return true; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1, 2, 3}; }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
@@ -69,7 +70,7 @@ public:
         if (arguments.size() > 1)
         {
             const auto & hash_col = arguments[1];
-            if (!isString(hash_col.type) || !isColumnConst(*hash_col.column.get()))
+            if (!isString(hash_col.type))
                 throw Exception(
                     ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                     "Second argument of function {} must be String, got {}",
@@ -80,7 +81,7 @@ public:
         if (arguments.size() > 2)
         {
             const auto & min_length_col = arguments[2];
-            if (!isUInt8(min_length_col.type) || !isColumnConst(*min_length_col.column.get()))
+            if (!isUInt8(min_length_col.type))
                 throw Exception(
                     ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                     "Third argument of function {} must be UInt8, got {}",
@@ -91,7 +92,7 @@ public:
         if (arguments.size() > 3)
         {
             const auto & alphabet_col = arguments[3];
-            if (!isString(alphabet_col.type) || !isColumnConst(*alphabet_col.column.get()))
+            if (!isString(alphabet_col.type))
                 throw Exception(
                     ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                     "Fourth argument of function {} must be String, got {}",

--- a/tests/queries/0_stateless/02293_hashid.reference
+++ b/tests/queries/0_stateless/02293_hashid.reference
@@ -8,5 +8,8 @@
 2	obmgndljgajpkeao
 3	dldokmpjpgjgeanb
 4	nkdlpgajngjnobme
-xkOpDGxQpVB
-jR
+YQrvD5XGvbx
+Bm3zaOq7zbp
+oV
+oV
+6b

--- a/tests/queries/0_stateless/02293_hashid.sql
+++ b/tests/queries/0_stateless/02293_hashid.sql
@@ -1,3 +1,4 @@
+-- Tags: no-backward-compatibility-check
 SET allow_experimental_hash_functions = 1;
 
 select number, hashid(number) from system.numbers limit 5;

--- a/tests/queries/0_stateless/02293_hashid.sql
+++ b/tests/queries/0_stateless/02293_hashid.sql
@@ -3,5 +3,13 @@ SET allow_experimental_hash_functions = 1;
 select number, hashid(number) from system.numbers limit 5;
 select number, hashid(number, 's3cr3t', 16, 'abcdefghijklmnop') from system.numbers limit 5;
 select hashid(1234567890123456, 's3cr3t');
+select hashid(1234567890123456, 's3cr3t2');
 
 SELECT  hashid(1, hashid(2));
+SELECT  hashid(1, 'k5');
+SELECT  hashid(1, 'k5_othersalt');
+
+-- https://github.com/ClickHouse/ClickHouse/issues/39672
+SELECT
+    JSONExtractRaw(257, NULL),
+    hashid(1024, if(rand() % 10, 'truetruetruetrue', NULL), 's3\0r3t'); -- {serverError 43}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix hashId crash and salt parameter not being used


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Closes #39672
While testing this I noticed that the salt wasn't being applied in some cases, so that's fixed too. This is an experimental feature, so I'm not sure if it's worth backporting.

In any case, the fact that all this wasn't working and nobody complained makes me wonder if this is necessary. I only fixed it because I stumbled upon #39672 
