### PR TITLE
WIP (Re?-)enable query compilation for ARM

### DIFF
--- a/contrib/llvm-project-cmake/CMakeLists.txt
+++ b/contrib/llvm-project-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (APPLE OR NOT ARCH_AMD64 OR SANITIZE STREQUAL "undefined" OR NOT USE_STATIC_LIBRARIES)
+if (APPLE OR NOT (ARCH_AMD64 OR ARCH_AARCH64) OR SANITIZE STREQUAL "undefined" OR NOT USE_STATIC_LIBRARIES)
    set (ENABLE_EMBEDDED_COMPILER_DEFAULT OFF)
 else()
    set (ENABLE_EMBEDDED_COMPILER_DEFAULT ON)
@@ -12,7 +12,6 @@ if (NOT ENABLE_EMBEDDED_COMPILER)
 endif()
 
 # TODO: Enable shared library build
-# TODO: Enable compilation on AArch64
 
 set (LLVM_VERSION "13.0.0bundled")
 set (LLVM_INCLUDE_DIRS
@@ -56,11 +55,11 @@ set (REQUIRED_LLVM_LIBRARIES
     LLVMDemangle
 )
 
-# if (ARCH_AMD64)
+if (ARCH_AMD64)
     list(APPEND REQUIRED_LLVM_LIBRARIES LLVMX86Info LLVMX86Desc LLVMX86CodeGen)
-# elseif (ARCH_AARCH64)
-#     list(APPEND REQUIRED_LLVM_LIBRARIES LLVMAArch64Info LLVMAArch64Desc LLVMAArch64CodeGen)
-# endif ()
+elseif (ARCH_AARCH64)
+    list(APPEND REQUIRED_LLVM_LIBRARIES LLVMAArch64Info LLVMAArch64Desc LLVMAArch64CodeGen)
+endif ()
 
 # ld: unknown option: --color-diagnostics
 # set (LINKER_SUPPORTS_COLOR_DIAGNOSTICS 0 CACHE INTERNAL "")
@@ -70,7 +69,7 @@ set (LLVM_COMPILER_CHECKED 1 CACHE INTERNAL "") # Skip internal compiler selecti
 set (LLVM_ENABLE_EH 1 CACHE INTERNAL "") # With exception handling
 set (LLVM_ENABLE_RTTI 1 CACHE INTERNAL "")
 set (LLVM_ENABLE_PIC 0 CACHE INTERNAL "")
-set (LLVM_TARGETS_TO_BUILD "X86" CACHE STRING "") # for x86 + ARM: "X86;AArch64"
+set (LLVM_TARGETS_TO_BUILD "X86;AArch64" CACHE STRING "")
 
 # Omit unnecessary stuff (just the options which are ON by default)
 set(LLVM_ENABLE_BACKTRACES 0 CACHE INTERNAL "")


### PR DESCRIPTION
It is not 100% clear to me if query compilation on ARM worked at some point in the past or not. There was some code for it in CMakeLists but in all CI builds, LLVM was disabled on ARM.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)