### PR TITLE
Add llvm-15 for llvm-symbolizer-15 for clang-15 (used for TSan)

### DIFF
--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -78,6 +78,7 @@ RUN export CODENAME="$(lsb_release --codename --short | tr 'A-Z' 'a-z')" \
     && apt-get update \
     && apt-get install \
         clang-15 \
+        llvm-15 \
         clang-tidy-15 \
         --yes --no-install-recommends \
     && apt-get clean


### PR DESCRIPTION
Simply installing llvm-15 over TSAN_SYMBOLIZER_PATH had been prefered
(to keep everything in one place and as simple as possible), though
TSAN_SYMBOLIZER_PATH should also work.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)