### PR TITLE
Better logging for docs builder

### DIFF
--- a/docker/docs/builder/run.sh
+++ b/docker/docs/builder/run.sh
@@ -25,6 +25,7 @@ done
 sed -i '/onBrokenMarkdownLinks:/ s/ignore/error/g' docusaurus.config.js
 
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
+  export CI=true 
   exec yarn build "$@"
 fi
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
CI=true is not pushed from github actions inside container, so it can use some fancy console output formats which may accidentally suppress the docusaurus output, making the real error not visible in CI report (see https://github.com/ClickHouse/ClickHouse/pull/41254#issuecomment-1259275622 )

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
