### PR TITLE
s3 table function can support select nested column using {column_name}.{subcolumn_name}

### DIFF
--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -583,6 +583,19 @@ void FormatFactory::markFormatSupportsSubsetOfColumns(const String & name)
     target = true;
 }
 
+void FormatFactory::markFormatSupportsSubcolumns(const String & name)
+{
+    auto & target = dict[name].supports_subcolumns;
+    if (target)
+        throw Exception("FormatFactory: Format " + name + " is already marked as supporting subcolumns", ErrorCodes::LOGICAL_ERROR);
+    target = true;
+}
+
+bool FormatFactory::checkIfFormatSupportsSubcolumns(const String & name) const
+{
+    const auto & target = getCreators(name);
+    return target.supports_subcolumns;
+}
 
 bool FormatFactory::checkIfFormatSupportsSubsetOfColumns(const String & name) const
 {

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -118,6 +118,7 @@ private:
         SchemaReaderCreator schema_reader_creator;
         ExternalSchemaReaderCreator external_schema_reader_creator;
         bool supports_parallel_formatting{false};
+        bool supports_subcolumns{false};
         bool supports_subset_of_columns{false};
         NonTrivialPrefixAndSuffixChecker non_trivial_prefix_and_suffix_checker;
         AppendSupportChecker append_support_checker;
@@ -205,8 +206,10 @@ public:
     void registerExternalSchemaReader(const String & name, ExternalSchemaReaderCreator external_schema_reader_creator);
 
     void markOutputFormatSupportsParallelFormatting(const String & name);
+    void markFormatSupportsSubcolumns(const String & name);
     void markFormatSupportsSubsetOfColumns(const String & name);
 
+    bool checkIfFormatSupportsSubcolumns(const String & name) const;
     bool checkIfFormatSupportsSubsetOfColumns(const String & name) const;
 
     bool checkIfFormatHasSchemaReader(const String & name) const;

--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
@@ -187,6 +187,7 @@ void registerInputFormatArrow(FormatFactory & factory)
         {
             return std::make_shared<ArrowBlockInputFormat>(buf, sample, false, format_settings);
         });
+    factory.markFormatSupportsSubcolumns("Arrow");
     factory.markFormatSupportsSubsetOfColumns("Arrow");
     factory.registerInputFormat(
         "ArrowStream",

--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -198,6 +198,7 @@ void registerInputFormatORC(FormatFactory & factory)
             {
                 return std::make_shared<ORCBlockInputFormat>(buf, sample, settings);
             });
+    factory.markFormatSupportsSubcolumns("ORC");
     factory.markFormatSupportsSubsetOfColumns("ORC");
 }
 

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -201,6 +201,7 @@ void registerInputFormatParquet(FormatFactory & factory)
             {
                 return std::make_shared<ParquetBlockInputFormat>(buf, sample, settings);
             });
+    factory.markFormatSupportsSubcolumns("Parquet");
     factory.markFormatSupportsSubsetOfColumns("Parquet");
 }
 

--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -773,7 +773,6 @@ Pipe StorageHive::read(
     sources_info->partition_name_types = partition_name_types;
 
     const auto header_block = storage_snapshot->metadata->getSampleBlock();
-    bool support_subset_columns = supportsSubcolumns();
 
     auto settings = context_->getSettingsRef();
     auto case_insensitive_matching = [&]() -> bool
@@ -793,15 +792,14 @@ Pipe StorageHive::read(
             sample_block.insert(header_block.getByName(column));
             continue;
         }
-        else if (support_subset_columns)
+
+        auto subset_column = nested_columns_extractor.extractColumn(column);
+        if (subset_column)
         {
-            auto subset_column = nested_columns_extractor.extractColumn(column);
-            if (subset_column)
-            {
-                sample_block.insert(std::move(*subset_column));
-                continue;
-            }
+            sample_block.insert(std::move(*subset_column));
+            continue;
         }
+
         if (column == "_path")
             sources_info->need_path_column = true;
         if (column == "_file")

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -828,6 +828,11 @@ std::shared_ptr<StorageS3Source::IteratorWrapper> StorageS3::createFileIterator(
     }
 }
 
+bool StorageS3::supportsSubcolumns() const
+{
+    return FormatFactory::instance().checkIfFormatSupportsSubcolumns(format_name);
+}
+
 bool StorageS3::supportsSubsetOfColumns() const
 {
     return FormatFactory::instance().checkIfFormatSupportsSubsetOfColumns(format_name);

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -253,6 +253,8 @@ private:
         ContextPtr ctx,
         std::unordered_map<String, S3::ObjectInfo> * object_infos = nullptr);
 
+    bool supportsSubcolumns() const override;
+
     bool supportsSubsetOfColumns() const override;
 
     static std::optional<ColumnsDescription> tryGetColumnsFromCache(

--- a/tests/queries/0_stateless/02245_s3_support_read_nested_column.reference
+++ b/tests/queries/0_stateless/02245_s3_support_read_nested_column.reference
@@ -1,0 +1,31 @@
+-- { echo }
+drop table if exists test_02245_s3_nested_parquet1;
+drop table if exists test_02245_s3_nested_parquet2;
+set input_format_parquet_import_nested = 1;
+create table test_02245_s3_nested_parquet1(a Int64, b Tuple(a Int64, b String)) engine=S3(s3_conn, filename='test_02245_s3_nested_parquet1_{_partition_id}', format='Parquet') partition by a;
+insert into test_02245_s3_nested_parquet1 values (1, (2, 'a'));
+select a, b.a, b.b from s3(s3_conn, filename='test_02245_s3_nested_parquet1_*', format='Parquet');  -- { serverError 47 }
+create table test_02245_s3_nested_parquet2(a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))) engine=S3(s3_conn, filename='test_02245_s3_nested_parquet2_{_partition_id}', format='Parquet') partition by a;
+insert into test_02245_s3_nested_parquet2 values (1, (2, (3, 'a')));
+select a, b.a, b.b.c, b.b.d from s3(s3_conn, filename='test_02245_s3_nested_parquet2_*', format='Parquet', structure='a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))');
+1	2	3	a
+drop table if exists test_02245_s3_nested_arrow1;
+drop table if exists test_02245_s3_nested_arrow2;
+set input_format_arrow_import_nested=1;
+create table test_02245_s3_nested_arrow1(a Int64, b Tuple(a Int64, b String)) engine=S3(s3_conn, filename='test_02245_s3_nested_arrow1_{_partition_id}', format='Arrow') partition by a;
+insert into test_02245_s3_nested_arrow1 values (1, (2, 'a'));
+select a, b.a, b.b from s3(s3_conn, filename='test_02245_s3_nested_arrow1_*', format='Arrow');  -- { serverError 47 }
+create table test_02245_s3_nested_arrow2(a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))) engine=S3(s3_conn, filename='test_02245_s3_nested_arrow2_{_partition_id}', format='Arrow') partition by a;
+insert into test_02245_s3_nested_arrow2 values (1, (2, (3, 'a')));
+select a, b.a, b.b.c, b.b.d from s3(s3_conn, filename='test_02245_s3_nested_arrow2_*', format='Arrow', structure='a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))');
+1	2	3	a
+drop table if exists test_02245_s3_nested_orc1;
+drop table if exists test_02245_s3_nested_orc2;
+set input_format_orc_import_nested=1;
+create table test_02245_s3_nested_orc1(a Int64, b Tuple(a Int64, b String)) engine=S3(s3_conn, filename='test_02245_s3_nested_orc1_{_partition_id}', format='ORC') partition by a;
+insert into test_02245_s3_nested_orc1 values (1, (2, 'a'));
+select a, b.a, b.b from s3(s3_conn, filename='test_02245_s3_nested_orc1_*', format='ORC');  -- { serverError 47 }
+create table test_02245_s3_nested_orc2(a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))) engine=S3(s3_conn, filename='test_02245_s3_nested_orc2_{_partition_id}', format='ORC') partition by a;
+insert into test_02245_s3_nested_orc2 values (1, (2, (3, 'a')));
+select a, b.a, b.b.c, b.b.d from s3(s3_conn, filename='test_02245_s3_nested_orc2_*', format='ORC', structure='a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))');
+1	2	3	a

--- a/tests/queries/0_stateless/02245_s3_support_read_nested_column.sql
+++ b/tests/queries/0_stateless/02245_s3_support_read_nested_column.sql
@@ -1,0 +1,44 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: Depends on AWS
+
+-- { echo }
+drop table if exists test_02245_s3_nested_parquet1;
+drop table if exists test_02245_s3_nested_parquet2;
+set input_format_parquet_import_nested = 1;
+create table test_02245_s3_nested_parquet1(a Int64, b Tuple(a Int64, b String)) engine=S3(s3_conn, filename='test_02245_s3_nested_parquet1_{_partition_id}', format='Parquet') partition by a;
+insert into test_02245_s3_nested_parquet1 values (1, (2, 'a'));
+
+select a, b.a, b.b from s3(s3_conn, filename='test_02245_s3_nested_parquet1_*', format='Parquet');  -- { serverError 47 }
+
+create table test_02245_s3_nested_parquet2(a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))) engine=S3(s3_conn, filename='test_02245_s3_nested_parquet2_{_partition_id}', format='Parquet') partition by a;
+insert into test_02245_s3_nested_parquet2 values (1, (2, (3, 'a')));
+
+select a, b.a, b.b.c, b.b.d from s3(s3_conn, filename='test_02245_s3_nested_parquet2_*', format='Parquet', structure='a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))');
+
+
+drop table if exists test_02245_s3_nested_arrow1;
+drop table if exists test_02245_s3_nested_arrow2;
+set input_format_arrow_import_nested=1;
+create table test_02245_s3_nested_arrow1(a Int64, b Tuple(a Int64, b String)) engine=S3(s3_conn, filename='test_02245_s3_nested_arrow1_{_partition_id}', format='Arrow') partition by a;
+insert into test_02245_s3_nested_arrow1 values (1, (2, 'a'));
+
+select a, b.a, b.b from s3(s3_conn, filename='test_02245_s3_nested_arrow1_*', format='Arrow');  -- { serverError 47 }
+
+create table test_02245_s3_nested_arrow2(a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))) engine=S3(s3_conn, filename='test_02245_s3_nested_arrow2_{_partition_id}', format='Arrow') partition by a;
+insert into test_02245_s3_nested_arrow2 values (1, (2, (3, 'a')));
+
+select a, b.a, b.b.c, b.b.d from s3(s3_conn, filename='test_02245_s3_nested_arrow2_*', format='Arrow', structure='a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))');
+
+
+drop table if exists test_02245_s3_nested_orc1;
+drop table if exists test_02245_s3_nested_orc2;
+set input_format_orc_import_nested=1;
+create table test_02245_s3_nested_orc1(a Int64, b Tuple(a Int64, b String)) engine=S3(s3_conn, filename='test_02245_s3_nested_orc1_{_partition_id}', format='ORC') partition by a;
+insert into test_02245_s3_nested_orc1 values (1, (2, 'a'));
+
+select a, b.a, b.b from s3(s3_conn, filename='test_02245_s3_nested_orc1_*', format='ORC');  -- { serverError 47 }
+
+create table test_02245_s3_nested_orc2(a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))) engine=S3(s3_conn, filename='test_02245_s3_nested_orc2_{_partition_id}', format='ORC') partition by a;
+insert into test_02245_s3_nested_orc2 values (1, (2, (3, 'a')));
+
+select a, b.a, b.b.c, b.b.d from s3(s3_conn, filename='test_02245_s3_nested_orc2_*', format='ORC', structure='a Int64, b Tuple(a Int64, b Tuple(c Int64, d String))');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support reading of subcolumns of nested types from storage `S3` and  table function `s3` with formats `Parquet`, `Arrow` and `ORC`


