### PR TITLE
Fix Jepsen with compressed binary

### DIFF
--- a/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/utils.clj
+++ b/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/utils.clj
@@ -196,13 +196,14 @@
   [url]
   (let [encoded-url (md5 url)
         expected-file-name (.getName (io/file url))
-        dest-file (str binaries-cache-dir "/" encoded-url)
+        dest-folder (str binaries-cache-dir "/" encoded-url)
+        dest-file (str dest-folder "/" "clickhouse")
         dest-symlink (str common-prefix "/" expected-file-name)
         wget-opts (concat cu/std-wget-opts [:-O dest-file])]
     (when-not (cu/exists? dest-file)
       (info "Downloading" url)
-      (do (c/exec :mkdir :-p binaries-cache-dir)
-          (c/cd binaries-cache-dir
+      (do (c/exec :mkdir :-p dest-folder)
+          (c/cd dest-folder
                 (cu/wget-helper! wget-opts url))))
     (c/exec :rm :-rf dest-symlink)
     (c/exec :ln :-s dest-file dest-symlink)

--- a/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/utils.clj
+++ b/tests/jepsen.clickhouse-keeper/src/jepsen/clickhouse_keeper/utils.clj
@@ -197,7 +197,7 @@
   (let [encoded-url (md5 url)
         expected-file-name (.getName (io/file url))
         dest-folder (str binaries-cache-dir "/" encoded-url)
-        dest-file (str dest-folder "/" "clickhouse")
+        dest-file (str dest-folder "/clickhouse")
         dest-symlink (str common-prefix "/" expected-file-name)
         wget-opts (concat cu/std-wget-opts [:-O dest-file])]
     (when-not (cu/exists? dest-file)


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Compressed binary will extract to `clickhouse` always, so the caching with renaming the downloaded file to URL hash doesn't work.
Instead, we can create a folder with that hash and download compressed binary as `clickhouse`.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
