### PR TITLE
Fix CaresPTRResolver race condition

### DIFF
--- a/src/Common/CaresPTRResolver.cpp
+++ b/src/Common/CaresPTRResolver.cpp
@@ -35,8 +35,13 @@ namespace DB
          * See https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L1187
          * That means it's safe to init it here, but we should be cautious when introducing new code that depends on c-ares and even updates
          * to grpc. As discussed in https://github.com/ClickHouse/ClickHouse/pull/37827#discussion_r919189085, c-ares should be adapted to be atomic
+         *
+         * Since C++ 11 static objects are initialized in a thread safe manner. The static qualifier also makes sure
+         * it'll be called/ initialized only once.
          * */
-        if (ares_library_init(ARES_LIB_INIT_ALL) != ARES_SUCCESS || ares_init(&channel) != ARES_SUCCESS)
+        static const auto library_init_result = ares_library_init(ARES_LIB_INIT_ALL);
+
+        if (library_init_result != ARES_SUCCESS || ares_init(&channel) != ARES_SUCCESS)
         {
             throw DB::Exception("Failed to initialize c-ares", DB::ErrorCodes::DNS_ERROR);
         }

--- a/src/Common/CaresPTRResolver.cpp
+++ b/src/Common/CaresPTRResolver.cpp
@@ -50,7 +50,12 @@ namespace DB
     CaresPTRResolver::~CaresPTRResolver()
     {
         ares_destroy(channel);
-        ares_library_cleanup();
+        /*
+         * Library initialization is currently done only once in the constructor. Multiple instances of CaresPTRResolver
+         * will be used in the lifetime of ClickHouse, thus it's problematic to have de-init here.
+         * In a practical view, it makes little to no sense to de-init a DNS library since DNS requests will happen
+         * until the end of the program. Hence, ares_library_cleanup() will not be called.
+         * */
     }
 
     std::vector<std::string> CaresPTRResolver::resolve(const std::string & ip)

--- a/src/Common/DNSPTRResolverProvider.cpp
+++ b/src/Common/DNSPTRResolverProvider.cpp
@@ -5,9 +5,8 @@ namespace DB
 {
     std::shared_ptr<DNSPTRResolver> DNSPTRResolverProvider::get()
     {
-        static auto cares_resolver = std::make_shared<CaresPTRResolver>(
+        return std::make_shared<CaresPTRResolver>(
             CaresPTRResolver::provider_token {}
         );
-        return cares_resolver;
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A segmentation fault that has CaresPTRResolver::resolve in the stack trace has been reported:

```
 {} <Fatal> BaseDaemon: 4. ? @ 0xbb48f5c in /usr/bin/clickhouse,2022-08-05T16:14:36.963240840Z
 <Fatal> BaseDaemon: 3. DB::CaresPTRResolver::resolve(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0xbb5196c in /usr/bin/clickhouse",2022-08-05T16:14:36.963236350Z
<Fatal> BaseDaemon: 2. ? @ 0x1b4c7163 in /usr/bin/clickhouse,2022-08-05T16:14:36.963230570Z
{} <Fatal> BaseDaemon: Stack trace: 0x1b4c7163 0xbb5196c 0xbb48f5c,2022-08-05T16:14:36.963204690Z
{} <Fatal> BaseDaemon: Address: 0x8 Access: read. Address not mapped to object.,2022-08-05T16:14:36.963198870Z
{} <Fatal> BaseDaemon: (version 22.7.2.15 (official build), build id: A975FB2E13DEF38A) (from thread 208) (no query) Received signal Segmentation fault (11)",2022-08-05T16:14:36.963170759Z
```
Looking at the full logs, this happened in multiple threads, which raises the suspicious of race conditions.

`DB::DNSResolver::reverseResolve` is called from multiple threads. The `DB::DNSPTRResolverProvider::get` method, called by reverseResolve, would return a singleton of `DB::CaresPTRResolver`. `DB::CaresPTRResolver` is not thread safe, mainly because of the `channel` member. The decision of having CaresPTRResolver as a singleton was made because of two reasons: 1. c-ares library initialization should happen only once 2. premature optimization.

This PR fixes this issue by using a fresh instance of CaresPTRResolver for each and every thread. Single initialization is handled by static initialization, which is thread safe and happens only once.

Tested with the below unit test:

```
TEST(Common, ReverseDNS)
{
    auto func = []()
    {
        auto resolver = DNSPTRResolverProvider::get();
        auto result = resolver->resolve("");
        assert(result.empty());
    };

    auto number_of_threads = 100u;
    std::vector<std::thread> threads;
    threads.reserve(number_of_threads);

    for (auto i = 0u; i < number_of_threads; i++)
    {
        threads.emplace_back(func);
    }

    for (auto & thread : threads)
    {
        thread.join();
    }
}
```

Previously, most of the times, it would crash with segfault. After the changes, it never crashed. Did around 10 runs.

Might close/ fix #39807

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
