### PR TITLE
Fix warning that ENABLE_REPLXX is unused

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -157,7 +157,6 @@ function run_cmake
         "-DUSE_UNWIND=1"
         "-DENABLE_NURAFT=1"
         "-DENABLE_JEMALLOC=1"
-        "-DENABLE_REPLXX=1"
     )
 
     export CCACHE_DIR="$FASTTEST_WORKSPACE/ccache"


### PR DESCRIPTION
- 3rd party lib replxx is mandatory since #37719
- remove the corresponding CMake switch from the fasttest build

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)