### PR TITLE
Make test_global_overcommit_tracker non-parallel

### DIFF
--- a/tests/integration/parallel_skip.json
+++ b/tests/integration/parallel_skip.json
@@ -48,6 +48,8 @@
   "test_system_replicated_fetches/test.py::test_system_replicated_fetches",
   "test_zookeeper_config_load_balancing/test.py::test_round_robin",
 
+  "test_global_overcommit_tracker/test.py::test_global_overcommit",
+
   "test_user_ip_restrictions/test.py::test_ipv4",
   "test_user_ip_restrictions/test.py::test_ipv6"
 ]


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

There are some issues with the test after #43105. It seems that the kernel is smart enough to share clickhouse binary between images.

https://play.clickhouse.com/play?user=play#c2VsZWN0IAp0b1N0YXJ0T2ZEYXkoY2hlY2tfc3RhcnRfdGltZSkgYXMgZCwKY291bnQoKSwgIGdyb3VwVW5pcUFycmF5KHB1bGxfcmVxdWVzdF9udW1iZXIpLCAgYW55KHJlcG9ydF91cmwpCmZyb20gY2hlY2tzIHdoZXJlICcyMDIyLTA2LTAxJyA8PSBjaGVja19zdGFydF90aW1lIGFuZCB0ZXN0X25hbWUgbGlrZSAnJXRlc3RfZ2xvYmFsX292ZXJjb21taXRfdHJhY2tlciUnIGFuZCB0ZXN0X3N0YXR1cyBpbiAoJ0ZBSUwnLCAnRkxBS1knKSBncm91cCBieSBkIG9yZGVyIGJ5IGQgZGVzYw==

cc @tavplubix 