### PR TITLE
And the last tiny fix for assignees

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -213,7 +213,7 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
             )
             self.cherrypick_pr.add_to_assignees(*self.pr.assignees)
         logging.info("Assign to the author of the original PR: %s", self.pr.user.login)
-        self.cherrypick_pr.add_to_assignees(*self.pr.user)
+        self.cherrypick_pr.add_to_assignees(self.pr.user)
 
     def create_backport(self):
         # Checkout the backport branch from the remote and make all changes to
@@ -251,7 +251,7 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
             )
             self.cherrypick_pr.add_to_assignees(*self.pr.assignees)
         logging.info("Assign to the author of the original PR: %s", self.pr.user.login)
-        self.backport_pr.add_to_assignees(*self.pr.user)
+        self.backport_pr.add_to_assignees(self.pr.user)
 
     @property
     def backported(self) -> bool:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Follow up for #40367. The `pr.user` is not iterable and causes issue