### PR TITLE
Fix cgroups for recent systemd

### DIFF
--- a/tests/ci/worker/ubuntu_ami_for_ci.sh
+++ b/tests/ci/worker/ubuntu_ami_for_ci.sh
@@ -24,6 +24,11 @@ runner_arch() {
   esac
 }
 
+# We have test for cgroups, and it's broken with cgroups v2
+# Ubuntu 22.04 has it enabled by default
+sed -r '/GRUB_CMDLINE_LINUX=/ s/"(.*)"/"\1 systemd.unified_cgroup_hierarchy=0"/' -i /etc/default/grub
+update-grub
+
 apt-get update
 
 apt-get install --yes --no-install-recommends \


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
After updating runners to 22.04 cgroups stopped to work in privileged mode, here's the issue https://github.com/moby/moby/issues/42275#issuecomment-1115055846


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
