### PR TITLE
groupid in entrypoint

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -17,7 +17,7 @@ if [ "$(id -u)" = "0" ]; then
     GROUP=$CLICKHOUSE_GID
 else
     USER="$(id -u)"
-    GROUP="$(id -g)"
+    GROUP="$(id -gn)"
     DO_CHOWN=0
 fi
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
groupid in entrypoint

The problem is on openshift the clickhouse process owner is the root group.
The `getgrnam_r` function fails if you pass a group called "0" as the name argument.
This can be avoided if the entrypoint script uses `id -gn` rather than `id -g` in the case the user is non-root.

This should probably be reworked though, it doesn't make sense that `clickhouse su clickhouse:root` succeeds where `clickhouse su clickhouse:0` fails

https://github.com/ClickHouse/ClickHouse/issues/38583#issuecomment-1176344192

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
