### PR TITLE
Fix old bug to remove `refs/head` from ref name

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -87,7 +87,7 @@ class PRInfo:
         self.body = ""
         self.diff_urls = []
         self.release_pr = 0
-        ref = github_event.get("ref", "refs/head/master")
+        ref = github_event.get("ref", "refs/heads/master")
         if ref and ref.startswith("refs/heads/"):
             ref = ref[11:]
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the wrong default ref. Looks like it's related only to scheduled events.