### PR TITLE
Add table_uuid to system.parts

### DIFF
--- a/src/Interpreters/PartLog.cpp
+++ b/src/Interpreters/PartLog.cpp
@@ -6,6 +6,7 @@
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeEnum.h>
+#include <DataTypes/DataTypeUUID.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Interpreters/PartLog.h>
@@ -100,6 +101,7 @@ NamesAndTypesList PartLogElement::getNamesAndTypes()
 
         {"database", std::make_shared<DataTypeString>()},
         {"table", std::make_shared<DataTypeString>()},
+        {"table_uuid", std::make_shared<DataTypeUUID>()},
         {"part_name", std::make_shared<DataTypeString>()},
         {"partition_id", std::make_shared<DataTypeString>()},
         {"part_type", std::make_shared<DataTypeString>()},
@@ -137,6 +139,7 @@ void PartLogElement::appendToBlock(MutableColumns & columns) const
 
     columns[i++]->insert(database_name);
     columns[i++]->insert(table_name);
+    columns[i++]->insert(table_uuid);
     columns[i++]->insert(part_name);
     columns[i++]->insert(partition_id);
     columns[i++]->insert(part_type.toString());
@@ -205,6 +208,7 @@ bool PartLog::addNewParts(
 
             elem.database_name = table_id.database_name;
             elem.table_name = table_id.table_name;
+            elem.table_uuid = table_id.uuid;
             elem.partition_id = part->info.partition_id;
             elem.part_name = part->name;
             elem.disk_name = part->getDataPartStorage().getDiskName();

--- a/src/Interpreters/PartLog.h
+++ b/src/Interpreters/PartLog.h
@@ -4,6 +4,7 @@
 #include <Interpreters/SystemLog.h>
 #include <Core/NamesAndTypes.h>
 #include <Core/NamesAndAliases.h>
+#include <Core/UUID.h>
 #include <Storages/MergeTree/MergeType.h>
 #include <Storages/MergeTree/MergeAlgorithm.h>
 
@@ -55,6 +56,7 @@ struct PartLogElement
 
     String database_name;
     String table_name;
+    UUID table_uuid{UUIDHelpers::Nil};
     String part_name;
     String partition_id;
     String disk_name;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1848,6 +1848,7 @@ void MergeTreeData::removePartsFinally(const MergeTreeData::DataPartsVector & pa
 
         part_log_elem.database_name = table_id.database_name;
         part_log_elem.table_name = table_id.table_name;
+        part_log_elem.table_uuid = table_id.uuid;
 
         for (const auto & part : parts)
         {
@@ -6598,6 +6599,7 @@ try
 
     part_log_elem.database_name = table_id.database_name;
     part_log_elem.table_name = table_id.table_name;
+    part_log_elem.table_uuid = table_id.uuid;
     part_log_elem.partition_id = MergeTreePartInfo::fromPartName(new_part_name, format_version).partition_id;
     part_log_elem.part_name = new_part_name;
 

--- a/tests/queries/0_stateless/02491_part_log_has_table_uuid.reference
+++ b/tests/queries/0_stateless/02491_part_log_has_table_uuid.reference
@@ -1,0 +1,3 @@
+NewPart	NotAMerge
+MergeParts	RegularMerge
+RemovePart	NotAMerge

--- a/tests/queries/0_stateless/02491_part_log_has_table_uuid.sql
+++ b/tests/queries/0_stateless/02491_part_log_has_table_uuid.sql
@@ -1,0 +1,16 @@
+create table data_02491 (key Int) engine=MergeTree() order by tuple();
+insert into data_02491 values (1);
+optimize table data_02491 final;
+truncate table data_02491;
+
+system flush logs;
+with (select uuid from system.tables where database = currentDatabase() and table = 'data_02491') as table_uuid_
+select event_type, merge_reason from system.part_log
+where
+    database = currentDatabase() and
+    table = 'data_02491' and
+    table_uuid = table_uuid_ and
+    table_uuid != toUUIDOrDefault(Null)
+order by event_time_microseconds;
+
+drop table data_02491;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add table_uuid to system.parts

Can be useful if the table constantly recreated, i.e. in some tests.