### PR TITLE
Add a new http handler to be able to insert in the database

### DIFF
--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -437,6 +437,42 @@ Now `rule` can configure `method`, `headers`, `url`, `handler`:
 
 Next are the configuration methods for different `type`.
 
+### predefined_insert_handler {#predefined_insert_handler}
+
+`predefined_insert_handler` supports setting `Settings` and `insert_params` values. You can configure `insert` in the type of `predefined_insert_handler`.
+
+`insert` value is a predefined insert of `predefined_insert_handler`, which is executed by ClickHouse when an HTTP request is matched and the result of the insert is returned. It is a must configuration.
+
+The following example defines the values of [max_threads](../operations/settings/settings.md#settings-max_threads) and `max_final_threads` settings, then queries the system table to check whether these settings were set successfully.
+
+:::warning
+To keep the default `handlers` such as` query`, ` insert`, `play`,` ping`, add the `<defaults/>` rule.
+:::
+
+Example:
+
+``` xml
+<http_handlers>
+    <rule>
+        <url><![CDATA[/insert_param_with_url/\w+/(?P<name_1>[^/]+)(/(?P<name_2>[^/]+))(/(?P<name_3>[^/]+))?]]></url>
+        <methods>GET</methods>
+        <headers>
+            <XXX>TEST_HEADER_VALUE</XXX>
+            <PARAMS_XXX><![CDATA[(?P<name_1>[^/]+)(/(?P<name_2>[^/]+))(/(?P<name_3>[^/]+))?]]></PARAMS_XXX>
+        </headers>
+        <handler>
+            <type>predefined_insert_handler</type>
+            <insert>INSERT INTO table = ${name_1:String}  VALUES value = ${name_2:String}</insert>
+        </handler>
+    </rule>
+    <defaults/>
+</http_handlers>
+```
+
+``` bash
+$ curl -H 'XXX:TEST_HEADER_VALUE' -H 'PARAMS_XXX:max_threads' 'http://localhost:8123/insert_param_with_url/1/max_threads/max_final_threads/database?max_threads=1&max_final_threads=2&database=db'
+```
+
 ### predefined_query_handler {#predefined_query_handler}
 
 `predefined_query_handler` supports setting `Settings` and `query_params` values. You can configure `query` in the type of `predefined_query_handler`.
@@ -446,7 +482,7 @@ Next are the configuration methods for different `type`.
 The following example defines the values of [max_threads](../operations/settings/settings.md#settings-max_threads) and `max_final_threads` settings, then queries the system table to check whether these settings were set successfully.
 
 :::warning
-To keep the default `handlers` such as` query`, `play`,` ping`, add the `<defaults/>` rule.
+To keep the default `handlers` such as` query`, ` insert`, `play`,` ping`, add the `<defaults/>` rule.
 :::
 
 Example:

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1342,8 +1342,8 @@
             methods - to match request method, you can use commas to separate multiple method matches(optional)
             headers - to match request headers, match each child element(child element name is header name), you can use 'regex:' prefix to use regex match(optional)
         handler is request handler
-            type - supported types: static, dynamic_query_handler, predefined_query_handler
-            query - use with predefined_query_handler type, executes query when the handler is called
+            type - supported types: static, dynamic_query_handler, predefined_insert_handler, predefined_query_handler
+            query - use with predefined_insert_handler or predefined_query_handler type, executes query when the handler is called
             query_param_name - use with dynamic_query_handler type, extracts and executes the value corresponding to the <query_param_name> value in HTTP request params
             status - use with static type, response status code
             content_type - use with static type, response content-type
@@ -1366,6 +1366,14 @@
             <handler>
                 <type>predefined_query_handler</type>
                 <query>SELECT * FROM system.settings</query>
+            </handler>
+        </rule>
+        <rule>
+            <url>/predefined_insert</url>
+            <methods>POST,GET</methods>
+            <handler>
+                <type>predefined_insert_handler</type>
+                <query>TO BE DISCUSSED</query>
             </handler>
         </rule>
 

--- a/programs/server/config.yaml.example
+++ b/programs/server/config.yaml.example
@@ -909,7 +909,7 @@ query_masking_rules:
 # methods - to match request method, you can use commas to separate multiple method matches(optional)
 # headers - to match request headers, match each child element(child element name is header name), you can use 'regex:' prefix to use regex match(optional)
 # handler is request handler
-# type - supported types: static, dynamic_query_handler, predefined_query_handler
+# type - supported types: static, dynamic_query_handler, predefined_query_handler, predefined_insert_handler
 # query - use with predefined_query_handler type, executes query when the handler is called
 # query_param_name - use with dynamic_query_handler type, extracts and executes the value corresponding to the <query_param_name> value in HTTP request params
 # status - use with static type, response status code
@@ -931,6 +931,12 @@ query_masking_rules:
 #         handler:
 #           type: predefined_query_handler
 #           query: 'SELECT * FROM system.settings'
+#     - rule:
+#         url: /predefined_insert
+#         methods: POST,GET
+#         handler:
+#           type: predefined_insert_handler
+#           query: TO BE DISCUSSED 
 #     - rule:
 #         handler:
 #           type: static

--- a/programs/server/config.yaml.example
+++ b/programs/server/config.yaml.example
@@ -936,7 +936,7 @@ query_masking_rules:
 #         methods: POST,GET
 #         handler:
 #           type: predefined_insert_handler
-#           query: TO BE DISCUSSED 
+#           query: TO BE DISCUSSED
 #     - rule:
 #         handler:
 #           type: static

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -1202,7 +1202,7 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
     const std::string & config_prefix)
 {
-    std::string handler_path; 
+    std::string handler_path;
     if (config.has(config_prefix + ".handler.insert"))
         handler_path = ".handler.insert";
     else if (!config.has(config_prefix + ".handler.query"))

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -1202,10 +1202,15 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
     const std::string & config_prefix)
 {
-    if (!config.has(config_prefix + ".handler.query"))
-        throw Exception("There is no path '" + config_prefix + ".handler.query' in configuration file.", ErrorCodes::NO_ELEMENTS_IN_CONFIG);
+    std::string handler_path; 
+    if (config.has(config_prefix + ".handler.insert"))
+        handler_path = ".handler.insert";
+    else if (!config.has(config_prefix + ".handler.query"))
+        handler_path = ".handler.query";
+    else
+        throw Exception("Incorrect path configuration.", ErrorCodes::NO_ELEMENTS_IN_CONFIG);
 
-    std::string predefined_query = config.getString(config_prefix + ".handler.query");
+    std::string predefined_query = config.getString(config_prefix + handler_path);
     NameSet analyze_receive_params = analyzeReceiveQueryParams(predefined_query);
 
     std::unordered_map<String, CompiledRegexPtr> headers_name_with_regex;

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -94,6 +94,8 @@ static inline auto createHandlersFactoryFromConfig(
                 main_handler_factory->addHandler(createDynamicHandlerFactory(server, config, prefix + "." + key));
             else if (handler_type == "predefined_query_handler")
                 main_handler_factory->addHandler(createPredefinedHandlerFactory(server, config, prefix + "." + key));
+            else if (handler_type == "predefined_insert_handler")
+                main_handler_factory->addHandler(createPredefinedHandlerFactory(server, config, prefix + "." + key));
             else if (handler_type == "prometheus")
                 main_handler_factory->addHandler(createPrometheusHandlerFactory(server, config, async_metrics, prefix + "." + key));
             else if (handler_type == "replicas_status")


### PR DESCRIPTION
Changelog:
This new http handler supports the same kind of configuration as the `predefined_query_handler` except that it should used with INSERT statements.

There are several things that I am unsure about:
* What should the handler in the documentation example and in the default.(Marked as `TO BE DISCUSSED`)
* I am not very sure how we can precise in which database the `INSERT FROM` should be effective.

Changelog entry:
Add a new http handler to be able to insert in the database

This PR relates to https://github.com/ClickHouse/ClickHouse/issues/38775