### PR TITLE
Remove confusing warning when perform_ttl_move_on_insert is false

### DIFF
--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -74,6 +74,10 @@ public:
     /// Returns valid reservation or nullptr when failure.
     virtual ReservationPtr reserve(UInt64 bytes) = 0;
 
+    /// Whether this is a disk or a volume.
+    virtual bool isDisk() const { return false; }
+    virtual bool isVolume() const { return false; }
+
     virtual ~Space() = default;
 };
 
@@ -107,6 +111,9 @@ public:
         : executor(executor_)
     {
     }
+
+    /// This is a disk.
+    bool isDisk() const override { return true; }
 
     virtual DiskTransactionPtr createTransaction();
 

--- a/src/Disks/IStoragePolicy.h
+++ b/src/Disks/IStoragePolicy.h
@@ -55,6 +55,7 @@ public:
     /// Get volume by index.
     virtual VolumePtr getVolume(size_t index) const = 0;
     virtual VolumePtr tryGetVolumeByName(const String & volume_name) const = 0;
+    virtual VolumePtr tryGetVolumeByDisk(const DiskPtr & disk_ptr) const = 0;
     VolumePtr getVolumeByName(const String & volume_name) const;
     /// Checks if storage policy can be replaced by another one.
     virtual void checkCompatibleWith(const StoragePolicyPtr & new_storage_policy) const = 0;

--- a/src/Disks/IVolume.h
+++ b/src/Disks/IVolume.h
@@ -66,6 +66,9 @@ public:
 
     virtual ReservationPtr reserve(UInt64 bytes) override = 0;
 
+    /// This is a volume.
+    bool isVolume() const override { return true; }
+
     /// Volume name from config
     const String & getName() const override { return name; }
     virtual VolumeType getType() const = 0;

--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -322,6 +322,15 @@ size_t StoragePolicy::getVolumeIndexByDisk(const DiskPtr & disk_ptr) const
 }
 
 
+VolumePtr StoragePolicy::tryGetVolumeByDisk(const DiskPtr & disk_ptr) const
+{
+    auto it = volume_index_by_disk_name.find(disk_ptr->getName());
+    if (it == volume_index_by_disk_name.end())
+        return nullptr;
+    return getVolume(it->second);
+}
+
+
 void StoragePolicy::buildVolumeIndices()
 {
     for (size_t index = 0; index < volumes.size(); ++index)

--- a/src/Disks/StoragePolicy.h
+++ b/src/Disks/StoragePolicy.h
@@ -85,6 +85,9 @@ public:
 
     VolumePtr tryGetVolumeByName(const String & volume_name) const override;
 
+    /// Finds a volume which contains a specified disk.
+    VolumePtr tryGetVolumeByDisk(const DiskPtr & disk_ptr) const override;
+
     /// Checks if storage policy can be replaced by another one.
     void checkCompatibleWith(const StoragePolicyPtr & new_storage_policy) const override;
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -867,9 +867,12 @@ public:
 
     /// Return alter conversions for part which must be applied on fly.
     AlterConversions getAlterConversionsForPart(MergeTreeDataPartPtr part) const;
-    /// Returns destination disk or volume for the TTL rule according to current storage policy
-    /// 'is_insert' - is TTL move performed on new data part insert.
-    SpacePtr getDestinationForMoveTTL(const TTLDescription & move_ttl, bool is_insert = false) const;
+
+    /// Returns destination disk or volume for the TTL rule according to current storage policy.
+    SpacePtr getDestinationForMoveTTL(const TTLDescription & move_ttl) const;
+
+    /// Whether INSERT of a data part which is already expired should move it immediately to a volume/disk declared in move rule.
+    bool shouldPerformTTLMoveOnInsert(const SpacePtr & move_destination) const;
 
     /// Checks if given part already belongs destination disk or volume for the
     /// TTL rule.


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
Remove confusing warning when inserting with `perform_ttl_move_on_insert`=false.