### PR TITLE
Fix: make test_read_only_table more stable

### DIFF
--- a/tests/integration/test_read_only_table/test.py
+++ b/tests/integration/test_read_only_table/test.py
@@ -85,5 +85,7 @@ def test_restart_zookeeper(start_cluster):
 
     for table_id in range(NUM_TABLES):
         node1.query_with_retry(
-            sql = f"INSERT INTO test_table_{table_id} VALUES (6), (7), (8), (9), (10);", retry_count=10, sleep_time=1
+            sql=f"INSERT INTO test_table_{table_id} VALUES (6), (7), (8), (9), (10);",
+            retry_count=10,
+            sleep_time=1,
         )

--- a/tests/integration/test_read_only_table/test.py
+++ b/tests/integration/test_read_only_table/test.py
@@ -84,6 +84,6 @@ def test_restart_zookeeper(start_cluster):
     time.sleep(5)
 
     for table_id in range(NUM_TABLES):
-        node1.query(
-            f"INSERT INTO test_table_{table_id} VALUES (6), (7), (8), (9), (10);"
+        node1.query_with_retry(
+            sql = f"INSERT INTO test_table_{table_id} VALUES (6), (7), (8), (9), (10);", retry_count=10, sleep_time=1
         )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Added retries to INSERT queries after keeper node restart
See comments [here](https://github.com/ClickHouse/ClickHouse/pull/43117#issuecomment-1318563790)