### PR TITLE
Improve assignment and logging for cherry-pick and backport steps

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -206,8 +206,13 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
         )
         self.cherrypick_pr.add_to_labels(Labels.LABEL_CHERRYPICK)
         self.cherrypick_pr.add_to_labels(Labels.LABEL_DO_NOT_TEST)
-        if self.pr.assignee is not None:
-            self.cherrypick_pr.add_to_assignees(self.pr.assignee)
+        if self.pr.assignees:
+            logging.info(
+                "Assing to assignees of the original PR: %s",
+                ", ".join(user.login for user in self.pr.assignees),
+            )
+            self.cherrypick_pr.add_to_assignees(self.pr.assignees)
+        logging.info("Assign to the author of the original PR: %s", self.pr.user.login)
         self.cherrypick_pr.add_to_assignees(self.pr.user)
 
     def create_backport(self):
@@ -239,8 +244,13 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
             head=self.backport_branch,
         )
         self.backport_pr.add_to_labels(Labels.LABEL_BACKPORT)
-        if self.pr.assignee is not None:
-            self.cherrypick_pr.add_to_assignees(self.pr.assignee)
+        if self.pr.assignees:
+            logging.info(
+                "Assing to assignees of the original PR: %s",
+                ", ".join(user.login for user in self.pr.assignees),
+            )
+            self.cherrypick_pr.add_to_assignees(self.pr.assignees)
+        logging.info("Assign to the author of the original PR: %s", self.pr.user.login)
         self.backport_pr.add_to_assignees(self.pr.user)
 
     @property


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve logging to catch the issue faced in #40160