### PR TITLE
optimize insertFrom of ColumnAggregateFunction to share Aggregate State in some cases

### DIFF
--- a/src/Columns/ColumnAggregateFunction.cpp
+++ b/src/Columns/ColumnAggregateFunction.cpp
@@ -279,7 +279,7 @@ void ColumnAggregateFunction::insertRangeFrom(const IColumn & from, size_t start
 
         size_t end = start + length;
         for (size_t i = start; i < end; ++i)
-            insertFrom(from, i);
+            insertFromWithOwnership(from, i);
     }
     else
     {
@@ -448,7 +448,7 @@ void ColumnAggregateFunction::insertData(const char * pos, size_t /*length*/)
     data.push_back(*reinterpret_cast<const AggregateDataPtr *>(pos));
 }
 
-void ColumnAggregateFunction::insertFrom(const IColumn & from, size_t n)
+void ColumnAggregateFunction::insertFromWithOwnership(const IColumn & from, size_t n)
 {
     /// Must create new state of aggregate function and take ownership of it,
     ///  because ownership of states of aggregate function cannot be shared for individual rows,
@@ -456,6 +456,11 @@ void ColumnAggregateFunction::insertFrom(const IColumn & from, size_t n)
     ensureOwnership();
     insertDefault();
     insertMergeFrom(from, n);
+}
+
+void ColumnAggregateFunction::insertFrom(const IColumn & from, size_t n)
+{
+    insertRangeFrom(from, n, 1);
 }
 
 void ColumnAggregateFunction::insertFrom(ConstAggregateDataPtr place)

--- a/src/Columns/ColumnAggregateFunction.h
+++ b/src/Columns/ColumnAggregateFunction.h
@@ -98,6 +98,8 @@ private:
 
     ColumnAggregateFunction(const ColumnAggregateFunction & src_);
 
+    void insertFromWithOwnership(const IColumn & from, size_t n);
+
 public:
     ~ColumnAggregateFunction() override;
 

--- a/tests/performance/bitmap_array_element.xml
+++ b/tests/performance/bitmap_array_element.xml
@@ -1,0 +1,12 @@
+<test>
+    <query>
+		WITH
+            (
+                SELECT bitmapBuild(groupArray(number))
+                FROM numbers(10000000)
+            ) AS a,
+            [a, a, a] AS b
+        SELECT sum(bitmapCardinality(b[(number % 3) + 1]))
+        FROM numbers(10000)
+    </query>
+</test>

--- a/tests/performance/bitmap_array_element.xml
+++ b/tests/performance/bitmap_array_element.xml
@@ -1,6 +1,6 @@
 <test>
     <query>
-		WITH
+        WITH
             (
                 SELECT bitmapBuild(groupArray(number))
                 FROM numbers(10000000)

--- a/tests/performance/bitmap_array_element.xml
+++ b/tests/performance/bitmap_array_element.xml
@@ -3,7 +3,7 @@
         WITH
             (
                 SELECT bitmapBuild(groupArray(number))
-                FROM numbers(10000000)
+                FROM numbers(3000000)
             ) AS a,
             [a, a, a] AS b
         SELECT sum(bitmapCardinality(b[(number % 3) + 1]))


### PR DESCRIPTION
### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
optimize insertFrom of ColumnAggregateFunction to share Aggregate State in some cases.

`insertFrom` method of ColumnAggregateFunction always `ensureOwnership` of Aggregation State and make a copy for 
new inserted element, but in some cases  it's unneed and state can be shared. Like below:
- before optimize:
```sql
vccliu1645086827254-0 :) WITH
                             (
                                 SELECT bitmapBuild(groupArray(number))
                                 FROM numbers(10000000)
                             ) AS a,
                             [a, a, a] AS b
                         SELECT sum(bitmapCardinality(b[(number % 3) + 1]))
                         FROM numbers(1000)

WITH
    (
        SELECT bitmapBuild(groupArray(number))
        FROM numbers(10000000)
    ) AS a,
    [a, a, a] AS b
SELECT sum(bitmapCardinality(b[(number % 3) + 1]))
FROM numbers(1000)

Query id: 51861099-7acf-4e81-b7a1-75d97dfe62fc

┌─sum(bitmapCardinality(arrayElement(b, plus(modulo(number, 3), 1))))─┐
│                                                         10000000000 │
└─────────────────────────────────────────────────────────────────────┘

1 row in set. Elapsed: 1.253 sec. Processed 10.02 million rows, 80.19 MB (8.00 million rows/s., 64.02 MB/s.)
```
- after optimize:
```sql
vccliu1645086827254-0 :) WITH
                             (
                                 SELECT bitmapBuild(groupArray(number))
                                 FROM numbers(10000000)
                             ) AS a,
                             [a, a, a] AS b
                         SELECT sum(bitmapCardinality(b[(number % 3) + 1]))
                         FROM numbers(1000)

WITH
    (
        SELECT bitmapBuild(groupArray(number))
        FROM numbers(10000000)
    ) AS a,
    [a, a, a] AS b
SELECT sum(bitmapCardinality(b[(number % 3) + 1]))
FROM numbers(1000)

Query id: dc58f763-6e46-4f4d-ac72-e4f81ab6b9ff

┌─sum(bitmapCardinality(arrayElement(b, plus(modulo(number, 3), 1))))─┐
│                                                         10000000000 │
└─────────────────────────────────────────────────────────────────────┘

1 row in set. Elapsed: 0.460 sec. Processed 10.02 million rows, 80.19 MB (21.77 million rows/s., 174.14 MB/s.)
```
The main causes here is `b[number % 3 + 1]` which will call `arrayElement -> ColumnAggregateFunction::insertFrom`, before it make a lot of large bitmap copy but now all shared.