### PR TITLE
add lib_fuzzer and lib_fuzzer_no_main to llvm-project build

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -114,6 +114,7 @@ if (ENABLE_TESTS)
 endif()
 
 add_contrib (llvm-project-cmake llvm-project)
+add_contrib (libfuzzer-cmake llvm-project)
 add_contrib (libxml2-cmake libxml2)
 add_contrib (aws-s3-cmake
     aws

--- a/contrib/libfuzzer-cmake/CMakeLists.txt
+++ b/contrib/libfuzzer-cmake/CMakeLists.txt
@@ -1,0 +1,35 @@
+set(COMPILER_RT_FUZZER_SRC_DIR "${ClickHouse_SOURCE_DIR}/contrib/llvm-project/compiler-rt/lib/fuzzer")
+
+set(FUZZER_SRCS
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerCrossOver.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerDataFlowTrace.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerDriver.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtFunctionsDlsym.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtFunctionsWeak.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtFunctionsWindows.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtraCounters.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtraCountersDarwin.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtraCountersWindows.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerFork.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerIO.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerIOPosix.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerIOWindows.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerLoop.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerMerge.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerMutate.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerSHA1.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerTracePC.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtil.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilDarwin.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilFuchsia.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilLinux.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilPosix.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilWindows.cpp"
+)
+
+add_library(_fuzzer_no_main STATIC ${FUZZER_SRCS})
+add_library(ch_contrib::fuzzer_no_main ALIAS _fuzzer_no_main)
+
+add_library(_fuzzer STATIC ${FUZZER_SRCS} "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerMain.cpp")
+add_library(ch_contrib::fuzzer ALIAS _fuzzer)
+

--- a/contrib/llvm-project-cmake/CMakeLists.txt
+++ b/contrib/llvm-project-cmake/CMakeLists.txt
@@ -1,39 +1,3 @@
-set(COMPILER_RT_FUZZER_SRC_DIR "${ClickHouse_SOURCE_DIR}/contrib/llvm-project/compiler-rt/lib/fuzzer")
-
-set(FUZZER_SRCS
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerCrossOver.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerDataFlowTrace.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerDriver.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtFunctionsDlsym.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtFunctionsWeak.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtFunctionsWindows.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtraCounters.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtraCountersDarwin.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtraCountersWindows.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerFork.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerIO.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerIOPosix.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerIOWindows.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerLoop.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerMerge.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerMutate.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerSHA1.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerTracePC.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtil.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilDarwin.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilFuchsia.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilLinux.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilPosix.cpp"
-    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilWindows.cpp"
-)
-
-add_library(_fuzzer_no_main STATIC ${FUZZER_SRCS})
-add_library(ch_contrib::fuzzer_no_main ALIAS _fuzzer_no_main)
-
-add_library(_fuzzer STATIC ${FUZZER_SRCS} "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerMain.cpp")
-add_library(ch_contrib::fuzzer ALIAS _fuzzer)
-
-
 if (APPLE OR NOT ARCH_AMD64 OR SANITIZE STREQUAL "undefined")
    set (ENABLE_EMBEDDED_COMPILER_DEFAULT OFF)
 else()

--- a/contrib/llvm-project-cmake/CMakeLists.txt
+++ b/contrib/llvm-project-cmake/CMakeLists.txt
@@ -1,3 +1,39 @@
+set(COMPILER_RT_FUZZER_SRC_DIR "${ClickHouse_SOURCE_DIR}/contrib/llvm-project/compiler-rt/lib/fuzzer")
+
+set(FUZZER_SRCS
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerCrossOver.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerDataFlowTrace.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerDriver.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtFunctionsDlsym.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtFunctionsWeak.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtFunctionsWindows.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtraCounters.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtraCountersDarwin.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerExtraCountersWindows.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerFork.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerIO.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerIOPosix.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerIOWindows.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerLoop.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerMerge.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerMutate.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerSHA1.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerTracePC.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtil.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilDarwin.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilFuchsia.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilLinux.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilPosix.cpp"
+    "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerUtilWindows.cpp"
+)
+
+add_library(_fuzzer_no_main STATIC ${FUZZER_SRCS})
+add_library(ch_contrib::fuzzer_no_main ALIAS _fuzzer_no_main)
+
+add_library(_fuzzer STATIC ${FUZZER_SRCS} "${COMPILER_RT_FUZZER_SRC_DIR}/FuzzerMain.cpp")
+add_library(ch_contrib::fuzzer ALIAS _fuzzer)
+
+
 if (APPLE OR NOT ARCH_AMD64 OR SANITIZE STREQUAL "undefined")
    set (ENABLE_EMBEDDED_COMPILER_DEFAULT OFF)
 else()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Build libFuzzer libs from contrib/llvm-project