### PR TITLE
Add metrico applications (qryn, clickhouse-mate)

### DIFF
--- a/docs/en/interfaces/third-party/gui.md
+++ b/docs/en/interfaces/third-party/gui.md
@@ -73,6 +73,18 @@ Features:
 
 ClickHouse datasource plugin provides a support for ClickHouse as a backend database.
 
+### qryn (#qryn)
+
+[qryn](https://metrico.in) is a polyglot, high-performance observability stack for ClickHouse _(formerly cLoki)_ with native Grafana integrations allowing users to ingest and analyze logs, metrics and telemetry traces from any agent supporting Loki/LogQL, Prometheus/PromQL, OTLP/Tempo, Elastic, InfluxDB and many more.
+
+Features:
+
+- Built in Explore UI and LogQL CLI for querying, extracting and visualizing data
+- Native Grafana APIs support for querying, processing, ingesting, tracing and alerting without plugins
+- Powerful pipeline to dynamically search, filter and extract data from logs, events, traces and beyond
+- Ingestion and PUSH APIs transparently compatible with LogQL, PromQL, InfluxDB, Elastic and many more
+- Ready to use with Agents such as Promtail, Grafana-Agent, Vector, Logstash, Telegraf and many others
+
 ### DBeaver {#dbeaver}
 
 [DBeaver](https://dbeaver.io/) - universal desktop database client with ClickHouse support.
@@ -168,6 +180,20 @@ Features:
 - Supports user-defined index configuration
 - Supports alarm configuration
 - Support permission granularity to library and table permission configuration
+
+### ClickHouse-Mate {#clickmate}
+
+[ClickHouse-Mate](https://github.com/metrico/clickhouse-mate) is an angular web client + user interface to search and explore data in ClickHouse.
+
+Features:
+
+- ClickHouse SQL Query autocompletion
+- Fast Database and Table tree navigation
+- Advanced result Filtering and Sorting
+- Inline ClickHouse SQL documentation
+- Query Presets and History
+- 100% browser based, no server/backend
+
 
 ## Commercial {#commercial}
 

--- a/docs/en/interfaces/third-party/gui.md
+++ b/docs/en/interfaces/third-party/gui.md
@@ -194,6 +194,8 @@ Features:
 - Query Presets and History
 - 100% browser based, no server/backend
 
+The client is available for instant usage through github pages: https://metrico.github.io/clickhouse-mate/
+
 
 ## Commercial {#commercial}
 


### PR DESCRIPTION
This PR adds metrico apps (qryn, clickhouse-mate) to the 3rd party links in the documentation. Thanks!

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

