### PR TITLE
Fix projection part removal with zero-copy replication

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1629,6 +1629,8 @@ void IMergeTreeDataPart::remove()
 
     auto can_remove_callback = [this] ()
     {
+        /// Temporary projections are "subparts" which are generated during projections materialization
+        /// We can always remove them without any additional checks.
         if (isProjectionPart() && is_temp)
         {
             LOG_TRACE(storage.log, "Temporary projection part {} can be removed", name);
@@ -1648,6 +1650,8 @@ void IMergeTreeDataPart::remove()
     if (!isStoredOnDisk())
         return;
 
+    /// Projections should be never removed by themselves, they will be removed
+    /// with by parent part.
     if (isProjectionPart() && !is_temp)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Projection part {} should be removed by its parent {}.", name, parent_part->name);
 

--- a/tests/queries/0_stateless/02477_projection_materialize_and_zero_copy.sql
+++ b/tests/queries/0_stateless/02477_projection_materialize_and_zero_copy.sql
@@ -13,6 +13,6 @@ alter table t materialize projection p_norm settings mutations_sync = 1;
 
 SYSTEM FLUSH LOGS;
 
-SELECT * FROM system.text_log WHERE event_time >= now() - 30 and message like '%BAD_DATA_PART_NAME%';
+SELECT * FROM system.text_log WHERE event_time >= now() - 30 and level == 'Error' and message like '%BAD_DATA_PART_NAME%';
 
 DROP TABLE IF EXISTS t;

--- a/tests/queries/0_stateless/02477_projection_materialize_and_zero_copy.sql
+++ b/tests/queries/0_stateless/02477_projection_materialize_and_zero_copy.sql
@@ -1,0 +1,18 @@
+DROP TABLE IF EXISTS t;
+
+create table t (c1 Int64, c2 String, c3 DateTime, c4 Int8, c5 String, c6 String, c7 String, c8 String, c9 String, c10 String, c11 String, c12 String, c13 Int8, c14 Int64, c15 String, c16 String, c17 String, c18 Int64, c19 Int64, c20 Int64) engine ReplicatedMergeTree('/clickhouse/test/{database}/test_02477', '1') order by c18
+SETTINGS allow_remote_fs_zero_copy_replication=1;
+
+insert into t (c1, c18) select number, -number from numbers(2000000);
+
+alter table t add projection p_norm (select * order by c1);
+
+optimize table t final;
+
+alter table t materialize projection p_norm settings mutations_sync = 1;
+
+SYSTEM FLUSH LOGS;
+
+SELECT * FROM system.text_log WHERE event_time >= now() - 30 and message like '%BAD_DATA_PART_NAME%';
+
+DROP TABLE IF EXISTS t;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix redundant error message in the log when `MATERIALIZE`ing big projection in ReplicatedMergeTree with zero-copy replication.