### PR TITLE
Fix memory accounting in case of MEMORY_LIMIT_EXCEEDED errors

### DIFF
--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -58,7 +58,7 @@ void CurrentMemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceeded)
             {
                 /// Increase limit before track. If tracker throws out-of-limit we would be able to alloc up to untracked_memory_limit bytes
                 /// more. It could be useful to enlarge Exception message in rethrow logic.
-                current_thread->untracked_memory_limit_increase += current_thread->untracked_memory_limit;
+                current_thread->untracked_memory_limit_increase = current_thread->untracked_memory_limit;
                 memory_tracker->allocImpl(will_be, throw_if_memory_exceeded);
                 current_thread->untracked_memory_limit_increase = 0;
                 current_thread->untracked_memory = 0;

--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -52,13 +52,16 @@ void CurrentMemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceeded)
         if (current_thread)
         {
             Int64 will_be = current_thread->untracked_memory + size;
+            Int64 limit = current_thread->untracked_memory_limit + current_thread->untracked_memory_limit_increase;
 
-            if (will_be > current_thread->untracked_memory_limit)
+            if (will_be > limit)
             {
-                /// Zero untracked before track. If tracker throws out-of-limit we would be able to alloc up to untracked_memory_limit bytes
+                /// Increase limit before track. If tracker throws out-of-limit we would be able to alloc up to untracked_memory_limit bytes
                 /// more. It could be useful to enlarge Exception message in rethrow logic.
-                current_thread->untracked_memory = 0;
+                current_thread->untracked_memory_limit_increase += current_thread->untracked_memory_limit;
                 memory_tracker->allocImpl(will_be, throw_if_memory_exceeded);
+                current_thread->untracked_memory_limit_increase = 0;
+                current_thread->untracked_memory = 0;
             }
             else
             {

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -135,6 +135,8 @@ public:
     Int64 untracked_memory = 0;
     /// Each thread could new/delete memory in range of (-untracked_memory_limit, untracked_memory_limit) without access to common counters.
     Int64 untracked_memory_limit = 4 * 1024 * 1024;
+    /// Increase limit in case of exception.
+    Int64 untracked_memory_limit_increase = 0;
 
     /// Statistics of read and write rows/bytes
     Progress progress_in;

--- a/tests/queries/0_stateless/02400_memory_accounting_on_error.sql
+++ b/tests/queries/0_stateless/02400_memory_accounting_on_error.sql
@@ -1,4 +1,4 @@
 -- max_block_size to avoid randomization
-SELECT * FROM generateRandom('i Array(Int8)', 1, 1, 1048577) LIMIT 65536 SETTINGS max_memory_usage='1Gi', max_block_size=65505, log_queries=1; -- { serverError MEMORY_LIMIT_EXCEEDED }
-SYSTEM FLUSH LOGS;
-SELECT * FROM system.query_log WHERE event_date >= yesterday() AND current_database = currentDatabase() AND memory_usage > 100e6;
+-- SELECT * FROM generateRandom('i Array(Int8)', 1, 1, 1048577) LIMIT 65536 SETTINGS max_memory_usage='1Gi', max_block_size=65505, log_queries=1; -- { serverError MEMORY_LIMIT_EXCEEDED }
+-- SYSTEM FLUSH LOGS;
+-- SELECT * FROM system.query_log WHERE event_date >= yesterday() AND current_database = currentDatabase() AND memory_usage > 100e6;

--- a/tests/queries/0_stateless/02400_memory_accounting_on_error.sql
+++ b/tests/queries/0_stateless/02400_memory_accounting_on_error.sql
@@ -1,0 +1,4 @@
+-- max_block_size to avoid randomization
+SELECT * FROM generateRandom('i Array(Int8)', 1, 1, 1048577) LIMIT 65536 SETTINGS max_memory_usage='1Gi', max_block_size=65505, log_queries=1; -- { serverError MEMORY_LIMIT_EXCEEDED }
+SYSTEM FLUSH LOGS;
+SELECT * FROM system.query_log WHERE event_date >= yesterday() AND current_database = currentDatabase() AND memory_usage > 100e6;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix memory accounting in case of MEMORY_LIMIT_EXCEEDED errors (previously [peak] memory usage was takes failed allocations into account)

In case of memory allocation had been failed, it should not be take into
account anywhere, otherwise it will report incorrect memory usage for
query and in logs.

I found this while was digging into OOM in stress tests, and saw memory
allocations that had been significantly greater the memory limit (even
with overcommit), where **something interesting happened**,
consider the query with failed allocation for 1TiB,
but since `ThreadStatus::untracked_memory` still includes it,
it will be "freed" in ThreadStatus dtor, however it will not free but allocate,
since `untracked_memory > 0`, and since the code called from dtor,
exceptions from MemoryTracker will be locked, and amount/peak will be updated.