### PR TITLE
Proper separation of AST normalization and AST optimization

### DIFF
--- a/src/Interpreters/FuseSumCountAggregatesVisitor.h
+++ b/src/Interpreters/FuseSumCountAggregatesVisitor.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <unordered_map>
+#include <Interpreters/InDepthNodeVisitor.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
+
+namespace DB
+{
+
+struct FuseSumCountAggregates
+{
+    std::vector<ASTFunction *> sums{};
+    std::vector<ASTFunction *> counts{};
+    std::vector<ASTFunction *> avgs{};
+
+    void addFuncNode(ASTFunction * func)
+    {
+        if (func->name == "sum")
+            sums.push_back(func);
+        else if (func->name == "count")
+            counts.push_back(func);
+        else
+        {
+            assert(func->name == "avg");
+            avgs.push_back(func);
+        }
+    }
+
+    bool canBeFused() const
+    {
+        /// Need at least two different kinds of functions to fuse.
+        if (sums.empty() && counts.empty())
+            return false;
+        if (sums.empty() && avgs.empty())
+            return false;
+        if (counts.empty() && avgs.empty())
+            return false;
+        return true;
+    }
+};
+
+struct FuseSumCountAggregatesVisitorData
+{
+    using TypeToVisit = ASTFunction;
+
+    std::unordered_map<String, FuseSumCountAggregates> fuse_map;
+
+    void visit(ASTFunction & func, ASTPtr &)
+    {
+        if (func.name == "sum" || func.name == "avg" || func.name == "count")
+        {
+            if (func.arguments->children.empty())
+                return;
+
+            /// Probably we can extend it to match count() for non-nullable argument
+            /// to sum/avg with any other argument. Now we require strict match.
+            const auto argument = func.arguments->children.at(0)->getColumnName();
+            auto it = fuse_map.find(argument);
+            if (it != fuse_map.end())
+            {
+                it->second.addFuncNode(&func);
+            }
+            else
+            {
+                FuseSumCountAggregates funcs{};
+                funcs.addFuncNode(&func);
+                fuse_map[argument] = funcs;
+            }
+        }
+    }
+
+    /// Replaces one avg/sum/count function with an appropriate expression with sumCount().
+    static void replaceWithSumCount(String column_name, ASTFunction & func)
+    {
+        auto func_base = makeASTFunction("sumCount", std::make_shared<ASTIdentifier>(column_name));
+        auto exp_list = std::make_shared<ASTExpressionList>();
+        if (func.name == "sum" || func.name == "count")
+        {
+            /// Rewrite "sum" to sumCount().1, rewrite "count" to sumCount().2
+            UInt8 idx = (func.name == "sum" ? 1 : 2);
+            func.name = "tupleElement";
+            exp_list->children.push_back(func_base);
+            exp_list->children.push_back(std::make_shared<ASTLiteral>(idx));
+        }
+        else
+        {
+            /// Rewrite "avg" to sumCount().1 / sumCount().2
+            auto new_arg1 = makeASTFunction("tupleElement", func_base, std::make_shared<ASTLiteral>(UInt8(1)));
+            auto new_arg2 = makeASTFunction(
+                "CAST",
+                makeASTFunction("tupleElement", func_base, std::make_shared<ASTLiteral>(static_cast<UInt8>(2))),
+                std::make_shared<ASTLiteral>("Float64"));
+
+            func.name = "divide";
+            exp_list->children.push_back(new_arg1);
+            exp_list->children.push_back(new_arg2);
+        }
+        func.arguments = exp_list;
+        func.children.push_back(func.arguments);
+    }
+};
+
+using FuseSumCountAggregatesVisitor = InDepthNodeVisitor<OneTypeMatcher<FuseSumCountAggregatesVisitorData>, true>;
+
+}

--- a/src/Interpreters/LogicalExpressionsOptimizer.cpp
+++ b/src/Interpreters/LogicalExpressionsOptimizer.cpp
@@ -111,6 +111,9 @@ void LogicalExpressionsOptimizer::collectDisjunctiveEqualityChains()
 
         to_visit.pop_back();
 
+        if (visited_nodes.contains(to_node))
+            continue;
+
         bool found_chain = false;
 
         auto * function = to_node->as<ASTFunction>();
@@ -151,8 +154,7 @@ void LogicalExpressionsOptimizer::collectDisjunctiveEqualityChains()
             {
                 auto res = or_parent_map.insert(std::make_pair(function, ParentNodes{from_node}));
                 if (!res.second)
-                    throw Exception("LogicalExpressionsOptimizer: parent node information is corrupted",
-                        ErrorCodes::LOGICAL_ERROR);
+                    throw Exception("LogicalExpressionsOptimizer: parent node information is corrupted", ErrorCodes::LOGICAL_ERROR);
             }
         }
         else

--- a/src/Interpreters/TreeOptimizer.h
+++ b/src/Interpreters/TreeOptimizer.h
@@ -16,15 +16,18 @@ struct TreeRewriterResult;
 class TreeOptimizer
 {
 public:
+    /// For any AST
+    static void optimizeExpression(
+        ASTPtr & query,
+        TreeRewriterResult & result,
+        ContextPtr context);
 
-    static void apply(
+    /// For ASTSelectQuery only
+    static void optimizeSelect(
         ASTPtr & query,
         TreeRewriterResult & result,
         const std::vector<TableWithColumnNamesAndTypes> & tables_with_columns,
         ContextPtr context);
-
-    static void optimizeIf(ASTPtr & query, Aliases & aliases, bool if_chain_to_multiif);
-    static void optimizeCountConstantAndSumOne(ASTPtr & query);
 };
 
 }

--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -1159,9 +1159,6 @@ TreeRewriterResultPtr TreeRewriter::analyzeSelect(
     /// Executing scalar subqueries - replacing them with constant values.
     executeScalarSubqueries(query, getContext(), subquery_depth, result.scalars, result.local_scalars, select_options.only_analyze);
 
-    if (settings.legacy_column_name_of_tuple_literal)
-        markTupleLiteralsAsLegacy(query);
-
     /// Push the predicate expression down to subqueries. The optimization should be applied to both initial and secondary queries.
     result.rewrite_subqueries = PredicateExpressionsOptimizer(getContext(), tables_with_columns, settings).optimize(*select_query);
 
@@ -1169,6 +1166,10 @@ TreeRewriterResultPtr TreeRewriter::analyzeSelect(
     /// Only apply AST optimization for initial queries without explicit disability.
     if (is_initiator && !select_options.ignore_ast_optimizations)
         TreeOptimizer::optimizeSelect(query, result, tables_with_columns, getContext());
+
+    /// Should after optimize
+    if (settings.legacy_column_name_of_tuple_literal)
+        markTupleLiteralsAsLegacy(query);
 
     if (tables_with_columns.size() > 1)
     {

--- a/src/Interpreters/TreeRewriter.h
+++ b/src/Interpreters/TreeRewriter.h
@@ -131,7 +131,17 @@ public:
         std::shared_ptr<TableJoin> table_join = {}) const;
 
 private:
-    static void normalize(ASTPtr & query, Aliases & aliases, const NameSet & source_columns_set, bool ignore_alias, const Settings & settings, bool allow_self_aliases, ContextPtr context_);
-};
+    /// Apply changes to query based on current context, such as UDF expansion.
+    static void instantiate(ASTPtr & query, const Settings & settings);
 
+    /// Turning query into canonical form.
+    static void normalize(
+        ASTPtr & query,
+        Aliases & aliases,
+        const NameSet & source_columns_set,
+        bool ignore_alias,
+        const Settings & settings,
+        bool allow_self_aliases,
+        ContextPtr context_);
+};
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
There are a lot of AST transformations when doing `TreeRewriter::analyzeSelect`. They can be divided into three categories:

1. transformations that changes the meaning of a query: `aggregate_functions_null_for_empty`, `transform_null_in`, `count_distinct_implementation` etc
2. transformations that optimize something: `LogicalExpressionsOptimizer`, `optimize_if_chain_to_multiif`, etc
3. transformations that normalize query.

This PR tries to put all (1) into one places so that we can be more careful with those settings when applying them in `users.xml`.  
This PR tries to put all optimizations (2) into one place so that we can disable them as a whole.

The motivation of this PR is to resolve issues like https://github.com/ClickHouse/ClickHouse/issues/41647

We can have ASTSelectQuery appeared in metadata: MaterializedView, projections. (1) is dangerous to be changed as server default settings. 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
