### PR TITLE
Fix an assertion in `wasInvolvedInTransaction`

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1291,7 +1291,7 @@ catch (Exception & e)
 
 bool IMergeTreeDataPart::wasInvolvedInTransaction() const
 {
-    assert(!version.creation_tid.isEmpty() || (state == MergeTreeDataPartState::Temporary /* && std::uncaught_exceptions() */));
+    assert(!storage.data_parts_loading_finished || !version.creation_tid.isEmpty() || (state == MergeTreeDataPartState::Temporary /* && std::uncaught_exceptions() */));
     bool created_by_transaction = !version.creation_tid.isPrehistoric();
     bool removed_by_transaction = version.isRemovalTIDLocked() && version.removal_tid_lock != Tx::PrehistoricTID.getHash();
     return created_by_transaction || removed_by_transaction;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1560,6 +1560,7 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
     calculateColumnAndSecondaryIndexSizesImpl();
 
     LOG_DEBUG(log, "Loaded data parts ({} items)", data_parts_indexes.size());
+    data_parts_loading_finished = true;
 }
 
 /// Is the part directory old.

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1034,6 +1034,8 @@ protected:
     /// True if at least one part was created/removed with transaction.
     mutable std::atomic_bool transactions_enabled = false;
 
+    std::atomic_bool data_parts_loading_finished = false;
+
     /// Work with data parts
 
     struct TagByInfo{};


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes https://github.com/ClickHouse/ClickHouse/issues/41368
