### PR TITLE
Update README.md

### DIFF
--- a/utils/changelog/README.md
+++ b/utils/changelog/README.md
@@ -13,7 +13,8 @@ python3 changelog.py -h
 Usage example:
 
 ```
-git fetch --all # changelog.py depends on having the tags available, this will fetch them
+git fetch --tags # changelog.py depends on having the tags available, this will fetch them
+
 python3 changelog.py --output=changelog-v22.4.1.2305-prestable.md --gh-user-or-token="$GITHUB_TOKEN" v21.6.2.7-prestable
 python3 changelog.py --output=changelog-v22.4.1.2305-prestable.md --gh-user-or-token="$USER" --gh-password="$PASSWORD" v21.6.2.7-prestable
 ```

--- a/utils/changelog/README.md
+++ b/utils/changelog/README.md
@@ -13,6 +13,7 @@ python3 changelog.py -h
 Usage example:
 
 ```
+git fetch --all # changelog.py depends on having the tags available, this will fetch them
 python3 changelog.py --output=changelog-v22.4.1.2305-prestable.md --gh-user-or-token="$GITHUB_TOKEN" v21.6.2.7-prestable
 python3 changelog.py --output=changelog-v22.4.1.2305-prestable.md --gh-user-or-token="$USER" --gh-password="$PASSWORD" v21.6.2.7-prestable
 ```


### PR DESCRIPTION
When running `changelog.py` I did not have tags and needed to supply a `--from` with a commit SHA.  Having the tags allows the script to go back to the last release.


### Changelog category (leave one):
- Documentation (changelog entry is not required)




