### PR TITLE
Revert "Support NULLS FIRST in KeyCondition"

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -448,9 +448,8 @@ const KeyCondition::AtomMap KeyCondition::atom_map
         [] (RPNElement & out, const Field &)
         {
             out.function = RPNElement::FUNCTION_IS_NULL;
-            // isNull means +Inf (NULLS_LAST) or -Inf (NULLS_FIRST),
-            // which is equivalent to not in Range (-Inf, +Inf)
-            out.range = Range();
+            // When using NULL_LAST, isNull means [+Inf, +Inf]
+            out.range = Range(Field(POSITIVE_INFINITY));
             return true;
         }
     }
@@ -2228,10 +2227,7 @@ BoolMask KeyCondition::checkInHyperrectangle(
             /// No need to apply monotonic functions as nulls are kept.
             bool intersects = element.range.intersectsRange(*key_range);
             bool contains = element.range.containsRange(*key_range);
-
             rpn_stack.emplace_back(intersects, !contains);
-            if (element.function == RPNElement::FUNCTION_IS_NULL)
-                rpn_stack.back() = !rpn_stack.back();
         }
         else if (
             element.function == RPNElement::FUNCTION_IN_SET


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Reverts ClickHouse/ClickHouse#29528 which introduces a bug in nullable primary key https://github.com/ClickHouse/ClickHouse/issues/43111