### PR TITLE
Show read rows for reading from stdin in client

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1401,6 +1401,13 @@ try
     QueryPipeline pipeline(std::move(pipe));
     PullingAsyncPipelineExecutor executor(pipeline);
 
+    if (need_render_progress)
+    {
+        pipeline.setProgressCallback([this](const Progress & progress){
+            onProgress(progress);
+        });
+    }
+
     Block block;
     while (executor.pull(block))
     {
@@ -1445,12 +1452,6 @@ catch (...)
 
 void ClientBase::sendDataFromStdin(Block & sample, const ColumnsDescription & columns_description, ASTPtr parsed_query)
 {
-    if (need_render_progress)
-    {
-        /// Add callback to track reading from fd.
-        std_in.setProgressCallback(global_context);
-    }
-
     /// Send data read from stdin.
     try
     {

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1403,9 +1403,7 @@ try
 
     if (need_render_progress)
     {
-        pipeline.setProgressCallback([this](const Progress & progress){
-            onProgress(progress);
-        });
+        pipeline.setProgressCallback([this](const Progress & progress){ onProgress(progress); });
     }
 
     Block block;

--- a/tests/queries/0_stateless/02473_infile_progress.py
+++ b/tests/queries/0_stateless/02473_infile_progress.py
@@ -27,7 +27,7 @@ with client(name="client>", log=log) as client1:
     )
     client1.expect(prompt)
     client1.send(f"INSERT INTO test.infile_progress FROM INFILE '{filename}'")
-    client1.expect("Progress: 0.00 rows, 10.00 B.*\)")
+    client1.expect("Progress: 5.00 rows, 30.00 B.*\)")
     client1.expect(prompt)
 
     # send Ctrl-C

--- a/tests/queries/0_stateless/02473_infile_progress.py
+++ b/tests/queries/0_stateless/02473_infile_progress.py
@@ -27,7 +27,7 @@ with client(name="client>", log=log) as client1:
     )
     client1.expect(prompt)
     client1.send(f"INSERT INTO test.infile_progress FROM INFILE '{filename}'")
-    client1.expect("Progress: 0.00 rows, 10.00 B.*\)")
+    client1.expect("Progress: 5.00 rows, 10.00 B.*\)")
     client1.expect(prompt)
 
     # send Ctrl-C

--- a/tests/queries/0_stateless/02473_infile_progress.py
+++ b/tests/queries/0_stateless/02473_infile_progress.py
@@ -27,7 +27,7 @@ with client(name="client>", log=log) as client1:
     )
     client1.expect(prompt)
     client1.send(f"INSERT INTO test.infile_progress FROM INFILE '{filename}'")
-    client1.expect("Progress: 5.00 rows, 10.00 B.*\)")
+    client1.expect("Progress: 0.00 rows, 10.00 B.*\)")
     client1.expect(prompt)
 
     # send Ctrl-C


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Show read rows while reading from stdin from client. Closes https://github.com/ClickHouse/ClickHouse/issues/43423.