### PR TITLE
Make getResource() independent from the order of the sections

### DIFF
--- a/src/Common/SymbolIndex.cpp
+++ b/src/Common/SymbolIndex.cpp
@@ -99,23 +99,25 @@ void updateResources(ElfW(Addr) base_address, std::string_view object_name, std:
             name = name.substr((name[0] == '_') + strlen("binary_"));
             name = name.substr(0, name.size() - strlen("_start"));
 
-            resources.emplace(name, SymbolIndex::ResourcesBlob{
-                base_address,
-                object_name,
-                std::string_view{char_address, 0}, // NOLINT
-            });
+            auto & resource = resources[name];
+            if (!resource.base_address || resource.base_address == base_address)
+            {
+                resource.base_address = base_address;
+                resource.start = std::string_view{char_address, 0}; // NOLINT(bugprone-string-constructor)
+                resource.object_name = object_name;
+            }
         }
-        else if (name.ends_with("_end"))
+        if (name.ends_with("_end"))
         {
             name = name.substr((name[0] == '_') + strlen("binary_"));
             name = name.substr(0, name.size() - strlen("_end"));
 
-            auto it = resources.find(name);
-            if (it != resources.end() && it->second.base_address == base_address && it->second.data.empty())
+            auto & resource = resources[name];
+            if (!resource.base_address || resource.base_address == base_address)
             {
-                const char * start = it->second.data.data();
-                assert(char_address >= start);
-                it->second.data = std::string_view{start, static_cast<size_t>(char_address - start)};
+                resource.base_address = base_address;
+                resource.end = std::string_view{char_address, 0}; // NOLINT(bugprone-string-constructor)
+                resource.object_name = object_name;
             }
         }
     }

--- a/src/Common/SymbolIndex.h
+++ b/src/Common/SymbolIndex.h
@@ -51,7 +51,7 @@ public:
     std::string_view getResource(String name) const
     {
         if (auto it = data.resources.find(name); it != data.resources.end())
-            return it->second.data;
+            return it->second.data();
         return {};
     }
 
@@ -63,11 +63,18 @@ public:
     {
         /// Symbol can be presented in multiple shared objects,
         /// base_address will be used to compare only symbols from the same SO.
-        ElfW(Addr) base_address;
+        ElfW(Addr) base_address = 0;
         /// Just a human name of the SO.
         std::string_view object_name;
         /// Data blob.
-        std::string_view data;
+        std::string_view start;
+        std::string_view end;
+
+        std::string_view data() const
+        {
+            assert(end.data() >= start.data());
+            return std::string_view{start.data(), static_cast<size_t>(end.data() - start.data())};
+        }
     };
     using Resources = std::unordered_map<std::string_view /* symbol name */, ResourcesBlob>;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make getResource() independent from the order of the sections

It is possible for end section goes before begin section for some
resource, and this case it will not find it.

This is what happens here [1]:

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/41988/053fec3f451e97ac41b6c223d95013b758a9a330/fast_test.html

Cc: @alexey-milovidov 
Refs: #41988