### PR TITLE
Fix argument type check in AggregateFunctionAnalysisOfVariance

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionAnalysisOfVariance.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAnalysisOfVariance.cpp
@@ -18,8 +18,10 @@ AggregateFunctionPtr createAggregateFunctionAnalysisOfVariance(const std::string
     assertNoParameters(name, parameters);
     assertBinary(name, arguments);
 
-    if (!isNumber(arguments[0]) || !isNumber(arguments[1]))
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Aggregate function {} only supports numerical types", name);
+    if (!isNumber(arguments[0]))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Aggregate function {} only supports numerical argument types", name);
+    if (!WhichDataType(arguments[1]).isNativeUInt())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Second argument of aggregate function {} should be a native unsigned integer", name);
 
     return std::make_shared<AggregateFunctionAnalysisOfVariance>(arguments, parameters);
 }

--- a/src/AggregateFunctions/AggregateFunctionAnalysisOfVariance.h
+++ b/src/AggregateFunctions/AggregateFunctionAnalysisOfVariance.h
@@ -77,7 +77,7 @@ public:
     void insertResultInto(AggregateDataPtr __restrict place, IColumn & to, Arena *) const override
     {
         auto f_stat = data(place).getFStatistic();
-        if (std::isinf(f_stat) || isNaN(f_stat))
+        if (std::isinf(f_stat) || isNaN(f_stat) || f_stat < 0)
             throw Exception("F statistic is not defined or infinite for these arguments", ErrorCodes::BAD_ARGUMENTS);
 
         auto p_value = data(place).getPValue(f_stat);

--- a/src/AggregateFunctions/Moments.h
+++ b/src/AggregateFunctions/Moments.h
@@ -482,6 +482,8 @@ struct ZTestMoments
 template <typename T>
 struct AnalysisOfVarianceMoments
 {
+    constexpr static size_t MAX_GROUPS_NUMBER = 1024 * 1024;
+
     /// Sums of values within a group
     std::vector<T> xs1{};
     /// Sums of squared values within a group
@@ -493,6 +495,10 @@ struct AnalysisOfVarianceMoments
     {
         if (xs1.size() >= possible_size)
             return;
+
+        if (possible_size > MAX_GROUPS_NUMBER)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Too many groups for analysis of variance (should be no more than {}, got {})",
+                            MAX_GROUPS_NUMBER, possible_size);
 
         xs1.resize(possible_size, 0.0);
         xs2.resize(possible_size, 0.0);

--- a/tests/queries/0_stateless/02475_analysis_of_variance.sql
+++ b/tests/queries/0_stateless/02475_analysis_of_variance.sql
@@ -1,0 +1,10 @@
+
+SELECT analysisOfVariance(number, number % 2) FROM numbers(10) FORMAT Null;
+SELECT analysisOfVariance(number :: Decimal32(5), number % 2) FROM numbers(10) FORMAT Null;
+SELECT analysisOfVariance(number :: Decimal256(5), number % 2) FROM numbers(10) FORMAT Null;
+
+SELECT analysisOfVariance(1.11, -20); -- { serverError BAD_ARGUMENTS }
+SELECT analysisOfVariance(1.11, 20 :: UInt128); -- { serverError BAD_ARGUMENTS }
+SELECT analysisOfVariance(1.11, 9000000000000000); -- { serverError BAD_ARGUMENTS }
+
+SELECT analysisOfVariance(number, number % 2), analysisOfVariance(100000000000000000000., number % 65535) FROM numbers(1048575); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Ref https://github.com/ClickHouse/ClickHouse/pull/42131

It was reproduced in one of PR, but function is not included in test suite, how is it possible?

https://s3.amazonaws.com/clickhouse-test-reports/38191/6a4247ca32a702e3258a0a4a0f92e671109fc05d/stateless_tests__asan__[1/2]/clickhouse-server.err.log