### PR TITLE
Correct format of APPLY transformer param

### DIFF
--- a/src/Parsers/ASTColumnsTransformers.cpp
+++ b/src/Parsers/ASTColumnsTransformers.cpp
@@ -51,7 +51,13 @@ void ASTColumnsApplyTransformer::formatImpl(const FormatSettings & settings, For
         settings.ostr << func_name;
 
         if (parameters)
-            parameters->formatImpl(settings, state, frame);
+        {
+            auto nested_frame = frame;
+            nested_frame.expression_list_prepend_whitespace = false;
+            settings.ostr << "(";
+            parameters->formatImpl(settings, state, nested_frame);
+            settings.ostr << ")";
+        }
     }
 
     if (!column_name_prefix.empty())

--- a/tests/queries/0_stateless/01710_projection_with_column_transformers.reference
+++ b/tests/queries/0_stateless/01710_projection_with_column_transformers.reference
@@ -1,0 +1,1 @@
+CREATE TABLE default.foo\n(\n    `bar` String,\n    PROJECTION p\n    (\n        SELECT * APPLY groupUniqArray(100)\n    )\n)\nENGINE = MergeTree\nORDER BY bar\nSETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/01710_projection_with_column_transformers.sql
+++ b/tests/queries/0_stateless/01710_projection_with_column_transformers.sql
@@ -1,0 +1,11 @@
+drop table if exists foo;
+
+create table foo(bar String, projection p (select * apply groupUniqArray(100))) engine MergeTree order by bar;
+
+show create foo;
+
+detach table foo;
+
+attach table foo;
+
+drop table foo;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect format of APPLY column transformer which can break metadata if used in table definition. This fixes https://github.com/ClickHouse/ClickHouse/issues/37590

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
