### PR TITLE
tests: attempt to make 02293_part_log_has_merge_reason less flaky

### DIFF
--- a/tests/queries/0_stateless/02293_part_log_has_merge_reason.sql
+++ b/tests/queries/0_stateless/02293_part_log_has_merge_reason.sql
@@ -6,10 +6,10 @@ CREATE TABLE t_part_log_has_merge_type_table
     UserID UInt64,
     Comment String
 )
-ENGINE = MergeTree() 
+ENGINE = MergeTree()
 ORDER BY tuple()
 TTL event_time + INTERVAL 3 MONTH
-SETTINGS min_bytes_for_wide_part = 0, materialize_ttl_recalculate_only = true;
+SETTINGS min_bytes_for_wide_part = 0, materialize_ttl_recalculate_only = true, max_number_of_merges_with_ttl_in_pool = 100;
 
 INSERT INTO t_part_log_has_merge_type_table VALUES (now(), 1, 'username1');
 INSERT INTO t_part_log_has_merge_type_table VALUES (now() - INTERVAL 4 MONTH, 2, 'username2');
@@ -20,7 +20,7 @@ SYSTEM FLUSH LOGS;
 
 SELECT
     event_type,
-    merge_reason 
+    merge_reason
 FROM
     system.part_log
 WHERE


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/40003/acc33d4a116802eedc4e089f7e1612efe8e62d4d/stateless_tests__release__wide_parts_enabled_.html
Refs: #36912

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)