### PR TITLE
Randomization of tests with `DETACH`/`ATTACH` table

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -303,6 +303,8 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(Bool, opentelemetry_trace_processors, false, "Collect OpenTelemetry spans for processors.", 0) \
     M(Bool, prefer_column_name_to_alias, false, "Prefer using column names instead of aliases if possible.", 0) \
     M(Bool, prefer_global_in_and_join, false, "If enabled, all IN/JOIN operators will be rewritten as GLOBAL IN/JOIN. It's useful when the to-be-joined tables are only available on the initiator and we need to always scatter their data on-the-fly during distributed processing with the GLOBAL keyword. It's also useful to reduce the need to access the external sources joining external tables.", 0) \
+    M(Bool, reattach_tables_before_query_execution, false, "For testing purposes only. Detach and attach back all table that used in query before its execution.", 0) \
+    M(Float, reattach_tables_before_query_execution_probability, 0., "For testing purposes only. The probability of enabling 'reattach_tables_before_query_execution' if it's disabled.", 0) \
     \
     \
     /** Limits during query execution are part of the settings. \

--- a/src/Databases/DatabaseDictionary.h
+++ b/src/Databases/DatabaseDictionary.h
@@ -25,10 +25,9 @@ class DatabaseDictionary final : public IDatabase, WithContext
 public:
     DatabaseDictionary(const String & name_, ContextPtr context_);
 
-    String getEngineName() const override
-    {
-        return "Dictionary";
-    }
+    String getEngineName() const override { return "Dictionary"; }
+
+    bool supportsAttachingAndDetachingTables() const override { return false; }
 
     bool isTableExist(const String & table_name, ContextPtr context) const override;
 

--- a/src/Databases/DatabaseDictionary.h
+++ b/src/Databases/DatabaseDictionary.h
@@ -27,7 +27,7 @@ public:
 
     String getEngineName() const override { return "Dictionary"; }
 
-    bool supportsAttachingAndDetachingTables() const override { return false; }
+    bool supportsDetachingTables() const override { return false; }
 
     bool isTableExist(const String & table_name, ContextPtr context) const override;
 

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -29,6 +29,9 @@ public:
 
     String getEngineName() const override { return "Replicated"; }
 
+    /// Only DETACH TABLE PERMANENTLY is supported.
+    bool supportsDetachingTables() const override { return false; }
+
     /// If current query is initial, then the following methods add metadata updating ZooKeeper operations to current ZooKeeperMetadataTransaction.
     void dropTable(ContextPtr, const String & table_name, bool sync) override;
     void renameTable(ContextPtr context, const String & table_name, IDatabase & to_database,

--- a/src/Databases/DatabasesCommon.h
+++ b/src/Databases/DatabasesCommon.h
@@ -30,6 +30,8 @@ public:
 
     bool empty() const override;
 
+    bool supportsAttachingAndDetachingTables() const override { return true; }
+
     void attachTable(ContextPtr context, const String & table_name, const StoragePtr & table, const String & relative_table_path) override;
 
     StoragePtr detachTable(ContextPtr context, const String & table_name) override;

--- a/src/Databases/DatabasesCommon.h
+++ b/src/Databases/DatabasesCommon.h
@@ -30,7 +30,7 @@ public:
 
     bool empty() const override;
 
-    bool supportsAttachingAndDetachingTables() const override { return true; }
+    bool supportsDetachingTables() const override { return true; }
 
     void attachTable(ContextPtr context, const String & table_name, const StoragePtr & table, const String & relative_table_path) override;
 

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -202,7 +202,7 @@ public:
         throw Exception("There is no DROP TABLE query for Database" + getEngineName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
-    virtual bool supportsAttachingAndDetachingTables() const = 0;
+    virtual bool supportsDetachingTables() const = 0;
 
     /// Add a table to the database, but do not add it to the metadata. The database may not support this method.
     ///

--- a/src/Databases/IDatabase.h
+++ b/src/Databases/IDatabase.h
@@ -202,6 +202,8 @@ public:
         throw Exception("There is no DROP TABLE query for Database" + getEngineName(), ErrorCodes::NOT_IMPLEMENTED);
     }
 
+    virtual bool supportsAttachingAndDetachingTables() const = 0;
+
     /// Add a table to the database, but do not add it to the metadata. The database may not support this method.
     ///
     /// Note: ATTACH TABLE statement actually uses createTable method.

--- a/src/Databases/MySQL/DatabaseMySQL.h
+++ b/src/Databases/MySQL/DatabaseMySQL.h
@@ -78,6 +78,8 @@ public:
 
     void loadStoredObjects(ContextMutablePtr, LoadingStrictnessLevel /*mode*/, bool skip_startup_tables) override;
 
+    bool supportsAttachingAndDetachingTables() const override { return true; }
+
     StoragePtr detachTable(ContextPtr context, const String & table_name) override;
 
     void detachTablePermanently(ContextPtr context, const String & table_name) override;

--- a/src/Databases/MySQL/DatabaseMySQL.h
+++ b/src/Databases/MySQL/DatabaseMySQL.h
@@ -78,7 +78,7 @@ public:
 
     void loadStoredObjects(ContextMutablePtr, LoadingStrictnessLevel /*mode*/, bool skip_startup_tables) override;
 
-    bool supportsAttachingAndDetachingTables() const override { return true; }
+    bool supportsDetachingTables() const override { return true; }
 
     StoragePtr detachTable(ContextPtr context, const String & table_name) override;
 

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.h
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.h
@@ -55,7 +55,7 @@ public:
     void createTable(ContextPtr, const String & table_name, const StoragePtr & storage, const ASTPtr & create_query) override;
     void dropTable(ContextPtr, const String & table_name, bool sync) override;
 
-    bool supportsAttachingAndDetachingTables() const override { return true; }
+    bool supportsDetachingTables() const override { return true; }
 
     void attachTable(ContextPtr context, const String & table_name, const StoragePtr & storage, const String & relative_table_path) override;
     StoragePtr detachTable(ContextPtr context, const String & table_name) override;

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.h
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.h
@@ -55,6 +55,8 @@ public:
     void createTable(ContextPtr, const String & table_name, const StoragePtr & storage, const ASTPtr & create_query) override;
     void dropTable(ContextPtr, const String & table_name, bool sync) override;
 
+    bool supportsAttachingAndDetachingTables() const override { return true; }
+
     void attachTable(ContextPtr context, const String & table_name, const StoragePtr & storage, const String & relative_table_path) override;
     StoragePtr detachTable(ContextPtr context, const String & table_name) override;
 

--- a/src/Databases/SQLite/DatabaseSQLite.h
+++ b/src/Databases/SQLite/DatabaseSQLite.h
@@ -22,7 +22,7 @@ public:
 
     String getEngineName() const override { return "SQLite"; }
 
-    bool supportsAttachingAndDetachingTables() const override { return false; }
+    bool supportsDetachingTables() const override { return false; }
 
     bool canContainMergeTreeTables() const override { return false; }
 

--- a/src/Databases/SQLite/DatabaseSQLite.h
+++ b/src/Databases/SQLite/DatabaseSQLite.h
@@ -22,6 +22,8 @@ public:
 
     String getEngineName() const override { return "SQLite"; }
 
+    bool supportsAttachingAndDetachingTables() const override { return false; }
+
     bool canContainMergeTreeTables() const override { return false; }
 
     bool canContainDistributedTables() const override { return false; }

--- a/src/Interpreters/ActionLocksManager.cpp
+++ b/src/Interpreters/ActionLocksManager.cpp
@@ -54,6 +54,37 @@ void ActionLocksManager::remove(const StoragePtr & table, StorageActionBlockType
         storage_locks[table.get()].erase(action_type);
 }
 
+bool ActionLocksManager::has(const StorageID & table_id, StorageActionBlockType action_type) const
+{
+    if (auto table = DatabaseCatalog::instance().tryGetTable(table_id, getContext()))
+        return has(table, action_type);
+    return false;
+}
+
+bool ActionLocksManager::has(const StoragePtr & table, StorageActionBlockType action_type) const
+{
+    std::lock_guard lock(mutex);
+
+    auto it = storage_locks.find(table.get());
+    if (it == storage_locks.end())
+        return false;
+
+    return it->second.contains(action_type);
+}
+
+bool ActionLocksManager::hasAny(const StorageID & table_id) const
+{
+    if (auto table = DatabaseCatalog::instance().tryGetTable(table_id, getContext()))
+        return hasAny(table);
+    return false;
+}
+
+bool ActionLocksManager::hasAny(const StoragePtr & table) const
+{
+    std::lock_guard lock(mutex);
+    return storage_locks.contains(table.get());
+}
+
 void ActionLocksManager::cleanExpired()
 {
     std::lock_guard lock(mutex);

--- a/src/Interpreters/ActionLocksManager.h
+++ b/src/Interpreters/ActionLocksManager.h
@@ -28,6 +28,14 @@ public:
     void remove(const StorageID & table_id, StorageActionBlockType action_type);
     void remove(const StoragePtr & table, StorageActionBlockType action_type);
 
+    /// Checks whether there is a lock for specified table and action_type
+    bool has(const StorageID & table_id, StorageActionBlockType action_type) const;
+    bool has(const StoragePtr & table, StorageActionBlockType action_type) const;
+
+    /// Checks whether there is a lock for specified table and any action_type
+    bool hasAny(const StorageID & table_id) const;
+    bool hasAny(const StoragePtr & table) const;
+
     /// Removes all locks of non-existing tables
     void cleanExpired();
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -616,7 +616,8 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 
         logQuery(query_for_logging, context, internal, stage);
 
-        if (!internal)
+        bool is_initial_query = client_info.query_kind == ClientInfo::QueryKind::INITIAL_QUERY;
+        if (!internal && is_initial_query)
         {
             bool need_reattach_tables = settings.reattach_tables_before_query_execution;
             auto reattach_probability = settings.reattach_tables_before_query_execution_probability;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -416,6 +416,10 @@ static void reattachTablesUsedInQuery(const ASTPtr & query, ContextMutablePtr co
     CollectTablesInQueryVisitor::Data data(context);
     CollectTablesInQueryVisitor(data).visit(query);
 
+    /// Keep old settings, because they may be changed
+    /// during execution of ATTACH/DETACH queries.
+    auto old_settings = context->getSettings();
+
     for (const auto & table_id : data.tables)
     {
         if (table_id.getDatabaseName() == "system")
@@ -454,6 +458,8 @@ static void reattachTablesUsedInQuery(const ASTPtr & query, ContextMutablePtr co
         auto attach = executeQuery(attach_query, context, true);
         executeTrivialBlockIO(attach, context);
     }
+
+    context->setSettings(old_settings);
 }
 
 static std::tuple<ASTPtr, BlockIO> executeQueryImpl(

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1130,7 +1130,8 @@ private:
 
     void prepare()
     {
-        ctx->data_part_storage_builder->createDirectories();
+        if (ctx->new_data_part->isStoredOnDisk())
+            ctx->data_part_storage_builder->createDirectories();
 
         /// Note: this is done before creating input streams, because otherwise data.data_parts_mutex
         /// (which is locked in data.getTotalActiveSizeInBytes())

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -570,8 +570,25 @@ class TestCase:
 
         return testcase_args
 
-    def cli_random_settings(self) -> str:
-        return " ".join([f"--{setting}" for setting in self.random_settings])
+    @staticmethod
+    def cli_settings_list(settings_list) -> str:
+        return " ".join([f"--{setting}" for setting in settings_list])
+
+    def add_settings_impl(self, client_options, settings_to_add):
+        if len(self.base_url_params) == 0:
+            os.environ["CLICKHOUSE_URL_PARAMS"] = "&".join(settings_to_add)
+        else:
+            os.environ["CLICKHOUSE_URL_PARAMS"] = (
+                self.base_url_params + "&" + "&".join(settings_to_add)
+            )
+
+        new_options = (
+            f" --allow_repeated_settings {self.cli_settings_list(settings_to_add)}"
+        )
+        os.environ["CLICKHOUSE_CLIENT_OPT"] = (
+            self.base_client_options + new_options + " "
+        )
+        return client_options + new_options
 
     def add_random_settings(self, args, client_options):
         if self.tags and "no-random-settings" in self.tags:
@@ -579,18 +596,17 @@ class TestCase:
         if args.no_random_settings:
             return client_options
 
-        if len(self.base_url_params) == 0:
-            os.environ["CLICKHOUSE_URL_PARAMS"] = "&".join(self.random_settings)
-        else:
-            os.environ["CLICKHOUSE_URL_PARAMS"] = (
-                self.base_url_params + "&" + "&".join(self.random_settings)
-            )
+        return self.add_settings_impl(client_options, self.random_settings)
 
-        new_options = f" --allow_repeated_settings {self.cli_random_settings()}"
-        os.environ["CLICKHOUSE_CLIENT_OPT"] = (
-            self.base_client_options + new_options + " "
+    def add_random_detach(self, args, client_options):
+        if self.tags and "no-random-detach" in self.tags:
+            return client_options
+        if args.no_random_detach:
+            return client_options
+
+        return self.add_settings_impl(
+            client_options, ["reattach_tables_before_query_execution=1"]
         )
-        return client_options + new_options
 
     def remove_random_settings_from_env(self):
         os.environ["CLICKHOUSE_URL_PARAMS"] = self.base_url_params
@@ -602,9 +618,7 @@ class TestCase:
         if args.no_random_settings:
             return description
 
-        return (
-            f"{description}\nSettings used in the test: {self.cli_random_settings()}\n"
-        )
+        return f"{description}\nSettings used in the test: {self.cli_settings_list(self.random_settings)}\n"
 
     def __init__(self, suite, case: str, args, is_concurrent: bool):
         self.case: str = case  # case file name
@@ -1003,7 +1017,9 @@ class TestCase:
             try:
                 drop_database_query = "DROP DATABASE " + database
                 if args.replicated_database:
-                    drop_database_query += " ON CLUSTER test_cluster_database_replicated"
+                    drop_database_query += (
+                        " ON CLUSTER test_cluster_database_replicated"
+                    )
                 clickhouse_execute(
                     args,
                     drop_database_query,
@@ -1073,6 +1089,7 @@ class TestCase:
                 args, self.case_file, suite.suite_tmp_path
             )
             client_options = self.add_random_settings(args, client_options)
+            client_options = self.add_random_detach(args, client_options)
             proc, stdout, stderr, debug_log, total_time = self.run_single_test(
                 server_logs_level, client_options
             )
@@ -1199,7 +1216,7 @@ class TestSuite:
                 line = line.strip()
                 if line and not is_shebang(line):
                     return line
-            return ''
+            return ""
 
         def load_tags_from_file(filepath):
             comment_sign = get_comment_sign(filepath)
@@ -1723,7 +1740,7 @@ def removesuffix(text, *suffixes):
     return text
 
 
-def reportCoverageFor(args, what, query, permissive = False):
+def reportCoverageFor(args, what, query, permissive=False):
     value = clickhouse_execute(args, query).decode()
 
     if value != "":
@@ -1736,10 +1753,11 @@ def reportCoverageFor(args, what, query, permissive = False):
 
 
 def reportCoverage(args):
-    return reportCoverageFor(
-        args,
-        "functions",
-        """
+    return (
+        reportCoverageFor(
+            args,
+            "functions",
+            """
             SELECT name
             FROM system.functions
             WHERE NOT is_aggregate AND origin = 'System' AND alias_to = ''
@@ -1749,11 +1767,12 @@ def reportCoverage(args):
                 )
             ORDER BY name
         """,
-        True
-    ) and reportCoverageFor(
-        args,
-        "aggregate functions",
-        """
+            True,
+        )
+        and reportCoverageFor(
+            args,
+            "aggregate functions",
+            """
             SELECT name
             FROM system.functions
             WHERE is_aggregate AND origin = 'System' AND alias_to = ''
@@ -1762,11 +1781,12 @@ def reportCoverage(args):
                     SELECT arrayJoin(used_aggregate_functions) FROM system.query_log WHERE event_date >= yesterday()
                 )
             ORDER BY name
-        """
-    ) and reportCoverageFor(
-        args,
-        "aggregate function combinators",
-        """
+        """,
+        )
+        and reportCoverageFor(
+            args,
+            "aggregate function combinators",
+            """
             SELECT name
             FROM system.aggregate_function_combinators
             WHERE NOT is_internal
@@ -1775,11 +1795,12 @@ def reportCoverage(args):
                     SELECT arrayJoin(used_aggregate_function_combinators) FROM system.query_log WHERE event_date >= yesterday()
                 )
             ORDER BY name
-        """
-    ) and reportCoverageFor(
-        args,
-        "data type families",
-        """
+        """,
+        )
+        and reportCoverageFor(
+            args,
+            "data type families",
+            """
             SELECT name
             FROM system.data_type_families
             WHERE alias_to = '' AND name NOT LIKE 'Interval%'
@@ -1788,7 +1809,8 @@ def reportCoverage(args):
                     SELECT arrayJoin(used_data_type_families) FROM system.query_log WHERE event_date >= yesterday()
                 )
             ORDER BY name
-        """
+        """,
+        )
     )
 
 
@@ -1814,7 +1836,9 @@ def main(args):
         args, "system", "processes", "is_all_data_sent"
     )
 
-    if args.s3_storage and (BuildFlags.THREAD in args.build_flags or BuildFlags.DEBUG in args.build_flags):
+    if args.s3_storage and (
+        BuildFlags.THREAD in args.build_flags or BuildFlags.DEBUG in args.build_flags
+    ):
         args.no_random_settings = True
 
     if args.skip:
@@ -2145,6 +2169,12 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Disable settings randomization",
+    )
+    parser.add_argument(
+        "--no-random-detach",
+        action="store_true",
+        default=False,
+        help="Disable randomization of DETACH/ATTACH",
     )
 
     parser.add_argument(

--- a/tests/queries/0_stateless/00446_clear_column_in_partition_concurrent_zookeeper.sh
+++ b/tests/queries/0_stateless/00446_clear_column_in_partition_concurrent_zookeeper.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-replicated-database, no-parallel
+# Tags: zookeeper, no-replicated-database, no-parallel, no-random-detach
 # Tag no-replicated-database: Old syntax is not allowed
+# Tag no-random-detach: parallel queries
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00626_replace_partition_from_table.sql
+++ b/tests/queries/0_stateless/00626_replace_partition_from_table.sql
@@ -1,4 +1,5 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-random-detach
+-- Tag no-random-detach: it's a bug, will be fixed in https://github.com/ClickHouse/ClickHouse/pull/41145
 
 DROP TABLE IF EXISTS src;
 DROP TABLE IF EXISTS dst;

--- a/tests/queries/0_stateless/00652_mergetree_mutations.sh
+++ b/tests/queries/0_stateless/00652_mergetree_mutations.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-random-detach
+# Tag no-random-detach: mutation_id may be affected by DETACH/ATTACH
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00834_kill_mutation.sh
+++ b/tests/queries/0_stateless/00834_kill_mutation.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-debug, no-parallel
+# Tags: no-debug, no-parallel, no-random-detach
+# Tag no-random-detach: mutation_id may be affected by DETACH/ATTACH
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00834_kill_mutation_replicated_zookeeper.sh
+++ b/tests/queries/0_stateless/00834_kill_mutation_replicated_zookeeper.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: replica, no-debug, no-parallel
+# Tags: replica, no-debug, no-parallel, no-random-detach
+# Tag no-random-detach: mutation_id may be affected by DETACH/ATTACH
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/00952_part_frozen_info.sql
+++ b/tests/queries/0_stateless/00952_part_frozen_info.sql
@@ -1,3 +1,7 @@
+-- Tags: no-random-detach
+-- Tag no-random-detach: flag is_frozen is not persisted.
+-- Since, it's almost useless, there is no reason to fix it.
+
 DROP TABLE IF EXISTS part_info;
 CREATE TABLE part_info (t DateTime) ENGINE = MergeTree PARTITION BY toDate(t) ORDER BY (t);
 INSERT INTO part_info VALUES (toDateTime('1970-10-01 00:00:01')), (toDateTime('1970-10-02 00:00:01')), (toDateTime('1970-10-03 00:00:01'));

--- a/tests/queries/0_stateless/01010_low_cardinality_and_native_http.sh
+++ b/tests/queries/0_stateless/01010_low_cardinality_and_native_http.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
+# Tag no-random-detach: GET request is used in test, which implies readonly.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01083_log_family_disk_memory.sql
+++ b/tests/queries/0_stateless/01083_log_family_disk_memory.sql
@@ -1,3 +1,6 @@
+-- Tags: no-random-detach
+-- Tag no-random-detach: data is lost in memory disk after detach.
+
 DROP TABLE IF EXISTS log;
 
 CREATE TABLE log (x UInt8) ENGINE = StripeLog () SETTINGS disk = 'disk_memory';

--- a/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
+++ b/tests/queries/0_stateless/01149_zookeeper_mutation_stuck_after_replace_partition.sql
@@ -1,4 +1,7 @@
--- Tags: zookeeper
+-- Tags: zookeeper, no-random-detach
+-- Tag no-random-detach: "The local set of parts of table
+-- doesn't look like the set of parts in ZooKeeper"
+-- after DROP PARTITION and restart https://github.com/ClickHouse/ClickHouse/issues/37664
 
 set send_logs_level='error';
 drop table if exists mt;

--- a/tests/queries/0_stateless/01187_set_profile_as_setting.sh
+++ b/tests/queries/0_stateless/01187_set_profile_as_setting.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-random-settings
+# Tags: no-random-settings, no-random-detach
 
 unset CLICKHOUSE_LOG_COMMENT
 

--- a/tests/queries/0_stateless/01414_freeze_does_not_prevent_alters.sql
+++ b/tests/queries/0_stateless/01414_freeze_does_not_prevent_alters.sql
@@ -1,3 +1,7 @@
+-- Tags: no-random-detach
+-- Tag no-random-detach: flag is_frozen is not persisted.
+-- Since, it's almost useless, there is no reason to fix it.
+
 -- In previous ClickHouse versions, parts were not 100% immutable and FREEZE may prevent subsequent ALTERs.
 -- It's not longer the case. Let's prove it.
 

--- a/tests/queries/0_stateless/01459_manual_write_to_replicas_quorum.sh
+++ b/tests/queries/0_stateless/01459_manual_write_to_replicas_quorum.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: replica, no-replicated-database, no-parallel
+# Tags: replica, no-replicated-database, no-randon-detach
 # Tag no-replicated-database: Fails due to additional replicas or shards
+# Tag no-random-detach: it's a bug, will be fixed in https://github.com/ClickHouse/ClickHouse/pull/42509
 
 set -e
 

--- a/tests/queries/0_stateless/01475_read_subcolumns.sql
+++ b/tests/queries/0_stateless/01475_read_subcolumns.sql
@@ -1,4 +1,5 @@
--- Tags: no-s3-storage, no-random-settings
+-- Tags: no-s3-storage, no-random-settings, no-random-detach
+-- Tag no-random-detach: extra FileOpen while attach.
 
 SET use_uncompressed_cache = 0;
 

--- a/tests/queries/0_stateless/01533_distinct_nullable_uuid.sql
+++ b/tests/queries/0_stateless/01533_distinct_nullable_uuid.sql
@@ -1,3 +1,6 @@
+-- Tags: no-random-detach
+-- Tag no-random-detach: it's a bug, will be fixed in https://github.com/ClickHouse/ClickHouse/pull/41145
+
 DROP TABLE IF EXISTS bug_14144;
 
 CREATE TABLE bug_14144
@@ -32,7 +35,3 @@ SELECT COUNT() FROM (
 );
 
 DROP TABLE bug_14144;
-
-
-
-

--- a/tests/queries/0_stateless/01533_multiple_nested.sql
+++ b/tests/queries/0_stateless/01533_multiple_nested.sql
@@ -1,5 +1,5 @@
--- Tags: no-s3-storage
--- no-s3 because read FileOpen metric
+-- Tags: no-s3-storage, no-random-detach
+-- no-s3-storage and no-random-detach because read FileOpen metric
 DROP TABLE IF EXISTS nested;
 
 SET flatten_nested = 0;

--- a/tests/queries/0_stateless/01660_system_parts_smoke.sql
+++ b/tests/queries/0_stateless/01660_system_parts_smoke.sql
@@ -1,3 +1,6 @@
+-- Tags: no-random-detach
+-- Tag no-random-detach: test checks inactive parts, which may be removed after DETACH/ATTACH.
+
 -- There is different code path when:
 -- - _state is not requested
 -- - _state is requested

--- a/tests/queries/0_stateless/01666_merge_tree_max_query_limit.sh
+++ b/tests/queries/0_stateless/01666_merge_tree_max_query_limit.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
+# Tag no-random-detach: parallel running queries
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01709_inactive_parts_to_throw_insert.sql
+++ b/tests/queries/0_stateless/01709_inactive_parts_to_throw_insert.sql
@@ -1,3 +1,7 @@
+-- Tags: no-random-detach
+-- Tag no-random-detach: test relies on number of inactive parts,
+-- which may be removed after DETACH/ATTACH.
+
 drop table if exists data_01709;
 
 create table data_01709 (i int) engine MergeTree order by i settings old_parts_lifetime = 10000000000, min_bytes_for_wide_part = 0, inactive_parts_to_throw_insert = 1;

--- a/tests/queries/0_stateless/01758_optimize_skip_unused_shards_once.sh
+++ b/tests/queries/0_stateless/01758_optimize_skip_unused_shards_once.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: shard
+# Tags: shard, no-random-detach
+# Tag no-random-detach: extra logging at DETACH
 
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=trace
 

--- a/tests/queries/0_stateless/02002_row_level_filter_bug.sh
+++ b/tests/queries/0_stateless/02002_row_level_filter_bug.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
+# Tags: no-parallel, no-random-detach
 # Tag no-parallel: create user
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/02015_async_inserts_1.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_1.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02015_async_inserts_2.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-random-settings
+# Tags: no-random-settings, no-random-detach
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02015_async_inserts_3.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_3.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02015_async_inserts_4.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_4.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02015_async_inserts_5.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_5.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02015_async_inserts_6.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_6.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02015_async_inserts_7.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_7.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02015_async_inserts_stress_long.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_stress_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-random-settings, no-fasttest
+# Tags: no-random-settings, no-fasttest, no-random-detach
 
 set -e
 

--- a/tests/queries/0_stateless/02124_insert_deduplication_token_multiple_blocks.sh
+++ b/tests/queries/0_stateless/02124_insert_deduplication_token_multiple_blocks.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
+# Tag no-random-detach: test checks inactive parts, which may be removed after DETACH/ATTACH.
+
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh

--- a/tests/queries/0_stateless/02134_async_inserts_formats.sh
+++ b/tests/queries/0_stateless/02134_async_inserts_formats.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02361_fsync_profile_events.sh
+++ b/tests/queries/0_stateless/02361_fsync_profile_events.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-s3-storage
+# Tags: no-s3-storage, no-random-detach
 # Tag no-s3-storage: s3 does not have fsync
+# Tag no-random-detach: extra FileOpen while attach.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02369_lost_part_intersecting_merges.sh
+++ b/tests/queries/0_stateless/02369_lost_part_intersecting_merges.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: zookeeper
+# Tags: zookeeper, no-random-detach
+# Tag no-random-detach: test relies on DETACH/ATTACH in specific place
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02456_async_inserts_logs.sh
+++ b/tests/queries/0_stateless/02456_async_inserts_logs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-random-detach
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02461_reattach_tables.reference
+++ b/tests/queries/0_stateless/02461_reattach_tables.reference
@@ -1,0 +1,13 @@
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+OK
+55
+0
+0

--- a/tests/queries/0_stateless/02461_reattach_tables.sh
+++ b/tests/queries/0_stateless/02461_reattach_tables.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Tags: no-random-detach
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+MY_CLICKHOUSE_CLIENT=$(echo ${CLICKHOUSE_CLIENT} | sed 's/'"--send_logs_level=${CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL}"'/--send_logs_level=trace/g')
+
+function check_if_detached_impl()
+{
+    query="$1"
+    table="$2"
+    ${MY_CLICKHOUSE_CLIENT} \
+        --reattach_tables_before_query_execution=1  \
+        --query "$query" 2>&1 \
+        | grep -q "DETACH TABLE $CLICKHOUSE_DATABASE.$table"
+}
+
+function check_if_detached()
+{
+    check_if_detached_impl "$1" "$2"
+    if [ $? -eq 0 ]; then
+        echo "OK"
+    else
+        echo "FAIL"
+    fi
+}
+
+function check_if_not_detached()
+{
+    check_if_detached_impl "$1" "$2"
+    if [ $? -ne 0 ]; then
+        echo "OK"
+    else
+        echo "FAIL"
+    fi
+}
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_reattach_1"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_reattach_2"
+
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_reattach_1 (a UInt64) ENGINE = MergeTree ORDER BY a"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_reattach_2 (a UInt64) ENGINE = MergeTree ORDER BY a"
+
+check_if_detached "INSERT INTO t_reattach_1 VALUES (1)" "t_reattach_1"
+
+check_if_detached "SELECT * FROM t_reattach_1" "t_reattach_1"
+check_if_detached "SELECT * FROM t_reattach_1 JOIN t_reattach_2 USING a" "t_reattach_1"
+check_if_detached "SELECT * FROM t_reattach_1 JOIN t_reattach_2 USING a" "t_reattach_2"
+
+check_if_detached "INSERT INTO t_reattach_2 SELECT * FROM t_reattach_1" "t_reattach_1"
+check_if_detached "INSERT INTO t_reattach_2 SELECT * FROM t_reattach_1" "t_reattach_2"
+
+check_if_detached "EXISTS TABLE t_reattach_1" "t_reattach_1"
+check_if_detached "SHOW CREATE TABLE t_reattach_1" "t_reattach_1"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_reattach_1"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_reattach_2"
+
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_reattach_1 (a UInt64) ENGINE = Memory"
+
+check_if_not_detached "INSERT INTO t_reattach_1 VALUES (55)" "t_reattach_1"
+check_if_not_detached "SELECT * FROM t_reattach_1" "t_reattach_1"
+
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM t_reattach_1"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_reattach_1"
+
+${CLICKHOUSE_CLIENT} --reattach_tables_before_query_execution=1 -q "SELECT number FROM system.numbers LIMIT 1"
+${CLICKHOUSE_CLIENT} --reattach_tables_before_query_execution=1 -q "SELECT number FROM system.numbers LIMIT 1"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Randomly execute `DETACH`/`ATTACH` queries for all tables that are used in query from test before its execution.
