### PR TITLE
add a ReplacingMerge setting:"use_minimum_version_in_replacing".

### DIFF
--- a/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.h
@@ -22,6 +22,7 @@ public:
         const Block & header, size_t num_inputs,
         SortDescription description_, const String & version_column,
         size_t max_block_size,
+        bool use_minimum_version_in_replacing,
         WriteBuffer * out_row_sources_buf_ = nullptr,
         bool use_average_block_sizes = false);
 
@@ -31,6 +32,8 @@ private:
     MergedData merged_data;
 
     ssize_t version_column_number = -1;
+
+    bool use_minimum_version_in_replacing = false;
 
     using RowRef = detail::RowRefWithOwnedChunk;
     static constexpr size_t max_row_refs = 2; /// last, current.

--- a/src/Processors/Merges/ReplacingSortedTransform.h
+++ b/src/Processors/Merges/ReplacingSortedTransform.h
@@ -15,6 +15,7 @@ public:
         const Block & header, size_t num_inputs,
         SortDescription description_, const String & version_column,
         size_t max_block_size,
+        bool use_minimum_version_in_replacing,
         WriteBuffer * out_row_sources_buf_ = nullptr,
         bool use_average_block_sizes = false)
         : IMergingTransform(
@@ -24,6 +25,7 @@ public:
             std::move(description_),
             version_column,
             max_block_size,
+            use_minimum_version_in_replacing,
             out_row_sources_buf_,
             use_average_block_sizes)
     {

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -599,7 +599,8 @@ static void addMergingFinal(
     const SortDescription & sort_description,
     MergeTreeData::MergingParams merging_params,
     Names partition_key_columns,
-    size_t max_block_size)
+    size_t max_block_size,
+    const MergeTreeSettingsPtr data_settings)
 {
     const auto & header = pipe.getHeader();
     size_t num_outputs = pipe.numOutputPorts();
@@ -628,7 +629,7 @@ static void addMergingFinal(
 
             case MergeTreeData::MergingParams::Replacing:
                 return std::make_shared<ReplacingSortedTransform>(header, num_outputs,
-                            sort_description, merging_params.version_column, max_block_size);
+                            sort_description, merging_params.version_column, max_block_size, data_settings->use_minimum_version_in_replacing);
 
             case MergeTreeData::MergingParams::VersionedCollapsing:
                 return std::make_shared<VersionedCollapsingTransform>(header, num_outputs,
@@ -786,7 +787,8 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal(
                 sort_description,
                 data.merging_params,
                 partition_key_columns,
-                max_block_size);
+                max_block_size,
+                data_settings);
 
         partition_pipes.emplace_back(Pipe::unitePipes(std::move(pipes)));
     }

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -888,7 +888,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream()
         case MergeTreeData::MergingParams::Replacing:
             merged_transform = std::make_shared<ReplacingSortedTransform>(
                 header, pipes.size(), sort_description, ctx->merging_params.version_column,
-                merge_block_size, ctx->rows_sources_write_buf.get(), ctx->blocks_are_granules_size);
+                merge_block_size, data_settings->use_minimum_version_in_replacing, ctx->rows_sources_write_buf.get(), ctx->blocks_are_granules_size);
             break;
 
         case MergeTreeData::MergingParams::Graphite:

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -225,7 +225,7 @@ Block MergeTreeDataWriter::mergeBlock(
                 return nullptr;
             case MergeTreeData::MergingParams::Replacing:
                 return std::make_shared<ReplacingSortedAlgorithm>(
-                    block, 1, sort_description, merging_params.version_column, block_size + 1);
+                    block, 1, sort_description, merging_params.version_column, block_size + 1, data.getSettings()->use_minimum_version_in_replacing);
             case MergeTreeData::MergingParams::Collapsing:
                 return std::make_shared<CollapsingSortedAlgorithm>(
                     block, 1, sort_description, merging_params.sign_column,

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -65,6 +65,9 @@ struct Settings;
     M(UInt64, merge_tree_enable_clear_old_broken_detached, false, "Enable clearing old broken detached parts operation in background.", 0) \
     M(Bool, remove_rolled_back_parts_immediately, 1, "Setting for an incomplete experimental feature.", 0) \
     \
+    /** ReplacingMerge settings. */ \
+    M(Bool, use_minimum_version_in_replacing, false, "If true, With use the minimum version in ReplacingMergeTree.", 0) \
+    \
     /** Inserts settings. */ \
     M(UInt64, parts_to_delay_insert, 150, "If table contains at least that many active parts in single partition, artificially slow down insert into table.", 0) \
     M(UInt64, inactive_parts_to_delay_insert, 0, "If table contains at least that many inactive parts in single partition, artificially slow down insert into table.", 0) \


### PR DESCRIPTION
Once the parameter "use_minimum_version_in_replacing" is setted "true", then the minimum version will be used in the ReplacingMergeTree.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
add a ReplacingMerge setting:"use_minimum_version_in_replacing".
Once the parameter "use_minimum_version_in_replacing" is setted "true", then the minimum version will be used in the ReplacingMergeTree.
if you set specific version and keep "use_minimum_version_in_replacing" as "true", then you can get the minimum version not maximum one.
the "use_minimum_version_in_replacing" only works after setting specific version.
if not setting version, then we get the latest data, even you've aleary set "use_minimum_version_in_replacing" as "true".


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
