### PR TITLE
Fix keeper-bench in case of error during scheduling a thread

### DIFF
--- a/utils/keeper-bench/Runner.cpp
+++ b/utils/keeper-bench/Runner.cpp
@@ -167,6 +167,7 @@ void Runner::runBenchmark()
     }
     catch (...)
     {
+        shutdown = true;
         pool.wait();
         throw;
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alesapin 