### PR TITLE
Increase `request_timeout_ms` for s3 tests in CI

### DIFF
--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -8,6 +8,7 @@
                 <endpoint>http://localhost:11111/test/00170_test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
+                <request_timeout_ms>20000</request_timeout_ms>
             </s3_disk>
             <s3_disk_2>
                 <type>s3</type>
@@ -15,6 +16,7 @@
                 <endpoint>http://localhost:11111/test/00170_test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
+                <request_timeout_ms>20000</request_timeout_ms>
             </s3_disk_2>
             <s3_disk_3>
                 <type>s3</type>
@@ -22,6 +24,7 @@
                 <endpoint>http://localhost:11111/test/00170_test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
+                <request_timeout_ms>20000</request_timeout_ms>
             </s3_disk_3>
             <s3_disk_4>
                 <type>s3</type>
@@ -29,6 +32,7 @@
                 <endpoint>http://localhost:11111/test/00170_test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
+                <request_timeout_ms>20000</request_timeout_ms>
             </s3_disk_4>
             <s3_disk_5>
                 <type>s3</type>
@@ -36,6 +40,7 @@
                 <endpoint>http://localhost:11111/test/00170_test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
+                <request_timeout_ms>20000</request_timeout_ms>
             </s3_disk_5>
             <s3_disk_6>
                 <type>s3</type>
@@ -43,6 +48,7 @@
                 <endpoint>http://localhost:11111/test/00170_test/</endpoint>
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
+                <request_timeout_ms>20000</request_timeout_ms>
             </s3_disk_6>
             <!-- cache for s3 disks -->
             <s3_cache>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Previous value was 5000:
https://github.com/ClickHouse/ClickHouse/blob/cb530fa54c822409d8feb85707c1d341d4f6ea92/src/Disks/ObjectStorages/S3/diskSettings.cpp#L127-L128