### PR TITLE
Fix flaky 01233_check_table_with_metadata_cache

### DIFF
--- a/tests/queries/0_stateless/01233_check_table_with_metadata_cache.sh
+++ b/tests/queries/0_stateless/01233_check_table_with_metadata_cache.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long, no-s3-storage, no-random-settings
+# Tags: no-fasttest, long, no-s3-storage, no-random-settings, no-parallel
 # Tag no-fasttest: setting use_metadata_cache=true is not supported in fasttest, because clickhouse binary in fasttest is build without RocksDB.
 # Tag no-random-settings: random settings significantly slow down test with debug build (alternative: add no-debug tag)
 # To suppress Warning messages from CHECK TABLE

--- a/tests/queries/0_stateless/01233_check_table_with_metadata_cache.sh
+++ b/tests/queries/0_stateless/01233_check_table_with_metadata_cache.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long, no-s3-storage
+# Tags: no-fasttest, long, no-s3-storage, no-random-settings
 # Tag no-fasttest: setting use_metadata_cache=true is not supported in fasttest, because clickhouse binary in fasttest is build without RocksDB.
+# Tag no-random-settings: random settings significantly slow down test with debug build (alternative: add no-debug tag)
 # To suppress Warning messages from CHECK TABLE
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=error
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



