### PR TITLE
Skip hash logging on sanitizer builds

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -805,41 +805,43 @@ int Server::main(const std::vector<std::string> & /*args*/)
         /// that are interpreted (not executed) but can alter the behaviour of the program as well.
 
         /// Please keep the below log messages in-sync with the ones in daemon/BaseDaemon.cpp
-
-        String calculated_binary_hash = getHashOfLoadedBinaryHex();
-
         if (stored_binary_hash.empty())
         {
-            LOG_WARNING(log, "Integrity check of the executable skipped because the reference checksum could not be read."
-                " (calculated checksum: {})", calculated_binary_hash);
-        }
-        else if (calculated_binary_hash == stored_binary_hash)
-        {
-            LOG_INFO(log, "Integrity check of the executable successfully passed (checksum: {})", calculated_binary_hash);
+            LOG_WARNING(log, "Integrity check of the executable skipped because the reference checksum could not be read.");
         }
         else
         {
-            /// If program is run under debugger, ptrace will fail.
-            if (ptrace(PTRACE_TRACEME, 0, nullptr, nullptr) == -1)
+            String calculated_binary_hash = getHashOfLoadedBinaryHex();
+            if (calculated_binary_hash == stored_binary_hash)
             {
-                /// Program is run under debugger. Modification of it's binary image is ok for breakpoints.
-                global_context->addWarningMessage(
-                    fmt::format("Server is run under debugger and its binary image is modified (most likely with breakpoints).",
-                    calculated_binary_hash)
-                );
+                LOG_INFO(log, "Integrity check of the executable successfully passed (checksum: {})", calculated_binary_hash);
             }
             else
             {
-                throw Exception(ErrorCodes::CORRUPTED_DATA,
-                    "Calculated checksum of the executable ({0}) does not correspond"
-                    " to the reference checksum stored in the executable ({1})."
-                    " This may indicate one of the following:"
-                    " - the executable {2} was changed just after startup;"
-                    " - the executable {2} was corrupted on disk due to faulty hardware;"
-                    " - the loaded executable was corrupted in memory due to faulty hardware;"
-                    " - the file {2} was intentionally modified;"
-                    " - a logical error in the code."
-                    , calculated_binary_hash, stored_binary_hash, executable_path);
+                /// If program is run under debugger, ptrace will fail.
+                if (ptrace(PTRACE_TRACEME, 0, nullptr, nullptr) == -1)
+                {
+                    /// Program is run under debugger. Modification of it's binary image is ok for breakpoints.
+                    global_context->addWarningMessage(fmt::format(
+                        "Server is run under debugger and its binary image is modified (most likely with breakpoints).",
+                        calculated_binary_hash));
+                }
+                else
+                {
+                    throw Exception(
+                        ErrorCodes::CORRUPTED_DATA,
+                        "Calculated checksum of the executable ({0}) does not correspond"
+                        " to the reference checksum stored in the executable ({1})."
+                        " This may indicate one of the following:"
+                        " - the executable {2} was changed just after startup;"
+                        " - the executable {2} was corrupted on disk due to faulty hardware;"
+                        " - the loaded executable was corrupted in memory due to faulty hardware;"
+                        " - the file {2} was intentionally modified;"
+                        " - a logical error in the code.",
+                        calculated_binary_hash,
+                        stored_binary_hash,
+                        executable_path);
+                }
             }
         }
     }

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -355,27 +355,33 @@ private:
 #if defined(OS_LINUX)
         /// Write information about binary checksum. It can be difficult to calculate, so do it only after printing stack trace.
         /// Please keep the below log messages in-sync with the ones in programs/server/Server.cpp
-        String calculated_binary_hash = getHashOfLoadedBinaryHex();
+
         if (daemon.stored_binary_hash.empty())
         {
-            LOG_FATAL(log, "Integrity check of the executable skipped because the reference checksum could not be read."
-                " (calculated checksum: {})", calculated_binary_hash);
-        }
-        else if (calculated_binary_hash == daemon.stored_binary_hash)
-        {
-            LOG_FATAL(log, "Integrity check of the executable successfully passed (checksum: {})", calculated_binary_hash);
+            LOG_FATAL(log, "Integrity check of the executable skipped because the reference checksum could not be read.");
         }
         else
         {
-            LOG_FATAL(log, "Calculated checksum of the executable ({0}) does not correspond"
-                " to the reference checksum stored in the executable ({1})."
-                " This may indicate one of the following:"
-                " - the executable was changed just after startup;"
-                " - the executable was corrupted on disk due to faulty hardware;"
-                " - the loaded executable was corrupted in memory due to faulty hardware;"
-                " - the file was intentionally modified;"
-                " - a logical error in the code."
-                , calculated_binary_hash, daemon.stored_binary_hash);
+            String calculated_binary_hash = getHashOfLoadedBinaryHex();
+            if (calculated_binary_hash == daemon.stored_binary_hash)
+            {
+                LOG_FATAL(log, "Integrity check of the executable successfully passed (checksum: {})", calculated_binary_hash);
+            }
+            else
+            {
+                LOG_FATAL(
+                    log,
+                    "Calculated checksum of the executable ({0}) does not correspond"
+                    " to the reference checksum stored in the executable ({1})."
+                    " This may indicate one of the following:"
+                    " - the executable was changed just after startup;"
+                    " - the executable was corrupted on disk due to faulty hardware;"
+                    " - the loaded executable was corrupted in memory due to faulty hardware;"
+                    " - the file was intentionally modified;"
+                    " - a logical error in the code.",
+                    calculated_binary_hash,
+                    daemon.stored_binary_hash);
+            }
         }
 #endif
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

When building CH locally for development with sanitizers, running the server is a PITA as it's taking 5-10 seconds to start for no reason as it's calculating the hash of the binary even though it won't be compared with anything (since it's not stored).

For reference, this is with release mode (0.1 seconds):
```
2022.11.10 16:07:58.735009 [ 320316 ] {} <Trace> AsynchronousMetrics: Scanning /sys/devices/system/edac
2022.11.10 16:07:58.735020 [ 320316 ] {} <Trace> AsynchronousMetrics: Scanning /sys/class/hwmon
2022.11.10 16:07:58.831932 [ 320316 ] {} <Warning> Application: Integrity check of the executable skipped because the reference checksum could not be read. (calculated checksum: B323B78CF024E63D843060B4F14DC8D6)
``` 

And this is with MSAN (almost 9 seconds):
```
2022.11.10 15:35:18.498572 [ 297809 ] {} <Trace> AsynchronousMetrics: Scanning /sys/devices/system/edac
2022.11.10 15:35:18.498612 [ 297809 ] {} <Trace> AsynchronousMetrics: Scanning /sys/class/hwmon
2022.11.10 15:35:27.050233 [ 297809 ] {} <Warning> Application: Integrity check of the executable skipped because the reference checksum could not be read. (calculated checksum: 9605EEDE41FA722A6098DCED67667121)
```

I don't think having the checksum is worth waiting 8-10 seconds on server start when it can't be compared with anything, and I have my doubts the release 0.1 is worth either but it's much less painful.