### PR TITLE
Validate the CompressionMethod parameter of URL table engine

### DIFF
--- a/docs/en/engines/table-engines/special/url.md
+++ b/docs/en/engines/table-engines/special/url.md
@@ -13,6 +13,8 @@ Syntax: `URL(URL [,Format] [,CompressionMethod])`
 
 - The `Format` must be one that ClickHouse can use in `SELECT` queries and, if necessary, in `INSERTs`. For the full list of supported formats, see [Formats](../../../interfaces/formats.md#formats).
 
+    If this argument is not specified, ClickHouse detectes the format automatically from the suffix of the `URL` parameter. If the suffix of `URL` parameter does not match any supported formats, it fails to create table. For example, for engine expression `URL('http://localhost/test.json')`, `JSON` format is applied.
+
 - `CompressionMethod` indicates that whether the HTTP body should be compressed. If the compression is enabled, the HTTP packets sent by the URL engine contain 'Content-Encoding' header to indicate which compression method is used.
 
 To enable compression, please first make sure the remote HTTP endpoint indicated by the `URL` parameter supports corresponding compression algorithm.
@@ -27,6 +29,11 @@ The supported `CompressionMethod` should be one of following:
 - bz2
 - snappy
 - none
+- auto
+
+If `CompressionMethod` is not specified, it defaults to `auto`. This means ClickHouse detects compression method from the suffix of `URL` parameter automatically. If the suffix matches any of compression method listed above, corresponding compression is applied or there won't be any compression enabled.
+
+For example, for engine expression `URL('http://localhost/test.gzip')`, `gzip` compression method is applied, but for `URL('http://localhost/test.fr')`, no compression is enabled because the suffix `fr` does not match any compression methods above.
 
 ## Usage {#using-the-engine-in-the-clickhouse-server}
 

--- a/src/IO/CompressionMethod.cpp
+++ b/src/IO/CompressionMethod.cpp
@@ -94,7 +94,7 @@ CompressionMethod chooseCompressionMethod(const std::string & path, const std::s
         return CompressionMethod::None;
 
     throw Exception(
-        "Unknown compression method " + hint + ". Only 'auto', 'none', 'gzip', 'deflate', 'br', 'xz', 'zstd', 'lz4', 'bz2', 'snappy' are supported as compression methods",
+        "Unknown compression method '" + hint + "'. Only 'auto', 'none', 'gzip', 'deflate', 'br', 'xz', 'zstd', 'lz4', 'bz2', 'snappy' are supported as compression methods",
         ErrorCodes::NOT_IMPLEMENTED);
 }
 

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -967,6 +967,16 @@ URLBasedDataSourceConfiguration StorageURL::getConfiguration(ASTs & args, Contex
             configuration.compression_method = checkAndGetLiteralArgument<String>(args[2], "compression_method");
     }
 
+    /// Make sure compressionMethod is correct
+    try
+    {
+        chooseCompressionMethod(configuration.url, configuration.compression_method);
+    }
+    catch (const Exception & e)
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, e.what());
+    }
+
     if (configuration.format == "auto")
         configuration.format = FormatFactory::instance().getFormatFromFileName(configuration.url, true);
 

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -72,7 +72,7 @@ IStorageURLBase::IStorageURLBase(
     ASTPtr partition_by_)
     : IStorage(table_id_)
     , uri(uri_)
-    , compression_method(chooseCompressionMethod(uri_, compression_method_))
+    , compression_method(chooseCompressionMethod(Poco::URI(uri_).getPath(), compression_method_))
     , format_name(format_name_)
     , format_settings(format_settings_)
     , headers(headers_)

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -43,7 +43,7 @@ public:
     static ColumnsDescription getTableStructureFromData(
         const String & format,
         const String & uri,
-        const String & compression_method,
+        CompressionMethod compression_method,
         const ReadWriteBufferFromHTTP::HTTPHeaderEntries & headers,
         const std::optional<FormatSettings> & format_settings,
         ContextPtr context);
@@ -64,7 +64,7 @@ protected:
         ASTPtr partition_by = nullptr);
 
     String uri;
-    String compression_method;
+    CompressionMethod compression_method;
     String format_name;
     // For URL engine, we use format settings from server context + `SETTINGS`
     // clause of the `CREATE` query. In this case, format_settings is set.

--- a/src/Storages/StorageXDBC.cpp
+++ b/src/Storages/StorageXDBC.cpp
@@ -137,7 +137,7 @@ SinkToStoragePtr StorageXDBC::write(const ASTPtr & /* query */, const StorageMet
         metadata_snapshot->getSampleBlock(),
         local_context,
         ConnectionTimeouts::getHTTPTimeouts(local_context),
-        chooseCompressionMethod(uri, compression_method));
+        compression_method);
 }
 
 bool StorageXDBC::supportsSubsetOfColumns() const

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -115,7 +115,7 @@ ColumnsDescription TableFunctionURL::getActualTableStructure(ContextPtr context)
     if (structure == "auto")
         return StorageURL::getTableStructureFromData(format,
             filename,
-            chooseCompressionMethod(filename, compression_method),
+            chooseCompressionMethod(Poco::URI(filename).getPath(), compression_method),
             getHeaders(),
             std::nullopt,
             context);

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -113,7 +113,12 @@ ReadWriteBufferFromHTTP::HTTPHeaderEntries TableFunctionURL::getHeaders() const
 ColumnsDescription TableFunctionURL::getActualTableStructure(ContextPtr context) const
 {
     if (structure == "auto")
-        return StorageURL::getTableStructureFromData(format, filename, compression_method, getHeaders(), std::nullopt, context);
+        return StorageURL::getTableStructureFromData(format, 
+            filename,
+            chooseCompressionMethod(filename, compression_method),
+            getHeaders(),
+            std::nullopt,
+            context);
 
     return parseColumnsListFromString(structure, context);
 }

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -113,7 +113,7 @@ ReadWriteBufferFromHTTP::HTTPHeaderEntries TableFunctionURL::getHeaders() const
 ColumnsDescription TableFunctionURL::getActualTableStructure(ContextPtr context) const
 {
     if (structure == "auto")
-        return StorageURL::getTableStructureFromData(format, 
+        return StorageURL::getTableStructureFromData(format,
             filename,
             chooseCompressionMethod(filename, compression_method),
             getHeaders(),

--- a/tests/queries/0_stateless/01030_storage_url_syntax.sql
+++ b/tests/queries/0_stateless/01030_storage_url_syntax.sql
@@ -6,3 +6,61 @@ create table test_table_url_syntax (id UInt32) ENGINE = URL('','','','')
 ; -- { serverError 42 }
 drop table if exists test_table_url_syntax
 ;
+
+drop table if exists test_table_url
+;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint')
+; -- { serverError 36 }
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint.json');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'ErrorFormat')
+; -- { serverError 73 }
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'gzip');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'gz');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'deflate');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'brotli');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'lzma');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'zstd');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'lz4');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'bz2');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'snappy');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'none');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'auto');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint.gz', 'JSONEachRow');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint.fr', 'JSONEachRow');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow');
+drop table test_table_url;
+
+create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'zip')
+; -- { serverError 36 }
+

--- a/tests/queries/0_stateless/01030_storage_url_syntax.sql
+++ b/tests/queries/0_stateless/01030_storage_url_syntax.sql
@@ -62,5 +62,5 @@ create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint',
 drop table test_table_url;
 
 create table test_table_url(id UInt32) ENGINE = URL('http://localhost/endpoint', 'JSONEachRow', 'zip')
-; -- { serverError 36 }
+; -- { serverError 48 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Validate the compressionMethod parameter of URL table engine

When creating a table with URL engine, the `CompressionMethod` parameter is not checked. 
If the parameter value is mis-spelled, such error is reported when reading from this table or writing to the table. It's a little late for users to find such the error on table.

This PR:
1. adds checks for this parameter at the stage when a table is created, and rejects any invalid values.
2. update the doc to describe `Format` and `CompressionMethod` in more detail to help understand the default behaviour if these two are not provided on the engine.

