### PR TITLE
Fix #8685 - added systemd sd_notify implementation

### DIFF
--- a/packages/clickhouse-server.service
+++ b/packages/clickhouse-server.service
@@ -9,7 +9,10 @@ After=time-sync.target network-online.target
 Wants=time-sync.target
 
 [Service]
-Type=simple
+Type=notify
+
+# Switching off watchdog is very important for sd_notify to work correctly.
+Environment=CLICKHOUSE_WATCHDOG_ENABLE=0
 User=clickhouse
 Group=clickhouse
 Restart=always


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Systemd integration now correctly notifies systemd that service is really started and is ready to server requests.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
