### PR TITLE
Add logging during merge tree startup

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1318,7 +1318,7 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks)
     std::queue<std::vector<std::pair<String, DiskPtr>>> parts_queue;
     for (auto & [disk_name, disk_parts] : disk_part_map)
     {
-        LOG_INFO(log, "Found {} parts for disk '{}' to load", disk_name, disk_parts.size());
+        LOG_INFO(log, "Found {} parts for disk '{}' to load", disk_parts.size(), disk_name);
 
         if (disk_parts.empty())
             continue;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Can be too verbose, not sure.