### PR TITLE
Make thread ids in the process list and query_log unique to avoid waste

### DIFF
--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -78,7 +78,7 @@ public:
     InternalProfileEventsQueueWeakPtr profile_queue_ptr;
     std::function<void()> fatal_error_callback;
 
-    std::vector<UInt64> thread_ids;
+    std::unordered_set<UInt64> thread_ids;
     std::unordered_set<ThreadStatusPtr> threads;
 
     /// The first thread created this thread group

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -533,7 +533,7 @@ QueryStatusInfo QueryStatus::getInfo(bool get_thread_list, bool get_profile_even
         if (get_thread_list)
         {
             std::lock_guard lock(thread_group->mutex);
-            res.thread_ids = thread_group->thread_ids;
+            res.thread_ids.assign(thread_group->thread_ids.begin(), thread_group->thread_ids.end());
         }
 
         if (get_profile_events)

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -109,7 +109,7 @@ void ThreadStatus::setupState(const ThreadGroupStatusPtr & thread_group_)
         std::lock_guard lock(thread_group->mutex);
 
         /// NOTE: thread may be attached multiple times if it is reused from a thread pool.
-        thread_group->thread_ids.emplace_back(thread_id);
+        thread_group->thread_ids.insert(thread_id);
         thread_group->threads.insert(this);
 
         logs_queue_ptr = thread_group->logs_queue_ptr;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make thread ids in the process list and query_log unique to avoid waste.