### PR TITLE
Update docs for max_replica_delay_for_distributed_queries

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -747,7 +747,14 @@ Default value: 268435456.
 
 Disables lagging replicas for distributed queries. See [Replication](../../engines/table-engines/mergetree-family/replication.md).
 
-Sets the time in seconds. If a replica lags more than the set value, this replica is not used.
+Sets the time in seconds. If a replica's lag is greater than or equal to the set value, this replica is not used.
+
+Possible values:
+
+-   Positive integer.
+-   0 — Replica lags are not checked.
+
+To prevent the use of any replica with a non-zero lag, set this parameter to 1.
 
 Default value: 300.
 


### PR DESCRIPTION
A replica is unusable if its lag is greater than or equal to the
value of max_replica_delay_for_distributed_queries. However, the
current documentation says that a replica is only unusable if it lags
more than the set value.

Also, when the value of max_replica_delay_for_distributed_queries
is read, if it is 0, then a replica is considered up to date
right away without checking its delay. This behavior should be
documented.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
