### PR TITLE
Feature Improvement: Custom Key Names for Structured Logging Support

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -65,9 +65,31 @@
         in specified format like JSON.
         For example, as below:
         {"date_time":"1650918987.180175","thread_name":"#1","thread_id":"254545","level":"Trace","query_id":"","logger_name":"BaseDaemon","message":"Received signal 2","source_file":"../base/daemon/BaseDaemon.cpp; virtual void SignalListener::run()","source_line":"192"}
-        To enable JSON logging support, just uncomment <formatting> tag below.
+        To enable JSON logging support, please uncomment the entire <formatting> tag below.
+        
+        a) You can modify key names by changing values under tag values inside <names> tag.
+        For example, to change DATE_TIME to MY_DATE_TIME, you can do like:
+            <date_time>MY_DATE_TIME</date_time>
+        b) You can stop unwanted log properties to appear in logs. To do so, you can simply comment out (recommended)
+        that property from this file.
+        For example, if you do not want your log to print query_id, you can comment out only <query_id> tag.
+        However, if you comment out all the tags under <names>, the program will print default values for as
+        below.
         -->
-        <!-- <formatting>json</formatting> -->
+        <!-- <formatting>
+            <type>json</type>
+            <names>
+                <date_time>date_time</date_time>
+                <thread_name>thread_name</thread_name>
+                <thread_id>thread_id</thread_id>
+                <level>level</level>
+                <query_id>query_id</query_id>
+                <logger_name>logger_name</logger_name>
+                <message>message</message>
+                <source_file>source_file</source_file>
+                <source_line>source_line</source_line>
+            </names>
+        </formatting> -->
     </logger>
 
     <!-- Add headers to response in options request. OPTIONS method is used in CORS preflight requests. -->

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -1016,8 +1016,8 @@ void BaseDaemon::setupWatchdog()
         if (config().getRawString("logger.stream_compress", "false") == "true")
         {
             Poco::AutoPtr<OwnPatternFormatter> pf;
-            if (config().getString("logger.formatting", "") == "json")
-                pf = new OwnJSONPatternFormatter;
+            if (config().getString("logger.formatting.type", "") == "json")
+                pf = new OwnJSONPatternFormatter(config());
             else
                 pf = new OwnPatternFormatter;
             Poco::AutoPtr<DB::OwnFormattingChannel> log = new DB::OwnFormattingChannel(pf, new Poco::ConsoleChannel(std::cerr));

--- a/src/Loggers/Loggers.cpp
+++ b/src/Loggers/Loggers.cpp
@@ -100,7 +100,7 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
         Poco::AutoPtr<OwnPatternFormatter> pf;
 
         if (config.getString("logger.formatting.type", "") == "json")
-           pf = new OwnJSONPatternFormatter(config);
+            pf = new OwnJSONPatternFormatter(config);
         else
             pf = new OwnPatternFormatter;
 

--- a/src/Loggers/Loggers.cpp
+++ b/src/Loggers/Loggers.cpp
@@ -99,8 +99,8 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
 
         Poco::AutoPtr<OwnPatternFormatter> pf;
 
-        if (config.getString("logger.formatting", "") == "json")
-            pf = new OwnJSONPatternFormatter;
+        if (config.getString("logger.formatting.type", "") == "json")
+           pf = new OwnJSONPatternFormatter(config);
         else
             pf = new OwnPatternFormatter;
 
@@ -140,8 +140,8 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
 
         Poco::AutoPtr<OwnPatternFormatter> pf;
 
-        if (config.getString("logger.formatting", "") == "json")
-            pf = new OwnJSONPatternFormatter;
+        if (config.getString("logger.formatting.type", "") == "json")
+            pf = new OwnJSONPatternFormatter(config);
         else
             pf = new OwnPatternFormatter;
 
@@ -184,8 +184,8 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
 
         Poco::AutoPtr<OwnPatternFormatter> pf;
 
-        if (config.getString("logger.formatting", "") == "json")
-            pf = new OwnJSONPatternFormatter;
+        if (config.getString("logger.formatting.type", "") == "json")
+            pf = new OwnJSONPatternFormatter(config);
         else
             pf = new OwnPatternFormatter;
 
@@ -211,8 +211,8 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
         }
 
         Poco::AutoPtr<OwnPatternFormatter> pf;
-        if (config.getString("logger.formatting", "") == "json")
-            pf = new OwnJSONPatternFormatter;
+        if (config.getString("logger.formatting.type", "") == "json")
+            pf = new OwnJSONPatternFormatter(config);
         else
             pf = new OwnPatternFormatter(color_enabled);
         Poco::AutoPtr<DB::OwnFormattingChannel> log = new DB::OwnFormattingChannel(pf, new Poco::ConsoleChannel);

--- a/src/Loggers/OwnJSONPatternFormatter.cpp
+++ b/src/Loggers/OwnJSONPatternFormatter.cpp
@@ -8,37 +8,37 @@
 #include <Common/CurrentThread.h>
 #include <Common/HashTable/Hash.h>
 
-OwnJSONPatternFormatter::OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config_) : OwnPatternFormatter(), config(config_)
+OwnJSONPatternFormatter::OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config) : OwnPatternFormatter()
 {
     if (config.has("logger.formatting.names.date_time"))
-        this->date_time = config.getString("logger.formatting.names.date_time", "");
+        date_time = config.getString("logger.formatting.names.date_time", "");
 
     if (config.has("logger.formatting.names.thread_name"))
-        this->thread_name = config.getString("logger.formatting.names.thread_name", "");
+        thread_name = config.getString("logger.formatting.names.thread_name", "");
 
     if (config.has("logger.formatting.names.thread_id"))
-        this->thread_id = config.getString("logger.formatting.names.thread_id", "");
+        thread_id = config.getString("logger.formatting.names.thread_id", "");
 
     if (config.has("logger.formatting.names.level"))
-        this->level = config.getString("logger.formatting.names.level", "");
+        level = config.getString("logger.formatting.names.level", "");
 
     if (config.has("logger.formatting.names.query_id"))
-        this->query_id = config.getString("logger.formatting.names.query_id", "");
+        query_id = config.getString("logger.formatting.names.query_id", "");
 
     if (config.has("logger.formatting.names.logger_name"))
-        this->logger_name = config.getString("logger.formatting.names.logger_name", "");
+        logger_name = config.getString("logger.formatting.names.logger_name", "");
 
     if (config.has("logger.formatting.names.message"))
-        this->message = config.getString("logger.formatting.names.message", "");
+        message = config.getString("logger.formatting.names.message", "");
 
     if (config.has("logger.formatting.names.source_file"))
-        this->source_file_ = config.getString("logger.formatting.names.source_file", "");
+        source_file_ = config.getString("logger.formatting.names.source_file", "");
 
     if (config.has("logger.formatting.names.source_line"))
-        this->source_line = config.getString("logger.formatting.names.source_line", "");
+        source_line = config.getString("logger.formatting.names.source_line", "");
 
-    if (this->date_time.empty() && this->thread_name.empty() && this->thread_id.empty() && this->level.empty() && this->query_id.empty()
-        && this->logger_name.empty() && this->message.empty() && this->source_file_.empty() && this->source_line.empty())
+    if (date_time.empty() && thread_name.empty() && thread_id.empty() && level.empty() && query_id.empty()
+        && logger_name.empty() && message.empty() && source_file_.empty() && source_line.empty())
     {
         date_time = "date_time";
         thread_name = "thread_name";
@@ -62,9 +62,9 @@ void OwnJSONPatternFormatter::formatExtended(const DB::ExtendedLogMessage & msg_
     const Poco::Message & msg = msg_ext.base;
     DB::writeChar('{', wb);
 
-    if (!this->date_time.empty())
+    if (!date_time.empty())
     {
-        writeJSONString(this->date_time, wb, settings);
+        writeJSONString(date_time, wb, settings);
         DB::writeChar(':', wb);
 
         DB::writeChar('\"', wb);
@@ -81,47 +81,47 @@ void OwnJSONPatternFormatter::formatExtended(const DB::ExtendedLogMessage & msg_
         print_comma = true;
     }
 
-    if (!this->thread_name.empty())
+    if (!thread_name.empty())
     {
         if (print_comma)
             DB::writeChar(',', wb);
         else
             print_comma = true;
 
-        writeJSONString(this->thread_name, wb, settings);
+        writeJSONString(thread_name, wb, settings);
         DB::writeChar(':', wb);
 
         writeJSONString(msg.getThread(), wb, settings);
     }
 
-    if (!this->thread_id.empty())
+    if (!thread_id.empty())
     {
         if (print_comma)
             DB::writeChar(',', wb);
         else
             print_comma = true;
 
-        writeJSONString(this->thread_id, wb, settings);
+        writeJSONString(thread_id, wb, settings);
         DB::writeChar(':', wb);
         DB::writeChar('\"', wb);
         DB::writeIntText(msg_ext.thread_id, wb);
         DB::writeChar('\"', wb);
     }
 
-    if (!this->level.empty())
+    if (!level.empty())
     {
         if (print_comma)
             DB::writeChar(',', wb);
         else
             print_comma = true;
 
-        writeJSONString(this->level, wb, settings);
+        writeJSONString(level, wb, settings);
         DB::writeChar(':', wb);
         int priority = static_cast<int>(msg.getPriority());
         writeJSONString(std::to_string(priority), wb, settings);
     }
 
-    if (!this->query_id.empty())
+    if (!query_id.empty())
     {
         if (print_comma)
             DB::writeChar(',', wb);
@@ -131,44 +131,44 @@ void OwnJSONPatternFormatter::formatExtended(const DB::ExtendedLogMessage & msg_
         /// We write query_id even in case when it is empty (no query context)
         /// just to be convenient for various log parsers.
 
-        writeJSONString(this->query_id, wb, settings);
+        writeJSONString(query_id, wb, settings);
         DB::writeChar(':', wb);
         writeJSONString(msg_ext.query_id, wb, settings);
     }
 
-    if (!this->logger_name.empty())
+    if (!logger_name.empty())
     {
         if (print_comma)
             DB::writeChar(',', wb);
         else
             print_comma = true;
 
-        writeJSONString(this->logger_name, wb, settings);
+        writeJSONString(logger_name, wb, settings);
         DB::writeChar(':', wb);
 
         writeJSONString(msg.getSource(), wb, settings);
     }
 
-    if (!this->message.empty())
+    if (!message.empty())
     {
         if (print_comma)
             DB::writeChar(',', wb);
         else
             print_comma = true;
 
-        writeJSONString(this->message, wb, settings);
+        writeJSONString(message, wb, settings);
         DB::writeChar(':', wb);
         writeJSONString(msg.getText(), wb, settings);
     }
 
-    if (!this->source_file_.empty())
+    if (!source_file_.empty())
     {
         if (print_comma)
             DB::writeChar(',', wb);
         else
             print_comma = true;
 
-        writeJSONString(this->source_file_, wb, settings);
+        writeJSONString(source_file_, wb, settings);
         DB::writeChar(':', wb);
         const char * source_file = msg.getSourceFile();
         if (source_file != nullptr)
@@ -177,12 +177,12 @@ void OwnJSONPatternFormatter::formatExtended(const DB::ExtendedLogMessage & msg_
             writeJSONString("", wb, settings);
     }
 
-    if (!this->source_line.empty())
+    if (!source_line.empty())
     {
         if (print_comma)
             DB::writeChar(',', wb);
 
-        writeJSONString(this->source_line, wb, settings);
+        writeJSONString(source_line, wb, settings);
         DB::writeChar(':', wb);
         DB::writeChar('\"', wb);
         DB::writeIntText(msg.getSourceLine(), wb);

--- a/src/Loggers/OwnJSONPatternFormatter.cpp
+++ b/src/Loggers/OwnJSONPatternFormatter.cpp
@@ -8,93 +8,186 @@
 #include <Common/CurrentThread.h>
 #include <Common/HashTable/Hash.h>
 
-OwnJSONPatternFormatter::OwnJSONPatternFormatter() : OwnPatternFormatter("")
+OwnJSONPatternFormatter::OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config_) : OwnPatternFormatter(), config(config_)
 {
-}
+    if (config.has("logger.formatting.names.date_time"))
+        this->date_time = config.getString("logger.formatting.names.date_time", "");
 
+    if (config.has("logger.formatting.names.thread_name"))
+        this->thread_name = config.getString("logger.formatting.names.thread_name", "");
+
+    if (config.has("logger.formatting.names.thread_id"))
+        this->thread_id = config.getString("logger.formatting.names.thread_id", "");
+
+    if (config.has("logger.formatting.names.level"))
+        this->level = config.getString("logger.formatting.names.level", "");
+
+    if (config.has("logger.formatting.names.query_id"))
+        this->query_id = config.getString("logger.formatting.names.query_id", "");
+
+    if (config.has("logger.formatting.names.logger_name"))
+        this->logger_name = config.getString("logger.formatting.names.logger_name", "");
+
+    if (config.has("logger.formatting.names.message"))
+        this->message = config.getString("logger.formatting.names.message", "");
+
+    if (config.has("logger.formatting.names.source_file"))
+        this->source_file_ = config.getString("logger.formatting.names.source_file", "");
+
+    if (config.has("logger.formatting.names.source_line"))
+        this->source_line = config.getString("logger.formatting.names.source_line", "");
+
+    if (this->date_time.empty() && this->thread_name.empty() && this->thread_id.empty() && this->level.empty() && this->query_id.empty()
+        && this->logger_name.empty() && this->message.empty() && this->source_file_.empty() && this->source_line.empty())
+    {
+        date_time = "date_time";
+        thread_name = "thread_name";
+        thread_id = "thread_id";
+        level = "level";
+        query_id = "query_id";
+        logger_name = "logger_name";
+        message = "message";
+        source_file_ = "source_file";
+        source_line = "source_line";
+    }
+}
 
 void OwnJSONPatternFormatter::formatExtended(const DB::ExtendedLogMessage & msg_ext, std::string & text) const
 {
     DB::WriteBufferFromString wb(text);
 
     DB::FormatSettings settings;
+    bool print_comma = false;
 
     const Poco::Message & msg = msg_ext.base;
     DB::writeChar('{', wb);
 
-    writeJSONString("date_time", wb, settings);
-    DB::writeChar(':', wb);
+    if (!this->date_time.empty())
+    {
+        writeJSONString(this->date_time, wb, settings);
+        DB::writeChar(':', wb);
 
-    DB::writeChar('\"', wb);
-    /// Change delimiters in date for compatibility with old logs.
-    writeDateTimeUnixTimestamp(msg_ext.time_seconds, 0, wb);
-    DB::writeChar('.', wb);
-    DB::writeChar('0' + ((msg_ext.time_microseconds / 100000) % 10), wb);
-    DB::writeChar('0' + ((msg_ext.time_microseconds / 10000) % 10), wb);
-    DB::writeChar('0' + ((msg_ext.time_microseconds / 1000) % 10), wb);
-    DB::writeChar('0' + ((msg_ext.time_microseconds / 100) % 10), wb);
-    DB::writeChar('0' + ((msg_ext.time_microseconds / 10) % 10), wb);
-    DB::writeChar('0' + ((msg_ext.time_microseconds / 1) % 10), wb);
-    DB::writeChar('\"', wb);
+        DB::writeChar('\"', wb);
+        /// Change delimiters in date for compatibility with old logs.
+        writeDateTimeUnixTimestamp(msg_ext.time_seconds, 0, wb);
+        DB::writeChar('.', wb);
+        DB::writeChar('0' + ((msg_ext.time_microseconds / 100000) % 10), wb);
+        DB::writeChar('0' + ((msg_ext.time_microseconds / 10000) % 10), wb);
+        DB::writeChar('0' + ((msg_ext.time_microseconds / 1000) % 10), wb);
+        DB::writeChar('0' + ((msg_ext.time_microseconds / 100) % 10), wb);
+        DB::writeChar('0' + ((msg_ext.time_microseconds / 10) % 10), wb);
+        DB::writeChar('0' + ((msg_ext.time_microseconds / 1) % 10), wb);
+        DB::writeChar('\"', wb);
+        print_comma = true;
+    }
 
-    DB::writeChar(',', wb);
+    if (!this->thread_name.empty())
+    {
+        if (print_comma)
+            DB::writeChar(',', wb);
+        else
+            print_comma = true;
 
-    writeJSONString("thread_name", wb, settings);
-    DB::writeChar(':', wb);
+        writeJSONString(this->thread_name, wb, settings);
+        DB::writeChar(':', wb);
 
-    writeJSONString(msg.getThread(), wb, settings);
+        writeJSONString(msg.getThread(), wb, settings);
+    }
 
-    DB::writeChar(',', wb);
+    if (!this->thread_id.empty())
+    {
+        if (print_comma)
+            DB::writeChar(',', wb);
+        else
+            print_comma = true;
 
-    writeJSONString("thread_id", wb, settings);
-    DB::writeChar(':', wb);
-    DB::writeChar('\"', wb);
-    DB::writeIntText(msg_ext.thread_id, wb);
-    DB::writeChar('\"', wb);
+        writeJSONString(this->thread_id, wb, settings);
+        DB::writeChar(':', wb);
+        DB::writeChar('\"', wb);
+        DB::writeIntText(msg_ext.thread_id, wb);
+        DB::writeChar('\"', wb);
+    }
 
-    DB::writeChar(',', wb);
+    if (!this->level.empty())
+    {
+        if (print_comma)
+            DB::writeChar(',', wb);
+        else
+            print_comma = true;
 
-    writeJSONString("level", wb, settings);
-    DB::writeChar(':', wb);
-    int priority = static_cast<int>(msg.getPriority());
-    writeJSONString(std::to_string(priority), wb, settings);
-    DB::writeChar(',', wb);
+        writeJSONString(this->level, wb, settings);
+        DB::writeChar(':', wb);
+        int priority = static_cast<int>(msg.getPriority());
+        writeJSONString(std::to_string(priority), wb, settings);
+    }
 
-    /// We write query_id even in case when it is empty (no query context)
-    /// just to be convenient for various log parsers.
+    if (!this->query_id.empty())
+    {
+        if (print_comma)
+            DB::writeChar(',', wb);
+        else
+            print_comma = true;
 
-    writeJSONString("query_id", wb, settings);
-    DB::writeChar(':', wb);
-    writeJSONString(msg_ext.query_id, wb, settings);
+        /// We write query_id even in case when it is empty (no query context)
+        /// just to be convenient for various log parsers.
 
-    DB::writeChar(',', wb);
+        writeJSONString(this->query_id, wb, settings);
+        DB::writeChar(':', wb);
+        writeJSONString(msg_ext.query_id, wb, settings);
+    }
 
-    writeJSONString("logger_name", wb, settings);
-    DB::writeChar(':', wb);
+    if (!this->logger_name.empty())
+    {
+        if (print_comma)
+            DB::writeChar(',', wb);
+        else
+            print_comma = true;
 
-    writeJSONString(msg.getSource(), wb, settings);
-    DB::writeChar(',', wb);
+        writeJSONString(this->logger_name, wb, settings);
+        DB::writeChar(':', wb);
 
-    writeJSONString("message", wb, settings);
-    DB::writeChar(':', wb);
-    writeJSONString(msg.getText(), wb, settings);
-    DB::writeChar(',', wb);
+        writeJSONString(msg.getSource(), wb, settings);
+    }
 
-    writeJSONString("source_file", wb, settings);
-    DB::writeChar(':', wb);
-    const char * source_file = msg.getSourceFile();
-    if (source_file != nullptr)
-        writeJSONString(source_file, wb, settings);
-    else
-        writeJSONString("", wb, settings);
-    DB::writeChar(',', wb);
+    if (!this->message.empty())
+    {
+        if (print_comma)
+            DB::writeChar(',', wb);
+        else
+            print_comma = true;
 
-    writeJSONString("source_line", wb, settings);
-    DB::writeChar(':', wb);
-    DB::writeChar('\"', wb);
-    DB::writeIntText(msg.getSourceLine(), wb);
-    DB::writeChar('\"', wb);
+        writeJSONString(this->message, wb, settings);
+        DB::writeChar(':', wb);
+        writeJSONString(msg.getText(), wb, settings);
+    }
 
+    if (!this->source_file_.empty())
+    {
+        if (print_comma)
+            DB::writeChar(',', wb);
+        else
+            print_comma = true;
+
+        writeJSONString(this->source_file_, wb, settings);
+        DB::writeChar(':', wb);
+        const char * source_file = msg.getSourceFile();
+        if (source_file != nullptr)
+            writeJSONString(source_file, wb, settings);
+        else
+            writeJSONString("", wb, settings);
+    }
+
+    if (!this->source_line.empty())
+    {
+        if (print_comma)
+            DB::writeChar(',', wb);
+
+        writeJSONString(this->source_line, wb, settings);
+        DB::writeChar(':', wb);
+        DB::writeChar('\"', wb);
+        DB::writeIntText(msg.getSourceLine(), wb);
+        DB::writeChar('\"', wb);
+    }
     DB::writeChar('}', wb);
 }
 

--- a/src/Loggers/OwnJSONPatternFormatter.cpp
+++ b/src/Loggers/OwnJSONPatternFormatter.cpp
@@ -32,13 +32,13 @@ OwnJSONPatternFormatter::OwnJSONPatternFormatter(Poco::Util::AbstractConfigurati
         message = config.getString("logger.formatting.names.message", "");
 
     if (config.has("logger.formatting.names.source_file"))
-        source_file_ = config.getString("logger.formatting.names.source_file", "");
+        source_file = config.getString("logger.formatting.names.source_file", "");
 
     if (config.has("logger.formatting.names.source_line"))
         source_line = config.getString("logger.formatting.names.source_line", "");
 
     if (date_time.empty() && thread_name.empty() && thread_id.empty() && level.empty() && query_id.empty()
-        && logger_name.empty() && message.empty() && source_file_.empty() && source_line.empty())
+        && logger_name.empty() && message.empty() && source_file.empty() && source_line.empty())
     {
         date_time = "date_time";
         thread_name = "thread_name";
@@ -47,7 +47,7 @@ OwnJSONPatternFormatter::OwnJSONPatternFormatter(Poco::Util::AbstractConfigurati
         query_id = "query_id";
         logger_name = "logger_name";
         message = "message";
-        source_file_ = "source_file";
+        source_file = "source_file";
         source_line = "source_line";
     }
 }
@@ -161,18 +161,18 @@ void OwnJSONPatternFormatter::formatExtended(const DB::ExtendedLogMessage & msg_
         writeJSONString(msg.getText(), wb, settings);
     }
 
-    if (!source_file_.empty())
+    if (!source_file.empty())
     {
         if (print_comma)
             DB::writeChar(',', wb);
         else
             print_comma = true;
 
-        writeJSONString(source_file_, wb, settings);
+        writeJSONString(source_file, wb, settings);
         DB::writeChar(':', wb);
-        const char * source_file = msg.getSourceFile();
-        if (source_file != nullptr)
-            writeJSONString(source_file, wb, settings);
+        const char * source_file_name = msg.getSourceFile();
+        if (source_file_name != nullptr)
+            writeJSONString(source_file_name, wb, settings);
         else
             writeJSONString("", wb, settings);
     }

--- a/src/Loggers/OwnJSONPatternFormatter.cpp
+++ b/src/Loggers/OwnJSONPatternFormatter.cpp
@@ -8,7 +8,7 @@
 #include <Common/CurrentThread.h>
 #include <Common/HashTable/Hash.h>
 
-OwnJSONPatternFormatter::OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config) : OwnPatternFormatter()
+OwnJSONPatternFormatter::OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config)
 {
     if (config.has("logger.formatting.names.date_time"))
         date_time = config.getString("logger.formatting.names.date_time", "");

--- a/src/Loggers/OwnJSONPatternFormatter.h
+++ b/src/Loggers/OwnJSONPatternFormatter.h
@@ -24,9 +24,21 @@ class Loggers;
 
 class OwnJSONPatternFormatter : public OwnPatternFormatter
 {
-public:
-    OwnJSONPatternFormatter();
+  public:
+    OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config_);
 
     void format(const Poco::Message & msg, std::string & text) override;
     void formatExtended(const DB::ExtendedLogMessage & msg_ext, std::string & text) const override;
+  
+  private:
+    Poco::Util::AbstractConfiguration & config;
+    std::string date_time;
+    std::string thread_name;
+    std::string thread_id;
+    std::string level;
+    std::string query_id;
+    std::string logger_name;
+    std::string message;
+    std::string source_file_;
+    std::string source_line;
 };

--- a/src/Loggers/OwnJSONPatternFormatter.h
+++ b/src/Loggers/OwnJSONPatternFormatter.h
@@ -2,6 +2,7 @@
 
 
 #include <Poco/PatternFormatter.h>
+#include <Poco/Util/AbstractConfiguration.h>
 #include "ExtendedLogChannel.h"
 #include "OwnPatternFormatter.h"
 

--- a/src/Loggers/OwnJSONPatternFormatter.h
+++ b/src/Loggers/OwnJSONPatternFormatter.h
@@ -24,13 +24,13 @@ class Loggers;
 
 class OwnJSONPatternFormatter : public OwnPatternFormatter
 {
-  public:
+public:
     OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config_);
 
     void format(const Poco::Message & msg, std::string & text) override;
     void formatExtended(const DB::ExtendedLogMessage & msg_ext, std::string & text) const override;
-  
-  private:
+
+private:
     Poco::Util::AbstractConfiguration & config;
     std::string date_time;
     std::string thread_name;

--- a/src/Loggers/OwnJSONPatternFormatter.h
+++ b/src/Loggers/OwnJSONPatternFormatter.h
@@ -26,13 +26,12 @@ class Loggers;
 class OwnJSONPatternFormatter : public OwnPatternFormatter
 {
 public:
-    OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config_);
+    OwnJSONPatternFormatter(Poco::Util::AbstractConfiguration & config);
 
     void format(const Poco::Message & msg, std::string & text) override;
     void formatExtended(const DB::ExtendedLogMessage & msg_ext, std::string & text) const override;
 
 private:
-    Poco::Util::AbstractConfiguration & config;
     std::string date_time;
     std::string thread_name;
     std::string thread_id;

--- a/src/Loggers/OwnJSONPatternFormatter.h
+++ b/src/Loggers/OwnJSONPatternFormatter.h
@@ -39,6 +39,6 @@ private:
     std::string query_id;
     std::string logger_name;
     std::string message;
-    std::string source_file_;
+    std::string source_file;
     std::string source_line;
 };

--- a/tests/integration/test_structured_logging_json/configs/config_all_keys_json.xml
+++ b/tests/integration/test_structured_logging_json/configs/config_all_keys_json.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <logger>
+        <!-- Structured log formatting:
+        You can specify log format(for now, JSON only). In that case, the console log will be printed
+        in specified format like JSON.
+        For example, as below:
+        {"date_time":"1650918987.180175","thread_name":"#1","thread_id":"254545","level":"Trace","query_id":"","logger_name":"BaseDaemon","message":"Received signal 2","source_file":"../base/daemon/BaseDaemon.cpp; virtual void SignalListener::run()","source_line":"192"}
+        To enable JSON logging support, just uncomment <formatting> tag below.
+        -->
+        <formatting>
+            <type>json</type>
+            <names>
+                <date_time>DATE_TIME</date_time>
+                <thread_name>THREAD_NAME</thread_name>
+                <thread_id>THREAD_ID</thread_id>
+                <level>LEVEL</level>
+                <query_id>QUERY_ID</query_id>
+                <logger_name>LOGGER_NAME</logger_name>
+                <message>MESSAGE</message>
+                <source_file>SOURCE_FILE</source_file>
+                <source_line>SOURCE_LINE</source_line>
+            </names>
+        </formatting>
+    </logger>
+
+</clickhouse>

--- a/tests/integration/test_structured_logging_json/configs/config_json.xml
+++ b/tests/integration/test_structured_logging_json/configs/config_json.xml
@@ -8,7 +8,20 @@
         {"date_time":"1650918987.180175","thread_name":"#1","thread_id":"254545","level":"Trace","query_id":"","logger_name":"BaseDaemon","message":"Received signal 2","source_file":"../base/daemon/BaseDaemon.cpp; virtual void SignalListener::run()","source_line":"192"}
         To enable JSON logging support, just uncomment <formatting> tag below.
         -->
-        <formatting>json</formatting>
+        <formatting>
+            <type>json</type>
+            <names>
+                <date_time>DATE_TIME</date_time>
+                <thread_name>THREAD_NAME</thread_name>
+                <thread_id>THREAD_ID</thread_id>
+                <level>LEVEL</level>
+                <query_id>QUERY_ID</query_id>
+                <logger_name>LOGGER_NAME</logger_name>
+                <message>MESSAGE</message>
+                <source_file>SOURCE_FILE</source_file>
+                <source_line>SOURCE_LINE</source_line>
+            </names>
+        </formatting>
     </logger>
 
 </clickhouse>

--- a/tests/integration/test_structured_logging_json/configs/config_no_keys_json.xml
+++ b/tests/integration/test_structured_logging_json/configs/config_no_keys_json.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <logger>
+        <!-- Structured log formatting:
+        You can specify log format(for now, JSON only). In that case, the console log will be printed
+        in specified format like JSON.
+        For example, as below:
+        {"date_time":"1650918987.180175","thread_name":"#1","thread_id":"254545","level":"Trace","query_id":"","logger_name":"BaseDaemon","message":"Received signal 2","source_file":"../base/daemon/BaseDaemon.cpp; virtual void SignalListener::run()","source_line":"192"}
+        To enable JSON logging support, just uncomment <formatting> tag below.
+        -->
+        <formatting>
+            <type>json</type>
+            <!--<names>
+                <date_time>DATE_TIME</date_time>
+                <thread_name>THREAD_NAME</thread_name>
+                <thread_id>THREAD_ID</thread_id>
+                <level>LEVEL</level>
+                <query_id>QUERY_ID</query_id>
+                <logger_name>LOGGER_NAME</logger_name>
+                <message>MESSAGE</message>
+                <source_file>SOURCE_FILE</source_file>
+                <source_line>SOURCE_LINE</source_line>
+            </names>-->
+        </formatting>
+    </logger>
+
+</clickhouse>

--- a/tests/integration/test_structured_logging_json/configs/config_some_keys_json.xml
+++ b/tests/integration/test_structured_logging_json/configs/config_some_keys_json.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <logger>
+        <!-- Structured log formatting:
+        You can specify log format(for now, JSON only). In that case, the console log will be printed
+        in specified format like JSON.
+        For example, as below:
+        {"date_time":"1650918987.180175","thread_name":"#1","thread_id":"254545","level":"Trace","query_id":"","logger_name":"BaseDaemon","message":"Received signal 2","source_file":"../base/daemon/BaseDaemon.cpp; virtual void SignalListener::run()","source_line":"192"}
+        To enable JSON logging support, just uncomment <formatting> tag below.
+        -->
+        <formatting>
+            <type>json</type>
+            <names>
+                <date_time>DATE_TIME</date_time>
+                <thread_name>THREAD_NAME</thread_name>
+                <thread_id>THREAD_ID</thread_id>
+                <level>LEVEL</level>
+                <!--<query_id>QUERY_ID</query_id>
+                <logger_name>LOGGER_NAME</logger_name>-->
+                <message>MESSAGE</message>
+                <source_file>SOURCE_FILE</source_file>
+                <!--<source_line>SOURCE_LINE</source_line>-->
+            </names>
+        </formatting>
+    </logger>
+
+</clickhouse>

--- a/tests/integration/test_structured_logging_json/test.py
+++ b/tests/integration/test_structured_logging_json/test.py
@@ -94,8 +94,6 @@ def test_structured_logging_json_format(start_cluster):
         ["cat", "/etc/clickhouse-server/config.d/config_no_keys_json.xml"]
     )
 
-    assert (
-        valiade_everything(config_all_keys, node_all_keys, "config_all_keys")
-        and valiade_everything(config_some_keys, node_some_keys, "config_some_keys")
-        and valiade_everything(config_no_keys, node_no_keys, "config_no_keys")
-    )
+    assert valiade_everything(config_all_keys, node_all_keys, "config_all_keys") == True
+    assert valiade_everything(config_some_keys, node_some_keys, "config_some_keys") == True
+    assert valiade_everything(config_no_keys, node_no_keys, "config_no_keys") == True

--- a/tests/integration/test_structured_logging_json/test.py
+++ b/tests/integration/test_structured_logging_json/test.py
@@ -4,9 +4,15 @@ import json
 from xml.etree import ElementTree as ET
 
 cluster = ClickHouseCluster(__file__)
-node_all_keys = cluster.add_instance("node_all_keys", main_configs=["configs/config_all_keys_json.xml"])
-node_some_keys = cluster.add_instance("node_some_keys", main_configs=["configs/config_some_keys_json.xml"])
-node_no_keys = cluster.add_instance("node_no_keys", main_configs=["configs/config_no_keys_json.xml"])
+node_all_keys = cluster.add_instance(
+    "node_all_keys", main_configs=["configs/config_all_keys_json.xml"]
+)
+node_some_keys = cluster.add_instance(
+    "node_some_keys", main_configs=["configs/config_some_keys_json.xml"]
+)
+node_no_keys = cluster.add_instance(
+    "node_no_keys", main_configs=["configs/config_no_keys_json.xml"]
+)
 
 
 @pytest.fixture(scope="module")
@@ -25,6 +31,7 @@ def is_json(log_json):
         return False
     return True
 
+
 def validate_log_config_relation(config, logs, config_type):
     root = ET.fromstring(config)
     keys_in_config = set()
@@ -40,7 +47,7 @@ def validate_log_config_relation(config, logs, config_type):
         keys_in_config.add("source_file")
         keys_in_config.add("source_line")
     else:
-        for child in root.findall('.//names/*'):
+        for child in root.findall(".//names/*"):
             keys_in_config.add(child.text)
 
     try:
@@ -59,6 +66,7 @@ def validate_log_config_relation(config, logs, config_type):
         return False
     return True
 
+
 def validate_logs(logs):
     length = min(10, len(logs))
     result = True
@@ -66,14 +74,27 @@ def validate_logs(logs):
         result = result and is_json(logs[i])
     return result
 
+
 def valiade_everything(config, node, config_type):
     node.query("SELECT 1")
     logs = node.grep_in_log("").split("\n")
-    return validate_logs(logs) and validate_log_config_relation(config, logs, config_type)
+    return validate_logs(logs) and validate_log_config_relation(
+        config, logs, config_type
+    )
 
 def test_structured_logging_json_format2(start_cluster):
-    config_all_keys = node_all_keys.exec_in_container(["cat", "/etc/clickhouse-server/config.d/config_all_keys_json.xml"])
-    config_some_keys = node_some_keys.exec_in_container(["cat", "/etc/clickhouse-server/config.d/config_some_keys_json.xml"])
-    config_no_keys = node_no_keys.exec_in_container(["cat", "/etc/clickhouse-server/config.d/config_no_keys_json.xml"])
-    
-    assert valiade_everything(config_all_keys, node_all_keys, "config_all_keys") and valiade_everything(config_some_keys, node_some_keys, "config_some_keys") and valiade_everything(config_no_keys, node_no_keys, "config_no_keys")
+    config_all_keys = node_all_keys.exec_in_container(
+        ["cat", "/etc/clickhouse-server/config.d/config_all_keys_json.xml"]
+    )
+    config_some_keys = node_some_keys.exec_in_container(
+        ["cat", "/etc/clickhouse-server/config.d/config_some_keys_json.xml"]
+    )
+    config_no_keys = node_no_keys.exec_in_container(
+        ["cat", "/etc/clickhouse-server/config.d/config_no_keys_json.xml"]
+    )
+
+    assert (
+        valiade_everything(config_all_keys, node_all_keys, "config_all_keys")
+        and valiade_everything(config_some_keys, node_some_keys, "config_some_keys")
+        and valiade_everything(config_no_keys, node_no_keys, "config_no_keys")
+    )

--- a/tests/integration/test_structured_logging_json/test.py
+++ b/tests/integration/test_structured_logging_json/test.py
@@ -1,9 +1,12 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 import json
+from xml.etree import ElementTree as ET
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node", main_configs=["configs/config_json.xml"])
+node_all_keys = cluster.add_instance("node_all_keys", main_configs=["configs/config_all_keys_json.xml"])
+node_some_keys = cluster.add_instance("node_some_keys", main_configs=["configs/config_some_keys_json.xml"])
+node_no_keys = cluster.add_instance("node_no_keys", main_configs=["configs/config_no_keys_json.xml"])
 
 
 @pytest.fixture(scope="module")
@@ -22,11 +25,55 @@ def is_json(log_json):
         return False
     return True
 
+def validate_log_config_relation(config, logs, config_type):
+    root = ET.fromstring(config)
+    keys_in_config = set()
 
-def test_structured_logging_json_format(start_cluster):
-    node.query("SELECT 1")
+    if config_type == "config_no_keys":
+        keys_in_config.add("date_time")
+        keys_in_config.add("thread_name")
+        keys_in_config.add("thread_id")
+        keys_in_config.add("level")
+        keys_in_config.add("query_id")
+        keys_in_config.add("logger_name")
+        keys_in_config.add("message")
+        keys_in_config.add("source_file")
+        keys_in_config.add("source_line")
+    else:
+        for child in root.findall('.//names/*'):
+            keys_in_config.add(child.text)
 
-    logs = node.grep_in_log("").split("\n")
+    try:
+        length = min(10, len(logs))
+        for i in range(0, length):
+            json_log = json.loads(logs[i])
+            keys_in_log = set()
+            for log_key in json_log.keys():
+                keys_in_log.add(log_key)
+                if log_key not in keys_in_config:
+                    return False
+            for config_key in keys_in_config:
+                if config_key not in keys_in_log:
+                    return False
+    except ValueError as e:
+        return False
+    return True
+
+def validate_logs(logs):
     length = min(10, len(logs))
+    result = True
     for i in range(0, length):
-        assert is_json(logs[i])
+        result = result and is_json(logs[i])
+    return result
+
+def valiade_everything(config, node, config_type):
+    node.query("SELECT 1")
+    logs = node.grep_in_log("").split("\n")
+    return validate_logs(logs) and validate_log_config_relation(config, logs, config_type)
+
+def test_structured_logging_json_format2(start_cluster):
+    config_all_keys = node_all_keys.exec_in_container(["cat", "/etc/clickhouse-server/config.d/config_all_keys_json.xml"])
+    config_some_keys = node_some_keys.exec_in_container(["cat", "/etc/clickhouse-server/config.d/config_some_keys_json.xml"])
+    config_no_keys = node_no_keys.exec_in_container(["cat", "/etc/clickhouse-server/config.d/config_no_keys_json.xml"])
+    
+    assert valiade_everything(config_all_keys, node_all_keys, "config_all_keys") and valiade_everything(config_some_keys, node_some_keys, "config_some_keys") and valiade_everything(config_no_keys, node_no_keys, "config_no_keys")

--- a/tests/integration/test_structured_logging_json/test.py
+++ b/tests/integration/test_structured_logging_json/test.py
@@ -82,7 +82,8 @@ def valiade_everything(config, node, config_type):
         config, logs, config_type
     )
 
-def test_structured_logging_json_format2(start_cluster):
+
+def test_structured_logging_json_format(start_cluster):
     config_all_keys = node_all_keys.exec_in_container(
         ["cat", "/etc/clickhouse-server/config.d/config_all_keys_json.xml"]
     )

--- a/tests/integration/test_structured_logging_json/test.py
+++ b/tests/integration/test_structured_logging_json/test.py
@@ -95,5 +95,7 @@ def test_structured_logging_json_format(start_cluster):
     )
 
     assert valiade_everything(config_all_keys, node_all_keys, "config_all_keys") == True
-    assert valiade_everything(config_some_keys, node_some_keys, "config_some_keys") == True
+    assert (
+        valiade_everything(config_some_keys, node_some_keys, "config_some_keys") == True
+    )
     assert valiade_everything(config_no_keys, node_no_keys, "config_no_keys") == True


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
This is an extension of Structured logging feature which was merged in this PR #39277.
In this extension, user will be able to modify log key names. User will also be able to remove unwanted keys from log.
Consider this log below:
```{"date_time":"1650918987.180175","thread_name":"#1","thread_id":"254545","level":"Trace","query_id":"","logger_name":"BaseDaemon","message":"Received signal 2","source_file":"../base/daemon/BaseDaemon.cpp; virtual void SignalListener::run()","source_line":"192"}```. 

To enable JSON logging support, user need to uncomment the entire ```<formatting>``` tag below taken from `config.xml`.  

User will be able to modify key names by changing values under tag values inside <names> tag. For example, to change `date_time` to `MY_DATE_TIME`, user can do like:  
`<date_time>MY_DATE_TIME</date_time>`
 
User can stop unwanted log properties to appear in logs. To do so, they can simply comment out that property from this file.
For example, if you do not want your log to print query_id, you can comment out only `<query_id>` tag.However, if you comment out all the tags under <names>, the program will print default values for as below.  
   
        <!-- <formatting>
            <type>json</type>
            <names>
                <date_time>date_time</date_time>
                <thread_name>thread_name</thread_name>
                <thread_id>thread_id</thread_id>
                <level>level</level>
                <query_id>query_id</query_id>
                <logger_name>logger_name</logger_name>
                <message>message</message>
                <source_file>source_file</source_file>
                <source_line>source_line</source_line>
            </names>
        </formatting> -->

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
