### PR TITLE
Convert SQLite int8 column to ClickHouse int64

### DIFF
--- a/src/Databases/SQLite/fetchSQLiteTableStructure.cpp
+++ b/src/Databases/SQLite/fetchSQLiteTableStructure.cpp
@@ -35,9 +35,9 @@ static DataTypePtr convertSQLiteDataType(String type)
         res = std::make_shared<DataTypeInt8>();
     else if (type == "smallint")
         res = std::make_shared<DataTypeInt16>();
-    else if (type.starts_with("int") || type == "mediumint")
+    else if ((type.starts_with("int") && type != "int8") || type == "mediumint")
         res = std::make_shared<DataTypeInt32>();
-    else if (type == "bigint")
+    else if (type == "bigint" || type == "int8")
         res = std::make_shared<DataTypeInt64>();
     else if (type == "float")
         res = std::make_shared<DataTypeFloat32>();

--- a/tests/queries/0_stateless/01889_sqlite_read_write.reference
+++ b/tests/queries/0_stateless/01889_sqlite_read_write.reference
@@ -21,7 +21,7 @@ line3	3
 2	text2
 3	text3
 test types
-CREATE TABLE SQLite.table4\n(\n    `a` Nullable(Int32),\n    `b` Nullable(Int32),\n    `c` Nullable(Int8),\n    `d` Nullable(Int16),\n    `e` Nullable(Int32),\n    `bigint` Nullable(String),\n    `int2` Nullable(String),\n    `int8` Nullable(String)\n)\nENGINE = SQLite
+CREATE TABLE SQLite.table4\n(\n    `a` Nullable(Int32),\n    `b` Nullable(Int32),\n    `c` Nullable(Int8),\n    `d` Nullable(Int16),\n    `e` Nullable(Int32),\n    `f` Nullable(Int64),\n    `g` Nullable(Int32),\n    `h` Nullable(Int64)\n)\nENGINE = SQLite
 CREATE TABLE SQLite.table5\n(\n    `a` Nullable(String),\n    `b` Nullable(String),\n    `c` Nullable(Float64),\n    `d` Nullable(Float64),\n    `e` Nullable(Float64),\n    `f` Nullable(Float32)\n)\nENGINE = SQLite
 create table engine with table3
 CREATE TABLE default.sqlite_table3\n(\n    `col1` String,\n    `col2` Int32\n)\nENGINE = SQLite

--- a/tests/queries/0_stateless/01889_sqlite_read_write.sh
+++ b/tests/queries/0_stateless/01889_sqlite_read_write.sh
@@ -42,7 +42,7 @@ sqlite3 "${DB_PATH}" "INSERT INTO table3 VALUES ('not a null', 2)"
 sqlite3 "${DB_PATH}" 'INSERT INTO table3 VALUES (NULL, 3)'
 sqlite3 "${DB_PATH}" "INSERT INTO table3 VALUES ('', 4)"
 
-sqlite3 "${DB_PATH}" 'CREATE TABLE table4 (a int, b integer, c tinyint, d smallint, e mediumint, bigint, int2, int8)'
+sqlite3 "${DB_PATH}" 'CREATE TABLE table4 (a int, b integer, c tinyint, d smallint, e mediumint, f bigint, g int2, h int8)'
 sqlite3 "${DB_PATH}" 'CREATE TABLE table5 (a character(20), b varchar(10), c real, d double, e double precision, f float)'
 
 


### PR DESCRIPTION
SQLite int8 column uses 64 bit integers.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fixes SQLite int8 column conversion to int64 column in ClickHouse. Fixes #40639


