### PR TITLE
Disable clickhouse local and client non-interactive progress by default.

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -243,6 +243,7 @@ try
     registerAggregateFunctions();
 
     processConfig();
+    initTtyBuffer(toProgressOption(config().getString("progress", "default")));
 
     /// Includes delayed_interactive.
     if (is_interactive)
@@ -1088,8 +1089,6 @@ void Client::processConfig()
     }
     else
     {
-        std::string progress = config().getString("progress", "off");
-        need_render_progress = (Poco::icompare(progress, "off") && Poco::icompare(progress, "no") && Poco::icompare(progress, "false") && Poco::icompare(progress, "0"));
         echo_queries = config().getBool("echo", false);
         ignore_error = config().getBool("ignore-error", false);
 

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -1088,7 +1088,7 @@ void Client::processConfig()
     }
     else
     {
-        std::string progress = config().getString("progress", "tty");
+        std::string progress = config().getString("progress", "off");
         need_render_progress = (Poco::icompare(progress, "off") && Poco::icompare(progress, "no") && Poco::icompare(progress, "false") && Poco::icompare(progress, "0"));
         echo_queries = config().getBool("echo", false);
         ignore_error = config().getBool("ignore-error", false);

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -489,7 +489,7 @@ void LocalServer::processConfig()
     }
     else
     {
-        std::string progress = config().getString("progress", "tty");
+        std::string progress = config().getString("progress", "off");
         need_render_progress = (Poco::icompare(progress, "off") && Poco::icompare(progress, "no") && Poco::icompare(progress, "false") && Poco::icompare(progress, "0"));
         echo_queries = config().hasOption("echo") || config().hasOption("verbose");
         ignore_error = config().getBool("ignore-error", false);

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -414,6 +414,8 @@ try
     registerFormats();
 
     processConfig();
+    initTtyBuffer(toProgressOption(config().getString("progress", "default")));
+
     applyCmdSettings(global_context);
 
     if (is_interactive)
@@ -489,8 +491,6 @@ void LocalServer::processConfig()
     }
     else
     {
-        std::string progress = config().getString("progress", "off");
-        need_render_progress = (Poco::icompare(progress, "off") && Poco::icompare(progress, "no") && Poco::icompare(progress, "false") && Poco::icompare(progress, "0"));
         echo_queries = config().hasOption("echo") || config().hasOption("verbose");
         ignore_error = config().getBool("ignore-error", false);
         is_multiquery = true;

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2324,7 +2324,7 @@ void ClientBase::init(int argc, char ** argv)
         ("stage", po::value<std::string>()->default_value("complete"), "Request query processing up to specified stage: complete,fetch_columns,with_mergeable_state,with_mergeable_state_after_aggregation,with_mergeable_state_after_aggregation_and_limit")
         ("query_kind", po::value<std::string>()->default_value("initial_query"), "One of initial_query/secondary_query/no_query")
         ("query_id", po::value<std::string>(), "query_id")
-        ("progress", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::TTY, "tty"), "Print progress of queries execution - to TTY (default): tty|on|1|true|yes; to STDERR: err; OFF: off|0|false|no")
+        ("progress", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::OFF, "off"), "Print progress of queries execution - to TTY (default): tty|on|1|true|yes; to STDERR: err; OFF: off|0|false|no")
 
         ("disable_suggestion,A", "Disable loading suggestion data. Note that suggestion data is loaded asynchronously through a second connection to ClickHouse server. Also it is reasonable to disable suggestion if you want to paste a query with TAB characters. Shorthand option -A is for those who get used to mysql client.")
         ("time,t", "print query execution time to stderr in non-interactive mode (for benchmarks)")

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -119,22 +119,27 @@ namespace ProfileEvents
 namespace DB
 {
 
+ProgressOption toProgressOption(std::string progress)
+{
+    boost::to_upper(progress);
+
+    if (progress == "OFF" || progress == "FALSE" || progress == "0" || progress == "NO")
+        return ProgressOption::OFF;
+    if (progress == "TTY" || progress == "ON" || progress == "TRUE" || progress == "1" || progress == "YES")
+        return ProgressOption::TTY;
+    if (progress == "ERR")
+        return ProgressOption::ERR;
+    if (progress == "DEFAULT")
+        return ProgressOption::DEFAULT;
+
+    throw boost::program_options::validation_error(boost::program_options::validation_error::invalid_option_value);
+}
+
 std::istream& operator>> (std::istream & in, ProgressOption & progress)
 {
     std::string token;
     in >> token;
-
-    boost::to_upper(token);
-
-    if (token == "OFF" || token == "FALSE" || token == "0" || token == "NO")
-        progress = ProgressOption::OFF;
-    else if (token == "TTY" || token == "ON" || token == "TRUE" || token == "1" || token == "YES")
-        progress = ProgressOption::TTY;
-    else if (token == "ERR")
-        progress = ProgressOption::ERR;
-    else
-        throw boost::program_options::validation_error(boost::program_options::validation_error::invalid_option_value);
-
+    progress = toProgressOption(token);
     return in;
 }
 
@@ -662,56 +667,62 @@ void ClientBase::initLogsOutputStream()
     }
 }
 
-void ClientBase::initTtyBuffer(bool to_err)
+void ClientBase::initTtyBuffer(ProgressOption progress)
 {
-    if (!tty_buf)
+    if (tty_buf)
+        return;
+
+    if (progress == ProgressOption::OFF || (!is_interactive && progress == ProgressOption::DEFAULT))
     {
-        static constexpr auto tty_file_name = "/dev/tty";
+         need_render_progress = false;
+         return;
+    }
 
-        /// Output all progress bar commands to terminal at once to avoid flicker.
-        /// This size is usually greater than the window size.
-        static constexpr size_t buf_size = 1024;
+    static constexpr auto tty_file_name = "/dev/tty";
 
-        if (!to_err)
+    /// Output all progress bar commands to terminal at once to avoid flicker.
+    /// This size is usually greater than the window size.
+    static constexpr size_t buf_size = 1024;
+
+    if (is_interactive || progress == ProgressOption::TTY)
+    {
+        std::error_code ec;
+        std::filesystem::file_status tty = std::filesystem::status(tty_file_name, ec);
+
+        if (!ec && exists(tty) && is_character_file(tty)
+            && (tty.permissions() & std::filesystem::perms::others_write) != std::filesystem::perms::none)
         {
-            std::error_code ec;
-            std::filesystem::file_status tty = std::filesystem::status(tty_file_name, ec);
-
-            if (!ec && exists(tty) && is_character_file(tty)
-                && (tty.permissions() & std::filesystem::perms::others_write) != std::filesystem::perms::none)
+            try
             {
-                try
-                {
-                    tty_buf = std::make_unique<WriteBufferFromFile>(tty_file_name, buf_size);
+                tty_buf = std::make_unique<WriteBufferFromFile>(tty_file_name, buf_size);
 
-                    /// It is possible that the terminal file has writeable permissions
-                    /// but we cannot write anything there. Check it with invisible character.
-                    tty_buf->write('\0');
-                    tty_buf->next();
+                /// It is possible that the terminal file has writeable permissions
+                /// but we cannot write anything there. Check it with invisible character.
+                tty_buf->write('\0');
+                tty_buf->next();
 
-                    return;
-                }
-                catch (const Exception & e)
-                {
-                    if (tty_buf)
-                        tty_buf.reset();
+                return;
+            }
+            catch (const Exception & e)
+            {
+                if (tty_buf)
+                    tty_buf.reset();
 
-                    if (e.code() != ErrorCodes::CANNOT_OPEN_FILE)
-                        throw;
+                if (e.code() != ErrorCodes::CANNOT_OPEN_FILE)
+                    throw;
 
-                    /// It is normal if file exists, indicated as writeable but still cannot be opened.
-                    /// Fallback to other options.
-                }
+                /// It is normal if file exists, indicated as writeable but still cannot be opened.
+                /// Fallback to other options.
             }
         }
-
-        if (stderr_is_a_tty)
-        {
-            tty_buf = std::make_unique<WriteBufferFromFileDescriptor>(STDERR_FILENO, buf_size);
-        }
-        else
-            need_render_progress = false;
     }
+
+    if (stderr_is_a_tty || progress == ProgressOption::ERR)
+    {
+        tty_buf = std::make_unique<WriteBufferFromFileDescriptor>(STDERR_FILENO, buf_size);
+    }
+    else
+        need_render_progress = false;
 }
 
 void ClientBase::updateSuggest(const ASTPtr & ast)
@@ -2324,7 +2335,7 @@ void ClientBase::init(int argc, char ** argv)
         ("stage", po::value<std::string>()->default_value("complete"), "Request query processing up to specified stage: complete,fetch_columns,with_mergeable_state,with_mergeable_state_after_aggregation,with_mergeable_state_after_aggregation_and_limit")
         ("query_kind", po::value<std::string>()->default_value("initial_query"), "One of initial_query/secondary_query/no_query")
         ("query_id", po::value<std::string>(), "query_id")
-        ("progress", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::OFF, "off"), "Print progress of queries execution - to TTY: tty|on|1|true|yes; to STDERR: err; OFF (default): off|0|false|no")
+        ("progress", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::DEFAULT, "default"), "Print progress of queries execution - to TTY: tty|on|1|true|yes; to STDERR non-interactive mode: err; OFF: off|0|false|no; DEFAULT - interactive to TTY, non-interactive is off")
 
         ("disable_suggestion,A", "Disable loading suggestion data. Note that suggestion data is loaded asynchronously through a second connection to ClickHouse server. Also it is reasonable to disable suggestion if you want to paste a query with TAB characters. Shorthand option -A is for those who get used to mysql client.")
         ("time,t", "print query execution time to stderr in non-interactive mode (for benchmarks)")
@@ -2379,11 +2390,6 @@ void ClientBase::init(int argc, char ** argv)
     parseAndCheckOptions(options_description, options, common_arguments);
     po::notify(options);
 
-    if (options["progress"].as<ProgressOption>() == ProgressOption::OFF)
-        need_render_progress = false;
-    else
-        initTtyBuffer(options["progress"].as<ProgressOption>() == ProgressOption::ERR);
-
     if (options.count("version") || options.count("V"))
     {
         showClientVersion();
@@ -2437,6 +2443,9 @@ void ClientBase::init(int argc, char ** argv)
     {
         switch (options["progress"].as<ProgressOption>())
         {
+            case DEFAULT:
+                config().setString("progress", "default");
+                break;
             case OFF:
                 config().setString("progress", "off");
                 break;

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2324,7 +2324,7 @@ void ClientBase::init(int argc, char ** argv)
         ("stage", po::value<std::string>()->default_value("complete"), "Request query processing up to specified stage: complete,fetch_columns,with_mergeable_state,with_mergeable_state_after_aggregation,with_mergeable_state_after_aggregation_and_limit")
         ("query_kind", po::value<std::string>()->default_value("initial_query"), "One of initial_query/secondary_query/no_query")
         ("query_id", po::value<std::string>(), "query_id")
-        ("progress", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::OFF, "off"), "Print progress of queries execution - to TTY (default): tty|on|1|true|yes; to STDERR: err; OFF: off|0|false|no")
+        ("progress", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::OFF, "off"), "Print progress of queries execution - to TTY: tty|on|1|true|yes; to STDERR: err; OFF (default): off|0|false|no")
 
         ("disable_suggestion,A", "Disable loading suggestion data. Note that suggestion data is loaded asynchronously through a second connection to ClickHouse server. Also it is reasonable to disable suggestion if you want to paste a query with TAB characters. Shorthand option -A is for those who get used to mysql client.")
         ("time,t", "print query execution time to stderr in non-interactive mode (for benchmarks)")

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -38,10 +38,12 @@ enum MultiQueryProcessingStage
 
 enum ProgressOption
 {
+    DEFAULT,
     OFF,
     TTY,
     ERR,
 };
+ProgressOption toProgressOption(std::string progress);
 std::istream& operator>> (std::istream & in, ProgressOption & progress);
 
 void interruptSignalHandler(int signum);
@@ -153,7 +155,6 @@ private:
 
     void initOutputFormat(const Block & block, ASTPtr parsed_query);
     void initLogsOutputStream();
-    void initTtyBuffer(bool to_err = false);
 
     String prompt() const;
 
@@ -167,6 +168,8 @@ private:
 protected:
     static bool isSyncInsertWithData(const ASTInsertQuery & insert_query, const ContextPtr & context);
     bool processMultiQueryFromFile(const String & file_name);
+
+    void initTtyBuffer(ProgressOption progress);
 
     bool is_interactive = false; /// Use either interactive line editing interface or batch mode.
     bool is_multiquery = false;

--- a/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.expect
+++ b/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.expect
@@ -24,7 +24,7 @@ expect_after {
 spawn bash
 send "source $basedir/../shell_config.sh\r"
 
-send "yes | head -n10000000 | \$CLICKHOUSE_CLIENT --query \"insert into function null('foo String') format TSV\" >/dev/null\r"
+send "yes | head -n10000000 | \$CLICKHOUSE_CLIENT --progress --query \"insert into function null('foo String') format TSV\" >/dev/null\r"
 expect "Progress: "
 send "\3"
 

--- a/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
+++ b/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
@@ -24,7 +24,7 @@ expect_after {
 spawn bash
 send "source $basedir/../shell_config.sh\r"
 
-send "yes | head -n10000000 | \$CLICKHOUSE_LOCAL --query \"insert into function null('foo String') format TSV\" >/dev/null\r"
+send "yes | head -n10000000 | \$CLICKHOUSE_LOCAL --progress --query \"insert into function null('foo String') format TSV\" >/dev/null\r"
 expect "Progress: "
 send "\3"
 

--- a/tests/queries/0_stateless/02456_progress_tty.expect
+++ b/tests/queries/0_stateless/02456_progress_tty.expect
@@ -34,6 +34,16 @@ expect "Progress: "
 expect "█"
 send "\3"
 
+# But we can set it to false
+send "\$CLICKHOUSE_LOCAL --progress false --query 'SELECT sleep(1), \$\$Hello\$\$ FROM numbers(3) SETTINGS max_block_size = 1' 2>/dev/null\r"
+expect -exact "0\tHello\r\n"
+send "\3"
+
+# As well as to 0 for the same effect
+send "\$CLICKHOUSE_LOCAL --progress 0 --query 'SELECT sleep(1), \$\$Hello\$\$ FROM numbers(3) SETTINGS max_block_size = 1' 2>/dev/null\r"
+expect -exact "0\tHello\r\n"
+send "\3"
+
 # If we set it to 1, the progress will be displayed as well
 send "\$CLICKHOUSE_LOCAL --progress 1 --query 'SELECT sum(sleep(1) = 0) FROM numbers(3) SETTINGS max_block_size = 1' >/dev/null 2>&1\r"
 expect "Progress: "

--- a/tests/queries/0_stateless/02456_progress_tty.expect
+++ b/tests/queries/0_stateless/02456_progress_tty.expect
@@ -17,32 +17,21 @@ expect_after {
 spawn bash
 send "source $basedir/../shell_config.sh\r"
 
-# Progress is displayed by default
-send "\$CLICKHOUSE_LOCAL --query 'SELECT sum(sleep(1) = 0) FROM numbers(3) SETTINGS max_block_size = 1' >/dev/null\r"
-expect "Progress: "
-expect "█"
-send "\3"
-
-# It is true even if we redirect both stdout and stderr to /dev/null
-send "\$CLICKHOUSE_LOCAL --query 'SELECT sum(sleep(1) = 0) FROM numbers(3) SETTINGS max_block_size = 1' >/dev/null 2>&1\r"
-expect "Progress: "
-expect "█"
+# Progress is not displayed by default
+send "\$CLICKHOUSE_LOCAL --query 'SELECT sleep(1), \$\$Hello\$\$ FROM numbers(3) SETTINGS max_block_size = 1' 2>/dev/null\r"
+expect -exact "0\tHello\r\n"
 send "\3"
 
 # The option --progress has implicit value of true
-send "\$CLICKHOUSE_LOCAL --progress --query 'SELECT sum(sleep(1) = 0) FROM numbers(3) SETTINGS max_block_size = 1' >/dev/null 2>&1\r"
+send "\$CLICKHOUSE_LOCAL --progress --query 'SELECT sum(sleep(1) = 0) FROM numbers(3) SETTINGS max_block_size = 1' >/dev/null\r"
 expect "Progress: "
 expect "█"
 send "\3"
 
-# But we can set it to false
-send "\$CLICKHOUSE_LOCAL --progress false --query 'SELECT sleep(1), \$\$Hello\$\$ FROM numbers(3) SETTINGS max_block_size = 1' 2>/dev/null\r"
-expect -exact "0\tHello\r\n"
-send "\3"
-
-# As well as to 0 for the same effect
-send "\$CLICKHOUSE_LOCAL --progress 0 --query 'SELECT sleep(1), \$\$Hello\$\$ FROM numbers(3) SETTINGS max_block_size = 1' 2>/dev/null\r"
-expect -exact "0\tHello\r\n"
+# It works even if we redirect both stdout and stderr to /dev/null
+send "\$CLICKHOUSE_LOCAL --progress --query 'SELECT sum(sleep(1) = 0) FROM numbers(3) SETTINGS max_block_size = 1' >/dev/null 2>&1\r"
+expect "Progress: "
+expect "█"
 send "\3"
 
 # If we set it to 1, the progress will be displayed as well

--- a/tests/queries/0_stateless/helpers/client.py
+++ b/tests/queries/0_stateless/helpers/client.py
@@ -16,7 +16,9 @@ class client(object):
     def __init__(self, command=None, name="", log=None):
         self.client = uexpect.spawn(["/bin/bash", "--noediting"])
         if command is None:
-            command = os.environ.get("CLICKHOUSE_BINARY", "clickhouse") + " client --progress"
+            command = (
+                os.environ.get("CLICKHOUSE_BINARY", "clickhouse") + " client --progress"
+            )
         self.client.command = command
         self.client.eol("\r")
         self.client.logger(log, prefix=name)

--- a/tests/queries/0_stateless/helpers/client.py
+++ b/tests/queries/0_stateless/helpers/client.py
@@ -17,7 +17,7 @@ class client(object):
         self.client = uexpect.spawn(["/bin/bash", "--noediting"])
         if command is None:
             command = (
-                os.environ.get("CLICKHOUSE_BINARY", "clickhouse") + " client --progress"
+                os.environ.get("CLICKHOUSE_BINARY", "clickhouse") + " client"
             )
         self.client.command = command
         self.client.eol("\r")

--- a/tests/queries/0_stateless/helpers/client.py
+++ b/tests/queries/0_stateless/helpers/client.py
@@ -16,7 +16,7 @@ class client(object):
     def __init__(self, command=None, name="", log=None):
         self.client = uexpect.spawn(["/bin/bash", "--noediting"])
         if command is None:
-            command = os.environ.get("CLICKHOUSE_BINARY", "clickhouse") + " client"
+            command = os.environ.get("CLICKHOUSE_BINARY", "clickhouse") + " client --progress"
         self.client.command = command
         self.client.eol("\r")
         self.client.logger(log, prefix=name)

--- a/tests/queries/0_stateless/helpers/client.py
+++ b/tests/queries/0_stateless/helpers/client.py
@@ -16,9 +16,7 @@ class client(object):
     def __init__(self, command=None, name="", log=None):
         self.client = uexpect.spawn(["/bin/bash", "--noediting"])
         if command is None:
-            command = (
-                os.environ.get("CLICKHOUSE_BINARY", "clickhouse") + " client"
-            )
+            command = os.environ.get("CLICKHOUSE_BINARY", "clickhouse") + " client"
         self.client.command = command
         self.client.eol("\r")
         self.client.logger(log, prefix=name)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://github.com/ClickHouse/ClickHouse/pull/42003#issuecomment-1306165763