### PR TITLE
Do not reuse jemalloc memory in test_global_overcommit

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1148,6 +1148,9 @@ int Server::main(const std::vector<std::string> & /*args*/)
             total_memory_tracker.setDescription("(total)");
             total_memory_tracker.setMetric(CurrentMetrics::MemoryTracking);
 
+            bool allow_use_jemalloc_memory = config->getBool("allow_use_jemalloc_memory", true);
+            total_memory_tracker.setAllowUseJemallocMemory(allow_use_jemalloc_memory);
+
             auto * global_overcommit_tracker = global_context->getGlobalOvercommitTracker();
             total_memory_tracker.setOvercommitTracker(global_overcommit_tracker);
 

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -220,7 +220,7 @@ void MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceeded, MemoryT
     Int64 limit_to_check = current_hard_limit;
 
 #if USE_JEMALLOC
-    if (level == VariableContext::Global)
+    if (level == VariableContext::Global && allow_use_jemalloc_memory.load(std::memory_order_relaxed))
     {
         /// Jemalloc arenas may keep some extra memory.
         /// This memory was substucted from RSS to decrease memory drift.

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -55,6 +55,7 @@ private:
     std::atomic<Int64> soft_limit {0};
     std::atomic<Int64> hard_limit {0};
     std::atomic<Int64> profiler_limit {0};
+    std::atomic_bool allow_use_jemalloc_memory {true};
 
     static std::atomic<Int64> free_memory_in_allocator_arenas;
 
@@ -124,6 +125,10 @@ public:
     Int64 getSoftLimit() const
     {
         return soft_limit.load(std::memory_order_relaxed);
+    }
+    void setAllowUseJemallocMemory(bool value)
+    {
+        allow_use_jemalloc_memory.store(value, std::memory_order_relaxed);
     }
 
     /** Set limit if it was not set.

--- a/tests/integration/test_global_overcommit_tracker/configs/global_overcommit_tracker.xml
+++ b/tests/integration/test_global_overcommit_tracker/configs/global_overcommit_tracker.xml
@@ -1,3 +1,4 @@
 <clickhouse>
     <max_server_memory_usage>2000000000</max_server_memory_usage>
+    <allow_use_jemalloc_memory>false</allow_use_jemalloc_memory>
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

The test is flaky because `MemoryTracker` uses free `jemalloc` memory to increase the hard limit. This PR introduces a setting to disable this behavior.

cc @KochetovNicolai @tavplubix 