### PR TITLE
Fix stress test after #40420

### DIFF
--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -818,15 +818,25 @@ void FileSegmentRangeWriter::completeFileSegment(FileSegment & file_segment)
 
     if (file_segment.getDownloadedSize() > 0)
     {
-        /// file_segment->complete(DOWNLOADED) is not enough, because file segment capacity
-        /// was initially set with a margin as `max_file_segment_size`. => We need to always
-        /// resize to actual size after download finished.
         file_segment.getOrSetDownloader();
 
-        assert(file_segment.downloaded_size <= file_segment.range().size());
-        file_segment.segment_range = FileSegment::Range(
-            file_segment.segment_range.left, file_segment.segment_range.left + file_segment.downloaded_size - 1);
-        file_segment.reserved_size = file_segment.downloaded_size;
+        {
+            /// file_segment->complete(DOWNLOADED) is not enough, because file segment capacity
+            /// was initially set with a margin as `max_file_segment_size`. => We need to always
+            /// resize to actual size after download finished.
+            
+            /// Current file segment is downloaded as a part of write-through cache
+            /// and therefore cannot be concurrently accessed. Nevertheless, it can be
+            /// accessed by cache system tables if someone read from them,
+            /// therefore we need a mutex.
+            std::lock_guard segment_lock(file_segment.mutex);
+
+            assert(file_segment.downloaded_size <= file_segment.range().size());
+            file_segment.segment_range = FileSegment::Range(
+                file_segment.segment_range.left, 
+                file_segment.segment_range.left + file_segment.downloaded_size - 1);
+            file_segment.reserved_size = file_segment.downloaded_size;
+        }
 
         file_segment.completeWithState(FileSegment::State::DOWNLOADED);
 

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -829,7 +829,7 @@ void FileSegmentRangeWriter::completeFileSegment(FileSegment & file_segment)
             /// and therefore cannot be concurrently accessed. Nevertheless, it can be
             /// accessed by cache system tables if someone read from them,
             /// therefore we need a mutex.
-            std::lock_guard segment_lock(file_segment.mutex);
+            std::scoped_lock lock(cache->mutex, file_segment.mutex);
 
             assert(file_segment.downloaded_size <= file_segment.range().size());
             file_segment.segment_range = FileSegment::Range(

--- a/src/Common/FileSegment.cpp
+++ b/src/Common/FileSegment.cpp
@@ -824,7 +824,7 @@ void FileSegmentRangeWriter::completeFileSegment(FileSegment & file_segment)
             /// file_segment->complete(DOWNLOADED) is not enough, because file segment capacity
             /// was initially set with a margin as `max_file_segment_size`. => We need to always
             /// resize to actual size after download finished.
-            
+
             /// Current file segment is downloaded as a part of write-through cache
             /// and therefore cannot be concurrently accessed. Nevertheless, it can be
             /// accessed by cache system tables if someone read from them,
@@ -833,7 +833,7 @@ void FileSegmentRangeWriter::completeFileSegment(FileSegment & file_segment)
 
             assert(file_segment.downloaded_size <= file_segment.range().size());
             file_segment.segment_range = FileSegment::Range(
-                file_segment.segment_range.left, 
+                file_segment.segment_range.left,
                 file_segment.segment_range.left + file_segment.downloaded_size - 1);
             file_segment.reserved_size = file_segment.downloaded_size;
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Broken in https://github.com/ClickHouse/ClickHouse/pull/40420.