### PR TITLE
assert unused value in test_replicated_merge_tree_compatibility

### DIFF
--- a/tests/integration/test_replicated_merge_tree_compatibility/test.py
+++ b/tests/integration/test_replicated_merge_tree_compatibility/test.py
@@ -73,4 +73,4 @@ def test_replicated_merge_tree_defaults_compatibility(started_cluster):
     node2.restart_with_latest_version()
 
     node1.query(create_query.format(replica=1))
-    node1.query("EXISTS TABLE test.table") == "1\n"
+    assert node1.query("EXISTS TABLE test.table") == "1\n"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
