### PR TITLE
Another sync replicas in test_recovery_replica

### DIFF
--- a/tests/integration/test_recovery_replica/test.py
+++ b/tests/integration/test_recovery_replica/test.py
@@ -196,7 +196,7 @@ def test_update_metadata(start_cluster):
 
     node1.query("ALTER TABLE update_metadata MODIFY COLUMN col1 String")
     node1.query("ALTER TABLE update_metadata ADD COLUMN col2 INT")
-    sync_replicas("update_metadata")
+    node3.query("SYSTEM SYNC REPLICA update_metadata")
     for i in range(1, 11):
         node3.query(
             "INSERT INTO update_metadata VALUES ({}, '{}', {})".format(

--- a/tests/integration/test_recovery_replica/test.py
+++ b/tests/integration/test_recovery_replica/test.py
@@ -196,6 +196,7 @@ def test_update_metadata(start_cluster):
 
     node1.query("ALTER TABLE update_metadata MODIFY COLUMN col1 String")
     node1.query("ALTER TABLE update_metadata ADD COLUMN col2 INT")
+    sync_replicas("update_metadata")
     for i in range(1, 11):
         node3.query(
             "INSERT INTO update_metadata VALUES ({}, '{}', {})".format(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Occasional fail in test - we need to sync replicas after ALTER TABLE
https://s3.amazonaws.com/clickhouse-test-reports/41743/ff8c74800d261d0659a179c6924bf9d8042e7e2b/integration_tests__release__[2/2].html
