### PR TITLE
Check content of `format_version` file in `MergeTreeData`

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -282,8 +282,8 @@ MergeTreeData::MergeTreeData(
 
     checkTTLExpressions(metadata_, metadata_);
 
-    /// format_file always contained on any data path
-    PathWithDisk version_file;
+    const auto format_version_path = fs::path(relative_data_path) / MergeTreeData::FORMAT_VERSION_FILE_NAME;
+    std::optional<UInt32> read_format_version;
     /// Creating directories, if not exist.
     for (const auto & disk : getDisks())
     {
@@ -292,29 +292,30 @@ MergeTreeData::MergeTreeData(
 
         disk->createDirectories(relative_data_path);
         disk->createDirectories(fs::path(relative_data_path) / MergeTreeData::DETACHED_DIR_NAME);
-        String current_version_file_path = fs::path(relative_data_path) / MergeTreeData::FORMAT_VERSION_FILE_NAME;
 
-        if (disk->exists(current_version_file_path))
+        if (disk->exists(format_version_path))
         {
-            if (!version_file.first.empty())
-                throw Exception(ErrorCodes::CORRUPTED_DATA, "Duplication of version file {} and {}", fullPath(version_file.second, version_file.first), current_version_file_path);
-            version_file = {current_version_file_path, disk};
+            auto buf = disk->readFile(format_version_path);
+            UInt32 current_format_version{0};
+            readIntText(current_format_version, *buf);
+            if (!buf->eof())
+                throw Exception(ErrorCodes::CORRUPTED_DATA, "Bad version file: {}", fullPath(disk, format_version_path));
+
+            if (!read_format_version.has_value())
+                read_format_version = current_format_version;
+            else if (*read_format_version != current_format_version)
+                throw Exception(ErrorCodes::CORRUPTED_DATA, "Version file on {} contains version {} expected version is {}.", fullPath(disk, format_version_path), current_format_version, *read_format_version);
         }
     }
 
-    /// If not choose any
-    if (version_file.first.empty())
-        version_file = {fs::path(relative_data_path) / MergeTreeData::FORMAT_VERSION_FILE_NAME, getStoragePolicy()->getAnyDisk()};
-
-    bool version_file_exists = version_file.second->exists(version_file.first);
-
     // When data path or file not exists, ignore the format_version check
-    if (!attach || !version_file_exists)
+    if (!attach || !read_format_version)
     {
         format_version = min_format_version;
-        if (!version_file.second->isReadOnly())
+        auto disk = getStoragePolicy()->getAnyDisk();
+        if (!disk->isReadOnly())
         {
-            auto buf = version_file.second->writeFile(version_file.first, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, context_->getWriteSettings());
+            auto buf = disk->writeFile(format_version_path, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, context_->getWriteSettings());
             writeIntText(format_version.toUnderType(), *buf);
             if (getContext()->getSettingsRef().fsync_metadata)
                 buf->sync();
@@ -322,12 +323,7 @@ MergeTreeData::MergeTreeData(
     }
     else
     {
-        auto buf = version_file.second->readFile(version_file.first);
-        UInt32 read_format_version;
-        readIntText(read_format_version, *buf);
-        format_version = read_format_version;
-        if (!buf->eof())
-            throw Exception("Bad version file: " + fullPath(version_file.second, version_file.first), ErrorCodes::CORRUPTED_DATA);
+        format_version = *read_format_version;
     }
 
     if (format_version < min_format_version)

--- a/tests/integration/test_storage_policies/configs/disk2_only.xml
+++ b/tests/integration/test_storage_policies/configs/disk2_only.xml
@@ -1,0 +1,18 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <disk2>
+                <path>/var/lib/clickhouse2/</path>
+            </disk2>
+        </disks>
+        <policies>
+            <test_policy>
+                <volumes>
+                    <volume2>
+                        <disk>disk2</disk>
+                    </volume2>
+                </volumes>
+            </test_policy>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_storage_policies/configs/disks.xml
+++ b/tests/integration/test_storage_policies/configs/disks.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <disk1>
+                <path>/var/lib/clickhouse1/</path>
+            </disk1>
+            <disk2>
+                <path>/var/lib/clickhouse2/</path>
+            </disk2>
+        </disks>
+        <policies>
+            <test_policy>
+                <volumes>
+                    <volume1>
+                        <disk>disk1</disk>
+                    </volume1>
+                    <volume2>
+                        <disk>disk2</disk>
+                    </volume2>
+                </volumes>
+            </test_policy>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_storage_policies/test.py
+++ b/tests/integration/test_storage_policies/test.py
@@ -1,0 +1,32 @@
+import os
+
+import pytest
+from helpers.test_tools import TSV
+from helpers.cluster import ClickHouseCluster
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+CONFIG_DIR = os.path.join(SCRIPT_DIR, "configs")
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", main_configs=['configs/disks.xml'], stay_alive=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_storage_policy_configuration_change(started_cluster):
+    node.query("CREATE TABLE a (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS storage_policy = 'test_policy'")
+
+    node.stop_clickhouse()
+    node.copy_file_to_container(os.path.join(CONFIG_DIR, "disk2_only.xml"), "/etc/clickhouse-server/config.d/disks.xml")
+    node.start_clickhouse()
+
+    node.stop_clickhouse()
+    node.copy_file_to_container(os.path.join(CONFIG_DIR, "disks.xml"), "/etc/clickhouse-server/config.d/disks.xml")
+    node.start_clickhouse()

--- a/tests/integration/test_storage_policies/test.py
+++ b/tests/integration/test_storage_policies/test.py
@@ -8,7 +8,7 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 CONFIG_DIR = os.path.join(SCRIPT_DIR, "configs")
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node", main_configs=['configs/disks.xml'], stay_alive=True)
+node = cluster.add_instance("node", main_configs=["configs/disks.xml"], stay_alive=True)
 
 
 @pytest.fixture(scope="module")
@@ -21,12 +21,20 @@ def started_cluster():
 
 
 def test_storage_policy_configuration_change(started_cluster):
-    node.query("CREATE TABLE a (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS storage_policy = 'test_policy'")
+    node.query(
+        "CREATE TABLE a (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS storage_policy = 'test_policy'"
+    )
 
     node.stop_clickhouse()
-    node.copy_file_to_container(os.path.join(CONFIG_DIR, "disk2_only.xml"), "/etc/clickhouse-server/config.d/disks.xml")
+    node.copy_file_to_container(
+        os.path.join(CONFIG_DIR, "disk2_only.xml"),
+        "/etc/clickhouse-server/config.d/disks.xml",
+    )
     node.start_clickhouse()
 
     node.stop_clickhouse()
-    node.copy_file_to_container(os.path.join(CONFIG_DIR, "disks.xml"), "/etc/clickhouse-server/config.d/disks.xml")
+    node.copy_file_to_container(
+        os.path.join(CONFIG_DIR, "disks.xml"),
+        "/etc/clickhouse-server/config.d/disks.xml",
+    )
     node.start_clickhouse()


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check and compare the content of `format_version` file in `MergeTreeData` so tables can be loaded even if the storage policy was changed.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
