### PR TITLE
Add interactive history search with fzf-like utility (fzf/sk) to clickhouse-client/local

### DIFF
--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -513,7 +513,7 @@ void ReplxxLineReader::openInteractiveHistorySearch()
     /// - SKIM_DEFAULT_OPTIONS
     /// - FZF_DEFAULT_OPTS
     std::string fuzzy_finder_command = fmt::format(
-        "{} --read0 --height=30% < {} > {}",
+        "{} --read0 --tac --no-sort --tiebreak=index --bind=ctrl-r:toggle-sort --height=30% < {} > {}",
         fuzzy_finder, history_file.getPath(), output_file.getPath());
     char * const argv[] = {sh, sh_c, fuzzy_finder_command.data(), nullptr};
 

--- a/base/base/ReplxxLineReader.h
+++ b/base/base/ReplxxLineReader.h
@@ -27,6 +27,7 @@ private:
     void addToHistory(const String & line) override;
     int executeEditor(const std::string & path);
     void openEditor();
+    void openInteractiveHistorySearch();
 
     replxx::Replxx rx;
     replxx::Replxx::highlighter_callback_t highlighter;

--- a/base/base/ReplxxLineReader.h
+++ b/base/base/ReplxxLineReader.h
@@ -37,4 +37,5 @@ private:
     bool bracketed_paste_enabled = false;
 
     std::string editor;
+    std::string fuzzy_finder;
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add interactive history search with fzf-like utility (fzf/sk) for `clickhouse-client`/`clickhouse-local` (note you can use `FZF_DEFAULT_OPTS`/`SKIM_DEFAULT_OPTIONS` to additionally configure the behavior)

First patch contains small refactoring to make the code cleaner.

And other two adds interactive navigation through history in `clickhouse-client`/`clickhouse-local` with [`fzf`](https://github.com/junegunn/fzf) and [`skim`](https://github.com/lotabout/skim)

[![asciicast](https://asciinema.org/a/523381.svg)](https://asciinema.org/a/523381)