### PR TITLE
Better error message when restoring covered parts

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -391,6 +391,7 @@ else
                -e "Missing columns: 'v3' while processing query: 'v3, k, v1, v2, p'" \
                -e "This engine is deprecated and is not supported in transactions" \
                -e "[Queue = DB::MergeMutateRuntimeQueue]: Code: 235. DB::Exception: Part" \
+               -e "The set of parts restored in place of" \
         /var/log/clickhouse-server/clickhouse-server.backward.clean.log | zgrep -Fa "<Error>" > /test_output/bc_check_error_messages.txt \
         && echo -e 'Backward compatibility check: Error message in clickhouse-server.log (see bc_check_error_messages.txt)\tFAIL' >> /test_output/test_results.tsv \
         || echo -e 'Backward compatibility check: No Error messages in clickhouse-server.log\tOK' >> /test_output/test_results.tsv

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3195,8 +3195,10 @@ void MergeTreeData::forgetPartAndMoveToDetached(const MergeTreeData::DataPartPtr
                 pos = (*it)->info.max_block + 1;
                 restored.push_back((*it)->name);
             }
-            else
+            else if ((*it)->info.partition_id == part->info.partition_id)
                 update_error(it);
+            else
+                error = true;
         }
         else
             error = true;
@@ -3217,7 +3219,7 @@ void MergeTreeData::forgetPartAndMoveToDetached(const MergeTreeData::DataPartPtr
                 update_error(it);
 
             if ((*it)->getState() != DataPartState::Active)
-                    activate_part(it);
+                activate_part(it);
 
             pos = (*it)->info.max_block + 1;
             restored.push_back((*it)->name);


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It could produce misleading messages like `The set of parts restored in place of 8_31_41_2 looks incomplete. There might or might not be a data loss. Suspicious parts: 7_47_47_0 (state Active) ` if there are no covered parts (`7_47_47_0` is from different partition). But this error may normally happen, so also suppress it in BC check.

Maybe we can update loading logic a bit (deactivate ignored parts in the same place where we deactivate uncommitted parts) and remove this "restore covered" logic completely.