### PR TITLE
Don't visit the AST for UDFs if none are registered

### DIFF
--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -6,29 +6,30 @@
 #include <Common/checkStackSize.h>
 #include <Core/SettingsEnums.h>
 
-#include <Interpreters/TreeRewriter.h>
-#include <Interpreters/LogicalExpressionsOptimizer.h>
-#include <Interpreters/QueryAliasesVisitor.h>
 #include <Interpreters/ArrayJoinedColumnsVisitor.h>
-#include <Interpreters/TranslateQualifiedNamesVisitor.h>
-#include <Interpreters/Context.h>
-#include <Interpreters/FunctionNameNormalizer.h>
-#include <Interpreters/MarkTableIdentifiersVisitor.h>
-#include <Interpreters/QueryNormalizer.h>
-#include <Interpreters/GroupingSetsRewriterVisitor.h>
-#include <Interpreters/ExecuteScalarSubqueriesVisitor.h>
 #include <Interpreters/CollectJoinOnKeysVisitor.h>
-#include <Interpreters/RequiredSourceColumnsVisitor.h>
-#include <Interpreters/GetAggregatesVisitor.h>
-#include <Interpreters/UserDefinedSQLFunctionVisitor.h>
-#include <Interpreters/TableJoin.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ExecuteScalarSubqueriesVisitor.h>
 #include <Interpreters/ExpressionActions.h> /// getSmallestColumn()
-#include <Interpreters/getTableExpressions.h>
-#include <Interpreters/TreeOptimizer.h>
-#include <Interpreters/replaceAliasColumnsInQuery.h>
-#include <Interpreters/evaluateConstantExpression.h>
+#include <Interpreters/FunctionNameNormalizer.h>
+#include <Interpreters/GetAggregatesVisitor.h>
+#include <Interpreters/GroupingSetsRewriterVisitor.h>
+#include <Interpreters/LogicalExpressionsOptimizer.h>
+#include <Interpreters/MarkTableIdentifiersVisitor.h>
 #include <Interpreters/PredicateExpressionsOptimizer.h>
+#include <Interpreters/QueryAliasesVisitor.h>
+#include <Interpreters/QueryNormalizer.h>
+#include <Interpreters/RequiredSourceColumnsVisitor.h>
 #include <Interpreters/RewriteOrderByVisitor.hpp>
+#include <Interpreters/TableJoin.h>
+#include <Interpreters/TranslateQualifiedNamesVisitor.h>
+#include <Interpreters/TreeOptimizer.h>
+#include <Interpreters/TreeRewriter.h>
+#include <Interpreters/UserDefinedSQLFunctionFactory.h>
+#include <Interpreters/UserDefinedSQLFunctionVisitor.h>
+#include <Interpreters/evaluateConstantExpression.h>
+#include <Interpreters/getTableExpressions.h>
+#include <Interpreters/replaceAliasColumnsInQuery.h>
 #include <Interpreters/replaceForPositionalArguments.h>
 
 #include <Parsers/IAST_fwd.h>
@@ -1405,8 +1406,11 @@ TreeRewriterResultPtr TreeRewriter::analyze(
 void TreeRewriter::normalize(
     ASTPtr & query, Aliases & aliases, const NameSet & source_columns_set, bool ignore_alias, const Settings & settings, bool allow_self_aliases, ContextPtr context_)
 {
-    UserDefinedSQLFunctionVisitor::Data data_user_defined_functions_visitor;
-    UserDefinedSQLFunctionVisitor(data_user_defined_functions_visitor).visit(query);
+    if (!UserDefinedSQLFunctionFactory::instance().empty())
+    {
+        UserDefinedSQLFunctionVisitor::Data data_user_defined_functions_visitor;
+        UserDefinedSQLFunctionVisitor(data_user_defined_functions_visitor).visit(query);
+    }
 
     CustomizeCountDistinctVisitor::Data data_count_distinct{settings.count_distinct_implementation};
     CustomizeCountDistinctVisitor(data_count_distinct).visit(query);

--- a/src/Interpreters/UserDefinedSQLFunctionFactory.cpp
+++ b/src/Interpreters/UserDefinedSQLFunctionFactory.cpp
@@ -160,4 +160,9 @@ std::vector<std::string> UserDefinedSQLFunctionFactory::getAllRegisteredNames() 
     return registered_names;
 }
 
+bool UserDefinedSQLFunctionFactory::empty() const
+{
+    std::lock_guard lock(mutex);
+    return function_name_to_create_query.size() == 0;
+}
 }

--- a/src/Interpreters/UserDefinedSQLFunctionFactory.cpp
+++ b/src/Interpreters/UserDefinedSQLFunctionFactory.cpp
@@ -163,6 +163,6 @@ std::vector<std::string> UserDefinedSQLFunctionFactory::getAllRegisteredNames() 
 bool UserDefinedSQLFunctionFactory::empty() const
 {
     std::lock_guard lock(mutex);
-    return function_name_to_create_query.size() == 0;
+    return function_name_to_create_query.empty();
 }
 }

--- a/src/Interpreters/UserDefinedSQLFunctionFactory.h
+++ b/src/Interpreters/UserDefinedSQLFunctionFactory.h
@@ -43,6 +43,9 @@ public:
     /// Get all user defined functions registered names.
     std::vector<String> getAllRegisteredNames() const override;
 
+    /// Check whether any UDFs have been registered
+    bool empty() const;
+
 private:
     std::unordered_map<String, ASTPtr> function_name_to_create_query;
     mutable std::mutex mutex;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Don't visit the AST for UDFs if none are registered


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

More work to reduce query interpretation (https://github.com/ClickHouse/ClickHouse/issues/39996)

In this case perf is showing that ~1% of the query (in the query for https://github.com/ClickHouse/ClickHouse/pull/40065) is spent on the UserDefinedSQLFunctionMatcher visitor:
```
-    1.05%     0.23%           755  TCPHandler      libclickhouse_interpreters.so                        [.] DB::UserDefinedSQLFunctionMatcher::visit                                                                                                       ▒
   - 0.82% DB::UserDefinedSQLFunctionMatcher::visit                                                                                                                                                                                                         ▒
      - 0.79% DB::UserDefinedSQLFunctionMatcher::tryToReplaceFunction                                                                                                                                                                                       ▒
           0.69% DB::UserDefinedSQLFunctionFactory::tryGet
```

It doesn't make sense to pay for this visitor if you are not using UDFs.