### PR TITLE
Fix: integration test, standalone keeper mode

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_keeper.yml
+++ b/docker/test/integration/runner/compose/docker_compose_keeper.yml
@@ -9,6 +9,9 @@ services:
               source: ${keeper_binary:-}
               target: /usr/bin/clickhouse
             - type: bind
+              source: ${keeper_binary:-}
+              target: /usr/bin/clickhouse-keeper
+            - type: bind
               source: ${keeper_config_dir1:-}
               target: /etc/clickhouse-keeper
             - type: bind
@@ -39,6 +42,9 @@ services:
               source: ${keeper_binary:-}
               target: /usr/bin/clickhouse
             - type: bind
+              source: ${keeper_binary:-}
+              target: /usr/bin/clickhouse-keeper
+            - type: bind
               source: ${keeper_config_dir2:-}
               target: /etc/clickhouse-keeper
             - type: bind
@@ -68,6 +74,9 @@ services:
             - type: bind
               source: ${keeper_binary:-}
               target: /usr/bin/clickhouse
+            - type: bind
+              source: ${keeper_binary:-}
+              target: /usr/bin/clickhouse-keeper
             - type: bind
               source: ${keeper_config_dir3:-}
               target: /etc/clickhouse-keeper

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -792,7 +792,9 @@ class ClickHouseCluster:
         binary_dir = os.path.dirname(self.server_bin_path)
 
         # always prefer clickhouse-keeper standalone binary
-        if os.path.exists(os.path.join(binary_dir, "clickhouse-keeper")) and not os.path.islink(os.path.join(binary_dir, "clickhouse-keeper")):
+        if os.path.exists(
+            os.path.join(binary_dir, "clickhouse-keeper")
+        ) and not os.path.islink(os.path.join(binary_dir, "clickhouse-keeper")):
             binary_path = os.path.join(binary_dir, "clickhouse-keeper")
             keeper_cmd_prefix = "clickhouse-keeper"
         else:

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -792,7 +792,7 @@ class ClickHouseCluster:
         binary_dir = os.path.dirname(self.server_bin_path)
 
         # always prefer clickhouse-keeper standalone binary
-        if os.path.exists(os.path.join(binary_dir, "clickhouse-keeper")):
+        if os.path.exists(os.path.join(binary_dir, "clickhouse-keeper")) and not os.path.islink(os.path.join(binary_dir, "clickhouse-keeper")):
             binary_path = os.path.join(binary_dir, "clickhouse-keeper")
             keeper_cmd_prefix = "clickhouse-keeper"
         else:


### PR DESCRIPTION
### Changelog category:
- Not for changelog (changelog entry is not required)

There is logic regarding which keeper binary use to start keeper cluster in an integration test
There 2 options:
(1) standalone keeper binary (expected binary name `clickhouse-keeper`)
(2) `clickhouse` binary with keeper inside

Fixed:
- option (1) didn't work since `docker_compose_keeper.yaml` didn't create target `clickhouse-keeper` at all
- if `clickhouse-keeper` existed, option (1) was taken but `clickhouse-keeper` could be just a link to `clickhouse` binary (the link is created always during build if cmake option `BUILD_STANDALONE_KEEPER` is `OFF`)