### PR TITLE
Fix Keeper segfault during shutdown when RAFT server failed to start

### DIFF
--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -574,7 +574,7 @@ void KeeperDispatcher::shutdown()
             /// Clear all registered sessions
             std::lock_guard lock(session_to_response_callback_mutex);
 
-            if (hasLeader())
+            if (server && hasLeader())
             {
                 close_requests.reserve(session_to_response_callback.size());
                 // send to leader CLOSE requests for active sessions
@@ -598,7 +598,7 @@ void KeeperDispatcher::shutdown()
         }
 
         // if there is no leader, there is no reason to do CLOSE because it's a write request
-        if (hasLeader() && !close_requests.empty())
+        if (server && hasLeader() && !close_requests.empty())
         {
             LOG_INFO(log, "Trying to close {} session(s)", close_requests.size());
             const auto raft_result = server->putRequestBatch(close_requests);

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -545,7 +545,7 @@ bool KeeperServer::isFollower() const
 
 bool KeeperServer::isLeaderAlive() const
 {
-    return raft_instance->is_leader_alive();
+    return raft_instance && raft_instance->is_leader_alive();
 }
 
 /// TODO test whether taking failed peer in count


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Raft can fail to start (e.g. if the port for interserver communication is used) so we cannot check for leader during shutdown if the server doesn't exist.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
