### PR TITLE
Add observer mode to (zoo)keeper cluster discovery feature

### DIFF
--- a/src/Common/Config/ConfigHelper.h
+++ b/src/Common/Config/ConfigHelper.h
@@ -15,6 +15,6 @@ namespace DB::ConfigHelper
 
 /// The behavior is like `config.getBool(key, default_)`,
 /// except when the tag is empty (aka. self-closing), `empty_as` will be used instead of throwing Poco::Exception.
-bool getBool(const Poco::Util::AbstractConfiguration & config, const std::string & key, bool default_, bool empty_as);
+bool getBool(const Poco::Util::AbstractConfiguration & config, const std::string & key, bool default_ = false, bool empty_as = true);
 
 }

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -13,6 +13,7 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/ZooKeeper/Types.h>
 #include <Common/setThreadName.h>
+#include <Common/Config/ConfigHelper.h>
 
 #include <Core/ServerUUID.h>
 
@@ -126,7 +127,8 @@ ClusterDiscovery::ClusterDiscovery(
                 /* zk_root_= */ config.getString(prefix + ".path"),
                 /* port= */ context->getTCPPort(),
                 /* secure= */ config.getBool(prefix + ".secure", false),
-                /* shard_id= */ config.getUInt(prefix + ".shard", 0)
+                /* shard_id= */ config.getUInt(prefix + ".shard", 0),
+                /* observer_mode= */ ConfigHelper::getBool(config, prefix + ".observer")
             )
         );
     }
@@ -240,6 +242,11 @@ ClusterPtr ClusterDiscovery::makeCluster(const ClusterInfo & cluster_info)
     return cluster;
 }
 
+static bool contains(const Strings & list, const String & value)
+{
+    return std::find(list.begin(), list.end(), value) != list.end();
+}
+
 /// Reads data from zookeeper and tries to update cluster.
 /// Returns true on success (or no update required).
 bool ClusterDiscovery::updateCluster(ClusterInfo & cluster_info)
@@ -252,7 +259,7 @@ bool ClusterDiscovery::updateCluster(ClusterInfo & cluster_info)
     Strings node_uuids = getNodeNames(zk, cluster_info.zk_root, cluster_info.name, &start_version, false);
     auto & nodes_info = cluster_info.nodes_info;
 
-    if (std::find(node_uuids.begin(), node_uuids.end(), current_node_name) == node_uuids.end())
+    if (!cluster_info.current_node_is_observer && !contains(node_uuids, current_node_name))
     {
         LOG_ERROR(log, "Can't find current node in cluster '{}', will register again", cluster_info.name);
         registerInZk(zk, cluster_info);
@@ -292,6 +299,12 @@ bool ClusterDiscovery::updateCluster(ClusterInfo & cluster_info)
 
 void ClusterDiscovery::registerInZk(zkutil::ZooKeeperPtr & zk, ClusterInfo & info)
 {
+    if (info.current_node_is_observer)
+    {
+        LOG_DEBUG(log, "Current node {} is observer of cluster {}", current_node_name, info.name);
+        return;
+    }
+
     LOG_DEBUG(log, "Registering current node {} in cluster {}", current_node_name, info.name);
 
     String node_path = getShardsListPath(info.zk_root) / current_node_name;

--- a/src/Interpreters/ClusterDiscovery.h
+++ b/src/Interpreters/ClusterDiscovery.h
@@ -72,11 +72,19 @@ private:
         Stopwatch watch;
 
         NodeInfo current_node;
+        /// Current node may not belong to cluster, to be just an observer.
+        bool current_node_is_observer = false;
 
-        explicit ClusterInfo(const String & name_, const String & zk_root_, UInt16 port, bool secure, size_t shard_id)
+        explicit ClusterInfo(const String & name_,
+                             const String & zk_root_,
+                             UInt16 port,
+                             bool secure,
+                             size_t shard_id,
+                             bool observer_mode)
             : name(name_)
             , zk_root(zk_root_)
             , current_node(getFQDNOrHostName() + ":" + toString(port), secure, shard_id)
+            , current_node_is_observer(observer_mode)
         {
         }
     };

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -73,6 +73,7 @@
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/parseQuery.h>
 #include <Common/StackTrace.h>
+#include <Common/Config/ConfigHelper.h>
 #include <Common/Config/ConfigProcessor.h>
 #include <Common/Config/AbstractConfigurationComparison.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
@@ -2402,7 +2403,7 @@ void Context::startClusterDiscovery()
 void Context::setClustersConfig(const ConfigurationPtr & config, bool enable_discovery, const String & config_name)
 {
     std::lock_guard lock(shared->clusters_mutex);
-    if (config->getBool("allow_experimental_cluster_discovery", false) && enable_discovery && !shared->cluster_discovery)
+    if (ConfigHelper::getBool(*config, "allow_experimental_cluster_discovery") && enable_discovery && !shared->cluster_discovery)
     {
         shared->cluster_discovery = std::make_unique<ClusterDiscovery>(*config, getGlobalContext());
     }

--- a/tests/integration/test_cluster_discovery/config/config_observer.xml
+++ b/tests/integration/test_cluster_discovery/config/config_observer.xml
@@ -4,7 +4,7 @@
         <test_auto_cluster>
             <discovery>
                 <path>/clickhouse/discovery/test_auto_cluster</path>
-                <shard>3</shard>
+                <observer/>
             </discovery>
         </test_auto_cluster>
         <two_shards>

--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -13,7 +13,7 @@ shard_configs = {
     2: "config/config.xml",
     3: "config/config_shard3.xml",
     4: "config/config.xml",
-    'observer': "config/config_observer.xml",
+    "observer": "config/config_observer.xml",
 }
 
 nodes = {
@@ -83,23 +83,23 @@ def test_cluster_discovery_startup_and_stop(start_cluster):
     total_shards = 3
     # one node is observer
     total_nodes = len(nodes) - 1
-    check_nodes_count([nodes[0], nodes[2], nodes['observer']], total_nodes)
-    check_shard_num([nodes[0], nodes[2], nodes['observer']], total_shards)
+    check_nodes_count([nodes[0], nodes[2], nodes["observer"]], total_nodes)
+    check_shard_num([nodes[0], nodes[2], nodes["observer"]], total_shards)
 
     nodes[1].stop_clickhouse(kill=True)
-    check_nodes_count([nodes[0], nodes[2], nodes['observer']], total_nodes - 1)
+    check_nodes_count([nodes[0], nodes[2], nodes["observer"]], total_nodes - 1)
 
     # node_1 was the only node in shard '1'
-    check_shard_num([nodes[0], nodes[2], nodes['observer']], total_shards - 1)
+    check_shard_num([nodes[0], nodes[2], nodes["observer"]], total_shards - 1)
 
     nodes[3].stop_clickhouse()
-    check_nodes_count([nodes[0], nodes[2], nodes['observer']], total_nodes - 2)
+    check_nodes_count([nodes[0], nodes[2], nodes["observer"]], total_nodes - 2)
 
     nodes[1].start_clickhouse()
-    check_nodes_count([nodes[0], nodes[2], nodes['observer']], total_nodes - 1)
+    check_nodes_count([nodes[0], nodes[2], nodes["observer"]], total_nodes - 1)
 
     nodes[3].start_clickhouse()
-    check_nodes_count([nodes[0], nodes[2], nodes['observer']], total_nodes)
+    check_nodes_count([nodes[0], nodes[2], nodes["observer"]], total_nodes)
 
     # regular cluster is not affected
     check_nodes_count([nodes[1], nodes[2]], 2, cluster_name="two_shards", retries=1)

--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -8,11 +8,11 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 shard_configs = {
-    "node_0": "config/config.xml",
-    "node_1": "config/config_shard1.xml",
-    "node_2": "config/config.xml",
-    "node_3": "config/config_shard3.xml",
-    "node_4": "config/config.xml",
+    "node0": "config/config.xml",
+    "node1": "config/config_shard1.xml",
+    "node2": "config/config.xml",
+    "node3": "config/config_shard3.xml",
+    "node4": "config/config.xml",
     "node_observer": "config/config_observer.xml",
 }
 
@@ -89,38 +89,38 @@ def test_cluster_discovery_startup_and_stop(start_cluster):
     total_nodes = len(nodes) - 1
 
     check_nodes_count(
-        [nodes["node_0"], nodes["node_2"], nodes["node_observer"]], total_nodes
+        [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_nodes
     )
     check_shard_num(
-        [nodes["node_0"], nodes["node_2"], nodes["node_observer"]], total_shards
+        [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_shards
     )
 
-    nodes["node_1"].stop_clickhouse(kill=True)
+    nodes["node1"].stop_clickhouse(kill=True)
     check_nodes_count(
-        [nodes["node_0"], nodes["node_2"], nodes["node_observer"]], total_nodes - 1
+        [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_nodes - 1
     )
 
-    # node_1 was the only node in shard '1'
+    # node1 was the only node in shard '1'
     check_shard_num(
-        [nodes["node_0"], nodes["node_2"], nodes["node_observer"]], total_shards - 1
+        [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_shards - 1
     )
 
-    nodes["node_3"].stop_clickhouse()
+    nodes["node3"].stop_clickhouse()
     check_nodes_count(
-        [nodes["node_0"], nodes["node_2"], nodes["node_observer"]], total_nodes - 2
+        [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_nodes - 2
     )
 
-    nodes["node_1"].start_clickhouse()
+    nodes["node1"].start_clickhouse()
     check_nodes_count(
-        [nodes["node_0"], nodes["node_2"], nodes["node_observer"]], total_nodes - 1
+        [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_nodes - 1
     )
 
-    nodes["node_3"].start_clickhouse()
+    nodes["node3"].start_clickhouse()
     check_nodes_count(
-        [nodes["node_0"], nodes["node_2"], nodes["node_observer"]], total_nodes
+        [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_nodes
     )
 
     # regular cluster is not affected
     check_nodes_count(
-        [nodes["node_1"], nodes["node_2"]], 2, cluster_name="two_shards", retries=1
+        [nodes["node1"], nodes["node2"]], 2, cluster_name="two_shards", retries=1
     )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Add observer mode to (zoo)keeper cluster discovery feature. In this mode node itself doesn't belong to cluster.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
