### PR TITLE
Fix incorrect UserTimeMicroseconds/SystemTimeMicroseconds accounting

### DIFF
--- a/src/Common/ThreadProfileEvents.h
+++ b/src/Common/ThreadProfileEvents.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <base/types.h>
+#include <base/getThreadId.h>
 #include <Common/ProfileEvents.h>
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -47,6 +48,8 @@ struct RUsageCounters
     UInt64 soft_page_faults = 0;
     UInt64 hard_page_faults = 0;
 
+    UInt64 thread_id = 0;
+
     RUsageCounters() = default;
     RUsageCounters(const ::rusage & rusage_, UInt64 real_time_)
     {
@@ -61,6 +64,8 @@ struct RUsageCounters
 
         soft_page_faults = static_cast<UInt64>(rusage.ru_minflt);
         hard_page_faults = static_cast<UInt64>(rusage.ru_majflt);
+
+        thread_id = getThreadId();
     }
 
     static RUsageCounters current()
@@ -78,6 +83,12 @@ struct RUsageCounters
 
     static void incrementProfileEvents(const RUsageCounters & prev, const RUsageCounters & curr, ProfileEvents::Counters & profile_events)
     {
+        chassert(prev.thread_id == curr.thread_id);
+        /// LONG_MAX is ~106751 days
+        chassert(curr.real_time - prev.real_time < LONG_MAX);
+        chassert(curr.user_time - prev.user_time < LONG_MAX);
+        chassert(curr.sys_time - prev.sys_time < LONG_MAX);
+
         profile_events.increment(ProfileEvents::RealTimeMicroseconds,   (curr.real_time - prev.real_time) / 1000U);
         profile_events.increment(ProfileEvents::UserTimeMicroseconds,   (curr.user_time - prev.user_time) / 1000U);
         profile_events.increment(ProfileEvents::SystemTimeMicroseconds, (curr.sys_time - prev.sys_time) / 1000U);

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -131,6 +131,12 @@ void ThreadStatus::setupState(const ThreadGroupStatusPtr & thread_group_)
     thread_state = ThreadState::AttachedToQuery;
 }
 
+void ThreadStatus::setInternalThread()
+{
+    chassert(!query_profiler_real && !query_profiler_cpu);
+    internal_thread = true;
+}
+
 void ThreadStatus::initializeQuery()
 {
     setupState(std::make_shared<ThreadGroupStatus>());
@@ -177,41 +183,44 @@ void ThreadStatus::initPerformanceCounters()
     // query_start_time_nanoseconds cannot be used here since RUsageCounters expect CLOCK_MONOTONIC
     *last_rusage = RUsageCounters::current();
 
-    if (auto query_context_ptr = query_context.lock())
+    if (!internal_thread)
     {
-        const Settings & settings = query_context_ptr->getSettingsRef();
-        if (settings.metrics_perf_events_enabled)
+        if (auto query_context_ptr = query_context.lock())
+        {
+            const Settings & settings = query_context_ptr->getSettingsRef();
+            if (settings.metrics_perf_events_enabled)
+            {
+                try
+                {
+                    current_thread_counters.initializeProfileEvents(
+                        settings.metrics_perf_events_list);
+                }
+                catch (...)
+                {
+                    tryLogCurrentException(__PRETTY_FUNCTION__);
+                }
+            }
+        }
+
+        if (!taskstats)
         {
             try
             {
-                current_thread_counters.initializeProfileEvents(
-                    settings.metrics_perf_events_list);
+                taskstats = TasksStatsCounters::create(thread_id);
             }
             catch (...)
             {
-                tryLogCurrentException(__PRETTY_FUNCTION__);
+                tryLogCurrentException(log);
             }
         }
+        if (taskstats)
+            taskstats->reset();
     }
-
-    if (!taskstats)
-    {
-        try
-        {
-            taskstats = TasksStatsCounters::create(thread_id);
-        }
-        catch (...)
-        {
-            tryLogCurrentException(log);
-        }
-    }
-    if (taskstats)
-        taskstats->reset();
 }
 
 void ThreadStatus::finalizePerformanceCounters()
 {
-    if (performance_counters_finalized)
+    if (performance_counters_finalized || internal_thread)
         return;
 
     performance_counters_finalized = true;
@@ -270,7 +279,7 @@ void ThreadStatus::resetPerformanceCountersLastUsage()
 
 void ThreadStatus::initQueryProfiler()
 {
-    if (!query_profiler_enabled)
+    if (internal_thread)
         return;
 
     /// query profilers are useless without trace collector

--- a/src/Processors/Transforms/buildPushingToViewsChain.cpp
+++ b/src/Processors/Transforms/buildPushingToViewsChain.cpp
@@ -275,10 +275,8 @@ Chain buildPushingToViewsChain(
         SCOPE_EXIT({ current_thread = original_thread; });
 
         std::unique_ptr<ThreadStatus> view_thread_status_ptr = std::make_unique<ThreadStatus>();
-        /// Disable query profiler for this ThreadStatus since the running (main query) thread should already have one
-        /// If we didn't disable it, then we could end up with N + 1 (N = number of dependencies) profilers which means
-        /// N times more interruptions
-        view_thread_status_ptr->disableProfiling();
+        /// Copy of a ThreadStatus should be internal.
+        view_thread_status_ptr->setInternalThread();
         /// view_thread_status_ptr will be moved later (on and on), so need to capture raw pointer.
         view_thread_status_ptr->deleter = [thread_status = view_thread_status_ptr.get(), running_group]
         {


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect UserTimeMicroseconds/SystemTimeMicroseconds accounting

After #40732 it became possible that getrusage() (from detachQuery(),
from buildPushingToViewsChain()) will be called for incorrect thread,
and so when the difference will be calculated it will be simply garbage.

But actually the root of this problem is #25714, after which it became
possible to have multiple ThreadStatus for one thread, and this is very
tricky (sigh).

Here are some other thoughts about it:
- Make ThreadStatus nested - decided that complexity does not worth it,
  at least only for this case
- Move some members into ThreadGroupStatus - will break per-thread
  statistics (and hence query_thread_log, BTW does somebody uses it?)
- Move some members into a separate structure

But decided to fix the issue w/o any refactoring, to make easy for
backport.

Fixes: #42757 (cc @filimonov @alexey-milovidov )