### PR TITLE
Fix cluster yaml format to correctly generate xml

### DIFF
--- a/tests/integration/test_config_yaml_full/configs/config.d/test_cluster_with_incorrect_pw.yaml
+++ b/tests/integration/test_config_yaml_full/configs/config.d/test_cluster_with_incorrect_pw.yaml
@@ -1,11 +1,12 @@
 remote_servers:
   test_cluster_with_incorrect_pw:
     shard:
-      internal_replication: true
-      replica:
-        - host: 127.0.0.1
+      - internal_replication: true
+        replica:
+          host: 127.0.0.1
           port: 9000
           password: foo
-        - host: 127.0.0.2
+        replica:
+          host: 127.0.0.2
           port: 9000
           password: foo


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `tests/integration/test_config_yaml_full/configs/config.d/test_cluster_with_incorrect_pw.yaml` to correctly generate `/var/lib/clickhouse/preprocessed_configs/config.xml` for cluster configuration. 

The current `test_cluster_with_incorrect_pw.yaml` generates the following cluster configuration where replicas are not represented correctly.
```
        <test_cluster_with_incorrect_pw>
            <shard>
                <internal_replication>true</internal_replication>
                <replica>
                    <host>127.0.0.1</host>
                    <port>9000</port>
                    <password>foo</password>
                    <host>127.0.0.2</host>
                    <port>9000</port>
                    <password>foo</password>
                </replica>
            </shard>
        </test_cluster_with_incorrect_pw>
```

The updated `test_cluster_with_incorrect_pw.yaml` generates the cluster configuration with two replicas correctly.
```
        <test_cluster_with_incorrect_pw>
            <shard>
                <internal_replication>true</internal_replication>
                <replica>
                    <host>127.0.0.1</host>
                    <port>9000</port>
                    <password>foo</password>
                </replica>
                <replica>
                    <host>127.0.0.2</host>
                    <port>9000</port>
                    <password>foo</password>
                </replica>
            </shard>
        </test_cluster_with_incorrect_pw>
```

Closes #40561
> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
