### PR TITLE
Stop background operations before converting database from Ordinary

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2974,7 +2974,7 @@ const IHostContextPtr & Context::getHostContext() const
 }
 
 
-std::shared_ptr<ActionLocksManager> Context::getActionLocksManager()
+std::shared_ptr<ActionLocksManager> Context::getActionLocksManager() const
 {
     auto lock = getLock();
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -936,7 +936,7 @@ public:
     bool applyDeletedMask() const { return apply_deleted_mask; }
     void setApplyDeletedMask(bool apply) { apply_deleted_mask = apply; }
 
-    ActionLocksManagerPtr getActionLocksManager();
+    ActionLocksManagerPtr getActionLocksManager() const;
 
     enum class ApplicationType
     {

--- a/src/Interpreters/InterpreterSystemQuery.h
+++ b/src/Interpreters/InterpreterSystemQuery.h
@@ -16,6 +16,9 @@ namespace DB
 class Context;
 class AccessRightsElements;
 class ASTSystemQuery;
+class IDatabase;
+
+using DatabasePtr = std::shared_ptr<IDatabase>;
 
 
 /** Implement various SYSTEM queries.
@@ -36,6 +39,10 @@ public:
     InterpreterSystemQuery(const ASTPtr & query_ptr_, ContextMutablePtr context_);
 
     BlockIO execute() override;
+
+    static void startStopActionInDatabase(StorageActionBlockType action_type, bool start,
+                                          const String & database_name, const DatabasePtr & database,
+                                          const ContextPtr & local_context, Poco::Logger * log);
 
 private:
     ASTPtr query_ptr;


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed "possible deadlock avoided" error on automatic conversion of database engine from Ordinary to Atomic


Followup to https://github.com/ClickHouse/ClickHouse/pull/39933