### PR TITLE
copy self-extracting to output

### DIFF
--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -104,6 +104,7 @@ if [ -n "$MAKE_DEB" ]; then
 fi
 
 mv ./programs/clickhouse* /output
+[ -x ./programs/self-extracting/clickhouse ] && mv ./programs/self-extracting/clickhouse /output
 mv ./src/unit_tests_dbms /output ||: # may not exist for some binary builds
 find . -name '*.so' -print -exec mv '{}' /output \;
 find . -name '*.so.*' -print -exec mv '{}' /output \;

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -69,6 +69,8 @@ function download
     wget_with_retry "$BINARY_URL_TO_DOWNLOAD"
 
     chmod +x clickhouse
+    # clickhouse may be compressed - run once to decompress
+    ./clickhouse ||:
     ln -s ./clickhouse ./clickhouse-server
     ln -s ./clickhouse ./clickhouse-client
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Deploy compressed self-extracting clickhouse to s3

Closes #34755


This is a second attempt - previous decompressor could not properly decompress if executable was called through link or/and by PATH - which made necessary to explicitly run compressed executable in tests - now it should be not necessary - fixed in #40011