### PR TITLE
Fix zlib-ng build issue for s390x

### DIFF
--- a/contrib/zlib-ng-cmake/CMakeLists.txt
+++ b/contrib/zlib-ng-cmake/CMakeLists.txt
@@ -2,8 +2,10 @@ set (SOURCE_DIR ${CMAKE_SOURCE_DIR}/contrib/zlib-ng)
 
 add_definitions(-DZLIB_COMPAT)
 add_definitions(-DWITH_GZFILEOP)
-add_definitions(-DUNALIGNED_OK)
-add_definitions(-DUNALIGNED64_OK)
+if(NOT ARCH_S390X)
+    add_definitions(-DUNALIGNED_OK)
+    add_definitions(-DUNALIGNED64_OK)
+endif()
 
 set (HAVE_UNISTD_H 1)
 add_definitions(-D_LARGEFILE64_SOURCE=1 -D__USE_LARGEFILE64)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
The CMakeLists.txt in zlib-ng-make cannot build working zlib-ng library for s390x because s390x zlib-ng doesn't support UNALIGNED_OK and UNALIGNED64_OK  related code, and causes the following unit test failures:

```
[  FAILED  ] All/ArchiveReaderAndWriterTest.SingleFileInArchive/0, where GetParam() = ".zip" (1 ms)
[  FAILED  ] All/ArchiveReaderAndWriterTest.TwoFilesInArchive/0, where GetParam() = ".zip" (0 ms)
[  FAILED  ] All/ArchiveReaderAndWriterTest.InMemory/0, where GetParam() = ".zip" (1 ms)
[  FAILED  ] All/ArchiveReaderAndWriterTest.Password/0, where GetParam() = ".zip" (9 ms)
```
The PR fixed the issue by disabling UNALIGNED_OK and UNALIGNED64_OK macros for s390x.

### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed zlib-ng build issue for s390x

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
