### PR TITLE
Fix docs for Base58

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -523,7 +523,7 @@ Query:
 
 ``` sql
 SELECT base58Encode('Encoded');
-SELECT base58Encode('3dc8KtHrwM');
+SELECT base58Decode('3dc8KtHrwM');
 ```
 
 Result:

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -495,7 +495,7 @@ If the ‘s’ string is non-empty and does not contain the ‘c’ character at
 
 Returns the string ‘s’ that was converted from the encoding in ‘from’ to the encoding in ‘to’.
 
-## Base58Encode(plaintext), Base58Decode(encoded_text)
+## base58Encode(plaintext), base58Decode(encoded_text)
 
 Accepts a String and encodes/decodes it using [Base58](https://tools.ietf.org/id/draft-msporny-base58-01.html) encoding scheme using "Bitcoin" alphabet.
 

--- a/docs/ru/sql-reference/functions/string-functions.md
+++ b/docs/ru/sql-reference/functions/string-functions.md
@@ -518,18 +518,18 @@ base58Decode(encoded)
 Запрос:
 
 ``` sql
-SELECT base58Encode('encode');
-SELECT base58Decode('izCFiDUY');
+SELECT base58Encode('Encoded');
+SELECT base58Decode('3dc8KtHrwM');
 ```
 
 Результат:
 ```text
-┌─base58Encode('encode', 'flickr')─┐
-│ SvyTHb1D                         │
-└──────────────────────────────────┘
-┌─base58Decode('izCFiDUY', 'ripple')─┐
-│ decode                             │
-└────────────────────────────────────┘
+┌─base58Encode('Encoded')─┐
+│ 3dc8KtHrwM              │
+└─────────────────────────┘
+┌─base58Decode('3dc8KtHrwM')─┐
+│ Encoded                    │
+└────────────────────────────┘
 ```
 
 ## base64Encode(s) {#base64encode}

--- a/docs/ru/sql-reference/functions/string-functions.md
+++ b/docs/ru/sql-reference/functions/string-functions.md
@@ -16,7 +16,7 @@ sidebar_label: "Функции для работы со строками"
 empty(x)
 ```
 
-Строка считается непустой, если содержит хотя бы один байт, пусть даже это пробел или нулевой байт. 
+Строка считается непустой, если содержит хотя бы один байт, пусть даже это пробел или нулевой байт.
 
 Функция также поддерживает работу с типами [Array](array-functions.md#function-empty) и [UUID](uuid-functions.md#empty).
 
@@ -56,7 +56,7 @@ SELECT empty('text');
 notEmpty(x)
 ```
 
-Строка считается непустой, если содержит хотя бы один байт, пусть даже это пробел или нулевой байт. 
+Строка считается непустой, если содержит хотя бы один байт, пусть даже это пробел или нулевой байт.
 
 Функция также поддерживает работу с типами [Array](array-functions.md#function-notempty) и [UUID](uuid-functions.md#notempty).
 
@@ -491,21 +491,21 @@ SELECT concat(key1, key2), sum(value) FROM key_val GROUP BY (key1, key2);
 
 Возвращает сконвертированную из кодировки from в кодировку to строку s.
 
-## Base58Encode(plaintext), Base58Decode(encoded_text) {#base58}
+## base58Encode(plaintext), base58Decode(encoded_text) {#base58}
 
 Принимает на вход строку или колонку строк и кодирует/раскодирует их с помощью схемы кодирования [Base58](https://tools.ietf.org/id/draft-msporny-base58-01.html) с использованием стандартного алфавита Bitcoin.
 
 **Синтаксис**
 
 ```sql
-encodeBase58(decoded)
-decodeBase58(encoded)
+base58Encode(decoded)
+base58Decode(encoded)
 ```
 
 **Аргументы**
 
 - `decoded` — Колонка или строка типа [String](../../sql-reference/data-types/string.md).
-- `encoded` — Колонка или строка типа [String](../../sql-reference/data-types/string.md). Если входная строка не является корректным кодом для какой-либо другой строки, возникнет исключение `1001`.
+- `encoded` — Колонка или строка типа [String](../../sql-reference/data-types/string.md). Если входная строка не является корректным кодом для какой-либо другой строки, возникнет исключение.
 
 **Возвращаемое значение**
 
@@ -518,16 +518,16 @@ decodeBase58(encoded)
 Запрос:
 
 ``` sql
-SELECT encodeBase58('encode');
-SELECT decodeBase58('izCFiDUY');
+SELECT base58Encode('encode');
+SELECT base58Decode('izCFiDUY');
 ```
 
 Результат:
 ```text
-┌─encodeBase58('encode', 'flickr')─┐
+┌─base58Encode('encode', 'flickr')─┐
 │ SvyTHb1D                         │
 └──────────────────────────────────┘
-┌─decodeBase58('izCFiDUY', 'ripple')─┐
+┌─base58Decode('izCFiDUY', 'ripple')─┐
 │ decode                             │
 └────────────────────────────────────┘
 ```


### PR DESCRIPTION
Fix typos in base58 docs

### Changelog category (leave one):
- Documentation (changelog entry is not required)