### PR TITLE
Throw not implemented for window frame type 'groups' in analyzer

### DIFF
--- a/src/Planner/PlannerWindowFunctions.cpp
+++ b/src/Planner/PlannerWindowFunctions.cpp
@@ -11,6 +11,11 @@
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
+
 namespace
 {
 
@@ -65,6 +70,11 @@ std::vector<WindowDescription> extractWindowDescriptions(const QueryTreeNodes & 
         auto & window_function_node_typed = window_function_node->as<FunctionNode &>();
 
         auto function_window_description = extractWindowDescriptionFromWindowNode(window_function_node_typed.getWindowNode(), planner_context);
+
+        auto frame_type = function_window_description.frame.type;
+        if (frame_type != WindowFrame::FrameType::ROWS && frame_type != WindowFrame::FrameType::RANGE)
+            throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Window frame '{}' is not implemented", frame_type);
+
         auto window_name = function_window_description.window_name;
 
         auto [it, _] = window_name_to_description.emplace(window_name, std::move(function_window_description));

--- a/tests/queries/0_stateless/02478_window_frame_type_groups.sql
+++ b/tests/queries/0_stateless/02478_window_frame_type_groups.sql
@@ -1,0 +1,7 @@
+SET allow_experimental_analyzer = 0;
+
+SELECT toUInt64(dense_rank(1) OVER (ORDER BY 100 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)) FROM numbers(10); -- { serverError 48 }
+
+SET allow_experimental_analyzer = 1;
+
+SELECT toUInt64(dense_rank(1) OVER (ORDER BY 100 ASC GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)) FROM numbers(10); -- { serverError 48 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

To correspond to https://github.com/ClickHouse/ClickHouse/blob/d02d1fd4892fac1151977b7a73122bfdd96f3e8c/src/Interpreters/ExpressionAnalyzer.cpp#L759-L761

Otherwise it leads to assert https://github.com/ClickHouse/ClickHouse/blob/d02d1fd4892fac1151977b7a73122bfdd96f3e8c/src/Processors/Transforms/WindowTransform.cpp#L652

Close https://github.com/ClickHouse/ClickHouse/issues/42924