### PR TITLE
Better parallel hash JOIN for floats

### DIFF
--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -90,7 +90,7 @@ void ColumnVector<T>::updateWeakHash32(WeakHash32 & hash) const
 
     while (begin < end)
     {
-        *hash_data = intHashCRC32(*begin, *hash_data);
+        *hash_data = hashCRC32(*begin, *hash_data);
         ++begin;
         ++hash_data;
     }

--- a/src/Common/HashTable/Hash.h
+++ b/src/Common/HashTable/Hash.h
@@ -220,7 +220,7 @@ template <typename T> struct HashCRC32;
 
 template <typename T>
 requires (sizeof(T) <= sizeof(UInt64))
-inline size_t hashCRC32(T key)
+inline size_t hashCRC32(T key, DB::UInt64 updated_value = -1)
 {
     union
     {
@@ -229,14 +229,14 @@ inline size_t hashCRC32(T key)
     } u;
     u.out = 0;
     u.in = key;
-    return intHashCRC32(u.out);
+    return intHashCRC32(u.out, updated_value);
 }
 
 template <typename T>
 requires (sizeof(T) > sizeof(UInt64))
-inline size_t hashCRC32(T key)
+inline size_t hashCRC32(T key, DB::UInt64 updated_value = -1)
 {
-    return intHashCRC32(key, -1);
+    return intHashCRC32(key, updated_value);
 }
 
 #define DEFINE_HASH(T) \


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Parallel hash JOIN for Float data types might be suboptimal. Make it better.