### PR TITLE
Fix "While sending batch" error message is too long (on Distributed async send)

### DIFF
--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -819,10 +819,18 @@ struct StorageDistributedDirectoryMonitor::Batch
             }
             else
             {
-                std::vector<std::string> files(file_index_to_path.size());
+                std::vector<std::string> files;
                 for (const auto && file_info : file_index_to_path | boost::adaptors::indexed())
-                    files[file_info.index()] = file_info.value().second;
-                e.addMessage(fmt::format("While sending batch {}", fmt::join(files, "\n")));
+                {
+                    if (file_info.index() > 8)
+                    {
+                        files.push_back("...");
+                        break;
+                    }
+
+                    files.push_back(file_info.value().second);
+                }
+                e.addMessage(fmt::format("While sending batch, nums: {}, files: {}", file_index_to_path.size(), fmt::join(files, "\n")));
 
                 throw;
             }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When the batch sending fails for some reason, it cannot be automatically recovered, and if it is not processed in time, it will lead to accumulation, and the printed error message will become longer and longer, which will cause the http thread to block.


