### PR TITLE
Clear thread::id when ThreadFromGlobalPool exits.

### DIFF
--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -178,7 +178,10 @@ public:
             func = std::forward<Function>(func),
             args = std::make_tuple(std::forward<Args>(args)...)]() mutable /// mutable is needed to destroy capture
         {
-            SCOPE_EXIT(state->event.set());
+            SCOPE_EXIT(
+                state->thread_id = std::thread::id();
+                state->event.set();
+            );
 
             state->thread_id = std::this_thread::get_id();
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Half of #42577