### PR TITLE
Fix race on write in `ReplicatedMergeTree`

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4507,6 +4507,9 @@ void StorageReplicatedMergeTree::assertNotReadonly() const
 
 SinkToStoragePtr StorageReplicatedMergeTree::write(const ASTPtr & /*query*/, const StorageMetadataPtr & metadata_snapshot, ContextPtr local_context)
 {
+    if (!initialization_done)
+        throw Exception(ErrorCodes::NOT_INITIALIZED, "Table is not initialized yet");
+
     /// If table is read-only because it doesn't have metadata in zk yet, then it's not possible to insert into it
     /// Without this check, we'll write data parts on disk, and afterwards will remove them since we'll fail to commit them into zk
     /// In case of remote storage like s3, it'll generate unnecessary PUT requests


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It's more correct and it avoids the race on `has_metadata_in_zookeeper`.

https://s3.amazonaws.com/clickhouse-test-reports/43026/01b63fd98acd2e1c77c15f2bf0004111e9bfd9ae/stateless_tests__tsan__s3_storage__[3/3]/stderr.log
https://s3.amazonaws.com/clickhouse-test-reports/43026/01b63fd98acd2e1c77c15f2bf0004111e9bfd9ae/stateless_tests__tsan__s3_storage__[3/3].html

cc @tavplubix 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
