### PR TITLE
Check grants for databases in case of renaming databases

### DIFF
--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -16,6 +16,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
+    extern const int LOGICAL_ERROR;
 }
 
 InterpreterRenameQuery::InterpreterRenameQuery(const ASTPtr & query_ptr_, ContextPtr context_)
@@ -31,11 +32,11 @@ BlockIO InterpreterRenameQuery::execute()
     if (!rename.cluster.empty())
     {
         DDLQueryOnClusterParams params;
-        params.access_to_check = getRequiredAccess();
+        params.access_to_check = getRequiredAccess(rename.database ? RenameType::RenameDatabase : RenameType::RenameTable);
         return executeDDLQueryOnCluster(query_ptr, getContext(), params);
     }
 
-    getContext()->checkAccess(getRequiredAccess());
+    getContext()->checkAccess(getRequiredAccess(rename.database ? RenameType::RenameDatabase : RenameType::RenameTable));
 
     String path = getContext()->getPath();
     String current_database = getContext()->getCurrentDatabase();
@@ -165,18 +166,35 @@ BlockIO InterpreterRenameQuery::executeToDatabase(const ASTRenameQuery &, const 
     return {};
 }
 
-AccessRightsElements InterpreterRenameQuery::getRequiredAccess() const
+AccessRightsElements InterpreterRenameQuery::getRequiredAccess(InterpreterRenameQuery::RenameType type) const
 {
     AccessRightsElements required_access;
     const auto & rename = query_ptr->as<const ASTRenameQuery &>();
     for (const auto & elem : rename.elements)
     {
-        required_access.emplace_back(AccessType::SELECT | AccessType::DROP_TABLE, elem.from.database, elem.from.table);
-        required_access.emplace_back(AccessType::CREATE_TABLE | AccessType::INSERT, elem.to.database, elem.to.table);
-        if (rename.exchange)
+        if (type == RenameType::RenameTable)
         {
-            required_access.emplace_back(AccessType::CREATE_TABLE | AccessType::INSERT, elem.from.database, elem.from.table);
-            required_access.emplace_back(AccessType::SELECT | AccessType::DROP_TABLE, elem.to.database, elem.to.table);
+            required_access.emplace_back(AccessType::SELECT | AccessType::DROP_TABLE, elem.from.database, elem.from.table);
+            required_access.emplace_back(AccessType::CREATE_TABLE | AccessType::INSERT, elem.to.database, elem.to.table);
+            if (rename.exchange)
+            {
+                required_access.emplace_back(AccessType::CREATE_TABLE | AccessType::INSERT , elem.from.database, elem.from.table);
+                required_access.emplace_back(AccessType::SELECT | AccessType::DROP_TABLE, elem.to.database, elem.to.table);
+            }
+        }
+        else if (type == RenameType::RenameDatabase)
+        {
+            required_access.emplace_back(AccessType::SELECT | AccessType::DROP_DATABASE, elem.from.database);
+            required_access.emplace_back(AccessType::CREATE_DATABASE | AccessType::INSERT, elem.to.database);
+            if (rename.exchange)
+            {
+                required_access.emplace_back(AccessType::CREATE_DATABASE | AccessType::INSERT , elem.from.database);
+                required_access.emplace_back(AccessType::SELECT | AccessType::DROP_DATABASE, elem.to.database);
+            }
+        }
+        else
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown type of rename query");
         }
     }
     return required_access;

--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -186,11 +186,6 @@ AccessRightsElements InterpreterRenameQuery::getRequiredAccess(InterpreterRename
         {
             required_access.emplace_back(AccessType::SELECT | AccessType::DROP_DATABASE, elem.from.database);
             required_access.emplace_back(AccessType::CREATE_DATABASE | AccessType::INSERT, elem.to.database);
-            if (rename.exchange)
-            {
-                required_access.emplace_back(AccessType::CREATE_DATABASE | AccessType::INSERT , elem.from.database);
-                required_access.emplace_back(AccessType::SELECT | AccessType::DROP_DATABASE, elem.to.database);
-            }
         }
         else
         {

--- a/src/Interpreters/InterpreterRenameQuery.h
+++ b/src/Interpreters/InterpreterRenameQuery.h
@@ -63,7 +63,13 @@ private:
     BlockIO executeToTables(const ASTRenameQuery & rename, const RenameDescriptions & descriptions, TableGuards & ddl_guards);
     BlockIO executeToDatabase(const ASTRenameQuery & rename, const RenameDescriptions & descriptions);
 
-    AccessRightsElements getRequiredAccess() const;
+    enum class RenameType
+    {
+        RenameTable,
+        RenameDatabase
+    };
+
+    AccessRightsElements getRequiredAccess(RenameType type) const;
 
     ASTPtr query_ptr;
     bool renamed_instead_of_exchange{false};

--- a/tests/queries/0_stateless/02416_rename_database_rbac.sh
+++ b/tests/queries/0_stateless/02416_rename_database_rbac.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02416_rename_database_rbac.sh
+++ b/tests/queries/0_stateless/02416_rename_database_rbac.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
-
-CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=none
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02416_rename_database_rbac.sh
+++ b/tests/queries/0_stateless/02416_rename_database_rbac.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=none
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --multiline --multiquery -q """
+DROP DATABASE IF EXISTS database_02416;
+CREATE DATABASE database_02416;
+
+DROP USER IF EXISTS user_test_02416;
+CREATE USER user_test_02416 IDENTIFIED WITH plaintext_password BY 'user_test_02416';
+
+GRANT CREATE DATABASE ON *.* TO 'user_test_02416' WITH GRANT OPTION;
+GRANT DROP DATABASE ON *.* TO 'user_test_02416' WITH GRANT OPTION;
+REVOKE DROP DATABASE ON database_02416.* FROM 'user_test_02416';
+GRANT CREATE TABLE ON *.* TO 'user_test_02416' WITH GRANT OPTION;
+GRANT DROP TABLE ON *.* TO 'user_test_02416' WITH GRANT OPTION;
+"""
+${CLICKHOUSE_CLIENT} --multiline --multiquery --user user_test_02416 --password user_test_02416 -q """
+RENAME DATABASE user_test_02416 to aaaaaaaaa; -- { serverError 497 }
+"""


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed a behaviour when user with explicitly revoked grant for dropping databases can still drop it.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
