### PR TITLE
Fix wrong exception code in the `bitmapTransform` function

### DIFF
--- a/src/Functions/FunctionsBitmap.h
+++ b/src/Functions/FunctionsBitmap.h
@@ -20,12 +20,13 @@
 // inside.
 #include <AggregateFunctions/AggregateFunctionGroupBitmapData.h>
 
+
 namespace DB
 {
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
-    extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
 
 /** Bitmap functions.
@@ -640,7 +641,7 @@ private:
             }
 
             if (from_end - from_start != to_end - to_start)
-                throw Exception("From array size and to array size mismatch", ErrorCodes::LOGICAL_ERROR);
+                throw Exception("From array size and to array size mismatch", ErrorCodes::BAD_ARGUMENTS);
 
             col_to->insertDefault();
             AggregateFunctionGroupBitmapData<T> & bitmap_data_2

--- a/tests/queries/0_stateless/02430_bitmap_transform_exception_code.sql
+++ b/tests/queries/0_stateless/02430_bitmap_transform_exception_code.sql
@@ -1,0 +1,1 @@
+SELECT bitmapTransform(arrayReduce('groupBitmapState', [1]), [1, 2], [1, 2, 3]); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #28166.