### PR TITLE
Speed up reading uniqState

### DIFF
--- a/src/AggregateFunctions/UniquesHashSet.h
+++ b/src/AggregateFunctions/UniquesHashSet.h
@@ -424,14 +424,30 @@ public:
 
         alloc(new_size_degree);
 
-        for (size_t i = 0; i < m_size; ++i)
+        if (m_size <= 1)
         {
-            HashValue x = 0;
-            DB::readIntBinary(x, rb);
-            if (x == 0)
-                has_zero = true;
-            else
-                reinsertImpl(x);
+            for (size_t i = 0; i < m_size; ++i)
+            {
+                HashValue x = 0;
+                DB::readIntBinary(x, rb);
+                if (x == 0)
+                    has_zero = true;
+                else
+                    reinsertImpl(x);
+            }
+        }
+        else
+        {
+            auto hs = std::make_unique<HashValue[]>(m_size);
+            rb.readStrict(reinterpret_cast<char *>(hs.get()), m_size * sizeof(HashValue));
+
+            for (size_t i = 0; i < m_size; ++i)
+            {
+                if (hs[i] == 0)
+                    has_zero = true;
+                else
+                    reinsertImpl(hs[i]);
+            }
         }
     }
 
@@ -458,11 +474,24 @@ public:
             resize(new_size_degree);
         }
 
-        for (size_t i = 0; i < rhs_size; ++i)
+        if (rhs_size <= 1)
         {
-            HashValue x = 0;
-            DB::readIntBinary(x, rb);
-            insertHash(x);
+            for (size_t i = 0; i < rhs_size; ++i)
+            {
+                HashValue x = 0;
+                DB::readIntBinary(x, rb);
+                insertHash(x);
+            }
+        }
+        else
+        {
+            auto hs = std::make_unique<HashValue[]>(rhs_size);
+            rb.readStrict(reinterpret_cast<char *>(hs.get()), rhs_size * sizeof(HashValue));
+
+            for (size_t i = 0; i < rhs_size; ++i)
+            {
+                insertHash(hs[i]);
+            }
         }
     }
 

--- a/tests/performance/uniq_stored.xml
+++ b/tests/performance/uniq_stored.xml
@@ -1,39 +1,58 @@
 <test>
     <create_query>
-        create table landing (
-            t DateTime,
+        create table matview_1
+        (
             a String,
-            b String
-        ) Engine=MergeTree partition by tuple() order by a settings index_granularity = 1024;
+            b_count AggregateFunction(uniq, UInt64)
+        ) Engine=MergeTree partition by tuple()
+        ORDER by tuple()
+        SETTINGS index_granularity = 1024;
     </create_query>
+
     <create_query>
-        create table matview (
+        create table matview_10000
+        (
             a String,
             b_count AggregateFunction(uniq, String)
-        ) Engine=AggregatingMergeTree partition by tuple() order by a settings index_granularity = 1024;
-    </create_query>
-    <create_query>
-        CREATE MATERIALIZED VIEW mv TO matview AS (
-            SELECT a, uniqState(b) b_count
-            FROM landing
-            GROUP BY a
-        );
+        ) Engine=MergeTree partition by tuple()
+        ORDER by tuple()
+        SETTINGS index_granularity = 1024;
     </create_query>
 
-    <drop_query>DROP TABLE IF EXISTS mv</drop_query>
-    <drop_query>DROP TABLE IF EXISTS matview</drop_query>
-    <drop_query>DROP TABLE IF EXISTS landing</drop_query>
+
+    <drop_query>DROP TABLE IF EXISTS matview_1</drop_query>
+    <drop_query>DROP TABLE IF EXISTS matview_10000</drop_query>
 
     <fill_query>
-        insert into landing	select today()-1, toString(rand()%1000),	concat('usr',toString(number%500)) from numbers(10000000);
+        INSERT INTO matview_10000
+        SELECT a, uniqState(b) b_count
+        FROM
+        (
+            SELECT toString(rand() % 1000) a, toString(number % 10000) b
+            FROM numbers_mt(20000000)
+        )
+        GROUP BY a
+        SETTINGS max_insert_threads=8;
     </fill_query>
-    <fill_query>
-        insert into landing select today()-2, toString(rand()%1000), concat('usr',toString(number%400)) from numbers(10000000);
-    </fill_query>
-    <fill_query>
-        insert into landing select today()-3, toString(rand()%1000), concat('usr',toString(number%200)) from numbers(10000000);
-    </fill_query>
+    <fill_query>OPTIMIZE TABLE matview_10000 FINAL</fill_query>
 
-    <query>select a, uniqMerge(b_count) as b_count from matview prewhere a='555' group by a FORMAT Null SETTINGS max_threads=1;</query>
-    <query>select uniqMerge(b_count) as b_count from matview FORMAT Null SETTINGS max_threads=1;</query>
+    <fill_query>
+        INSERT INTO matview_1
+        SELECT '1', uniqState(number) b_count
+        FROM
+        (
+            SELECT *
+            FROM numbers_mt(2000000)
+        )
+        GROUP BY number
+        SETTINGS max_insert_threads=8;
+    </fill_query>
+    <fill_query>OPTIMIZE TABLE matview_1 FINAL</fill_query>
+
+    <!-- Test with ~10000 elements per state -->
+    <query>select a, uniqMerge(b_count) as b_count from matview_10000 prewhere a='55' group by a FORMAT Null SETTINGS max_threads=1;</query>
+    <query>select uniqMerge(b_count) as b_count from matview_10000 FORMAT Null SETTINGS max_threads=1;</query>
+
+    <!-- Test with ~1 elements per state -->
+    <query>select uniqMerge(b_count) as b_count FROM matview_1 FORMAT Null SETTINGS max_threads=1;</query>
 </test>

--- a/tests/performance/uniq_stored.xml
+++ b/tests/performance/uniq_stored.xml
@@ -1,0 +1,39 @@
+<test>
+    <create_query>
+        create table landing (
+            t DateTime,
+            a String,
+            b String
+        ) Engine=MergeTree partition by tuple() order by a settings index_granularity = 1024;
+    </create_query>
+    <create_query>
+        create table matview (
+            a String,
+            b_count AggregateFunction(uniq, String)
+        ) Engine=AggregatingMergeTree partition by tuple() order by a settings index_granularity = 1024;
+    </create_query>
+    <create_query>
+        CREATE MATERIALIZED VIEW mv TO matview AS (
+            SELECT a, uniqState(b) b_count
+            FROM landing
+            GROUP BY a
+        );
+    </create_query>
+
+    <drop_query>DROP TABLE IF EXISTS mv</drop_query>
+    <drop_query>DROP TABLE IF EXISTS matview</drop_query>
+    <drop_query>DROP TABLE IF EXISTS landing</drop_query>
+
+    <fill_query>
+        insert into landing	select today()-1, toString(rand()%1000),	concat('usr',toString(number%500)) from numbers(10000000);
+    </fill_query>
+    <fill_query>
+        insert into landing select today()-2, toString(rand()%1000), concat('usr',toString(number%400)) from numbers(10000000);
+    </fill_query>
+    <fill_query>
+        insert into landing select today()-3, toString(rand()%1000), concat('usr',toString(number%200)) from numbers(10000000);
+    </fill_query>
+
+    <query>select a, uniqMerge(b_count) as b_count from matview prewhere a='555' group by a FORMAT Null SETTINGS max_threads=1;</query>
+    <query>select uniqMerge(b_count) as b_count from matview FORMAT Null SETTINGS max_threads=1;</query>
+</test>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up reading UniquesHashSet (uniqState from disk for example)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

In some cases, the uniqMerge process for a query was completely dominated by the many calls to read data from the buffer into a uniqState state. Let's read all the integers in a block to avoid the overhead.


Example:

* Setup:
```sql
select version();

drop database if exists tt;

create database tt;

create table tt.landing (
	t DateTime,
	a String,
	b String
) Engine=MergeTree partition by tuple() order by a settings index_granularity = 1024;

create table tt.matview (
	a String,
	b_count AggregateFunction(uniq, String)
) Engine=AggregatingMergeTree partition by tuple() order by a settings index_granularity = 1024;

CREATE MATERIALIZED VIEW tt.mv TO tt.matview AS (
	SELECT a, uniqState(b) b_count
	FROM tt.landing
	GROUP BY a
);

insert into tt.landing select today()-1, toString(rand()%1000), concat('usr',toString(number%500)) from numbers(10000000);
insert into tt.landing select today()-2, toString(rand()%1000), concat('usr',toString(number%400)) from numbers(10000000);
insert into tt.landing select today()-3, toString(rand()%1000), concat('usr',toString(number%200)) from numbers(10000000);
```

* `clickhouse-benchmark --query "select a, uniqMerge(b_count) as b_count from tt.matview prewhere a='555' group by a FORMAT Null SETTINGS max_threads=1;" -i 2000`
  - Master: localhost:9000, queries 2000, QPS: 151.412, RPS: 151411.945, MiB/s: 21.207, result RPS: 0.000, result MiB/s: 0.000.
  - Changes: localhost:9000, queries 2000, QPS: 282.340, RPS: 282339.980, MiB/s: 39.545, result RPS: 0.000, result MiB/s: 0.000.

* `clickhouse-benchmark --query "select a, uniqMerge(b_count) as b_count from tt.matview group by a FORMAT Null SETTINGS max_threads=1;" -i 1000`
  - Master: localhost:9000, queries 1000, QPS: 81.189, RPS: 81188.559, MiB/s: 11.371, result RPS: 0.000, result MiB/s: 0.000.
  - Changes: localhost:9000, queries 1000, QPS: 105.919, RPS: 105919.390, MiB/s: 14.835, result RPS: 0.000, result MiB/s: 0.000.


