### PR TITLE
Infer Object type only when allow_experimental_object_type is enabled

### DIFF
--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -100,6 +100,7 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.json.try_infer_numbers_from_strings = settings.input_format_json_try_infer_numbers_from_strings;
     format_settings.json.validate_types_from_metadata = settings.input_format_json_validate_types_from_metadata;
     format_settings.json.validate_utf8 = settings.output_format_json_validate_utf8;
+    format_settings.json.try_infer_objects = context->getSettingsRef().allow_experimental_object_type;
     format_settings.null_as_default = settings.input_format_null_as_default;
     format_settings.decimal_trailing_zeros = settings.output_format_decimal_trailing_zeros;
     format_settings.parquet.row_group_size = settings.output_format_parquet_row_group_size;

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -153,6 +153,7 @@ struct FormatSettings
         bool try_infer_numbers_from_strings = false;
         bool validate_types_from_metadata = true;
         bool validate_utf8 = false;
+        bool try_infer_objects = false;
     } json;
 
     struct

--- a/src/Formats/JSONUtils.cpp
+++ b/src/Formats/JSONUtils.cpp
@@ -225,7 +225,7 @@ namespace JSONUtils
                 if (!type)
                     continue;
 
-                if (isObject(type))
+                if (settings.json.try_infer_objects && isObject(type))
                     return std::make_shared<DataTypeObject>("json", true);
 
                 value_types.push_back(type);
@@ -240,7 +240,11 @@ namespace JSONUtils
                 are_types_equal &= value_types[i]->equals(*value_types[0]);
 
             if (!are_types_equal)
+            {
+                if (!settings.json.try_infer_objects)
+                    return nullptr;
                 return std::make_shared<DataTypeObject>("json", true);
+            }
 
             return std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(), value_types[0]);
         }

--- a/tests/queries/0_stateless/01825_type_json_schema_inference.sh
+++ b/tests/queries/0_stateless/01825_type_json_schema_inference.sh
@@ -19,7 +19,8 @@ filename="${user_files_path}/${CLICKHOUSE_TEST_UNIQUE_NAME}/data.json"
 echo '{"id": 1, "obj": {"k1": 1, "k2": {"k3": 2, "k4": [{"k5": 3}, {"k5": 4}]}}, "s": "foo"}' > $filename
 echo '{"id": 2, "obj": {"k2": {"k3": "str", "k4": [{"k6": 55}]}, "some": 42}, "s": "bar"}' >> $filename
 
-${CLICKHOUSE_CLIENT} -q "INSERT INTO t_json_inference SELECT * FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data.json', 'JSONEachRow')"
+${CLICKHOUSE_CLIENT} -q "INSERT INTO t_json_inference SELECT * FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data.json', 'JSONEachRow')" --allow_experimental_object_type 1
+
 ${CLICKHOUSE_CLIENT} -q "SELECT * FROM t_json_inference FORMAT JSONEachRow" --output_format_json_named_tuples_as_objects 1
 ${CLICKHOUSE_CLIENT} -q "SELECT toTypeName(obj) FROM t_json_inference LIMIT 1"
 
@@ -30,7 +31,7 @@ ${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_json_inference (id UInt64, obj String, s
 echo '{"obj": "aaa", "id": 1, "s": "foo"}' > $filename
 echo '{"id": 2, "obj": "bbb", "s": "bar"}' >> $filename
 
-${CLICKHOUSE_CLIENT} -q "INSERT INTO t_json_inference SELECT * FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data.json', 'JSONEachRow')"
+${CLICKHOUSE_CLIENT} -q "INSERT INTO t_json_inference SELECT * FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data.json', 'JSONEachRow')" --allow_experimental_object_type 1
 ${CLICKHOUSE_CLIENT} -q "SELECT * FROM t_json_inference FORMAT JSONEachRow" --output_format_json_named_tuples_as_objects 1
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_inference"
@@ -38,14 +39,14 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_inference"
 echo '{"map": {"k1": 1, "k2": 2}, "obj": {"k1": 1, "k2": {"k3": 2}}}' > $filename
 
 ${CLICKHOUSE_CLIENT} -q "SELECT map, obj, toTypeName(map) AS map_type, toTypeName(obj) AS obj_type \
-    FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data.json', 'JSONEachRow') FORMAT JSONEachRow" --output_format_json_named_tuples_as_objects 1
+    FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data.json', 'JSONEachRow') FORMAT JSONEachRow" --output_format_json_named_tuples_as_objects 1 --allow_experimental_object_type 1
 
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_json_inference (obj JSON, map Map(String, UInt64)) \
     ENGINE = MergeTree ORDER BY tuple()" --allow_experimental_object_type 1
 
 echo '{"map": {"k1": 1, "k2": 2}, "obj": {"k1": 1, "k2": 2}}' > $filename
 
-${CLICKHOUSE_CLIENT} -q "INSERT INTO t_json_inference SELECT * FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data.json', 'JSONEachRow')"
+${CLICKHOUSE_CLIENT} -q "INSERT INTO t_json_inference SELECT * FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/data.json', 'JSONEachRow')" --allow_experimental_object_type 1
 ${CLICKHOUSE_CLIENT} -q "SELECT * FROM t_json_inference FORMAT JSONEachRow" --output_format_json_named_tuples_as_objects 1
 ${CLICKHOUSE_CLIENT} -q "SELECT toTypeName(obj) FROM t_json_inference LIMIT 1"
 

--- a/tests/queries/0_stateless/02268_json_maps_and_objects.sql
+++ b/tests/queries/0_stateless/02268_json_maps_and_objects.sql
@@ -1,4 +1,5 @@
 -- Tags: no-fasttest
+set allow_experimental_object_type=1;
 desc format(JSONEachRow, '{"x" : {"a" : "Some string"}}, {"x" : {"b" : [1, 2, 3]}}, {"x" : {"c" : {"d" : 10}}}');
 desc format(JSONEachRow, '{"x" : {"a" : "Some string"}}, {"x" : {"b" : [1, 2, 3], "c" : {"42" : 42}}}');
 desc format(JSONEachRow, '{"x" : [{"a" : "Some string"}]}, {"x" : [{"b" : [1, 2, 3]}]}');

--- a/tests/queries/0_stateless/02326_numbers_from_json_strings_schema_inference.sql
+++ b/tests/queries/0_stateless/02326_numbers_from_json_strings_schema_inference.sql
@@ -1,6 +1,7 @@
 -- Tags: no-fasttest
 
 set input_format_json_try_infer_numbers_from_strings=1;
+set allow_experimental_object_type=1;
 
 desc format(JSONEachRow, '{"x" : "123"}');
 desc format(JSONEachRow, '{"x" : ["123", 123, 12.3]}');

--- a/tests/queries/0_stateless/02416_json_object_inference.sql
+++ b/tests/queries/0_stateless/02416_json_object_inference.sql
@@ -1,2 +1,6 @@
 -- Tags: no-fasttest
+set allow_experimental_object_type=1;
 desc format(JSONEachRow, '{"a" : {"b" : {"c" : 1, "d" : "str"}}}');
+set allow_experimental_object_type=0;
+desc format(JSONEachRow, '{"a" : {"b" : {"c" : 1, "d" : "str"}}}'); -- {serverError 652}
+


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

