### PR TITLE
Better workaround for emitting .debug_aranges section

### DIFF
--- a/cmake/ld.lld.in
+++ b/cmake/ld.lld.in
@@ -3,15 +3,15 @@
 # This is a workaround for bug in llvm/clang,
 # that does not produce .debug_aranges with LTO
 #
-# NOTE: this is a temporary solution, that should be removed once [1] will be
-# resolved.
+# NOTE: this is a temporary solution, that should be removed after upgrading to
+# clang-16/llvm-16.
 #
-#   [1]: https://discourse.llvm.org/t/clang-does-not-produce-full-debug-aranges-section-with-thinlto/64898/8
+# Refs: https://reviews.llvm.org/D133092
 
 # NOTE: only -flto=thin is supported.
 # NOTE: it is not possible to check was there -gdwarf-aranges initially or not.
 if [[ "$*" =~ -plugin-opt=thinlto ]]; then
-    exec "@LLD_PATH@" -mllvm -generate-arange-section "$@"
+    exec "@LLD_PATH@" -plugin-opt=-generate-arange-section "$@"
 else
     exec "@LLD_PATH@" "$@"
 fi


### PR DESCRIPTION
Note, that this is just a syntastic change, that should not makes any difference (well the only difference is that now it supports gold and other links, since the option is handled by the plugin itself instead of the linker).

Refs: https://reviews.llvm.org/D133092

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #40873