### PR TITLE
Fix error handling in clickhouse_helper.py

### DIFF
--- a/tests/ci/clickhouse_helper.py
+++ b/tests/ci/clickhouse_helper.py
@@ -37,12 +37,8 @@ class ClickHouseHelper:
                     url, params=params, data=json_str, headers=auth
                 )
             except Exception as e:
-                logging.warning(
-                    "Received exception while sending data to %s on %s attempt: %s",
-                    url,
-                    i,
-                    e,
-                )
+                error = f"Received exception while sending data to {url} on {i} attempt: {e}"
+                logging.warning(error)
                 continue
 
             logging.info("Response content '%s'", response.content)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix failures like this https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614

```
WARNING:root:Received exception while sending data to https://play.clickhouse.com/ on 4 attempt: HTTPSConnectionPool(host='play.clickhouse.com', port=443): Max retries exceeded with url: /?database=default&query=INSERT+INTO+checks+FORMAT+JSONEachRow&date_time_input_format=best_effort&send_logs_level=warning (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7faba42bbc10>: Failed to establish a new connection: [Errno 111] Connection refused'))
[10366](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10367)
Traceback (most recent call last):
[10367](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10368)
  File "/home/ubuntu/actions-runner/_work/_temp/fasttest/ClickHouse/tests/ci/fast_test_check.py", line 224, in <module>
[10368](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10369)
    ch_helper.insert_events_into(db="default", table="checks", events=prepared_events)
[10369](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10370)
  File "/home/ubuntu/actions-runner/_work/_temp/fasttest/ClickHouse/tests/ci/clickhouse_helper.py", line 98, in insert_events_into
[10370](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10371)
    self._insert_json_str_info(db, table, ",".join(jsons))
[10371](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10372)
  File "/home/ubuntu/actions-runner/_work/_temp/fasttest/ClickHouse/tests/ci/clickhouse_helper.py", line 79, in _insert_json_str_info
[10372](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10373)
    self._insert_json_str_info_impl(self.url, self.auth, db, table, json_str)
[10373](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10374)
  File "/home/ubuntu/actions-runner/_work/_temp/fasttest/ClickHouse/tests/ci/clickhouse_helper.py", line 76, in _insert_json_str_info_impl
[10374](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10375)
    raise InsertException(error)
[10375](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10376)
UnboundLocalError: local variable 'error' referenced before assignment
[10376](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10377)
INFO:root:Update Mergeable Check by Fast test
[10377](https://github.com/ClickHouse/ClickHouse/actions/runs/3327413336/jobs/5502223614#step:7:10378)
Error: Process completed with exit code 1.
```

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
