### PR TITLE
Fixed cache parameter name

### DIFF
--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -155,7 +155,7 @@ Example of configuration for versions earlier than 22.8:
                 <endpoint>...</endpoint>
                 ... s3 configuration ...
                 <data_cache_enabled>1</data_cache_enabled>
-                <data_cache_size>10000000</data_cache_size>
+                <data_cache_max_size>10000000</data_cache_max_size>
             </s3>
         </disks>
         <policies>


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Documentation stated that for 22.3 until 22.7  the cache parameter to set the size of the external cache was `data_cache_size`. 
It did not work because the name was incorrect. The correct one is `data_cache_max_size`.

Test setting for 2GB:

- v22.3
```log
<Information> Disk(disk_s3): Disk registered with cache path: /var/lib/clickhouse/disks/disk_s3/data_cache/. Cache size: 2147483648, max cache elements size: 1048576, max_file_segment_size: 104857600
```

- v22.6 - v22.7
```
DESCRIBE CACHE s3_cache
FORMAT Vertical

Row 1:
──────
max_size:                          2147483648
max_elements:                      1048576
max_file_segment_size:             104857600
cache_on_write_operations:         0
enable_cache_hits_threshold:       0
current_size:                      0
current_elements:                  0
path:                              /var/lib/clickhouse/cache/
do_not_evict_index_and_mark_files: 1

