### PR TITLE
RFC: Add MemoryTrackerFaultInjectorInThread

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -6,6 +6,7 @@
 #include <Common/Exception.h>
 #include <Common/LockMemoryExceptionInThread.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/MemoryTrackerFaultInjectorInThread.h>
 #include <Common/formatReadable.h>
 #include <Common/ProfileEvents.h>
 #include <Common/thread_local_rng.h>
@@ -192,7 +193,7 @@ void MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceeded, MemoryT
     }
 
     std::bernoulli_distribution fault(fault_probability);
-    if (unlikely(fault_probability > 0.0 && fault(thread_local_rng)))
+    if (unlikely(fault_probability > 0.0 && fault(thread_local_rng) || MemoryTrackerFaultInjectorInThread::faulty()))
     {
         if (memoryTrackerCanThrow(level, true) && throw_if_memory_exceeded)
         {

--- a/src/Common/MemoryTrackerFaultInjectorInThread.cpp
+++ b/src/Common/MemoryTrackerFaultInjectorInThread.cpp
@@ -1,0 +1,28 @@
+#include <Common/MemoryTrackerFaultInjectorInThread.h>
+#include <Common/thread_local_rng.h>
+#include <random>
+
+thread_local uint64_t MemoryTrackerFaultInjectorInThread::counter = 0;
+thread_local double MemoryTrackerFaultInjectorInThread::probability = 0.;
+
+MemoryTrackerFaultInjectorInThread::MemoryTrackerFaultInjectorInThread(double probability_)
+{
+    ++counter;
+    previous_probability = probability;
+    probability = probability_;
+}
+MemoryTrackerFaultInjectorInThread::~MemoryTrackerFaultInjectorInThread()
+{
+    --counter;
+    probability = previous_probability;
+}
+
+bool MemoryTrackerFaultInjectorInThread::faulty()
+{
+    if (counter)
+    {
+        std::bernoulli_distribution fault(probability);
+        return fault(thread_local_rng);
+    }
+    return false;
+}

--- a/src/Common/MemoryTrackerFaultInjectorInThread.h
+++ b/src/Common/MemoryTrackerFaultInjectorInThread.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include <Common/VariableContext.h>
+
+/// Fault injector for MemoryTracker.
+struct MemoryTrackerFaultInjectorInThread
+{
+private:
+    static thread_local uint64_t counter;
+    static thread_local double probability;
+    double previous_probability = 0;
+
+public:
+    /// @probability - probability for the allocation request to fail.
+    explicit MemoryTrackerFaultInjectorInThread(double probability_ = 1);
+    ~MemoryTrackerFaultInjectorInThread();
+
+    MemoryTrackerFaultInjectorInThread(const MemoryTrackerFaultInjectorInThread &) = delete;
+    MemoryTrackerFaultInjectorInThread & operator=(const MemoryTrackerFaultInjectorInThread &) = delete;
+
+    /// Does this allocation should fail?
+    static bool faulty();
+};


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This is an injector that can catch some problems (maybe it worth add it to some major places and enable under some setting?).