### PR TITLE
Fix rare possible hung on query cancellation

### DIFF
--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -109,6 +109,13 @@ bool ExecutingGraph::expandPipeline(std::stack<uint64_t> & stack, uint64_t pid)
 
     {
         std::lock_guard guard(processors_mutex);
+        /// Do not add new processors to existing list, since the query was already cancelled.
+        if (cancelled)
+        {
+            for (auto & processor : new_processors)
+                processor->cancel();
+            return false;
+        }
         processors->insert(processors->end(), new_processors.begin(), new_processors.end());
     }
 
@@ -388,6 +395,7 @@ void ExecutingGraph::cancel()
     std::lock_guard guard(processors_mutex);
     for (auto & processor : *processors)
         processor->cancel();
+    cancelled = true;
 }
 
 }

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -157,6 +157,7 @@ private:
     UpgradableMutex nodes_mutex;
 
     const bool profile_processors;
+    bool cancelled = false;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix rare possible hung on query cancellation

Some queries can hung after cancelling (because enough rows had been read for Distributed queries) or after KILL. Example of such query is a Distributed query that uses DelayedSource that uses ExpandPipeline to add new processors, and in this case it is possible that all already existing processes was cancelled but new had been added and now PipelineExecutor will wait for them undefinitelly since nobody will read from them and nobody will cancel them either.

Cc: @KochetovNicolai 

Fixes: #29618
Fixes: #38560