### PR TITLE
Fix download_binary, use proper version and commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,11 @@ jobs:
         cp -r "$GITHUB_WORKSPACE" "$TEMP_PATH"
         cd "$REPO_COPY"
         # Download and push packages to artifactory
-        python3 ./tests/ci/push_to_artifactory.py --release "${{ github.ref }}" \
-          --commit '${{ github.sha }}' --artifactory-url "${{ secrets.JFROG_ARTIFACTORY_URL }}" --all
+        python3 ./tests/ci/push_to_artifactory.py --release '${{ github.ref }}' \
+          --commit '${{ github.sha }}' --artifactory-url '${{ secrets.JFROG_ARTIFACTORY_URL }}' --all
         # Download macos binaries to ${{runner.temp}}/download_binary
-        python3 ./tests/ci/download_binary.py binary_darwin binary_darwin_aarch64
+        python3 ./tests/ci/download_binary.py --version '${{ github.ref }}' \
+          --commit '${{ github.sha }}' binary_darwin binary_darwin_aarch64
         mv '${{runner.temp}}/download_binary/'clickhouse-* '${{runner.temp}}/push_to_artifactory'
     - name: Upload packages to release assets
       uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix [broken](https://github.com/ClickHouse/ClickHouse/actions/runs/3045066169/jobs/4906166607#step:5:162) download, the CI checks out master.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
