### PR TITLE
Fix default value of enable_positional_arguments in documentation

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -3102,7 +3102,7 @@ Possible values:
 -   0 — Positional arguments aren't supported.
 -   1 — Positional arguments are supported: column numbers can use instead of column names.
 
-Default value: `0`.
+Default value: `1`.
 
 **Example**
 


### PR DESCRIPTION
Changelog category (leave one):
- Documentation (changelog entry is not required)