### PR TITLE
Fix possible segfault in expression parser

### DIFF
--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1582,6 +1582,9 @@ public:
     {
         if (parsed_interval_kind)
         {
+            if (elements.size() < 2)
+                return false;
+
             elements[0] = makeASTFunction(interval_kind.toNameOfFunctionToIntervalDataType(), elements[0]);
             node = makeASTFunction(function_name, elements[1], elements[0]);
         }

--- a/tests/queries/0_stateless/02472_segfault_expression_parser.sql
+++ b/tests/queries/0_stateless/02472_segfault_expression_parser.sql
@@ -1,0 +1,1 @@
+SELECT TIMESTAMP_SUB (SELECT ILIKE INTO OUTFILE , accurateCast ) FROM TIMESTAMP_SUB ( MINUTE , ) GROUP BY accurateCast; -- { clientError 62 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/42597.