### PR TITLE
A bit more safe code in ReplicatedMergeTreeSink

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
@@ -117,7 +117,7 @@ private:
     struct DelayedChunk;
     std::unique_ptr<DelayedChunk> delayed_chunk;
 
-    void finishDelayedChunk(zkutil::ZooKeeperPtr & zookeeper);
+    void finishDelayedChunk();
 };
 
 }


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

After https://github.com/ClickHouse/ClickHouse/pull/34219 (https://github.com/ClickHouse/ClickHouse/pull/33291) there's a small chance that parts are committed in a new session in `onFinish()` and ephemeral locks for block numbers were lost. As a result, for example, some mutation might skip these parts (if mutation got greater block number, but finished before parts were committed). Or these block numbers could be considered as gaps and an intersecting merge could be assigned.

