### PR TITLE
Fix buffer resize with `remote_filesystem_read_method=read` + fs cache

### DIFF
--- a/src/Disks/IO/AsynchronousReadIndirectBufferFromRemoteFS.h
+++ b/src/Disks/IO/AsynchronousReadIndirectBufferFromRemoteFS.h
@@ -3,6 +3,7 @@
 #include <Common/config.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/AsynchronousReader.h>
+#include <IO/ReadSettings.h>
 #include <utility>
 
 namespace Poco { class Logger; }
@@ -11,7 +12,6 @@ namespace DB
 {
 
 class ReadBufferFromRemoteFSGather;
-struct ReadSettings;
 
 /**
  * Reads data from S3/HDFS/Web using stored paths in metadata.
@@ -63,6 +63,8 @@ private:
     bool hasPendingDataToRead();
 
     std::future<IAsynchronousReader::Result> asyncReadInto(char * data, size_t size);
+
+    ReadSettings read_settings;
 
     IAsynchronousReader & reader;
 

--- a/src/Disks/IO/ReadIndirectBufferFromRemoteFS.cpp
+++ b/src/Disks/IO/ReadIndirectBufferFromRemoteFS.cpp
@@ -1,7 +1,6 @@
 #include "ReadIndirectBufferFromRemoteFS.h"
 
 #include <Disks/IO/ReadBufferFromRemoteFSGather.h>
-#include <IO/ReadSettings.h>
 
 
 namespace DB
@@ -17,6 +16,7 @@ ReadIndirectBufferFromRemoteFS::ReadIndirectBufferFromRemoteFS(
     std::shared_ptr<ReadBufferFromRemoteFSGather> impl_, const ReadSettings & settings)
     : ReadBufferFromFileBase(settings.remote_fs_buffer_size, nullptr, 0)
     , impl(impl_)
+    , read_settings(settings)
 {
 }
 
@@ -92,24 +92,27 @@ off_t ReadIndirectBufferFromRemoteFS::seek(off_t offset_, int whence)
 
 bool ReadIndirectBufferFromRemoteFS::nextImpl()
 {
-    /// Transfer current position and working_buffer to actual ReadBuffer
-    swap(*impl);
+    chassert(internal_buffer.size() == read_settings.remote_fs_buffer_size);
+    chassert(file_offset_of_buffer_end <= impl->getFileSize());
 
-    assert(!impl->hasPendingData());
-    /// Position and working_buffer will be updated in next() call
-    auto result = impl->next();
-    /// and assigned to current buffer.
-    swap(*impl);
+    auto [size, offset] = impl->readInto(internal_buffer.begin(), internal_buffer.size(), file_offset_of_buffer_end, /* ignore */0);
 
-    if (result)
+    chassert(offset <= size);
+    chassert(size <= internal_buffer.size());
+
+    if (size)
     {
-        file_offset_of_buffer_end += available();
-        BufferBase::set(working_buffer.begin() + offset(), available(), 0);
+        file_offset_of_buffer_end = impl->getFileOffsetOfBufferEnd();
+        working_buffer = Buffer(internal_buffer.begin() + offset, internal_buffer.begin() + size);
     }
 
-    assert(file_offset_of_buffer_end == impl->file_offset_of_buffer_end);
+    /// In case of multiple files for the same file in clickhouse (i.e. log family)
+    /// file_offset_of_buffer_end will not match getImplementationBufferOffset()
+    /// so we use [impl->getImplementationBufferOffset(), impl->getFileSize()]
+    chassert(file_offset_of_buffer_end >= impl->getImplementationBufferOffset());
+    chassert(file_offset_of_buffer_end <= impl->getFileSize());
 
-    return result;
+    return size;
 }
 
 }

--- a/src/Disks/IO/ReadIndirectBufferFromRemoteFS.h
+++ b/src/Disks/IO/ReadIndirectBufferFromRemoteFS.h
@@ -2,6 +2,7 @@
 
 #include <Common/config.h>
 #include <IO/ReadBufferFromFile.h>
+#include <IO/ReadSettings.h>
 #include <utility>
 
 
@@ -9,7 +10,6 @@ namespace DB
 {
 
 class ReadBufferFromRemoteFSGather;
-struct ReadSettings;
 
 /**
 * Reads data from S3/HDFS/Web using stored paths in metadata.
@@ -39,6 +39,8 @@ private:
     bool nextImpl() override;
 
     std::shared_ptr<ReadBufferFromRemoteFSGather> impl;
+
+    ReadSettings read_settings;
 
     size_t file_offset_of_buffer_end = 0;
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bad inefficiency of `remote_filesystem_read_method=read` with filesystem cache. Closes https://github.com/ClickHouse/ClickHouse/issues/42125. 