### PR TITLE
Use magic_enum to get the name of QueryTreeNodeType

### DIFF
--- a/src/Analyzer/IQueryTreeNode.cpp
+++ b/src/Analyzer/IQueryTreeNode.cpp
@@ -10,6 +10,8 @@
 
 #include <Parsers/ASTWithAlias.h>
 
+#include <magic_enum.hpp>
+
 namespace DB
 {
 
@@ -20,26 +22,7 @@ namespace ErrorCodes
 
 const char * toString(QueryTreeNodeType type)
 {
-    switch (type)
-    {
-        case QueryTreeNodeType::IDENTIFIER: return "IDENTIFIER";
-        case QueryTreeNodeType::MATCHER: return "MATCHER";
-        case QueryTreeNodeType::TRANSFORMER: return "TRANSFORMER";
-        case QueryTreeNodeType::LIST: return "LIST";
-        case QueryTreeNodeType::CONSTANT: return "CONSTANT";
-        case QueryTreeNodeType::FUNCTION: return "FUNCTION";
-        case QueryTreeNodeType::COLUMN: return "COLUMN";
-        case QueryTreeNodeType::LAMBDA: return "LAMBDA";
-        case QueryTreeNodeType::SORT: return "SORT";
-        case QueryTreeNodeType::INTERPOLATE: return "INTERPOLATE";
-        case QueryTreeNodeType::WINDOW: return "WINDOW";
-        case QueryTreeNodeType::TABLE: return "TABLE";
-        case QueryTreeNodeType::TABLE_FUNCTION: return "TABLE_FUNCTION";
-        case QueryTreeNodeType::QUERY: return "QUERY";
-        case QueryTreeNodeType::ARRAY_JOIN: return "ARRAY_JOIN";
-        case QueryTreeNodeType::JOIN: return "JOIN";
-        case QueryTreeNodeType::UNION: return "UNION";
-    }
+    return magic_enum::enum_name(type).data();
 }
 
 IQueryTreeNode::IQueryTreeNode(size_t children_size, size_t weak_pointers_size)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use magic_enum to get the name of QueryTreeNodeType.