### PR TITLE
Every MergeTree setting must have documentation

### DIFF
--- a/tests/queries/0_stateless/02395_every_merge_tree_setting_must_have_documentation.sql
+++ b/tests/queries/0_stateless/02395_every_merge_tree_setting_must_have_documentation.sql
@@ -1,0 +1,1 @@
+SELECT name FROM system.merge_tree_settings WHERE length(description) < 10;


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enforce documentation for every MergeTree setting.