### PR TITLE
Pin the cryptography version to not break lambdas

### DIFF
--- a/tests/ci/cancel_and_rerun_workflow_lambda/requirements.txt
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/requirements.txt
@@ -1,3 +1,3 @@
 requests
 PyJWT
-cryptography
+cryptography==37.0.4

--- a/tests/ci/metrics_lambda/requirements.txt
+++ b/tests/ci/metrics_lambda/requirements.txt
@@ -1,3 +1,3 @@
 requests
 PyJWT
-cryptography
+cryptography==37.0.4

--- a/tests/ci/termination_lambda/requirements.txt
+++ b/tests/ci/termination_lambda/requirements.txt
@@ -1,3 +1,3 @@
 requests
 PyJWT
-cryptography
+cryptography==37.0.4

--- a/tests/ci/token_lambda/requirements.txt
+++ b/tests/ci/token_lambda/requirements.txt
@@ -1,3 +1,3 @@
 requests
 PyJWT
-cryptography
+cryptography==37.0.4

--- a/tests/ci/workflow_approve_rerun_lambda/requirements.txt
+++ b/tests/ci/workflow_approve_rerun_lambda/requirements.txt
@@ -1,3 +1,3 @@
 requests
 PyJWT
-cryptography
+cryptography==37.0.4


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
w/o pinning the lambdas break with `Unable to import module 'app': /lib64/libc.so.6: version `GLIBC_2.28' not found`