### PR TITLE
Fix possible logical error in arrayElement function with Map

### DIFF
--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -875,7 +875,8 @@ bool FunctionArrayElement::matchKeyToIndexStringConst(
     return castColumnString(&data, [&](const auto & data_column)
     {
         using DataColumn = std::decay_t<decltype(data_column)>;
-
+        if (index.getType() != Field::Types::String)
+            return false;
         MatcherStringConst<DataColumn> matcher{data_column, get<const String &>(index)};
         executeMatchKeyToIndex(offsets, matched_idxs, matcher);
         return true;

--- a/tests/queries/0_stateless/02407_array_element_from_map_wrong_type.sql
+++ b/tests/queries/0_stateless/02407_array_element_from_map_wrong_type.sql
@@ -1,0 +1,1 @@
+select m[0], materialize(map('key', 42)) as m; -- {serverError ILLEGAL_TYPE_OF_ARGUMENT}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible logical error `'Invalid Field get from type UInt64 to type String'` in arrayElement function with Map


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
