### PR TITLE
Better logs in clickhouse-disks

### DIFF
--- a/programs/disks/DisksApp.cpp
+++ b/programs/disks/DisksApp.cpp
@@ -57,7 +57,7 @@ void DisksApp::addOptions(
         ("config-file,C", po::value<String>(), "Set config file")
         ("disk", po::value<String>(), "Set disk name")
         ("command_name", po::value<String>(), "Name for command to do")
-        ("send-logs", "Send logs")
+        ("save-logs", "Save logs to a file")
         ("log-level", po::value<String>(), "Logging level")
         ;
 
@@ -82,10 +82,10 @@ void DisksApp::processOptions()
         config().setString("config-file", options["config-file"].as<String>());
     if (options.count("disk"))
         config().setString("disk", options["disk"].as<String>());
-    if (options.count("send-logs"))
-        config().setBool("send-logs", true);
+    if (options.count("save-logs"))
+        config().setBool("save-logs", true);
     if (options.count("log-level"))
-        Poco::Logger::root().setLevel(options["log-level"].as<std::string>());
+        config().setString("log-level", options["log-level"].as<String>());
 }
 
 void DisksApp::init(std::vector<String> & common_arguments)
@@ -149,15 +149,6 @@ void DisksApp::parseAndCheckOptions(
 
 int DisksApp::main(const std::vector<String> & /*args*/)
 {
-    if (config().has("send-logs"))
-    {
-        auto log_level = config().getString("log-level", "trace");
-        Poco::Logger::root().setLevel(Poco::Logger::parseLevel(log_level));
-
-        auto log_path = config().getString("logger.clickhouse-disks", "/var/log/clickhouse-server/clickhouse-disks.log");
-        Poco::Logger::root().setChannel(Poco::AutoPtr<Poco::FileChannel>(new Poco::FileChannel(log_path)));
-    }
-
     if (config().has("config-file") || fs::exists(getDefaultConfigFileName()))
     {
         String config_path = config().getString("config-file", getDefaultConfigFileName());
@@ -169,6 +160,20 @@ int DisksApp::main(const std::vector<String> & /*args*/)
     else
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "No config-file specifiged");
+    }
+
+    if (config().has("save-logs"))
+    {
+        auto log_level = config().getString("log-level", "trace");
+        Poco::Logger::root().setLevel(Poco::Logger::parseLevel(log_level));
+
+        auto log_path = config().getString("logger.clickhouse-disks", "/var/log/clickhouse-server/clickhouse-disks.log");
+        Poco::Logger::root().setChannel(Poco::AutoPtr<Poco::FileChannel>(new Poco::FileChannel(log_path)));
+    }
+    else
+    {
+        auto log_level = config().getString("log-level", "none");
+        Poco::Logger::root().setLevel(Poco::Logger::parseLevel(log_level));
     }
 
     registerDisks();

--- a/tests/integration/test_disks_app_func/test.py
+++ b/tests/integration/test_disks_app_func/test.py
@@ -37,7 +37,7 @@ def test_disks_app_func_ld(started_cluster):
     source = cluster.instances["disks_app_test"]
 
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "list-disks"]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "list-disks"]
     )
 
     disks = out.split("\n")
@@ -51,7 +51,7 @@ def test_disks_app_func_ls(started_cluster):
     init_data(source)
 
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "--disk", "test1", "list", "."]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "--disk", "test1", "list", "."]
     )
 
     files = out.split("\n")
@@ -62,7 +62,7 @@ def test_disks_app_func_ls(started_cluster):
         [
             "/usr/bin/clickhouse",
             "disks",
-            "--send-logs",
+            "--save-logs",
             "--disk",
             "test1",
             "list",
@@ -89,7 +89,7 @@ def test_disks_app_func_cp(started_cluster):
                 [
                     "/usr/bin/clickhouse",
                     "disks",
-                    "--send-logs",
+                    "--save-logs",
                     "--disk",
                     "test1",
                     "write",
@@ -114,7 +114,7 @@ def test_disks_app_func_cp(started_cluster):
     )
 
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "--disk", "test2", "list", "."]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "--disk", "test2", "list", "."]
     )
 
     assert "path1" in out
@@ -123,7 +123,7 @@ def test_disks_app_func_cp(started_cluster):
         [
             "/usr/bin/clickhouse",
             "disks",
-            "--send-logs",
+            "--save-logs",
             "--disk",
             "test2",
             "remove",
@@ -135,7 +135,7 @@ def test_disks_app_func_cp(started_cluster):
         [
             "/usr/bin/clickhouse",
             "disks",
-            "--send-logs",
+            "--save-logs",
             "--disk",
             "test1",
             "remove",
@@ -146,13 +146,13 @@ def test_disks_app_func_cp(started_cluster):
     # alesapin: Why we need list one more time?
     # kssenii: it is an assertion that the file is indeed deleted
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "--disk", "test2", "list", "."]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "--disk", "test2", "list", "."]
     )
 
     assert "path1" not in out
 
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "--disk", "test1", "list", "."]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "--disk", "test1", "list", "."]
     )
 
     assert "path1" not in out
@@ -174,7 +174,7 @@ def test_disks_app_func_ln(started_cluster):
     )
 
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "list", "data/default/"]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "list", "data/default/"]
     )
 
     files = out.split("\n")
@@ -196,7 +196,7 @@ def test_disks_app_func_rm(started_cluster):
                 [
                     "/usr/bin/clickhouse",
                     "disks",
-                    "--send-logs",
+                    "--save-logs",
                     "--disk",
                     "test2",
                     "write",
@@ -207,7 +207,7 @@ def test_disks_app_func_rm(started_cluster):
     )
 
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "--disk", "test2", "list", "."]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "--disk", "test2", "list", "."]
     )
 
     assert "path3" in out
@@ -216,7 +216,7 @@ def test_disks_app_func_rm(started_cluster):
         [
             "/usr/bin/clickhouse",
             "disks",
-            "--send-logs",
+            "--save-logs",
             "--disk",
             "test2",
             "remove",
@@ -225,7 +225,7 @@ def test_disks_app_func_rm(started_cluster):
     )
 
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "--disk", "test2", "list", "."]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "--disk", "test2", "list", "."]
     )
 
     assert "path3" not in out
@@ -237,7 +237,7 @@ def test_disks_app_func_mv(started_cluster):
     init_data(source)
 
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "--disk", "test1", "list", "."]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "--disk", "test1", "list", "."]
     )
 
     files = out.split("\n")
@@ -257,7 +257,7 @@ def test_disks_app_func_mv(started_cluster):
     )
 
     out = source.exec_in_container(
-        ["/usr/bin/clickhouse", "disks", "--send-logs", "--disk", "test1", "list", "."]
+        ["/usr/bin/clickhouse", "disks", "--save-logs", "--disk", "test1", "list", "."]
     )
 
     files = out.split("\n")
@@ -277,7 +277,7 @@ def test_disks_app_func_read_write(started_cluster):
                 [
                     "/usr/bin/clickhouse",
                     "disks",
-                    "--send-logs",
+                    "--save-logs",
                     "--disk",
                     "test1",
                     "write",
@@ -291,7 +291,7 @@ def test_disks_app_func_read_write(started_cluster):
         [
             "/usr/bin/clickhouse",
             "disks",
-            "--send-logs",
+            "--save-logs",
             "--disk",
             "test1",
             "read",


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Change the name of the parameter and small improvements. Continuation of https://github.com/ClickHouse/ClickHouse/pull/42302