### PR TITLE
Update woboq_codebrowser location

### DIFF
--- a/docker/test/codebrowser/Dockerfile
+++ b/docker/test/codebrowser/Dockerfile
@@ -36,10 +36,7 @@ RUN arch=${TARGETARCH:-amd64} \
 # repo versions doesn't work correctly with C++17
 # also we push reports to s3, so we add index.html to subfolder urls
 # https://github.com/ClickHouse-Extras/woboq_codebrowser/commit/37e15eaf377b920acb0b48dbe82471be9203f76b
-# TODO: remove branch in a few weeks after merge, e.g. in May or June 2022
-#
-# FIXME: update location of a repo
-RUN git clone https://github.com/azat/woboq_codebrowser --branch llvm-15 \
+RUN git clone https://github.com/ClickHouse/woboq_codebrowser \
   && cd woboq_codebrowser \
   && cmake . -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang\+\+-${LLVM_VERSION} -DCMAKE_C_COMPILER=clang-${LLVM_VERSION} \
   && ninja \


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: https://github.com/ClickHouse/woboq_codebrowser/pull/6
Follow-up for: #41046