### PR TITLE
changed type name for s3 plain storage

### DIFF
--- a/src/Disks/DiskType.h
+++ b/src/Disks/DiskType.h
@@ -11,6 +11,7 @@ enum class DataSourceType
     Local,
     RAM,
     S3,
+    S3_Plain,
     HDFS,
     WebServer,
     AzureBlobStorage,
@@ -26,6 +27,8 @@ inline String toString(DataSourceType data_source_type)
             return "memory";
         case DataSourceType::S3:
             return "s3";
+        case DataSourceType::S3_Plain:
+            return "s3_plain";
         case DataSourceType::HDFS:
             return "hdfs";
         case DataSourceType::WebServer:

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -213,7 +213,9 @@ public:
     template <class ...Args>
     S3PlainObjectStorage(Args && ...args)
         : S3ObjectStorage("S3PlainObjectStorage", std::forward<Args>(args)...)
-    {}
+    {
+        data_source_description.type = DataSourceType::S3_Plain;
+    }
 };
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Renamed a disk for S3PlainObjectStorage in system.disks table from s3 to s3_plain
