### PR TITLE
Fix clang-tidy build

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionCategoricalInformationValue.cpp
+++ b/src/AggregateFunctions/AggregateFunctionCategoricalInformationValue.cpp
@@ -35,12 +35,12 @@ private:
     using Counter = UInt64;
     size_t category_count;
 
-    Counter & counter(AggregateDataPtr __restrict place, size_t i, bool what) const
+    static Counter & counter(AggregateDataPtr __restrict place, size_t i, bool what)
     {
         return reinterpret_cast<Counter *>(place)[i * 2 + (what ? 1 : 0)];
     }
 
-    const Counter & counter(ConstAggregateDataPtr __restrict place, size_t i, bool what) const
+    static const Counter & counter(ConstAggregateDataPtr __restrict place, size_t i, bool what)
     {
         return reinterpret_cast<const Counter *>(place)[i * 2 + (what ? 1 : 0)];
     }


### PR DESCRIPTION
Tidy report [1]:

    src/AggregateFunctions/CMakeFiles/clickhouse_aggregate_functions.dir/AggregateFunctionCategoricalInformationValue.cpp.o -c ../src/AggregateFunctions/AggregateFunctionCategoricalInformationValue.cpp
    /build/build_docker/../src/AggregateFunctions/AggregateFunctionCategoricalInformationValue.cpp:38:15: error: method 'counter' can be made static [readability-convert-member-functions-to-static,-warnings-as-errors]
        Counter & counter(AggregateDataPtr __restrict place, size_t i, bool what) const
                  ^                                                               ~~~~~
        static
    /build/build_docker/../src/AggregateFunctions/AggregateFunctionCategoricalInformationValue.cpp:43:21: error: method 'counter' can be made static [readability-convert-member-functions-to-static,-warnings-as-errors]
        const Counter & counter(ConstAggregateDataPtr __restrict place, size_t i, bool what) const
                        ^                                                                    ~~~~~
        static
    178520 warnings generated.

  [1]: https://s3.amazonaws.com/clickhouse-builds/41459/64b44be513607d59e4b89dd9fb518b8cf4acba21/clickhouse_special_build_check/report.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #41449 (cc @alexey-milovidov )