### PR TITLE
Fix a bug that CORS headers are missing in some HTTP responses

### DIFF
--- a/tests/queries/0_stateless/02029_test_options_requests.reference
+++ b/tests/queries/0_stateless/02029_test_options_requests.reference
@@ -3,3 +3,8 @@
 < Access-Control-Allow-Headers: origin, x-requested-with
 < Access-Control-Allow-Methods: POST, GET, OPTIONS
 < Access-Control-Max-Age: 86400
+< HTTP/1.1 403 Forbidden
+< Access-Control-Allow-Origin: *
+< Access-Control-Allow-Headers: origin, x-requested-with
+< Access-Control-Allow-Methods: POST, GET, OPTIONS
+< Access-Control-Max-Age: 86400

--- a/tests/queries/0_stateless/02029_test_options_requests.sh
+++ b/tests/queries/0_stateless/02029_test_options_requests.sh
@@ -6,3 +6,6 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # grep all fields, that should be set for CORS support (see CORS.xml)
 $CLICKHOUSE_CURL "${CLICKHOUSE_URL}" -X OPTIONS -vs 2>&1 | grep -E "HTTP/1.1 204 No Content|Access-Control-Allow-Origin|Access-Control-Allow-Headers|Access-Control-Allow-Methods|Access-Control-Max-Age"
+
+# grep all fields, that should be set for CORS support (see CORS.xml)
+echo 'SELECT 1' | $CLICKHOUSE_CURL -X POST -H 'Origin: clickhouse-test' "${CLICKHOUSE_URL}&password=wrong_password" --data @- -vs 2>&1 | grep -E "HTTP/1.1 403 Forbidden|Access-Control-Allow-Origin|Access-Control-Allow-Headers|Access-Control-Allow-Methods|Access-Control-Max-Age"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a bug that CORS headers are missing in some HTTP responses

### Description

In current implementation, for HTTP POST requests, CORS headers are added after user authentication. If the authentication fails, the returned HTTP response has no CORS headers. This leads some front-end libs, such as axios, fail to process the response - they can't even get the http status nor the error message because the missed headers block them to do so.

To make the front-end projects correctly handle such 403 exceptions or in case of any exception raised before CORS headers are added, we need to make some adjustment to current CORS handling, that is adding these headers before a query is processed.

BTW, there is a very old setting `add_http_cors_header`, this setting does not work if the authentication fails. The contradiction is we can only get the user setting after the authentication but the CORS processing requires us to add headers before any processing.

Link to #29155 for better understanding.