### PR TITLE
Add option for loading only system tables with clickhouse-local

### DIFF
--- a/docker/test/stateless/run.sh
+++ b/docker/test/stateless/run.sh
@@ -179,17 +179,17 @@ pigz < /var/log/clickhouse-server/clickhouse-server.log > /test_output/clickhous
 #   for files >64MB, we want this files to be compressed explicitly
 for table in query_log zookeeper_log trace_log transactions_info_log
 do
-    clickhouse-local --path /var/lib/clickhouse/ -q "select * from system.$table format TSVWithNamesAndTypes" | pigz > /test_output/$table.tsv.gz ||:
+    clickhouse-local --path /var/lib/clickhouse/ --only-system-tables -q "select * from system.$table format TSVWithNamesAndTypes" | pigz > /test_output/$table.tsv.gz ||:
     if [[ -n "$USE_DATABASE_REPLICATED" ]] && [[ "$USE_DATABASE_REPLICATED" -eq 1 ]]; then
-        clickhouse-local --path /var/lib/clickhouse1/ -q "select * from system.$table format TSVWithNamesAndTypes" | pigz > /test_output/$table.1.tsv.gz ||:
-        clickhouse-local --path /var/lib/clickhouse2/ -q "select * from system.$table format TSVWithNamesAndTypes" | pigz > /test_output/$table.2.tsv.gz ||:
+        clickhouse-local --path /var/lib/clickhouse1/ --only-system-tables -q "select * from system.$table format TSVWithNamesAndTypes" | pigz > /test_output/$table.1.tsv.gz ||:
+        clickhouse-local --path /var/lib/clickhouse2/ --only-system-tables -q "select * from system.$table format TSVWithNamesAndTypes" | pigz > /test_output/$table.2.tsv.gz ||:
     fi
 done
 
 # Also export trace log in flamegraph-friendly format.
 for trace_type in CPU Memory Real
 do
-    clickhouse-local --path /var/lib/clickhouse/ -q "
+    clickhouse-local --path /var/lib/clickhouse/ --only-system-tables -q "
             select
                 arrayStringConcat((arrayMap(x -> concat(splitByChar('/', addressToLine(x))[-1], '#', demangle(addressToSymbol(x)) ), trace)), ';') AS stack,
                 count(*) AS samples

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -622,9 +622,13 @@ void LocalServer::processConfig()
         attachSystemTablesLocal(global_context, *createMemoryDatabaseIfNotExists(global_context, DatabaseCatalog::SYSTEM_DATABASE));
         attachInformationSchema(global_context, *createMemoryDatabaseIfNotExists(global_context, DatabaseCatalog::INFORMATION_SCHEMA));
         attachInformationSchema(global_context, *createMemoryDatabaseIfNotExists(global_context, DatabaseCatalog::INFORMATION_SCHEMA_UPPERCASE));
-        loadMetadata(global_context);
         startupSystemTables();
-        DatabaseCatalog::instance().loadDatabases();
+
+        if (!config().has("only-system-tables"))
+        {
+            loadMetadata(global_context);
+            DatabaseCatalog::instance().loadDatabases();
+        }
 
         LOG_DEBUG(log, "Loaded metadata.");
     }
@@ -715,6 +719,7 @@ void LocalServer::addOptions(OptionsDescription & options_description)
 
         ("no-system-tables", "do not attach system tables (better startup time)")
         ("path", po::value<std::string>(), "Storage path")
+        ("only-system-tables", "attach only system tables from specified path")
         ("top_level_domains_path", po::value<std::string>(), "Path to lists with custom TLDs")
         ;
 }
@@ -743,6 +748,8 @@ void LocalServer::processOptions(const OptionsDescription &, const CommandLineOp
         config().setString("table-structure", options["structure"].as<std::string>());
     if (options.count("no-system-tables"))
         config().setBool("no-system-tables", true);
+    if (options.count("only-system-tables"))
+        config().setBool("only-system-tables", true);
 
     if (options.count("input-format"))
         config().setString("table-data-format", options["input-format"].as<std::string>());


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Logs weren't saved for Stateless tests using Replicated database (clickhouse-local couldn't load tables with macros).
We only need system tables for logs so we ignore all other tables with an option.

cc @tavplubix 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
