### PR TITLE
Fix sanitizer reports in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2678,7 +2678,9 @@ class ClickHouseCluster:
             # Check server logs for Fatal messages and sanitizer failures.
             # NOTE: we cannot do this via docker since in case of Fatal message container may already die.
             for name, instance in self.instances.items():
-                if instance.contains_in_log(SANITIZER_SIGN, from_host=True):
+                if instance.contains_in_log(
+                    SANITIZER_SIGN, from_host=True, filename="stderr.log"
+                ):
                     sanitizer_assert_instance = instance.grep_in_log(
                         SANITIZER_SIGN, from_host=True, filename="stderr.log"
                     )


### PR DESCRIPTION
Before they was ignored because first there was a check for a sign of sanitizer (==================), but it was done by clickhouse-server.log, while sanitizer write to stderr.log.

Example of such situation - https://github.com/ClickHouse/ClickHouse/pull/42130#issuecomment-1285383169

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)