### PR TITLE
Fix bad_cast in Annoy index

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -419,6 +419,8 @@ Supported data types: `Int*`, `UInt*`, `Float*`, `Enum`, `Date`, `DateTime`, `St
 
 For `Map` data type client can specify if index should be created for keys or values using [mapKeys](../../../sql-reference/functions/tuple-map-functions.md#mapkeys) or [mapValues](../../../sql-reference/functions/tuple-map-functions.md#mapvalues) function.
 
+There are also special-purpose and experimental indexes to support approximate nearest neighbor (ANN) queries. See [here](annindexes.md) for details.
+
 The following functions can use the filter: [equals](../../../sql-reference/functions/comparison-functions.md), [notEquals](../../../sql-reference/functions/comparison-functions.md), [in](../../../sql-reference/functions/in-functions), [notIn](../../../sql-reference/functions/in-functions), [has](../../../sql-reference/functions/array-functions#hasarr-elem), [hasAny](../../../sql-reference/functions/array-functions#hasany), [hasAll](../../../sql-reference/functions/array-functions#hasall).
 
 Example of index creation for `Map` data type

--- a/src/Storages/MergeTree/MergeTreeIndexAnnoy.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexAnnoy.cpp
@@ -9,6 +9,7 @@
 #include <Interpreters/castColumn.h>
 #include <Columns/ColumnArray.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeTuple.h>
 
 
 namespace DB
@@ -64,9 +65,11 @@ uint64_t AnnoyIndex<Dist>::getNumOfDimensions() const
 
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
-    extern const int INCORRECT_QUERY;
+    extern const int ILLEGAL_COLUMN;
     extern const int INCORRECT_DATA;
+    extern const int INCORRECT_NUMBER_OF_COLUMNS;
+    extern const int INCORRECT_QUERY;
+    extern const int LOGICAL_ERROR;
 }
 
 MergeTreeIndexGranuleAnnoy::MergeTreeIndexGranuleAnnoy(const String & index_name_, const Block & index_sample_block_)
@@ -132,9 +135,7 @@ void MergeTreeIndexAggregatorAnnoy::update(const Block & block, size_t * pos, si
         return;
 
     if (index_sample_block.columns() > 1)
-    {
         throw Exception("Only one column is supported", ErrorCodes::LOGICAL_ERROR);
-    }
 
     auto index_column_name = index_sample_block.getByPosition(0).name;
     const auto & column_cut = block.getByName(index_column_name).column->cut(*pos, rows_read);
@@ -144,27 +145,22 @@ void MergeTreeIndexAggregatorAnnoy::update(const Block & block, size_t * pos, si
         const auto & data = column_array->getData();
         const auto & array = typeid_cast<const ColumnFloat32&>(data).getData();
         if (array.empty())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Array have 0 rows, but {} expected", rows_read);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Array has 0 rows, {} rows expected", rows_read);
         const auto & offsets = column_array->getOffsets();
         size_t num_rows = offsets.size();
 
-        /// All sizes are the same
+        /// Check all sizes are the same
         size_t size = offsets[0];
         for (size_t i = 0; i < num_rows - 1; ++i)
-        {
             if (offsets[i + 1] - offsets[i] != size)
-            {
                 throw Exception(ErrorCodes::INCORRECT_DATA, "Arrays should have same length");
-            }
-        }
+
         index = std::make_shared<AnnoyIndex>(size);
 
         index->add_item(index->get_n_items(), array.data());
         /// add all rows from 1 to num_rows - 1 (this is the same as the beginning of the last element)
         for (size_t current_row = 1; current_row < num_rows; ++current_row)
-        {
             index->add_item(index->get_n_items(), &array[offsets[current_row - 1]]);
-        }
     }
     else
     {
@@ -181,19 +177,13 @@ void MergeTreeIndexAggregatorAnnoy::update(const Block & block, size_t * pos, si
         {
             const auto& pod_array = typeid_cast<const ColumnFloat32*>(column.get())->getData();
             for (size_t i = 0; i < pod_array.size(); ++i)
-            {
                 data[i].push_back(pod_array[i]);
-            }
         }
         assert(!data.empty());
         if (!index)
-        {
             index = std::make_shared<AnnoyIndex>(data[0].size());
-        }
         for (const auto& item : data)
-        {
             index->add_item(index->get_n_items(), item.data());
-        }
     }
 
     *pos += rows_read;
@@ -222,7 +212,7 @@ std::vector<size_t> MergeTreeIndexConditionAnnoy::getUsefulRanges(MergeTreeIndex
 {
     UInt64 limit = condition.getLimit();
     UInt64 index_granularity = condition.getIndexGranularity();
-    std::optional<float> comp_dist = condition.getQueryType() == ANN::ANNQueryInformation::Type::Where ?
+    std::optional<float> comp_dist = condition.getQueryType() == ApproximateNearestNeighbour::ANNQueryInformation::Type::Where ?
      std::optional<float>(condition.getComparisonDistanceForWhereQuery()) : std::nullopt;
 
     if (comp_dist && comp_dist.value() < 0)
@@ -232,16 +222,13 @@ std::vector<size_t> MergeTreeIndexConditionAnnoy::getUsefulRanges(MergeTreeIndex
 
     auto granule = std::dynamic_pointer_cast<MergeTreeIndexGranuleAnnoy>(idx_granule);
     if (granule == nullptr)
-    {
         throw Exception("Granule has the wrong type", ErrorCodes::LOGICAL_ERROR);
-    }
+
     auto annoy = granule->index;
 
     if (condition.getNumOfDimensions() != annoy->getNumOfDimensions())
-    {
         throw Exception("The dimension of the space in the request (" + toString(condition.getNumOfDimensions()) + ") "
             + "does not match with the dimension in the index (" + toString(annoy->getNumOfDimensions()) + ")", ErrorCodes::INCORRECT_QUERY);
-    }
 
     /// neighbors contain indexes of dots which were closest to target vector
     std::vector<UInt64> neighbors;
@@ -268,22 +255,24 @@ std::vector<size_t> MergeTreeIndexConditionAnnoy::getUsefulRanges(MergeTreeIndex
     for (size_t i = 0; i < neighbors.size(); ++i)
     {
         if (comp_dist && distances[i] > comp_dist)
-        {
             continue;
-        }
         granule_numbers.insert(neighbors[i] / index_granularity);
     }
 
     std::vector<size_t> result_vector;
     result_vector.reserve(granule_numbers.size());
     for (auto granule_number : granule_numbers)
-    {
         result_vector.push_back(granule_number);
-    }
 
     return result_vector;
 }
 
+
+MergeTreeIndexAnnoy::MergeTreeIndexAnnoy(const IndexDescription & index_, uint64_t number_of_trees_)
+    : IMergeTreeIndex(index_)
+    , number_of_trees(number_of_trees_)
+{
+}
 
 MergeTreeIndexGranulePtr MergeTreeIndexAnnoy::createIndexGranule() const
 {
@@ -307,6 +296,40 @@ MergeTreeIndexPtr annoyIndexCreator(const IndexDescription & index)
     return std::make_shared<MergeTreeIndexAnnoy>(index, param);
 }
 
+static void assertIndexColumnsType(const Block & header)
+{
+    DataTypePtr column_data_type_ptr = header.getDataTypes()[0];
+
+    if (const auto * array_type = typeid_cast<const DataTypeArray *>(column_data_type_ptr.get()))
+    {
+        TypeIndex nested_type_index = array_type->getNestedType()->getTypeId();
+        if (!WhichDataType(nested_type_index).isFloat32())
+            throw Exception(
+                ErrorCodes::ILLEGAL_COLUMN,
+                "Unexpected type {} of Annoy index. Only Array(Float32) and Tuple(Float32) are supported.",
+                column_data_type_ptr->getName());
+    }
+    else if (const auto * tuple_type = typeid_cast<const DataTypeTuple *>(column_data_type_ptr.get()))
+    {
+        const DataTypes & nested_types = tuple_type->getElements();
+        for (const auto & type : nested_types)
+        {
+            TypeIndex nested_type_index = type->getTypeId();
+            if (!WhichDataType(nested_type_index).isFloat32())
+                throw Exception(
+                    ErrorCodes::ILLEGAL_COLUMN,
+                    "Unexpected type {} of Annoy index. Only Array(Float32) and Tuple(Float32) are supported.",
+                    column_data_type_ptr->getName());
+        }
+    }
+    else
+        throw Exception(
+            ErrorCodes::ILLEGAL_COLUMN,
+            "Unexpected type {} of Annoy index. Only Array(Float32) and Tuple(Float32) are supported.",
+            column_data_type_ptr->getName());
+
+}
+
 void annoyIndexValidator(const IndexDescription & index, bool /* attach */)
 {
     if (index.arguments.size() != 1)
@@ -317,6 +340,11 @@ void annoyIndexValidator(const IndexDescription & index, bool /* attach */)
     {
         throw Exception("Annoy index argument must be UInt64.", ErrorCodes::INCORRECT_QUERY);
     }
+
+    if (index.column_names.size() != 1 || index.data_types.size() != 1)
+        throw Exception("Annoy indexes must be created on a single column", ErrorCodes::INCORRECT_NUMBER_OF_COLUMNS);
+
+    assertIndexColumnsType(index.sample_block);
 }
 
 }

--- a/src/Storages/MergeTree/MergeTreeIndexAnnoy.h
+++ b/src/Storages/MergeTree/MergeTreeIndexAnnoy.h
@@ -10,8 +10,6 @@
 namespace DB
 {
 
-namespace ANN = ApproximateNearestNeighbour;
-
 // auxiliary namespace for working with spotify-annoy library
 // mainly for serialization and deserialization of the index
 namespace ApproximateNearestNeighbour
@@ -33,7 +31,7 @@ namespace ApproximateNearestNeighbour
 
 struct MergeTreeIndexGranuleAnnoy final : public IMergeTreeIndexGranule
 {
-    using AnnoyIndex = ANN::AnnoyIndex<>;
+    using AnnoyIndex = ApproximateNearestNeighbour::AnnoyIndex<>;
     using AnnoyIndexPtr = std::shared_ptr<AnnoyIndex>;
 
     MergeTreeIndexGranuleAnnoy(const String & index_name_, const Block & index_sample_block_);
@@ -57,7 +55,7 @@ struct MergeTreeIndexGranuleAnnoy final : public IMergeTreeIndexGranule
 
 struct MergeTreeIndexAggregatorAnnoy final : IMergeTreeIndexAggregator
 {
-    using AnnoyIndex = ANN::AnnoyIndex<>;
+    using AnnoyIndex = ApproximateNearestNeighbour::AnnoyIndex<>;
     using AnnoyIndexPtr = std::shared_ptr<AnnoyIndex>;
 
     MergeTreeIndexAggregatorAnnoy(const String & index_name_, const Block & index_sample_block, uint64_t number_of_trees);
@@ -74,7 +72,7 @@ struct MergeTreeIndexAggregatorAnnoy final : IMergeTreeIndexAggregator
 };
 
 
-class MergeTreeIndexConditionAnnoy final : public ANN::IMergeTreeIndexConditionAnn
+class MergeTreeIndexConditionAnnoy final : public ApproximateNearestNeighbour::IMergeTreeIndexConditionAnn
 {
 public:
     MergeTreeIndexConditionAnnoy(
@@ -91,18 +89,14 @@ public:
     ~MergeTreeIndexConditionAnnoy() override = default;
 
 private:
-    ANN::ANNCondition condition;
+    ApproximateNearestNeighbour::ANNCondition condition;
 };
 
 
 class MergeTreeIndexAnnoy : public IMergeTreeIndex
 {
 public:
-    MergeTreeIndexAnnoy(const IndexDescription & index_, uint64_t number_of_trees_)
-        : IMergeTreeIndex(index_)
-        , number_of_trees(number_of_trees_)
-    {}
-
+    MergeTreeIndexAnnoy(const IndexDescription & index_, uint64_t number_of_trees_);
     ~MergeTreeIndexAnnoy() override = default;
 
     MergeTreeIndexGranulePtr createIndexGranule() const override;

--- a/tests/queries/0_stateless/02354_annoy.sql
+++ b/tests/queries/0_stateless/02354_annoy.sql
@@ -44,3 +44,71 @@ ORDER BY L2Distance(embedding, [0.0, 0.0])
 LIMIT 3; -- { serverError 80 }
 
 DROP TABLE IF EXISTS 02354_annoy;
+
+-- ------------------------------------
+-- Check that weird base columns are rejected
+
+-- Index spans >1 column
+
+CREATE TABLE 02354_annoy
+(
+    id Int32,
+    embedding Array(Float32),
+    INDEX annoy_index (embedding, id) TYPE annoy(100) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity=5; -- {serverError 7 }
+
+-- Index must be created on Array(Float32) or Tuple(Float32)
+
+CREATE TABLE 02354_annoy
+(
+    id Int32,
+    embedding Float32,
+    INDEX annoy_index embedding TYPE annoy(100) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity=5; -- {serverError 44 }
+
+
+CREATE TABLE 02354_annoy
+(
+    id Int32,
+    embedding Array(Float64),
+    INDEX annoy_index embedding TYPE annoy(100) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity=5; -- {serverError 44 }
+
+CREATE TABLE 02354_annoy
+(
+    id Int32,
+    embedding Tuple(Float32, Float64),
+    INDEX annoy_index embedding TYPE annoy(100) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity=5; -- {serverError 44 }
+
+CREATE TABLE 02354_annoy
+(
+    id Int32,
+    embedding Array(LowCardinality(Float32)),
+    INDEX annoy_index embedding TYPE annoy(100) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity=5; -- {serverError 44 }
+
+CREATE TABLE 02354_annoy
+(
+    id Int32,
+    embedding Array(Nullable(Float32)),
+    INDEX annoy_index embedding TYPE annoy(100) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity=5; -- {serverError 44 }


### PR DESCRIPTION
- Problem originally found by data type fuzzer https://s3.amazonaws.com/clickhouse-test-reports/42180/2f83d8790581dce0ffeec56c137b1d13160cfa7b/fuzzer_astfuzzermsan//report.html

- This commit restricts which data types are allowed for Annoy indexes (similar things are done for other index types).

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bad_assert during INSERT into Annoy indexes over non-Float32 columns