### PR TITLE
Fix bug in settings input_format_tsv_skip_first_lines of format TSV

### DIFF
--- a/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TabSeparatedRowInputFormat.cpp
@@ -240,7 +240,7 @@ void TabSeparatedFormatReader::checkNullValueForNonNullable(DataTypePtr type)
 
 void TabSeparatedFormatReader::skipPrefixBeforeHeader()
 {
-    for (size_t i = 0; i != format_settings.csv.skip_first_lines; ++i)
+    for (size_t i = 0; i != format_settings.tsv.skip_first_lines; ++i)
         readRow();
 }
 

--- a/tests/queries/0_stateless/02314_csv_tsv_skip_first_lines.sql
+++ b/tests/queries/0_stateless/02314_csv_tsv_skip_first_lines.sql
@@ -7,6 +7,6 @@ select * from file(data_02314.csv) settings input_format_csv_skip_first_lines=5;
 
 insert into function file(data_02314.tsv) select number, number + 1 from numbers(5) settings engine_file_truncate_on_insert=1;
 insert into function file(data_02314.tsv) select number, number + 1, number + 2 from numbers(5);
-desc file(data_02314.tsv) settings input_format_csv_skip_first_lines=5;
-select * from file(data_02314.tsv) settings input_format_csv_skip_first_lines=5;
+desc file(data_02314.tsv) settings input_format_tsv_skip_first_lines=5;
+select * from file(data_02314.tsv) settings input_format_tsv_skip_first_lines=5;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix settings input_format_tsv_skip_first_lines


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

cc: @Avogar, @antonio2368