### PR TITLE
Fix possible pipeline stuck exception for queries with OFFSET

### DIFF
--- a/src/Processors/OffsetTransform.cpp
+++ b/src/Processors/OffsetTransform.cpp
@@ -96,13 +96,14 @@ OffsetTransform::Status OffsetTransform::preparePair(PortsData & data)
     auto & input = *data.input_port;
 
     /// Check can output.
-    bool output_finished = false;
+
     if (output.isFinished())
     {
-        output_finished = true;
+        input.close();
+        return Status::Finished;
     }
 
-    if (!output_finished && !output.canPush())
+    if (!output.canPush())
     {
         input.setNotNeeded();
         return Status::PortFull;

--- a/tests/queries/0_stateless/02429_offset_pipeline_stuck_bug.sql
+++ b/tests/queries/0_stateless/02429_offset_pipeline_stuck_bug.sql
@@ -1,0 +1,4 @@
+CREATE TABLE t ENGINE = Log AS SELECT * FROM system.numbers LIMIT 20;
+SET enable_optimize_predicate_expression = 0;
+SELECT number FROM (select number FROM t ORDER BY number OFFSET 3) WHERE number < NULL;
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible `pipeline stuck` exception for queries with `OFFSET`. The error was found with `enable_optimize_predicate_expression = 0` and always false condition in `WHERE`. Fixes #41383