### PR TITLE
Ignore SAVEPOINT queries in MaterializedMySQL

### DIFF
--- a/src/Core/MySQL/MySQLReplication.cpp
+++ b/src/Core/MySQL/MySQLReplication.cpp
@@ -118,7 +118,7 @@ namespace MySQLReplication
         }
         else if (query.starts_with("SAVEPOINT"))
         {
-            throw ReplicationError("ParseQueryEvent: Unsupported query event:" + query, ErrorCodes::LOGICAL_ERROR);
+            typ = QUERY_SAVEPOINT;
         }
     }
 
@@ -941,6 +941,7 @@ namespace MySQLReplication
                 {
                     case QUERY_EVENT_MULTI_TXN_FLAG:
                     case QUERY_EVENT_XA:
+                    case QUERY_SAVEPOINT:
                     {
                         event = std::make_shared<DryRunEvent>(std::move(query->header));
                         break;

--- a/src/Core/MySQL/MySQLReplication.h
+++ b/src/Core/MySQL/MySQLReplication.h
@@ -368,7 +368,8 @@ namespace MySQLReplication
     {
         QUERY_EVENT_DDL = 0,
         QUERY_EVENT_MULTI_TXN_FLAG = 1,
-        QUERY_EVENT_XA = 2
+        QUERY_EVENT_XA = 2,
+        QUERY_SAVEPOINT = 3,
     };
 
     class QueryEvent : public EventBase

--- a/tests/integration/test_materialized_mysql_database/test.py
+++ b/tests/integration/test_materialized_mysql_database/test.py
@@ -509,3 +509,10 @@ def test_materialized_database_mysql_date_type_to_date32(
     materialize_with_ddl.materialized_database_mysql_date_type_to_date32(
         clickhouse_node, started_mysql_5_7, "mysql57"
     )
+
+
+def test_savepoint_query(
+    started_cluster, started_mysql_8_0, started_mysql_5_7, clickhouse_node
+):
+    materialize_with_ddl.savepoint(clickhouse_node, started_mysql_8_0, "mysql80")
+    materialize_with_ddl.savepoint(clickhouse_node, started_mysql_5_7, "mysql57")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Handle (ignore) SAVEPOINT queries in MaterializedMySQL

Fixes #42856