### PR TITLE
Check the behaviour of query_log read/write stats in INSERT queries

### DIFF
--- a/tests/queries/0_stateless/02423_insert_stats_behaviour.reference
+++ b/tests/queries/0_stateless/02423_insert_stats_behaviour.reference
@@ -1,0 +1,12 @@
+read_rows=1	read_bytes=8	written_rows=1	written_bytes=8	query=INSERT into target_1 FORMAT CSV 
+read_rows=10	read_bytes=80	written_rows=10	written_bytes=80	query=INSERT INTO target_1 FORMAT Native\n
+read_rows=10	read_bytes=80	written_rows=10	written_bytes=80	query=INSERT INTO target_1 FORMAT RowBinary\n
+read_rows=5	read_bytes=40	written_rows=4	written_bytes=32	query=INSERT into floats FORMAT CSV 
+read_rows=32	read_bytes=256	written_rows=40	written_bytes=320	query=INSERT INTO floats FORMAT Native\n
+read_rows=32	read_bytes=256	written_rows=40	written_bytes=320	query=INSERT INTO floats FORMAT RowBinary\n
+read_rows=1	read_bytes=8	written_rows=1	written_bytes=8	source_query=INSERT into floats FORMAT CSV 	view_query=SELECT * FROM default.floats
+read_rows=3	read_bytes=24	written_rows=2	written_bytes=16	source_query=INSERT into floats FORMAT CSV 	view_query=SELECT * FROM default.floats, numbers(2) AS n
+read_rows=10	read_bytes=80	written_rows=10	written_bytes=80	source_query=INSERT INTO floats FORMAT Native\n	view_query=SELECT * FROM default.floats
+read_rows=12	read_bytes=96	written_rows=20	written_bytes=160	source_query=INSERT INTO floats FORMAT Native\n	view_query=SELECT * FROM default.floats, numbers(2) AS n
+read_rows=10	read_bytes=80	written_rows=10	written_bytes=80	source_query=INSERT INTO floats FORMAT RowBinary\n	view_query=SELECT * FROM default.floats
+read_rows=12	read_bytes=96	written_rows=20	written_bytes=160	source_query=INSERT INTO floats FORMAT RowBinary\n	view_query=SELECT * FROM default.floats, numbers(2) AS n

--- a/tests/queries/0_stateless/02423_insert_stats_behaviour.sh
+++ b/tests/queries/0_stateless/02423_insert_stats_behaviour.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "CREATE TABLE floats (v Float64) Engine=MergeTree() ORDER BY tuple();"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE target_1 (v Float64) Engine=MergeTree() ORDER BY tuple();"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE target_2 (v Float64) Engine=MergeTree() ORDER BY tuple();"
+$CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW floats_to_target TO target_1 AS SELECT * FROM floats"
+$CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW floats_to_target_2 TO target_2 AS SELECT * FROM floats, numbers(2) n"
+
+# Insertions into table without MVs
+$CLICKHOUSE_CLIENT -q "INSERT into target_1 FORMAT CSV 1.0"
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format Native | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT+INTO+target_1+FORMAT+Native" --data-binary @-
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format RowBinary | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT+INTO+target_1+FORMAT+RowBinary" --data-binary @-
+
+# Insertions into table without 2 MVs (1:1 and 1:2 rows)
+$CLICKHOUSE_CLIENT -q "INSERT into floats FORMAT CSV 1.0"
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format Native | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT+INTO+floats+FORMAT+Native" --data-binary @-
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format RowBinary | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT+INTO+floats+FORMAT+RowBinary" --data-binary @-
+
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS"
+$CLICKHOUSE_CLIENT -q \
+  "SELECT
+    read_rows,
+    read_bytes,
+    written_rows,
+    written_bytes,
+    query
+  FROM system.query_log
+  WHERE
+        event_date >= yesterday()
+    AND event_time > now() - INTERVAL 600 SECOND
+    AND type = 'QueryFinish'
+    AND query_kind = 'Insert'
+    AND current_database == currentDatabase()
+  ORDER BY event_time_microseconds ASC
+  FORMAT TSKV"
+
+$CLICKHOUSE_CLIENT -q \
+  "SELECT
+    read_rows,
+    read_bytes,
+    written_rows,
+    written_bytes,
+    ql.query as source_query,
+    view_query
+  FROM system.query_views_log
+  INNER JOIN
+  (
+      SELECT
+        query_id, query, event_time_microseconds
+      FROM system.query_log
+      WHERE
+            event_date >= yesterday()
+        AND event_time > now() - INTERVAL 600 SECOND
+        AND type = 'QueryFinish'
+        AND query_kind = 'Insert'
+        AND current_database == currentDatabase()
+  ) ql
+  ON system.query_views_log.initial_query_id = ql.query_id
+  ORDER BY ql.event_time_microseconds ASC, view_query ASC
+  FORMAT TSKV"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Related to https://github.com/ClickHouse/ClickHouse/pull/37543#issuecomment-1246982227

Verify how system.query_log stats work on insert queries:
* Read bytes/rows: Includes the rows read from the input (both for queries but also for inline data), and the data read by the dependent materialized views (including the inserted block).
* Write bytes/rows: Includes the bytes written both to the landing table and to the target of any materialized views.

No changes in behaviour, just making sure there is a test for this so it doesn't change (again) inadvertently. cc @KochetovNicolai 


BTW, once this is accepted the idea is to make sure the other places where metrics are shown, like the `X-Clickhouse-Summary` header for example, match those numbers too.