### PR TITLE
Fix macOS M1 builds due to sprintf deprecation

### DIFF
--- a/utils/db-generator/query_db_generator.cpp
+++ b/utils/db-generator/query_db_generator.cpp
@@ -59,7 +59,7 @@ std::string randomDate()
     int32_t month = rng() % 12 + 1;
     int32_t day = rng() % 12 + 1;
     char answer[13];
-    size_t size = sprintf(answer, "'%04u-%02u-%02u'", year, month, day);
+    size_t size = snprintf(answer, sizeof(answer), "'%04u-%02u-%02u'", year, month, day);
     return std::string(answer, size);
 }
 
@@ -72,8 +72,9 @@ std::string randomDatetime()
     int32_t minutes = rng() % 60;
     int32_t seconds = rng() % 60;
     char answer[22];
-    size_t size = sprintf(
+    size_t size = snprintf(
             answer,
+            sizeof(answer),
             "'%04u-%02u-%02u %02u:%02u:%02u'",
             year,
             month,

--- a/utils/zookeeper-adjust-block-numbers-to-parts/main.cpp
+++ b/utils/zookeeper-adjust-block-numbers-to-parts/main.cpp
@@ -179,7 +179,7 @@ void setCurrentBlockNumber(zkutil::ZooKeeper & zk, const std::string & path, Int
             if (number != current_block_number)
             {
                 char suffix[11] = "";
-                size_t size = sprintf(suffix, "%010lld", current_block_number);
+                size_t size = snprintf(suffix, sizeof(suffix), "%010lld", current_block_number);
                 std::string expected_path = block_prefix + std::string(suffix, size);
                 std::cerr << "\t" << path_created << ": Ephemeral node has been created with an unexpected path (expected something like "
                           << expected_path << ")." << std::endl;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix compilation errors due to `sprintf` deprecation in favor of `snprintf` in macOS 13:

```
 error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
                size_t size = sprintf(suffix, "%010lld", current_block_number);
                              ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
```

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
