### PR TITLE
Fixed the restriction on maximum size of replicated fetches

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -279,7 +279,7 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
     , restarting_thread(*this)
     , part_moves_between_shards_orchestrator(*this)
     , renaming_restrictions(renaming_restrictions_)
-    , replicated_fetches_pool_size(getContext()->getSettingsRef().background_fetches_pool_size)
+    , replicated_fetches_pool_size(getContext()->getFetchesExecutor()->getMaxTasksCount())
     , replicated_fetches_throttler(std::make_shared<Throttler>(getSettings()->max_replicated_fetches_network_bandwidth, getContext()->getReplicatedFetchesThrottler()))
     , replicated_sends_throttler(std::make_shared<Throttler>(getSettings()->max_replicated_sends_network_bandwidth, getContext()->getReplicatedSendsThrottler()))
 {

--- a/tests/integration/test_limited_replicated_fetches/configs/custom_settings.xml
+++ b/tests/integration/test_limited_replicated_fetches/configs/custom_settings.xml
@@ -1,7 +1,3 @@
 <clickhouse>
-    <profiles>
-        <default>
-            <background_fetches_pool_size>3</background_fetches_pool_size>
-        </default>
-    </profiles>
+    <background_fetches_pool_size>3</background_fetches_pool_size>
 </clickhouse>

--- a/tests/integration/test_limited_replicated_fetches/test.py
+++ b/tests/integration/test_limited_replicated_fetches/test.py
@@ -11,10 +11,10 @@ import os
 cluster = ClickHouseCluster(__file__)
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 node1 = cluster.add_instance(
-    "node1", user_configs=["configs/custom_settings.xml"], with_zookeeper=True
+    "node1", main_configs=["configs/custom_settings.xml"], with_zookeeper=True
 )
 node2 = cluster.add_instance(
-    "node2", user_configs=["configs/custom_settings.xml"], with_zookeeper=True
+    "node2", main_configs=["configs/custom_settings.xml"], with_zookeeper=True
 )
 
 MAX_THREADS_FOR_FETCH = 3


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The maximum size of fetches for each table accidentally was set to 8 while the pool size could be bigger. Now the maximum size of fetches for table is equal to the pool size.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
