### PR TITLE
Download ccache from release PRs for backports

### DIFF
--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -291,7 +291,9 @@ def main():
 
     logging.info("Will try to fetch cache for our build")
     try:
-        get_ccache_if_not_exists(ccache_path, s3_helper, pr_info.number, TEMP_PATH)
+        get_ccache_if_not_exists(
+            ccache_path, s3_helper, pr_info.number, TEMP_PATH, pr_info.release_pr
+        )
     except Exception as e:
         # In case there are issues with ccache, remove the path and do not fail a build
         logging.info("Failed to get ccache, building without it. Error: %s", e)

--- a/tests/ci/ccache_utils.py
+++ b/tests/ci/ccache_utils.py
@@ -11,6 +11,7 @@ import requests  # type: ignore
 
 from compress_files import decompress_fast, compress_fast
 from env_helper import S3_DOWNLOAD, S3_BUILDS_BUCKET
+from s3_helper import S3Helper
 
 DOWNLOAD_RETRIES_COUNT = 5
 
@@ -57,12 +58,19 @@ def dowload_file_with_progress(url, path):
 
 
 def get_ccache_if_not_exists(
-    path_to_ccache_dir, s3_helper, current_pr_number, temp_path
+    path_to_ccache_dir: str,
+    s3_helper: S3Helper,
+    current_pr_number: int,
+    temp_path: str,
+    release_pr: int,
 ) -> int:
     """returns: number of PR for downloaded PR. -1 if ccache not found"""
     ccache_name = os.path.basename(path_to_ccache_dir)
     cache_found = False
     prs_to_check = [current_pr_number]
+    # Release PR is either 0 or defined
+    if release_pr:
+        prs_to_check.append(release_pr)
     ccache_pr = -1
     if current_pr_number != 0:
         prs_to_check.append(0)

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
 
     logging.info("Will try to fetch cache for our build")
     ccache_for_pr = get_ccache_if_not_exists(
-        cache_path, s3_helper, pr_info.number, temp_path
+        cache_path, s3_helper, pr_info.number, temp_path, pr_info.release_pr
     )
     upload_master_ccache = ccache_for_pr in (-1, 0)
 

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -86,7 +86,7 @@ class PRInfo:
         self.changed_files = set()  # type: Set[str]
         self.body = ""
         self.diff_urls = []
-        self.release_pr = ""
+        self.release_pr = 0
         ref = github_event.get("ref", "refs/head/master")
         if ref and ref.startswith("refs/heads/"):
             ref = ref[11:]


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now we download the ccache for the master (0) if no ccache is found for the current PR. It's not so useful for backports to old releases. Now we'll additionally download ccache for the release PR.