### PR TITLE
Fix conversion from nullable fixed string to string

### DIFF
--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -55,6 +55,7 @@
 #include <Columns/ColumnLowCardinality.h>
 #include <Interpreters/Context.h>
 #include <Common/HashTable/HashMap.h>
+#include <Core/Types.h>
 
 
 namespace DB
@@ -1519,9 +1520,11 @@ struct ConvertImpl<DataTypeUInt8, DataTypeUInt8, Name, ConvertDefaultBehaviorTag
 template <typename Name>
 struct ConvertImpl<DataTypeFixedString, DataTypeString, Name, ConvertDefaultBehaviorTag>
 {
-    static ColumnPtr execute(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t /*input_rows_count*/)
+    static ColumnPtr execute(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type, size_t /*input_rows_count*/)
     {
-        if (const ColumnFixedString * col_from = checkAndGetColumn<ColumnFixedString>(arguments[0].column.get()))
+        ColumnUInt8::MutablePtr null_map = copyNullMap(arguments[0].column);
+        const auto & nested =  columnGetNested(arguments[0]);
+        if (const ColumnFixedString * col_from = checkAndGetColumn<ColumnFixedString>(nested.column.get()))
         {
             auto col_to = ColumnString::create();
 
@@ -1537,19 +1540,24 @@ struct ConvertImpl<DataTypeFixedString, DataTypeString, Name, ConvertDefaultBeha
             size_t offset_to = 0;
             for (size_t i = 0; i < size; ++i)
             {
-                size_t bytes_to_copy = n;
-                while (bytes_to_copy > 0 && data_from[offset_from + bytes_to_copy - 1] == 0)
-                    --bytes_to_copy;
+                if (!null_map || !null_map->getData()[i])
+                {
+                    size_t bytes_to_copy = n;
+                    while (bytes_to_copy > 0 && data_from[offset_from + bytes_to_copy - 1] == 0)
+                        --bytes_to_copy;
 
-                memcpy(&data_to[offset_to], &data_from[offset_from], bytes_to_copy);
-                offset_from += n;
-                offset_to += bytes_to_copy;
+                    memcpy(&data_to[offset_to], &data_from[offset_from], bytes_to_copy);
+                    offset_to += bytes_to_copy;
+                }
                 data_to[offset_to] = 0;
                 ++offset_to;
                 offsets_to[i] = offset_to;
+                offset_from += n;
             }
 
             data_to.resize(offset_to);
+            if (return_type->isNullable() && null_map)
+                return ColumnNullable::create(std::move(col_to), std::move(null_map));
             return col_to;
         }
         else

--- a/tests/queries/0_stateless/02426_to_string_nullable_fixedstring.reference
+++ b/tests/queries/0_stateless/02426_to_string_nullable_fixedstring.reference
@@ -1,0 +1,11 @@
+a	Nullable(FixedString(1))	a
+Nullable(FixedString(1))	\N
+Nullable(FixedString(1))	1
+Nullable(FixedString(1))	2
+Nullable(FixedString(1))	\N
+Nullable(FixedString(1))	4
+Nullable(FixedString(1))	5
+Nullable(FixedString(1))	\N
+Nullable(FixedString(1))	7
+Nullable(FixedString(1))	8
+Nullable(FixedString(1))	\N

--- a/tests/queries/0_stateless/02426_to_string_nullable_fixedstring.reference
+++ b/tests/queries/0_stateless/02426_to_string_nullable_fixedstring.reference
@@ -1,11 +1,11 @@
 a	Nullable(FixedString(1))	a
-Nullable(FixedString(1))	\N
-Nullable(FixedString(1))	1
-Nullable(FixedString(1))	2
-Nullable(FixedString(1))	\N
-Nullable(FixedString(1))	4
-Nullable(FixedString(1))	5
-Nullable(FixedString(1))	\N
-Nullable(FixedString(1))	7
-Nullable(FixedString(1))	8
-Nullable(FixedString(1))	\N
+0	Nullable(FixedString(1))	\N
+1	Nullable(FixedString(1))	1
+2	Nullable(FixedString(1))	2
+3	Nullable(FixedString(1))	\N
+4	Nullable(FixedString(1))	4
+5	Nullable(FixedString(1))	5
+6	Nullable(FixedString(1))	\N
+7	Nullable(FixedString(1))	7
+8	Nullable(FixedString(1))	8
+9	Nullable(FixedString(1))	\N

--- a/tests/queries/0_stateless/02426_to_string_nullable_fixedstring.sql
+++ b/tests/queries/0_stateless/02426_to_string_nullable_fixedstring.sql
@@ -1,0 +1,2 @@
+SELECT CAST('a', 'Nullable(FixedString(1))') as s,  toTypeName(s), toString(s);
+SELECT toTypeName(s), toString(s) FROM (SELECT if(number % 3 = 0, NULL, toFixedString(toString(number), 1)) AS s from numbers(10))

--- a/tests/queries/0_stateless/02426_to_string_nullable_fixedstring.sql
+++ b/tests/queries/0_stateless/02426_to_string_nullable_fixedstring.sql
@@ -1,2 +1,2 @@
 SELECT CAST('a', 'Nullable(FixedString(1))') as s,  toTypeName(s), toString(s);
-SELECT toTypeName(s), toString(s) FROM (SELECT if(number % 3 = 0, NULL, toFixedString(toString(number), 1)) AS s from numbers(10))
+SELECT number, toTypeName(s), toString(s) FROM (SELECT number, if(number % 3 = 0, NULL, toFixedString(toString(number), 1)) AS s from numbers(10)) ORDER BY number;


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix conversion from nullable fixed string to string

Handle NULL directly in `ConvertImpl<DataTypeFixedString, DataTypeString, Name, ConvertDefaultBehaviorTag>` as `FunctionConvert` won't use default implementation for NULL when converting to string anymore after  #26123
Close #41490


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
