### PR TITLE
Fix uncaught DNS_ERROR on failed connection to replicas

### DIFF
--- a/src/Client/ConnectionEstablisher.cpp
+++ b/src/Client/ConnectionEstablisher.cpp
@@ -16,6 +16,7 @@ namespace ErrorCodes
     extern const int ATTEMPT_TO_READ_AFTER_EOF;
     extern const int NETWORK_ERROR;
     extern const int SOCKET_TIMEOUT;
+    extern const int DNS_ERROR;
 }
 
 ConnectionEstablisher::ConnectionEstablisher(

--- a/src/Client/ConnectionEstablisher.cpp
+++ b/src/Client/ConnectionEstablisher.cpp
@@ -90,6 +90,7 @@ void ConnectionEstablisher::run(ConnectionEstablisher::TryResult & result, std::
     catch (const Exception & e)
     {
         if (e.code() != ErrorCodes::NETWORK_ERROR && e.code() != ErrorCodes::SOCKET_TIMEOUT
+            && e.code() != ErrorCodes::DNS_ERROR
             && e.code() != ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF)
             throw;
 

--- a/tests/queries/0_stateless/00965_shard_unresolvable_addresses.sql
+++ b/tests/queries/0_stateless/00965_shard_unresolvable_addresses.sql
@@ -2,7 +2,7 @@
 
 SET prefer_localhost_replica = 1;
 
-SELECT count() FROM remote('127.0.0.1,localhos', system.one); -- { serverError 198 }
+SELECT count() FROM remote('127.0.0.1,localhos', system.one); -- { serverError 279 }
 SELECT count() FROM remote('127.0.0.1|localhos', system.one);
 
 -- Clear cache to avoid future errors in the logs


### PR DESCRIPTION
DNS_ERROR would cause the replica to not be marked as unusable, resulting in the replica being repeatedly reattempted on subsequent queries and for connection failover to not function.
(This is common in Kubernetes setups where a replica has failed and it's DNS record is returning NXDOMAIN)

On SELECT of a Distributed table, would additionally result in an intermittent query error if the failed replica is chosen:
`Code: 198. DB::Exception: Received from localhost:9000. DB::Exception: Not found address of host: chi-clickhouse-main-2-0: While executing Remote. (DNS_ERROR)`

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix uncaught DNS_ERROR on failed connection to replicas.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
