### PR TITLE
Fix build on master

### DIFF
--- a/src/Common/CaresPTRResolver.cpp
+++ b/src/Common/CaresPTRResolver.cpp
@@ -128,7 +128,7 @@ namespace DB
             int number_of_fds_ready = 0;
             if (!readable_sockets.empty())
             {
-                number_of_fds_ready = poll(readable_sockets.data(), readable_sockets.size(), timeout);
+                number_of_fds_ready = poll(readable_sockets.data(), readable_sockets.size(), static_cast<int>(timeout));
             }
 
             if (number_of_fds_ready > 0)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`src/Common/CaresPTRResolver.cpp:126:27`
error: implicit conversion loses integer precision: 'int64_t' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
