### PR TITLE
Fix gdb index (makes gdb 17x faster)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,8 +199,8 @@ endif ()
 option(ADD_GDB_INDEX_FOR_GOLD "Add .gdb-index to resulting binaries for gold linker.")
 
 if (NOT CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE")
-    # Can be lld or ld-lld.
-    if (LINKER_NAME MATCHES "lld$")
+    # Can be lld or ld-lld or lld-13 or /path/to/lld.
+    if (LINKER_NAME MATCHES "lld")
         set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gdb-index")
         set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gdb-index")
         message (STATUS "Adding .gdb-index via --gdb-index linker option.")


### PR DESCRIPTION
Right now LINKER_NAME contains version so it does not work:

    Aug 27 13:02:10 -- Using linker: /usr/bin/ld.lld-14

Without this patch:

    $ time gdb ~/ch/clickhouse/.bld-release/programs/clickhouse -batch

    real    1m20.564s
    user    1m18.622s
    sys     0m1.940s

    $ time lldb-13 clickhouse -batch
    real    0m9.353s
    user    1m31.035s
    sys     0m8.346s

With:

    $ time gdb clickhouse -batch
    real    0m4.769s
    user    0m3.969s
    sys     0m0.800s

    $ time lldb clickhouse -batch
    real    0m6.703s
    user    0m45.383s
    sys     0m4.934s

So by just adding 4.15MiB to the binary size, gdb start up time improved
17 times.

    $ objdump -j .gdb_index -h .bld-release/programs/clickhouse

    .bld-release/programs/clickhouse:     file format elf64-x86-64

    Sections:
    Idx Name          Size      VMA               LMA               File off  Algn
     40 .gdb_index    00426d74  0000000000000000  0000000000000000  7fb43443  2**0
                      CONTENTS, READONLY, DEBUGGING

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)