### PR TITLE
Fix race on system restart replica

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -573,7 +573,9 @@ StoragePtr InterpreterSystemQuery::tryRestartReplica(const StorageID & replica, 
 
         database->detachTable(system_context, replica.table_name);
     }
+    UUID uuid = table->getStorageID().uuid;
     table.reset();
+    database->waitDetachedTableNotInUse(uuid);
 
     /// Attach actions
     /// getCreateTableQuery must return canonical CREATE query representation, there are no need for AST postprocessing

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -428,8 +428,6 @@ void TCPHandler::runImpl()
             if (e.code() == ErrorCodes::UNKNOWN_PACKET_FROM_CLIENT)
                 throw;
 
-            LOG_TEST(log, "Going to close connection due to exception: {}", e.message());
-
             /// If there is UNEXPECTED_PACKET_FROM_CLIENT emulate network_error
             /// to break the loop, but do not throw to send the exception to
             /// the client.
@@ -439,6 +437,9 @@ void TCPHandler::runImpl()
             /// If a timeout occurred, try to inform client about it and close the session
             if (e.code() == ErrorCodes::SOCKET_TIMEOUT)
                 network_error = true;
+
+            if (network_error)
+                LOG_TEST(log, "Going to close connection due to exception: {}", e.message());
         }
         catch (const Poco::Net::NetException & e)
         {


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


```
2022.08.22 11:29:14.001382 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Debug> executeQuery: (from [::1]:35186) (comment: 01108_restart_replicas_rename_deadlock_zookeeper.sh) SYSTEM RESTART REPLICA replica_01108_1_tmp (stage: Complete)
2022.08.22 11:29:14.001625 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Trace> ContextAccess (default): Access granted: SYSTEM RESTART REPLICA ON test_qvt3bp.replica_01108_1_tmp
2022.08.22 11:29:14.001683 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Information> test_qvt3bp.replica_01108_1_tmp (654e5f39-bdd2-469b-933d-cf519ea2528d): Stopped being leader
2022.08.22 11:29:14.001716 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Trace> test_qvt3bp.replica_01108_3 (ReplicatedMergeTreeRestartingThread): Restarting thread finished
2022.08.22 11:29:14.002294 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Trace> test_qvt3bp.replica_01108_3 (ReplicatedMergeTreeRestartingThread): Waiting for threads to finish
2022.08.22 11:29:14.002352 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Trace> test_qvt3bp.replica_01108_3 (ReplicatedMergeTreeRestartingThread): Threads finished
2022.08.22 11:29:14.002380 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Trace> test_qvt3bp.replica_01108_3 (PartMovesBetweenShardsOrchestrator): PartMovesBetweenShardsOrchestrator thread finished
2022.08.22 11:29:14.004893 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Debug> test_qvt3bp.replica_01108_1_tmp (654e5f39-bdd2-469b-933d-cf519ea2528d): Loading data parts
2022.08.22 11:29:14.006233 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Debug> test_qvt3bp.replica_01108_1_tmp (654e5f39-bdd2-469b-933d-cf519ea2528d): Loaded data parts (1 items)
2022.08.22 11:29:14.009195 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Trace> test_qvt3bp.replica_01108_1_tmp (ReplicatedMergeTreeRestartingThread): Restarting thread finished
2022.08.22 11:29:14.009261 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Trace> test_qvt3bp.replica_01108_1_tmp (ReplicatedMergeTreeRestartingThread): Waiting for threads to finish
2022.08.22 11:29:14.009322 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Trace> test_qvt3bp.replica_01108_1_tmp (ReplicatedMergeTreeRestartingThread): Threads finished
2022.08.22 11:29:14.009375 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Trace> test_qvt3bp.replica_01108_1_tmp (PartMovesBetweenShardsOrchestrator): PartMovesBetweenShardsOrchestrator thread finished
2022.08.22 11:29:14.031118 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Error> executeQuery: Code: 57. DB::Exception: Cannot attach table with UUID 654e5f39-bdd2-469b-933d-cf519ea2528d, because it was detached but still used by some query. Retry later. (TABLE_ALREADY_EXISTS) (version 22.9.1.1) (from [::1]:35186) (comment: 01108_restart_replicas_rename_deadlock_zookeeper.sh) (in query: SYSTEM RESTART REPLICA replica_01108_1_tmp), Stack trace (when copying this message, always include the lines below):
2022.08.22 11:29:14.031508 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Test> TCPHandler: Going to close connection due to exception: Cannot attach table with UUID 654e5f39-bdd2-469b-933d-cf519ea2528d, because it was detached but still used by some query. Retry later.
2022.08.22 11:29:14.031779 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Error> TCPHandler: Code: 57. DB::Exception: Cannot attach table with UUID 654e5f39-bdd2-469b-933d-cf519ea2528d, because it was detached but still used by some query. Retry later. (TABLE_ALREADY_EXISTS), Stack trace (when copying this message, always include the lines below):
2022.08.22 11:29:14.031921 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Debug> TCPHandler: Processed in 0.031527865 sec.
2022.08.22 11:29:14.032026 [ 95244 ] {b4b1ff9d-4a4d-41e4-b704-04ee182dd13c} <Debug> MemoryTracker: Peak memory usage (for query): 2.03 MiB
```

It should not happen, because SYSTEM RESTART REPLICA locks table exclusively, but seems like in rare cases some threads may hold shared pointer to a table (hopefully, for a short period) without holding shared lock.