### PR TITLE
Fix clickhouse-test hang in case of CREATE DATABASE fails

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -914,7 +914,7 @@ class TestCase:
         description_full += result.description
         description_full += "\n"
 
-        if result.status == TestStatus.FAIL:
+        if result.status == TestStatus.FAIL and self.testcase_args:
             description_full += "Database: " + self.testcase_args.testcase_database
 
         result.description = description_full


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)