### PR TITLE
make /etc/default/clickhouse compatible between systemd and initV

### DIFF
--- a/packages/clickhouse-server.init
+++ b/packages/clickhouse-server.init
@@ -47,9 +47,10 @@ CLICKHOUSE_PIDFILE="$CLICKHOUSE_PIDDIR/$PROGRAM.pid"
 # Some systems lack "flock"
 command -v flock >/dev/null && FLOCK=flock
 
-# Override defaults from optional config file
+# Override defaults from optional config file and export them automatically
+set -a
 test -f /etc/default/clickhouse && . /etc/default/clickhouse
-
+set +a
 
 die()
 {


### PR DESCRIPTION
this change allows to make /etc/default/clickhouse compatible 


initV &  systemD:
```
# cat /etc/default/clickhouse

CLICKHOUSE_WATCHDOG_ENABLE=0
TZ=Europe/Moscow
```

Before this change it had to be

initV:
```
# cat /etc/default/clickhouse

export CLICKHOUSE_WATCHDOG_ENABLE=0
export TZ=Europe/Moscow
```

systemD:

```
# cat /etc/default/clickhouse

CLICKHOUSE_WATCHDOG_ENABLE=0
TZ=Europe/Moscow
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
