### PR TITLE
Add documentation for `system.asynchronous_metrics`.

### DIFF
--- a/programs/server/MetricsTransmitter.cpp
+++ b/programs/server/MetricsTransmitter.cpp
@@ -123,7 +123,7 @@ void MetricsTransmitter::transmit(std::vector<ProfileEvents::Count> & prev_count
     {
         for (const auto & name_value : async_metrics_values)
         {
-            key_vals.emplace_back(asynchronous_metrics_path_prefix + name_value.first, name_value.second);
+            key_vals.emplace_back(asynchronous_metrics_path_prefix + name_value.first, name_value.second.value);
         }
     }
 

--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -12,6 +12,7 @@
 
 #include <fmt/format.h>
 
+
 namespace Poco { class Logger; }
 
 

--- a/src/Interpreters/AsynchronousMetricLog.cpp
+++ b/src/Interpreters/AsynchronousMetricLog.cpp
@@ -47,7 +47,7 @@ void AsynchronousMetricLog::addValues(const AsynchronousMetricValues & values)
     for (const auto & [key, value] : values)
     {
         element.metric_name = key;
-        element.value = round(value * precision) / precision;
+        element.value = round(value.value * precision) / precision;
 
         add(element);
     }

--- a/src/Interpreters/AsynchronousMetricLog.h
+++ b/src/Interpreters/AsynchronousMetricLog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Interpreters/SystemLog.h>
+#include <Interpreters/AsynchronousMetrics.h>
 #include <Common/ProfileEvents.h>
 #include <Common/CurrentMetrics.h>
 #include <Core/NamesAndTypes.h>
@@ -14,12 +15,8 @@
 namespace DB
 {
 
-using AsynchronousMetricValue = double;
-using AsynchronousMetricValues = std::unordered_map<std::string, AsynchronousMetricValue>;
-
 /** AsynchronousMetricLog is a log of metric values measured at regular time interval.
   */
-
 struct AsynchronousMetricLogElement
 {
     UInt16 event_date;

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1669,7 +1669,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
 
         new_values["NumberOfDatabases"] = { number_of_databases, "Total number of databases on the server." };
         new_values["NumberOfTables"] = { total_number_of_tables, "Total number of tables summed across the databases on the server, excluding the databases that cannot contain MergeTree tables."
-            "The excluded database engines are those who generate the set of tables on the fly, like `Lazy`, `MySQL`, `PostgreSQL`, `SQlite`."};
+            " The excluded database engines are those who generate the set of tables on the fly, like `Lazy`, `MySQL`, `PostgreSQL`, `SQlite`."};
 
         new_values["TotalBytesOfMergeTreeTables"] = { total_number_of_bytes, "Total amount of bytes (compressed, including data and indices) stored in all tables of MergeTree family." };
         new_values["TotalRowsOfMergeTreeTables"] = { total_number_of_rows, "Total amount of rows (records) stored in all tables of MergeTree family." };

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1139,7 +1139,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
     }
     catch (...)
     {
-        LOG_DEBUG(log, getCurrentExceptionMessage(false));
+        LOG_DEBUG(log, "Cannot read the statistics from block devices: {}", getCurrentExceptionMessage(false));
 
         /// Try to reopen block devices in case of error
         /// (i.e. ENOENT or ENODEV means that some disk had been replaced, and it may appear with a new name)

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1139,7 +1139,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
     }
     catch (...)
     {
-        LOG_DEBUG(log, "Cannot read the statistics from block devices: {}", getCurrentExceptionMessage(false));
+        LOG_DEBUG(log, "Cannot read statistics from block devices: {}", getCurrentExceptionMessage(false));
 
         /// Try to reopen block devices in case of error
         /// (i.e. ENOENT or ENODEV means that some disk had been replaced, and it may appear with a new name)

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -669,7 +669,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
     // the following calls will return stale values. It increments and returns
     // the current epoch number, which might be useful to log as a sanity check.
     auto epoch = updateJemallocEpoch();
-    new_values["jemalloc.epoch"] = { epoch, "An internal incremental update number of the statistics of JeMalloc (a low-level memory allocator), used in all other `jemalloc` metrics." };
+    new_values["jemalloc.epoch"] = { epoch, "An internal incremental update number of the statistics of jemalloc (Jason Evans' memory allocator), used in all other `jemalloc` metrics." };
 
     // Collect the statistics themselves.
     saveJemallocMetric<size_t>(new_values, "allocated");

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1054,7 +1054,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
                         " This does not include the memory used by the OS page cache memory, in bytes."
                         " The page cache memory is also available for usage by programs, so the value of this metric can be confusing."
                         " See the `OSMemoryAvailable` metric instead."
-                        " For convenience we also provide OSMemoryFreePlusCached, that should be somewhat similar to OSMemoryAvailable."
+                        " For convenience we also provide the `OSMemoryFreePlusCached` metric, that should be somewhat similar to OSMemoryAvailable."
                         " See also https://www.linuxatemyram.com/."
                         " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
                 }

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1200,7 +1200,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
 
 #define BLOCK_DEVICE_EXPLANATION \
     " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." \
-    " See https://www.kernel.org/doc/Documentation/block/stat.txt"
+    " Source: `/sys/block`. See https://www.kernel.org/doc/Documentation/block/stat.txt"
 
             new_values["BlockReadOps_" + name] = { delta_values.read_ios,
                 "Number of read operations requested from the block device."
@@ -1403,7 +1403,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
             Int64 temperature = 0;
             readText(temperature, in);
             new_values[fmt::format("Temperature{}", i)] = { temperature * 0.001,
-                "The temperature of the corresponding device in ℃. A sensor can return an unrealistic value." };
+                "The temperature of the corresponding device in ℃. A sensor can return an unrealistic value. Source: `/sys/class/thermal`" };
         }
     }
     catch (...)
@@ -1443,10 +1443,10 @@ void AsynchronousMetrics::update(TimePoint update_time)
 
                 if (sensor_name.empty())
                     new_values[fmt::format("Temperature_{}", hwmon_name)] = { temperature * 0.001,
-                        "The temperature reported by the corresponding hardware monitor in ℃. A sensor can return an unrealistic value." };
+                        "The temperature reported by the corresponding hardware monitor in ℃. A sensor can return an unrealistic value. Source: `/sys/class/hwmon`" };
                 else
                     new_values[fmt::format("Temperature_{}_{}", hwmon_name, sensor_name)] = { temperature * 0.001,
-                        "The temperature reported by the corresponding hardware monitor and the corresponding sensor in ℃. A sensor can return an unrealistic value." };
+                        "The temperature reported by the corresponding hardware monitor and the corresponding sensor in ℃. A sensor can return an unrealistic value. Source: `/sys/class/hwmon`" };
             }
         }
     }
@@ -1485,7 +1485,8 @@ void AsynchronousMetrics::update(TimePoint update_time)
                 new_values[fmt::format("EDAC{}_Correctable", i)] = { errors,
                     "The number of correctable ECC memory errors."
                     " A high number of this value indicates bad RAM which has to be immediately replaced,"
-                    " because in presence of a high number of corrected errors, a number of silent errors may happen as well, leading to data corruption." };
+                    " because in presence of a high number of corrected errors, a number of silent errors may happen as well, leading to data corruption."
+                    " Source: `/sys/devices/system/edac/mc/`" };
             }
 
             if (edac[i].second)
@@ -1497,7 +1498,8 @@ void AsynchronousMetrics::update(TimePoint update_time)
                 new_values[fmt::format("EDAC{}_Uncorrectable", i)] = { errors,
                     "The number of uncorrectable ECC memory errors."
                     " A non-zero number of this value indicates bad RAM which has to be immediately replaced,"
-                    " because it indicates potential data corruption." };
+                    " because it indicates potential data corruption."
+                    " Source: `/sys/devices/system/edac/mc/`" };
             }
         }
     }

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -703,7 +703,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
 #if !defined(OS_FREEBSD)
         new_values["MemoryShared"] = { data.shared,
             "The amount of memory used by the server process, that is also shared by another processes, in bytes."
-            " ClickHouse does not use shared memory, and the only case for this metric to be higher than zero is the usage of the system's C library (`libc`)."
+            " ClickHouse does not use shared memory, but some memory can be labeled by OS as shared for its own reasons."
             " This metric does not make a lot of sense to watch, and it exists only for completeness reasons."};
 #endif
         new_values["MemoryCode"] = { data.code,
@@ -870,40 +870,40 @@ void AsynchronousMetrics::update(TimePoint update_time)
                             delta_values_all_cpus = delta_values;
 
                         new_values["OSUserTime" + cpu_suffix] = { delta_values.user * multiplier,
-                            "The ratio of time the CPU core was running userspace code. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time the CPU core was running userspace code. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " This includes also the time when the CPU was under-utilized due to the reasons internal to the CPU (memory loads, pipeline stalls, branch mispredictions, running another SMT core)."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                         new_values["OSNiceTime" + cpu_suffix] = { delta_values.nice * multiplier,
-                            "The ratio of time the CPU core was running userspace code with higher priority. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time the CPU core was running userspace code with higher priority. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                         new_values["OSSystemTime" + cpu_suffix] = { delta_values.system * multiplier,
-                            "The ratio of time the CPU core was running OS kernel (system) code. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time the CPU core was running OS kernel (system) code. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                         new_values["OSIdleTime" + cpu_suffix] = { delta_values.idle * multiplier,
-                            "The ratio of time the CPU core was idle (not even ready to run a process waiting for IO) from the OS kernel standpoint. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time the CPU core was idle (not even ready to run a process waiting for IO) from the OS kernel standpoint. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " This does not include the time when the CPU was under-utilized due to the reasons internal to the CPU (memory loads, pipeline stalls, branch mispredictions, running another SMT core)."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                         new_values["OSIOWaitTime" + cpu_suffix] = { delta_values.iowait * multiplier,
-                            "The ratio of time the CPU core was not running the code but when the OS kernel did not run any other process on this CPU as the processes were waiting for IO. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time the CPU core was not running the code but when the OS kernel did not run any other process on this CPU as the processes were waiting for IO. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                         new_values["OSIrqTime" + cpu_suffix] = { delta_values.irq * multiplier,
-                            "The ratio of time spent for running hardware interrupt requests on the CPU. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time spent for running hardware interrupt requests on the CPU. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " A high number of this metric may indicate hardware misconfiguration or a very high network load."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                         new_values["OSSoftIrqTime" + cpu_suffix] = { delta_values.softirq * multiplier,
-                            "The ratio of time spent for running software interrupt requests on the CPU. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time spent for running software interrupt requests on the CPU. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " A high number of this metric may indicate inefficient software running on the system."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                         new_values["OSStealTime" + cpu_suffix] = { delta_values.steal * multiplier,
-                            "The ratio of time spent in other operating systems by the CPU when running in a virtualized environment. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time spent in other operating systems by the CPU when running in a virtualized environment. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " Not every virtualized environments present this metric, and most of them don't."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                         new_values["OSGuestTime" + cpu_suffix] = { delta_values.guest * multiplier,
-                            "The ratio of time spent running a virtual CPU for guest operating systems under the control of the Linux kernel (See `man procfs`). This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time spent running a virtual CPU for guest operating systems under the control of the Linux kernel (See `man procfs`). This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " This metric is irrelevant for ClickHouse, but still exists for completeness."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                         new_values["OSGuestNiceTime" + cpu_suffix] = { delta_values.guest_nice * multiplier,
-                            "The ratio of time spent running a virtual CPU for guest operating systems under the control of the Linux kernel, when a guest was set to a higher priority (See `man procfs`). This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
+                            "The ratio of time spent running a virtual CPU for guest operating systems under the control of the Linux kernel, when a guest was set to a higher priority (See `man procfs`). This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server."
                             " This metric is irrelevant for ClickHouse, but still exists for completeness."
                             " The value for a single CPU core will be in the interval [0..1]. The value for all CPU cores is calculated as a sum across them [0..num cores]."};
                     }
@@ -932,7 +932,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
                     skipToNextLineOrEOF(*proc_stat);
                     new_values["OSProcessesRunning"] = { processes_running,
                         "The number of runnable (running or ready to run) threads by the operating system."
-                        " This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                        " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
                 }
                 else if (name == "procs_blocked")
                 {
@@ -941,7 +941,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
                     skipToNextLineOrEOF(*proc_stat);
                     new_values["OSProcessesBlocked"] = { processes_blocked,
                         "Number of threads blocked waiting for I/O to complete (`man procfs`)."
-                        " This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                        " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
                 }
                 else
                     skipToNextLineOrEOF(*proc_stat);
@@ -951,9 +951,9 @@ void AsynchronousMetrics::update(TimePoint update_time)
             {
                 ProcStatValuesOther delta_values = current_other_values - proc_stat_values_other;
 
-                new_values["OSInterrupts"] = { delta_values.interrupts, "The number of interrupts on the host machine. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
-                new_values["OSContextSwitches"] = { delta_values.context_switches, "The number of context switches that the system underwent on the host machine. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
-                new_values["OSProcessesCreated"] = { delta_values.processes_created, "The number of processes created. This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                new_values["OSInterrupts"] = { delta_values.interrupts, "The number of interrupts on the host machine. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                new_values["OSContextSwitches"] = { delta_values.context_switches, "The number of context switches that the system underwent on the host machine. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                new_values["OSProcessesCreated"] = { delta_values.processes_created, "The number of processes created. This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
 
                 /// Also write values normalized to 0..1 by diving to the number of CPUs.
                 /// These values are good to be averaged across the cluster of non-uniform servers.
@@ -1056,35 +1056,35 @@ void AsynchronousMetrics::update(TimePoint update_time)
                         " See the `OSMemoryAvailable` metric instead."
                         " For convenience we also provide OSMemoryFreePlusCached, that should be somewhat similar to OSMemoryAvailable."
                         " See also https://www.linuxatemyram.com/."
-                        " This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                        " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
                 }
                 else if (name == "MemAvailable:")
                 {
                     new_values["OSMemoryAvailable"] = { bytes, "The amount of memory available to be used by programs, in bytes. This is very similar to the `OSMemoryFreePlusCached` metric."
-                        " This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                        " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
                 }
                 else if (name == "Buffers:")
                 {
                     new_values["OSMemoryBuffers"] = { bytes, "The amount of memory used by OS kernel buffers, in bytes. This should be typically small, and large values may indicate a misconfiguration of the OS."
-                        " This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                        " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
                 }
                 else if (name == "Cached:")
                 {
                     free_plus_cached_bytes += bytes;
                     new_values["OSMemoryCached"] = { bytes, "The amount of memory used by the OS page cache, in bytes. Typically, almost all available memory is used by the OS page cache - high values of this metric are normal and expected."
-                        " This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                        " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
                 }
                 else if (name == "SwapCached:")
                 {
                     new_values["OSMemorySwapCached"] = { bytes, "The amount of memory in swap that was also loaded in RAM. Swap should be disabled on production systems. If the value of this metric is large, it indicates a misconfiguration."
-                        " This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                        " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
                 }
 
                 skipToNextLineOrEOF(*meminfo);
             }
 
-            new_values["OSMemoryFreePlusCached"] = { free_plus_cached_bytes, "The amount of free memory or OS page cache memory on the host system, in bytes. This memory is available to be used by programs. The value should be very similar to `OSMemoryAvailable`."
-                " This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+            new_values["OSMemoryFreePlusCached"] = { free_plus_cached_bytes, "The amount of free memory plus OS page cache memory on the host system, in bytes. This memory is available to be used by programs. The value should be very similar to `OSMemoryAvailable`."
+                " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
         }
         catch (...)
         {
@@ -1153,7 +1153,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
             uint64_t open_files = 0;
             readText(open_files, *file_nr);
             new_values["OSOpenFiles"] = { open_files, "The total number of opened files on the host machine."
-                " This is system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
+                " This is a system-wide metric, it includes all the processes on the host machine, not just clickhouse-server." };
         }
         catch (...)
         {

--- a/src/Interpreters/AsynchronousMetrics.cpp
+++ b/src/Interpreters/AsynchronousMetrics.cpp
@@ -1210,7 +1210,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
                 BLOCK_DEVICE_EXPLANATION };
             new_values["BlockDiscardOps_" + name] = { delta_values.discard_ops,
                 "Number of discard operations requested from the block device. These operations are relevant for SSD."
-                " They are not used by ClickHouse, but can be used by other processes on the system."
+                " Discard operations are not used by ClickHouse, but can be used by other processes on the system."
                 BLOCK_DEVICE_EXPLANATION };
 
             new_values["BlockReadMerges_" + name] = { delta_values.read_merges,
@@ -1221,7 +1221,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
                 BLOCK_DEVICE_EXPLANATION };
             new_values["BlockDiscardMerges_" + name] = { delta_values.discard_merges,
                 "Number of discard operations requested from the block device and merged together by the OS IO scheduler."
-                " These operations are relevant for SSD. They are not used by ClickHouse, but can be used by other processes on the system."
+                " These operations are relevant for SSD. Discard operations are not used by ClickHouse, but can be used by other processes on the system."
                 BLOCK_DEVICE_EXPLANATION };
 
             new_values["BlockReadBytes_" + name] = { delta_values.read_sectors * sector_size,
@@ -1235,7 +1235,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
                 BLOCK_DEVICE_EXPLANATION };
             new_values["BlockDiscardBytes_" + name] = { delta_values.discard_sectors * sector_size,
                 "Number of discarded bytes on the block device."
-                " These operations are relevant for SSD. They are not used by ClickHouse, but can be used by other processes on the system."
+                " These operations are relevant for SSD. Discard operations are not used by ClickHouse, but can be used by other processes on the system."
                 BLOCK_DEVICE_EXPLANATION };
 
             new_values["BlockReadTime_" + name] = { delta_values.read_ticks * time_multiplier,
@@ -1246,7 +1246,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
                 BLOCK_DEVICE_EXPLANATION };
             new_values["BlockDiscardTime_" + name] = { delta_values.discard_ticks * time_multiplier,
                 "Time in seconds spend in discard operations requested from the block device, summed across all the operations."
-                " These operations are relevant for SSD. They are not used by ClickHouse, but can be used by other processes on the system."
+                " These operations are relevant for SSD. Discard operations are not used by ClickHouse, but can be used by other processes on the system."
                 BLOCK_DEVICE_EXPLANATION };
 
             new_values["BlockInFlightOps_" + name] = { delta_values.in_flight_ios,

--- a/src/Interpreters/AsynchronousMetrics.h
+++ b/src/Interpreters/AsynchronousMetrics.h
@@ -18,16 +18,23 @@
 
 namespace Poco
 {
-class Logger;
+    class Logger;
 }
 
 namespace DB
 {
 
-class ProtocolServerAdapter;
 class ReadBuffer;
 
-using AsynchronousMetricValue = double;
+struct AsynchronousMetricValue
+{
+    double value;
+    const char * documentation;
+
+    AsynchronousMetricValue(double value_, const char * documentation_) : value(value_), documentation(documentation_) {}
+    AsynchronousMetricValue(size_t value_, const char * documentation_) : value(value_), documentation(documentation_) {}
+};
+
 using AsynchronousMetricValues = std::unordered_map<std::string, AsynchronousMetricValue>;
 
 struct ProtocolServerMetrics
@@ -42,6 +49,9 @@ struct ProtocolServerMetrics
   *
   * This includes both ClickHouse-related metrics (like memory usage of ClickHouse process)
   *  and common OS-related metrics (like total memory usage on the server).
+  *
+  * All the values are either gauge type (like the total number of tables, the current memory usage).
+  * Or delta-counters representing some accumulation during the interval of time.
   */
 class AsynchronousMetrics : WithContext
 {

--- a/src/Interpreters/AsynchronousMetrics.h
+++ b/src/Interpreters/AsynchronousMetrics.h
@@ -31,8 +31,9 @@ struct AsynchronousMetricValue
     double value;
     const char * documentation;
 
-    AsynchronousMetricValue(double value_, const char * documentation_) : value(value_), documentation(documentation_) {}
-    AsynchronousMetricValue(size_t value_, const char * documentation_) : value(value_), documentation(documentation_) {}
+    template <typename T>
+    AsynchronousMetricValue(T value_, const char * documentation_)
+        : value(static_cast<double>(value_)), documentation(documentation_) {}
     AsynchronousMetricValue() = default; /// For std::unordered_map::operator[].
 };
 

--- a/src/Interpreters/AsynchronousMetrics.h
+++ b/src/Interpreters/AsynchronousMetrics.h
@@ -33,6 +33,7 @@ struct AsynchronousMetricValue
 
     AsynchronousMetricValue(double value_, const char * documentation_) : value(value_), documentation(documentation_) {}
     AsynchronousMetricValue(size_t value_, const char * documentation_) : value(value_), documentation(documentation_) {}
+    AsynchronousMetricValue() = default; /// For std::unordered_map::operator[].
 };
 
 using AsynchronousMetricValues = std::unordered_map<std::string, AsynchronousMetricValue>;

--- a/src/Server/PrometheusMetricsWriter.cpp
+++ b/src/Server/PrometheusMetricsWriter.cpp
@@ -108,11 +108,16 @@ void PrometheusMetricsWriter::write(WriteBuffer & wb) const
 
             if (!replaceInvalidChars(key))
                 continue;
+
             auto value = name_value.second;
 
+            std::string metric_doc{value.documentation};
+            convertHelpToSingleLine(metric_doc);
+
             // TODO: add HELP section? asynchronous_metrics contains only key and value
+            writeOutLine(wb, "# HELP", key, metric_doc);
             writeOutLine(wb, "# TYPE", key, "gauge");
-            writeOutLine(wb, key, value);
+            writeOutLine(wb, key, value.value);
         }
     }
 

--- a/src/Server/PrometheusMetricsWriter.h
+++ b/src/Server/PrometheusMetricsWriter.h
@@ -3,10 +3,10 @@
 #include <string>
 
 #include <Interpreters/AsynchronousMetrics.h>
-
 #include <IO/WriteBuffer.h>
 
 #include <Poco/Util/AbstractConfiguration.h>
+
 
 namespace DB
 {

--- a/src/Server/ProtocolServerAdapter.h
+++ b/src/Server/ProtocolServerAdapter.h
@@ -6,8 +6,10 @@
 #include <memory>
 #include <string>
 
+
 namespace DB
 {
+
 class GRPCServer;
 class TCPServer;
 

--- a/src/Storages/System/StorageSystemAsynchronousMetrics.cpp
+++ b/src/Storages/System/StorageSystemAsynchronousMetrics.cpp
@@ -12,6 +12,7 @@ NamesAndTypesList StorageSystemAsynchronousMetrics::getNamesAndTypes()
     return {
         {"metric", std::make_shared<DataTypeString>()},
         {"value", std::make_shared<DataTypeFloat64>()},
+        {"description", std::make_shared<DataTypeString>()},
     };
 }
 
@@ -27,7 +28,8 @@ void StorageSystemAsynchronousMetrics::fillData(MutableColumns & res_columns, Co
     for (const auto & name_value : async_metrics_values)
     {
         res_columns[0]->insert(name_value.first);
-        res_columns[1]->insert(name_value.second);
+        res_columns[1]->insert(name_value.second.value);
+        res_columns[2]->insert(name_value.second.documentation);
     }
 }
 

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -23,7 +23,8 @@ COMMENT 'SYSTEM TABLE is built on the fly.'
 CREATE TABLE system.asynchronous_metrics
 (
     `metric` String,
-    `value` Float64
+    `value` Float64,
+    `description` String
 )
 ENGINE = SystemAsynchronousMetrics
 COMMENT 'SYSTEM TABLE is built on the fly.'

--- a/tests/queries/0_stateless/02480_every_asynchronous_metric_must_have_documentation.sql
+++ b/tests/queries/0_stateless/02480_every_asynchronous_metric_must_have_documentation.sql
@@ -1,0 +1,1 @@
+SELECT metric FROM system.asynchronous_metrics WHERE length(description) < 10;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement.


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The `system.asynchronous_metrics` gets embedded documentation. This documentation is also exported to Prometheus. Fixed an error with the metrics about `cache` disks - they were calculated only for one arbitrary cache disk instead all of them. This closes #7644.