### PR TITLE
Disable 02122_join_group_by_timeout for debug

### DIFF
--- a/tests/queries/0_stateless/02122_join_group_by_timeout.sh
+++ b/tests/queries/0_stateless/02122_join_group_by_timeout.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Tags: no-debug
+
+# no-debug: Query is canceled by timeout after max_execution_time,
+#           but sending an exception to the client may hang
+#           for more than MAX_PROCESS_WAIT seconds in a slow debug build,
+#           and test will fail.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Ref https://github.com/ClickHouse/ClickHouse/issues/41820