### PR TITLE
Fix possible error Attempt to read after eof in CSV schema inference

### DIFF
--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -636,8 +636,9 @@ concept WithResize = requires (T value)
 template <typename Vector>
 void readCSVStringInto(Vector & s, ReadBuffer & buf, const FormatSettings::CSV & settings)
 {
+    /// Empty string
     if (buf.eof())
-        throwReadAfterEOF();
+        return;
 
     const char delimiter = settings.delimiter;
     const char maybe_quote = *buf.position();

--- a/tests/queries/0_stateless/02410_csv_empty_fields_inference.reference
+++ b/tests/queries/0_stateless/02410_csv_empty_fields_inference.reference
@@ -1,0 +1,8 @@
+c1	Nullable(String)					
+c2	Nullable(String)					
+c3	Nullable(String)					
+c4	Nullable(String)					
+c1	Nullable(Int64)					
+c2	Nullable(String)					
+c3	Nullable(String)					
+c4	Nullable(String)					

--- a/tests/queries/0_stateless/02410_csv_empty_fields_inference.sql
+++ b/tests/queries/0_stateless/02410_csv_empty_fields_inference.sql
@@ -1,0 +1,2 @@
+desc format(CSV, ',,,');
+desc format(CSV, '123,,abv,')


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible error Attempt to read after eof in CSV schema inference


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
