### PR TITLE
Make automatic download script choose between ARMv8.0 or ARMv8.2 builds

### DIFF
--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -12,7 +12,7 @@ then
         DIR="amd64"
     elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
     then
-        DIR="aarch64"
+        DIR="aarch64v80compat" # ARMv8.0 for maximum compatibility
     elif [ "${ARCH}" = "powerpc64le" -o "${ARCH}" = "ppc64le" ]
     then
         DIR="powerpc64le"
@@ -22,12 +22,6 @@ then
     if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
     then
         DIR="freebsd"
-    elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
-    then
-        DIR="freebsd-aarch64"
-    elif [ "${ARCH}" = "powerpc64le" -o "${ARCH}" = "ppc64le" ]
-    then
-        DIR="freebsd-powerpc64le"
     fi
 elif [ "${OS}" = "Darwin" ]
 then
@@ -42,7 +36,7 @@ fi
 
 if [ -z "${DIR}" ]
 then
-    echo "The '${OS}' operating system with the '${ARCH}' architecture is not supported."
+    echo "Operating system '${OS}' / architecture '${ARCH}' is unsupported."
     exit 1
 fi
 

--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -12,7 +12,16 @@ then
         DIR="amd64"
     elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
     then
-        DIR="aarch64v80compat" # ARMv8.0 for maximum compatibility
+        # If the system is >=ARMv8.2 (https://en.wikipedia.org/wiki/AArch64), choose the corresponding build, else fall back to a v8.0
+        # compat build. Unfortunately, 1. the ARM ISA level cannot be read directly, we need to guess from the "features" in /proc/cpuinfo,
+        # and 2. the flags in /proc/cpuinfo are named differently than the flags passed to the compiler (cmake/cpu_features.cmake).
+        ARMV82=$(grep -m 1 'Features' /proc/cpuinfo | awk '/asimd/ && /sha1/ && /aes/ && /atomics/')
+        if [ "${ARMV82}" ]
+        then
+            DIR="aarch64"
+        else
+            DIR="aarch64v80compat"
+        fi
     elif [ "${ARCH}" = "powerpc64le" -o "${ARCH}" = "ppc64le" ]
     then
         DIR="powerpc64le"

--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -12,9 +12,9 @@ then
         DIR="amd64"
     elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
     then
-        # If the system is >=ARMv8.2 (https://en.wikipedia.org/wiki/AArch64), choose the corresponding build, else fall back to a v8.0
-        # compat build. Unfortunately, 1. the ARM ISA level cannot be read directly, we need to guess from the "features" in /proc/cpuinfo,
-        # and 2. the flags in /proc/cpuinfo are named differently than the flags passed to the compiler (cmake/cpu_features.cmake).
+        # If the system has >=ARMv8.2 (https://en.wikipedia.org/wiki/AArch64), choose the corresponding build, else fall back to a v8.0
+        # compat build. Unfortunately, the ARM ISA level cannot be read directly, we need to guess from the "features" in /proc/cpuinfo.
+        # Also, the flags in /proc/cpuinfo are named differently than the flags passed to the compiler (cmake/cpu_features.cmake).
         ARMV82=$(grep -m 1 'Features' /proc/cpuinfo | awk '/asimd/ && /sha1/ && /aes/ && /atomics/')
         if [ "${ARMV82}" ]
         then

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -136,6 +136,7 @@ CI_CONFIG = {
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",
+            "static_binary_name": "aarch64v80compat",
             "libraries": "static",
             "tidy": "disable",
             "with_coverage": False,


### PR DESCRIPTION
- follow-up to #41610

- universal.sh now downloads the optimal ClickHouse binary for the current platform (either ARMv8.0 or ARMv8.2). Some guessing is done for that.

- Also add property static_binary_name (ci_config.py) so that the binary can be placed into the right location.

- Remove the unsupported combinations FreeBSD Aarch64 and PPC for which we provide no binaries.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)