### PR TITLE
Fix: DISTINCT in order fails with LOGICAL_ERROR

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/distinctReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/distinctReadInOrder.cpp
@@ -44,6 +44,12 @@ size_t tryDistinctReadInOrder(QueryPlan::Node * parent_node, QueryPlan::Nodes &)
     if (!read_from_merge_tree)
         return 0;
 
+    /// if reading from merge tree doesn't provide any output order, we can do nothing
+    /// it means that no ordering can provided or supported for a particular sorting key
+    /// for example, tuple() or sipHash(string)
+    if (read_from_merge_tree->getOutputStream().sort_description.empty())
+        return 0;
+
     /// find non-const columns in DISTINCT
     const ColumnsWithTypeAndName & distinct_columns = pre_distinct->getOutputStream().header.getColumnsWithTypeAndName();
     std::set<std::string_view> non_const_columns;

--- a/tests/queries/0_stateless/02317_distinct_in_order_optimization.reference
+++ b/tests/queries/0_stateless/02317_distinct_in_order_optimization.reference
@@ -110,3 +110,10 @@ select distinct a, b, x, y from (select a, b, 1 as x, 2 as y from distinct_in_or
 0
 -- check that distinct in order WITHOUT order by and WITH filter returns the same result as ordinary distinct
 0
+-- bug 42185, distinct in order and empty sort description
+-- distinct in order, sorting key tuple()
+1
+0
+-- distinct in order, sorting key contains function
+2000-01-01 00:00:00
+2000-01-01

--- a/tests/queries/0_stateless/02317_distinct_in_order_optimization.sql
+++ b/tests/queries/0_stateless/02317_distinct_in_order_optimization.sql
@@ -95,3 +95,23 @@ select count() as diff from (select distinct * from distinct_in_order except sel
 drop table if exists distinct_in_order;
 drop table if exists ordinary_distinct;
 drop table if exists distinct_cardinality_low;
+
+-- bug 42185
+drop table if exists sorting_key_empty_tuple;
+drop table if exists sorting_key_contain_function;
+
+select '-- bug 42185, distinct in order and empty sort description';
+select '-- distinct in order, sorting key tuple()';
+create table sorting_key_empty_tuple (a int, b int) engine=MergeTree() order by tuple();
+insert into sorting_key_empty_tuple select number % 2, number % 5 from numbers(1,10);
+select distinct a from sorting_key_empty_tuple;
+
+select '-- distinct in order, sorting key contains function';
+create table sorting_key_contain_function (datetime DateTime, a int) engine=MergeTree() order by (toDate(datetime));
+insert into sorting_key_contain_function values ('2000-01-01', 1);
+insert into sorting_key_contain_function values ('2000-01-01', 2);
+select distinct datetime from sorting_key_contain_function;
+select distinct toDate(datetime) from sorting_key_contain_function;
+
+drop table sorting_key_empty_tuple;
+drop table sorting_key_contain_function;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
DISTINCT in order fails with LOGICAL_ERROR if first column in sorting key contains function

Fix #42185