### PR TITLE
Provide missing documentation for `arrayWithConstant`

### DIFF
--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -162,6 +162,10 @@ Creates an array from the function arguments.
 The arguments must be constants and have types that have the smallest common type. At least one argument must be passed, because otherwise it isn’t clear which type of array to create. That is, you can’t use this function to create an empty array (to do that, use the ‘emptyArray\*’ function described above).
 Returns an ‘Array(T)’ type result, where ‘T’ is the smallest common type out of the passed arguments.
 
+## arrayWithConstant(length, elem)
+
+Creates an array of length `length` filled with the constant `elem`.
+
 ## arrayConcat
 
 Combines arrays passed as arguments.


### PR DESCRIPTION
Documentation of `arrayWithConstant(l, const)`-function, as this was not part of the documentation so far.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)
