### PR TITLE
Support query parameters in describe table query

### DIFF
--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -1,16 +1,17 @@
-#include <Common/typeid_cast.h>
-#include <Common/quoteString.h>
 #include <Columns/IColumn.h>
-#include <DataTypes/IDataType.h>
 #include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/IDataType.h>
 #include <Formats/FormatSettings.h>
 #include <IO/ReadBufferFromString.h>
-#include <Parsers/ASTIdentifier.h>
-#include <Parsers/ASTLiteral.h>
-#include <Parsers/ASTQueryParameter.h>
 #include <Interpreters/IdentifierSemantic.h>
 #include <Interpreters/ReplaceQueryParameterVisitor.h>
 #include <Interpreters/addTypeConversionToAST.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTQueryParameter.h>
+#include <Parsers/TablePropertiesQueriesASTs.h>
+#include <Common/quoteString.h>
+#include <Common/typeid_cast.h>
 
 
 namespace DB
@@ -30,7 +31,12 @@ void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
     else if (ast->as<ASTIdentifier>() || ast->as<ASTTableIdentifier>())
         visitIdentifier(ast);
     else
-        visitChildren(ast);
+    {
+        if (auto * describe_query = dynamic_cast<ASTDescribeQuery *>(ast.get()); describe_query && describe_query->table_expression)
+            visitChildren(describe_query->table_expression);
+        else
+            visitChildren(ast);
+    }
 }
 
 

--- a/tests/queries/0_stateless/02377_extend_protocol_with_query_parameters.reference
+++ b/tests/queries/0_stateless/02377_extend_protocol_with_query_parameters.reference
@@ -7,3 +7,10 @@ UInt64	String	DateTime	Map(UUID, Array(Float32))
 13	str	2022-08-04 18:30:53	{'10':[11,12],'13':[14,15]}
 1
 1
+_CAST(42, \'Int64\')	Int64					
+_CAST([1, 2, 3], \'Array(UInt8)\')	Array(UInt8)					
+_CAST(((\'abc\', 22), (\'def\', 33)), \'Map(String, UInt8)\')	Map(String, UInt8)					
+_CAST([[4, 5, 6], [7], [8, 9]], \'Array(Array(UInt8))\')	Array(Array(UInt8))					
+_CAST(((10, [11, 12]), (13, [14, 15])), \'Map(UInt8, Array(UInt8))\')	Map(UInt8, Array(UInt8))					
+_CAST(((\'ghj\', ((\'klm\', [16, 17]))), (\'nop\', ((\'rst\', [18])))), \'Map(String, Map(String, Array(UInt8)))\')	Map(String, Map(String, Array(UInt8)))					
+a	Int8					

--- a/tests/queries/0_stateless/02377_extend_protocol_with_query_parameters.sh
+++ b/tests/queries/0_stateless/02377_extend_protocol_with_query_parameters.sh
@@ -68,13 +68,27 @@ $CLICKHOUSE_CLIENT -n -q "select {n: UInt8} -- { serverError 456 }"
 $CLICKHOUSE_CLIENT -n -q "set param_n = 12; set param_n = 13; select {n: UInt8}"
 
 
-# but multiple different parameters could be defined within each session
+# multiple different parameters could be defined within each session
 $CLICKHOUSE_CLIENT -n -q "
   set param_a = 13, param_b = 'str';
   set param_c = '2022-08-04 18:30:53';
   set param_d = '{\'10\': [11, 12], \'13\': [14, 15]}';
   select {a: UInt32}, {b: String}, {c: DateTime}, {d: Map(String, Array(UInt8))}"
 
+
 # empty parameter name is not allowed
 $CLICKHOUSE_CLIENT --param_="" -q "select 1" 2>&1 | grep -c 'Code: 36'
 $CLICKHOUSE_CLIENT -q "set param_ = ''" 2>&1 | grep -c 'Code: 36'
+
+
+# parameters are also supported for DESCRIBE TABLE queries
+$CLICKHOUSE_CLIENT \
+  --param_id="42" \
+  --param_arr="[1, 2, 3]" \
+  --param_map="{'abc': 22, 'def': 33}" \
+  --param_mul_arr="[[4, 5, 6], [7], [8, 9]]" \
+  --param_map_arr="{10: [11, 12], 13: [14, 15]}" \
+  --param_map_map_arr="{'ghj': {'klm': [16, 17]}, 'nop': {'rst': [18]}}" \
+  -q "describe table(select {id: Int64}, {arr: Array(UInt8)}, {map: Map(String, UInt8)}, {mul_arr: Array(Array(UInt8))}, {map_arr: Map(UInt8, Array(UInt8))}, {map_map_arr: Map(String, Map(String, Array(UInt8)))})"
+
+$CLICKHOUSE_CLIENT --param_p=42 -q "describe table (select * from (select {p:Int8} as a group by a) order by a)"


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Query parameters supported in DESCRIBE TABLE query.

Closes: #24301