### PR TITLE
clickhouse-test: enable ZooKeeper tests by default

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1759,7 +1759,7 @@ def main(args):
         stop_time = time() + args.global_time_limit
 
     if args.zookeeper is None:
-       args.zookeeper = True
+        args.zookeeper = True
 
     if args.shard is None:
         args.shard = bool(extract_key(' --key listen_host | grep -E "127.0.0.2|::"'))

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1759,10 +1759,7 @@ def main(args):
         stop_time = time() + args.global_time_limit
 
     if args.zookeeper is None:
-        try:
-            args.zookeeper = int(extract_key(" --key zookeeper | grep . | wc -l")) > 0
-        except ValueError:
-            args.zookeeper = False
+       args.zookeeper = True
 
     if args.shard is None:
         args.shard = bool(extract_key(' --key listen_host | grep -E "127.0.0.2|::"'))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
