### PR TITLE
Kafka sasl settings config in create table

### DIFF
--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -586,6 +586,21 @@ public:
         return !(*this == rhs);
     }
 
+    template <typename CharT>
+    std::enable_if_t<sizeof(CharT) == 1> assignString(const CharT * data, size_t size)
+    {
+        assert(which == Types::String);
+        String * ptr = reinterpret_cast<String *>(&storage);
+        ptr->assign(reinterpret_cast<const char *>(data), size);
+    }
+
+    void assignString(String && str)
+    {
+        assert(which == Types::String);
+        String * ptr = reinterpret_cast<String *>(&storage);
+        ptr->assign(std::move(str));
+    }
+
     /// Field is template parameter, to allow universal reference for field,
     /// that is useful for const and non-const .
     template <typename F, typename FieldRef>
@@ -667,22 +682,6 @@ private:
         assert(which == TypeToEnum<JustT>::value);
         JustT * MAY_ALIAS ptr = reinterpret_cast<JustT *>(&storage);
         *ptr = std::forward<T>(x);
-    }
-
-    template <typename CharT>
-    requires (sizeof(CharT) == 1)
-    void assignString(const CharT * data, size_t size)
-    {
-        assert(which == Types::String);
-        String * ptr = reinterpret_cast<String *>(&storage);
-        ptr->assign(reinterpret_cast<const char *>(data), size);
-    }
-
-    void assignString(String && str)
-    {
-        assert(which == Types::String);
-        String * ptr = reinterpret_cast<String *>(&storage);
-        ptr->assign(std::move(str));
     }
 
     void create(const Field & x)

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -690,6 +690,17 @@ ASTPtr DatabaseOnDisk::getCreateQueryFromMetadata(const String & database_metada
     if (ast)
     {
         auto & ast_create_query = ast->as<ASTCreateQuery &>();
+        if (ast_create_query.storage &&
+            ast_create_query.storage->engine->name == "Kafka")
+        {
+          for (auto &it : ast_create_query.storage->settings->changes)
+          {
+            if (it.name == "kafka_sasl_password")
+            {
+              it.value.assignString("xxxxx",5);
+            }
+          }
+        }
         ast_create_query.attach = false;
         ast_create_query.setDatabase(getDatabaseName());
     }

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -153,8 +153,8 @@ ProcessList::EntryPtr ProcessList::insert(const String & query_, const IAST * as
                 if (!is_unlimited_query && settings.max_concurrent_queries_for_user
                     && user_process_list->second.queries.size() >= settings.max_concurrent_queries_for_user)
                     throw Exception("Too many simultaneous queries for user " + client_info.current_user
-                        + ". Current: " + toString(user_process_list->second.queries.size())
-                        + ", maximum: " + settings.max_concurrent_queries_for_user.toString(),
+                       + ". Current: " + toString(user_process_list->second.queries.size())
+                       + ", maximum: " + settings.max_concurrent_queries_for_user.toString(),
                         ErrorCodes::TOO_MANY_SIMULTANEOUS_QUERIES);
 
                 auto running_query = user_process_list->second.queries.find(client_info.current_query_id);

--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -32,6 +32,8 @@ class ASTStorage;
     M(Bool, kafka_thread_per_consumer, false, "Provide independent thread for each consumer", 0) \
     M(HandleKafkaErrorMode, kafka_handle_error_mode, HandleKafkaErrorMode::DEFAULT, "How to handle errors for Kafka engine. Passible values: default, stream.", 0) \
     M(Bool, kafka_commit_on_select, false, "Commit messages when select query is made", 0) \
+    M(String, kafka_sasl_username, "", "A sasl user name for each kafa table.", 0) \
+    M(String, kafka_sasl_password, "", "A sasl password for each kafka table.", 0)
 
     /** TODO: */
     /* https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md */

--- a/src/Storages/Kafka/KafkaSettings.h
+++ b/src/Storages/Kafka/KafkaSettings.h
@@ -33,7 +33,9 @@ class ASTStorage;
     M(HandleKafkaErrorMode, kafka_handle_error_mode, HandleKafkaErrorMode::DEFAULT, "How to handle errors for Kafka engine. Passible values: default, stream.", 0) \
     M(Bool, kafka_commit_on_select, false, "Commit messages when select query is made", 0) \
     M(String, kafka_sasl_username, "", "A sasl user name for each kafa table.", 0) \
-    M(String, kafka_sasl_password, "", "A sasl password for each kafka table.", 0)
+    M(String, kafka_sasl_password, "", "A sasl password for each kafka table.", 0) \
+    M(String, kafka_security_protocol, "", "A security protocol for each kafka table.", 0) \
+    M(String, kafka_sasl_mechanism, "", "A sasl mechanism for each kafka table.", 0)
 
     /** TODO: */
     /* https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md */

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -428,6 +428,24 @@ ProducerBufferPtr StorageKafka::createWriteBuffer(const Block & header)
     conf.set("client.software.name", VERSION_NAME);
     conf.set("client.software.version", VERSION_DESCRIBE);
     // TODO: fill required settings
+    if (sasl_user != "")
+    {
+        conf.set("sasl.username", sasl_user);
+        conf.set("sasl.password", sasl_password);
+        if (security_protocol != "")
+        {
+            conf.set("security.protocol", security_protocol);
+        } else {
+            conf.set("security.protocol", "sasl_plaintext");
+        }
+        if (sasl_mechanism != "")
+        {
+            conf.set("sasl.mechanism", sasl_mechanism);
+        } else {
+            conf.set("sasl.mechanism", "PLAIN");
+        }
+    }
+
     updateConfiguration(conf);
 
     auto producer = std::make_shared<cppkafka::Producer>(conf);

--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -218,6 +218,8 @@ StorageKafka::StorageKafka(
     , settings_adjustments(createSettingsAdjustments())
     , sasl_user(kafka_settings->kafka_sasl_username.value)
     , sasl_password(kafka_settings->kafka_sasl_password.value)
+    , security_protocol(kafka_settings->kafka_security_protocol.value)
+    , sasl_mechanism(kafka_settings->kafka_sasl_mechanism.value)
     , thread_per_consumer(kafka_settings->kafka_thread_per_consumer.value)
     , collection_name(collection_name_)
 {
@@ -470,10 +472,20 @@ ConsumerBufferPtr StorageKafka::createReadBuffer(size_t consumer_number)
 
     if (sasl_user != "")
     {
-      conf.set("security.protocol", "sasl_plaintext");
-      conf.set("sasl.mechanism", "PLAIN");
       conf.set("sasl.username", sasl_user);
       conf.set("sasl.password", sasl_password);
+      if (security_protocol != "")
+      {
+          conf.set("security.protocol", security_protocol);
+      } else {
+          conf.set("security.protocol", "sasl_plaintext");
+      }
+      if (sasl_mechanism != "")
+      {
+          conf.set("sasl.mechanism", sasl_mechanism);
+      } else {
+          conf.set("sasl.mechanism", "PLAIN");
+      }
     }
 
     // Create a consumer and subscribe to topics
@@ -850,6 +862,8 @@ void registerStorageKafka(StorageFactory & factory)
             CHECK_KAFKA_STORAGE_ARGUMENT(10, kafka_commit_every_batch, 0)
             CHECK_KAFKA_STORAGE_ARGUMENT(11, kafka_sasl_username, 0)
             CHECK_KAFKA_STORAGE_ARGUMENT(12, kafka_sasl_password, 0)
+            CHECK_KAFKA_STORAGE_ARGUMENT(13, kafka_security_protocol, 0)
+            CHECK_KAFKA_STORAGE_ARGUMENT(14, kafka_sasl_mechanism, 0)
         }
 
         #undef CHECK_KAFKA_STORAGE_ARGUMENT

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -100,6 +100,8 @@ private:
 
     const String sasl_user;
     const String sasl_password;
+    const String security_protocol;
+    const String sasl_mechanism;
 
     // Stream thread
     struct TaskContext

--- a/src/Storages/Kafka/StorageKafka.h
+++ b/src/Storages/Kafka/StorageKafka.h
@@ -98,6 +98,9 @@ private:
 
     std::mutex mutex;
 
+    const String sasl_user;
+    const String sasl_password;
+
     // Stream thread
     struct TaskContext
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Currently When user create kafka engine table, if their kafka cluster need sasl settings, must ask ClickHouse DBA to help them config the sasl setting in the config.xml.
And actually in the real prod env, a lot of user maybe need create kafka engine table for real - time ingestion. And it will spend a lot of DBA time to change the config.xml and restart clickhouse-server

So Implemented this improvement feature, user can add sasl settings when they create table
like :
CREATE TABLE test.kafka_sasl
(
    `TableName` String,
    `Data` String,
    `UpdateType` String
)
ENGINE = Kafka
SETTINGS kafka_broker_list = '1xxx', kafka_topic_list = 'xxx', kafka_group_name = 'xxx', kafka_format = 'JSONEachRow', kafka_num_consumers = 1,  kafka_sasl_username = '14166', kafka_sasl_password = 'EXbahu59', kafka_security_protocol='sasl_plaintext', kafka_sasl_mechanism='SCRAM-SHA-512'

And for password safety , when user show create table to see the table create stmt, in the kafka_sasl_password filed will show 'xxxxx' instead of real password value


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
