### PR TITLE
use ROBOT_CLICKHOUSE_COMMIT_TOKEN for create-pull-request

### DIFF
--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -50,6 +50,7 @@ jobs:
         branch: auto/${{ env.GITHUB_TAG }}
         delete-branch: true
         title: Update version_date.tsv and changelogs after ${{ env.GITHUB_TAG }}
+        labels: do not test
         body: |
           Update version_date.tsv and changelogs after ${{ env.GITHUB_TAG }}
 

--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -41,6 +41,8 @@ jobs:
         git diff HEAD
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.ROBOT_CLICKHOUSE_COMMIT_TOKEN }}
       with:
         author: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
         committer: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"

--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -13,13 +13,24 @@ on: # yamllint disable-line rule:truthy
     - 'v*-prestable'
     - 'v*-stable'
     - 'v*-lts'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Test tag'
+        required: true 
+        type: string
 
 
 jobs:
   UpdateVersions:
     runs-on: [self-hosted, style-checker]
     steps:
+    - name: Set test tag
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "GITHUB_TAG=${{ inputs.tag }}" >> "$GITHUB_ENV"
     - name: Get tag name
+      if: github.event_name != 'workflow_dispatch'
       run: |
         echo "GITHUB_TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
     - name: Check out repository code

--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set test tag
       if: github.event_name == 'workflow_dispatch'
       run: |
-        echo "GITHUB_TAG=${{ inputs.tag }}" >> "$GITHUB_ENV"
+        echo "GITHUB_TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
     - name: Get tag name
       if: github.event_name != 'workflow_dispatch'
       run: |

--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -17,7 +17,7 @@ on: # yamllint disable-line rule:truthy
     inputs:
       tag:
         description: 'Test tag'
-        required: true 
+        required: true
         type: string
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Workaround for issue when CI doesn't start if PR was created by action:
https://github.com/peter-evans/create-pull-request/issues/48
