### PR TITLE
CheckLabels: Print message that 'can be tested' is missing

### DIFF
--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -87,14 +87,17 @@ def should_run_checks_for_pr(pr_info: PRInfo) -> Tuple[bool, str, str]:
     # Consider the labels and whether the user is trusted.
     print("Got labels", pr_info.labels)
     if FORCE_TESTS_LABEL in pr_info.labels:
+        print(f"Label '{FORCE_TESTS_LABEL}' set, forcing remaining checks")
         return True, f"Labeled '{FORCE_TESTS_LABEL}'", "pending"
 
     if DO_NOT_TEST_LABEL in pr_info.labels:
+        print(f"Label '{DO_NOT_TEST_LABEL}' set, skipping remaining checks")
         return False, f"Labeled '{DO_NOT_TEST_LABEL}'", "success"
 
     if CAN_BE_TESTED_LABEL not in pr_info.labels and not pr_is_by_trusted_user(
         pr_info.user_login, pr_info.user_orgs
     ):
+        print(f"PRs by untrusted users need the '{CAN_BE_TESTED_LABEL}' label - please contact a member of the core team")
         return False, "Needs 'can be tested' label", "failure"
 
     if OK_SKIP_LABELS.intersection(pr_info.labels):
@@ -219,7 +222,7 @@ if __name__ == "__main__":
     elif SUBMODULE_CHANGED_LABEL in pr_info.labels:
         pr_labels_to_remove.append(SUBMODULE_CHANGED_LABEL)
 
-    print(f"change labels: add {pr_labels_to_add}, remove {pr_labels_to_remove}")
+    print(f"Change labels: add {pr_labels_to_add}, remove {pr_labels_to_remove}")
     if pr_labels_to_add:
         post_labels(gh, pr_info, pr_labels_to_add)
 

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -97,7 +97,9 @@ def should_run_checks_for_pr(pr_info: PRInfo) -> Tuple[bool, str, str]:
     if CAN_BE_TESTED_LABEL not in pr_info.labels and not pr_is_by_trusted_user(
         pr_info.user_login, pr_info.user_orgs
     ):
-        print(f"PRs by untrusted users need the '{CAN_BE_TESTED_LABEL}' label - please contact a member of the core team")
+        print(
+            f"PRs by untrusted users need the '{CAN_BE_TESTED_LABEL}' label - please contact a member of the core team"
+        )
         return False, "Needs 'can be tested' label", "failure"
 
     if OK_SKIP_LABELS.intersection(pr_info.labels):


### PR DESCRIPTION
Prints a message in the output of CheckLabels that label 'can be tested' must be added manually by a member of the core team if the PR was done by an untrusted user.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)