### PR TITLE
Update doc about building on macOS

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -37,7 +37,7 @@ sudo xcode-select --install
 
 ``` bash
 brew update
-brew install cmake ninja libtool gettext llvm gcc binutils grep findutils
+brew install ccache cmake ninja libtool gettext llvm gcc binutils grep findutils
 ```
 
 ## Checkout ClickHouse Sources {#checkout-clickhouse-sources}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


ccache is required to build by default, update the doc to reflect it on macOS.