### PR TITLE
Fix flaky 02449_check_dependencies_and_table_shutdown

### DIFF
--- a/tests/queries/0_stateless/02449_check_dependencies_and_table_shutdown.reference
+++ b/tests/queries/0_stateless/02449_check_dependencies_and_table_shutdown.reference
@@ -1,4 +1,4 @@
-CREATE DICTIONARY default.dict\n(\n    `id` UInt32,\n    `value` String\n)\nPRIMARY KEY id\nSOURCE(CLICKHOUSE(HOST \'localhost\' PORT 9000 USER \'default\' DB \'default\' TABLE \'view\'))\nLIFETIME(MIN 0 MAX 600)\nLAYOUT(HASHED())
+CREATE DICTIONARY default.dict\n(\n    `id` UInt32,\n    `value` String\n)\nPRIMARY KEY id\nSOURCE(CLICKHOUSE(HOST \'localhost\' PORT 9000 USER \'default\' DB \'default\' TABLE \'view\'))\nLIFETIME(MIN 600 MAX 600)\nLAYOUT(HASHED())
 CREATE TABLE default.table\n(\n    `col` String MATERIALIZED dictGet(\'default.dict\', \'value\', toUInt32(1))\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS index_granularity = 8192
 1	v
 1	v

--- a/tests/queries/0_stateless/02449_check_dependencies_and_table_shutdown.sql
+++ b/tests/queries/0_stateless/02449_check_dependencies_and_table_shutdown.sql
@@ -8,7 +8,7 @@ INSERT INTO view VALUES (1, 'v');
 CREATE DICTIONARY dict (id UInt32, value String)
 PRIMARY KEY id
 SOURCE(CLICKHOUSE(host 'localhost' port tcpPort() user 'default' db currentDatabase() table 'view'))
-LAYOUT (HASHED()) LIFETIME (600);
+LAYOUT (HASHED()) LIFETIME (MIN 600 MAX 600);
 
 SHOW CREATE dict;
 


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/43195/f5270a6ebeeac6221079524b4a602908e26d6f0c/stateless_tests__debug__%5B3/3%5D.html
