### PR TITLE
Add check to CompressionCodecDelta

### DIFF
--- a/src/Compression/CompressionCodecDelta.cpp
+++ b/src/Compression/CompressionCodecDelta.cpp
@@ -137,7 +137,6 @@ void CompressionCodecDelta::doDecompressData(const char * source, UInt32 source_
 
     if (uncompressed_size == 0)
         return;
-    
     UInt8 bytes_size = source[0];
 
     if (bytes_size == 0)

--- a/src/Compression/CompressionCodecDelta.cpp
+++ b/src/Compression/CompressionCodecDelta.cpp
@@ -135,6 +135,9 @@ void CompressionCodecDelta::doDecompressData(const char * source, UInt32 source_
     if (source_size < 2)
         throw Exception("Cannot decompress. File has wrong header", ErrorCodes::CANNOT_DECOMPRESS);
 
+    if (uncompressed_size == 0)
+        return;
+    
     UInt8 bytes_size = source[0];
 
     if (bytes_size == 0)

--- a/src/Compression/CompressionCodecDelta.cpp
+++ b/src/Compression/CompressionCodecDelta.cpp
@@ -137,6 +137,7 @@ void CompressionCodecDelta::doDecompressData(const char * source, UInt32 source_
 
     if (uncompressed_size == 0)
         return;
+
     UInt8 bytes_size = source[0];
 
     if (bytes_size == 0)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Additional check on zero uncompressed size is added to `CompressionCodecDelta`.

This closes #43125