### PR TITLE
Apply changes to http handlers on fly without server restart

### DIFF
--- a/programs/server/Server.h
+++ b/programs/server/Server.h
@@ -67,6 +67,9 @@ protected:
 
 private:
     ContextMutablePtr global_context;
+    /// Updated/recent config, to compare http_handlers
+    ConfigurationPtr latest_config;
+
     Poco::Net::SocketAddress socketBindListen(
         const Poco::Util::AbstractConfiguration & config,
         Poco::Net::ServerSocket & socket,

--- a/src/Backups/BackupCoordinationReplicatedTables.cpp
+++ b/src/Backups/BackupCoordinationReplicatedTables.cpp
@@ -248,6 +248,7 @@ BackupCoordinationReplicatedTables::getMutations(const String & table_shared_id,
         return {};
 
     std::vector<MutationInfo> res;
+    res.reserve(table_info.mutations.size());
     for (const auto & [mutation_id, mutation_entry] : table_info.mutations)
         res.emplace_back(MutationInfo{mutation_id, mutation_entry});
     return res;

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -5,7 +5,7 @@
 #include <Access/Credentials.h>
 #include <Interpreters/Context.h>
 
-#include <Poco/Util/LayeredConfiguration.h>
+#include <Poco/Util/AbstractConfiguration.h>
 
 #include "HTTPHandler.h"
 #include "NotFoundHandler.h"
@@ -27,7 +27,11 @@ namespace ErrorCodes
 }
 
 static void addCommonDefaultHandlersFactory(HTTPRequestHandlerFactoryMain & factory, IServer & server);
-static void addDefaultHandlersFactory(HTTPRequestHandlerFactoryMain & factory, IServer & server, AsynchronousMetrics & async_metrics);
+static void addDefaultHandlersFactory(
+    HTTPRequestHandlerFactoryMain & factory,
+    IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    AsynchronousMetrics & async_metrics);
 
 HTTPRequestHandlerFactoryMain::HTTPRequestHandlerFactoryMain(const std::string & name_)
     : log(&Poco::Logger::get(name_)), name(name_)
@@ -59,37 +63,41 @@ std::unique_ptr<HTTPRequestHandler> HTTPRequestHandlerFactoryMain::createRequest
 }
 
 static inline auto createHandlersFactoryFromConfig(
-    IServer & server, const std::string & name, const String & prefix, AsynchronousMetrics & async_metrics)
+    IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & name,
+    const String & prefix,
+    AsynchronousMetrics & async_metrics)
 {
     auto main_handler_factory = std::make_shared<HTTPRequestHandlerFactoryMain>(name);
 
     Poco::Util::AbstractConfiguration::Keys keys;
-    server.config().keys(prefix, keys);
+    config.keys(prefix, keys);
 
     for (const auto & key : keys)
     {
         if (key == "defaults")
         {
-            addDefaultHandlersFactory(*main_handler_factory, server, async_metrics);
+            addDefaultHandlersFactory(*main_handler_factory, server, config, async_metrics);
         }
         else if (startsWith(key, "rule"))
         {
-            const auto & handler_type = server.config().getString(prefix + "." + key + ".handler.type", "");
+            const auto & handler_type = config.getString(prefix + "." + key + ".handler.type", "");
 
             if (handler_type.empty())
                 throw Exception("Handler type in config is not specified here: " + prefix + "." + key + ".handler.type",
                     ErrorCodes::INVALID_CONFIG_PARAMETER);
 
             if (handler_type == "static")
-                main_handler_factory->addHandler(createStaticHandlerFactory(server, prefix + "." + key));
+                main_handler_factory->addHandler(createStaticHandlerFactory(server, config, prefix + "." + key));
             else if (handler_type == "dynamic_query_handler")
-                main_handler_factory->addHandler(createDynamicHandlerFactory(server, prefix + "." + key));
+                main_handler_factory->addHandler(createDynamicHandlerFactory(server, config, prefix + "." + key));
             else if (handler_type == "predefined_query_handler")
-                main_handler_factory->addHandler(createPredefinedHandlerFactory(server, prefix + "." + key));
+                main_handler_factory->addHandler(createPredefinedHandlerFactory(server, config, prefix + "." + key));
             else if (handler_type == "prometheus")
-                main_handler_factory->addHandler(createPrometheusHandlerFactory(server, async_metrics, prefix + "." + key));
+                main_handler_factory->addHandler(createPrometheusHandlerFactory(server, config, async_metrics, prefix + "." + key));
             else if (handler_type == "replicas_status")
-                main_handler_factory->addHandler(createReplicasStatusHandlerFactory(server, prefix + "." + key));
+                main_handler_factory->addHandler(createReplicasStatusHandlerFactory(server, config, prefix + "." + key));
             else
                 throw Exception("Unknown handler type '" + handler_type + "' in config here: " + prefix + "." + key + ".handler.type",
                     ErrorCodes::INVALID_CONFIG_PARAMETER);
@@ -103,16 +111,16 @@ static inline auto createHandlersFactoryFromConfig(
 }
 
 static inline HTTPRequestHandlerFactoryPtr
-createHTTPHandlerFactory(IServer & server, const std::string & name, AsynchronousMetrics & async_metrics)
+createHTTPHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const std::string & name, AsynchronousMetrics & async_metrics)
 {
-    if (server.config().has("http_handlers"))
+    if (config.has("http_handlers"))
     {
-        return createHandlersFactoryFromConfig(server, name, "http_handlers", async_metrics);
+        return createHandlersFactoryFromConfig(server, config, name, "http_handlers", async_metrics);
     }
     else
     {
         auto factory = std::make_shared<HTTPRequestHandlerFactoryMain>(name);
-        addDefaultHandlersFactory(*factory, server, async_metrics);
+        addDefaultHandlersFactory(*factory, server, config, async_metrics);
         return factory;
     }
 }
@@ -129,18 +137,18 @@ static inline HTTPRequestHandlerFactoryPtr createInterserverHTTPHandlerFactory(I
     return factory;
 }
 
-HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server, AsynchronousMetrics & async_metrics, const std::string & name)
+HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, AsynchronousMetrics & async_metrics, const std::string & name)
 {
     if (name == "HTTPHandler-factory" || name == "HTTPSHandler-factory")
-        return createHTTPHandlerFactory(server, name, async_metrics);
+        return createHTTPHandlerFactory(server, config, name, async_metrics);
     else if (name == "InterserverIOHTTPHandler-factory" || name == "InterserverIOHTTPSHandler-factory")
         return createInterserverHTTPHandlerFactory(server, name);
     else if (name == "PrometheusHandler-factory")
     {
         auto factory = std::make_shared<HTTPRequestHandlerFactoryMain>(name);
         auto handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
-            server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics));
-        handler->attachStrictPath(server.config().getString("prometheus.endpoint", "/metrics"));
+            server, PrometheusMetricsWriter(config, "prometheus", async_metrics));
+        handler->attachStrictPath(config.getString("prometheus.endpoint", "/metrics"));
         handler->allowGetAndHeadRequest();
         factory->addHandler(handler);
         return factory;
@@ -185,7 +193,11 @@ void addCommonDefaultHandlersFactory(HTTPRequestHandlerFactoryMain & factory, IS
     factory.addHandler(js_handler);
 }
 
-void addDefaultHandlersFactory(HTTPRequestHandlerFactoryMain & factory, IServer & server, AsynchronousMetrics & async_metrics)
+void addDefaultHandlersFactory(
+    HTTPRequestHandlerFactoryMain & factory,
+    IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    AsynchronousMetrics & async_metrics)
 {
     addCommonDefaultHandlersFactory(factory, server);
 
@@ -195,11 +207,11 @@ void addDefaultHandlersFactory(HTTPRequestHandlerFactoryMain & factory, IServer 
 
     /// We check that prometheus handler will be served on current (default) port.
     /// Otherwise it will be created separately, see createHandlerFactory(...).
-    if (server.config().has("prometheus") && server.config().getInt("prometheus.port", 0) == 0)
+    if (config.has("prometheus") && config.getInt("prometheus.port", 0) == 0)
     {
         auto prometheus_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
-            server, PrometheusMetricsWriter(server.config(), "prometheus", async_metrics));
-        prometheus_handler->attachStrictPath(server.config().getString("prometheus.endpoint", "/metrics"));
+            server, PrometheusMetricsWriter(config, "prometheus", async_metrics));
+        prometheus_handler->attachStrictPath(config.getString("prometheus.endpoint", "/metrics"));
         prometheus_handler->allowGetAndHeadRequest();
         factory.addHandler(prometheus_handler);
     }

--- a/src/Server/HTTPHandlerFactory.h
+++ b/src/Server/HTTPHandlerFactory.h
@@ -7,7 +7,7 @@
 #include <Common/StringUtils/StringUtils.h>
 #include <Common/logger_useful.h>
 
-#include <Poco/Util/LayeredConfiguration.h>
+#include <Poco/Util/AbstractConfiguration.h>
 
 namespace DB
 {
@@ -63,7 +63,7 @@ public:
         };
     }
 
-    void addFiltersFromConfig(Poco::Util::AbstractConfiguration & config, const std::string & prefix)
+    void addFiltersFromConfig(const Poco::Util::AbstractConfiguration & config, const std::string & prefix)
     {
         Poco::Util::AbstractConfiguration::Keys filters_type;
         config.keys(prefix, filters_type);
@@ -126,16 +126,34 @@ private:
     std::function<std::unique_ptr<HTTPRequestHandler> ()> creator;
 };
 
-HTTPRequestHandlerFactoryPtr createStaticHandlerFactory(IServer & server, const std::string & config_prefix);
+HTTPRequestHandlerFactoryPtr createStaticHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix);
 
-HTTPRequestHandlerFactoryPtr createDynamicHandlerFactory(IServer & server, const std::string & config_prefix);
+HTTPRequestHandlerFactoryPtr createDynamicHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix);
 
-HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server, const std::string & config_prefix);
+HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix);
 
-HTTPRequestHandlerFactoryPtr createReplicasStatusHandlerFactory(IServer & server, const std::string & config_prefix);
+HTTPRequestHandlerFactoryPtr createReplicasStatusHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix);
 
 HTTPRequestHandlerFactoryPtr
-createPrometheusHandlerFactory(IServer & server, AsynchronousMetrics & async_metrics, const std::string & config_prefix);
+createPrometheusHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    AsynchronousMetrics & async_metrics,
+    const std::string & config_prefix);
 
-HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server, AsynchronousMetrics & async_metrics, const std::string & name);
+/// @param server - used in handlers to check IServer::isCancelled()
+/// @param config - not the same as server.config(), since it can be newer
+/// @param async_metrics - used for prometheus (in case of prometheus.asynchronous_metrics=true)
+HTTPRequestHandlerFactoryPtr createHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    AsynchronousMetrics & async_metrics,
+    const std::string & name);
+
 }

--- a/src/Server/HTTPHandlerRequestFilter.h
+++ b/src/Server/HTTPHandlerRequestFilter.h
@@ -39,7 +39,7 @@ static inline bool checkExpression(std::string_view match_str, const std::pair<S
     return match_str == expression.first;
 }
 
-static inline auto methodsFilter(Poco::Util::AbstractConfiguration & config, const std::string & config_path) /// NOLINT
+static inline auto methodsFilter(const Poco::Util::AbstractConfiguration & config, const std::string & config_path) /// NOLINT
 {
     std::vector<String> methods;
     Poco::StringTokenizer tokenizer(config.getString(config_path), ",");
@@ -63,7 +63,7 @@ static inline auto getExpression(const std::string & expression)
     return std::make_pair(expression, compiled_regex);
 }
 
-static inline auto urlFilter(Poco::Util::AbstractConfiguration & config, const std::string & config_path) /// NOLINT
+static inline auto urlFilter(const Poco::Util::AbstractConfiguration & config, const std::string & config_path) /// NOLINT
 {
     return [expression = getExpression(config.getString(config_path))](const HTTPServerRequest & request)
     {
@@ -74,7 +74,7 @@ static inline auto urlFilter(Poco::Util::AbstractConfiguration & config, const s
     };
 }
 
-static inline auto headersFilter(Poco::Util::AbstractConfiguration & config, const std::string & prefix) /// NOLINT
+static inline auto headersFilter(const Poco::Util::AbstractConfiguration & config, const std::string & prefix) /// NOLINT
 {
     std::unordered_map<String, std::pair<String, CompiledRegexPtr>> headers_expression;
     Poco::Util::AbstractConfiguration::Keys headers_name;

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -42,11 +42,14 @@ void PrometheusRequestHandler::handleRequest(HTTPServerRequest & request, HTTPSe
 }
 
 HTTPRequestHandlerFactoryPtr
-createPrometheusHandlerFactory(IServer & server, AsynchronousMetrics & async_metrics, const std::string & config_prefix)
+createPrometheusHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    AsynchronousMetrics & async_metrics,
+    const std::string & config_prefix)
 {
     auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(
-        server, PrometheusMetricsWriter(server.config(), config_prefix + ".handler", async_metrics));
-    factory->addFiltersFromConfig(server.config(), config_prefix);
+        server, PrometheusMetricsWriter(config, config_prefix + ".handler", async_metrics));
+    factory->addFiltersFromConfig(config, config_prefix);
     return factory;
 }
 

--- a/src/Server/ReplicasStatusHandler.cpp
+++ b/src/Server/ReplicasStatusHandler.cpp
@@ -108,10 +108,12 @@ void ReplicasStatusHandler::handleRequest(HTTPServerRequest & request, HTTPServe
     }
 }
 
-HTTPRequestHandlerFactoryPtr createReplicasStatusHandlerFactory(IServer & server, const std::string & config_prefix)
+HTTPRequestHandlerFactoryPtr createReplicasStatusHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix)
 {
     auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<ReplicasStatusHandler>>(server);
-    factory->addFiltersFromConfig(server.config(), config_prefix);
+    factory->addFiltersFromConfig(config, config_prefix);
     return factory;
 }
 

--- a/src/Server/StaticRequestHandler.cpp
+++ b/src/Server/StaticRequestHandler.cpp
@@ -169,15 +169,17 @@ StaticRequestHandler::StaticRequestHandler(IServer & server_, const String & exp
 {
 }
 
-HTTPRequestHandlerFactoryPtr createStaticHandlerFactory(IServer & server, const std::string & config_prefix)
+HTTPRequestHandlerFactoryPtr createStaticHandlerFactory(IServer & server,
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix)
 {
-    int status = server.config().getInt(config_prefix + ".handler.status", 200);
-    std::string response_content = server.config().getRawString(config_prefix + ".handler.response_content", "Ok.\n");
-    std::string response_content_type = server.config().getString(config_prefix + ".handler.content_type", "text/plain; charset=UTF-8");
+    int status = config.getInt(config_prefix + ".handler.status", 200);
+    std::string response_content = config.getRawString(config_prefix + ".handler.response_content", "Ok.\n");
+    std::string response_content_type = config.getString(config_prefix + ".handler.content_type", "text/plain; charset=UTF-8");
     auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(
         server, std::move(response_content), std::move(status), std::move(response_content_type));
 
-    factory->addFiltersFromConfig(server.config(), config_prefix);
+    factory->addFiltersFromConfig(config, config_prefix);
 
     return factory;
 }

--- a/tests/integration/test_server_reload/configs/overrides_from_zk.xml
+++ b/tests/integration/test_server_reload/configs/overrides_from_zk.xml
@@ -6,4 +6,5 @@
     <mysql_port from_zk="/clickhouse/ports/mysql" replace="replace" />
     <postgresql_port from_zk="/clickhouse/ports/postgresql" replace="replace" />
     <grpc_port from_zk="/clickhouse/ports/grpc" replace="replace" />
+    <http_handlers from_zk="/clickhouse/http_handlers" replace="replace" />
 </yandex>


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Apply changes to http handlers on fly without server restart

This has been implemented by simply restarting http servers in case of http_handlers directive in configuration xml had been changed.

But, for this I have to change the handlers interface to accept configuration separatelly, since the configuration that contains in the server is the configuration with which server had been started.