### PR TITLE
fix heap buffer overflow by limiting http chunk size

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -280,7 +280,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, http_max_fields, 1000000, "Maximum number of fields in HTTP header", 0) \
     M(UInt64, http_max_field_name_size, 1048576, "Maximum length of field name in HTTP header", 0) \
     M(UInt64, http_max_field_value_size, 1048576, "Maximum length of field value in HTTP header", 0) \
-    M(UInt64, http_max_chunk_size, 32*1024*1024, "Maximum value of a chunk size in HTTP chunked transfer encoding", 0) \
+    M(UInt64, http_max_chunk_size, 100_GiB, "Maximum value of a chunk size in HTTP chunked transfer encoding", 0) \
     M(Bool, http_skip_not_found_url_for_globs, true, "Skip url's for globs with HTTP_NOT_FOUND error", 0) \
     M(Bool, optimize_throw_if_noop, false, "If setting is enabled and OPTIMIZE query didn't actually assign a merge then an explanatory exception is thrown", 0) \
     M(Bool, use_index_for_in_with_subqueries, true, "Try using an index if there is a subquery or a table expression on the right side of the IN operator.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -280,6 +280,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, http_max_fields, 1000000, "Maximum number of fields in HTTP header", 0) \
     M(UInt64, http_max_field_name_size, 1048576, "Maximum length of field name in HTTP header", 0) \
     M(UInt64, http_max_field_value_size, 1048576, "Maximum length of field value in HTTP header", 0) \
+    M(UInt64, http_max_chunk_size, 32*1024*1024, "Maximum value of a chunk size in HTTP chunked transfer encoding", 0) \
     M(Bool, http_skip_not_found_url_for_globs, true, "Skip url's for globs with HTTP_NOT_FOUND error", 0) \
     M(Bool, optimize_throw_if_noop, false, "If setting is enabled and OPTIMIZE query didn't actually assign a merge then an explanatory exception is thrown", 0) \
     M(Bool, use_index_for_in_with_subqueries, true, "Try using an index if there is a subquery or a table expression on the right side of the IN operator.", 0) \

--- a/src/IO/BufferWithOwnMemory.h
+++ b/src/IO/BufferWithOwnMemory.h
@@ -8,6 +8,8 @@
 #include <Common/Exception.h>
 #include <Core/Defines.h>
 
+#include <base/arithmeticOverflow.h>
+
 
 namespace ProfileEvents
 {
@@ -18,6 +20,11 @@ namespace ProfileEvents
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int ARGUMENT_OUT_OF_BOUND;
+}
 
 
 /** Replacement for std::vector<char> to use in buffers.
@@ -38,9 +45,9 @@ struct Memory : boost::noncopyable, Allocator
     Memory() = default;
 
     /// If alignment != 0, then allocate memory aligned to specified value.
-    explicit Memory(size_t size_, size_t alignment_ = 0) : m_capacity(size_), m_size(m_capacity), alignment(alignment_)
+    explicit Memory(size_t size_, size_t alignment_ = 0) : alignment(alignment_)
     {
-        alloc();
+        alloc(size_);
     }
 
     ~Memory()
@@ -75,28 +82,26 @@ struct Memory : boost::noncopyable, Allocator
 
     void resize(size_t new_size)
     {
-        if (0 == m_capacity)
+        if (!m_data)
         {
-            m_size = new_size;
-            m_capacity = new_size;
-            alloc();
+            alloc(new_size);
+            return;
         }
-        else if (new_size <= m_capacity - pad_right)
+
+        if (new_size <= m_capacity - pad_right)
         {
             m_size = new_size;
             return;
         }
-        else
-        {
-            size_t new_capacity = align(new_size, alignment) + pad_right;
 
-            size_t diff = new_capacity - m_capacity;
-            ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, diff);
+        size_t new_capacity = alignWithPadding(new_size, alignment);
 
-            m_data = static_cast<char *>(Allocator::realloc(m_data, m_capacity, new_capacity, alignment));
-            m_capacity = new_capacity;
-            m_size = m_capacity - pad_right;
-        }
+        size_t diff = new_capacity - m_capacity;
+        ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, diff);
+
+        m_data = static_cast<char *>(Allocator::realloc(m_data, m_capacity, new_capacity, alignment));
+        m_capacity = new_capacity;
+        m_size = new_size;
     }
 
 private:
@@ -108,24 +113,47 @@ private:
         if (!(value % alignment))
             return value;
 
-        return (value + alignment - 1) / alignment * alignment;
+        // original expression is (value + alignment - 1) / alignment * alignment;
+
+        size_t res = 0;
+
+        if (common::addOverflow<size_t>(value, alignment - 1, res))
+            throw Exception("value is too big to apply alignment", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+
+        res /= alignment;
+
+        if (common::mulOverflow<size_t>(res, alignment, res))
+            throw Exception("value is too big to apply alignment", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+
+        return res;
     }
 
-    void alloc()
+    static size_t alignWithPadding(const size_t value, const size_t alignment)
     {
-        if (!m_capacity)
+        size_t res = align(value, alignment);
+
+        if (common::addOverflow<size_t>(res, pad_right, res))
+            throw Exception("value is too big to apply padding 3", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+
+        return res;
+    }
+
+    void alloc(size_t new_size)
+    {
+        if (!new_size)
         {
             m_data = nullptr;
             return;
         }
 
-        ProfileEvents::increment(ProfileEvents::IOBufferAllocs);
-        ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, m_capacity);
+        size_t new_capacity = alignWithPadding(new_size, alignment);
 
-        size_t new_capacity = align(m_capacity, alignment) + pad_right;
+        ProfileEvents::increment(ProfileEvents::IOBufferAllocs);
+        ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, new_capacity);
+
         m_data = static_cast<char *>(Allocator::alloc(new_capacity, alignment));
         m_capacity = new_capacity;
-        m_size = m_capacity - pad_right;
+        m_size = new_size;
     }
 
     void dealloc()

--- a/src/IO/BufferWithOwnMemory.h
+++ b/src/IO/BufferWithOwnMemory.h
@@ -94,7 +94,7 @@ struct Memory : boost::noncopyable, Allocator
             return;
         }
 
-        size_t new_capacity = alignWithPadding(new_size, alignment);
+        size_t new_capacity = withPadding(new_size);
 
         size_t diff = new_capacity - m_capacity;
         ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, diff);
@@ -105,35 +105,12 @@ struct Memory : boost::noncopyable, Allocator
     }
 
 private:
-    static size_t align(const size_t value, const size_t alignment)
+    static size_t withPadding(size_t value)
     {
-        if (!alignment)
-            return value;
-
-        if (!(value % alignment))
-            return value;
-
-        // original expression is (value + alignment - 1) / alignment * alignment;
-
         size_t res = 0;
 
-        if (common::addOverflow<size_t>(value, alignment - 1, res))
-            throw Exception("value is too big to apply alignment", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
-
-        res /= alignment;
-
-        if (common::mulOverflow<size_t>(res, alignment, res))
-            throw Exception("value is too big to apply alignment", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
-
-        return res;
-    }
-
-    static size_t alignWithPadding(const size_t value, const size_t alignment)
-    {
-        size_t res = align(value, alignment);
-
-        if (common::addOverflow<size_t>(res, pad_right, res))
-            throw Exception("value is too big to apply padding 3", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+        if (common::addOverflow<size_t>(value, pad_right, res))
+            throw Exception("value is too big to apply padding", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
 
         return res;
     }
@@ -146,7 +123,7 @@ private:
             return;
         }
 
-        size_t new_capacity = alignWithPadding(new_size, alignment);
+        size_t new_capacity = withPadding(new_size);
 
         ProfileEvents::increment(ProfileEvents::IOBufferAllocs);
         ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, new_capacity);

--- a/src/IO/HTTPChunkedReadBuffer.cpp
+++ b/src/IO/HTTPChunkedReadBuffer.cpp
@@ -32,6 +32,9 @@ size_t HTTPChunkedReadBuffer::readChunkHeader()
         ++in->position();
     } while (!in->eof() && isHexDigit(*in->position()));
 
+    if (res > max_chunk_size)
+        throw Exception("Chunk size exceeded the limit", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+
     /// NOTE: If we want to read any chunk extensions, it should be done here.
 
     skipToCarriageReturnOrEOF(*in);

--- a/src/IO/HTTPChunkedReadBuffer.h
+++ b/src/IO/HTTPChunkedReadBuffer.h
@@ -10,9 +10,12 @@ namespace DB
 class HTTPChunkedReadBuffer : public BufferWithOwnMemory<ReadBuffer>
 {
 public:
-    explicit HTTPChunkedReadBuffer(std::unique_ptr<ReadBuffer> in_) : in(std::move(in_)) {}
+    explicit HTTPChunkedReadBuffer(std::unique_ptr<ReadBuffer> in_, size_t max_chunk_size_)
+        : max_chunk_size(max_chunk_size_), in(std::move(in_))
+    {}
 
 private:
+    const size_t max_chunk_size;
     std::unique_ptr<ReadBuffer> in;
 
     size_t readChunkHeader();

--- a/src/IO/tests/gtest_memory_resize.cpp
+++ b/src/IO/tests/gtest_memory_resize.cpp
@@ -1,0 +1,326 @@
+#include <IO/WriteHelpers.h>
+#include <IO/ReadHelpers.h>
+#include <IO/BufferWithOwnMemory.h>
+#include <gtest/gtest.h>
+
+#define EXPECT_THROW_ERROR_CODE(statement, expected_exception, expected_code)    \
+    EXPECT_THROW(                                                                \
+        try                                                                      \
+        {                                                                        \
+            statement;                                                           \
+        }                                                                        \
+        catch (const expected_exception & e)                                     \
+        {                                                                        \
+            EXPECT_EQ(expected_code, e.code());                                  \
+            throw;                                                               \
+        }                                                                        \
+    , expected_exception)
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ARGUMENT_OUT_OF_BOUND;
+    extern const int LOGICAL_ERROR;
+    extern const int CANNOT_ALLOCATE_MEMORY;
+}
+
+}
+
+using namespace DB;
+
+class DummyAllocator
+{
+    void * DUMMY_ADDRESS = reinterpret_cast<void *>(1);
+
+public:
+    void * alloc(size_t size, size_t /*alignment*/ = 0)
+    {
+        checkSize(size);
+        if (size)
+            return DUMMY_ADDRESS;
+        else
+            return nullptr;
+    }
+
+    void * realloc(void * /*buf*/, size_t /*old_size*/, size_t new_size, size_t /*alignment*/ = 0)
+    {
+        checkSize(new_size);
+        return DUMMY_ADDRESS;
+    }
+
+    void free([[maybe_unused]] void * buf, size_t /*size*/)
+    {
+        assert(buf == DUMMY_ADDRESS);
+    }
+
+    // the same check as in Common/Allocator.h
+    void checkSize(size_t size)
+    {
+        /// More obvious exception in case of possible overflow (instead of just "Cannot mmap").
+        if (size >= 0x8000000000000000ULL)
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Too large size ({}) passed to allocator. It indicates an error.", size);
+    }
+};
+
+TEST(MemoryResizeTest, SmallInitAndSmallResize)
+{
+    {
+        auto memory = Memory<DummyAllocator>(0);
+        ASSERT_EQ(memory.m_data, nullptr);
+        ASSERT_EQ(memory.m_capacity, 0);
+        ASSERT_EQ(memory.m_size, 0);
+
+        memory.resize(0);
+        ASSERT_EQ(memory.m_data, nullptr);
+        ASSERT_EQ(memory.m_capacity, 0);
+        ASSERT_EQ(memory.m_size, 0);
+
+        memory.resize(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 16);
+        ASSERT_EQ(memory.m_size, 1);
+    }
+
+    {
+        auto memory = Memory<DummyAllocator>(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 16);
+        ASSERT_EQ(memory.m_size, 1);
+
+        memory.resize(0);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 16);
+        ASSERT_EQ(memory.m_size, 0);
+
+        memory.resize(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 16);
+        ASSERT_EQ(memory.m_size, 1);
+    }
+}
+
+TEST(MemoryResizeTest, SmallInitAndBigResizeOverflowWhenPadding)
+{
+    {
+        auto memory = Memory<DummyAllocator>(0);
+        ASSERT_EQ(memory.m_data, nullptr);
+        ASSERT_EQ(memory.m_capacity, 0);
+        ASSERT_EQ(memory.m_size, 0);
+
+        EXPECT_THROW_ERROR_CODE(memory.resize(std::numeric_limits<size_t>::max()), Exception, ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+        ASSERT_EQ(memory.m_data, nullptr); // state is intact after exception
+        ASSERT_EQ(memory.m_size, 0);
+        ASSERT_EQ(memory.m_capacity, 0);
+
+        memory.resize(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 16);
+        ASSERT_EQ(memory.m_size, 1);
+
+        memory.resize(2);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 17);
+        ASSERT_EQ(memory.m_size, 2);
+
+        EXPECT_THROW_ERROR_CODE(memory.resize(std::numeric_limits<size_t>::max()), Exception, ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+        ASSERT_TRUE(memory.m_data); // state is intact after exception
+        ASSERT_EQ(memory.m_capacity, 17);
+        ASSERT_EQ(memory.m_size, 2);
+
+        memory.resize(0x8000000000000000ULL-16);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 0x8000000000000000ULL - 1);
+        ASSERT_EQ(memory.m_size, 0x8000000000000000ULL - 16);
+
+#ifndef ABORT_ON_LOGICAL_ERROR
+        EXPECT_THROW_ERROR_CODE(memory.resize(0x8000000000000000ULL-15), Exception, ErrorCodes::LOGICAL_ERROR);
+        ASSERT_TRUE(memory.m_data);  // state is intact after exception
+        ASSERT_EQ(memory.m_capacity, 0x8000000000000000ULL - 1);
+        ASSERT_EQ(memory.m_size, 0x8000000000000000ULL - 16);
+#endif
+    }
+
+    {
+        auto memory = Memory<DummyAllocator>(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 16);
+        ASSERT_EQ(memory.m_size, 1);
+
+        EXPECT_THROW_ERROR_CODE(memory.resize(std::numeric_limits<size_t>::max()), Exception, ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+        ASSERT_TRUE(memory.m_data); // state is intact after exception
+        ASSERT_EQ(memory.m_capacity, 16);
+        ASSERT_EQ(memory.m_size, 1);
+
+        memory.resize(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 16);
+        ASSERT_EQ(memory.m_size, 1);
+
+#ifndef ABORT_ON_LOGICAL_ERROR
+        EXPECT_THROW_ERROR_CODE(memory.resize(0x8000000000000000ULL-15), Exception, ErrorCodes::LOGICAL_ERROR);
+        ASSERT_TRUE(memory.m_data); // state is intact after exception
+        ASSERT_EQ(memory.m_capacity, 16);
+        ASSERT_EQ(memory.m_size, 1);
+#endif
+    }
+}
+
+
+TEST(MemoryResizeTest, BigInitAndSmallResizeOverflowWhenPadding)
+{
+    {
+        EXPECT_THROW_ERROR_CODE(
+        {
+            auto memory = Memory<DummyAllocator>(std::numeric_limits<size_t>::max());
+        }
+        , Exception
+        , ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+    }
+
+    {
+        EXPECT_THROW_ERROR_CODE(
+        {
+            auto memory = Memory<DummyAllocator>(std::numeric_limits<size_t>::max() - 1);
+        }
+        , Exception
+        , ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+    }
+
+    {
+        EXPECT_THROW_ERROR_CODE(
+        {
+            auto memory = Memory<DummyAllocator>(std::numeric_limits<size_t>::max() - 10);
+        }
+        , Exception
+        , ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+    }
+
+#ifndef ABORT_ON_LOGICAL_ERROR
+    {
+        EXPECT_THROW_ERROR_CODE(
+        {
+            auto memory = Memory<DummyAllocator>(std::numeric_limits<size_t>::max() - 15);
+        }
+        , Exception
+        , ErrorCodes::LOGICAL_ERROR);
+    }
+
+    {
+        EXPECT_THROW_ERROR_CODE(
+        {
+            auto memory = Memory<DummyAllocator>(0x8000000000000000ULL - 15);
+        }
+        , Exception
+        , ErrorCodes::LOGICAL_ERROR);
+    }
+#endif
+
+    {
+       auto memory = Memory<DummyAllocator>(0x8000000000000000ULL - 16);
+       ASSERT_TRUE(memory.m_data);
+       ASSERT_EQ(memory.m_capacity, 0x8000000000000000ULL - 1);
+       ASSERT_EQ(memory.m_size, 0x8000000000000000ULL - 16);
+
+        memory.resize(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 0x8000000000000000ULL - 1);
+        ASSERT_EQ(memory.m_size, 1);
+    }
+}
+
+TEST(MemoryResizeTest, AlignmentInRealAllocator)
+{
+    {
+        auto memory = Memory<>(0, 3); // not the power of 2 but less than MALLOC_MIN_ALIGNMENT 8 so user-defined alignment is ignored at Allocator
+        ASSERT_EQ(memory.m_data, nullptr);
+        ASSERT_EQ(memory.m_capacity, 0);
+        ASSERT_EQ(memory.m_size, 0);
+
+        memory.resize(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 18);
+        ASSERT_EQ(memory.m_size, 1);
+
+        memory.resize(2);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 18);
+        ASSERT_EQ(memory.m_size, 2);
+
+        memory.resize(3);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 18);
+        ASSERT_EQ(memory.m_size, 3);
+
+        memory.resize(4);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 21);
+        ASSERT_EQ(memory.m_size, 4);
+
+        memory.resize(0);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 21);
+        ASSERT_EQ(memory.m_size, 0);
+
+        memory.resize(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 21);
+        ASSERT_EQ(memory.m_size, 1);
+    }
+
+    {
+        auto memory = Memory<>(0, 10); // not the power of 2
+        ASSERT_EQ(memory.m_data, nullptr);
+        ASSERT_EQ(memory.m_capacity, 0);
+        ASSERT_EQ(memory.m_size, 0);
+
+        EXPECT_THROW_ERROR_CODE(memory.resize(1), ErrnoException, ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+        ASSERT_EQ(memory.m_data, nullptr); // state is intact after exception
+        ASSERT_EQ(memory.m_capacity, 0);
+        ASSERT_EQ(memory.m_size, 0);
+    }
+
+    {
+        auto memory = Memory<>(0, 32);
+        ASSERT_EQ(memory.m_data, nullptr);
+        ASSERT_EQ(memory.m_capacity, 0);
+        ASSERT_EQ(memory.m_size, 0);
+
+        memory.resize(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 47);
+        ASSERT_EQ(memory.m_size, 1);
+
+        memory.resize(32);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 47);
+        ASSERT_EQ(memory.m_size, 32);
+    }
+}
+
+TEST(MemoryResizeTest, SomeAlignmentOverflowWhenAlignment)
+{
+    {
+        auto memory = Memory<DummyAllocator>(0, 31);
+        ASSERT_EQ(memory.m_data, nullptr);
+        ASSERT_EQ(memory.m_capacity, 0);
+        ASSERT_EQ(memory.m_size, 0);
+
+        memory.resize(0);
+        ASSERT_EQ(memory.m_data, nullptr);
+        ASSERT_EQ(memory.m_capacity, 0);
+        ASSERT_EQ(memory.m_size, 0);
+
+        memory.resize(1);
+        ASSERT_TRUE(memory.m_data);
+        ASSERT_EQ(memory.m_capacity, 46);
+        ASSERT_EQ(memory.m_size, 1);
+
+        EXPECT_THROW_ERROR_CODE(memory.resize(std::numeric_limits<size_t>::max()), Exception, ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+        ASSERT_TRUE(memory.m_data); // state is intact after exception
+        ASSERT_EQ(memory.m_capacity, 46);
+        ASSERT_EQ(memory.m_size, 1);
+    }
+
+}

--- a/src/IO/tests/gtest_memory_resize.cpp
+++ b/src/IO/tests/gtest_memory_resize.cpp
@@ -269,6 +269,7 @@ TEST(MemoryResizeTest, AlignmentWithRealAllocator)
         ASSERT_EQ(memory.m_size, 1);
     }
 
+#if !defined(ADDRESS_SANITIZER) && !defined(THREAD_SANITIZER) && !defined(MEMORY_SANITIZER) && !defined(UNDEFINED_BEHAVIOR_SANITIZER)
     {
         auto memory = Memory<>(0, 10); // not the power of 2
         ASSERT_EQ(memory.m_data, nullptr);
@@ -280,6 +281,7 @@ TEST(MemoryResizeTest, AlignmentWithRealAllocator)
         ASSERT_EQ(memory.m_capacity, 0);
         ASSERT_EQ(memory.m_size, 0);
     }
+#endif
 
     {
         auto memory = Memory<>(0, 32);

--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -46,7 +46,7 @@ HTTPServerRequest::HTTPServerRequest(ContextPtr context, HTTPServerResponse & re
     readRequest(*in);  /// Try parse according to RFC7230
 
     if (getChunkedTransferEncoding())
-        stream = std::make_unique<HTTPChunkedReadBuffer>(std::move(in));
+        stream = std::make_unique<HTTPChunkedReadBuffer>(std::move(in), context->getSettingsRef().http_max_chunk_size);
     else if (hasContentLength())
         stream = std::make_unique<LimitReadBuffer>(std::move(in), getContentLength(), false);
     else if (getMethod() != HTTPRequest::HTTP_GET && getMethod() != HTTPRequest::HTTP_HEAD && getMethod() != HTTPRequest::HTTP_DELETE)

--- a/tests/queries/0_stateless/02403_big_http_chunk_size.python
+++ b/tests/queries/0_stateless/02403_big_http_chunk_size.python
@@ -29,7 +29,6 @@ def main():
     lines = data.splitlines()
 
     print(lines.pop(0))
-    lines.pop(0)
 
     headers = {}
     for x in lines:

--- a/tests/queries/0_stateless/02403_big_http_chunk_size.python
+++ b/tests/queries/0_stateless/02403_big_http_chunk_size.python
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from socket import socket, AF_INET, SOCK_STREAM
+import os
+
+
+EXCEPTION_CODE_HEADER = "X-ClickHouse-Exception-Code"
+TRANSFER_ENCODING_HEADER = "Transfer-Encoding"
+
+
+def main():
+    host = os.environ['CLICKHOUSE_HOST']
+    port = int(os.environ['CLICKHOUSE_PORT_HTTP'])
+
+    sock = socket(AF_INET, SOCK_STREAM)
+    sock.connect((host, port))
+    sock.settimeout(5)
+    s = "POST /play HTTP/1.1\r\n"
+    s += "Host: %s\r\n" % host
+    s += "Content-type: multipart/form-data\r\n"
+    s += "Transfer-encoding: chunked\r\n"
+    s += "\r\n"
+    s += "ffffffffffffffff"
+    s += "\r\n"
+    s += "X" * 100000
+    sock.sendall(s.encode())
+    data = sock.recv(10000).decode()
+    sock.close()
+
+    lines = data.splitlines()
+
+    print(lines.pop(0))
+    lines.pop(0)
+
+    headers = {}
+    for x in lines:
+        x = x.strip()
+        if not x:
+            continue
+        tokens = x.split(":", 1)
+        if len(tokens) < 2:
+            continue
+        key, val = tokens
+        headers[key.strip()] = val.strip()
+
+    print("encoding type", headers[TRANSFER_ENCODING_HEADER])
+    print("error code", headers[EXCEPTION_CODE_HEADER])
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/queries/0_stateless/02403_big_http_chunk_size.reference
+++ b/tests/queries/0_stateless/02403_big_http_chunk_size.reference
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+encoding type chunked
+error code 1000

--- a/tests/queries/0_stateless/02403_big_http_chunk_size.sh
+++ b/tests/queries/0_stateless/02403_big_http_chunk_size.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# We should have correct env vars from shell_config.sh to run this test
+python3 "$CURDIR"/02403_big_http_chunk_size.python


### PR DESCRIPTION
02403_big_http_chunk_size -- test which make clickhouse crash.
Client sends data with chunked mode. It is up to client what to write to the chunks headers. Client is able to write there 2^64 us chunks size. Clickhouse parse chunks size from stream safely.  Chunks size is passed to the BufferWithOwnMemory::Memory::resize method. Integer overflow happens when Memory calculates how many bytes need to allocate, when padding is added. Turns out that Memory decided to allocate a few bytes when size was huge. After that HTTPChunkedReadBuffer writes a data after allocated memory.

I suggest to bound maximum chunk size which clickhouse accept. So there is new option http_max_chunk_size in the Setting with default value ~~32KB~~ 100G. Whatever implementation of Memory is used, Clickhouse should check the user input and rejects suspicious requests.
Also the implementation of class Memory have to be correct when big numbers are passed. If it is impossible, to add padding, then it throws exception instead wrong result.

In case when client sends chunk size bigger that value server just closes the connection. Unfortunately a client sees some generic exception without proper error message and code in that and similar cases. But server writes log with that event correctly with error log level.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This bug was found and send through ClickHouse bug-bounty [program](https://github.com/ClickHouse/ClickHouse/issues/38986) by *kiojj*.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
