### PR TITLE
Optimize branch misses in AssociativeApplierImpl::apply

### DIFF
--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -168,10 +168,7 @@ public:
     inline ResultValueType apply(const size_t i) const
     {
         const auto a = !!vec[i];
-        if constexpr (Op::isSaturable())
-            return Op::isSaturatedValue(a) ? a : Op::apply(a, next.apply(i));
-        else
-            return Op::apply(a, next.apply(i));
+        return Op::apply(a, next.apply(i));
     }
 
 private:


### PR DESCRIPTION
The short-circuit evaluation was implemented when applying the saturable operators (and, or) on a vector of ColumnUInt8. However, its control flow would be compiled as a series of conditional branch instructions which are hard to predict by the hardware and as a result, the overall performance is lowered. To remedy this issue, the short-circuit is removed and the whole expression is evaluated instead.

A microbenchmark is implemented to evaluate the performance of the AssociativeApplierImpl::apply method.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Currently, the only saturable operators are And and Or, and their code paths are affected by this change. 

The performance experiments of **SSB** (Star Schema Benchmark) on the ICX device (Intel Xeon Platinum 8380 CPU, 80 cores, 160 threads) shows that this change could bring improvements of **9.7%, 34.8% and 32.3%** to the QPS of the query 1.1, 1.2, and 1.3 respectively, while keeping the performance of the rest cases unaffected. Overall, the geomean of all subcases' QPS increased by around **5.7%**.

To clarify the generality of this optimization, we implemented a microbenchmark which mocked the user data in _ColumnUInt8_ with different zero ratios and measured the elapsed time of _AssociativeApplierImpl::apply_ method when it was applied to an N-_ColumnUInt8_ vector (N=1,2,...,8). The performance results indicated that this change could bring performance gain to all N-zero-ratio combinations, and especially to cases whose branch targets are hard for processors to predict. 

For And operator:
|N\Zero Ratio|0|0.2|0.4|0.6|0.8|1|
| ----- | ---- | ---- | ---- | ---- | ---- | ---- |
|1|1.26x|1.88x|1.35x|1.65x|1.31x|1.38x|
|2|6.79x|37.50x|68.72x|64.99x|37.09x|8.04x|
|3|7.57x|40.93x|74.17x|71.94x|46.52x|7.69x|
|4|18.56x|42.21x|72.70x|69.10x|28.81x|6.84x|
|5|19.76x|39.50x|59.09x|59.74x|33.15x|7.89x|
|6|19.08x|36.83x|50.71x|50.27x|31.16x|4.85x|
|7|11.93x|36.39x|50.19x|48.24x|29.32x|5.90x|
|8|20.54x|28.46x|45.13x|43.82x|26.67x|5.14x|

For Or operator:
|N\Zero Ratio|0|0.2|0.4|0.6|0.8|1|
| ----- | ---- | ---- | ---- | ---- | ---- | ---- |
|1|1.17x|1.51x|1.02x|1.65x|1.38x|1.03x|
|2|6.25x|37.06x|70.42x|70.77x|39.78x|13.43x|
|3|9.09x|46.33x|75.60x|75.37x|44.29x|20.78x|
|4|4.46x|45.08x|73.40x|70.56x|46.67x|25.40x|
|5|4.38x|45.16x|71.02x|71.75x|49.68x|27.52x|
|6|7.92x|30.73x|70.03x|69.96x|50.46x|31.87x|
|7|7.29x|39.45x|63.71x|68.54x|50.53x|32.30x|
|8|6.48x|36.11x|61.48x|63.59x|49.84x|32.81x|

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
