### PR TITLE
Mv doc symlinks to includes

### DIFF
--- a/docs/ru/about-us/_category_.yml
+++ b/docs/ru/about-us/_category_.yml
@@ -1,0 +1,8 @@
+position: 80
+label: 'About Us'
+collapsible: true
+collapsed: true
+link:
+  type: generated-index
+  title: About Us
+  slug: /ru/about-us/

--- a/docs/ru/about-us/adopters.mdx
+++ b/docs/ru/about-us/adopters.mdx
@@ -1,0 +1,8 @@
+---
+sidebar_label: Adopters
+title: ClickHouse Adopters
+---
+
+import Adopters from '@site/docs/en/about-us/adopters.md';
+
+<Adopters />

--- a/docs/ru/about-us/support.mdx
+++ b/docs/ru/about-us/support.mdx
@@ -1,0 +1,8 @@
+---
+sidebar_label: Commercial Support
+title: ClickHouse Commercial Support Service
+---
+
+import Support from '@site/docs/en/about-us/support.md';
+
+<Support />

--- a/docs/ru/whats-new/changelog/2017.mdx
+++ b/docs/ru/whats-new/changelog/2017.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 6
+sidebar_label: 2017
+title: 2017 Changelog
+---
+
+import Changelog from '@site/docs/en/whats-new/changelog/2017.md';
+
+<Changelog />

--- a/docs/ru/whats-new/changelog/2018.mdx
+++ b/docs/ru/whats-new/changelog/2018.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 5
+sidebar_label: 2018
+title: 2018 Changelog
+---
+
+import Changelog from '@site/docs/en/whats-new/changelog/2018.md';
+
+<Changelog />

--- a/docs/ru/whats-new/changelog/2019.mdx
+++ b/docs/ru/whats-new/changelog/2019.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 4
+sidebar_label: 2019
+title: 2019 Changelog
+---
+
+import Changelog from '@site/docs/en/whats-new/changelog/2019.md';
+
+<Changelog />

--- a/docs/ru/whats-new/changelog/2020.mdx
+++ b/docs/ru/whats-new/changelog/2020.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 3
+sidebar_label: 2020
+title: 2020 Changelog
+---
+
+import Changelog from '@site/docs/en/whats-new/changelog/2020.md';
+
+<Changelog />

--- a/docs/ru/whats-new/changelog/2021.mdx
+++ b/docs/ru/whats-new/changelog/2021.mdx
@@ -1,0 +1,9 @@
+---
+sidebar_position: 2
+sidebar_label: 2021
+title: 2021 Changelog
+---
+
+import Changelog from '@site/docs/en/whats-new/changelog/2021.md';
+
+<Changelog />

--- a/docs/ru/whats-new/changelog/_category_.yml
+++ b/docs/ru/whats-new/changelog/_category_.yml
@@ -1,0 +1,6 @@
+label: 'Changelog'
+collapsible: true
+collapsed: true
+link:
+  type: doc
+  id: ru/whats-new/changelog/index

--- a/docs/ru/whats-new/changelog/index.mdx
+++ b/docs/ru/whats-new/changelog/index.mdx
@@ -1,0 +1,10 @@
+---
+sidebar_position: 1
+sidebar_label: 2022
+title: 2022 Changelog
+slug: /ru/whats-new/changelog/index
+---
+
+import Changelog from '@site/docs/en/whats-new/changelog/index.md';
+
+<Changelog />

--- a/docs/ru/whats-new/index.md
+++ b/docs/ru/whats-new/index.md
@@ -1,9 +1,0 @@
----
-slug: /ru/whats-new/
-sidebar_label: "Что нового?"
-sidebar_position: 82
----
-
-# Что нового в ClickHouse?
-
-Планы развития вкратце изложены [здесь](https://github.com/ClickHouse/ClickHouse/issues/32513), а новости по предыдущим релизам подробно описаны в [журнале изменений](./changelog/index.md).

--- a/docs/ru/whats-new/roadmap.mdx
+++ b/docs/ru/whats-new/roadmap.mdx
@@ -1,0 +1,8 @@
+---
+sidebar_label: Roadmap
+title: Roadmap 
+---
+
+import Roadmap from '@site/docs/en/whats-new/roadmap.md';
+
+<Roadmap />


### PR DESCRIPTION
Symlinks seem to work ok, but there are two issues:
- they generate warnings during build about having two documents on the same route
- the UX is poor, the user bounces from their chosen language in the navbar to the source language (usually English)
Using MDX includes fixes these.

### Changelog category (leave one):
- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
