### PR TITLE
Remove non-existed released trains

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -59,7 +59,7 @@ clickhouse-client # or "clickhouse-client --password" if you set up a password.
 
 </details>
 
-You can replace `stable` with `lts` or `testing` to use different [release trains](../faq/operations/production.md) based on your needs.
+You can replace `stable` with `lts` to use different [release kinds](../faq/operations/production.md) based on your needs.
 
 You can also download and install packages manually from [here](https://packages.clickhouse.com/deb/pool/stable).
 
@@ -106,7 +106,7 @@ clickhouse-client # or "clickhouse-client --password" if you set up a password.
 
 </details>
 
-If you want to use the most recent version, replace `stable` with `testing` (this is recommended for your testing environments). `prestable` is sometimes also available.
+You can replace `stable` with `lts` to use different [release kinds](../faq/operations/production.md) based on your needs.
 
 Then run these commands to install packages:
 


### PR DESCRIPTION

### Changelog category (leave one):
- Documentation (changelog entry is not required)

After checking the new [ClickHouse mirror repository](https://packages.clickhouse.com), it only present the `stable` and `lts` releasing trains for `RPM` and `DEB` packages. And other releasing trains are only existed in the [old mirror repository](https://repos.clickhouse.com).