### PR TITLE
Set sync_request_timeout to 10 to avoid reconnections in tests

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1486,7 +1486,7 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
         if (with_output && with_output->settings_ast)
             apply_query_settings(*with_output->settings_ast);
 
-        if (!connection->checkConnected())
+        if (!connection->checkConnected(connection_parameters.timeouts))
             connect();
 
         ASTPtr input_function;
@@ -1830,7 +1830,7 @@ bool ClientBase::executeMultiQuery(const String & all_queries_text)
 
                     have_error = false;
 
-                    if (!connection->checkConnected())
+                    if (!connection->checkConnected(connection_parameters.timeouts))
                         connect();
                 }
 
@@ -2047,7 +2047,7 @@ void ClientBase::runInteractive()
             /// Client-side exception during query execution can result in the loss of
             /// sync in the connection protocol.
             /// So we reconnect and allow to enter the next query.
-            if (!connection->checkConnected())
+            if (!connection->checkConnected(connection_parameters.timeouts))
                 connect();
         }
     }

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -69,8 +69,7 @@ Connection::Connection(const String & host_, UInt16 port_,
     const String & cluster_secret_,
     const String & client_name_,
     Protocol::Compression compression_,
-    Protocol::Secure secure_,
-    Poco::Timespan sync_request_timeout_)
+    Protocol::Secure secure_)
     : host(host_), port(port_), default_database(default_database_)
     , user(user_), password(password_), quota_key(quota_key_)
     , cluster(cluster_)
@@ -78,7 +77,6 @@ Connection::Connection(const String & host_, UInt16 port_,
     , client_name(client_name_)
     , compression(compression_)
     , secure(secure_)
-    , sync_request_timeout(sync_request_timeout_)
     , log_wrapper(*this)
 {
     /// Don't connect immediately, only on first need.
@@ -386,7 +384,7 @@ void Connection::forceConnected(const ConnectionTimeouts & timeouts)
     {
         connect(timeouts);
     }
-    else if (!ping())
+    else if (!ping(timeouts))
     {
         LOG_TRACE(log_wrapper.get(), "Connection was closed, will reconnect.");
         connect(timeouts);
@@ -406,11 +404,11 @@ void Connection::sendClusterNameAndSalt()
 }
 #endif
 
-bool Connection::ping()
+bool Connection::ping(const ConnectionTimeouts & timeouts)
 {
     try
     {
-        TimeoutSetter timeout_setter(*socket, sync_request_timeout, true);
+        TimeoutSetter timeout_setter(*socket, timeouts.sync_request_timeout, true);
 
         UInt64 pong = 0;
         writeVarUInt(Protocol::Client::Ping, *out);
@@ -454,7 +452,7 @@ TablesStatusResponse Connection::getTablesStatus(const ConnectionTimeouts & time
     if (!connected)
         connect(timeouts);
 
-    TimeoutSetter timeout_setter(*socket, sync_request_timeout, true);
+    TimeoutSetter timeout_setter(*socket, timeouts.sync_request_timeout, true);
 
     writeVarUInt(Protocol::Client::TablesStatusRequest, *out);
     request.write(*out, server_revision);

--- a/src/Client/Connection.h
+++ b/src/Client/Connection.h
@@ -56,8 +56,7 @@ public:
         const String & cluster_secret_,
         const String & client_name_,
         Protocol::Compression compression_,
-        Protocol::Secure secure_,
-        Poco::Timespan sync_request_timeout_ = Poco::Timespan(DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC, 0));
+        Protocol::Secure secure_);
 
     ~Connection() override;
 
@@ -124,7 +123,7 @@ public:
 
     bool isConnected() const override { return connected; }
 
-    bool checkConnected() override { return connected && ping(); }
+    bool checkConnected(const ConnectionTimeouts & timeouts) override { return connected && ping(timeouts); }
 
     void disconnect() override;
 
@@ -207,8 +206,6 @@ private:
       */
     ThrottlerPtr throttler;
 
-    Poco::Timespan sync_request_timeout;
-
     /// From where to read query execution result.
     std::shared_ptr<ReadBuffer> maybe_compressed_in;
     std::unique_ptr<NativeReader> block_in;
@@ -253,7 +250,7 @@ private:
 #if USE_SSL
     void sendClusterNameAndSalt();
 #endif
-    bool ping();
+    bool ping(const ConnectionTimeouts & timeouts);
 
     Block receiveData();
     Block receiveLogData();

--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -69,6 +69,8 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
             Poco::Timespan(config.getInt("send_timeout", DBMS_DEFAULT_SEND_TIMEOUT_SEC), 0),
             Poco::Timespan(config.getInt("receive_timeout", DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC), 0),
             Poco::Timespan(config.getInt("tcp_keep_alive_timeout", 0), 0));
+
+    timeouts.sync_request_timeout = Poco::Timespan(config.getInt("sync_request_timeout", DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC), 0);
 }
 
 ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfiguration & config)

--- a/src/Client/IServerConnection.h
+++ b/src/Client/IServerConnection.h
@@ -121,7 +121,7 @@ public:
     virtual bool isConnected() const = 0;
 
     /// Check if connection is still active with ping request.
-    virtual bool checkConnected() = 0;
+    virtual bool checkConnected(const ConnectionTimeouts & /*timeouts*/) = 0;
 
     /** Disconnect.
       * This may be used, if connection is left in unsynchronised state

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -121,7 +121,7 @@ public:
 
     bool isConnected() const override { return true; }
 
-    bool checkConnected() override { return true; }
+    bool checkConnected(const ConnectionTimeouts & /*timeouts*/) override { return true; }
 
     void disconnect() override {}
 

--- a/src/IO/ConnectionTimeouts.h
+++ b/src/IO/ConnectionTimeouts.h
@@ -24,7 +24,7 @@ struct ConnectionTimeouts
     Poco::Timespan receive_data_timeout;
 
     /// Timeout for synchronous request-result protocol call (like Ping or TablesStatus)
-    Poco::Timespan sync_request_timeout = DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC;
+    Poco::Timespan sync_request_timeout = Poco::Timespan(DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC, 0);
 
     ConnectionTimeouts() = default;
 

--- a/src/IO/ConnectionTimeouts.h
+++ b/src/IO/ConnectionTimeouts.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Defines.h>
 #include <Interpreters/Context_fwd.h>
 
 #include <Poco/Timespan.h>
@@ -21,6 +22,9 @@ struct ConnectionTimeouts
     /// Timeouts for HedgedConnections
     Poco::Timespan hedged_connection_timeout;
     Poco::Timespan receive_data_timeout;
+
+    /// Timeout for synchronous request-result protocol call (like Ping or TablesStatus)
+    Poco::Timespan sync_request_timeout = DBMS_DEFAULT_SYNC_REQUEST_TIMEOUT_SEC;
 
     ConnectionTimeouts() = default;
 

--- a/tests/config/client_config.xml
+++ b/tests/config/client_config.xml
@@ -11,4 +11,7 @@
             </invalidCertificateHandler>
         </client>
     </openSSL>
+
+    <!-- Default timeout if 5 sec. Set it to 10 to avoid tests flakiness with slow builds (debug, tsan) -->
+    <sync_request_timeout>10</sync_request_timeout>
 </config>

--- a/tests/config/client_config.xml
+++ b/tests/config/client_config.xml
@@ -12,6 +12,6 @@
         </client>
     </openSSL>
 
-    <!-- Default timeout if 5 sec. Set it to 10 to avoid tests flakiness with slow builds (debug, tsan) -->
+    <!-- Default timeout is 5 sec. Set it to 10 to avoid tests flakiness with slow builds (debug, tsan) -->
     <sync_request_timeout>10</sync_request_timeout>
 </config>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Some tests are flaky, because 5 seconds is not enough sometimes to receive ping from server. It causes reconnection and loss of session context:
https://s3.amazonaws.com/clickhouse-test-reports/0/1b44cb5c973847436486fbf22c930e407e94d76b/stateless_tests__thread__[2/3].html
```
2022.08.11 05:58:04.860245 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Debug> executeQuery: (from [::1]:43538) (TID: (32, 33, 9b3f7a15-b50d-4b53-b417-7075e40e0005), TIDH: 16531253050162090767) (comment: 02345_implicit_transaction.sql) INSERT INTO landing SELECT * FROM numbers(10000); (stage: Complete)
2022.08.11 05:58:04.860641 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Trace> ContextAccess (default): Access granted: INSERT(n) ON test_1uvvah.landing
2022.08.11 05:58:04.861184 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Trace> ContextAccess (default): Access granted: CREATE TEMPORARY TABLE ON *.*
2022.08.11 05:58:04.862190 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
2022.08.11 05:58:04.863812 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Test> test_1uvvah.landing (ed3f6a6e-b771-472d-9932-6ce4209e71bd): Got 0 parts (of 0) visible in snapshot 32 (TID (32, 33, 9b3f7a15-b50d-4b53-b417-7075e40e0005)): 
2022.08.11 05:58:04.865106 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Trace> ContextAccess (default): Access granted: SELECT(n) ON test_1uvvah.landing
2022.08.11 05:58:04.960195 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Trace> TransactionLog: Rolling back transaction (32, 33, 9b3f7a15-b50d-4b53-b417-7075e40e0005)
2022.08.11 05:58:04.961079 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Error> executeQuery: Code: 395. DB::Exception: Value passed to 'throwIf' function is non zero: while executing 'FUNCTION throwIf(equals(n, 3333) :: 2) -> throwIf(equals(n, 3333)) UInt8 : 1': while pushing to view test_1uvvah.landing_to_target (b2071291-da4b-4594-a944-3ced6c49f4f6). (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) (version 22.8.1.1 (official build)) (from [::1]:43538) (comment: 02345_implicit_transaction.sql) (in query: INSERT INTO landing SELECT * FROM numbers(10000);), Stack trace (when copying this message, always include the lines below):
2022.08.11 05:58:04.962489 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Test> TCPHandler: Going to close connection due to exception: Value passed to 'throwIf' function is non zero: while executing 'FUNCTION throwIf(equals(n, 3333) :: 2) -> throwIf(equals(n, 3333)) UInt8 : 1': while pushing to view test_1uvvah.landing_to_target (b2071291-da4b-4594-a944-3ced6c49f4f6)
2022.08.11 05:58:04.962766 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Error> TCPHandler: Code: 395. DB::Exception: Value passed to 'throwIf' function is non zero: while executing 'FUNCTION throwIf(equals(n, 3333) :: 2) -> throwIf(equals(n, 3333)) UInt8 : 1': while pushing to view test_1uvvah.landing_to_target (b2071291-da4b-4594-a944-3ced6c49f4f6). (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO), Stack trace (when copying this message, always include the lines below):

2022.08.11 05:58:09.970014 [ 1495 ] {b63c707b-0565-4aca-b514-bb2c3e83c43e} <Debug> executeQuery: (from [::1]:43554) (comment: 02345_implicit_transaction.sql) ROLLBACK (stage: Complete)

2022.08.11 05:58:11.026128 [ 1345 ] {17924887-2503-468d-ab49-6e890c80c0b4} <Debug> MemoryTracker: Peak memory usage (for query): 3.13 MiB.
2022.08.11 05:58:11.026223 [ 1345 ] {} <Debug> TCPHandler: Processed in 6.168162283 sec.
2022.08.11 05:58:11.026550 [ 1345 ] {} <Test> TCPHandler: Closing connection (open: true, cancelled: false, eof: true)
2022.08.11 05:58:11.026638 [ 1345 ] {} <Debug> TCPHandler: Done processing connection.
2022.08.11 05:58:11.029836 [ 1345 ] {} <Debug> TCP-Session: 067359b9-fefd-4737-ab3f-246977328e8f Destroying unnamed session

2022.08.11 05:58:11.227526 [ 1495 ] {b63c707b-0565-4aca-b514-bb2c3e83c43e} <Error> executeQuery: Code: 649. DB::Exception: There is no current transaction. (INVALID_TRANSACTION) (version 22.8.1.1 (official build)) (from [::1]:43554) (comment: 02345_implicit_transaction.sql) (in query: ROLLBACK), Stack trace (when copying this message, always include the lines below):
2022.08.11 05:58:11.227904 [ 1495 ] {b63c707b-0565-4aca-b514-bb2c3e83c43e} <Test> TCPHandler: Going to close connection due to exception: There is no current transaction
2022.08.11 05:58:11.228006 [ 1495 ] {b63c707b-0565-4aca-b514-bb2c3e83c43e} <Error> TCPHandler: Code: 649. DB::Exception: There is no current transaction. (INVALID_TRANSACTION), Stack trace (when copying this message, always include the lines below):
2022.08.11 05:58:11.228197 [ 1495 ] {b63c707b-0565-4aca-b514-bb2c3e83c43e} <Debug> MemoryTracker: Peak memory usage (for query): 0.00 B.
```

#39925
Slightly related to #36587