### PR TITLE
Add `on: workflow_call` to debug CI

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -2,7 +2,7 @@
 name: Debug
 
 'on':
-  [push, pull_request, release, workflow_dispatch]
+  [push, pull_request, release, workflow_dispatch, workflow_call]
 
 jobs:
   DebugInfo:

--- a/docker/test/style/Dockerfile
+++ b/docker/test/style/Dockerfile
@@ -1,7 +1,7 @@
 # docker build -t clickhouse/style-test .
 FROM ubuntu:20.04
-ARG ACT_VERSION=0.2.25
-ARG ACTIONLINT_VERSION=1.6.8
+ARG ACT_VERSION=0.2.33
+ARG ACTIONLINT_VERSION=1.6.22
 
 # ARG for quick switch to a given ubuntu mirror
 ARG apt_archive="http://archive.ubuntu.com"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Following up on #42997, updated the GitHub actions linters