### PR TITLE
Fix a bug in CAST function parser

### DIFF
--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1197,6 +1197,9 @@ public:
                 if (!mergeElement())
                     return false;
 
+                if (elements.size() != 2)
+                    return false;
+
                 elements = {makeASTFunction("CAST", elements[0], elements[1])};
                 finished = true;
                 return true;
@@ -1406,7 +1409,7 @@ public:
 protected:
     bool getResultImpl(ASTPtr & node) override
     {
-        if (state == 2)
+        if (state == 2 && elements.size() == 2)
             std::swap(elements[1], elements[0]);
 
         node = makeASTFunction("position", std::move(elements));

--- a/tests/queries/0_stateless/02476_fix_cast_parser_bug.sql
+++ b/tests/queries/0_stateless/02476_fix_cast_parser_bug.sql
@@ -1,0 +1,1 @@
+SELECT CAST(a, b -> c) ++; -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `AddressSanitizer: container-overflow` under ASAN build.
