### PR TITLE
Fix "Cumulative sum" example in "Window functions"

### DIFF
--- a/docs/en/sql-reference/window-functions/index.md
+++ b/docs/en/sql-reference/window-functions/index.md
@@ -430,9 +430,9 @@ FROM
 ### Cumulative sum.
 
 ```sql
-CREATE TABLE events
+CREATE TABLE warehouse
 (
-    `metric` String,
+    `item` String,
     `ts` DateTime,
     `value` Float
 )


### PR DESCRIPTION
Fixes a problem in "Cumulative sum" example in "Window functions" documentation,  when CREATE TABLE part of example was not match to SQL examples.

see: https://clickhouse.com/docs/en/sql-reference/window-functions/#cumulative-sum

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes a problem in "Cumulative sum" example in "Window functions" documentation, when CREATE TABLE part of example was not match to SQL examples
