### PR TITLE
Added client option to display the number of locally processed rows

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1671,6 +1671,11 @@ void ClientBase::processParsedSingleQuery(const String & full_query, const Strin
         std::cerr << progress_indication.elapsedSeconds() << "\n";
     }
 
+    if (!is_interactive && print_num_processed_rows)
+    {
+        std::cout << "Processed rows: " << processed_rows << "\n";
+    }
+
     if (have_error && report_error)
         processError(full_query);
 }
@@ -2368,6 +2373,7 @@ void ClientBase::init(int argc, char ** argv)
         ("hardware-utilization", "print hardware utilization information in progress bar")
         ("print-profile-events", po::value(&profile_events.print)->zero_tokens(), "Printing ProfileEvents packets")
         ("profile-events-delay-ms", po::value<UInt64>()->default_value(profile_events.delay_ms), "Delay between printing `ProfileEvents` packets (-1 - print only totals, 0 - print every single packet)")
+        ("print-num-processed-rows", "print the number of locally processed rows")
 
         ("interactive", "Process queries-file or --query query and start interactive mode")
         ("pager", po::value<std::string>(), "Pipe all output into this command (less or similar)")
@@ -2446,6 +2452,8 @@ void ClientBase::init(int argc, char ** argv)
         config().setBool("print-profile-events", true);
     if (options.count("profile-events-delay-ms"))
         config().setUInt64("profile-events-delay-ms", options["profile-events-delay-ms"].as<UInt64>());
+    if (options.count("print-num-processed-rows"))
+        print_num_processed_rows = true;
     if (options.count("progress"))
     {
         switch (options["progress"].as<ProgressOption>())

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2373,7 +2373,7 @@ void ClientBase::init(int argc, char ** argv)
         ("hardware-utilization", "print hardware utilization information in progress bar")
         ("print-profile-events", po::value(&profile_events.print)->zero_tokens(), "Printing ProfileEvents packets")
         ("profile-events-delay-ms", po::value<UInt64>()->default_value(profile_events.delay_ms), "Delay between printing `ProfileEvents` packets (-1 - print only totals, 0 - print every single packet)")
-        ("print-num-processed-rows", "print the number of locally processed rows")
+        ("processed-rows", "print the number of locally processed rows")
 
         ("interactive", "Process queries-file or --query query and start interactive mode")
         ("pager", po::value<std::string>(), "Pipe all output into this command (less or similar)")
@@ -2452,7 +2452,7 @@ void ClientBase::init(int argc, char ** argv)
         config().setBool("print-profile-events", true);
     if (options.count("profile-events-delay-ms"))
         config().setUInt64("profile-events-delay-ms", options["profile-events-delay-ms"].as<UInt64>());
-    if (options.count("print-num-processed-rows"))
+    if (options.count("processed-rows"))
         print_num_processed_rows = true;
     if (options.count("progress"))
     {

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -253,6 +253,7 @@ protected:
     bool need_render_profile_events = true;
     bool written_first_block = false;
     size_t processed_rows = 0; /// How many rows have been read or written.
+    bool print_num_processed_rows = false; /// Whether to print the number of processed rows at
 
     bool print_stack_trace = false;
     /// The last exception that was received from the server. Is used for the

--- a/tests/queries/0_stateless/02480_client_option_print_num_processed_rows.expect
+++ b/tests/queries/0_stateless/02480_client_option_print_num_processed_rows.expect
@@ -22,10 +22,10 @@ send -- "\$CLICKHOUSE_CLIENT --query 'DROP TABLE IF EXISTS num_processed_rows_te
 send -- "\$CLICKHOUSE_CLIENT --query 'CREATE TABLE num_processed_rows_test_0 (val String) ENGINE = Memory;' >/dev/null 2>&1\r"
 
 ### When requested we should get the count on exit:
-send -- "\$CLICKHOUSE_CLIENT --print-num-processed-rows --query \"INSERT INTO num_processed_rows_test_0 VALUES (\'x\');\" \r"
+send -- "\$CLICKHOUSE_CLIENT --processed-rows --query \"INSERT INTO num_processed_rows_test_0 VALUES (\'x\');\" \r"
 expect "Processed rows: 1"
 
-send "yes | head -n7757 | \$CLICKHOUSE_CLIENT --print-num-processed-rows --query 'INSERT INTO num_processed_rows_test_0 format TSV\'\r"
+send "yes | head -n7757 | \$CLICKHOUSE_CLIENT --processed-rows --query 'INSERT INTO num_processed_rows_test_0 format TSV\'\r"
 expect "Processed rows: 7757"
 
 

--- a/tests/queries/0_stateless/02480_client_option_print_num_processed_rows.expect
+++ b/tests/queries/0_stateless/02480_client_option_print_num_processed_rows.expect
@@ -1,0 +1,42 @@
+#!/usr/bin/expect -f
+
+set basedir [file dirname $argv0]
+set basename [file tail $argv0]
+exp_internal -f $env(CLICKHOUSE_TMP)/$basename.debuglog 0
+
+log_user 0
+set timeout 60
+match_max 100000
+set stty_init "rows 25 cols 120"
+
+expect_after {
+    eof { exp_continue }
+    timeout { exit 1 }
+}
+
+spawn bash
+send "source $basedir/../shell_config.sh\r"
+
+send -- "\$CLICKHOUSE_CLIENT --query 'DROP TABLE IF EXISTS num_processed_rows_test_0' >/dev/null 2>&1\r"
+
+send -- "\$CLICKHOUSE_CLIENT --query 'CREATE TABLE num_processed_rows_test_0 (val String) ENGINE = Memory;' >/dev/null 2>&1\r"
+
+### When requested we should get the count on exit:
+send -- "\$CLICKHOUSE_CLIENT --print-num-processed-rows --query \"INSERT INTO num_processed_rows_test_0 VALUES (\'x\');\" \r"
+expect "Processed rows: 1"
+
+send "yes | head -n7757 | \$CLICKHOUSE_CLIENT --print-num-processed-rows --query 'INSERT INTO num_processed_rows_test_0 format TSV\'\r"
+expect "Processed rows: 7757"
+
+
+
+### By default it should not show up:
+
+send -- "\$CLICKHOUSE_CLIENT --query \"INSERT INTO num_processed_rows_test_0 VALUES (\'x\');\" && echo OK\r"
+expect -exact "OK\r"
+
+send "yes | head -n7757 | \$CLICKHOUSE_CLIENT --query 'INSERT INTO num_processed_rows_test_0 format TSV\' && echo OK\r"
+expect -exact "OK\r"
+
+send "exit\r"
+expect eof


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added client option to display the number of locally processed rows in non-interactive mode (--print-num-processed-rows)

Fixes #3682


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
