### PR TITLE
Disable 02390_prometheus_ClickHouseStatusInfo_DictionaryStatus with Ordinary database

### DIFF
--- a/tests/queries/0_stateless/02390_prometheus_ClickHouseStatusInfo_DictionaryStatus.sh
+++ b/tests/queries/0_stateless/02390_prometheus_ClickHouseStatusInfo_DictionaryStatus.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-ordinary-database
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/45d69951e261e5ee7b1f62dfaccd4d017f98801a/stateless_tests__release__databaseordinary_.html
Test added in #39926, but it cannot work with Ordinary database