### PR TITLE
Manually backport 41586 to 22.8

### DIFF
--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -195,7 +195,7 @@ QueryPipelineBuilderPtr QueryPlan::buildQueryPipeline(
             stack.push(Frame{.node = frame.node->children[next_child]});
     }
 
-    /// last_pipeline->setProgressCallback(build_pipeline_settings.progress_callback);
+    last_pipeline->setProgressCallback(build_pipeline_settings.progress_callback);
     last_pipeline->setProcessListElement(build_pipeline_settings.process_list_element);
     last_pipeline->addResources(std::move(resources));
 

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -544,6 +544,11 @@ void QueryPipelineBuilder::setProcessListElement(QueryStatus * elem)
     process_list_element = elem;
 }
 
+void QueryPipelineBuilder::setProgressCallback(ProgressCallback callback)
+{
+    progress_callback = callback;
+}
+
 PipelineExecutorPtr QueryPipelineBuilder::execute()
 {
     if (!isCompleted())
@@ -564,6 +569,7 @@ QueryPipeline QueryPipelineBuilder::getPipeline(QueryPipelineBuilder builder)
     res.addResources(std::move(builder.resources));
     res.setNumThreads(builder.getNumThreads());
     res.setProcessListElement(builder.process_list_element);
+    res.setProgressCallback(builder.progress_callback);
     return res;
 }
 

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -149,6 +149,7 @@ public:
     const Block & getHeader() const { return pipe.getHeader(); }
 
     void setProcessListElement(QueryStatus * elem);
+    void setProgressCallback(ProgressCallback callback);
 
     /// Recommend number of threads for pipeline execution.
     size_t getNumThreads() const
@@ -189,6 +190,7 @@ private:
     size_t max_threads = 0;
 
     QueryStatus * process_list_element = nullptr;
+    ProgressCallback progress_callback = nullptr;
 
     void checkInitialized();
     void checkInitializedAndNotCompleted();

--- a/tests/queries/0_stateless/02423_insert_summary_behaviour.reference
+++ b/tests/queries/0_stateless/02423_insert_summary_behaviour.reference
@@ -1,0 +1,8 @@
+No materialized views
+< X-ClickHouse-Summary: {"read_rows":"1","read_bytes":"8","written_rows":"1","written_bytes":"8","total_rows_to_read":"0","result_rows":"1","result_bytes":"8"}
+< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"10","written_bytes":"80","total_rows_to_read":"0","result_rows":"10","result_bytes":"80"}
+< X-ClickHouse-Summary: {"read_rows":"10","read_bytes":"80","written_rows":"10","written_bytes":"80","total_rows_to_read":"0","result_rows":"10","result_bytes":"80"}
+With materialized views
+< X-ClickHouse-Summary: {"read_rows":"5","read_bytes":"40","written_rows":"4","written_bytes":"32","total_rows_to_read":"2","result_rows":"4","result_bytes":"32"}
+< X-ClickHouse-Summary: {"read_rows":"32","read_bytes":"256","written_rows":"40","written_bytes":"320","total_rows_to_read":"2","result_rows":"40","result_bytes":"320"}
+< X-ClickHouse-Summary: {"read_rows":"32","read_bytes":"256","written_rows":"40","written_bytes":"320","total_rows_to_read":"2","result_rows":"40","result_bytes":"320"}

--- a/tests/queries/0_stateless/02423_insert_summary_behaviour.sh
+++ b/tests/queries/0_stateless/02423_insert_summary_behaviour.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "CREATE TABLE floats (v Float64) Engine=MergeTree() ORDER BY tuple();"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE target_1 (v Float64) Engine=MergeTree() ORDER BY tuple();"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE target_2 (v Float64) Engine=MergeTree() ORDER BY tuple();"
+$CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW floats_to_target TO target_1 AS SELECT * FROM floats"
+$CLICKHOUSE_CLIENT -q "CREATE MATERIALIZED VIEW floats_to_target_2 TO target_2 AS SELECT * FROM floats, numbers(2) n"
+
+echo "No materialized views"
+${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&wait_end_of_query=1&query=INSERT+INTO+target_1" -d "VALUES(1.0)" -v 2>&1 | grep 'X-ClickHouse-Summary'
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format Native | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&wait_end_of_query=1&query=INSERT+INTO+target_1+FORMAT+Native" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary'
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format RowBinary | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&wait_end_of_query=1&query=INSERT+INTO+target_1+FORMAT+RowBinary" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary'
+
+echo "With materialized views"
+${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&wait_end_of_query=1&query=INSERT+INTO+floats" -d "VALUES(1.0)" -v 2>&1 | grep 'X-ClickHouse-Summary'
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format Native | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&wait_end_of_query=1&query=INSERT+INTO+floats+FORMAT+Native" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary'
+$CLICKHOUSE_LOCAL -q "SELECT number::Float64 AS v FROM numbers(10)" --format RowBinary | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&wait_end_of_query=1&query=INSERT+INTO+floats+FORMAT+RowBinary" --data-binary @- -v 2>&1 | grep 'X-ClickHouse-Summary'


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix read bytes/rows in X-ClickHouse-Summary with materialized views

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

 Backport to #41586. Since 22.8 is a LTS I think it's worth having this backported there to set the get the expected values matching system.query_logs