### PR TITLE
Fix typo in cmake code related to fuzzing

### DIFF
--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -85,7 +85,7 @@ if (SANITIZE)
             # and they have a bunch of flags not halt the program if UIO happend and even to silence that warnings.
             # But for unknown reason that flags don't work with ClickHouse or we don't understand how to properly use them,
             # that's why we often receive reports about UIO. The simplest way to avoid this is just  set this flag here.
-            set(UBSAN_FLAGS "${SAN_FLAGS} -fno-sanitize=unsigned-integer-overflow")
+            set(UBSAN_FLAGS "${UBSAN_FLAGS} -fno-sanitize=unsigned-integer-overflow")
         endif()
         if (COMPILER_CLANG)
             set (UBSAN_FLAGS "${UBSAN_FLAGS} -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/tests/ubsan_suppressions.txt")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
