### PR TITLE
Remove parser logic for WITH GROUPING SETS

### DIFF
--- a/src/Parsers/ParserSelectQuery.cpp
+++ b/src/Parsers/ParserSelectQuery.cpp
@@ -224,8 +224,6 @@ bool ParserSelectQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             select_query->group_by_with_rollup = true;
         else if (s_cube.ignore(pos, expected))
             select_query->group_by_with_cube = true;
-        else if (s_grouping_sets.ignore(pos, expected))
-            select_query->group_by_with_grouping_sets = true;
         else if (s_totals.ignore(pos, expected))
             select_query->group_by_with_totals = true;
         else


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Remove parser logic for WITH GROUPING SETS, otherwise the following query will crash the server:

```sql
SELECT number, number%2, count() FROM numbers(10) GROUP BY number, number%2 WITH GROUPING SETS;
```


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
