### PR TITLE
move title to frontmatter in troubleshooting doc

### DIFF
--- a/docs/en/operations/troubleshooting.md
+++ b/docs/en/operations/troubleshooting.md
@@ -2,9 +2,8 @@
 slug: /en/operations/troubleshooting
 sidebar_position: 46
 sidebar_label: Troubleshooting
+title: Troubleshooting
 ---
-
-# Troubleshooting
 
 -   [Installation](#troubleshooting-installation-errors)
 -   [Connecting to the server](#troubleshooting-accepts-no-connections)


### PR DESCRIPTION
This allows me to include the doc within another markdown.

### Changelog category (leave one):
- Documentation (changelog entry is not required)
