### PR TITLE
add mdx and jsx to list of doc files

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -20,10 +20,12 @@ SKIP_MERGEABLE_CHECK_LABEL = "skip mergeable check"
 DIFF_IN_DOCUMENTATION_EXT = [
     ".html",
     ".md",
+    ".mdx",
     ".yml",
     ".txt",
     ".css",
     ".js",
+    ".jsx",
     ".xml",
     ".ico",
     ".conf",


### PR DESCRIPTION
Change to CI check.  adds `.mdx` and `.jsx` to the list of files to be considered for doc build CI.  We had some non-compliant docs get past the docs check because they were `.mdx` files.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
