### PR TITLE
rename update file as it is included in Manage > Updates

### DIFF
--- a/docs/en/operations/_update.md
+++ b/docs/en/operations/_update.md
@@ -1,10 +1,7 @@
----
-slug: /en/operations/update
-sidebar_position: 47
-sidebar_label: ClickHouse Upgrade
----
 
-# ClickHouse Upgrade
+[//]: # (This file is included in Manage > Updates)
+
+## Self-managed ClickHouse Upgrade
 
 If ClickHouse was installed from `deb` packages, execute the following commands on the server:
 


### PR DESCRIPTION
The Self-managed and Cloud update docs are combined at Manage > Updates.  This PR renames the file to _update.md so that it does not show alone in the nav.  

Must be merged with https://github.com/ClickHouse/clickhouse-docs/pull/514

### Changelog category (leave one):
- Documentation (changelog entry is not required)
