### PR TITLE
Allow autoremoval of old parts if detach_not_byte_identical_parts enabled

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartInfo.h
+++ b/src/Storages/MergeTree/MergeTreePartInfo.h
@@ -163,7 +163,9 @@ struct DetachedPartInfo : public MergeTreePartInfo
         "ignored",
         "broken-on-start",
         "deleting",
-        "clone"
+        "clone",
+        "merge-not-byte-identical",
+        "mutate-not-byte-identical"
     });
 
     /// NOTE: It may parse part info incorrectly.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow autoremoval of old & detached parts if detach_not_byte_identical_parts enabled.

See also https://github.com/ClickHouse/ClickHouse/pull/28708 https://github.com/ClickHouse/ClickHouse/pull/37975

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
