### PR TITLE
Minor modification

### DIFF
--- a/src/Storages/MergeTree/MergeTreeMarksLoader.h
+++ b/src/Storages/MergeTree/MergeTreeMarksLoader.h
@@ -1,7 +1,9 @@
 #pragma once
+
 #include <Storages/MergeTree/IDataPartStorage.h>
 #include <Storages/MarkCache.h>
 #include <IO/ReadSettings.h>
+
 
 namespace DB
 {
@@ -23,6 +25,9 @@ public:
         const ReadSettings & read_settings_,
         size_t columns_in_mark_ = 1);
 
+    /// Must be called before calling to getMark.
+    void load();
+
     const MarkInCompressedFile & getMark(size_t row_index, size_t column_index = 0);
 
 private:
@@ -36,8 +41,7 @@ private:
     MarkCache::MappedPtr marks;
     ReadSettings read_settings;
 
-    void loadMarks();
-    MarkCache::MappedPtr loadMarksImpl();
+    MarkCache::MappedPtr loadImpl();
 };
 
 }

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -207,6 +207,8 @@ void MergeTreeReaderCompact::readData(
 {
     const auto & [name, type] = name_and_type;
 
+    marks_loader.load();
+
     adjustUpperBound(current_task_last_mark); /// Must go before seek.
 
     if (!isContinuousReading(from_mark, column_position))

--- a/src/Storages/MergeTree/MergeTreeReaderStream.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderStream.cpp
@@ -54,6 +54,9 @@ void MergeTreeReaderStream::init()
     if (initialized)
         return;
     initialized = true;
+
+    marks_loader.load();
+
     /// Compute the size of the buffer.
     size_t max_mark_range_bytes = 0;
     size_t sum_mark_range_bytes = 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This modification is unneeded, but I'm searching for some elegant way for concurrent loading of marks.
Maybe make MarkCache have its own ThreadPool and make it return std::future.