### PR TITLE
Fix `KeeperTCPHandler` data race

### DIFF
--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -395,6 +395,7 @@ void KeeperTCPHandler::runImpl()
     };
 
     session_stopwatch.start();
+    connected.store(true, std::memory_order_release);
     bool close_received = false;
 
     try
@@ -584,6 +585,9 @@ KeeperConnectionStats & KeeperTCPHandler::getConnectionStats()
 
 void KeeperTCPHandler::dumpStats(WriteBufferFromOwnString & buf, bool brief)
 {
+    if (!connected.load(std::memory_order_acquire))
+        return;
+
     auto & stats = getConnectionStats();
 
     writeText(' ', buf);

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -325,6 +325,7 @@ void KeeperTCPHandler::runImpl()
     int32_t four_letter_cmd = header;
     if (!isHandShake(four_letter_cmd))
     {
+        connected.store(true, std::memory_order_relaxed);
         tryExecuteFourLetterWordCmd(four_letter_cmd);
         return;
     }

--- a/src/Server/KeeperTCPHandler.h
+++ b/src/Server/KeeperTCPHandler.h
@@ -81,6 +81,8 @@ private:
     std::shared_ptr<ReadBufferFromPocoSocket> in;
     std::shared_ptr<WriteBufferFromPocoSocket> out;
 
+    std::atomic<bool> connected{false};
+
     void runImpl();
 
     void sendHandshake(bool has_leader);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Close #42528 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
