### PR TITLE
Make LDAPR a prerequisite for downloading the ARMv8.2 build

### DIFF
--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -15,7 +15,7 @@ then
         # If the system has >=ARMv8.2 (https://en.wikipedia.org/wiki/AArch64), choose the corresponding build, else fall back to a v8.0
         # compat build. Unfortunately, the ARM ISA level cannot be read directly, we need to guess from the "features" in /proc/cpuinfo.
         # Also, the flags in /proc/cpuinfo are named differently than the flags passed to the compiler (cmake/cpu_features.cmake).
-        ARMV82=$(grep -m 1 'Features' /proc/cpuinfo | awk '/asimd/ && /sha1/ && /aes/ && /atomics/')
+        ARMV82=$(grep -m 1 'Features' /proc/cpuinfo | awk '/asimd/ && /sha1/ && /aes/ && /atomics/ && /lrcpc/')
         if [ "${ARMV82}" ]
         then
             DIR="aarch64"


### PR DESCRIPTION
The ARMv8.2 build now requires presence of LDAPR instructions. Make the same assumption in `universal.sh` (= the automatic download script).

See https://github.com/ClickHouse/ClickHouse/pull/41778#discussion_r980136159

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)