### PR TITLE
Use sorting for full_sorting_merge join

### DIFF
--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -58,6 +58,25 @@ bool SortDescription::hasPrefix(const SortDescription & prefix) const
     return true;
 }
 
+bool SortDescription::hasPrefix(const Names & prefix) const
+{
+    if (prefix.size() > size())
+        return false;
+
+    SortDescription prefix_desc;
+    for (size_t i = 0; i < prefix.size(); ++i)
+        prefix_desc.emplace_back(prefix[i], this->at(i).direction, this->at(i).nulls_direction);
+    return this->hasPrefix(prefix_desc);
+}
+
+Names SortDescription::getColumnNames() const
+{
+    Names res;
+    for (const auto & column : *this)
+        res.push_back(column.column_name);
+    return res;
+}
+
 #if USE_EMBEDDED_COMPILER
 
 static CHJIT & getJITInstance()

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -58,17 +58,6 @@ bool SortDescription::hasPrefix(const SortDescription & prefix) const
     return true;
 }
 
-bool SortDescription::hasPrefix(const Names & prefix) const
-{
-    if (prefix.size() > size())
-        return false;
-
-    SortDescription prefix_desc;
-    for (size_t i = 0; i < prefix.size(); ++i)
-        prefix_desc.emplace_back(prefix[i], this->at(i).direction, this->at(i).nulls_direction);
-    return this->hasPrefix(prefix_desc);
-}
-
 Names SortDescription::getColumnNames() const
 {
     Names res;

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -40,10 +40,16 @@ struct FillColumnDescription
 /// Description of the sorting rule by one column.
 struct SortColumnDescription
 {
+    /// Ascending: 1
+    /// Descending: -1
+    using Direction = int;
+
     std::string column_name; /// The name of the column.
-    int direction;           /// 1 - ascending, -1 - descending.
-    int nulls_direction;     /// 1 - NULLs and NaNs are greater, -1 - less.
-                             /// To achieve NULLS LAST, set it equal to direction, to achieve NULLS FIRST, set it opposite.
+
+    Direction direction;
+    /// To achieve NULLS LAST, set nulls_direction equal to direction, to achieve NULLS FIRST, set it opposite.
+    Direction nulls_direction;
+
     std::shared_ptr<Collator> collator; /// Collator for locale-specific comparison of strings
     bool with_fill;
     FillColumnDescription fill_description;
@@ -121,6 +127,10 @@ public:
     bool compile_sort_description = false;
 
     bool hasPrefix(const SortDescription & prefix) const;
+    /// Check prefix without considering direction
+    bool hasPrefix(const Names & prefix) const;
+
+    Names getColumnNames() const;
 };
 
 /** Compile sort description for header_types.

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -89,6 +89,11 @@ struct SortColumnDescription
         return !(*this == other);
     }
 
+    bool isDefaultDirection() const
+    {
+        return direction == 1 && nulls_direction == 1;
+    }
+
     std::string dump() const { return fmt::format("{}:dir {}nulls {}", column_name, direction, nulls_direction); }
 
     void explain(JSONBuilder::JSONMap & map) const;

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -2001,22 +2001,22 @@ static bool isColumnSortingPreserved(const ActionsDAG::Node * start_node, const 
 }
 
 bool ActionsDAG::isSortingPreserved(
-    const Block & input_header, const SortDescription & sort_description, const String & ignore_output_column) const
+    const Block & input_header, const Names & sort_column_names, const String & ignore_output_column) const
 {
-    if (sort_description.empty())
+    if (sort_column_names.empty())
         return true;
 
     if (hasArrayJoin())
         return false;
 
     const Block & output_header = updateHeader(input_header);
-    for (const auto & desc : sort_description)
+    for (const auto & column_name : sort_column_names)
     {
         /// header contains column with the same name
-        if (output_header.findByName(desc.column_name))
+        if (output_header.findByName(column_name))
         {
             /// find the corresponding node in output
-            const auto * output_node = tryFindInOutputs(desc.column_name);
+            const auto * output_node = tryFindInOutputs(column_name);
             if (!output_node)
             {
                 /// sorted column name in header but NOT in expression output -> no expression is applied to it -> sorting preserved
@@ -2031,7 +2031,7 @@ bool ActionsDAG::isSortingPreserved(
             if (output_node->result_name == ignore_output_column)
                 continue;
 
-            if (isColumnSortingPreserved(output_node, desc.column_name))
+            if (isColumnSortingPreserved(output_node, column_name))
             {
                 preserved = true;
                 break;

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -2001,22 +2001,22 @@ static bool isColumnSortingPreserved(const ActionsDAG::Node * start_node, const 
 }
 
 bool ActionsDAG::isSortingPreserved(
-    const Block & input_header, const Names & sort_column_names, const String & ignore_output_column) const
+    const Block & input_header, const SortDescription & sort_description, const String & ignore_output_column) const
 {
-    if (sort_column_names.empty())
+    if (sort_description.empty())
         return true;
 
     if (hasArrayJoin())
         return false;
 
     const Block & output_header = updateHeader(input_header);
-    for (const auto & column_name : sort_column_names)
+    for (const auto & desc : sort_description)
     {
         /// header contains column with the same name
-        if (output_header.findByName(column_name))
+        if (output_header.findByName(desc.column_name))
         {
             /// find the corresponding node in output
-            const auto * output_node = tryFindInOutputs(column_name);
+            const auto * output_node = tryFindInOutputs(desc.column_name);
             if (!output_node)
             {
                 /// sorted column name in header but NOT in expression output -> no expression is applied to it -> sorting preserved
@@ -2031,7 +2031,7 @@ bool ActionsDAG::isSortingPreserved(
             if (output_node->result_name == ignore_output_column)
                 continue;
 
-            if (isColumnSortingPreserved(output_node, column_name))
+            if (isColumnSortingPreserved(output_node, desc.column_name))
             {
                 preserved = true;
                 break;

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -316,7 +316,7 @@ public:
         const ColumnsWithTypeAndName & all_inputs);
 
     bool
-    isSortingPreserved(const Block & input_header, const SortDescription & sort_description, const String & ignore_output_column = "") const;
+    isSortingPreserved(const Block & input_header, const Names & sort_column_names, const String & ignore_output_column = "") const;
 
 private:
     Node & addNode(Node node);

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -316,7 +316,7 @@ public:
         const ColumnsWithTypeAndName & all_inputs);
 
     bool
-    isSortingPreserved(const Block & input_header, const Names & sort_column_names, const String & ignore_output_column = "") const;
+    isSortingPreserved(const Block & input_header, const SortDescription & sort_description, const String & ignore_output_column = "") const;
 
 private:
     Node & addNode(Node node);

--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -36,8 +36,8 @@ static UInt32 toPowerOfTwo(UInt32 x)
 }
 
 ConcurrentHashJoin::ConcurrentHashJoin(ContextPtr context_, std::shared_ptr<TableJoin> table_join_, size_t slots_, const Block & right_sample_block, bool any_take_last_row_)
-    : context(context_)
-    , table_join(table_join_)
+    : IJoin(table_join_)
+    , context(context_)
     , slots(toPowerOfTwo(std::min<size_t>(slots_, 256)))
 {
     for (size_t i = 0; i < slots; ++i)
@@ -121,11 +121,6 @@ void ConcurrentHashJoin::setTotals(const Block & block)
         std::lock_guard lock(totals_mutex);
         totals = block;
     }
-}
-
-const Block & ConcurrentHashJoin::getTotals() const
-{
-    return totals;
 }
 
 size_t ConcurrentHashJoin::getTotalRowCount() const

--- a/src/Interpreters/ConcurrentHashJoin.h
+++ b/src/Interpreters/ConcurrentHashJoin.h
@@ -37,12 +37,10 @@ public:
     explicit ConcurrentHashJoin(ContextPtr context_, std::shared_ptr<TableJoin> table_join_, size_t slots_, const Block & right_sample_block, bool any_take_last_row_ = false);
     ~ConcurrentHashJoin() override = default;
 
-    const TableJoin & getTableJoin() const override { return *table_join; }
     bool addJoinedBlock(const Block & block, bool check_limits) override;
     void checkTypesOfKeys(const Block & block) const override;
     void joinBlock(Block & block, std::shared_ptr<ExtraBlock> & not_processed) override;
     void setTotals(const Block & block) override;
-    const Block & getTotals() const override;
     size_t getTotalRowCount() const override;
     size_t getTotalByteCount() const override;
     bool alwaysReturnsEmptySet() const override;
@@ -58,12 +56,10 @@ private:
     };
 
     ContextPtr context;
-    std::shared_ptr<TableJoin> table_join;
     size_t slots;
     std::vector<std::shared_ptr<InternalHashJoin>> hash_joins;
 
     std::mutex totals_mutex;
-    Block totals;
 
     IColumn::Selector selectDispatchBlock(const Strings & key_columns_names, const Block & from_block);
     Blocks dispatchBlock(const Strings & key_columns_names, const Block & from_block);

--- a/src/Interpreters/DirectJoin.cpp
+++ b/src/Interpreters/DirectJoin.cpp
@@ -64,7 +64,7 @@ static MutableColumns convertBlockStructure(
 DirectKeyValueJoin::DirectKeyValueJoin(std::shared_ptr<TableJoin> table_join_,
                                        const Block & right_sample_block_,
                                        std::shared_ptr<const IKeyValueEntity> storage_)
-    : table_join(table_join_)
+    : IJoin(table_join_)
     , storage(storage_)
     , right_sample_block(right_sample_block_)
     , log(&Poco::Logger::get("DirectKeyValueJoin"))

--- a/src/Interpreters/DirectJoin.h
+++ b/src/Interpreters/DirectJoin.h
@@ -25,8 +25,6 @@ public:
         const Block & right_sample_block_,
         std::shared_ptr<const IKeyValueEntity> storage_);
 
-    virtual const TableJoin & getTableJoin() const override { return *table_join; }
-
     virtual bool addJoinedBlock(const Block &, bool) override;
     virtual void checkTypesOfKeys(const Block &) const override;
 
@@ -49,7 +47,6 @@ public:
     }
 
 private:
-    std::shared_ptr<TableJoin> table_join;
     std::shared_ptr<const IKeyValueEntity> storage;
     Block right_sample_block;
     Block sample_block_with_columns_to_add;

--- a/src/Interpreters/ExpressionAnalyzer.h
+++ b/src/Interpreters/ExpressionAnalyzer.h
@@ -228,7 +228,7 @@ struct ExpressionAnalysisResult
     bool remove_where_filter = false;
     bool optimize_read_in_order = false;
     bool optimize_aggregation_in_order = false;
-    bool join_has_delayed_stream = false;
+    Names optimize_join_in_order;
 
     bool use_grouping_set_key = false;
 
@@ -361,6 +361,7 @@ public:
     /// Create Set-s that we make from IN section to use index on them.
     void makeSetsForIndex(const ASTPtr & node);
 
+    const SelectQueryOptions & getOptions() const { return query_options; }
 private:
     StorageMetadataPtr metadata_snapshot;
     /// If non-empty, ignore all expressions not from this list.

--- a/src/Interpreters/FullSortingMergeJoin.cpp
+++ b/src/Interpreters/FullSortingMergeJoin.cpp
@@ -4,70 +4,74 @@
 namespace DB
 {
 
-namespace
+static std::unordered_map<String, size_t> getSortIndexes(const DataStream & data_stream, const NameSet & key_names)
 {
-
-SortDescription getSortDescription(const DataStream & data_stream, const Names & key_names)
-{
-    SortDescription sort_descr;
+    UNUSED(key_names);
+    std::unordered_map<String, size_t> sort_indexes;
     if (data_stream.sort_mode >= DataStream::SortMode::Port)
     {
-        std::unordered_map<String, SortColumnDescription> sort_columns_map;
-        for (const auto & desc : data_stream.sort_description)
-            sort_columns_map.emplace(desc.column_name, desc);
-
-        /// Use prefix of current sorting as much as possible
-        for (const auto & key_name : key_names)
+        for (size_t i = 0; i < data_stream.sort_description.size(); ++i)
         {
-            if (auto desc = sort_columns_map.find(key_name); desc != sort_columns_map.end())
-                sort_descr.emplace_back(desc->second);
-            else
+            const auto & desc = data_stream.sort_description[i];
+            if (!desc.isDefaultDirection() || !key_names.contains(desc.column_name))
                 break;
+            sort_indexes[desc.column_name] = i;
         }
     }
-    return sort_descr;
+    return sort_indexes;
 }
 
+static size_t getIdxFromNameMap(const std::unordered_map<String, size_t> & indexes, const String & name)
+{
+    auto it = indexes.find(name);
+    /// If key not found, use the maximal possible value
+    if (it == indexes.end())
+        return indexes.size();
+    return it->second;
 }
 
-void FullSortingMergeJoin::getSortDescriptions(
+/* Use existing sorting as much as possible, and still need to keep correspondence between keys.
+ * A query can have keys in any order in ON or USING expression.
+ *
+ * Example:
+ * `JOIN ON t1.a2 = t2.b3 AND t1.a1 = t2.b1 AND t1.a5 = t2.b4 AND t1.a1 = t2.b2 AND t1.a4 = t2.b3`
+ * Assume we have streams sorted by `(a1, a2, a3, a4, a5)` and `(b1, b2, b3, b4)`
+ * We want to put keys into the result in the same order.
+ * So, the join keys would be `[<a1, b1>, <a1, b2>, <a2, b3>, <a4, b3>, <a5, b4>]`
+ * It would use sort prefixes `(a1, a2)` and `(b1, b2, b3, b4)`.
+ *
+ * Only ascending and direction can be used (because the current implementation of merge join expects it).
+ */
+void FullSortingMergeJoin::deduceSortDescriptions(
     const DataStream & left_data_stream, const Names & left_key_names,
     const DataStream & right_data_stream, const Names & right_key_names,
     SortDescription & left_sort_descr, SortDescription & right_sort_descr)
 {
     assert(left_key_names.size() == right_key_names.size());
+    size_t keys_size = left_key_names.size();
 
-    left_sort_descr = getSortDescription(left_data_stream, left_key_names);
-    right_sort_descr = getSortDescription(right_data_stream, right_key_names);
 
-    /// Use common directions
-    size_t n = std::max(left_sort_descr.size(), right_sort_descr.size());
-    for (size_t pos = 0; pos < n; ++pos)
+    /// Collect positions in the sort description for each key.
+    const auto & left_indexes = getSortIndexes(left_data_stream, NameSet(left_key_names.begin(), left_key_names.end()));
+    const auto & right_indexes = getSortIndexes(right_data_stream, NameSet(right_key_names.begin(), right_key_names.end()));
+
+    std::vector<std::pair<String, String>> keys;
+    for (size_t i = 0; i < keys_size; ++i)
+        keys.emplace_back(left_key_names[i], right_key_names[i]);
+
+    /// Sort keys pairwise according to the order in the sorting prefix.
+    std::stable_sort(keys.begin(), keys.end(), [&left_indexes, &right_indexes](const auto & key1, const auto & key2)
     {
-        if (left_sort_descr.size() <= pos)
-        {
-            left_sort_descr.emplace_back(left_key_names[pos], right_sort_descr[pos].direction, right_sort_descr[pos].nulls_direction);
-        }
-        else if (right_sort_descr.size() <= pos)
-        {
-            right_sort_descr.emplace_back(right_key_names[pos], left_sort_descr[pos].direction, left_sort_descr[pos].nulls_direction);
-        }
-        else
-        {
-            /// If both are sorted by same prefix by in different directions, then we can use one of them and resort another one
-            left_sort_descr[pos].direction = right_sort_descr[pos].direction;
-            left_sort_descr[pos].nulls_direction = right_sort_descr[pos].nulls_direction;
-        }
+        if (getIdxFromNameMap(left_indexes, key1.first) < getIdxFromNameMap(left_indexes, key2.first))
+            return true;
+        return getIdxFromNameMap(right_indexes, key1.second) < getIdxFromNameMap(right_indexes, key2.second);
+    });
+
+    for (const auto & key : keys)
+    {
+        left_sort_descr.emplace_back(key.first);
+        right_sort_descr.emplace_back(key.second);
     }
-
-    /// Not sorted by all keys, add rest of them
-
-    for (size_t pos = left_sort_descr.size(); pos < left_key_names.size(); ++pos)
-        left_sort_descr.emplace_back(left_key_names[pos]);
-
-    for (size_t pos = right_sort_descr.size(); pos < right_key_names.size(); ++pos)
-        right_sort_descr.emplace_back(right_key_names[pos]);
 }
-
 
 }

--- a/src/Interpreters/FullSortingMergeJoin.cpp
+++ b/src/Interpreters/FullSortingMergeJoin.cpp
@@ -1,0 +1,73 @@
+#include <Interpreters/FullSortingMergeJoin.h>
+#include <Processors/QueryPlan/IQueryPlanStep.h>
+
+namespace DB
+{
+
+namespace
+{
+
+SortDescription getSortDescription(const DataStream & data_stream, const Names & key_names)
+{
+    SortDescription sort_descr;
+    if (data_stream.sort_mode >= DataStream::SortMode::Port)
+    {
+        std::unordered_map<String, SortColumnDescription> sort_columns_map;
+        for (const auto & desc : data_stream.sort_description)
+            sort_columns_map.emplace(desc.column_name, desc);
+
+        /// Use prefix of current sorting as much as possible
+        for (const auto & key_name : key_names)
+        {
+            if (auto desc = sort_columns_map.find(key_name); desc != sort_columns_map.end())
+                sort_descr.emplace_back(desc->second);
+            else
+                break;
+        }
+    }
+    return sort_descr;
+}
+
+}
+
+void FullSortingMergeJoin::getSortDescriptions(
+    const DataStream & left_data_stream, const Names & left_key_names,
+    const DataStream & right_data_stream, const Names & right_key_names,
+    SortDescription & left_sort_descr, SortDescription & right_sort_descr)
+{
+    assert(left_key_names.size() == right_key_names.size());
+
+    left_sort_descr = getSortDescription(left_data_stream, left_key_names);
+    right_sort_descr = getSortDescription(right_data_stream, right_key_names);
+
+    /// Use common directions
+    size_t n = std::max(left_sort_descr.size(), right_sort_descr.size());
+    for (size_t pos = 0; pos < n; ++pos)
+    {
+        if (left_sort_descr.size() <= pos)
+        {
+            left_sort_descr.emplace_back(left_key_names[pos], right_sort_descr[pos].direction, right_sort_descr[pos].nulls_direction);
+        }
+        else if (right_sort_descr.size() <= pos)
+        {
+            right_sort_descr.emplace_back(right_key_names[pos], left_sort_descr[pos].direction, left_sort_descr[pos].nulls_direction);
+        }
+        else
+        {
+            /// If both are sorted by same prefix by in different directions, then we can use one of them and resort another one
+            left_sort_descr[pos].direction = right_sort_descr[pos].direction;
+            left_sort_descr[pos].nulls_direction = right_sort_descr[pos].nulls_direction;
+        }
+    }
+
+    /// Not sorted by all keys, add rest of them
+
+    for (size_t pos = left_sort_descr.size(); pos < left_key_names.size(); ++pos)
+        left_sort_descr.emplace_back(left_key_names[pos]);
+
+    for (size_t pos = right_sort_descr.size(); pos < right_key_names.size(); ++pos)
+        right_sort_descr.emplace_back(right_key_names[pos]);
+}
+
+
+}

--- a/src/Interpreters/FullSortingMergeJoin.cpp
+++ b/src/Interpreters/FullSortingMergeJoin.cpp
@@ -6,9 +6,8 @@ namespace DB
 
 static std::unordered_map<String, size_t> getSortIndexes(const DataStream & data_stream, const NameSet & key_names)
 {
-    UNUSED(key_names);
     std::unordered_map<String, size_t> sort_indexes;
-    if (data_stream.sort_mode >= DataStream::SortMode::Port)
+    if (data_stream.sort_scope >= DataStream::SortScope::Stream)
     {
         for (size_t i = 0; i < data_stream.sort_description.size(); ++i)
         {
@@ -30,26 +29,34 @@ static size_t getIdxFromNameMap(const std::unordered_map<String, size_t> & index
     return it->second;
 }
 
-/* Use existing sorting as much as possible, and still need to keep correspondence between keys.
+/*
+ * Reorder join keys to use existing sorting as much as possible keeping correspondence between keys.
  * A query can have keys in any order in ON or USING expression.
  *
  * Example:
- * `JOIN ON t1.a2 = t2.b3 AND t1.a1 = t2.b1 AND t1.a5 = t2.b4 AND t1.a1 = t2.b2 AND t1.a4 = t2.b3`
+ * ```
+ * SELECT ... JOIN ... ON
+ *   t1.a1 = t2.b1 AND
+ *   t1.a1 = t2.b2 AND
+ *   t1.a2 = t2.b3 AND
+ *   t1.a4 = t2.b3 AND
+ *   t1.a5 = t2.b4
+ * ```
  * Assume we have streams sorted by `(a1, a2, a3, a4, a5)` and `(b1, b2, b3, b4)`
  * We want to put keys into the result in the same order.
- * So, the join keys would be `[<a1, b1>, <a1, b2>, <a2, b3>, <a4, b3>, <a5, b4>]`
+ * So, the join keys would be `(a1, a1, a2, a4, a5)` and `(b1, b2, b3, b3, b4)`
  * It would use sort prefixes `(a1, a2)` and `(b1, b2, b3, b4)`.
  *
  * Only ascending and direction can be used (because the current implementation of merge join expects it).
  */
-void FullSortingMergeJoin::deduceSortDescriptions(
-    const DataStream & left_data_stream, const Names & left_key_names,
-    const DataStream & right_data_stream, const Names & right_key_names,
-    SortDescription & left_sort_descr, SortDescription & right_sort_descr)
+void FullSortingMergeJoin::reorderJoinKeysUseSort(
+    const DataStream & left_data_stream,
+    const DataStream & right_data_stream,
+    Names & left_key_names,
+    Names & right_key_names)
 {
     assert(left_key_names.size() == right_key_names.size());
     size_t keys_size = left_key_names.size();
-
 
     /// Collect positions in the sort description for each key.
     const auto & left_indexes = getSortIndexes(left_data_stream, NameSet(left_key_names.begin(), left_key_names.end()));
@@ -57,7 +64,7 @@ void FullSortingMergeJoin::deduceSortDescriptions(
 
     std::vector<std::pair<String, String>> keys;
     for (size_t i = 0; i < keys_size; ++i)
-        keys.emplace_back(left_key_names[i], right_key_names[i]);
+        keys.emplace_back(std::move(left_key_names[i]), std::move(right_key_names[i]));
 
     /// Sort keys pairwise according to the order in the sorting prefix.
     std::stable_sort(keys.begin(), keys.end(), [&left_indexes, &right_indexes](const auto & key1, const auto & key2)
@@ -67,10 +74,12 @@ void FullSortingMergeJoin::deduceSortDescriptions(
         return getIdxFromNameMap(right_indexes, key1.second) < getIdxFromNameMap(right_indexes, key2.second);
     });
 
+    left_key_names.clear();
+    right_key_names.clear();
     for (const auto & key : keys)
     {
-        left_sort_descr.emplace_back(key.first);
-        right_sort_descr.emplace_back(key.second);
+        left_key_names.emplace_back(std::move(key.first));
+        right_key_names.emplace_back(std::move(key.second));
     }
 }
 

--- a/src/Interpreters/FullSortingMergeJoin.h
+++ b/src/Interpreters/FullSortingMergeJoin.h
@@ -5,9 +5,11 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <Poco/Logger.h>
+#include <Core/SortDescription.h>
 
 namespace DB
 {
+class DataStream;
 
 namespace ErrorCodes
 {
@@ -19,6 +21,15 @@ namespace ErrorCodes
 /// Dummy class, actual joining is done by MergeTransform
 class FullSortingMergeJoin : public IJoin
 {
+public:
+    /// Helper methods to build proper plan for this type of join
+
+    /// Returns left_sort_descr and right_sort_descr
+    static void getSortDescriptions(
+        const DataStream & left_data_stream, const Names & left_key_names,
+        const DataStream & right_data_stream, const Names & right_key_names,
+        SortDescription & left_sort_descr, SortDescription & right_sort_descr);
+
 public:
     explicit FullSortingMergeJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block_)
         : table_join(table_join_)

--- a/src/Interpreters/FullSortingMergeJoin.h
+++ b/src/Interpreters/FullSortingMergeJoin.h
@@ -25,7 +25,7 @@ public:
     /// Helper methods to build proper plan for this type of join
 
     /// Returns left_sort_descr and right_sort_descr
-    static void getSortDescriptions(
+    static void deduceSortDescriptions(
         const DataStream & left_data_stream, const Names & left_key_names,
         const DataStream & right_data_stream, const Names & right_key_names,
         SortDescription & left_sort_descr, SortDescription & right_sort_descr);

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -215,7 +215,7 @@ static ColumnWithTypeAndName correctNullability(ColumnWithTypeAndName && column,
 }
 
 HashJoin::HashJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block_, bool any_take_last_row_)
-    : table_join(table_join_)
+    : IJoin(table_join_)
     , kind(table_join->kind())
     , strictness(table_join->strictness())
     , any_take_last_row(any_take_last_row_)

--- a/src/Interpreters/HashJoin.h
+++ b/src/Interpreters/HashJoin.h
@@ -150,8 +150,6 @@ class HashJoin : public IJoin
 public:
     HashJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block, bool any_take_last_row_ = false);
 
-    const TableJoin & getTableJoin() const override { return *table_join; }
-
     /** Add block of data from right hand of JOIN to the map.
       * Returns false, if some limit was exceeded and you should not insert more data.
       */
@@ -359,7 +357,6 @@ private:
 
     friend class JoinSource;
 
-    std::shared_ptr<TableJoin> table_join;
     JoinKind kind;
     JoinStrictness strictness;
 

--- a/src/Interpreters/IJoin.h
+++ b/src/Interpreters/IJoin.h
@@ -7,6 +7,7 @@
 #include <Core/Block.h>
 #include <Columns/IColumn.h>
 #include <Common/Exception.h>
+#include <Core/SortDescription.h>
 
 namespace DB
 {
@@ -81,8 +82,19 @@ public:
     virtual std::shared_ptr<NotJoinedBlocks>
     getNonJoinedBlocks(const Block & left_sample_block, const Block & result_sample_block, UInt64 max_block_size) const = 0;
 
+    void setSortDescriptions(const SortDescription & left_descr, const SortDescription & right_descr)
+    {
+        this->lhs_sort_descr = left_descr;
+        this->rhs_sort_descr = right_descr;
+    }
+
+    std::pair<const SortDescription *, const SortDescription *> getSortDescriptions() const { return {&lhs_sort_descr, &rhs_sort_descr}; }
+
 private:
     Block totals;
+
+    SortDescription lhs_sort_descr;
+    SortDescription rhs_sort_descr;
 };
 
 

--- a/src/Interpreters/IJoin.h
+++ b/src/Interpreters/IJoin.h
@@ -44,9 +44,16 @@ enum class JoinPipelineType
 class IJoin
 {
 public:
+    explicit IJoin(std::shared_ptr<TableJoin> table_join_)
+        : table_join(std::move(table_join_))
+    {
+        assert(table_join);
+    }
+
     virtual ~IJoin() = default;
 
-    virtual const TableJoin & getTableJoin() const = 0;
+    TableJoin & getTableJoin() { return *table_join; }
+    const TableJoin & getTableJoin() const { return *table_join; }
 
     /// Add block of data from right hand of JOIN.
     /// @returns false, if some limit was exceeded and you should not insert more data.
@@ -82,19 +89,10 @@ public:
     virtual std::shared_ptr<NotJoinedBlocks>
     getNonJoinedBlocks(const Block & left_sample_block, const Block & result_sample_block, UInt64 max_block_size) const = 0;
 
-    void setSortDescriptions(const SortDescription & left_descr, const SortDescription & right_descr)
-    {
-        this->lhs_sort_descr = left_descr;
-        this->rhs_sort_descr = right_descr;
-    }
-
-    std::pair<const SortDescription *, const SortDescription *> getSortDescriptions() const { return {&lhs_sort_descr, &rhs_sort_descr}; }
-
-private:
+protected:
     Block totals;
 
-    SortDescription lhs_sort_descr;
-    SortDescription rhs_sort_descr;
+    std::shared_ptr<TableJoin> table_join;
 };
 
 

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1467,8 +1467,8 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                         SortDescription sort_descr;
                         {
                             /// Join keys may contain duplicates, remove them
-                            /// Example: JOIN ON t1.x = t2.a AND t1.x = t2.b AND t1.y = t2.c
-                            /// We need to sort t1 by [x, y] (not [x, x, y]).
+                            /// Example: JOIN ON t1.x = t2.a AND t1.x = t2.b AND t1.y = t2.c AND t1.x = t2.d
+                            /// We need to sort t1 by [x, y] (not [x, x, y, x]).
                             NameSet existing;
                             for (const auto & desc : join_sort_descr)
                             {
@@ -1543,7 +1543,7 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
 
                         SortDescription left_sort_descr;
                         SortDescription right_sort_descr;
-                        FullSortingMergeJoin::getSortDescriptions(
+                        FullSortingMergeJoin::deduceSortDescriptions(
                             query_plan.getCurrentDataStream(), join_clause.key_names_left,
                             joined_plan->getCurrentDataStream(), join_clause.key_names_right,
                             left_sort_descr, right_sort_descr);

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2282,7 +2282,7 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
         bool can_use_projection_if_present = !query_info.projection || query_info.projection->complete;
 
         /// Create optimizer with prepared actions.
-        /// Maybe we will need to calc input_order_info later, e.g. while reading from StorageMerge.
+        /// TODO: It's better to calc input_order_info later, e.g. while reading from StorageMerge.
         if (optimize_anything_in_order && can_use_projection_if_present)
         {
             if (optimize_read_in_order)

--- a/src/Interpreters/JoinSwitcher.cpp
+++ b/src/Interpreters/JoinSwitcher.cpp
@@ -18,9 +18,9 @@ static ColumnWithTypeAndName correctNullability(ColumnWithTypeAndName && column,
 }
 
 JoinSwitcher::JoinSwitcher(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block_)
-    : limits(table_join_->sizeLimits())
+    : IJoin(table_join_)
+    , limits(table_join_->sizeLimits())
     , switched(false)
-    , table_join(table_join_)
     , right_sample_block(right_sample_block_.cloneEmpty())
 {
     join = std::make_shared<HashJoin>(table_join, right_sample_block);

--- a/src/Interpreters/JoinSwitcher.h
+++ b/src/Interpreters/JoinSwitcher.h
@@ -18,8 +18,6 @@ class JoinSwitcher : public IJoin
 public:
     JoinSwitcher(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block_);
 
-    const TableJoin & getTableJoin() const override { return *table_join; }
-
     /// Add block of data from right hand of JOIN into current join object.
     /// If join-in-memory memory limit exceeded switches to join-on-disk and continue with it.
     /// @returns false, if join-on-disk disk limit exceeded
@@ -71,7 +69,6 @@ private:
     SizeLimits limits;
     bool switched;
     mutable std::mutex switch_mutex;
-    std::shared_ptr<TableJoin> table_join;
     const Block right_sample_block;
 
     /// Change join-in-memory to join-on-disk moving right hand JOIN data from one to another.

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -465,7 +465,7 @@ void joinInequalsLeft(const Block & left_block, MutableColumns & left_columns,
 
 
 MergeJoin::MergeJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block_)
-    : table_join(table_join_)
+    : IJoin(table_join_)
     , size_limits(table_join->sizeLimits())
     , right_sample_block(right_sample_block_)
     , is_any_join(table_join->strictness() == JoinStrictness::Any)
@@ -1142,10 +1142,10 @@ void MergeJoin::addConditionJoinColumn(Block & block, JoinTableSide block_side) 
     }
 }
 
-bool MergeJoin::isSupported(const std::shared_ptr<TableJoin> & table_join)
+bool MergeJoin::isSupported(const std::shared_ptr<TableJoin> & table_join_)
 {
-    auto kind = table_join->kind();
-    auto strictness = table_join->strictness();
+    auto kind = table_join_->kind();
+    auto strictness = table_join_->strictness();
 
     bool is_any = (strictness == JoinStrictness::Any);
     bool is_all = (strictness == JoinStrictness::All);
@@ -1154,7 +1154,7 @@ bool MergeJoin::isSupported(const std::shared_ptr<TableJoin> & table_join)
     bool all_join = is_all && (isInner(kind) || isLeft(kind) || isRight(kind) || isFull(kind));
     bool special_left = isInnerOrLeft(kind) && (is_any || is_semi);
 
-    return (all_join || special_left) && table_join->oneDisjunct();
+    return (all_join || special_left) && table_join_->oneDisjunct();
 }
 
 MergeJoin::RightBlockInfo::RightBlockInfo(std::shared_ptr<Block> block_, size_t block_number_, size_t & skip_, RowBitmaps * bitmaps_)

--- a/src/Interpreters/MergeJoin.h
+++ b/src/Interpreters/MergeJoin.h
@@ -23,7 +23,6 @@ class MergeJoin : public IJoin
 public:
     MergeJoin(std::shared_ptr<TableJoin> table_join_, const Block & right_sample_block);
 
-    const TableJoin & getTableJoin() const override { return *table_join; }
     bool addJoinedBlock(const Block & block, bool check_limits) override;
     void checkTypesOfKeys(const Block & block) const override;
     void joinBlock(Block &, ExtraBlockPtr & not_processed) override;
@@ -73,7 +72,6 @@ private:
     using Cache = CacheBase<size_t, Block, std::hash<size_t>, BlockByteWeight>;
 
     mutable std::shared_mutex rwlock;
-    std::shared_ptr<TableJoin> table_join;
     SizeLimits size_limits;
     SortDescription left_sort_description;
     SortDescription right_sort_description;

--- a/src/Interpreters/SelectQueryOptions.h
+++ b/src/Interpreters/SelectQueryOptions.h
@@ -51,6 +51,9 @@ struct SelectQueryOptions
     bool settings_limit_offset_done = false;
     bool is_explain = false; /// The value is true if it's explain statement.
 
+    /// For right side of join
+    Names optimize_join_read_in_order;
+
     /// These two fields are used to evaluate shardNum() and shardCount() function when
     /// prefer_localhost_replica == 1 and local instance is selected. They are needed because local
     /// instance might have multiple shards and scalars can only hold one value.
@@ -155,6 +158,12 @@ struct SelectQueryOptions
     SelectQueryOptions & setExplain(bool value = true)
     {
         is_explain = value;
+        return *this;
+    }
+
+    SelectQueryOptions & setJoinSortBy(const Names & names)
+    {
+        optimize_join_read_in_order = names;
         return *this;
     }
 };

--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -511,7 +511,7 @@ void TableJoin::inferJoinKeyCommonType(const LeftNamesAndTypes & left, const Rig
         if (clauses.size() != 1)
             throw DB::Exception("ASOF join over multiple keys is not supported", ErrorCodes::NOT_IMPLEMENTED);
 
-        auto asof_key_type = right_types.find(clauses.back().key_names_right.back());
+        auto asof_key_type = right_types.find(clauses.front().key_names_right.back());
         if (asof_key_type != right_types.end() && asof_key_type->second->isNullable())
             throw DB::Exception("ASOF join over right table Nullable column is not implemented", ErrorCodes::NOT_IMPLEMENTED);
     }
@@ -694,13 +694,13 @@ static void sortPairwise(std::vector<String> & lhs, std::vector<String> & rhs, b
 {
     assert(lhs.size() == rhs.size());
     size_t size = lhs.size();
-    if (keep_last)
-        size--;
 
     std::vector<size_t> permutation(size);
     std::iota(permutation.begin(), permutation.end(), 0);
     auto cmp = [&lhs, &rhs](size_t i, size_t j) { return lhs[i] == lhs[j] ? rhs[i] < rhs[j] : lhs[i] < lhs[j]; };
-    std::stable_sort(permutation.begin(), permutation.end(), cmp);
+
+    auto end_it = keep_last ? std::prev(permutation.end()) : permutation.end();
+    std::stable_sort(permutation.begin(), end_it, cmp);
 
     std::vector<String> lhs_sorted(size);
     std::vector<String> rhs_sorted(size);

--- a/src/Interpreters/TableJoin.h
+++ b/src/Interpreters/TableJoin.h
@@ -244,6 +244,8 @@ public:
 
     void addOnKeys(ASTPtr & left_table_ast, ASTPtr & right_table_ast);
 
+    void sortKeys();
+
     /* Conditions for left/right table from JOIN ON section.
      *
      * Conditions for left and right tables stored separately and united with 'and' function into one column.
@@ -263,6 +265,7 @@ public:
     bool hasOn() const { return table_join.on_expression != nullptr; }
 
     String getOriginalName(const String & column_name) const;
+    Names getOriginalNames(const Names & column_names) const;
     NamesWithAliases getNamesWithAliases(const NameSet & required_columns) const;
     NamesWithAliases getRequiredColumns(const Block & sample, const Names & action_required_columns) const;
 

--- a/src/Interpreters/TableJoin.h
+++ b/src/Interpreters/TableJoin.h
@@ -244,7 +244,7 @@ public:
 
     void addOnKeys(ASTPtr & left_table_ast, ASTPtr & right_table_ast);
 
-    void sortKeys();
+    void normalizeKeys();
 
     /* Conditions for left/right table from JOIN ON section.
      *

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -782,6 +782,7 @@ void collectJoinedColumns(TableJoin & analyzed_join, ASTTableJoin & table_join,
                 throw DB::Exception(ErrorCodes::NOT_IMPLEMENTED, "Only `hash` join supports multiple ORs for keys in JOIN ON section");
         }
     }
+    analyzed_join.sortKeys();
 }
 
 

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -782,7 +782,7 @@ void collectJoinedColumns(TableJoin & analyzed_join, ASTTableJoin & table_join,
                 throw DB::Exception(ErrorCodes::NOT_IMPLEMENTED, "Only `hash` join supports multiple ORs for keys in JOIN ON section");
         }
     }
-    analyzed_join.sortKeys();
+    analyzed_join.normalizeKeys();
 }
 
 

--- a/src/Processors/QueryPlan/ExpressionStep.cpp
+++ b/src/Processors/QueryPlan/ExpressionStep.cpp
@@ -10,25 +10,16 @@
 namespace DB
 {
 
-static ITransformingStep::Traits getTraits(const ActionsDAGPtr & actions, const Block & header, const SortDescription & sort_description,
-                                           const NameSet & perserve_sorting_by)
+static ITransformingStep::Traits getTraits(const ActionsDAGPtr & actions, const Block & header,
+                                           const SortDescription & sort_description, bool force_sorting)
 {
-    Names sort_column_names;
-    for (const auto & sort_desc : sort_description)
-    {
-        /// For some columns we know from user that they are sorted
-        if (!perserve_sorting_by.contains(sort_desc.column_name))
-            sort_column_names.push_back(sort_desc.column_name);
-    }
-    bool preserves_sorting = actions->isSortingPreserved(header, sort_column_names);
-
     return ITransformingStep::Traits
     {
         {
             .preserves_distinct_columns = !actions->hasArrayJoin(),
             .returns_single_stream = false,
             .preserves_number_of_streams = true,
-            .preserves_sorting = preserves_sorting,
+            .preserves_sorting = force_sorting || actions->isSortingPreserved(header, sort_description),
         },
         {
             .preserves_number_of_rows = !actions->hasArrayJoin(),
@@ -36,35 +27,21 @@ static ITransformingStep::Traits getTraits(const ActionsDAGPtr & actions, const 
     };
 }
 
-static NameSet getMapValues(const NameToNameMap & map)
-{
-    NameSet keys;
-    for (const auto & it : map)
-        keys.insert(it.second);
-    return keys;
-}
-
-static void mapSortDescriptionNames(SortDescription & sort_desc, const NameToNameMap & name_mapping)
-{
-    for (auto & desc : sort_desc)
-    {
-        auto it = name_mapping.find(desc.column_name);
-        if (it != name_mapping.end())
-            desc.column_name = it->second;
-    }
-}
-
-ExpressionStep::ExpressionStep(const DataStream & input_stream_, const ActionsDAGPtr & actions_dag_, const NameToNameMap & perserve_sort_hint_)
+ExpressionStep::ExpressionStep(const DataStream & input_stream_, const ActionsDAGPtr & actions_dag_, const SortDescription & result_sort_desc_)
     : ITransformingStep(
         input_stream_,
         ExpressionTransform::transformHeader(input_stream_.header, *actions_dag_),
-        getTraits(actions_dag_, input_stream_.header, input_stream_.sort_description, getMapValues(perserve_sort_hint_)))
+        getTraits(actions_dag_,
+                  input_stream_.header,
+                  result_sort_desc_.empty() ? input_stream_.sort_description : result_sort_desc_,
+                  !result_sort_desc_.empty()))
     , actions_dag(actions_dag_)
-    , perserve_sort_hint(perserve_sort_hint_)
+    , result_sort_desc(result_sort_desc_)
 {
     /// Some columns may be removed by expression.
     updateDistinctColumns(output_stream->header, output_stream->distinct_columns);
-    mapSortDescriptionNames(output_stream->sort_description, perserve_sort_hint);
+    if (!result_sort_desc.empty())
+        output_stream->sort_description = result_sort_desc;
 }
 
 void ExpressionStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings)
@@ -121,8 +98,8 @@ void ExpressionStep::updateOutputStream()
 {
     const auto & output_header = ExpressionTransform::transformHeader(input_streams.front().header, *actions_dag);
     output_stream = createOutputStream(input_streams.front(), output_header, getDataStreamTraits());
-
-    mapSortDescriptionNames(output_stream->sort_description, perserve_sort_hint);
+    if (!result_sort_desc.empty())
+        output_stream->sort_description = result_sort_desc;
 }
 
 }

--- a/src/Processors/QueryPlan/ExpressionStep.h
+++ b/src/Processors/QueryPlan/ExpressionStep.h
@@ -14,8 +14,11 @@ class JoiningTransform;
 class ExpressionStep : public ITransformingStep
 {
 public:
-
-    explicit ExpressionStep(const DataStream & input_stream_, const ActionsDAGPtr & actions_dag_);
+    /// ExpressionStep is trying to preserve sorting if it is possible.
+    /// But changes can be pretty sophisticated, so we can pass perserve_sort_hint_ to specify columns that keep order.
+    /// Because columns can be renamed, it accepts name mapping.
+    explicit ExpressionStep(const DataStream & input_stream_, const ActionsDAGPtr & actions_dag_,
+                            const NameToNameMap & perserve_sort_hint_ = {});
     String getName() const override { return "Expression"; }
 
     void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings) override;
@@ -26,10 +29,14 @@ public:
 
     void describeActions(JSONBuilder::JSONMap & map) const override;
 
+    void preserveSortingHint();
+
 private:
     void updateOutputStream() override;
 
     ActionsDAGPtr actions_dag;
+
+    NameToNameMap perserve_sort_hint;
 };
 
 }

--- a/src/Processors/QueryPlan/ExpressionStep.h
+++ b/src/Processors/QueryPlan/ExpressionStep.h
@@ -15,10 +15,9 @@ class ExpressionStep : public ITransformingStep
 {
 public:
     /// ExpressionStep is trying to preserve sorting if it is possible.
-    /// But changes can be pretty sophisticated, so we can pass perserve_sort_hint_ to specify columns that keep order.
-    /// Because columns can be renamed, it accepts name mapping.
+    /// Step can be sophisticated, so we can use explicit sort description in cases when we know result sorting.
     explicit ExpressionStep(const DataStream & input_stream_, const ActionsDAGPtr & actions_dag_,
-                            const NameToNameMap & perserve_sort_hint_ = {});
+                            const SortDescription & result_sort_desc_ = {});
     String getName() const override { return "Expression"; }
 
     void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings) override;
@@ -29,14 +28,12 @@ public:
 
     void describeActions(JSONBuilder::JSONMap & map) const override;
 
-    void preserveSortingHint();
-
 private:
     void updateOutputStream() override;
 
     ActionsDAGPtr actions_dag;
 
-    NameToNameMap perserve_sort_hint;
+    SortDescription result_sort_desc;
 };
 
 }

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -11,7 +11,7 @@ namespace DB
 
 static ITransformingStep::Traits getTraits(const ActionsDAGPtr & expression, const Block & header, const SortDescription & sort_description, bool remove_filter_column, const String & filter_column_name)
 {
-    bool preserves_sorting = expression->isSortingPreserved(header, sort_description, remove_filter_column ? filter_column_name : "");
+    bool preserves_sorting = expression->isSortingPreserved(header, sort_description.getColumnNames(), remove_filter_column ? filter_column_name : "");
     if (remove_filter_column)
     {
         preserves_sorting &= find_if(

--- a/src/Processors/QueryPlan/FilterStep.cpp
+++ b/src/Processors/QueryPlan/FilterStep.cpp
@@ -11,7 +11,7 @@ namespace DB
 
 static ITransformingStep::Traits getTraits(const ActionsDAGPtr & expression, const Block & header, const SortDescription & sort_description, bool remove_filter_column, const String & filter_column_name)
 {
-    bool preserves_sorting = expression->isSortingPreserved(header, sort_description.getColumnNames(), remove_filter_column ? filter_column_name : "");
+    bool preserves_sorting = expression->isSortingPreserved(header, sort_description, remove_filter_column ? filter_column_name : "");
     if (remove_filter_column)
     {
         preserves_sorting &= find_if(

--- a/src/Processors/QueryPlan/IQueryPlanStep.h
+++ b/src/Processors/QueryPlan/IQueryPlanStep.h
@@ -33,6 +33,7 @@ public:
 
     /// Sorting scope
     enum class SortScope
+    enum class SortMode : UInt8
     {
         None,
         Chunk, /// Separate chunks are sorted
@@ -60,6 +61,12 @@ public:
     bool hasEqualHeaderWith(const DataStream & other) const
     {
         return blocksHaveEqualStructure(header, other.header);
+    }
+
+    template <typename T>
+    bool isSortedBy(const T & prefix) const
+    {
+        return sort_mode >= SortMode::Port && sort_description.hasPrefix(prefix);
     }
 };
 

--- a/src/Processors/QueryPlan/IQueryPlanStep.h
+++ b/src/Processors/QueryPlan/IQueryPlanStep.h
@@ -32,8 +32,7 @@ public:
     bool has_single_port = false;
 
     /// Sorting scope
-    enum class SortScope
-    enum class SortMode : UInt8
+    enum class SortScope : UInt8
     {
         None,
         Chunk, /// Separate chunks are sorted
@@ -63,10 +62,9 @@ public:
         return blocksHaveEqualStructure(header, other.header);
     }
 
-    template <typename T>
-    bool isSortedBy(const T & prefix) const
+    bool isSortedBy(const SortDescription & prefix) const
     {
-        return sort_mode >= SortMode::Port && sort_description.hasPrefix(prefix);
+        return sort_scope >= SortScope::Stream && sort_description.hasPrefix(prefix);
     }
 };
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -139,6 +139,7 @@ ReadFromMergeTree::ReadFromMergeTree(
                 break;
             sort_description.emplace_back(column_name, sort_direction);
         }
+
         if (!sort_description.empty())
         {
             auto const & settings = context->getSettingsRef();
@@ -149,7 +150,6 @@ ReadFromMergeTree::ReadFromMergeTree(
         }
 
         output_stream->sort_description = std::move(sort_description);
-
     }
 }
 

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -25,7 +25,7 @@ public:
         size_t min_free_disk_space_,
         bool optimize_sorting_by_input_stream_properties_);
 
-    /// FinishSorting
+    /// FinishSorting: input stream should be sorted by prefix_description.
     SortingStep(
         const DataStream & input_stream_,
         SortDescription prefix_description_,
@@ -33,7 +33,7 @@ public:
         size_t max_block_size_,
         UInt64 limit_);
 
-    /// MergingSorted
+    /// MergingSorted: input stream should be partially sorted (each port is sorted).
     SortingStep(
         const DataStream & input_stream,
         SortDescription sort_description_,

--- a/src/Processors/Transforms/MergeJoinTransform.h
+++ b/src/Processors/Transforms/MergeJoinTransform.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <memory>
@@ -24,6 +25,11 @@ namespace Poco { class Logger; }
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
 
 class IJoin;
 using JoinPtr = std::shared_ptr<IJoin>;
@@ -197,6 +203,9 @@ public:
         : sample_block(sample_block_.cloneEmpty())
         , desc(description_)
     {
+        bool is_default_sort_direction = std::all_of(desc.begin(), desc.end(), [](const auto & col_desc) { return col_desc.isDefaultDirection(); });
+        if (!is_default_sort_direction)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected nulls last ascending sorting");
     }
 
     bool fullyCompleted() const;

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -10,6 +10,7 @@
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <Processors/Transforms/MergingAggregatedMemoryEfficientTransform.h>
 #include <Processors/Transforms/JoiningTransform.h>
+#include <Processors/Transforms/CheckSortedTransform.h>
 #include <Processors/Transforms/MergeJoinTransform.h>
 #include <Processors/Formats/IOutputFormat.h>
 #include <Processors/Executors/PipelineExecutor.h>
@@ -22,7 +23,7 @@
 #include <Interpreters/TableJoin.h>
 #include <Common/typeid_cast.h>
 #include <Common/CurrentThread.h>
-#include "Core/SortDescription.h"
+#include <Core/SortDescription.h>
 #include <QueryPipeline/narrowPipe.h>
 #include <Processors/DelayedPortsProcessor.h>
 #include <Processors/RowsBeforeLimitCounter.h>
@@ -348,14 +349,15 @@ std::unique_ptr<QueryPipelineBuilder> QueryPipelineBuilder::joinPipelinesYShaped
 
     left->pipe.dropExtremes();
     right->pipe.dropExtremes();
-    if (left->getNumStreams() != 1 || right->getNumStreams() != 1)
-        throw Exception("Join is supported only for pipelines with one output port", ErrorCodes::LOGICAL_ERROR);
+
+    if (left->pipe.output_ports.size() != 1 || right->pipe.output_ports.size() != 1)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Join is supported only for pipelines with one output port, got {} and {}",
+            left->pipe.output_ports.size(), right->pipe.output_ports.size());
 
     if (left->hasTotals() || right->hasTotals())
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Current join algorithm is supported only for pipelines without totals");
 
     Blocks inputs = {left->getHeader(), right->getHeader()};
-
     auto joining = std::make_shared<MergeJoinTransform>(join, inputs, out_header, max_block_size);
 
     return mergePipelines(std::move(left), std::move(right), std::move(joining), collected_processors);

--- a/src/Storages/ReadInOrderOptimizer.cpp
+++ b/src/Storages/ReadInOrderOptimizer.cpp
@@ -220,7 +220,7 @@ InputOrderInfoPtr ReadInOrderOptimizer::getInputOrderImpl(
             break;
 
         int current_direction = matchSortDescriptionAndKey(
-            actions.empty() ? ExpressionActions::Actions{} : actions[i]->getActions(),
+            actions.empty() ? ExpressionActions::Actions{} : actions[desc_pos]->getActions(),
             description[desc_pos],
             sorting_key_columns[key_pos]);
         bool is_matched = current_direction && (desc_pos == 0 || current_direction == read_direction);

--- a/src/Storages/ReadInOrderOptimizer.h
+++ b/src/Storages/ReadInOrderOptimizer.h
@@ -25,7 +25,7 @@ public:
 
 private:
     InputOrderInfoPtr getInputOrderImpl(
-        const StorageMetadataPtr & metadata_snapshot,
+        const Names & sorting_key_columns,
         const SortDescription & description,
         const ManyExpressionActions & actions,
         const ContextPtr & context,

--- a/tests/queries/0_stateless/02403_sorted_full_join.sh
+++ b/tests/queries/0_stateless/02403_sorted_full_join.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -mn -q """
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+
+CREATE TABLE t1 (x UInt64, y UInt64, val UInt64) ENGINE = MergeTree ORDER BY (x, y)
+AS SELECT sipHash64(number, '11') % 1000 AS x, sipHash64(number, '12') % 1000 AS y, sipHash64(number, '13') % 1000 FROM numbers(1000);
+
+CREATE TABLE t2 (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY (a, b)
+AS SELECT sipHash64(number, '21') % 1000 AS a, sipHash64(number, '22') % 1000 AS b FROM numbers(1000);
+
+CREATE TABLE t3 (x UInt64, y UInt64) ENGINE = MergeTree ORDER BY (x, y)
+AS SELECT sipHash64(number, '21') % 1000 AS x, sipHash64(number, '22') % 1000 AS y FROM numbers(1000);
+"""
+
+# test_query <expected_number_of_sort_steps> <query>
+function test_query {
+    expected_result=${1}
+    query_str="${2}"
+
+    # count the number of PartialSortingTransform's in the pipeline
+    result=$( $CLICKHOUSE_CLIENT \
+        --join_algorithm=full_sorting_merge \
+        --optimize_sorting_by_input_stream_properties=1 \
+        --optimize_read_in_order=1 --max_threads=8 --max_block_size=128 \
+        -q "EXPLAIN PIPELINE ${query_str}" | grep 'PartialSortingTransform' | wc -l )
+
+    test "$result" -eq "$expected_result" || echo "fail ${BASH_LINENO[0]}: $expected_result != $result in '${query_str}'"
+}
+
+test_query 0 'SELECT * FROM t1 JOIN t3 USING (x)'
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x'
+
+test_query 0 'SELECT * FROM t1 JOIN t3 USING (x, y)'
+test_query 0 'SELECT * FROM t1 JOIN t3 USING (y, x)'
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.y = t3.y'
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.y = t3.y AND t1.x = t3.x'
+
+test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.x = t2.a'
+test_query 0 'SELECT * FROM t1 JOIN t2 ON x = a'
+
+test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.x = t2.a AND t1.y = t2.b AND t1.x = t2.b'
+
+test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.x = t2.a AND t1.y = t2.b'
+test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.y = t2.b AND t1.x = t2.a'
+test_query 0 'SELECT * FROM t1 JOIN t2 ON x = a AND y = b'
+test_query 0 'SELECT * FROM t1 JOIN t2 ON y = b AND x = a'
+
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.x = t3.y'
+
+# sort only one stream
+test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.val = t3.x AND t1.y = t3.y'
+test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.y AND t1.y = t3.y'
+test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.y AND t1.x = t3.y'
+
+# two sorts for inner subqueries, don't resort
+test_query 2 '
+    SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
+        ORDER BY x, y DESC ) AS t1
+    JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))
+        ORDER BY a, b DESC ) AS t2
+    ON t1.x = t2.a AND t1.y = t2.b'
+
+# two sorts for inner subqueries + resort one stream, because it's sorted in different direction
+test_query 3 '
+    SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
+        ORDER BY x DESC, y DESC ) AS t1
+    JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))
+        ORDER BY a, b DESC ) AS t2
+    ON t1.x = t2.a AND t1.y = t2.b'
+
+test_query 3 '
+    SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
+        ORDER BY x, y DESC ) AS t1
+    JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))
+        ORDER BY a DESC, b DESC ) AS t2
+    ON t1.x = t2.a AND t1.y = t2.b'

--- a/tests/queries/0_stateless/02403_sorted_full_join.sh
+++ b/tests/queries/0_stateless/02403_sorted_full_join.sh
@@ -8,9 +8,12 @@ $CLICKHOUSE_CLIENT -mn -q """
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 DROP TABLE IF EXISTS t3;
+DROP TABLE IF EXISTS t4;
+DROP TABLE IF EXISTS ta1;
+DROP TABLE IF EXISTS ta2;
 
 CREATE TABLE t1 (x UInt64, y UInt64, val UInt64) ENGINE = MergeTree ORDER BY (x, y)
-AS SELECT sipHash64(number, '11') % 100, sipHash64(number, '12') % 100, sipHash64(number, '13') % 1000 FROM numbers(1000);
+AS SELECT sipHash64(number, '11') % 100, sipHash64(number, '12') % 100, sipHash64(number, '13') % 100 FROM numbers(1000);
 
 CREATE TABLE t2 (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY (a, b)
 AS SELECT sipHash64(number, '21') % 100, sipHash64(number, '22') % 100 FROM numbers(1000);
@@ -20,6 +23,21 @@ AS SELECT sipHash64(number, '21') % 100, sipHash64(number, '22') % 100 FROM numb
 
 CREATE TABLE t4 (y UInt64, x UInt64) ENGINE = MergeTree ORDER BY (y, x)
 AS SELECT sipHash64(number, '21') % 100, sipHash64(number, '22') % 100 FROM numbers(1000);
+
+CREATE TABLE ta1 (a1 UInt64, a2 UInt64, a3 UInt64, a4 UInt64, a5 UInt64, a6 UInt64, a7 UInt64, a8 UInt64, a9 UInt64, a10 UInt64)
+ENGINE = MergeTree ORDER BY (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
+AS SELECT
+    sipHash64(number, 'a11') % 2, sipHash64(number, 'a12') % 2, sipHash64(number, 'a13') % 2, sipHash64(number, 'a14') % 2, sipHash64(number, 'a15') % 2,
+    sipHash64(number, 'a16') % 2, sipHash64(number, 'a17') % 2, sipHash64(number, 'a18') % 2, sipHash64(number, 'a19') % 2, sipHash64(number, 'a20') % 2
+FROM numbers(1000);
+
+CREATE TABLE ta2 (a1 UInt64, a2 UInt64, a3 UInt64, a4 UInt64, a5 UInt64, a6 UInt64, a7 UInt64, a8 UInt64, a9 UInt64, a10 UInt64)
+ENGINE = MergeTree ORDER BY (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
+AS SELECT
+    sipHash64(number, 'a21') % 2, sipHash64(number, 'a22') % 2, sipHash64(number, 'a23') % 2, sipHash64(number, 'a24') % 2, sipHash64(number, 'a25') % 2,
+    sipHash64(number, 'a26') % 2, sipHash64(number, 'a27') % 2, sipHash64(number, 'a28') % 2, sipHash64(number, 'a29') % 2, sipHash64(number, 'a30') % 2
+FROM numbers(1000);
+
 """
 
 # test_query <expected_number_of_sort_steps> <query>
@@ -34,7 +52,7 @@ function test_query {
         --optimize_read_in_order=1 --max_threads=8 --max_block_size=128 \
         -q "EXPLAIN PIPELINE ${query_str}" | grep 'PartialSortingTransform' | wc -l )
 
-    test "$result" -eq "$expected_result" || echo "fail ${BASH_LINENO[0]}: $expected_result != $result in '${query_str}'"
+    test "$result" -eq "$expected_result" || echo "fail ${BASH_LINENO[0]}: expected: $expected_result, got: $result in '${query_str}'"
 }
 
 test_query 0 'SELECT * FROM t1 JOIN t3 USING (x)'
@@ -42,8 +60,10 @@ test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x'
 test_query 0 'SELECT * FROM t1 JOIN t4 ON t1.x = t4.y'
 
 test_query 0 'SELECT * FROM t1 JOIN t3 USING (x, y)'
+test_query 0 'SELECT * FROM t1 JOIN t3 USING (x, x, x, y, y, y, y, x, x, x)'
 test_query 0 'SELECT * FROM t1 JOIN t3 USING (y, x)'
 test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.y = t3.y'
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.y = t3.y AND t1.y = t3.y AND t1.y = t3.y AND t1.x = t3.x AND t1.x = t3.x'
 test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.y = t3.y AND t1.x = t3.x'
 
 test_query 0 'SELECT * FROM t1 JOIN t4 ON t1.x = t4.y AND t1.y = t4.x'
@@ -61,30 +81,42 @@ test_query 0 'SELECT * FROM t1 JOIN t2 ON y = b AND x = a'
 
 test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.x = t3.y'
 
+test_query 0 'SELECT * FROM ta1 JOIN ta2 USING (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)'
+test_query 0 'SELECT * FROM ta1 JOIN ta2 USING (a10, a9, a8, a7, a6, a5, a4, a3, a2, a1)'
+test_query 0 'SELECT * FROM ta1 JOIN ta2 USING (a9, a7, a8, a10, a5, a3, a6, a4, a1, a2)'
+
+test_query 0 'SELECT * FROM ta1 JOIN t1 ON ta1.a1 = t1.x AND ta1.a2 = t1.x AND ta1.a3 = t1.x AND ta1.a4 = t1.x AND ta1.a5 = t1.x
+                                       AND ta1.a6 = t1.x AND ta1.a7 = t1.y AND ta1.a8 = t1.y AND ta1.a9 = t1.y AND ta1.a10 = t1.y'
+
+test_query 0 'SELECT * FROM ta1 JOIN t1 ON ta1.a6 = t1.x AND ta1.a3 = t1.x AND ta1.a1 = t1.x AND ta1.a7 = t1.y AND ta1.a4 = t1.x
+                                       AND ta1.a5 = t1.x AND ta1.a8 = t1.y AND ta1.a10 = t1.y AND ta1.a2 = t1.x AND ta1.a9 = t1.y'
+
+test_query 1 'SELECT * FROM ta1 JOIN ta2 ON ta1.a2 = ta2.a1 AND ta1.a3 = ta2.a2 AND ta1.a2 = ta2.a3 AND ta1.a2 = ta2.a4'
+
 # sort only one stream
 test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.val = t3.x AND t1.y = t3.y'
 test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.y AND t1.y = t3.y'
 test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.y AND t1.x = t3.y'
 
-# two sorts for inner subqueries, don't resort
-test_query 2 '
+# two sorts for inner subqueries, and one for right
+test_query 3 '
     SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
-        ORDER BY x, y DESC ) AS t1
+        ORDER BY x, y ) AS t1
     JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))
         ORDER BY a, b DESC ) AS t2
     ON t1.x = t2.a AND t1.y = t2.b'
 
-# two sorts for inner subqueries + resort one stream, because it's sorted in different direction
-test_query 3 '
+# two sorts for inner subqueries and two resorts
+test_query 4 '
     SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
         ORDER BY x DESC, y DESC ) AS t1
     JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))
         ORDER BY a, b DESC ) AS t2
     ON t1.x = t2.a AND t1.y = t2.b'
 
-test_query 3 '
+test_query 4 '
     SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
-        ORDER BY x, y DESC ) AS t1
+        ORDER BY x DESC, y DESC ) AS t1
     JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))
         ORDER BY a DESC, b DESC ) AS t2
     ON t1.x = t2.a AND t1.y = t2.b'


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Use sorting in `full_sorting_merge` JOIN if stream already sorted


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
