### PR TITLE
tests/stress: improve OOM detection (add separate check by dmesg)

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -445,6 +445,13 @@ else
     [ -s /test_output/bc_check_fatal_messages.txt ] || rm /test_output/bc_check_fatal_messages.txt
 fi
 
+dmesg -T > /test_output/dmesg.log
+
+# OOM in dmesg -- those are real
+grep -q -F -e 'Out of memory: Killed process' -e 'oom_reaper: reaped process' -e 'oom-kill:constraint=CONSTRAINT_NONE' /test_output/dmesg.log \
+    && echo -e 'OOM in dmesg\tFAIL' >> /test_output/test_results.tsv \
+    || echo -e 'No OOM in dmesg\tOK' >> /test_output/test_results.tsv
+
 tar -chf /test_output/coordination.tar /var/lib/clickhouse/coordination ||:
 mv /var/log/clickhouse-server/stderr.log /test_output/
 
@@ -466,5 +473,3 @@ for core in core.*; do
     pigz $core
     mv $core.gz /test_output/
 done
-
-dmesg -T > /test_output/dmesg.log


### PR DESCRIPTION
Right now if you will look at the [OOM errors](https://play.clickhouse.com/play?user=play#c2VsZWN0CiAgcmVwb3J0X3VybCwKICByZXBsYWNlKHJlcG9ydF91cmwsICcuaHRtbCcsICcvZG1lc2cubG9nJykgYXMgbG9nX3VybCwKICB0b0RhdGVUaW1lKG1heChjaGVja19zdGFydF90aW1lKSwgJ0V1cm9wZS9Nb3Njb3cnKSBhcyBkdF9tc2ssCiAgY291bnRJZih0ZXN0X25hbWUgPSAnT09NIGtpbGxlciAob3Igc2lnbmFsIDkpIGluIGNsaWNraG91c2Utc2VydmVyLmxvZycpIGFzIGlzX29vbSwKICBjb3VudElmKHRlc3RfbmFtZSA9ICdObyBxdWVyaWVzIGh1bmcnKSBhcyBub19oYW5nCmZyb20gY2hlY2tzCndoZXJlCiAgcmVwb3J0X3VybCBMSUtFICclc3RyZXNzJScgQU5ECiAgLS0gdGltZSBvZiBtZXJnZSBodHRwczovL2dpdGh1Yi5jb20vQ2xpY2tIb3VzZS9DbGlja0hvdXNlL3B1bGwvNDAyNDkKICAtLWNoZWNrX3N0YXJ0X3RpbWUgPj0gdG9EYXRlVGltZSgnMjAyMi0wOC0xNyAxMjo1MTowMCcsICdFdXJvcGUvQW1zdGVyZGFtJykgYW5kCiAgY2hlY2tfc3RhcnRfdGltZSA+PSAnMjAyMi0wOC0wMSAwMDowMDowMCcgYW5kCiAgLS0gc3RyZXNzIG9uIHRvcCBvZiBzMyBoYXMgbG90cyBvZiBodW5nCiAgcHVsbF9yZXF1ZXN0X251bWJlciAhPSAzNjgzNwpncm91cCBieSByZXBvcnRfdXJsCmhhdmluZwogIGlzX29vbSBBTkQKICAtLSBpbiBjYXNlIG9mIGh1bmcgY2hlY2sgZmFpbGVkIGl0IG1heSBiZSB0aGUgZ2RiJ3MgZmF1bHQgb2YgT09NCiAgbm9faGFuZwpvcmRlciBieSBkdF9tc2sgZGVzYw==):
- OOM killer (or signal 9) in clickhouse-server.log
- Backward compatibility check: OOM messages in clickhouse-server.log

Most of them are not real, but just clickhouse server got KILLed by
clickhouse stop, #40678 may imporove the situation, but to definitely
sure that there was OOM let's look at dmesg.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)