### PR TITLE
Fix Codec T64 on s390x

### DIFF
--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -307,7 +307,19 @@ void reverseTransposeBytes(const UInt64 * matrix, UInt32 col, T & value)
 template <typename T>
 void load(const char * src, T * buf, UInt32 tail = 64)
 {
-    memcpy(buf, src, tail * sizeof(T));
+    if constexpr (std::endian::native == std::endian::little)
+    {
+        memcpy(buf, src, tail * sizeof(T));
+    }
+    else
+    {
+        /// Since the algorithm uses little-endian integers, data is loaded
+        /// as little-endian types on big-endian machine(s390x, etc.)
+        for (UInt32 i = 0; i < tail; i++)
+        {
+            buf[i] = unalignedLoadLE<T>(src + i * sizeof(T));
+        }
+    }
 }
 
 template <typename T>

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -314,7 +314,7 @@ void load(const char * src, T * buf, UInt32 tail = 64)
     else
     {
         /// Since the algorithm uses little-endian integers, data is loaded
-        /// as little-endian types on big-endian machine(s390x, etc.)
+        /// as little-endian types on big-endian machine (s390x, etc).
         for (UInt32 i = 0; i < tail; ++i)
         {
             buf[i] = unalignedLoadLE<T>(src + i * sizeof(T));

--- a/src/Compression/CompressionCodecT64.cpp
+++ b/src/Compression/CompressionCodecT64.cpp
@@ -315,7 +315,7 @@ void load(const char * src, T * buf, UInt32 tail = 64)
     {
         /// Since the algorithm uses little-endian integers, data is loaded
         /// as little-endian types on big-endian machine(s390x, etc.)
-        for (UInt32 i = 0; i < tail; i++)
+        for (UInt32 i = 0; i < tail; ++i)
         {
             buf[i] = unalignedLoadLE<T>(src + i * sizeof(T));
         }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
The T64 compression codec algorithm assumes little-endian integer being used, this will fail the following function tests on big-endian machines like s390x:
- 00870_t64_codec
- 00871_t64_codec_signed
- 00872_t64_bit_codec

The fix is to load data in little endian on big-endian machines(Note that nothing needs to be done for function store(), otherwise the result would be in little endian).

### Changelog category (leave one):
- Build Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed Endian issue in T64 compression codec on s390x


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
