### PR TITLE
Improve clickhouse start command

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -221,7 +221,7 @@ For non-Linux operating systems and for AArch64 CPU architecture, ClickHouse bui
     curl -O 'https://builds.clickhouse.com/master/aarch64/clickhouse' && chmod a+x ./clickhouse
     ```
 
-Run `sudo ./clickhouse install` to install ClickHouse system-wide (also with needed configuration files, configuring users etc.). Then run `clickhouse start` commands to start the clickhouse-server and `clickhouse-client` to connect to it.
+Run `sudo ./clickhouse install` to install ClickHouse system-wide (also with needed configuration files, configuring users etc.). Then run `sudo clickhouse start` commands to start the clickhouse-server and `clickhouse-client` to connect to it.
 
 Use the `clickhouse client` to connect to the server, or `clickhouse local` to process local data.
 


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)=

After using the `sudo ./clickhouse install` command to install and configure ClickHouse server, I think it should use the `sudo clickhouse start` command to avoid the permission issue.
