### PR TITLE
Minor fix implicit cast CaresPTRResolver

### DIFF
--- a/src/Common/CaresPTRResolver.cpp
+++ b/src/Common/CaresPTRResolver.cpp
@@ -128,7 +128,7 @@ namespace DB
             int number_of_fds_ready = 0;
             if (!readable_sockets.empty())
             {
-                number_of_fds_ready = poll(readable_sockets.data(), static_cast<unsigned int>(readable_sockets.size()), static_cast<int>(timeout));
+                number_of_fds_ready = poll(readable_sockets.data(), static_cast<nfds_t>(readable_sockets.size()), static_cast<int>(timeout));
             }
 
             if (number_of_fds_ready > 0)

--- a/src/Common/CaresPTRResolver.cpp
+++ b/src/Common/CaresPTRResolver.cpp
@@ -128,7 +128,7 @@ namespace DB
             int number_of_fds_ready = 0;
             if (!readable_sockets.empty())
             {
-                number_of_fds_ready = poll(readable_sockets.data(), readable_sockets.size(), timeout);
+                number_of_fds_ready = poll(readable_sockets.data(), static_cast<unsigned int>(readable_sockets.size()), static_cast<int>(timeout));
             }
 
             if (number_of_fds_ready > 0)

--- a/utils/iotest/iotest_nonblock.cpp
+++ b/utils/iotest/iotest_nonblock.cpp
@@ -101,7 +101,7 @@ int mainImpl(int argc, char ** argv)
     size_t ops = 0;
     while (ops < count)
     {
-        if (poll(polls.data(), static_cast<unsigned int>(descriptors), -1) <= 0)
+        if (poll(polls.data(), static_cast<nfds_t>(descriptors), -1) <= 0)
             throwFromErrno("poll failed", ErrorCodes::SYSTEM_ERROR);
         for (size_t i = 0; i < descriptors; ++i)
         {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I'm getting the following errors when compiling master in OSX ARM64 (M1):

```bash
/private/tmp/ch_master/src/Common/CaresPTRResolver.cpp:131:94: error: implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'int' [-Werror,-Wshorten-64-to-32]
                number_of_fds_ready = poll(readable_sockets.data(), readable_sockets.size(), timeout);
                                      ~~~~                                                   ^~~~~~~
/private/tmp/ch_master/src/Common/CaresPTRResolver.cpp:131:86: error: implicit conversion loses integer precision: 'std::span<type-parameter-0-0, 18446744073709551615>::size_type' (aka 'unsigned long') to 'nfds_t' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
                number_of_fds_ready = poll(readable_sockets.data(), readable_sockets.size(), timeout);
                                      ~~~~                          ~~~~~~~~~~~~~~~~~^~~~~~
```

I'm not sure about what could be different with `timeout` since looks like c-ares `timeval` it's defined as `long` in all architectures. 

```c++
/*
 * Definition of timeval struct for platforms that don't have it.
 */

#ifndef HAVE_STRUCT_TIMEVAL
struct timeval {
 long tv_sec;
 long tv_usec;
};
#endif
```

But looks like `nfds_t` is defined as `unsigned int` in OSX ARM64 but as `unsigned long` in other architectures (this will explain the change from here also #42658)