### PR TITLE
Fix TSan errors (correctly ignore _exit interception)

### DIFF
--- a/base/base/safeExit.cpp
+++ b/base/base/safeExit.cpp
@@ -1,6 +1,7 @@
 #if defined(OS_LINUX)
 #    include <sys/syscall.h>
 #endif
+#include <cstdlib>
 #include <unistd.h>
 #include <base/safeExit.h>
 #include <base/defines.h> /// for THREAD_SANITIZER

--- a/base/base/safeExit.cpp
+++ b/base/base/safeExit.cpp
@@ -3,6 +3,7 @@
 #endif
 #include <unistd.h>
 #include <base/safeExit.h>
+#include <base/defines.h> /// for THREAD_SANITIZER
 
 [[noreturn]] void safeExit(int code)
 {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix TSan errors (correctly ignore _exit interception)

Because safeExit() does not includes header with defines, it does not know about THREAD_SANITIZER.

And it also fixes Azure blob storage, actually everything is fine with the sdk itself, the problem is only in TSan that intercepts _exit() and report leak, even thoug that tread will be joined later.

Refs: #23056 (#23616)
Fixes: #38474
Closes: #42640
Fixes: #42638
Fixes: #34988
Cc: @alexey-milovidov, @tavplubix