### PR TITLE
Remove too long test from the test suite with S3

### DIFF
--- a/tests/queries/0_stateless/00632_get_sample_block_cache.sql
+++ b/tests/queries/0_stateless/00632_get_sample_block_cache.sql
@@ -1,4 +1,4 @@
--- Tags: long, no-s3-storage
+-- Tags: long, no-s3-storage, no-asan
 
 SET joined_subquery_requires_alias = 0;
 

--- a/tests/queries/0_stateless/00632_get_sample_block_cache.sql
+++ b/tests/queries/0_stateless/00632_get_sample_block_cache.sql
@@ -1,4 +1,4 @@
--- Tags: long
+-- Tags: long, no-s3-storage
 
 SET joined_subquery_requires_alias = 0;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
