### PR TITLE
Better exception message for duplicate column names in schema inference

### DIFF
--- a/src/Processors/Formats/ISchemaReader.cpp
+++ b/src/Processors/Formats/ISchemaReader.cpp
@@ -134,7 +134,7 @@ NamesAndTypesList IRowSchemaReader::readSchema()
     }
     else
     {
-        std::unordered_set<String> names_set;
+        std::unordered_set<std::string_view> names_set;
         for (const auto & name : column_names)
         {
             if (names_set.contains(name))
@@ -253,7 +253,7 @@ NamesAndTypesList IRowWithNamesSchemaReader::readSchema()
             /// We reached eof.
             break;
 
-        std::unordered_set<String> names_set; /// We should check for duplicate column names in current row
+        std::unordered_set<std::string_view> names_set; /// We should check for duplicate column names in current row
         for (auto & [name, new_type] : new_names_and_types)
         {
             if (names_set.contains(name))

--- a/src/Processors/Formats/ISchemaReader.cpp
+++ b/src/Processors/Formats/ISchemaReader.cpp
@@ -132,6 +132,16 @@ NamesAndTypesList IRowSchemaReader::readSchema()
             ErrorCodes::INCORRECT_DATA,
             "The number of column names {} differs with the number of types {}", column_names.size(), data_types.size());
     }
+    else
+    {
+        std::unordered_set<String> names_set;
+        for (const auto & name : column_names)
+        {
+            if (names_set.contains(name))
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Duplicate column name found while schema inference: \"{}\"", name);
+            names_set.insert(name);
+        }
+    }
 
     for (size_t i = 0; i != column_names.size(); ++i)
     {
@@ -224,6 +234,9 @@ NamesAndTypesList IRowWithNamesSchemaReader::readSchema()
     names_order.reserve(names_and_types.size());
     for (const auto & [name, type] : names_and_types)
     {
+        if (names_to_types.contains(name))
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Duplicate column name found while schema inference: \"{}\"", name);
+
         auto hint_it = hints.find(name);
         if (hint_it != hints.end())
             names_to_types[name] = hint_it->second;
@@ -240,8 +253,13 @@ NamesAndTypesList IRowWithNamesSchemaReader::readSchema()
             /// We reached eof.
             break;
 
+        std::unordered_set<String> names_set; /// We should check for duplicate column names in current row
         for (auto & [name, new_type] : new_names_and_types)
         {
+            if (names_set.contains(name))
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Duplicate column name found while schema inference: \"{}\"", name);
+            names_set.insert(name);
+
             auto it = names_to_types.find(name);
             /// If we didn't see this column before, just add it.
             if (it == names_to_types.end())

--- a/tests/queries/0_stateless/02455_duplicate_column_names_in_schema_inference.sql
+++ b/tests/queries/0_stateless/02455_duplicate_column_names_in_schema_inference.sql
@@ -1,0 +1,5 @@
+desc format(JSONEachRow, '{"x" : 1, "x" : 2}'); -- {serverError INCORRECT_DATA}
+desc format(JSONEachRow, '{"x" : 1, "y" : 2}\n{"x" : 2, "x" : 3}'); -- {serverError INCORRECT_DATA}
+desc format(CSVWithNames, 'a,b,a\n1,2,3'); -- {serverError INCORRECT_DATA}
+desc format(CSV, '1,2,3') settings column_names_for_schema_inference='a, b, a'; -- {serverError INCORRECT_DATA}
+

--- a/tests/queries/0_stateless/02455_duplicate_column_names_in_schema_inference.sql
+++ b/tests/queries/0_stateless/02455_duplicate_column_names_in_schema_inference.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 desc format(JSONEachRow, '{"x" : 1, "x" : 2}'); -- {serverError INCORRECT_DATA}
 desc format(JSONEachRow, '{"x" : 1, "y" : 2}\n{"x" : 2, "x" : 3}'); -- {serverError INCORRECT_DATA}
 desc format(CSVWithNames, 'a,b,a\n1,2,3'); -- {serverError INCORRECT_DATA}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)