### PR TITLE
collectFilesToSkip() in MutateTask now supports new index file extension .idx2 for MinMax

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -490,7 +490,8 @@ static NameSet collectFilesToSkip(
 
     for (const auto & index : indices_to_recalc)
     {
-        files_to_skip.insert(index->getFileName() + ".idx");
+        /// Since MinMax index has .idx2 extension, we need to add correct extension.
+        files_to_skip.insert(index->getFileName() + index->getSerializedFileExtension());
         files_to_skip.insert(index->getFileName() + mrk_extension);
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug in collectFilesToSkip() by adding correct file extension(.idx or idx2) for indexes to be recalculated, avoid wrong hard links. Fixed #39896.

### Descriptions
When mutating some columns in WIDE part, we collect some files to skip to create hard links, then later skipped files need to be updated / recalculated. However,  the MinMax type index now has .idx2 extension instead of .idx. Therefore, we need to update code in  collectFilesToSkip() to skip correct index files to recalc. 

=== recreation ==
create table t(a int, b int, c int, index i_b(b) type minmax granularity 4) engine = MergeTree order by a settings min_bytes_for_wide_part=0;
INSERT INTO t SELECT number, number, number FROM numbers(10);

set mutations_sync=1;

alter table t MATERIALIZE INDEX i_b;
alter table t update b=-1 where a<3;

=== before fix ===
~/clickhouse-test/data/data/default/t/all_1_1_0_3$ ls -l
total 52
-rw-r----- 3 ubuntu ubuntu  67 Aug 10 16:56 a.bin
-rw-r----- 3 ubuntu ubuntu  48 Aug 10 16:56 a.mrk2
-rw-r----- 1 ubuntu ubuntu  59 Aug 10 16:57 b.bin
-rw-r----- 1 ubuntu ubuntu  48 Aug 10 16:57 b.mrk2
-rw-r----- 3 ubuntu ubuntu  67 Aug 10 16:56 c.bin
-rw-r----- 1 ubuntu ubuntu 315 Aug 10 16:57 checksums.txt
-rw-r----- 3 ubuntu ubuntu  48 Aug 10 16:56 c.mrk2
-rw-r----- 1 ubuntu ubuntu  67 Aug 10 16:57 columns.txt
-rw-r----- 3 ubuntu ubuntu   2 Aug 10 16:56 count.txt
-rw-r----- 1 ubuntu ubuntu  10 Aug 10 16:57 default_compression_codec.txt
-rw-r----- 3 ubuntu ubuntu   8 Aug 10 16:56 primary.idx
-rw-r----- **3** ubuntu ubuntu  34 Aug 10 16:57 skp_idx_i_b.idx2  <<< hard links
-rw-r----- 1 ubuntu ubuntu  24 Aug 10 16:57 skp_idx_i_b.mrk2

=== after fix ===
~/clickhouse-test/data/data/default/t/all_1_1_0_3$ ll
total 60
drwxr-x--- 2 ubuntu ubuntu 4096 Aug 11 09:55 ./
drwxr-x--- 6 ubuntu ubuntu 4096 Aug 11 09:55 ../
-rw-r----- 3 ubuntu ubuntu   67 Aug 11 09:55 a.bin
-rw-r----- 3 ubuntu ubuntu   48 Aug 11 09:55 a.mrk2
-rw-r----- 1 ubuntu ubuntu   59 Aug 11 09:55 b.bin
-rw-r----- 1 ubuntu ubuntu   48 Aug 11 09:55 b.mrk2
-rw-r----- 3 ubuntu ubuntu   67 Aug 11 09:55 c.bin
-rw-r----- 1 ubuntu ubuntu  315 Aug 11 09:55 checksums.txt
-rw-r----- 3 ubuntu ubuntu   48 Aug 11 09:55 c.mrk2
-rw-r----- 1 ubuntu ubuntu   67 Aug 11 09:55 columns.txt
-rw-r----- 3 ubuntu ubuntu    2 Aug 11 09:55 count.txt
-rw-r----- 1 ubuntu ubuntu   10 Aug 11 09:55 default_compression_codec.txt
-rw-r----- 3 ubuntu ubuntu    8 Aug 11 09:55 primary.idx
-rw-r----- **1** ubuntu ubuntu   34 Aug 11 09:55 skp_idx_i_b.idx2
-rw-r----- 1 ubuntu ubuntu   24 Aug 11 09:55 skp_idx_i_b.mrk2