### PR TITLE
Fix create set with wrong header when data type is lowcardinality

### DIFF
--- a/src/Interpreters/Set.cpp
+++ b/src/Interpreters/Set.cpp
@@ -131,6 +131,7 @@ void Set::setHeader(const ColumnsWithTypeAndName & header)
         if (const auto * low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(data_types.back().get()))
         {
             data_types.back() = low_cardinality_type->getDictionaryType();
+            set_elements_types.back() = low_cardinality_type->getDictionaryType();
             materialized_columns.emplace_back(key_columns.back()->convertToFullColumnIfLowCardinality());
             key_columns.back() = materialized_columns.back().get();
         }

--- a/tests/queries/0_stateless/02467_set_with_lowcardinality_type.reference
+++ b/tests/queries/0_stateless/02467_set_with_lowcardinality_type.reference
@@ -1,0 +1,2 @@
+1	test
+1	test

--- a/tests/queries/0_stateless/02467_set_with_lowcardinality_type.sql
+++ b/tests/queries/0_stateless/02467_set_with_lowcardinality_type.sql
@@ -1,0 +1,30 @@
+DROP TABLE IF EXISTS bloom_filter_nullable_index__fuzz_0;
+CREATE TABLE bloom_filter_nullable_index__fuzz_0
+(
+    `order_key` UInt64,
+    `str` Nullable(String),
+    INDEX idx str TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY order_key SETTINGS index_granularity = 6;
+
+INSERT INTO bloom_filter_nullable_index__fuzz_0 VALUES (1, 'test');
+INSERT INTO bloom_filter_nullable_index__fuzz_0 VALUES (2, 'test2');
+
+DROP TABLE IF EXISTS bloom_filter_nullable_index__fuzz_1;
+CREATE TABLE bloom_filter_nullable_index__fuzz_1
+(
+    `order_key` UInt64,
+    `str` Nullable(String),
+    INDEX idx str TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY order_key SETTINGS index_granularity = 6;
+
+INSERT INTO bloom_filter_nullable_index__fuzz_0 VALUES (1, 'test');
+INSERT INTO bloom_filter_nullable_index__fuzz_0 VALUES (2, 'test2');
+
+DROP TABLE IF EXISTS nullable_string_value__fuzz_2;
+CREATE TABLE nullable_string_value__fuzz_2 (`value` LowCardinality(String)) ENGINE = TinyLog;
+INSERT INTO nullable_string_value__fuzz_2 VALUES ('test');
+
+SELECT * FROM bloom_filter_nullable_index__fuzz_0 WHERE str IN (SELECT value FROM nullable_string_value__fuzz_2);
+SELECT * FROM bloom_filter_nullable_index__fuzz_1 WHERE str IN (SELECT value FROM nullable_string_value__fuzz_2);

--- a/tests/queries/0_stateless/02467_set_with_lowcardinality_type.sql
+++ b/tests/queries/0_stateless/02467_set_with_lowcardinality_type.sql
@@ -15,7 +15,7 @@ DROP TABLE IF EXISTS bloom_filter_nullable_index__fuzz_1;
 CREATE TABLE bloom_filter_nullable_index__fuzz_1
 (
     `order_key` UInt64,
-    `str` Nullable(String),
+    `str` String,
     INDEX idx str TYPE bloom_filter GRANULARITY 1
 )
 ENGINE = MergeTree ORDER BY order_key SETTINGS index_granularity = 6;

--- a/tests/queries/0_stateless/02467_set_with_lowcardinality_type.sql
+++ b/tests/queries/0_stateless/02467_set_with_lowcardinality_type.sql
@@ -1,3 +1,4 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/42460
 DROP TABLE IF EXISTS bloom_filter_nullable_index__fuzz_0;
 CREATE TABLE bloom_filter_nullable_index__fuzz_0
 (


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix create Set with wrong header when data type is LowCardinality. Closes #42460.
