### PR TITLE
Fix annoying messages in AsynchronousMetrics

### DIFF
--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -12,6 +12,7 @@
 
 #include <fmt/format.h>
 
+
 namespace Poco { class Logger; }
 
 

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1139,7 +1139,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
     }
     catch (...)
     {
-        LOG_DEBUG(log, getCurrentExceptionMessage(false));
+        LOG_DEBUG(log, "Cannot read the statistics from block devices: {}", getCurrentExceptionMessage(false));
 
         /// Try to reopen block devices in case of error
         /// (i.e. ENOENT or ENODEV means that some disk had been replaced, and it may appear with a new name)

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1139,7 +1139,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
     }
     catch (...)
     {
-        LOG_DEBUG(log, "Cannot read the statistics from block devices: {}", getCurrentExceptionMessage(false));
+        LOG_DEBUG(log, "Cannot read statistics from block devices: {}", getCurrentExceptionMessage(false));
 
         /// Try to reopen block devices in case of error
         /// (i.e. ENOENT or ENODEV means that some disk had been replaced, and it may appear with a new name)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve error reporting in the collection of OS-related info for the `system.asynchronous_metrics` table.