### PR TITLE
Add exclusions from the Snyk scan

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file
+exclude:
+  global:
+    - tests/**


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Remove the `tests` directory as it does not represent the runtime code.