### PR TITLE
Self-extracting: add --exec param, allow compressed to be renamed

### DIFF
--- a/utils/self-extracting-executable/compressor.cpp
+++ b/utils/self-extracting-executable/compressor.cpp
@@ -287,6 +287,7 @@ int compressFiles(const char* out_name, const char* exec, char* filenames[], int
         size_t nlen = strlen(names[i]) + 1;
         files_data[i].name_length = htole64(nlen);
         sum_file_size += nlen;
+        /// if no --exec is specified nor it's empty - file which is matching output name is executable
         if (!is_exec && !exec && strcmp(names[i], out_name) == 0)
             files_data[i].exec = true;
 

--- a/utils/self-extracting-executable/compressor.cpp
+++ b/utils/self-extracting-executable/compressor.cpp
@@ -444,7 +444,7 @@ inline void usage(FILE * out, const char * name)
         "\t--decompressor - path to decompressor\n"
         "\t--exec - path to an input file to execute after decompression, if omitted then\n"
         "\t         an <input_file> having the same name as <output_file> becomes such executable.\n"
-        "\t         This executable uppon decompression will substitute started compressed preserving compressed name.\n",
+        "\t         This executable upon decompression will substitute started compressed preserving compressed name.\n",
         name, ZSTD_maxCLevel());
 }
 

--- a/utils/self-extracting-executable/compressor.cpp
+++ b/utils/self-extracting-executable/compressor.cpp
@@ -444,7 +444,7 @@ inline void usage(FILE * out, const char * name)
         "\t--decompressor - path to decompressor\n"
         "\t--exec - path to an input file to execute after decompression, if omitted then\n"
         "\t         an <input_file> having the same name as <output_file> becomes such executable.\n"
-        "\t         This executable uppon decompression will substitute started compressed preserving compressed name.",
+        "\t         This executable uppon decompression will substitute started compressed preserving compressed name.\n",
         name, ZSTD_maxCLevel());
 }
 

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -226,8 +226,7 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
         file_info = *reinterpret_cast<FileData*>(input + files_pointer);
         files_pointer += sizeof(FileData);
 
-        size_t file_name_len =
-            (strcmp(input + files_pointer, name) ? le64toh(file_info.name_length) : le64toh(file_info.name_length) + 13 + 7);
+        size_t file_name_len = file_info.exec ? strlen(name) + 13 + 7 : le64toh(file_info.name_length);
 
         size_t file_path_len = path ? strlen(path) + 1 + file_name_len : file_name_len;
 
@@ -238,9 +237,9 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
             strcat(file_name, path);
             strcat(file_name, "/");
         }
-        strcat(file_name, input + files_pointer);
+        strcat(file_name, file_info.exec ? name : input + files_pointer);
         files_pointer += le64toh(file_info.name_length);
-        if (file_name_len != le64toh(file_info.name_length))
+        if (file_info.exec)
         {
             strcat(file_name, ".decompressed.XXXXXX");
             int fd = mkstemp(file_name);

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -226,7 +226,7 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
         file_info = *reinterpret_cast<FileData*>(input + files_pointer);
         files_pointer += sizeof(FileData);
 
-        size_t file_name_len = file_info.exec ? strlen(name) + 13 + 7 : le64toh(file_info.name_length);
+        size_t file_name_len = file_info.exec ? strlen(name) + 13 + 7 + 1 : le64toh(file_info.name_length);
 
         size_t file_path_len = path ? strlen(path) + 1 + file_name_len : file_name_len;
 

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -226,6 +226,7 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
         file_info = *reinterpret_cast<FileData*>(input + files_pointer);
         files_pointer += sizeof(FileData);
 
+        /// for output filename matching compressed allow additional 13 + 7 symbols for ".decompressed.XXXXXX" suffix
         size_t file_name_len = file_info.exec ? strlen(name) + 13 + 7 + 1 : le64toh(file_info.name_length);
 
         size_t file_path_len = path ? strlen(path) + 1 + file_name_len : file_name_len;

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -440,7 +440,7 @@ int main(int/* argc*/, char* argv[])
             return 1;
         }
 
-        if(has_exec)
+        if (has_exec)
         {
             execv(self, argv);
 

--- a/utils/self-extracting-executable/types.h
+++ b/utils/self-extracting-executable/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -43,5 +44,6 @@ struct FileData
     uint64_t name_length       = 0;
     uint64_t uncompressed_size = 0;
     uint64_t umask             = 0;
+    bool     exec              = false;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

New parameter --exec for compressor allows to explicitly specify executable to be executed upon decompression. Compressed executable can have different name than one selected for execution, and running executable will replace compressed under its name - this also allows for compressed executable to be renamed.