### PR TITLE
Remove `accurate_Cast` and `accurate_CastOrNull`, which are unused

### DIFF
--- a/src/Functions/CastOverloadResolver.cpp
+++ b/src/Functions/CastOverloadResolver.cpp
@@ -8,8 +8,7 @@ namespace DB
 REGISTER_FUNCTION(CastOverloadResolvers)
 {
     factory.registerFunction<CastInternalOverloadResolver<CastType::nonAccurate>>(FunctionFactory::CaseInsensitive);
-    factory.registerFunction<CastInternalOverloadResolver<CastType::accurate>>();
-    factory.registerFunction<CastInternalOverloadResolver<CastType::accurateOrNull>>();
+    /// Note: "internal" (not affected by null preserving setting) versions of accurate cast functions are unneeded.
 
     factory.registerFunction<CastOverloadResolver<CastType::nonAccurate>>(FunctionFactory::CaseInsensitive);
     factory.registerFunction<CastOverloadResolver<CastType::accurate>>();

--- a/src/Functions/CastOverloadResolver.h
+++ b/src/Functions/CastOverloadResolver.h
@@ -9,14 +9,13 @@ namespace ErrorCodes
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
 
-/*
- * CastInternal does not preserve nullability of the data type,
- * i.e. CastInternal(toNullable(toInt8(1)) as Int32) will be Int32(1).
- *
- * Cast preserves nullability according to setting `cast_keep_nullable`,
- * i.e. Cast(toNullable(toInt8(1)) as Int32) will be Nullable(Int32(1)) if `cast_keep_nullable` == 1.
-**/
-template<CastType cast_type, bool internal, typename CastName, typename FunctionName>
+/** CastInternal does not preserve nullability of the data type,
+  * i.e. CastInternal(toNullable(toInt8(1)) as Int32) will be Int32(1).
+  *
+  * Cast preserves nullability according to setting `cast_keep_nullable`,
+  * i.e. Cast(toNullable(toInt8(1)) as Int32) will be Nullable(Int32(1)) if `cast_keep_nullable` == 1.
+  */
+template <CastType cast_type, bool internal, typename CastName, typename FunctionName>
 class CastOverloadResolverImpl : public IFunctionOverloadResolver
 {
 public:


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove the functions `accurate_Cast` and `accurate_CastOrNull` (they are different to `accurateCast` and `accurateCastOrNull` by underscore in the name and they are not affected by the value of `cast_keep_nullable` setting). These functions were undocumented, untested, unused, and unneeded. They appeared to be alive due to code generalization.