### PR TITLE
Replace positional arguments with column names

### DIFF
--- a/docs/en/sql-reference/functions/array-join.md
+++ b/docs/en/sql-reference/functions/array-join.md
@@ -63,8 +63,8 @@ FROM
         ['Firefox', 'Chrome', 'Chrome'] AS browsers
 )
 GROUP BY
-    2,
-    3
+    city,
+    browser
 ```
 
 ``` text
@@ -98,8 +98,8 @@ ARRAY JOIN
     cities AS city,
     browsers AS browser
 GROUP BY
-    2,
-    3
+    city,
+    browser
 ```
 
 ``` text
@@ -126,8 +126,8 @@ FROM
         ['Firefox', 'Chrome', 'Chrome'] AS browsers
 )
 GROUP BY
-    2,
-    3
+    city,
+    browser
 ```
 
 ``` text


### PR DESCRIPTION
Although these examples work for recent versions of CH, it won't for older versions because in older versions, by default `enable_positional_arguments=0`.

It brings confusion to users. Therefore I've changed positinal arguments to actual column names so these samples codes can also run on older versions.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)