### PR TITLE
add a new parameter of ReplacingMergeTree engine.

### DIFF
--- a/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/ReplacingSortedAlgorithm.h
@@ -2,6 +2,7 @@
 #include <Processors/Merges/Algorithms/IMergingAlgorithmWithSharedChunks.h>
 #include <Processors/Merges/Algorithms/MergedData.h>
 #include <Processors/Transforms/ColumnGathererTransform.h>
+#include <Storages/MergeTree/MergeTreeData.h>
 
 namespace Poco
 {
@@ -21,6 +22,7 @@ public:
     ReplacingSortedAlgorithm(
         const Block & header, size_t num_inputs,
         SortDescription description_, const String & version_column,
+        const MergeTreeData::MergingParams::VersionRule & version_rule,
         size_t max_block_size,
         WriteBuffer * out_row_sources_buf_ = nullptr,
         bool use_average_block_sizes = false);
@@ -31,6 +33,8 @@ private:
     MergedData merged_data;
 
     ssize_t version_column_number = -1;
+
+    bool use_minimum_version_in_replacing = false;
 
     using RowRef = detail::RowRefWithOwnedChunk;
     static constexpr size_t max_row_refs = 2; /// last, current.

--- a/src/Processors/Merges/ReplacingSortedTransform.h
+++ b/src/Processors/Merges/ReplacingSortedTransform.h
@@ -14,6 +14,7 @@ public:
     ReplacingSortedTransform(
         const Block & header, size_t num_inputs,
         SortDescription description_, const String & version_column,
+        const MergeTreeData::MergingParams::VersionRule & version_rule,
         size_t max_block_size,
         WriteBuffer * out_row_sources_buf_ = nullptr,
         bool use_average_block_sizes = false)
@@ -23,6 +24,7 @@ public:
             num_inputs,
             std::move(description_),
             version_column,
+            version_rule,
             max_block_size,
             out_row_sources_buf_,
             use_average_block_sizes)

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -628,7 +628,7 @@ static void addMergingFinal(
 
             case MergeTreeData::MergingParams::Replacing:
                 return std::make_shared<ReplacingSortedTransform>(header, num_outputs,
-                            sort_description, merging_params.version_column, max_block_size);
+                            sort_description, merging_params.version_column, merging_params.version_rule, max_block_size);
 
             case MergeTreeData::MergingParams::VersionedCollapsing:
                 return std::make_shared<VersionedCollapsingTransform>(header, num_outputs,

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -887,7 +887,7 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::createMergedStream()
 
         case MergeTreeData::MergingParams::Replacing:
             merged_transform = std::make_shared<ReplacingSortedTransform>(
-                header, pipes.size(), sort_description, ctx->merging_params.version_column,
+                header, pipes.size(), sort_description, ctx->merging_params.version_column, ctx->merging_params.version_rule,
                 merge_block_size, ctx->rows_sources_write_buf.get(), ctx->blocks_are_granules_size);
             break;
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -708,6 +708,10 @@ void MergeTreeData::MergingParams::check(const StorageInMemoryMetadata & metadat
         throw Exception("Version column for MergeTree cannot be specified in modes except Replacing or VersionedCollapsing.",
                         ErrorCodes::LOGICAL_ERROR);
 
+    if (version_rule != Unknown && mode != MergingParams::Replacing)
+        throw Exception("Version rule for MergeTree cannot be specified in modes except Replacing.",
+                        ErrorCodes::LOGICAL_ERROR);
+
     if (!columns_to_sum.empty() && mode != MergingParams::Summing)
         throw Exception("List of columns to sum for MergeTree cannot be specified in all modes except Summing.",
                         ErrorCodes::LOGICAL_ERROR);
@@ -929,6 +933,34 @@ String MergeTreeData::MergingParams::getModeName() const
     }
 
     UNREACHABLE();
+}
+
+String MergeTreeData::MergingParams::getVersionRuleName() const
+{
+    switch (version_rule)
+    {
+        case Maximum:      return "maximum";
+        case Minimum:      return "minimum";
+        case Unknown:      return "unknown";
+    }
+
+    UNREACHABLE();
+}
+
+MergeTreeData::MergingParams::VersionRule MergeTreeData::MergingParams::getVersionRuleByName(const String & versionRuleName) const
+{
+    if (versionRuleName == "maximum")
+    {
+        return Maximum;
+    }
+    else if (versionRuleName == "minimum")
+    {
+        return Minimum;
+    }
+    else
+    {
+        return Unknown;
+    }
 }
 
 Int64 MergeTreeData::getMaxBlockNumber() const

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -335,6 +335,14 @@ public:
             VersionedCollapsing = 7,
         };
 
+        /// For Replacing mode. version_column rule
+        enum VersionRule
+        {
+            Unknown             = 0,
+            Maximum             = 1,
+            Minimum             = 2,
+        };
+
         Mode mode;
 
         /// For Collapsing and VersionedCollapsing mode.
@@ -346,6 +354,9 @@ public:
         /// For Replacing and VersionedCollapsing mode. Can be empty for Replacing.
         String version_column;
 
+        /// For Replacing mode. Can be empty for Replacing.
+        VersionRule version_rule = Unknown;
+
         /// For Graphite mode.
         Graphite::Params graphite_params;
 
@@ -353,6 +364,10 @@ public:
         void check(const StorageInMemoryMetadata & metadata) const;
 
         String getModeName() const;
+
+        String getVersionRuleName() const;
+
+        VersionRule getVersionRuleByName(const String & versionRuleName) const;
     };
 
     /// Attach the table corresponding to the directory in full_path inside policy (must end with /), with the given columns.

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -225,7 +225,7 @@ Block MergeTreeDataWriter::mergeBlock(
                 return nullptr;
             case MergeTreeData::MergingParams::Replacing:
                 return std::make_shared<ReplacingSortedAlgorithm>(
-                    block, 1, sort_description, merging_params.version_column, block_size + 1);
+                    block, 1, sort_description, merging_params.version_column, merging_params.version_rule, block_size + 1);
             case MergeTreeData::MergingParams::Collapsing:
                 return std::make_shared<CollapsingSortedAlgorithm>(
                     block, 1, sort_description, merging_params.sign_column,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
With the minimum version, if minimum specified.
this is new version rule of the maximum version or minimum version

### Change details
add a new parameter of ReplacingMergeTree engine.

This extra parameter is an optional column; however, if enabled, the version column becomes mandatory. This “new parameter” allows backward compatibility with previous versions of the ReplacingMergeTree by being an option at the creation of the table

- "if ver is not specified",after deduplication, the very last row from the most recent insert will remain for each unique sorting key.
- "if ver is specified",after deduplication, With the maximum version.
- "if ver is specified and minimum is specified",after deduplication, With the minimum version.

If you set it incorrectly, you will be prompted for the correct parameter type
![image](https://user-images.githubusercontent.com/67011523/197025590-421fa2b6-5a54-4473-8fbe-94f45f07fca7.png)


### Explain
````
CREATE TABLE test1(user_id Int64,str String,version Int64) ENGINE = ReplacingMergeTree() ORDER BY user_id;
INSERT INTO test1(user_id, str, version) VALUES('111','1aa', '15'),('111','1aa', '5'),('111','1aa', '10');
SELECT * FROM test1 final;
┌─user_id─┬─str─┬─version─┐
│   111   │ 1aa │   10    │

CREATE TABLE test2(user_id Int64,str String,version Int64) ENGINE = ReplacingMergeTree(version) ORDER BY user_id;
INSERT INTO test2(user_id, str, version) VALUES('111','1aa', '15'),('111','1aa', '5'),('111','1aa', '10');
SELECT * FROM test2 final;
┌─user_id─┬─str─┬─version─┐
│   111   │ 1aa │   15    │

CREATE TABLE test3(user_id Int64,str String,version Int64) ENGINE = ReplacingMergeTree(version, minimum) ORDER BY user_id;
INSERT INTO test3(user_id, str, version) VALUES('111','1aa', '15'),('111','1aa', '5'),('111','1aa', '10');
SELECT * FROM test3 final;
┌─user_id─┬─str─┬─version─┐
│   111   │ 1aa │    5    │
````

### Required help
#42393
This is another pr I submitted. Its function is the same, but it controlling this with a setting.
I'm not sure which one is better
> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
