### PR TITLE
ci: add symlink for llvm-symbolizer (to make symbolizer work)

### DIFF
--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -83,5 +83,8 @@ RUN export CODENAME="$(lsb_release --codename --short | tr 'A-Z' 'a-z')" \
         --yes --no-install-recommends \
     && apt-get clean
 
+# for external_symbolizer_path
+RUN ln -s /usr/bin/llvm-symbolizer-15 /usr/bin/llvm-symbolizer
+
 COPY build.sh /
 CMD ["bash", "-c", "/build.sh 2>&1"]


### PR DESCRIPTION
Simply installing llvm-symbolizer-$VER is not enough, since it does not
contain proper symblink, while LLVM is looking only for
"llvm-symbolizer" (without version) - [1]:

  [1]:
https://github.com/llvm/llvm-project/blob/c444af1c20b35555f2fdb2c1ca38d3f23b2faebd/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp#L454

Follow-up for: #40655

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)