### PR TITLE
[do not merge, tests only] Try to use OpenSSL instead of BoringSSL (which is worse)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,7 +495,7 @@ endif ()
 
 enable_testing() # Enable for tests without binary
 
-option(ENABLE_EXTERNAL_OPENSSL "This option is insecure and not recommended for any occasions. If it is enabled, it allows building with alternative OpenSSL library. By default, ClickHouse is using BoringSSL, which is better. Do not use this option." OFF)
+option(ENABLE_EXTERNAL_OPENSSL "This option is insecure and not recommended for any occasions. If it is enabled, it allows building with alternative OpenSSL library. By default, ClickHouse is using BoringSSL, which is better. Do not use this option." ON)
 
 if (ENABLE_EXTERNAL_OPENSSL)
     message (STATUS "Build and uses OpenSSL library instead of BoringSSL. This is strongly discouraged. Your build of ClickHouse will be unsupported.")


### PR DESCRIPTION
Changes to support the OpenSSL using the build flag. User will be provided with the option to select between BoringSSL and OpenSSL. By default, the BoringSSL in-house build will be used.

This PR is the second step to support the OpenSSL changes and follow-up for the PR [41142](https://github.com/ClickHouse/ClickHouse/pull/41142)

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This PR is to support the OpenSSL in-house build like the BoringSSL submodule. Build flag i.e. ENABLE_EXTERNAL_OPENSSL is used to choose between BoringSSL and OpenSSL.
By default, the BoringSSL in-house build will be used.

In case of OpenSSL, AEAD mode exclusively supported in BoringSSL and is not supported by OpenSSL. So, the encrypted compression will be disabled.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
