### PR TITLE
Further preparation for catboost integration into library-bridge

### DIFF
--- a/programs/library-bridge/LibraryBridgeHandlerFactory.cpp
+++ b/programs/library-bridge/LibraryBridgeHandlerFactory.cpp
@@ -26,13 +26,13 @@ std::unique_ptr<HTTPRequestHandler> LibraryBridgeHandlerFactory::createRequestHa
     if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET)
     {
         if (uri.getPath() == "/extdict_ping")
-            return std::make_unique<LibraryBridgeExistsHandler>(keep_alive_timeout, getContext());
+            return std::make_unique<ExternalDictionaryLibraryBridgeExistsHandler>(keep_alive_timeout, getContext());
     }
 
     if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST)
     {
         if (uri.getPath() == "/extdict_request")
-            return std::make_unique<LibraryBridgeRequestHandler>(keep_alive_timeout, getContext());
+            return std::make_unique<ExternalDictionaryLibraryBridgeRequestHandler>(keep_alive_timeout, getContext());
     }
 
     return nullptr;

--- a/programs/library-bridge/LibraryBridgeHandlers.cpp
+++ b/programs/library-bridge/LibraryBridgeHandlers.cpp
@@ -78,14 +78,14 @@ static void writeData(Block data, OutputFormatPtr format)
     executor.execute();
 }
 
-LibraryBridgeRequestHandler::LibraryBridgeRequestHandler(size_t keep_alive_timeout_, ContextPtr context_)
+ExternalDictionaryLibraryBridgeRequestHandler::ExternalDictionaryLibraryBridgeRequestHandler(size_t keep_alive_timeout_, ContextPtr context_)
     : WithContext(context_)
-    , log(&Poco::Logger::get("LibraryBridgeRequestHandler"))
+    , log(&Poco::Logger::get("ExternalDictionaryLibraryBridgeRequestHandler"))
     , keep_alive_timeout(keep_alive_timeout_)
 {
 }
 
-void LibraryBridgeRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
+void ExternalDictionaryLibraryBridgeRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     LOG_TRACE(log, "Request URI: {}", request.getURI());
     HTMLForm params(getContext()->getSettingsRef(), request);
@@ -340,14 +340,14 @@ void LibraryBridgeRequestHandler::handleRequest(HTTPServerRequest & request, HTT
     }
 }
 
-LibraryBridgeExistsHandler::LibraryBridgeExistsHandler(size_t keep_alive_timeout_, ContextPtr context_)
+ExternalDictionaryLibraryBridgeExistsHandler::ExternalDictionaryLibraryBridgeExistsHandler(size_t keep_alive_timeout_, ContextPtr context_)
     : WithContext(context_)
     , keep_alive_timeout(keep_alive_timeout_)
-    , log(&Poco::Logger::get("LibraryBridgeExistsHandler"))
+    , log(&Poco::Logger::get("ExternalDictionaryLibraryBridgeExistsHandler"))
 {
 }
 
-void LibraryBridgeExistsHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
+void ExternalDictionaryLibraryBridgeExistsHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response)
 {
     try
     {

--- a/programs/library-bridge/LibraryBridgeHandlers.h
+++ b/programs/library-bridge/LibraryBridgeHandlers.h
@@ -17,10 +17,10 @@ namespace DB
 /// names of dictionary attributes, sample block to parse block of null values, block of null values. Everything is
 /// passed in binary format and is urlencoded. When dictionary is cloned, a new handler is created.
 /// Each handler is unique to dictionary.
-class LibraryBridgeRequestHandler : public HTTPRequestHandler, WithContext
+class ExternalDictionaryLibraryBridgeRequestHandler : public HTTPRequestHandler, WithContext
 {
 public:
-    LibraryBridgeRequestHandler(size_t keep_alive_timeout_, ContextPtr context_);
+    ExternalDictionaryLibraryBridgeRequestHandler(size_t keep_alive_timeout_, ContextPtr context_);
 
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
@@ -32,10 +32,10 @@ private:
 };
 
 
-class LibraryBridgeExistsHandler : public HTTPRequestHandler, WithContext
+class ExternalDictionaryLibraryBridgeExistsHandler : public HTTPRequestHandler, WithContext
 {
 public:
-    LibraryBridgeExistsHandler(size_t keep_alive_timeout_, ContextPtr context_);
+    ExternalDictionaryLibraryBridgeExistsHandler(size_t keep_alive_timeout_, ContextPtr context_);
 
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 

--- a/programs/library-bridge/LibraryBridgeHandlers.h
+++ b/programs/library-bridge/LibraryBridgeHandlers.h
@@ -9,7 +9,6 @@
 namespace DB
 {
 
-
 /// Handler for requests to Library Dictionary Source, returns response in RowBinary format.
 /// When a library dictionary source is created, it sends 'extDict_libNew' request to library bridge (which is started on first
 /// request to it, if it was not yet started). On this request a new sharedLibrayHandler is added to a

--- a/programs/odbc-bridge/IdentifierQuoteHandler.cpp
+++ b/programs/odbc-bridge/IdentifierQuoteHandler.cpp
@@ -5,6 +5,7 @@
 #include <DataTypes/DataTypeFactory.h>
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
+#include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Parsers/ParserQueryWithOutput.h>
 #include <Parsers/parseQuery.h>
@@ -16,8 +17,6 @@
 #include "getIdentifierQuote.h"
 #include "validateODBCConnectionString.h"
 #include "ODBCPooledConnectionFactory.h"
-
-#include <charconv>
 
 
 namespace DB
@@ -35,27 +34,25 @@ void IdentifierQuoteHandler::handleRequest(HTTPServerRequest & request, HTTPServ
         LOG_WARNING(log, fmt::runtime(message));
     };
 
+    size_t version;
+
     if (!params.has("version"))
-    {
-        process_error("No 'version' in request URL");
-        return;
-    }
+        version = 0; /// assumed version for too old servers which do not send a version
     else
     {
         String version_str = params.get("version");
-        size_t version;
-        auto [_, ec] = std::from_chars(version_str.data(), version_str.data() + version_str.size(), version);
-        if (ec != std::errc())
+        if (!tryParse(version, version_str))
         {
             process_error("Unable to parse 'version' string in request URL: '" + version_str + "' Check if the server and library-bridge have the same version.");
             return;
         }
-        if (version != XDBC_BRIDGE_PROTOCOL_VERSION)
-        {
-            // backwards compatibility is for now deemed unnecessary, just let the user upgrade the server and bridge to the same version
-            process_error("Server and library-bridge have different versions: '" + std::to_string(version) + "' vs. '" + std::to_string(LIBRARY_BRIDGE_PROTOCOL_VERSION) + "'");
-            return;
-        }
+    }
+
+    if (version != XDBC_BRIDGE_PROTOCOL_VERSION)
+    {
+        /// backwards compatibility is considered unnecessary for now, just let the user know that the server and the bridge must be upgraded together
+        process_error("Server and library-bridge have different versions: '" + std::to_string(version) + "' vs. '" + std::to_string(LIBRARY_BRIDGE_PROTOCOL_VERSION) + "'");
+        return;
     }
 
     if (!params.has("connection_string"))

--- a/programs/odbc-bridge/IdentifierQuoteHandler.cpp
+++ b/programs/odbc-bridge/IdentifierQuoteHandler.cpp
@@ -10,11 +10,14 @@
 #include <Parsers/parseQuery.h>
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>
+#include <Common/BridgeProtocolVersion.h>
 #include <Common/logger_useful.h>
 #include <base/scope_guard.h>
 #include "getIdentifierQuote.h"
 #include "validateODBCConnectionString.h"
 #include "ODBCPooledConnectionFactory.h"
+
+#include <charconv>
 
 
 namespace DB
@@ -31,6 +34,29 @@ void IdentifierQuoteHandler::handleRequest(HTTPServerRequest & request, HTTPServ
             *response.send() << message << std::endl;
         LOG_WARNING(log, fmt::runtime(message));
     };
+
+    if (!params.has("version"))
+    {
+        process_error("No 'version' in request URL");
+        return;
+    }
+    else
+    {
+        String version_str = params.get("version");
+        size_t version;
+        auto [_, ec] = std::from_chars(version_str.data(), version_str.data() + version_str.size(), version);
+        if (ec != std::errc())
+        {
+            process_error("Unable to parse 'version' string in request URL: '" + version_str + "' Check if the server and library-bridge have the same version.");
+            return;
+        }
+        if (version != XDBC_BRIDGE_PROTOCOL_VERSION)
+        {
+            // backwards compatibility is for now deemed unnecessary, just let the user upgrade the server and bridge to the same version
+            process_error("Server and library-bridge have different versions: '" + std::to_string(version) + "' vs. '" + std::to_string(LIBRARY_BRIDGE_PROTOCOL_VERSION) + "'");
+            return;
+        }
+    }
 
     if (!params.has("connection_string"))
     {

--- a/programs/odbc-bridge/MainHandler.cpp
+++ b/programs/odbc-bridge/MainHandler.cpp
@@ -22,7 +22,6 @@
 #include <Server/HTTP/HTMLForm.h>
 #include <Common/config.h>
 
-#include <charconv>
 #include <mutex>
 #include <memory>
 
@@ -57,28 +56,27 @@ void ODBCHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse 
     HTMLForm params(getContext()->getSettingsRef(), request);
     LOG_TRACE(log, "Request URI: {}", request.getURI());
 
+    size_t version;
+
     if (!params.has("version"))
-    {
-        processError(response, "No 'version' in request URL");
-        return;
-    }
+        version = 0; /// assumed version for too old servers which do not send a version
     else
     {
         String version_str = params.get("version");
-        size_t version;
-        auto [_, ec] = std::from_chars(version_str.data(), version_str.data() + version_str.size(), version);
-        if (ec != std::errc())
+        if (!tryParse(version, version_str))
         {
             processError(response, "Unable to parse 'version' string in request URL: '" + version_str + "' Check if the server and library-bridge have the same version.");
             return;
         }
-        if (version != XDBC_BRIDGE_PROTOCOL_VERSION)
-        {
-            // backwards compatibility is for now deemed unnecessary, just let the user upgrade the server and bridge to the same version
-            processError(response, "Server and library-bridge have different versions: '" + std::to_string(version) + "' vs. '" + std::to_string(LIBRARY_BRIDGE_PROTOCOL_VERSION) + "'");
-            return;
-        }
     }
+
+    if (version != XDBC_BRIDGE_PROTOCOL_VERSION)
+    {
+        /// backwards compatibility is considered unnecessary for now, just let the user know that the server and the bridge must be upgraded together
+        processError(response, "Server and library-bridge have different versions: '" + std::to_string(version) + "' vs. '" + std::to_string(LIBRARY_BRIDGE_PROTOCOL_VERSION) + "'");
+        return;
+    }
+
 
     if (mode == "read")
         params.read(request.getStream());

--- a/programs/odbc-bridge/SchemaAllowedHandler.cpp
+++ b/programs/odbc-bridge/SchemaAllowedHandler.cpp
@@ -4,6 +4,7 @@
 
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
+#include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>
@@ -13,8 +14,6 @@
 #include "ODBCPooledConnectionFactory.h"
 #include <sql.h>
 #include <sqlext.h>
-
-#include <charconv>
 
 
 namespace DB
@@ -43,28 +42,27 @@ void SchemaAllowedHandler::handleRequest(HTTPServerRequest & request, HTTPServer
         LOG_WARNING(log, fmt::runtime(message));
     };
 
+    size_t version;
+
     if (!params.has("version"))
-    {
-        process_error("No 'version' in request URL");
-        return;
-    }
+        version = 0; /// assumed version for too old servers which do not send a version
     else
     {
         String version_str = params.get("version");
-        size_t version;
-        auto [_, ec] = std::from_chars(version_str.data(), version_str.data() + version_str.size(), version);
-        if (ec != std::errc())
+        if (!tryParse(version, version_str))
         {
             process_error("Unable to parse 'version' string in request URL: '" + version_str + "' Check if the server and library-bridge have the same version.");
             return;
         }
-        if (version != XDBC_BRIDGE_PROTOCOL_VERSION)
-        {
-            // backwards compatibility is for now deemed unnecessary, just let the user upgrade the server and bridge to the same version
-            process_error("Server and library-bridge have different versions: '" + std::to_string(version) + "' vs. '" + std::to_string(LIBRARY_BRIDGE_PROTOCOL_VERSION) + "'");
-            return;
-        }
     }
+
+    if (version != XDBC_BRIDGE_PROTOCOL_VERSION)
+    {
+        /// backwards compatibility is considered unnecessary for now, just let the user know that the server and the bridge must be upgraded together
+        process_error("Server and library-bridge have different versions: '" + std::to_string(version) + "' vs. '" + std::to_string(LIBRARY_BRIDGE_PROTOCOL_VERSION) + "'");
+        return;
+    }
+
 
     if (!params.has("connection_string"))
     {

--- a/src/BridgeHelper/ExternalDictionaryLibraryBridgeHelper.cpp
+++ b/src/BridgeHelper/ExternalDictionaryLibraryBridgeHelper.cpp
@@ -59,6 +59,7 @@ Poco::URI ExternalDictionaryLibraryBridgeHelper::getMainURI() const
 Poco::URI ExternalDictionaryLibraryBridgeHelper::createRequestURI(const String & method) const
 {
     auto uri = getMainURI();
+    uri.addQueryParameter("version", std::to_string(LIBRARY_BRIDGE_PROTOCOL_VERSION));
     uri.addQueryParameter("dictionary_id", toString(dictionary_id));
     uri.addQueryParameter("method", method);
     return uri;

--- a/src/BridgeHelper/ExternalDictionaryLibraryBridgeHelper.cpp
+++ b/src/BridgeHelper/ExternalDictionaryLibraryBridgeHelper.cpp
@@ -31,16 +31,10 @@ ExternalDictionaryLibraryBridgeHelper::ExternalDictionaryLibraryBridgeHelper(
         const Block & sample_block_,
         const Field & dictionary_id_,
         const LibraryInitData & library_data_)
-    : IBridgeHelper(context_->getGlobalContext())
-    , log(&Poco::Logger::get("ExternalDictionaryLibraryBridgeHelper"))
+    : LibraryBridgeHelper(context_->getGlobalContext())
     , sample_block(sample_block_)
-    , config(context_->getConfigRef())
-    , http_timeout(context_->getGlobalContext()->getSettingsRef().http_receive_timeout.value)
     , library_data(library_data_)
     , dictionary_id(dictionary_id_)
-    , bridge_host(config.getString("library_bridge.host", DEFAULT_HOST))
-    , bridge_port(config.getUInt("library_bridge.port", DEFAULT_PORT))
-    , http_timeouts(ConnectionTimeouts::getHTTPTimeouts(context_))
 {
 }
 
@@ -68,22 +62,6 @@ Poco::URI ExternalDictionaryLibraryBridgeHelper::createRequestURI(const String &
     uri.addQueryParameter("dictionary_id", toString(dictionary_id));
     uri.addQueryParameter("method", method);
     return uri;
-}
-
-
-Poco::URI ExternalDictionaryLibraryBridgeHelper::createBaseURI() const
-{
-    Poco::URI uri;
-    uri.setHost(bridge_host);
-    uri.setPort(bridge_port);
-    uri.setScheme("http");
-    return uri;
-}
-
-
-void ExternalDictionaryLibraryBridgeHelper::startBridge(std::unique_ptr<ShellCommand> cmd) const
-{
-    getContext()->addBridgeCommand(std::move(cmd));
 }
 
 
@@ -225,6 +203,14 @@ QueryPipeline ExternalDictionaryLibraryBridgeHelper::loadAll()
 }
 
 
+static String getDictIdsString(const std::vector<UInt64> & ids)
+{
+    WriteBufferFromOwnString out;
+    writeVectorBinary(ids, out);
+    return out.str();
+}
+
+
 QueryPipeline ExternalDictionaryLibraryBridgeHelper::loadIds(const std::vector<uint64_t> & ids)
 {
     startBridgeSync();
@@ -282,14 +268,5 @@ QueryPipeline ExternalDictionaryLibraryBridgeHelper::loadBase(const Poco::URI & 
     source->addBuffer(std::move(read_buf_ptr));
     return QueryPipeline(std::move(source));
 }
-
-
-String ExternalDictionaryLibraryBridgeHelper::getDictIdsString(const std::vector<UInt64> & ids)
-{
-    WriteBufferFromOwnString out;
-    writeVectorBinary(ids, out);
-    return out.str();
-}
-
 
 }

--- a/src/BridgeHelper/ExternalDictionaryLibraryBridgeHelper.h
+++ b/src/BridgeHelper/ExternalDictionaryLibraryBridgeHelper.h
@@ -2,10 +2,9 @@
 
 #include <Interpreters/Context.h>
 #include <IO/ReadWriteBufferFromHTTP.h>
-#include <Poco/Logger.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/URI.h>
-#include <BridgeHelper/IBridgeHelper.h>
+#include <BridgeHelper/LibraryBridgeHelper.h>
 #include <QueryPipeline/QueryPipeline.h>
 
 
@@ -14,7 +13,8 @@ namespace DB
 
 class Pipe;
 
-class ExternalDictionaryLibraryBridgeHelper : public IBridgeHelper
+// Class to access the external dictionary part of the clickhouse-library-bridge.
+class ExternalDictionaryLibraryBridgeHelper : public LibraryBridgeHelper
 {
 
 public:
@@ -25,7 +25,6 @@ public:
         String dict_attributes;
     };
 
-    static constexpr inline size_t DEFAULT_PORT = 9012;
     static constexpr inline auto PING_HANDLER = "/extdict_ping";
     static constexpr inline auto MAIN_HANDLER = "/extdict_request";
 
@@ -56,26 +55,6 @@ protected:
 
     bool bridgeHandShake() override;
 
-    void startBridge(std::unique_ptr<ShellCommand> cmd) const override;
-
-    String serviceAlias() const override { return "clickhouse-library-bridge"; }
-
-    String serviceFileName() const override { return serviceAlias(); }
-
-    size_t getDefaultPort() const override { return DEFAULT_PORT; }
-
-    bool startBridgeManually() const override { return false; }
-
-    String configPrefix() const override { return "library_bridge"; }
-
-    const Poco::Util::AbstractConfiguration & getConfig() const override { return config; }
-
-    Poco::Logger * getLog() const override { return log; }
-
-    Poco::Timespan getHTTPTimeout() const override { return http_timeout; }
-
-    Poco::URI createBaseURI() const override;
-
     QueryPipeline loadBase(const Poco::URI & uri, ReadWriteBufferFromHTTP::OutStreamCallback out_stream_callback = {});
 
     bool executeRequest(const Poco::URI & uri, ReadWriteBufferFromHTTP::OutStreamCallback out_stream_callback = {}) const;
@@ -94,20 +73,10 @@ private:
 
     Poco::URI createRequestURI(const String & method) const;
 
-    static String getDictIdsString(const std::vector<UInt64> & ids);
-
-    Poco::Logger * log;
     const Block sample_block;
-    const Poco::Util::AbstractConfiguration & config;
-    const Poco::Timespan http_timeout;
-
     LibraryInitData library_data;
     Field dictionary_id;
-    std::string bridge_host;
-    size_t bridge_port;
     bool library_initialized = false;
-    ConnectionTimeouts http_timeouts;
-    Poco::Net::HTTPBasicCredentials credentials{};
 };
 
 }

--- a/src/BridgeHelper/LibraryBridgeHelper.cpp
+++ b/src/BridgeHelper/LibraryBridgeHelper.cpp
@@ -1,0 +1,34 @@
+#include "LibraryBridgeHelper.h"
+
+namespace DB
+{
+
+LibraryBridgeHelper::LibraryBridgeHelper(ContextPtr context_)
+    : IBridgeHelper(context_)
+    , config(context_->getConfigRef())
+    , log(&Poco::Logger::get("LibraryBridgeHelper"))
+    , http_timeout(context_->getGlobalContext()->getSettingsRef().http_receive_timeout.value)
+    , bridge_host(config.getString("library_bridge.host", DEFAULT_HOST))
+    , bridge_port(config.getUInt("library_bridge.port", DEFAULT_PORT))
+    , http_timeouts(ConnectionTimeouts::getHTTPTimeouts(context_))
+{
+}
+
+
+void LibraryBridgeHelper::startBridge(std::unique_ptr<ShellCommand> cmd) const
+{
+    getContext()->addBridgeCommand(std::move(cmd));
+}
+
+
+Poco::URI LibraryBridgeHelper::createBaseURI() const
+{
+    Poco::URI uri;
+    uri.setHost(bridge_host);
+    uri.setPort(bridge_port);
+    uri.setScheme("http");
+    return uri;
+}
+
+
+}

--- a/src/BridgeHelper/LibraryBridgeHelper.h
+++ b/src/BridgeHelper/LibraryBridgeHelper.h
@@ -6,6 +6,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/URI.h>
 #include <BridgeHelper/IBridgeHelper.h>
+#include <Common/BridgeProtocolVersion.h>
 
 namespace DB
 {

--- a/src/BridgeHelper/LibraryBridgeHelper.h
+++ b/src/BridgeHelper/LibraryBridgeHelper.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <Interpreters/Context.h>
+#include <IO/ReadWriteBufferFromHTTP.h>
+#include <Poco/Logger.h>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/URI.h>
+#include <BridgeHelper/IBridgeHelper.h>
+
+namespace DB
+{
+
+// Common base class to access the clickhouse-library-bridge.
+class LibraryBridgeHelper : public IBridgeHelper
+{
+protected:
+    explicit LibraryBridgeHelper(ContextPtr context_);
+
+    void startBridge(std::unique_ptr<ShellCommand> cmd) const override;
+
+    String serviceAlias() const override { return "clickhouse-library-bridge"; }
+
+    String serviceFileName() const override { return serviceAlias(); }
+
+    size_t getDefaultPort() const override { return DEFAULT_PORT; }
+
+    bool startBridgeManually() const override { return false; }
+
+    String configPrefix() const override { return "library_bridge"; }
+
+    const Poco::Util::AbstractConfiguration & getConfig() const override { return config; }
+
+    Poco::Logger * getLog() const override { return log; }
+
+    Poco::Timespan getHTTPTimeout() const override { return http_timeout; }
+
+    Poco::URI createBaseURI() const override;
+
+    static constexpr inline size_t DEFAULT_PORT = 9012;
+
+    const Poco::Util::AbstractConfiguration & config;
+    Poco::Logger * log;
+    const Poco::Timespan http_timeout;
+    std::string bridge_host;
+    size_t bridge_port;
+    ConnectionTimeouts http_timeouts;
+    Poco::Net::HTTPBasicCredentials credentials{};
+};
+
+}

--- a/src/BridgeHelper/XDBCBridgeHelper.h
+++ b/src/BridgeHelper/XDBCBridgeHelper.h
@@ -9,6 +9,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/URI.h>
 #include <Poco/Util/AbstractConfiguration.h>
+#include <Common/BridgeProtocolVersion.h>
 #include <Common/ShellCommand.h>
 #include <Common/logger_useful.h>
 #include <IO/ConnectionTimeoutsContext.h>
@@ -86,6 +87,7 @@ protected:
     {
         auto uri = createBaseURI();
         uri.setPath(MAIN_HANDLER);
+        uri.addQueryParameter("version", std::to_string(XDBC_BRIDGE_PROTOCOL_VERSION));
         return uri;
     }
 
@@ -163,6 +165,7 @@ protected:
     {
         auto uri = createBaseURI();
         uri.setPath(COL_INFO_HANDLER);
+        uri.addQueryParameter("version", std::to_string(XDBC_BRIDGE_PROTOCOL_VERSION));
         return uri;
     }
 
@@ -184,6 +187,7 @@ protected:
 
             auto uri = createBaseURI();
             uri.setPath(SCHEMA_ALLOWED_HANDLER);
+            uri.addQueryParameter("version", std::to_string(XDBC_BRIDGE_PROTOCOL_VERSION));
             uri.addQueryParameter("connection_string", getConnectionString());
 
             ReadWriteBufferFromHTTP buf(uri, Poco::Net::HTTPRequest::HTTP_POST, {}, ConnectionTimeouts::getHTTPTimeouts(getContext()), credentials);
@@ -204,6 +208,7 @@ protected:
 
             auto uri = createBaseURI();
             uri.setPath(IDENTIFIER_QUOTE_HANDLER);
+            uri.addQueryParameter("version", std::to_string(XDBC_BRIDGE_PROTOCOL_VERSION));
             uri.addQueryParameter("connection_string", getConnectionString());
 
             ReadWriteBufferFromHTTP buf(uri, Poco::Net::HTTPRequest::HTTP_POST, {}, ConnectionTimeouts::getHTTPTimeouts(getContext()), credentials);

--- a/src/Common/BridgeProtocolVersion.h
+++ b/src/Common/BridgeProtocolVersion.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstddef>
+
+namespace DB
+{
+
+// Version of protocol between clickhouse-server and clickhouse-library-bridge. Increment if you change it in a non-compatible way.
+static constexpr size_t LIBRARY_BRIDGE_PROTOCOL_VERSION = 1;
+
+// Version of protocol between clickhouse-server and clickhouse-xdbc-bridge. Increment if you change it in a non-compatible way.
+static constexpr size_t XDBC_BRIDGE_PROTOCOL_VERSION = 1;
+
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The individual commits contain more detailed descriptions.

The major change here is a new simple version field added to clickhouse-xdbc/library-bridges as discussed internally today.