### PR TITLE
Implement LIKE with vectorscan

### DIFF
--- a/src/Functions/CountSubstringsImpl.h
+++ b/src/Functions/CountSubstringsImpl.h
@@ -36,7 +36,8 @@ struct CountSubstringsImpl
         const ColumnString::Offsets & haystack_offsets,
         const std::string & needle,
         const ColumnPtr & start_pos,
-        PaddedPODArray<UInt64> & res)
+        PaddedPODArray<UInt64> & res,
+        bool /*allow_hyperscan*/)
     {
         const UInt8 * const begin = haystack_data.data();
         const UInt8 * const end = haystack_data.data() + haystack_data.size();
@@ -138,7 +139,8 @@ struct CountSubstringsImpl
         const ColumnString::Chars & needle_data,
         const ColumnString::Offsets & needle_offsets,
         const ColumnPtr & start_pos,
-        PaddedPODArray<UInt64> & res)
+        PaddedPODArray<UInt64> & res,
+        bool /*allow_hyperscan*/)
     {
         ColumnString::Offset prev_haystack_offset = 0;
         ColumnString::Offset prev_needle_offset = 0;
@@ -191,7 +193,8 @@ struct CountSubstringsImpl
         const ColumnString::Chars & needle_data,
         const ColumnString::Offsets & needle_offsets,
         const ColumnPtr & start_pos,
-        PaddedPODArray<UInt64> & res)
+        PaddedPODArray<UInt64> & res,
+        bool /*allow_hyperscan*/)
     {
         /// NOTE You could use haystack indexing. But this is a rare case.
 

--- a/src/Functions/FunctionsStringSearch.h
+++ b/src/Functions/FunctionsStringSearch.h
@@ -91,23 +91,30 @@ public:
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
         if (arguments.size() < 2 || 3 < arguments.size())
-            throw Exception("Number of arguments for function " + getName() + " doesn't match: passed "
-                + toString(arguments.size()) + ", should be 2 or 3.",
-                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
+            throw Exception(
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Number of arguments for function {} doesn't match: passed {}, should be 2 or 3.",
+                getName(), arguments.size());
 
         if (!isStringOrFixedString(arguments[0]))
             throw Exception(
-                "Illegal type " + arguments[0]->getName() + " of argument of function " + getName(), ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of argument of function {}",
+                arguments[0]->getName(), getName());
 
         if (!isString(arguments[1]))
             throw Exception(
-                "Illegal type " + arguments[1]->getName() + " of argument of function " + getName(), ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of argument of function {}",
+                arguments[1]->getName(), getName());
 
         if (arguments.size() >= 3)
         {
             if (!isUnsignedInteger(arguments[2]))
                 throw Exception(
-                    "Illegal type " + arguments[2]->getName() + " of argument of function " + getName(), ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT);
+                    ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                    "Illegal type {} of argument of function {}",
+                    arguments[2]->getName(), getName());
         }
 
         return std::make_shared<DataTypeNumber<typename Impl::ResultType>>();
@@ -196,9 +203,11 @@ public:
                 vec_res);
         else
             throw Exception(
-                "Illegal columns " + arguments[0].column->getName() + " and "
-                    + arguments[1].column->getName() + " of arguments of function " + getName(),
-                ErrorCodes::ILLEGAL_COLUMN);
+                ErrorCodes::ILLEGAL_COLUMN,
+                "Illegal columns {} and {} of arguments of function {}",
+                arguments[0].column->getName(),
+                arguments[1].column->getName(),
+                getName());
 
         return col_res;
     }

--- a/src/Functions/FunctionsStringSearch.h
+++ b/src/Functions/FunctionsStringSearch.h
@@ -66,7 +66,17 @@ class FunctionsStringSearch : public IFunction
 {
 public:
     static constexpr auto name = Impl::name;
-    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionsStringSearch>(); }
+    const bool allow_hyperscan;
+
+    static FunctionPtr create(ContextPtr context)
+    {
+        const auto & settings = context->getSettingsRef();
+        return std::make_shared<FunctionsStringSearch>(settings.allow_hyperscan);
+    }
+
+    explicit FunctionsStringSearch(bool allow_hyperscan_)
+        : allow_hyperscan(allow_hyperscan_)
+    {}
 
     String getName() const override { return name; }
 
@@ -172,14 +182,16 @@ public:
                 col_needle_vector->getChars(),
                 col_needle_vector->getOffsets(),
                 column_start_pos,
-                vec_res);
+                vec_res,
+                allow_hyperscan);
         else if (col_haystack_vector && col_needle_const)
             Impl::vectorConstant(
                 col_haystack_vector->getChars(),
                 col_haystack_vector->getOffsets(),
                 col_needle_const->getValue<String>(),
                 column_start_pos,
-                vec_res);
+                vec_res,
+                allow_hyperscan);
         else if (col_haystack_vector_fixed && col_needle_vector)
             Impl::vectorFixedVector(
                 col_haystack_vector_fixed->getChars(),
@@ -187,20 +199,23 @@ public:
                 col_needle_vector->getChars(),
                 col_needle_vector->getOffsets(),
                 column_start_pos,
-                vec_res);
+                vec_res,
+                allow_hyperscan);
         else if (col_haystack_vector_fixed && col_needle_const)
             Impl::vectorFixedConstant(
                 col_haystack_vector_fixed->getChars(),
                 col_haystack_vector_fixed->getN(),
                 col_needle_const->getValue<String>(),
-                vec_res);
+                vec_res,
+                allow_hyperscan);
         else if (col_haystack_const && col_needle_vector)
             Impl::constantVector(
                 col_haystack_const->getValue<String>(),
                 col_needle_vector->getChars(),
                 col_needle_vector->getOffsets(),
                 column_start_pos,
-                vec_res);
+                vec_res,
+                allow_hyperscan);
         else
             throw Exception(
                 ErrorCodes::ILLEGAL_COLUMN,

--- a/src/Functions/FunctionsVisitParam.h
+++ b/src/Functions/FunctionsVisitParam.h
@@ -91,7 +91,8 @@ struct ExtractParamImpl
         const ColumnString::Offsets & haystack_offsets,
         std::string needle,
         const ColumnPtr & start_pos,
-        PaddedPODArray<ResultType> & res)
+        PaddedPODArray<ResultType> & res,
+        bool /*allow_hyperscan*/)
     {
         if (start_pos != nullptr)
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function '{}' doesn't support start_pos argument", name);

--- a/src/Functions/HasTokenImpl.h
+++ b/src/Functions/HasTokenImpl.h
@@ -31,7 +31,8 @@ struct HasTokenImpl
         const ColumnString::Offsets & haystack_offsets,
         const std::string & pattern,
         const ColumnPtr & start_pos,
-        PaddedPODArray<UInt8> & res)
+        PaddedPODArray<UInt8> & res,
+        bool /*allow_hyperscan*/)
     {
         if (start_pos != nullptr)
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function '{}' does not support start_pos argument", name);

--- a/src/Functions/MatchImpl.h
+++ b/src/Functions/MatchImpl.h
@@ -25,7 +25,7 @@ namespace impl
 /// Is the [I]LIKE expression reduced to finding a substring in a string?
 inline bool likePatternIsSubstring(std::string_view pattern, String & res)
 {
-    if (pattern.size() < 2 || pattern.front() != '%' || pattern.back() != '%')
+    if (pattern.size() < 2 || !pattern.starts_with('%') || !pattern.ends_with('%'))
         return false;
 
     res.clear();
@@ -101,9 +101,7 @@ struct MatchImpl
     static constexpr bool case_insensitive = (case_ == MatchTraits::Case::Insensitive);
     static constexpr bool negate = (result_ == MatchTraits::Result::Negate);
 
-    using Searcher = std::conditional_t<case_insensitive,
-          VolnitskyCaseInsensitiveUTF8,
-          VolnitskyUTF8>;
+    using Searcher = std::conditional_t<case_insensitive, VolnitskyCaseInsensitiveUTF8, VolnitskyUTF8>;
 
     static void vectorConstant(
         const ColumnString::Chars & haystack_data,
@@ -115,13 +113,12 @@ struct MatchImpl
         const size_t haystack_size = haystack_offsets.size();
 
         assert(haystack_size == res.size());
-
         assert(start_pos_ == nullptr);
 
         if (haystack_offsets.empty())
             return;
 
-        /// A simple case where the [I]LIKE expression reduces to finding a substring in a string
+        /// Special case that the [I]LIKE expression reduces to finding a substring in a string
         String strstr_pattern;
         if (is_like && impl::likePatternIsSubstring(needle, strstr_pattern))
         {
@@ -158,105 +155,101 @@ struct MatchImpl
             /// Tail, in which there can be no substring.
             if (i < res.size())
                 memset(&res[i], negate, (res.size() - i) * sizeof(res[0]));
+
+            return;
+        }
+
+        const auto & regexp = Regexps::Regexp(Regexps::createRegexp<is_like, /*no_capture*/ true, case_insensitive>(needle));
+
+        String required_substring;
+        bool is_trivial;
+        bool required_substring_is_prefix; /// for `anchored` execution of the regexp.
+
+        regexp.getAnalyzeResult(required_substring, is_trivial, required_substring_is_prefix);
+
+        if (required_substring.empty())
+        {
+            if (!regexp.getRE2()) /// An empty regexp. Always matches.
+                memset(res.data(), !negate, haystack_size * sizeof(res[0]));
+            else
+            {
+                size_t prev_offset = 0;
+                for (size_t i = 0; i < haystack_size; ++i)
+                {
+                    const bool match = regexp.getRE2()->Match(
+                            {reinterpret_cast<const char *>(&haystack_data[prev_offset]), haystack_offsets[i] - prev_offset - 1},
+                            0,
+                            haystack_offsets[i] - prev_offset - 1,
+                            re2_st::RE2::UNANCHORED,
+                            nullptr,
+                            0);
+                    res[i] = negate ^ match;
+
+                    prev_offset = haystack_offsets[i];
+                }
+            }
         }
         else
         {
-            const auto & regexp = Regexps::Regexp(Regexps::createRegexp<is_like, /*no_capture*/ true, case_insensitive>(needle));
+            /// NOTE This almost matches with the case of impl::likePatternIsSubstring.
 
-            String required_substring;
-            bool is_trivial;
-            bool required_substring_is_prefix; /// for `anchored` execution of the regexp.
+            const UInt8 * const begin = haystack_data.data();
+            const UInt8 * const end = haystack_data.begin() + haystack_data.size();
+            const UInt8 * pos = begin;
 
-            regexp.getAnalyzeResult(required_substring, is_trivial, required_substring_is_prefix);
+            /// The current index in the array of strings.
+            size_t i = 0;
 
-            if (required_substring.empty())
+            Searcher searcher(required_substring.data(), required_substring.size(), end - pos);
+
+            /// We will search for the next occurrence in all rows at once.
+            while (pos < end && end != (pos = searcher.search(pos, end - pos)))
             {
-                if (!regexp.getRE2()) /// An empty regexp. Always matches.
+                /// Determine which index it refers to.
+                while (begin + haystack_offsets[i] <= pos)
                 {
-                    if (haystack_size)
-                        memset(res.data(), !negate, haystack_size * sizeof(res[0]));
+                    res[i] = negate;
+                    ++i;
                 }
-                else
+
+                /// We check that the entry does not pass through the boundaries of strings.
+                if (pos + required_substring.size() < begin + haystack_offsets[i])
                 {
-                    size_t prev_offset = 0;
-                    for (size_t i = 0; i < haystack_size; ++i)
+                    /// And if it does not, if necessary, we check the regexp.
+                    if (is_trivial)
+                        res[i] = !negate;
+                    else
                     {
+                        const char * str_data = reinterpret_cast<const char *>(&haystack_data[haystack_offsets[i - 1]]);
+                        size_t str_size = haystack_offsets[i] - haystack_offsets[i - 1] - 1;
+
+                        /** Even in the case of `required_substring_is_prefix` use UNANCHORED check for regexp,
+                          *  so that it can match when `required_substring` occurs into the string several times,
+                          *  and at the first occurrence, the regexp is not a match.
+                          */
+                        const size_t start_pos = (required_substring_is_prefix) ? (reinterpret_cast<const char *>(pos) - str_data) : 0;
+                        const size_t end_pos = str_size;
+
                         const bool match = regexp.getRE2()->Match(
-                                {reinterpret_cast<const char *>(&haystack_data[prev_offset]), haystack_offsets[i] - prev_offset - 1},
-                                0,
-                                haystack_offsets[i] - prev_offset - 1,
+                                {str_data, str_size},
+                                start_pos,
+                                end_pos,
                                 re2_st::RE2::UNANCHORED,
                                 nullptr,
                                 0);
                         res[i] = negate ^ match;
-
-                        prev_offset = haystack_offsets[i];
                     }
                 }
+                else
+                    res[i] = negate;
+
+                pos = begin + haystack_offsets[i];
+                ++i;
             }
-            else
-            {
-                /// NOTE This almost matches with the case of impl::likePatternIsSubstring.
 
-                const UInt8 * const begin = haystack_data.data();
-                const UInt8 * const end = haystack_data.begin() + haystack_data.size();
-                const UInt8 * pos = begin;
-
-                /// The current index in the array of strings.
-                size_t i = 0;
-
-                Searcher searcher(required_substring.data(), required_substring.size(), end - pos);
-
-                /// We will search for the next occurrence in all rows at once.
-                while (pos < end && end != (pos = searcher.search(pos, end - pos)))
-                {
-                    /// Determine which index it refers to.
-                    while (begin + haystack_offsets[i] <= pos)
-                    {
-                        res[i] = negate;
-                        ++i;
-                    }
-
-                    /// We check that the entry does not pass through the boundaries of strings.
-                    if (pos + required_substring.size() < begin + haystack_offsets[i])
-                    {
-                        /// And if it does not, if necessary, we check the regexp.
-
-                        if (is_trivial)
-                            res[i] = !negate;
-                        else
-                        {
-                            const char * str_data = reinterpret_cast<const char *>(&haystack_data[haystack_offsets[i - 1]]);
-                            size_t str_size = haystack_offsets[i] - haystack_offsets[i - 1] - 1;
-
-                            /** Even in the case of `required_substring_is_prefix` use UNANCHORED check for regexp,
-                              *  so that it can match when `required_substring` occurs into the string several times,
-                              *  and at the first occurrence, the regexp is not a match.
-                              */
-                            const size_t start_pos = (required_substring_is_prefix) ? (reinterpret_cast<const char *>(pos) - str_data) : 0;
-                            const size_t end_pos = str_size;
-
-                            const bool match = regexp.getRE2()->Match(
-                                    {str_data, str_size},
-                                    start_pos,
-                                    end_pos,
-                                    re2_st::RE2::UNANCHORED,
-                                    nullptr,
-                                    0);
-                            res[i] = negate ^ match;
-                        }
-                    }
-                    else
-                        res[i] = negate;
-
-                    pos = begin + haystack_offsets[i];
-                    ++i;
-                }
-
-                /// Tail, in which there can be no substring.
-                if (i < res.size())
-                    memset(&res[i], negate, (res.size() - i) * sizeof(res[0]));
-            }
+            /// Tail, in which there can be no substring.
+            if (i < res.size())
+                memset(&res[i], negate, (res.size() - i) * sizeof(res[0]));
         }
     }
 
@@ -274,7 +267,7 @@ struct MatchImpl
         if (haystack.empty())
             return;
 
-        /// A simple case where the LIKE expression reduces to finding a substring in a string
+        /// Special case that the [I]LIKE expression reduces to finding a substring in a string
         String strstr_pattern;
         if (is_like && impl::likePatternIsSubstring(needle, strstr_pattern))
         {
@@ -316,109 +309,105 @@ struct MatchImpl
             /// Tail, in which there can be no substring.
             if (i < res.size())
                 memset(&res[i], negate, (res.size() - i) * sizeof(res[0]));
+
+            return;
+        }
+
+        const auto & regexp = Regexps::Regexp(Regexps::createRegexp<is_like, /*no_capture*/ true, case_insensitive>(needle));
+
+        String required_substring;
+        bool is_trivial;
+        bool required_substring_is_prefix; /// for `anchored` execution of the regexp.
+
+        regexp.getAnalyzeResult(required_substring, is_trivial, required_substring_is_prefix);
+
+        if (required_substring.empty())
+        {
+            if (!regexp.getRE2()) /// An empty regexp. Always matches.
+                memset(res.data(), !negate, haystack_size * sizeof(res[0]));
+            else
+            {
+                size_t offset = 0;
+                for (size_t i = 0; i < haystack_size; ++i)
+                {
+                    const bool match = regexp.getRE2()->Match(
+                            {reinterpret_cast<const char *>(&haystack[offset]), N},
+                            0,
+                            N,
+                            re2_st::RE2::UNANCHORED,
+                            nullptr,
+                            0);
+                    res[i] = negate ^ match;
+
+                    offset += N;
+                }
+            }
         }
         else
         {
-            const auto & regexp = Regexps::Regexp(Regexps::createRegexp<is_like, /*no_capture*/ true, case_insensitive>(needle));
+            /// NOTE This almost matches with the case of likePatternIsSubstring.
 
-            String required_substring;
-            bool is_trivial;
-            bool required_substring_is_prefix; /// for `anchored` execution of the regexp.
+            const UInt8 * const begin = haystack.data();
+            const UInt8 * const end = haystack.data() + haystack.size();
+            const UInt8 * pos = begin;
 
-            regexp.getAnalyzeResult(required_substring, is_trivial, required_substring_is_prefix);
+            size_t i = 0;
+            const UInt8 * next_pos = begin;
 
-            if (required_substring.empty())
+            /// If required substring is larger than string size - it cannot be found.
+            if (required_substring.size() <= N)
             {
-                if (!regexp.getRE2()) /// An empty regexp. Always matches.
+                Searcher searcher(required_substring.data(), required_substring.size(), end - pos);
+
+                /// We will search for the next occurrence in all rows at once.
+                while (pos < end && end != (pos = searcher.search(pos, end - pos)))
                 {
-                    if (haystack_size)
-                        memset(res.data(), !negate, haystack_size * sizeof(res[0]));
-                }
-                else
-                {
-                    size_t offset = 0;
-                    for (size_t i = 0; i < haystack_size; ++i)
+                    /// Let's determine which index it refers to.
+                    while (next_pos + N <= pos)
                     {
-                        const bool match = regexp.getRE2()->Match(
-                                {reinterpret_cast<const char *>(&haystack[offset]), N},
-                                0,
-                                N,
-                                re2_st::RE2::UNANCHORED,
-                                nullptr,
-                                0);
-                        res[i] = negate ^ match;
-
-                        offset += N;
-                    }
-                }
-            }
-            else
-            {
-                /// NOTE This almost matches with the case of likePatternIsSubstring.
-
-                const UInt8 * const begin = haystack.data();
-                const UInt8 * const end = haystack.data() + haystack.size();
-                const UInt8 * pos = begin;
-
-                size_t i = 0;
-                const UInt8 * next_pos = begin;
-
-                /// If required substring is larger than string size - it cannot be found.
-                if (required_substring.size() <= N)
-                {
-                    Searcher searcher(required_substring.data(), required_substring.size(), end - pos);
-
-                    /// We will search for the next occurrence in all rows at once.
-                    while (pos < end && end != (pos = searcher.search(pos, end - pos)))
-                    {
-                        /// Let's determine which index it refers to.
-                        while (next_pos + N <= pos)
-                        {
-                            res[i] = negate;
-                            next_pos += N;
-                            ++i;
-                        }
+                        res[i] = negate;
                         next_pos += N;
-
-                        if (pos + required_substring.size() <= next_pos)
-                        {
-                            /// And if it does not, if necessary, we check the regexp.
-
-                            if (is_trivial)
-                                res[i] = !negate;
-                            else
-                            {
-                                const char * str_data = reinterpret_cast<const char *>(next_pos - N);
-
-                                /** Even in the case of `required_substring_is_prefix` use UNANCHORED check for regexp,
-                                *  so that it can match when `required_substring` occurs into the string several times,
-                                *  and at the first occurrence, the regexp is not a match.
-                                */
-                                const size_t start_pos = (required_substring_is_prefix) ? (reinterpret_cast<const char *>(pos) - str_data) : 0;
-                                const size_t end_pos = N;
-
-                                const bool match = regexp.getRE2()->Match(
-                                        {str_data, N},
-                                        start_pos,
-                                        end_pos,
-                                        re2_st::RE2::UNANCHORED,
-                                        nullptr,
-                                        0);
-                                res[i] = negate ^ match;
-                            }
-                        }
-                        else
-                            res[i] = negate;
-
-                        pos = next_pos;
                         ++i;
                     }
-                }
+                    next_pos += N;
 
-                /// Tail, in which there can be no substring.
-                if (i < res.size())
-                    memset(&res[i], negate, (res.size() - i) * sizeof(res[0]));
+                    if (pos + required_substring.size() <= next_pos)
+                    {
+                        /// And if it does not, if necessary, we check the regexp.
+                        if (is_trivial)
+                            res[i] = !negate;
+                        else
+                        {
+                            const char * str_data = reinterpret_cast<const char *>(next_pos - N);
+
+                            /** Even in the case of `required_substring_is_prefix` use UNANCHORED check for regexp,
+                            *  so that it can match when `required_substring` occurs into the string several times,
+                            *  and at the first occurrence, the regexp is not a match.
+                            */
+                            const size_t start_pos = (required_substring_is_prefix) ? (reinterpret_cast<const char *>(pos) - str_data) : 0;
+                            const size_t end_pos = N;
+
+                            const bool match = regexp.getRE2()->Match(
+                                    {str_data, N},
+                                    start_pos,
+                                    end_pos,
+                                    re2_st::RE2::UNANCHORED,
+                                    nullptr,
+                                    0);
+                            res[i] = negate ^ match;
+                        }
+                    }
+                    else
+                        res[i] = negate;
+
+                    pos = next_pos;
+                    ++i;
+                }
             }
+
+            /// Tail, in which there can be no substring.
+            if (i < res.size())
+                memset(&res[i], negate, (res.size() - i) * sizeof(res[0]));
         }
     }
 
@@ -434,7 +423,6 @@ struct MatchImpl
 
         assert(haystack_size == needle_offset.size());
         assert(haystack_size == res.size());
-
         assert(start_pos_ == nullptr);
 
         if (haystack_offsets.empty())
@@ -481,9 +469,7 @@ struct MatchImpl
                 if (required_substr.empty())
                 {
                     if (!regexp->getRE2()) /// An empty regexp. Always matches.
-                    {
                         res[i] = !negate;
-                    }
                     else
                     {
                         const bool match = regexp->getRE2()->Match(
@@ -502,15 +488,11 @@ struct MatchImpl
                     const auto * match = searcher.search(cur_haystack_data, cur_haystack_length);
 
                     if (match == cur_haystack_data + cur_haystack_length)
-                    {
                         res[i] = negate; // no match
-                    }
                     else
                     {
                         if (is_trivial)
-                        {
                             res[i] = !negate; // no wildcards in pattern
-                        }
                         else
                         {
                             const size_t start_pos = (required_substring_is_prefix) ? (match - cur_haystack_data) : 0;
@@ -546,7 +528,6 @@ struct MatchImpl
 
         assert(haystack_size == needle_offset.size());
         assert(haystack_size == res.size());
-
         assert(start_pos_ == nullptr);
 
         if (haystack.empty())
@@ -593,9 +574,7 @@ struct MatchImpl
                 if (required_substr.empty())
                 {
                     if (!regexp->getRE2()) /// An empty regexp. Always matches.
-                    {
                         res[i] = !negate;
-                    }
                     else
                     {
                         const bool match = regexp->getRE2()->Match(
@@ -614,15 +593,11 @@ struct MatchImpl
                     const auto * match = searcher.search(cur_haystack_data, cur_haystack_length);
 
                     if (match == cur_haystack_data + cur_haystack_length)
-                    {
                         res[i] = negate; // no match
-                    }
                     else
                     {
                         if (is_trivial)
-                        {
                             res[i] = !negate; // no wildcards in pattern
-                        }
                         else
                         {
                             const size_t start_pos = (required_substring_is_prefix) ? (match - cur_haystack_data) : 0;

--- a/src/Functions/PositionImpl.h
+++ b/src/Functions/PositionImpl.h
@@ -192,7 +192,8 @@ struct PositionImpl
         const ColumnString::Offsets & haystack_offsets,
         const std::string & needle,
         const ColumnPtr & start_pos,
-        PaddedPODArray<UInt64> & res)
+        PaddedPODArray<UInt64> & res,
+        bool /*allow_hyperscan*/)
     {
         const UInt8 * const begin = haystack_data.data();
         const UInt8 * const end = haystack_data.data() + haystack_data.size();
@@ -303,7 +304,8 @@ struct PositionImpl
         const ColumnString::Chars & needle_data,
         const ColumnString::Offsets & needle_offsets,
         const ColumnPtr & start_pos,
-        PaddedPODArray<UInt64> & res)
+        PaddedPODArray<UInt64> & res,
+        bool /*allow_hyperscan*/)
     {
         ColumnString::Offset prev_haystack_offset = 0;
         ColumnString::Offset prev_needle_offset = 0;
@@ -363,7 +365,8 @@ struct PositionImpl
         const ColumnString::Chars & needle_data,
         const ColumnString::Offsets & needle_offsets,
         const ColumnPtr & start_pos,
-        PaddedPODArray<UInt64> & res)
+        PaddedPODArray<UInt64> & res,
+        bool /*allow_hyperscan*/)
     {
         /// NOTE You could use haystack indexing. But this is a rare case.
 

--- a/src/Functions/map.cpp
+++ b/src/Functions/map.cpp
@@ -311,7 +311,7 @@ public:
         const ColumnString * column_string = checkAndGetColumn<ColumnString>(column_tuple.getColumn(0));
         const ColumnFixedString * column_fixed_string = checkAndGetColumn<ColumnFixedString>(column_tuple.getColumn(0));
 
-        FunctionLike func_like;
+        FunctionLike func_like(/*allow_hyperscan*/ false);
 
         for (size_t row = 0; row < input_rows_count; ++row)
         {
@@ -451,7 +451,7 @@ public:
         const ColumnString * keys_string_column = checkAndGetColumn<ColumnString>(keys_column);
         const ColumnFixedString * keys_fixed_string_column = checkAndGetColumn<ColumnFixedString>(keys_column);
 
-        FunctionLike func_like;
+        FunctionLike func_like(/*allow_hyperscan*/ false);
 
         //create result data
         MutableColumnPtr keys_data = key_type->createColumn();

--- a/src/Functions/notLike.cpp
+++ b/src/Functions/notLike.cpp
@@ -12,7 +12,8 @@ struct NameNotLike
     static constexpr auto name = "notLike";
 };
 
-using FunctionNotLike = FunctionsStringSearch<MatchImpl<NameNotLike, MatchTraits::Syntax::Like, MatchTraits::Case::Sensitive, MatchTraits::Result::Negate>>;
+using NotLikeImpl = MatchImpl<NameNotLike, MatchTraits::Syntax::Like, MatchTraits::Case::Sensitive, MatchTraits::Result::Negate>;
+using FunctionNotLike = FunctionsStringSearch<NotLikeImpl>;
 
 }
 


### PR DESCRIPTION
Fixes #42906

Benchmark results:

Test data:
```
create table test((id UInt64, haystack String) Engine=MergeTree() order by id;
insert into test select number, concat('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. ', toString(number)) as d FROM numbers(50000000);
optimize table test final;
```

|  | re2 | vectorscan | vectorscan + regexp cache |  |
| --- | --- | --- | --- | --- |
| Lorem% | 0.94 | 0.96 | 0.96 | Match at beginning, all match |
| %laborum% | 0.96 | 0.96 | 0.96 | Match at end, all match |
| _____ _____ _____ ___ _____ ___________ adipiscing% | 1.11 | 4.00 | 1.18 | Lots of _, all match |
| %ipsum%sit%consectetur%elit%do%tempor%ut%et%magna%Ut%ad%veniam%nostrud%ullamco% | 1.48 | 5.11 | 2.68 | Lots of %, none match |

--> no significant improvement, discarding this PR

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Speed up SQL function "like" (and variants) using the vectorscan library