### PR TITLE
Fix quality typo

### DIFF
--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -7,7 +7,7 @@ sidebar_label: Client Libraries
 # Client Libraries from Third-party Developers
 
 :::warning
-ClickHouse Inc does **not** maintain the libraries listed below and hasn’t done any extensive testing to ensure their quality.
+ClickHouse Inc does **not** maintain the libraries listed below and hasn’t done any extensive testing to ensure their qualities.
 :::
 
 -   Python


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required).
- Fix the `quality` typo for `plural`.