### PR TITLE
Resolve findings from clang-tidy

### DIFF
--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -316,8 +316,8 @@ size_t ColumnUnique<ColumnType>::getNullValueIndex() const
     return 0;
 }
 
-
-namespace
+template <typename ColumnType>
+size_t ColumnUnique<ColumnType>::uniqueInsert(const Field & x)
 {
     class FieldVisitorGetData : public StaticVisitor<>
     {
@@ -350,12 +350,7 @@ namespace
         void operator() (const DecimalField<Decimal256> & x) { res = {reinterpret_cast<const char *>(&x), sizeof(x)}; }
         void operator() (const bool & x) { res = {reinterpret_cast<const char *>(&x), sizeof(x)}; }
     };
-}
 
-
-template <typename ColumnType>
-size_t ColumnUnique<ColumnType>::uniqueInsert(const Field & x)
-{
     if (x.isNull())
         return getNullValueIndex();
 


### PR DESCRIPTION
The changes aim to resolve the following clang-tidy findings:
* do not use unnamed namespaces in header files
* destructor of 'ColumnString' is public and non-virtual

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)