### PR TITLE
Increase threshold for using physical cores for `max_threads`

### DIFF
--- a/src/Common/getNumberOfPhysicalCPUCores.cpp
+++ b/src/Common/getNumberOfPhysicalCPUCores.cpp
@@ -48,7 +48,7 @@ static unsigned getNumberOfPhysicalCPUCoresImpl()
     /// Let's limit ourself to the number of physical cores.
     /// But if the number of logical cores is small - maybe it is a small machine
     /// or very limited cloud instance and it is reasonable to use all the cores.
-    if (cpu_count >= 8)
+    if (cpu_count >= 32)
         cpu_count /= 2;
 #endif
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
On x86_64 number of logical cores will be used as default value for `max_threads` if it is less than 32 (previous value is 8).