### PR TITLE
Replace unbounded vectorscan cache by bounded cache

### DIFF
--- a/src/Functions/MatchImpl.h
+++ b/src/Functions/MatchImpl.h
@@ -476,8 +476,7 @@ struct MatchImpl
             }
             else
             {
-                cache.getOrSet<is_like, /*no_capture*/ true, case_insensitive>(needle, regexp);
-
+                regexp = cache.getOrSet<is_like, /*no_capture*/ true, case_insensitive>(needle);
                 regexp->getAnalyzeResult(required_substr, is_trivial, required_substring_is_prefix);
 
                 if (required_substr.empty())
@@ -589,8 +588,7 @@ struct MatchImpl
             }
             else
             {
-                cache.getOrSet<is_like, /*no_capture*/ true, case_insensitive>(needle, regexp);
-
+                regexp = cache.getOrSet<is_like, /*no_capture*/ true, case_insensitive>(needle);
                 regexp->getAnalyzeResult(required_substr, is_trivial, required_substring_is_prefix);
 
                 if (required_substr.empty())

--- a/src/Functions/MultiMatchAllIndicesImpl.h
+++ b/src/Functions/MultiMatchAllIndicesImpl.h
@@ -86,7 +86,7 @@ struct MultiMatchAllIndicesImpl
             return;
         }
 
-        const auto & hyperscan_regex = MultiRegexps::get</*SaveIndices=*/true, WithEditDistance>(needles, edit_distance);
+        const auto * hyperscan_regex = MultiRegexps::get</*SaveIndices=*/true, WithEditDistance>(needles, edit_distance);
         hs_scratch_t * scratch = nullptr;
         hs_error_t err = hs_clone_scratch(hyperscan_regex->getScratch(), &scratch);
 
@@ -197,7 +197,7 @@ struct MultiMatchAllIndicesImpl
 
             checkHyperscanRegexp(needles, max_hyperscan_regexp_length, max_hyperscan_regexp_total_length);
 
-            const auto & hyperscan_regex = MultiRegexps::get</*SaveIndices=*/true, WithEditDistance>(needles, edit_distance);
+            const auto * hyperscan_regex = MultiRegexps::get</*SaveIndices=*/true, WithEditDistance>(needles, edit_distance);
             hs_scratch_t * scratch = nullptr;
             hs_error_t err = hs_clone_scratch(hyperscan_regex->getScratch(), &scratch);
 

--- a/src/Functions/MultiMatchAllIndicesImpl.h
+++ b/src/Functions/MultiMatchAllIndicesImpl.h
@@ -86,9 +86,10 @@ struct MultiMatchAllIndicesImpl
             return;
         }
 
-        const auto * hyperscan_regex = MultiRegexps::get</*SaveIndices=*/true, WithEditDistance>(needles, edit_distance);
+        MultiRegexps::DeferredConstructedRegexpsPtr deferred_constructed_regexps = MultiRegexps::getOrSet</*SaveIndices*/ true, WithEditDistance>(needles, edit_distance);
+        MultiRegexps::Regexps * regexps = deferred_constructed_regexps->get();
         hs_scratch_t * scratch = nullptr;
-        hs_error_t err = hs_clone_scratch(hyperscan_regex->getScratch(), &scratch);
+        hs_error_t err = hs_clone_scratch(regexps->getScratch(), &scratch);
 
         if (err != HS_SUCCESS)
             throw Exception("Could not clone scratch space for hyperscan", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
@@ -114,7 +115,7 @@ struct MultiMatchAllIndicesImpl
                 throw Exception("Too long string to search", ErrorCodes::TOO_MANY_BYTES);
             /// scan, check, update the offsets array and the offset of haystack.
             err = hs_scan(
-                hyperscan_regex->getDB(),
+                regexps->getDB(),
                 reinterpret_cast<const char *>(haystack_data.data()) + offset,
                 length,
                 0,
@@ -197,9 +198,10 @@ struct MultiMatchAllIndicesImpl
 
             checkHyperscanRegexp(needles, max_hyperscan_regexp_length, max_hyperscan_regexp_total_length);
 
-            const auto * hyperscan_regex = MultiRegexps::get</*SaveIndices=*/true, WithEditDistance>(needles, edit_distance);
+            MultiRegexps::DeferredConstructedRegexpsPtr deferred_constructed_regexps = MultiRegexps::getOrSet</*SaveIndices*/ true, WithEditDistance>(needles, edit_distance);
+            MultiRegexps::Regexps * regexps = deferred_constructed_regexps->get();
             hs_scratch_t * scratch = nullptr;
-            hs_error_t err = hs_clone_scratch(hyperscan_regex->getScratch(), &scratch);
+            hs_error_t err = hs_clone_scratch(regexps->getScratch(), &scratch);
 
             if (err != HS_SUCCESS)
                 throw Exception("Could not clone scratch space for hyperscan", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
@@ -224,7 +226,7 @@ struct MultiMatchAllIndicesImpl
 
             /// scan, check, update the offsets array and the offset of haystack.
             err = hs_scan(
-                hyperscan_regex->getDB(),
+                regexps->getDB(),
                 reinterpret_cast<const char *>(haystack_data.data()) + prev_haystack_offset,
                 cur_haystack_length,
                 0,

--- a/src/Functions/MultiMatchAnyImpl.h
+++ b/src/Functions/MultiMatchAnyImpl.h
@@ -100,9 +100,11 @@ struct MultiMatchAnyImpl
             return;
         }
 #if USE_VECTORSCAN
-        const auto * hyperscan_regex = MultiRegexps::get</*SaveIndices*/ FindAnyIndex, WithEditDistance>(needles, edit_distance);
+        MultiRegexps::DeferredConstructedRegexpsPtr deferred_constructed_regexps = MultiRegexps::getOrSet</*SaveIndices*/ FindAnyIndex, WithEditDistance>(needles, edit_distance);
+        MultiRegexps::Regexps * regexps = deferred_constructed_regexps->get();
+
         hs_scratch_t * scratch = nullptr;
-        hs_error_t err = hs_clone_scratch(hyperscan_regex->getScratch(), &scratch);
+        hs_error_t err = hs_clone_scratch(regexps->getScratch(), &scratch);
 
         if (err != HS_SUCCESS)
             throw Exception("Could not clone scratch space for vectorscan", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
@@ -133,7 +135,7 @@ struct MultiMatchAnyImpl
             /// zero the result, scan, check, update the offset.
             res[i] = 0;
             err = hs_scan(
-                hyperscan_regex->getDB(),
+                regexps->getDB(),
                 reinterpret_cast<const char *>(haystack_data.data()) + offset,
                 length,
                 0,
@@ -224,9 +226,10 @@ struct MultiMatchAnyImpl
 
             checkHyperscanRegexp(needles, max_hyperscan_regexp_length, max_hyperscan_regexp_total_length);
 
-            const auto * hyperscan_regex = MultiRegexps::get</*SaveIndices*/ FindAnyIndex, WithEditDistance>(needles, edit_distance);
+            MultiRegexps::DeferredConstructedRegexpsPtr deferred_constructed_regexps = MultiRegexps::getOrSet</*SaveIndices*/ FindAnyIndex, WithEditDistance>(needles, edit_distance);
+            MultiRegexps::Regexps * regexps = deferred_constructed_regexps->get();
             hs_scratch_t * scratch = nullptr;
-            hs_error_t err = hs_clone_scratch(hyperscan_regex->getScratch(), &scratch);
+            hs_error_t err = hs_clone_scratch(regexps->getScratch(), &scratch);
 
             if (err != HS_SUCCESS)
                 throw Exception("Could not clone scratch space for vectorscan", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
@@ -256,7 +259,7 @@ struct MultiMatchAnyImpl
             /// zero the result, scan, check, update the offset.
             res[i] = 0;
             err = hs_scan(
-                hyperscan_regex->getDB(),
+                regexps->getDB(),
                 reinterpret_cast<const char *>(haystack_data.data()) + prev_haystack_offset,
                 cur_haystack_length,
                 0,

--- a/src/Functions/MultiMatchAnyImpl.h
+++ b/src/Functions/MultiMatchAnyImpl.h
@@ -100,7 +100,7 @@ struct MultiMatchAnyImpl
             return;
         }
 #if USE_VECTORSCAN
-        const auto & hyperscan_regex = MultiRegexps::get</*SaveIndices*/ FindAnyIndex, WithEditDistance>(needles, edit_distance);
+        const auto * hyperscan_regex = MultiRegexps::get</*SaveIndices*/ FindAnyIndex, WithEditDistance>(needles, edit_distance);
         hs_scratch_t * scratch = nullptr;
         hs_error_t err = hs_clone_scratch(hyperscan_regex->getScratch(), &scratch);
 
@@ -155,7 +155,7 @@ struct MultiMatchAnyImpl
         memset(accum.data(), 0, accum.size());
         for (size_t j = 0; j < needles.size(); ++j)
         {
-            MatchImpl<Name, MatchTraits::Syntax::Re2, MatchTraits::Case::Sensitive, MatchTraits::Result::DontNegate>::vectorConstant(haystack_data, haystack_offsets, std::string(needles[j].data(), needles[j].size()), nullptr, accum);
+            MatchImpl<Name, MatchTraits::Syntax::Re2, MatchTraits::Case::Sensitive, MatchTraits::Result::DontNegate>::vectorConstant(haystack_data, haystack_offsets, String(needles[j].data(), needles[j].size()), nullptr, accum);
             for (size_t i = 0; i < res.size(); ++i)
             {
                 if constexpr (FindAny)
@@ -224,7 +224,7 @@ struct MultiMatchAnyImpl
 
             checkHyperscanRegexp(needles, max_hyperscan_regexp_length, max_hyperscan_regexp_total_length);
 
-            const auto & hyperscan_regex = MultiRegexps::get</*SaveIndices*/ FindAnyIndex, WithEditDistance>(needles, edit_distance);
+            const auto * hyperscan_regex = MultiRegexps::get</*SaveIndices*/ FindAnyIndex, WithEditDistance>(needles, edit_distance);
             hs_scratch_t * scratch = nullptr;
             hs_error_t err = hs_clone_scratch(hyperscan_regex->getScratch(), &scratch);
 

--- a/src/Functions/Regexps.h
+++ b/src/Functions/Regexps.h
@@ -14,6 +14,7 @@
 #include <Common/config.h>
 #include <base/defines.h>
 #include <base/StringRef.h>
+#include <boost/container_hash/hash.hpp>
 
 #include "config_functions.h"
 
@@ -83,7 +84,7 @@ public:
     }
 
 private:
-    constexpr static size_t CACHE_SIZE = 100; // collision probability
+    constexpr static size_t CACHE_SIZE = 100; /// collision probability
 
     std::hash<String> hasher;
     struct Bucket
@@ -133,7 +134,9 @@ private:
 class DeferredConstructedRegexps
 {
 public:
-    void setConstructor(std::function<Regexps()> constructor_) { constructor = std::move(constructor_); }
+    explicit DeferredConstructedRegexps(std::function<Regexps()> constructor_)
+        : constructor(std::move(constructor_))
+    {}
 
     Regexps * get()
     {
@@ -145,18 +148,12 @@ public:
     }
 
 private:
-    std::function<Regexps()> constructor;
+    std::function<Regexps()> constructor TSA_GUARDED_BY(mutex);
     std::optional<Regexps> regexps TSA_GUARDED_BY(mutex);
     std::mutex mutex;
 };
 
-struct Pool
-{
-    /// Mutex for finding in map.
-    std::mutex mutex;
-    /// (Patterns + possible edit_distance) -> (database + scratch area)
-    std::map<std::pair<std::vector<String>, std::optional<UInt32>>, DeferredConstructedRegexps> storage;
-};
+using DeferredConstructedRegexpsPtr = std::shared_ptr<DeferredConstructedRegexps>;
 
 template <bool save_indices, bool WithEditDistance>
 inline Regexps constructRegexps(const std::vector<String> & str_patterns, [[maybe_unused]] std::optional<UInt32> edit_distance)
@@ -262,44 +259,85 @@ inline Regexps constructRegexps(const std::vector<String> & str_patterns, [[mayb
     return {db, scratch};
 }
 
-/// If WithEditDistance is False, edit_distance must be nullopt
-/// Also, we use templates here because each instantiation of function
-/// template has its own copy of local static variables which must not be the same
-/// for different hyperscan compilations.
-template <bool save_indices, bool WithEditDistance>
-inline Regexps * get(const std::vector<std::string_view> & patterns, std::optional<UInt32> edit_distance)
+/// Maps string pattern vectors + edit distance to compiled vectorscan regexps. Uses the same eviction mechanism as the LocalCacheTable for
+/// re2 patterns. Because vectorscan regexes are overall more heavy-weight (more expensive compilation, regexes can grow up to multiple
+/// MBs, usage of scratch space), 1. GlobalCacheTable is a global singleton and, as a result, needs locking 2. the pattern compilation is
+/// done outside GlobalCacheTable's lock, at the cost of another level of locking.
+struct GlobalCacheTable
 {
-    static Pool known_regexps; /// Different variables for different pattern parameters, thread-safe in C++11
+    constexpr static size_t CACHE_SIZE = 500; /// collision probability
+
+    struct Bucket
+    {
+        std::vector<String> patterns;          /// key
+        std::optional<UInt32> edit_distance;   /// key
+        /// The compiled patterns and their state (vectorscan 'database' + scratch space) are wrapped in a shared_ptr. Refcounting guarantees
+        /// that eviction of a pattern does not affect parallel threads still using the pattern.
+        DeferredConstructedRegexpsPtr regexps; /// value
+    };
+
+    std::array<Bucket, CACHE_SIZE> known_regexps TSA_GUARDED_BY(mutex);
+    std::mutex mutex;
+
+    static size_t getBucketIndexFor(const std::vector<String> patterns, std::optional<UInt32> edit_distance)
+    {
+        size_t hash = 0;
+        for (const auto & pattern : patterns)
+            boost::hash_combine(hash, pattern);
+        boost::hash_combine(hash, edit_distance);
+        return hash % CACHE_SIZE;
+    }
+};
+
+/// If WithEditDistance is False, edit_distance must be nullopt. Also, we use templates here because each instantiation of function template
+/// has its own copy of local static variables which must not be the same for different hyperscan compilations.
+template <bool save_indices, bool WithEditDistance>
+inline DeferredConstructedRegexpsPtr getOrSet(const std::vector<std::string_view> & patterns, std::optional<UInt32> edit_distance)
+{
+    static GlobalCacheTable pool; /// Different variables for different pattern parameters, thread-safe in C++11
 
     std::vector<String> str_patterns;
     str_patterns.reserve(patterns.size());
     for (const auto & pattern : patterns)
         str_patterns.emplace_back(String(pattern));
 
-    /// Lock pool to find compiled regexp for given pattern + edit distance.
-    std::unique_lock lock(known_regexps.mutex);
+    size_t bucket_idx = GlobalCacheTable::getBucketIndexFor(str_patterns, edit_distance);
 
-    auto it = known_regexps.storage.find({str_patterns, edit_distance});
+    /// Lock cache to find compiled regexp for given pattern vector + edit distance.
+    std::lock_guard lock(pool.mutex);
 
-    if (known_regexps.storage.end() == it)
+    GlobalCacheTable::Bucket & bucket = pool.known_regexps[bucket_idx];
+
+    /// Pattern compilation is expensive and we don't want to block other threads reading from / inserting into the cache while we hold the
+    /// cache lock during pattern compilation. Therefore, when a cache entry is created or replaced, only set the regexp constructor method
+    /// and compile outside the cache lock.
+    /// Note that the string patterns and the edit distance is passed into the constructor lambda by value, i.e. copied - it is not an
+    /// option to reference the corresponding string patterns / edit distance key in the cache table bucket because the cache entry may
+    /// already be evicted at the time the compilation starts.
+
+    if (bucket.regexps == nullptr) [[unlikely]]
     {
-        /// Not found. Pattern compilation is expensive and we don't want to block other threads reading from /inserting into the pool while
-        /// we hold the pool lock during pattern compilation. Therefore, only set the constructor method and compile outside the pool lock.
-        it = known_regexps.storage.emplace(
-                std::piecewise_construct,
-                std::make_tuple(std::move(str_patterns), edit_distance),
-                std::make_tuple())
-            .first;
-        it->second.setConstructor(
-            [&str_patterns = it->first.first, edit_distance]()
-            {
-                return constructRegexps<save_indices, WithEditDistance>(str_patterns, edit_distance);
-            }
-        );
+        /// insert new entry
+        auto deferred_constructed_regexps = std::make_shared<DeferredConstructedRegexps>(
+                [str_patterns, edit_distance]()
+                {
+                    return constructRegexps<save_indices, WithEditDistance>(str_patterns, edit_distance);
+                });
+        bucket = {std::move(str_patterns), edit_distance, deferred_constructed_regexps};
     }
+    else
+        if (bucket.patterns != str_patterns || bucket.edit_distance != edit_distance)
+        {
+            /// replace existing entry
+            auto deferred_constructed_regexps = std::make_shared<DeferredConstructedRegexps>(
+                    [str_patterns, edit_distance]()
+                    {
+                        return constructRegexps<save_indices, WithEditDistance>(str_patterns, edit_distance);
+                    });
+            bucket = {std::move(str_patterns), edit_distance, deferred_constructed_regexps};
+        }
 
-    lock.unlock();
-    return it->second.get(); /// Possibly compile pattern now.
+    return bucket.regexps;
 }
 
 }


### PR DESCRIPTION
VectorScan patterns can grow large (up to multiple MBs) and queries
involving different VectorScan patterns lead to an ever increasing
pattern cache size.

With this PR, the unbounded cache for vectorscan patterns is
replaced by a bounded cache with "CacheTable" eviction strategy, similar
to what we have for re2 patterns. The cache size is currently hard-coded
to 500 entries.

Fixes #19869

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Avoid continuously growing memory consumption of pattern cache when using functions multi(Fuzzy)Match(Any|AllIndices|AnyIndex)()