### PR TITLE
Adjust cancel and rerun workflow names to the actual

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -6,7 +6,7 @@ env:
 
 on: # yamllint disable-line rule:truthy
   workflow_run:
-    workflows: ["PullRequestCI", "ReleaseCI", "DocsCheck", "BackportPR"]
+    workflows: ["PullRequestCI", "ReleaseBranchCI", "DocsCheck", "BackportPR"]
     types:
       - requested
 jobs:

--- a/tests/ci/cancel_and_rerun_workflow_lambda/app.py
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/app.py
@@ -15,7 +15,7 @@ import boto3  # type: ignore
 NEED_RERUN_OR_CANCELL_WORKFLOWS = {
     "PullRequestCI",
     "DocsCheck",
-    "DocsRelease",
+    "DocsReleaseChecks",
     "BackportPR",
 }
 

--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -61,11 +61,11 @@ TRUSTED_WORKFLOW_IDS = {
 
 NEED_RERUN_WORKFLOWS = {
     "BackportPR",
-    "Docs",
-    "DocsRelease",
+    "DocsCheck",
+    "DocsReleaseChecks",
     "MasterCI",
     "PullRequestCI",
-    "ReleaseCI",
+    "ReleaseBranchCI",
 }
 
 # Individual trusted contirbutors who are not in any trusted organization.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix missing proper workflow names in lambdas and workflow references