### PR TITLE
Sanitize thirdparty libraries for public flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,7 +592,7 @@ add_subdirectory (programs)
 add_subdirectory (tests)
 add_subdirectory (utils)
 
-include (cmake/sanitize_target_link_libraries.cmake)
+include (cmake/sanitize_targets.cmake)
 
 # Build native targets if necessary
 get_property(NATIVE_BUILD_TARGETS GLOBAL PROPERTY NATIVE_BUILD_TARGETS)

--- a/cmake/sanitize_targets.cmake
+++ b/cmake/sanitize_targets.cmake
@@ -1,3 +1,13 @@
+# https://stackoverflow.com/a/62311397/328260
+macro (get_all_targets_recursive targets dir)
+    get_property (subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach (subdir ${subdirectories})
+        get_all_targets_recursive (${targets} ${subdir})
+    endforeach ()
+    get_property (current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    list (APPEND ${targets} ${current_targets})
+endmacro ()
+
 # When you will try to link target with the directory (that exists), cmake will
 # skip this without an error, only the following warning will be reported:
 #
@@ -18,23 +28,12 @@
 #   -- but cannot be used with link_libraries()
 # - use BUILDSYSTEM_TARGETS property to get list of all targets and sanitize
 #   -- this will work.
-
-# https://stackoverflow.com/a/62311397/328260
 function (get_all_targets var)
     set (targets)
     get_all_targets_recursive (targets ${CMAKE_CURRENT_SOURCE_DIR})
     set (${var} ${targets} PARENT_SCOPE)
 endfunction()
-macro (get_all_targets_recursive targets dir)
-    get_property (subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
-    foreach (subdir ${subdirectories})
-        get_all_targets_recursive (${targets} ${subdir})
-    endforeach ()
-    get_property (current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
-    list (APPEND ${targets} ${current_targets})
-endmacro ()
-
-macro (sanitize_link_libraries target)
+function (sanitize_link_libraries target)
     get_target_property(target_type ${target} TYPE)
     if (${target_type} STREQUAL "INTERFACE_LIBRARY")
         get_property(linked_libraries TARGET ${target} PROPERTY INTERFACE_LINK_LIBRARIES)
@@ -48,9 +47,35 @@ macro (sanitize_link_libraries target)
             message(FATAL_ERROR "${target} requested to link with directory: ${linked_library}")
         endif()
     endforeach()
-endmacro()
-
+endfunction()
 get_all_targets (all_targets)
 foreach (target ${all_targets})
     sanitize_link_libraries(${target})
 endforeach()
+
+#
+# Do not allow to define -W* from contrib publically (INTERFACE/PUBLIC).
+#
+function (get_contrib_targets var)
+    set (targets)
+    get_all_targets_recursive (targets ${CMAKE_CURRENT_SOURCE_DIR}/contrib)
+    set (${var} ${targets} PARENT_SCOPE)
+endfunction()
+function (sanitize_interface_flags target)
+    get_target_property(target_type ${target} TYPE)
+    get_property(compile_definitions TARGET ${target} PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+    get_property(compile_options TARGET ${target} PROPERTY INTERFACE_COMPILE_OPTIONS)
+    if (NOT "${compile_options}" STREQUAL "")
+        message(FATAL_ERROR "${target} set INTERFACE_COMPILE_OPTIONS to ${compile_options}. This is forbidden.")
+    endif()
+    if ("${compile_definitions}" MATCHES "-Wl,")
+        # linker option - OK
+    elseif ("${compile_definitions}" MATCHES "-W")
+        message(FATAL_ERROR "${target} contains ${compile_definitions} flags in INTERFACE_COMPILE_DEFINITIONS. This is forbidden.")
+    endif()
+endfunction()
+get_contrib_targets (contrib_targets)
+foreach (contrib_target ${contrib_targets})
+    sanitize_interface_flags(${contrib_target})
+endforeach()
+


### PR DESCRIPTION
Public flags, especially -Wxx (i.e. -Wno-XX) can hide some warnings, that had been added in the main cmake rules of ClickHouse.

This patch had been tested manually with the following patch:

    ```patch
    diff --git a/contrib/jemalloc-cmake/CMakeLists.txt b/contrib/jemalloc-cmake/CMakeLists.txt
    index d5ea69d4926..7e79fba0c16 100644
    --- a/contrib/jemalloc-cmake/CMakeLists.txt
    +++ b/contrib/jemalloc-cmake/CMakeLists.txt
    @@ -158,6 +158,7 @@ target_include_directories(_jemalloc SYSTEM PRIVATE
         "${CMAKE_CURRENT_BINARY_DIR}/${JEMALLOC_INCLUDE_PREFIX}/jemalloc/internal")

     target_compile_definitions(_jemalloc PRIVATE -DJEMALLOC_NO_PRIVATE_NAMESPACE)
    +target_compile_options(_jemalloc INTERFACE -Wno-error) # also PUBLIC had been checked

     if (CMAKE_BUILD_TYPE_UC STREQUAL "DEBUG")
         target_compile_definitions(_jemalloc PRIVATE
    ```

And cmake gave:

    CMake Error at cmake/sanitize_targets.cmake:69 (message):
      _jemalloc set INTERFACE_COMPILE_OPTIONS to -Wno-error.  This is forbidden.
    Call Stack (most recent call first):
      cmake/sanitize_targets.cmake:79 (sanitize_interface_flags)
      CMakeLists.txt:595 (include)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #12447 (cc @alexey-milovidov )