### PR TITLE
Rename pr-backported label to avoid confusion

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -46,7 +46,7 @@ from ssh import SSHKey
 class Labels:
     LABEL_MUST_BACKPORT = "pr-must-backport"
     LABEL_BACKPORT = "pr-backport"
-    LABEL_BACKPORTED = "pr-backported"
+    LABEL_BACKPORTS_CREATED = "pr-backports-created"
     LABEL_CHERRYPICK = "pr-cherrypick"
     LABEL_DO_NOT_TEST = "do not test"
 
@@ -321,7 +321,7 @@ class Backport:
         tomorrow = date.today() + timedelta(days=1)
         logging.info("Receive PRs suppose to be backported")
         self.prs_for_backport = self.gh.get_pulls_from_search(
-            query=f"{self._query} -label:pr-backported",
+            query=f"{self._query} -label:{Labels.LABEL_BACKPORTS_CREATED}",
             label=",".join(self.labels_to_backport + [Labels.LABEL_MUST_BACKPORT]),
             merged=[since_date, tomorrow],
         )
@@ -407,11 +407,11 @@ class Backport:
         if self.dry_run:
             logging.info("DRY RUN: would mark PR #%s as done", pr.number)
             return
-        pr.add_to_labels(Labels.LABEL_BACKPORTED)
+        pr.add_to_labels(Labels.LABEL_BACKPORTS_CREATED)
         logging.info(
             "PR #%s is successfully labeled with `%s`",
             pr.number,
-            Labels.LABEL_BACKPORTED,
+            Labels.LABEL_BACKPORTS_CREATED,
         )
 
     @property

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -44,11 +44,11 @@ from ssh import SSHKey
 
 
 class Labels:
-    LABEL_MUST_BACKPORT = "pr-must-backport"
-    LABEL_BACKPORT = "pr-backport"
-    LABEL_BACKPORTS_CREATED = "pr-backports-created"
-    LABEL_CHERRYPICK = "pr-cherrypick"
-    LABEL_DO_NOT_TEST = "do not test"
+    MUST_BACKPORT = "pr-must-backport"
+    BACKPORT = "pr-backport"
+    BACKPORTS_CREATED = "pr-backports-created"
+    CHERRYPICK = "pr-cherrypick"
+    DO_NOT_TEST = "do not test"
 
 
 class ReleaseBranch:
@@ -204,8 +204,8 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
             base=self.backport_branch,
             head=self.cherrypick_branch,
         )
-        self.cherrypick_pr.add_to_labels(Labels.LABEL_CHERRYPICK)
-        self.cherrypick_pr.add_to_labels(Labels.LABEL_DO_NOT_TEST)
+        self.cherrypick_pr.add_to_labels(Labels.CHERRYPICK)
+        self.cherrypick_pr.add_to_labels(Labels.DO_NOT_TEST)
         self._assign_new_pr(self.cherrypick_pr)
 
     def create_backport(self):
@@ -236,7 +236,7 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
             base=self.name,
             head=self.backport_branch,
         )
-        self.backport_pr.add_to_labels(Labels.LABEL_BACKPORT)
+        self.backport_pr.add_to_labels(Labels.BACKPORT)
         self._assign_new_pr(self.backport_pr)
 
     def _assign_new_pr(self, new_pr: PullRequest):
@@ -321,8 +321,8 @@ class Backport:
         tomorrow = date.today() + timedelta(days=1)
         logging.info("Receive PRs suppose to be backported")
         self.prs_for_backport = self.gh.get_pulls_from_search(
-            query=f"{self._query} -label:{Labels.LABEL_BACKPORTS_CREATED}",
-            label=",".join(self.labels_to_backport + [Labels.LABEL_MUST_BACKPORT]),
+            query=f"{self._query} -label:{Labels.BACKPORTS_CREATED}",
+            label=",".join(self.labels_to_backport + [Labels.MUST_BACKPORT]),
             merged=[since_date, tomorrow],
         )
         logging.info(
@@ -342,7 +342,7 @@ class Backport:
 
     def process_pr(self, pr: PullRequest):
         pr_labels = [label.name for label in pr.labels]
-        if Labels.LABEL_MUST_BACKPORT in pr_labels:
+        if Labels.MUST_BACKPORT in pr_labels:
             branches = [
                 ReleaseBranch(br, pr) for br in self.release_branches
             ]  # type: List[ReleaseBranch]
@@ -407,11 +407,11 @@ class Backport:
         if self.dry_run:
             logging.info("DRY RUN: would mark PR #%s as done", pr.number)
             return
-        pr.add_to_labels(Labels.LABEL_BACKPORTS_CREATED)
+        pr.add_to_labels(Labels.BACKPORTS_CREATED)
         logging.info(
             "PR #%s is successfully labeled with `%s`",
             pr.number,
-            Labels.LABEL_BACKPORTS_CREATED,
+            Labels.BACKPORTS_CREATED,
         )
 
     @property


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Rename `pr-backported` label to `pr-backports-created`