### PR TITLE
Fix parts removal in case of connection loss

### DIFF
--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -131,18 +131,18 @@ bool ReadBufferFromS3::nextImpl()
             ProfileEvents::increment(ProfileEvents::ReadBufferFromS3Microseconds, watch.elapsedMicroseconds());
             break;
         }
-        catch (const Exception & e)
+        catch (Exception & e)
         {
             watch.stop();
             ProfileEvents::increment(ProfileEvents::ReadBufferFromS3Microseconds, watch.elapsedMicroseconds());
             ProfileEvents::increment(ProfileEvents::ReadBufferFromS3RequestsErrors, 1);
 
-            if (const auto * s3_exception = dynamic_cast<const S3Exception *>(&e))
+            if (auto * s3_exception = dynamic_cast<S3Exception *>(&e))
             {
                 /// It doesn't make sense to retry Access Denied or No Such Key
                 if (!s3_exception->isRetryableError())
                 {
-                    tryLogCurrentException(log, fmt::format("while reading key: {}, from bucket: {}", key, bucket));
+                    s3_exception->addMessage("while reading key: {}, from bucket: {}", key, bucket);
                     throw;
                 }
             }

--- a/src/IO/S3Common.h
+++ b/src/IO/S3Common.h
@@ -55,7 +55,7 @@ public:
     bool isRetryableError() const;
 
 private:
-    const Aws::S3::S3Errors code;
+    Aws::S3::S3Errors code;
 };
 }
 

--- a/src/Storages/MergeTree/DataPartStorageOnDisk.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDisk.cpp
@@ -209,7 +209,7 @@ void DataPartStorageOnDisk::remove(
     std::list<ProjectionChecksums> projections,
     bool is_temp,
     MergeTreeDataPartState state,
-    Poco::Logger * log) const
+    Poco::Logger * log)
 {
     /// NOTE We rename part to delete_tmp_<relative_path> instead of delete_tmp_<name> to avoid race condition
     /// when we try to remove two parts with the same name, but different relative paths,
@@ -259,6 +259,7 @@ void DataPartStorageOnDisk::remove(
     try
     {
         disk->moveDirectory(from, to);
+        onRename(root_path, part_dir_without_slash);
     }
     catch (const fs::filesystem_error & e)
     {
@@ -271,9 +272,7 @@ void DataPartStorageOnDisk::remove(
     }
 
     if (!can_remove_description)
-    {
         can_remove_description.emplace(can_remove_callback());
-    }
 
     // Record existing projection directories so we don't remove them twice
     std::unordered_set<String> projection_directories;

--- a/src/Storages/MergeTree/DataPartStorageOnDisk.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDisk.h
@@ -45,8 +45,7 @@ public:
     void checkConsistency(const MergeTreeDataPartChecksums & checksums) const override;
 
     void remove(
-        bool can_remove_shared_data,
-        const NameSet & names_not_to_remove,
+        CanRemoveCallback && can_remove_callback,
         const MergeTreeDataPartChecksums & checksums,
         std::list<ProjectionChecksums> projections,
         bool is_temp,

--- a/src/Storages/MergeTree/DataPartStorageOnDisk.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDisk.h
@@ -50,7 +50,7 @@ public:
         std::list<ProjectionChecksums> projections,
         bool is_temp,
         MergeTreeDataPartState state,
-        Poco::Logger * log) const override;
+        Poco::Logger * log) override;
 
     std::string getRelativePathForPrefix(Poco::Logger * log, const String & prefix, bool detached) const override;
 

--- a/src/Storages/MergeTree/IDataPartStorage.h
+++ b/src/Storages/MergeTree/IDataPartStorage.h
@@ -12,6 +12,13 @@ namespace DB
 class ReadBufferFromFileBase;
 class WriteBufferFromFileBase;
 
+struct CanRemoveDescription
+{
+    bool can_remove_anything;
+    NameSet files_not_to_remove;
+
+};
+using CanRemoveCallback = std::function<CanRemoveDescription()>;
 
 class IDataPartStorageIterator
 {
@@ -113,8 +120,7 @@ public:
     /// can_remove_shared_data, names_not_to_remove are specific for DiskObjectStorage.
     /// projections, checksums are needed to avoid recursive listing
     virtual void remove(
-        bool can_remove_shared_data,
-        const NameSet & names_not_to_remove,
+        CanRemoveCallback && can_remove_callback,
         const MergeTreeDataPartChecksums & checksums,
         std::list<ProjectionChecksums> projections,
         bool is_temp,

--- a/src/Storages/MergeTree/IDataPartStorage.h
+++ b/src/Storages/MergeTree/IDataPartStorage.h
@@ -125,7 +125,7 @@ public:
         std::list<ProjectionChecksums> projections,
         bool is_temp,
         MergeTreeDataPartState state,
-        Poco::Logger * log) const = 0;
+        Poco::Logger * log) = 0;
 
     /// Get a name like 'prefix_partdir_tryN' which does not exist in a root dir.
     /// TODO: remove it.

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1433,7 +1433,7 @@ void IMergeTreeDataPart::remove() const
     assert(assertHasValidVersionMetadata());
     part_is_probably_removed_from_disk = true;
 
-    auto can_remove_callback = [&] ()
+    auto can_remove_callback = [this] ()
     {
         auto [can_remove, files_not_to_remove] = canRemovePart();
         if (!can_remove)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1093,7 +1093,7 @@ void MergeTreeData::loadDataPartsFromDisk(
             }
             catch (...)
             {
-                tryLogCurrentException(log, fmt::format("while calculating part {} on path {}", part->name, part_path));
+                tryLogCurrentException(log, fmt::format("while calculating part size {} on path {}", part->name, part_path));
             }
 
             std::string part_size_str = "failed to calculate size";

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2187,11 +2187,7 @@ void MergeTreeData::dropAllData()
         try
         {
             LOG_INFO(log, "dropAllData: removing table directory recursive to cleanup garbage");
-
-            if (disk->supportZeroCopyReplication() && settings_ptr->allow_remote_fs_zero_copy_replication)
-                disk->removeSharedRecursive(relative_data_path, true, {});
-            else
-                disk->removeRecursive(relative_data_path);
+            disk->removeRecursive(relative_data_path);
         }
         catch (const fs::filesystem_error & e)
         {

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7604,7 +7604,7 @@ std::pair<bool, NameSet> StorageReplicatedMergeTree::unlockSharedData(const IMer
     }
     else
     {
-        LOG_TRACE(log, "Part {} looks temporary, because checksums file doesn't exists, blobs can be removed", part.name);
+        LOG_TRACE(log, "Part {} looks temporary, because {} file doesn't exists, blobs can be removed", part.name, IMergeTreeDataPart::FILE_FOR_REFERENCES_CHECK);
         /// Temporary part with some absent file cannot be locked in shared mode
         return std::make_pair(true, NameSet{});
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
