### PR TITLE
Fix broken links in system tables docs

### DIFF
--- a/docs/en/operations/system-tables/information_schema.md
+++ b/docs/en/operations/system-tables/information_schema.md
@@ -178,7 +178,7 @@ Columns:
 -   `view_definition` ([String](../../sql-reference/data-types/string.md)) — `SELECT` query for view.
 -   `check_option` ([String](../../sql-reference/data-types/string.md)) — `NONE`, no checking.
 -   `is_updatable` ([Enum8](../../sql-reference/data-types/enum.md)) — `NO`, the view is not updated.
--   `is_insertable_into` ([Enum8](../../sql-reference/data-types/enum.md)) — Shows whether the created view is [materialized](../../sql-reference/statements/create/view.md#materialized-view). Possible values:
+-   `is_insertable_into` ([Enum8](../../sql-reference/data-types/enum.md)) — Shows whether the created view is [materialized](../../sql-reference/statements/create/view.md/#materialized-view). Possible values:
     -   `NO` — The created view is not materialized.
     -   `YES` — The created view is materialized.
 -   `is_trigger_updatable` ([Enum8](../../sql-reference/data-types/enum.md)) — `NO`, the trigger is not updated.

--- a/docs/en/operations/system-tables/information_schema.md
+++ b/docs/en/operations/system-tables/information_schema.md
@@ -178,7 +178,7 @@ Columns:
 -   `view_definition` ([String](../../sql-reference/data-types/string.md)) — `SELECT` query for view.
 -   `check_option` ([String](../../sql-reference/data-types/string.md)) — `NONE`, no checking.
 -   `is_updatable` ([Enum8](../../sql-reference/data-types/enum.md)) — `NO`, the view is not updated.
--   `is_insertable_into` ([Enum8](../../sql-reference/data-types/enum.md)) — Shows whether the created view is [materialized](../../sql-reference/statements/create/view/#materialized). Possible values:
+-   `is_insertable_into` ([Enum8](../../sql-reference/data-types/enum.md)) — Shows whether the created view is [materialized](../../sql-reference/statements/create/view.md#materialized-view). Possible values:
     -   `NO` — The created view is not materialized.
     -   `YES` — The created view is materialized.
 -   `is_trigger_updatable` ([Enum8](../../sql-reference/data-types/enum.md)) — `NO`, the trigger is not updated.

--- a/docs/en/operations/system-tables/replicated_fetches.md
+++ b/docs/en/operations/system-tables/replicated_fetches.md
@@ -68,6 +68,5 @@ thread_id:                   54
 
 **See Also**
 
--   [Managing ReplicatedMergeTree Tables](../../sql-reference/statements/system.md#managing-replicatedmergetree-tables)
+-   [Managing ReplicatedMergeTree Tables](../../sql-reference/statements/system.md/#managing-replicatedmergetree-tables)
 
-[Original article](https://clickhouse.com/docs/en/operations/system-tables/replicated_fetches/) <!--hide-->

--- a/docs/en/operations/system-tables/replicated_fetches.md
+++ b/docs/en/operations/system-tables/replicated_fetches.md
@@ -68,6 +68,6 @@ thread_id:                   54
 
 **See Also**
 
--   [Managing ReplicatedMergeTree Tables](../../sql-reference/statements/system/#query-language-system-replicated)
+-   [Managing ReplicatedMergeTree Tables](../../sql-reference/statements/system.md#managing-replicatedmergetree-tables)
 
-[Original article](https://clickhouse.com/docs/en/operations/system_tables/replicated_fetches) <!--hide-->
+[Original article](https://clickhouse.com/docs/en/operations/system-tables/replicated_fetches/) <!--hide-->


### PR DESCRIPTION
Signed-off-by: 94rain <21193371+94rain@users.noreply.github.com>

Replace 3 broken links in system tables docs with the correct links, verified by building docs via [this guide](https://github.com/ClickHouse/ClickHouse/blob/master/docs/tools/README.md#build-the-docs-locally-use-build-py)
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
N/A


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
