### PR TITLE
Rename canonicalRand to randCanonical

### DIFF
--- a/docs/en/sql-reference/functions/random-functions.md
+++ b/docs/en/sql-reference/functions/random-functions.md
@@ -24,7 +24,7 @@ Returns a pseudo-random UInt64 number, evenly distributed among all UInt64-type 
 
 Uses a linear congruential generator.
 
-## canonicalRand
+## randCanonical
 The function generates pseudo random results with independent and identically distributed uniformly distributed values in [0, 1).
 
 Non-deterministic. Return type is Float64.

--- a/src/Functions/canonicalRand.cpp
+++ b/src/Functions/canonicalRand.cpp
@@ -34,7 +34,7 @@ private:
 
 struct NameCanonicalRand
 {
-    static constexpr auto name = "canonicalRand";
+    static constexpr auto name = "randCanonical";
 };
 
 class FunctionCanonicalRand : public FunctionRandomImpl<CanonicalRandImpl, Float64, NameCanonicalRand>
@@ -52,7 +52,7 @@ REGISTER_FUNCTION(CanonicalRand)
 The function generates pseudo random results with independent and identically distributed uniformly distributed values in [0, 1).
 Non-deterministic. Return type is Float64.
         )",
-        Documentation::Examples{{"canonicalRand", "SELECT canonicalRand()"}},
+        Documentation::Examples{{"randCanonical", "SELECT randCanonical()"}},
         Documentation::Categories{"Mathematical"}});
 }
 

--- a/tests/queries/0_stateless/01047_nullable_rand.sql
+++ b/tests/queries/0_stateless/01047_nullable_rand.sql
@@ -1,13 +1,13 @@
 select toTypeName(rand(cast(4 as Nullable(UInt8))));
-select toTypeName(canonicalRand(CAST(4 as Nullable(UInt8))));
+select toTypeName(randCanonical(CAST(4 as Nullable(UInt8))));
 select toTypeName(randConstant(CAST(4 as Nullable(UInt8))));
 select toTypeName(rand(Null));
-select toTypeName(canonicalRand(Null));
+select toTypeName(randCanonical(Null));
 select toTypeName(randConstant(Null));
 
 select rand(cast(4 as Nullable(UInt8))) * 0;
-select canonicalRand(cast(4 as Nullable(UInt8))) * 0;
+select randCanonical(cast(4 as Nullable(UInt8))) * 0;
 select randConstant(CAST(4 as Nullable(UInt8))) * 0;
 select rand(Null) * 0;
-select canonicalRand(Null) * 0;
+select randCanonical(Null) * 0;
 select randConstant(Null) * 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

To make name consistent with other `rand*` functions.
No release includes this function yet, so it is safe to rename.

cc @taiyang-li 