### PR TITLE
Support BACKUP to S3 with as-is path/data structure

### DIFF
--- a/docs/en/operations/backup.md
+++ b/docs/en/operations/backup.md
@@ -171,6 +171,55 @@ end_time:          2022-08-30 09:21:46
 1 row in set. Elapsed: 0.002 sec.
 ```
 
+## Backup to S3
+
+It is possible to `BACKUP`/`RESTORE` to S3, but this disk should be configured
+in a proper way, since by default you will need to backup metadata from local
+disk to make backup full.
+
+First of all, you need to configure S3 disk in a special way:
+
+```xml
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <s3_plain>
+                <type>s3_plain</type>
+                <endpoint></endpoint>
+                <access_key_id></access_key_id>
+                <secret_access_key></secret_access_key>
+            </s3_plain>
+        </disks>
+        <policies>
+            <s3>
+                <volumes>
+                    <main>
+                        <disk>s3</disk>
+                    </main>
+                </volumes>
+            </s3>
+        </policies>
+    </storage_configuration>
+
+    <backups>
+        <allowed_disk>s3_plain</allowed_disk>
+    </backups>
+</clickhouse>
+```
+
+And then `BACKUP`/`RESTORE` as usual:
+
+```sql
+BACKUP TABLE data TO Disk('s3_plain', 'cloud_backup');
+RESTORE TABLE data AS data_restored FROM Disk('s3_plain', 'cloud_backup');
+```
+
+:::note
+But keep in mind that:
+- This disk should not be used for `MergeTree` itself, only for `BACKUP`/`RESTORE`
+- It has excessive API calls
+:::
+
 ## Alternatives
 
 ClickHouse stores data on disk, and there are many ways to backup disks.  These are some alternatives that have been used in the past, and that may fit in well in your environment.

--- a/src/Disks/ObjectStorages/FakeMetadataStorageFromDisk.h
+++ b/src/Disks/ObjectStorages/FakeMetadataStorageFromDisk.h
@@ -9,6 +9,7 @@
 namespace DB
 {
 
+/// Store metadata in the disk itself.
 class FakeMetadataStorageFromDisk final : public IMetadataStorage
 {
 private:

--- a/src/Disks/ObjectStorages/LocalObjectStorage.h
+++ b/src/Disks/ObjectStorages/LocalObjectStorage.h
@@ -12,6 +12,7 @@ class Logger;
 namespace DB
 {
 
+/// Treat local disk as an object storage (for interface compatibility).
 class LocalObjectStorage : public IObjectStorage
 {
 public:

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
@@ -10,6 +10,8 @@
 namespace DB
 {
 
+/// Store metadata on a separate disk
+/// (used for object storages, like S3 and related).
 class MetadataStorageFromDisk final : public IMetadataStorage
 {
 private:

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -1,0 +1,229 @@
+#include "MetadataStorageFromPlainObjectStorage.h"
+#include <Disks/IDisk.h>
+#include <Disks/ObjectStorages/StaticDirectoryIterator.h>
+#include <Common/filesystemHelpers.h>
+#include <Common/logger_useful.h>
+#include <Common/StringUtils/StringUtils.h>
+#include <IO/WriteHelpers.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+    extern const int LOGICAL_ERROR;
+}
+
+MetadataStorageFromPlainObjectStorage::MetadataStorageFromPlainObjectStorage(
+    ObjectStoragePtr object_storage_,
+    const std::string & object_storage_root_path_)
+    : object_storage(object_storage_)
+    , object_storage_root_path(object_storage_root_path_)
+{
+}
+
+MetadataTransactionPtr MetadataStorageFromPlainObjectStorage::createTransaction() const
+{
+    return std::make_shared<MetadataStorageFromPlainObjectStorageTransaction>(*this);
+}
+
+const std::string & MetadataStorageFromPlainObjectStorage::getPath() const
+{
+    return object_storage_root_path;
+}
+
+bool MetadataStorageFromPlainObjectStorage::exists(const std::string & path) const
+{
+    auto object = StoredObject::create(*object_storage, fs::path(object_storage_root_path) / path);
+    return object_storage->exists(object);
+}
+
+bool MetadataStorageFromPlainObjectStorage::isFile(const std::string & path) const
+{
+    /// NOTE: This check is inaccurate and has excessive API calls
+    return !isDirectory(path) && exists(path);
+}
+
+bool MetadataStorageFromPlainObjectStorage::isDirectory(const std::string & path) const
+{
+    std::string directory = path;
+    trimRight(directory);
+    directory += "/";
+
+    /// NOTE: This check is far from ideal, since it work only if the directory
+    /// really has files, and has excessive API calls
+    RelativePathsWithSize children;
+    object_storage->listPrefix(directory, children);
+    return !children.empty();
+}
+
+Poco::Timestamp MetadataStorageFromPlainObjectStorage::getLastModified(const std::string &) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "getLastModified is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+struct stat MetadataStorageFromPlainObjectStorage::stat(const std::string &) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "stat is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+time_t MetadataStorageFromPlainObjectStorage::getLastChanged(const std::string &) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "getLastChanged is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+uint64_t MetadataStorageFromPlainObjectStorage::getFileSize(const String & path) const
+{
+    RelativePathsWithSize children;
+    object_storage->listPrefix(path, children);
+    if (children.empty())
+        return 0;
+    if (children.size() != 1)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "listPrefix() return multiple paths ({}) for {}", children.size(), path);
+    return children.front().bytes_size;
+}
+
+std::vector<std::string> MetadataStorageFromPlainObjectStorage::listDirectory(const std::string & path) const
+{
+    RelativePathsWithSize children;
+    object_storage->listPrefix(path, children);
+
+    std::vector<std::string> result;
+    for (const auto & path_size : children)
+    {
+        result.push_back(path_size.relative_path);
+    }
+    return result;
+}
+
+DirectoryIteratorPtr MetadataStorageFromPlainObjectStorage::iterateDirectory(const std::string & path) const
+{
+    /// NOTE: this is not required for BACKUP/RESTORE, but this is a first step
+    /// towards MergeTree on plain S3.
+    auto paths = listDirectory(path);
+    std::vector<std::filesystem::path> fs_paths(paths.begin(), paths.end());
+    return std::make_unique<StaticDirectoryIterator>(std::move(fs_paths));
+}
+
+std::string MetadataStorageFromPlainObjectStorage::readFileToString(const std::string &) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "readFileToString is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+std::unordered_map<String, String> MetadataStorageFromPlainObjectStorage::getSerializedMetadata(const std::vector<String> &) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "getSerializedMetadata is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+StoredObjects MetadataStorageFromPlainObjectStorage::getStorageObjects(const std::string & path) const
+{
+    std::string blob_name = object_storage->generateBlobNameForPath(path);
+
+    std::string object_path = fs::path(object_storage_root_path) / blob_name;
+    size_t object_size = getFileSize(object_path);
+
+    auto object = StoredObject::create(*object_storage, object_path, object_size, /* exists */true);
+    return {std::move(object)};
+}
+
+uint32_t MetadataStorageFromPlainObjectStorage::getHardlinkCount(const std::string &) const
+{
+    return 1;
+}
+
+const IMetadataStorage & MetadataStorageFromPlainObjectStorageTransaction::getStorageForNonTransactionalReads() const
+{
+    return metadata_storage;
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::writeStringToFile(const std::string &, const std::string & /* data */)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "writeStringToFile is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::setLastModified(const std::string &, const Poco::Timestamp &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "setLastModified is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::unlinkFile(const std::string & path)
+{
+    auto object = StoredObject::create(*metadata_storage.object_storage, fs::path(metadata_storage.object_storage_root_path) / path);
+    metadata_storage.object_storage->removeObject(object);
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::removeRecursive(const std::string &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "removeRecursive is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::createDirectory(const std::string &)
+{
+    /// Noop. It is an Object Storage not a filesystem.
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::createDirectoryRecursive(const std::string &)
+{
+    /// Noop. It is an Object Storage not a filesystem.
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::removeDirectory(const std::string &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "removeDirectory is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::moveFile(const std::string & /* path_from */, const std::string & /* path_to */)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "moveFile is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::moveDirectory(const std::string & /* path_from */, const std::string & /* path_to */)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "moveDirectory is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::replaceFile(const std::string & /* path_from */, const std::string & /* path_to */)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "replaceFile is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::chmod(const String &, mode_t)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "chmod is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::setReadOnly(const std::string &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "setReadOnly is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::createHardLink(const std::string & /* path_from */, const std::string & /* path_to */)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "createHardLink is not implemented for MetadataStorageFromPlainObjectStorage");
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::createEmptyMetadataFile(const std::string &)
+{
+    /// Noop, no separate metadata.
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::createMetadataFile(
+    const std::string &, const std::string & /* blob_name */, uint64_t /* size_in_bytes */)
+{
+    /// Noop, no separate metadata.
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::addBlobToMetadata(
+    const std::string &, const std::string & /* blob_name */, uint64_t /* size_in_bytes */)
+{
+    /// Noop, local metadata files is only one file, it is the metadata file itself.
+}
+
+void MetadataStorageFromPlainObjectStorageTransaction::unlinkMetadata(const std::string &)
+{
+    /// Noop, no separate metadata.
+}
+
+}

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <Disks/IDisk.h>
+#include <Disks/ObjectStorages/IMetadataStorage.h>
+#include <Disks/ObjectStorages/MetadataFromDiskTransactionState.h>
+#include <Disks/ObjectStorages/MetadataStorageFromDiskTransactionOperations.h>
+
+
+namespace DB
+{
+
+/// Object storage is used as a filesystem, in a limited form:
+/// - no directory concept, files only
+/// - no stat/chmod/...
+/// - no move/...
+/// - limited unlink support
+///
+/// Also it has excessive API calls.
+///
+/// It is used to allow BACKUP/RESTORE to ObjectStorage (S3/...) with the same
+/// structure as on disk MergeTree, and does not requires metadata from local
+/// disk to restore.
+class MetadataStorageFromPlainObjectStorage final : public IMetadataStorage
+{
+private:
+    friend class MetadataStorageFromPlainObjectStorageTransaction;
+
+    ObjectStoragePtr object_storage;
+    std::string object_storage_root_path;
+
+public:
+    MetadataStorageFromPlainObjectStorage(
+        ObjectStoragePtr object_storage_,
+        const std::string & object_storage_root_path_);
+
+    MetadataTransactionPtr createTransaction() const override;
+
+    const std::string & getPath() const override;
+
+    bool exists(const std::string & path) const override;
+
+    bool isFile(const std::string & path) const override;
+
+    bool isDirectory(const std::string & path) const override;
+
+    uint64_t getFileSize(const String & path) const override;
+
+    Poco::Timestamp getLastModified(const std::string & path) const override;
+
+    time_t getLastChanged(const std::string & path) const override;
+
+    bool supportsChmod() const override { return false; }
+
+    bool supportsStat() const override { return false; }
+
+    struct stat stat(const String & path) const override;
+
+    std::vector<std::string> listDirectory(const std::string & path) const override;
+
+    DirectoryIteratorPtr iterateDirectory(const std::string & path) const override;
+
+    std::string readFileToString(const std::string & path) const override;
+
+    std::unordered_map<String, String> getSerializedMetadata(const std::vector<String> & file_paths) const override;
+
+    uint32_t getHardlinkCount(const std::string & path) const override;
+
+    DiskPtr getDisk() const { return {}; }
+
+    StoredObjects getStorageObjects(const std::string & path) const override;
+
+    std::string getObjectStorageRootPath() const override { return object_storage_root_path; }
+};
+
+class MetadataStorageFromPlainObjectStorageTransaction final : public IMetadataTransaction
+{
+private:
+    const MetadataStorageFromPlainObjectStorage & metadata_storage;
+
+    std::vector<MetadataOperationPtr> operations;
+public:
+    MetadataStorageFromPlainObjectStorageTransaction(const MetadataStorageFromPlainObjectStorage & metadata_storage_)
+        : metadata_storage(metadata_storage_)
+    {}
+
+    ~MetadataStorageFromPlainObjectStorageTransaction() override = default;
+
+    const IMetadataStorage & getStorageForNonTransactionalReads() const final;
+
+    void commit() final {}
+
+    void writeStringToFile(const std::string & path, const std::string & data) override;
+
+    void createEmptyMetadataFile(const std::string & path) override;
+
+    void createMetadataFile(const std::string & path, const std::string & blob_name, uint64_t size_in_bytes) override;
+
+    void addBlobToMetadata(const std::string & path, const std::string & blob_name, uint64_t size_in_bytes) override;
+
+    void setLastModified(const std::string & path, const Poco::Timestamp & timestamp) override;
+
+    bool supportsChmod() const override { return false; }
+
+    void chmod(const String & path, mode_t mode) override;
+
+    void setReadOnly(const std::string & path) override;
+
+    void unlinkFile(const std::string & path) override;
+
+    void createDirectory(const std::string & path) override;
+
+    void createDirectoryRecursive(const std::string & path) override;
+
+    void removeDirectory(const std::string & path) override;
+
+    void removeRecursive(const std::string & path) override;
+
+    void createHardLink(const std::string & path_from, const std::string & path_to) override;
+
+    void moveFile(const std::string & path_from, const std::string & path_to) override;
+
+    void moveDirectory(const std::string & path_from, const std::string & path_to) override;
+
+    void replaceFile(const std::string & path_from, const std::string & path_to) override;
+
+    void unlinkMetadata(const std::string & path) override;
+};
+
+}

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -43,8 +43,11 @@ struct S3ObjectStorageSettings
 
 class S3ObjectStorage : public IObjectStorage
 {
-public:
+private:
+    friend class S3PlainObjectStorage;
+
     S3ObjectStorage(
+        const char * logger_name,
         std::unique_ptr<Aws::S3::S3Client> && client_,
         std::unique_ptr<S3ObjectStorageSettings> && s3_settings_,
         String version_id_,
@@ -61,6 +64,15 @@ public:
         data_source_description.description = connection_string;
         data_source_description.is_cached = false;
         data_source_description.is_encrypted = false;
+
+        log = &Poco::Logger::get(logger_name);
+    }
+
+public:
+    template <class ...Args>
+    S3ObjectStorage(std::unique_ptr<Aws::S3::S3Client> && client_, Args && ...args)
+        : S3ObjectStorage("S3ObjectStorage", std::move(client_), std::forward<Args>(args)...)
+    {
     }
 
     DataSourceDescription getDataSourceDescription() const override
@@ -181,8 +193,24 @@ private:
 
     const String version_id;
 
-    Poco::Logger * log = &Poco::Logger::get("S3ObjectStorage");
+    Poco::Logger * log;
     DataSourceDescription data_source_description;
+};
+
+/// Do not encode keys, store as-is, and do not require separate disk for metadata.
+/// But because of this does not support renames/hardlinks/attrs/...
+///
+/// NOTE: This disk has excessive API calls.
+class S3PlainObjectStorage : public S3ObjectStorage
+{
+public:
+    std::string generateBlobNameForPath(const std::string & path) override { return path; }
+    std::string getName() const override { return "S3PlainObjectStorage"; }
+
+    template <class ...Args>
+    S3PlainObjectStorage(Args && ...args)
+        : S3ObjectStorage("S3PlainObjectStorage", std::forward<Args>(args)...)
+    {}
 };
 
 }

--- a/src/Disks/ObjectStorages/StaticDirectoryIterator.h
+++ b/src/Disks/ObjectStorages/StaticDirectoryIterator.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Disks/DirectoryIterator.h>
+#include <vector>
+#include <filesystem>
+#include <string>
+
+namespace DB
+{
+
+class StaticDirectoryIterator final : public IDirectoryIterator
+{
+public:
+    explicit StaticDirectoryIterator(std::vector<std::filesystem::path> && dir_file_paths_)
+        : dir_file_paths(std::move(dir_file_paths_))
+        , iter(dir_file_paths.begin())
+    {}
+
+    void next() override { ++iter; }
+
+    bool isValid() const override { return iter != dir_file_paths.end(); }
+
+    std::string path() const override { return iter->string(); }
+
+    std::string name() const override { return iter->filename(); }
+
+private:
+    std::vector<std::filesystem::path> dir_file_paths;
+    std::vector<std::filesystem::path>::iterator iter;
+};
+
+}

--- a/src/Disks/ObjectStorages/Web/MetadataStorageFromStaticFilesWebServer.cpp
+++ b/src/Disks/ObjectStorages/Web/MetadataStorageFromStaticFilesWebServer.cpp
@@ -1,5 +1,6 @@
 #include "MetadataStorageFromStaticFilesWebServer.h"
 #include <Disks/IDisk.h>
+#include <Disks/ObjectStorages/StaticDirectoryIterator.h>
 #include <Common/filesystemHelpers.h>
 #include <Common/logger_useful.h>
 #include <Common/escapeForFileName.h>
@@ -15,26 +16,6 @@ namespace ErrorCodes
     extern const int FILE_DOESNT_EXIST;
     extern const int NETWORK_ERROR;
 }
-
-class DiskWebServerDirectoryIterator final : public IDirectoryIterator
-{
-public:
-    explicit DiskWebServerDirectoryIterator(std::vector<fs::path> && dir_file_paths_)
-        : dir_file_paths(std::move(dir_file_paths_)), iter(dir_file_paths.begin()) {}
-
-    void next() override { ++iter; }
-
-    bool isValid() const override { return iter != dir_file_paths.end(); }
-
-    String path() const override { return iter->string(); }
-
-    String name() const override { return iter->filename(); }
-
-private:
-    std::vector<fs::path> dir_file_paths;
-    std::vector<fs::path>::iterator iter;
-};
-
 
 MetadataStorageFromStaticFilesWebServer::MetadataStorageFromStaticFilesWebServer(
     const WebObjectStorage & object_storage_)
@@ -169,7 +150,7 @@ DirectoryIteratorPtr MetadataStorageFromStaticFilesWebServer::iterateDirectory(c
 
     if (!initializeIfNeeded(path))
     {
-        return std::make_unique<DiskWebServerDirectoryIterator>(std::move(dir_file_paths));
+        return std::make_unique<StaticDirectoryIterator>(std::move(dir_file_paths));
     }
 
     assertExists(path);
@@ -181,7 +162,7 @@ DirectoryIteratorPtr MetadataStorageFromStaticFilesWebServer::iterateDirectory(c
     }
 
     LOG_TRACE(object_storage.log, "Iterate directory {} with {} files", path, dir_file_paths.size());
-    return std::make_unique<DiskWebServerDirectoryIterator>(std::move(dir_file_paths));
+    return std::make_unique<StaticDirectoryIterator>(std::move(dir_file_paths));
 }
 
 std::string MetadataStorageFromStaticFilesWebServer::readFileToString(const std::string &) const

--- a/tests/integration/test_backup_restore_s3/configs/storage_conf.xml
+++ b/tests/integration/test_backup_restore_s3/configs/storage_conf.xml
@@ -1,0 +1,42 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <s3>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+                <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>
+            </s3>
+            <s3_plain>
+                <type>s3_plain</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+                <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>
+            </s3_plain>
+            <hdd>
+                <type>local</type>
+                <path>/</path>
+            </hdd>
+        </disks>
+        <policies>
+            <s3>
+                <volumes>
+                    <main>
+                        <disk>s3</disk>
+                    </main>
+                </volumes>
+            </s3>
+        </policies>
+    </storage_configuration>
+
+    <backups>
+        <allowed_disk>default</allowed_disk>
+
+        <allowed_disk>s3</allowed_disk>
+        <allowed_disk>s3_plain</allowed_disk>
+
+        <allowed_path>/backups/</allowed_path>
+    </backups>
+</clickhouse>

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# pylint: disable=unused-argument
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/storage_conf.xml"],
+    with_minio=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.mark.parametrize(
+    "storage_policy,to_disk",
+    [
+        pytest.param(
+            "default",
+            "default",
+            id="from_local_to_local",
+        ),
+        pytest.param(
+            "s3",
+            "default",
+            id="from_s3_to_local",
+        ),
+        pytest.param(
+            "default",
+            "s3",
+            id="from_local_to_s3",
+        ),
+        pytest.param(
+            "s3",
+            "s3_plain",
+            id="from_s3_to_s3_plain",
+        ),
+        pytest.param(
+            "default",
+            "s3_plain",
+            id="from_local_to_s3_plain",
+        ),
+    ],
+)
+def test_backup_restore(start_cluster, storage_policy, to_disk):
+    backup_name = storage_policy + "_" + to_disk
+    node.query(
+        f"""
+    DROP TABLE IF EXISTS data NO DELAY;
+    CREATE TABLE data (key Int, value String, array Array(String)) Engine=MergeTree() ORDER BY tuple() SETTINGS storage_policy='{storage_policy}';
+    INSERT INTO data SELECT * FROM generateRandom('key Int, value String, array Array(String)') LIMIT 1000;
+    BACKUP TABLE data TO Disk('{to_disk}', '{backup_name}');
+    RESTORE TABLE data AS data_restored FROM Disk('{to_disk}', '{backup_name}');
+    SELECT throwIf(
+        (SELECT groupArray(tuple(*)) FROM data) !=
+        (SELECT groupArray(tuple(*)) FROM data_restored),
+        'Data does not matched after BACKUP/RESTORE'
+    );
+    DROP TABLE data NO DELAY;
+    DROP TABLE data_restored NO DELAY;
+    """
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support BACKUP to S3 with as-is path/data structure

Right now backup to S3 does not make a lot of sense, since:
- it has random names, and to decoding them
- requires metadata from local disk (/var/lib/disks/DISK/BACKUP_NAME)
- or send_metadata (but it is also tricky even with it)

So this patch adds simpler interface for S3, it is only suitable for BACKUP/RESTORE, so don't try to use it for MergeTree engine.

It is done by adding separate disk - `simple_s3` for this, that:
- does not support any extended features, like renames/hardlinks/attrs/...
- only write/read/unlink/list files

Cc: @vitlibar 