### PR TITLE
Fix lowerUTF8()/upperUTF8() in case of symbol was in between 16-byte boundary

### DIFF
--- a/src/Functions/LowerUpperUTF8Impl.h
+++ b/src/Functions/LowerUpperUTF8Impl.h
@@ -104,7 +104,7 @@ struct LowerUpperUTF8Impl
 
     /** Converts a single code point starting at `src` to desired case, storing result starting at `dst`.
      *    `src` and `dst` are incremented by corresponding sequence lengths. */
-    static void toCase(const UInt8 *& src, const UInt8 * src_end, UInt8 *& dst)
+    static bool toCase(const UInt8 *& src, const UInt8 * src_end, UInt8 *& dst, bool partial)
     {
         if (src[0] <= ascii_upper_bound)
         {
@@ -136,6 +136,11 @@ struct LowerUpperUTF8Impl
             static const Poco::UTF8Encoding utf8;
 
             size_t src_sequence_length = UTF8::seqLength(*src);
+            /// In case partial buffer was passed (due to SSE optimization)
+            /// we cannot convert it with current src_end, but we may have more
+            /// bytes to convert and eventually got correct symbol.
+            if (partial && src_sequence_length > static_cast<size_t>(src_end-src))
+                return false;
 
             auto src_code_point = UTF8::convertUTF8ToCodePoint(src, src_end - src);
             if (src_code_point)
@@ -152,7 +157,7 @@ struct LowerUpperUTF8Impl
                     {
                         src += dst_sequence_length;
                         dst += dst_sequence_length;
-                        return;
+                        return true;
                     }
                 }
             }
@@ -161,6 +166,8 @@ struct LowerUpperUTF8Impl
             ++dst;
             ++src;
         }
+
+        return true;
     }
 
 private:
@@ -229,7 +236,14 @@ private:
                 const UInt8 * expected_end = std::min(src + bytes_sse, row_end);
 
                 while (src < expected_end)
-                    toCase(src, expected_end, dst);
+                {
+                    if (!toCase(src, expected_end, dst, /* partial= */ true))
+                    {
+                        /// Fallback to handling byte by byte.
+                        src_end_sse = src;
+                        break;
+                    }
+                }
             }
         }
 
@@ -245,7 +259,7 @@ private:
             chassert(row_end >= src);
 
             while (src < row_end)
-                toCase(src, row_end, dst);
+                toCase(src, row_end, dst, /* partial= */ false);
             ++offset_it;
         }
     }

--- a/src/Functions/LowerUpperUTF8Impl.h
+++ b/src/Functions/LowerUpperUTF8Impl.h
@@ -230,16 +230,6 @@ private:
 
                 while (src < expected_end)
                     toCase(src, expected_end, dst);
-
-                /// adjust src_end_sse by pushing it forward or backward
-                const auto diff = src - expected_end;
-                if (diff != 0)
-                {
-                    if (src_end_sse + diff < src_end)
-                        src_end_sse += diff;
-                    else
-                        src_end_sse -= bytes_sse - diff;
-                }
             }
         }
 

--- a/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.reference
+++ b/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.reference
@@ -13,3 +13,18 @@ select length(str), if(l_ == '\xe2', h_, l_), if(u_ == '\xe2', h_, u_) from utf8
 -- https://github.com/ClickHouse/ClickHouse/issues/42756
 SELECT lowerUTF8('КВ АМ И СЖ');
 кв ам и сж
+SELECT upperUTF8('кв ам и сж');
+КВ АМ И СЖ
+SELECT lowerUTF8('КВ АМ И СЖ КВ АМ И СЖ');
+кв ам и сж кв ам и сж
+SELECT upperUTF8('кв ам и сж кв ам и сж');
+КВ АМ И СЖ КВ АМ И СЖ
+-- Test at 32 and 64 byte boundaries
+SELECT lowerUTF8(repeat('0', 16) || 'КВ АМ И СЖ');
+0000000000000000кв ам и сж
+SELECT upperUTF8(repeat('0', 16) || 'кв ам и сж');
+0000000000000000КВ АМ И СЖ
+SELECT lowerUTF8(repeat('0', 48) || 'КВ АМ И СЖ');
+000000000000000000000000000000000000000000000000кв ам и сж
+SELECT upperUTF8(repeat('0', 48) || 'кв ам и сж');
+000000000000000000000000000000000000000000000000КВ АМ И СЖ

--- a/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.reference
+++ b/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.reference
@@ -9,3 +9,7 @@ select length(str), if(l_ == '\xe2', h_, l_), if(u_ == '\xe2', h_, u_) from utf8
 15,"foo⚊barbazbam","FOO⚊BARBAZBAM"
 1,"0xE2","0xE2"
 15,"foo⚊barbazbam","FOO⚊BARBAZBAM"
+-- NOTE: regression test for introduced bug
+-- https://github.com/ClickHouse/ClickHouse/issues/42756
+SELECT lowerUTF8('КВ АМ И СЖ');
+кв ам и сж

--- a/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.sql
+++ b/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.sql
@@ -8,3 +8,7 @@ insert into utf8_overlap values ('\xe2'), ('Foo⚊BarBazBam'), ('\xe2'), ('Foo�
 --                                             MONOGRAM FOR YANG
 with lowerUTF8(str) as l_, upperUTF8(str) as u_, '0x' || hex(str) as h_
 select length(str), if(l_ == '\xe2', h_, l_), if(u_ == '\xe2', h_, u_) from utf8_overlap format CSV;
+
+-- NOTE: regression test for introduced bug
+-- https://github.com/ClickHouse/ClickHouse/issues/42756
+SELECT lowerUTF8('КВ АМ И СЖ');

--- a/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.sql
+++ b/tests/queries/0_stateless/02071_lower_upper_utf8_row_overlaps.sql
@@ -12,3 +12,11 @@ select length(str), if(l_ == '\xe2', h_, l_), if(u_ == '\xe2', h_, u_) from utf8
 -- NOTE: regression test for introduced bug
 -- https://github.com/ClickHouse/ClickHouse/issues/42756
 SELECT lowerUTF8('КВ АМ И СЖ');
+SELECT upperUTF8('кв ам и сж');
+SELECT lowerUTF8('КВ АМ И СЖ КВ АМ И СЖ');
+SELECT upperUTF8('кв ам и сж кв ам и сж');
+-- Test at 32 and 64 byte boundaries
+SELECT lowerUTF8(repeat('0', 16) || 'КВ АМ И СЖ');
+SELECT upperUTF8(repeat('0', 16) || 'кв ам и сж');
+SELECT lowerUTF8(repeat('0', 48) || 'КВ АМ И СЖ');
+SELECT upperUTF8(repeat('0', 48) || 'кв ам и сж');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix lowerUTF8()/upperUTF8() in case of symbol was in between 16-byte boundary (very frequent case of you have strings > 16 bytes long)

In lowerUTF8()/upperUTF8() there is an SSE optimization that handles
16 byte at a time, but only for ASCII, for UTF8 symbols converion will
be done by symbol.

Consider the following example:

    КВ АМ И СЖ
             ^ - offset is 15, length of sequence is 2
                 so first byte of a symbol is in first 16 bytes
                 second byte of a symbol is not ther

And in this case it will be handled incorrectly because it will try to
process oly these 16 bytes w/o looking forward.

This had been broken by #41286, before this patch it does not looks at
the row boundaries but only at the string end and so this sutation
wasn't possible.

Fixes: #42756