### PR TITLE
stylecheck renewed and version in docker set explicitely

### DIFF
--- a/base/glibc-compatibility/memcpy/memcpy.h
+++ b/base/glibc-compatibility/memcpy/memcpy.h
@@ -214,4 +214,3 @@ tail:
 
     return ret;
 }
-

--- a/docker/test/style/Dockerfile
+++ b/docker/test/style/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
     python3-pip \
     shellcheck \
     yamllint \
-    && pip3 install black boto3 codespell dohq-artifactory PyGithub unidiff pylint==2.6.2 \
+    && pip3 install black==22.8.0 boto3 codespell==2.2.1 dohq-artifactory PyGithub unidiff pylint==2.6.2 \
     && apt-get clean \
     && rm -rf /root/.cache/pip
 

--- a/src/Common/Stopwatch.h
+++ b/src/Common/Stopwatch.h
@@ -152,4 +152,3 @@ private:
     /// Most significant bit is a lock. When it is set, compareAndRestartDeferred method will return false.
     UInt64 nanoseconds(UInt64 prev_time) const { return clock_gettime_ns_adjusted(prev_time, clock_type) & 0x7FFFFFFFFFFFFFFFULL; }
 };
-

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -810,7 +810,7 @@ void registerStorageKafka(StorageFactory & factory)
         /** Arguments of engine is following:
           * - Kafka broker list
           * - List of topics
-          * - Group ID (may be a constraint expression with a string result)
+          * - Group ID (may be a constant expression with a string result)
           * - Message format (string)
           * - Row delimiter
           * - Schema (optional, if the format supports it)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Addresses https://github.com/ClickHouse/ClickHouse/issues/40666 
Since typos are already fixed in e64436fef https://github.com/ClickHouse/ClickHouse/pull/40920  by @antonio2368 , this is only about explicit pip modules versions in Docker container.
Besides this, I think (though not 100% sure) that one typo was resolved incorrectly.