### PR TITLE
Fix Endian issue in FileEncryption for s390x

### DIFF
--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -7,6 +7,7 @@
 #include <limits>
 #include <algorithm>
 #include <iterator>
+#include <bit>
 
 #include <type_traits>
 
@@ -1027,15 +1028,17 @@ requires is_arithmetic_v<T> && (sizeof(T) <= 8)
 inline void readBinaryBigEndian(T & x, ReadBuffer & buf)    /// Assuming little endian architecture.
 {
     readPODBinary(x, buf);
-
-    if constexpr (sizeof(x) == 1)
-        return;
-    else if constexpr (sizeof(x) == 2)
-        x = __builtin_bswap16(x);
-    else if constexpr (sizeof(x) == 4)
-        x = __builtin_bswap32(x);
-    else if constexpr (sizeof(x) == 8)
-        x = __builtin_bswap64(x);
+    if constexpr (std::endian::native == std::endian::little)
+    {
+        if constexpr (sizeof(x) == 1)
+            return;
+        else if constexpr (sizeof(x) == 2)
+            x = __builtin_bswap16(x);
+        else if constexpr (sizeof(x) == 4)
+            x = __builtin_bswap32(x);
+        else if constexpr (sizeof(x) == 8)
+            x = __builtin_bswap64(x);
+    }
 }
 
 template <typename T>

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <iterator>
 #include <concepts>
+#include <bit>
 
 #include <pcg-random/pcg_random.hpp>
 
@@ -1110,13 +1111,15 @@ template <typename T>
 requires is_arithmetic_v<T> && (sizeof(T) <= 8)
 inline void writeBinaryBigEndian(T x, WriteBuffer & buf)    /// Assuming little endian architecture.
 {
-    if constexpr (sizeof(x) == 2)
-        x = __builtin_bswap16(x);
-    else if constexpr (sizeof(x) == 4)
-        x = __builtin_bswap32(x);
-    else if constexpr (sizeof(x) == 8)
-        x = __builtin_bswap64(x);
-
+    if constexpr (std::endian::native == std::endian::little)
+    {
+        if constexpr (sizeof(x) == 2)
+            x = __builtin_bswap16(x);
+        else if constexpr (sizeof(x) == 4)
+            x = __builtin_bswap32(x);
+        else if constexpr (sizeof(x) == 8)
+            x = __builtin_bswap64(x);
+    }
     writePODBinary(x, buf);
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
In ReadHelpers and WriteHelpers, there is an Endian issue when reading/writing binary BigEndian data:

readBinaryBigEndian() and writeBinaryBigEndian() reverted byte orders which is unnecessary in BigEndian machines like s390x.

This causes the code which are using functions failed in s390x. For example, the following unit test failed:

```
./src/IO/tests/gtest_file_encryption.cpp:31: Failure
Expected equality of these values:
  param.after_inc
    Which is: "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x1"
  iv.toString()
    Which is: "\0\0\0\0\0\0\0\0\x1\0\0\0\0\0\0\0"
[  FAILED  ] All/FileEncryptionInitVectorTest.InitVector/0, where GetParam() = ...
```
The fix is to disable the byte-order reverting code for BigEndian machines.

### Changelog category (leave one):
- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed Endian issues in reading/writing BigEndian binary data in ReadHelpers and WriteHelpers code for s390x architecture (which is not supported by ClickHouse).

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
