### PR TITLE
Ignore core.autocrlf for tests references

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 contrib/* linguist-vendored
 *.h linguist-language=C++
 tests/queries/0_stateless/data_json/* binary
+tests/queries/0_stateless/*.reference -crlf


### PR DESCRIPTION
That way if you have non standard `core.autocrlf`, CRLF will not be converted in `*.reference`:

```
warning: in the working copy of 'tests/queries/0_stateless/02457_insert_select_progress_http.reference', CRLF will be replaced by LF the next time Git touches it
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)