### PR TITLE
Manually backport 38864 to 22.3

### DIFF
--- a/src/Common/RWLock.h
+++ b/src/Common/RWLock.h
@@ -90,6 +90,7 @@ private:
 
     RWLockImpl() = default;
     void unlock(GroupsContainer::iterator group_it, const String & query_id) noexcept;
-    void dropOwnerGroupAndPassOwnership(GroupsContainer::iterator group_it) noexcept;
+    /// @param next - notify next after begin, used on writer lock failures
+    void dropOwnerGroupAndPassOwnership(GroupsContainer::iterator group_it, bool next) noexcept;
 };
 }

--- a/tests/queries/0_stateless/02352_rwlock.reference
+++ b/tests/queries/0_stateless/02352_rwlock.reference
@@ -1,0 +1,1 @@
+WRITE locking attempt on "default_ordinary.data_02352" has timed out

--- a/tests/queries/0_stateless/02352_rwlock.sh
+++ b/tests/queries/0_stateless/02352_rwlock.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Test that ensures that WRITE lock failure notifies READ.
+# In other words to ensure that after WRITE lock failure (DROP),
+# READ lock (SELECT) available instantly.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+function wait_query_by_id_started()
+{
+    local query_id=$1 && shift
+    # wait for query to be started
+    while [ "$($CLICKHOUSE_CLIENT "$@" -q "select count() from system.processes where query_id = '$query_id'")" -ne 1 ]; do
+        sleep 0.1
+    done
+}
+
+# to avoid removal via separate thread
+$CLICKHOUSE_CLIENT -q "CREATE DATABASE ${CLICKHOUSE_DATABASE}_ordinary Engine=Ordinary" --allow_deprecated_database_ordinary=1
+$CLICKHOUSE_CLIENT -q "CREATE TABLE ${CLICKHOUSE_DATABASE}_ordinary.data_02352 (key Int) Engine=Null()"
+
+query_id="insert-$(random_str 10)"
+# 20 seconds sleep
+$CLICKHOUSE_CLIENT --query_id "$query_id" -q "INSERT INTO ${CLICKHOUSE_DATABASE}_ordinary.data_02352 SELECT sleepEachRow(1) FROM numbers(20) GROUP BY number" &
+wait_query_by_id_started "$query_id"
+
+query_id="drop-$(random_str 10)"
+# 10 second wait
+$CLICKHOUSE_CLIENT --query_id "$query_id" -q "DROP TABLE ${CLICKHOUSE_DATABASE}_ordinary.data_02352 SYNC" --lock_acquire_timeout 10 > >(grep -m1 -o 'WRITE locking attempt on ".*" has timed out') 2>&1 &
+wait_query_by_id_started "$query_id"
+
+# NOTE: we need to run SELECT after DROP and
+# if the bug is there, then the query will wait 20 seconds (INSERT), instead of 10 (DROP) and will fail
+#
+# 11 seconds wait (DROP + 1 second lag)
+$CLICKHOUSE_CLIENT -q "SELECT * FROM ${CLICKHOUSE_DATABASE}_ordinary.data_02352" --lock_acquire_timeout 11
+
+# wait DROP and INSERT
+wait
+
+$CLICKHOUSE_CLIENT -q "DROP DATABASE ${CLICKHOUSE_DATABASE}_ordinary"

--- a/tests/queries/0_stateless/02352_rwlock.sh
+++ b/tests/queries/0_stateless/02352_rwlock.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel -- to avoid running it in parallel, this will avoid possible issues due to high pressure
 
 # Test that ensures that WRITE lock failure notifies READ.
 # In other words to ensure that after WRITE lock failure (DROP),
@@ -13,31 +15,73 @@ function wait_query_by_id_started()
     local query_id=$1 && shift
     # wait for query to be started
     while [ "$($CLICKHOUSE_CLIENT "$@" -q "select count() from system.processes where query_id = '$query_id'")" -ne 1 ]; do
-        sleep 0.1
+        if [ "$(
+            $CLICKHOUSE_CLIENT -nm -q "
+                system flush logs;
+
+                select count() from system.query_log
+                where
+                    event_date >= yesterday() and
+                    current_database = '$CLICKHOUSE_DATABASE' and
+                    type = 'QueryFinish' and
+                    query_id = '$query_id'
+            "
+        )" -eq 1 ]; then
+            return 1
+        else
+            sleep 0.1
+        fi
     done
+
+    return 0
 }
 
 # to avoid removal via separate thread
 $CLICKHOUSE_CLIENT -q "CREATE DATABASE ${CLICKHOUSE_DATABASE}_ordinary Engine=Ordinary" --allow_deprecated_database_ordinary=1
-$CLICKHOUSE_CLIENT -q "CREATE TABLE ${CLICKHOUSE_DATABASE}_ordinary.data_02352 (key Int) Engine=Null()"
 
-query_id="insert-$(random_str 10)"
-# 20 seconds sleep
-$CLICKHOUSE_CLIENT --query_id "$query_id" -q "INSERT INTO ${CLICKHOUSE_DATABASE}_ordinary.data_02352 SELECT sleepEachRow(1) FROM numbers(20) GROUP BY number" &
-wait_query_by_id_started "$query_id"
+# It is possible that the subsequent after INSERT query will be processed
+# only after INSERT finished, it is unlikely, but it happens few times in
+# debug build on CI, so if this will happen, then DROP query will be
+# finished instantly, and to avoid flakiness we will retry in this case
+while :; do
+    $CLICKHOUSE_CLIENT -nm -q "
+        DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}_ordinary.data_02352;
+        CREATE TABLE ${CLICKHOUSE_DATABASE}_ordinary.data_02352 (key Int) Engine=Null();
+    "
 
-query_id="drop-$(random_str 10)"
-# 10 second wait
-$CLICKHOUSE_CLIENT --query_id "$query_id" -q "DROP TABLE ${CLICKHOUSE_DATABASE}_ordinary.data_02352 SYNC" --lock_acquire_timeout 10 > >(grep -m1 -o 'WRITE locking attempt on ".*" has timed out') 2>&1 &
-wait_query_by_id_started "$query_id"
+    insert_query_id="insert-$(random_str 10)"
+    # 20 seconds sleep
+    $CLICKHOUSE_CLIENT --query_id "$insert_query_id" -q "INSERT INTO ${CLICKHOUSE_DATABASE}_ordinary.data_02352 SELECT sleepEachRow(1) FROM numbers(20) GROUP BY number" &
+    if ! wait_query_by_id_started "$insert_query_id"; then
+        wait
+        continue
+    fi
 
-# NOTE: we need to run SELECT after DROP and
-# if the bug is there, then the query will wait 20 seconds (INSERT), instead of 10 (DROP) and will fail
-#
-# 11 seconds wait (DROP + 1 second lag)
-$CLICKHOUSE_CLIENT -q "SELECT * FROM ${CLICKHOUSE_DATABASE}_ordinary.data_02352" --lock_acquire_timeout 11
+    drop_query_id="drop-$(random_str 10)"
+    # 10 second wait
+    $CLICKHOUSE_CLIENT --query_id "$drop_query_id" -q "DROP TABLE ${CLICKHOUSE_DATABASE}_ordinary.data_02352 SYNC" --lock_acquire_timeout 10 > >(
+        grep -m1 -o 'WRITE locking attempt on ".*" has timed out'
+    ) 2>&1 &
+    if ! wait_query_by_id_started "$drop_query_id"; then
+        wait
+        continue
+    fi
+    # Check INSERT query again, and retry if it does not exist.
+    if ! wait_query_by_id_started "$insert_query_id"; then
+        wait
+        continue
+    fi
 
-# wait DROP and INSERT
-wait
+    # NOTE: we need to run SELECT after DROP and
+    # if the bug is there, then the query will wait 20 seconds (INSERT), instead of 10 (DROP) and will fail
+    #
+    # 11 seconds wait (DROP + 1 second lag)
+    $CLICKHOUSE_CLIENT -q "SELECT * FROM ${CLICKHOUSE_DATABASE}_ordinary.data_02352" --lock_acquire_timeout 11
+
+    # wait DROP and INSERT
+    wait
+
+    break
+done | uniq
 
 $CLICKHOUSE_CLIENT -q "DROP DATABASE ${CLICKHOUSE_DATABASE}_ordinary"

--- a/tests/queries/0_stateless/02352_rwlock.sh
+++ b/tests/queries/0_stateless/02352_rwlock.sh
@@ -10,6 +10,13 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+
+function auxiliar_random_str()
+{
+    local n=$1 && shift
+    tr -cd '[:lower:]' < /dev/urandom | head -c"$n"
+}
+
 function wait_query_by_id_started()
 {
     local query_id=$1 && shift
@@ -49,7 +56,7 @@ while :; do
         CREATE TABLE ${CLICKHOUSE_DATABASE}_ordinary.data_02352 (key Int) Engine=Null();
     "
 
-    insert_query_id="insert-$(random_str 10)"
+    insert_query_id="insert-$(auxiliar_random_str 10)"
     # 20 seconds sleep
     $CLICKHOUSE_CLIENT --query_id "$insert_query_id" -q "INSERT INTO ${CLICKHOUSE_DATABASE}_ordinary.data_02352 SELECT sleepEachRow(1) FROM numbers(20) GROUP BY number" &
     if ! wait_query_by_id_started "$insert_query_id"; then
@@ -57,7 +64,7 @@ while :; do
         continue
     fi
 
-    drop_query_id="drop-$(random_str 10)"
+    drop_query_id="drop-$(auxiliar_random_str 10)"
     # 10 second wait
     $CLICKHOUSE_CLIENT --query_id "$drop_query_id" -q "DROP TABLE ${CLICKHOUSE_DATABASE}_ordinary.data_02352 SYNC" --lock_acquire_timeout 10 > >(
         grep -m1 -o 'WRITE locking attempt on ".*" has timed out'


### PR DESCRIPTION
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix waiting of shared lock after exclusive lock failure

When WRITE lock attemp fails (exclusive lock for ALTER/DELETE), and
there are multiple READ locks (shared lock for SELECT/INSERT), i.e. one
INSERT is in progress and one SELECT is queued after ALTER/DELETE
started but before it fails, this SELECT will wait until INSERT will
finishes.

This happens because in case of WRITE lock failure it does not notify
the next READ lock that can be acquired.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

This PR backports #38864 to 22.3. The changes made there fix bugs when failing to acquire a shared mutex exclusively. This happens when executing an `ALTER` OR `DROP` query on an Ordinary database, or a `TRUNCATE` on a non replicated table while executing `SELECT` or `INSERT` operations (that get a shared lock).

It includes the original PR (#38864), a subsequent one to fix test flakiness (https://github.com/ClickHouse/ClickHouse/pull/39941) and a small change to adapt the test to work on 22.3 (`random_str` function).

cc/ @azat 