### PR TITLE
Adding arch setting in the package mirror URL

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -99,7 +99,7 @@ It is recommended to use official pre-compiled `deb` packages for Debian or Ubun
 sudo apt-get install -y apt-transport-https ca-certificates dirmngr
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754
 
-echo "deb https://packages.clickhouse.com/deb stable main" | sudo tee \
+echo "deb [arch=$(dpkg --print-architecture)] https://packages.clickhouse.com/deb stable main" | sudo tee \
     /etc/apt/sources.list.d/clickhouse.list
 sudo apt-get update
 


### PR DESCRIPTION
### Changelog category (leave one):

- Documentation (changelog entry is not required)
- To avoid the following message when running the `sudo apt-get update` or `sudo apt update` command:

```sh
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://packages.clickhouse.com/deb stable InRelease' doesn't support architecture 'i386'
```

It should add the `[arch=amd64]` setting and the above situation is affected in the Ubuntu 18.04.
