### PR TITLE
Optimize the lock contentions for ThreadGroupStatus::mutex

### DIFF
--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -350,7 +350,10 @@ void ThreadStatus::detachQuery(bool exit_if_already_detached, bool thread_exits)
 
     /// Avoid leaking of ThreadGroupStatus::finished_threads_counters_memory
     /// (this is in case someone uses system thread but did not call getProfileEventsCountersAndMemoryForThreads())
-    thread_group->getProfileEventsCountersAndMemoryForThreads();
+    {
+        std::lock_guard guard(thread_group->mutex);
+        auto stats = std::move(thread_group->finished_threads_counters_memory);
+    }
 
     thread_group.reset();
 


### PR DESCRIPTION
The release of ThreadGroupStatus::finished_threads_counters_memory via the getProfileEventsCountersAndMemoryForThreads method brings lots of lock contentions for ThreadGroupStatus::mutex and lowers the overall performance. This commit optimizes this performance issue by replacing the method call with an equivalent but more lightweight code block.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The performance experiments of **SSB** (Star Schema Benchmark) on the ICX device (Intel Xeon Platinum 8380 CPU, 80 cores, 160 threads) shows that this change could bring a **2.95x** improvement of the geomean of all subcases' QPS.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
