### PR TITLE
Attempt to fix abort from parallel parsing

### DIFF
--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -224,7 +224,7 @@ public:
         ///         thread->join();
         /// Where join() won't be executed in case when we call it
         /// from the same std::thread and it will end to std::abort().
-        /// So we just reset the state in this case.
+        /// So we just do nothing in this case
         if (state->finished)
             return;
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -226,7 +226,7 @@ public:
         /// from the same std::thread and it will end to std::abort().
         /// So we just reset the state in this case.
         if (state->finished)
-            state.reset();
+            return;
 
         if (initialized())
             abort();

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -178,7 +178,11 @@ public:
             func = std::forward<Function>(func),
             args = std::make_tuple(std::forward<Args>(args)...)]() mutable /// mutable is needed to destroy capture
         {
-            SCOPE_EXIT(state->event.set());
+            SCOPE_EXIT(
+            {
+                state->finished = true;
+                state->event.set();
+            });
 
             state->thread_id = std::this_thread::get_id();
 
@@ -237,6 +241,15 @@ public:
     {
         if (!state)
             return false;
+        /// The problem is that the our ThreadFromGlobalPool can be actually finished
+        /// before we try to join the thread or check whether it is joinable or not.
+        /// In some places we have code like:
+        ///     if (thread->joinable())
+        ///         thread->join();
+        /// Where join() won't be executed in case when we call it
+        /// from the same std::thread and it will end to std::abort().
+        if (state->finished)
+            return true;
         /// Thread cannot join itself.
         if (state->thread_id == std::this_thread::get_id())
             return false;
@@ -252,6 +265,9 @@ protected:
 
         /// The state used in this object and inside the thread job.
         Poco::Event event;
+
+        /// To allow joining to the same
+        std::atomic<bool> finished{true};
     };
     std::shared_ptr<State> state;
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -267,7 +267,7 @@ protected:
         Poco::Event event;
 
         /// To allow joining to the same
-        std::atomic<bool> finished{true};
+        std::atomic<bool> finished{false};
     };
     std::shared_ptr<State> state;
 

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -266,7 +266,7 @@ protected:
         /// The state used in this object and inside the thread job.
         Poco::Event event;
 
-        /// To allow joining to the same
+        /// To allow joining to the same std::thread after finishing
         std::atomic<bool> finished{false};
     };
     std::shared_ptr<State> state;


### PR DESCRIPTION

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This closes https://github.com/ClickHouse/ClickHouse/issues/42009

CC @azat 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
