### PR TITLE
Make 02242_system_filesystem_cache_log_table output stable

### DIFF
--- a/tests/queries/0_stateless/02242_system_filesystem_cache_log_table.reference
+++ b/tests/queries/0_stateless/02242_system_filesystem_cache_log_table.reference
@@ -11,12 +11,12 @@ SYSTEM STOP MERGES test;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100000);
 SELECT 2240, 's3_cache', * FROM test FORMAT Null;
 SYSTEM FLUSH LOGS;
-SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2240%s3_cache%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1);
+SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2240%s3_cache%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1) ORDER BY file_segment_range, read_type;
 (0,519)	READ_FROM_FS_AND_DOWNLOADED_TO_CACHE
 (0,808110)	READ_FROM_FS_AND_DOWNLOADED_TO_CACHE
 SELECT 2241, 's3_cache', * FROM test FORMAT Null;
 SYSTEM FLUSH LOGS;
-SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2241%s3_cache%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1);
+SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2241%s3_cache%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1) ORDER BY file_segment_range, read_type;
 (0,808110)	READ_FROM_CACHE
 
 Using storage policy: local_cache
@@ -32,11 +32,11 @@ SYSTEM STOP MERGES test;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100000);
 SELECT 2240, 'local_cache', * FROM test FORMAT Null;
 SYSTEM FLUSH LOGS;
-SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2240%local_cache%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1);
+SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2240%local_cache%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1) ORDER BY file_segment_range, read_type;
 (0,519)	READ_FROM_FS_AND_DOWNLOADED_TO_CACHE
 (0,808110)	READ_FROM_FS_AND_DOWNLOADED_TO_CACHE
 SELECT 2241, 'local_cache', * FROM test FORMAT Null;
 SYSTEM FLUSH LOGS;
-SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2241%local_cache%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1);
+SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2241%local_cache%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1) ORDER BY file_segment_range, read_type;
 (0,808110)	READ_FROM_CACHE
 

--- a/tests/queries/0_stateless/filesystem_cache_queries/02242_system_filesystem_cache_log_table.queries
+++ b/tests/queries/0_stateless/filesystem_cache_queries/02242_system_filesystem_cache_log_table.queries
@@ -12,8 +12,8 @@ INSERT INTO test SELECT number, toString(number) FROM numbers(100000);
 
 SELECT 2240, '_storagePolicy', * FROM test FORMAT Null;
 SYSTEM FLUSH LOGS;
-SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2240%_storagePolicy%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1);
+SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2240%_storagePolicy%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1) ORDER BY file_segment_range, read_type;
 
 SELECT 2241, '_storagePolicy', * FROM test FORMAT Null;
 SYSTEM FLUSH LOGS;
-SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2241%_storagePolicy%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1);
+SELECT file_segment_range, read_type FROM system.filesystem_cache_log WHERE query_id = (SELECT query_id from system.query_log where query LIKE '%SELECT 2241%_storagePolicy%' AND current_database = currentDatabase() AND type = 'QueryFinish' ORDER BY event_time desc LIMIT 1) ORDER BY file_segment_range, read_type;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
