### PR TITLE
Support build with clang-16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,8 @@ if (COMPILER_CLANG)
             set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Xclang -fuse-ctor-homing")
         endif()
     endif()
+
+    no_warning(enum-constexpr-conversion) # breaks Protobuf in clang-16
 endif ()
 
 # If compiler has support for -Wreserved-identifier. It is difficult to detect by clang version,
@@ -606,4 +608,3 @@ if (NATIVE_BUILD_TARGETS
         COMMAND ${CMAKE_COMMAND} --build "${NATIVE_BUILD_DIR}" --target ${NATIVE_BUILD_TARGETS}
         COMMAND_ECHO STDOUT)
 endif ()
-

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -42,6 +42,7 @@ if (COMPILER_CLANG)
     no_warning(weak-template-vtables)
     no_warning(weak-vtables)
     no_warning(thread-safety-negative) # experimental flag, too many false positives
+    no_warning(enum-constexpr-conversion) # breaks magic-enum library in clang-16
     # TODO Enable conversion, sign-conversion, double-promotion warnings.
 elseif (COMPILER_GCC)
     # Add compiler options only to c++ compiler


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support build with `clang-16` (trunk). This closes #39949.