### PR TITLE
Build latest tags ONLY from master branch

### DIFF
--- a/tests/ci/docker_images_check.py
+++ b/tests/ci/docker_images_check.py
@@ -164,7 +164,7 @@ def gen_versions(
     # The order is important, PR number is used as cache during the build
     versions = [str(pr_info.number), pr_commit_version]
     result_version = pr_commit_version
-    if pr_info.number == 0:
+    if pr_info.number == 0 and pr_info.base_name == "master":
         # First get the latest for cache
         versions.insert(0, "latest")
 

--- a/tests/ci/docker_test.py
+++ b/tests/ci/docker_test.py
@@ -99,6 +99,11 @@ class TestDockerImageCheck(unittest.TestCase):
 
     def test_gen_version(self):
         pr_info = PRInfo(PRInfo.default_event.copy())
+        pr_info.base_name = "anything-else"
+        versions, result_version = di.gen_versions(pr_info, None)
+        self.assertEqual(versions, ["0", "0-HEAD"])
+        self.assertEqual(result_version, "0-HEAD")
+        pr_info.base_name = "master"
         versions, result_version = di.gen_versions(pr_info, None)
         self.assertEqual(versions, ["latest", "0", "0-HEAD"])
         self.assertEqual(result_version, "0-HEAD")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not build the `latest` tagged images from branches but master