### PR TITLE
Feature: Support set global variable && set global on cluster variable

### DIFF
--- a/src/Access/Common/AccessType.h
+++ b/src/Access/Common/AccessType.h
@@ -197,6 +197,7 @@ enum class AccessType
     M(CLUSTER, "", GLOBAL, ALL) /* ON CLUSTER queries */ \
     \
     M(ALL, "ALL PRIVILEGES", GROUP, NONE) /* full access */ \
+    M(SET_GLOBAL, "SET GLOBAL", GLOBAL, ALL) \
     M(NONE, "USAGE, NO PRIVILEGES", GROUP, NONE) /* no access */
 
 #define DECLARE_ACCESS_TYPE_ENUM_CONST(name, aliases, node_type, parent_group_name) \

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -777,9 +777,14 @@ void Context::setUser(const UUID & user_id_)
 
     current_roles = std::make_shared<std::vector<UUID>>(user->granted_roles.findGranted(user->default_roles));
 
+
     auto default_profile_info = access->getDefaultProfileInfo();
     settings_constraints_and_current_profiles = default_profile_info->getConstraintsAndProfileIDs();
+
     applySettingsChanges(default_profile_info->settings);
+
+    if (getGlobalContext()->global_set)
+        applySettingsChanges(getGlobalContext()->getSettingsChanges());
 
     if (!user->default_database.empty())
         setCurrentDatabase(user->default_database);

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -385,6 +385,8 @@ public:
 
     KitchenSink kitchen_sink;
 
+    bool global_set = false;
+
 private:
     using SampleBlockCache = std::unordered_map<std::string, Block>;
     mutable SampleBlockCache sample_block_cache;
@@ -415,6 +417,8 @@ private:
     Context();
     Context(const Context &);
     Context & operator=(const Context &);
+
+    SettingsChanges settings_changes;
 
 public:
     /// Create initial Context with ContextShared and etc.
@@ -633,6 +637,16 @@ public:
     void applySettingChange(const SettingChange & change);
     void applySettingsChanges(const SettingsChanges & changes);
 
+    void setSettingsChanges(const SettingsChanges & changes)
+    {
+        settings_changes = changes;
+    }
+
+    SettingsChanges & getSettingsChanges()
+    {
+        return settings_changes;
+    }
+
     /// Checks the constraints.
     void checkSettingsConstraints(const SettingChange & change) const;
     void checkSettingsConstraints(const SettingsChanges & changes) const;
@@ -730,6 +744,8 @@ public:
     void makeGlobalContext() { initGlobal(); global_context = shared_from_this(); }
 
     const Settings & getSettingsRef() const { return settings; }
+
+    Settings & getMutableSettingsRef() { return settings; }
 
     void setProgressCallback(ProgressCallback callback);
     /// Used in executeQuery() to pass it to the QueryPipeline.

--- a/src/Interpreters/InterpreterSetQuery.cpp
+++ b/src/Interpreters/InterpreterSetQuery.cpp
@@ -1,6 +1,8 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/InterpreterSetQuery.h>
 #include <Parsers/ASTSetQuery.h>
+#include <Interpreters/executeDDLQueryOnCluster.h>
+#include <Access/Common/AccessRightsElement.h>
 
 namespace DB
 {
@@ -9,10 +11,33 @@ namespace DB
 BlockIO InterpreterSetQuery::execute()
 {
     const auto & ast = query_ptr->as<ASTSetQuery &>();
-    getContext()->checkSettingsConstraints(ast.changes);
-    auto session_context = getContext()->getSessionContext();
-    session_context->applySettingsChanges(ast.changes);
-    session_context->addQueryParameters(ast.query_parameters);
+    if (!ast.cluster.empty())
+    {
+        /// set on cluster need permission SET GLOBAL
+        DDLQueryOnClusterParams params;
+        params.access_to_check = getRequiredAccess();
+        return executeDDLQueryOnCluster(query_ptr, getContext(), params);
+    }
+
+    if (ast.getKind() == ASTSetQuery::Global)
+    {
+        /// set global need permission SET GLOBAL
+        getContext()->checkAccess(getRequiredAccess());
+        getContext()->getGlobalContext()->global_set = true;
+        getContext()->getGlobalContext()->setSettingsChanges(ast.changes);
+    }
+    if (ast.getKind() == ASTSetQuery::Session)
+    {
+        /* global level settings change no need check constraints
+         * for instance, set allow_ddl = 0; set global can set allow_ddl =1,
+         * but set session can not change this allow_ddl from 0 to 1;
+         */
+        getContext()->checkSettingsConstraints(ast.changes);
+        auto session_context = getContext()->getSessionContext();
+        session_context->applySettingsChanges(ast.changes);
+        session_context->addQueryParameters(ast.query_parameters);
+    }
+
     return {};
 }
 
@@ -22,6 +47,21 @@ void InterpreterSetQuery::executeForCurrentContext()
     const auto & ast = query_ptr->as<ASTSetQuery &>();
     getContext()->checkSettingsConstraints(ast.changes);
     getContext()->applySettingsChanges(ast.changes);
+}
+
+
+AccessRightsElements InterpreterSetQuery::getRequiredAccess() const
+{
+    AccessRightsElements required_access;
+
+    const auto & ast = query_ptr->as<ASTSetQuery &>();
+
+    if (ast.getKind() == ASTSetQuery::Global)
+    {
+        required_access.emplace_back(AccessType::SET_GLOBAL);
+    }
+
+    return required_access;
 }
 
 }

--- a/src/Interpreters/InterpreterSetQuery.h
+++ b/src/Interpreters/InterpreterSetQuery.h
@@ -3,6 +3,7 @@
 #include <Interpreters/IInterpreter.h>
 #include <Parsers/IAST_fwd.h>
 
+#include <Access/Common/AccessRightsElement.h>
 
 namespace DB
 {
@@ -26,6 +27,8 @@ public:
     void executeForCurrentContext();
 
     bool supportsTransactions() const override { return true; }
+
+    AccessRightsElements getRequiredAccess() const;
 
 private:
     ASTPtr query_ptr;

--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -22,7 +22,11 @@ void ASTSetQuery::updateTreeHashImpl(SipHash & hash_state) const
 void ASTSetQuery::formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const
 {
     if (is_standalone)
+    {
         format.ostr << (format.hilite ? hilite_keyword : "") << "SET " << (format.hilite ? hilite_none : "");
+        if (kind == SetKind::Global)
+            format.ostr << "global ";
+    }
 
     for (auto it = changes.begin(); it != changes.end(); ++it)
     {
@@ -32,6 +36,9 @@ void ASTSetQuery::formatImpl(const FormatSettings & format, FormatState &, Forma
         formatSettingName(it->name, format.ostr);
         format.ostr << " = " << applyVisitor(FieldVisitorToString(), it->value);
     }
+
+    if (is_standalone)
+        formatOnCluster(format);
 }
 
 }

--- a/src/Parsers/ASTSetQuery.h
+++ b/src/Parsers/ASTSetQuery.h
@@ -3,15 +3,21 @@
 #include <Core/Names.h>
 #include <Parsers/IAST.h>
 #include <Common/SettingsChanges.h>
+#include <Parsers/ASTQueryWithOnCluster.h>
 
 namespace DB
 {
 
 /** SET query
   */
-class ASTSetQuery : public IAST
+class ASTSetQuery : public IAST, public ASTQueryWithOnCluster
 {
 public:
+    enum SetKind
+    {
+        Session, /// set works on current session context;
+        Global, /// set works on global context level;
+    };
     bool is_standalone = true; /// If false, this AST is a part of another query, such as SELECT.
 
     /// To support overriding certain settings in a **subquery**, we add a ASTSetQuery with Settings to all subqueries, containing
@@ -26,11 +32,37 @@ public:
     /** Get the text that identifies this element. */
     String getID(char) const override { return "Set"; }
 
+    SetKind getKind() const { return kind; }
+
+    void setSetKind(SetKind set_kind)
+    {
+        kind = set_kind;
+    }
+
     ASTPtr clone() const override { return std::make_shared<ASTSetQuery>(*this); }
 
     void formatImpl(const FormatSettings & format, FormatState &, FormatStateStacked) const override;
 
     void updateTreeHashImpl(SipHash & hash_state) const override;
+
+    ASTPtr getRewrittenASTWithoutOnCluster(const WithoutOnClusterASTRewriteParams &) const override
+    {
+       return removeOnCluster<ASTSetQuery>(clone());
+    }
+
+private:
+    SetKind kind;
+
+    static String toString (SetKind kind)
+    {
+        switch (kind)
+        {
+            case Session: return "SET";
+            case Global: return "SET GLOBAL";
+        }
+
+        __builtin_unreachable();
+    }
 };
 
 }


### PR DESCRIPTION
Description:
============
For avoid to modify the config file frequently, implemented
the sql interface to modify server management variables, so
after execute this sql cmd. all sessions varibales will be
changed

Solution:
=========
Support Syntax:
set global xxx;
set global xxx on cluster

eg:
default max_execution_time=60
clickhouse-client 1
set global max_execution_time=80;

clickhouse-client 2
login into clickhouse-server
select value from system.settings where name='max_execution_time'

value = 80

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature
- Improvement
- Bug Fix (user-visible misbehavior in official stable or prestable release)
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
