### PR TITLE
Make 01111_create_drop_replicated_db_stress less flaky

### DIFF
--- a/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
+++ b/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
@@ -51,7 +51,7 @@ function create_table()
         database=$($CLICKHOUSE_CLIENT -q "select name from system.databases where name like '${CLICKHOUSE_DATABASE}%' order by rand() limit 1")
         if [ -z "$database" ]; then return; fi
         $CLICKHOUSE_CLIENT --distributed_ddl_task_timeout=0 -q \
-        "create table $database.rmt_$RANDOM (n int) engine=ReplicatedMergeTree order by tuple() -- suppress $CLICKHOUSE_TEST_ZOOKEEPER_PREFIX" \
+        "create table $database.rmt_${RANDOM}_${RANDOM}_${RANDOM} (n int) engine=ReplicatedMergeTree order by tuple() -- suppress $CLICKHOUSE_TEST_ZOOKEEPER_PREFIX" \
         2>&1| grep -Fa "Exception: " | grep -Fv "Macro 'uuid' and empty arguments" | grep -Fv "Cannot enqueue query" | grep -Fv "ZooKeeper session expired" | grep -Fv UNKNOWN_DATABASE
         sleep 0.$RANDOM
     done


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/e2e1ca26e992ffcbfb90eda6f21a30cdf6c96dc9/stateless_tests__release__s3_storage_/runlog.log
```
2022-08-26 06:44:06 01111_create_drop_replicated_db_stress:                                 [ FAIL ] 36.72 sec. - having having exception in stdout: 
2022-08-26 06:44:06 [localhost] 2022.08.26 06:43:57.049462 [ 3312 ] {27d59327-cd9b-4b9e-935e-1361fe6e7f3d} <Error> executeQuery: Code: 57. DB::Exception: Table default_repl_9.rmt_17407 already exists. (TABLE_ALREADY_EXISTS) (version 22.9.1.465 (official build)) (from 0.0.0.0:0) (comment: 01111_create_drop_replicated_db_stress.sh) (in query: /* ddl_entry=query-0000000023 */ CREATE TABLE default_repl_9.rmt_17407 UUID '96951ce3-0621-46ec-8611-58865b086018' (`n` Int32) ENGINE = ReplicatedMergeTree ORDER BY tuple()), Stack trace (when copying this message, always include the lines below):
2022-08-26 06:44:06 [localhost] 2022.08.26 06:43:57.050316 [ 3312 ] {27d59327-cd9b-4b9e-935e-1361fe6e7f3d} <Error> executeQuery: Code: 57. DB::Exception: Table default_repl_9.rmt_17407 already exists. (TABLE_ALREADY_EXISTS) (version 22.9.1.465 (official build)) (from [::1]:60624) (comment: 01111_create_drop_replicated_db_stress.sh) (in query: create table default_repl_9.rmt_17407 (n int) engine=ReplicatedMergeTree order by tuple() -- suppress 01111_create_drop_replicated_db_stress_default), Stack trace (when copying this message, always include the lines below):
2022-08-26 06:44:06 Code: 57. DB::Exception: Received from localhost:9000. DB::Exception: Table default_repl_9.rmt_17407 already exists. (TABLE_ALREADY_EXISTS)
2022-08-26 06:44:06 
2022-08-26 06:44:06 Settings used in the test: --max_insert_threads=0 --group_by_two_level_threshold=1 --group_by_two_level_threshold_bytes=1 --distributed_aggregation_memory_efficient=0 --fsync_metadata=1 --output_format_parallel_formatting=0 --input_format_parallel_parsing=1 --min_chunk_bytes_for_parallel_parsing=12340786 --max_read_buffer_size=568803 --prefer_localhost_replica=0 --max_block_size=67048 --max_threads=28 --optimize_or_like_chain=1 --optimize_read_in_order=0 --read_in_order_two_level_merge_threshold=24 --optimize_aggregation_in_order=1 --aggregation_in_order_max_block_bytes=41697827 --use_uncompressed_cache=1 --min_bytes_to_use_direct_io=0 --min_bytes_to_use_mmap_io=753543657 --local_filesystem_read_method=read --remote_filesystem_read_method=threadpool --local_filesystem_read_prefetch=0 --remote_filesystem_read_prefetch=0 --compile_expressions=1 --compile_aggregate_expressions=1 --compile_sort_description=0 --merge_tree_coarse_index_granularity=15 --optimize_distinct_in_order=1 --optimize_sorting_by_input_stream_properties=0
2022-08-26 06:44:06 
2022-08-26 06:44:06 Database: test_5876rz
```
