### PR TITLE
Fix attempts to add query access info to non-existent context when building view push chain

### DIFF
--- a/src/Processors/Transforms/buildPushingToViewsChain.cpp
+++ b/src/Processors/Transforms/buildPushingToViewsChain.cpp
@@ -366,7 +366,7 @@ Chain buildPushingToViewsChain(
         chains.emplace_back(std::move(out));
 
         /// Add the view to the query access info so it can appear in system.query_log
-        if (!no_destination)
+        if (!no_destination && context->hasQueryContext())
         {
             context->getQueryContext()->addQueryAccessInfo(
                 backQuoteIfNeed(database_table.getDatabaseName()), views_data->views.back().runtime_stats->target_name, {}, "", database_table.getFullTableName());


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix attempts to add query access info to non-existent context when building view push chain. Resolves issues with attaching materialized views to the destination table of a window view (https://github.com/ClickHouse/ClickHouse/issues/41400).

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
