### PR TITLE
fix documentation slug in Chinese folder

### DIFF
--- a/docs/zh/development/tests.md
+++ b/docs/zh/development/tests.md
@@ -1,5 +1,5 @@
 ---
-slug: /en/development/tests
+slug: /zh/development/tests
 sidebar_position: 70
 sidebar_label: Testing
 title: ClickHouse Testing


### PR DESCRIPTION
The slug was set to `en` and this is a doc in the `zh` folder.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

