### PR TITLE
Manually backport a fix for StorageLog to 22.3 LTS

### DIFF
--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -719,6 +719,7 @@ void StorageLog::rename(const String & new_path_to_table_data, const StorageID &
 {
     assert(table_path != new_path_to_table_data);
     {
+        disk->createDirectories(new_path_to_table_data);
         disk->moveDirectory(table_path, new_path_to_table_data);
 
         table_path = new_path_to_table_data;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The change is taken from https://github.com/ClickHouse/ClickHouse/pull/39933
Fixes https://github.com/ClickHouse/ClickHouse/issues/41259