### PR TITLE
Update MergeTree settings docs to match current defaults

### DIFF
--- a/docs/en/operations/settings/merge-tree-settings.md
+++ b/docs/en/operations/settings/merge-tree-settings.md
@@ -15,7 +15,7 @@ Possible values:
 
 -   Any positive integer.
 
-Default value: 10.
+Default value: 100.
 
 Override example in `config.xml`:
 
@@ -231,7 +231,7 @@ Possible values:
 
 -   Any positive integer.
 
-Default value: 1800
+Default value: 10800
 
 ## try_fetch_recompressed_part_timeout
 
@@ -261,7 +261,7 @@ Possible values:
 
 -   Any positive integer.
 
-Default value: 10
+Default value: 100
 
 ## max_suspicious_broken_parts_bytes
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Update MergeTree settings docs to match current defaults


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
