### PR TITLE
Try fix flaky test_storage_nats

### DIFF
--- a/src/Storages/NATS/NATSSettings.h
+++ b/src/Storages/NATS/NATSSettings.h
@@ -24,7 +24,8 @@ class ASTStorage;
     M(Milliseconds, nats_flush_interval_ms, 0, "Timeout for flushing data from NATS.", 0) \
     M(String, nats_username, "", "NATS username", 0) \
     M(String, nats_password, "", "NATS password", 0) \
-    M(String, nats_token, "", "NATS token", 0)
+    M(String, nats_token, "", "NATS token", 0) \
+    M(UInt64, nats_startup_connect_tries, 5, "Number of connect tries at startup", 0) \
 
 #define LIST_OF_NATS_SETTINGS(M) \
     NATS_RELATED_SETTINGS(M) \


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There is a NATS internal error at startup of the table:
```
E           helpers.client.QueryRuntimeException: Client failed! Return code: 153, stderr: Received exception from server (version 22.9.1):
E           Code: 665. DB::Exception: Received from 172.16.7.3:9000. DB::Exception: Cannot connect to url : nats1:4444. Nats last error: (conn.c:1887): Expected 'PONG', got ''. Stack trace:
```