### PR TITLE
move title to frontmatter to allow inclusion in other docs

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -4,9 +4,8 @@ sidebar_position: 1
 keywords: [clickhouse, install, installation, docs]
 description: ClickHouse can run on any Linux, FreeBSD, or Mac OS X with x86_64, AArch64, or PowerPC64LE CPU architecture.
 slug: /en/getting-started/install
+title: Installation
 ---
-
-# Installation
 
 ## System Requirements {#system-requirements}
 


### PR DESCRIPTION
Move title to frontmatter to allow including the install instructions in other docs.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

