### PR TITLE
Drop leftovers of libexecinfo

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -368,8 +368,6 @@ target_link_libraries(clickhouse_common_io PUBLIC ch_contrib::re2_st)
 target_link_libraries(clickhouse_common_io PUBLIC ch_contrib::re2)
 
 target_link_libraries(clickhouse_common_io
-        PRIVATE
-            ${EXECINFO_LIBRARIES}
         PUBLIC
             boost::program_options
             boost::system

--- a/src/Daemon/CMakeLists.txt
+++ b/src/Daemon/CMakeLists.txt
@@ -11,7 +11,7 @@ if (OS_DARWIN AND NOT USE_STATIC_LIBRARIES)
     target_link_libraries (daemon PUBLIC -Wl,-undefined,dynamic_lookup)
 endif()
 
-target_link_libraries (daemon PUBLIC loggers common PRIVATE clickhouse_common_io clickhouse_common_config ${EXECINFO_LIBRARIES})
+target_link_libraries (daemon PUBLIC loggers common PRIVATE clickhouse_common_io clickhouse_common_config)
 
 if (TARGET ch_contrib::sentry)
     target_link_libraries (daemon PRIVATE ch_contrib::sentry)


### PR DESCRIPTION
libexecinfo was perhaps used in the past but today it is unused

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)