### PR TITLE
Base58 fix handling leading 0 / '1'

### DIFF
--- a/src/Common/base58.h
+++ b/src/Common/base58.h
@@ -11,7 +11,7 @@ inline size_t encodeBase58(const char8_t * src, size_t srclen, char8_t * dst)
 
     size_t processed = 0;
     size_t zeros = 0;
-    for ( ;*src == '\0' && processed < srclen-1; ++src)
+    for (;*src == '\0' && processed < srclen-1; ++src)
     {
         ++processed;
         ++zeros;
@@ -71,7 +71,7 @@ inline size_t decodeBase58(const char8_t * src, size_t srclen, char8_t * dst)
 
     size_t processed = 0;
     size_t zeros = 0;
-    for ( ;*src == '1' && processed < srclen-1; ++src)
+    for (;*src == '1' && processed < srclen-1; ++src)
     {
         ++processed;
         ++zeros;

--- a/src/Common/base58.h
+++ b/src/Common/base58.h
@@ -5,12 +5,22 @@
 namespace DB
 {
 
-inline size_t encodeBase58(const char8_t * src, char8_t * dst)
+inline size_t encodeBase58(const char8_t * src, size_t srclen, char8_t * dst)
 {
     const char * base58_encoding_alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
+    size_t processed = 0;
+    size_t zeros = 0;
+    for ( ;*src == '\0' && processed < srclen-1; ++src)
+    {
+        ++processed;
+        ++zeros;
+        *dst++ = '1';
+    }
+
     size_t idx = 0;
-    for (; *src; ++src)
+
+    while (processed < srclen-1)
     {
         unsigned int carry = static_cast<unsigned char>(*src);
         for (size_t j = 0; j < idx; ++j)
@@ -24,6 +34,8 @@ inline size_t encodeBase58(const char8_t * src, char8_t * dst)
             dst[idx++] = static_cast<unsigned char>(carry % 58);
             carry /= 58;
         }
+        ++src;
+        ++processed;
     }
 
     size_t c_idx = idx >> 1;
@@ -37,23 +49,38 @@ inline size_t encodeBase58(const char8_t * src, char8_t * dst)
     {
         dst[c_idx] = base58_encoding_alphabet[static_cast<unsigned char>(dst[c_idx])];
     }
+
     dst[idx] = '\0';
-    return idx + 1;
+    return zeros + idx + 1;
 }
 
-inline size_t decodeBase58(const char8_t * src, char8_t * dst)
+inline size_t decodeBase58(const char8_t * src, size_t srclen, char8_t * dst)
 {
     const signed char uint_max = UINT_MAX;
     const signed char map_digits[128]
         = {uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max,
            uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max,
            uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max,
-           uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, 0,  1,  2,  3,  4,  5,  6,  7,  8,        uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, 9,  10, 11, 12, 13, 14, 15, 16,       uint_max, 17, 18, 19, 20, 21,       uint_max, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
-           uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,       uint_max, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,       uint_max, uint_max, uint_max, uint_max, uint_max};
+           uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, 0,        1,        2,
+           3,        4,        5,        6,        7,        8,        uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, uint_max,
+           9,        10,       11,       12,       13,       14,       15,       16,       uint_max, 17,       18,       19,       20,
+           21,       uint_max, 22,       23,       24,       25,       26,       27,       28,       29,       30,       31,       32,
+           uint_max, uint_max, uint_max, uint_max, uint_max, uint_max, 33,       34,       35,       36,       37,       38,       39,
+           40,       41,       42,       43,       uint_max, 44,       45,       46,       47,       48,       49,       50,       51,
+           52,       53,       54,       55,       56,       57,       uint_max, uint_max, uint_max, uint_max, uint_max};
+
+    size_t processed = 0;
+    size_t zeros = 0;
+    for ( ;*src == '1' && processed < srclen-1; ++src)
+    {
+        ++processed;
+        ++zeros;
+        *dst++ = '\0';
+    }
 
     size_t idx = 0;
 
-    for (; *src; ++src)
+    while (processed < srclen-1)
     {
         unsigned int carry = map_digits[*src];
         if (unlikely(carry == UINT_MAX))
@@ -71,6 +98,8 @@ inline size_t decodeBase58(const char8_t * src, char8_t * dst)
             dst[idx++] = static_cast<unsigned char>(carry & 0xff);
             carry >>= 8;
         }
+        ++src;
+        ++processed;
     }
 
     size_t c_idx = idx >> 1;
@@ -81,7 +110,7 @@ inline size_t decodeBase58(const char8_t * src, char8_t * dst)
         dst[idx - (i + 1)] = s;
     }
     dst[idx] = '\0';
-    return idx + 1;
+    return zeros + idx + 1;
 }
 
 }

--- a/src/Functions/FunctionBase58Conversion.h
+++ b/src/Functions/FunctionBase58Conversion.h
@@ -48,7 +48,7 @@ struct Base58Encode
         for (size_t row = 0; row < input_rows_count; ++row)
         {
             size_t srclen = src_offsets[row] - src_offset_prev;
-            auto encoded_size = encodeBase58(src, dst_pos);
+            auto encoded_size = encodeBase58(src, srclen, dst_pos);
 
             src += srclen;
             dst_pos += encoded_size;
@@ -90,7 +90,7 @@ struct Base58Decode
         {
             size_t srclen = src_offsets[row] - src_offset_prev;
 
-            auto decoded_size = decodeBase58(src, dst_pos);
+            auto decoded_size = decodeBase58(src, srclen, dst_pos);
             if (!decoded_size)
                 throw Exception("Invalid Base58 value, cannot be decoded", ErrorCodes::BAD_ARGUMENTS);
 

--- a/tests/queries/0_stateless/02337_base58.reference
+++ b/tests/queries/0_stateless/02337_base58.reference
@@ -21,3 +21,6 @@ foo
 foob
 fooba
 foobar
+
+1
+1

--- a/tests/queries/0_stateless/02337_base58.sql
+++ b/tests/queries/0_stateless/02337_base58.sql
@@ -9,4 +9,7 @@ SELECT base58Decode('Hold my beer...'); -- { serverError 36 }
 SELECT base58Decode(encoded) FROM (SELECT base58Encode(val) as encoded FROM (select arrayJoin(['', 'f', 'fo', 'foo', 'foob', 'fooba', 'foobar', 'Hello world!']) val));
 
 SELECT base58Encode(val) FROM (select arrayJoin(['', 'f', 'fo', 'foo', 'foob', 'fooba', 'foobar']) val);
-SELECT base58Decode(val) FROM (select arrayJoin(['', '2m', '8o8', 'bQbp', '3csAg9', 'CZJRhmz', 't1Zv2yaZ']) val);
+SELECT base58Decode(val) FROM (select arrayJoin(['', '2m', '8o8', 'bQbp', '3csAg9', 'CZJRhmz', 't1Zv2yaZ', '']) val);
+
+SELECT base58Encode(base58Decode('1BWutmTvYPwDtmw9abTkS4Ssr8no61spGAvW1X6NDix')) == '1BWutmTvYPwDtmw9abTkS4Ssr8no61spGAvW1X6NDix';
+select base58Encode('\x00\x0b\xe3\xe1\xeb\xa1\x7a\x47\x3f\x89\xb0\xf7\xe8\xe2\x49\x40\xf2\x0a\xeb\x8e\xbc\xa7\x1a\x88\xfd\xe9\x5d\x4b\x83\xb7\x1a\x09') == '1BWutmTvYPwDtmw9abTkS4Ssr8no61spGAvW1X6NDix';


### PR DESCRIPTION
Fixes #40587, fixes #40536.
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `base58Encode / base58Decode` handling leading 0 / '1'