### PR TITLE
Fix default value used in row level filter

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -315,7 +315,9 @@ MergeTreeReadTaskColumns getReadTaskColumns(
         /// 1. Columns for row level filter
         if (prewhere_info->row_level_filter)
         {
-            Names row_filter_column_names =  prewhere_info->row_level_filter->getRequiredColumnsNames();
+            Names row_filter_column_names = prewhere_info->row_level_filter->getRequiredColumnsNames();
+            injectRequiredColumns(
+                data_part_info_for_reader, storage_snapshot, with_subcolumns, row_filter_column_names);
             result.pre_columns.push_back(storage_snapshot->getColumnsByNames(options, row_filter_column_names));
             pre_name_set.insert(row_filter_column_names.begin(), row_filter_column_names.end());
         }
@@ -323,7 +325,7 @@ MergeTreeReadTaskColumns getReadTaskColumns(
         /// 2. Columns for prewhere
         Names all_pre_column_names = prewhere_info->prewhere_actions->getRequiredColumnsNames();
 
-        const auto injected_pre_columns = injectRequiredColumns(
+        injectRequiredColumns(
              data_part_info_for_reader, storage_snapshot, with_subcolumns, all_pre_column_names);
 
         for (const auto & name : all_pre_column_names)

--- a/tests/queries/0_stateless/02481_default_value_used_in_row_level_filter.reference
+++ b/tests/queries/0_stateless/02481_default_value_used_in_row_level_filter.reference
@@ -1,0 +1,16 @@
+-- { echoOn }
+
+SELECT a, c FROM test_rlp WHERE c%2 == 0 AND b < 5;
+0	10
+2	12
+4	14
+DROP POLICY IF EXISTS test_rlp_policy ON test_rlp;
+CREATE ROW POLICY test_rlp_policy ON test_rlp FOR SELECT USING c%2 == 0 TO default;
+SELECT a, c FROM test_rlp WHERE b < 5 SETTINGS optimize_move_to_prewhere = 0;
+0	10
+2	12
+4	14
+SELECT a, c FROM test_rlp PREWHERE b < 5;
+0	10
+2	12
+4	14

--- a/tests/queries/0_stateless/02481_default_value_used_in_row_level_filter.sql
+++ b/tests/queries/0_stateless/02481_default_value_used_in_row_level_filter.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS test_rlp;
+
+CREATE TABLE test_rlp (a Int32, b Int32) ENGINE=MergeTree() ORDER BY a SETTINGS index_granularity=5;
+
+INSERT INTO test_rlp SELECT number, number FROM numbers(15);
+
+ALTER TABLE test_rlp ADD COLUMN c Int32 DEFAULT b+10;
+
+-- { echoOn }
+
+SELECT a, c FROM test_rlp WHERE c%2 == 0 AND b < 5;
+
+DROP POLICY IF EXISTS test_rlp_policy ON test_rlp;
+
+CREATE ROW POLICY test_rlp_policy ON test_rlp FOR SELECT USING c%2 == 0 TO default;
+
+SELECT a, c FROM test_rlp WHERE b < 5 SETTINGS optimize_move_to_prewhere = 0;
+
+SELECT a, c FROM test_rlp PREWHERE b < 5;
+
+-- { echoOff }
+
+DROP POLICY test_rlp_policy ON test_rlp;
+
+DROP TABLE test_rlp;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix a bug when row level filter uses default value of column


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
