### PR TITLE
Do not include libcxx library for C

### DIFF
--- a/contrib/libcxx-cmake/CMakeLists.txt
+++ b/contrib/libcxx-cmake/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(cxx ${SRCS})
 set_target_properties(cxx PROPERTIES FOLDER "contrib/libcxx-cmake")
 
 target_include_directories(cxx SYSTEM BEFORE PRIVATE $<BUILD_INTERFACE:${LIBCXX_SOURCE_DIR}/src>)
-target_include_directories(cxx SYSTEM BEFORE PUBLIC  $<BUILD_INTERFACE:${LIBCXX_SOURCE_DIR}/include>)
+target_include_directories(cxx SYSTEM BEFORE PUBLIC  $<$<COMPILE_LANGUAGE:CXX>:$<BUILD_INTERFACE:${LIBCXX_SOURCE_DIR}/include>>)
 target_compile_definitions(cxx PRIVATE -D_LIBCPP_BUILDING_LIBRARY -DLIBCXX_BUILDING_LIBCXXABI)
 
 # Enable capturing stack traces for all exceptions.


### PR DESCRIPTION
If you will have the same header in both libraries you may have some tricky failures.

And there is at least one header that exists in both: stdatomic.h

Right now there is a workaround for this header, that allows to use C++ version of this header for C - the workaround is called "set _LIBCPP_COMPILER_CLANG_BASED not only for CXX" [1] and use include_next [2].

  [1]: https://github.com/ClickHouse/libcxx/blob/9a457ab3c64a533a06922b386b284215c17ce627/include/__config#L39
  [2]: https://github.com/ClickHouse/libcxx/blob/9a457ab3c64a533a06922b386b284215c17ce627/include/stdatomic.h#L223-L231

However #42730 (cc @rschu1ze) changes this, and now it fails to compile because of this.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)