### PR TITLE
Fix linker error

### DIFF
--- a/src/Daemon/CMakeLists.txt
+++ b/src/Daemon/CMakeLists.txt
@@ -14,5 +14,5 @@ endif()
 target_link_libraries (daemon PUBLIC loggers common PRIVATE clickhouse_common_io clickhouse_common_config ${EXECINFO_LIBRARIES})
 
 if (TARGET ch_contrib::sentry)
-    target_link_libraries (daemon PRIVATE ch_contrib::sentry)
+    target_link_libraries (daemon PRIVATE ch_contrib::sentry dbms)
 endif ()


### PR DESCRIPTION
When trying to set up a [split build](https://clickhouse.com/docs/en/development/developer-instruction/#split-build) I get the following linker error:
```
[build] FAILED: src/Daemon/libdaemond.so 
[build] ld.lld-14: error: undefined symbol: DB::toString(DB::Field const&)
[build] >>> referenced by SentryWriter.cpp:44 (/root/projects/github/ClibMouse/ClickHouse/src/Daemon/SentryWriter.cpp:44)
[build] >>>               src/Daemon/CMakeFiles/daemon.dir/SentryWriter.cpp.o:((anonymous namespace)::setExtras())
[build] clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I'm using the following CMake flags:
```
FLATBUFFERS_BUILD_SHAREDLIB = 1
GLIBC_COMPATIBILITY = 0
USE_STATIC_LIBRARIES = 0
SPLIT_SHARED_LIBRARIES = 1
```

The change resolves this error and the linking successfully concludes.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)