### PR TITLE
add link to formats from SQL reference

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -2,9 +2,8 @@
 slug: /en/interfaces/formats
 sidebar_position: 21
 sidebar_label: Input and Output Formats
+title: Formats for Input and Output Data
 ---
-
-# Formats for Input and Output Data
 
 ClickHouse can accept and return data in various formats. A format supported for input can be used to parse the data provided to `INSERT`s, to perform `SELECT`s from a file-backed table such as File, URL or HDFS, or to read an external dictionary. A format supported for output can be used to arrange the
 results of a `SELECT`, and to perform `INSERT`s into a file-backed table.

--- a/docs/en/sql-reference/formats.mdx
+++ b/docs/en/sql-reference/formats.mdx
@@ -1,0 +1,10 @@
+---
+slug: /en/sql-reference/formats
+sidebar_position: 50
+sidebar_label: Input and Output Formats
+title: Formats for Input and Output Data
+---
+
+import Content from '@site/docs/en/interfaces/formats.md';
+
+<Content />


### PR DESCRIPTION
Add a link in docs to the input / output formats from the SQL reference 

### Changelog category (leave one):
- Documentation (changelog entry is not required)

