### PR TITLE
Add ability to load hashed dictionaries using multiple threads

### DIFF
--- a/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-layout.md
+++ b/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-layout.md
@@ -164,6 +164,15 @@ Configuration example:
 <layout>
   <hashed>
     <shards>10</shards>
+    <!-- Size of the backlog for blocks in parallel queue.
+
+         Since the bottleneck in parallel loading is rehash, and so to avoid
+         stalling because of thread is doing rehash, you need to have some
+         backlog.
+
+         10000 is good balance between memory and speed.
+         Even for 10e10 elements and can handle all the load without starvation. -->
+    <shard_load_queue_backlog>10000</shard_load_queue_backlog>
   </hashed>
 </layout>
 ```
@@ -171,7 +180,7 @@ Configuration example:
 or
 
 ``` sql
-LAYOUT(HASHED(SHARDS 10))
+LAYOUT(HASHED(SHARDS 10 [SHARD_LOAD_QUEUE_BACKLOG 10000]))
 ```
 
 ### sparse_hashed
@@ -209,6 +218,7 @@ Configuration example:
   <complex_key_hashed>
     <preallocate>0</preallocate>
     <shards>1</shards>
+    <!-- <shard_load_queue_backlog>10000</shard_load_queue_backlog> -->
   </complex_key_hashed>
 </layout>
 ```
@@ -216,7 +226,7 @@ Configuration example:
 or
 
 ``` sql
-LAYOUT(COMPLEX_KEY_HASHED([PREALLOCATE 0] [SHARDS 1]))
+LAYOUT(COMPLEX_KEY_HASHED([PREALLOCATE 0] [SHARDS 1] [SHARD_LOAD_QUEUE_BACKLOG 10000]))
 ```
 
 ### complex_key_sparse_hashed
@@ -237,7 +247,7 @@ Configuration example:
 or
 
 ``` sql
-LAYOUT(COMPLEX_KEY_SPARSE_HASHED([PREALLOCATE 0] [SHARDS 1]))
+LAYOUT(COMPLEX_KEY_SPARSE_HASHED([PREALLOCATE 0] [SHARDS 1] [SHARD_LOAD_QUEUE_BACKLOG 10000]))
 ```
 
 ### hashed_array

--- a/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-layout.md
+++ b/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts-dict-layout.md
@@ -156,6 +156,24 @@ or
 LAYOUT(HASHED(PREALLOCATE 0))
 ```
 
+If `shards` greater then 1 (default is `1`) the dictionary will load data in parallel, useful if you have huge amount of elements in one dictionary.
+
+Configuration example:
+
+``` xml
+<layout>
+  <hashed>
+    <shards>10</shards>
+  </hashed>
+</layout>
+```
+
+or
+
+``` sql
+LAYOUT(HASHED(SHARDS 10))
+```
+
 ### sparse_hashed
 
 Similar to `hashed`, but uses less memory in favor more CPU usage.
@@ -178,6 +196,8 @@ or
 LAYOUT(SPARSE_HASHED([PREALLOCATE 0]))
 ```
 
+It is also possible to use `shards` for this type of dictionary, and again it is more important for `sparse_hashed` then for `hashed`, since `sparse_hashed` is slower.
+
 ### complex_key_hashed
 
 This type of storage is for use with composite [keys](../../../sql-reference/dictionaries/external-dictionaries/external-dicts-dict-structure.md). Similar to `hashed`.
@@ -186,14 +206,17 @@ Configuration example:
 
 ``` xml
 <layout>
-  <complex_key_hashed />
+  <complex_key_hashed>
+    <preallocate>0</preallocate>
+    <shards>1</shards>
+  </complex_key_hashed>
 </layout>
 ```
 
 or
 
 ``` sql
-LAYOUT(COMPLEX_KEY_HASHED())
+LAYOUT(COMPLEX_KEY_HASHED([PREALLOCATE 0] [SHARDS 1]))
 ```
 
 ### complex_key_sparse_hashed
@@ -204,14 +227,17 @@ Configuration example:
 
 ``` xml
 <layout>
-  <complex_key_sparse_hashed />
+  <complex_key_sparse_hashed>
+    <preallocate>0</preallocate>
+    <shards>1</shards>
+  </complex_key_sparse_hashed>
 </layout>
 ```
 
 or
 
 ``` sql
-LAYOUT(COMPLEX_KEY_SPARSE_HASHED())
+LAYOUT(COMPLEX_KEY_SPARSE_HASHED([PREALLOCATE 0] [SHARDS 1]))
 ```
 
 ### hashed_array

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -38,8 +38,8 @@ namespace ErrorCodes
     extern const int UNSUPPORTED_METHOD;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-HashedDictionary<dictionary_key_type, sparse>::HashedDictionary(
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+HashedDictionary<dictionary_key_type, sparse, sharded>::HashedDictionary(
     const StorageID & dict_id_,
     const DictionaryStructure & dict_struct_,
     DictionarySourcePtr source_ptr_,
@@ -57,8 +57,8 @@ HashedDictionary<dictionary_key_type, sparse>::HashedDictionary(
     calculateBytesAllocated();
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getColumn(
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+ColumnPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getColumn(
     const std::string & attribute_name,
     const DataTypePtr & result_type,
     const Columns & key_columns,
@@ -164,8 +164,8 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getColumn(
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::hasKeys(const Columns & key_columns, const DataTypes & key_types) const
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse, sharded>::hasKeys(const Columns & key_columns, const DataTypes & key_types) const
 {
     if (dictionary_key_type == DictionaryKeyType::Complex)
         dict_struct.validateKeyTypes(key_types);
@@ -223,8 +223,8 @@ ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::hasKeys(const Co
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchy(ColumnPtr key_column [[maybe_unused]], const DataTypePtr &) const
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+ColumnPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getHierarchy(ColumnPtr key_column [[maybe_unused]], const DataTypePtr &) const
 {
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
     {
@@ -286,8 +286,8 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchy(ColumnPtr 
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::isInHierarchy(
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse, sharded>::isInHierarchy(
     ColumnPtr key_column [[maybe_unused]],
     ColumnPtr in_key_column [[maybe_unused]],
     const DataTypePtr &) const
@@ -356,8 +356,8 @@ ColumnUInt8::Ptr HashedDictionary<dictionary_key_type, sparse>::isInHierarchy(
         return nullptr;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-DictionaryHierarchyParentToChildIndexPtr HashedDictionary<dictionary_key_type, sparse>::getHierarchicalIndex() const
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+DictionaryHierarchyParentToChildIndexPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getHierarchicalIndex() const
 {
     if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
     {
@@ -391,8 +391,8 @@ DictionaryHierarchyParentToChildIndexPtr HashedDictionary<dictionary_key_type, s
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getDescendants(
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+ColumnPtr HashedDictionary<dictionary_key_type, sparse, sharded>::getDescendants(
     ColumnPtr key_column [[maybe_unused]],
     const DataTypePtr &,
     size_t level [[maybe_unused]],
@@ -417,8 +417,8 @@ ColumnPtr HashedDictionary<dictionary_key_type, sparse>::getDescendants(
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-void HashedDictionary<dictionary_key_type, sparse>::createAttributes()
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+void HashedDictionary<dictionary_key_type, sparse, sharded>::createAttributes()
 {
     const auto size = dict_struct.attributes.size();
     attributes.reserve(size);
@@ -449,8 +449,8 @@ void HashedDictionary<dictionary_key_type, sparse>::createAttributes()
         arena = std::make_unique<Arena>();
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-void HashedDictionary<dictionary_key_type, sparse>::updateData()
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+void HashedDictionary<dictionary_key_type, sparse, sharded>::updateData()
 {
     /// NOTE: updateData() does not preallocation since it may increase memory usage.
 
@@ -492,8 +492,8 @@ void HashedDictionary<dictionary_key_type, sparse>::updateData()
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-void HashedDictionary<dictionary_key_type, sparse>::blockToAttributes(const Block & block, std::optional<UInt64> current_shard)
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+void HashedDictionary<dictionary_key_type, sparse, sharded>::blockToAttributes(const Block & block, std::optional<UInt64> current_shard)
 {
     size_t skip_keys_size_offset = dict_struct.getKeysSize();
     size_t new_element_count = 0;
@@ -599,8 +599,8 @@ void HashedDictionary<dictionary_key_type, sparse>::blockToAttributes(const Bloc
     element_count += new_element_count;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-void HashedDictionary<dictionary_key_type, sparse>::resize(size_t added_rows)
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+void HashedDictionary<dictionary_key_type, sparse, sharded>::resize(size_t added_rows)
 {
     if (unlikely(!added_rows))
         return;
@@ -638,9 +638,9 @@ void HashedDictionary<dictionary_key_type, sparse>::resize(size_t added_rows)
     }
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
 template <typename AttributeType, bool is_nullable, typename ValueSetter, typename DefaultValueExtractor>
-void HashedDictionary<dictionary_key_type, sparse>::getItemsImpl(
+void HashedDictionary<dictionary_key_type, sparse, sharded>::getItemsImpl(
     const Attribute & attribute,
     DictionaryKeysExtractor<dictionary_key_type> & keys_extractor,
     ValueSetter && set_value [[maybe_unused]],
@@ -681,8 +681,8 @@ void HashedDictionary<dictionary_key_type, sparse>::getItemsImpl(
     found_count.fetch_add(keys_found, std::memory_order_relaxed);
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-void HashedDictionary<dictionary_key_type, sparse>::loadData()
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+void HashedDictionary<dictionary_key_type, sparse, sharded>::loadData()
 {
     if (!source_ptr->hasUpdateField())
     {
@@ -750,8 +750,8 @@ void HashedDictionary<dictionary_key_type, sparse>::loadData()
             getFullName());
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-void HashedDictionary<dictionary_key_type, sparse>::buildHierarchyParentToChildIndexIfNeeded()
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+void HashedDictionary<dictionary_key_type, sparse, sharded>::buildHierarchyParentToChildIndexIfNeeded()
 {
     if (!dict_struct.hierarchical_attribute_index)
         return;
@@ -760,8 +760,8 @@ void HashedDictionary<dictionary_key_type, sparse>::buildHierarchyParentToChildI
         hierarchical_index = getHierarchicalIndex();
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-void HashedDictionary<dictionary_key_type, sparse>::calculateBytesAllocated()
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+void HashedDictionary<dictionary_key_type, sparse, sharded>::calculateBytesAllocated()
 {
     size_t attributes_size = attributes.size();
     bytes_allocated += attributes_size * sizeof(attributes.front());
@@ -832,8 +832,8 @@ void HashedDictionary<dictionary_key_type, sparse>::calculateBytesAllocated()
         bytes_allocated += arena->size();
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
-Pipe HashedDictionary<dictionary_key_type, sparse>::read(const Names & column_names, size_t max_block_size, size_t num_streams) const
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+Pipe HashedDictionary<dictionary_key_type, sparse, sharded>::read(const Names & column_names, size_t max_block_size, size_t num_streams) const
 {
     PaddedPODArray<HashedDictionary::KeyType> keys;
 
@@ -900,9 +900,9 @@ Pipe HashedDictionary<dictionary_key_type, sparse>::read(const Names & column_na
     return result;
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
 template <typename GetContainerFunc>
-void HashedDictionary<dictionary_key_type, sparse>::getAttributeContainer(size_t attribute_index, GetContainerFunc && get_container_func)
+void HashedDictionary<dictionary_key_type, sparse, sharded>::getAttributeContainer(size_t attribute_index, GetContainerFunc && get_container_func)
 {
     assert(attribute_index < attributes.size());
 
@@ -921,9 +921,9 @@ void HashedDictionary<dictionary_key_type, sparse>::getAttributeContainer(size_t
     callOnDictionaryAttributeType(attribute.type, type_call);
 }
 
-template <DictionaryKeyType dictionary_key_type, bool sparse>
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
 template <typename GetContainerFunc>
-void HashedDictionary<dictionary_key_type, sparse>::getAttributeContainer(size_t attribute_index, GetContainerFunc && get_container_func) const
+void HashedDictionary<dictionary_key_type, sparse, sharded>::getAttributeContainer(size_t attribute_index, GetContainerFunc && get_container_func) const
 {
     const_cast<std::decay_t<decltype(*this)> *>(this)->getAttributeContainer(attribute_index, [&](auto & attribute_container)
     {
@@ -931,10 +931,14 @@ void HashedDictionary<dictionary_key_type, sparse>::getAttributeContainer(size_t
     });
 }
 
-template class HashedDictionary<DictionaryKeyType::Simple, true>;
-template class HashedDictionary<DictionaryKeyType::Simple, false>;
-template class HashedDictionary<DictionaryKeyType::Complex, true>;
-template class HashedDictionary<DictionaryKeyType::Complex, false>;
+template class HashedDictionary<DictionaryKeyType::Simple, false, false>;
+template class HashedDictionary<DictionaryKeyType::Simple, false, true>;
+template class HashedDictionary<DictionaryKeyType::Simple, true, false>;
+template class HashedDictionary<DictionaryKeyType::Simple, true, true>;
+template class HashedDictionary<DictionaryKeyType::Complex, false, false>;
+template class HashedDictionary<DictionaryKeyType::Complex, false, true>;
+template class HashedDictionary<DictionaryKeyType::Complex, true, false>;
+template class HashedDictionary<DictionaryKeyType::Complex, true, true>;
 
 void registerDictionaryHashed(DictionaryFactory & factory)
 {
@@ -990,16 +994,36 @@ void registerDictionaryHashed(DictionaryFactory & factory)
         if (dictionary_key_type == DictionaryKeyType::Simple)
         {
             if (sparse)
-                return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, true>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            {
+                if (shards > 1)
+                    return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, true, true>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+                else
+                    return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, true, false>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            }
             else
-                return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, false>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            {
+                if (shards > 1)
+                    return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, false, true>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+                else
+                    return std::make_unique<HashedDictionary<DictionaryKeyType::Simple, false, false>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            }
         }
         else
         {
             if (sparse)
-                return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, true>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            {
+                if (shards > 1)
+                    return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, true, true>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+                else
+                    return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, true, false>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            }
             else
-                return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, false>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            {
+                if (shards > 1)
+                    return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, false, true>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+                else
+                    return std::make_unique<HashedDictionary<DictionaryKeyType::Complex, false, false>>(dict_id, dict_struct, std::move(source_ptr), configuration);
+            }
         }
     };
 

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -706,7 +706,7 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::updateData()
 }
 
 template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
-size_t HashedDictionary<dictionary_key_type, sparse, sharded>::blockToAttributes(const Block & block, DictionaryKeysArenaHolder<dictionary_key_type> & arena_holder, UInt64 shard)
+void HashedDictionary<dictionary_key_type, sparse, sharded>::blockToAttributes(const Block & block, DictionaryKeysArenaHolder<dictionary_key_type> & arena_holder, UInt64 shard)
 {
     size_t skip_keys_size_offset = dict_struct.getKeysSize();
     size_t new_element_count = 0;
@@ -740,7 +740,7 @@ size_t HashedDictionary<dictionary_key_type, sparse, sharded>::blockToAttributes
         }
 
         element_count += new_element_count;
-        return new_element_count;
+        return;
     }
 
     for (size_t attribute_index = 0; attribute_index < attributes_size; ++attribute_index)
@@ -802,7 +802,6 @@ size_t HashedDictionary<dictionary_key_type, sparse, sharded>::blockToAttributes
     }
 
     element_count += new_element_count;
-    return new_element_count;
 }
 
 template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -206,6 +206,13 @@ HashedDictionary<dictionary_key_type, sparse, sharded>::HashedDictionary(
 template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
 HashedDictionary<dictionary_key_type, sparse, sharded>::~HashedDictionary()
 {
+    /// Do a regular sequential destroy in case of non sharded dictionary
+    ///
+    /// Note, that even in non-sharded dictionaries you can have multiple hash
+    /// tables, since each attribute is stored in a separate hash table.
+    if constexpr (!sharded)
+        return;
+
     size_t shards = std::max<size_t>(configuration.shards, 1);
     size_t attributes_tables = std::max<size_t>(attributes.size(), 1 /* no_attributes_containers */);
     ThreadPool pool(shards * attributes_tables);

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -1185,6 +1185,9 @@ void registerDictionaryHashed(DictionaryFactory & factory)
             dict_lifetime,
         };
 
+        if (source_ptr->hasUpdateField() && shards > 1)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,"{}: SHARDS parameter does not supports for updatable source (UPDATE_FIELD)", full_name);
+
         if (dictionary_key_type == DictionaryKeyType::Simple)
         {
             if (sparse)

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -211,7 +211,7 @@ private:
 
     void createAttributes();
 
-    size_t blockToAttributes(const Block & block);
+    size_t blockToAttributes(const Block & block, UInt64 shard);
 
     void updateData();
 
@@ -225,7 +225,9 @@ private:
     {
         if constexpr (!sharded)
             return 0;
-        return key % configuration.shards;
+        /// NOTE: function here should not match with the DefaultHash<> since
+        /// it used for the HashMap/sparse_hash_map.
+        return intHashCRC32(key) % configuration.shards;
     }
     UInt64 getShard(StringRef key) const
     {

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -211,7 +211,7 @@ private:
 
     void createAttributes();
 
-    size_t blockToAttributes(const Block & block, UInt64 shard);
+    size_t blockToAttributes(const Block & block, DictionaryKeysArenaHolder<dictionary_key_type> & arena_holder, UInt64 shard);
 
     void updateData();
 

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -234,7 +234,7 @@ private:
     {
         if constexpr (!sharded)
             return 0;
-        return getShard(StringRefHash()(key));
+        return StringRefHash()(key) % configuration.shards;
     }
 
     template <typename AttributeType, bool is_nullable, typename ValueSetter, typename DefaultValueExtractor>

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -50,6 +50,7 @@ public:
         DictionarySourcePtr source_ptr_,
         const HashedDictionaryStorageConfiguration & configuration_,
         BlockPtr update_field_loaded_block_ = nullptr);
+    ~HashedDictionary() override;
 
     std::string getTypeName() const override
     {

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -33,8 +33,13 @@ struct HashedDictionaryStorageConfiguration
 };
 
 template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
+class ParallelDictionaryLoader;
+
+template <DictionaryKeyType dictionary_key_type, bool sparse, bool sharded>
 class HashedDictionary final : public IDictionary
 {
+    friend class ParallelDictionaryLoader<dictionary_key_type, sparse, sharded>;
+
 public:
     using KeyType = std::conditional_t<dictionary_key_type == DictionaryKeyType::Simple, UInt64, StringRef>;
 
@@ -204,7 +209,7 @@ private:
 
     void createAttributes();
 
-    void blockToAttributes(const Block & block, std::optional<UInt64> current_shard);
+    size_t blockToAttributes(const Block & block);
 
     void updateData();
 
@@ -241,6 +246,8 @@ private:
     void getAttributeContainer(size_t attribute_index, GetContainerFunc && get_container_func) const;
 
     void resize(size_t added_rows);
+
+    Poco::Logger * log;
 
     const DictionaryStructure dict_struct;
     const DictionarySourcePtr source_ptr;

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -229,6 +229,7 @@ private:
         /// it used for the HashMap/sparse_hash_map.
         return intHashCRC32(key) % configuration.shards;
     }
+
     UInt64 getShard(StringRef key) const
     {
         if constexpr (!sharded)

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -28,6 +28,7 @@ struct HashedDictionaryStorageConfiguration
 {
     const bool preallocate;
     const UInt64 shards;
+    const UInt64 shard_load_queue_backlog;
     const bool require_nonempty;
     const DictionaryLifetime lifetime;
 };

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -211,7 +211,7 @@ private:
 
     void createAttributes();
 
-    size_t blockToAttributes(const Block & block, DictionaryKeysArenaHolder<dictionary_key_type> & arena_holder, UInt64 shard);
+    void blockToAttributes(const Block & block, DictionaryKeysArenaHolder<dictionary_key_type> & arena_holder, UInt64 shard);
 
     void updateData();
 

--- a/tests/performance/hashed_dictionary_sharded.xml
+++ b/tests/performance/hashed_dictionary_sharded.xml
@@ -1,0 +1,93 @@
+<test>
+    <substitutions>
+        <substitution>
+            <name>layout_suffix</name>
+            <values>
+                <value>HASHED</value>
+                <value>SPARSE_HASHED</value>
+            </values>
+        </substitution>
+
+        <substitution>
+            <name>shards</name>
+            <values>
+                <value>1</value>
+                <value>8</value>
+                <value>16</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>
+        CREATE TABLE simple_key_dictionary_source_table
+        (
+            id UInt64,
+            value_int UInt64
+        ) ENGINE = Memory
+    </create_query>
+
+    <create_query>
+        CREATE TABLE complex_key_dictionary_source_table
+        (
+            id UInt64,
+            id_key String,
+            value_int UInt64
+        ) ENGINE = Memory
+    </create_query>
+
+    <create_query>
+        CREATE DICTIONARY IF NOT EXISTS simple_key_{layout_suffix}_dictionary_s{shards}
+        (
+            id UInt64,
+            value_int UInt64
+        )
+        PRIMARY KEY id
+        SOURCE(CLICKHOUSE(TABLE 'simple_key_dictionary_source_table'))
+        LAYOUT({layout_suffix}(SHARDS {shards}))
+        LIFETIME(0)
+    </create_query>
+
+    <create_query>
+        CREATE DICTIONARY IF NOT EXISTS complex_key_{layout_suffix}_dictionary_s{shards}
+        (
+            id UInt64,
+            id_key String,
+            value_int UInt64
+        )
+        PRIMARY KEY id, id_key
+        SOURCE(CLICKHOUSE(TABLE 'complex_key_dictionary_source_table'))
+        LAYOUT(COMPLEX_KEY_{layout_suffix}(SHARDS {shards}))
+        LIFETIME(0)
+    </create_query>
+
+    <fill_query>INSERT INTO simple_key_dictionary_source_table SELECT number, number FROM numbers(3e6)</fill_query>
+    <fill_query>INSERT INTO complex_key_dictionary_source_table SELECT number, toString(number), number FROM numbers(2e6)</fill_query>
+
+    <fill_query>SYSTEM RELOAD DICTIONARY simple_key_{layout_suffix}_dictionary_s{shards}</fill_query>
+    <fill_query>SYSTEM RELOAD DICTIONARY complex_key_{layout_suffix}_dictionary_s{shards}</fill_query>
+
+    <query>SYSTEM RELOAD DICTIONARY simple_key_{layout_suffix}_dictionary_s{shards}</query>
+    <query>SYSTEM RELOAD DICTIONARY complex_key_{layout_suffix}_dictionary_s{shards}</query>
+
+    <query>
+        WITH rand64() % toUInt64(5e6) as key
+        SELECT dictHas('default.simple_key_{layout_suffix}_dictionary_s{shards}', key)
+        FROM system.numbers
+        LIMIT 3e6
+        FORMAT Null
+    </query>
+
+    <query>
+        WITH (rand64() % toUInt64(2e6), toString(rand64() % toUInt64(2e6))) as key
+        SELECT dictHas('default.complex_key_{layout_suffix}_dictionary_s{shards}', key)
+        FROM system.numbers
+        LIMIT 2e6
+        FORMAT Null
+    </query>
+
+    <drop_query>DROP DICTIONARY IF EXISTS simple_key_{layout_suffix}_dictionary_s{shards}</drop_query>
+    <drop_query>DROP DICTIONARY IF EXISTS complex_key_{layout_suffix}_dictionary_s{shards}</drop_query>
+
+    <drop_query>DROP TABLE IF EXISTS simple_key_dictionary_source_table</drop_query>
+    <drop_query>DROP TABLE IF EXISTS complex_key_dictionary_source_table</drop_query>
+</test>

--- a/tests/performance/hashed_dictionary_sharded.xml
+++ b/tests/performance/hashed_dictionary_sharded.xml
@@ -60,8 +60,8 @@
         LIFETIME(0)
     </create_query>
 
-    <fill_query>INSERT INTO simple_key_dictionary_source_table SELECT number, number FROM numbers(3e6)</fill_query>
-    <fill_query>INSERT INTO complex_key_dictionary_source_table SELECT number, toString(number), number FROM numbers(2e6)</fill_query>
+    <fill_query>INSERT INTO simple_key_dictionary_source_table SELECT number, number FROM numbers(3_000_000)</fill_query>
+    <fill_query>INSERT INTO complex_key_dictionary_source_table SELECT number, toString(number), number FROM numbers(2_000_000)</fill_query>
 
     <fill_query>SYSTEM RELOAD DICTIONARY simple_key_{layout_suffix}_dictionary_s{shards}</fill_query>
     <fill_query>SYSTEM RELOAD DICTIONARY complex_key_{layout_suffix}_dictionary_s{shards}</fill_query>
@@ -70,18 +70,16 @@
     <query>SYSTEM RELOAD DICTIONARY complex_key_{layout_suffix}_dictionary_s{shards}</query>
 
     <query>
-        WITH rand64() % toUInt64(5e6) as key
+        WITH rand64() % 3_000_000 as key
         SELECT dictHas('default.simple_key_{layout_suffix}_dictionary_s{shards}', key)
-        FROM system.numbers
-        LIMIT 3e6
+        FROM numbers(3_000_000)
         FORMAT Null
     </query>
 
     <query>
-        WITH (rand64() % toUInt64(2e6), toString(rand64() % toUInt64(2e6))) as key
+        WITH (rand64() % 2_000_000, toString(rand64() % 2_000_000)) as key
         SELECT dictHas('default.complex_key_{layout_suffix}_dictionary_s{shards}', key)
-        FROM system.numbers
-        LIMIT 2e6
+        FROM numbers(2_000_000)
         FORMAT Null
     </query>
 

--- a/tests/performance/hierarchical_dictionaries.xml
+++ b/tests/performance/hierarchical_dictionaries.xml
@@ -9,6 +9,14 @@
         </substitution>
 
         <substitution>
+            <name>dictionary_shards</name>
+            <values>
+                <value>1</value>
+                <value>16</value>
+            </values>
+        </substitution>
+
+        <substitution>
             <name>func</name>
             <values>
                 <value>dictGetHierarchy</value>
@@ -26,14 +34,14 @@
     </create_query>
 
     <create_query>
-        CREATE DICTIONARY hierarchical_{dictionary_layout}_dictionary
+        CREATE DICTIONARY hierarchical_{dictionary_layout}_shards{dictionary_shards}_dictionary
         (
             id UInt64,
             parent_id UInt64 HIERARCHICAL
         )
         PRIMARY KEY id
         SOURCE(CLICKHOUSE(DB 'default' TABLE 'hierarchical_dictionary_source_table'))
-        LAYOUT({dictionary_layout})
+        LAYOUT({dictionary_layout}(SHARDS {dictionary_shards}))
         LIFETIME(0);
     </create_query>
 
@@ -65,10 +73,10 @@
         SELECT {func}('hierarchical_flat_dictionary', number + 1) FROM numbers(1000000) FORMAT Null;
     </query>
     <query>
-        SELECT {func}('hierarchical_{dictionary_layout}_dictionary', number + 1) FROM numbers(1000000) FORMAT Null;
+        SELECT {func}('hierarchical_{dictionary_layout}_shards{dictionary_shards}_dictionary', number + 1) FROM numbers(1000000) FORMAT Null;
     </query>
 
-    <drop_query>DROP DICTIONARY IF EXISTS hierarchical_{dictionary_layout}_dictionary;</drop_query>
+    <drop_query>DROP DICTIONARY IF EXISTS hierarchical_{dictionary_layout}_shards{dictionary_shards}_dictionary;</drop_query>
     <drop_query>DROP DICTIONARY IF EXISTS hierarchical_flat_dictionary;</drop_query>
     <drop_query>DROP TABLE IF EXISTS hierarchical_dictionary_source_table;</drop_query>
 </test>

--- a/tests/queries/0_stateless/01509_dictionary_preallocate.sh
+++ b/tests/queries/0_stateless/01509_dictionary_preallocate.sh
@@ -54,7 +54,6 @@ $CLICKHOUSE_CLIENT -nm -q "
     LAYOUT(SPARSE_HASHED(PREALLOCATE 1))
     LIFETIME(0);
     SHOW CREATE DICTIONARY dict_01509_preallocate;
-    SYSTEM RELOAD DICTIONARY dict_01509_preallocate;
 "
 (
     # start new shell to avoid overriding variables for other client invocation

--- a/tests/queries/0_stateless/02391_dictionary_shards.reference
+++ b/tests/queries/0_stateless/02391_dictionary_shards.reference
@@ -27,14 +27,8 @@ create dictionary dict_10_string (key String, value UInt16) primary key key sour
 show create dict_10_string;
 CREATE DICTIONARY default.dict_10_string\n(\n    `key` String,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE data_string))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(SPARSE_HASHED(SHARDS 10))
 system reload dictionary dict_10_string; -- { serverError CANNOT_PARSE_TEXT }
-create dictionary dict_10_incremental (key UInt64, value UInt16) primary key key source(clickhouse(table data_last_access update_field last_access)) layout(sparse_hashed(shards 10)) lifetime(min 5 max 5);
-show create dict_10_incremental;
-CREATE DICTIONARY default.dict_10_incremental\n(\n    `key` UInt64,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE data_last_access UPDATE_FIELD last_access))\nLIFETIME(MIN 5 MAX 5)\nLAYOUT(SPARSE_HASHED(SHARDS 10))
-system reload dictionary dict_10_incremental;
-select element_count from system.dictionaries where database = currentDatabase() and name = 'dict_10_incremental';
-100000
-select count() from data where dictGetUInt16('dict_10_incremental', 'value', key) != value;
-0
+create dictionary dict_10_incremental (key UInt64, value UInt16) primary key key source(clickhouse(table data_last_access update_field last_access)) layout(sparse_hashed(shards 10)) lifetime(0);
+system reload dictionary dict_10_incremental; -- { serverError BAD_ARGUMENTS }
 create dictionary complex_dict_10 (k1 UInt64, k2 UInt64, value UInt16) primary key k1, k2 source(clickhouse(table complex_data)) layout(complex_key_sparse_hashed(shards 10)) lifetime(0);
 system reload dictionary complex_dict_10;
 select element_count from system.dictionaries where database = currentDatabase() and name = 'complex_dict_10';

--- a/tests/queries/0_stateless/02391_dictionary_shards.reference
+++ b/tests/queries/0_stateless/02391_dictionary_shards.reference
@@ -27,6 +27,14 @@ create dictionary dict_10_string (key String, value UInt16) primary key key sour
 show create dict_10_string;
 CREATE DICTIONARY default.dict_10_string\n(\n    `key` String,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE data_string))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(SPARSE_HASHED(SHARDS 10))
 system reload dictionary dict_10_string; -- { serverError CANNOT_PARSE_TEXT }
+create dictionary dict_10_incremental (key UInt64, value UInt16) primary key key source(clickhouse(table data_last_access update_field last_access)) layout(sparse_hashed(shards 10)) lifetime(min 5 max 5);
+show create dict_10_incremental;
+CREATE DICTIONARY default.dict_10_incremental\n(\n    `key` UInt64,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE data_last_access UPDATE_FIELD last_access))\nLIFETIME(MIN 5 MAX 5)\nLAYOUT(SPARSE_HASHED(SHARDS 10))
+system reload dictionary dict_10_incremental;
+select element_count from system.dictionaries where database = currentDatabase() and name = 'dict_10_incremental';
+100000
+select count() from data where dictGetUInt16('dict_10_incremental', 'value', key) != value;
+0
 create dictionary complex_dict_10 (k1 UInt64, k2 UInt64, value UInt16) primary key k1, k2 source(clickhouse(table complex_data)) layout(complex_key_sparse_hashed(shards 10)) lifetime(0);
 system reload dictionary complex_dict_10;
 select element_count from system.dictionaries where database = currentDatabase() and name = 'complex_dict_10';

--- a/tests/queries/0_stateless/02391_dictionary_shards.reference
+++ b/tests/queries/0_stateless/02391_dictionary_shards.reference
@@ -1,0 +1,35 @@
+-- { echoOn }
+create dictionary dict (key UInt64, value UInt16) primary key key source(clickhouse(table data)) layout(sparse_hashed()) lifetime(0);
+show create dict;
+CREATE DICTIONARY default.dict\n(\n    `key` UInt64,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE data))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(SPARSE_HASHED())
+system reload dictionary dict;
+select element_count from system.dictionaries where database = currentDatabase() and name = 'dict';
+100000
+select count() from data where dictGetUInt16('dict', 'value', key) != value;
+0
+create dictionary dict_10 (key UInt64, value UInt16) primary key key source(clickhouse(table data)) layout(sparse_hashed(shards 10)) lifetime(0);
+show create dict_10;
+CREATE DICTIONARY default.dict_10\n(\n    `key` UInt64,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE data))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(SPARSE_HASHED(SHARDS 10))
+system reload dictionary dict_10;
+select element_count from system.dictionaries where database = currentDatabase() and name = 'dict_10';
+100000
+select count() from data where dictGetUInt16('dict_10', 'value', key) != value;
+0
+create dictionary dict_10_uint8 (key UInt8, value UInt16) primary key key source(clickhouse(table data)) layout(sparse_hashed(shards 10)) lifetime(0);
+show create dict_10_uint8;
+CREATE DICTIONARY default.dict_10_uint8\n(\n    `key` UInt8,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE data))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(SPARSE_HASHED(SHARDS 10))
+system reload dictionary dict_10_uint8;
+select element_count from system.dictionaries where database = currentDatabase() and name = 'dict_10';
+100000
+select count() from data where dictGetUInt16('dict_10_uint8', 'value', key) != value;
+0
+create dictionary dict_10_string (key String, value UInt16) primary key key source(clickhouse(table data_string)) layout(sparse_hashed(shards 10)) lifetime(0);
+show create dict_10_string;
+CREATE DICTIONARY default.dict_10_string\n(\n    `key` String,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE data_string))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(SPARSE_HASHED(SHARDS 10))
+system reload dictionary dict_10_string; -- { serverError CANNOT_PARSE_TEXT }
+create dictionary complex_dict_10 (k1 UInt64, k2 UInt64, value UInt16) primary key k1, k2 source(clickhouse(table complex_data)) layout(complex_key_sparse_hashed(shards 10)) lifetime(0);
+system reload dictionary complex_dict_10;
+select element_count from system.dictionaries where database = currentDatabase() and name = 'complex_dict_10';
+100000
+select count() from complex_data where dictGetUInt16('complex_dict_10', 'value', (k1, k2)) != value;
+0

--- a/tests/queries/0_stateless/02391_dictionary_shards.sql
+++ b/tests/queries/0_stateless/02391_dictionary_shards.sql
@@ -5,12 +5,10 @@ drop dictionary if exists dict_10_string;
 drop dictionary if exists dict_10_incremental;
 drop dictionary if exists complex_dict_10;
 drop table if exists data;
-drop table if exists data_last_access;
 drop table if exists data_string;
 drop table if exists complex_data;
 
 create table data (key UInt64, value UInt16) engine=Memory() as select number, number from numbers(1e5);
-create table data_last_access (key UInt64, value UInt16, last_access DateTime) engine=Memory() as select number, number, now() from numbers(1e5);
 create table data_string (key String, value UInt16) engine=Memory() as select 'foo' || number::String, number from numbers(1e5);
 create table complex_data (k1 UInt64, k2 UInt64, value UInt16) engine=Memory() as select number, number, number from numbers(1e5);
 
@@ -37,11 +35,8 @@ create dictionary dict_10_string (key String, value UInt16) primary key key sour
 show create dict_10_string;
 system reload dictionary dict_10_string; -- { serverError CANNOT_PARSE_TEXT }
 
-create dictionary dict_10_incremental (key UInt64, value UInt16) primary key key source(clickhouse(table data_last_access update_field last_access)) layout(sparse_hashed(shards 10)) lifetime(min 5 max 5);
-show create dict_10_incremental;
-system reload dictionary dict_10_incremental;
-select element_count from system.dictionaries where database = currentDatabase() and name = 'dict_10_incremental';
-select count() from data where dictGetUInt16('dict_10_incremental', 'value', key) != value;
+create dictionary dict_10_incremental (key UInt64, value UInt16) primary key key source(clickhouse(table data_last_access update_field last_access)) layout(sparse_hashed(shards 10)) lifetime(0);
+system reload dictionary dict_10_incremental; -- { serverError BAD_ARGUMENTS }
 
 create dictionary complex_dict_10 (k1 UInt64, k2 UInt64, value UInt16) primary key k1, k2 source(clickhouse(table complex_data)) layout(complex_key_sparse_hashed(shards 10)) lifetime(0);
 system reload dictionary complex_dict_10;

--- a/tests/queries/0_stateless/02391_dictionary_shards.sql
+++ b/tests/queries/0_stateless/02391_dictionary_shards.sql
@@ -1,0 +1,40 @@
+drop dictionary if exists dict;
+drop dictionary if exists dict_10;
+drop dictionary if exists dict_10_uint8;
+drop dictionary if exists dict_10_string;
+drop dictionary if exists complex_dict_10;
+drop table if exists data;
+drop table if exists data_string;
+drop table if exists complex_data;
+
+create table data (key UInt64, value UInt16) engine=Memory() as select number, number from numbers(1e5);
+create table data_string (key String, value UInt16) engine=Memory() as select 'foo' || number::String, number from numbers(1e5);
+create table complex_data (k1 UInt64, k2 UInt64, value UInt16) engine=Memory() as select number, number, number from numbers(1e5);
+
+-- { echoOn }
+create dictionary dict (key UInt64, value UInt16) primary key key source(clickhouse(table data)) layout(sparse_hashed()) lifetime(0);
+show create dict;
+system reload dictionary dict;
+select element_count from system.dictionaries where database = currentDatabase() and name = 'dict';
+select count() from data where dictGetUInt16('dict', 'value', key) != value;
+
+create dictionary dict_10 (key UInt64, value UInt16) primary key key source(clickhouse(table data)) layout(sparse_hashed(shards 10)) lifetime(0);
+show create dict_10;
+system reload dictionary dict_10;
+select element_count from system.dictionaries where database = currentDatabase() and name = 'dict_10';
+select count() from data where dictGetUInt16('dict_10', 'value', key) != value;
+
+create dictionary dict_10_uint8 (key UInt8, value UInt16) primary key key source(clickhouse(table data)) layout(sparse_hashed(shards 10)) lifetime(0);
+show create dict_10_uint8;
+system reload dictionary dict_10_uint8;
+select element_count from system.dictionaries where database = currentDatabase() and name = 'dict_10';
+select count() from data where dictGetUInt16('dict_10_uint8', 'value', key) != value;
+
+create dictionary dict_10_string (key String, value UInt16) primary key key source(clickhouse(table data_string)) layout(sparse_hashed(shards 10)) lifetime(0);
+show create dict_10_string;
+system reload dictionary dict_10_string; -- { serverError CANNOT_PARSE_TEXT }
+
+create dictionary complex_dict_10 (k1 UInt64, k2 UInt64, value UInt16) primary key k1, k2 source(clickhouse(table complex_data)) layout(complex_key_sparse_hashed(shards 10)) lifetime(0);
+system reload dictionary complex_dict_10;
+select element_count from system.dictionaries where database = currentDatabase() and name = 'complex_dict_10';
+select count() from complex_data where dictGetUInt16('complex_dict_10', 'value', (k1, k2)) != value;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added sharding support in HashedDictionary to allow parallel load (almost linear scaling based on number of shards).

Right now dictionaries (here I will talk about only
HASHED/SPARSE_HASHED/COMPLEX_KEY_HASHED/COMPLEX_KEY_SPARSE_HASHED)
can load data only in one thread, since it uses one hash table that
cannot be filled from multiple threads.

And in case you have very big dictionary (i.e. 10e9 elements), it can
take a awhile to load them, especially for SPARSE_HASHED variants (and
if you have such amount of elements there, you are likely use
SPARSE_HASHED, since it requires less memory), in my env it takes ~4
hours, which is enormous amount of time.

So this patch add support of shards for dictionaries, number of shards
determine how much hash tables will use this dictionary, also, and which
is more important, how much threads it can use to load the data.