### PR TITLE
Fix after #41508

### DIFF
--- a/src/Parsers/ParserDescribeCacheQuery.cpp
+++ b/src/Parsers/ParserDescribeCacheQuery.cpp
@@ -11,11 +11,12 @@ bool ParserDescribeCacheQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
 {
     ParserKeyword p_describe("DESCRIBE");
     ParserKeyword p_desc("DESC");
-    ParserKeyword p_cache("FILESYSTEM CACHE");
+    ParserKeyword p_filesystem("FILESYSTEM");
+    ParserKeyword p_cache("CACHE");
     ParserLiteral p_cache_name;
 
     if ((!p_describe.ignore(pos, expected) && !p_desc.ignore(pos, expected))
-        || !p_cache.ignore(pos, expected))
+        || !p_filesystem.ignore(pos, expected) || !p_cache.ignore(pos, expected))
         return false;
 
     auto query = std::make_shared<ASTDescribeCacheQuery>();

--- a/src/Parsers/ParserShowTablesQuery.cpp
+++ b/src/Parsers/ParserShowTablesQuery.cpp
@@ -24,7 +24,8 @@ bool ParserShowTablesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     ParserKeyword s_clusters("CLUSTERS");
     ParserKeyword s_cluster("CLUSTER");
     ParserKeyword s_dictionaries("DICTIONARIES");
-    ParserKeyword s_caches("FILESYSTEM CACHES");
+    ParserKeyword s_filesystem("FILESYSTEM");
+    ParserKeyword s_caches("CACHES");
     ParserKeyword s_settings("SETTINGS");
     ParserKeyword s_changed("CHANGED");
     ParserKeyword s_from("FROM");
@@ -92,7 +93,7 @@ bool ParserShowTablesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
                 return false;
         }
     }
-    else if (s_caches.ignore(pos, expected))
+    else if (s_filesystem.ignore(pos, expected) && s_caches.ignore(pos, expected))
     {
         query->caches = true;
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fix after https://github.com/ClickHouse/ClickHouse/pull/41508.

It went unnoticed because surprisingly the test (which checks this cases) works in case queries are executed from client when passed to stdin from file as it is done in clickhouse-test, but not in any other case.

Not for changelog because it is broken only in master.