### PR TITLE
Fix incorrect trace log line on dict reload

### DIFF
--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -714,7 +714,10 @@ public:
                         /// Object was never loaded successfully and should be reloaded.
                         startLoading(info);
                     }
-                    LOG_TRACE(log, "Object '{}' is neither loaded nor failed, so it will not be reloaded as outdated.", info.name);
+                    else
+                    {
+                        LOG_TRACE(log, "Object '{}' is neither loaded nor failed, so it will not be reloaded as outdated.", info.name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Introduced here: https://github.com/ClickHouse/ClickHouse/commit/9d9ae0095698bdb4ca87013943ccc968a9562c30


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
