### PR TITLE
Fix an invalid type of a column after attach and alter.

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -315,7 +315,12 @@ void ReplicatedMergeTreeSink::commitPart(
     DataPartStorageBuilderPtr builder,
     size_t replicas_num)
 {
-    metadata_snapshot->check(part->getColumns());
+    /// It is possible that we alter a part with different types of source columns.
+    /// In this case, if column was not altered, the result type will be different with what we have in metadata.
+    /// For now, consider it is ok. See 02461_alter_update_respect_part_column_type_bug for an example.
+    ///
+    /// metadata_snapshot->check(part->getColumns());
+
     assertSessionIsNotExpired(zookeeper);
 
     String temporary_part_relative_path = part->data_part_storage->getPartDirectory();

--- a/tests/queries/0_stateless/02012_zookeeper_changed_enum_type_incompatible.reference
+++ b/tests/queries/0_stateless/02012_zookeeper_changed_enum_type_incompatible.reference
@@ -1,0 +1,4 @@
+one	1
+two	1
+one	1
+two	1

--- a/tests/queries/0_stateless/02012_zookeeper_changed_enum_type_incompatible.sql
+++ b/tests/queries/0_stateless/02012_zookeeper_changed_enum_type_incompatible.sql
@@ -11,5 +11,6 @@ alter table enum_alter_issue detach partition id 'all';
 alter table enum_alter_issue modify column a Enum8('one' = 1, 'two' = 2, 'three' = 3);
 insert into enum_alter_issue values ('one', 1), ('two', 1);
 
-alter table enum_alter_issue attach partition id 'all'; -- {serverError TYPE_MISMATCH}
+alter table enum_alter_issue attach partition id 'all';
+select * from enum_alter_issue;
 drop table enum_alter_issue;

--- a/tests/queries/0_stateless/02461_alter_update_respect_part_column_type_bug.reference
+++ b/tests/queries/0_stateless/02461_alter_update_respect_part_column_type_bug.reference
@@ -1,0 +1,9 @@
+1	one	test1
+one	one	test1
+one	one	test
+one	one	test
+-----
+1	one	test1
+one	one	test1
+one	one	test
+one	one	test

--- a/tests/queries/0_stateless/02461_alter_update_respect_part_column_type_bug.sql
+++ b/tests/queries/0_stateless/02461_alter_update_respect_part_column_type_bug.sql
@@ -1,0 +1,94 @@
+drop table if exists src;
+create table src( A Int64, B String, C String) Engine=MergeTree order by A SETTINGS min_bytes_for_wide_part=0;
+insert into src values(1, 'one', 'test');
+
+alter table src detach partition tuple();
+alter table src modify column B Nullable(String);
+alter table src attach partition tuple();
+
+alter table src update C = 'test1' where 1 settings mutations_sync=2;
+select * from src;
+
+
+drop table if exists src;
+create table src( A String, B String, C String) Engine=MergeTree order by A SETTINGS min_bytes_for_wide_part=0;
+insert into src values('one', 'one', 'test');
+
+alter table src detach partition tuple();
+alter table src modify column A LowCardinality(String);
+alter table src attach partition tuple();
+
+alter table src update C = 'test1' where 1 settings mutations_sync=2;
+select * from src;
+
+
+drop table if exists src;
+create table src( A String, B String, C String) Engine=MergeTree order by A SETTINGS min_bytes_for_wide_part=0;
+insert into src values('one', 'one', 'test');
+
+alter table src detach partition tuple();
+alter table src modify column A LowCardinality(String);
+alter table src attach partition tuple();
+
+alter table src modify column C LowCardinality(String);
+select * from src;
+
+drop table if exists src;
+create table src( A String, B String, C String) Engine=MergeTree order by A SETTINGS min_bytes_for_wide_part=0;
+insert into src values('one', 'one', 'test');
+
+alter table src detach partition tuple();
+alter table src modify column B Nullable(String);
+alter table src attach partition tuple();
+
+alter table src rename column B to D;
+select * from src;
+
+select '-----';
+
+drop table if exists src;
+create table src( A Int64, B String, C String) Engine=ReplicatedMergeTree('/clickhouse/{database}/test/src1', '1') order by A SETTINGS min_bytes_for_wide_part=0;
+insert into src values(1, 'one', 'test');
+
+alter table src detach partition tuple();
+alter table src modify column B Nullable(String);
+alter table src attach partition tuple();
+
+alter table src update C = 'test1' where 1 settings mutations_sync=2;
+select * from src;
+
+
+drop table if exists src;
+create table src( A String, B String, C String) Engine=ReplicatedMergeTree('/clickhouse/{database}/test/src2', '1') order by A SETTINGS min_bytes_for_wide_part=0;
+insert into src values('one', 'one', 'test');
+
+alter table src detach partition tuple();
+alter table src modify column A LowCardinality(String);
+alter table src attach partition tuple();
+
+alter table src update C = 'test1' where 1 settings mutations_sync=2;
+select * from src;
+
+
+drop table if exists src;
+create table src( A String, B String, C String) Engine=ReplicatedMergeTree('/clickhouse/{database}/test/src3', '1') order by A SETTINGS min_bytes_for_wide_part=0;
+insert into src values('one', 'one', 'test');
+
+alter table src detach partition tuple();
+alter table src modify column A LowCardinality(String);
+alter table src attach partition tuple();
+
+alter table src modify column C LowCardinality(String);
+select * from src;
+
+drop table if exists src;
+create table src( A String, B String, C String) Engine=ReplicatedMergeTree('/clickhouse/{database}/test/src4', '1') order by A SETTINGS min_bytes_for_wide_part=0;
+insert into src values('one', 'one', 'test');
+
+alter table src detach partition tuple();
+alter table src modify column B Nullable(String);
+alter table src attach partition tuple();
+
+alter table src rename column B to D;
+select * from src;
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`ALTER UPDATE` of attached part (with columns different from table schema) could create an invalid `columns.txt` metadata on disk. Reading from such part could fail with errors or return invalid data. Fixes #42161.