### PR TITLE
Add more current metrics for cache

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -92,6 +92,8 @@
     M(FilesystemCacheReadBuffers, "Number of active cache buffers") \
     M(CacheFileSegments, "Number of existing cache file segments") \
     M(CacheDetachedFileSegments, "Number of existing detached cache file segments") \
+    M(FilesystemCacheSize, "Filesystem cache size in bytes") \
+    M(FilesystemCacheElements, "Filesystem cache elements (file segments)") \
     M(S3Requests, "S3 requests") \
     M(KeeperAliveConnections, "Number of alive connections") \
     M(KeeperOutstandingRequets, "Number of outstanding requests") \

--- a/src/Common/LRUFileCachePriority.cpp
+++ b/src/Common/LRUFileCachePriority.cpp
@@ -1,4 +1,11 @@
 #include <Common/LRUFileCachePriority.h>
+#include <Common/CurrentMetrics.h>
+
+namespace CurrentMetrics
+{
+    extern const Metric FilesystemCacheSize;
+    extern const Metric FilesystemCacheElements;
+}
 
 namespace DB
 {
@@ -22,8 +29,13 @@ IFileCachePriority::WriteIterator LRUFileCachePriority::add(const Key & key, siz
                 entry.size);
     }
 #endif
+
     auto iter = queue.insert(queue.end(), FileCacheRecord(key, offset, size));
     cache_size += size;
+
+    CurrentMetrics::add(CurrentMetrics::FilesystemCacheSize, size);
+    CurrentMetrics::add(CurrentMetrics::FilesystemCacheElements);
+
     return std::make_shared<LRUFileCacheIterator>(this, iter);
 }
 
@@ -39,8 +51,17 @@ bool LRUFileCachePriority::contains(const Key & key, size_t offset, std::lock_gu
 
 void LRUFileCachePriority::removeAll(std::lock_guard<std::mutex> &)
 {
+    CurrentMetrics::sub(CurrentMetrics::FilesystemCacheSize, cache_size);
+    CurrentMetrics::sub(CurrentMetrics::FilesystemCacheElements, queue.size());
+
     queue.clear();
     cache_size = 0;
+}
+
+LRUFileCachePriority::LRUFileCacheIterator::LRUFileCacheIterator(
+    LRUFileCachePriority * cache_priority_, LRUFileCachePriority::LRUQueueIterator queue_iter_)
+    : cache_priority(cache_priority_), queue_iter(queue_iter_)
+{
 }
 
 IFileCachePriority::ReadIterator LRUFileCachePriority::getLowestPriorityReadIterator(std::lock_guard<std::mutex> &)
@@ -56,6 +77,29 @@ IFileCachePriority::WriteIterator LRUFileCachePriority::getLowestPriorityWriteIt
 size_t LRUFileCachePriority::getElementsNum(std::lock_guard<std::mutex> &) const
 {
     return queue.size();
+}
+
+void LRUFileCachePriority::LRUFileCacheIterator::removeAndGetNext(std::lock_guard<std::mutex> &)
+{
+    cache_priority->cache_size -= queue_iter->size;
+
+    CurrentMetrics::sub(CurrentMetrics::FilesystemCacheSize, queue_iter->size);
+    CurrentMetrics::sub(CurrentMetrics::FilesystemCacheElements);
+
+    queue_iter = cache_priority->queue.erase(queue_iter);
+}
+
+void LRUFileCachePriority::LRUFileCacheIterator::incrementSize(size_t size_increment, std::lock_guard<std::mutex> &)
+{
+    cache_priority->cache_size += size_increment;
+    CurrentMetrics::add(CurrentMetrics::FilesystemCacheSize, size_increment);
+    queue_iter->size += size_increment;
+}
+
+void LRUFileCachePriority::LRUFileCacheIterator::use(std::lock_guard<std::mutex> &)
+{
+    queue_iter->hits++;
+    cache_priority->queue.splice(cache_priority->queue.end(), cache_priority->queue, queue_iter);
 }
 
 };

--- a/src/Common/LRUFileCachePriority.h
+++ b/src/Common/LRUFileCachePriority.h
@@ -37,14 +37,11 @@ private:
 class LRUFileCachePriority::LRUFileCacheIterator : public IFileCachePriority::IIterator
 {
 public:
-    LRUFileCacheIterator(LRUFileCachePriority * file_cache_, LRUFileCachePriority::LRUQueueIterator queue_iter_)
-        : file_cache(file_cache_), queue_iter(queue_iter_)
-    {
-    }
+    LRUFileCacheIterator(LRUFileCachePriority * cache_priority_, LRUFileCachePriority::LRUQueueIterator queue_iter_);
 
     void next() const override { queue_iter++; }
 
-    bool valid() const override { return queue_iter != file_cache->queue.end(); }
+    bool valid() const override { return queue_iter != cache_priority->queue.end(); }
 
     const Key & key() const override { return queue_iter->key; }
 
@@ -54,26 +51,14 @@ public:
 
     size_t hits() const override { return queue_iter->hits; }
 
-    void removeAndGetNext(std::lock_guard<std::mutex> &) override
-    {
-        file_cache->cache_size -= queue_iter->size;
-        queue_iter = file_cache->queue.erase(queue_iter);
-    }
+    void removeAndGetNext(std::lock_guard<std::mutex> &) override;
 
-    void incrementSize(size_t size_increment, std::lock_guard<std::mutex> &) override
-    {
-        file_cache->cache_size += size_increment;
-        queue_iter->size += size_increment;
-    }
+    void incrementSize(size_t size_increment, std::lock_guard<std::mutex> &) override;
 
-    void use(std::lock_guard<std::mutex> &) override
-    {
-        queue_iter->hits++;
-        file_cache->queue.splice(file_cache->queue.end(), file_cache->queue, queue_iter);
-    }
+    void use(std::lock_guard<std::mutex> &) override;
 
 private:
-    LRUFileCachePriority * file_cache;
+    LRUFileCachePriority * cache_priority;
     mutable LRUFileCachePriority::LRUQueueIterator queue_iter;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add current metrics for fs cache: `FilesystemCacheSize` and `FilesystemCacheElements`
