### PR TITLE
Add function tryBase58Decode()

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -565,6 +565,10 @@ Result:
 └────────────────────────────┘
 ```
 
+## tryBase58Decode(s)
+
+Similar to base58Decode, but returns en empty string in case of error.
+
 ## base64Encode(s)
 
 Encodes ‘s’ string into base64
@@ -579,7 +583,7 @@ Alias: `FROM_BASE64`.
 
 ## tryBase64Decode(s)
 
-Similar to base64Decode, but in case of error an empty string would be returned.
+Similar to base64Decode, but returns an empty string in case of error.
 
 ## endsWith(s, suffix)
 

--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -567,7 +567,7 @@ Result:
 
 ## tryBase58Decode(s)
 
-Similar to base58Decode, but returns en empty string in case of error.
+Similar to base58Decode, but returns an empty string in case of error.
 
 ## base64Encode(s)
 

--- a/src/Common/Base58.cpp
+++ b/src/Common/Base58.cpp
@@ -1,4 +1,4 @@
-#include <Common/base58.h>
+#include <Common/Base58.h>
 
 
 namespace DB

--- a/src/Common/Base58.h
+++ b/src/Common/Base58.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Core/Types.h>
+#include <base/types.h>
 #include <optional>
 
 

--- a/src/Functions/FunctionBase58Conversion.h
+++ b/src/Functions/FunctionBase58Conversion.h
@@ -99,7 +99,8 @@ struct Base58Decode
             size_t current_src_offset = src_offsets[row];
             size_t src_length = current_src_offset - prev_src_offset - 1;
             std::optional<size_t> decoded_size = decodeBase58(&src[prev_src_offset], src_length, &dst[current_dst_offset]);
-            if (!decoded_size) {
+            if (!decoded_size)
+            {
                 if constexpr (ErrorHandling == Base58DecodeErrorHandling::ThrowException)
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid Base58 value, cannot be decoded");
                 else

--- a/src/Functions/FunctionBase58Conversion.h
+++ b/src/Functions/FunctionBase58Conversion.h
@@ -6,7 +6,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 #include <IO/WriteHelpers.h>
-#include <Common/base58.h>
+#include <Common/Base58.h>
 #include <cstring>
 
 
@@ -62,9 +62,16 @@ struct Base58Encode
     }
 };
 
+enum class Base58DecodeErrorHandling
+{
+    ThrowException,
+    ReturnEmptyString
+};
+
+template <typename Name, Base58DecodeErrorHandling ErrorHandling>
 struct Base58Decode
 {
-    static constexpr auto name = "base58Decode";
+    static constexpr auto name = Name::name;
 
     static void process(const ColumnString & src_column, ColumnString::MutablePtr & dst_column, size_t input_rows_count)
     {
@@ -92,8 +99,12 @@ struct Base58Decode
             size_t current_src_offset = src_offsets[row];
             size_t src_length = current_src_offset - prev_src_offset - 1;
             std::optional<size_t> decoded_size = decodeBase58(&src[prev_src_offset], src_length, &dst[current_dst_offset]);
-            if (!decoded_size)
-                throw Exception("Invalid Base58 value, cannot be decoded", ErrorCodes::BAD_ARGUMENTS);
+            if (!decoded_size) {
+                if constexpr (ErrorHandling == Base58DecodeErrorHandling::ThrowException)
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid Base58 value, cannot be decoded");
+                else
+                    decoded_size = 0;
+            }
 
             prev_src_offset = current_src_offset;
             current_dst_offset += *decoded_size;
@@ -113,33 +124,23 @@ class FunctionBase58Conversion : public IFunction
 public:
     static constexpr auto name = Func::name;
 
-    static FunctionPtr create(ContextPtr)
-    {
-        return std::make_shared<FunctionBase58Conversion>();
-    }
-
-    String getName() const override
-    {
-        return Func::name;
-    }
-
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionBase58Conversion>(); }
+    String getName() const override { return Func::name; }
     size_t getNumberOfArguments() const override { return 1; }
-
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
-
     bool useDefaultImplementationForConstants() const override { return true; }
-
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
         if (arguments.size() != 1)
-            throw Exception("Wrong number of arguments for function " + getName() + ":  1 expected.", ErrorCodes::BAD_ARGUMENTS);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Wrong number of arguments for function {}: 1 expected.", getName());
 
         if (!isString(arguments[0].type))
             throw Exception(
-                "Illegal type " + arguments[0].type->getName() + " of first argument of function " + getName() + ". Must be String.",
-                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of first argument of function {}. Must be String.",
+                arguments[0].type->getName(), getName());
 
         return std::make_shared<DataTypeString>();
     }
@@ -150,8 +151,9 @@ public:
         const ColumnString * input = checkAndGetColumn<ColumnString>(column_string.get());
         if (!input)
             throw Exception(
-                "Illegal column " + arguments[0].column->getName() + " of first argument of function " + getName() + ", must be String",
-                ErrorCodes::ILLEGAL_COLUMN);
+                ErrorCodes::ILLEGAL_COLUMN,
+                "Illegal column {} of first argument of function {}, must be String",
+                arguments[0].column->getName(), getName());
 
         auto dst_column = ColumnString::create();
 

--- a/src/Functions/FunctionBase64Conversion.h
+++ b/src/Functions/FunctionBase64Conversion.h
@@ -59,34 +59,22 @@ class FunctionBase64Conversion : public IFunction
 public:
     static constexpr auto name = Func::name;
 
-    static FunctionPtr create(ContextPtr)
-    {
-        return std::make_shared<FunctionBase64Conversion>();
-    }
-
-    String getName() const override
-    {
-        return Func::name;
-    }
-
-    size_t getNumberOfArguments() const override
-    {
-        return 1;
-    }
-
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionBase64Conversion>(); }
+    String getName() const override { return Func::name; }
+    size_t getNumberOfArguments() const override { return 1; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
-
-    bool useDefaultImplementationForConstants() const override
-    {
-        return true;
-    }
+    bool useDefaultImplementationForConstants() const override { return true; }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
+        if (arguments.size() != 1)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Wrong number of arguments for function {}: 1 expected.", getName());
+
         if (!WhichDataType(arguments[0].type).isString())
             throw Exception(
-                "Illegal type " + arguments[0].type->getName() + " of 1st argument of function " + getName() + ". Must be String.",
-                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of 1st argument of function {}. Must be String.",
+                arguments[0].type->getName(), getName());
 
         return std::make_shared<DataTypeString>();
     }
@@ -98,8 +86,9 @@ public:
 
         if (!input)
             throw Exception(
-                "Illegal column " + arguments[0].column->getName() + " of first argument of function " + getName() + ", must be of type String",
-                ErrorCodes::ILLEGAL_COLUMN);
+                ErrorCodes::ILLEGAL_COLUMN,
+                "Illegal column {} of first argument of function {}, must be of type String",
+                arguments[0].column->getName(), getName());
 
         auto dst_column = ColumnString::create();
         auto & dst_data = dst_column->getChars();
@@ -145,7 +134,10 @@ public:
 #endif
 
                     if (!outlen)
-                        throw Exception("Failed to " + getName() + " input '" + String(reinterpret_cast<const char *>(source), srclen) + "'", ErrorCodes::INCORRECT_DATA);
+                        throw Exception(
+                                ErrorCodes::INCORRECT_DATA,
+                                "Failed to {} input '{}'",
+                                getName(), String(reinterpret_cast<const char *>(source), srclen));
                 }
             }
             else

--- a/src/Functions/FunctionBase64Conversion.h
+++ b/src/Functions/FunctionBase64Conversion.h
@@ -19,6 +19,7 @@ using namespace GatherUtils;
 
 namespace ErrorCodes
 {
+    extern const int BAD_ARGUMENTS;
     extern const int ILLEGAL_COLUMN;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int INCORRECT_DATA;

--- a/src/Functions/base58Decode.cpp
+++ b/src/Functions/base58Decode.cpp
@@ -1,0 +1,24 @@
+#include <Functions/FunctionBase58Conversion.h>
+#include <Functions/FunctionFactory.h>
+
+namespace DB
+{
+namespace
+{
+
+struct NameBase58Decode
+{
+    static constexpr auto name = "base58Decode";
+};
+
+using Base58DecodeImpl = Base58Decode<NameBase58Decode, Base58DecodeErrorHandling::ThrowException>;
+using FunctionBase58Decode = FunctionBase58Conversion<Base58DecodeImpl>;
+
+}
+
+REGISTER_FUNCTION(Base58Decode)
+{
+    factory.registerFunction<FunctionBase58Decode>();
+}
+
+}

--- a/src/Functions/base58Encode.cpp
+++ b/src/Functions/base58Encode.cpp
@@ -7,9 +7,4 @@ REGISTER_FUNCTION(Base58Encode)
 {
     factory.registerFunction<FunctionBase58Conversion<Base58Encode>>();
 }
-
-REGISTER_FUNCTION(Base58Decode)
-{
-    factory.registerFunction<FunctionBase58Conversion<Base58Decode>>();
-}
 }

--- a/src/Functions/tryBase58Decode.cpp
+++ b/src/Functions/tryBase58Decode.cpp
@@ -1,0 +1,24 @@
+#include <Functions/FunctionBase58Conversion.h>
+#include <Functions/FunctionFactory.h>
+
+namespace DB
+{
+namespace
+{
+
+struct NameTryBase58Decode
+{
+    static constexpr auto name = "tryBase58Decode";
+};
+
+using TryBase58DecodeImpl = Base58Decode<NameTryBase58Decode, Base58DecodeErrorHandling::ReturnEmptyString>;
+using FunctionTryBase58Decode = FunctionBase58Conversion<TryBase58DecodeImpl>;
+
+}
+
+REGISTER_FUNCTION(TryBase58Decode)
+{
+    factory.registerFunction<FunctionTryBase58Decode>();
+}
+
+}

--- a/tests/queries/0_stateless/00732_base64_functions.sql
+++ b/tests/queries/0_stateless/00732_base64_functions.sql
@@ -1,8 +1,16 @@
 -- Tags: no-fasttest
 
 SET send_logs_level = 'fatal';
+
 SELECT base64Encode(val) FROM (select arrayJoin(['', 'f', 'fo', 'foo', 'foob', 'fooba', 'foobar']) val);
+
 SELECT base64Decode(val) FROM (select arrayJoin(['', 'Zg==', 'Zm8=', 'Zm9v', 'Zm9vYg==', 'Zm9vYmE=', 'Zm9vYmFy']) val);
 SELECT base64Decode(base64Encode('foo')) = 'foo', base64Encode(base64Decode('Zm9v')) == 'Zm9v';
+
 SELECT tryBase64Decode('Zm9vYmF=Zm9v');
+
+SELECT base64Encode(val, 'excess argument') FROM (select arrayJoin(['', 'f', 'fo', 'foo', 'foob', 'fooba', 'foobar']) val); -- { serverError 42 }
+SELECT base64Decode(val, 'excess argument') FROM (select arrayJoin(['', 'Zg==', 'Zm8=', 'Zm9v', 'Zm9vYg==', 'Zm9vYmE=', 'Zm9vYmFy']) val); -- { serverError 42 }
+SELECT tryBase64Decode('Zm9vYmF=Zm9v', 'excess argument'); -- { serverError 42 }
+
 SELECT base64Decode('Zm9vYmF=Zm9v'); -- { serverError 117 }

--- a/tests/queries/0_stateless/02337_base58.reference
+++ b/tests/queries/0_stateless/02337_base58.reference
@@ -8,6 +8,22 @@ fooba
 foobar
 Hello world!
 
+f
+fo
+foo
+foob
+fooba
+foobar
+Hello world!
+
+
+foob
+
+
+
+foobar
+
+
 2m
 8o8
 bQbp

--- a/tests/queries/0_stateless/02337_base58.sql
+++ b/tests/queries/0_stateless/02337_base58.sql
@@ -5,6 +5,8 @@ SELECT base58Encode('Hold my beer...', 'Second arg'); -- { serverError 42 }
 SELECT base58Decode('Hold my beer...'); -- { serverError 36 }
 
 SELECT base58Decode(encoded) FROM (SELECT base58Encode(val) as encoded FROM (select arrayJoin(['', 'f', 'fo', 'foo', 'foob', 'fooba', 'foobar', 'Hello world!']) val));
+SELECT tryBase58Decode(encoded) FROM (SELECT base58Encode(val) as encoded FROM (select arrayJoin(['', 'f', 'fo', 'foo', 'foob', 'fooba', 'foobar', 'Hello world!']) val));
+SELECT tryBase58Decode(val) FROM (SELECT arrayJoin(['Hold my beer', 'Hold another beer', '3csAg9', 'And a wine', 'And another wine', 'And a lemonade', 't1Zv2yaZ', 'And another wine']) val);
 
 SELECT base58Encode(val) FROM (select arrayJoin(['', 'f', 'fo', 'foo', 'foob', 'fooba', 'foobar']) val);
 SELECT base58Decode(val) FROM (select arrayJoin(['', '2m', '8o8', 'bQbp', '3csAg9', 'CZJRhmz', 't1Zv2yaZ', '']) val);

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -908,6 +908,7 @@ trimBoth
 trimLeft
 trimRight
 trunc
+tryBase58Decode
 tumble
 tumbleEnd
 tumbleStart

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.sql
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.sql
@@ -15,5 +15,5 @@ AND name NOT IN (
     'h3ToGeoBoundary', 'h3ToParent', 'h3ToString', 'h3UnidirectionalEdgeIsValid', 'h3kRing', 'stringToH3',
     'geoToS2', 's2CapContains', 's2CapUnion', 's2CellsIntersect', 's2GetNeighbors', 's2RectAdd', 's2RectContains', 's2RectIntersection', 's2RectUnion', 's2ToGeo',
     'normalizeUTF8NFC', 'normalizeUTF8NFD', 'normalizeUTF8NFKC', 'normalizeUTF8NFKD',
-    'lemmatize', 'tokenize', 'stem', 'synonyms'
+    'lemmatize', 'tokenize', 'stem', 'synonyms' -- these functions are not enabled in fast test
 ) ORDER BY name;


### PR DESCRIPTION
- makes it consistent with `tryBase64Decode()`

- follow-up to #39292

- further minor changes:

  - rename Common/base58.(h|cpp) to Common/Base58.(h|cpp) for constency with Common/Base64.(h|cpp)

  - check that (encode|decode|tryDecode)Base64() is passed just one argument

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add function "tryBase58Decode()", similar to the existing function "tryBase64Decode()"