### PR TITLE
adding one link and note about disk usage for projections

### DIFF
--- a/docs/en/sql-reference/statements/alter/projection.md
+++ b/docs/en/sql-reference/statements/alter/projection.md
@@ -11,6 +11,14 @@ Projections store data in a format that optimizes query execution, this feature 
 
 You can define one or more projections for a table, and during the query analysis the projection with the least data to scan will be selected by ClickHouse without modifying the query provided by the user.
 
+:::note Disk usage
+
+Projections will create internally a new hidden table, this means that more IO and space on disk will be required.
+Example, If the projection has defined a different primary key, all the data from the original table will be duplicated.
+:::
+
+You can see more technical details about how projections work internally on this [page]([url](https://clickhouse.com/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-multiple/#option-3-projections)).
+
 ## Example filtering without using primary keys
 
 Creating the table:

--- a/docs/en/sql-reference/statements/alter/projection.md
+++ b/docs/en/sql-reference/statements/alter/projection.md
@@ -17,7 +17,7 @@ Projections will create internally a new hidden table, this means that more IO a
 Example, If the projection has defined a different primary key, all the data from the original table will be duplicated.
 :::
 
-You can see more technical details about how projections work internally on this [page]([url](https://clickhouse.com/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-multiple/#option-3-projections)).
+You can see more technical details about how projections work internally on this [page](/docs/en/guides/improving-query-performance/sparse-primary-indexes/sparse-primary-indexes-multiple.md/#option-3-projections).
 
 ## Example filtering without using primary keys
 


### PR DESCRIPTION
I have found a great page that explain more in deep the Projections, and with images explain how they work behind the scenes. I have also added a note as it's true we do not mention that creating projections will increase the disk usage.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)
