### PR TITLE
Add retries for more commands in `test_keeper_force_recovery`

### DIFF
--- a/tests/integration/test_keeper_force_recovery/test.py
+++ b/tests/integration/test_keeper_force_recovery/test.py
@@ -54,6 +54,7 @@ def get_fake_zk(nodename, timeout=30.0):
     _fake_zk_instance = KazooClient(
         hosts=cluster.get_instance_ip(nodename) + ":9181",
         timeout=timeout,
+        connection_retry=KazooRetry(max_tries=10),
         command_retry=KazooRetry(max_tries=10),
     )
 
@@ -93,9 +94,9 @@ def wait_nodes(nodes):
 
 
 def wait_and_assert_data(zk, path, data):
-    while zk.exists(path) is None:
+    while zk.retry(zk.exists, path) is None:
         time.sleep(0.1)
-    assert zk.get(path)[0] == data.encode()
+    assert zk.retry(zk.get, path)[0] == data.encode()
 
 
 def close_zk(zk):


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


It seems it can still fail on timeout or connection loss for some requests.

https://s3.amazonaws.com/clickhouse-test-reports/0/b827f3bccf9f0d5a7efb2493942362ca989d8f3c/integration_tests__asan__[1/3].html

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
