### PR TITLE
Added log message to StorageMerge to know which tables are being read from

### DIFF
--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -83,6 +83,8 @@ private:
     String source_database_name_or_regexp;
     bool database_is_regexp = false;
 
+    Poco::Logger * log;
+
     /// (Database, Table, Lock, TableName)
     using StorageWithLockAndName = std::tuple<String, StoragePtr, TableLockHolder, String>;
     using StorageListWithLocks = std::list<StorageWithLockAndName>;


### PR DESCRIPTION

### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Report https://s3.amazonaws.com/clickhouse-test-reports/42411/f424e16500988de37461f7d11cf7647971dbd654/fuzzer_astfuzzermsan//report.html
```
2022.10.19 21:59:29.908535 [ 159 ] {e2799893-1e18-47dc-9577-f7698d541288} <Fatal> : Logical error: 'Invalid type for filter in PREWHERE: String'.
2022.10.19 21:59:55.903147 [ 416 ] {} <Fatal> BaseDaemon: ########################################
2022.10.19 21:59:55.903347 [ 416 ] {} <Fatal> BaseDaemon: (version 22.10.1.1, build id: 98EF4F105CDDFD70F115A73B45C4E2EFB6E587B5) (from thread 159) (query_id: e2799893-1e18-47dc-9577-f7698d541288) (query: SELECT * FROM m_table__fuzz_44 WHERE y ORDER BY x ASC NULLS FIRST) Received signal Aborted (6)
2022.10.19 21:59:55.903511 [ 416 ] {} <Fatal> BaseDaemon:
2022.10.19 21:59:55.903695 [ 416 ] {} <Fatal> BaseDaemon: Stack trace: 0x7f2d409c000b 0x7f2d4099f859 0x25cce255 0x25cce7f3 0x46347102 0x462cece8 0x44702d5a 0x446b72f0 0x446ad62f 0x44d432e3 0x436bc374 0x436b2429 0x46238d2f 0x462a1b92 0x412e7743 0x41ee74c5 0x41eda53d 0x452b3eff 0x452f2fde 0x50e0bafe 0x50e0ce8f 0x515295ec 0x51525042 0x51520f29 0x7f2d40b77609 0x7f2d40a9c133
2022.10.19 21:59:55.903870 [ 416 ] {} <Fatal> BaseDaemon: 4. raise @ 0x7f2d409c000b in ?
2022.10.19 21:59:55.904025 [ 416 ] {} <Fatal> BaseDaemon: 5. abort @ 0x7f2d4099f859 in ?
2022.10.19 21:59:56.091790 [ 416 ] {} <Fatal> BaseDaemon: 6. ./build_docker/../src/Common/Exception.cpp:40: DB::abortOnFailedAssertion(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) @ 0x25cce255 in /workspace/clickhouse
2022.10.19 21:59:56.242033 [ 416 ] {} <Fatal> BaseDaemon: 7.1. inlined from ./build_docker/../src/Common/Exception.cpp:0: DB::handle_error_code(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool, std::__1::vector<void*, std::__1::allocator<void*> > const&)
2022.10.19 21:59:56.242194 [ 416 ] {} <Fatal> BaseDaemon: 7. ./build_docker/../src/Common/Exception.cpp:70: DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x25cce7f3 in /workspace/clickhouse
2022.10.19 21:59:56.426828 [ 416 ] {} <Fatal> BaseDaemon: 8. ./build_docker/../src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp:0: DB::MergeTreeBaseSelectProcessor::transformHeader(DB::Block, std::__1::shared_ptr<DB::PrewhereInfo> const&, std::__1::shared_ptr<DB::IDataType const> const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) @ 0x46347102 in /workspace/clickhouse
2022.10.19 21:59:56.858151 [ 416 ] {} <Fatal> BaseDaemon: 9. ./build_docker/../src/Processors/QueryPlan/ReadFromMergeTree.cpp:0: DB::ReadFromMergeTree::ReadFromMergeTree(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const> > >, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >, DB::MergeTreeData const&, DB::SelectQueryInfo const&, std::__1::shared_ptr<DB::StorageSnapshot>, std::__1::shared_ptr<DB::Context const>, unsigned long, unsigned long, bool, std::__1::shared_ptr<std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, long> > > >, Poco::Logger*, std::__1::shared_ptr<DB::MergeTreeDataSelectAnalysisResult>, bool) @ 0x462cece8 in /workspace/clickhouse
2022.10.19 21:59:57.651024 [ 416 ] {} <Fatal> BaseDaemon: 10.1. inlined from ./build_docker/../contrib/libcxx/include/vector:399: ~vector
2022.10.19 21:59:57.651144 [ 416 ] {} <Fatal> BaseDaemon: 10. ./build_docker/../contrib/libcxx/include/__memory/unique_ptr.h:725: std::__1::__unique_if<DB::ReadFromMergeTree>::__unique_single std::__1::make_unique<DB::ReadFromMergeTree, std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const> > >, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, DB::MergeTreeData const&, DB::SelectQueryInfo const&, std::__1::shared_ptr<DB::StorageSnapshot> const&, std::__1::shared_ptr<DB::Context const>&, unsigned long const&, unsigned int const&, bool&, std::__1::shared_ptr<std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, long> > > >&, Poco::Logger* const&, std::__1::shared_ptr<DB::MergeTreeDataSelectAnalysisResult>&, bool&>(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const> > >&&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, DB::MergeTreeData const&, DB::SelectQueryInfo const&, std::__1::shared_ptr<DB::StorageSnapshot> const&, std::__1::shared_ptr<DB::Context const>&, unsigned long const&, unsigned int const&, bool&, std::__1::shared_ptr<std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, long> > > >&, Poco::Logger* const&, std::__1::shared_ptr<DB::MergeTreeDataSelectAnalysisResult>&, bool&) @ 0x44702d5a in /workspace/clickhouse
2022.10.19 21:59:58.240225 [ 416 ] {} <Fatal> BaseDaemon: 11. ./build_docker/../src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp:1343: DB::MergeTreeDataSelectExecutor::readFromParts(std::__1::vector<std::__1::shared_ptr<DB::IMergeTreeDataPart const>, std::__1::allocator<std::__1::shared_ptr<DB::IMergeTreeDataPart const> > >, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, std::__1::shared_ptr<DB::StorageSnapshot> const&, DB::SelectQueryInfo const&, std::__1::shared_ptr<DB::Context const>, unsigned long, unsigned int, std::__1::shared_ptr<std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, long> > > >, std::__1::shared_ptr<DB::MergeTreeDataSelectAnalysisResult>, bool) const @ 0x446b72f0 in /workspace/clickhouse
2022.10.19 21:59:58.744716 [ 416 ] {} <Fatal> BaseDaemon: 12. ./build_docker/../src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp:161: DB::MergeTreeDataSelectExecutor::read(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, std::__1::shared_ptr<DB::StorageSnapshot> const&, DB::SelectQueryInfo const&, std::__1::shared_ptr<DB::Context const>, unsigned long, unsigned int, DB::QueryProcessingStage::Enum, std::__1::shared_ptr<std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, long> > > >, bool) const @ 0x446ad62f in /workspace/clickhouse
2022.10.19 21:59:59.201805 [ 416 ] {} <Fatal> BaseDaemon: 13. ./build_docker/../src/Storages/StorageMergeTree.cpp:0: DB::StorageMergeTree::read(DB::QueryPlan&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, std::__1::shared_ptr<DB::StorageSnapshot> const&, DB::SelectQueryInfo&, std::__1::shared_ptr<DB::Context const>, DB::QueryProcessingStage::Enum, unsigned long, unsigned int) @ 0x44d432e3 in /workspace/clickhouse
2022.10.19 21:59:59.617866 [ 416 ] {} <Fatal> BaseDaemon: 14.1. inlined from ./build_docker/../src/Processors/QueryPlan/QueryPlan.h:54: DB::QueryPlan::isInitialized() const
2022.10.19 21:59:59.617985 [ 416 ] {} <Fatal> BaseDaemon: 14. ./build_docker/../src/Storages/StorageMerge.cpp:560: DB::ReadFromMerge::createSources(std::__1::shared_ptr<DB::StorageSnapshot> const&, DB::SelectQueryInfo&, DB::QueryProcessingStage::Enum const&, unsigned long, DB::Block const&, std::__1::vector<DB::ReadFromMerge::AliasData, std::__1::allocator<DB::ReadFromMerge::AliasData> > const&, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::shared_ptr<DB::IStorage>, std::__1::shared_ptr<DB::RWLockImpl::LockHolderImpl>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, std::__1::shared_ptr<DB::Context>, unsigned long, bool) @ 0x436bc374 in /workspace/clickhouse
2022.10.19 22:00:00.159380 [ 416 ] {} <Fatal> BaseDaemon: 15. ./build_docker/../src/Storages/StorageMerge.cpp:452: DB::ReadFromMerge::initializePipeline(DB::QueryPipelineBuilder&, DB::BuildQueryPipelineSettings const&) @ 0x436b2429 in /workspace/clickhouse
2022.10.19 22:00:00.217658 [ 416 ] {} <Fatal> BaseDaemon: 16. ./build_docker/../src/Processors/QueryPlan/ISourceStep.cpp:0: DB::ISourceStep::updatePipeline(std::__1::vector<std::__1::unique_ptr<DB::QueryPipelineBuilder, std::__1::default_delete<DB::QueryPipelineBuilder> >, std::__1::allocator<std::__1::unique_ptr<DB::QueryPipelineBuilder, std::__1::default_delete<DB::QueryPipelineBuilder> > > >, DB::BuildQueryPipelineSettings const&) @ 0x46238d2f in /workspace/clickhouse
2022.10.19 22:00:00.333032 [ 416 ] {} <Fatal> BaseDaemon: 17. ./build_docker/../src/Processors/QueryPlan/QueryPlan.cpp:0: DB::QueryPlan::buildQueryPipeline(DB::QueryPlanOptimizationSettings const&, DB::BuildQueryPipelineSettings const&) @ 0x462a1b92 in /workspace/clickhouse
2022.10.19 22:00:00.571825 [ 416 ] {} <Fatal> BaseDaemon: 18. ./build_docker/../src/Interpreters/InterpreterSelectWithUnionQuery.cpp:370: DB::InterpreterSelectWithUnionQuery::execute() @ 0x412e7743 in /workspace/clickhouse
2022.10.19 22:00:00.947659 [ 416 ] {} <Fatal> BaseDaemon: 19. ./build_docker/../src/Interpreters/executeQuery.cpp:709: DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x41ee74c5 in /workspace/clickhouse
2022.10.19 22:00:01.361691 [ 416 ] {} <Fatal> BaseDaemon: 20. ./build_docker/../src/Interpreters/executeQuery.cpp:1105: DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum) @ 0x41eda53d in /workspace/clickhouse
2022.10.19 22:00:01.628580 [ 416 ] {} <Fatal> BaseDaemon: 21. ./build_docker/../src/Server/TCPHandler.cpp:374: DB::TCPHandler::runImpl() @ 0x452b3eff in /workspace/clickhouse
2022.10.19 22:00:02.030789 [ 416 ] {} <Fatal> BaseDaemon: 22. ./build_docker/../src/Server/TCPHandler.cpp:1899: DB::TCPHandler::run() @ 0x452f2fde in /workspace/clickhouse
2022.10.19 22:00:02.038167 [ 416 ] {} <Fatal> BaseDaemon: 23. ./build_docker/../contrib/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x50e0bafe in /workspace/clickhouse
2022.10.19 22:00:02.062624 [ 416 ] {} <Fatal> BaseDaemon: 24.1. inlined from ./build_docker/../contrib/libcxx/include/__memory/unique_ptr.h:312: std::__1::unique_ptr<Poco::Net::TCPServerConnection, std::__1::default_delete<Poco::Net::TCPServerConnection> >::reset(Poco::Net::TCPServerConnection*)
2022.10.19 22:00:02.062741 [ 416 ] {} <Fatal> BaseDaemon: 24.2. inlined from ./build_docker/../contrib/libcxx/include/__memory/unique_ptr.h:269: ~unique_ptr
2022.10.19 22:00:02.062789 [ 416 ] {} <Fatal> BaseDaemon: 24. ./build_docker/../contrib/poco/Net/src/TCPServerDispatcher.cpp:116: Poco::Net::TCPServerDispatcher::run() @ 0x50e0ce8f in /workspace/clickhouse
2022.10.19 22:00:02.087936 [ 416 ] {} <Fatal> BaseDaemon: 25. ./build_docker/../contrib/poco/Foundation/src/ThreadPool.cpp:0: Poco::PooledThread::run() @ 0x515295ec in /workspace/clickhouse
2022.10.19 22:00:02.114905 [ 416 ] {} <Fatal> BaseDaemon: 26. ./build_docker/../contrib/poco/Foundation/src/Thread.cpp:56: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x51525042 in /workspace/clickhouse
2022.10.19 22:00:02.138468 [ 416 ] {} <Fatal> BaseDaemon: 27. ./build_docker/../contrib/poco/Foundation/src/Thread_POSIX.cpp:360: Poco::ThreadImpl::runnableEntry(void*) @ 0x51520f29 in /workspace/clickhouse
2022.10.19 22:00:02.138584 [ 416 ] {} <Fatal> BaseDaemon: 28. ? @ 0x7f2d40b77609 in ?
2022.10.19 22:00:02.138634 [ 416 ] {} <Fatal> BaseDaemon: 29. clone @ 0x7f2d40a9c133 in ?
2022.10.19 22:00:04.069076 [ 416 ] {} <Fatal> BaseDaemon: Integrity check of the executable skipped because the reference checksum could not be read. (calculated checksum: 8DF0D7CF55522D45198BAAABC1057210)

```

The problem is that this table has engine Merge... And I don't know how to reproduce this
```
2022.10.19 21:59:10.050159 [ 159 ] {ad987884-1c74-4583-886a-30f85a1f1de3} <Debug> executeQuery: (from [::ffff:127.0.0.1]:60758) CREATE TABLE m_table__fuzz_44 (`x` Int16, `y` Nullable(Float32)) ENGINE = Merge(currentDatabase(), '^table_') (stage: Complete)
2022.10.19 21:59:10.050384 [ 159 ] {ad987884-1c74-4583-886a-30f85a1f1de3} <Trace> ContextAccess (default): Access granted: CREATE TABLE ON default.m_table__fuzz_44
```


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
