### PR TITLE
Fix preserving user configs in rpm packages

### DIFF
--- a/packages/clickhouse-client.yaml
+++ b/packages/clickhouse-client.yaml
@@ -37,7 +37,7 @@ deb:
 contents:
 - src: root/etc/clickhouse-client/config.xml
   dst: /etc/clickhouse-client/config.xml
-  type: config
+  type: config|noreplace
 - src: root/usr/bin/clickhouse-benchmark
   dst: /usr/bin/clickhouse-benchmark
 - src: root/usr/bin/clickhouse-compressor

--- a/packages/clickhouse-keeper.yaml
+++ b/packages/clickhouse-keeper.yaml
@@ -29,7 +29,7 @@ deb:
 contents:
 - src: root/etc/clickhouse-keeper/keeper_config.xml
   dst: /etc/clickhouse-keeper/keeper_config.xml
-  type: config
+  type: config|noreplace
 - src: root/usr/bin/clickhouse-keeper
   dst: /usr/bin/clickhouse-keeper
 # docs

--- a/packages/clickhouse-server.yaml
+++ b/packages/clickhouse-server.yaml
@@ -44,10 +44,10 @@ deb:
 contents:
 - src: root/etc/clickhouse-server/config.xml
   dst: /etc/clickhouse-server/config.xml
-  type: config
+  type: config|noreplace
 - src: root/etc/clickhouse-server/users.xml
   dst: /etc/clickhouse-server/users.xml
-  type: config
+  type: config|noreplace
 - src: clickhouse-server.init
   dst: /etc/init.d/clickhouse-server
 - src: clickhouse-server.service


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Before the fix, the user-defined config was preserved by RPM in `$file.rpmsave`. The PR fixes it and won't replace the user's files from packages.