### PR TITLE
(faster session reinitialization) Remove timeout for reestablishing new connection in case of read-only table error

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2054,7 +2054,12 @@ zkutil::ZooKeeperPtr Context::getZooKeeper() const
     if (!shared->zookeeper)
         shared->zookeeper = std::make_shared<zkutil::ZooKeeper>(config, "zookeeper", getZooKeeperLog());
     else if (shared->zookeeper->expired())
+    {
+        Stopwatch watch;
+        LOG_DEBUG(shared->log, "Trying to establish a new connection with ZooKeeper");
         shared->zookeeper = shared->zookeeper->startNewSession();
+        LOG_DEBUG(shared->log, "Establishing a new connection with ZooKeeper took {} ms", watch.elapsedMilliseconds());
+    }
 
     return shared->zookeeper;
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -68,7 +68,6 @@ void ReplicatedMergeTreeRestartingThread::run()
             LOG_TEST(log, "Replica appeared not to be active. Resheduling restarting thread immediately");
             task->schedule();
         }
-            
     }
     catch (...)
     {
@@ -121,7 +120,7 @@ bool ReplicatedMergeTreeRestartingThread::runImpl()
 
     try
     {
-        storage.setZooKeeper();   
+        storage.setZooKeeper();
     }
     catch (const Coordination::Exception &)
     {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -161,7 +161,7 @@ bool ReplicatedMergeTreeRestartingThread::runImpl()
     storage.cleanup_thread.start();
     storage.part_check_thread.start();
 
-    LOG_DEBUG(log, "Everything is Ok. Table started successfully!");
+    LOG_DEBUG(log, "Table started successfully");
 
     return true;
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -129,7 +129,7 @@ bool ReplicatedMergeTreeRestartingThread::runImpl()
     try
     {
         Stopwatch watch;
-        LOG_DEBUG(log, "Trying to establish new connection");
+        LOG_DEBUG(log, "Trying to establish a new connection");
         storage.setZooKeeper();
         LOG_DEBUG(log, "Establishing a new connection took {} ms", watch.elapsedMilliseconds());
     }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -338,7 +338,7 @@ void ReplicatedMergeTreeRestartingThread::partialShutdown(bool part_of_full_shut
 
     storage.partial_shutdown_called = true;
     storage.partial_shutdown_event.set();
-    storage.replica_is_active_node.reset();
+    storage.replica_is_active_node = nullptr;
 
 
     Stopwatch watch;

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
@@ -40,7 +40,7 @@ private:
     String active_node_identifier;
 
     BackgroundSchedulePool::TaskHolder task;
-    Int64 check_period_ms;            /// The frequency of checking expiration of session in ZK.
+    Int64 check_period_ms;                  /// The frequency of checking expiration of session in ZK.
     bool first_time = true;                 /// Activate replica for the first time.
 
     void run();

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
@@ -40,7 +40,7 @@ private:
     String active_node_identifier;
 
     BackgroundSchedulePool::TaskHolder task;
-    Int64 check_period_ms;                  /// The frequency of checking expiration of session in ZK.
+    Int64 check_period_ms;            /// The frequency of checking expiration of session in ZK.
     bool first_time = true;                 /// Activate replica for the first time.
 
     void run();

--- a/tests/integration/test_read_only_table/test.py
+++ b/tests/integration/test_read_only_table/test.py
@@ -1,0 +1,74 @@
+import time
+import re
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+
+def fill_nodes(nodes):
+    for node in nodes:
+        node.query(
+            f"""
+                CREATE TABLE test_table(a UInt64)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/replicated', '{node.name}') ORDER BY tuple();
+            """
+        )
+
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance("node1", with_zookeeper=True)
+node2 = cluster.add_instance("node2", with_zookeeper=True)
+node3 = cluster.add_instance("node3", with_zookeeper=True)
+nodes = [node1, node2, node3]
+
+
+def sync_replicas(table):
+    for node in nodes:
+        node.query(f"SYSTEM SYNC REPLICA {table}")
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+
+        fill_nodes([node1, node2, node3])
+
+        yield cluster
+
+    except Exception as ex:
+        print(ex)
+
+    finally:
+        cluster.shutdown()
+
+
+def test_restart_zookeeper(start_cluster):
+
+    node1.query("INSERT INTO test_table VALUES (1), (2), (3), (4), (5);")
+
+    def get_zookeeper_which_node_connected_to(node):
+        line =  str(
+            node.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    "lsof -a -i4 -i6 -itcp -w | grep 2181 | grep ESTABLISHED",
+                ],
+                privileged=True,
+                user="root",
+            )
+        ).strip()
+
+        pattern = re.compile(r"zoo[0-9]+", re.IGNORECASE)
+        result = pattern.findall(line)
+        assert len(result) == 1, "ClickHouse must be connected only to one Zookeeper at a time"
+        return result[0]
+
+    node1_zk = get_zookeeper_which_node_connected_to(node1)
+
+    # ClickHouse should +- immediately reconnect to another zookeper node
+    cluster.stop_zookeeper_nodes([node1_zk])
+    time.sleep(10)
+
+    node1.query("INSERT INTO test_table VALUES (6), (7), (8), (9), (10);")

--- a/tests/integration/test_read_only_table/test.py
+++ b/tests/integration/test_read_only_table/test.py
@@ -8,6 +8,7 @@ from helpers.test_tools import assert_eq_with_retry
 
 NUM_TABLES = 10
 
+
 def fill_nodes(nodes):
     for table_id in range(NUM_TABLES):
         for node in nodes:
@@ -17,7 +18,6 @@ def fill_nodes(nodes):
                     ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/replicated/{table_id}', '{node.name}') ORDER BY tuple();
                 """
             )
-            
 
 
 cluster = ClickHouseCluster(__file__)
@@ -51,7 +51,9 @@ def start_cluster():
 def test_restart_zookeeper(start_cluster):
 
     for table_id in range(NUM_TABLES):
-        node1.query(f"INSERT INTO test_table_{table_id} VALUES (1), (2), (3), (4), (5);")
+        node1.query(
+            f"INSERT INTO test_table_{table_id} VALUES (1), (2), (3), (4), (5);"
+        )
         # sync_replicas(f"test_table_{table_id}")
 
     logging.info("Inserted test data and initialized all tables")
@@ -83,4 +85,6 @@ def test_restart_zookeeper(start_cluster):
     time.sleep(10)
 
     for table_id in range(NUM_TABLES):
-        node1.query(f"INSERT INTO test_table_{table_id} VALUES (6), (7), (8), (9), (10);")
+        node1.query(
+            f"INSERT INTO test_table_{table_id} VALUES (6), (7), (8), (9), (10);"
+        )

--- a/tests/integration/test_read_only_table/test.py
+++ b/tests/integration/test_read_only_table/test.py
@@ -5,6 +5,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 
+
 def fill_nodes(nodes):
     for node in nodes:
         node.query(
@@ -48,7 +49,7 @@ def test_restart_zookeeper(start_cluster):
     node1.query("INSERT INTO test_table VALUES (1), (2), (3), (4), (5);")
 
     def get_zookeeper_which_node_connected_to(node):
-        line =  str(
+        line = str(
             node.exec_in_container(
                 [
                     "bash",
@@ -62,7 +63,9 @@ def test_restart_zookeeper(start_cluster):
 
         pattern = re.compile(r"zoo[0-9]+", re.IGNORECASE)
         result = pattern.findall(line)
-        assert len(result) == 1, "ClickHouse must be connected only to one Zookeeper at a time"
+        assert (
+            len(result) == 1
+        ), "ClickHouse must be connected only to one Zookeeper at a time"
         return result[0]
 
     node1_zk = get_zookeeper_which_node_connected_to(node1)


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When ZooKeeper session expires the MergeTreeRestartingThread will be notified automatically and almost instantly but it need to try several times to establish new connection. This PR enables retries without any timeout after first error occur. This closes https://github.com/ClickHouse/ClickHouse/issues/42251


