### PR TITLE
Fixes for s3_plain disk that will allow to attach Wide parts

### DIFF
--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
@@ -147,7 +147,8 @@ std::unique_ptr<AzureObjectStorageSettings> getAzureBlobStorageSettings(const Po
         config.getUInt64(config_prefix + ".max_single_part_upload_size", 100 * 1024 * 1024),
         config.getUInt64(config_prefix + ".min_bytes_for_seek", 1024 * 1024),
         config.getInt(config_prefix + ".max_single_read_retries", 3),
-        config.getInt(config_prefix + ".max_single_download_retries", 3)
+        config.getInt(config_prefix + ".max_single_download_retries", 3),
+        config.getInt(config_prefix + ".list_object_keys_size", 1000)
     );
 }
 

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -149,10 +149,17 @@ void AzureObjectStorage::findAllFiles(const std::string & path, RelativePathsWit
     blobs_list_options.Prefix = path;
 
     auto blobs_list_response = client_ptr->ListBlobs(blobs_list_options);
-    auto blobs_list = blobs_list_response.Blobs;
+    for (;;)
+    {
+        auto blobs_list = blobs_list_response.Blobs;
 
-    for (const auto & blob : blobs_list)
-        children.emplace_back(blob.Name, blob.BlobSize);
+        for (const auto & blob : blobs_list)
+            children.emplace_back(blob.Name, blob.BlobSize);
+
+        if (!blobs_list_response.HasPage())
+            break;
+        blobs_list_response.MoveToNextPage();
+    }
 }
 
 /// Remove file. Throws exception if file doesn't exists or it's a directory.

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -149,6 +149,8 @@ void AzureObjectStorage::findAllFiles(const std::string & path, RelativePathsWit
     blobs_list_options.Prefix = path;
     if (max_keys)
         blobs_list_options.PageSizeHint = max_keys;
+    else
+        blobs_list_options.PageSizeHint = settings.get()->list_object_keys_size;
 
     auto blobs_list_response = client_ptr->ListBlobs(blobs_list_options);
     for (;;)

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
@@ -84,7 +84,7 @@ public:
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         const WriteSettings & write_settings = {}) override;
 
-    void findAllFiles(const std::string & path, RelativePathsWithSize & children) const override;
+    void findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const override;
 
     /// Remove file. Throws exception if file doesn't exists or it's a directory.
     void removeObject(const StoredObject & object) override;

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
@@ -29,11 +29,13 @@ struct AzureObjectStorageSettings
         uint64_t max_single_part_upload_size_,
         uint64_t min_bytes_for_seek_,
         int max_single_read_retries_,
-        int max_single_download_retries_)
+        int max_single_download_retries_,
+        int list_object_keys_size_)
         : max_single_part_upload_size(max_single_part_upload_size_)
         , min_bytes_for_seek(min_bytes_for_seek_)
         , max_single_read_retries(max_single_read_retries_)
         , max_single_download_retries(max_single_download_retries_)
+        , list_object_keys_size(list_object_keys_size_)
     {
     }
 
@@ -41,6 +43,7 @@ struct AzureObjectStorageSettings
     uint64_t min_bytes_for_seek;
     size_t max_single_read_retries;
     size_t max_single_download_retries;
+    int list_object_keys_size;
 };
 
 using AzureClient = Azure::Storage::Blobs::BlobContainerClient;

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -282,9 +282,9 @@ std::unique_ptr<IObjectStorage> CachedObjectStorage::cloneObjectStorage(
     return object_storage->cloneObjectStorage(new_namespace, config, config_prefix, context);
 }
 
-void CachedObjectStorage::findAllFiles(const std::string & path, RelativePathsWithSize & children) const
+void CachedObjectStorage::findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const
 {
-    object_storage->findAllFiles(path, children);
+    object_storage->findAllFiles(path, children, max_keys);
 }
 
 ObjectMetadata CachedObjectStorage::getObjectMetadata(const std::string & path) const

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -72,7 +72,7 @@ public:
         const std::string & config_prefix,
         ContextPtr context) override;
 
-    void findAllFiles(const std::string & path, RelativePathsWithSize & children) const override;
+    void findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const override;
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
 

--- a/src/Disks/ObjectStorages/DiskObjectStorageRemoteMetadataRestoreHelper.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageRemoteMetadataRestoreHelper.cpp
@@ -390,7 +390,7 @@ void DiskObjectStorageRemoteMetadataRestoreHelper::restoreFiles(IObjectStorage *
     };
 
     RelativePathsWithSize children;
-    source_object_storage->findAllFiles(restore_information.source_path, children);
+    source_object_storage->findAllFiles(restore_information.source_path, children, /* max_keys= */ 0);
 
     restore_files(children);
 
@@ -540,7 +540,7 @@ void DiskObjectStorageRemoteMetadataRestoreHelper::restoreFileOperations(IObject
     };
 
     RelativePathsWithSize children;
-    source_object_storage->findAllFiles(restore_information.source_path + "operations/", children);
+    source_object_storage->findAllFiles(restore_information.source_path + "operations/", children, /* max_keys= */ 0);
     restore_file_operations(children);
 
     if (restore_information.detached)

--- a/src/Disks/ObjectStorages/IObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/IObjectStorage.cpp
@@ -14,7 +14,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-void IObjectStorage::findAllFiles(const std::string &, RelativePathsWithSize &) const
+void IObjectStorage::findAllFiles(const std::string &, RelativePathsWithSize &, int) const
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "findAllFiles() is not supported");
 }

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -73,13 +73,17 @@ public:
     ///     find . -type f
     ///
     /// @param children - out files (relative paths) with their sizes.
+    /// @param max_keys - return not more then max_keys children
+    /// NOTE: max_keys is not the same as list_object_keys_size (disk property)
+    /// - if max_keys is set not more then max_keys keys should be returned
+    /// - however list_object_keys_size determine the size of the batch and should return all keys
     ///
     /// NOTE: It makes sense only for real object storages (S3, Azure), since
     /// it is used only for one of the following:
     /// - send_metadata (to restore metadata)
     ///   - see DiskObjectStorage::restoreMetadataIfNeeded()
     /// - MetadataStorageFromPlainObjectStorage - only for s3_plain disk
-    virtual void findAllFiles(const std::string & path, RelativePathsWithSize & children) const;
+    virtual void findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const;
 
     /// Analog of directory content for object storage (object storage does not
     /// have "directory" definition, but it can be emulated with usage of

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -39,8 +39,11 @@ std::filesystem::path MetadataStorageFromPlainObjectStorage::getAbsolutePath(con
 
 bool MetadataStorageFromPlainObjectStorage::exists(const std::string & path) const
 {
-    auto object = StoredObject::create(*object_storage, getAbsolutePath(path));
-    return object_storage->exists(object);
+    RelativePathsWithSize children;
+    /// NOTE: exists() cannot be used here since it works only for existing
+    /// key, and does not work for some intermediate path.
+    object_storage->findAllFiles(getAbsolutePath(path), children, 1);
+    return !children.empty();
 }
 
 bool MetadataStorageFromPlainObjectStorage::isFile(const std::string & path) const

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -66,7 +66,7 @@ bool MetadataStorageFromPlainObjectStorage::isDirectory(const std::string & path
 uint64_t MetadataStorageFromPlainObjectStorage::getFileSize(const String & path) const
 {
     RelativePathsWithSize children;
-    object_storage->findAllFiles(getAbsolutePath(path), children);
+    object_storage->findAllFiles(getAbsolutePath(path), children, 1);
     if (children.empty())
         return 0;
     if (children.size() != 1)

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -88,6 +88,11 @@ std::vector<std::string> MetadataStorageFromPlainObjectStorage::listDirectory(co
         result.push_back(path_size.relative_path);
     for (const auto & directory : directories)
         result.push_back(directory);
+    for (auto & row : result)
+    {
+        chassert(row.starts_with(object_storage_root_path));
+        row.erase(0, object_storage_root_path.size());
+    }
     return result;
 }
 

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -299,7 +299,12 @@ void S3ObjectStorage::getDirectoryContents(const std::string & path,
 
     Aws::S3::Model::ListObjectsV2Request request;
     request.SetBucket(bucket);
-    request.SetPrefix(path);
+    /// NOTE: if you do "ls /foo" instead of "ls /foo/" over S3 with this API
+    /// it will return only "/foo" itself without any underlying nodes.
+    if (path.ends_with("/"))
+        request.SetPrefix(path);
+    else
+        request.SetPrefix(path + "/");
     request.SetMaxKeys(settings_ptr->list_object_keys_size);
     request.SetDelimiter("/");
 

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -105,7 +105,7 @@ public:
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         const WriteSettings & write_settings = {}) override;
 
-    void findAllFiles(const std::string & path, RelativePathsWithSize & children) const override;
+    void findAllFiles(const std::string & path, RelativePathsWithSize & children, int max_keys) const override;
     void getDirectoryContents(const std::string & path,
         RelativePathsWithSize & files,
         std::vector<std::string> & directories) const override;

--- a/tests/integration/test_attach_backup_from_s3_plain/configs/disk_s3.xml
+++ b/tests/integration/test_attach_backup_from_s3_plain/configs/disk_s3.xml
@@ -9,23 +9,38 @@
                 <secret_access_key>minio123</secret_access_key>
                 <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>
             </backup_disk_s3_plain>
-            <attach_disk_s3_plain>
+            <s3_backup_compact>
                 <type>s3_plain</type>
-                <!-- NOTE: /backup/ is a name of BACKUP -->
-                <endpoint>http://minio1:9001/root/data/disks/disk_s3_plain/backup/</endpoint>
+                <!-- NOTE: /backup_compact/ is a name of BACKUP -->
+                <endpoint>http://minio1:9001/root/data/disks/disk_s3_plain/backup_compact/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>minio123</secret_access_key>
                 <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>
-            </attach_disk_s3_plain>
+            </s3_backup_compact>
+            <s3_backup_wide>
+                <type>s3_plain</type>
+                <!-- NOTE: /backup_wide/ is a name of BACKUP -->
+                <endpoint>http://minio1:9001/root/data/disks/disk_s3_plain/backup_wide/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+                <s3_max_single_part_upload_size>33554432</s3_max_single_part_upload_size>
+            </s3_backup_wide>
         </disks>
         <policies>
-            <attach_policy_s3_plain>
+            <s3_backup_compact>
                 <volumes>
                     <main>
-                        <disk>attach_disk_s3_plain</disk>
+                        <disk>s3_backup_compact</disk>
                     </main>
                 </volumes>
-            </attach_policy_s3_plain>
+            </s3_backup_compact>
+            <s3_backup_wide>
+                <volumes>
+                    <main>
+                        <disk>s3_backup_wide</disk>
+                    </main>
+                </volumes>
+            </s3_backup_wide>
         </policies>
     </storage_configuration>
     <backups>

--- a/tests/integration/test_attach_backup_from_s3_plain/test.py
+++ b/tests/integration/test_attach_backup_from_s3_plain/test.py
@@ -21,20 +21,51 @@ def start_cluster():
         cluster.shutdown()
 
 
-def test_attach_backup():
+@pytest.mark.parametrize(
+    "table_name,backup_name,storage_policy,min_bytes_for_wide_part",
+    [
+        pytest.param(
+            "compact", "backup_compact", "s3_backup_compact", int(1e9), id="compact"
+        ),
+        pytest.param("wide", "backup_wide", "s3_backup_wide", int(0), id="wide"),
+    ],
+)
+def test_attach_compact_part(
+    table_name, backup_name, storage_policy, min_bytes_for_wide_part
+):
     node.query(
         f"""
+    -- Catch any errors (NOTE: warnings are ok)
+    set send_logs_level='error';
+
     -- BACKUP writes Ordinary like structure
     set allow_deprecated_database_ordinary=1;
-    create database ordinary engine=Ordinary;
 
-    create table ordinary.test_backup_attach engine=MergeTree() order by tuple() as select * from numbers(100);
+    create database ordinary_db engine=Ordinary;
+
+    create table ordinary_db.{table_name} engine=MergeTree() order by tuple() as select * from numbers(100);
     -- NOTE: name of backup ("backup") is significant.
-    backup table ordinary.test_backup_attach TO Disk('backup_disk_s3_plain', 'backup');
+    backup table ordinary_db.{table_name} TO Disk('backup_disk_s3_plain', '{backup_name}');
 
-    drop table ordinary.test_backup_attach;
-    attach table ordinary.test_backup_attach (number UInt64) engine=MergeTree() order by tuple() settings storage_policy='attach_policy_s3_plain';
+    drop table ordinary_db.{table_name};
+    attach table ordinary_db.{table_name} (number UInt64)
+    engine=MergeTree()
+    order by tuple()
+    settings
+        min_bytes_for_wide_part={min_bytes_for_wide_part},
+        storage_policy='{storage_policy}';
     """
     )
 
-    assert int(node.query("select count() from ordinary.test_backup_attach")) == 100
+    assert int(node.query(f"select count() from ordinary_db.{table_name}")) == 100
+
+    node.query(
+        f"""
+    -- NOTE: be aware not to DROP the table, but DETACH first to keep it in S3.
+    detach table ordinary_db.{table_name};
+
+    -- NOTE: DROP DATABASE cannot be done w/o this due to metadata leftovers
+    set force_remove_data_recursively_on_drop=1;
+    drop database ordinary_db sync;
+    """
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes for s3_plain disk that will allow to attach Wide parts

### Changes
- Fix `S3ObjectStorage::getDirectoryContents()` method
- Remove common prefix in `MetadataStorageFromPlainObjectStorage::listDirectory()`
- Fix `MetadataStorageFromPlainObjectStorage::exists()` by using `IOjbectStorage::findAllFiles()` over `IObjectStorage::exists()`
- Slightly optimize by limiting `max_keys`

Follow-up for: #42628 (cc @vitlibar )