### PR TITLE
Set linker for RISC-V 64

### DIFF
--- a/cmake/linux/toolchain-riscv64.cmake
+++ b/cmake/linux/toolchain-riscv64.cmake
@@ -21,6 +21,11 @@ set (CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} --gcc-toolchain=${TOOLCHAIN_PATH}")
 set (CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=bfd")
 set (CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=bfd")
 
+# Currently, lld does not work with the error:
+# ld.lld: error: section size decrease is too large
+# But GNU BinUtils work.
+set (LINKER_NAME "riscv64-linux-gnu-ld.bfd" CACHE STRING "Linker name" FORCE)
+
 set (HAS_PRE_1970_EXITCODE "0" CACHE STRING "Result from TRY_RUN" FORCE)
 set (HAS_PRE_1970_EXITCODE__TRYRUN_OUTPUT "" CACHE STRING "Output from TRY_RUN" FORCE)
 

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -41,6 +41,9 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
     && apt-get install gcc-11 g++-11 --yes \
     && apt-get clean
 
+# A cross-linker for RISC-V 64 (we need it, because LLVM's LLD does not work):
+RUN apt-get install binutils-riscv64-linux-gnu
+
 # Architecture of the image when BuildKit/buildx is used
 ARG TARGETARCH
 ARG NFPM_VERSION=2.16.0


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prepare RISC-V 64 build to run in CI. This is for #40141.