### PR TITLE
Accounting of temporary data on the disk, pt1

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1498,7 +1498,7 @@ If not set, [tmp_path](#tmp-path) is used, otherwise it is ignored.
 - `move_factor` is ignored.
 - `keep_free_space_bytes` is ignored.
 - `max_data_part_size_bytes` is ignored.
-- Уou must have exactly one volume in that policy.
+- Policy should have exactly one volume with local disks.
 :::
 
 ## uncompressed_cache_size {#server-settings-uncompressed_cache_size}

--- a/docs/ru/operations/server-configuration-parameters/settings.md
+++ b/docs/ru/operations/server-configuration-parameters/settings.md
@@ -1342,12 +1342,13 @@ TCP порт для защищённого обмена данными с кли
 
 Если политика не задана, используется [tmp_path](#tmp-path). В противном случае `tmp_path` игнорируется.
 
-    :::note "Примечание"
-    - `move_factor` игнорируется.
-    - `keep_free_space_bytes` игнорируется.
-    - `max_data_part_size_bytes` игнорируется.
-    - В данной политике у вас должен быть ровно один том.
-    :::
+:::note "Примечание"
+- `move_factor` игнорируется.
+- `keep_free_space_bytes` игнорируется.
+- `max_data_part_size_bytes` игнорируется.
+- В данной политике должен быть ровно один том, содержащий только локальный диски.
+:::
+
 ## uncompressed_cache_size {#server-settings-uncompressed_cache_size}
 
 Размер кеша (в байтах) для несжатых данных, используемых движками таблиц семейства [MergeTree](../../operations/server-configuration-parameters/settings.md).

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -203,7 +203,7 @@ void LocalServer::tryInitPath()
 
     global_context->setPath(path);
 
-    global_context->setTemporaryStorage(path + "tmp");
+    global_context->setTemporaryStorage(path + "tmp", "", 0);
     global_context->setFlagsPath(path + "flags");
 
     global_context->setUserFilesPath(""); // user's files are everywhere

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -971,7 +971,8 @@ int Server::main(const std::vector<std::string> & /*args*/)
     {
         std::string tmp_path = config().getString("tmp_path", path / "tmp/");
         std::string tmp_policy = config().getString("tmp_policy", "");
-        const VolumePtr & volume = global_context->setTemporaryStorage(tmp_path, tmp_policy);
+        size_t tmp_max_size = config().getString("tmp_max_size", 0);
+        const VolumePtr & volume = global_context->setTemporaryStorage(tmp_path, tmp_policy, tmp_max_size);
         for (const DiskPtr & disk : volume->getDisks())
             setupTmpPath(log, disk->getPath());
     }

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -209,7 +209,7 @@ try
             fs::remove(it->path());
         }
         else
-            LOG_DEBUG(log, "Skipped file in temporary path {}", it->path().string());
+            LOG_DEBUG(log, "Found unknown file in temporary path {}", it->path().string());
     }
 }
 catch (...)

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -971,7 +971,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     {
         std::string tmp_path = config().getString("tmp_path", path / "tmp/");
         std::string tmp_policy = config().getString("tmp_policy", "");
-        size_t tmp_max_size = config().getString("tmp_max_size", 0);
+        size_t tmp_max_size = config().getUInt64("tmp_max_size", 0);
         const VolumePtr & volume = global_context->setTemporaryStorage(tmp_path, tmp_policy, tmp_max_size);
         for (const DiskPtr & disk : volume->getDisks())
             setupTmpPath(log, disk->getPath());

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -399,6 +399,9 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, max_network_bandwidth_for_user, 0, "The maximum speed of data exchange over the network in bytes per second for all concurrently running user queries. Zero means unlimited.", 0)\
     M(UInt64, max_network_bandwidth_for_all_users, 0, "The maximum speed of data exchange over the network in bytes per second for all concurrently running queries. Zero means unlimited.", 0) \
     \
+    M(UInt64, max_temp_data_on_disk_size_for_user, 0, "The maximum amount of data consumed by temorary files on disk in bytes for all concurrently running user queries. Zero means unlimited.", 0)\
+    M(UInt64, max_temp_data_on_disk_size_for_query, 0, "The maximum amount of data consumed by temorary files on disk in bytes for all concurrently running queries. Zero means unlimited.", 0)\
+    \
     M(UInt64, backup_threads, 16, "The maximum number of threads to execute BACKUP requests.", 0) \
     M(UInt64, restore_threads, 16, "The maximum number of threads to execute RESTORE requests.", 0) \
     \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -399,8 +399,8 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(UInt64, max_network_bandwidth_for_user, 0, "The maximum speed of data exchange over the network in bytes per second for all concurrently running user queries. Zero means unlimited.", 0)\
     M(UInt64, max_network_bandwidth_for_all_users, 0, "The maximum speed of data exchange over the network in bytes per second for all concurrently running queries. Zero means unlimited.", 0) \
     \
-    M(UInt64, max_temp_data_on_disk_size_for_user, 0, "The maximum amount of data consumed by temorary files on disk in bytes for all concurrently running user queries. Zero means unlimited.", 0)\
-    M(UInt64, max_temp_data_on_disk_size_for_query, 0, "The maximum amount of data consumed by temorary files on disk in bytes for all concurrently running queries. Zero means unlimited.", 0)\
+    M(UInt64, max_temp_data_on_disk_size_for_user, 0, "The maximum amount of data consumed by temporary files on disk in bytes for all concurrently running user queries. Zero means unlimited.", 0)\
+    M(UInt64, max_temp_data_on_disk_size_for_query, 0, "The maximum amount of data consumed by temporary files on disk in bytes for all concurrently running queries. Zero means unlimited.", 0)\
     \
     M(UInt64, backup_threads, 16, "The maximum number of threads to execute BACKUP requests.", 0) \
     M(UInt64, restore_threads, 16, "The maximum number of threads to execute RESTORE requests.", 0) \

--- a/src/Disks/DiskDecorator.cpp
+++ b/src/Disks/DiskDecorator.cpp
@@ -241,4 +241,11 @@ DiskObjectStoragePtr DiskDecorator::createDiskObjectStorage()
     return delegate->createDiskObjectStorage();
 }
 
+DiskPtr DiskDecorator::getNestedDisk() const
+{
+    if (const auto * decorator = dynamic_cast<const DiskDecorator *>(delegate.get()))
+        return decorator->getNestedDisk();
+    return delegate;
+}
+
 }

--- a/src/Disks/DiskDecorator.h
+++ b/src/Disks/DiskDecorator.h
@@ -107,6 +107,13 @@ public:
     bool supportsChmod() const override { return delegate->supportsChmod(); }
     void chmod(const String & path, mode_t mode) override { delegate->chmod(path, mode); }
 
+    const IDisk & getNestedDisk() const
+    {
+        if (const auto * decorator = dynamic_cast<const DiskDecorator *>(delegate.get()))
+            return decorator->getNestedDisk();
+        return *delegate;
+    }
+
 protected:
     Executor & getExecutor() override;
 

--- a/src/Disks/DiskDecorator.h
+++ b/src/Disks/DiskDecorator.h
@@ -107,12 +107,7 @@ public:
     bool supportsChmod() const override { return delegate->supportsChmod(); }
     void chmod(const String & path, mode_t mode) override { delegate->chmod(path, mode); }
 
-    const IDisk & getNestedDisk() const
-    {
-        if (const auto * decorator = dynamic_cast<const DiskDecorator *>(delegate.get()))
-            return decorator->getNestedDisk();
-        return *delegate;
-    }
+    virtual DiskPtr getNestedDisk() const;
 
 protected:
     Executor & getExecutor() override;

--- a/src/Disks/DiskRestartProxy.cpp
+++ b/src/Disks/DiskRestartProxy.cpp
@@ -331,6 +331,20 @@ void DiskRestartProxy::getRemotePathsRecursive(
     return DiskDecorator::getRemotePathsRecursive(path, paths_map);
 }
 
+DiskPtr DiskRestartProxy::getNestedDisk() const
+{
+    DiskPtr delegate_copy;
+
+    {
+        ReadLock lock (mutex);
+        delegate_copy = delegate;
+    }
+
+    if (const auto * decorator = dynamic_cast<const DiskDecorator *>(delegate_copy.get()))
+        return decorator->getNestedDisk();
+    return delegate_copy;
+}
+
 void DiskRestartProxy::restart(ContextPtr context)
 {
     /// Speed up processing unhealthy requests.

--- a/src/Disks/DiskRestartProxy.h
+++ b/src/Disks/DiskRestartProxy.h
@@ -71,6 +71,8 @@ public:
 
     void restart(ContextPtr context);
 
+    DiskPtr getNestedDisk() const override;
+
 private:
     friend class RestartAwareReadBuffer;
     friend class RestartAwareWriteBuffer;

--- a/src/Formats/NativeReader.cpp
+++ b/src/Formats/NativeReader.cpp
@@ -237,6 +237,7 @@ Block NativeReader::read()
             else
                 tmp_res.insert({col.type->createColumn()->cloneResized(rows), col.type, col.name});
         }
+        tmp_res.info = res.info;
 
         res.swap(tmp_res);
     }

--- a/src/Formats/TemporaryFileStream.cpp
+++ b/src/Formats/TemporaryFileStream.cpp
@@ -12,20 +12,20 @@ namespace DB
 {
 
 /// To read the data that was flushed into the temporary data file.
-TemporaryFileStream::TemporaryFileStream(const std::string & path)
+TemporaryFileStreamLegacy::TemporaryFileStreamLegacy(const std::string & path)
     : file_in(path)
     , compressed_in(file_in)
     , block_in(std::make_unique<NativeReader>(compressed_in, DBMS_TCP_PROTOCOL_VERSION))
 {}
 
-TemporaryFileStream::TemporaryFileStream(const std::string & path, const Block & header_)
+TemporaryFileStreamLegacy::TemporaryFileStreamLegacy(const std::string & path, const Block & header_)
     : file_in(path)
     , compressed_in(file_in)
     , block_in(std::make_unique<NativeReader>(compressed_in, header_, 0))
 {}
 
 /// Flush data from input stream into file for future reading
-TemporaryFileStream::Stat TemporaryFileStream::write(const std::string & path, const Block & header, QueryPipelineBuilder builder, const std::string & codec)
+TemporaryFileStreamLegacy::Stat TemporaryFileStreamLegacy::write(const std::string & path, const Block & header, QueryPipelineBuilder builder, const std::string & codec)
 {
     WriteBufferFromFile file_buf(path);
     CompressedWriteBuffer compressed_buf(file_buf, CompressionCodecFactory::instance().get(codec, {}));

--- a/src/Formats/TemporaryFileStream.h
+++ b/src/Formats/TemporaryFileStream.h
@@ -10,7 +10,7 @@ namespace DB
 {
 
 /// To read the data that was flushed into the temporary data file.
-struct TemporaryFileStream
+struct TemporaryFileStreamLegacy
 {
     struct Stat
     {
@@ -22,8 +22,8 @@ struct TemporaryFileStream
     CompressedReadBuffer compressed_in;
     std::unique_ptr<NativeReader> block_in;
 
-    explicit TemporaryFileStream(const std::string & path);
-    TemporaryFileStream(const std::string & path, const Block & header_);
+    explicit TemporaryFileStreamLegacy(const std::string & path);
+    TemporaryFileStreamLegacy(const std::string & path, const Block & header_);
 
     /// Flush data from input stream into file for future reading
     static Stat write(const std::string & path, const Block & header, QueryPipelineBuilder builder, const std::string & codec);

--- a/src/Formats/TemporaryFileStreamLegacy.cpp
+++ b/src/Formats/TemporaryFileStreamLegacy.cpp
@@ -1,4 +1,4 @@
-#include <Formats/TemporaryFileStream.h>
+#include <Formats/TemporaryFileStreamLegacy.h>
 #include <Formats/NativeReader.h>
 #include <Formats/NativeWriter.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>

--- a/src/Formats/TemporaryFileStreamLegacy.h
+++ b/src/Formats/TemporaryFileStreamLegacy.h
@@ -9,6 +9,8 @@
 namespace DB
 {
 
+/// Used only in MergeJoin
+/// TODO: use `TemporaryDataOnDisk` instead
 /// To read the data that was flushed into the temporary data file.
 struct TemporaryFileStreamLegacy
 {

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -570,8 +570,8 @@ Aggregator::Aggregator(const Block & header_, const Params & params_)
     : header(header_)
     , keys_positions(calculateKeysPositions(header, params_))
     , params(params_)
-    , min_bytes_for_prefetch(getMinBytesForPrefetch())
     , tmp_data(params.tmp_data_scope ? std::make_unique<TemporaryDataOnDisk>(params.tmp_data_scope) : nullptr)
+    , min_bytes_for_prefetch(getMinBytesForPrefetch())
 {
     /// Use query-level memory tracker
     if (auto * memory_tracker_child = CurrentThread::getMemoryTracker())
@@ -1617,14 +1617,14 @@ void Aggregator::writeToTemporaryFile(AggregatedDataVariants & data_variants, si
         " ({:.3f} rows/sec., {}/sec. uncompressed, {}/sec. compressed)",
         elapsed_seconds,
         rows,
-        ReadableSize(stat.uncompressed_bytes),
-        ReadableSize(stat.compressed_bytes),
-        static_cast<double>(stat.uncompressed_bytes) / rows,
-        static_cast<double>(stat.compressed_bytes) / rows,
-        static_cast<double>(stat.uncompressed_bytes) / stat.compressed_bytes,
+        ReadableSize(uncompressed_size),
+        ReadableSize(compressed_size),
+        static_cast<double>(uncompressed_size) / rows,
+        static_cast<double>(compressed_size) / rows,
+        static_cast<double>(uncompressed_size) / compressed_size,
         static_cast<double>(rows) / elapsed_seconds,
-        ReadableSize(static_cast<double>(stat.uncompressed_bytes) / elapsed_seconds),
-        ReadableSize(static_cast<double>(stat.compressed_bytes) / elapsed_seconds));
+        ReadableSize(static_cast<double>(uncompressed_size) / elapsed_seconds),
+        ReadableSize(static_cast<double>(compressed_size) / elapsed_seconds));
 }
 
 template <typename Method>

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -572,6 +572,7 @@ Aggregator::Aggregator(const Block & header_, const Params & params_)
     , params(params_)
     , min_bytes_for_prefetch(getMinBytesForPrefetch())
     , tmp_data(std::make_unique<TemporaryDataOnDisk>(params.tmp_data, 0))
+    , tmp_data(params.tmp_data ? std::make_unique<TemporaryDataOnDisk>(params.tmp_data, 0) : nullptr)
 {
     /// Use query-level memory tracker
     if (auto * memory_tracker_child = CurrentThread::getMemoryTracker())

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1601,7 +1601,7 @@ void Aggregator::writeToTemporaryFile(AggregatedDataVariants & data_variants, si
         data_variants.without_key = place;
     }
 
-    auto stat = out_stream.finishWriting();
+    auto stat = out_stream.finishWriting(false);
 
     ProfileEvents::increment(ProfileEvents::ExternalAggregationCompressedBytes, stat.compressed_size);
     ProfileEvents::increment(ProfileEvents::ExternalAggregationUncompressedBytes, stat.uncompressed_size);

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -35,6 +35,7 @@
 #include <Interpreters/JIT/CompiledExpressionCache.h>
 #include <Core/ProtocolDefines.h>
 #include <Disks/TemporaryFileOnDisk.h>
+#include <Interpreters/TemporaryDataOnDisk.h>
 
 #include <Parsers/ASTSelectQuery.h>
 
@@ -1565,27 +1566,22 @@ void Aggregator::writeToTemporaryFile(AggregatedDataVariants & data_variants, si
     Stopwatch watch;
     size_t rows = data_variants.size();
 
-    auto file = createTempFile(max_temp_file_size);
-
-    const auto & path = file->path();
-    WriteBufferFromFile file_buf(path);
-    CompressedWriteBuffer compressed_buf(file_buf);
-    NativeWriter block_out(compressed_buf, DBMS_TCP_PROTOCOL_VERSION, getHeader(false));
-
-    LOG_DEBUG(log, "Writing part of aggregation data into temporary file {}", path);
+    auto out_stream = tmp_data.createStream(CurrentMetrics::TemporaryFilesForAggregation, max_temp_file_size);
     ProfileEvents::increment(ProfileEvents::ExternalAggregationWritePart);
+
+    LOG_DEBUG(log, "Writing part of aggregation data into temporary file {}", out_stream->path());
 
     /// Flush only two-level data and possibly overflow data.
 
 #define M(NAME) \
     else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
-        writeToTemporaryFileImpl(data_variants, *data_variants.NAME, block_out);
+        writeToTemporaryFileImpl(data_variants, *data_variants.NAME, out_stream);
 
     if (false) {} // NOLINT
     APPLY_FOR_VARIANTS_TWO_LEVEL(M)
 #undef M
     else
-        throw Exception("Unknown aggregated data variant.", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
+        throw Exception("Unknown aggregated data variant", ErrorCodes::UNKNOWN_AGGREGATED_DATA_VARIANT);
 
     /// NOTE Instead of freeing up memory and creating new hash tables and arenas, you can re-use the old ones.
     data_variants.init(data_variants.type);
@@ -1598,61 +1594,29 @@ void Aggregator::writeToTemporaryFile(AggregatedDataVariants & data_variants, si
         data_variants.without_key = place;
     }
 
-    block_out.flush();
-    compressed_buf.next();
-    file_buf.next();
+    auto stat = out_stream.finishWriting();
+
+    ProfileEvents::increment(ProfileEvents::ExternalAggregationCompressedBytes, stat.compressed_bytes);
+    ProfileEvents::increment(ProfileEvents::ExternalAggregationUncompressedBytes, stat.uncompressed_bytes);
+    ProfileEvents::increment(ProfileEvents::ExternalProcessingCompressedBytesTotal, stat.compressed_bytes);
+    ProfileEvents::increment(ProfileEvents::ExternalProcessingUncompressedBytesTotal, stat.uncompressed_bytes);
 
     double elapsed_seconds = watch.elapsedSeconds();
-    size_t compressed_bytes = file_buf.count();
-    size_t uncompressed_bytes = compressed_buf.count();
-
-    {
-        std::lock_guard lock(temporary_files.mutex);
-        temporary_files.files.emplace_back(std::move(file));
-        temporary_files.sum_size_uncompressed += uncompressed_bytes;
-        temporary_files.sum_size_compressed += compressed_bytes;
-    }
-
-    ProfileEvents::increment(ProfileEvents::ExternalAggregationCompressedBytes, compressed_bytes);
-    ProfileEvents::increment(ProfileEvents::ExternalAggregationUncompressedBytes, uncompressed_bytes);
-    ProfileEvents::increment(ProfileEvents::ExternalProcessingCompressedBytesTotal, compressed_bytes);
-    ProfileEvents::increment(ProfileEvents::ExternalProcessingUncompressedBytesTotal, uncompressed_bytes);
-
     LOG_DEBUG(log,
         "Written part in {:.3f} sec., {} rows, {} uncompressed, {} compressed,"
         " {:.3f} uncompressed bytes per row, {:.3f} compressed bytes per row, compression rate: {:.3f}"
         " ({:.3f} rows/sec., {}/sec. uncompressed, {}/sec. compressed)",
         elapsed_seconds,
         rows,
-        ReadableSize(uncompressed_bytes),
-        ReadableSize(compressed_bytes),
-        static_cast<double>(uncompressed_bytes) / rows,
-        static_cast<double>(compressed_bytes) / rows,
-        static_cast<double>(uncompressed_bytes) / compressed_bytes,
+        ReadableSize(stat.uncompressed_bytes),
+        ReadableSize(stat.compressed_bytes),
+        static_cast<double>(stat.uncompressed_bytes) / rows,
+        static_cast<double>(stat.compressed_bytes) / rows,
+        static_cast<double>(stat.uncompressed_bytes) / stat.compressed_bytes,
         static_cast<double>(rows) / elapsed_seconds,
-        ReadableSize(static_cast<double>(uncompressed_bytes) / elapsed_seconds),
-        ReadableSize(static_cast<double>(compressed_bytes) / elapsed_seconds));
+        ReadableSize(static_cast<double>(stat.uncompressed_bytes) / elapsed_seconds),
+        ReadableSize(static_cast<double>(stat.compressed_bytes) / elapsed_seconds));
 }
-
-
-TemporaryFileOnDiskHolder Aggregator::createTempFile(size_t max_temp_file_size) const
-{
-    auto file = std::make_unique<TemporaryFileOnDisk>(params.tmp_volume->getDisk(), CurrentMetrics::TemporaryFilesForAggregation);
-
-    // enoughSpaceInDirectory() is not enough to make it right, since
-    // another process (or another thread of aggregator) can consume all
-    // space.
-    //
-    // But true reservation (IVolume::reserve()) cannot be used here since
-    // current_memory_usage does not takes compression into account and
-    // will reserve way more that actually will be used.
-    //
-    // Hence let's do a simple check.
-    if (max_temp_file_size > 0 && !enoughSpaceInDirectory(file->getPath(), max_temp_file_size))
-        throw Exception(ErrorCodes::NOT_ENOUGH_SPACE, "Not enough space for external aggregation in '{}'", file->path());
-    return file;
-}
-
 
 template <typename Method>
 Block Aggregator::convertOneBucketToBlock(
@@ -1703,7 +1667,7 @@ template <typename Method>
 void Aggregator::writeToTemporaryFileImpl(
     AggregatedDataVariants & data_variants,
     Method & method,
-    NativeWriter & out) const
+    TemporaryFileStream & out) const
 {
     size_t max_temporary_block_size_rows = 0;
     size_t max_temporary_block_size_bytes = 0;

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1601,7 +1601,7 @@ void Aggregator::writeToTemporaryFile(AggregatedDataVariants & data_variants, si
         data_variants.without_key = place;
     }
 
-    auto stat = out_stream.finishWriting(false);
+    auto stat = out_stream.finishWriting();
 
     ProfileEvents::increment(ProfileEvents::ExternalAggregationCompressedBytes, stat.compressed_size);
     ProfileEvents::increment(ProfileEvents::ExternalAggregationUncompressedBytes, stat.uncompressed_size);

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -571,8 +571,7 @@ Aggregator::Aggregator(const Block & header_, const Params & params_)
     , keys_positions(calculateKeysPositions(header, params_))
     , params(params_)
     , min_bytes_for_prefetch(getMinBytesForPrefetch())
-    , tmp_data(std::make_unique<TemporaryDataOnDisk>(params.tmp_data, 0))
-    , tmp_data(params.tmp_data ? std::make_unique<TemporaryDataOnDisk>(params.tmp_data, 0) : nullptr)
+    , tmp_data(params.tmp_data_scope ? std::make_unique<TemporaryDataOnDisk>(params.tmp_data_scope) : nullptr)
 {
     /// Use query-level memory tracker
     if (auto * memory_tracker_child = CurrentThread::getMemoryTracker())

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1575,7 +1575,7 @@ void Aggregator::writeToTemporaryFile(AggregatedDataVariants & data_variants, si
 
 #define M(NAME) \
     else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
-        writeToTemporaryFileImpl(data_variants, *data_variants.NAME, out_stream);
+        writeToTemporaryFileImpl(data_variants, *data_variants.NAME, *out_stream);
 
     if (false) {} // NOLINT
     APPLY_FOR_VARIANTS_TWO_LEVEL(M)

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1071,25 +1071,21 @@ public:
     /// For external aggregation.
     void writeToTemporaryFile(AggregatedDataVariants & data_variants, size_t max_temp_file_size = 0) const;
 
-    TemporaryFileOnDiskHolder createTempFile(size_t max_temp_file_size) const;
-
-    bool hasTemporaryFiles() const { return !temporary_files.empty(); }
+    bool hasTemporaryData() const { return !tmp_data.getStreams().empty(); }
 
     struct TemporaryFiles
     {
-        std::vector<TemporaryFileOnDiskHolder> files;
-        size_t sum_size_uncompressed = 0;
-        size_t sum_size_compressed = 0;
+        std::vector<TemporaryFileStreamPtr> tmp_streams;
         mutable std::mutex mutex;
 
         bool empty() const
         {
             std::lock_guard lock(mutex);
-            return files.empty();
+            return tmp_streams.empty();
         }
     };
 
-    const TemporaryFiles & getTemporaryFiles() const { return temporary_files; }
+    const TemporaryDataOnDisk & getTemporaryData() const { return tmp_data; }
 
     /// Get data structure of the result.
     Block getHeader(bool final) const;
@@ -1148,7 +1144,7 @@ private:
     Poco::Logger * log = &Poco::Logger::get("Aggregator");
 
     /// For external aggregation.
-    mutable TemporaryFiles temporary_files;
+    mutable TemporaryDataOnDisk tmp_data;
 
     size_t min_bytes_for_prefetch = 0;
 

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -29,6 +29,7 @@
 #include <Interpreters/AggregateDescription.h>
 #include <Interpreters/AggregationCommon.h>
 #include <Interpreters/JIT/compileFunction.h>
+#include <Interpreters/TemporaryDataOnDisk.h>
 
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnFixedString.h>
@@ -1075,7 +1076,7 @@ public:
 
     struct TemporaryFiles
     {
-        std::vector<TemporaryFileStreamPtr> tmp_streams;
+        std::vector<TemporaryFileStreamHolder> tmp_streams;
         mutable std::mutex mutex;
 
         bool empty() const

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1133,7 +1133,7 @@ private:
     Poco::Logger * log = &Poco::Logger::get("Aggregator");
 
     /// For external aggregation.
-    mutable TemporaryDataOnDiskHolder tmp_data;
+    mutable TemporaryDataOnDiskPtr tmp_data;
 
     size_t min_bytes_for_prefetch = 0;
 

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -926,7 +926,7 @@ public:
         /// Return empty result when aggregating without keys on empty set.
         bool empty_result_for_aggregation_by_empty_set;
 
-        VolumePtr tmp_volume;
+        std::shared_ptr<TemporaryDataOnDisk> tmp_data;
 
         /// Settings is used to determine cache size. No threads are created.
         size_t max_threads;
@@ -971,7 +971,7 @@ public:
             size_t group_by_two_level_threshold_bytes_,
             size_t max_bytes_before_external_group_by_,
             bool empty_result_for_aggregation_by_empty_set_,
-            VolumePtr tmp_volume_,
+            std::shared_ptr<TemporaryDataOnDisk> tmp_data_,
             size_t max_threads_,
             size_t min_free_disk_space_,
             bool compile_aggregate_expressions_,
@@ -991,7 +991,7 @@ public:
             , group_by_two_level_threshold_bytes(group_by_two_level_threshold_bytes_)
             , max_bytes_before_external_group_by(max_bytes_before_external_group_by_)
             , empty_result_for_aggregation_by_empty_set(empty_result_for_aggregation_by_empty_set_)
-            , tmp_volume(tmp_volume_)
+            , tmp_data(std::move(tmp_data_))
             , max_threads(max_threads_)
             , min_free_disk_space(min_free_disk_space_)
             , compile_aggregate_expressions(compile_aggregate_expressions_)
@@ -1072,7 +1072,7 @@ public:
     /// For external aggregation.
     void writeToTemporaryFile(AggregatedDataVariants & data_variants, size_t max_temp_file_size = 0) const;
 
-    bool hasTemporaryData() const { return !tmp_data.getStreams().empty(); }
+    bool hasTemporaryData() const { return tmp_data && !tmp_data->getStreams().empty(); }
 
     struct TemporaryFiles
     {
@@ -1086,7 +1086,7 @@ public:
         }
     };
 
-    const TemporaryDataOnDisk & getTemporaryData() const { return tmp_data; }
+    TemporaryDataOnDisk & getTemporaryData() const { return *tmp_data; }
 
     /// Get data structure of the result.
     Block getHeader(bool final) const;
@@ -1145,7 +1145,7 @@ private:
     Poco::Logger * log = &Poco::Logger::get("Aggregator");
 
     /// For external aggregation.
-    mutable TemporaryDataOnDisk tmp_data;
+    TemporaryDataOnDiskPtr tmp_data;
 
     size_t min_bytes_for_prefetch = 0;
 
@@ -1248,7 +1248,7 @@ private:
     void writeToTemporaryFileImpl(
         AggregatedDataVariants & data_variants,
         Method & method,
-        NativeWriter & out) const;
+        TemporaryFileStream & out) const;
 
     /// Merge NULL key data from hash table `src` into `dst`.
     template <typename Method, typename Table>

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -1074,7 +1074,7 @@ public:
 
     bool hasTemporaryData() const { return tmp_data && !tmp_data->empty(); }
 
-    TemporaryDataOnDisk & getTemporaryData() const { return *tmp_data; }
+    const TemporaryDataOnDisk & getTemporaryData() const { return *tmp_data; }
 
     /// Get data structure of the result.
     Block getHeader(bool final) const;
@@ -1133,7 +1133,7 @@ private:
     Poco::Logger * log = &Poco::Logger::get("Aggregator");
 
     /// For external aggregation.
-    mutable TemporaryDataOnDiskPtr tmp_data;
+    TemporaryDataOnDiskPtr tmp_data;
 
     size_t min_bytes_for_prefetch = 0;
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2936,14 +2936,13 @@ void Context::shutdown()
         }
     }
 
-    // Special volumes might also use disks that require shutdown.
-    if (auto tmp_volume = shared->temp_data_on_disk->getVolume())
+    /// Special volumes might also use disks that require shutdown.
+    auto & tmp_data = shared->temp_data_on_disk;
+    if (tmp_data && tmp_data->getVolume())
     {
-        auto & disks = tmp_volume->getDisks();
+        auto & disks = tmp_data->getVolume()->getDisks();
         for (auto & disk : disks)
-        {
             disk->shutdown();
-        }
     }
 
     shared->shutdown();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -189,7 +189,7 @@ struct ContextSharedPart : boost::noncopyable
     ConfigurationPtr config;                                /// Global configuration settings.
 
     String tmp_path;                                        /// Path to the temporary files that occur when processing the request.
-    std::shared_ptr<TemporaryDataOnDisk> temp_data_on_disk; /// Temporary files that occur when processing the request.
+    TemporaryDataOnDiskScopePtr temp_data_on_disk;          /// Temporary files that occur when processing the request accouned here.
 
     mutable std::unique_ptr<EmbeddedDictionaries> embedded_dictionaries;    /// Metrica's dictionaries. Have lazy initialization.
     mutable std::unique_ptr<ExternalDictionariesLoader> external_dictionaries_loader;
@@ -690,7 +690,7 @@ VolumePtr Context::getTemporaryVolume() const
     return nullptr;
 }
 
-std::shared_ptr<TemporaryDataOnDisk> Context::getSharedTempDataOnDisk() const
+TemporaryDataOnDiskScopePtr Context::getTempDataOnDisk() const
 {
     auto lock = getLock();
     if (this->temp_data_on_disk)
@@ -698,12 +698,7 @@ std::shared_ptr<TemporaryDataOnDisk> Context::getSharedTempDataOnDisk() const
     return shared->temp_data_on_disk;
 }
 
-std::unique_ptr<TemporaryDataOnDisk> Context::getTempDataOnDisk() const
-{
-    return std::make_unique<TemporaryDataOnDisk>(getSharedTempDataOnDisk(), 0);
-}
-
-void Context::setTempDataOnDisk(std::shared_ptr<TemporaryDataOnDisk> temp_data_on_disk_)
+void Context::setTempDataOnDisk(TemporaryDataOnDiskScopePtr temp_data_on_disk_)
 {
     auto lock = getLock();
     this->temp_data_on_disk = std::move(temp_data_on_disk_);
@@ -767,7 +762,7 @@ VolumePtr Context::setTemporaryStorage(const String & path, const String & polic
                 "Disk '{}' is not local and can't be used for temporary files", disk->getName());
     }
 
-    shared->temp_data_on_disk = std::make_shared<TemporaryDataOnDisk>(volume, max_size);
+    shared->temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(volume, max_size);
     return volume;
 }
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -189,7 +189,7 @@ struct ContextSharedPart : boost::noncopyable
     ConfigurationPtr config;                                /// Global configuration settings.
 
     String tmp_path;                                        /// Path to the temporary files that occur when processing the request.
-    TemporaryDataOnDiskScopePtr temp_data_on_disk;          /// Temporary files that occur when processing the request accouned here.
+    TemporaryDataOnDiskScopePtr temp_data_on_disk;          /// Temporary files that occur when processing the request accounted here.
 
     mutable std::unique_ptr<EmbeddedDictionaries> embedded_dictionaries;    /// Metrica's dictionaries. Have lazy initialization.
     mutable std::unique_ptr<ExternalDictionariesLoader> external_dictionaries_loader;

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -763,15 +763,16 @@ VolumePtr Context::setTemporaryStorage(const String & path, const String & polic
             throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Temporary disk is null");
 
         /// Check that underlying disk is local (can be wrapped in decorator)
-        const IDisk * disk_ptr = disk.get();
-        if (auto disk_decorator = dynamic_cast<const DiskDecorator *>(disk_ptr))
-            disk_ptr = &disk_decorator->getNestedDisk();
+        DiskPtr disk_ptr = disk;
+        if (const auto * disk_decorator = dynamic_cast<const DiskDecorator *>(disk_ptr.get()))
+            disk_ptr = disk_decorator->getNestedDisk();
 
-        if (dynamic_cast<const DiskLocal *>(disk_ptr) == nullptr)
+        if (dynamic_cast<const DiskLocal *>(disk_ptr.get()) == nullptr)
         {
+            const auto * disk_raw_ptr = disk_ptr.get();
             throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG,
                 "Disk '{}' ({}) is not local and can't be used for temporary files",
-                disk_ptr->getName(), typeid(*disk_ptr).name());
+                disk_ptr->getName(), typeid(*disk_raw_ptr).name());
         }
     }
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -162,7 +162,6 @@ using ReadTaskCallback = std::function<String()>;
 using MergeTreeReadTaskCallback = std::function<std::optional<PartitionReadResponse>(PartitionReadRequest)>;
 
 class TemporaryDataOnDisk;
-using TemporaryDataOnDiskPtr = std::shared_ptr<TemporaryDataOnDisk>;
 
 #if USE_ROCKSDB
 class MergeTreeMetadataCache;
@@ -364,8 +363,8 @@ private:
     /// A flag, used to mark if reader needs to apply deleted rows mask.
     bool apply_deleted_mask = true;
 
-    /// Temprary data for query execution.
-    TemporaryDataOnDiskPtr temp_data_on_disk;
+    /// Temporary data for query execution.
+    std::shared_ptr<TemporaryDataOnDisk> temp_data_on_disk;
 public:
     /// Some counters for current query execution.
     /// Most of them are workarounds and should be removed in the future.
@@ -441,8 +440,9 @@ public:
 
     VolumePtr getTemporaryVolume() const; /// TODO: remove, use `getTempDataOnDisk`
 
-    TemporaryDataOnDiskPtr getTempDataOnDisk() const;
-    void setTempDataOnDisk(const TemporaryDataOnDiskPtr & temp_data_on_disk_);
+    std::shared_ptr<TemporaryDataOnDisk> getSharedTempDataOnDisk() const;
+    std::unique_ptr<TemporaryDataOnDisk> getTempDataOnDisk() const;
+    void setTempDataOnDisk(std::shared_ptr<TemporaryDataOnDisk> temp_data_on_disk_);
 
     void setPath(const String & path);
     void setFlagsPath(const String & path);

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -161,6 +161,8 @@ using ReadTaskCallback = std::function<String()>;
 
 using MergeTreeReadTaskCallback = std::function<std::optional<PartitionReadResponse>(PartitionReadRequest)>;
 
+class TemporaryDataOnDisk;
+using TemporaryDataOnDiskPtr = std::shared_ptr<TemporaryDataOnDisk>;
 
 #if USE_ROCKSDB
 class MergeTreeMetadataCache;
@@ -362,6 +364,8 @@ private:
     /// A flag, used to mark if reader needs to apply deleted rows mask.
     bool apply_deleted_mask = true;
 
+    /// Temprary data for query execution.
+    TemporaryDataOnDiskPtr temp_data_on_disk;
 public:
     /// Some counters for current query execution.
     /// Most of them are workarounds and should be removed in the future.
@@ -435,7 +439,10 @@ public:
     /// A list of warnings about server configuration to place in `system.warnings` table.
     Strings getWarnings() const;
 
-    VolumePtr getTemporaryVolume() const;
+    VolumePtr getTemporaryVolume() const; /// TODO: remove, use `getTempDataOnDisk`
+
+    TemporaryDataOnDiskPtr getTempDataOnDisk() const;
+    void setTempDataOnDisk(const TemporaryDataOnDiskPtr & temp_data_on_disk_);
 
     void setPath(const String & path);
     void setFlagsPath(const String & path);
@@ -446,7 +453,7 @@ public:
 
     void addWarningMessage(const String & msg) const;
 
-    VolumePtr setTemporaryStorage(const String & path, const String & policy_name = "");
+    VolumePtr setTemporaryStorage(const String & path, const String & policy_name = "", size_t max_size = 0);
 
     using ConfigurationPtr = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -453,7 +453,7 @@ public:
 
     void addWarningMessage(const String & msg) const;
 
-    VolumePtr setTemporaryStorage(const String & path, const String & policy_name = "", size_t max_size = 0);
+    VolumePtr setTemporaryStorage(const String & path, const String & policy_name, size_t max_size);
 
     using ConfigurationPtr = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -161,7 +161,8 @@ using ReadTaskCallback = std::function<String()>;
 
 using MergeTreeReadTaskCallback = std::function<std::optional<PartitionReadResponse>(PartitionReadRequest)>;
 
-class TemporaryDataOnDisk;
+class TemporaryDataOnDiskScope;
+using TemporaryDataOnDiskScopePtr = std::shared_ptr<TemporaryDataOnDiskScope>;
 
 #if USE_ROCKSDB
 class MergeTreeMetadataCache;
@@ -363,8 +364,8 @@ private:
     /// A flag, used to mark if reader needs to apply deleted rows mask.
     bool apply_deleted_mask = true;
 
-    /// Temporary data for query execution.
-    std::shared_ptr<TemporaryDataOnDisk> temp_data_on_disk;
+    /// Temporary data for query execution accounting.
+    TemporaryDataOnDiskScopePtr temp_data_on_disk;
 public:
     /// Some counters for current query execution.
     /// Most of them are workarounds and should be removed in the future.
@@ -440,9 +441,8 @@ public:
 
     VolumePtr getTemporaryVolume() const; /// TODO: remove, use `getTempDataOnDisk`
 
-    std::shared_ptr<TemporaryDataOnDisk> getSharedTempDataOnDisk() const;
-    std::unique_ptr<TemporaryDataOnDisk> getTempDataOnDisk() const;
-    void setTempDataOnDisk(std::shared_ptr<TemporaryDataOnDisk> temp_data_on_disk_);
+    TemporaryDataOnDiskScopePtr getTempDataOnDisk() const;
+    void setTempDataOnDisk(TemporaryDataOnDiskScopePtr temp_data_on_disk_);
 
     void setPath(const String & path);
     void setFlagsPath(const String & path);

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1453,7 +1453,7 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                             settings.max_bytes_before_remerge_sort,
                             settings.remerge_sort_lowered_memory_bytes_ratio,
                             settings.max_bytes_before_external_sort,
-                            this->context->getTemporaryVolume(),
+                            this->context->getTempDataOnDisk(),
                             settings.min_free_disk_space_for_temporary_data,
                             settings.optimize_sorting_by_input_stream_properties);
                         sorting_step->setStepDescription(fmt::format("Sort {} before JOIN", join_pos));
@@ -2354,7 +2354,7 @@ static Aggregator::Params getAggregatorParams(
         settings.empty_result_for_aggregation_by_empty_set
             || (settings.empty_result_for_aggregation_by_constant_keys_on_empty_set && keys.empty()
                 && query_analyzer.hasConstAggregationKeys()),
-        context.getTemporaryVolume(),
+        context.getTempDataOnDisk(),
         settings.max_threads,
         settings.min_free_disk_space_for_temporary_data,
         settings.compile_aggregate_expressions,
@@ -2616,7 +2616,7 @@ void InterpreterSelectQuery::executeWindow(QueryPlan & query_plan)
                 settings.max_bytes_before_remerge_sort,
                 settings.remerge_sort_lowered_memory_bytes_ratio,
                 settings.max_bytes_before_external_sort,
-                context->getTemporaryVolume(),
+                context->getTempDataOnDisk(),
                 settings.min_free_disk_space_for_temporary_data,
                 settings.optimize_sorting_by_input_stream_properties);
             sorting_step->setStepDescription("Sorting for window '" + window.window_name + "'");
@@ -2675,7 +2675,7 @@ void InterpreterSelectQuery::executeOrder(QueryPlan & query_plan, InputOrderInfo
         settings.max_bytes_before_remerge_sort,
         settings.remerge_sort_lowered_memory_bytes_ratio,
         settings.max_bytes_before_external_sort,
-        context->getTemporaryVolume(),
+        context->getTempDataOnDisk(),
         settings.min_free_disk_space_for_temporary_data,
         settings.optimize_sorting_by_input_stream_properties);
 

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -1032,7 +1032,7 @@ std::shared_ptr<Block> MergeJoin::loadRightBlock(size_t pos) const
     {
         auto load_func = [&]() -> std::shared_ptr<Block>
         {
-            TemporaryFileStream input(flushed_right_blocks[pos]->path(), materializeBlock(right_sample_block));
+            TemporaryFileStreamLegacy input(flushed_right_blocks[pos]->path(), materializeBlock(right_sample_block));
             return std::make_shared<Block>(input.block_in->read());
         };
 

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -10,6 +10,7 @@
 #include <Interpreters/MergeJoin.h>
 #include <Interpreters/TableJoin.h>
 #include <Interpreters/JoinUtils.h>
+#include <Interpreters/TemporaryDataOnDisk.h>
 #include <Interpreters/sortBlock.h>
 #include <Processors/Sources/BlocksListSource.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -4,7 +4,7 @@
 #include <Columns/ColumnLowCardinality.h>
 
 #include <Core/SortCursor.h>
-#include <Formats/TemporaryFileStream.h>
+#include <Formats/TemporaryFileStreamLegacy.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/MergeJoin.h>

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -564,6 +564,10 @@ ProcessList::Info ProcessList::getInfo(bool get_thread_list, bool get_profile_ev
 }
 
 
+ProcessListForUser::ProcessListForUser(ProcessList * global_process_list)
+    : ProcessListForUser(nullptr, global_process_list)
+{}
+
 ProcessListForUser::ProcessListForUser(ContextPtr global_context, ProcessList * global_process_list)
     : user_overcommit_tracker(global_process_list, this)
 {

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -214,7 +214,7 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
             thread_group->memory_tracker.setParent(&user_process_list.user_memory_tracker);
             if (user_process_list.user_temp_data_on_disk)
             {
-                query_context->setTempDataOnDisk(std::make_shared<TemporaryDataOnDisk>(
+                query_context->setTempDataOnDisk(std::make_shared<TemporaryDataOnDiskScope>(
                     user_process_list.user_temp_data_on_disk, settings.max_temp_data_on_disk_size_for_query));
             }
             thread_group->query = query_;
@@ -572,7 +572,7 @@ ProcessListForUser::ProcessListForUser(ContextPtr global_context, ProcessList * 
     if (global_context)
     {
         size_t size_limit = global_context->getSettingsRef().max_temp_data_on_disk_size_for_user;
-        user_temp_data_on_disk = std::make_shared<TemporaryDataOnDisk>(global_context->getSharedTempDataOnDisk(), size_limit);
+        user_temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(global_context->getTempDataOnDisk(), size_limit);
     }
 }
 

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -198,7 +198,7 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
 
         auto user_process_list_it = user_to_queries.find(client_info.current_user);
         if (user_process_list_it == user_to_queries.end())
-            user_process_list_it = user_to_queries.emplace(client_info.current_user, this).first;
+            user_process_list_it = user_to_queries.emplace(client_info.current_user, ProcessListForUser(query_context->getGlobalContext(), this)).first;
         ProcessListForUser & user_process_list = user_process_list_it->second;
 
         /// Actualize thread group info
@@ -208,6 +208,11 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
             std::lock_guard lock_thread_group(thread_group->mutex);
             thread_group->performance_counters.setParent(&user_process_list.user_performance_counters);
             thread_group->memory_tracker.setParent(&user_process_list.user_memory_tracker);
+            if (user_process_list.user_temp_data_on_disk)
+            {
+                query_context->setTempDataOnDisk(std::make_shared<TemporaryDataOnDisk>(
+                    user_process_list.user_temp_data_on_disk, settings.max_temp_data_on_disk_size_for_query));
+            }
             thread_group->query = query_;
             thread_group->one_line_query = toOneLineQuery(query_);
             thread_group->normalized_query_hash = normalizedQueryHash<false>(query_);
@@ -555,10 +560,16 @@ ProcessList::Info ProcessList::getInfo(bool get_thread_list, bool get_profile_ev
 }
 
 
-ProcessListForUser::ProcessListForUser(ProcessList * global_process_list)
+ProcessListForUser::ProcessListForUser(ContextPtr global_context, ProcessList * global_process_list)
     : user_overcommit_tracker(global_process_list, this)
 {
     user_memory_tracker.setOvercommitTracker(&user_overcommit_tracker);
+
+    if (global_context)
+    {
+        size_t size_limit = global_context->getSettingsRef().max_temp_data_on_disk_size_for_user;
+        user_temp_data_on_disk = std::make_shared<TemporaryDataOnDisk>(global_context->getTempDataOnDisk(), size_limit);
+    }
 }
 
 

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -246,7 +246,7 @@ struct ProcessListForUser
     /// Limit and counter for memory of all simultaneously running queries of single user.
     MemoryTracker user_memory_tracker{VariableContext::User};
 
-    std::shared_ptr<TemporaryDataOnDisk> user_temp_data_on_disk;
+    TemporaryDataOnDiskScopePtr user_temp_data_on_disk;
 
     UserOvercommitTracker user_overcommit_tracker;
 

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -236,7 +236,9 @@ struct ProcessListForUserInfo
 /// Data about queries for one user.
 struct ProcessListForUser
 {
-    explicit ProcessListForUser(ContextPtr global_context, ProcessList * global_process_list);
+    explicit ProcessListForUser(ProcessList * global_process_list);
+
+    ProcessListForUser(ContextPtr global_context, ProcessList * global_process_list);
 
     /// query_id -> ProcessListElement(s). There can be multiple queries with the same query_id as long as all queries except one are cancelled.
     using QueryToElement = std::unordered_map<String, QueryStatus *>;

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -246,7 +246,7 @@ struct ProcessListForUser
     /// Limit and counter for memory of all simultaneously running queries of single user.
     MemoryTracker user_memory_tracker{VariableContext::User};
 
-    TemporaryDataOnDiskPtr user_temp_data_on_disk;
+    std::shared_ptr<TemporaryDataOnDisk> user_temp_data_on_disk;
 
     UserOvercommitTracker user_overcommit_tracker;
 
@@ -379,7 +379,7 @@ public:
       * If timeout is passed - throw an exception.
       * Don't count KILL QUERY queries.
       */
-    EntryPtr insert(const String & query_, const IAST * ast, ContextPtr query_context);
+    EntryPtr insert(const String & query_, const IAST * ast, ContextMutablePtr query_context);
 
     /// Number of currently executing queries.
     size_t size() const { return processes.size(); }

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -5,6 +5,8 @@
 #include <Interpreters/CancellationCode.h>
 #include <Interpreters/ClientInfo.h>
 #include <Interpreters/QueryPriorities.h>
+#include <Interpreters/TemporaryDataOnDisk.h>
+#include <Interpreters/Context.h>
 #include <QueryPipeline/BlockIO.h>
 #include <QueryPipeline/ExecutionSpeedLimits.h>
 #include <Storages/IStorage_fwd.h>
@@ -234,7 +236,7 @@ struct ProcessListForUserInfo
 /// Data about queries for one user.
 struct ProcessListForUser
 {
-    explicit ProcessListForUser(ProcessList * global_process_list);
+    explicit ProcessListForUser(ContextPtr global_context, ProcessList * global_process_list);
 
     /// query_id -> ProcessListElement(s). There can be multiple queries with the same query_id as long as all queries except one are cancelled.
     using QueryToElement = std::unordered_map<String, QueryStatus *>;
@@ -243,6 +245,8 @@ struct ProcessListForUser
     ProfileEvents::Counters user_performance_counters{VariableContext::User, &ProfileEvents::global_counters};
     /// Limit and counter for memory of all simultaneously running queries of single user.
     MemoryTracker user_memory_tracker{VariableContext::User};
+
+    TemporaryDataOnDiskPtr user_temp_data_on_disk;
 
     UserOvercommitTracker user_overcommit_tracker;
 
@@ -257,6 +261,7 @@ struct ProcessListForUser
     /// Clears network bandwidth Throttler, so it will not count periods of inactivity.
     void resetTrackers()
     {
+        /// TODO: should we drop user_temp_data_on_disk here?
         user_memory_tracker.reset();
         if (user_throttler)
             user_throttler.reset();

--- a/src/Interpreters/SortedBlocksWriter.cpp
+++ b/src/Interpreters/SortedBlocksWriter.cpp
@@ -5,7 +5,7 @@
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Processors/Merges/MergingSortedTransform.h>
 #include <Processors/Sources/TemporaryFileLazySource.h>
-#include <Formats/TemporaryFileStream.h>
+#include <Formats/TemporaryFileStreamLegacy.h>
 #include <Disks/IVolume.h>
 #include <Disks/TemporaryFileOnDisk.h>
 

--- a/src/Interpreters/SortedBlocksWriter.cpp
+++ b/src/Interpreters/SortedBlocksWriter.cpp
@@ -39,7 +39,7 @@ namespace
 TemporaryFileOnDiskHolder flushToFile(const DiskPtr & disk, const Block & header, QueryPipelineBuilder pipeline, const String & codec)
 {
     auto tmp_file = std::make_unique<TemporaryFileOnDisk>(disk, CurrentMetrics::TemporaryFilesForJoin);
-    auto write_stat = TemporaryFileStream::write(tmp_file->getPath(), header, std::move(pipeline), codec);
+    auto write_stat = TemporaryFileStreamLegacy::write(tmp_file->getPath(), header, std::move(pipeline), codec);
 
     ProfileEvents::increment(ProfileEvents::ExternalProcessingCompressedBytesTotal, write_stat.compressed_bytes);
     ProfileEvents::increment(ProfileEvents::ExternalProcessingUncompressedBytesTotal, write_stat.uncompressed_bytes);

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -1,0 +1,134 @@
+#include <Interpreters/TemporaryDataOnDisk.h>
+
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int MEMORY_LIMIT_EXCEEDED;
+}
+
+void TemporaryDataOnDisk::changeAlloc(size_t compressed_bytes, size_t uncompressed_bytes, bool is_dealloc)
+{
+    if (is_dealloc)
+    {
+        stat.uncompressed_bytes -= uncompressed_bytes;
+        stat.compressed_bytes -= compressed_bytes;
+    }
+    else
+    {
+        stat.uncompressed_bytes += uncompressed_bytes;
+        stat.compressed_bytes += compressed_bytes;
+    }
+
+    if (parent)
+        parent->changeAlloc(compressed_bytes, uncompressed_bytes, is_dealloc);
+
+    if (limit && !is_dealloc)
+    {
+        if (stat.compressed_bytes > limit)
+            throw Exception("Memory limit exceeded", ErrorCodes::MEMORY_LIMIT_EXCEEDED);
+    }
+}
+
+TemporaryFileStream::TemporaryFileStream(TemporaryFileOnDiskHolder file_, TemporaryDataOnDisk * parent_)
+    : parent(parent_)
+    , file(file_)
+    , out_writer(std::make_unique<OutputWriter>(file->path(), header))
+{
+}
+
+TemporaryFileStreamPtr TemporaryDataOnDisk::createStream(CurrentMetrics::Value metric_scope, size_t max_temp_file_size)
+{
+    DiskPtr disk = nullptr;
+    ReservationPtr reservation = nullptr;
+    if (max_temp_file_size > 0)
+    {
+        reservation = tmp_volume->reserve(size);
+        if (!reservation)
+            throw Exception("Not enough space on temporary disk", ErrorCodes::NOT_ENOUGH_SPACE);
+        disk = reservation->getDisk();
+    }
+    else
+    {
+        disk = volume->getDisk();
+    }
+
+    TemporaryFileOnDiskHolder tmp_file = std::make_unique<TemporaryFileOnDisk>(disk, metric_scope);
+    return std::make_unique<TemporaryFileStream>(tmp_file, this);
+}
+
+
+~TemporaryFileStream::TemporaryFileStream()
+{
+    try
+    {
+        dealloc(stat.compressed_bytes, stat.uncompressed_bytes);
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+}
+
+
+struct TemporaryFileStream::OutputWriter
+{
+    OutputWriter(const String & path, const Block & header)
+        : out_file_buf(path)
+        , out_compressed_buf(out_file_buf)
+        , out_writer(out_compressed_buf, DBMS_TCP_PROTOCOL_VERSION, header)
+    {
+    }
+
+    void write(const Block & block)
+    {
+        if (finalized)
+            throw Exception("Cannot write to finalized stream", ErrorCodes::LOGICAL_ERROR);
+        out_writer.write(block);
+    }
+
+
+    void finalize()
+    {
+        if (finalized)
+            return;
+        out_writer.finalize();
+        out_compressed_buf.next();
+        out_file_buf.next();
+    }
+
+    ~OutputWriter()
+    {
+        try
+        {
+            finalize();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
+
+    WriteBufferFromFile out_file_buf;
+    CompressedWriteBuffer out_compressed_buf;
+    NativeWriter out_writer;
+
+    bool finalized = false;
+};
+
+struct TemporaryFileStream::InputReader
+{
+    InputReader(const String & path, const Block & header)
+        : in_file_buf(path)
+        , in_compressed_buf(in_file_buf)
+        , in_reader(in_compressed_buf, header, DBMS_TCP_PROTOCOL_VERSION)
+    {
+    }
+
+    ReadBufferFromFile in_file_buf;
+    CompressedReadBuffer in_compressed_buf;
+    NativeReader in_reader;
+};
+
+}

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -170,7 +170,7 @@ void TemporaryFileStream::write(const Block & block)
     out_writer->write(block);
 }
 
-TemporaryFileStream::Stat TemporaryFileStream::finishWriting()
+TemporaryFileStream::Stat TemporaryFileStream::finishWriting(bool use_header)
 {
     if (out_writer)
     {
@@ -180,7 +180,12 @@ TemporaryFileStream::Stat TemporaryFileStream::finishWriting()
         updateAllocAndCheck();
         out_writer.reset();
 
-        in_reader = std::make_unique<InputReader>(file->path(), header);
+        /// TODO: workaround to make aggregation work
+        /// For some reason NativeReader constuctors behave differently ?
+        if (use_header)
+            in_reader = std::make_unique<InputReader>(file->path(), header);
+        else
+            in_reader = std::make_unique<InputReader>(file->path());
     }
     return stat;
 }

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -170,7 +170,7 @@ void TemporaryFileStream::write(const Block & block)
     out_writer->write(block);
 }
 
-TemporaryFileStream::Stat TemporaryFileStream::finishWriting(bool use_header)
+TemporaryFileStream::Stat TemporaryFileStream::finishWriting()
 {
     if (out_writer)
     {
@@ -180,12 +180,7 @@ TemporaryFileStream::Stat TemporaryFileStream::finishWriting(bool use_header)
         updateAllocAndCheck();
         out_writer.reset();
 
-        /// TODO: workaround to make aggregation work
-        /// For some reason NativeReader constuctors behave differently ?
-        if (use_header)
-            in_reader = std::make_unique<InputReader>(file->path(), header);
-        else
-            in_reader = std::make_unique<InputReader>(file->path());
+        in_reader = std::make_unique<InputReader>(file->path(), header);
     }
     return stat;
 }

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -126,7 +126,7 @@ TemporaryFileStream::TemporaryFileStream(TemporaryFileOnDiskHolder file_, const 
 void TemporaryFileStream::write(const Block & block)
 {
     if (!out_writer)
-        throw Exception("Writing has beed finished", ErrorCodes::LOGICAL_ERROR);
+        throw Exception("Writing has been finished", ErrorCodes::LOGICAL_ERROR);
 
     out_writer->write(block);
     updateAlloc();

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <boost/noncopyable.hpp>
+
+#include <Interpreters/Context.h>
+#include <Disks/TemporaryFileOnDisk.h>
+
+
+namespace DB
+{
+
+
+class TemporaryFileStream;
+using TemporaryFileStreamPtr = std::unique_ptr<TemporaryFileStream>;
+
+
+/// Holds set of temporary files on disk and account amound of written data.
+/// If limit is set, throws exception if limit is exceeded.
+/// Data can be nested, so parent account all data written by children.
+/// New file stream is created with `createStream`.
+/// Streams are owned by this object and will be deleted when it is deleted.
+class TemporaryDataOnDisk : boost::noncopyable
+{
+public:
+    explicit TemporaryDataOnDisk(VolumePtr volume_, size_t limit_)
+        : volume(volume_), limit(limit_)
+    {}
+
+    explicit TemporaryDataOnDisk(TemporaryDataOnDisk * parent_, size_t limit_)
+        : parent(parent_), volume(parent->volume), limit(limit_)
+    {}
+
+    TemporaryFileStream & createStream();
+
+private:
+    void changeAlloc(size_t compressed_bytes, size_t uncompressed_bytes, bool is_dealloc);
+
+protected:
+
+    void alloc(size_t compressed_bytes, size_t uncompressed_bytes) { changeAlloc(compressed_bytes, uncompressed_bytes, false); }
+    void dealloc(size_t compressed_bytes, size_t uncompressed_bytes) { changeAlloc(compressed_bytes, uncompressed_bytes, true); }
+
+    struct Stat
+    {
+        std::atomic<size_t> compressed_bytes;
+        std::atomic<size_t> uncompressed_bytes;
+    };
+
+    TemporaryDataOnDisk * parent = nullptr;
+    VolumePtr volume;
+
+    std::vector<TemporaryFileStreamPtr> streams;
+
+    Stat stat;
+    size_t limit = 0;
+};
+
+/// Data can be written into this stream and then read.
+/// After finish writing, call `finishWriting` and then `read` to read the data.
+/// It's a leaf node in temporary data tree described above.
+class TemporaryFileStream final : private TemporaryDataOnDisk
+{
+public:
+    using Stat = TemporaryDataOnDisk::Stat;
+
+    TemporaryFileStream(TemporaryFileOnDiskHolder file_, TemporaryDataOnDisk * parent_);
+
+    void write(const Block & block);
+    Stat finishWriting();
+    bool isWriteFinished() const;
+
+    Block read();
+
+    ~TemporaryFileStream();
+
+private:
+    TemporaryFileOnDiskHolder file;
+
+    struct OutputWriter;
+    std::unique_ptr<OutputWriter> out_writer;
+
+    struct InputReader;
+    std::unique_ptr<InputReader> in_reader;
+};
+
+}

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -9,42 +9,38 @@
 namespace DB
 {
 
+class TemporaryDataOnDiskScope;
+using TemporaryDataOnDiskScopePtr = std::shared_ptr<TemporaryDataOnDiskScope>;
+
 class TemporaryDataOnDisk;
-using TemporaryDataOnDiskPtr = std::unique_ptr<TemporaryDataOnDisk>;
+using TemporaryDataOnDiskHolder = std::unique_ptr<TemporaryDataOnDisk>;
 
 class TemporaryFileStream;
 using TemporaryFileStreamHolder = std::unique_ptr<TemporaryFileStream>;
 
 
-/// Holds set of temporary files on disk and account amount of written data.
-/// If limit is set, throws exception if limit is exceeded.
-/// Data can be nested, so parent account all data written by children.
-/// New file stream is created with `createStream`.
-/// Streams are owned by this object and will be deleted when it is deleted.
-class TemporaryDataOnDisk : boost::noncopyable
+/*
+ * Used to account amount of temporary data written to dicsk.
+ * If limit is set, throws exception if limit is exceeded.
+ * Data can be nested, so parent scope accounts all data written by childrens.
+ * Scopes are: global -> per-user -> per-query -> per-purpose (sorting, aggregation, etc).
+ */
+class TemporaryDataOnDiskScope : boost::noncopyable
 {
-
-friend class TemporaryFileStream;
-
 public:
-    struct Stat
+    struct StatAtomic
     {
         std::atomic<size_t> compressed_size;
         std::atomic<size_t> uncompressed_size;
     };
 
-    explicit TemporaryDataOnDisk(VolumePtr volume_, size_t limit_)
+    explicit TemporaryDataOnDiskScope(VolumePtr volume_, size_t limit_)
         : volume(std::move(volume_)), limit(limit_)
     {}
 
-    explicit TemporaryDataOnDisk(std::shared_ptr<TemporaryDataOnDisk> parent_, size_t limit_)
+    explicit TemporaryDataOnDiskScope(TemporaryDataOnDiskScopePtr parent_, size_t limit_)
         : parent(std::move(parent_)), volume(parent->volume), limit(limit_)
     {}
-
-    TemporaryFileStream & createStream(const Block & header, CurrentMetrics::Value metric_scope, size_t reserve_size = 0);
-    std::vector<TemporaryFileStreamHolder> & getStreams() { return streams; }
-
-    const Stat & getStat() const { return stat; }
 
     /// TODO: remove
     /// Refactor all code that uses volume directly to use TemporaryDataOnDisk.
@@ -53,25 +49,59 @@ public:
 protected:
     void deltaAlloc(int compressed_size, int uncompressed_size);
 
-    std::shared_ptr<TemporaryDataOnDisk> parent = nullptr;
+    TemporaryDataOnDiskScopePtr parent = nullptr;
     VolumePtr volume;
 
-    std::mutex mutex; /// Protects streams
-    std::vector<TemporaryFileStreamHolder> streams;
-
-    Stat stat;
+    StatAtomic stat;
     size_t limit = 0;
 };
 
-/// Data can be written into this stream and then read.
-/// After finish writing, call `finishWriting` and then `read` to read the data.
-/// It's a leaf node in temporary data tree described above.
+/*
+ * Holds the set of temporary files.
+ * New file stream is created with `createStream`.
+ * Streams are owned by this object and will be deleted when it is deleted.
+ * It's a leaf node in temorarty data scope tree.
+ */
+class TemporaryDataOnDisk : private TemporaryDataOnDiskScope
+{
+    friend class TemporaryFileStream; /// to allow it to call `deltaAlloc` to account data
+public:
+    using TemporaryDataOnDiskScope::StatAtomic;
+
+    explicit TemporaryDataOnDisk(TemporaryDataOnDiskScopePtr parent_)
+        : TemporaryDataOnDiskScope(std::move(parent_), 0)
+    {}
+
+    TemporaryFileStream & createStream(const Block & header, CurrentMetrics::Value metric_scope, size_t reserve_size = 0);
+
+    std::vector<TemporaryFileStream *> getStreams();
+    bool empty() const { return streams.empty();}
+
+    const StatAtomic & getStat() const { return stat; }
+
+private:
+    std::mutex mutex; /// Protects streams
+    std::vector<TemporaryFileStreamHolder> streams;
+};
+
+/*
+ * Data can be written into this stream and then read.
+ * After finish writing, call `finishWriting` and then `read` to read the data.
+ * Account amount of data written to disk in parent scope.
+ */
 class TemporaryFileStream : boost::noncopyable
 {
 public:
-    using Stat = TemporaryDataOnDisk::Stat;
+    struct Stat
+    {
+        /// Statistics for file
+        /// Non-atomic because we don't allow to `read` or `write` into single file from multiple threads
+        size_t compressed_size = 0;
+        size_t uncompressed_size = 0;
+        size_t written_rows = 0;
+    };
 
-    TemporaryFileStream(TemporaryFileOnDiskHolder file_, const Block & header, TemporaryDataOnDisk * parent_);
+    TemporaryFileStream(TemporaryFileOnDiskHolder file_, const Block & header_, TemporaryDataOnDisk * parent_);
 
     void write(const Block & block);
     Stat finishWriting();
@@ -80,7 +110,7 @@ public:
     Block read();
 
     const String & path() const { return file->getPath(); }
-    Block getHeader() const;
+    Block getHeader() const { return header; }
 
     ~TemporaryFileStream();
 
@@ -89,11 +119,11 @@ private:
 
     TemporaryDataOnDisk * parent;
 
-    size_t compressed_size = 0;
-    size_t uncompressed_size = 0;
-    size_t written_rows = 0;
+    Block header;
 
     TemporaryFileOnDiskHolder file;
+
+    Stat stat;
 
     struct OutputWriter;
     std::unique_ptr<OutputWriter> out_writer;

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -72,9 +72,10 @@ public:
         : TemporaryDataOnDiskScope(std::move(parent_), 0)
     {}
 
-    TemporaryFileStream & createStream(const Block & header, CurrentMetrics::Value metric_scope, size_t reserve_size = 0);
+    /// If max_file_size > 0, then check that there's enough space on the disk and throw an exception in case of lack of free space
+    TemporaryFileStream & createStream(const Block & header, CurrentMetrics::Value metric_scope, size_t max_file_size = 0);
 
-    std::vector<TemporaryFileStream *> getStreams();
+    std::vector<TemporaryFileStream *> getStreams() const;
     bool empty() const;
 
     const StatAtomic & getStat() const { return stat; }

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -103,7 +103,7 @@ public:
     TemporaryFileStream(TemporaryFileOnDiskHolder file_, const Block & header_, TemporaryDataOnDisk * parent_);
 
     void write(const Block & block);
-    Stat finishWriting(bool use_header = true);
+    Stat finishWriting();
     bool isWriteFinished() const;
 
     Block read();

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -103,7 +103,7 @@ public:
     TemporaryFileStream(TemporaryFileOnDiskHolder file_, const Block & header_, TemporaryDataOnDisk * parent_);
 
     void write(const Block & block);
-    Stat finishWriting();
+    Stat finishWriting(bool use_header = true);
     bool isWriteFinished() const;
 
     Block read();

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -116,6 +116,10 @@ public:
 private:
     void updateAllocAndCheck();
 
+    /// Finalize everything, close reader and writer, delete file
+    void finalize();
+    bool isFinalized() const;
+
     TemporaryDataOnDisk * parent;
 
     Block header;

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -22,7 +22,7 @@ using TemporaryFileStreamHolder = std::unique_ptr<TemporaryFileStream>;
 /*
  * Used to account amount of temporary data written to dicsk.
  * If limit is set, throws exception if limit is exceeded.
- * Data can be nested, so parent scope accounts all data written by childrens.
+ * Data can be nested, so parent scope accounts all data written by children.
  * Scopes are: global -> per-user -> per-query -> per-purpose (sorting, aggregation, etc).
  */
 class TemporaryDataOnDiskScope : boost::noncopyable

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -85,12 +85,13 @@ public:
     ~TemporaryFileStream();
 
 private:
-    void updateAlloc();
+    void updateAlloc(size_t rows_added);
 
     TemporaryDataOnDisk * parent;
 
     size_t compressed_size = 0;
     size_t uncompressed_size = 0;
+    size_t written_rows = 0;
 
     TemporaryFileOnDiskHolder file;
 

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -177,7 +177,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
                     transform_params->params.group_by_two_level_threshold_bytes,
                     transform_params->params.max_bytes_before_external_group_by,
                     transform_params->params.empty_result_for_aggregation_by_empty_set,
-                    transform_params->params.tmp_data,
+                    transform_params->params.tmp_data_scope,
                     transform_params->params.max_threads,
                     transform_params->params.min_free_disk_space,
                     transform_params->params.compile_aggregate_expressions,

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -177,7 +177,7 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
                     transform_params->params.group_by_two_level_threshold_bytes,
                     transform_params->params.max_bytes_before_external_group_by,
                     transform_params->params.empty_result_for_aggregation_by_empty_set,
-                    transform_params->params.tmp_volume,
+                    transform_params->params.tmp_data,
                     transform_params->params.max_threads,
                     transform_params->params.min_free_disk_space,
                     transform_params->params.compile_aggregate_expressions,

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -37,7 +37,7 @@ SortingStep::SortingStep(
     size_t max_bytes_before_remerge_,
     double remerge_lowered_memory_bytes_ratio_,
     size_t max_bytes_before_external_sort_,
-    VolumePtr tmp_volume_,
+    TemporaryDataOnDiskPtr tmp_data_,
     size_t min_free_disk_space_,
     bool optimize_sorting_by_input_stream_properties_)
     : ITransformingStep(input_stream, input_stream.header, getTraits(limit_))
@@ -49,10 +49,13 @@ SortingStep::SortingStep(
     , max_bytes_before_remerge(max_bytes_before_remerge_)
     , remerge_lowered_memory_bytes_ratio(remerge_lowered_memory_bytes_ratio_)
     , max_bytes_before_external_sort(max_bytes_before_external_sort_)
-    , tmp_volume(tmp_volume_)
+    , tmp_data(tmp_data_)
     , min_free_disk_space(min_free_disk_space_)
     , optimize_sorting_by_input_stream_properties(optimize_sorting_by_input_stream_properties_)
 {
+    if (max_bytes_before_external_sort && tmp_data == nullptr)
+        throw Exception("Temporary data storage for external sorting is not provided", ErrorCodes::LOGICAL_ERROR);
+
     /// TODO: check input_stream is partially sorted by the same description.
     output_stream->sort_description = result_description;
     output_stream->sort_scope = DataStream::SortScope::Global;
@@ -189,7 +192,7 @@ void SortingStep::mergeSorting(QueryPipelineBuilder & pipeline, const SortDescri
                 max_bytes_before_remerge / pipeline.getNumStreams(),
                 remerge_lowered_memory_bytes_ratio,
                 max_bytes_before_external_sort,
-                tmp_volume,
+                tmp_data,
                 min_free_disk_space);
         });
 }

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -12,6 +12,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 static ITransformingStep::Traits getTraits(size_t limit)
 {
     return ITransformingStep::Traits
@@ -37,7 +42,7 @@ SortingStep::SortingStep(
     size_t max_bytes_before_remerge_,
     double remerge_lowered_memory_bytes_ratio_,
     size_t max_bytes_before_external_sort_,
-    TemporaryDataOnDiskPtr tmp_data_,
+    std::shared_ptr<TemporaryDataOnDisk> tmp_data_,
     size_t min_free_disk_space_,
     bool optimize_sorting_by_input_stream_properties_)
     : ITransformingStep(input_stream, input_stream.header, getTraits(limit_))
@@ -192,7 +197,7 @@ void SortingStep::mergeSorting(QueryPipelineBuilder & pipeline, const SortDescri
                 max_bytes_before_remerge / pipeline.getNumStreams(),
                 remerge_lowered_memory_bytes_ratio,
                 max_bytes_before_external_sort,
-                tmp_data,
+                std::make_unique<TemporaryDataOnDisk>(tmp_data, 0),
                 min_free_disk_space);
         });
 }

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -42,7 +42,7 @@ SortingStep::SortingStep(
     size_t max_bytes_before_remerge_,
     double remerge_lowered_memory_bytes_ratio_,
     size_t max_bytes_before_external_sort_,
-    std::shared_ptr<TemporaryDataOnDisk> tmp_data_,
+    TemporaryDataOnDiskScopePtr tmp_data_,
     size_t min_free_disk_space_,
     bool optimize_sorting_by_input_stream_properties_)
     : ITransformingStep(input_stream, input_stream.header, getTraits(limit_))
@@ -197,7 +197,7 @@ void SortingStep::mergeSorting(QueryPipelineBuilder & pipeline, const SortDescri
                 max_bytes_before_remerge / pipeline.getNumStreams(),
                 remerge_lowered_memory_bytes_ratio,
                 max_bytes_before_external_sort,
-                std::make_unique<TemporaryDataOnDisk>(tmp_data, 0),
+                std::make_unique<TemporaryDataOnDisk>(tmp_data),
                 min_free_disk_space);
         });
 }

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -2,7 +2,7 @@
 #include <Processors/QueryPlan/ITransformingStep.h>
 #include <Core/SortDescription.h>
 #include <QueryPipeline/SizeLimits.h>
-#include <Disks/IVolume.h>
+#include <Interpreters/TemporaryDataOnDisk.h>
 
 namespace DB
 {
@@ -21,7 +21,7 @@ public:
         size_t max_bytes_before_remerge_,
         double remerge_lowered_memory_bytes_ratio_,
         size_t max_bytes_before_external_sort_,
-        VolumePtr tmp_volume_,
+        TemporaryDataOnDiskPtr tmp_data_,
         size_t min_free_disk_space_,
         bool optimize_sorting_by_input_stream_properties_);
 
@@ -85,7 +85,8 @@ private:
     size_t max_bytes_before_remerge = 0;
     double remerge_lowered_memory_bytes_ratio = 0;
     size_t max_bytes_before_external_sort = 0;
-    VolumePtr tmp_volume;
+    TemporaryDataOnDiskPtr tmp_data = nullptr;
+
     size_t min_free_disk_space = 0;
     const bool optimize_sorting_by_input_stream_properties = false;
 };

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -21,7 +21,7 @@ public:
         size_t max_bytes_before_remerge_,
         double remerge_lowered_memory_bytes_ratio_,
         size_t max_bytes_before_external_sort_,
-        TemporaryDataOnDiskPtr tmp_data_,
+        std::shared_ptr<TemporaryDataOnDisk> tmp_data_,
         size_t min_free_disk_space_,
         bool optimize_sorting_by_input_stream_properties_);
 
@@ -85,7 +85,7 @@ private:
     size_t max_bytes_before_remerge = 0;
     double remerge_lowered_memory_bytes_ratio = 0;
     size_t max_bytes_before_external_sort = 0;
-    TemporaryDataOnDiskPtr tmp_data = nullptr;
+    std::shared_ptr<TemporaryDataOnDisk> tmp_data = nullptr;
 
     size_t min_free_disk_space = 0;
     const bool optimize_sorting_by_input_stream_properties = false;

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -21,7 +21,7 @@ public:
         size_t max_bytes_before_remerge_,
         double remerge_lowered_memory_bytes_ratio_,
         size_t max_bytes_before_external_sort_,
-        std::shared_ptr<TemporaryDataOnDisk> tmp_data_,
+        TemporaryDataOnDiskScopePtr tmp_data_,
         size_t min_free_disk_space_,
         bool optimize_sorting_by_input_stream_properties_);
 
@@ -85,7 +85,7 @@ private:
     size_t max_bytes_before_remerge = 0;
     double remerge_lowered_memory_bytes_ratio = 0;
     size_t max_bytes_before_external_sort = 0;
-    std::shared_ptr<TemporaryDataOnDisk> tmp_data = nullptr;
+    TemporaryDataOnDiskScopePtr tmp_data = nullptr;
 
     size_t min_free_disk_space = 0;
     const bool optimize_sorting_by_input_stream_properties = false;

--- a/src/Processors/Sources/TemporaryFileLazySource.cpp
+++ b/src/Processors/Sources/TemporaryFileLazySource.cpp
@@ -18,7 +18,7 @@ Chunk TemporaryFileLazySource::generate()
         return {};
 
     if (!stream)
-        stream = std::make_unique<TemporaryFileStream>(path, header);
+        stream = std::make_unique<TemporaryFileStreamLegacy>(path, header);
 
     auto block = stream->block_in->read();
     if (!block)

--- a/src/Processors/Sources/TemporaryFileLazySource.cpp
+++ b/src/Processors/Sources/TemporaryFileLazySource.cpp
@@ -1,5 +1,5 @@
 #include <Processors/Sources/TemporaryFileLazySource.h>
-#include <Formats/TemporaryFileStream.h>
+#include <Formats/TemporaryFileStreamLegacy.h>
 
 namespace DB
 {

--- a/src/Processors/Sources/TemporaryFileLazySource.h
+++ b/src/Processors/Sources/TemporaryFileLazySource.h
@@ -5,7 +5,7 @@
 namespace DB
 {
 
-struct TemporaryFileStream;
+struct TemporaryFileStreamLegacy;
 
 class TemporaryFileLazySource : public ISource
 {
@@ -22,7 +22,7 @@ private:
     Block header;
     bool done;
 
-    std::unique_ptr<TemporaryFileStream> stream;
+    std::unique_ptr<TemporaryFileStreamLegacy> stream;
 };
 
 }

--- a/src/Processors/TTL/TTLAggregationAlgorithm.cpp
+++ b/src/Processors/TTL/TTLAggregationAlgorithm.cpp
@@ -34,7 +34,7 @@ TTLAggregationAlgorithm::TTLAggregationAlgorithm(
         0,
         settings.max_bytes_before_external_group_by,
         settings.empty_result_for_aggregation_by_empty_set,
-        storage_.getContext()->getTemporaryVolume(),
+        storage_.getContext()->getTempDataOnDisk(),
         settings.max_threads,
         settings.min_free_disk_space_for_temporary_data,
         settings.compile_aggregate_expressions,

--- a/src/Processors/Transforms/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/AggregatingTransform.cpp
@@ -600,7 +600,7 @@ void AggregatingTransform::initGenerate()
             }
         }
 
-        auto & tmp_data = params->aggregator.getTemporaryData();
+        const auto & tmp_data = params->aggregator.getTemporaryData();
 
         Pipe pipe;
         {

--- a/src/Processors/Transforms/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/AggregatingTransform.cpp
@@ -53,7 +53,7 @@ namespace
     class SourceFromNativeStream : public ISource
     {
     public:
-        SourceFromNativeStream(TemporaryFileStream * tmp_stream_)
+        explicit SourceFromNativeStream(TemporaryFileStream * tmp_stream_)
             : ISource(tmp_stream_->getHeader())
             , tmp_stream(tmp_stream_)
         {}

--- a/src/Processors/Transforms/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/AggregatingTransform.cpp
@@ -53,7 +53,7 @@ namespace
     class SourceFromNativeStream : public ISource
     {
     public:
-        SourceFromNativeStream(const TemporaryFileStreamPtr & tmp_stream_)
+        SourceFromNativeStream(TemporaryFileStreamHolder & tmp_stream_)
             : ISource(tmp_stream_->getHeader())
             , tmp_stream(tmp_stream_)
         {}
@@ -70,7 +70,7 @@ namespace
         }
 
     private:
-        const TemporaryFileStreamPtr & tmp_stream;
+        TemporaryFileStreamHolder & tmp_stream;
     };
 }
 
@@ -595,9 +595,9 @@ void AggregatingTransform::initGenerate()
             }
         }
 
-        const auto & tmp_data = params->aggregator.getTemporaryData();
-        Pipe pipe;
+        auto & tmp_data = params->aggregator.getTemporaryData();
 
+        Pipe pipe;
         {
             auto header = params->aggregator.getHeader(false);
             Pipes pipes;
@@ -611,9 +611,9 @@ void AggregatingTransform::initGenerate()
         LOG_DEBUG(
             log,
             "Will merge {} temporary files of size {} compressed, {} uncompressed.",
-            files.files.size(),
-            ReadableSize(files.sum_size_compressed),
-            ReadableSize(files.sum_size_uncompressed));
+            tmp_data.getStreams().size(),
+            ReadableSize(tmp_data.getStat().compressed_size),
+            ReadableSize(tmp_data.getStat().uncompressed_size));
 
         addMergingAggregatedMemoryEfficientTransform(pipe, params, temporary_data_merge_threads);
 

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -39,12 +39,12 @@ namespace ErrorCodes
 class BufferingToFileTransform : public IAccumulatingTransform
 {
 public:
-    BufferingToFileTransform(const Block & header, Poco::Logger * log_, std::string path_)
-        : IAccumulatingTransform(header, header), log(log_)
-        , path(std::move(path_)), file_buf_out(path), compressed_buf_out(file_buf_out)
-        , out_stream(std::make_unique<NativeWriter>(compressed_buf_out, 0, header))
+    BufferingToFileTransform(const Block & header, TemporaryFileStream & tmp_stream_, Poco::Logger * log_)
+        : IAccumulatingTransform(header, header)
+        , tmp_stream(tmp_stream_)
+        , log(log_)
     {
-        LOG_INFO(log, "Sorting and writing part of data into temporary file {}", path);
+        LOG_INFO(log, "Sorting and writing part of data into temporary file {}", tmp_stream.path());
         ProfileEvents::increment(ProfileEvents::ExternalSortWritePart);
     }
 
@@ -52,71 +52,42 @@ public:
 
     void consume(Chunk chunk) override
     {
-        out_stream->write(getInputPort().getHeader().cloneWithColumns(chunk.detachColumns()));
+        Block block = getInputPort().getHeader().cloneWithColumns(chunk.detachColumns());
+        tmp_stream.write(std::move(block));
     }
 
     Chunk generate() override
     {
-        if (out_stream)
+        if (!tmp_stream.isWriteFinished())
         {
-            out_stream->flush();
-            compressed_buf_out.next();
-            file_buf_out.next();
-
-            auto stat = updateWriteStat();
+            auto stat = tmp_stream.finishWriting();
+            updateWriteStat(stat);
 
             LOG_INFO(log, "Done writing part of data into temporary file {}, compressed {}, uncompressed {} ",
                 path, ReadableSize(static_cast<double>(stat.compressed_size)), ReadableSize(static_cast<double>(stat.uncompressed_size)));
-
-            out_stream.reset();
-
-            file_in = std::make_unique<ReadBufferFromFile>(path);
-            compressed_in = std::make_unique<CompressedReadBuffer>(*file_in);
-            block_in = std::make_unique<NativeReader>(*compressed_in, getOutputPort().getHeader(), 0);
         }
 
-        if (!block_in)
-            return {};
-
-        auto block = block_in->read();
+        Block block = tmp_stream.read();
         if (!block)
-        {
-            block_in.reset();
             return {};
-        }
 
         UInt64 num_rows = block.rows();
         return Chunk(block.getColumns(), num_rows);
     }
 
 private:
-    struct Stat
+    void updateWriteStat(TemporaryFileStream::Stat stat)
     {
-        size_t compressed_size = 0;
-        size_t uncompressed_size = 0;
-    };
+        ProfileEvents::increment(ProfileEvents::ExternalProcessingCompressedBytesTotal, stat.compressed_size);
+        ProfileEvents::increment(ProfileEvents::ExternalProcessingUncompressedBytesTotal, stat.uncompressed_size);
 
-    Stat updateWriteStat()
-    {
-        Stat res{compressed_buf_out.getCompressedBytes(), compressed_buf_out.getUncompressedBytes()};
-
-        ProfileEvents::increment(ProfileEvents::ExternalProcessingCompressedBytesTotal, res.compressed_size);
-        ProfileEvents::increment(ProfileEvents::ExternalProcessingUncompressedBytesTotal, res.uncompressed_size);
-
-        ProfileEvents::increment(ProfileEvents::ExternalSortCompressedBytes, res.compressed_size);
-        ProfileEvents::increment(ProfileEvents::ExternalSortUncompressedBytes, res.uncompressed_size);
-        return res;
+        ProfileEvents::increment(ProfileEvents::ExternalSortCompressedBytes, stat.compressed_size);
+        ProfileEvents::increment(ProfileEvents::ExternalSortUncompressedBytes, stat.uncompressed_size);
     }
 
-    Poco::Logger * log;
-    std::string path;
-    WriteBufferFromFile file_buf_out;
-    CompressedWriteBuffer compressed_buf_out;
-    std::unique_ptr<NativeWriter> out_stream;
+    TemporaryFileStream & tmp_stream;
 
-    std::unique_ptr<ReadBufferFromFile> file_in;
-    std::unique_ptr<CompressedReadBuffer> compressed_in;
-    std::unique_ptr<NativeReader> block_in;
+    Poco::Logger * log;
 };
 
 MergeSortingTransform::MergeSortingTransform(
@@ -128,13 +99,13 @@ MergeSortingTransform::MergeSortingTransform(
     size_t max_bytes_before_remerge_,
     double remerge_lowered_memory_bytes_ratio_,
     size_t max_bytes_before_external_sort_,
-    VolumePtr tmp_volume_,
+    TemporaryDataOnDisk tmp_data_,
     size_t min_free_disk_space_)
     : SortingTransform(header, description_, max_merged_block_size_, limit_, increase_sort_description_compile_attempts)
     , max_bytes_before_remerge(max_bytes_before_remerge_)
     , remerge_lowered_memory_bytes_ratio(remerge_lowered_memory_bytes_ratio_)
     , max_bytes_before_external_sort(max_bytes_before_external_sort_)
-    , tmp_volume(tmp_volume_)
+    , tmp_data(tmp_data_)
     , min_free_disk_space(min_free_disk_space_)
 {
 }
@@ -210,16 +181,11 @@ void MergeSortingTransform::consume(Chunk chunk)
     if (max_bytes_before_external_sort && sum_bytes_in_blocks > max_bytes_before_external_sort)
     {
         size_t size = sum_bytes_in_blocks + min_free_disk_space;
-        auto reservation = tmp_volume->reserve(size);
-        if (!reservation)
-            throw Exception("Not enough space for external sort in temporary storage", ErrorCodes::NOT_ENOUGH_SPACE);
+        auto & tmp_stream = tmp_data->createStream(CurrentMetrics::TemporaryFilesForSort, size)
 
-        temporary_files.emplace_back(std::make_unique<TemporaryFileOnDisk>(reservation->getDisk(), CurrentMetrics::TemporaryFilesForSort));
-
-        const std::string & path = temporary_files.back()->path();
         merge_sorter
             = std::make_unique<MergeSorter>(header_without_constants, std::move(chunks), description, max_merged_block_size, limit);
-        auto current_processor = std::make_shared<BufferingToFileTransform>(header_without_constants, log, path);
+        auto current_processor = std::make_shared<BufferingToFileTransform>(header_without_constants, log, tmp_stream);
 
         processors.emplace_back(current_processor);
 

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -99,7 +99,7 @@ MergeSortingTransform::MergeSortingTransform(
     size_t max_bytes_before_remerge_,
     double remerge_lowered_memory_bytes_ratio_,
     size_t max_bytes_before_external_sort_,
-    TemporaryDataOnDisk tmp_data_,
+    TemporaryDataOnDiskPtr tmp_data_,
     size_t min_free_disk_space_)
     : SortingTransform(header, description_, max_merged_block_size_, limit_, increase_sort_description_compile_attempts)
     , max_bytes_before_remerge(max_bytes_before_remerge_)
@@ -181,7 +181,7 @@ void MergeSortingTransform::consume(Chunk chunk)
     if (max_bytes_before_external_sort && sum_bytes_in_blocks > max_bytes_before_external_sort)
     {
         size_t size = sum_bytes_in_blocks + min_free_disk_space;
-        auto & tmp_stream = tmp_data->createStream(CurrentMetrics::TemporaryFilesForSort, size)
+        auto & tmp_stream = tmp_data.createStream(CurrentMetrics::TemporaryFilesForSort, size)
 
         merge_sorter
             = std::make_unique<MergeSorter>(header_without_constants, std::move(chunks), description, max_merged_block_size, limit);

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -93,7 +93,7 @@ MergeSortingTransform::MergeSortingTransform(
     size_t max_bytes_before_remerge_,
     double remerge_lowered_memory_bytes_ratio_,
     size_t max_bytes_before_external_sort_,
-    TemporaryDataOnDiskHolder tmp_data_,
+    TemporaryDataOnDiskPtr tmp_data_,
     size_t min_free_disk_space_)
     : SortingTransform(header, description_, max_merged_block_size_, limit_, increase_sort_description_compile_attempts)
     , max_bytes_before_remerge(max_bytes_before_remerge_)

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -58,11 +58,11 @@ public:
             updateWriteStat(stat);
 
             LOG_INFO(log, "Done writing part of data into temporary file {}, compressed {}, uncompressed {} ",
-                tmp_stream.path(), ReadableSize(static_cast<double>(stat.compressed_size.load())), ReadableSize(static_cast<double>(stat.uncompressed_size.load())));
+                tmp_stream.path(), ReadableSize(static_cast<double>(stat.compressed_size)), ReadableSize(static_cast<double>(stat.uncompressed_size)));
         }
 
         Block block = tmp_stream.read();
-        if (!block || block.rows() == 0)
+        if (!block)
             return {};
 
         UInt64 num_rows = block.rows();
@@ -93,7 +93,7 @@ MergeSortingTransform::MergeSortingTransform(
     size_t max_bytes_before_remerge_,
     double remerge_lowered_memory_bytes_ratio_,
     size_t max_bytes_before_external_sort_,
-    TemporaryDataOnDiskPtr tmp_data_,
+    TemporaryDataOnDiskHolder tmp_data_,
     size_t min_free_disk_space_)
     : SortingTransform(header, description_, max_merged_block_size_, limit_, increase_sort_description_compile_attempts)
     , max_bytes_before_remerge(max_bytes_before_remerge_)

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -4,6 +4,7 @@
 #include <Core/SortDescription.h>
 #include <Common/filesystemHelpers.h>
 #include <Disks/TemporaryFileOnDisk.h>
+#include <Interpreters/TemporaryDataOnDisk.h>
 #include <Common/logger_useful.h>
 
 
@@ -28,7 +29,7 @@ public:
         size_t max_bytes_before_remerge_,
         double remerge_lowered_memory_bytes_ratio_,
         size_t max_bytes_before_external_sort_,
-        TemporaryDataOnDisk tmp_data_,
+        TemporaryDataOnDiskPtr tmp_data_,
         size_t min_free_disk_space_);
 
     String getName() const override { return "MergeSortingTransform"; }
@@ -44,7 +45,7 @@ private:
     size_t max_bytes_before_remerge;
     double remerge_lowered_memory_bytes_ratio;
     size_t max_bytes_before_external_sort;
-    TemporaryDataOnDisk tmp_data;
+    TemporaryDataOnDiskPtr tmp_data;
     size_t min_free_disk_space;
 
     size_t sum_rows_in_blocks = 0;

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -28,7 +28,7 @@ public:
         size_t max_bytes_before_remerge_,
         double remerge_lowered_memory_bytes_ratio_,
         size_t max_bytes_before_external_sort_,
-        VolumePtr tmp_volume_,
+        TemporaryDataOnDisk tmp_data_,
         size_t min_free_disk_space_);
 
     String getName() const override { return "MergeSortingTransform"; }
@@ -44,7 +44,7 @@ private:
     size_t max_bytes_before_remerge;
     double remerge_lowered_memory_bytes_ratio;
     size_t max_bytes_before_external_sort;
-    VolumePtr tmp_volume;
+    TemporaryDataOnDisk tmp_data;
     size_t min_free_disk_space;
 
     size_t sum_rows_in_blocks = 0;

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -56,9 +56,6 @@ private:
     /// If remerge doesn't save memory at least several times, mark it as useless and don't do it anymore.
     bool remerge_is_useful = true;
 
-    /// Everything below is for external sorting.
-    std::vector<TemporaryFileOnDiskHolder> temporary_files;
-
     /// Merge all accumulated blocks to keep no more than limit rows.
     void remerge();
 

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -29,7 +29,7 @@ public:
         size_t max_bytes_before_remerge_,
         double remerge_lowered_memory_bytes_ratio_,
         size_t max_bytes_before_external_sort_,
-        TemporaryDataOnDiskPtr tmp_data_,
+        TemporaryDataOnDiskHolder tmp_data_,
         size_t min_free_disk_space_);
 
     String getName() const override { return "MergeSortingTransform"; }
@@ -45,7 +45,7 @@ private:
     size_t max_bytes_before_remerge;
     double remerge_lowered_memory_bytes_ratio;
     size_t max_bytes_before_external_sort;
-    TemporaryDataOnDiskPtr tmp_data;
+    TemporaryDataOnDiskHolder tmp_data;
     size_t min_free_disk_space;
 
     size_t sum_rows_in_blocks = 0;

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -29,7 +29,7 @@ public:
         size_t max_bytes_before_remerge_,
         double remerge_lowered_memory_bytes_ratio_,
         size_t max_bytes_before_external_sort_,
-        TemporaryDataOnDiskHolder tmp_data_,
+        TemporaryDataOnDiskPtr tmp_data_,
         size_t min_free_disk_space_);
 
     String getName() const override { return "MergeSortingTransform"; }
@@ -45,7 +45,7 @@ private:
     size_t max_bytes_before_remerge;
     double remerge_lowered_memory_bytes_ratio;
     size_t max_bytes_before_external_sort;
-    TemporaryDataOnDiskHolder tmp_data;
+    TemporaryDataOnDiskPtr tmp_data;
     size_t min_free_disk_space;
 
     size_t sum_rows_in_blocks = 0;

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -600,7 +600,7 @@ void HTTPHandler::processQuery(
 
         if (buffer_until_eof)
         {
-            const std::string tmp_path(server.context()->getTemporaryVolume()->getDisk()->getPath());
+            const std::string tmp_path(server.context()->getTempDataOnDisk->getVolume()->getDisk()->getPath());
             const std::string tmp_path_template(tmp_path + "http_buffers/");
 
             auto create_tmp_disk_buffer = [tmp_path_template] (const WriteBufferPtr &)

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -600,7 +600,7 @@ void HTTPHandler::processQuery(
 
         if (buffer_until_eof)
         {
-            const std::string tmp_path(server.context()->getTempDataOnDisk->getVolume()->getDisk()->getPath());
+            const std::string tmp_path(server.context()->getTemporaryVolume()->getDisk()->getPath());
             const std::string tmp_path_template(tmp_path + "http_buffers/");
 
             auto create_tmp_disk_buffer = [tmp_path_template] (const WriteBufferPtr &)

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -310,7 +310,7 @@ QueryPlanPtr MergeTreeDataSelectExecutor::read(
                 settings.group_by_two_level_threshold_bytes,
                 settings.max_bytes_before_external_group_by,
                 settings.empty_result_for_aggregation_by_empty_set,
-                context->getTemporaryVolume(),
+                context->getTempDataOnDisk(),
                 settings.max_threads,
                 settings.min_free_disk_space_for_temporary_data,
                 settings.compile_aggregate_expressions,

--- a/tests/queries/0_stateless/00107_totals_after_having.sql
+++ b/tests/queries/0_stateless/00107_totals_after_having.sql
@@ -30,7 +30,7 @@ SELECT intDiv(number, 2) AS k, count(), argMax(toString(number), number) FROM (S
 
 SELECT '*** External aggregation.';
 
-SET max_bytes_before_external_group_by=1000000;
+SET max_bytes_before_external_group_by = 1000000;
 SET group_by_two_level_threshold = 100000;
 
 SELECT '**** totals_mode = after_having_auto';


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Support limiting of temporary data stored on disk using settings `max_temporary_data_on_disk_size_for_user`/`max_temporary_data_on_disk_size_for_query` .


Use new interface for:
- [x] Sorting
- [x] Aggregation
- [ ] Partial Merge Join
- [ ] Backups ???
- [ ] Check other places where temporary files are used
- [ ] Documentation for the new settings

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
