### PR TITLE
Fix: bad cast from type DB::ColumnLowCardinality to DB::ColumnString

### DIFF
--- a/src/DataTypes/Serializations/SerializationString.cpp
+++ b/src/DataTypes/Serializations/SerializationString.cpp
@@ -84,11 +84,12 @@ void SerializationString::deserializeBinary(IColumn & column, ReadBuffer & istr)
 
 void SerializationString::serializeBinaryBulk(const IColumn & column, WriteBuffer & ostr, size_t offset, size_t limit) const
 {
-    const ColumnString & column_string = typeid_cast<const ColumnString &>(column);
+    const auto & full_column = column.convertToFullColumnIfLowCardinality();
+    const ColumnString & column_string = typeid_cast<const ColumnString &>(*full_column);
     const ColumnString::Chars & data = column_string.getChars();
     const ColumnString::Offsets & offsets = column_string.getOffsets();
 
-    size_t size = column.size();
+    size_t size = column_string.size();
     if (!size)
         return;
 

--- a/tests/queries/0_stateless/02475_bad_cast_low_cardinality_to_string_bug.reference
+++ b/tests/queries/0_stateless/02475_bad_cast_low_cardinality_to_string_bug.reference
@@ -1,0 +1,2 @@
+bbbbb
+bbbbb

--- a/tests/queries/0_stateless/02475_bad_cast_low_cardinality_to_string_bug.sql
+++ b/tests/queries/0_stateless/02475_bad_cast_low_cardinality_to_string_bug.sql
@@ -1,0 +1,1 @@
+SELECT if(materialize(0), extract(materialize(CAST('aaaaaa', 'LowCardinality(String)')), '\\w'), extract(materialize(CAST('bbbbb', 'LowCardinality(String)')), '\\w*')) AS res FROM numbers(2);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix bad cast from type DB::ColumnLowCardinality to DB::ColumnString for specific queries.

Close #42818