### PR TITLE
Fix LOGICAL_ERROR with max_read_buffer_size=0 during reading marks

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3460,6 +3460,13 @@ ReadSettings Context::getReadSettings() const
 
     res.remote_read_min_bytes_for_seek = settings.remote_read_min_bytes_for_seek;
 
+    /// Zero read buffer will not make progress.
+    if (!settings.max_read_buffer_size)
+    {
+        throw Exception(ErrorCodes::INVALID_SETTING_VALUE,
+            "Invalid value '{}' for max_read_buffer_size", settings.max_read_buffer_size);
+    }
+
     res.local_fs_buffer_size = settings.max_read_buffer_size;
     res.remote_fs_buffer_size = settings.max_read_buffer_size;
     res.direct_io_threshold = settings.min_bytes_to_use_direct_io;

--- a/tests/queries/0_stateless/02052_last_granula_adjust_LOGICAL_ERROR.sql.j2
+++ b/tests/queries/0_stateless/02052_last_granula_adjust_LOGICAL_ERROR.sql.j2
@@ -12,7 +12,7 @@ as select number, repeat(toString(number), 5) from numbers({{ rows_in_table }});
 
 -- avoid any optimizations with ignore(*)
 select * apply max from data_02052_{{ rows_in_table }}_wide{{ wide }} settings max_read_buffer_size=1, max_threads=1;
-select * apply max from data_02052_{{ rows_in_table }}_wide{{ wide }} settings max_read_buffer_size=0, max_threads=1; -- { serverError CANNOT_READ_ALL_DATA }
+select * apply max from data_02052_{{ rows_in_table }}_wide{{ wide }} settings max_read_buffer_size=0, max_threads=1; -- { serverError INVALID_SETTING_VALUE }
 
 drop table data_02052_{{ rows_in_table }}_wide{{ wide }};
 {% endfor %}

--- a/tests/queries/0_stateless/02411_merge_tree_zero_max_read_buffer_size.sql
+++ b/tests/queries/0_stateless/02411_merge_tree_zero_max_read_buffer_size.sql
@@ -1,0 +1,17 @@
+-- Tags: no-parallel
+-- Tag no-parallel: due to SYSTEM DROP MARK CACHE
+
+--- Regression test for possible LOGICAL_ERROR with max_read_buffer_size=0
+--- (when marks was reading with max_read_buffer_size=0, hence DROP MARK CACHE is required)
+
+DROP TABLE IF EXISTS data_02411;
+CREATE TABLE data_02411
+(
+    key Int32
+)
+ENGINE = MergeTree
+ORDER BY key
+SETTINGS min_bytes_for_wide_part = 0, index_granularity = 8192;
+INSERT INTO data_02411 SELECT * FROM numbers(100);
+SYSTEM DROP MARK CACHE;
+SELECT * FROM data_02411 FORMAT Null SETTINGS max_read_buffer_size=0; -- { serverError INVALID_SETTING_VALUE }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix LOGICAL_ERROR with max_read_buffer_size=0 during reading marks

The problem is that the buffer size validated after marks reading in
MergeTreeReaderStream::init(), since it requires to read marks first.

And later it is passed to AsynchronousReadBufferFromFileDescriptor,
which throws LOGICAL_ERROR because buffer_size < alignment.

Fix this my simply disallow such values for max_read_buffer_size (I
thougt about modifying createReadBufferFromFileBase(), but it is not
used for remote reads -- remote_fs_buffer_size).

Fixes: #40669 (cc @davenger )