### PR TITLE
Fix cleaning up broken detached part after timeout

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1990,10 +1990,11 @@ size_t MergeTreeData::clearOldBrokenPartsFromDetachedDirectory()
 
     renamed_parts.tryRenameAll();
 
-    for (const auto & [old_name, new_name, disk] : renamed_parts.old_and_new_names)
+    for (auto & [old_name, new_name, disk] : renamed_parts.old_and_new_names)
     {
         removeDetachedPart(disk, fs::path(relative_data_path) / "detached" / new_name / "", old_name, false);
         LOG_DEBUG(log, "Removed broken detached part {} due to a timeout for broken detached parts", old_name);
+        old_name.clear();
     }
 
     return renamed_parts.old_and_new_names.size();

--- a/tests/integration/test_broken_detached_part_clean_up/test.py
+++ b/tests/integration/test_broken_detached_part_clean_up/test.py
@@ -96,6 +96,9 @@ def remove_broken_detached_part_impl(table, node, expect_broken_prefix):
     assert "unexpected_all_42_1337_5" in result
 
     time.sleep(15)
+    assert node.contains_in_log(
+        "Removed broken detached part unexpected_all_42_1337_5 due to a timeout"
+    )
 
     result = node.exec_in_container(["ls", path_to_detached])
     print(result)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix background clean up of broken detached parts.
