### PR TITLE
Add a warning message to release.py script, require release type

### DIFF
--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -444,7 +444,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="Script to release a new ClickHouse version, requires `git` and "
-        "`gh` (github-cli) commands",
+        "`gh` (github-cli) commands "
+        "!!! LAUNCH IT ONLY FROM THE MASTER BRANCH !!!",
     )
 
     parser.add_argument(
@@ -468,10 +469,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--type",
-        default="minor",
+        required=True,
         choices=Release.BIG + Release.SMALL,
         dest="release_type",
-        help="a release type, new branch is created only for 'major' and 'minor'",
+        help="a release type to bump the major.minor.patch version part, "
+        "new branch is created only for 'major' and 'minor'",
     )
     parser.add_argument("--with-release-branch", default=True, help=argparse.SUPPRESS)
     parser.add_argument(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a warning for the script, and require release type to avoid mistakes.