### PR TITLE
Enable `show_addresses_in_stack_traces` by default

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1405,6 +1405,6 @@
          Regardless of this configuration, the addresses are visible in the system.stack_trace and system.trace_log tables
          if the user has access to these tables.
          I don't recommend to change this setting.
-    -->
     <show_addresses_in_stack_traces>false</show_addresses_in_stack_traces>
+    -->
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The setting `show_addresses_in_stack_traces` was accidentally disabled in default `config.xml`. It's removed from the config now, so the setting is enabled by default. 
