### PR TITLE
Add server UUID for disks access checks (read/read-by-offset/write/delete) to avoid possible races

### DIFF
--- a/programs/copier/ClusterCopierApp.cpp
+++ b/programs/copier/ClusterCopierApp.cpp
@@ -160,7 +160,7 @@ void ClusterCopierApp::mainImpl()
     registerTableFunctions();
     registerStorages();
     registerDictionaries();
-    registerDisks();
+    registerDisks(/* global_skip_access_check= */ true);
     registerFormats();
 
     static const std::string default_database = "_local";

--- a/programs/disks/DisksApp.cpp
+++ b/programs/disks/DisksApp.cpp
@@ -176,7 +176,7 @@ int DisksApp::main(const std::vector<String> & /*args*/)
         Poco::Logger::root().setLevel(Poco::Logger::parseLevel(log_level));
     }
 
-    registerDisks();
+    registerDisks(/* global_skip_access_check= */ true);
     registerFormats();
 
     shared_context = Context::createShared();

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -413,7 +413,7 @@ try
     registerTableFunctions();
     registerStorages();
     registerDictionaries();
-    registerDisks();
+    registerDisks(/* global_skip_access_check= */ true);
     registerFormats();
 
     processConfig();

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -679,7 +679,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
     registerTableFunctions();
     registerStorages();
     registerDictionaries();
-    registerDisks();
+    registerDisks(/* global_skip_access_check= */ false);
     registerFormats();
     registerRemoteFileMetadatas();
 

--- a/src/Disks/DiskDecorator.cpp
+++ b/src/Disks/DiskDecorator.cpp
@@ -4,7 +4,10 @@
 
 namespace DB
 {
-DiskDecorator::DiskDecorator(const DiskPtr & delegate_) : delegate(delegate_)
+
+DiskDecorator::DiskDecorator(const DiskPtr & delegate_)
+    : IDisk(/* name_= */ "<decorator>")
+    , delegate(delegate_)
 {
 }
 
@@ -226,9 +229,9 @@ void DiskDecorator::shutdown()
     delegate->shutdown();
 }
 
-void DiskDecorator::startup(ContextPtr context)
+void DiskDecorator::startupImpl(ContextPtr context)
 {
-    delegate->startup(context);
+    delegate->startupImpl(context);
 }
 
 void DiskDecorator::applyNewSettings(const Poco::Util::AbstractConfiguration & config, ContextPtr context, const String & config_prefix, const DisksMap & map)

--- a/src/Disks/DiskDecorator.h
+++ b/src/Disks/DiskDecorator.h
@@ -81,7 +81,7 @@ public:
     void onFreeze(const String & path) override;
     SyncGuardPtr getDirectorySyncGuard(const String & path) const override;
     void shutdown() override;
-    void startup(ContextPtr context) override;
+    void startupImpl(ContextPtr context) override;
     void applyNewSettings(const Poco::Util::AbstractConfiguration & config, ContextPtr context, const String & config_prefix, const DisksMap & map) override;
 
     bool supportsCache() const override { return delegate->supportsCache(); }

--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -369,15 +369,16 @@ void DiskEncrypted::applyNewSettings(
     current_settings.set(std::move(new_settings));
 }
 
-void registerDiskEncrypted(DiskFactory & factory)
+void registerDiskEncrypted(DiskFactory & factory, bool global_skip_access_check)
 {
-    auto creator = [](const String & name,
-                      const Poco::Util::AbstractConfiguration & config,
-                      const String & config_prefix,
-                      ContextPtr context,
-                      const DisksMap & map) -> DiskPtr
+    auto creator = [global_skip_access_check](
+        const String & name,
+        const Poco::Util::AbstractConfiguration & config,
+        const String & config_prefix,
+        ContextPtr context,
+        const DisksMap & map) -> DiskPtr
     {
-        bool skip_access_check = config.getBool(config_prefix + ".skip_access_check", false);
+        bool skip_access_check = global_skip_access_check || config.getBool(config_prefix + ".skip_access_check", false);
         DiskPtr disk = std::make_shared<DiskEncrypted>(name, config, config_prefix, map);
         disk->startup(context, skip_access_check);
         return disk;

--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -33,7 +33,7 @@ public:
     DiskEncrypted(const String & name_, const Poco::Util::AbstractConfiguration & config_, const String & config_prefix_, const DisksMap & map_);
     DiskEncrypted(const String & name_, std::unique_ptr<const DiskEncryptedSettings> settings_);
 
-    const String & getName() const override { return name; }
+    const String & getName() const override { return encrypted_name; }
     const String & getPath() const override { return disk_absolute_path; }
 
     ReservationPtr reserve(UInt64 bytes) override;
@@ -261,7 +261,7 @@ private:
         return disk_path + path;
     }
 
-    const String name;
+    const String encrypted_name;
     const String disk_path;
     const String disk_absolute_path;
     MultiVersion<DiskEncryptedSettings> current_settings;

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -762,7 +762,7 @@ void registerDiskLocal(DiskFactory & factory, bool global_skip_access_check)
         std::shared_ptr<IDisk> disk
             = std::make_shared<DiskLocal>(name, path, keep_free_space_bytes, context, config.getUInt("local_disk_check_period_ms", 0));
         disk->startup(context, skip_access_check);
-        return std::make_shared<DiskRestartProxy>(disk, skip_access_check);
+        return std::make_shared<DiskRestartProxy>(disk);
     };
     factory.registerDiskType("local", creator);
 }

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -626,10 +626,16 @@ void DiskLocal::checkAccessImpl(const String & path)
     try
     {
         fs::create_directories(disk_path);
+        if (!FS::canWrite(disk_path))
+        {
+            LOG_ERROR(logger, "Cannot write to the root directory of disk {} ({}).", name, disk_path);
+            readonly = true;
+            return;
+        }
     }
     catch (...)
     {
-        LOG_ERROR(logger, "Cannot create the directory of disk {} ({}).", name, disk_path);
+        LOG_ERROR(logger, "Cannot create the root directory of disk {} ({}).", name, disk_path);
         readonly = true;
         return;
     }

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -637,7 +637,7 @@ void DiskLocal::checkAccessImpl(const String & path)
     IDisk::checkAccessImpl(path);
 }
 
-bool DiskLocal::setup()
+void DiskLocal::setup()
 {
     try
     {
@@ -652,7 +652,7 @@ bool DiskLocal::setup()
 
     /// If disk checker is disabled, just assume RW by default.
     if (!disk_checker)
-        return true;
+        return;
 
     try
     {
@@ -676,6 +676,7 @@ bool DiskLocal::setup()
 
     /// Try to create a new checker file. The disk status can be either broken or readonly.
     if (disk_checker_magic_number == -1)
+    {
         try
         {
             pcg32_fast rng(randomSeed());
@@ -695,12 +696,12 @@ bool DiskLocal::setup()
                 disk_checker_path,
                 name);
             disk_checker_can_check_read = false;
-            return true;
+            return;
         }
+    }
 
     if (disk_checker_magic_number == -1)
         throw Exception("disk_checker_magic_number is not initialized. It's a bug", ErrorCodes::LOGICAL_ERROR);
-    return true;
 }
 
 void DiskLocal::startupImpl(ContextPtr)
@@ -711,8 +712,7 @@ void DiskLocal::startupImpl(ContextPtr)
 
     try
     {
-        if (!setup())
-            readonly = true;
+        setup();
     }
     catch (...)
     {

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -110,6 +110,7 @@ public:
     void applyNewSettings(const Poco::Util::AbstractConfiguration & config, ContextPtr context, const String & config_prefix, const DisksMap &) override;
 
     bool isBroken() const override { return broken; }
+    bool isReadOnly() const override { return readonly; }
 
     void startupImpl(ContextPtr context) override;
 

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -28,8 +28,6 @@ public:
         ContextPtr context,
         UInt64 local_disk_check_period_ms);
 
-    const String & getName() const override { return name; }
-
     const String & getPath() const override { return disk_path; }
 
     ReservationPtr reserve(UInt64 bytes) override;
@@ -113,7 +111,7 @@ public:
 
     bool isBroken() const override { return broken; }
 
-    void startup(ContextPtr) override;
+    void startupImpl(ContextPtr) override;
 
     void shutdown() override;
 
@@ -143,7 +141,6 @@ private:
     /// Read magic number from disk checker file. Return std::nullopt if exception happens.
     std::optional<UInt32> readDiskCheckerMagicNumber() const noexcept;
 
-    const String name;
     const String disk_path;
     const String disk_checker_path = ".disk_checker_file";
     std::atomic<UInt64> keep_free_space_bytes;

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -137,9 +137,9 @@ protected:
 private:
     std::optional<UInt64> tryReserve(UInt64 bytes);
 
-    /// Setup disk for healthy check. Returns true if it's read-write, false if read-only.
+    /// Setup disk for healthy check.
     /// Throw exception if it's not possible to setup necessary files and directories.
-    bool setup();
+    void setup();
 
     /// Read magic number from disk checker file. Return std::nullopt if exception happens.
     std::optional<UInt32> readDiskCheckerMagicNumber() const noexcept;

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -111,7 +111,7 @@ public:
 
     bool isBroken() const override { return broken; }
 
-    void startupImpl(ContextPtr) override;
+    void startupImpl(ContextPtr context) override;
 
     void shutdown() override;
 
@@ -130,6 +130,9 @@ public:
     void chmod(const String & path, mode_t mode) override;
 
     MetadataStoragePtr getMetadataStorage() override;
+
+protected:
+    void checkAccessImpl(const String & path) override;
 
 private:
     std::optional<UInt64> tryReserve(UInt64 bytes);

--- a/src/Disks/DiskMemory.cpp
+++ b/src/Disks/DiskMemory.cpp
@@ -461,15 +461,16 @@ MetadataStoragePtr DiskMemory::getMetadataStorage()
 using DiskMemoryPtr = std::shared_ptr<DiskMemory>;
 
 
-void registerDiskMemory(DiskFactory & factory)
+void registerDiskMemory(DiskFactory & factory, bool global_skip_access_check)
 {
-    auto creator = [](const String & name,
-                      const Poco::Util::AbstractConfiguration & config,
-                      const String & config_prefix,
-                      ContextPtr context,
-                      const DisksMap & /*map*/) -> DiskPtr
+    auto creator = [global_skip_access_check](
+        const String & name,
+        const Poco::Util::AbstractConfiguration & config,
+        const String & config_prefix,
+        ContextPtr context,
+        const DisksMap & /*map*/) -> DiskPtr
     {
-        bool skip_access_check = config.getBool(config_prefix + ".skip_access_check", false);
+        bool skip_access_check = global_skip_access_check || config.getBool(config_prefix + ".skip_access_check", false);
         DiskPtr disk = std::make_shared<DiskMemory>(name);
         disk->startup(context, skip_access_check);
         return disk;

--- a/src/Disks/DiskMemory.cpp
+++ b/src/Disks/DiskMemory.cpp
@@ -143,7 +143,7 @@ private:
 
 DiskMemory::DiskMemory(const String & name_)
     : IDisk(name_)
-    , disk_path("memory://" + name_ + '/')
+    , disk_path("memory(" + name_ + ')')
 {}
 
 ReservationPtr DiskMemory::reserve(UInt64 /*bytes*/)

--- a/src/Disks/DiskMemory.h
+++ b/src/Disks/DiskMemory.h
@@ -8,7 +8,7 @@
 
 namespace DB
 {
-class DiskMemory;
+
 class ReadBufferFromFileBase;
 class WriteBufferFromFileBase;
 
@@ -22,9 +22,7 @@ class WriteBufferFromFileBase;
 class DiskMemory : public IDisk
 {
 public:
-    explicit DiskMemory(const String & name_) : name(name_), disk_path("memory://" + name_ + '/') {}
-
-    const String & getName() const override { return name; }
+    explicit DiskMemory(const String & name_);
 
     const String & getPath() const override { return disk_path; }
 
@@ -121,7 +119,6 @@ private:
     };
     using Files = std::unordered_map<String, FileData>; /// file path -> file data
 
-    const String name;
     const String disk_path;
     Files files;
     mutable std::mutex mutex;

--- a/src/Disks/DiskRestartProxy.cpp
+++ b/src/Disks/DiskRestartProxy.cpp
@@ -78,8 +78,10 @@ private:
     ReadLock lock;
 };
 
-DiskRestartProxy::DiskRestartProxy(DiskPtr & delegate_)
-    : DiskDecorator(delegate_) { }
+DiskRestartProxy::DiskRestartProxy(DiskPtr & delegate_, bool skip_access_check_)
+    : DiskDecorator(delegate_)
+    , skip_access_check(skip_access_check_)
+{}
 
 ReservationPtr DiskRestartProxy::reserve(UInt64 bytes)
 {
@@ -368,7 +370,7 @@ void DiskRestartProxy::restart(ContextPtr context)
 
     LOG_INFO(log, "Restart lock acquired. Restarting disk {}", DiskDecorator::getName());
 
-    DiskDecorator::startup(context);
+    DiskDecorator::startup(context, skip_access_check);
 
     LOG_INFO(log, "Disk restarted {}", DiskDecorator::getName());
 }

--- a/src/Disks/DiskRestartProxy.cpp
+++ b/src/Disks/DiskRestartProxy.cpp
@@ -78,9 +78,8 @@ private:
     ReadLock lock;
 };
 
-DiskRestartProxy::DiskRestartProxy(DiskPtr & delegate_, bool skip_access_check_)
+DiskRestartProxy::DiskRestartProxy(DiskPtr & delegate_)
     : DiskDecorator(delegate_)
-    , skip_access_check(skip_access_check_)
 {}
 
 ReservationPtr DiskRestartProxy::reserve(UInt64 bytes)
@@ -370,7 +369,8 @@ void DiskRestartProxy::restart(ContextPtr context)
 
     LOG_INFO(log, "Restart lock acquired. Restarting disk {}", DiskDecorator::getName());
 
-    DiskDecorator::startup(context, skip_access_check);
+    /// NOTE: access checking will cause deadlock here, so skip it.
+    DiskDecorator::startup(context, /* skip_access_check= */ true);
 
     LOG_INFO(log, "Disk restarted {}", DiskDecorator::getName());
 }

--- a/src/Disks/DiskRestartProxy.h
+++ b/src/Disks/DiskRestartProxy.h
@@ -21,7 +21,7 @@ class RestartAwareWriteBuffer;
 class DiskRestartProxy : public DiskDecorator
 {
 public:
-    explicit DiskRestartProxy(DiskPtr & delegate_);
+    explicit DiskRestartProxy(DiskPtr & delegate_, bool skip_access_check_);
 
     ReservationPtr reserve(UInt64 bytes) override;
     const String & getPath() const override;
@@ -79,6 +79,7 @@ private:
 
     /// Mutex to protect RW access.
     mutable std::shared_timed_mutex mutex;
+    bool skip_access_check;
 
     Poco::Logger * log = &Poco::Logger::get("DiskRestartProxy");
 };

--- a/src/Disks/DiskRestartProxy.h
+++ b/src/Disks/DiskRestartProxy.h
@@ -21,7 +21,7 @@ class RestartAwareWriteBuffer;
 class DiskRestartProxy : public DiskDecorator
 {
 public:
-    explicit DiskRestartProxy(DiskPtr & delegate_, bool skip_access_check_);
+    explicit DiskRestartProxy(DiskPtr & delegate_);
 
     ReservationPtr reserve(UInt64 bytes) override;
     const String & getPath() const override;
@@ -79,7 +79,6 @@ private:
 
     /// Mutex to protect RW access.
     mutable std::shared_timed_mutex mutex;
-    bool skip_access_check;
 
     Poco::Logger * log = &Poco::Logger::get("DiskRestartProxy");
 };

--- a/src/Disks/IDisk.cpp
+++ b/src/Disks/IDisk.cpp
@@ -6,6 +6,7 @@
 #include <Poco/Logger.h>
 #include <Common/logger_useful.h>
 #include <Common/setThreadName.h>
+#include <Core/ServerUUID.h>
 #include <Disks/ObjectStorages/MetadataStorageFromDisk.h>
 #include <Disks/ObjectStorages/FakeMetadataStorageFromDisk.h>
 #include <Disks/ObjectStorages/LocalObjectStorage.h>
@@ -17,6 +18,8 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
+    extern const int CANNOT_READ_ALL_DATA;
+    extern const int LOGICAL_ERROR;
 }
 
 bool IDisk::isDirectoryEmpty(const String & path) const
@@ -124,6 +127,76 @@ void IDisk::truncateFile(const String &, size_t)
 SyncGuardPtr IDisk::getDirectorySyncGuard(const String & /* path */) const
 {
     return nullptr;
+}
+
+void IDisk::checkAccess()
+try
+{
+    if (isReadOnly())
+    {
+        LOG_DEBUG(&Poco::Logger::get("IDisk"),
+            "Skip access check for disk {} (read-only disk).",
+            getName());
+        return;
+    }
+
+    DB::UUID server_uuid = DB::ServerUUID::get();
+    if (server_uuid == DB::UUIDHelpers::Nil)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Server UUID is not initialized");
+    const String path = fmt::format("clickhouse_access_check_{}", DB::toString(server_uuid));
+    const std::string_view payload("test", 4);
+
+    /// NOTE: should we mark the disk readonly if the write/unlink fails instead of throws?
+
+    /// write
+    {
+        auto file = writeFile(path, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite);
+        try
+        {
+            file->write(payload.data(), payload.size());
+        }
+        catch (...)
+        {
+            /// Log current exception, because finalize() can throw a different exception.
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+            file->finalize();
+            throw;
+        }
+    }
+
+    /// read
+    {
+        auto file = readFile(path);
+        String buf(payload.size(), '0');
+        file->readStrict(buf.data(), buf.size());
+        if (buf != payload)
+        {
+            throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
+                "Content of {}::{} does not matches after read ({} vs {})", name, path, buf, payload);
+        }
+    }
+
+    /// read with offset
+    {
+        auto file = readFile(path);
+        auto offset = 2;
+        String buf(payload.size() - offset, '0');
+        file->seek(offset, 0);
+        file->readStrict(buf.data(), buf.size());
+        if (buf != payload.substr(offset))
+        {
+            throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
+                "Content of {}::{} does not matches after read with offset ({} vs {})", name, path, buf, payload.substr(offset));
+        }
+    }
+
+    /// remove
+    removeFile(path);
+}
+catch (Exception & e)
+{
+    e.addMessage(fmt::format("While checking access for disk {}", name));
+    throw;
 }
 
 }

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -320,12 +320,9 @@ public:
     /// Invoked when Global Context is shutdown.
     virtual void shutdown() {}
 
-    void startup(ContextPtr context, bool skip_access_check)
-    {
-        if (!skip_access_check)
-            checkAccess();
-        startupImpl(context);
-    }
+    /// Performs access check and custom action on disk startup.
+    void startup(ContextPtr context, bool skip_access_check);
+
     /// Performs custom action on disk startup.
     virtual void startupImpl(ContextPtr) {}
 
@@ -410,6 +407,8 @@ public:
 protected:
     friend class DiskDecorator;
 
+    const String name;
+
     /// Returns executor to perform asynchronous operations.
     virtual Executor & getExecutor() { return *executor; }
 
@@ -418,8 +417,7 @@ protected:
     /// A derived class may override copy() to provide a faster implementation.
     void copyThroughBuffers(const String & from_path, const std::shared_ptr<IDisk> & to_disk, const String & to_path, bool copy_root_dir = true);
 
-protected:
-    const String name;
+    virtual void checkAccessImpl(const String & path);
 
 private:
     std::shared_ptr<Executor> executor;

--- a/src/Disks/ObjectStorages/AzureBlobStorage/registerDiskAzureBlobStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/registerDiskAzureBlobStorage.cpp
@@ -17,9 +17,9 @@
 namespace DB
 {
 
-void registerDiskAzureBlobStorage(DiskFactory & factory)
+void registerDiskAzureBlobStorage(DiskFactory & factory, bool global_skip_access_check)
 {
-    auto creator = [](
+    auto creator = [global_skip_access_check](
         const String & name,
         const Poco::Util::AbstractConfiguration & config,
         const String & config_prefix,
@@ -48,7 +48,7 @@ void registerDiskAzureBlobStorage(DiskFactory & factory)
             copy_thread_pool_size
         );
 
-        bool skip_access_check = config.getBool(config_prefix + ".skip_access_check", false);
+        bool skip_access_check = global_skip_access_check || config.getBool(config_prefix + ".skip_access_check", false);
         azure_blob_storage_disk->startup(context, skip_access_check);
 
         return std::make_shared<DiskRestartProxy>(azure_blob_storage_disk, skip_access_check);
@@ -64,7 +64,7 @@ void registerDiskAzureBlobStorage(DiskFactory & factory)
 namespace DB
 {
 
-void registerDiskAzureBlobStorage(DiskFactory &) {}
+void registerDiskAzureBlobStorage(DiskFactory &, bool /* global_skip_access_check */) {}
 
 }
 

--- a/src/Disks/ObjectStorages/AzureBlobStorage/registerDiskAzureBlobStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/registerDiskAzureBlobStorage.cpp
@@ -51,7 +51,7 @@ void registerDiskAzureBlobStorage(DiskFactory & factory, bool global_skip_access
         bool skip_access_check = global_skip_access_check || config.getBool(config_prefix + ".skip_access_check", false);
         azure_blob_storage_disk->startup(context, skip_access_check);
 
-        return std::make_shared<DiskRestartProxy>(azure_blob_storage_disk, skip_access_check);
+        return std::make_shared<DiskRestartProxy>(azure_blob_storage_disk);
     };
 
     factory.registerDiskType("azure_blob_storage", creator);

--- a/src/Disks/ObjectStorages/AzureBlobStorage/registerDiskAzureBlobStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/registerDiskAzureBlobStorage.cpp
@@ -17,52 +17,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int PATH_ACCESS_DENIED;
-}
-
-namespace
-{
-
-constexpr char test_file[] = "test.txt";
-constexpr char test_str[] = "test";
-constexpr size_t test_str_size = 4;
-
-void checkWriteAccess(IDisk & disk)
-{
-    auto file = disk.writeFile(test_file, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite);
-    file->write(test_str, test_str_size);
-}
-
-void checkReadAccess(IDisk & disk)
-{
-    auto file = disk.readFile(test_file);
-    String buf(test_str_size, '0');
-    file->readStrict(buf.data(), test_str_size);
-    if (buf != test_str)
-        throw Exception("No read access to disk", ErrorCodes::PATH_ACCESS_DENIED);
-}
-
-void checkReadWithOffset(IDisk & disk)
-{
-    auto file = disk.readFile(test_file);
-    auto offset = 2;
-    auto test_size = test_str_size - offset;
-    String buf(test_size, '0');
-    file->seek(offset, 0);
-    file->readStrict(buf.data(), test_size);
-    if (buf != test_str + offset)
-        throw Exception("Failed to read file with offset", ErrorCodes::PATH_ACCESS_DENIED);
-}
-
-void checkRemoveAccess(IDisk & disk)
-{
-    disk.removeFile(test_file);
-}
-
-}
-
 void registerDiskAzureBlobStorage(DiskFactory & factory)
 {
     auto creator = [](
@@ -94,17 +48,10 @@ void registerDiskAzureBlobStorage(DiskFactory & factory)
             copy_thread_pool_size
         );
 
-        if (!config.getBool(config_prefix + ".skip_access_check", false))
-        {
-            checkWriteAccess(*azure_blob_storage_disk);
-            checkReadAccess(*azure_blob_storage_disk);
-            checkReadWithOffset(*azure_blob_storage_disk);
-            checkRemoveAccess(*azure_blob_storage_disk);
-        }
+        bool skip_access_check = config.getBool(config_prefix + ".skip_access_check", false);
+        azure_blob_storage_disk->startup(context, skip_access_check);
 
-        azure_blob_storage_disk->startup(context);
-
-        return std::make_shared<DiskRestartProxy>(azure_blob_storage_disk);
+        return std::make_shared<DiskRestartProxy>(azure_blob_storage_disk, skip_access_check);
     };
 
     factory.registerDiskType("azure_blob_storage", creator);

--- a/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
+++ b/src/Disks/ObjectStorages/Cached/registerDiskCache.cpp
@@ -16,7 +16,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
-void registerDiskCache(DiskFactory & factory)
+void registerDiskCache(DiskFactory & factory, bool /* global_skip_access_check */)
 {
     auto creator = [](const String & name,
                     const Poco::Util::AbstractConfiguration & config,

--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -109,8 +109,7 @@ DiskObjectStorage::DiskObjectStorage(
     ObjectStoragePtr object_storage_,
     bool send_metadata_,
     uint64_t thread_pool_size_)
-    : IDisk(getAsyncExecutor(log_name, thread_pool_size_))
-    , name(name_)
+    : IDisk(name_, getAsyncExecutor(log_name, thread_pool_size_))
     , object_storage_root_path(object_storage_root_path_)
     , log (&Poco::Logger::get("DiskObjectStorage(" + log_name + ")"))
     , metadata_storage(std::move(metadata_storage_))
@@ -420,9 +419,8 @@ void DiskObjectStorage::shutdown()
     LOG_INFO(log, "Disk {} shut down", name);
 }
 
-void DiskObjectStorage::startup(ContextPtr context)
+void DiskObjectStorage::startupImpl(ContextPtr context)
 {
-
     LOG_INFO(log, "Starting up disk {}", name);
     object_storage->startup();
 

--- a/src/Disks/ObjectStorages/DiskObjectStorage.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.h
@@ -45,8 +45,6 @@ public:
 
     bool supportParallelWrite() const override { return object_storage->supportParallelWrite(); }
 
-    const String & getName() const override { return name; }
-
     const String & getPath() const override { return metadata_storage->getPath(); }
 
     StoredObjects getStorageObjects(const String & local_path) const override;
@@ -138,7 +136,7 @@ public:
 
     void shutdown() override;
 
-    void startup(ContextPtr context) override;
+    void startupImpl(ContextPtr context) override;
 
     ReservationPtr reserve(UInt64 bytes) override;
 
@@ -212,7 +210,6 @@ private:
     /// execution.
     DiskTransactionPtr createObjectStorageTransaction();
 
-    const String name;
     const String object_storage_root_path;
     Poco::Logger * log;
 

--- a/src/Disks/ObjectStorages/HDFS/registerDiskHDFS.cpp
+++ b/src/Disks/ObjectStorages/HDFS/registerDiskHDFS.cpp
@@ -55,7 +55,7 @@ void registerDiskHDFS(DiskFactory & factory, bool global_skip_access_check)
             copy_thread_pool_size);
         disk->startup(context, skip_access_check);
 
-        return std::make_shared<DiskRestartProxy>(disk, skip_access_check);
+        return std::make_shared<DiskRestartProxy>(disk);
     };
 
     factory.registerDiskType("hdfs", creator);

--- a/src/Disks/ObjectStorages/S3/registerDiskS3.cpp
+++ b/src/Disks/ObjectStorages/S3/registerDiskS3.cpp
@@ -167,7 +167,7 @@ void registerDiskS3(DiskFactory & factory, bool global_skip_access_check)
 
         std::shared_ptr<IDisk> disk_result = s3disk;
 
-        return std::make_shared<DiskRestartProxy>(disk_result, skip_access_check);
+        return std::make_shared<DiskRestartProxy>(disk_result);
     };
     factory.registerDiskType("s3", creator);
     factory.registerDiskType("s3_plain", creator);

--- a/src/Disks/ObjectStorages/Web/registerDiskWebServer.cpp
+++ b/src/Disks/ObjectStorages/Web/registerDiskWebServer.cpp
@@ -23,6 +23,7 @@ void registerDiskWebServer(DiskFactory & factory)
                       const DisksMap & /*map*/) -> DiskPtr
     {
         String uri{config.getString(config_prefix + ".endpoint")};
+        bool skip_access_check = config.getBool(config_prefix + ".skip_access_check", false);
 
         if (!uri.ends_with('/'))
             throw Exception(
@@ -41,7 +42,7 @@ void registerDiskWebServer(DiskFactory & factory)
         auto metadata_storage = std::make_shared<MetadataStorageFromStaticFilesWebServer>(assert_cast<const WebObjectStorage &>(*object_storage));
         std::string root_path;
 
-        return std::make_shared<DiskObjectStorage>(
+        DiskPtr disk = std::make_shared<DiskObjectStorage>(
             disk_name,
             root_path,
             "DiskWebServer",
@@ -49,6 +50,8 @@ void registerDiskWebServer(DiskFactory & factory)
             object_storage,
             /* send_metadata */false,
             /* threadpool_size */16);
+        disk->startup(context, skip_access_check);
+        return disk;
     };
 
     factory.registerDiskType("web", creator);

--- a/src/Disks/ObjectStorages/Web/registerDiskWebServer.cpp
+++ b/src/Disks/ObjectStorages/Web/registerDiskWebServer.cpp
@@ -14,16 +14,17 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
-void registerDiskWebServer(DiskFactory & factory)
+void registerDiskWebServer(DiskFactory & factory, bool global_skip_access_check)
 {
-    auto creator = [](const String & disk_name,
-                      const Poco::Util::AbstractConfiguration & config,
-                      const String & config_prefix,
-                      ContextPtr context,
-                      const DisksMap & /*map*/) -> DiskPtr
+    auto creator = [global_skip_access_check](
+        const String & disk_name,
+        const Poco::Util::AbstractConfiguration & config,
+        const String & config_prefix,
+        ContextPtr context,
+        const DisksMap & /*map*/) -> DiskPtr
     {
         String uri{config.getString(config_prefix + ".endpoint")};
-        bool skip_access_check = config.getBool(config_prefix + ".skip_access_check", false);
+        bool skip_access_check = global_skip_access_check || config.getBool(config_prefix + ".skip_access_check", false);
 
         if (!uri.ends_with('/'))
             throw Exception(

--- a/src/Disks/registerDisks.cpp
+++ b/src/Disks/registerDisks.cpp
@@ -7,55 +7,55 @@
 namespace DB
 {
 
-void registerDiskLocal(DiskFactory & factory);
-void registerDiskMemory(DiskFactory & factory);
+void registerDiskLocal(DiskFactory & factory, bool global_skip_access_check);
+void registerDiskMemory(DiskFactory & factory, bool global_skip_access_check);
 
 #if USE_AWS_S3
-void registerDiskS3(DiskFactory & factory);
+void registerDiskS3(DiskFactory & factory, bool global_skip_access_check);
 #endif
 
 #if USE_AZURE_BLOB_STORAGE
-void registerDiskAzureBlobStorage(DiskFactory & factory);
+void registerDiskAzureBlobStorage(DiskFactory & factory, bool global_skip_access_check);
 #endif
 
 #if USE_SSL
-void registerDiskEncrypted(DiskFactory & factory);
+void registerDiskEncrypted(DiskFactory & factory, bool global_skip_access_check);
 #endif
 
 #if USE_HDFS
-void registerDiskHDFS(DiskFactory & factory);
+void registerDiskHDFS(DiskFactory & factory, bool global_skip_access_check);
 #endif
 
-void registerDiskWebServer(DiskFactory & factory);
+void registerDiskWebServer(DiskFactory & factory, bool global_skip_access_check);
 
-void registerDiskCache(DiskFactory & factory);
+void registerDiskCache(DiskFactory & factory, bool global_skip_access_check);
 
-void registerDisks()
+void registerDisks(bool global_skip_access_check)
 {
     auto & factory = DiskFactory::instance();
 
-    registerDiskLocal(factory);
-    registerDiskMemory(factory);
+    registerDiskLocal(factory, global_skip_access_check);
+    registerDiskMemory(factory, global_skip_access_check);
 
 #if USE_AWS_S3
-    registerDiskS3(factory);
+    registerDiskS3(factory, global_skip_access_check);
 #endif
 
 #if USE_AZURE_BLOB_STORAGE
-    registerDiskAzureBlobStorage(factory);
+    registerDiskAzureBlobStorage(factory, global_skip_access_check);
 #endif
 
 #if USE_SSL
-    registerDiskEncrypted(factory);
+    registerDiskEncrypted(factory, global_skip_access_check);
 #endif
 
 #if USE_HDFS
-    registerDiskHDFS(factory);
+    registerDiskHDFS(factory, global_skip_access_check);
 #endif
 
-    registerDiskWebServer(factory);
+    registerDiskWebServer(factory, global_skip_access_check);
 
-    registerDiskCache(factory);
+    registerDiskCache(factory, global_skip_access_check);
 }
 
 }

--- a/src/Disks/registerDisks.h
+++ b/src/Disks/registerDisks.h
@@ -2,5 +2,10 @@
 
 namespace DB
 {
-void registerDisks();
+
+/// @param global_skip_access_check - skip access check regardless regardless
+///                                   .skip_access_check config directive (used
+///                                   for clickhouse-disks)
+void registerDisks(bool global_skip_access_check);
+
 }

--- a/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
+++ b/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
@@ -33,7 +33,7 @@ try
         registerTableFunctions();
         registerStorages();
         registerDictionaries();
-        registerDisks();
+        registerDisks(/* global_skip_access_check= */ true);
         registerFormats();
 
         return true;

--- a/tests/integration/test_disk_types/configs/storage.xml
+++ b/tests/integration/test_disk_types/configs/storage.xml
@@ -12,7 +12,7 @@
             </disk_memory>
             <disk_hdfs>
                 <type>hdfs</type>
-                <endpoint>hdfs://hdfs1:9000/data/</endpoint>
+                <endpoint>hdfs://hdfs1:9000/</endpoint>
             </disk_hdfs>
             <disk_encrypted>
                 <type>encrypted</type>

--- a/tests/integration/test_disk_types/test.py
+++ b/tests/integration/test_disk_types/test.py
@@ -1,7 +1,6 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
-from pyhdfs import HdfsClient
 
 disk_types = {
     "default": "local",
@@ -23,9 +22,6 @@ def cluster():
             with_hdfs=True,
         )
         cluster.start()
-
-        fs = HdfsClient(hosts=cluster.hdfs_ip)
-        fs.mkdirs("/data")
 
         yield cluster
     finally:

--- a/tests/integration/test_disk_types/test.py
+++ b/tests/integration/test_disk_types/test.py
@@ -1,6 +1,7 @@
 import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
+from pyhdfs import HdfsClient
 
 disk_types = {
     "default": "local",
@@ -22,6 +23,10 @@ def cluster():
             with_hdfs=True,
         )
         cluster.start()
+
+        fs = HdfsClient(hosts=cluster.hdfs_ip)
+        fs.mkdirs("/data")
+
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_log_family_hdfs/configs/storage_conf.xml
+++ b/tests/integration/test_log_family_hdfs/configs/storage_conf.xml
@@ -4,6 +4,8 @@
             <hdfs>
                 <type>hdfs</type>
                 <endpoint>hdfs://hdfs1:9000/clickhouse/</endpoint>
+                <!-- FIXME: chicken and egg problem with current cluster.py -->
+                <skip_access_check>true</skip_access_check>
             </hdfs>
         </disks>
     </storage_configuration>

--- a/tests/integration/test_merge_tree_hdfs/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_hdfs/configs/config.d/storage_conf.xml
@@ -4,6 +4,8 @@
             <hdfs>
                 <type>hdfs</type>
                 <endpoint>hdfs://hdfs1:9000/clickhouse/</endpoint>
+                <!-- FIXME: chicken and egg problem with current cluster.py -->
+                <skip_access_check>true</skip_access_check>
             </hdfs>
             <hdd>
                 <type>local</type>

--- a/tests/integration/test_replicated_merge_tree_hdfs_zero_copy/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_replicated_merge_tree_hdfs_zero_copy/configs/config.d/storage_conf.xml
@@ -4,14 +4,20 @@
             <hdfs1>
                 <type>hdfs</type>
                 <endpoint>hdfs://hdfs1:9000/clickhouse1/</endpoint>
+                <!-- FIXME: chicken and egg problem with current cluster.py -->
+                <skip_access_check>true</skip_access_check>
             </hdfs1>
             <hdfs1_again>
                 <type>hdfs</type>
                 <endpoint>hdfs://hdfs1:9000/clickhouse1/</endpoint>
+                <!-- FIXME: chicken and egg problem with current cluster.py -->
+                <skip_access_check>true</skip_access_check>
             </hdfs1_again>
             <hdfs2>
                 <type>hdfs</type>
                 <endpoint>hdfs://hdfs1:9000/clickhouse2/</endpoint>
+                <!-- FIXME: chicken and egg problem with current cluster.py -->
+                <skip_access_check>true</skip_access_check>
             </hdfs2>
         </disks>
         <policies>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add server UUID for disks access checks (read/read-by-offset/write/delete) to avoid possible races. Plus now disks checks will be done for all disks, and not only S3/Azure.

Otherwise, if you are lucky enough, race condition is possible, and you can get some errors because one server already removed the file while another was trying to read it.

But it was possible only for:
- batch deletes check for "s3" disk
- and all checks for "s3_plain" disk, since this disk does not uses random names

Fixes: #37791