### PR TITLE
Update default value of allow_experimental_projection_optimization

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -2939,7 +2939,7 @@ Possible values:
 -   0 — Projection optimization disabled.
 -   1 — Projection optimization enabled.
 
-Default value: `0`.
+Default value: `1`.
 
 ## force_optimize_projection {#force-optimize-projection}
 


### PR DESCRIPTION
The setting is actually obsolete, but we should probably keep it around for older versions of ClickHouse

### Changelog category (leave one):
- Documentation (changelog entry is not required)

