### PR TITLE
fix ignore projection logic error

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1302,7 +1302,7 @@ private:
                     *ctx->source_part->data_part_storage, it->name(), destination);
                 hardlinked_files.insert(it->name());
             }
-            else if (!endsWith(".tmp_proj", it->name())) // ignore projection tmp merge dir
+            else if (!endsWith(it->name(), ".tmp_proj")) // ignore projection tmp merge dir
             {
                 // it's a projection part directory
                 ctx->data_part_storage_builder->createProjection(destination);


### PR DESCRIPTION
### Changelog category
- Not for changelog


In src/Storages/MergeTree/MutateTask.cpp:1305
> 
            else if (!endsWith(".tmp_proj", it->name())) // ignore projection tmp merge dir

`endsWith(a, b)` used to check b is suffix of a.
So, here should be `endsWith(it->name(), ".tmp_proj")`