### PR TITLE
Fix flaky test

### DIFF
--- a/tests/queries/0_stateless/01926_order_by_desc_limit.sql
+++ b/tests/queries/0_stateless/01926_order_by_desc_limit.sql
@@ -20,6 +20,6 @@ SETTINGS max_memory_usage = '400M';
 SYSTEM FLUSH LOGS;
 
 SELECT read_rows < 110000 FROM system.query_log
-WHERE type = 'QueryFinish' AND current_database = currentDatabase()
-AND event_time > now() - INTERVAL 10 SECOND
-AND lower(query) LIKE lower('SELECT s FROM order_by_desc ORDER BY u%');
+    WHERE type = 'QueryFinish' AND current_database = currentDatabase()
+    AND event_time > now() - INTERVAL 600 SECOND
+    AND lower(query) LIKE lower('SELECT s FROM order_by_desc ORDER BY u%');


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


10 seconds is not always enough. Set it to 600 seconds, which is a global test timeout.
See #43403