### PR TITLE
Remove cruft about gcc

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionUniqUpTo.h
+++ b/src/AggregateFunctions/AggregateFunctionUniqUpTo.h
@@ -18,11 +18,6 @@
 #include <IO/WriteHelpers.h>
 
 
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
-
 namespace DB
 {
 struct Settings;
@@ -291,7 +286,3 @@ public:
 
 
 }
-
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif

--- a/src/AggregateFunctions/ReservoirSamplerDeterministic.h
+++ b/src/AggregateFunctions/ReservoirSamplerDeterministic.h
@@ -165,11 +165,6 @@ public:
         sorted = false;
     }
 
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-
     void write(DB::WriteBuffer & buf) const
     {
         size_t size = samples.size();
@@ -192,10 +187,6 @@ public:
             DB::writePODBinary(elem, buf);
         }
     }
-
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 private:
     /// We allocate some memory on the stack to avoid allocations when there are many objects with a small number of elements.

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -114,12 +114,6 @@ public:
         return sizeAt(n) == 1;
     }
 
-/// Suppress gcc 7.3.1 warning: '*((void*)&<anonymous> +8)' may be used uninitialized in this function
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
     void insert(const Field & x) override
     {
         const String & s = x.get<const String &>();
@@ -131,10 +125,6 @@ public:
         memcpy(chars.data() + old_size, s.c_str(), size_to_append);
         offsets.push_back(new_size);
     }
-
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
     void insertFrom(const IColumn & src_, size_t n) override
     {

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -281,14 +281,6 @@ private:
 #endif
 };
 
-/** When using AllocatorWithStackMemory, located on the stack,
-  *  GCC 4.9 mistakenly assumes that we can call `free` from a pointer to the stack.
-  * In fact, the combination of conditions inside AllocatorWithStackMemory does not allow this.
-  */
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
-#endif
 
 /** Allocator with optimization to place small memory ranges in automatic memory.
   */
@@ -366,7 +358,3 @@ extern template class Allocator<false, false>;
 extern template class Allocator<true, false>;
 extern template class Allocator<false, true>;
 extern template class Allocator<true, true>;
-
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif

--- a/src/Common/DateLUTImpl.h
+++ b/src/Common/DateLUTImpl.h
@@ -29,13 +29,6 @@
 #define DATE_LUT_ADD ((1970 - DATE_LUT_MIN_YEAR) * 366L * 86400)
 
 
-#if defined(__PPC__)
-#if !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-#endif
-
-
 /// Flags for toYearWeek() function.
 enum class WeekModeFlag : UInt8
 {
@@ -1445,9 +1438,3 @@ public:
         return s;
     }
 };
-
-#if defined(__PPC__)
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#endif

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -225,9 +225,7 @@ public:
     void clear() { c_end = c_start; }
 
     template <typename ... TAllocatorParams>
-#if defined(__clang__)
     ALWAYS_INLINE /// Better performance in clang build, worse performance in gcc build.
-#endif
     void reserve(size_t n, TAllocatorParams &&... allocator_params)
     {
         if (n > capacity())

--- a/src/Common/examples/compact_array.cpp
+++ b/src/Common/examples/compact_array.cpp
@@ -1,9 +1,3 @@
-/// Bug in GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59124
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
-
 #include <Common/CompactArray.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/ReadBufferFromFile.h>
@@ -262,7 +256,3 @@ int main()
     runTests();
     return 0;
 }
-
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif

--- a/src/Common/examples/parallel_aggregation.cpp
+++ b/src/Common/examples/parallel_aggregation.cpp
@@ -69,11 +69,6 @@ static void aggregate1(Map & map, Source::const_iterator begin, Source::const_it
         ++map[*it];
 }
 
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
 static void aggregate12(Map & map, Source::const_iterator begin, Source::const_iterator end)
 {
     Map::LookupResult found = nullptr;
@@ -121,10 +116,6 @@ static void aggregate22(MapTwoLevel & map, Source::const_iterator begin, Source:
         ++found->getMapped();
     }
 }
-
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 static void merge2(MapTwoLevel * maps, size_t num_threads, size_t bucket)
 {

--- a/src/Common/examples/parallel_aggregation2.cpp
+++ b/src/Common/examples/parallel_aggregation2.cpp
@@ -62,11 +62,6 @@ struct AggregateIndependent
     }
 };
 
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
 template <typename Map>
 struct AggregateIndependentWithSequentialKeysOptimization
 {
@@ -114,11 +109,6 @@ struct AggregateIndependentWithSequentialKeysOptimization
         pool.wait();
     }
 };
-
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
 
 template <typename Map>
 struct MergeSequential
@@ -265,19 +255,10 @@ struct Creator
     void operator()(Value &) const {}
 };
 
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
 struct Updater
 {
     void operator()(Value & x) const { ++x; }
 };
-
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 struct Merger
 {

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -105,10 +105,6 @@ template <typename T> bool decimalEqual(T x, T y, UInt32 x_scale, UInt32 y_scale
 template <typename T> bool decimalLess(T x, T y, UInt32 x_scale, UInt32 y_scale);
 template <typename T> bool decimalLessOrEqual(T x, T y, UInt32 x_scale, UInt32 y_scale);
 
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 template <typename T>
 class DecimalField
 {
@@ -168,9 +164,6 @@ private:
     T dec;
     UInt32 scale;
 };
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 template <typename T> constexpr bool is_decimal_field = false;
 template <> constexpr inline bool is_decimal_field<DecimalField<Decimal32>> = true;
@@ -594,11 +587,6 @@ public:
         switch (field.which)
         {
             case Types::Null:    return f(field.template get<Null>());
-// gcc 8.2.1
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
             case Types::UInt64:  return f(field.template get<UInt64>());
             case Types::UInt128: return f(field.template get<UInt128>());
             case Types::UInt256: return f(field.template get<UInt256>());
@@ -622,9 +610,6 @@ public:
             case Types::Decimal128: return f(field.template get<DecimalField<Decimal128>>());
             case Types::Decimal256: return f(field.template get<DecimalField<Decimal256>>());
             case Types::AggregateFunctionState: return f(field.template get<AggregateFunctionStateData>());
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
         }
 
         __builtin_unreachable();

--- a/src/Core/Types.h
+++ b/src/Core/Types.h
@@ -42,11 +42,6 @@ struct Null
     }
 };
 
-/// Ignore strange gcc warning https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55776
-#if !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-#endif
 /// @note Except explicitly described you should not assume on TypeIndex numbers and/or their orders in this enum.
 enum class TypeIndex
 {
@@ -89,9 +84,6 @@ enum class TypeIndex
     Map,
     Object,
 };
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 
 using UInt128 = ::UInt128;

--- a/src/Disks/tests/gtest_disk.cpp
+++ b/src/Disks/tests/gtest_disk.cpp
@@ -7,12 +7,6 @@
 namespace fs = std::filesystem;
 
 
-#if !defined(__clang__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wsuggest-override"
-#endif
-
-
 template <typename T>
 DB::DiskPtr createDisk();
 

--- a/src/Functions/GatherUtils/Sources.h
+++ b/src/Functions/GatherUtils/Sources.h
@@ -140,17 +140,12 @@ struct NumericArraySource : public ArraySourceImpl<NumericArraySource<T>>
 
 
 /// The methods can be virtual or not depending on the template parameter. See IStringSource.
-#if !defined(__clang__)
-#   pragma GCC diagnostic push
+#pragma GCC diagnostic push
+#ifdef HAS_SUGGEST_OVERRIDE
 #   pragma GCC diagnostic ignored "-Wsuggest-override"
-#elif __clang_major__ >= 11
-#   pragma GCC diagnostic push
-#   ifdef HAS_SUGGEST_OVERRIDE
-#       pragma GCC diagnostic ignored "-Wsuggest-override"
-#   endif
-#   ifdef HAS_SUGGEST_DESTRUCTOR_OVERRIDE
-#       pragma GCC diagnostic ignored "-Wsuggest-destructor-override"
-#   endif
+#endif
+#ifdef HAS_SUGGEST_DESTRUCTOR_OVERRIDE
+#   pragma GCC diagnostic ignored "-Wsuggest-destructor-override"
 #endif
 
 template <typename Base>
@@ -233,9 +228,7 @@ struct ConstSource : public Base
     }
 };
 
-#if !defined(__clang__) || __clang_major__ >= 11
-#   pragma GCC diagnostic pop
-#endif
+#pragma GCC diagnostic pop
 
 struct StringSource
 {

--- a/src/Functions/PolygonUtils.h
+++ b/src/Functions/PolygonUtils.h
@@ -12,11 +12,6 @@
 
 /// Warning in boost::geometry during template strategy substitution.
 #pragma GCC diagnostic push
-
-#if !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #include <boost/geometry.hpp>
@@ -286,15 +281,8 @@ void PointInPolygonWithGrid<CoordinateType>::calcGridAttributes(
     const Point & min_corner = box.min_corner();
     const Point & max_corner = box.max_corner();
 
-#pragma GCC diagnostic push
-#if !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
     cell_width = (max_corner.x() - min_corner.x()) / grid_size;
     cell_height = (max_corner.y() - min_corner.y()) / grid_size;
-
-#pragma GCC diagnostic pop
 
     if (cell_width == 0 || cell_height == 0)
     {
@@ -330,10 +318,6 @@ void PointInPolygonWithGrid<CoordinateType>::buildGrid()
 
     for (size_t row = 0; row < grid_size; ++row)
     {
-#pragma GCC diagnostic push
-#if !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
         CoordinateType y_min = min_corner.y() + row * cell_height;
         CoordinateType y_max = min_corner.y() + (row + 1) * cell_height;
 
@@ -341,7 +325,6 @@ void PointInPolygonWithGrid<CoordinateType>::buildGrid()
         {
             CoordinateType x_min = min_corner.x() + col * cell_width;
             CoordinateType x_max = min_corner.x() + (col + 1) * cell_width;
-#pragma GCC diagnostic pop
             Box cell_box(Point(x_min, y_min), Point(x_max, y_max));
 
             MultiPolygon intersection;

--- a/src/IO/parseDateTimeBestEffort.cpp
+++ b/src/IO/parseDateTimeBestEffort.cpp
@@ -45,12 +45,6 @@ inline size_t readAlpha(char * res, size_t max_chars, ReadBuffer & in)
     return num_chars;
 }
 
-#if defined(__PPC__)
-#if !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-#endif
-
 template <size_t digit, size_t power_of_ten, typename T>
 inline void readDecimalNumberImpl(T & res, const char * src)
 {
@@ -655,12 +649,6 @@ ReturnType parseDateTime64BestEffortImpl(DateTime64 & res, UInt32 scale, ReadBuf
 }
 
 }
-
-#if defined(__PPC__)
-#if !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#endif
 
 void parseDateTimeBestEffort(time_t & res, ReadBuffer & in, const DateLUTImpl & local_time_zone, const DateLUTImpl & utc_time_zone)
 {

--- a/src/Storages/MergeTree/DataPartStorageOnDisk.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDisk.cpp
@@ -354,18 +354,11 @@ void DataPartStorageOnDisk::clearDirectory(
         /// Remove each expected file in directory, then remove directory itself.
         RemoveBatchRequest request;
 
-#if !defined(__clang__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wunused-variable"
-#endif
         for (const auto & [file, _] : checksums.files)
         {
             if (skip_directories.find(file) == skip_directories.end())
                 request.emplace_back(fs::path(dir) / file);
         }
-#if !defined(__clang__)
-#    pragma GCC diagnostic pop
-#endif
 
         for (const auto & file : {"checksums.txt", "columns.txt"})
             request.emplace_back(fs::path(dir) / file);

--- a/src/Storages/tests/gtest_storage_log.cpp
+++ b/src/Storages/tests/gtest_storage_log.cpp
@@ -5,8 +5,6 @@
 #include <Disks/tests/gtest_disk.h>
 #include <Formats/FormatFactory.h>
 #include <IO/ReadHelpers.h>
-#include <IO/WriteBufferFromOStream.h>
-#include <Interpreters/Context.h>
 #include <Storages/StorageLog.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Common/typeid_cast.h>
@@ -18,17 +16,11 @@
 #include <Processors/Executors/PushingPipelineExecutor.h>
 #include <Processors/Executors/CompletedPipelineExecutor.h>
 #include <Processors/Sinks/SinkToStorage.h>
-#include <QueryPipeline/Chain.h>
 #include <QueryPipeline/QueryPipeline.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/BuildQueryPipelineSettings.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
-
-#if !defined(__clang__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wsuggest-override"
-#endif
 
 
 DB::StoragePtr createStorage(DB::DiskPtr & disk)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It is related mostly to older gcc versions.
Nevertheless, we don't use gcc.