### PR TITLE
Add different reactions when external command stderr has data

### DIFF
--- a/src/Client/ConnectionEstablisher.cpp
+++ b/src/Client/ConnectionEstablisher.cpp
@@ -170,7 +170,7 @@ bool ConnectionEstablisherAsync::checkTimeout()
 
     epoll_event events[2];
     events[0].data.fd = events[1].data.fd = -1;
-    size_t ready_count = epoll.getManyReady(2, events, false);
+    size_t ready_count = epoll.getManyReady(2, events, 0);
     for (size_t i = 0; i != ready_count; ++i)
     {
         if (events[i].data.fd == socket_fd)

--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -388,7 +388,7 @@ int HedgedConnections::getReadyFileDescriptor(AsyncCallback async_callback)
     bool blocking = !static_cast<bool>(async_callback);
     while (events_count == 0)
     {
-        events_count = epoll.getManyReady(1, &event, blocking);
+        events_count = epoll.getManyReady(1, &event, blocking ? -1 : 0);
         if (!events_count && async_callback)
             async_callback(epoll.getFileDescriptor(), 0, AsyncEventTimeoutType::NONE, epoll.getDescription(), AsyncTaskExecutor::Event::READ | AsyncTaskExecutor::Event::ERROR);
     }

--- a/src/Common/Epoll.h
+++ b/src/Common/Epoll.h
@@ -30,10 +30,11 @@ public:
     /// Remove file descriptor to epoll.
     void remove(int fd);
 
-    /// Get events from epoll. Events are written in events_out, this function returns an amount of ready events.
-    /// If blocking is false and there are no ready events,
-    /// return empty vector, otherwise wait for ready events.
-    size_t getManyReady(int max_events, epoll_event * events_out, bool blocking) const;
+    /// Get events from epoll. Events are written in events_out, this function returns an amount of
+    /// ready events. The timeout argument specifies the number of milliseconds to wait for ready
+    /// events. Timeout of -1 causes epoll_wait() to block indefinitely, while specifying a timeout
+    /// equal to zero will return immediately, even if no events are available.
+    size_t getManyReady(int max_events, epoll_event * events_out, int timeout) const;
 
     int getFileDescriptor() const { return epoll_fd; }
 

--- a/src/Common/ShellCommandSettings.cpp
+++ b/src/Common/ShellCommandSettings.cpp
@@ -1,7 +1,8 @@
+#include <Common/ShellCommandSettings.h>
+
+#include <magic_enum.hpp>
 #include <Poco/String.h>
 #include <Common/Exception.h>
-#include <Common/ShellCommandSettings.h>
-#include <magic_enum.hpp>
 
 namespace DB
 {
@@ -15,7 +16,17 @@ ExternalCommandStderrReaction parseExternalCommandStderrReaction(const std::stri
 {
     auto reaction = magic_enum::enum_cast<ExternalCommandStderrReaction>(Poco::toUpper(config));
     if (!reaction)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown stderr reaction: {}. Possible values are 'none', 'log' and 'throw'", config);
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown stderr_reaction: {}. Possible values are 'none', 'log' and 'throw'", config);
+
+    return *reaction;
+}
+
+ExternalCommandErrorExitReaction parseExternalCommandErrorExitReaction(const std::string & config)
+{
+    auto reaction = magic_enum::enum_cast<ExternalCommandErrorExitReaction>(Poco::toUpper(config));
+    if (!reaction)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "Unknown error_exit_reaction: {}. Possible values are 'none', 'log_first' and 'log_last'", config);
 
     return *reaction;
 }

--- a/src/Common/ShellCommandSettings.cpp
+++ b/src/Common/ShellCommandSettings.cpp
@@ -1,0 +1,23 @@
+#include <Poco/String.h>
+#include <Common/Exception.h>
+#include <Common/ShellCommandSettings.h>
+#include <magic_enum.hpp>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+
+ExternalCommandStderrReaction parseExternalCommandStderrReaction(const std::string & config)
+{
+    auto reaction = magic_enum::enum_cast<ExternalCommandStderrReaction>(Poco::toUpper(config));
+    if (!reaction)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown stderr reaction: {}. Possible values are 'none', 'log' and 'throw'", config);
+
+    return *reaction;
+}
+
+}

--- a/src/Common/ShellCommandSettings.cpp
+++ b/src/Common/ShellCommandSettings.cpp
@@ -16,17 +16,10 @@ ExternalCommandStderrReaction parseExternalCommandStderrReaction(const std::stri
 {
     auto reaction = magic_enum::enum_cast<ExternalCommandStderrReaction>(Poco::toUpper(config));
     if (!reaction)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown stderr_reaction: {}. Possible values are 'none', 'log' and 'throw'", config);
-
-    return *reaction;
-}
-
-ExternalCommandErrorExitReaction parseExternalCommandErrorExitReaction(const std::string & config)
-{
-    auto reaction = magic_enum::enum_cast<ExternalCommandErrorExitReaction>(Poco::toUpper(config));
-    if (!reaction)
         throw Exception(
-            ErrorCodes::BAD_ARGUMENTS, "Unknown error_exit_reaction: {}. Possible values are 'none', 'log_first' and 'log_last'", config);
+            ErrorCodes::BAD_ARGUMENTS,
+            "Unknown stderr_reaction: {}. Possible values are 'none', 'log', 'log_first', 'log_last' and 'throw'",
+            config);
 
     return *reaction;
 }

--- a/src/Common/ShellCommandSettings.h
+++ b/src/Common/ShellCommandSettings.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+namespace DB
+{
+
+enum class ExternalCommandStderrReaction
+{
+    NONE, /// Do nothing.
+    LOG,  /// Try to log all outputs of stderr from the external command.
+    THROW /// Throw exception when the external command outputs something to its stderr.
+};
+
+ExternalCommandStderrReaction parseExternalCommandStderrReaction(const std::string & config);
+
+}

--- a/src/Common/ShellCommandSettings.h
+++ b/src/Common/ShellCommandSettings.h
@@ -8,10 +8,19 @@ namespace DB
 enum class ExternalCommandStderrReaction
 {
     NONE, /// Do nothing.
-    LOG,  /// Try to log all outputs of stderr from the external command.
+    LOG, /// Try to log all outputs of stderr from the external command.
     THROW /// Throw exception when the external command outputs something to its stderr.
 };
 
 ExternalCommandStderrReaction parseExternalCommandStderrReaction(const std::string & config);
+
+enum class ExternalCommandErrorExitReaction
+{
+    NONE, /// Do nothing.
+    LOG_FIRST, /// Try to log first 1_KiB outputs of stderr from the external command.
+    LOG_LAST /// Same as above, but log last 1_KiB outputs.
+};
+
+ExternalCommandErrorExitReaction parseExternalCommandErrorExitReaction(const std::string & config);
 
 }

--- a/src/Common/ShellCommandSettings.h
+++ b/src/Common/ShellCommandSettings.h
@@ -8,19 +8,12 @@ namespace DB
 enum class ExternalCommandStderrReaction
 {
     NONE, /// Do nothing.
-    LOG, /// Try to log all outputs of stderr from the external command.
-    THROW /// Throw exception when the external command outputs something to its stderr.
+    LOG, /// Try to log all outputs of stderr from the external command immediately.
+    LOG_FIRST, /// Try to log first 1_KiB outputs of stderr from the external command after exit.
+    LOG_LAST, /// Same as above, but log last 1_KiB outputs.
+    THROW /// Immediately throw exception when the external command outputs something to its stderr.
 };
 
 ExternalCommandStderrReaction parseExternalCommandStderrReaction(const std::string & config);
-
-enum class ExternalCommandErrorExitReaction
-{
-    NONE, /// Do nothing.
-    LOG_FIRST, /// Try to log first 1_KiB outputs of stderr from the external command.
-    LOG_LAST /// Same as above, but log last 1_KiB outputs.
-};
-
-ExternalCommandErrorExitReaction parseExternalCommandErrorExitReaction(const std::string & config);
 
 }

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -181,4 +181,9 @@ IMPLEMENT_SETTING_ENUM(S3QueueMode, ErrorCodes::BAD_ARGUMENTS,
 IMPLEMENT_SETTING_ENUM(S3QueueAction, ErrorCodes::BAD_ARGUMENTS,
                        {{"keep", S3QueueAction::KEEP},
                         {"delete", S3QueueAction::DELETE}})
+
+IMPLEMENT_SETTING_ENUM(ExternalCommandStderrReaction, ErrorCodes::BAD_ARGUMENTS,
+    {{"none", ExternalCommandStderrReaction::NONE},
+     {"log", ExternalCommandStderrReaction::LOG},
+     {"throw", ExternalCommandStderrReaction::THROW}})
 }

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -186,4 +186,9 @@ IMPLEMENT_SETTING_ENUM(ExternalCommandStderrReaction, ErrorCodes::BAD_ARGUMENTS,
     {{"none", ExternalCommandStderrReaction::NONE},
      {"log", ExternalCommandStderrReaction::LOG},
      {"throw", ExternalCommandStderrReaction::THROW}})
+
+IMPLEMENT_SETTING_ENUM(ExternalCommandErrorExitReaction, ErrorCodes::BAD_ARGUMENTS,
+    {{"none", ExternalCommandErrorExitReaction::NONE},
+     {"log_first", ExternalCommandErrorExitReaction::LOG_FIRST},
+     {"log_last", ExternalCommandErrorExitReaction::LOG_LAST}})
 }

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -185,10 +185,8 @@ IMPLEMENT_SETTING_ENUM(S3QueueAction, ErrorCodes::BAD_ARGUMENTS,
 IMPLEMENT_SETTING_ENUM(ExternalCommandStderrReaction, ErrorCodes::BAD_ARGUMENTS,
     {{"none", ExternalCommandStderrReaction::NONE},
      {"log", ExternalCommandStderrReaction::LOG},
+     {"log_first", ExternalCommandStderrReaction::LOG_FIRST},
+     {"log_last", ExternalCommandStderrReaction::LOG_LAST},
      {"throw", ExternalCommandStderrReaction::THROW}})
 
-IMPLEMENT_SETTING_ENUM(ExternalCommandErrorExitReaction, ErrorCodes::BAD_ARGUMENTS,
-    {{"none", ExternalCommandErrorExitReaction::NONE},
-     {"log_first", ExternalCommandErrorExitReaction::LOG_FIRST},
-     {"log_last", ExternalCommandErrorExitReaction::LOG_LAST}})
 }

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -241,4 +241,6 @@ DECLARE_SETTING_ENUM(S3QueueAction)
 
 DECLARE_SETTING_ENUM(ExternalCommandStderrReaction)
 
+DECLARE_SETTING_ENUM(ExternalCommandErrorExitReaction)
+
 }

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -241,6 +241,4 @@ DECLARE_SETTING_ENUM(S3QueueAction)
 
 DECLARE_SETTING_ENUM(ExternalCommandStderrReaction)
 
-DECLARE_SETTING_ENUM(ExternalCommandErrorExitReaction)
-
 }

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -5,6 +5,7 @@
 #include <QueryPipeline/SizeLimits.h>
 #include <Formats/FormatSettings.h>
 #include <IO/ReadSettings.h>
+#include <Common/ShellCommandSettings.h>
 
 
 namespace DB
@@ -237,5 +238,7 @@ enum class S3QueueAction
 };
 
 DECLARE_SETTING_ENUM(S3QueueAction)
+
+DECLARE_SETTING_ENUM(ExternalCommandStderrReaction)
 
 }

--- a/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -114,10 +114,7 @@ QueryPipeline ExecutableDictionarySource::loadAll()
     auto command = configuration.command;
     updateCommandIfNeeded(command, coordinator_configuration.execute_direct, context);
 
-    ShellCommandSourceConfiguration command_configuration {
-        .check_exit_code = true,
-    };
-    return QueryPipeline(coordinator->createPipe(command, configuration.command_arguments, {}, sample_block, context, command_configuration));
+    return QueryPipeline(coordinator->createPipe(command, configuration.command_arguments, {}, sample_block, context));
 }
 
 QueryPipeline ExecutableDictionarySource::loadUpdatedAll()
@@ -152,10 +149,7 @@ QueryPipeline ExecutableDictionarySource::loadUpdatedAll()
 
     LOG_TRACE(log, "loadUpdatedAll {}", command);
 
-    ShellCommandSourceConfiguration command_configuration {
-        .check_exit_code = true,
-    };
-    return QueryPipeline(coordinator->createPipe(command, command_arguments, {}, sample_block, context, command_configuration));
+    return QueryPipeline(coordinator->createPipe(command, command_arguments, {}, sample_block, context));
 }
 
 QueryPipeline ExecutableDictionarySource::loadIds(const std::vector<UInt64> & ids)
@@ -186,11 +180,7 @@ QueryPipeline ExecutableDictionarySource::getStreamForBlock(const Block & block)
     Pipes shell_input_pipes;
     shell_input_pipes.emplace_back(std::move(shell_input_pipe));
 
-    ShellCommandSourceConfiguration command_configuration {
-        .check_exit_code = true,
-    };
-
-    auto pipe = coordinator->createPipe(command, configuration.command_arguments, std::move(shell_input_pipes), sample_block, context, command_configuration);
+    auto pipe = coordinator->createPipe(command, configuration.command_arguments, std::move(shell_input_pipes), sample_block, context);
 
     if (configuration.implicit_key)
         pipe.addTransform(std::make_shared<TransformWithAdditionalColumns>(block, pipe.getHeader()));
@@ -276,6 +266,9 @@ void registerDictionarySourceExecutable(DictionarySourceFactory & factory)
             .command_read_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_read_timeout", 10000),
             .command_write_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_write_timeout", 10000),
             .stderr_reaction = parseExternalCommandStderrReaction(config.getString(settings_config_prefix + ".stderr_reaction", "none")),
+            .error_exit_reaction
+                = parseExternalCommandErrorExitReaction(config.getString(settings_config_prefix + ".error_exit_reaction", "none")),
+            .check_exit_code = config.getBool(settings_config_prefix + ".check_exit_code", true),
             .is_executable_pool = false,
             .send_chunk_header = config.getBool(settings_config_prefix + ".send_chunk_header", false),
             .execute_direct = config.getBool(settings_config_prefix + ".execute_direct", false)

--- a/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -266,8 +266,6 @@ void registerDictionarySourceExecutable(DictionarySourceFactory & factory)
             .command_read_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_read_timeout", 10000),
             .command_write_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_write_timeout", 10000),
             .stderr_reaction = parseExternalCommandStderrReaction(config.getString(settings_config_prefix + ".stderr_reaction", "none")),
-            .error_exit_reaction
-                = parseExternalCommandErrorExitReaction(config.getString(settings_config_prefix + ".error_exit_reaction", "none")),
             .check_exit_code = config.getBool(settings_config_prefix + ".check_exit_code", true),
             .is_executable_pool = false,
             .send_chunk_header = config.getBool(settings_config_prefix + ".send_chunk_header", false),

--- a/src/Dictionaries/ExecutableDictionarySource.cpp
+++ b/src/Dictionaries/ExecutableDictionarySource.cpp
@@ -275,6 +275,7 @@ void registerDictionarySourceExecutable(DictionarySourceFactory & factory)
             .command_termination_timeout_seconds = config.getUInt64(settings_config_prefix + ".command_termination_timeout", 10),
             .command_read_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_read_timeout", 10000),
             .command_write_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_write_timeout", 10000),
+            .stderr_reaction = parseExternalCommandStderrReaction(config.getString(settings_config_prefix + ".stderr_reaction", "none")),
             .is_executable_pool = false,
             .send_chunk_header = config.getBool(settings_config_prefix + ".send_chunk_header", false),
             .execute_direct = config.getBool(settings_config_prefix + ".execute_direct", false)

--- a/src/Dictionaries/ExecutablePoolDictionarySource.cpp
+++ b/src/Dictionaries/ExecutablePoolDictionarySource.cpp
@@ -233,6 +233,7 @@ void registerDictionarySourceExecutablePool(DictionarySourceFactory & factory)
             .command_termination_timeout_seconds = config.getUInt64(settings_config_prefix + ".command_termination_timeout", 10),
             .command_read_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_read_timeout", 10000),
             .command_write_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_write_timeout", 10000),
+            .stderr_reaction = parseExternalCommandStderrReaction(config.getString(settings_config_prefix + ".stderr_reaction", "none")),
             .pool_size = config.getUInt64(settings_config_prefix + ".pool_size", 16),
             .max_command_execution_time_seconds = max_command_execution_time,
             .is_executable_pool = true,

--- a/src/Dictionaries/ExecutablePoolDictionarySource.cpp
+++ b/src/Dictionaries/ExecutablePoolDictionarySource.cpp
@@ -233,8 +233,6 @@ void registerDictionarySourceExecutablePool(DictionarySourceFactory & factory)
             .command_read_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_read_timeout", 10000),
             .command_write_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_write_timeout", 10000),
             .stderr_reaction = parseExternalCommandStderrReaction(config.getString(settings_config_prefix + ".stderr_reaction", "none")),
-            .error_exit_reaction
-                = parseExternalCommandErrorExitReaction(config.getString(settings_config_prefix + ".error_exit_reaction", "none")),
             .check_exit_code = config.getBool(settings_config_prefix + ".check_exit_code", true),
             .pool_size = config.getUInt64(settings_config_prefix + ".pool_size", 16),
             .max_command_execution_time_seconds = max_command_execution_time,

--- a/src/Dictionaries/ExecutablePoolDictionarySource.cpp
+++ b/src/Dictionaries/ExecutablePoolDictionarySource.cpp
@@ -132,7 +132,6 @@ QueryPipeline ExecutablePoolDictionarySource::getStreamForBlock(const Block & bl
     ShellCommandSourceConfiguration command_configuration;
     command_configuration.read_fixed_number_of_rows = true;
     command_configuration.number_of_rows_to_read = block.rows();
-    command_configuration.check_exit_code = true;
 
     Pipes shell_input_pipes;
     shell_input_pipes.emplace_back(std::move(shell_input_pipe));
@@ -234,6 +233,9 @@ void registerDictionarySourceExecutablePool(DictionarySourceFactory & factory)
             .command_read_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_read_timeout", 10000),
             .command_write_timeout_milliseconds = config.getUInt64(settings_config_prefix + ".command_write_timeout", 10000),
             .stderr_reaction = parseExternalCommandStderrReaction(config.getString(settings_config_prefix + ".stderr_reaction", "none")),
+            .error_exit_reaction
+                = parseExternalCommandErrorExitReaction(config.getString(settings_config_prefix + ".error_exit_reaction", "none")),
+            .check_exit_code = config.getBool(settings_config_prefix + ".check_exit_code", true),
             .pool_size = config.getUInt64(settings_config_prefix + ".pool_size", 16),
             .max_command_execution_time_seconds = max_command_execution_time,
             .is_executable_pool = true,

--- a/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
+++ b/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
@@ -171,6 +171,8 @@ ExternalLoader::LoadablePtr ExternalUserDefinedExecutableFunctionsLoader::create
     size_t command_termination_timeout_seconds = config.getUInt64(key_in_config + ".command_termination_timeout", 10);
     size_t command_read_timeout_milliseconds = config.getUInt64(key_in_config + ".command_read_timeout", 10000);
     size_t command_write_timeout_milliseconds = config.getUInt64(key_in_config + ".command_write_timeout", 10000);
+    ExternalCommandStderrReaction stderr_reaction
+        = parseExternalCommandStderrReaction(config.getString(key_in_config + ".stderr_reaction", "none"));
 
     size_t pool_size = 0;
     size_t max_command_execution_time = 0;
@@ -238,6 +240,7 @@ ExternalLoader::LoadablePtr ExternalUserDefinedExecutableFunctionsLoader::create
         .command_termination_timeout_seconds = command_termination_timeout_seconds,
         .command_read_timeout_milliseconds = command_read_timeout_milliseconds,
         .command_write_timeout_milliseconds = command_write_timeout_milliseconds,
+        .stderr_reaction = stderr_reaction,
         .pool_size = pool_size,
         .max_command_execution_time_seconds = max_command_execution_time,
         .is_executable_pool = is_executable_pool,

--- a/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
+++ b/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
@@ -173,8 +173,7 @@ ExternalLoader::LoadablePtr ExternalUserDefinedExecutableFunctionsLoader::create
     size_t command_write_timeout_milliseconds = config.getUInt64(key_in_config + ".command_write_timeout", 10000);
     ExternalCommandStderrReaction stderr_reaction
         = parseExternalCommandStderrReaction(config.getString(key_in_config + ".stderr_reaction", "none"));
-    ExternalCommandErrorExitReaction error_exit_reaction
-        = parseExternalCommandErrorExitReaction(config.getString(key_in_config + ".error_exit_reaction", "none"));
+    bool check_exit_code = config.getBool(key_in_config + ".check_exit_code", true);
 
     size_t pool_size = 0;
     size_t max_command_execution_time = 0;
@@ -243,7 +242,7 @@ ExternalLoader::LoadablePtr ExternalUserDefinedExecutableFunctionsLoader::create
         .command_read_timeout_milliseconds = command_read_timeout_milliseconds,
         .command_write_timeout_milliseconds = command_write_timeout_milliseconds,
         .stderr_reaction = stderr_reaction,
-        .error_exit_reaction = error_exit_reaction,
+        .check_exit_code = check_exit_code,
         .pool_size = pool_size,
         .max_command_execution_time_seconds = max_command_execution_time,
         .is_executable_pool = is_executable_pool,

--- a/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
+++ b/src/Functions/UserDefined/ExternalUserDefinedExecutableFunctionsLoader.cpp
@@ -173,6 +173,8 @@ ExternalLoader::LoadablePtr ExternalUserDefinedExecutableFunctionsLoader::create
     size_t command_write_timeout_milliseconds = config.getUInt64(key_in_config + ".command_write_timeout", 10000);
     ExternalCommandStderrReaction stderr_reaction
         = parseExternalCommandStderrReaction(config.getString(key_in_config + ".stderr_reaction", "none"));
+    ExternalCommandErrorExitReaction error_exit_reaction
+        = parseExternalCommandErrorExitReaction(config.getString(key_in_config + ".error_exit_reaction", "none"));
 
     size_t pool_size = 0;
     size_t max_command_execution_time = 0;
@@ -241,6 +243,7 @@ ExternalLoader::LoadablePtr ExternalUserDefinedExecutableFunctionsLoader::create
         .command_read_timeout_milliseconds = command_read_timeout_milliseconds,
         .command_write_timeout_milliseconds = command_write_timeout_milliseconds,
         .stderr_reaction = stderr_reaction,
+        .error_exit_reaction = error_exit_reaction,
         .pool_size = pool_size,
         .max_command_execution_time_seconds = max_command_execution_time,
         .is_executable_pool = is_executable_pool,

--- a/src/Processors/Executors/PollingQueue.cpp
+++ b/src/Processors/Executors/PollingQueue.cpp
@@ -74,7 +74,7 @@ PollingQueue::TaskData PollingQueue::wait(std::unique_lock<std::mutex> & lock)
 
     epoll_event event;
     event.data.ptr = nullptr;
-    epoll.getManyReady(1, &event, true);
+    epoll.getManyReady(1, &event, -1);
 
     lock.lock();
 

--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -103,18 +103,23 @@ class TimeoutReadBufferFromFileDescriptor : public BufferWithOwnMemory<ReadBuffe
 {
 public:
     explicit TimeoutReadBufferFromFileDescriptor(
-        int stdout_fd_, int stderr_fd_, size_t timeout_milliseconds_, ExternalCommandStderrReaction stderr_reaction_)
+        int stdout_fd_,
+        int stderr_fd_,
+        size_t timeout_milliseconds_,
+        ExternalCommandStderrReaction stderr_reaction_,
+        ExternalCommandErrorExitReaction error_exit_reaction_)
         : stdout_fd(stdout_fd_)
         , stderr_fd(stderr_fd_)
         , timeout_milliseconds(timeout_milliseconds_)
         , stderr_reaction(stderr_reaction_)
+        , error_exit_reaction(error_exit_reaction_)
     {
         makeFdNonBlocking(stdout_fd);
         makeFdNonBlocking(stderr_fd);
 
 #if defined(OS_LINUX)
         epoll.add(stdout_fd);
-        if (stderr_reaction != ExternalCommandStderrReaction::NONE)
+        if (stderr_reaction != ExternalCommandStderrReaction::NONE || error_exit_reaction != ExternalCommandErrorExitReaction::NONE)
             epoll.add(stderr_fd);
 #endif
     }
@@ -124,7 +129,7 @@ public:
         size_t bytes_read = 0;
 
 #if defined(OS_LINUX)
-        static constexpr size_t STDERR_BUFFER_SIZE = 16_KiB;
+        static constexpr size_t BUFFER_SIZE = 4_KiB;
 
         while (!bytes_read)
         {
@@ -146,7 +151,7 @@ public:
 
             if (has_stderr)
             {
-                stderr_buf.resize(STDERR_BUFFER_SIZE);
+                stderr_buf.resize(BUFFER_SIZE);
                 ssize_t res = ::read(stderr_fd, stderr_buf.data(), stderr_buf.size());
 
                 if (res > 0)
@@ -157,6 +162,25 @@ public:
                     else if (stderr_reaction == ExternalCommandStderrReaction::LOG)
                         LOG_WARNING(
                             &::Poco::Logger::get("TimeoutReadBufferFromFileDescriptor"), "Executable generates stderr: {}", stderr_buf);
+
+                    if (error_exit_reaction == ExternalCommandErrorExitReaction::LOG_FIRST)
+                    {
+                        if (BUFFER_SIZE - error_exit_buf.size() < size_t(res))
+                            res = BUFFER_SIZE - error_exit_buf.size();
+
+                        if (res > 0)
+                            error_exit_buf.append(stderr_buf.begin(), stderr_buf.begin() + res);
+                    }
+                    else if (error_exit_reaction == ExternalCommandErrorExitReaction::LOG_LAST)
+                    {
+                        if (res + error_exit_buf.size() > BUFFER_SIZE)
+                        {
+                            std::shift_left(error_exit_buf.begin(), error_exit_buf.end(), res + error_exit_buf.size() - BUFFER_SIZE);
+                            error_exit_buf.resize(BUFFER_SIZE - res);
+                        }
+
+                        error_exit_buf += stderr_buf;
+                    }
                 }
             }
 
@@ -218,11 +242,14 @@ public:
         tryMakeFdBlocking(stderr_fd);
     }
 
+    String error_exit_buf;
+
 private:
     int stdout_fd;
     int stderr_fd;
     size_t timeout_milliseconds;
     [[maybe_unused]] ExternalCommandStderrReaction stderr_reaction;
+    [[maybe_unused]] ExternalCommandErrorExitReaction error_exit_reaction;
 
 #if defined(OS_LINUX)
     Epoll epoll;
@@ -322,6 +349,8 @@ namespace
             const std::string & format_,
             size_t command_read_timeout_milliseconds,
             ExternalCommandStderrReaction stderr_reaction,
+            ExternalCommandErrorExitReaction error_exit_reaction,
+            bool check_exit_code_,
             const Block & sample_block_,
             std::unique_ptr<ShellCommand> && command_,
             std::vector<SendDataTask> && send_data_tasks = {},
@@ -335,12 +364,10 @@ namespace
             , command(std::move(command_))
             , configuration(configuration_)
             , timeout_command_out(
-                  command->out.getFD(),
-                  command->err.getFD(),
-                  command_read_timeout_milliseconds,
-                  stderr_reaction)
+                  command->out.getFD(), command->err.getFD(), command_read_timeout_milliseconds, stderr_reaction, error_exit_reaction)
             , command_holder(std::move(command_holder_))
             , process_pool(process_pool_)
+            , check_exit_code(check_exit_code_ || error_exit_reaction != ExternalCommandErrorExitReaction::NONE)
         {
             for (auto && send_data_task : send_data_tasks)
             {
@@ -389,7 +416,12 @@ namespace
                     thread.join();
 
             if (command_is_invalid)
+            {
                 command = nullptr;
+                if (!timeout_command_out.error_exit_buf.empty())
+                    LOG_ERROR(
+                        &::Poco::Logger::get("ShellCommandSource"), "Executable fails with stderr: {}", timeout_command_out.error_exit_buf);
+            }
 
             if (command_holder && process_pool)
             {
@@ -431,7 +463,7 @@ namespace
 
                 if (!executor->pull(chunk))
                 {
-                    if (configuration.check_exit_code)
+                    if (check_exit_code)
                         command->wait();
                     return {};
                 }
@@ -490,6 +522,8 @@ namespace
 
         ShellCommandHolderPtr command_holder;
         std::shared_ptr<ProcessPool> process_pool;
+
+        bool check_exit_code = false;
 
         QueryPipeline pipeline;
         std::unique_ptr<PullingPipelineExecutor> executor;
@@ -650,6 +684,8 @@ Pipe ShellCommandSourceCoordinator::createPipe(
         configuration.format,
         configuration.command_read_timeout_milliseconds,
         configuration.stderr_reaction,
+        configuration.error_exit_reaction,
+        configuration.check_exit_code,
         std::move(sample_block),
         std::move(process),
         std::move(tasks),

--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -73,7 +73,7 @@ static int pollWithTimeout(pollfd * pfds, size_t num, size_t timeout_millisecond
     while (true)
     {
         Stopwatch watch;
-        res = poll(pfds, num, static_cast<int>(timeout_milliseconds));
+        res = poll(pfds, static_cast<nfds_t>(num), static_cast<int>(timeout_milliseconds));
 
         if (res < 0)
         {
@@ -139,7 +139,7 @@ public:
         {
             pfds[0].revents = 0;
             pfds[1].revents = 0;
-            size_t num_events = pollWithTimeout(pfds, num_pfds, static_cast<int>(timeout_milliseconds));
+            size_t num_events = pollWithTimeout(pfds, num_pfds, timeout_milliseconds);
             if (0 == num_events)
                 throw Exception(ErrorCodes::TIMEOUT_EXCEEDED, "Pipe read timeout exceeded {} milliseconds", timeout_milliseconds);
 

--- a/src/Processors/Sources/ShellCommandSource.h
+++ b/src/Processors/Sources/ShellCommandSource.h
@@ -58,11 +58,10 @@ public:
         /// Reaction when external command outputs data to its stderr.
         ExternalCommandStderrReaction stderr_reaction = ExternalCommandStderrReaction::NONE;
 
-        /// Reaction when external command exits with non-zero code.
-        ExternalCommandErrorExitReaction error_exit_reaction = ExternalCommandErrorExitReaction::NONE;
-
         /// Will throw if the command exited with
-        /// non-zero status code
+        /// non-zero status code.
+        /// NOTE: If executable pool is used, we cannot check exit code,
+        /// which makes this configuration no effect.
         size_t check_exit_code = false;
 
         /// Pool size valid only if executable_pool = true

--- a/src/Processors/Sources/ShellCommandSource.h
+++ b/src/Processors/Sources/ShellCommandSource.h
@@ -4,6 +4,7 @@
 
 #include <base/BorrowedObjectPool.h>
 
+#include <Common/ShellCommandSettings.h>
 #include <Common/ShellCommand.h>
 #include <Common/ThreadPool.h>
 
@@ -56,6 +57,9 @@ public:
 
         /// Timeout for writing data to command stdin
         size_t command_write_timeout_milliseconds = 10000;
+
+        /// Reaction when external command outputs data to its stderr.
+        ExternalCommandStderrReaction stderr_reaction = ExternalCommandStderrReaction::NONE;
 
         /// Pool size valid only if executable_pool = true
         size_t pool_size = 16;

--- a/src/Processors/Sources/ShellCommandSource.h
+++ b/src/Processors/Sources/ShellCommandSource.h
@@ -34,9 +34,6 @@ struct ShellCommandSourceConfiguration
     size_t number_of_rows_to_read = 0;
     /// Max block size
     size_t max_block_size = DEFAULT_BLOCK_SIZE;
-    /// Will throw if the command exited with
-    /// non-zero status code
-    size_t check_exit_code = false;
 };
 
 class ShellCommandSourceCoordinator
@@ -60,6 +57,13 @@ public:
 
         /// Reaction when external command outputs data to its stderr.
         ExternalCommandStderrReaction stderr_reaction = ExternalCommandStderrReaction::NONE;
+
+        /// Reaction when external command exits with non-zero code.
+        ExternalCommandErrorExitReaction error_exit_reaction = ExternalCommandErrorExitReaction::NONE;
+
+        /// Will throw if the command exited with
+        /// non-zero status code
+        size_t check_exit_code = false;
 
         /// Pool size valid only if executable_pool = true
         size_t pool_size = 16;

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -76,7 +76,7 @@ bool RemoteQueryExecutorReadContext::checkTimeout(bool blocking)
     epoll_event events[3];
     events[0].data.fd = events[1].data.fd = events[2].data.fd = -1;
 
-    size_t num_events = epoll.getManyReady(3, events, blocking);
+    size_t num_events = epoll.getManyReady(3, events, blocking ? -1 : 0);
 
     bool is_socket_ready = false;
 

--- a/src/Storages/ExecutableSettings.h
+++ b/src/Storages/ExecutableSettings.h
@@ -14,7 +14,8 @@ class ASTStorage;
     M(UInt64, max_command_execution_time, 10, "Max command execution time in seconds.", 0) \
     M(UInt64, command_termination_timeout, 10, "Command termination timeout in seconds.", 0) \
     M(UInt64, command_read_timeout, 10000, "Timeout for reading data from command stdout in milliseconds.", 0) \
-    M(UInt64, command_write_timeout, 10000, "Timeout for writing data to command stdin in milliseconds.", 0)
+    M(UInt64, command_write_timeout, 10000, "Timeout for writing data to command stdin in milliseconds.", 0) \
+    M(ExternalCommandStderrReaction, stderr_reaction, ExternalCommandStderrReaction::NONE, "Reaction when external command outputs data to its stderr.", 0)
 
 DECLARE_SETTINGS_TRAITS(ExecutableSettingsTraits, LIST_OF_EXECUTABLE_SETTINGS)
 

--- a/src/Storages/ExecutableSettings.h
+++ b/src/Storages/ExecutableSettings.h
@@ -15,7 +15,8 @@ class ASTStorage;
     M(UInt64, command_termination_timeout, 10, "Command termination timeout in seconds.", 0) \
     M(UInt64, command_read_timeout, 10000, "Timeout for reading data from command stdout in milliseconds.", 0) \
     M(UInt64, command_write_timeout, 10000, "Timeout for writing data to command stdin in milliseconds.", 0) \
-    M(ExternalCommandStderrReaction, stderr_reaction, ExternalCommandStderrReaction::NONE, "Reaction when external command outputs data to its stderr.", 0)
+    M(ExternalCommandStderrReaction, stderr_reaction, ExternalCommandStderrReaction::NONE, "Reaction when external command outputs data to its stderr.", 0) \
+    M(ExternalCommandErrorExitReaction, error_exit_reaction, ExternalCommandErrorExitReaction::NONE, "Reaction when external command exits with non-zero code.", 0) \
 
 DECLARE_SETTINGS_TRAITS(ExecutableSettingsTraits, LIST_OF_EXECUTABLE_SETTINGS)
 

--- a/src/Storages/ExecutableSettings.h
+++ b/src/Storages/ExecutableSettings.h
@@ -16,7 +16,7 @@ class ASTStorage;
     M(UInt64, command_read_timeout, 10000, "Timeout for reading data from command stdout in milliseconds.", 0) \
     M(UInt64, command_write_timeout, 10000, "Timeout for writing data to command stdin in milliseconds.", 0) \
     M(ExternalCommandStderrReaction, stderr_reaction, ExternalCommandStderrReaction::NONE, "Reaction when external command outputs data to its stderr.", 0) \
-    M(ExternalCommandErrorExitReaction, error_exit_reaction, ExternalCommandErrorExitReaction::NONE, "Reaction when external command exits with non-zero code.", 0) \
+    M(Bool, check_exit_code, true, "Throw exception if the command exited with non-zero status code.", 0) \
 
 DECLARE_SETTINGS_TRAITS(ExecutableSettingsTraits, LIST_OF_EXECUTABLE_SETTINGS)
 

--- a/src/Storages/ExecutableSettings.h
+++ b/src/Storages/ExecutableSettings.h
@@ -16,7 +16,7 @@ class ASTStorage;
     M(UInt64, command_read_timeout, 10000, "Timeout for reading data from command stdout in milliseconds.", 0) \
     M(UInt64, command_write_timeout, 10000, "Timeout for writing data to command stdin in milliseconds.", 0) \
     M(ExternalCommandStderrReaction, stderr_reaction, ExternalCommandStderrReaction::NONE, "Reaction when external command outputs data to its stderr.", 0) \
-    M(Bool, check_exit_code, true, "Throw exception if the command exited with non-zero status code.", 0) \
+    M(Bool, check_exit_code, false, "Throw exception if the command exited with non-zero status code.", 0) \
 
 DECLARE_SETTINGS_TRAITS(ExecutableSettingsTraits, LIST_OF_EXECUTABLE_SETTINGS)
 

--- a/src/Storages/StorageExecutable.cpp
+++ b/src/Storages/StorageExecutable.cpp
@@ -93,6 +93,7 @@ StorageExecutable::StorageExecutable(
         .command_read_timeout_milliseconds = settings.command_read_timeout,
         .command_write_timeout_milliseconds = settings.command_write_timeout,
         .stderr_reaction = settings.stderr_reaction,
+        .error_exit_reaction = settings.error_exit_reaction,
 
         .pool_size = settings.pool_size,
         .max_command_execution_time_seconds = settings.max_command_execution_time,

--- a/src/Storages/StorageExecutable.cpp
+++ b/src/Storages/StorageExecutable.cpp
@@ -93,7 +93,7 @@ StorageExecutable::StorageExecutable(
         .command_read_timeout_milliseconds = settings.command_read_timeout,
         .command_write_timeout_milliseconds = settings.command_write_timeout,
         .stderr_reaction = settings.stderr_reaction,
-        .error_exit_reaction = settings.error_exit_reaction,
+        .check_exit_code = settings.check_exit_code,
 
         .pool_size = settings.pool_size,
         .max_command_execution_time_seconds = settings.max_command_execution_time,

--- a/src/Storages/StorageExecutable.cpp
+++ b/src/Storages/StorageExecutable.cpp
@@ -92,6 +92,7 @@ StorageExecutable::StorageExecutable(
         .command_termination_timeout_seconds = settings.command_termination_timeout,
         .command_read_timeout_milliseconds = settings.command_read_timeout,
         .command_write_timeout_milliseconds = settings.command_write_timeout,
+        .stderr_reaction = settings.stderr_reaction,
 
         .pool_size = settings.pool_size,
         .max_command_execution_time_seconds = settings.max_command_execution_time,

--- a/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
+++ b/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
@@ -348,25 +348,50 @@
 
     <function>
         <type>executable</type>
-        <name>test_function_always_error_exit_log_first_python</name>
+        <name>test_function_always_error_log_first_python</name>
         <return_type>String</return_type>
         <argument>
             <type>UInt64</type>
         </argument>
         <format>TabSeparated</format>
         <command>input_log_error.py</command>
-        <error_exit_reaction>log_first</error_exit_reaction>
+        <stderr_reaction>log_first</stderr_reaction>
     </function>
 
     <function>
         <type>executable</type>
-        <name>test_function_always_error_exit_log_last_python</name>
+        <name>test_function_always_error_log_last_python</name>
         <return_type>String</return_type>
         <argument>
             <type>UInt64</type>
         </argument>
         <format>TabSeparated</format>
         <command>input_log_error.py</command>
-        <error_exit_reaction>log_last</error_exit_reaction>
+        <stderr_reaction>log_last</stderr_reaction>
+    </function>
+
+    <function>
+        <type>executable</type>
+        <name>test_function_exit_error_ignore_python</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt64</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input_exit_error.py</command>
+        <check_exit_code>0</check_exit_code>
+    </function>
+
+    <function>
+        <type>executable</type>
+        <name>test_function_exit_error_fail_python</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt64</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input_exit_error.py</command>
+        <!-- default -->
+        <!-- <check_exit_code>1</check_exit_code> -->
     </function>
 </functions>

--- a/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
+++ b/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
@@ -345,4 +345,28 @@
         <command>input_always_error.py</command>
         <stderr_reaction>log</stderr_reaction>
     </function>
+
+    <function>
+        <type>executable</type>
+        <name>test_function_always_error_exit_log_first_python</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt64</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input_log_error.py</command>
+        <error_exit_reaction>log_first</error_exit_reaction>
+    </function>
+
+    <function>
+        <type>executable</type>
+        <name>test_function_always_error_exit_log_last_python</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt64</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input_log_error.py</command>
+        <error_exit_reaction>log_last</error_exit_reaction>
+    </function>
 </functions>

--- a/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
+++ b/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
@@ -322,4 +322,27 @@
         <command>input_parameter.py {test_parameter:UInt64}</command>
     </function>
 
+    <function>
+        <type>executable</type>
+        <name>test_function_always_error_throw_python</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt64</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input_always_error.py</command>
+        <stderr_reaction>throw</stderr_reaction>
+    </function>
+
+    <function>
+        <type>executable</type>
+        <name>test_function_always_error_log_python</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt64</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input_always_error.py</command>
+        <stderr_reaction>log</stderr_reaction>
+    </function>
 </functions>

--- a/tests/integration/test_executable_user_defined_function/test.py
+++ b/tests/integration/test_executable_user_defined_function/test.py
@@ -327,10 +327,7 @@ def test_executable_function_always_error_python(started_cluster):
         f"{{{query_id}}} <Warning> TimeoutReadBufferFromFileDescriptor: Executable generates stderr at the end:  {'b' * 1024}{'c' * (3 * 1024)}\n"
     )
 
-    assert (
-        node.query("SELECT test_function_exit_error_ignore_python(1)")
-        == "Key 1\n"
-    )
+    assert node.query("SELECT test_function_exit_error_ignore_python(1)") == "Key 1\n"
 
     try:
         node.query("SELECT test_function_exit_error_fail_python(1)")

--- a/tests/integration/test_executable_user_defined_function/test.py
+++ b/tests/integration/test_executable_user_defined_function/test.py
@@ -306,3 +306,23 @@ def test_executable_function_always_error_python(started_cluster):
         + query_id
         + "} <Warning> TimeoutReadBufferFromFileDescriptor: Executable generates stderr: Fake error"
     )
+
+    query_id = uuid.uuid4().hex
+    try:
+        node.query("SELECT test_function_always_error_exit_log_first_python(1)", query_id=query_id)
+        assert False, "Exception have to be thrown"
+    except Exception as ex:
+        assert "DB::Exception: Child process was exited with return code 1" in str(ex)
+        assert node.contains_in_log(
+            f"{{{query_id}}} <Error> ShellCommandSource: Executable fails with stderr: {'a' * (3 * 1024)}{'b' * 1024}\n"
+        )
+
+    query_id = uuid.uuid4().hex
+    try:
+        node.query("SELECT test_function_always_error_exit_log_last_python(1)", query_id=query_id)
+        assert False, "Exception have to be thrown"
+    except Exception as ex:
+        assert "DB::Exception: Child process was exited with return code 1" in str(ex)
+        assert node.contains_in_log(
+            f"{{{query_id}}} <Error> ShellCommandSource: Executable fails with stderr: {'b' * 1024}{'c' * (3 * 1024)}\n"
+        )

--- a/tests/integration/test_executable_user_defined_function/test.py
+++ b/tests/integration/test_executable_user_defined_function/test.py
@@ -309,7 +309,10 @@ def test_executable_function_always_error_python(started_cluster):
 
     query_id = uuid.uuid4().hex
     try:
-        node.query("SELECT test_function_always_error_exit_log_first_python(1)", query_id=query_id)
+        node.query(
+            "SELECT test_function_always_error_exit_log_first_python(1)",
+            query_id=query_id,
+        )
         assert False, "Exception have to be thrown"
     except Exception as ex:
         assert "DB::Exception: Child process was exited with return code 1" in str(ex)
@@ -319,7 +322,10 @@ def test_executable_function_always_error_python(started_cluster):
 
     query_id = uuid.uuid4().hex
     try:
-        node.query("SELECT test_function_always_error_exit_log_last_python(1)", query_id=query_id)
+        node.query(
+            "SELECT test_function_always_error_exit_log_last_python(1)",
+            query_id=query_id,
+        )
         assert False, "Exception have to be thrown"
     except Exception as ex:
         assert "DB::Exception: Child process was exited with return code 1" in str(ex)

--- a/tests/integration/test_executable_user_defined_function/user_scripts/input_always_error.py
+++ b/tests/integration/test_executable_user_defined_function/user_scripts/input_always_error.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3
+
+import sys
+
+if __name__ == "__main__":
+    print("Fake error", file=sys.stderr)
+    sys.stderr.flush()
+    for line in sys.stdin:
+        print("Key " + line, end="")
+        sys.stdout.flush()

--- a/tests/integration/test_executable_user_defined_function/user_scripts/input_exit_error.py
+++ b/tests/integration/test_executable_user_defined_function/user_scripts/input_exit_error.py
@@ -3,8 +3,8 @@
 import sys
 
 if __name__ == "__main__":
-    print(f"{'a' * (3 * 1024)}{'b' * (3 * 1024)}{'c' * (3 * 1024)}", file=sys.stderr)
-    sys.stderr.flush()
     for line in sys.stdin:
         print("Key " + line, end="")
         sys.stdout.flush()
+
+    sys.exit(1)

--- a/tests/integration/test_executable_user_defined_function/user_scripts/input_log_error.py
+++ b/tests/integration/test_executable_user_defined_function/user_scripts/input_log_error.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+
+import sys
+
+if __name__ == "__main__":
+    print(f"{'a' * (3 * 1024)}{'b' * (3 * 1024)}{'c' * (3 * 1024)}", file=sys.stderr)
+    sys.stderr.flush()
+    for line in sys.stdin:
+        print("Key " + line, end="")
+        sys.stdout.flush()
+
+    sys.exit(1)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add  `stderr_reaction` configuration/setting to control the reaction (none, log or throw) when external command stderr has data. This helps make debugging  external command easier. 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
