### PR TITLE
Fix reusing of files > 4GB from base backup

### DIFF
--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -691,7 +691,7 @@ void BackupImpl::writeFile(const String & file_name, BackupEntryPtr entry)
     std::string from_file_name = "memory buffer";
     if (auto fname = entry->getFilePath(); !fname.empty())
         from_file_name = "file " + fname;
-    LOG_TRACE(log, "Writing backup for file {} from file {}", file_name, from_file_name);
+    LOG_TRACE(log, "Writing backup for file {} from {}", file_name, from_file_name);
 
     auto adjusted_path = removeLeadingSlash(file_name);
     if (coordination->getFileInfo(adjusted_path))

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -43,8 +43,8 @@ namespace ErrorCodes
 
 namespace
 {
-    const UInt64 INITIAL_BACKUP_VERSION = 1;
-    const UInt64 CURRENT_BACKUP_VERSION = 1;
+    const int INITIAL_BACKUP_VERSION = 1;
+    const int CURRENT_BACKUP_VERSION = 1;
 
     using SizeAndChecksum = IBackup::SizeAndChecksum;
     using FileInfo = IBackupCoordination::FileInfo;
@@ -275,7 +275,7 @@ void BackupImpl::writeBackupMetadata()
     assert(!is_internal_backup);
 
     Poco::AutoPtr<Poco::Util::XMLConfiguration> config{new Poco::Util::XMLConfiguration()};
-    config->setUInt64("version", CURRENT_BACKUP_VERSION);
+    config->setInt("version", CURRENT_BACKUP_VERSION);
     config->setString("timestamp", toString(LocalDateTime{timestamp}));
     config->setString("uuid", toString(*uuid));
 
@@ -367,7 +367,7 @@ void BackupImpl::readBackupMetadata()
     Poco::AutoPtr<Poco::Util::XMLConfiguration> config{new Poco::Util::XMLConfiguration()};
     config->load(stream);
 
-    version = config->getUInt64("version");
+    version = config->getInt("version");
     if ((version < INITIAL_BACKUP_VERSION) || (version > CURRENT_BACKUP_VERSION))
         throw Exception(ErrorCodes::BACKUP_VERSION_NOT_SUPPORTED, "Backup {}: Version {} is not supported", backup_name, version);
 

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -122,7 +122,7 @@ private:
     size_t num_files = 0;
     UInt64 uncompressed_size = 0;
     UInt64 compressed_size = 0;
-    UInt64 version;
+    int version;
     std::optional<BackupInfo> base_backup_info;
     std::shared_ptr<const IBackup> base_backup;
     std::optional<UUID> base_backup_uuid;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix reusing of files > 4GB from base backup

Previosly u64 numbers was truncated to u32 numbers during writing to the
mdatadata xml file, and further incremental backup cannot reuse them,
since the file in base backup is smaller.

P.S. There can be other places, I thought about enabling
-Wshorten-64-to-32, but there are lots of warnings right now.

Cc: @vitlibar 