### PR TITLE
"Fix" database names collision in functional tests

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -533,7 +533,7 @@ class TestCase:
         else:
             # If --database is not specified, we will create temporary database with
             # unique name and we will recreate and drop it for each test
-            def random_str(length=6):
+            def random_str(length=8):
                 alphabet = string.ascii_lowercase + string.digits
                 # NOTE: it is important not to use default random generator, since it shares state.
                 return "".join(

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -995,9 +995,12 @@ class TestCase:
                 args.timeout - (datetime.now() - start_time).total_seconds(), 20
             )
             try:
+                drop_database_query = "DROP DATABASE " + database
+                if args.replicated_database:
+                    drop_database_query += " ON CLUSTER test_cluster_database_replicated"
                 clickhouse_execute(
                     args,
-                    "DROP DATABASE " + database,
+                    drop_database_query,
                     timeout=seconds_left,
                     settings={
                         "log_comment": args.testcase_basename,


### PR DESCRIPTION

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/5a3e24c4e4c23b4e56a89ac0c06a0b357d92d3c7/stateless_tests__release__databasereplicated__[2/2].html

```
$ zgrep -Fa " CREATE DATABASE test_4gve7l" clickhouse-server.log.gz
2022.08.31 20:17:29.146685 [ 2700 ] {b537b22a-d9c7-4030-8656-b358a464b0b8} <Debug> executeQuery: (from [::1]:53296) (comment: 02006_client_test_hint_no_such_error_name.sh) CREATE DATABASE test_4gve7l ON CLUSTER test_cluster_database_replicated ENGINE=Replicated('/test/clickhouse/db/test_4gve7l', '{shard}', '{replica}')  (stage: Complete)
2022.08.31 20:17:29.151340 [ 1398 ] {} <Debug> DDLWorker: Executing query: CREATE DATABASE test_4gve7l UUID '229bb160-0186-4a68-997f-d02d74350ede' ENGINE = Replicated('/test/clickhouse/db/test_4gve7l', '{shard}', '{replica}')
2022.08.31 20:17:29.151478 [ 1398 ] {130f2e19-40d8-422e-87a6-1067c6a9491f} <Debug> executeQuery: (from 0.0.0.0:0, user: ) (comment: 02006_client_test_hint_no_such_error_name.sh) /* ddl_entry=query-0000000401 */ CREATE DATABASE test_4gve7l UUID '229bb160-0186-4a68-997f-d02d74350ede' ENGINE = Replicated('/test/clickhouse/db/test_4gve7l', '{shard}', '{replica}') (stage: Complete)
2022.08.31 20:17:29.158798 [ 1398 ] {130f2e19-40d8-422e-87a6-1067c6a9491f} <Debug> DDLWorker: Executed query: CREATE DATABASE test_4gve7l UUID '229bb160-0186-4a68-997f-d02d74350ede' ENGINE = Replicated('/test/clickhouse/db/test_4gve7l', '{shard}', '{replica}')
2022.08.31 20:21:36.558379 [ 10410 ] {2a9a9b93-12d1-4dea-87aa-0430275a656b} <Debug> executeQuery: (from [::1]:58908) (comment: 01474_bad_global_join.sql) CREATE DATABASE test_4gve7l ON CLUSTER test_cluster_database_replicated ENGINE=Replicated('/test/clickhouse/db/test_4gve7l', '{shard}', '{replica}')  (stage: Complete)
2022.08.31 20:21:36.561823 [ 1398 ] {} <Debug> DDLWorker: Executing query: CREATE DATABASE test_4gve7l UUID 'd71bbf94-23e2-483e-bc54-efa1c7eb454a' ENGINE = Replicated('/test/clickhouse/db/test_4gve7l', '{shard}', '{replica}')
2022.08.31 20:21:36.561964 [ 1398 ] {818af675-6908-48ac-a5b2-984b0d696719} <Debug> executeQuery: (from 0.0.0.0:0, user: ) (comment: 01474_bad_global_join.sql) /* ddl_entry=query-0000000996 */ CREATE DATABASE test_4gve7l UUID 'd71bbf94-23e2-483e-bc54-efa1c7eb454a' ENGINE = Replicated('/test/clickhouse/db/test_4gve7l', '{shard}', '{replica}') (stage: Complete)
2022.08.31 20:21:36.564871 [ 1398 ] {818af675-6908-48ac-a5b2-984b0d696719} <Debug> DDLWorker: Executed query: CREATE DATABASE test_4gve7l UUID 'd71bbf94-23e2-483e-bc54-efa1c7eb454a' ENGINE = Replicated('/test/clickhouse/db/test_4gve7l', '{shard}', '{replica}')
2022.08.31 20:21:36.662752 [ 10410 ] {2a9a9b93-12d1-4dea-87aa-0430275a656b} <Error> executeQuery: Code: 82. DB::Exception: There was an error on [localhost:29000]: Code: 82. DB::Exception: Database test_4gve7l already exists. (DATABASE_ALREADY_EXISTS) (version 22.9.1.931 (official build)). (DATABASE_ALREADY_EXISTS) (version 22.9.1.931 (official build)) (from [::1]:58908) (comment: 01474_bad_global_join.sql) (in query: CREATE DATABASE test_4gve7l ON CLUSTER test_cluster_database_replicated ENGINE=Replicated('/test/clickhouse/db/test_4gve7l', '{shard}', '{replica}') ), Stack trace (when copying this message, always include the lines below):

```
