### PR TITLE
Add `at` to runner AMI, bump gh runner version

### DIFF
--- a/tests/ci/worker/ubuntu_ami_for_ci.sh
+++ b/tests/ci/worker/ubuntu_ami_for_ci.sh
@@ -3,7 +3,7 @@ set -xeuo pipefail
 
 echo "Running prepare script"
 export DEBIAN_FRONTEND=noninteractive
-export RUNNER_VERSION=2.296.2
+export RUNNER_VERSION=2.298.2
 export RUNNER_HOME=/home/ubuntu/actions-runner
 
 deb_arch() {
@@ -33,6 +33,7 @@ apt-get update
 
 apt-get install --yes --no-install-recommends \
     apt-transport-https \
+    at \
     atop \
     binfmt-support \
     build-essential \


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Bump the GH runner version, and bring back `at` for the runner post-hook. Related to #42076