### PR TITLE
Fix CaresPTRResolver not reading hosts file

### DIFF
--- a/src/Access/Common/AllowedClientHosts.cpp
+++ b/src/Access/Common/AllowedClientHosts.cpp
@@ -110,7 +110,7 @@ namespace
     }
 
     /// Returns the host name by its address.
-    Strings getHostsByAddress(const IPAddress & address)
+    std::unordered_set<String> getHostsByAddress(const IPAddress & address)
     {
         auto hosts = DNSResolver::instance().reverseResolve(address);
 
@@ -526,7 +526,7 @@ bool AllowedClientHosts::contains(const IPAddress & client_address) const
             return true;
 
     /// Check `name_regexps`.
-    std::optional<Strings> resolved_hosts;
+    std::optional<std::unordered_set<String>> resolved_hosts;
     auto check_name_regexp = [&](const String & name_regexp_)
     {
         try

--- a/src/Common/CaresPTRResolver.h
+++ b/src/Common/CaresPTRResolver.h
@@ -25,16 +25,16 @@ namespace DB
         explicit CaresPTRResolver(provider_token);
         ~CaresPTRResolver() override;
 
-        std::vector<std::string> resolve(const std::string & ip) override;
+        std::unordered_set<std::string> resolve(const std::string & ip) override;
 
-        std::vector<std::string> resolve_v6(const std::string & ip) override;
+        std::unordered_set<std::string> resolve_v6(const std::string & ip) override;
 
     private:
         void wait();
 
-        void resolve(const std::string & ip, std::vector<std::string> & response);
+        void resolve(const std::string & ip, std::unordered_set<std::string> & response);
 
-        void resolve_v6(const std::string & ip, std::vector<std::string> & response);
+        void resolve_v6(const std::string & ip, std::unordered_set<std::string> & response);
 
         ares_channel channel;
     };

--- a/src/Common/DNSPTRResolver.h
+++ b/src/Common/DNSPTRResolver.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include <vector>
+#include <unordered_set>
 
 namespace DB
 {
@@ -10,9 +10,9 @@ namespace DB
 
         virtual ~DNSPTRResolver() = default;
 
-        virtual std::vector<std::string> resolve(const std::string & ip) = 0;
+        virtual std::unordered_set<std::string> resolve(const std::string & ip) = 0;
 
-        virtual std::vector<std::string> resolve_v6(const std::string & ip) = 0;
+        virtual std::unordered_set<std::string> resolve_v6(const std::string & ip) = 0;
 
     };
 }

--- a/src/Common/DNSResolver.cpp
+++ b/src/Common/DNSResolver.cpp
@@ -136,7 +136,7 @@ static DNSResolver::IPAddresses resolveIPAddressImpl(const std::string & host)
     return addresses;
 }
 
-static Strings reverseResolveImpl(const Poco::Net::IPAddress & address)
+static std::unordered_set<String> reverseResolveImpl(const Poco::Net::IPAddress & address)
 {
     auto ptr_resolver = DB::DNSPTRResolverProvider::get();
 
@@ -234,7 +234,7 @@ std::vector<Poco::Net::SocketAddress> DNSResolver::resolveAddressList(const std:
     return addresses;
 }
 
-Strings DNSResolver::reverseResolve(const Poco::Net::IPAddress & address)
+std::unordered_set<String> DNSResolver::reverseResolve(const Poco::Net::IPAddress & address)
 {
     if (impl->disable_cache)
         return reverseResolveImpl(address);

--- a/src/Common/DNSResolver.h
+++ b/src/Common/DNSResolver.h
@@ -37,7 +37,7 @@ public:
     std::vector<Poco::Net::SocketAddress> resolveAddressList(const std::string & host, UInt16 port);
 
     /// Accepts host IP and resolves its host names
-    Strings reverseResolve(const Poco::Net::IPAddress & address);
+    std::unordered_set<String> reverseResolve(const Poco::Net::IPAddress & address);
 
     /// Get this server host name
     String getHostName();

--- a/tests/integration/test_host_regexp_hosts_file_resolution/configs/host_regexp.xml
+++ b/tests/integration/test_host_regexp_hosts_file_resolution/configs/host_regexp.xml
@@ -1,0 +1,11 @@
+<yandex>
+    <users>
+        <test_dns>
+            <password/>
+            <networks>
+                <host_regexp>test1\.example\.com$</host_regexp>
+            </networks>
+            <profile>default</profile>
+        </test_dns>
+    </users>
+</yandex>

--- a/tests/integration/test_host_regexp_hosts_file_resolution/configs/listen_host.xml
+++ b/tests/integration/test_host_regexp_hosts_file_resolution/configs/listen_host.xml
@@ -1,0 +1,5 @@
+<yandex>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+</yandex>

--- a/tests/integration/test_host_regexp_hosts_file_resolution/test.py
+++ b/tests/integration/test_host_regexp_hosts_file_resolution/test.py
@@ -1,0 +1,45 @@
+import pytest
+from helpers.cluster import ClickHouseCluster, get_docker_compose_path, run_and_check
+import os
+
+DOCKER_COMPOSE_PATH = get_docker_compose_path()
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+cluster = ClickHouseCluster(__file__)
+
+ch_server = cluster.add_instance(
+    "clickhouse-server",
+    main_configs=["configs/listen_host.xml"],
+    user_configs=["configs/host_regexp.xml"],
+)
+
+client = cluster.add_instance(
+    "clickhouse-client",
+)
+
+
+def build_endpoint_v4(ip):
+    return f"'http://{ip}:8123/?query=SELECT+1&user=test_dns'"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    global cluster
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_host_regexp_multiple_ptr_hosts_file_v4(started_cluster):
+    server_ip = cluster.get_instance_ip("clickhouse-server")
+
+    ch_server.exec_in_container(
+        (["bash", "-c", f"echo '{server_ip} test1.example.com' > /etc/hosts"])
+    )
+
+    endpoint = build_endpoint_v4(server_ip)
+
+    assert "1\n" == client.exec_in_container((["bash", "-c", f"curl {endpoint}"]))

--- a/tests/integration/test_host_regexp_hosts_file_resolution/test.py
+++ b/tests/integration/test_host_regexp_hosts_file_resolution/test.py
@@ -35,9 +35,10 @@ def started_cluster():
 
 def test_host_regexp_multiple_ptr_hosts_file_v4(started_cluster):
     server_ip = cluster.get_instance_ip("clickhouse-server")
+    client_ip = cluster.get_instance_ip("clickhouse-client")
 
     ch_server.exec_in_container(
-        (["bash", "-c", f"echo '{server_ip} test1.example.com' > /etc/hosts"])
+        (["bash", "-c", f"echo '{client_ip} test1.example.com' > /etc/hosts"])
     )
 
     endpoint = build_endpoint_v4(server_ip)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In #40595 it was reported that the `host_regexp` functionality was not working properly with a name to address resolution in `/etc/hosts`. It's fixed.


### Details:
The existing CaresPTRResolver implementation checks only for the ptr records in `hostent::h_aliases`, which is filled by `c-ares` whenever one or multiple PTR records are returned from the DNS server. The caveat is that `c-ares` file resolution fills out `hostent::h_name` and leaves `hostent::h_aliases` empty. The solution is to read both members of the `hostent` returned structure. An unordered_set is used to prevent duplicates (`h_name` usually contains the same value as the first entry of `h_aliases`).

The interface was adapted and now an `unordered_set` is being returned. With the overhead of a linear copy, the `vector` interface could be preserved. Leaving it on the table and open for discussion.

Closes #40595 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
