### PR TITLE
s390x datetime64 conversion fix

### DIFF
--- a/base/base/bit_cast.h
+++ b/base/base/bit_cast.h
@@ -16,8 +16,8 @@ std::decay_t<To> bit_cast(const From & from)
      * Assume the source value is 0xAABBCCDD (i.e. sizeof(from) == 4). 
      * Its BE representation is 0xAABBCCDD, the LE representation is 0xDDCCBBAA. 
      * Further assume, sizeof(res) == 8 and that res is initially zeroed out.
-     * With LE, the result after bit_cast is 0xDDCCBBAA00000000 (no change to the previous behavior).
-     * With BE, we previously produced 0xAABBCCDD00000000 and we now produce 0x00000000AABBCCDD
+     * With LE, the result after bit_cast will be 0xDDCCBBAA00000000 --> input value == output value.
+     * With BE, the result after bit_cast will be 0x00000000AABBCCDD --> input value == output value.
      */
     To res {};
     static_assert(sizeof(From) <= sizeof(To));

--- a/base/base/bit_cast.h
+++ b/base/base/bit_cast.h
@@ -14,12 +14,12 @@ template <typename To, typename From>
 std::decay_t<To> bit_cast(const From & from)
 {
     To res {};
-    if constexpr (std::endian::native == std::endian::little || !std::is_arithmetic_v<To>)
+    if constexpr (std::endian::native == std::endian::little)
       memcpy(static_cast<void*>(&res), &from, std::min(sizeof(res), sizeof(from)));
     else
     {
       uint32_t offset = (sizeof(res) > sizeof(from)) ? (sizeof(res) - sizeof(from)) : 0;
-      reverseMemcpy(reinterpret_cast<char *>(&res) + offset, &from, std::min(sizeof(res), sizeof(from)));
+      memcpy(reinterpret_cast<char *>(&res) + offset, &from, std::min(sizeof(res), sizeof(from)));
     }
     return res;
 }

--- a/base/base/bit_cast.h
+++ b/base/base/bit_cast.h
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <algorithm>
 #include <type_traits>
+#include <base/unaligned.h>
 
 
 /** Returns value `from` converted to type `To` while retaining bit representation.
@@ -13,6 +14,12 @@ template <typename To, typename From>
 std::decay_t<To> bit_cast(const From & from)
 {
     To res {};
-    memcpy(static_cast<void*>(&res), &from, std::min(sizeof(res), sizeof(from)));
+    if constexpr (std::endian::native == std::endian::little || !std::is_arithmetic_v<To>)
+      memcpy(static_cast<void*>(&res), &from, std::min(sizeof(res), sizeof(from)));
+    else
+    {
+      uint32_t offset = (sizeof(res) > sizeof(from)) ? (sizeof(res) - sizeof(from)) : 0;
+      reverseMemcpy(reinterpret_cast<char *>(&res) + offset, &from, std::min(sizeof(res), sizeof(from)));
+    }
     return res;
 }

--- a/base/base/bit_cast.h
+++ b/base/base/bit_cast.h
@@ -13,12 +13,20 @@
 template <typename To, typename From>
 std::decay_t<To> bit_cast(const From & from)
 {
+    /**
+     * Assume the source value is 0xAABBCCDD (i.e. sizeof(from) == 4). 
+     * Its BE representation is 0xAABBCCDD, the LE representation is 0xDDCCBBAA. 
+     * Further assume, sizeof(res) == 8 and that res is initially zeroed out.
+     * With LE, the result after bit_cast is 0xDDCCBBAA00000000 (no change to the previous behavior).
+     * With BE, we previously produced 0xAABBCCDD00000000 and we now produce 0x00000000AABBCCDD
+     */
     To res {};
+    static_assert(sizeof(From) <= sizeof(To));
     if constexpr (std::endian::native == std::endian::little)
       memcpy(static_cast<void*>(&res), &from, std::min(sizeof(res), sizeof(from)));
     else
     {
-      uint32_t offset = (sizeof(res) > sizeof(from)) ? (sizeof(res) - sizeof(from)) : 0;
+      uint32_t offset = sizeof(res) - sizeof(to);
       memcpy(reinterpret_cast<char *>(&res) + offset, &from, std::min(sizeof(res), sizeof(from)));
     }
     return res;

--- a/base/base/bit_cast.h
+++ b/base/base/bit_cast.h
@@ -13,8 +13,8 @@ template <typename To, typename From>
 std::decay_t<To> bit_cast(const From & from)
 {
     /**
-     * Assume the source value is 0xAABBCCDD (i.e. sizeof(from) == 4). 
-     * Its BE representation is 0xAABBCCDD, the LE representation is 0xDDCCBBAA. 
+     * Assume the source value is 0xAABBCCDD (i.e. sizeof(from) == 4).
+     * Its BE representation is 0xAABBCCDD, the LE representation is 0xDDCCBBAA.
      * Further assume, sizeof(res) == 8 and that res is initially zeroed out.
      * With LE, the result after bit_cast will be 0xDDCCBBAA00000000 --> input value == output value.
      * With BE, the result after bit_cast will be 0x00000000AABBCCDD --> input value == output value.
@@ -25,7 +25,7 @@ std::decay_t<To> bit_cast(const From & from)
       memcpy(static_cast<void*>(&res), &from, std::min(sizeof(res), sizeof(from)));
     else
     {
-      uint32_t offset = sizeof(res) - sizeof(to);
+      uint32_t offset = sizeof(res) - sizeof(from);
       memcpy(reinterpret_cast<char *>(&res) + offset, &from, std::min(sizeof(res), sizeof(from)));
     }
     return res;

--- a/base/base/bit_cast.h
+++ b/base/base/bit_cast.h
@@ -20,13 +20,13 @@ std::decay_t<To> bit_cast(const From & from)
      * With BE, the result after bit_cast will be 0x00000000AABBCCDD --> input value == output value.
      */
     To res {};
-    static_assert(sizeof(From) <= sizeof(To));
     if constexpr (std::endian::native == std::endian::little)
       memcpy(static_cast<void*>(&res), &from, std::min(sizeof(res), sizeof(from)));
     else
     {
-      uint32_t offset = sizeof(res) - sizeof(from);
-      memcpy(reinterpret_cast<char *>(&res) + offset, &from, std::min(sizeof(res), sizeof(from)));
+      uint32_t offset_to = (sizeof(res) > sizeof(from)) ? (sizeof(res) - sizeof(from)) : 0;
+      uint32_t offset_from = (sizeof(from) > sizeof(res)) ? (sizeof(from) - sizeof(res)) : 0;
+      memcpy(reinterpret_cast<char *>(&res) + offset_to, reinterpret_cast<const char *>(&from) + offset_from, std::min(sizeof(res), sizeof(from)));
     }
     return res;
 }

--- a/base/base/bit_cast.h
+++ b/base/base/bit_cast.h
@@ -3,7 +3,6 @@
 #include <cstring>
 #include <algorithm>
 #include <type_traits>
-#include <base/unaligned.h>
 
 
 /** Returns value `from` converted to type `To` while retaining bit representation.

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -437,7 +437,12 @@ template <typename T>
 UInt64 ColumnVector<T>::get64(size_t n [[maybe_unused]]) const
 {
     if constexpr (is_arithmetic_v<T>)
-        return bit_cast<UInt64>(data[n]);
+    {
+        if constexpr (std::endian::native == std::endian::little)
+            return bit_cast<UInt64>(data[n]);
+        else
+            return __builtin_bswap64(bit_cast<UInt64>(data[n]));
+    }
     else
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot get the value of {} as UInt64", TypeName<T>);
 }

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -438,10 +438,7 @@ UInt64 ColumnVector<T>::get64(size_t n [[maybe_unused]]) const
 {
     if constexpr (is_arithmetic_v<T>)
     {
-        if constexpr (std::endian::native == std::endian::little)
-            return bit_cast<UInt64>(data[n]);
-        else
-            return __builtin_bswap64(bit_cast<UInt64>(data[n]));
+        return bit_cast<UInt64>(data[n]);
     }
     else
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot get the value of {} as UInt64", TypeName<T>);

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -437,12 +437,7 @@ template <typename T>
 UInt64 ColumnVector<T>::get64(size_t n [[maybe_unused]]) const
 {
     if constexpr (is_arithmetic_v<T>)
-    {
-        if constexpr (std::endian::native == std::endian::little)
-            return bit_cast<UInt64>(data[n]);
-        else
-            return __builtin_bswap64(bit_cast<UInt64>(data[n]));
-    }
+        return bit_cast<UInt64>(data[n]);
     else
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot get the value of {} as UInt64", TypeName<T>);
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
toDateTime64 conversion generates wrong time on z build, add bit_cast swap fix to support toDateTime64 on s390x platform

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
