### PR TITLE
Suppress ld warning in macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ option(ADD_GDB_INDEX_FOR_GOLD "Add .gdb-index to resulting binaries for gold lin
 
 if (NOT CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE")
     # Can be lld or ld-lld or lld-13 or /path/to/lld.
-    if (LINKER_NAME MATCHES "lld")
+    if (LINKER_NAME MATCHES "lld" AND OS_LINUX)
         set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gdb-index")
         set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gdb-index")
         message (STATUS "Adding .gdb-index via --gdb-index linker option.")
@@ -248,7 +248,7 @@ endif ()
 
 # Create BuildID when using lld. For other linkers it is created by default.
 # (NOTE: LINKER_NAME can be either path or name, and in different variants)
-if (LINKER_NAME MATCHES "lld")
+if (LINKER_NAME MATCHES "lld" AND OS_LINUX)
     # SHA1 is not cryptographically secure but it is the best what lld is offering.
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=sha1")
 endif ()

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -57,13 +57,14 @@ if (NOT LINKER_NAME)
     if (COMPILER_GCC)
         find_program (LLD_PATH NAMES "ld.lld")
         find_program (GOLD_PATH NAMES "ld.gold")
-    # llvm lld is a generic driver.
-    # Invoke ld.lld (Unix), ld64.lld (macOS), lld-link (Windows), wasm-ld (WebAssembly) instead
-    elseif (COMPILER_CLANG AND OS_LINUX)
-        find_program (LLD_PATH NAMES "ld.lld-${COMPILER_VERSION_MAJOR}" "lld-${COMPILER_VERSION_MAJOR}" "ld.lld" "lld")
-        find_program (GOLD_PATH NAMES "ld.gold" "gold")
-    elseif (COMPILER_CLANG AND OS_DARWIN)
-        find_program (LLD_PATH NAMES "ld64.lld-${COMPILER_VERSION_MAJOR}" "lld-${COMPILER_VERSION_MAJOR}" "ld64.lld" "lld")
+    elseif (COMPILER_CLANG)
+        # llvm lld is a generic driver.
+        # Invoke ld.lld (Unix), ld64.lld (macOS), lld-link (Windows), wasm-ld (WebAssembly) instead
+        if (OS_LINUX)
+            find_program (LLD_PATH NAMES "ld.lld-${COMPILER_VERSION_MAJOR}" "ld.lld")
+        elseif (OS_DARWIN)
+            find_program (LLD_PATH NAMES "ld64.lld-${COMPILER_VERSION_MAJOR}" "ld64.lld")
+        endif ()
         find_program (GOLD_PATH NAMES "ld.gold" "gold")
     endif ()
 endif()

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -57,14 +57,19 @@ if (NOT LINKER_NAME)
     if (COMPILER_GCC)
         find_program (LLD_PATH NAMES "ld.lld")
         find_program (GOLD_PATH NAMES "ld.gold")
-    elseif (COMPILER_CLANG)
+    # llvm lld is a generic driver.
+    # Invoke ld.lld (Unix), ld64.lld (macOS), lld-link (Windows), wasm-ld (WebAssembly) instead
+    elseif (COMPILER_CLANG AND OS_LINUX)
         find_program (LLD_PATH NAMES "ld.lld-${COMPILER_VERSION_MAJOR}" "lld-${COMPILER_VERSION_MAJOR}" "ld.lld" "lld")
+        find_program (GOLD_PATH NAMES "ld.gold" "gold")
+    elseif (COMPILER_CLANG AND OS_DARWIN)
+        find_program (LLD_PATH NAMES "ld64.lld-${COMPILER_VERSION_MAJOR}" "lld-${COMPILER_VERSION_MAJOR}" "ld64.lld" "lld")
         find_program (GOLD_PATH NAMES "ld.gold" "gold")
     endif ()
 endif()
 
-if (OS_LINUX AND NOT LINKER_NAME)
-    # prefer lld linker over gold or ld on linux
+if ((OS_LINUX OR OS_DARWIN) AND NOT LINKER_NAME)
+    # prefer lld linker over gold or ld on linux and macos
     if (LLD_PATH)
         if (COMPILER_GCC)
             # GCC driver requires one of supported linker names like "lld".


### PR DESCRIPTION
Signed-off-by: Lloyd-Pottiger <yan1579196623@gmail.com>

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

use llvm `l64.lld` in macOS suppress ld warnings, close #42282

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
