### PR TITLE
Speed up replaceRegexpOne/All with vectorscan 

### DIFF
--- a/docs/en/sql-reference/functions/string-replace-functions.md
+++ b/docs/en/sql-reference/functions/string-replace-functions.md
@@ -6,28 +6,29 @@ sidebar_label: For Replacing in Strings
 
 # Functions for Searching and Replacing in Strings
 
-:::note    
+:::note
 Functions for [searching](../../sql-reference/functions/string-search-functions.md) and [other manipulations with strings](../../sql-reference/functions/string-functions.md) are described separately.
 :::
 
 ## replaceOne(haystack, pattern, replacement)
 
-Replaces the first occurrence, if it exists, of the ‘pattern’ substring in ‘haystack’ with the ‘replacement’ substring.
-Hereafter, ‘pattern’ and ‘replacement’ must be constants.
+Replaces the first occurrence of the substring ‘pattern’ (if it exists) in ‘haystack’ by the ‘replacement’ string.
+‘pattern’ and ‘replacement’ must be constants.
 
 ## replaceAll(haystack, pattern, replacement), replace(haystack, pattern, replacement)
 
-Replaces all occurrences of the ‘pattern’ substring in ‘haystack’ with the ‘replacement’ substring.
+Replaces all occurrences of the substring ‘pattern’ in ‘haystack’ by the ‘replacement’ string.
 
 ## replaceRegexpOne(haystack, pattern, replacement)
 
-Replacement using the ‘pattern’ regular expression. A re2 regular expression.
-Replaces only the first occurrence, if it exists.
-A pattern can be specified as ‘replacement’. This pattern can include substitutions `\0-\9`.
-The substitution `\0` includes the entire regular expression. Substitutions `\1-\9` correspond to the subpattern numbers.To use the `\` character in a template, escape it using `\`.
-Also keep in mind that a string literal requires an extra escape.
+Replaces the first occurrence of the substring matching the regular expression ‘pattern’ in ‘haystack‘ by the ‘replacement‘ string.
+‘pattern‘ must be a constant [re2 regular expression](https://github.com/google/re2/wiki/Syntax).
+‘replacement’ must be a plain constant string or a constant string containing substitutions `\0-\9`.
+Substitutions `\1-\9` correspond to the 1st to 9th capturing group (submatch), substitution `\0` corresponds to the entire match.
+To use a verbatim `\` character in the ‘pattern‘ or ‘replacement‘ string, escape it using `\`.
+Also keep in mind that string literals require an extra escaping.
 
-Example 1. Converting the date to American format:
+Example 1. Converting ISO dates to American format:
 
 ``` sql
 SELECT DISTINCT
@@ -62,7 +63,7 @@ SELECT replaceRegexpOne('Hello, World!', '.*', '\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0')
 
 ## replaceRegexpAll(haystack, pattern, replacement)
 
-This does the same thing, but replaces all the occurrences. Example:
+Like ‘replaceRegexpOne‘, but replaces all occurrences of the pattern. Example:
 
 ``` sql
 SELECT replaceRegexpAll('Hello, World!', '.', '\\0\\0') AS res

--- a/src/Functions/FunctionStringReplace.h
+++ b/src/Functions/FunctionStringReplace.h
@@ -38,18 +38,21 @@ public:
     {
         if (!isStringOrFixedString(arguments[0]))
             throw Exception(
-                "Illegal type " + arguments[0]->getName() + " of first argument of function " + getName(),
-                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of first argument of function {}",
+                arguments[0]->getName(), getName());
 
         if (!isStringOrFixedString(arguments[1]))
             throw Exception(
-                "Illegal type " + arguments[1]->getName() + " of second argument of function " + getName(),
-                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of second argument of function {}",
+                arguments[1]->getName(), getName());
 
         if (!isStringOrFixedString(arguments[2]))
             throw Exception(
-                "Illegal type " + arguments[2]->getName() + " of third argument of function " + getName(),
-                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of third argument of function {}",
+                arguments[2]->getName(), getName());
 
         return std::make_shared<DataTypeString>();
     }
@@ -61,7 +64,10 @@ public:
         const ColumnPtr column_replacement = arguments[2].column;
 
         if (!isColumnConst(*column_needle) || !isColumnConst(*column_replacement))
-            throw Exception("2nd and 3rd arguments of function " + getName() + " must be constants.", ErrorCodes::ILLEGAL_COLUMN);
+            throw Exception(
+                ErrorCodes::ILLEGAL_COLUMN,
+                "2nd and 3rd arguments of function {} must be constants.",
+                getName());
 
         const IColumn * c1 = arguments[1].column.get();
         const IColumn * c2 = arguments[2].column.get();
@@ -71,7 +77,9 @@ public:
         String replacement = c2_const->getValue<String>();
 
         if (needle.empty())
-            throw Exception("Length of the second argument of function replace must be greater than 0.", ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+            throw Exception(
+                ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+                "Length of the second argument of function replace must be greater than 0.");
 
         if (const ColumnString * col = checkAndGetColumn<ColumnString>(column_src.get()))
         {
@@ -87,8 +95,9 @@ public:
         }
         else
             throw Exception(
-                "Illegal column " + arguments[0].column->getName() + " of first argument of function " + getName(),
-                ErrorCodes::ILLEGAL_COLUMN);
+                ErrorCodes::ILLEGAL_COLUMN,
+                "Illegal column {} of first argument of function {}",
+                arguments[0].column->getName(), getName());
     }
 };
 

--- a/src/Functions/FunctionStringReplace.h
+++ b/src/Functions/FunctionStringReplace.h
@@ -24,6 +24,7 @@ class FunctionStringReplace : public IFunction
 public:
     static constexpr auto name = Name::name;
     const bool allow_hyperscan;
+    mutable typename Impl::MatchState match_state;
 
     static FunctionPtr create(ContextPtr context)
     {
@@ -94,13 +95,13 @@ public:
         if (const ColumnString * col = checkAndGetColumn<ColumnString>(column_src.get()))
         {
             auto col_res = ColumnString::create();
-            Impl::vector(col->getChars(), col->getOffsets(), needle, replacement, col_res->getChars(), col_res->getOffsets(), allow_hyperscan);
+            Impl::vector(col->getChars(), col->getOffsets(), needle, replacement, col_res->getChars(), col_res->getOffsets(), allow_hyperscan, match_state);
             return col_res;
         }
         else if (const ColumnFixedString * col_fixed = checkAndGetColumn<ColumnFixedString>(column_src.get()))
         {
             auto col_res = ColumnString::create();
-            Impl::vectorFixed(col_fixed->getChars(), col_fixed->getN(), needle, replacement, col_res->getChars(), col_res->getOffsets(), allow_hyperscan);
+            Impl::vectorFixed(col_fixed->getChars(), col_fixed->getN(), needle, replacement, col_res->getChars(), col_res->getOffsets(), allow_hyperscan, match_state);
             return col_res;
         }
         else

--- a/src/Functions/MultiMatchAllIndicesImpl.h
+++ b/src/Functions/MultiMatchAllIndicesImpl.h
@@ -91,7 +91,7 @@ struct MultiMatchAllIndicesImpl
         hs_error_t err = hs_clone_scratch(regexps->getScratch(), &scratch);
 
         if (err != HS_SUCCESS)
-            throw Exception("Could not clone scratch space for hyperscan", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+            throw Exception("Could not clone scratch space for vectorscan", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
 
         MultiRegexps::ScratchPtr smart_scratch(scratch);
 
@@ -203,7 +203,7 @@ struct MultiMatchAllIndicesImpl
             hs_error_t err = hs_clone_scratch(regexps->getScratch(), &scratch);
 
             if (err != HS_SUCCESS)
-                throw Exception("Could not clone scratch space for hyperscan", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
+                throw Exception("Could not clone scratch space for vectorscan", ErrorCodes::CANNOT_ALLOCATE_MEMORY);
 
             MultiRegexps::ScratchPtr smart_scratch(scratch);
 

--- a/src/Functions/Regexps.h
+++ b/src/Functions/Regexps.h
@@ -38,6 +38,7 @@ namespace ErrorCodes
 
 namespace Regexps
 {
+
 using Regexp = OptimizedRegularExpressionSingleThreaded;
 using RegexpPtr = std::shared_ptr<Regexp>;
 
@@ -112,11 +113,11 @@ struct HyperscanDeleter
 };
 
 /// Helper unique pointers to correctly delete the allocated space when hyperscan cannot compile something and we throw an exception.
-using CompilerError = std::unique_ptr<hs_compile_error_t, HyperscanDeleter<decltype(&hs_free_compile_error), &hs_free_compile_error>>;
+using CompilerErrorPtr = std::unique_ptr<hs_compile_error_t, HyperscanDeleter<decltype(&hs_free_compile_error), &hs_free_compile_error>>;
 using ScratchPtr = std::unique_ptr<hs_scratch_t, HyperscanDeleter<decltype(&hs_free_scratch), &hs_free_scratch>>;
 using DataBasePtr = std::unique_ptr<hs_database_t, HyperscanDeleter<decltype(&hs_free_database), &hs_free_database>>;
 
-/// Database is thread safe across multiple threads and Scratch is not but we can copy it whenever we use it in the searcher.
+/// Database is immutable/thread-safe across multiple threads. Scratch is not but we can copy it whenever we use it in the searcher.
 class Regexps
 {
 public:
@@ -154,7 +155,7 @@ private:
 
 using DeferredConstructedRegexpsPtr = std::shared_ptr<DeferredConstructedRegexps>;
 
-template <bool save_indices, bool WithEditDistance>
+template <bool save_indices, bool with_edit_distance>
 inline Regexps constructRegexps(const std::vector<String> & str_patterns, [[maybe_unused]] std::optional<UInt32> edit_distance)
 {
     /// Common pointers
@@ -168,7 +169,7 @@ inline Regexps constructRegexps(const std::vector<String> & str_patterns, [[mayb
     patterns.reserve(str_patterns.size());
     flags.reserve(str_patterns.size());
 
-    if constexpr (WithEditDistance)
+    if constexpr (with_edit_distance)
     {
         ext_exprs.reserve(str_patterns.size());
         ext_exprs_ptrs.reserve(str_patterns.size());
@@ -186,7 +187,7 @@ inline Regexps constructRegexps(const std::vector<String> & str_patterns, [[mayb
          * as it is said in the Hyperscan documentation. https://intel.github.io/hyperscan/dev-reference/performance.html#single-match-flag
          */
         flags.push_back(HS_FLAG_DOTALL | HS_FLAG_SINGLEMATCH | HS_FLAG_ALLOWEMPTY | HS_FLAG_UTF8);
-        if constexpr (WithEditDistance)
+        if constexpr (with_edit_distance)
         {
             /// Hyperscan currently does not support UTF8 matching with edit distance.
             flags.back() &= ~HS_FLAG_UTF8;
@@ -211,7 +212,7 @@ inline Regexps constructRegexps(const std::vector<String> & str_patterns, [[mayb
     }
 
     hs_error_t err;
-    if constexpr (!WithEditDistance)
+    if constexpr (!with_edit_distance)
         err = hs_compile_multi(
             patterns.data(),
             flags.data(),
@@ -236,7 +237,7 @@ inline Regexps constructRegexps(const std::vector<String> & str_patterns, [[mayb
     if (err != HS_SUCCESS)
     {
         /// CompilerError is a unique_ptr, so correct memory free after the exception is thrown.
-        CompilerError error(compile_error);
+        CompilerErrorPtr error(compile_error);
 
         if (error->expression < 0)
             throw Exception(ErrorCodes::LOGICAL_ERROR, String(error->message));
@@ -253,7 +254,7 @@ inline Regexps constructRegexps(const std::vector<String> & str_patterns, [[mayb
 
     /// If not HS_SUCCESS, it is guaranteed that the memory would not be allocated for scratch.
     if (err != HS_SUCCESS)
-        throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Could not allocate scratch space for hyperscan");
+        throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Could not allocate scratch space for vectorscan");
 
     return {db, scratch};
 }
@@ -288,9 +289,9 @@ struct GlobalCacheTable
     }
 };
 
-/// If WithEditDistance is False, edit_distance must be nullopt. Also, we use templates here because each instantiation of function template
+/// If with_edit_distance is False, edit_distance must be nullopt. Also, we use templates here because each instantiation of function template
 /// has its own copy of local static variables which must not be the same for different hyperscan compilations.
-template <bool save_indices, bool WithEditDistance>
+template <bool save_indices, bool with_edit_distance>
 inline DeferredConstructedRegexpsPtr getOrSet(const std::vector<std::string_view> & patterns, std::optional<UInt32> edit_distance)
 {
     static GlobalCacheTable pool; /// Different variables for different pattern parameters, thread-safe in C++11
@@ -320,7 +321,7 @@ inline DeferredConstructedRegexpsPtr getOrSet(const std::vector<std::string_view
         auto deferred_constructed_regexps = std::make_shared<DeferredConstructedRegexps>(
                 [str_patterns, edit_distance]()
                 {
-                    return constructRegexps<save_indices, WithEditDistance>(str_patterns, edit_distance);
+                    return constructRegexps<save_indices, with_edit_distance>(str_patterns, edit_distance);
                 });
         bucket = {std::move(str_patterns), edit_distance, deferred_constructed_regexps};
     }
@@ -331,7 +332,7 @@ inline DeferredConstructedRegexpsPtr getOrSet(const std::vector<std::string_view
             auto deferred_constructed_regexps = std::make_shared<DeferredConstructedRegexps>(
                     [str_patterns, edit_distance]()
                     {
-                        return constructRegexps<save_indices, WithEditDistance>(str_patterns, edit_distance);
+                        return constructRegexps<save_indices, with_edit_distance>(str_patterns, edit_distance);
                     });
             bucket = {std::move(str_patterns), edit_distance, deferred_constructed_regexps};
         }

--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -4,6 +4,7 @@
 #include <base/types.h>
 #include <Columns/ColumnString.h>
 #include <IO/WriteHelpers.h>
+#include <shared_mutex>
 
 #include "config.h"
 
@@ -20,6 +21,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int CANNOT_ALLOCATE_MEMORY;
     extern const int HYPERSCAN_CANNOT_SCAN_TEXT;
+    extern const int LOGICAL_ERROR;
 }
 
 struct ReplaceRegexpTraits
@@ -176,7 +178,9 @@ struct ReplaceRegexpImpl
         ColumnString::Offset & res_offset,
         hs_database_t * db,
         hs_scratch_t * scratch,
-        const Instructions & instructions)
+        const Instructions & instructions,
+        std::unordered_map<size_t, size_t> matches,
+        std::vector<size_t> matches_from)
     {
         /// Vectorscan poses two challenges:
         /// 1. Unlike re2, matches are not guaranteed to be in order. E.g. on_match() may be called
@@ -188,15 +192,14 @@ struct ReplaceRegexpImpl
         /// 2. While re2 does greedy matching (which it inherited from libpcre), vectorscan reports
         ///    *all* matches for a given position. So to emulate greedy matching, we retain only the
         ///    rightmost match for each position.
-        std::map<size_t, size_t> matches; // (from, to)
 
         auto on_match = [](unsigned int /*id*/,
                            unsigned long long from, // NOLINT(google-runtime-int)
                            unsigned long long to, // NOLINT(google-runtime-int)
                            unsigned int /*flags*/,
-                           void * context_) -> int
+                           void * context) -> int
         {
-            std::map<size_t, size_t> * ctx_matches = static_cast<std::map<size_t, size_t> *>(context_);
+            std::unordered_map<size_t, size_t> * ctx_matches = static_cast<std::unordered_map<size_t, size_t> *>(context);
 
             auto match = ctx_matches->find(from);
             if (match == ctx_matches->end())
@@ -212,9 +215,17 @@ struct ReplaceRegexpImpl
         if (err != HS_SUCCESS && err != HS_SCAN_TERMINATED)
             throw Exception(ErrorCodes::HYPERSCAN_CANNOT_SCAN_TEXT, "Failed to scan with vectorscan");
 
+        /// Sort matches
+        matches_from.reserve(matches.size());
+        for (auto [from, _] : matches)
+            matches_from.push_back(from);
+        std::sort(matches_from.begin(), matches_from.end());
+
         size_t match_pos = 0;
-        for (auto [from, to] : matches)
+
+        for (size_t from : matches_from)
         {
+            size_t to = matches[from];
             /// Copy prefix before current match without modification
             size_t bytes_to_copy = from - match_pos;
             res_data.resize(res_data.size() + bytes_to_copy);
@@ -237,6 +248,9 @@ struct ReplaceRegexpImpl
             match_pos = to;
         }
 
+        matches.clear();
+        matches_from.clear();
+
         /// Copy suffix behind last match without modification
         if (match_pos != haystack_length)
         {
@@ -252,6 +266,25 @@ struct ReplaceRegexpImpl
     }
 #endif
 
+    struct MatchState
+    {
+#if USE_VECTORSCAN
+        std::shared_mutex mutex;
+        hs_database_t * db = nullptr;
+        hs_scratch_t * scratch = nullptr;
+
+        ~MatchState()
+        {
+            std::lock_guard lock(mutex);
+            assert((!db && !scratch) || (db && !scratch) || (db && scratch)); // (!db && scratch) should be impossible
+            if (scratch)
+                hs_free_scratch(scratch);
+            if (db)
+                hs_free_database(db);
+        }
+#endif
+    };
+
     static void vector(
         const ColumnString::Chars & data,
         const ColumnString::Offsets & offsets,
@@ -259,7 +292,8 @@ struct ReplaceRegexpImpl
         const String & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        [[maybe_unused]] bool allow_hyperscan)
+        [[maybe_unused]] bool allow_hyperscan,
+        [[maybe_unused]] MatchState & match_state)
     {
         ColumnString::Offset res_offset = 0;
         res_data.reserve(data.size());
@@ -290,39 +324,58 @@ struct ReplaceRegexpImpl
         bool use_vectorscan = (num_captures_in_needle == 0) && allow_hyperscan && replace == ReplaceRegexpTraits::Replace::All;
         if (use_vectorscan)
         {
+            // TODO
             /// Because we rely on the HS_FLAG_SOM_LEFTMOST flag here and other usages of vectorscan
             /// in ClickHouse don't, we can't use the internal regexp cache. Instead construct database
             /// and scratch area directly.
-            hs_database_t * db = nullptr;
-            hs_compile_error_t * compile_error = nullptr;
 
-            hs_error_t err = hs_compile(
-                needle.c_str(),
-                HS_FLAG_SOM_LEFTMOST | HS_FLAG_DOTALL | HS_FLAG_ALLOWEMPTY | HS_FLAG_UTF8,
-                HS_MODE_BLOCK,
-                nullptr,
-                &db,
-                &compile_error);
+            std::shared_lock shared_lock(match_state.mutex);
 
-            if (err != HS_SUCCESS)
+            hs_error_t err;
+
+            if (match_state.db == nullptr || match_state.scratch == nullptr)
             {
-                SCOPE_EXIT({ hs_free_compile_error(compile_error); });
-                throw Exception(
-                        ErrorCodes::BAD_ARGUMENTS,
-                        compile_error->message);
+                shared_lock.unlock();
+                {
+                    std::lock_guard exclusive_lock(match_state.mutex);
+
+                    if (match_state.db == nullptr)
+                    {
+                        hs_compile_error_t * compile_error = nullptr;
+                        err = hs_compile(
+                            needle.c_str(),
+                            HS_FLAG_SOM_LEFTMOST | HS_FLAG_DOTALL | HS_FLAG_ALLOWEMPTY | HS_FLAG_UTF8,
+                            HS_MODE_BLOCK,
+                            nullptr,
+                            &match_state.db,
+                            &compile_error);
+                        if (err != HS_SUCCESS)
+                        {
+                            SCOPE_EXIT({ hs_free_compile_error(compile_error); });
+                            throw Exception(
+                                    ErrorCodes::LOGICAL_ERROR,
+                                    compile_error->message);
+                        }
+                    }
+                    if (match_state.scratch == nullptr)
+                    {
+                        err = hs_alloc_scratch(match_state.db, &match_state.scratch);
+                        if (err != HS_SUCCESS)
+                            throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Could not allocate scratch space for vectorscan");
+                    }
+                }
+                shared_lock.lock();
             }
 
-            SCOPE_EXIT({ hs_free_database(db); });
-
-            hs_scratch_t * scratch = nullptr;
-
-            err = hs_alloc_scratch(db, &scratch);
+            hs_scratch_t * local_scratch = nullptr;
+            err = hs_clone_scratch(match_state.scratch, &local_scratch);
             if (err != HS_SUCCESS)
-                throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Could not allocate scratch space for vectorscan");
-
-            SCOPE_EXIT({ hs_free_scratch(scratch); });
+                throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Could not clone scratch space for vectorscan");
+            SCOPE_EXIT({ hs_free_scratch(local_scratch); });
 
             Instructions instructions = createInstructions(replacement, num_captures_in_needle /* "\0" capture */ + 1);
+            std::unordered_map<size_t, size_t> matches; // (from, to)
+            std::vector<size_t> matches_from;
 
             for (size_t i = 0; i < size; ++i)
             {
@@ -330,7 +383,7 @@ struct ReplaceRegexpImpl
                 const char * haystack_data = reinterpret_cast<const char *>(data.data() + from);
                 const size_t haystack_length = static_cast<unsigned>(offsets[i] - from - 1);
 
-                processStringWithVectorscan(haystack_data, haystack_length, res_data, res_offset, db, scratch, instructions);
+                processStringWithVectorscan(haystack_data, haystack_length, res_data, res_offset, match_state.db, local_scratch, instructions, matches, matches_from);
                 res_offsets[i] = res_offset;
             }
 
@@ -358,7 +411,8 @@ struct ReplaceRegexpImpl
         const String & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        [[maybe_unused]] bool allow_hyperscan)
+        [[maybe_unused]] bool allow_hyperscan,
+        [[maybe_unused]] MatchState & match_state)
     {
         ColumnString::Offset res_offset = 0;
         size_t size = data.size() / n;
@@ -389,39 +443,58 @@ struct ReplaceRegexpImpl
         bool use_vectorscan = (num_captures_in_needle == 0) && allow_hyperscan && replace == ReplaceRegexpTraits::Replace::All;
         if (use_vectorscan)
         {
+            // TODO
             /// Because we rely on the HS_FLAG_SOM_LEFTMOST flag here and other usages of vectorscan
             /// in ClickHouse don't, we can't use the internal regexp cache. Instead construct database
             /// and scratch area directly.
-            hs_database_t * db = nullptr;
-            hs_compile_error_t * compile_error = nullptr;
 
-            hs_error_t err = hs_compile(
-                needle.c_str(),
-                HS_FLAG_SOM_LEFTMOST | HS_FLAG_DOTALL | HS_FLAG_ALLOWEMPTY | HS_FLAG_UTF8,
-                HS_MODE_BLOCK,
-                nullptr,
-                &db,
-                &compile_error);
+            std::shared_lock shared_lock(match_state.mutex);
 
-            if (err != HS_SUCCESS)
+            hs_error_t err;
+
+            if (match_state.db == nullptr || match_state.scratch == nullptr)
             {
-                SCOPE_EXIT({ hs_free_compile_error(compile_error); });
-                throw Exception(
-                        ErrorCodes::LOGICAL_ERROR,
-                        compile_error->message);
+                shared_lock.unlock();
+                {
+                    std::lock_guard exclusive_lock(match_state.mutex);
+
+                    if (match_state.db == nullptr)
+                    {
+                        hs_compile_error_t * compile_error = nullptr;
+                        err = hs_compile(
+                            needle.c_str(),
+                            HS_FLAG_SOM_LEFTMOST | HS_FLAG_DOTALL | HS_FLAG_ALLOWEMPTY | HS_FLAG_UTF8,
+                            HS_MODE_BLOCK,
+                            nullptr,
+                            &match_state.db,
+                            &compile_error);
+                        if (err != HS_SUCCESS)
+                        {
+                            SCOPE_EXIT({ hs_free_compile_error(compile_error); });
+                            throw Exception(
+                                    ErrorCodes::LOGICAL_ERROR,
+                                    compile_error->message);
+                        }
+                    }
+                    if (match_state.scratch == nullptr)
+                    {
+                        err = hs_alloc_scratch(match_state.db, &match_state.scratch);
+                        if (err != HS_SUCCESS)
+                            throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Could not allocate scratch space for vectorscan");
+                    }
+                }
+                shared_lock.lock();
             }
 
-            SCOPE_EXIT({ hs_free_database(db); });
-
-            hs_scratch_t * scratch = nullptr;
-
-            err = hs_alloc_scratch(db, &scratch);
+            hs_scratch_t * local_scratch = nullptr;
+            err = hs_clone_scratch(match_state.scratch, &local_scratch);
             if (err != HS_SUCCESS)
-                throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Could not allocate scratch space for vectorscan");
-
-            SCOPE_EXIT({ hs_free_scratch(scratch); });
+                throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Could not clone scratch space for vectorscan");
+            SCOPE_EXIT({ hs_free_scratch(local_scratch); });
 
             Instructions instructions = createInstructions(replacement, num_captures_in_needle /* "\0" capture */ + 1);
+            std::unordered_map<size_t, size_t> matches; // (from, to)
+            std::vector<size_t> matches_from;
 
             for (size_t i = 0; i < size; ++i)
             {
@@ -429,7 +502,7 @@ struct ReplaceRegexpImpl
                 const char * haystack_data = reinterpret_cast<const char *>(data.data() + from);
                 const size_t haystack_length = n;
 
-                processStringWithVectorscan(haystack_data, haystack_length, res_data, res_offset, db, scratch, instructions);
+                processStringWithVectorscan(haystack_data, haystack_length, res_data, res_offset, match_state.db, local_scratch, instructions, matches, matches_from);
                 res_offsets[i] = res_offset;
             }
 

--- a/src/Functions/ReplaceRegexpImpl.h
+++ b/src/Functions/ReplaceRegexpImpl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <base/types.h>
-#include <Common/Volnitsky.h>
 #include <Columns/ColumnString.h>
 #include <IO/WriteHelpers.h>
 
@@ -17,131 +16,130 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
+struct ReplaceRegexpTraits
+{
+    enum class Replace
+    {
+        First,
+        All
+    };
+};
 
 /** Replace all matches of regexp 'needle' to string 'replacement'. 'needle' and 'replacement' are constants.
-  * 'replacement' could contain substitutions, for example: '\2-\3-\1'
+  * 'replacement' can contain substitutions, for example: '\2-\3-\1'
   */
-template <bool replace_one = false>
+template <ReplaceRegexpTraits::Replace replace>
 struct ReplaceRegexpImpl
 {
-    /// Sequence of instructions, describing how to get resulting string.
     struct Instruction
     {
-        /// If not negative - perform substitution of n-th subpattern from the regexp match.
+        /// If not negative, perform substitution of n-th subpattern from the regexp match.
         int substitution_num = -1;
-        /// Otherwise - paste this string verbatim.
-        std::string literal;
+        /// Otherwise, paste this literal string verbatim.
+        String literal;
 
-        Instruction(int substitution_num_) : substitution_num(substitution_num_) {} /// NOLINT
-        Instruction(std::string literal_) : literal(std::move(literal_)) {} /// NOLINT
+        explicit Instruction(int substitution_num_) : substitution_num(substitution_num_) {}
+        explicit Instruction(String literal_) : literal(std::move(literal_)) {}
     };
 
+    /// Decomposes the replacement string into a sequence of substitutions and literals.
+    /// E.g. "abc\1de\2fg\1\2" --> inst("abc"), inst(1), inst("de"), inst(2), inst("fg"), inst(1), inst(2)
     using Instructions = std::vector<Instruction>;
 
-    static const size_t max_captures = 10;
+    static constexpr int max_captures = 10;
 
-
-    static Instructions createInstructions(const std::string & s, int num_captures)
+    static Instructions createInstructions(std::string_view replacement, int num_captures)
     {
         Instructions instructions;
 
-        String now;
-        for (size_t i = 0; i < s.size(); ++i)
+        String literals;
+        for (size_t i = 0; i < replacement.size(); ++i)
         {
-            if (s[i] == '\\' && i + 1 < s.size())
+            if (replacement[i] == '\\' && i + 1 < replacement.size())
             {
-                if (isNumericASCII(s[i + 1])) /// Substitution
+                if (isNumericASCII(replacement[i + 1])) /// Substitution
                 {
-                    if (!now.empty())
+                    if (!literals.empty())
                     {
-                        instructions.emplace_back(now);
-                        now = "";
+                        instructions.emplace_back(literals);
+                        literals = "";
                     }
-                    instructions.emplace_back(s[i + 1] - '0');
+                    instructions.emplace_back(replacement[i + 1] - '0');
                 }
                 else
-                    now += s[i + 1]; /// Escaping
+                    literals += replacement[i + 1]; /// Escaping
                 ++i;
             }
             else
-                now += s[i]; /// Plain character
+                literals += replacement[i]; /// Plain character
         }
 
-        if (!now.empty())
-        {
-            instructions.emplace_back(now);
-            now = "";
-        }
+        if (!literals.empty())
+            instructions.emplace_back(literals);
 
-        for (const auto & it : instructions)
-            if (it.substitution_num >= num_captures)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                    "Invalid replace instruction in replacement string. Id: {}, but regexp has only {} subpatterns",
-                    it.substitution_num, num_captures - 1);
+        for (const auto & instr : instructions)
+            if (instr.substitution_num >= num_captures)
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Id {} in replacement string is an invalid substitution, regexp has only {} capturing groups",
+                    instr.substitution_num, num_captures - 1);
 
         return instructions;
     }
 
-
     static void processString(
-        const re2_st::StringPiece & input,
+        const char * haystack_data,
+        size_t haystack_length,
         ColumnString::Chars & res_data,
         ColumnString::Offset & res_offset,
-        re2_st::RE2 & searcher,
+        const re2_st::RE2 & searcher,
         int num_captures,
         const Instructions & instructions)
     {
+        re2_st::StringPiece haystack(haystack_data, haystack_length);
         re2_st::StringPiece matches[max_captures];
 
         size_t copy_pos = 0;
         size_t match_pos = 0;
 
-        while (match_pos < static_cast<size_t>(input.length()))
+        while (match_pos < haystack_length)
         {
             /// If no more replacements possible for current string
             bool can_finish_current_string = false;
 
-            if (searcher.Match(input, match_pos, input.length(), re2_st::RE2::Anchor::UNANCHORED, matches, num_captures))
+            if (searcher.Match(haystack, match_pos, haystack_length, re2_st::RE2::Anchor::UNANCHORED, matches, num_captures))
             {
-                const auto & match = matches[0];
-                size_t bytes_to_copy = (match.data() - input.data()) - copy_pos;
+                const auto & match = matches[0]; /// Complete match (\0)
+                size_t bytes_to_copy = (match.data() - haystack.data()) - copy_pos;
 
-                /// Copy prefix before matched regexp without modification
+                /// Copy prefix before current match without modification
                 res_data.resize(res_data.size() + bytes_to_copy);
-                memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], input.data() + copy_pos, bytes_to_copy);
+                memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], haystack.data() + copy_pos, bytes_to_copy);
                 res_offset += bytes_to_copy;
                 copy_pos += bytes_to_copy + match.length();
                 match_pos = copy_pos;
 
-                /// Do substitution instructions
-                for (const auto & it : instructions)
+                /// Substitute inside current match using instructions
+                for (const auto & instr : instructions)
                 {
-                    if (it.substitution_num >= 0)
-                    {
-                        const auto & substitution = matches[it.substitution_num];
-
-                        res_data.resize(res_data.size() + substitution.length());
-                        memcpy(&res_data[res_offset], substitution.data(), substitution.length());
-                        res_offset += substitution.length();
-                    }
+                    std::string_view replacement;
+                    if (instr.substitution_num >= 0)
+                        replacement = std::string_view(matches[instr.substitution_num].data(), matches[instr.substitution_num].size());
                     else
-                    {
-                        const auto & literal = it.literal;
-
-                        res_data.resize(res_data.size() + literal.size());
-                        memcpy(&res_data[res_offset], literal.data(), literal.size());
-                        res_offset += literal.size();
-                    }
+                        replacement = instr.literal;
+                    res_data.resize(res_data.size() + replacement.size());
+                    memcpy(&res_data[res_offset], replacement.data(), replacement.size());
+                    res_offset += replacement.size();
                 }
 
-                if (replace_one)
+                if constexpr (replace == ReplaceRegexpTraits::Replace::First)
                     can_finish_current_string = true;
 
-                if (match.length() == 0)
+                if (match.empty())
                 {
                     /// Step one character to avoid infinite loop
                     ++match_pos;
-                    if (match_pos >= static_cast<size_t>(input.length()))
+                    if (match_pos >= haystack_length)
                         can_finish_current_string = true;
                 }
             }
@@ -151,10 +149,10 @@ struct ReplaceRegexpImpl
             /// If ready, append suffix after match to end of string.
             if (can_finish_current_string)
             {
-                res_data.resize(res_data.size() + input.length() - copy_pos);
-                memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], input.data() + copy_pos, input.length() - copy_pos);
-                res_offset += input.length() - copy_pos;
-                copy_pos = input.length();
+                res_data.resize(res_data.size() + haystack_length - copy_pos);
+                memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], haystack.data() + copy_pos, haystack_length - copy_pos);
+                res_offset += haystack_length - copy_pos;
+                copy_pos = haystack_length;
                 match_pos = copy_pos;
             }
         }
@@ -164,12 +162,11 @@ struct ReplaceRegexpImpl
         ++res_offset;
     }
 
-
     static void vector(
         const ColumnString::Chars & data,
         const ColumnString::Offsets & offsets,
-        const std::string & needle,
-        const std::string & replacement,
+        const String & needle,
+        const String & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets)
     {
@@ -178,11 +175,19 @@ struct ReplaceRegexpImpl
         size_t size = offsets.size();
         res_offsets.resize(size);
 
-        typename re2_st::RE2::Options regexp_options;
-        /// Never write error messages to stderr. It's ignorant to do it from library code.
+        re2_st::RE2::Options regexp_options;
+        /// Don't write error messages to stderr.
         regexp_options.set_log_errors(false);
+
         re2_st::RE2 searcher(needle, regexp_options);
-        int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, static_cast<int>(max_captures));
+
+        if (!searcher.ok())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "The pattern argument is not a valid re2 pattern: {}",
+                searcher.error());
+
+        int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
 
         Instructions instructions = createInstructions(replacement, num_captures);
 
@@ -190,9 +195,10 @@ struct ReplaceRegexpImpl
         for (size_t i = 0; i < size; ++i)
         {
             size_t from = i > 0 ? offsets[i - 1] : 0;
-            re2_st::StringPiece input(reinterpret_cast<const char *>(data.data() + from), offsets[i] - from - 1);
+            const char * haystack_data = reinterpret_cast<const char *>(data.data() + from);
+            const size_t haystack_length = static_cast<unsigned>(offsets[i] - from - 1);
 
-            processString(input, res_data, res_offset, searcher, num_captures, instructions);
+            processString(haystack_data, haystack_length, res_data, res_offset, searcher, num_captures, instructions);
             res_offsets[i] = res_offset;
         }
     }
@@ -200,8 +206,8 @@ struct ReplaceRegexpImpl
     static void vectorFixed(
         const ColumnString::Chars & data,
         size_t n,
-        const std::string & needle,
-        const std::string & replacement,
+        const String & needle,
+        const String & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets)
     {
@@ -210,20 +216,29 @@ struct ReplaceRegexpImpl
         res_data.reserve(data.size());
         res_offsets.resize(size);
 
-        typename re2_st::RE2::Options regexp_options;
-        /// Never write error messages to stderr. It's ignorant to do it from library code.
+        re2_st::RE2::Options regexp_options;
+        /// Don't write error messages to stderr.
         regexp_options.set_log_errors(false);
+
         re2_st::RE2 searcher(needle, regexp_options);
-        int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, static_cast<int>(max_captures));
+
+        if (!searcher.ok())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "The pattern argument is not a valid re2 pattern: {}",
+                searcher.error());
+
+        int num_captures = std::min(searcher.NumberOfCapturingGroups() + 1, max_captures);
 
         Instructions instructions = createInstructions(replacement, num_captures);
 
         for (size_t i = 0; i < size; ++i)
         {
             size_t from = i * n;
-            re2_st::StringPiece input(reinterpret_cast<const char *>(data.data() + from), n);
+            const char * haystack_data = reinterpret_cast<const char *>(data.data() + from);
+            const size_t haystack_length = n;
 
-            processString(input, res_data, res_offset, searcher, num_captures, instructions);
+            processString(haystack_data, haystack_length, res_data, res_offset, searcher, num_captures, instructions);
             res_offsets[i] = res_offset;
         }
     }

--- a/src/Functions/ReplaceStringImpl.h
+++ b/src/Functions/ReplaceStringImpl.h
@@ -8,9 +8,17 @@
 namespace DB
 {
 
+struct ReplaceStringTraits
+{
+    enum class Replace
+    {
+        First,
+        All
+    };
+};
 /** Replace one or all occurencies of substring 'needle' to 'replacement'. 'needle' and 'replacement' are constants.
   */
-template <bool replace_one = false>
+template <ReplaceStringTraits::Replace replace>
 struct ReplaceStringImpl
 {
     static void vector(
@@ -66,7 +74,7 @@ struct ReplaceStringImpl
                 memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                 res_offset += replacement.size();
                 pos = match + needle.size();
-                if (replace_one)
+                if constexpr (replace == ReplaceStringTraits::Replace::First)
                     can_finish_current_string = true;
             }
             else
@@ -155,7 +163,7 @@ struct ReplaceStringImpl
                 memcpy(&res_data[res_offset], replacement.data(), replacement.size());
                 res_offset += replacement.size();
                 pos = match + needle.size();
-                if (replace_one || pos == begin + n * (i + 1))
+                if (replace == ReplaceStringTraits::Replace::First || pos == begin + n * (i + 1))
                     can_finish_current_string = true;
             }
             else

--- a/src/Functions/ReplaceStringImpl.h
+++ b/src/Functions/ReplaceStringImpl.h
@@ -21,6 +21,10 @@ struct ReplaceStringTraits
 template <ReplaceStringTraits::Replace replace>
 struct ReplaceStringImpl
 {
+    struct MatchState
+    {
+    };
+
     static void vector(
         const ColumnString::Chars & data,
         const ColumnString::Offsets & offsets,
@@ -28,7 +32,8 @@ struct ReplaceStringImpl
         const std::string & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        bool /*allow_hyperscan*/)
+        bool /*allow_hyperscan*/,
+        MatchState /*match_state*/)
     {
         const UInt8 * begin = data.data();
         const UInt8 * pos = begin;
@@ -105,7 +110,8 @@ struct ReplaceStringImpl
         const std::string & replacement,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
-        bool /*allow_hyperscan*/)
+        bool /*allow_hyperscan*/,
+        MatchState /*match_state*/)
     {
         const UInt8 * begin = data.data();
         const UInt8 * pos = begin;

--- a/src/Functions/ReplaceStringImpl.h
+++ b/src/Functions/ReplaceStringImpl.h
@@ -27,7 +27,8 @@ struct ReplaceStringImpl
         const std::string & needle,
         const std::string & replacement,
         ColumnString::Chars & res_data,
-        ColumnString::Offsets & res_offsets)
+        ColumnString::Offsets & res_offsets,
+        bool /*allow_hyperscan*/)
     {
         const UInt8 * begin = data.data();
         const UInt8 * pos = begin;
@@ -103,7 +104,8 @@ struct ReplaceStringImpl
         const std::string & needle,
         const std::string & replacement,
         ColumnString::Chars & res_data,
-        ColumnString::Offsets & res_offsets)
+        ColumnString::Offsets & res_offsets,
+        bool /*allow_hyperscan*/)
     {
         const UInt8 * begin = data.data();
         const UInt8 * pos = begin;

--- a/src/Functions/replaceAll.cpp
+++ b/src/Functions/replaceAll.cpp
@@ -13,7 +13,7 @@ struct NameReplaceAll
     static constexpr auto name = "replaceAll";
 };
 
-using FunctionReplaceAll = FunctionStringReplace<ReplaceStringImpl<false>, NameReplaceAll>;
+using FunctionReplaceAll = FunctionStringReplace<ReplaceStringImpl<ReplaceStringTraits::Replace::All>, NameReplaceAll>;
 
 }
 

--- a/src/Functions/replaceOne.cpp
+++ b/src/Functions/replaceOne.cpp
@@ -13,7 +13,7 @@ struct NameReplaceOne
     static constexpr auto name = "replaceOne";
 };
 
-using FunctionReplaceOne = FunctionStringReplace<ReplaceStringImpl<true>, NameReplaceOne>;
+using FunctionReplaceOne = FunctionStringReplace<ReplaceStringImpl<ReplaceStringTraits::Replace::First>, NameReplaceOne>;
 
 }
 

--- a/src/Functions/replaceRegexpAll.cpp
+++ b/src/Functions/replaceRegexpAll.cpp
@@ -13,7 +13,7 @@ struct NameReplaceRegexpAll
     static constexpr auto name = "replaceRegexpAll";
 };
 
-using FunctionReplaceRegexpAll = FunctionStringReplace<ReplaceRegexpImpl<false>, NameReplaceRegexpAll>;
+using FunctionReplaceRegexpAll = FunctionStringReplace<ReplaceRegexpImpl<ReplaceRegexpTraits::Replace::All>, NameReplaceRegexpAll>;
 
 }
 

--- a/src/Functions/replaceRegexpOne.cpp
+++ b/src/Functions/replaceRegexpOne.cpp
@@ -13,7 +13,7 @@ struct NameReplaceRegexpOne
     static constexpr auto name = "replaceRegexpOne";
 };
 
-using FunctionReplaceRegexpOne = FunctionStringReplace<ReplaceRegexpImpl<true>, NameReplaceRegexpOne>;
+using FunctionReplaceRegexpOne = FunctionStringReplace<ReplaceRegexpImpl<ReplaceRegexpTraits::Replace::First>, NameReplaceRegexpOne>;
 
 }
 


### PR DESCRIPTION
This PR optimizes SQL function `replaceRegexpAll` for the common case that the replacement string contains no substitutions `\1 ... \9` (the trivial substitution `\0` is allowed). In that case, we now evaluate the input using vectorscan instead of re2. Inspiration for this came from https://github.com/StarRocks/starrocks/pull/10028, but here we take it even further and don't limit ourselves to constant patterns.

Note for reviewers: Instead of reviewing everything, it makes more sense to review the (few) individual commits individually.

Benchmark results:

``` sql
-- Generated test data:
insert into test select number, concat('prefix ', toString(toDateTime64('1970-01-01', 3) + number), ' midfix ', toString(toDateTime64('1970-01-01', 3) + number), ' suffix') as d FROM numbers(50000000);

--

┌─id───────┬─haystack─────────────────────────────────────────────────────────────┐
│  0       │ prefix 1970-01-01 00:00:00.000 midfix 1970-01-01 00:00:00.000 suffix │
│  1       │ prefix 1970-01-01 00:00:01.000 midfix 1970-01-01 00:00:01.000 suffix │
│  2       │ prefix 1970-01-01 00:00:02.000 midfix 1970-01-01 00:00:02.000 suffix │

 ... ~50 mil. rows ...

│ 49990001 │ prefix 1971-08-02 14:06:41.000 midfix 1971-08-02 14:06:41.000 suffix │
│ 49990000 │ prefix 1971-08-02 14:06:40.000 midfix 1971-08-02 14:06:40.000 suffix │
└─────────────────────────────────────────────────────────────────────────────────┘
```

Test query:
```sql
select replaceRegexpAll(haystack, pattern, replacement) from test SETTINGS allow_hyperscan=0/1
```

pattern | replacement | allow_hyperscan = 0  | allow_hyperscan = 1 (before tuning) | allow_hyperscan (after tuning) | comment |
| ------ | ------------ | ---------------------- | ------------------- | ---------- | --- |
| 'abc' | 'X' | 1.67 s | 1.68 s | 1.67 s | non-regex, matches nothing |
| 'midfix' | 'X' | 1.55 s | 1.56 s | 1.56 s | non-regex, matches all, simple replacement |
| 'midfix' | '\\0 XYZ \\0 ZXY \\0 YZX \\0' | 2.3 s | 2.3 s | 2.27 s | non-regex, matches all, complex replacement |
| '[xifdim]' | 'X' | 5.3 s | 3.4 s | 4.9 s | regexp (character class), matches all, simple replacement |
| '(pre\|mid\|suf)fix' | 'X' | 1.7 s | 1.7 s | 2.1 s | regexp (disjunction), matches all, simple replacement |
| '197.*fix' | 'X' | 1.2 s | 2.0 s | 2.1 s | regexp (kleene star), matches all, simple replacement |
| '0*' | 'X' | 22 s | "Start of match is not currently supported for patterns which match an empty buffer" | "Start of match is not currently supported for patterns which match an empty buffer" | regexp (kleene star), matches all, simple replacement |
| '[^t]' | 'X' | 23.3 s | 21.2 s | 17.1 s | regexp (negated character class), matches all, simple replacement |
| '197(0\|1)-\d\d-.* \d\d:\d\d:\d\d.000 midfix' | 'X' | 1.6 s | 1.6 s | 1.7 s | complex regexp, matches all, simple replacement |

Before tuning = 2nd commit.

After tuning = 3rd commit (compile vectorscan database and allocate scratch space just once per predicate instead of once per chunk, buffer matches in hash map instead of red/black tree).

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up SQL function "replaceRegexpAll" for the common case that the replacement string contains no substitutions "\1" - "\9".