### PR TITLE
Add a CI step to mark commits as ready for release

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1056,6 +1056,23 @@ jobs:
           docker ps --quiet | xargs --no-run-if-empty docker kill ||:
           docker ps --all --quiet | xargs --no-run-if-empty docker rm -f ||:
           sudo rm -fr "$TEMP_PATH"
+  MarkReleaseReady:
+    needs:
+      - BuilderBinDarwin
+      - BuilderBinDarwinAarch64
+      - BuilderDebRelease
+      - BuilderDebAarch64
+    runs-on: [self-hosted, style-checker]
+    steps:
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Mark Commit Release Ready
+        run: |
+          cd "$GITHUB_WORKSPACE/tests/ci"
+          python3 mark_release_ready.py
 ##############################################################################################
 ########################### FUNCTIONAl STATELESS TESTS #######################################
 ##############################################################################################
@@ -3069,6 +3086,7 @@ jobs:
     needs:
       - DockerHubPush
       - BuilderReport
+      - MarkReleaseReady
       - FunctionalStatelessTestDebug0
       - FunctionalStatelessTestDebug1
       - FunctionalStatelessTestDebug2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3086,6 +3086,7 @@ jobs:
     needs:
       - DockerHubPush
       - BuilderReport
+      - BuilderSpecialReport
       - MarkReleaseReady
       - FunctionalStatelessTestDebug0
       - FunctionalStatelessTestDebug1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3579,6 +3579,7 @@ jobs:
       - DockerServerImages
       - CheckLabels
       - BuilderReport
+      - BuilderSpecialReport
       - FastTest
       - FunctionalStatelessTestDebug0
       - FunctionalStatelessTestDebug1

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -615,6 +615,23 @@ jobs:
           docker ps --quiet | xargs --no-run-if-empty docker kill ||:
           docker ps --all --quiet | xargs --no-run-if-empty docker rm -f ||:
           sudo rm -fr "$TEMP_PATH"
+  MarkReleaseReady:
+    needs:
+      - BuilderBinDarwin
+      - BuilderBinDarwinAarch64
+      - BuilderDebRelease
+      - BuilderDebAarch64
+    runs-on: [self-hosted, style-checker]
+    steps:
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Mark Commit Release Ready
+        run: |
+          cd "$GITHUB_WORKSPACE/tests/ci"
+          python3 mark_release_ready.py
 ##############################################################################################
 ########################### FUNCTIONAl STATELESS TESTS #######################################
 ##############################################################################################
@@ -1888,6 +1905,7 @@ jobs:
       - DockerServerImages
       - BuilderReport
       - BuilderSpecialReport
+      - MarkReleaseReady
       - FunctionalStatelessTestDebug0
       - FunctionalStatelessTestDebug1
       - FunctionalStatelessTestDebug2

--- a/tests/ci/mark_release_ready.py
+++ b/tests/ci/mark_release_ready.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+from commit_status_helper import get_commit
+from env_helper import GITHUB_JOB_URL
+from get_robot_token import get_best_robot_token
+from github_helper import GitHub
+from pr_info import PRInfo
+
+RELEASE_READY_STATUS = "Ready for release"
+
+
+def main():
+    pr_info = PRInfo()
+    gh = GitHub(get_best_robot_token(), per_page=100)
+    commit = get_commit(gh, pr_info.sha)
+    commit.create_status(
+        context=RELEASE_READY_STATUS,
+        description="the release can be created from the commit",
+        state="success",
+        target_url=GITHUB_JOB_URL(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -118,6 +118,8 @@ class Release:
             except subprocess.CalledProcessError:
                 logging.fatal("Repo contains uncommitted changes")
                 raise
+            if self._git.branch != "master":
+                raise Exception("the script must be launched only from master")
 
         self.set_release_branch()
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a CI step to mark commits as ready for release; soft-forbid launching a release script from branches but master