### PR TITLE
move title to frontmatter, remove orig article link

### DIFF
--- a/docs/en/operations/access-rights.md
+++ b/docs/en/operations/access-rights.md
@@ -151,4 +151,3 @@ Management queries:
 
     By default, SQL-driven access control and account management is disabled for all users. You need to configure at least one user in the `users.xml` configuration file and set the value of the [access_management](../operations/settings/settings-users.md#access_management-user-setting) setting to 1.
 
-[Original article](https://clickhouse.com/docs/en/operations/access_rights/) <!--hide-->

--- a/docs/en/operations/quotas.md
+++ b/docs/en/operations/quotas.md
@@ -2,9 +2,8 @@
 slug: /en/operations/quotas
 sidebar_position: 51
 sidebar_label: Quotas
+title: Quotas
 ---
-
-# Quotas
 
 Quotas allow you to limit resource usage over a period of time or track the use of resources.
 Quotas are set up in the user config, which is usually ‘users.xml’.
@@ -118,4 +117,3 @@ For distributed query processing, the accumulated amounts are stored on the requ
 
 When the server is restarted, quotas are reset.
 
-[Original article](https://clickhouse.com/docs/en/operations/quotas/) <!--hide-->


### PR DESCRIPTION
These are changes that I make when I want to include a markdown file into a different spot in the nav.  Moving the title from the body into the frontmatter allows me to override the title in the second location.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
