### PR TITLE
Fix backward incompatibility in Replicated database creation

### DIFF
--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -366,7 +366,7 @@ bool DatabaseReplicated::looksLikeReplicatedDatabasePath(const ZooKeeperPtr & cu
         return false;
     if (maybe_database_mark.starts_with(REPLICATED_DATABASE_MARK))
         return true;
-    if (maybe_database_mark.empty())
+    if (!maybe_database_mark.empty())
         return false;
 
     /// Old versions did not have REPLICATED_DATABASE_MARK. Check specific nodes exist and add mark.


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Old versions of Replicated database doesn't have a special marker in [Zoo]Keeper. We need to check only whether the node contains come obscure data instead of special mark.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
