### PR TITLE
Provide full stacktrace in case of uncaught exception during server startup

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -262,6 +262,7 @@ void Keeper::defineOptions(Poco::Util::OptionSet & options)
 }
 
 int Keeper::main(const std::vector<std::string> & /*args*/)
+try
 {
     Poco::Logger * log = &logger();
 
@@ -472,6 +473,12 @@ int Keeper::main(const std::vector<std::string> & /*args*/)
     waitForTerminationRequest();
 
     return Application::EXIT_OK;
+}
+catch (...)
+{
+    /// Poco does not provide stacktrace.
+    tryLogCurrentException("Application");
+    throw;
 }
 
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -647,6 +647,7 @@ static void sanityChecks(Server & server)
 }
 
 int Server::main(const std::vector<std::string> & /*args*/)
+try
 {
     Poco::Logger * log = &logger();
 
@@ -1844,6 +1845,12 @@ int Server::main(const std::vector<std::string> & /*args*/)
     }
 
     return Application::EXIT_OK;
+}
+catch (...)
+{
+    /// Poco does not provide stacktrace.
+    tryLogCurrentException("Application");
+    throw;
 }
 
 std::unique_ptr<TCPProtocolStackFactory> Server::buildProtocolStackFromConfig(


### PR DESCRIPTION
Without it, it is hard to understand where the problem is.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)