### PR TITLE
tests: fix 00926_adaptive_index_granularity_pk/00489_pk_subexpression flakiness

### DIFF
--- a/tests/queries/0_stateless/00489_pk_subexpression.sql
+++ b/tests/queries/0_stateless/00489_pk_subexpression.sql
@@ -1,7 +1,20 @@
 DROP TABLE IF EXISTS pk;
 
 set allow_deprecated_syntax_for_merge_tree=1;
-CREATE TABLE pk (d Date DEFAULT '2000-01-01', x DateTime, y UInt64, z UInt64) ENGINE = MergeTree(d, (toStartOfMinute(x), y, z), 1);
+-- NOTE: here the timezone is pinned to UTC, to avoid issues with "partial
+-- timezones" (timezones that does not starts from 00:00), like
+-- Africa/Monrovia, for which toStartOfMinute(0) and toStartOfMinute(59) can
+-- give different values:
+--
+--     SELECT
+--         toDateTime(0, 'Africa/Monrovia') AS sec0,
+--         toDateTime(59, 'Africa/Monrovia') AS sec59
+--
+--     ┌────────────────sec0─┬───────────────sec59─┐
+--     │ 1969-12-31 23:15:30 │ 1969-12-31 23:16:29 │
+--     └─────────────────────┴─────────────────────┘
+--
+CREATE TABLE pk (d Date DEFAULT '2000-01-01', x DateTime, y UInt64, z UInt64) ENGINE = MergeTree(d, (toStartOfMinute(x, 'UTC'), y, z), 1);
 
 INSERT INTO pk (x, y, z) VALUES (1, 11, 1235), (2, 11, 4395), (3, 22, 3545), (4, 22, 6984), (5, 33, 4596), (61, 11, 4563), (62, 11, 4578), (63, 11, 3572), (64, 22, 5786), (65, 22, 5786), (66, 22, 2791), (67, 22, 2791), (121, 33, 2791), (122, 33, 2791), (123, 33, 1235), (124, 44, 4935), (125, 44, 4578), (126, 55, 5786), (127, 55, 2791), (128, 55, 1235);
 

--- a/tests/queries/0_stateless/00926_adaptive_index_granularity_pk.sql
+++ b/tests/queries/0_stateless/00926_adaptive_index_granularity_pk.sql
@@ -4,7 +4,20 @@ SET send_logs_level = 'fatal';
 SELECT '----00489----';
 DROP TABLE IF EXISTS pk;
 
-CREATE TABLE pk (d Date DEFAULT '2000-01-01', x DateTime, y UInt64, z UInt64) ENGINE = MergeTree() PARTITION BY d ORDER BY (toStartOfMinute(x), y, z) SETTINGS index_granularity_bytes=19, min_index_granularity_bytes=9, write_final_mark = 0; -- one row granule
+-- NOTE: here the timezone is pinned to UTC, to avoid issues with "partial
+-- timezones" (timezones that does not starts from 00:00), like
+-- Africa/Monrovia, for which toStartOfMinute(0) and toStartOfMinute(59) can
+-- give different values:
+--
+--     SELECT
+--         toDateTime(0, 'Africa/Monrovia') AS sec0,
+--         toDateTime(59, 'Africa/Monrovia') AS sec59
+--
+--     ┌────────────────sec0─┬───────────────sec59─┐
+--     │ 1969-12-31 23:15:30 │ 1969-12-31 23:16:29 │
+--     └─────────────────────┴─────────────────────┘
+--
+CREATE TABLE pk (d Date DEFAULT '2000-01-01', x DateTime, y UInt64, z UInt64) ENGINE = MergeTree() PARTITION BY d ORDER BY (toStartOfMinute(x, 'UTC'), y, z) SETTINGS index_granularity_bytes=19, min_index_granularity_bytes=9, write_final_mark = 0; -- one row granule
 
 INSERT INTO pk (x, y, z) VALUES (1, 11, 1235), (2, 11, 4395), (3, 22, 3545), (4, 22, 6984), (5, 33, 4596), (61, 11, 4563), (62, 11, 4578), (63, 11, 3572), (64, 22, 5786), (65, 22, 5786), (66, 22, 2791), (67, 22, 2791), (121, 33, 2791), (122, 33, 2791), (123, 33, 1235), (124, 44, 4935), (125, 44, 4578), (126, 55, 5786), (127, 55, 2791), (128, 55, 1235);
 


### PR DESCRIPTION
It is possible for toStartOfMinute() to give different result for 0 and
59, for partial timezones (timezone that does not starts from 00:00,
like Africa/Monrovia).

Before #36656 it fails for another reason, because of overflows [1], but
now it fails because it simply return different minutes.

  [1]: https://github.com/ClickHouse/ClickHouse/pull/29953#discussion_r800550280

Simply pin the UTC there.

Fixes: #37786 (cc @tavplubix )

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)