### PR TITLE
Don't throw if shared ID already created in `StorageReplicatedMergeTree`

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
@@ -182,6 +182,7 @@ void ReplicatedMergeTreeAttachThread::runImpl()
     storage.createNewZooKeeperNodes();
     storage.syncPinnedPartUUIDs();
 
+    std::lock_guard lock(storage.table_shared_id_mutex);
     storage.createTableSharedID();
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The added code for `getTableSharedID` (used for zero-copy) didn't take into account that attach is now done in the background.
https://s3.amazonaws.com/clickhouse-test-reports/43080/5bd8e2338b99700345a63fbf38b167c0aae47d4b/stress_test__ubsan_.html
https://s3.amazonaws.com/clickhouse-test-reports/43080/5bd8e2338b99700345a63fbf38b167c0aae47d4b/stress_test__ubsan_/fatal_messages.txt
cc @alesapin 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
