### PR TITLE
use input token instead of env var

### DIFF
--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -53,10 +53,9 @@ jobs:
         git diff HEAD
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.ROBOT_CLICKHOUSE_COMMIT_TOKEN }}
       with:
         author: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
+        token: ${{ secrets.ROBOT_CLICKHOUSE_COMMIT_TOKEN }}
         committer: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
         commit-message: Update version_date.tsv and changelogs after ${{ env.GITHUB_TAG }}
         branch: auto/${{ env.GITHUB_TAG }}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#40067 second attempt