### PR TITLE
Exclude slow tests from fasttest profile

### DIFF
--- a/tests/queries/0_stateless/00705_drop_create_merge_tree.sh
+++ b/tests/queries/0_stateless/00705_drop_create_merge_tree.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
+
 set -e
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/00953_zookeeper_suetin_deduplication_bug.sh
+++ b/tests/queries/0_stateless/00953_zookeeper_suetin_deduplication_bug.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-replicated-database
+# Tags: zookeeper, no-replicated-database, no-fasttest
 # Tag no-replicated-database: Requires investigation
 
 set -e

--- a/tests/queries/0_stateless/00956_sensitive_data_masking.sh
+++ b/tests/queries/0_stateless/00956_sensitive_data_masking.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 # Get all server logs
 export CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL="trace"

--- a/tests/queries/0_stateless/01014_lazy_database_basic.sh
+++ b/tests/queries/0_stateless/01014_lazy_database_basic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01019_alter_materialized_view_atomic.sh
+++ b/tests/queries/0_stateless/01019_alter_materialized_view_atomic.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 set -e
 

--- a/tests/queries/0_stateless/01107_atomic_db_detach_attach.sh
+++ b/tests/queries/0_stateless/01107_atomic_db_detach_attach.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01150_ddl_guard_rwr.sh
+++ b/tests/queries/0_stateless/01150_ddl_guard_rwr.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal
 

--- a/tests/queries/0_stateless/01192_rename_database_zookeeper.sh
+++ b/tests/queries/0_stateless/01192_rename_database_zookeeper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-parallel
+# Tags: zookeeper, no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01249_flush_interactive.sh
+++ b/tests/queries/0_stateless/01249_flush_interactive.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01280_ttl_where_group_by.sh
+++ b/tests/queries/0_stateless/01280_ttl_where_group_by.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01361_fover_remote_num_tries.sh
+++ b/tests/queries/0_stateless/01361_fover_remote_num_tries.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01632_tinylog_read_write.sh
+++ b/tests/queries/0_stateless/01632_tinylog_read_write.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 set -e
 

--- a/tests/queries/0_stateless/01654_test_writer_block_sequence.sh
+++ b/tests/queries/0_stateless/01654_test_writer_block_sequence.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01903_csvwithnames_subset_of_columns.sh
+++ b/tests/queries/0_stateless/01903_csvwithnames_subset_of_columns.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02015_async_inserts_stress_long.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_stress_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-random-settings
+# Tags: no-random-settings, no-fasttest
 
 set -e
 

--- a/tests/queries/0_stateless/02044_url_glob_parallel.sh
+++ b/tests/queries/0_stateless/02044_url_glob_parallel.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: distributed
+# Tags: distributed, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02067_lost_part_s3.sql
+++ b/tests/queries/0_stateless/02067_lost_part_s3.sql
@@ -1,4 +1,4 @@
--- Tags: no-backward-compatibility-check
+-- Tags: no-backward-compatibility-check, no-fasttest
 
 DROP TABLE IF EXISTS partslost_0;
 DROP TABLE IF EXISTS partslost_1;

--- a/tests/queries/0_stateless/02104_overcommit_memory.sh
+++ b/tests/queries/0_stateless/02104_overcommit_memory.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02122_4letter_words_stress_zookeeper.sh
+++ b/tests/queries/0_stateless/02122_4letter_words_stress_zookeeper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02124_buffer_with_type_map_long.sh
+++ b/tests/queries/0_stateless/02124_buffer_with_type_map_long.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02125_lz4_compression_bug.sh
+++ b/tests/queries/0_stateless/02125_lz4_compression_bug.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02193_async_insert_tcp_client_1.sql
+++ b/tests/queries/0_stateless/02193_async_insert_tcp_client_1.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 SET log_queries = 1;
 
 DROP TABLE IF EXISTS t_async_insert_02193_1;

--- a/tests/queries/0_stateless/02246_async_insert_quota.sh
+++ b/tests/queries/0_stateless/02246_async_insert_quota.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02271_replace_partition_many_tables.sql
+++ b/tests/queries/0_stateless/02271_replace_partition_many_tables.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 DROP TABLE IF EXISTS replace_partition_source;
 DROP TABLE IF EXISTS replace_partition_dest1;
 DROP TABLE IF EXISTS replace_partition_dest1_2;

--- a/tests/queries/0_stateless/02294_overcommit_overflow.sh
+++ b/tests/queries/0_stateless/02294_overcommit_overflow.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02340_parts_refcnt_mergetree.sh
+++ b/tests/queries/0_stateless/02340_parts_refcnt_mergetree.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02352_rwlock.sh
+++ b/tests/queries/0_stateless/02352_rwlock.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-fasttest
 # Tag no-parallel -- to avoid running it in parallel, this will avoid possible issues due to high pressure
 
 # Test that ensures that WRITE lock failure notifies READ.

--- a/tests/queries/0_stateless/02401_merge_tree_old_tmp_dirs_cleanup.sql
+++ b/tests/queries/0_stateless/02401_merge_tree_old_tmp_dirs_cleanup.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 DROP TABLE IF EXISTS test_inserts;
 
 CREATE TABLE test_inserts (`key` Int, `part` Int) ENGINE = MergeTree PARTITION BY part ORDER BY key


### PR DESCRIPTION
99% of all tests in the fasttest profile run in one sec or less. The excluded tests each take 10 sec or more, the slowest being 02271_replace_partition_many_tables with 30 sec.

Savings, measured:
- (checkout + build: 3:05 min)
- test exccution before: 6:38 min, now: 3:31 min

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)