### PR TITLE
remove indent as it causes codeblock

### DIFF
--- a/docs/en/sql-reference/table-functions/index.md
+++ b/docs/en/sql-reference/table-functions/index.md
@@ -9,13 +9,13 @@ Table functions are methods for constructing tables.
 
 You can use table functions in:
 
--   [FROM](../../sql-reference/statements/select/from.md) clause of the `SELECT` query.
+-  [FROM](../../sql-reference/statements/select/from.md) clause of the `SELECT` query.
 
-        The method for creating a temporary table that is available only in the current query. The table is deleted when the query finishes.
+   The method for creating a temporary table that is available only in the current query. The table is deleted when the query finishes.
 
 -   [CREATE TABLE AS table_function()](../../sql-reference/statements/create/table.md) query.
 
-        It's one of the methods of creating a table.
+   It's one of the methods of creating a table.
 
 -   [INSERT INTO TABLE FUNCTION](../../sql-reference/statements/insert-into.md#inserting-into-table-function) query.
 
@@ -38,4 +38,3 @@ You can’t use table functions if the [allow_ddl](../../operations/settings/per
 | [s3](../../sql-reference/table-functions/s3.md)                  | Creates a [S3](../../engines/table-engines/integrations/s3.md)-engine table.                                                           |
 | [sqlite](../../sql-reference/table-functions/sqlite.md)          | Creates a [sqlite](../../engines/table-engines/integrations/sqlite.md)-engine table.                                                       |
 
-[Original article](https://clickhouse.com/docs/en/sql-reference/table-functions/) <!--hide-->


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

indenting four spaces in markdown creates a codeblock.

closes https://github.com/ClickHouse/clickhouse-docs/issues/244


