### PR TITLE
Optimize CurrentMemoryTracker alloc and free

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -23,6 +23,7 @@ if (COMPILER_CLANG)
     no_warning(zero-length-array)
     no_warning(c++98-compat-pedantic)
     no_warning(c++98-compat)
+    no_warning(c++20-compat) # Use constinit in C++20 without warnings
     no_warning(conversion)
     no_warning(ctad-maybe-unsupported) # clang 9+, linux-only
     no_warning(disabled-macro-expansion)

--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -43,13 +43,6 @@ ProfileEvents::Counters & CurrentThread::getProfileEvents()
     return current_thread ? current_thread->performance_counters : ProfileEvents::global_counters;
 }
 
-MemoryTracker * CurrentThread::getMemoryTracker()
-{
-    if (unlikely(!current_thread))
-        return nullptr;
-    return &current_thread->memory_tracker;
-}
-
 void CurrentThread::updateProgressIn(const Progress & value)
 {
     if (unlikely(!current_thread))

--- a/src/Common/CurrentThread.h
+++ b/src/Common/CurrentThread.h
@@ -54,7 +54,12 @@ public:
     static void updatePerformanceCounters();
 
     static ProfileEvents::Counters & getProfileEvents();
-    static MemoryTracker * getMemoryTracker();
+    inline ALWAYS_INLINE static MemoryTracker * getMemoryTracker()
+    {
+        if (unlikely(!current_thread))
+            return nullptr;
+        return &current_thread->memory_tracker;
+    }
 
     /// Update read and write rows (bytes) statistics (used in system.query_thread_log)
     static void updateProgressIn(const Progress & value);

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -24,15 +24,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wc++20-compat"
-#endif
 thread_local ThreadStatus constinit * current_thread = nullptr;
-thread_local ThreadStatus * main_thread = nullptr;
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 #if !defined(SANITIZER)
 namespace

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -24,9 +24,15 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-
-thread_local ThreadStatus * current_thread = nullptr;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++20-compat"
+#endif
+thread_local ThreadStatus constinit * current_thread = nullptr;
 thread_local ThreadStatus * main_thread = nullptr;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #if !defined(SANITIZER)
 namespace

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -102,14 +102,16 @@ public:
 
 using ThreadGroupStatusPtr = std::shared_ptr<ThreadGroupStatus>;
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wc++20-compat"
-#endif
+/**
+ * We use **constinit** here to tell the compiler the current_thread variable is initialized.
+ * If we didn't help the compiler, then it would most likely add a check before every use of the variable to initialize it if needed.
+ * Instead it will trust that we are doing the right thing (and we do initialize it to nullptr) and emit more optimal code.
+ * This is noticeable in functions like CurrentMemoryTracker::free and CurrentMemoryTracker::allocImpl
+ * See also:
+ * - https://en.cppreference.com/w/cpp/language/constinit
+ * - https://github.com/ClickHouse/ClickHouse/pull/40078
+ */
 extern thread_local constinit ThreadStatus * current_thread;
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 /** Encapsulates all per-thread info (ProfileEvents, MemoryTracker, query_id, query context, etc.).
   * The object must be created in thread function and destroyed in the same thread before the exit.

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -102,8 +102,14 @@ public:
 
 using ThreadGroupStatusPtr = std::shared_ptr<ThreadGroupStatus>;
 
-
-extern thread_local ThreadStatus * current_thread;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++20-compat"
+#endif
+extern thread_local constinit ThreadStatus * current_thread;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 /** Encapsulates all per-thread info (ProfileEvents, MemoryTracker, query_id, query context, etc.).
   * The object must be created in thread function and destroyed in the same thread before the exit.


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Optimize CurrentMemoryTracker alloc and free


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Pure experimentation. Do not merge.

The current assembly for alloc and free for CurrentMemoryTracker is pretty bad:

```
       │     Disassembly of section .text:                                                                                                                                                                                                                  ▒
       │                                                                                                                                                                                                                                                    ▒
       │     000000000ba32d60 <CurrentMemoryTracker::free(long)@@Base>:                                                                                                                                                                                     ▒
   852 │       push   %r15                                                                                                                                                                                                                                  ▒
    68 │       push   %r14                                                                                                                                                                                                                                  ▒
    29 │       push   %rbx                                                                                                                                                                                                                                  ▒
     4 │       mov    %rdi,%r14                                                                                                                                                                                                                             ▒
    58 │       cmpq   $0x0,fma@plt+0x4af0                                                                                                                                                                                                                   ▒
     3 │     ↓ je     17                                                                                                                                                                                                                                    ▒
       │     → call   TLS init function for DB::current_thread@plt                                                                                                                                                                                          ▒
    27 │ 17:   mov    %fs:0xffffffffffff9bb0,%rax                                                                                                                                                                                                           ▒
   832 │       test   %rax,%rax                                                                                                                                                                                                                             ▒
    13 │     ↓ je     168                                                                                                                                                                                                                                   ▒
       │       cmpq   $0x0,fma@plt+0x4af0                                                                                                                                                                                                                   ▒
    75 │     ↓ je     41                                                                                                                                                                                                                                    ▒
       │     → call   TLS init function for DB::current_thread@plt                                                                                                                                                                                          ▒
       │       mov    %fs:0xffffffffffff9bb0,%rax                                                                                                                                                                                                           ▒
    29 │ 41:   lea    0x30(%rax),%rcx                                                                                                                                                                                                                       ▒
     7 │ 45:   mov    DB::MainThreadStatus::main_thread@@Base,%rdx                                                                                                                                                                                          ▒
    63 │       test   %rdx,%rdx                                                                                                                                                                                                                             ▒
     5 │       mov    $0x1daf5ed0,%ebx                                                                                                                                                                                                                      ▒
    19 │       cmove  %rdx,%rbx                                                                                                                                                                                                                             ▒
   786 │       test   %rcx,%rcx                                                                                                                                                                                                                             ▒
     8 │       cmovne %rcx,%rbx                                                                                                                                                                                                                             ▒
    88 │       nop                                                                                                                                                                                                                                          ▒
    22 │       test   %rbx,%rbx                                                                                                                                                                                                                             ▒
    12 │     ↓ je     162                                                                                                                                                                                                                                   ▒
       │       cmpq   $0x0,fma@plt+0x4af0                                                                                                                                                                                                                   ▒
    76 │     ↓ je     81                                                                                                                                                                                                                                    ▒
       │     → call   TLS init function for DB::current_thread@plt                                                                                                                                                                                          ▒
       │       mov    %fs:0xffffffffffff9bb0,%rax                                                                                                                                                                                                           ▒
     6 │ 81:   test   %rax,%rax                                                                                                                                                                                                                             ▒
    35 │     ↓ je     c6                                                                                                                                                                                                                                    ▒
       │       cmpq   $0x0,fma@plt+0x4af0                                                                                                                                                                                                                   ▒
   849 │     ↓ je     d6                                                                                                                                                                                                                                    ▒
       │     → call   TLS init function for DB::current_thread@plt                                                                                                                                                                                          ▒
       │       mov    %fs:0xffffffffffff9bb0,%rax                                                                                                                                                                                                           ▒
       │       sub    %r14,0xa0(%rax)                                                                                                                                                                                                                       ▒
       │     → call   TLS init function for DB::current_thread@plt                                                                                                                                                                                          ▒
       │       mov    %fs:0xffffffffffff9bb0,%rax                                                                                                                                                                                                           ▒
       │       mov    0xa0(%rax),%r15                                                                                                                                                                                                                       ▒
       │       cmpq   $0x0,fma@plt+0x4af0                                                                                                                                                                                                                   ▒
       │     ↓ jne    f1                                                                                                                                                                                                                                    ▒
       │     ↓ jmp    ff                                                                                                                                                                                                                                    ▒
       │ c6:   mov    %rbx,%rdi                                                                                                                                                                                                                             ▒
       │       mov    %r14,%rsi                                                                                                                                                                                                                             ▒
       │       pop    %rbx                                                                                                                                                                                                                                  ▒
       │       pop    %r14                                                                                                                                                                                                                                  ▒
       │       pop    %r15                                                                                                                                                                                                                                  ▒
       │     → jmp    MemoryTracker::free                                                                                                                                                                                                                   ▒
     7 │ d6:   mov    0xa0(%rax),%r15                                                                                                                                                                                                                       ▒
   105 │       sub    %r14,%r15                                                                                                                                                                                                                             ▒
    35 │       mov    %r15,0xa0(%rax)                                                                                                                                                                                                                       ▒
    28 │       cmpq   $0x0,fma@plt+0x4af0                                                                                                                                                                                                                   ▒
    64 │    │↓ je     ff                                                                                                                                                                                                                                    ▒
       │ f1:│→ call   TLS init function for DB::current_thread@plt                                                                                                                                                                                          ▒
       │    │  mov    %fs:0xffffffffffff9bb0,%rax                                                                                                                                                                                                           ▒
    12 │ ff:│  xor    %ecx,%ecx                                                                                                                                                                                                                             ▒
    22 │    │  sub    0xa8(%rax),%rcx                                                                                                                                                                                                                       ▒
   819 │    │  cmp    %rcx,%r15                                                                                                                                                                                                                             ▒
    28 │    │↓ jge    162                                                                                                                                                                                                                                   ▒
       │    │  cmpq   $0x0,fma@plt+0x4af0                                                                                                                                                                                                                   ▒
     1 │    │↓ je     13d                                                                                                                                                                                                                                   ▒
       │    │→ call   TLS init function for DB::current_thread@plt                                                                                                                                                                                          ▒
       │    │  mov    %fs:0xffffffffffff9bb0,%rax                                                                                                                                                                                                           ▒
       │    │  xor    %esi,%esi                                                                                                                                                                                                                             ▒
       │    │  sub    0xa0(%rax),%rsi                                                                                                                                                                                                                       ▒
       │    │  mov    %rbx,%rdi                                                                                                                                                                                                                             ▒
       │    │→ call   MemoryTracker::free                                                                                                                                                                                                                   ▒
       │    │→ call   TLS init function for DB::current_thread@plt                                                                                                                                                                                          ▒
       │    │↓ jmp    14e                                                                                                                                                                                                                                   ▒
       │13d:│  xor    %esi,%esi                                                                                                                                                                                                                             ▒
       │    │  sub    0xa0(%rax),%rsi                                                                                                                                                                                                                       ▒
     1 │    │  mov    %rbx,%rdi                                                                                                                                                                                                                             ▒
       │    │→ call   MemoryTracker::free                                                                                                                                                                                                                   ▒
       │14e:│  mov    %fs:0xffffffffffff9bb0,%rax                                                                                                                                                                                                           ▒
       │    │  movq   $0x0,0xa0(%rax)                                                                                                                                                                                                                       ▒
       │162:│  pop    %rbx                                                                                                                                                                                                                                  ▒
   100 │    │  pop    %r14                                                                                                                                                                                                                                  ▒
    34 │    │  pop    %r15                                                                                                                                                                                                                                  ▒
    16 │    │← ret                                                                                                                                                                                                                                          ▒
       │168:│  xor    %eax,%eax                                                                                                                                                                                                                             ▒
       │    │  xor    %ecx,%ecx                                                                                                                                                                                                                             ▒
       │    └──jmp    45
```

Notice the terrible `TLS init function for DB::current_thread@plt` calls everywhere.

We can make it better by telling the compiler to inline some things (might not be necessary) and more importantly by using [constinit](https://en.cppreference.com/w/cpp/language/constinit); that way we let it know that the thread local variable is initialized and does not need to check it every single time it accesses it:

```
       │    Disassembly of section .text:                                                                                                                                                                                                                   ▒
       │                                                                                                                                                                                                                                                    ▒
       │    000000000fab3760 <CurrentMemoryTracker::free(long)>:                                                                                                                                                                                            ▒
       │    CurrentMemoryTracker::free(long):                                                                                                                                                                                                               ▒
    45 │      push  %rbx                                                                                                                                                                                                                                    ▒
    29 │      mov   %rdi,%rax                                                                                                                                                                                                                               ▒
    42 │      mov   $0xffffffffffff9b98,%rbx                                                                                                                                                                                                                ▒
    55 │      mov   %fs:(%rbx),%rcx                                                                                                                                                                                                                         ▒
   202 │      lea   0x30(%rcx),%rdi                                                                                                                                                                                                                         ▒
     9 │      lea   DB::MainThreadStatus::main_thread,%rdx                                                                                                                                                                                                  ▒
   773 │      mov   (%rdx),%rdx                                                                                                                                                                                                                             ▒
    64 │      mov   %rdx,%rsi                                                                                                                                                                                                                               ▒
       │      test  %rdx,%rdx                                                                                                                                                                                                                               ▒
    33 │    ↓ je    2c                                                                                                                                                                                                                                      ▒
       │      lea   total_memory_tracker,%rsi                                                                                                                                                                                                               ▒
    32 │2c:   test  %rcx,%rcx                                                                                                                                                                                                                               ▒
    49 │      cmove %rsi,%rdi                                                                                                                                                                                                                               ▒
   122 │      or    %rcx,%rdx                                                                                                                                                                                                                               ▒
     1 │    ↓ je    73                                                                                                                                                                                                                                      ▒
       │      test  %rcx,%rcx                                                                                                                                                                                                                               ▒
   766 │    ↓ je    75                                                                                                                                                                                                                                      ▒
       │      mov   0xa0(%rcx),%rsi                                                                                                                                                                                                                         ▒
    70 │      sub   %rax,%rsi                                                                                                                                                                                                                               ▒
     5 │      mov   %rsi,0xa0(%rcx)                                                                                                                                                                                                                         ▒
    25 │      xor   %eax,%eax                                                                                                                                                                                                                               ◆
    49 │      sub   0xa8(%rcx),%rax                                                                                                                                                                                                                         ▒
    77 │      cmp   %rax,%rsi                                                                                                                                                                                                                               ▒
   161 │    ↓ jge   73                                                                                                                                                                                                                                      ▒
       │      neg   %rsi                                                                                                                                                                                                                                    ▒
       │    → call  MemoryTracker::free                                                                                                                                                                                                                     ▒
       │      mov   %fs:(%rbx),%rax                                                                                                                                                                                                                         ▒
       │      movq  $0x0,0xa0(%rax)                                                                                                                                                                                                                         ▒
       │73:   pop   %rbx                                                                                                                                                                                                                                    ▒
    10 │    ← ret                                                                                                                                                                                                                                           ▒
       │75:   mov   %rax,%rsi                                                                                                                                                                                                                               ▒
       │      pop   %rbx                                                                                                                                                                                                                                    ▒
       │    → jmp   MemoryTracker::free 
```

Perf profile from 22.7 official build:
```
+    1.86%     1.86%          6261  TCPHandler    clickhouse  [.] CurrentMemoryTracker::allocImpl                                                                                                                                                           ◆
     1.54%     1.53%          5194  TCPHandler    clickhouse  [.] CurrentMemoryTracker::free                                                                                                                                                                ▒
     0.01%     0.01%            53  QueryPullPip  clickhouse  [.] CurrentMemoryTracker::allocImpl                                                                                                                                                           ▒
     0.01%     0.01%            42  QueryPullPip  clickhouse  [.] CurrentMemoryTracker::free                                                                                                                                                                ▒
     0.00%     0.00%             3  ThreadPool    clickhouse  [.] CurrentMemoryTracker::allocImpl                                                                                                                                                           ▒
     0.00%     0.00%             2  AsyncMetrics  clickhouse  [.] CurrentMemoryTracker::free 
```

With the changes I see this:
```
+    1.18%     1.18%          4190  TCPHandler    clickhouse  [.] CurrentMemoryTracker::allocNoThrow                                                                                                                                                        ◆
     0.73%     0.73%          2595  TCPHandler    clickhouse  [.] CurrentMemoryTracker::free                                                                                                                                                                ▒
     0.02%     0.02%            74  TCPHandler    clickhouse  [.] CurrentMemoryTracker::alloc                                                                                                                                                               ▒
     0.01%     0.01%            28  QueryPullPip  clickhouse  [.] CurrentMemoryTracker::allocNoThrow                                                                                                                                                        ▒
     0.00%     0.00%            23  QueryPullPip  clickhouse  [.] CurrentMemoryTracker::free                                                                                                                                                                ▒
     0.00%     0.00%             6  QueryPullPip  clickhouse  [.] CurrentMemoryTracker::alloc                                                                                                                                                               ▒
     0.00%     0.00%             2  ThreadPool    clickhouse  [.] CurrentMemoryTracker::allocNoThrow                                                                                                                                                        ▒
     0.00%     0.00%             2  AsyncMetrics  clickhouse  [.] CurrentMemoryTracker::allocNoThrow                                                                                                                                                        ▒
     0.00%     0.00%             1  AsyncMetrics  clickhouse  [.] CurrentMemoryTracker::free  
```


Let's see if it has any impact on the CI benchmarks and if it does I'll look for a cleaner way to silence the warning (we are using C++20 and mandating a recent compiler) and check if there are other places of the code that could see a similar improvement.