### PR TITLE
Update Fedora build info

### DIFF
--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -105,7 +105,7 @@ ninja
 Example for Fedora Rawhide:
 ``` bash
 sudo yum update
-yum --nogpg install git cmake make clang-c++ python3
+sudo yum --nogpg install git cmake make clang python3 ccache
 git clone --recursive https://github.com/ClickHouse/ClickHouse.git
 mkdir build && cd build
 cmake ../ClickHouse


### PR DESCRIPTION
I am using Fedora 36.

yum install of `clang-c++` failed for me, `clang` worked.  And I had an error message telling me to install `ccache` also.


### Changelog category (leave one):
- Documentation (changelog entry is not required)

