### PR TITLE
Remove noise from the build process

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionCategoricalInformationValue.cpp
+++ b/src/AggregateFunctions/AggregateFunctionCategoricalInformationValue.cpp
@@ -35,12 +35,12 @@ private:
     using Counter = UInt64;
     size_t category_count;
 
-    Counter & counter(AggregateDataPtr __restrict place, size_t i, bool what) const
+    static Counter & counter(AggregateDataPtr __restrict place, size_t i, bool what)
     {
         return reinterpret_cast<Counter *>(place)[i * 2 + (what ? 1 : 0)];
     }
 
-    const Counter & counter(ConstAggregateDataPtr __restrict place, size_t i, bool what) const
+    static const Counter & counter(ConstAggregateDataPtr __restrict place, size_t i, bool what)
     {
         return reinterpret_cast<const Counter *>(place)[i * 2 + (what ? 1 : 0)];
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


I don't like this:
```
$ ninja clickhouse
[0/2] Re-checking globbed directories...
[5343/8979] Generating include_private/lib/krb5/error_tables/kv5m_err.c, include_private/lib/krb5/error_tables/kv5m_err.h, include_private/kv5m_err.h
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_h.awk outfile=kv5m_err.h /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/kv5m_err.et
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_c.awk outfile=kv5m_err.c textdomain= localedir= /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/kv5m_err.et
[5344/8979] Generating include_private/lib/krb5/error_tables/k5e1_err.c, include_private/lib/krb5/error_tables/k5e1_err.h, include_private/k5e1_err.h
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_h.awk outfile=k5e1_err.h /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/k5e1_err.et
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_c.awk outfile=k5e1_err.c textdomain= localedir= /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/k5e1_err.et
[5348/8979] Generating include_private/lib/krb5/error_tables/kdb5_err.c, include_private/lib/krb5/error_tables/kdb5_err.h, include_private/kdb5_err.h
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_h.awk outfile=kdb5_err.h /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/kdb5_err.et
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_c.awk outfile=kdb5_err.c textdomain= localedir= /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/kdb5_err.et
[5349/8979] Generating include_private/lib/krb5/error_tables/asn1_err.c, include_private/lib/krb5/error_tables/asn1_err.h, include_private/asn1_err.h
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_h.awk outfile=asn1_err.h /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/asn1_err.et
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_c.awk outfile=asn1_err.c textdomain= localedir= /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/asn1_err.et
[5353/8979] Generating include_private/lib/krb5/error_tables/krb5_err.c, include_private/lib/krb5/error_tables/krb5_err.h, include_private/krb5_err.h
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_h.awk outfile=krb5_err.h /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/krb5_err.et
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_c.awk outfile=krb5_err.c textdomain= localedir= /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/krb5_err.et
[5354/8979] Generating include_private/lib/krb5/error_tables/krb524_err.c, include_private/lib/krb5/error_tables/krb524_err.h, include_private/krb524_err.h
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_h.awk outfile=krb524_err.h /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/krb524_err.et
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_c.awk outfile=krb524_err.c textdomain= localedir= /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/krb5/error_tables/krb524_err.et
[5372/8979] Generating include_private/lib/gssapi/generic/gssapi_err_generic.c, include_private/lib/gssapi/generic/gssapi_err_generic.h, include_private/gssapi_err_generic.h
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_h.awk outfile=gssapi_err_generic.h /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/gssapi/generic/gssapi_err_generic.et
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_c.awk outfile=gssapi_err_generic.c textdomain= localedir= /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/gssapi/generic/gssapi_err_generic.et
[5373/8979] Generating include_private/util/profile/prof_err.c, include_private/util/profile/prof_err.h, include_private/prof_err.h
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_h.awk outfile=prof_err.h /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/util/profile/prof_err.et
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_c.awk outfile=prof_err.c textdomain= localedir= /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/util/profile/prof_err.et
[5374/8979] Generating include_private/lib/gssapi/krb5/gssapi_err_krb5.c, include_private/lib/gssapi/krb5/gssapi_err_krb5.h, include_private/gssapi_err_krb5.h
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_h.awk outfile=gssapi_err_krb5.h /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/gssapi/krb5/gssapi_err_krb5.et
+ /usr/bin/awk -f /home/milovidov/work/ClickHouse/contrib/krb5/src/util/et/et_c.awk outfile=gssapi_err_krb5.c textdomain= localedir= /home/milovidov/work/ClickHouse/build_ubsan/contrib/krb5-cmake/include_private/lib/gssapi/krb5/gssapi_err_krb5.et
[8979/8979] Linking CXX executable programs/clickhouse
```