### PR TITLE
Remove some outdated comments

### DIFF
--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -8,7 +8,7 @@
 #  sudo apt-get install ninja-build
 
 
-if (NOT DEFINED ENV{CLION_IDE} AND NOT DEFINED ENV{XCODE_IDE})
+if (NOT DEFINED ENV{XCODE_IDE})
     find_program(NINJA_PATH ninja)
     if (NINJA_PATH)
         set(CMAKE_GENERATOR "Ninja" CACHE INTERNAL "")

--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -7,10 +7,6 @@
 # How to install Ninja on Ubuntu:
 #  sudo apt-get install ninja-build
 
-# CLion does not support Ninja
-# You can add your vote on CLion task tracker:
-# https://youtrack.jetbrains.com/issue/CPP-2659
-# https://youtrack.jetbrains.com/issue/CPP-870
 
 if (NOT DEFINED ENV{CLION_IDE} AND NOT DEFINED ENV{XCODE_IDE})
     find_program(NINJA_PATH ninja)


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


CLion support ninja well now.
https://blog.jetbrains.com/clion/2019/10/clion-2019-3-eap-ninja-cmake-generators/
