### PR TITLE
Do not allow invalid sequences influence other rows in lowerUTF8/upperUTF8

### DIFF
--- a/tests/performance/lower_upper_utf8.xml
+++ b/tests/performance/lower_upper_utf8.xml
@@ -1,0 +1,4 @@
+<test>
+    <query>SELECT lowerUTF8(SearchPhrase) FROM hits_100m_single FORMAT Null</query>
+    <query>SELECT upperUTF8(SearchPhrase) FROM hits_100m_single FORMAT Null</query>
+</test>

--- a/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.reference
+++ b/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.reference
@@ -1,0 +1,11 @@
+-- { echoOn }
+-- NOTE: total string size should be > 16 (sizeof(__m128i))
+insert into utf8_overlap values ('\xe2'), ('Foo⚊BarBazBam'), ('\xe2'), ('Foo⚊BarBazBam');
+--                                             ^
+--                                             MONOGRAM FOR YANG
+with lowerUTF8(str) as l_, upperUTF8(str) as u_, '0x' || hex(str) as h_
+select length(str), if(l_ == '\xe2', h_, l_), if(u_ == '\xe2', h_, u_) from utf8_overlap format CSV;
+1,"0xE2","0xE2"
+15,"foo⚊barbazbam","FOO⚊BARBAZBAM"
+1,"0xE2","0xE2"
+15,"foo⚊barbazbam","FOO⚊BARBAZBAM"

--- a/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.sql
+++ b/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.sql
@@ -1,0 +1,10 @@
+drop table if exists utf8_overlap;
+create table utf8_overlap (str String) engine=Memory();
+
+-- { echoOn }
+-- NOTE: total string size should be > 16 (sizeof(__m128i))
+insert into utf8_overlap values ('\xe2'), ('Foo⚊BarBazBam'), ('\xe2'), ('Foo⚊BarBazBam');
+--                                             ^
+--                                             MONOGRAM FOR YANG
+with lowerUTF8(str) as l_, upperUTF8(str) as u_, '0x' || hex(str) as h_
+select length(str), if(l_ == '\xe2', h_, l_), if(u_ == '\xe2', h_, u_) from utf8_overlap format CSV;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not allow invalid sequences influence other rows in lowerUTF8/upperUTF8

Right now lowerUTF8() and upperUTF8() does not respect row boundaries,
and so one row may break another.