### PR TITLE
Docs: Remove obsolete modelEvaluate() mention

### DIFF
--- a/docs/en/sql-reference/functions/other-functions.md
+++ b/docs/en/sql-reference/functions/other-functions.md
@@ -1818,11 +1818,6 @@ Result:
 └──────────────────────────────────────────────────┘
 ```
 
-## modelEvaluate(model_name, …)
-
-Evaluate external model.
-Accepts a model name and model arguments. Returns Float64.
-
 ## catboostEvaluate(path_to_model, feature_1, feature_2, …, feature_n)
 
 Evaluate external catboost model. [CatBoost](https://catboost.ai) is an open-source gradient boosting library developed by Yandex for machine learing.

--- a/docs/ru/sql-reference/functions/other-functions.md
+++ b/docs/ru/sql-reference/functions/other-functions.md
@@ -1722,12 +1722,6 @@ SELECT joinGet(db_test.id_val,'val',toUInt32(number)) from numbers(4) SETTINGS j
 └──────────────────────────────────────────────────┘
 ```
 
-## modelEvaluate(model_name, …) {#function-modelevaluate}
-
-Оценивает внешнюю модель.
-
-Принимает на вход имя и аргументы модели. Возвращает Float64.
-
 ## throwIf(x\[, message\[, error_code\]\]) {#throwifx-custom-message}
 
 Бросает исключение, если аргумент не равен нулю.

--- a/docs/zh/sql-reference/functions/other-functions.md
+++ b/docs/zh/sql-reference/functions/other-functions.md
@@ -625,11 +625,6 @@ ORDER BY k ASC
 
 使用指定的连接键从Join类型引擎的表中获取数据。
 
-## modelEvaluate(model_name, …) {#function-modelevaluate}
-
-使用外部模型计算。
-接受模型的名称以及模型的参数。返回Float64类型的值。
-
 ## throwIf(x) {#throwifx}
 
 如果参数不为零则抛出异常。


### PR DESCRIPTION
Removes a documentation leftover from the recent `modelEvaluate()`-to-`catboostEvaluate()` transition.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)