### PR TITLE
tests/stress: capture stacktrace of server hungs if pid was removed already

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -104,12 +104,16 @@ EOL
 
 function stop()
 {
+    local pid
+    # Preserve the pid, since the server can hung after the PID will be deleted.
+    pid="$(cat /var/run/clickhouse-server/clickhouse-server.pid)"
+
     clickhouse stop --do-not-kill && return
     # We failed to stop the server with SIGTERM. Maybe it hang, let's collect stacktraces.
     kill -TERM "$(pidof gdb)" ||:
     sleep 5
     echo "thread apply all backtrace (on stop)" >> /test_output/gdb.log
-    gdb -batch -ex 'thread apply all backtrace' -p "$(cat /var/run/clickhouse-server/clickhouse-server.pid)" | ts '%Y-%m-%d %H:%M:%S' >> /test_output/gdb.log
+    gdb -batch -ex 'thread apply all backtrace' -p "$pid" | ts '%Y-%m-%d %H:%M:%S' >> /test_output/gdb.log
     clickhouse stop --force
 }
 


### PR DESCRIPTION
Here is one example from CI:

```
Found pid = 1413 in the list of running processes.
The process with pid = 1413 is running.
Process (pid = 1413) is still running. Will not try to kill it.
++ pidof gdb
+ kill -TERM ''
/run.sh: line 110: kill: `': not a pid or valid job spec
+ :
+ sleep 5
+ echo 'thread apply all backtrace (on stop)'
+ ts '%Y-%m-%d %H:%M:%S'
++ cat /var/run/clickhouse-server/clickhouse-server.pid
cat: /var/run/clickhouse-server/clickhouse-server.pid: No such file or directory
+ gdb -batch -ex 'thread apply all backtrace' -p ''
Argument required (process-id to attach).
```

So `clickhouse-server` received SIGTERM, did everything, removed the pid file, but did not terminated:

```
2022.08.26 15:28:41.094039 [ 1413 ] {} <Trace> ShellCommand: Try wait for shell command pid 17663 with timeout 0
2022.08.26 15:28:41.094123 [ 1413 ] {} <Trace> ShellCommand: Will kill shell command pid 17663 with SIGTERM
2022.08.26 15:28:59.625895 [ 1413 ] {} <Debug> MemoryTracker: Peak memory usage (for user): 2.00 MiB.
2022.08.26 15:28:59.626183 [ 1413 ] {} <Debug> MemoryTracker: Peak memory usage (for user): 20.13 KiB.
2022.08.26 15:28:59.627544 [ 1413 ] {} <Debug> Application: Destroyed global context.
2022.08.26 15:28:59.859093 [ 1413 ] {} <Information> Application: shutting down
2022.08.26 15:28:59.859157 [ 1413 ] {} <Debug> Application: Uninitializing subsystem: Logging Subsystem
2022.08.26 15:28:59.859260 [ 1416 ] {} <Trace> BaseDaemon: Received signal -2
2022.08.26 15:28:59.859321 [ 1416 ] {} <Information> BaseDaemon: Stop SignalListener thread
2022.08.26 15:29:24.985224 [ 1411 ] {} <Fatal> Application: Child process was terminated by signal 9 (KILL). If it is not done by 'forcestop' command or manually, the possible cause is OOM Killer (see 'dmesg' and look at the '/var/log/kern.log' for the details).
```

CI: https://s3.amazonaws.com/clickhouse-test-reports/36837/704c4b2c5bf3d653378a2e513cfb56cc2917bb4a/stress_test__thread_.html
Cc: @tavplubix 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)