### PR TITLE
Fix incorrect queries in example

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1289,14 +1289,14 @@ ENGINE = MergeTree
 ORDER BY A
 SETTINGS non_replicated_deduplication_window = 100;
 
-INSERT INTO test_table Values SETTINGS insert_deduplication_token = 'test' (1);
+INSERT INTO test_table SETTINGS insert_deduplication_token = 'test' VALUES (1);
 
 -- the next insert won't be deduplicated because insert_deduplication_token is different
-INSERT INTO test_table Values SETTINGS insert_deduplication_token = 'test1' (1);
+INSERT INTO test_table SETTINGS insert_deduplication_token = 'test1' VALUES (1);
 
 -- the next insert will be deduplicated because insert_deduplication_token
 -- is the same as one of the previous
-INSERT INTO test_table Values SETTINGS insert_deduplication_token = 'test' (2);
+INSERT INTO test_table SETTINGS insert_deduplication_token = 'test' VALUES (2);
 
 SELECT * FROM test_table
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Setting `insert_deduplication_token`: fix incorrect queries in example
