### PR TITLE
Bump minimum required ARM ISA to v8.2 and add v8.0 compat build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -887,6 +887,51 @@ jobs:
           docker ps --quiet | xargs --no-run-if-empty docker kill ||:
           docker ps --all --quiet | xargs --no-run-if-empty docker rm -f ||:
           sudo rm -fr "$TEMP_PATH" "$CACHES_PATH"
+  BuilderBinAarch64V80Compat:
+    needs: [DockerHubPush]
+    runs-on: [self-hosted, builder]
+    steps:
+      - name: Set envs
+        run: |
+          cat >> "$GITHUB_ENV" << 'EOF'
+          TEMP_PATH=${{runner.temp}}/build_check
+          IMAGES_PATH=${{runner.temp}}/images_path
+          REPO_COPY=${{runner.temp}}/build_check/ClickHouse
+          CACHES_PATH=${{runner.temp}}/../ccaches
+          BUILD_NAME=binary_aarch64_v80compat
+          EOF
+      - name: Download changed images
+        uses: actions/download-artifact@v2
+        with:
+          name: changed_images
+          path: ${{ env.IMAGES_PATH }}
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # otherwise we will have no info about contributors
+      - name: Build
+        run: |
+          git -C "$GITHUB_WORKSPACE" submodule sync --recursive
+          git -C "$GITHUB_WORKSPACE" submodule update --depth=1 --recursive --init --jobs=10
+          sudo rm -fr "$TEMP_PATH"
+          mkdir -p "$TEMP_PATH"
+          cp -r "$GITHUB_WORKSPACE" "$TEMP_PATH"
+          cd "$REPO_COPY/tests/ci" && python3 build_check.py "$BUILD_NAME"
+      - name: Upload build URLs to artifacts
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.BUILD_URLS }}
+          path: ${{ env.TEMP_PATH }}/${{ env.BUILD_URLS }}.json
+      - name: Cleanup
+        if: always()
+        run: |
+          docker ps --quiet | xargs --no-run-if-empty docker kill ||:
+          docker ps --all --quiet | xargs --no-run-if-empty docker rm -f ||:
+          sudo rm -fr "$TEMP_PATH" "$CACHES_PATH"
 ############################################################################################
 ##################################### Docker images  #######################################
 ############################################################################################
@@ -972,6 +1017,7 @@ jobs:
       # - BuilderBinGCC
       - BuilderBinPPC64
       - BuilderBinAmd64SSE2
+      - BuilderBinAarch64V80Compat
       - BuilderBinClangTidy
       - BuilderDebShared
     runs-on: [self-hosted, style-checker]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -940,6 +940,49 @@ jobs:
           docker ps --quiet | xargs --no-run-if-empty docker kill ||:
           docker ps --all --quiet | xargs --no-run-if-empty docker rm -f ||:
           sudo rm -fr "$TEMP_PATH" "$CACHES_PATH"
+  BuilderBinAarch64V80Compat:
+    needs: [DockerHubPush, FastTest, StyleCheck]
+    runs-on: [self-hosted, builder]
+    steps:
+      - name: Set envs
+        run: |
+          cat >> "$GITHUB_ENV" << 'EOF'
+          TEMP_PATH=${{runner.temp}}/build_check
+          IMAGES_PATH=${{runner.temp}}/images_path
+          REPO_COPY=${{runner.temp}}/build_check/ClickHouse
+          CACHES_PATH=${{runner.temp}}/../ccaches
+          BUILD_NAME=binary_aarch64_v80compat
+          EOF
+      - name: Download changed images
+        uses: actions/download-artifact@v2
+        with:
+          name: changed_images
+          path: ${{ env.IMAGES_PATH }}
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          git -C "$GITHUB_WORKSPACE" submodule sync --recursive
+          git -C "$GITHUB_WORKSPACE" submodule update --depth=1 --recursive --init --jobs=10
+          sudo rm -fr "$TEMP_PATH"
+          mkdir -p "$TEMP_PATH"
+          cp -r "$GITHUB_WORKSPACE" "$TEMP_PATH"
+          cd "$REPO_COPY/tests/ci" && python3 build_check.py "$BUILD_NAME"
+      - name: Upload build URLs to artifacts
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.BUILD_URLS }}
+          path: ${{ env.TEMP_PATH }}/${{ env.BUILD_URLS }}.json
+      - name: Cleanup
+        if: always()
+        run: |
+          docker ps --quiet | xargs --no-run-if-empty docker kill ||:
+          docker ps --all --quiet | xargs --no-run-if-empty docker rm -f ||:
+          sudo rm -fr "$TEMP_PATH" "$CACHES_PATH"
 ############################################################################################
 ##################################### Docker images  #######################################
 ############################################################################################
@@ -1025,6 +1068,7 @@ jobs:
       # - BuilderBinGCC
       - BuilderBinPPC64
       - BuilderBinAmd64SSE2
+      - BuilderBinAarch64V80Compat
       - BuilderBinClangTidy
       - BuilderDebShared
     runs-on: [self-hosted, style-checker]

--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -17,7 +17,7 @@ if (ARCH_NATIVE)
     set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=native")
 
 elseif (ARCH_AARCH64)
-    # ARM publishes almost every year a new revision of it's ISA [1]. Each revision comes with new mandatory and optional features from
+    # ARM publishes almost every year a new revision of it's ISA [1]. Each version comes with new mandatory and optional features from
     # which CPU vendors can pick and choose. This creates a lot of variability ... We provide two build "profiles", one for maximum
     # compatibility intended to run on all 64-bit ARM hardware released after 2013 (e.g. Raspberry Pi 4), and one for modern ARM server
     # CPUs, (e.g. Graviton).
@@ -26,19 +26,35 @@ elseif (ARCH_AARCH64)
     option (NO_ARMV81_OR_HIGHER "Disable ARMv8.1 or higher on Aarch64 for maximum compatibility with older/embedded hardware." 0)
 
     if (NO_ARMV81_OR_HIGHER)
-        # In v8.0, crc32 is optional, in v8.1 it's mandatory. Enable it regardless as __crc32()* is used in lot's of places and even very
-        # old ARM CPUs support it.
+        # crc32 is optional in v8.0 and mandatory in v8.1. Enable it as __crc32()* is used in lot's of places and even very old ARM CPUs
+        # support it.
         set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=armv8+crc")
     else ()
-        # ARMv8.2 is ancient but the baseline for Graviton 2 and 3 processors [1]. In particular, it includes LSE (first made mandatory with
-        # ARMv8.1) which provides nice speedups without having to fall back to v8.0  "-moutline-atomics" compat flag [2, 3, 4] that imposes
-        # a recent glibc with runtime dispatch helper, limiting our ability to run on old OSs.
+        # ARMv8.2 is quite ancient but the lowest common denominator supported by both Graviton 2 and 3 processors [1]. In particular, it
+        # includes LSE (made mandatory with ARMv8.1) which provides nice speedups without having to fall back to compat flag
+        # "-moutline-atomics" for v8.0 [2, 3, 4] that requires a recent glibc with runtime dispatch helper, limiting our ability to run on
+        # old OSs.
+        #
+        # simd:    NEON, introduced as optional in v8.0, A few extensions were added with v8.1 but it's still not mandatory. Enables the
+        #          compiler to auto-vectorize.
+        # sve:     Scalable Vector Extensions, introduced as optional in v8.2. Available in Graviton 3 but not in Graviton 2, and most likely
+        #          also not in CI machines. Compiler support for autovectorization is rudimentary at the time of writing, see [5]. Can be
+        #          enabled one-fine-day (TM) but not now.
+        # ssbs:    "Speculative Store Bypass Safe". Optional in v8.0, mandatory in v8.5. Meltdown/spectre countermeasure.
+        # crypto:  SHA1, SHA256, AES. Optional in v8.0. In v8.4, further algorithms were added but it's still optional, see [6].
+        # dotprod: Scalar vector product (SDOT and UDOT instructions). Probably the most obscure extra flag with doubtful performance benefits
+        #          but it has been activated since always, so why not enable it. It's not 100% clear in which revision this flag was
+        #          introduced as optional, either in v8.2 [7] or in v8.4 [8].
         #
         # [1] https://github.com/aws/aws-graviton-getting-started/blob/main/c-c%2B%2B.md
         # [2] https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/making-the-most-of-the-arm-architecture-in-gcc-10
         # [3] https://mysqlonarm.github.io/ARM-LSE-and-MySQL/
         # [4] https://dev.to/aws-builders/large-system-extensions-for-aws-graviton-processors-3eci
-        set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=armv8.2-a+crc+simd+crypto+dotprod+ssbs")
+        # [5] https://developer.arm.com/tools-and-software/open-source-software/developer-tools/llvm-toolchain/sve-support
+        # [6] https://developer.arm.com/documentation/100067/0612/armclang-Command-line-Options/-mcpu?lang=en
+        # [7] https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+        # [8] https://developer.arm.com/documentation/102651/a/What-are-dot-product-intructions-
+        set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=armv8.2-a+simd+crypto+dotprod+ssbs")
     endif ()
 
 elseif (ARCH_PPC64LE)

--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -26,7 +26,9 @@ elseif (ARCH_AARCH64)
     option (NO_ARMV81_OR_HIGHER "Disable ARMv8.1 or higher on Aarch64 for maximum compatibility with older/embedded hardware." 0)
 
     if (NO_ARMV81_OR_HIGHER)
-        set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=armv8")
+        # In v8.0, crc32 is optional, in v8.1 it's mandatory. Enable it regardless as __crc32()* is used in lot's of places and even very
+        # old ARM CPUs support it.
+        set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=armv8+crc")
     else ()
         # ARMv8.2 is ancient but the baseline for Graviton 2 and 3 processors [1]. In particular, it includes LSE (first made mandatory with
         # ARMv8.1) which provides nice speedups without having to fall back to v8.0  "-moutline-atomics" compat flag [2, 3, 4] that imposes

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -128,6 +128,7 @@ def parse_env_variables(
     DARWIN_SUFFIX = "-darwin"
     DARWIN_ARM_SUFFIX = "-darwin-aarch64"
     ARM_SUFFIX = "-aarch64"
+    ARM_V80COMPAT_SUFFIX = "-aarch64-v80compat"
     FREEBSD_SUFFIX = "-freebsd"
     PPC_SUFFIX = "-ppc64le"
     AMD64_SSE2_SUFFIX = "-amd64sse2"
@@ -140,6 +141,7 @@ def parse_env_variables(
     is_cross_darwin = compiler.endswith(DARWIN_SUFFIX)
     is_cross_darwin_arm = compiler.endswith(DARWIN_ARM_SUFFIX)
     is_cross_arm = compiler.endswith(ARM_SUFFIX)
+    is_cross_arm_v80compat = compiler.endswith(ARM_V80COMPAT_SUFFIX)
     is_cross_ppc = compiler.endswith(PPC_SUFFIX)
     is_cross_freebsd = compiler.endswith(FREEBSD_SUFFIX)
     is_amd64_sse2 = compiler.endswith(AMD64_SSE2_SUFFIX)
@@ -177,6 +179,13 @@ def parse_env_variables(
         cmake_flags.append(
             "-DCMAKE_TOOLCHAIN_FILE=/build/cmake/linux/toolchain-aarch64.cmake"
         )
+        result.append("DEB_ARCH=arm64")
+    elif is_cross_arm_v80compat:
+        cc = compiler[: -len(ARM_V80COMPAT_SUFFIX)]
+        cmake_flags.append(
+            "-DCMAKE_TOOLCHAIN_FILE=/build/cmake/linux/toolchain-aarch64.cmake"
+        )
+        cmake_flags.append("-DNO_ARMV81_OR_HIGHER=1")
         result.append("DEB_ARCH=arm64")
     elif is_cross_freebsd:
         cc = compiler[: -len(FREEBSD_SUFFIX)]
@@ -343,6 +352,7 @@ if __name__ == "__main__":
             "clang-15-darwin",
             "clang-15-darwin-aarch64",
             "clang-15-aarch64",
+            "clang-15-aarch64-v80compat",
             "clang-15-ppc64le",
             "clang-15-amd64sse2",
             "clang-15-freebsd",

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -131,6 +131,15 @@ CI_CONFIG = {
             "tidy": "disable",
             "with_coverage": False,
         },
+        "binary_aarch64_v80compat": {
+            "compiler": "clang-15-aarch64-v80compat",
+            "build_type": "",
+            "sanitizer": "",
+            "package_type": "binary",
+            "libraries": "static",
+            "tidy": "disable",
+            "with_coverage": False,
+        },
         "binary_freebsd": {
             "compiler": "clang-15-freebsd",
             "build_type": "",
@@ -189,6 +198,7 @@ CI_CONFIG = {
             "binary_shared",
             "binary_darwin",
             "binary_aarch64",
+            "binary_aarch64_v80compat",
             "binary_freebsd",
             "binary_darwin_aarch64",
             "binary_ppc64le",


### PR DESCRIPTION
Goals of this PR:
- Enable ARM LSE instructions which showed promising performance results in #40509 (they were made mandatory with ARMv8.1)
- Provide binaries for users with old or embedded ARM hardware (e.g. #41155)
- Document extra ARM build flags

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Aarch64 binaries now require at least ARMv8.2, released in 2016. Most notably, this enables use of ARM LSE, i.e. native atomic operations. Also, CMake build option "NO_ARMV81_OR_HIGHER" has been added to allow compilation of binaries for older ARMv8.0 hardware, e.g. Raspberry Pi 4.