### PR TITLE
Fix logical error in write-through cache found by stress test

### DIFF
--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
@@ -77,7 +77,7 @@ void CachedOnDiskWriteBufferFromFile::nextImpl()
 
 void CachedOnDiskWriteBufferFromFile::cacheData(char * data, size_t size)
 {
-    if (stop_caching)
+    if (cache_in_error_state_or_disabled)
         return;
 
     if (!cache_writer)
@@ -88,14 +88,13 @@ void CachedOnDiskWriteBufferFromFile::cacheData(char * data, size_t size)
 
     Stopwatch watch(CLOCK_MONOTONIC);
 
+    cache_in_error_state_or_disabled = true;
+
     try
     {
         if (!cache_writer->write(data, size, current_download_offset, is_persistent_cache_file))
         {
             LOG_INFO(log, "Write-through cache is stopped as cache limit is reached and nothing can be evicted");
-
-            /// No space left, disable caching.
-            stop_caching = true;
             return;
         }
     }
@@ -122,6 +121,8 @@ void CachedOnDiskWriteBufferFromFile::cacheData(char * data, size_t size)
 
     current_file_segment_counters.increment(
         ProfileEvents::FileSegmentWriteMicroseconds, watch.elapsedMicroseconds());
+
+    cache_in_error_state_or_disabled = false;
 }
 
 void CachedOnDiskWriteBufferFromFile::appendFilesystemCacheLog(const FileSegment & file_segment)

--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
@@ -51,7 +51,7 @@ private:
     bool enable_cache_log;
     std::shared_ptr<FilesystemCacheLog> cache_log;
 
-    bool stop_caching = false;
+    bool cache_in_error_state_or_disabled = false;
 
     ProfileEvents::Counters current_file_segment_counters;
     std::unique_ptr<FileSegmentRangeWriter> cache_writer;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible logical error in write-through cache, which happened because not all types of exception were handled as needed. Closes https://github.com/ClickHouse/ClickHouse/issues/41208.