### PR TITLE
fix clickhouse-client backslash_cmd bug in multiline mode.

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1984,7 +1984,7 @@ void ClientBase::runInteractive()
     }
 
     LineReader::Patterns query_extenders = {"\\"};
-    LineReader::Patterns query_delimiters = {";", "\\G", "\\G;"};
+    LineReader::Patterns query_delimiters = {";", "\\G", "\\G;", "\\l", "\\d", "\\q", "\\Q"};
 
 #if USE_REPLXX
     replxx::Replxx::highlighter_callback_t highlight_callback{};

--- a/src/Parsers/Lexer.cpp
+++ b/src/Parsers/Lexer.cpp
@@ -350,7 +350,7 @@ Token Lexer::nextTokenImpl()
         case '\\':
         {
             ++pos;
-            if (pos < end && *pos == 'G')
+            if (pos < end && (*pos == 'G' || *pos == 'd' || *pos == 'l' || *pos == 'q' || *pos == 'Q'))
                 return Token(TokenType::VerticalDelimiter, token_begin, ++pos);
             return Token(TokenType::Error, token_begin, pos);
         }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix clickhouse-client backslash_cmd bug in multiline mode.
1. Contains \l \d \q \Q commands.



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
