### PR TITLE
Add setting to disable limit on kafka_num_consumers

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -966,7 +966,13 @@ Default value: 5000.
 
 See also:
 
--   [Apache Kafka](https://kafka.apache.org/)
+- [Apache Kafka](https://kafka.apache.org/)
+
+## kafka_disable_num_consumers_limit {#kafka-disable-num-consumers-limit}
+
+Disable limit on kafka_num_consumers that depends on the number of available CPU cores.
+
+Default value: false.
 
 ## use_uncompressed_cache {#setting-use_uncompressed_cache}
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -532,6 +532,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, max_entries_for_hash_table_stats, 10'000, "How many entries hash table statistics collected during aggregation is allowed to have", 0) \
     M(UInt64, max_size_to_preallocate_for_aggregation, 10'000'000, "For how many elements it is allowed to preallocate space in all hash tables in total before aggregation", 0) \
     \
+    M(Bool, kafka_disable_num_consumers_limit, false, "Disable limit on kafka_num_consiners that depends on the number of available CPU cores", 0) \
     /** Experimental feature for moving data between shards. */ \
     \
     M(Bool, allow_experimental_query_deduplication, false, "Experimental data deduplication for SELECT queries based on part UUIDs", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -532,7 +532,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, max_entries_for_hash_table_stats, 10'000, "How many entries hash table statistics collected during aggregation is allowed to have", 0) \
     M(UInt64, max_size_to_preallocate_for_aggregation, 10'000'000, "For how many elements it is allowed to preallocate space in all hash tables in total before aggregation", 0) \
     \
-    M(Bool, kafka_disable_num_consumers_limit, false, "Disable limit on kafka_num_consiners that depends on the number of available CPU cores", 0) \
+    M(Bool, kafka_disable_num_consumers_limit, false, "Disable limit on kafka_num_consumers that depends on the number of available CPU cores", 0) \
     /** Experimental feature for moving data between shards. */ \
     \
     M(Bool, allow_experimental_query_deduplication, false, "Experimental data deduplication for SELECT queries based on part UUIDs", 0) \

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -40,8 +40,6 @@
 #include <Common/getNumberOfPhysicalCPUCores.h>
 #include <Common/quoteString.h>
 #include <Common/setThreadName.h>
-#include <Common/typeid_cast.h>
-
 
 #include <Common/CurrentMetrics.h>
 #include <Common/ProfileEvents.h>
@@ -847,7 +845,7 @@ void registerStorageKafka(StorageFactory & factory)
         auto num_consumers = kafka_settings->kafka_num_consumers.value;
         auto max_consumers = std::max<uint32_t>(getNumberOfPhysicalCPUCores(), 16);
 
-        if (num_consumers > max_consumers)
+        if (!args.getLocalContext()->getSettingsRef().kafka_disable_num_consumers_limit && num_consumers > max_consumers)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "The number of consumers can not be bigger than {}. "
                             "A single consumer can read any number of partitions. Extra consumers are relatively expensive, "

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4115,7 +4115,6 @@ def test_num_consumers_limit(kafka_cluster):
 
     assert "BAD_ARGUMENTS" in error
 
-
     instance.query(
         """
         SET kafka_disable_num_consumers_limit = 1;

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -4102,6 +4102,32 @@ def test_issue26643(kafka_cluster):
     # kafka_cluster.open_bash_shell('instance')
 
 
+def test_num_consumers_limit(kafka_cluster):
+    instance.query("DROP TABLE IF EXISTS test.kafka")
+
+    error = instance.query_and_get_error(
+        """
+        CREATE TABLE test.kafka (key UInt64, value UInt64)
+            ENGINE = Kafka('{kafka_broker}:19092', '{kafka_topic_old}', '{kafka_group_name_old}', '{kafka_format_json_each_row}', '\\n', '', 100)
+            SETTINGS kafka_commit_on_select = 1;
+        """
+    )
+
+    assert "BAD_ARGUMENTS" in error
+
+
+    instance.query(
+        """
+        SET kafka_disable_num_consumers_limit = 1;
+        CREATE TABLE test.kafka (key UInt64, value UInt64)
+            ENGINE = Kafka('{kafka_broker}:19092', '{kafka_topic_old}', '{kafka_group_name_old}', '{kafka_format_json_each_row}', '\\n', '', 100)
+            SETTINGS kafka_commit_on_select = 1;
+        """
+    )
+
+    instance.query("DROP TABLE test.kafka")
+
+
 if __name__ == "__main__":
     cluster.start()
     input("Cluster created, press any key to destroy...")


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add setting to disable limit on kafka_num_consumers. Closes https://github.com/ClickHouse/ClickHouse/issues/40331


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
