### PR TITLE
check limits for an AST in select parser fuzzer

### DIFF
--- a/src/Parsers/fuzzers/select_parser_fuzzer.cpp
+++ b/src/Parsers/fuzzers/select_parser_fuzzer.cpp
@@ -12,7 +12,15 @@ try
     std::string input = std::string(reinterpret_cast<const char*>(data), size);
 
     DB::ParserQueryWithOutput parser(input.data() + input.size());
-    DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, 1000);
+
+    const UInt64 max_parser_depth = 1000;
+    DB::ASTPtr ast = parseQuery(parser, input.data(), input.data() + input.size(), "", 0, max_parser_depth);
+
+    const UInt64 max_ast_depth = 1000;
+    ast->checkDepth(max_ast_depth);
+
+    const UInt64 max_ast_elements = 50000;
+    ast->checkSize(max_ast_elements);
 
     DB::WriteBufferFromOwnString wb;
     DB::formatAST(*ast, wb);


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/43251

Check limits for an AST in select parser fuzzer as Clickhouse does on a request.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
