### PR TITLE
tests: disable zero copy replication to suppress warning in 01650_fetch_patition_with_macro_in_zk_path_long

### DIFF
--- a/tests/queries/0_stateless/01650_fetch_patition_with_macro_in_zk_path_long.sql
+++ b/tests/queries/0_stateless/01650_fetch_patition_with_macro_in_zk_path_long.sql
@@ -5,13 +5,15 @@ DROP TABLE IF EXISTS restore_01640;
 
 CREATE TABLE test_01640(i Int64, d Date, s String)
 ENGINE = ReplicatedMergeTree('/clickhouse/{database}/{shard}/tables/test_01640','{replica}') 
-PARTITION BY toYYYYMM(d) ORDER BY i;
+PARTITION BY toYYYYMM(d) ORDER BY i
+SETTINGS allow_remote_fs_zero_copy_replication=0;
 
 insert into test_01640 values (1, '2021-01-01','some');
 
 CREATE TABLE restore_01640(i Int64, d Date, s String)
 ENGINE = ReplicatedMergeTree('/clickhouse/{database}/{shard}/tables/restore_01640','{replica}')
-PARTITION BY toYYYYMM(d) ORDER BY i;
+PARTITION BY toYYYYMM(d) ORDER BY i
+SETTINGS allow_remote_fs_zero_copy_replication=0;
 
 ALTER TABLE restore_01640 FETCH PARTITION tuple(toYYYYMM(toDate('2021-01-01')))
   FROM '/clickhouse/{database}/{shard}/tables/test_01640';


### PR DESCRIPTION
Since FETCH PARTITION explicitly do not use zero copy replication, and actually it makes zero sense for it.

Fixes: #41108 (cc @alesapin)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)