### PR TITLE
split concurrent_threads_soft_limit setting into two

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -743,13 +743,24 @@ On hosts with low RAM and swap, you possibly need setting `max_server_memory_usa
 
 -   [max_server_memory_usage](#max_server_memory_usage)
 
-## concurrent_threads_soft_limit {#concurrent_threads_soft_limit}
-The maximum number of query processing threads, excluding threads for retrieving data from remote servers, allowed to run all queries. This is not a hard limit. In case if the limit is reached the query will still get one thread to run.
+## concurrent_threads_soft_limit_num {#concurrent_threads_soft_limit_num}
+The maximum number of query processing threads, excluding threads for retrieving data from remote servers, allowed to run all queries. This is not a hard limit. In case if the limit is reached the query will still get at least one thread to run. Query can upscale to desired number of threads during execution if more threads become available.
 
 Possible values:
+
 -   Positive integer.
 -   0 — No limit.
--   -1 — The parameter is initialized by number of logical cores multiplies by 3. Which is a good heuristic for CPU-bound tasks.
+
+Default value: `0`.
+
+## concurrent_threads_soft_limit_ratio_to_cores {#concurrent_threads_soft_limit_ratio_to_cores}
+The maximum number of query processing threads as multiple of number of logical cores.
+More details: [concurrent_threads_soft_limit_num](#concurrent-threads-soft-limit-num).
+
+Possible values:
+
+-   Positive integer.
+-   0 — No limit.
 
 Default value: `0`.
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1156,22 +1156,20 @@ int Server::main(const std::vector<std::string> & /*args*/)
             if (config->has("max_partition_size_to_drop"))
                 global_context->setMaxPartitionSizeToDrop(config->getUInt64("max_partition_size_to_drop"));
 
-            if (config->has("concurrent_threads_soft_limit"))
+            ConcurrencyControl::SlotCount concurrent_threads_soft_limit = ConcurrencyControl::Unlimited;
+            if (config->has("concurrent_threads_soft_limit_num"))
             {
-                auto concurrent_threads_soft_limit = config->getInt("concurrent_threads_soft_limit", 0);
-                if (concurrent_threads_soft_limit == -1)
-                {
-                    // Based on tests concurrent_threads_soft_limit has an optimal value when it's about 3 times of logical CPU cores
-                    constexpr size_t thread_factor = 3;
-                    concurrent_threads_soft_limit = std::thread::hardware_concurrency() * thread_factor;
-                }
-                if (concurrent_threads_soft_limit)
-                    ConcurrencyControl::instance().setMaxConcurrency(concurrent_threads_soft_limit);
-                else
-                    ConcurrencyControl::instance().setMaxConcurrency(ConcurrencyControl::Unlimited);
+                auto value = config->getInt("concurrent_threads_soft_limit_num", 0);
+                if (value > 0)
+                    concurrent_threads_soft_limit = std::min(concurrent_threads_soft_limit, value);
             }
-            else
-                ConcurrencyControl::instance().setMaxConcurrency(ConcurrencyControl::Unlimited);
+            if (config->has("concurrent_threads_soft_limit_ratio_to_cores"))
+            {
+                auto value = config->getInt("concurrent_threads_soft_limit_ratio_to_cores", 0) * std::thread::hardware_concurrency();
+                if (value > 0)
+                    concurrent_threads_soft_limit = std::min(concurrent_threads_soft_limit, value);
+            }
+            ConcurrencyControl::instance().setMaxConcurrency(concurrent_threads_soft_limit);
 
             if (config->has("max_concurrent_queries"))
                 global_context->getProcessList().setMaxSize(config->getInt("max_concurrent_queries", 0));

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1159,13 +1159,13 @@ int Server::main(const std::vector<std::string> & /*args*/)
             ConcurrencyControl::SlotCount concurrent_threads_soft_limit = ConcurrencyControl::Unlimited;
             if (config->has("concurrent_threads_soft_limit_num"))
             {
-                auto value = config->getInt("concurrent_threads_soft_limit_num", 0);
+                auto value = config->getUInt64("concurrent_threads_soft_limit_num", 0);
                 if (value > 0)
                     concurrent_threads_soft_limit = std::min(concurrent_threads_soft_limit, value);
             }
             if (config->has("concurrent_threads_soft_limit_ratio_to_cores"))
             {
-                auto value = config->getInt("concurrent_threads_soft_limit_ratio_to_cores", 0) * std::thread::hardware_concurrency();
+                auto value = config->getUInt64("concurrent_threads_soft_limit_ratio_to_cores", 0) * std::thread::hardware_concurrency();
                 if (value > 0)
                     concurrent_threads_soft_limit = std::min(concurrent_threads_soft_limit, value);
             }

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1160,14 +1160,14 @@ int Server::main(const std::vector<std::string> & /*args*/)
             if (config->has("concurrent_threads_soft_limit_num"))
             {
                 auto value = config->getUInt64("concurrent_threads_soft_limit_num", 0);
-                if (value > 0)
-                    concurrent_threads_soft_limit = std::min(concurrent_threads_soft_limit, value);
+                if (value > 0 && value < concurrent_threads_soft_limit)
+                    concurrent_threads_soft_limit = value;
             }
             if (config->has("concurrent_threads_soft_limit_ratio_to_cores"))
             {
                 auto value = config->getUInt64("concurrent_threads_soft_limit_ratio_to_cores", 0) * std::thread::hardware_concurrency();
-                if (value > 0)
-                    concurrent_threads_soft_limit = std::min(concurrent_threads_soft_limit, value);
+                if (value > 0 && value < concurrent_threads_soft_limit)
+                    concurrent_threads_soft_limit = value;
             }
             ConcurrencyControl::instance().setMaxConcurrency(concurrent_threads_soft_limit);
 

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -281,12 +281,12 @@
     <http_server_default_response><![CDATA[<html ng-app="SMI2"><head><base href="http://ui.tabix.io/"></head><body><div ui-view="" class="content-ui"></div><script src="http://loader.tabix.io/master.js"></script></body></html>]]></http_server_default_response>
     -->
 
-    <!-- Maximum number of query processing threads to run all queries.
-         Note that This is not a hard limit. In case if the limit is reached the query will still get one thread to run.
-         For value equals to -1 this parameter is initialized by number of logical cores multiplies by 3.
-         Which is a good heuristic for CPU-bound tasks.
+    <!-- The maximum number of query processing threads, excluding threads for retrieving data from remote servers, allowed to run all queries.
+         This is not a hard limit. In case if the limit is reached the query will still get at least one thread to run.
+         Query can upscale to desired number of threads during execution if more threads become available.
     -->
-    <concurrent_threads_soft_limit>0</concurrent_threads_soft_limit>
+    <concurrent_threads_soft_limit_num>0</concurrent_threads_soft_limit_num>
+    <concurrent_threads_soft_limit_ratio_to_cores>0</concurrent_threads_soft_limit_ratio_to_cores>
 
     <!-- Maximum number of concurrent queries. -->
     <max_concurrent_queries>100</max_concurrent_queries>

--- a/tests/integration/test_concurrent_threads_soft_limit/configs/config_defined_1.xml
+++ b/tests/integration/test_concurrent_threads_soft_limit/configs/config_defined_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <clickhouse>
-    <concurrent_threads_soft_limit>1</concurrent_threads_soft_limit>
+    <concurrent_threads_soft_limit_num>1</concurrent_threads_soft_limit_num>
     <query_log>
       <database>system</database>
       <table>query_log</table>

--- a/tests/integration/test_concurrent_threads_soft_limit/configs/config_defined_50.xml
+++ b/tests/integration/test_concurrent_threads_soft_limit/configs/config_defined_50.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <clickhouse>
-    <concurrent_threads_soft_limit>50</concurrent_threads_soft_limit>
+    <concurrent_threads_soft_limit_num>50</concurrent_threads_soft_limit_num>
     <query_log>
       <database>system</database>
       <table>query_log</table>

--- a/tests/integration/test_concurrent_threads_soft_limit/configs/config_limit_reached.xml
+++ b/tests/integration/test_concurrent_threads_soft_limit/configs/config_limit_reached.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <clickhouse>
-    <concurrent_threads_soft_limit>10</concurrent_threads_soft_limit>
+    <concurrent_threads_soft_limit_num>10</concurrent_threads_soft_limit_num>
     <query_log>
       <database>system</database>
       <table>query_log</table>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
