### PR TITLE
increase default max_suspicious_broken_parts to 100

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -84,7 +84,7 @@ struct Settings;
     M(Seconds, remote_fs_execute_merges_on_single_replica_time_threshold, 3 * 60 * 60, "When greater than zero only a single replica starts the merge immediately if merged part on shared storage and 'allow_remote_fs_zero_copy_replication' is enabled.", 0) \
     M(Seconds, try_fetch_recompressed_part_timeout, 7200, "Recompression works slow in most cases, so we don't start merge with recompression until this timeout and trying to fetch recompressed part from replica which assigned this merge with recompression.", 0) \
     M(Bool, always_fetch_merged_part, false, "If true, replica never merge parts and always download merged parts from other replicas.", 0) \
-    M(UInt64, max_suspicious_broken_parts, 10, "Max broken parts, if more - deny automatic deletion.", 0) \
+    M(UInt64, max_suspicious_broken_parts, 100, "Max broken parts, if more - deny automatic deletion.", 0) \
     M(UInt64, max_suspicious_broken_parts_bytes, 1ULL * 1024 * 1024 * 1024, "Max size of all broken parts, if more - deny automatic deletion.", 0) \
     M(UInt64, max_files_to_modify_in_alter_columns, 75, "Not apply ALTER if number of files for modification(deletion, addition) more than this.", 0) \
     M(UInt64, max_files_to_remove_in_alter_columns, 50, "Not apply ALTER, if number of files for deletion more than this.", 0) \


### PR DESCRIPTION
closes: https://github.com/ClickHouse/ClickHouse/issues/41423

We often see complaints about startup issue `Suspiciously many (12 parts, 0.00 B in total) broken parts to remove while maximum allowed broken parts count is 10` and in 100% cases it's because of an unexpected restart and files with 0 size or parts without half of files. The maximum number that I saw in public chats or from Altinity clients is 70 broken parts.

(it seems the modern hardware (ssd) + arbitrary partitioning allow to create a more parts per second than it was in 2016 when max_suspicious_broken_parts = 10 was good enough)

Personally I set max_suspicious_broken_parts = 100.

Anyway this behaviour is secured by `max_suspicious_broken_parts_bytes │ 1073741824`


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

