### PR TITLE
Fix query_views_log with Window views

### DIFF
--- a/src/Interpreters/QueryViewsLog.cpp
+++ b/src/Interpreters/QueryViewsLog.cpp
@@ -28,7 +28,8 @@ NamesAndTypesList QueryViewsLogElement::getNamesAndTypes()
     auto view_type_datatype = std::make_shared<DataTypeEnum8>(DataTypeEnum8::Values{
         {"Default", static_cast<Int8>(ViewType::DEFAULT)},
         {"Materialized", static_cast<Int8>(ViewType::MATERIALIZED)},
-        {"Live", static_cast<Int8>(ViewType::LIVE)}});
+        {"Live", static_cast<Int8>(ViewType::LIVE)},
+        {"Window", static_cast<Int8>(ViewType::WINDOW)}});
 
     return {
         {"event_date", std::make_shared<DataTypeDate>()},

--- a/tests/queries/0_stateless/02125_query_views_log_window_function.reference
+++ b/tests/queries/0_stateless/02125_query_views_log_window_function.reference
@@ -1,0 +1,40 @@
+-- { echo }
+
+WITH
+    (
+        SELECT initial_query_id
+        FROM system.query_log
+        WHERE current_database = currentDatabase()
+          AND event_date >= yesterday()
+          AND query LIKE '-- INSERT INTO wv%'
+        LIMIT 1
+    ) AS q_id
+SELECT view_name, view_type, view_query, read_rows, read_bytes, written_rows, written_bytes
+FROM system.query_views_log
+WHERE initial_query_id = q_id FORMAT Vertical;
+Row 1:
+──────
+view_name:     default.wv
+view_type:     Window
+view_query:    SELECT count(id), tumbleStart(w_id) AS window_start FROM default.data GROUP BY windowID(timestamp, toIntervalSecond('10')) AS w_id
+read_rows:     1
+read_bytes:    12
+written_rows:  0
+written_bytes: 0
+WITH
+    (
+        SELECT initial_query_id
+        FROM system.query_log
+        WHERE current_database = currentDatabase()
+          AND event_date >= yesterday()
+          AND query LIKE '-- INSERT INTO wv%'
+        LIMIT 1
+    ) AS q_id
+SELECT views
+FROM system.query_log
+WHERE initial_query_id = q_id
+  AND type = 'QueryFinish'
+FORMAT Vertical;
+Row 1:
+──────
+views: ['default.wv']

--- a/tests/queries/0_stateless/02125_query_views_log_window_function.sql
+++ b/tests/queries/0_stateless/02125_query_views_log_window_function.sql
@@ -1,0 +1,38 @@
+set allow_experimental_window_view = 1;
+CREATE TABLE data ( `id` UInt64, `timestamp` DateTime) ENGINE = Memory;
+CREATE WINDOW VIEW wv Engine Memory as select count(id), tumbleStart(w_id) as window_start from data group by tumble(timestamp, INTERVAL '10' SECOND) as w_id;
+
+-- INSERT INTO wv
+INSERT INTO data VALUES(1,now());
+
+SYSTEM FLUSH LOGS;
+
+-- { echo }
+
+WITH
+    (
+        SELECT initial_query_id
+        FROM system.query_log
+        WHERE current_database = currentDatabase()
+          AND event_date >= yesterday()
+          AND query LIKE '-- INSERT INTO wv%'
+        LIMIT 1
+    ) AS q_id
+SELECT view_name, view_type, view_query, read_rows, read_bytes, written_rows, written_bytes
+FROM system.query_views_log
+WHERE initial_query_id = q_id FORMAT Vertical;
+
+WITH
+    (
+        SELECT initial_query_id
+        FROM system.query_log
+        WHERE current_database = currentDatabase()
+          AND event_date >= yesterday()
+          AND query LIKE '-- INSERT INTO wv%'
+        LIMIT 1
+    ) AS q_id
+SELECT views
+FROM system.query_log
+WHERE initial_query_id = q_id
+  AND type = 'QueryFinish'
+FORMAT Vertical;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix query_views_log with Window views


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Closes https://github.com/ClickHouse/ClickHouse/issues/41118
Window views are experimental and I don't think this has ever worked, so I doubt it's necessary to backport this.