### PR TITLE
Fix `test_keeper_four_word_command::test_cmd_stat`

### DIFF
--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -367,7 +367,7 @@ def test_cmd_stat(started_cluster):
         assert result["Received"] == "10"
         assert result["Sent"] == "10"
         assert int(result["Connections"]) == 1
-        assert int(result["Zxid"]) > 14
+        assert int(result["Zxid"]) >= 10
         assert result["Mode"] == "leader"
         assert result["Node count"] == "13"
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

cc @devcrafter 
it's a simple fix, 10 Creates guarantee at least 10 ZXID, not 14 (before ZXID was increased with RAFT log idx so it was higher).
It's interesting how it didn't fail before, the same cluster is reused for all tests in module so ZXID was increased by other tests.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
