### PR TITLE
Use send_metadata instead of send_object_metadata

### DIFF
--- a/tests/integration/test_join_set_family_s3/configs/minio.xml
+++ b/tests/integration/test_join_set_family_s3/configs/minio.xml
@@ -6,7 +6,7 @@
                 <endpoint>http://minio1:9001/root/data/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
-                <send_object_metadata>true</send_object_metadata>
+                <send_metadata>true</send_metadata>
             </s3>
         </disks>
     </storage_configuration>

--- a/tests/integration/test_join_set_family_s3/configs/minio.xml
+++ b/tests/integration/test_join_set_family_s3/configs/minio.xml
@@ -6,7 +6,6 @@
                 <endpoint>http://minio1:9001/root/data/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
-                <send_metadata>true</send_metadata>
             </s3>
         </disks>
     </storage_configuration>

--- a/tests/integration/test_log_family_s3/configs/minio.xml
+++ b/tests/integration/test_log_family_s3/configs/minio.xml
@@ -6,7 +6,7 @@
                 <endpoint>http://minio1:9001/root/data/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
-                <send_object_metadata>true</send_object_metadata>
+                <send_metadata>true</send_metadata>
             </s3>
         </disks>
     </storage_configuration>

--- a/tests/integration/test_log_family_s3/configs/minio.xml
+++ b/tests/integration/test_log_family_s3/configs/minio.xml
@@ -6,7 +6,6 @@
                 <endpoint>http://minio1:9001/root/data/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
-                <send_metadata>true</send_metadata>
             </s3>
         </disks>
     </storage_configuration>


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

`send_object_metadata` is not a valid setting, it should be `send_metadata` instead  https://github.com/ClickHouse/ClickHouse/blob/eeb0a3584effc8367bdb8c8a6fbc5e524197c33c/src/Disks/ObjectStorages/S3/registerDiskS3.cpp#L153

