### PR TITLE
Fix possible crash for SELECT from Merge table

### DIFF
--- a/src/Interpreters/MonotonicityCheckVisitor.h
+++ b/src/Interpreters/MonotonicityCheckVisitor.h
@@ -70,6 +70,9 @@ public:
             if (!pos)
                 return false;
 
+            if (*pos >= tables.size())
+                return false;
+
             if (auto data_type_and_name = tables[*pos].columns.tryGetByName(identifier->shortName()))
             {
                 arg_data_type = data_type_and_name->type;

--- a/src/Interpreters/MonotonicityCheckVisitor.h
+++ b/src/Interpreters/MonotonicityCheckVisitor.h
@@ -70,6 +70,9 @@ public:
             if (!pos)
                 return false;
 
+            /// It is possible that tables list is empty.
+            /// IdentifierSemantic get the position from AST, and it can be not valid to use it.
+            /// Example is re-analysing a part of AST for storage Merge, see 02147_order_by_optimizations.sql
             if (*pos >= tables.size())
                 return false;
 

--- a/tests/queries/0_stateless/02147_order_by_optimizations.sql
+++ b/tests/queries/0_stateless/02147_order_by_optimizations.sql
@@ -13,3 +13,7 @@ SET optimize_monotonous_functions_in_order_by = 1;
 EXPLAIN SYNTAX SELECT * FROM t_02147 ORDER BY toStartOfHour(date), v;
 EXPLAIN SYNTAX SELECT * FROM t_02147_dist ORDER BY toStartOfHour(date), v;
 EXPLAIN SYNTAX SELECT * FROM t_02147_merge ORDER BY toStartOfHour(date), v;
+
+drop table t_02147;
+CREATE TABLE t_02147 (date DateTime, v UInt32) ENGINE = MergeTree ORDER BY date;
+select *, toString(t.v) as s from t_02147_merge as t order by date, s;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible crash in `SELECT` from `Merge` table with enabled `optimize_monotonous_functions_in_order_by` setting. Fixes #41269