### PR TITLE
stress: increase timeout for server waiting after TERM

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -131,8 +131,14 @@ function stop()
     # Preserve the pid, since the server can hung after the PID will be deleted.
     pid="$(cat /var/run/clickhouse-server/clickhouse-server.pid)"
 
-    # Increase default waiting timeout for sanitizers and debug builds
-    clickhouse stop --max-tries 180 --do-not-kill && return
+    # --max-tries is supported only since 22.12
+    if dpkg --compare-versions "$(clickhouse local -q 'select version()')" ge "22.12"; then
+        # Increase default waiting timeout for sanitizers and debug builds
+        clickhouse stop --max-tries 180 --do-not-kill && return
+    else
+        clickhouse stop --do-not-kill && return
+    fi
+
     # We failed to stop the server with SIGTERM. Maybe it hang, let's collect stacktraces.
     kill -TERM "$(pidof gdb)" ||:
     sleep 5

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -131,7 +131,8 @@ function stop()
     # Preserve the pid, since the server can hung after the PID will be deleted.
     pid="$(cat /var/run/clickhouse-server/clickhouse-server.pid)"
 
-    clickhouse stop --do-not-kill && return
+    # Increase default waiting timeout for sanitizers and debug builds
+    clickhouse stop --max-tries 180 --do-not-kill && return
     # We failed to stop the server with SIGTERM. Maybe it hang, let's collect stacktraces.
     kill -TERM "$(pidof gdb)" ||:
     sleep 5


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
stress: increase timeout for server waiting after TERM

Greater timeout after TERM may reduce about of KILL (like in [1]), let's try.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/43146/953457de281d1167f51d91de9c3ca8df32780b30/stress_test__msan_.html