### PR TITLE
Reduce verbosity of part fetcher

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -613,11 +613,11 @@ MergeTreeData::MutableDataPartPtr Fetcher::fetchSelectedPart(
     if (!disk)
     {
         disk = reservation->getDisk();
-        LOG_INFO(log, "Disk for fetch is not provided, getting disk from reservation {} with type {}", disk->getName(), toString(disk->getDataSourceDescription().type));
-    }
-    else
-    {
-        LOG_INFO(log, "Disk for fetch is disk {} with type {}", disk->getName(), toString(disk->getDataSourceDescription().type));
+        LOG_TRACE(
+            log,
+            "Disk for fetch is not provided, getting disk from reservation {} with type {}",
+            disk->getName(),
+            toString(disk->getDataSourceDescription().type));
     }
 
     UInt64 revision = parse<UInt64>(in->getResponseCookie("disk_revision", "0"));


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Note that I've removed the else part since the same information was logged already in that case.

Reduces the verbosity of the fetcher because right now the logs are filled with INFO messages like:
```
2022.09.28 12:38:32.387944 [ 55 ] {} <Information> public.t_d54105846e494ab7a5c234be76b3d3bc (1d04c102-ad3a-4b3c-b355-e5d8b92c2206) (Fetcher): Disk for fetch is not provided, getting disk from reservation default with type local
2022.09.28 12:38:32.427049 [ 49 ] {} <Information> public.t_d54105846e494ab7a5c234be76b3d3bc (1d04c102-ad3a-4b3c-b355-e5d8b92c2206) (Fetcher): Disk for fetch is not provided, getting disk from reservation default with type local
2022.09.28 12:38:32.455140 [ 52 ] {} <Information> public.t_a547e801d17b4eb1ab34e2a303657373 (eadf1743-9f25-4c7e-8b37-b6ba0cbf1e47) (Fetcher): Disk for fetch is not provided, getting disk from reservation default with type local
2022.09.28 12:38:32.456982 [ 53 ] {} <Information> public.t_487860db4eb84e468d62929845703e97 (cf89e408-654b-4d79-8a37-fdb74e6b67b4) (Fetcher): Disk for fetch is not provided, getting disk from reservation default with type local
2022.09.28 12:38:32.463460 [ 54 ] {} <Information> d_57fc85.t_5c49110b51044a6b93e7b51243b7ebc7 (c846079e-d96c-4586-8a40-9db6bb494869) (Fetcher): Disk for fetch is not provided, getting disk from reservation minio with type s3
2022.09.28 12:38:32.470901 [ 51 ] {} <Information> d_57fc85.t_5c49110b51044a6b93e7b51243b7ebc7 (c846079e-d96c-4586-8a40-9db6bb494869) (Fetcher): Disk for fetch is not provided, getting disk from reservation minio with type s3
2022.09.28 12:38:32.484394 [ 50 ] {} <Information> public.t_d54105846e494ab7a5c234be76b3d3bc (1d04c102-ad3a-4b3c-b355-e5d8b92c2206) (Fetcher): Disk for fetch is not provided, getting disk from reservation default with type local
2022.09.28 12:38:32.485735 [ 55 ] {} <Information> d_57fc85.t_5c49110b51044a6b93e7b51243b7ebc7 (c846079e-d96c-4586-8a40-9db6bb494869) (Fetcher): Disk for fetch is not provided, getting disk from reservation minio with type s3
2022.09.28 12:38:32.492112 [ 49 ] {} <Information> public.t_a99801bea65b465489f7b08d54e3a4a3 (b55a0715-f4cb-48a7-9526-08b3cea06dd6) (Fetcher): Disk for fetch is not provided, getting disk from reservation default with type local
2022.09.28 12:38:32.496094 [ 52 ] {} <Information> public.t_a360285b62f74ddd99ad9f3b34f3b359 (0896086c-c948-47bd-98fa-421bcb4192f9) (Fetcher): Disk for fetch is not provided, getting disk from reservation default with type local
2022.09.28 12:38:32.498462 [ 53 ] {} <Information> d_57fc85.t_5c49110b51044a6b93e7b51243b7ebc7 (c846079e-d96c-4586-8a40-9db6bb494869) (Fetcher): Disk for fetch is not provided, getting disk from reservation minio with type s3
2022.09.28 12:38:32.501601 [ 48 ] {} <Information> d_57fc85.t_5c49110b51044a6b93e7b51243b7ebc7 (c846079e-d96c-4586-8a40-9db6bb494869) (Fetcher): Disk for fetch is not provided, getting disk from reservation minio with type s3
2022.09.28 12:38:32.538140 [ 52 ] {} <Information> public.t_d54105846e494ab7a5c234be76b3d3bc (1d04c102-ad3a-4b3c-b355-e5d8b92c2206) (Fetcher): Disk for fetch is not provided, getting disk from reservation default with type local
2022.09.28 12:38:32.553313 [ 49 ] {} <Information> d_57fc85.t_5c49110b51044a6b93e7b51243b7ebc7 (c846079e-d96c-4586-8a40-9db6bb494869) (Fetcher): Disk for fetch is not provided, getting disk from reservation minio with type s3
```

In the (near) future I'd like to also review the trace logs to keep only those that provide actual information, as otherwise activating trace (for monitor CI) with s3 disks seems madness.
