### PR TITLE
Fix Endian issues in Codec for s390x

### DIFF
--- a/src/Compression/CompressionCodecGorilla.cpp
+++ b/src/Compression/CompressionCodecGorilla.cpp
@@ -208,7 +208,7 @@ UInt32 compressDataForType(const char * source, UInt32 source_size, char * dest,
 
     const UInt32 items_count = source_size / sizeof(T);
 
-    unalignedStore<UInt32>(dest, items_count);
+    unalignedStoreLE<UInt32>(dest, items_count);
     dest += sizeof(items_count);
 
     T prev_value{};
@@ -217,8 +217,8 @@ UInt32 compressDataForType(const char * source, UInt32 source_size, char * dest,
 
     if (source < source_end)
     {
-        prev_value = unalignedLoad<T>(source);
-        unalignedStore<T>(dest, prev_value);
+        prev_value = unalignedLoadLE<T>(source);
+        unalignedStoreLE<T>(dest, prev_value);
 
         source += sizeof(prev_value);
         dest += sizeof(prev_value);
@@ -228,7 +228,7 @@ UInt32 compressDataForType(const char * source, UInt32 source_size, char * dest,
 
     while (source < source_end)
     {
-        const T curr_value = unalignedLoad<T>(source);
+        const T curr_value = unalignedLoadLE<T>(source);
         source += sizeof(curr_value);
 
         const auto xored_data = curr_value ^ prev_value;
@@ -274,7 +274,7 @@ void decompressDataForType(const char * source, UInt32 source_size, char * dest)
     if (source + sizeof(UInt32) > source_end)
         return;
 
-    const UInt32 items_count = unalignedLoad<UInt32>(source);
+    const UInt32 items_count = unalignedLoadLE<UInt32>(source);
     source += sizeof(items_count);
 
     T prev_value{};
@@ -283,8 +283,8 @@ void decompressDataForType(const char * source, UInt32 source_size, char * dest)
     if (source + sizeof(T) > source_end || items_count < 1)
         return;
 
-    prev_value = unalignedLoad<T>(source);
-    unalignedStore<T>(dest, prev_value);
+    prev_value = unalignedLoadLE<T>(source);
+    unalignedStoreLE<T>(dest, prev_value);
 
     source += sizeof(prev_value);
     dest += sizeof(prev_value);
@@ -326,7 +326,7 @@ void decompressDataForType(const char * source, UInt32 source_size, char * dest)
         }
         // else: 0b0 prefix - use prev_value
 
-        unalignedStore<T>(dest, curr_value);
+        unalignedStoreLE<T>(dest, curr_value);
         dest += sizeof(curr_value);
 
         prev_xored_info = curr_xored_info;

--- a/src/Compression/ICompressionCodec.cpp
+++ b/src/Compression/ICompressionCodec.cpp
@@ -86,8 +86,8 @@ UInt32 ICompressionCodec::compress(const char * source, UInt32 source_size, char
     UInt8 header_size = getHeaderSize();
     /// Write data from header_size
     UInt32 compressed_bytes_written = doCompressData(source, source_size, &dest[header_size]);
-    unalignedStore<UInt32>(&dest[1], compressed_bytes_written + header_size);
-    unalignedStore<UInt32>(&dest[5], source_size);
+    unalignedStoreLE<UInt32>(&dest[1], compressed_bytes_written + header_size);
+    unalignedStoreLE<UInt32>(&dest[5], source_size);
     return header_size + compressed_bytes_written;
 }
 
@@ -112,7 +112,7 @@ UInt32 ICompressionCodec::decompress(const char * source, UInt32 source_size, ch
 
 UInt32 ICompressionCodec::readCompressedBlockSize(const char * source)
 {
-    UInt32 compressed_block_size = unalignedLoad<UInt32>(&source[1]);
+    UInt32 compressed_block_size = unalignedLoadLE<UInt32>(&source[1]);
     if (compressed_block_size == 0)
         throw Exception(ErrorCodes::CORRUPTED_DATA, "Can't decompress data: header is corrupt with compressed block size 0");
     return compressed_block_size;
@@ -121,7 +121,7 @@ UInt32 ICompressionCodec::readCompressedBlockSize(const char * source)
 
 UInt32 ICompressionCodec::readDecompressedBlockSize(const char * source)
 {
-    UInt32 decompressed_block_size = unalignedLoad<UInt32>(&source[5]);
+    UInt32 decompressed_block_size = unalignedLoadLE<UInt32>(&source[5]);
     if (decompressed_block_size == 0)
         throw Exception(ErrorCodes::CORRUPTED_DATA, "Can't decompress data: header is corrupt with decompressed block size 0");
     return decompressed_block_size;

--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -175,7 +175,7 @@ private:
             throw std::runtime_error("No more data to read");
         }
 
-        current_value = unalignedLoad<T>(data);
+        current_value = unalignedLoadLE<T>(data);
         data = reinterpret_cast<const char *>(data) + sizeof(T);
     }
 };
@@ -371,7 +371,7 @@ CodecTestSequence makeSeq(Args && ... args)
     char * write_pos = data.data();
     for (const auto & v : vals)
     {
-        unalignedStore<T>(write_pos, v);
+        unalignedStoreLE<T>(write_pos, v);
         write_pos += sizeof(v);
     }
 
@@ -393,7 +393,7 @@ CodecTestSequence generateSeq(Generator gen, const char* gen_name, B Begin = 0, 
     {
         const T v = gen(static_cast<T>(i));
 
-        unalignedStore<T>(write_pos, v);
+        unalignedStoreLE<T>(write_pos, v);
         write_pos += sizeof(v);
     }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
There are Endian issues in codec(DoubleDelta and Gorilla) code, which causes codec compression failure in s390x. For example, the following unit test failure is caused by the issue:

`[  FAILED  ] Simple/CodecTest.TranscodingWithDataType/3, where GetParam() = (Codec{name: Gorilla}, CodecTestSequence{name: 25 values of Float64, type name: Float64, data size: 200 bytes}) (0 ms)
`

The fix is to use unalignedLoadLE and unalignedStoreLE in related code.
### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed Endian issues in Codec code for s390x architecture (which is not supported by ClickHouse).

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
