### PR TITLE
Fix bugs in MergeJoin when 'not_processed' is not null

### DIFF
--- a/src/Interpreters/MergeJoin.h
+++ b/src/Interpreters/MergeJoin.h
@@ -45,6 +45,7 @@ private:
     struct NotProcessed : public ExtraBlock
     {
         size_t left_position;
+        size_t left_key_tail;
         size_t right_position;
         size_t right_block;
     };
@@ -123,7 +124,8 @@ private:
 
     template <bool is_all>
     ExtraBlockPtr extraBlock(Block & processed, MutableColumns && left_columns, MutableColumns && right_columns,
-                             size_t left_position, size_t right_position, size_t right_block_number);
+                             size_t left_position, size_t left_key_tail, size_t right_position,
+                             size_t right_block_number);
 
     void mergeRightBlocks();
 


### PR DESCRIPTION
### Changelog category:
- Bug Fix


### Changelog entry:
Fix bugs in MergeJoin when 'not_processed' is not null.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
