### PR TITLE
Add debug information to nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,9 @@ env:
   workflow_dispatch:
 
 jobs:
+  Debug:
+    # The task for having a preserved ENV and event.json for later investigation
+    uses: ./.github/workflows/debug.yml
   DockerHubPushAarch64:
     runs-on: [self-hosted, style-checker-aarch64]
     steps:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a debug step to nightly builds