### PR TITLE
Try to print stacktraces if query timeouts in integration tests

### DIFF
--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -4,7 +4,8 @@ import tempfile
 import logging
 from threading import Timer
 
-DEFAULT_QUERY_TIMEOUT=600
+DEFAULT_QUERY_TIMEOUT = 600
+
 
 class Client:
     def __init__(self, host, port=9000, command="/usr/bin/clickhouse-client"):
@@ -31,6 +32,7 @@ class Client:
                     timeout=60,
                 ).get_answer_and_error()
                 raise
+
         return wrap
 
     @stacktraces_on_timeout_decorator

--- a/tests/integration/helpers/client.py
+++ b/tests/integration/helpers/client.py
@@ -18,7 +18,6 @@ class Client:
 
         self.command += ["--host", self.host, "--port", str(self.port), "--stacktrace"]
 
-    @staticmethod
     def stacktraces_on_timeout_decorator(func):
         def wrap(self, *args, **kwargs):
             try:


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It's supposed to help with failures like this: https://s3.amazonaws.com/clickhouse-test-reports/40175/dc97a30506bb629b90fbd70438eb1b451e83b8a7/integration_tests__release__[2/2].html
