### PR TITLE
Always run `BuilderReport` and `BuilderSpecialReport` in all CI types

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -466,6 +466,7 @@ jobs:
       - BuilderDebTsan
       - BuilderDebDebug
     runs-on: [self-hosted, style-checker]
+    if: ${{ success() || failure() }}
     steps:
       - name: Set envs
         run: |
@@ -504,6 +505,7 @@ jobs:
       - BuilderBinDarwin
       - BuilderBinDarwinAarch64
     runs-on: [self-hosted, style-checker]
+    if: ${{ success() || failure() }}
     steps:
       - name: Set envs
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -974,6 +974,7 @@ jobs:
       - BuilderDebTsan
       - BuilderDebUBsan
     runs-on: [self-hosted, style-checker]
+    if: ${{ success() || failure() }}
     steps:
       - name: Set envs
         run: |
@@ -1021,6 +1022,7 @@ jobs:
       - BuilderBinClangTidy
       - BuilderDebShared
     runs-on: [self-hosted, style-checker]
+    if: ${{ success() || failure() }}
     steps:
       - name: Set envs
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -112,7 +112,7 @@ jobs:
   StyleCheck:
     needs: DockerHubPush
     runs-on: [self-hosted, style-checker]
-    if: ${{ success() || failure() }}
+    if: ${{ success() || failure() || always() }}
     steps:
       - name: Set envs
         run: |

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -541,6 +541,7 @@ jobs:
       - BuilderDebMsan
       - BuilderDebDebug
     runs-on: [self-hosted, style-checker]
+    if: ${{ success() || failure() }}
     steps:
       - name: Set envs
         run: |
@@ -580,6 +581,7 @@ jobs:
       - BuilderBinDarwin
       - BuilderBinDarwinAarch64
     runs-on: [self-hosted, style-checker]
+    if: ${{ success() || failure() }}
     steps:
       - name: Set envs
         run: |


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix non-running builder reports on failed builds for workflows but pull_requests.