### PR TITLE
Suppress "Cannot find column <subquery> in ActionsDAG result"

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -1194,7 +1194,7 @@ ActionsDAGPtr ActionsDAG::merge(ActionsDAG && first, ActionsDAG && second)
             if (it == first_result.end() || it->second.empty())
             {
                 if (first.project_input)
-                    throw Exception(ErrorCodes::LOGICAL_ERROR,
+                    throw Exception(ErrorCodes::UNKNOWN_IDENTIFIER,
                                     "Cannot find column {} in ActionsDAG result", input_node->result_name);
 
                 first.inputs.push_back(input_node);


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://github.com/ClickHouse/ClickHouse/issues/39857 is top 1 reason of Stress Tests failures for about 2 weeks already, let's suppress it

cc: @KochetovNicolai 