### PR TITLE
Add log message and lower the retry timeout in MergeTreeRestartingThread

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -32,7 +32,7 @@ namespace ErrorCodes
 
 namespace
 {
-    constexpr auto retry_period_ms = 10 * 1000;
+    constexpr auto retry_period_ms = 1000;
 }
 
 /// Used to check whether it's us who set node `is_active`, or not.

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4180,6 +4180,7 @@ void StorageReplicatedMergeTree::startupImpl()
         /// And this is just a callback
         session_expired_callback_handler = EventNotifier::instance().subscribe(Coordination::Error::ZSESSIONEXPIRED, [this]()
         {
+            LOG_TEST(log, "Received event for expired session. Waking up restarting thread");
             restarting_thread.start();
         });
 


### PR DESCRIPTION

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
