### PR TITLE
Assign new cherry-pick and backport PRs

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -240,6 +240,7 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
         self._assign_new_pr(self.backport_pr)
 
     def _assign_new_pr(self, new_pr: PullRequest):
+        """Assign `new_pr` to author, merger and assignees of an original PR"""
         # It looks there some race when multiple .add_to_assignees are executed,
         # so we'll add all at once
         assignees = [self.pr.user, self.pr.merged_by]

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -242,7 +242,7 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
     def _assign_new_pr(self, new_pr: PullRequest):
         # It looks there some race when multiple .add_to_assignees are executed,
         # so we'll add all at once
-        assignees = [self.pr.user]
+        assignees = [self.pr.user, self.pr.merged_by]
         if self.pr.assignees:
             assignees.extend(self.pr.assignees)
         logging.info(

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -206,14 +206,7 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
         )
         self.cherrypick_pr.add_to_labels(Labels.LABEL_CHERRYPICK)
         self.cherrypick_pr.add_to_labels(Labels.LABEL_DO_NOT_TEST)
-        if self.pr.assignees:
-            logging.info(
-                "Assing to assignees of the original PR: %s",
-                ", ".join(user.login for user in self.pr.assignees),
-            )
-            self.cherrypick_pr.add_to_assignees(*self.pr.assignees)
-        logging.info("Assign to the author of the original PR: %s", self.pr.user.login)
-        self.cherrypick_pr.add_to_assignees(self.pr.user)
+        self._assign_new_pr(self.cherrypick_pr)
 
     def create_backport(self):
         # Checkout the backport branch from the remote and make all changes to
@@ -244,14 +237,20 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
             head=self.backport_branch,
         )
         self.backport_pr.add_to_labels(Labels.LABEL_BACKPORT)
+        self._assign_new_pr(self.backport_pr)
+
+    def _assign_new_pr(self, new_pr: PullRequest):
+        # It looks there some race when multiple .add_to_assignees are executed,
+        # so we'll add all at once
+        assignees = [self.pr.user]
         if self.pr.assignees:
-            logging.info(
-                "Assing to assignees of the original PR: %s",
-                ", ".join(user.login for user in self.pr.assignees),
-            )
-            self.cherrypick_pr.add_to_assignees(*self.pr.assignees)
-        logging.info("Assign to the author of the original PR: %s", self.pr.user.login)
-        self.backport_pr.add_to_assignees(self.pr.user)
+            assignees.extend(self.pr.assignees)
+        logging.info(
+            "Assing #%s to author and assignees of the original PR: %s",
+            new_pr.number,
+            ", ".join(user.login for user in assignees),
+        )
+        new_pr.add_to_assignees(*assignees)
 
     @property
     def backported(self) -> bool:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Create a private method for PR assigning, and attempt to get rid of the race with multiple assignments.

Follow up for #40811