### PR TITLE
CaresPTRResolver small safety improvement

### DIFF
--- a/src/Common/CaresPTRResolver.cpp
+++ b/src/Common/CaresPTRResolver.cpp
@@ -15,8 +15,8 @@ namespace DB
 
     static void callback(void * arg, int status, int, struct hostent * host)
     {
-        auto * ptr_records = reinterpret_cast<std::unordered_set<std::string>*>(arg);
-        if (status == ARES_SUCCESS && host->h_aliases)
+        auto * ptr_records = static_cast<std::unordered_set<std::string>*>(arg);
+        if (ptr_records && status == ARES_SUCCESS)
         {
             /*
              * In some cases (e.g /etc/hosts), hostent::h_name is filled and hostent::h_aliases is empty.
@@ -28,11 +28,14 @@ namespace DB
                 ptr_records->insert(ptr_record);
             }
 
-            int i = 0;
-            while (auto * ptr_record = host->h_aliases[i])
+            if (host->h_aliases)
             {
-                ptr_records->insert(ptr_record);
-                i++;
+                int i = 0;
+                while (auto * ptr_record = host->h_aliases[i])
+                {
+                    ptr_records->insert(ptr_record);
+                    i++;
+                }
             }
         }
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Previous to #40769, only `hostent::h_aliases` was being accessed. After that PR got merged, `hostent::h_name` started being accessed as well. This PR moves the first `hostent::h_aliases != nullptr` check that could prevent `hostent::h_name` from being accessed. During debugging, I observed that even when there are no aliases, `hostent::h_aliases` is not null. That's why it hasn't caused any problems, but proposing this change to be on the safe side.

I have edited this via github web UI, which means I didn't test it on ClickHouse itself. I did test, tho, on a pet project I have using the same wrapper. Plus, we have integ tests for both DNS server and `/etc/hosts`

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
