### PR TITLE
Change input_format_skip_unknown_fields default to 1

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -3433,7 +3433,7 @@ Possible values:
 -   0 — Disabled.
 -   1 — Enabled.
 
-Default value: 0.
+Default value: 1.
 
 ## input_format_with_names_use_header {#input_format_with_names_use_header}
 


### PR DESCRIPTION
As per PR https://github.com/ClickHouse/ClickHouse/pull/37192, `input_format_skip_unknown_fields` is enabled by default. Likewise, it is also set as `true` in the factory settings https://github.com/ClickHouse/ClickHouse/blob/master/src/Core/Settings.h#L696

Updating the docs to reflect the change.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
