### PR TITLE
Implement optimize_redundant_functions_in_order_by on top of QueryTree.

### DIFF
--- a/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
+++ b/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
@@ -1,0 +1,121 @@
+#include <Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.h>
+#include <Analyzer/ColumnNode.h>
+#include <Analyzer/FunctionNode.h>
+#include <Analyzer/InDepthQueryTreeVisitor.h>
+#include <Analyzer/QueryNode.h>
+#include <Analyzer/SortNode.h>
+#include <Functions/IFunction.h>
+
+namespace DB
+{
+
+namespace
+{
+
+class OptimizeRedundantFunctionsInOrderByVisitor : public InDepthQueryTreeVisitor<OptimizeRedundantFunctionsInOrderByVisitor>
+{
+
+    struct RedundancyVerdict
+    {
+        bool redundant = true;
+        bool done = false;
+    };
+
+    static constexpr RedundancyVerdict makeNonRedundant() noexcept { return { .redundant = false, .done = true }; }
+
+    std::unordered_set<String> existing_keys;
+
+    RedundancyVerdict isRedundantExpression(FunctionNode * function)
+    {
+        if (function->getArguments().getNodes().empty())
+            return makeNonRedundant();
+
+        if (function->getFunction()->isDeterministicInScopeOfQuery())
+            return makeNonRedundant();
+
+        // TODO: handle constants here
+        for (auto & arg : function->getArguments().getNodes())
+        {
+            switch (arg->getNodeType())
+            {
+                case QueryTreeNodeType::FUNCTION:
+                {
+                    auto subresult = isRedundantExpression(arg->as<FunctionNode>());
+                    if (subresult.done)
+                        return subresult;
+                    break;
+                }
+                case QueryTreeNodeType::COLUMN:
+                {
+                    auto * column = arg->as<ColumnNode>();
+                    if (!existing_keys.contains(column->getColumnName()))
+                        return makeNonRedundant();
+                    break;
+                }
+                default:
+                    return makeNonRedundant();
+            }
+        }
+
+        return {};
+    }
+
+public:
+    bool needChildVisit(QueryTreeNodePtr & node, QueryTreeNodePtr & /*parent*/)
+    {
+        if (node->as<FunctionNode>())
+            return false;
+        return true;
+    }
+
+    void visitImpl(QueryTreeNodePtr & node)
+    {
+        auto * query = node->as<QueryNode>();
+        if (!query)
+            return;
+
+        if (!query->hasOrderBy())
+            return;
+
+        auto & order_by = query->getOrderBy();
+        for (auto & elem : order_by.getNodes())
+        {
+            auto * order_by_elem = elem->as<SortNode>();
+            if (order_by_elem->withFill())
+                return;
+        }
+
+        QueryTreeNodes new_order_by;
+        new_order_by.reserve(order_by.getNodes().size());
+
+        for (auto & elem : order_by.getNodes())
+        {
+            auto * order_by_elem = elem->as<SortNode>();
+            if (auto * expr = order_by_elem->getExpression()->as<FunctionNode>())
+            {
+                if (isRedundantExpression(expr).redundant)
+                    continue;
+            }
+            else
+            {
+                auto * column = elem->as<ColumnNode>();
+                existing_keys.insert(column->getColumnName());
+            }
+
+            new_order_by.push_back(elem);
+        }
+        existing_keys.clear();
+
+        if (new_order_by.size() < order_by.getNodes().size())
+            order_by.getNodes() = std::move(new_order_by);
+    }
+};
+
+}
+
+void OptimizeRedundantFunctionsInOrderByPass::run(QueryTreeNodePtr query_tree_node, ContextPtr /*context*/)
+{
+    OptimizeRedundantFunctionsInOrderByVisitor().visit(query_tree_node);
+}
+
+}

--- a/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
+++ b/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
@@ -30,7 +30,7 @@ class OptimizeRedundantFunctionsInOrderByVisitor : public InDepthQueryTreeVisito
         if (function->getArguments().getNodes().empty())
             return makeNonRedundant();
 
-        if (function->getFunction()->isDeterministicInScopeOfQuery())
+        if (!function->getFunction()->isDeterministicInScopeOfQuery())
             return makeNonRedundant();
 
         // TODO: handle constants here
@@ -90,13 +90,13 @@ public:
 
         for (auto & elem : order_by.getNodes())
         {
-            auto * order_by_elem = elem->as<SortNode>();
-            if (auto * expr = order_by_elem->getExpression()->as<FunctionNode>())
+            auto & order_by_expr = elem->as<SortNode>()->getExpression();
+            if (auto * expr = order_by_expr->as<FunctionNode>())
             {
                 if (isRedundantExpression(expr).redundant)
                     continue;
             }
-            else if (auto * column = elem->as<ColumnNode>())
+            else if (auto * column = order_by_expr->as<ColumnNode>())
             {
                 existing_keys.insert(column->getColumnName());
             }

--- a/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
+++ b/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
@@ -96,9 +96,8 @@ public:
                 if (isRedundantExpression(expr).redundant)
                     continue;
             }
-            else
+            else if (auto * column = elem->as<ColumnNode>())
             {
-                auto * column = elem->as<ColumnNode>();
                 existing_keys.insert(column->getColumnName());
             }
 

--- a/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
+++ b/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
@@ -1,7 +1,7 @@
-#include <string_view>
 #include <Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.h>
 #include <Analyzer/ColumnNode.h>
 #include <Analyzer/FunctionNode.h>
+#include <Analyzer/HashUtils.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/QueryNode.h>
 #include <Analyzer/SortNode.h>
@@ -56,8 +56,7 @@ public:
                 }
                 case QueryTreeNodeType::COLUMN:
                 {
-                    auto * column = order_by_expr->as<ColumnNode>();
-                    existing_keys.insert(column->getColumnName());
+                    existing_keys.insert(order_by_expr);
                     break;
                 }
                 default:
@@ -73,7 +72,7 @@ public:
     }
 
 private:
-    std::unordered_set<std::string_view> existing_keys;
+    QueryTreeNodePtrWithHashSet existing_keys;
 
     bool isRedundantExpression(QueryTreeNodePtr function)
     {
@@ -103,8 +102,7 @@ private:
                 }
                 case QueryTreeNodeType::COLUMN:
                 {
-                    auto * column = node->as<ColumnNode>();
-                    if (!existing_keys.contains(column->getColumnName()))
+                    if (!existing_keys.contains(node))
                         return false;
                     break;
                 }

--- a/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
+++ b/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.cpp
@@ -16,7 +16,7 @@ namespace
 class OptimizeRedundantFunctionsInOrderByVisitor : public InDepthQueryTreeVisitor<OptimizeRedundantFunctionsInOrderByVisitor>
 {
 public:
-    bool needChildVisit(QueryTreeNodePtr & node, QueryTreeNodePtr & /*parent*/)
+    static bool needChildVisit(QueryTreeNodePtr & node, QueryTreeNodePtr & /*parent*/)
     {
         if (node->as<FunctionNode>())
             return false;

--- a/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.h
+++ b/src/Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Analyzer/IQueryTreePass.h>
+
+namespace DB
+{
+
+/** If ORDER BY has argument x followed by f(x) transforms it to ORDER BY x.
+  * Optimize ORDER BY x, y, f(x), g(x, y), f(h(x)), t(f(x), g(x)) into ORDER BY x, y
+  * in case if f(), g(), h(), t() are deterministic (in scope of query).
+  * Don't optimize ORDER BY f(x), g(x), x even if f(x) is bijection for x or g(x).
+  */
+class OptimizeRedundantFunctionsInOrderByPass final : public IQueryTreePass
+{
+public:
+    String getName() override { return "OptimizeRedundantFunctionsInOrderBy"; }
+
+    String getDescription() override { return "If ORDER BY has argument x followed by f(x) transforms it to ORDER BY x."; }
+
+    void run(QueryTreeNodePtr query_tree_node, ContextPtr context) override;
+};
+
+}

--- a/src/Analyzer/QueryTreePassManager.cpp
+++ b/src/Analyzer/QueryTreePassManager.cpp
@@ -15,6 +15,7 @@
 #include <Analyzer/Passes/OrderByLimitByDuplicateEliminationPass.h>
 #include <Analyzer/Passes/FuseFunctionsPass.h>
 #include <Analyzer/Passes/IfTransformStringsToEnumPass.h>
+#include <Analyzer/Passes/OptimizeRedundantFunctionsInOrderByPass.h>
 
 #include <IO/WriteHelpers.h>
 #include <IO/Operators.h>
@@ -91,7 +92,6 @@ public:
   * TODO: Support setting optimize_move_functions_out_of_any.
   * TODO: Support setting optimize_aggregators_of_group_by_keys.
   * TODO: Support setting optimize_duplicate_order_by_and_distinct.
-  * TODO: Support setting optimize_redundant_functions_in_order_by.
   * TODO: Support setting optimize_monotonous_functions_in_order_by.
   * TODO: Support settings.optimize_or_like_chain.
   * TODO: Add optimizations based on function semantics. Example: SELECT * FROM test_table WHERE id != id. (id is not nullable column).
@@ -202,6 +202,9 @@ void addQueryTreePasses(QueryTreePassManager & manager)
 
     if (settings.optimize_if_chain_to_multiif)
         manager.addPass(std::make_unique<IfChainToMultiIfPass>());
+
+    if (settings.optimize_redundant_functions_in_order_by)
+        manager.addPass(std::make_unique<OptimizeRedundantFunctionsInOrderByPass>());
 
     manager.addPass(std::make_unique<OrderByTupleEliminationPass>());
     manager.addPass(std::make_unique<OrderByLimitByDuplicateEliminationPass>());

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
@@ -1,6 +1,15 @@
 [0,1,2]
 [0,1,2]
 [0,1,2]
+[0,1,2]
+[0,1,2]
+[0,1,2]
+0	0	0	0
+0	1	1	1
+2	2	2	2
+3	3	3	3
+4	0		0
+5	0		0
 0	0	0	0
 0	1	1	1
 2	2	2	2
@@ -15,6 +24,14 @@
 1	1
 2	2
 3	3
+0	0
+1	1
+2	2
+3	3
+0	0
+1	1
+2	2
+3	3
 SELECT groupArray(x)
 FROM
 (
@@ -22,6 +39,32 @@ FROM
     FROM numbers(3)
     ORDER BY x ASC
 )
+QUERY id: 0
+  PROJECTION COLUMNS
+    groupArray(x) Array(UInt64)
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: groupArray, function_type: aggregate, result_type: Array(UInt64)
+        ARGUMENTS
+          LIST id: 3, nodes: 1
+            COLUMN id: 4, column_name: x, result_type: UInt64, source_id: 5
+  JOIN TREE
+    QUERY id: 5, is_subquery: 1
+      PROJECTION COLUMNS
+        x UInt64
+      PROJECTION
+        LIST id: 6, nodes: 1
+          COLUMN id: 7, column_name: number, result_type: UInt64, source_id: 8
+      JOIN TREE
+        TABLE_FUNCTION id: 8, table_function_name: numbers
+          ARGUMENTS
+            LIST id: 9, nodes: 1
+              CONSTANT id: 10, constant_value: UInt64_3, constant_value_type: UInt8
+      ORDER BY
+        LIST id: 11, nodes: 1
+          SORT id: 12, sort_direction: ASCENDING, with_fill: 0
+            EXPRESSION
+              COLUMN id: 7, column_name: number, result_type: UInt64, source_id: 8
 SELECT groupArray(x)
 FROM
 (
@@ -29,6 +72,32 @@ FROM
     FROM numbers(3)
     ORDER BY x ASC
 )
+QUERY id: 0
+  PROJECTION COLUMNS
+    groupArray(x) Array(UInt64)
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: groupArray, function_type: aggregate, result_type: Array(UInt64)
+        ARGUMENTS
+          LIST id: 3, nodes: 1
+            COLUMN id: 4, column_name: x, result_type: UInt64, source_id: 5
+  JOIN TREE
+    QUERY id: 5, is_subquery: 1
+      PROJECTION COLUMNS
+        x UInt64
+      PROJECTION
+        LIST id: 6, nodes: 1
+          COLUMN id: 7, column_name: number, result_type: UInt64, source_id: 8
+      JOIN TREE
+        TABLE_FUNCTION id: 8, table_function_name: numbers
+          ARGUMENTS
+            LIST id: 9, nodes: 1
+              CONSTANT id: 10, constant_value: UInt64_3, constant_value_type: UInt8
+      ORDER BY
+        LIST id: 11, nodes: 1
+          SORT id: 12, sort_direction: ASCENDING, with_fill: 0
+            EXPRESSION
+              COLUMN id: 7, column_name: number, result_type: UInt64, source_id: 8
 SELECT groupArray(x)
 FROM
 (
@@ -38,6 +107,38 @@ FROM
         exp(x) ASC,
         x ASC
 )
+QUERY id: 0
+  PROJECTION COLUMNS
+    groupArray(x) Array(UInt64)
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: groupArray, function_type: aggregate, result_type: Array(UInt64)
+        ARGUMENTS
+          LIST id: 3, nodes: 1
+            COLUMN id: 4, column_name: x, result_type: UInt64, source_id: 5
+  JOIN TREE
+    QUERY id: 5, is_subquery: 1
+      PROJECTION COLUMNS
+        x UInt64
+      PROJECTION
+        LIST id: 6, nodes: 1
+          COLUMN id: 7, column_name: number, result_type: UInt64, source_id: 8
+      JOIN TREE
+        TABLE_FUNCTION id: 8, table_function_name: numbers
+          ARGUMENTS
+            LIST id: 9, nodes: 1
+              CONSTANT id: 10, constant_value: UInt64_3, constant_value_type: UInt8
+      ORDER BY
+        LIST id: 11, nodes: 2
+          SORT id: 12, sort_direction: ASCENDING, with_fill: 0
+            EXPRESSION
+              FUNCTION id: 13, function_name: exp, function_type: ordinary, result_type: Float64
+                ARGUMENTS
+                  LIST id: 14, nodes: 1
+                    COLUMN id: 7, column_name: number, result_type: UInt64, source_id: 8
+          SORT id: 15, sort_direction: ASCENDING, with_fill: 0
+            EXPRESSION
+              COLUMN id: 7, column_name: number, result_type: UInt64, source_id: 8
 SELECT
     key,
     a,
@@ -52,6 +153,53 @@ ALL FULL OUTER JOIN test AS t USING (key)
 ORDER BY
     key ASC,
     t.key ASC
+QUERY id: 0
+  PROJECTION COLUMNS
+    key UInt64
+    a UInt8
+    b String
+    c Float64
+  PROJECTION
+    LIST id: 1, nodes: 4
+      COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+      COLUMN id: 4, column_name: a, result_type: UInt8, source_id: 5
+      COLUMN id: 6, column_name: b, result_type: String, source_id: 5
+      COLUMN id: 7, column_name: c, result_type: Float64, source_id: 5
+  JOIN TREE
+    JOIN id: 8, strictness: ALL, kind: FULL
+      LEFT TABLE EXPRESSION
+        QUERY id: 3, alias: s, is_subquery: 1
+          PROJECTION COLUMNS
+            key UInt64
+          PROJECTION
+            LIST id: 9, nodes: 1
+              FUNCTION id: 10, function_name: plus, function_type: ordinary, result_type: UInt64
+                ARGUMENTS
+                  LIST id: 11, nodes: 2
+                    COLUMN id: 12, column_name: number, result_type: UInt64, source_id: 13
+                    CONSTANT id: 14, constant_value: UInt64_2, constant_value_type: UInt8
+          JOIN TREE
+            TABLE_FUNCTION id: 13, table_function_name: numbers
+              ARGUMENTS
+                LIST id: 15, nodes: 1
+                  CONSTANT id: 16, constant_value: UInt64_4, constant_value_type: UInt8
+      RIGHT TABLE EXPRESSION
+        TABLE id: 5, alias: t, table_name: default.test
+      JOIN EXPRESSION
+        LIST id: 17, nodes: 1
+          COLUMN id: 18, column_name: key, result_type: UInt64, source_id: 8
+            EXPRESSION
+              LIST id: 19, nodes: 2
+                COLUMN id: 20, column_name: key, result_type: UInt64, source_id: 3
+                COLUMN id: 21, column_name: key, result_type: UInt64, source_id: 5
+  ORDER BY
+    LIST id: 22, nodes: 2
+      SORT id: 23, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 24, column_name: key, result_type: UInt64, source_id: 3
+      SORT id: 25, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 26, column_name: key, result_type: UInt64, source_id: 5
 SELECT
     key,
     a
@@ -59,6 +207,24 @@ FROM test
 ORDER BY
     key ASC,
     a ASC
+QUERY id: 0
+  PROJECTION COLUMNS
+    key UInt64
+    a UInt8
+  PROJECTION
+    LIST id: 1, nodes: 2
+      COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+      COLUMN id: 4, column_name: a, result_type: UInt8, source_id: 3
+  JOIN TREE
+    TABLE id: 3, table_name: default.test
+  ORDER BY
+    LIST id: 5, nodes: 2
+      SORT id: 6, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+      SORT id: 7, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 4, column_name: a, result_type: UInt8, source_id: 3
 SELECT
     key,
     a
@@ -66,6 +232,31 @@ FROM test
 ORDER BY
     key ASC,
     exp(key + a) ASC
+QUERY id: 0
+  PROJECTION COLUMNS
+    key UInt64
+    a UInt8
+  PROJECTION
+    LIST id: 1, nodes: 2
+      COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+      COLUMN id: 4, column_name: a, result_type: UInt8, source_id: 3
+  JOIN TREE
+    TABLE id: 3, table_name: default.test
+  ORDER BY
+    LIST id: 5, nodes: 2
+      SORT id: 6, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+      SORT id: 7, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          FUNCTION id: 8, function_name: exp, function_type: ordinary, result_type: Float64
+            ARGUMENTS
+              LIST id: 9, nodes: 1
+                FUNCTION id: 10, function_name: plus, function_type: ordinary, result_type: UInt64
+                  ARGUMENTS
+                    LIST id: 11, nodes: 2
+                      COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+                      COLUMN id: 4, column_name: a, result_type: UInt8, source_id: 3
 [0,1,2]
 [0,1,2]
 [0,1,2]

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
@@ -190,16 +190,16 @@ QUERY id: 0
           COLUMN id: 18, column_name: key, result_type: UInt64, source_id: 8
             EXPRESSION
               LIST id: 19, nodes: 2
-                COLUMN id: 20, column_name: key, result_type: UInt64, source_id: 3
-                COLUMN id: 21, column_name: key, result_type: UInt64, source_id: 5
+                COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+                COLUMN id: 20, column_name: key, result_type: UInt64, source_id: 5
   ORDER BY
-    LIST id: 22, nodes: 2
-      SORT id: 23, sort_direction: ASCENDING, with_fill: 0
+    LIST id: 21, nodes: 2
+      SORT id: 22, sort_direction: ASCENDING, with_fill: 0
         EXPRESSION
-          COLUMN id: 24, column_name: key, result_type: UInt64, source_id: 3
-      SORT id: 25, sort_direction: ASCENDING, with_fill: 0
+          COLUMN id: 23, column_name: key, result_type: UInt64, source_id: 3
+      SORT id: 24, sort_direction: ASCENDING, with_fill: 0
         EXPRESSION
-          COLUMN id: 26, column_name: key, result_type: UInt64, source_id: 5
+          COLUMN id: 25, column_name: key, result_type: UInt64, source_id: 5
 SELECT
     key,
     a
@@ -257,6 +257,28 @@ QUERY id: 0
                     LIST id: 11, nodes: 2
                       COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
                       COLUMN id: 4, column_name: a, result_type: UInt8, source_id: 3
+QUERY id: 0
+  PROJECTION COLUMNS
+    key UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+  JOIN TREE
+    TABLE id: 3, table_name: default.test
+  GROUP BY
+    LIST id: 4, nodes: 1
+      COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+  ORDER BY
+    LIST id: 5, nodes: 2
+      SORT id: 6, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          FUNCTION id: 7, function_name: avg, function_type: aggregate, result_type: Float64
+            ARGUMENTS
+              LIST id: 8, nodes: 1
+                COLUMN id: 9, column_name: a, result_type: UInt8, source_id: 3
+      SORT id: 10, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
 [0,1,2]
 [0,1,2]
 [0,1,2]

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.reference
@@ -279,6 +279,34 @@ QUERY id: 0
       SORT id: 10, sort_direction: ASCENDING, with_fill: 0
         EXPRESSION
           COLUMN id: 2, column_name: key, result_type: UInt64, source_id: 3
+QUERY id: 0
+  PROJECTION COLUMNS
+    t1.id UInt64
+    t2.id UInt64
+  PROJECTION
+    LIST id: 1, nodes: 2
+      COLUMN id: 2, column_name: id, result_type: UInt64, source_id: 3
+      COLUMN id: 4, column_name: id, result_type: UInt64, source_id: 5
+  JOIN TREE
+    JOIN id: 6, strictness: ALL, kind: INNER
+      LEFT TABLE EXPRESSION
+        TABLE id: 3, table_name: default.t1
+      RIGHT TABLE EXPRESSION
+        TABLE id: 5, table_name: default.t2
+      JOIN EXPRESSION
+        FUNCTION id: 7, function_name: equals, function_type: ordinary, result_type: UInt8
+          ARGUMENTS
+            LIST id: 8, nodes: 2
+              COLUMN id: 9, column_name: id, result_type: UInt64, source_id: 3
+              COLUMN id: 10, column_name: id, result_type: UInt64, source_id: 5
+  ORDER BY
+    LIST id: 11, nodes: 2
+      SORT id: 12, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 13, column_name: id, result_type: UInt64, source_id: 3
+      SORT id: 14, sort_direction: ASCENDING, with_fill: 0
+        EXPRESSION
+          COLUMN id: 15, column_name: id, result_type: UInt64, source_id: 5
 [0,1,2]
 [0,1,2]
 [0,1,2]

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
@@ -6,17 +6,29 @@ INSERT INTO test SELECT number, number, toString(number), number from numbers(4)
 set optimize_redundant_functions_in_order_by = 1;
 
 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x)) SETTINGS allow_experimental_analyzer=1;
 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(exp(x)));
+SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(exp(x))) SETTINGS allow_experimental_analyzer=1;
 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
+SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x) SETTINGS allow_experimental_analyzer=1;
 SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN test t USING(key) ORDER BY s.key, t.key;
+SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN test t USING(key) ORDER BY s.key, t.key SETTINGS allow_experimental_analyzer=1;
 SELECT key, a FROM test ORDER BY key, a, exp(key + a);
+SELECT key, a FROM test ORDER BY key, a, exp(key + a) SETTINGS allow_experimental_analyzer=1;
 SELECT key, a FROM test ORDER BY key, exp(key + a);
+SELECT key, a FROM test ORDER BY key, exp(key + a) SETTINGS allow_experimental_analyzer=1;
 EXPLAIN SYNTAX SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
+EXPLAIN QUERY TREE run_passes=1 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
 EXPLAIN SYNTAX SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(exp(x)));
+EXPLAIN QUERY TREE run_passes=1 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(exp(x)));
 EXPLAIN SYNTAX SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
+EXPLAIN QUERY TREE run_passes=1 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY exp(x), x);
 EXPLAIN SYNTAX SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN test t USING(key) ORDER BY s.key, t.key;
+EXPLAIN QUERY TREE run_passes=1 SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL JOIN test t USING(key) ORDER BY s.key, t.key;
 EXPLAIN SYNTAX SELECT key, a FROM test ORDER BY key, a, exp(key + a);
+EXPLAIN QUERY TREE run_passes=1 SELECT key, a FROM test ORDER BY key, a, exp(key + a);
 EXPLAIN SYNTAX SELECT key, a FROM test ORDER BY key, exp(key + a);
+EXPLAIN QUERY TREE run_passes=1 SELECT key, a FROM test ORDER BY key, exp(key + a);
 
 set optimize_redundant_functions_in_order_by = 0;
 

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
@@ -29,6 +29,7 @@ EXPLAIN SYNTAX SELECT key, a FROM test ORDER BY key, a, exp(key + a);
 EXPLAIN QUERY TREE run_passes=1 SELECT key, a FROM test ORDER BY key, a, exp(key + a);
 EXPLAIN SYNTAX SELECT key, a FROM test ORDER BY key, exp(key + a);
 EXPLAIN QUERY TREE run_passes=1 SELECT key, a FROM test ORDER BY key, exp(key + a);
+EXPLAIN QUERY TREE run_passes=1 SELECT key FROM test GROUP BY key ORDER BY avg(a), key;
 
 set optimize_redundant_functions_in_order_by = 0;
 

--- a/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
+++ b/tests/queries/0_stateless/01323_redundant_functions_in_order_by.sql
@@ -31,6 +31,13 @@ EXPLAIN SYNTAX SELECT key, a FROM test ORDER BY key, exp(key + a);
 EXPLAIN QUERY TREE run_passes=1 SELECT key, a FROM test ORDER BY key, exp(key + a);
 EXPLAIN QUERY TREE run_passes=1 SELECT key FROM test GROUP BY key ORDER BY avg(a), key;
 
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+CREATE TABLE t1 (id UInt64) ENGINE = MergeTree() ORDER BY id;
+CREATE TABLE t2 (id UInt64) ENGINE = MergeTree() ORDER BY id;
+
+EXPLAIN QUERY TREE run_passes=1 SELECT * FROM t1 INNER JOIN t2 ON t1.id = t2.id ORDER BY t1.id, t2.id;
+
 set optimize_redundant_functions_in_order_by = 0;
 
 SELECT groupArray(x) from (SELECT number as x FROM numbers(3) ORDER BY x, exp(x));
@@ -46,4 +53,6 @@ EXPLAIN SYNTAX SELECT * FROM (SELECT number + 2 AS key FROM numbers(4)) s FULL J
 EXPLAIN SYNTAX SELECT key, a FROM test ORDER BY key, a, exp(key + a);
 EXPLAIN SYNTAX SELECT key, a FROM test ORDER BY key, exp(key + a);
 
+DROP TABLE t1;
+DROP TABLE t2;
 DROP TABLE test;


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Implement `optimize_redundant_functions_in_order_by` on top of QueryTree. Part of #42648.