### PR TITLE
Fix NoneType error in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -914,7 +914,7 @@ class TestCase:
         description_full += result.description
         description_full += "\n"
 
-        if result.status == TestStatus.FAIL:
+        if result.status == TestStatus.FAIL and self.testcase_args is not None:
             description_full += "Database: " + self.testcase_args.testcase_database
 
         result.description = description_full


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix NoneType error in clickhouse-test. Exception might appear before `configure_testcase_args`, which will lead to `AttributeError: 'NoneType' object has no attribute 'testcase_database'`


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
