### PR TITLE
Fix build without TSA

### DIFF
--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -159,8 +159,8 @@
 #    define TSA_REQUIRES_SHARED(...)
 #    define TSA_NO_THREAD_SAFETY_ANALYSIS
 
-#    define TSA_SUPPRESS_WARNING_FOR_READ(x) ([&]() -> const auto & { return (x); }())
-#    define TSA_SUPPRESS_WARNING_FOR_WRITE(x) ([&]() -> auto & { return (x); }())
+#    define TSA_SUPPRESS_WARNING_FOR_READ(x) (x)
+#    define TSA_SUPPRESS_WARNING_FOR_WRITE(x) (x)
 #    define TSA_READ_ONE_THREAD(x) TSA_SUPPRESS_WARNING_FOR_READ(x)
 #endif
 

--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -142,7 +142,7 @@
 #    define TSA_NO_THREAD_SAFETY_ANALYSIS __attribute__((no_thread_safety_analysis))           /// disable TSA for a function
 
 /// Macros for suppressing TSA warnings for specific reads/writes (instead of suppressing it for the whole function)
-/// They use a lambda function to apply function attribute to a single statement. This enable us to supress warnings locally instead of
+/// They use a lambda function to apply function attribute to a single statement. This enable us to suppress warnings locally instead of
 /// suppressing them in the whole function
 /// Consider adding a comment when using these macros.
 #   define TSA_SUPPRESS_WARNING_FOR_READ(x) ([&]() TSA_NO_THREAD_SAFETY_ANALYSIS -> const auto & { return (x); }())

--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -159,9 +159,9 @@
 #    define TSA_REQUIRES_SHARED(...)
 #    define TSA_NO_THREAD_SAFETY_ANALYSIS
 
-#    define TSA_SUPPRESS_WARNING_FOR_READ(x)
-#    define TSA_SUPPRESS_WARNING_FOR_WRITE(x)
-#    define TSA_READ_ONE_THREAD(x)
+#    define TSA_SUPPRESS_WARNING_FOR_READ(x) ([&]() -> const auto & { return (x); }())
+#    define TSA_SUPPRESS_WARNING_FOR_WRITE(x) ([&]() -> auto & { return (x); }())
+#    define TSA_READ_ONE_THREAD(x) TSA_SUPPRESS_WARNING_FOR_READ(x)
 #endif
 
 /// A template function for suppressing warnings about unused variables or function results.

--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -142,7 +142,9 @@
 #    define TSA_NO_THREAD_SAFETY_ANALYSIS __attribute__((no_thread_safety_analysis))           /// disable TSA for a function
 
 /// Macros for suppressing TSA warnings for specific reads/writes (instead of suppressing it for the whole function)
-/// Consider adding a comment before using these macros.
+/// They use a lambda function to apply function attribute to a single statement. This enable us to supress warnings locally instead of
+/// suppressing them in the whole function
+/// Consider adding a comment when using these macros.
 #   define TSA_SUPPRESS_WARNING_FOR_READ(x) ([&]() TSA_NO_THREAD_SAFETY_ANALYSIS -> const auto & { return (x); }())
 #   define TSA_SUPPRESS_WARNING_FOR_WRITE(x) ([&]() TSA_NO_THREAD_SAFETY_ANALYSIS -> auto & { return (x); }())
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

I was doing some experiments and found that the build fails with the TSA macros if you aren't using clang because the code uses them with things like:
```
TSA_SUPPRESS_WARNING_FOR_READ(database_name)
```

So I've just duplicated the macros declaration without `__attribute__`.

It's not important at all since currently clang is the only supported compiler, but it's nice to keep things clean so experiments are possible.