### PR TITLE
Fix reinterpretAsString for s390x

### DIFF
--- a/src/Functions/reinterpretAs.cpp
+++ b/src/Functions/reinterpretAs.cpp
@@ -317,11 +317,21 @@ private:
             StringRef data = src.getDataAt(i);
 
             /// Cut trailing zero bytes.
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            size_t index = 0;
+            while (index < data.size && data.data[index] == 0)
+                    index++;
+            data.size -= index;
+#else
             while (data.size && data.data[data.size - 1] == 0)
                 --data.size;
-
+#endif
             data_to.resize(offset + data.size + 1);
-            memcpy(&data_to[offset], data.data, data.size);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            reverseMemcpy(&data_to[offset], data.data+index, data.size);
+#else
+            memcpy(&data_to[offset],data.data, data.size);
+#endif
             offset += data.size;
             data_to[offset] = 0;
             ++offset;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
There is an endian issue in reinterpretAsString function on s390x which can fail functional test 00003_reinterpret_as_string.
The reason is that in function executeToString() in Functions/reinterpertAs.cpp, the content of string wasn't copied correctly due to wrong starting index and also the order of bytes was wrong on big-endian machines.

The fix is to calculate correct starting index and copy the content in reverse order for big endian machines.

### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
Fix reinterpretAsString function for s390x

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
 