### PR TITLE
Fix truncate table does not hold lock correctly

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -213,7 +213,7 @@ BlockIO InterpreterDropQuery::executeToTableImpl(ContextPtr context_, ASTDropQue
             {
                 /// And for simple MergeTree we can stop merges before acquiring the lock
                 auto merges_blocker = table->getActionLock(ActionLocks::PartsMerge);
-                auto table_lock = table->lockExclusively(context_->getCurrentQueryId(), context_->getSettingsRef().lock_acquire_timeout);
+                table_lock = table->lockExclusively(context_->getCurrentQueryId(), context_->getSettingsRef().lock_acquire_timeout);
             }
 
             auto metadata_snapshot = table->getInMemoryMetadataPtr();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix truncate table does not hold lock correctly.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
