### PR TITLE
Avoid deadlock in case of new query and OOM

### DIFF
--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -82,8 +82,7 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
     bool is_unlimited_query = isUnlimitedQuery(ast);
 
     {
-        std::unique_lock lock(mutex);
-        OvercommitTrackerBlockerInThread overcommit_blocker; // To avoid deadlock in case of OOM
+        auto [lock, overcommit_blocker] = safeLock(); // To avoid deadlock in case of OOM
         IAST::QueryKind query_kind = ast->getQueryKind();
 
         const auto queue_max_wait_ms = settings.queue_max_wait_ms.totalMilliseconds();

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -270,6 +270,7 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
 
 ProcessListEntry::~ProcessListEntry()
 {
+    OvercommitTrackerBlockerInThread overcommit_tracker_blocker;
     std::lock_guard lock(parent.mutex);
 
     String user = it->getClientInfo().current_user;
@@ -497,6 +498,7 @@ ProcessList::Info ProcessList::getInfo(bool get_thread_list, bool get_profile_ev
     Info per_query_infos;
 
     std::lock_guard lock(mutex);
+    OvercommitTrackerBlockerInThread overcommit_tracker_blocker;
 
     per_query_infos.reserve(processes.size());
     for (const auto & process : processes)
@@ -532,6 +534,7 @@ ProcessList::UserInfo ProcessList::getUserInfo(bool get_profile_events) const
     UserInfo per_user_infos;
 
     std::lock_guard lock(mutex);
+    OvercommitTrackerBlockerInThread overcommit_tracker_blocker;
 
     per_user_infos.reserve(user_to_queries.size());
 

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -83,6 +83,7 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
 
     {
         std::unique_lock lock(mutex);
+        OvercommitTrackerBlockerInThread overcommit_blocker; // To avoid deadlock in case of OOM
         IAST::QueryKind query_kind = ast->getQueryKind();
 
         const auto queue_max_wait_ms = settings.queue_max_wait_ms.totalMilliseconds();

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -297,7 +297,7 @@ protected:
         OvercommitTrackerBlockerInThread blocker;
     };
 
-    // It is forbiden to do allocations/deallocations with acqiured mutex and
+    // It is forbidden to do allocations/deallocations with acquired mutex and
     // enabled OvercommitTracker. This leads to deadlock in the case of OOM.
     LockAndBlocker safeLock() const noexcept { return { std::unique_lock{mutex}, {} }; }
     Lock unsafeLock() const noexcept { return std::unique_lock{mutex}; }

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -285,7 +285,26 @@ public:
 };
 
 
-class ProcessList
+class ProcessListBase
+{
+    mutable std::mutex mutex;
+
+protected:
+    using Lock = std::unique_lock<std::mutex>;
+    struct LockAndBlocker
+    {
+        Lock lock;
+        OvercommitTrackerBlockerInThread blocker;
+    };
+
+    // It is forbiden to do allocations/deallocations with acqiured mutex and
+    // enabled OvercommitTracker. This leads to deadlock in the case of OOM.
+    LockAndBlocker safeLock() const noexcept { return { std::unique_lock{mutex}, {} }; }
+    Lock unsafeLock() const noexcept { return std::unique_lock{mutex}; }
+};
+
+
+class ProcessList : public ProcessListBase
 {
 public:
     using Element = QueryStatus;
@@ -304,19 +323,11 @@ public:
 
 protected:
     friend class ProcessListEntry;
+    friend struct ::OvercommitTracker;
     friend struct ::UserOvercommitTracker;
     friend struct ::GlobalOvercommitTracker;
 
-    mutable std::mutex mutex;
     mutable std::condition_variable have_space;        /// Number of currently running queries has become less than maximum.
-
-    struct LockAndBlocker
-    {
-        std::lock_guard<std::mutex> guard;
-        OvercommitTrackerBlockerInThread blocker;
-    };
-
-    LockAndBlocker safeLock() const noexcept { return { std::lock_guard{mutex}, {} }; }
 
     /// List of queries
     Container processes;
@@ -368,19 +379,19 @@ public:
 
     void setMaxSize(size_t max_size_)
     {
-        std::lock_guard lock(mutex);
+        auto lock = unsafeLock();
         max_size = max_size_;
     }
 
     void setMaxInsertQueriesAmount(size_t max_insert_queries_amount_)
     {
-        std::lock_guard lock(mutex);
+        auto lock = unsafeLock();
         max_insert_queries_amount = max_insert_queries_amount_;
     }
 
     void setMaxSelectQueriesAmount(size_t max_select_queries_amount_)
     {
-        std::lock_guard lock(mutex);
+        auto lock = unsafeLock();
         max_select_queries_amount = max_select_queries_amount_;
     }
 

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -310,6 +310,14 @@ protected:
     mutable std::mutex mutex;
     mutable std::condition_variable have_space;        /// Number of currently running queries has become less than maximum.
 
+    struct LockAndBlocker
+    {
+        std::lock_guard<std::mutex> guard;
+        OvercommitTrackerBlockerInThread blocker;
+    };
+
+    LockAndBlocker safeLock() const noexcept { return { std::lock_guard{mutex}, {} }; }
+
     /// List of queries
     Container processes;
     size_t max_size = 0;        /// 0 means no limit. Otherwise, when limit exceeded, an exception is thrown.


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

During insertion of a new query to the `ProcessList` allocations happen. If we reach the memory limit during these allocations we can not use `OvercommitTracker`, because `ProcessList::mutex` is already acquired. Fixes #40611.