### PR TITLE
test: fix 01051_system_stack_trace flakiness

### DIFF
--- a/tests/queries/0_stateless/01051_system_stack_trace.reference
+++ b/tests/queries/0_stateless/01051_system_stack_trace.reference
@@ -5,7 +5,7 @@ SELECT count() > 0 FROM system.stack_trace WHERE query_id != '';
 SELECT countIf(thread_id > 0) > 0 FROM system.stack_trace;
 1
 -- optimization for trace
-SELECT length(trace) > 0 FROM system.stack_trace LIMIT 1;
+SELECT count(trace) > 0 FROM system.stack_trace WHERE length(trace) > 0 LIMIT 1;
 1
 -- optimization for query_id
 SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' LIMIT 1;

--- a/tests/queries/0_stateless/01051_system_stack_trace.sql
+++ b/tests/queries/0_stateless/01051_system_stack_trace.sql
@@ -5,7 +5,7 @@ SELECT count() > 0 FROM system.stack_trace WHERE query_id != '';
 -- opimization for not reading /proc/self/task/{}/comm and avoid sending signal
 SELECT countIf(thread_id > 0) > 0 FROM system.stack_trace;
 -- optimization for trace
-SELECT length(trace) > 0 FROM system.stack_trace LIMIT 1;
+SELECT count(trace) > 0 FROM system.stack_trace WHERE length(trace) > 0 LIMIT 1;
 -- optimization for query_id
 SELECT length(query_id) > 0 FROM system.stack_trace WHERE query_id != '' LIMIT 1;
 -- optimization for thread_name


### PR DESCRIPTION
Before test failed if clickhouse-server timed out while obtaining stack trace for the first thread from the list, fix this by getting first row with non empty trace.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @alexey-milovidov 