### PR TITLE
Fix execution of version_helper.py to use git tweaks

### DIFF
--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -344,7 +344,7 @@ def main():
         update_contributors()
         return
 
-    version = get_version_from_repo(args.version_path)
+    version = get_version_from_repo(args.version_path, Git(True))
 
     if args.update:
         version = version.update(args.update)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
W/o the fix `./version_helper.py` didn't show the proper tweak. Now it works for both shallow and full checkout