### PR TITLE
ci/stress: clear dmesg before run to fix "OOM in dmesg" check

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -3,6 +3,9 @@
 # shellcheck disable=SC2086
 # shellcheck disable=SC2024
 
+# Avoid overlaps with previous runs
+dmesg --clear
+
 set -x
 
 # Thread Fuzzer allows to check more permutations of possible thread scheduling


### PR DESCRIPTION
CI: https://s3.amazonaws.com/clickhouse-test-reports/40772/afa137ae2b6108e72c2d6e43556a04548afa2ea9/stress_test__ubsan_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required

Follow-up for: #40704