### PR TITLE
Fix flaky 01926_order_by_desc_limit

### DIFF
--- a/tests/queries/0_stateless/01926_order_by_desc_limit.sql
+++ b/tests/queries/0_stateless/01926_order_by_desc_limit.sql
@@ -21,5 +21,5 @@ SYSTEM FLUSH LOGS;
 
 SELECT read_rows < 110000 FROM system.query_log
 WHERE type = 'QueryFinish' AND current_database = currentDatabase()
-AND event_time > now() - INTERVAL 10 SECOND
+AND event_date >= yesterday()
 AND lower(query) LIKE lower('SELECT s FROM order_by_desc ORDER BY u%');


### PR DESCRIPTION
CI captures [1] too long logs flush:

    $ clickhouse-local --file query_log.tsv.gz --input-format TabSeparatedWithNamesAndTypes -q "select event_time, query from table where Settings['log_comment'] = '01926_order_by_desc_limit.sql' and type = 'QueryFinish' and (lower(query) LIKE lower('SELECT s FROM order_by_desc ORDER BY u%') or query like '%query_log%') format Vertical"
    Row 1:
    ──────
    event_time: 2022-11-20 12:46:42
    query:      SELECT s FROM order_by_desc ORDER BY u DESC LIMIT 10 FORMAT Null
    SETTINGS max_memory_usage = '400M';

    Row 2:
    ──────
    event_time: 2022-11-20 12:46:47
    query:      SELECT s FROM order_by_desc ORDER BY u LIMIT 10 FORMAT Null
    SETTINGS max_memory_usage = '400M';

    Row 3:
    ──────
    event_time: 2022-11-20 12:46:54
    query:      SELECT read_rows < 110000 FROM system.query_log
    WHERE type = 'QueryFinish' AND current_database = currentDatabase()
    AND event_time > now() - INTERVAL 10 SECOND
    AND lower(query) LIKE lower('SELECT s FROM order_by_desc ORDER BY u%');

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/43143/c393af2812cb56a60a99d48c15c0443d2da98a8b/stateless_tests__tsan__[2/5].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)