### PR TITLE
Fixed crash when `decrypt`ing bogus input

### DIFF
--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -62,14 +62,19 @@ public:
 
     /**
      * If isNullAt(n) returns false, returns the nested column's getDataAt(n), otherwise returns a special value
-     * EMPTY_STRING_REF indicating that data is not present.
+     * with size == 0 indicating that data is not present.
      */
     StringRef getDataAt(size_t n) const override
     {
+        auto nestedData = getNestedColumn().getDataAt(n);
         if (isNullAt(n))
-            return EMPTY_STRING_REF;
+        {
+            // data for NULL-items must have valid data pointer, otherwise some assumtions down the road are broken.
+            // see ColumnArray::getDataAt() for example.
+            nestedData.size = 0;
+        }
 
-        return getNestedColumn().getDataAt(n);
+        return nestedData;
     }
 
     /// Will insert null value if pos=nullptr

--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -439,7 +439,7 @@ private:
         validateFunctionArgumentTypes(*this, arguments,
             FunctionArgumentDescriptors{
                 {"mode", &isStringOrFixedString<IDataType>, isColumnConst, "decryption mode string"},
-                {"input", nullptr, nullptr, "ciphertext"},
+                {"input", &isStringOrFixedString<IDataType>, nullptr, "ciphertext"},
                 {"key", &isStringOrFixedString<IDataType>, nullptr, "decryption key binary string"},
             },
             optional_args

--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -768,7 +768,7 @@ private:
 
             UInt64 index = 0;
 
-            if (elem != EMPTY_STRING_REF)
+            if (elem.size == 0 && col_arg_cloned->isNullAt(0))
             {
                 if (std::optional<UInt64> maybe_index = col_lc_dict.getOrFindValueIndex(elem); maybe_index)
                     index = *maybe_index;

--- a/tests/queries/0_stateless/01318_decrypt.sql
+++ b/tests/queries/0_stateless/01318_decrypt.sql
@@ -51,12 +51,16 @@ SELECT aes_decrypt_mysql('aes-128-ecb', 'text', 'key', 'IV', 1213); --{serverErr
 SELECT decrypt('aes-128-ecb', 'text', 'key', 'IV', 1213); --{serverError 43} bad AAD type
 SELECT decrypt('aes-128-gcm', 'text', 'key', 'IV', 1213); --{serverError 43} bad AAD type
 
+-- Invalid ciphertext type
+SELECT decrypt('aes-128-gcm', [1024, 65535, NULL, NULL, 9223372036854775807, 1048576, NULL], 'text', 'key', 'IV'); -- {serverError 36}
+
 -- Invalid ciphertext should cause an error or produce garbage
 SELECT ignore(decrypt('aes-128-ecb', 'hello there', '1111111111111111')); -- {serverError 454} 1
 SELECT ignore(decrypt('aes-128-cbc', 'hello there', '1111111111111111')); -- {serverError 454} 2
 SELECT ignore(decrypt('aes-128-ofb', 'hello there', '1111111111111111')); -- GIGO
 SELECT ignore(decrypt('aes-128-ctr', 'hello there', '1111111111111111')); -- GIGO
 SELECT decrypt('aes-128-ctr', '', '1111111111111111') == '';
+
 
 
 -----------------------------------------------------------------------------------------


### PR DESCRIPTION
### Changelog category
- Bug Fix

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not allow anything but String or FixedString as `ciphertext` parameter of `decrypt`.
...


Closes: #39987
