### PR TITLE
Fix insufficient argument check for encryption functions

### DIFF
--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -167,8 +167,8 @@ private:
         validateFunctionArgumentTypes(*this, arguments,
             FunctionArgumentDescriptors{
                 {"mode", &isStringOrFixedString<IDataType>, isColumnConst, "encryption mode string"},
-                {"input", &isStringOrFixedString<IDataType>, nullptr, "plaintext"},
-                {"key", &isStringOrFixedString<IDataType>, nullptr, "encryption key binary string"},
+                {"input", &isStringOrFixedString<IDataType>, {}, "plaintext"},
+                {"key", &isStringOrFixedString<IDataType>, {}, "encryption key binary string"},
             },
             optional_args
         );
@@ -439,8 +439,8 @@ private:
         validateFunctionArgumentTypes(*this, arguments,
             FunctionArgumentDescriptors{
                 {"mode", &isStringOrFixedString<IDataType>, isColumnConst, "decryption mode string"},
-                {"input", nullptr, nullptr, "ciphertext"},
-                {"key", &isStringOrFixedString<IDataType>, nullptr, "decryption key binary string"},
+                {"input", &isStringOrFixedString<IDataType>, {}, "ciphertext"},
+                {"key", &isStringOrFixedString<IDataType>, {}, "decryption key binary string"},
             },
             optional_args
         );

--- a/tests/queries/0_stateless/02384_decrypt_bad_arguments.sql
+++ b/tests/queries/0_stateless/02384_decrypt_bad_arguments.sql
@@ -1,0 +1,1 @@
+SELECT decrypt('aes-128-gcm', [1024, 65535, NULL, NULL, 9223372036854775807, 1048576, NULL], 'text', 'key', 'IV'); -- { serverError 43 }

--- a/tests/queries/0_stateless/02384_decrypt_bad_arguments.sql
+++ b/tests/queries/0_stateless/02384_decrypt_bad_arguments.sql
@@ -1,1 +1,2 @@
+-- Tags: no-fasttest
 SELECT decrypt('aes-128-gcm', [1024, 65535, NULL, NULL, 9223372036854775807, 1048576, NULL], 'text', 'key', 'IV'); -- { serverError 43 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix insufficient argument check for encryption functions (found by query fuzzer). This closes #39987.
