### PR TITLE
More robust protection from recursive Buffer

### DIFF
--- a/src/Storages/StorageBuffer.h
+++ b/src/Storages/StorageBuffer.h
@@ -169,6 +169,8 @@ private:
     void backgroundFlush();
     void reschedule();
 
+    StoragePtr getDestinationTable() const;
+
     BackgroundSchedulePool & bg_pool;
     BackgroundSchedulePoolTaskHolder flush_handle;
 };

--- a/tests/queries/0_stateless/02420_buffer_table_points_to_itself.sql
+++ b/tests/queries/0_stateless/02420_buffer_table_points_to_itself.sql
@@ -1,0 +1,7 @@
+-- Tags: no-parallel
+-- no-parallel to avoid seeing INFINITE_LOOP in other tests
+
+-- Test for total_rows with recursive buffer.
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (key UInt32) Engine=Buffer(default, test, 16, 10, 100, 10000, 1000000, 10000000, 100000000);
+SELECT * FROM system.tables WHERE database = currentDatabase() AND table = 'test' FORMAT Null; -- { serverError INFINITE_LOOP }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
More robust protection from recursive Buffer (fix possible SIGSEGV for `select * from system.tables` when Buffer points to itself)

This fixes the following places:
- IStorage::totalRows()
- flushing buffer
- StorageBuffer::mayBenefitFromIndexForIn() (lack of check for table
  existence)

And it also makes this error fatal, i.e. now you will always got
INFINITE_LOOP error, while before getQueryProcessingStage() ignores the
error.

Fixes: #40637 (cc @alexey-milovidov )