### PR TITLE
Temporary files evict fs cache

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -207,7 +207,7 @@ void LocalServer::tryInitPath()
 
     global_context->setPath(path);
 
-    global_context->setTemporaryStorage(path + "tmp", "", 0);
+    global_context->setTemporaryStoragePath(path + "tmp/", 0);
     global_context->setFlagsPath(path + "flags");
 
     global_context->setUserFilesPath(""); // user's files are everywhere

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -203,46 +203,6 @@ int mainEntryClickHouseServer(int argc, char ** argv)
 namespace
 {
 
-void setupTmpPath(Poco::Logger * log, const std::string & path)
-try
-{
-    LOG_DEBUG(log, "Setting up {} to store temporary data in it", path);
-
-    fs::create_directories(path);
-
-    /// Clearing old temporary files.
-    fs::directory_iterator dir_end;
-    size_t unknown_files = 0;
-    for (fs::directory_iterator it(path); it != dir_end; ++it)
-    {
-        if (it->is_regular_file() && startsWith(it->path().filename(), "tmp"))
-        {
-            LOG_DEBUG(log, "Removing old temporary file {}", it->path().string());
-            fs::remove(it->path());
-        }
-        else
-        {
-            unknown_files++;
-            if (unknown_files < 100)
-                LOG_DEBUG(log, "Found unknown {} {} in temporary path",
-                    it->is_regular_file() ? "file" : (it->is_directory() ? "directory" : "element"),
-                    it->path().string());
-        }
-    }
-
-    if (unknown_files)
-        LOG_DEBUG(log, "Found {} unknown files in temporary path", unknown_files);
-}
-catch (...)
-{
-    DB::tryLogCurrentException(
-        log,
-        fmt::format(
-            "Caught exception while setup temporary path: {}. It is ok to skip this exception as cleaning old temporary files is not "
-            "necessary",
-            path));
-}
-
 size_t waitServersToFinish(std::vector<DB::ProtocolServerAdapter> & servers, size_t seconds_to_wait)
 {
     const size_t sleep_max_ms = 1000 * seconds_to_wait;
@@ -1037,13 +997,21 @@ try
     LOG_TRACE(log, "Initialized DateLUT with time zone '{}'.", DateLUT::instance().getTimeZone());
 
     /// Storage with temporary data for processing of heavy queries.
+    if (auto temporary_policy = config().getString("tmp_policy", ""); !temporary_policy.empty())
+    {
+        size_t max_size = config().getUInt64("max_temporary_data_on_disk_size", 0);
+        global_context->setTemporaryStoragePolicy(temporary_policy, max_size);
+    }
+    else if (auto temporary_cache = config().getString("tmp_cache", ""); !temporary_cache.empty())
+    {
+        size_t max_size = config().getUInt64("max_temporary_data_on_disk_size", 0);
+        global_context->setTemporaryStorageInCache(temporary_cache, max_size);
+    }
+    else
     {
         std::string temporary_path = config().getString("tmp_path", path / "tmp/");
-        std::string temporary_policy = config().getString("tmp_policy", "");
         size_t max_size = config().getUInt64("max_temporary_data_on_disk_size", 0);
-        const VolumePtr & volume = global_context->setTemporaryStorage(temporary_path, temporary_policy, max_size);
-        for (const DiskPtr & disk : volume->getDisks())
-            setupTmpPath(log, disk->getPath());
+        global_context->setTemporaryStoragePath(temporary_path, max_size);
     }
 
     /** Directory with 'flags': files indicating temporary settings for the server set by system administrator.
@@ -1442,7 +1410,7 @@ try
     }
     catch (...)
     {
-        tryLogCurrentException(log);
+        tryLogCurrentException(log, "Caught exception while setting up access control.");
         throw;
     }
 

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -64,11 +64,11 @@ bool enoughSpaceInDirectory(const std::string & path, size_t data_size)
     return data_size <= free_space;
 }
 
-std::unique_ptr<TemporaryFile> createTemporaryFile(const std::string & folder_path)
+std::unique_ptr<PocoTemporaryFile> createTemporaryFile(const std::string & folder_path)
 {
     ProfileEvents::increment(ProfileEvents::ExternalProcessingFilesTotal);
     fs::create_directories(folder_path);
-    return std::make_unique<TemporaryFile>(folder_path);
+    return std::make_unique<PocoTemporaryFile>(folder_path);
 }
 
 #if !defined(OS_LINUX)

--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -64,11 +64,11 @@ bool enoughSpaceInDirectory(const std::string & path, size_t data_size)
     return data_size <= free_space;
 }
 
-std::unique_ptr<TemporaryFile> createTemporaryFile(const std::string & path)
+std::unique_ptr<TemporaryFile> createTemporaryFile(const std::string & folder_path)
 {
     ProfileEvents::increment(ProfileEvents::ExternalProcessingFilesTotal);
-    fs::create_directories(path);
-    return std::make_unique<TemporaryFile>(path);
+    fs::create_directories(folder_path);
+    return std::make_unique<TemporaryFile>(folder_path);
 }
 
 #if !defined(OS_LINUX)

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -17,7 +17,7 @@ namespace DB
 using TemporaryFile = Poco::TemporaryFile;
 
 bool enoughSpaceInDirectory(const std::string & path, size_t data_size);
-std::unique_ptr<TemporaryFile> createTemporaryFile(const std::string & path);
+std::unique_ptr<TemporaryFile> createTemporaryFile(const std::string & folder_path);
 
 
 // Determine what block device is responsible for specified path

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -14,10 +14,10 @@ namespace fs = std::filesystem;
 namespace DB
 {
 
-using TemporaryFile = Poco::TemporaryFile;
+using PocoTemporaryFile = Poco::TemporaryFile;
 
 bool enoughSpaceInDirectory(const std::string & path, size_t data_size);
-std::unique_ptr<TemporaryFile> createTemporaryFile(const std::string & folder_path);
+std::unique_ptr<PocoTemporaryFile> createTemporaryFile(const std::string & folder_path);
 
 
 // Determine what block device is responsible for specified path

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -951,7 +951,7 @@ bool CachedOnDiskReadBufferFromFile::nextImplStep()
             }
             else
             {
-                LOG_TRACE(log, "No space left in cache, will continue without cache download");
+                LOG_TRACE(log, "No space left in cache to reserve {} bytes, will continue without cache download", size);
                 file_segment->completeWithState(FileSegment::State::PARTIALLY_DOWNLOADED_NO_CONTINUATION);
             }
 

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -118,10 +118,7 @@ void CachedOnDiskReadBufferFromFile::initialize(size_t offset, size_t size)
     }
     else
     {
-        CreateFileSegmentSettings create_settings{
-            .is_persistent = is_persistent
-        };
-
+        CreateFileSegmentSettings create_settings(is_persistent ? FileSegmentKind::Persistent : FileSegmentKind::Regular);
         file_segments_holder.emplace(cache->getOrSet(cache_key, offset, size, create_settings));
     }
 

--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
@@ -51,14 +51,31 @@ FileSegmentRangeWriter::FileSegmentRangeWriter(
 {
 }
 
-bool FileSegmentRangeWriter::write(const char * data, size_t size, size_t offset, bool is_persistent)
+bool FileSegmentRangeWriter::write(const char * data, size_t size, size_t offset, FileSegmentKind segment_kind)
 {
-    size_t written_size = tryWrite(data, size, offset, is_persistent, true);
-    chassert(written_size == 0 || written_size == size);
+    size_t written_size = tryWrite(data, size, offset, segment_kind, true);
     return written_size == size;
 }
 
-size_t FileSegmentRangeWriter::tryWrite(const char * data, size_t size, size_t offset, bool is_persistent, bool strict)
+size_t FileSegmentRangeWriter::tryWrite(const char * data, size_t size, size_t offset, FileSegmentKind segment_kind, bool strict)
+{
+    size_t total_written_size = 0;
+    while (size > 0)
+    {
+        size_t written_size = tryWriteImpl(data, size, offset, segment_kind, strict);
+        chassert(written_size <= size);
+        if (written_size == 0)
+            break;
+
+        data += written_size;
+        size -= written_size;
+        offset += written_size;
+        total_written_size += written_size;
+    }
+    return total_written_size;
+}
+
+size_t FileSegmentRangeWriter::tryWriteImpl(const char * data, size_t size, size_t offset, FileSegmentKind segment_kind, bool strict)
 {
     if (finalized)
         return 0;
@@ -67,7 +84,7 @@ size_t FileSegmentRangeWriter::tryWrite(const char * data, size_t size, size_t o
 
     if (current_file_segment_it == file_segments.end())
     {
-        current_file_segment_it = allocateFileSegment(current_file_segment_write_offset, is_persistent);
+        current_file_segment_it = allocateFileSegment(current_file_segment_write_offset, segment_kind);
     }
     else
     {
@@ -85,7 +102,7 @@ size_t FileSegmentRangeWriter::tryWrite(const char * data, size_t size, size_t o
         if (file_segment->range().size() == file_segment->getDownloadedSize())
         {
             completeFileSegment(*file_segment);
-            current_file_segment_it = allocateFileSegment(current_file_segment_write_offset, is_persistent);
+            current_file_segment_it = allocateFileSegment(current_file_segment_write_offset, segment_kind);
         }
     }
 
@@ -103,8 +120,11 @@ size_t FileSegmentRangeWriter::tryWrite(const char * data, size_t size, size_t o
     size_t reserved_size = file_segment->tryReserve(size, strict);
     if (reserved_size == 0 || (strict && reserved_size != size))
     {
-        file_segment->completeWithState(FileSegment::State::PARTIALLY_DOWNLOADED_NO_CONTINUATION);
-        appendFilesystemCacheLog(*file_segment);
+        if (strict)
+        {
+            file_segment->completeWithState(FileSegment::State::PARTIALLY_DOWNLOADED_NO_CONTINUATION);
+            appendFilesystemCacheLog(*file_segment);
+        }
 
         LOG_DEBUG(
             &Poco::Logger::get("FileSegmentRangeWriter"),
@@ -114,7 +134,7 @@ size_t FileSegmentRangeWriter::tryWrite(const char * data, size_t size, size_t o
         return 0;
     }
 
-    /// shrink
+    /// Shrink to reserved size, because we can't write more than reserved
     size = reserved_size;
 
     try
@@ -133,9 +153,9 @@ size_t FileSegmentRangeWriter::tryWrite(const char * data, size_t size, size_t o
     return size;
 }
 
-size_t FileSegmentRangeWriter::tryReserve(size_t size, size_t offset, bool is_persistent, bool strict)
+bool FileSegmentRangeWriter::reserve(size_t size, size_t offset)
 {
-    return tryWrite(nullptr, size, offset, is_persistent, strict);
+    return write(nullptr, size, offset, FileSegmentKind::Temporary);
 }
 
 void FileSegmentRangeWriter::finalize(bool clear)
@@ -177,7 +197,7 @@ FileSegmentRangeWriter::~FileSegmentRangeWriter()
     }
 }
 
-FileSegments::iterator FileSegmentRangeWriter::allocateFileSegment(size_t offset, bool is_persistent)
+FileSegments::iterator FileSegmentRangeWriter::allocateFileSegment(size_t offset, FileSegmentKind segment_kind)
 {
     /**
     * Allocate a new file segment starting `offset`.
@@ -186,10 +206,7 @@ FileSegments::iterator FileSegmentRangeWriter::allocateFileSegment(size_t offset
 
     std::lock_guard cache_lock(cache->mutex);
 
-    CreateFileSegmentSettings create_settings
-    {
-        .is_persistent = is_persistent,
-    };
+    CreateFileSegmentSettings create_settings(segment_kind);
 
     /// We set max_file_segment_size to be downloaded,
     /// if we have less size to write, file segment will be resized in complete() method.
@@ -301,7 +318,8 @@ void CachedOnDiskWriteBufferFromFile::cacheData(char * data, size_t size)
 
     try
     {
-        if (!cache_writer->write(data, size, current_download_offset, is_persistent_cache_file))
+        auto segment_kind = is_persistent_cache_file ? FileSegmentKind::Persistent : FileSegmentKind::Regular;
+        if (!cache_writer->write(data, size, current_download_offset, segment_kind))
         {
             LOG_INFO(log, "Write-through cache is stopped as cache limit is reached and nothing can be evicted");
             return;

--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
@@ -114,7 +114,6 @@ size_t FileSegmentRangeWriter::tryWrite(const char * data, size_t size, size_t o
         return 0;
     }
 
-
     /// shrink
     size = reserved_size;
 
@@ -132,6 +131,11 @@ size_t FileSegmentRangeWriter::tryWrite(const char * data, size_t size, size_t o
     current_file_segment_write_offset += size;
 
     return size;
+}
+
+size_t FileSegmentRangeWriter::tryReserve(size_t size, size_t offset, bool is_persistent, bool strict)
+{
+    return tryWrite(nullptr, size, offset, is_persistent, strict);
 }
 
 void FileSegmentRangeWriter::finalize(bool clear)

--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
@@ -4,6 +4,7 @@
 #include <IO/WriteSettings.h>
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/FilesystemCacheLog.h>
+#include <Common/filesystemHelpers.h>
 
 namespace Poco
 {
@@ -33,8 +34,11 @@ public:
     * it until it is full and then allocate next file segment.
     */
     bool write(const char * data, size_t size, size_t offset, bool is_persistent);
+    size_t tryWrite(const char * data, size_t size, size_t offset, bool is_persistent, bool strict = false);
 
-    void finalize();
+    void finalize(bool clear = false);
+
+    size_t currentOffset() const { return current_file_segment_write_offset; }
 
     ~FileSegmentRangeWriter();
 
@@ -43,7 +47,7 @@ private:
 
     void appendFilesystemCacheLog(const FileSegment & file_segment);
 
-    void completeFileSegment(FileSegment & file_segment);
+    void completeFileSegment(FileSegment & file_segment, std::optional<FileSegment::State> state = {});
 
     FileCache * cache;
     FileSegment::Key key;

--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
@@ -34,7 +34,19 @@ public:
     * it until it is full and then allocate next file segment.
     */
     bool write(const char * data, size_t size, size_t offset, bool is_persistent);
+
+    /* Tries to write data to current file segment.
+     * Size of written data may be less than requested_size, because current file segment may not have enough space.
+     * In strict mode, if current file segment doesn't have enough space, then exception is thrown.
+     *
+     * Returns size of written data.
+     * If returned non zero value, then we can try to write again.
+     * If no space is available, returns zero.
+     */
     size_t tryWrite(const char * data, size_t size, size_t offset, bool is_persistent, bool strict = false);
+
+    /// Same as tryWrite, but doesn't write anything, just reserves some space in cache
+    size_t tryReserve(size_t size, size_t offset, bool is_persistent, bool strict = false);
 
     void finalize(bool clear = false);
 

--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.h
@@ -44,10 +44,11 @@ public:
      */
     size_t tryWrite(const char * data, size_t size, size_t offset, FileSegmentKind segment_kind = FileSegmentKind::Regular, bool strict = false);
 
-    /// Same as `write`, but doesn't write anything, just reserves some space in cache
+    /// Same as `write/tryWrite`, but doesn't write anything, just reserves some space in cache
     bool reserve(size_t size, size_t offset);
+    size_t tryReserve(size_t size, size_t offset);
 
-    void finalize(bool clear = false);
+    void finalize();
 
     size_t currentOffset() const { return current_file_segment_write_offset; }
 

--- a/src/Disks/IO/FileCachePlaceholder.cpp
+++ b/src/Disks/IO/FileCachePlaceholder.cpp
@@ -1,0 +1,7 @@
+#include <Disks/IO/FileCachePlaceholder.h>
+
+namespace DB
+{
+
+
+}

--- a/src/Disks/IO/FileCachePlaceholder.cpp
+++ b/src/Disks/IO/FileCachePlaceholder.cpp
@@ -3,5 +3,84 @@
 namespace DB
 {
 
+void ISpacePlaceholder::reserveCapacity(size_t requested_capacity)
+{
+    chassert(used_space <= capacity);
+
+    size_t remaining_space = capacity - used_space;
+    /// TODO LOG_TEST
+    LOG_DEBUG(&Poco::Logger::get("ISpacePlaceholder"), "reserving {} bytes (used_space: {}, capacity: {})", requested_capacity, used_space, capacity);
+
+    if (requested_capacity <= remaining_space)
+        return;
+
+    size_t capacity_to_reserve = requested_capacity - remaining_space;
+    reserveImpl(capacity_to_reserve);
+    capacity += capacity_to_reserve;
+}
+
+void ISpacePlaceholder::setUsed(size_t size)
+{
+    /// TODO LOG_TEST
+    LOG_DEBUG(&Poco::Logger::get("ISpacePlaceholder"), "using {} bytes ({} already used, {} capacity)", size, used_space, capacity);
+
+    if (used_space + size > capacity)
+    {
+        LOG_WARNING(&Poco::Logger::get("ISpacePlaceholder"), "Used space is greater than capacity. It may lead to not enough space error");
+        reserveCapacity(size);
+    }
+
+    used_space = used_space + size;
+
+}
+
+FileCachePlaceholder::FileCachePlaceholder(FileCache * cache, const String & name)
+    : key_name(name)
+    , file_cache(cache)
+{
+}
+
+
+void FileCachePlaceholder::reserveImpl(size_t requested_size)
+{
+    String key = fmt::format("{}_{}", key_name, cache_writers.size());
+    auto cache_writer = std::make_unique<FileSegmentRangeWriter>(file_cache,
+                                                                 file_cache->hash(key),
+                                                                 /* cache_log_ */ nullptr,
+                                                                 /* query_id_ */ "",
+                                                                 /* source_path_ */ key);
+
+    while (requested_size > 0)
+    {
+        size_t current_offset = cache_writer->currentOffset();
+        size_t written = cache_writer->tryWrite(nullptr, requested_size, current_offset, /* is_persistent */ false, /* strict */ false);
+        if (written == 0)
+        {
+            cache_writer->finalize(/* clear */ true);
+            throw Exception(ErrorCodes::NOT_ENOUGH_SPACE,
+                "Cannot reserve space in file cache ({} bytes required, {} / {} bytes used, {} / {} elements used)",
+                requested_size, file_cache->getUsedCacheSize(), file_cache->getTotalMaxSize(),
+                file_cache->getFileSegmentsNum(), file_cache->getTotalMaxElements());
+        }
+        requested_size -= written;
+    }
+
+    cache_writers.push_back(std::move(cache_writer));
+}
+
+FileCachePlaceholder::~FileCachePlaceholder()
+{
+    try
+    {
+        for (auto & cache_writer : cache_writers)
+        {
+            cache_writer->finalize(/* clear */ true);
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+}
 
 }

--- a/src/Disks/IO/FileCachePlaceholder.h
+++ b/src/Disks/IO/FileCachePlaceholder.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <Interpreters/Cache/FileCache.h>
+#include <Disks/IO/CachedOnDiskWriteBufferFromFile.h>
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace DB
+{
+
+
+namespace ErrorCodes
+{
+    extern const int NOT_ENOUGH_SPACE;
+}
+
+
+class ISpacePlaceholder
+{
+
+public:
+    void reserveCapacity(size_t requested_capacity)
+    {
+        chassert(used_space <= capacity);
+
+        size_t remaining_space = capacity - used_space;
+        if (requested_capacity <= remaining_space)
+            return;
+
+        size_t capacity_to_reserve = requested_capacity - remaining_space;
+        reserveImpl(capacity_to_reserve);
+        capacity += capacity_to_reserve;
+    }
+
+    void setUsed(size_t size)
+    {
+        if (used_space + size > capacity)
+        {
+            LOG_WARNING(&Poco::Logger::get("ISpacePlaceholder"), "Used space is greater than capacity. It may lead to not enough space error");
+            reserveCapacity(used_space + size - capacity);
+        }
+
+        used_space = used_space + size;
+    }
+
+    virtual ~ISpacePlaceholder() = default;
+
+private:
+    virtual void reserveImpl(size_t size) = 0;
+
+    size_t capacity = 0;
+    size_t used_space = 0;
+};
+
+class FileCachePlaceholder : public ISpacePlaceholder
+{
+public:
+    FileCachePlaceholder(FileCache * cache, const String & name)
+        : key(cache->hash(name))
+        , directory(cache->getPathInLocalCache(key))
+        , cache_writer(cache, key, nullptr, "", name)
+    {
+
+    }
+
+    fs::path getDirectoryPath() const
+    {
+        return directory;
+    }
+
+    void reserveImpl(size_t size) override
+    {
+        while (size > 0)
+        {
+            size_t current_offset = cache_writer.currentOffset();
+            size_t written = cache_writer.tryWrite(nullptr, size, current_offset, /* is_persistent */ false);
+            if (written == 0)
+                throw Exception(ErrorCodes::NOT_ENOUGH_SPACE, "Cannot reserve space in file cache ({} bytes required)", size);
+            size -= written;
+        }
+    }
+
+    ~FileCachePlaceholder() override
+    {
+        try
+        {
+            cache_writer.finalize(/* clear */ true);
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
+
+private:
+    FileSegment::Key key;
+    fs::path directory;
+
+    FileSegmentRangeWriter cache_writer;
+};
+
+}

--- a/src/Disks/IO/FileCachePlaceholder.h
+++ b/src/Disks/IO/FileCachePlaceholder.h
@@ -3,6 +3,9 @@
 #include <Interpreters/Cache/FileCache.h>
 #include <Disks/IO/CachedOnDiskWriteBufferFromFile.h>
 
+#include <Poco/Logger.h>
+#include <Poco/ConsoleChannel.h>
+
 #include <filesystem>
 
 namespace fs = std::filesystem;
@@ -10,40 +13,16 @@ namespace fs = std::filesystem;
 namespace DB
 {
 
-
 namespace ErrorCodes
 {
     extern const int NOT_ENOUGH_SPACE;
 }
 
-
 class ISpacePlaceholder
 {
-
 public:
-    void reserveCapacity(size_t requested_capacity)
-    {
-        chassert(used_space <= capacity);
-
-        size_t remaining_space = capacity - used_space;
-        if (requested_capacity <= remaining_space)
-            return;
-
-        size_t capacity_to_reserve = requested_capacity - remaining_space;
-        reserveImpl(capacity_to_reserve);
-        capacity += capacity_to_reserve;
-    }
-
-    void setUsed(size_t size)
-    {
-        if (used_space + size > capacity)
-        {
-            LOG_WARNING(&Poco::Logger::get("ISpacePlaceholder"), "Used space is greater than capacity. It may lead to not enough space error");
-            reserveCapacity(used_space + size - capacity);
-        }
-
-        used_space = used_space + size;
-    }
+    void reserveCapacity(size_t requested_capacity);
+    void setUsed(size_t size);
 
     virtual ~ISpacePlaceholder() = default;
 
@@ -54,51 +33,21 @@ private:
     size_t used_space = 0;
 };
 
+
 class FileCachePlaceholder : public ISpacePlaceholder
 {
 public:
-    FileCachePlaceholder(FileCache * cache, const String & name)
-        : key(cache->hash(name))
-        , directory(cache->getPathInLocalCache(key))
-        , cache_writer(cache, key, nullptr, "", name)
-    {
+    FileCachePlaceholder(FileCache * cache, const String & name);
 
-    }
+    void reserveImpl(size_t requested_size) override;
 
-    fs::path getDirectoryPath() const
-    {
-        return directory;
-    }
-
-    void reserveImpl(size_t size) override
-    {
-        while (size > 0)
-        {
-            size_t current_offset = cache_writer.currentOffset();
-            size_t written = cache_writer.tryWrite(nullptr, size, current_offset, /* is_persistent */ false);
-            if (written == 0)
-                throw Exception(ErrorCodes::NOT_ENOUGH_SPACE, "Cannot reserve space in file cache ({} bytes required)", size);
-            size -= written;
-        }
-    }
-
-    ~FileCachePlaceholder() override
-    {
-        try
-        {
-            cache_writer.finalize(/* clear */ true);
-        }
-        catch (...)
-        {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
-        }
-    }
+    ~FileCachePlaceholder() override;
 
 private:
-    FileSegment::Key key;
-    fs::path directory;
+    std::string key_name;
+    FileCache * file_cache;
 
-    FileSegmentRangeWriter cache_writer;
+    std::vector<std::unique_ptr<FileSegmentRangeWriter>> cache_writers;
 };
 
 }

--- a/src/Disks/IO/FileCachePlaceholder.h
+++ b/src/Disks/IO/FileCachePlaceholder.h
@@ -49,13 +49,12 @@ public:
 
     void reserveImpl(size_t requested_size) override;
 
-    ~FileCachePlaceholder() override;
-
 private:
     std::string key_name;
     FileCache * file_cache;
 
     /// On each reserveImpl() call we create new FileSegmentRangeWriter that would be hold space
+    /// It's required to easily release already reserved space on unsuccessful attempt
     std::vector<std::unique_ptr<FileSegmentRangeWriter>> cache_writers;
 };
 

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -113,6 +113,8 @@ public:
 
     WriteSettings getAdjustedSettingsFromMetadataFile(const WriteSettings & settings, const std::string & path) const override;
 
+    FileCachePtr getCache() const { return cache; }
+
 private:
     FileCache::Key getCacheKey(const std::string & path) const;
 

--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -519,6 +519,14 @@ void DiskObjectStorage::wrapWithCache(FileCachePtr cache, const FileCacheSetting
     object_storage = std::make_shared<CachedObjectStorage>(object_storage, cache, cache_settings, layer_name);
 }
 
+FileCachePtr DiskObjectStorage::getCache() const
+{
+    const auto * cached_object_storage = typeid_cast<CachedObjectStorage *>(object_storage.get());
+    if (!cached_object_storage)
+        return nullptr;
+    return cached_object_storage->getCache();
+}
+
 NameSet DiskObjectStorage::getCacheLayersNames() const
 {
     NameSet cache_layers;

--- a/src/Disks/ObjectStorages/DiskObjectStorage.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.h
@@ -186,6 +186,7 @@ public:
     /// There can be any number of cache layers:
     /// DiskObjectStorage(CachedObjectStorage(...CacheObjectStorage(S3ObjectStorage)...))
     void wrapWithCache(FileCachePtr cache, const FileCacheSettings & cache_settings, const String & layer_name);
+    FileCachePtr getCache() const;
 
     /// Get structure of object storage this disk works with. Examples:
     /// DiskObjectStorage(S3ObjectStorage)

--- a/src/Disks/TemporaryFileInPath.cpp
+++ b/src/Disks/TemporaryFileInPath.cpp
@@ -1,0 +1,10 @@
+#include <Disks/TemporaryFileInPath.h>
+
+
+
+namespace DB
+{
+
+
+
+}

--- a/src/Disks/TemporaryFileInPath.cpp
+++ b/src/Disks/TemporaryFileInPath.cpp
@@ -1,10 +1,20 @@
 #include <Disks/TemporaryFileInPath.h>
-
-
+#include <Common/filesystemHelpers.h>
 
 namespace DB
 {
 
+TemporaryFileInPath::TemporaryFileInPath(const String & folder_path)
+    : tmp_file(createTemporaryFile(folder_path))
+{
+    chassert(tmp_file);
+}
 
+String TemporaryFileInPath::getPath() const
+{
+    return tmp_file->path();
+}
+
+TemporaryFileInPath::~TemporaryFileInPath() = default;
 
 }

--- a/src/Disks/TemporaryFileInPath.h
+++ b/src/Disks/TemporaryFileInPath.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Disks/TemporaryFileOnDisk.h>
+#include <Common/filesystemHelpers.h>
+
+namespace DB
+{
+
+/// Wrapper around Poco::TemporaryFile to implement ITemporaryFile.
+class TemporaryFileInPath : public ITemporaryFile
+{
+public:
+    explicit TemporaryFileInPath(const String & folder_path)
+        : tmp_file(createTemporaryFile(folder_path))
+    {
+        chassert(tmp_file);
+    }
+
+    String getPath() const override { return tmp_file->path(); }
+
+private:
+    std::unique_ptr<TemporaryFile> tmp_file;
+};
+
+
+
+}

--- a/src/Disks/TemporaryFileInPath.h
+++ b/src/Disks/TemporaryFileInPath.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Disks/TemporaryFileOnDisk.h>
-#include <Common/filesystemHelpers.h>
+#include <Poco/TemporaryFile.h>
 
 namespace DB
 {
@@ -10,18 +10,12 @@ namespace DB
 class TemporaryFileInPath : public ITemporaryFile
 {
 public:
-    explicit TemporaryFileInPath(const String & folder_path)
-        : tmp_file(createTemporaryFile(folder_path))
-    {
-        chassert(tmp_file);
-    }
+    explicit TemporaryFileInPath(const String & folder_path);
+    String getPath() const override;
 
-    String getPath() const override { return tmp_file->path(); }
-
+    ~TemporaryFileInPath() override;
 private:
-    std::unique_ptr<TemporaryFile> tmp_file;
+    std::unique_ptr<Poco::TemporaryFile> tmp_file;
 };
-
-
 
 }

--- a/src/Disks/TemporaryFileOnDisk.cpp
+++ b/src/Disks/TemporaryFileOnDisk.cpp
@@ -2,6 +2,7 @@
 #include <Poco/TemporaryFile.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/logger_useful.h>
+#include <Disks/TemporaryFileInPath.h>
 
 #include <filesystem>
 
@@ -14,7 +15,6 @@ namespace CurrentMetrics
 {
     extern const Metric TotalTemporaryFiles;
 }
-
 
 namespace DB
 {

--- a/src/Disks/TemporaryFileOnDisk.h
+++ b/src/Disks/TemporaryFileOnDisk.h
@@ -9,21 +9,30 @@ namespace DB
 {
 using DiskPtr = std::shared_ptr<IDisk>;
 
+class ITemporaryFile
+{
+public:
+    virtual String getPath() const = 0;
+    virtual ~ITemporaryFile() = default;
+};
+
+using TemporaryFileHolder = std::unique_ptr<ITemporaryFile>;
+
 /// This class helps with the handling of temporary files or directories.
 /// A unique name for the temporary file or directory is automatically chosen based on a specified prefix.
 /// Create a directory in the constructor.
 /// The destructor always removes the temporary file or directory with all contained files.
-class TemporaryFileOnDisk
+class TemporaryFileOnDisk : public ITemporaryFile
 {
 public:
     explicit TemporaryFileOnDisk(const DiskPtr & disk_);
     explicit TemporaryFileOnDisk(const DiskPtr & disk_, CurrentMetrics::Value metric_scope);
     explicit TemporaryFileOnDisk(const DiskPtr & disk_, const String & prefix);
 
-    ~TemporaryFileOnDisk();
+    ~TemporaryFileOnDisk() override;
 
     DiskPtr getDisk() const { return disk; }
-    String getPath() const;
+    String getPath() const override;
 
 private:
     DiskPtr disk;

--- a/src/Formats/NativeWriter.cpp
+++ b/src/Formats/NativeWriter.cpp
@@ -64,8 +64,10 @@ static void writeData(const ISerialization & serialization, const ColumnPtr & co
 }
 
 
-void NativeWriter::write(const Block & block)
+size_t NativeWriter::write(const Block & block)
 {
+    size_t written_before = ostr.count();
+
     /// Additional information about the block.
     if (client_revision > 0)
         block.info.write(ostr);
@@ -161,6 +163,10 @@ void NativeWriter::write(const Block & block)
 
     if (index)
         index->blocks.emplace_back(std::move(index_block));
+
+    size_t written_after = ostr.count();
+    size_t written_size = written_after - written_before;
+    return written_size;
 }
 
 }

--- a/src/Formats/NativeWriter.h
+++ b/src/Formats/NativeWriter.h
@@ -27,6 +27,8 @@ public:
         IndexForNativeFormat * index_ = nullptr, size_t initial_size_of_file_ = 0);
 
     Block getHeader() const { return header; }
+
+    /// Returns the number of bytes written.
     size_t write(const Block & block);
     void flush();
 

--- a/src/Formats/NativeWriter.h
+++ b/src/Formats/NativeWriter.h
@@ -27,7 +27,7 @@ public:
         IndexForNativeFormat * index_ = nullptr, size_t initial_size_of_file_ = 0);
 
     Block getHeader() const { return header; }
-    void write(const Block & block);
+    size_t write(const Block & block);
     void flush();
 
     static String getContentType() { return "application/octet-stream"; }

--- a/src/IO/WriteBufferFromTemporaryFile.cpp
+++ b/src/IO/WriteBufferFromTemporaryFile.cpp
@@ -13,7 +13,7 @@ namespace ErrorCodes
 }
 
 
-WriteBufferFromTemporaryFile::WriteBufferFromTemporaryFile(std::unique_ptr<TemporaryFile> && tmp_file_)
+WriteBufferFromTemporaryFile::WriteBufferFromTemporaryFile(std::unique_ptr<PocoTemporaryFile> && tmp_file_)
     : WriteBufferFromFile(tmp_file_->path(), DBMS_DEFAULT_BUFFER_SIZE, O_RDWR | O_TRUNC | O_CREAT, 0600), tmp_file(std::move(tmp_file_))
 {}
 
@@ -40,11 +40,11 @@ public:
         return std::make_shared<ReadBufferFromTemporaryWriteBuffer>(fd, file_name, std::move(origin->tmp_file));
     }
 
-    ReadBufferFromTemporaryWriteBuffer(int fd_, const std::string & file_name_, std::unique_ptr<TemporaryFile> && tmp_file_)
+    ReadBufferFromTemporaryWriteBuffer(int fd_, const std::string & file_name_, std::unique_ptr<PocoTemporaryFile> && tmp_file_)
         : ReadBufferFromFile(fd_, file_name_), tmp_file(std::move(tmp_file_))
     {}
 
-    std::unique_ptr<TemporaryFile> tmp_file;
+    std::unique_ptr<PocoTemporaryFile> tmp_file;
 };
 
 

--- a/src/IO/WriteBufferFromTemporaryFile.h
+++ b/src/IO/WriteBufferFromTemporaryFile.h
@@ -20,11 +20,11 @@ public:
     ~WriteBufferFromTemporaryFile() override;
 
 private:
-    explicit WriteBufferFromTemporaryFile(std::unique_ptr<TemporaryFile> && tmp_file);
+    explicit WriteBufferFromTemporaryFile(std::unique_ptr<PocoTemporaryFile> && tmp_file);
 
     std::shared_ptr<ReadBuffer> getReadBufferImpl() override;
 
-    std::unique_ptr<TemporaryFile> tmp_file;
+    std::unique_ptr<PocoTemporaryFile> tmp_file;
 
     friend class ReadBufferFromTemporaryWriteBuffer;
 };

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -2,6 +2,7 @@
 
 #include <Common/randomSeed.h>
 #include <Common/SipHash.h>
+#include <Common/logger_useful.h>
 #include <Interpreters/Cache/FileCacheSettings.h>
 #include <Interpreters/Cache/LRUFileCachePriority.h>
 #include <IO/ReadHelpers.h>
@@ -11,6 +12,7 @@
 #include <IO/Operators.h>
 #include <pcg-random/pcg_random.hpp>
 #include <filesystem>
+
 
 namespace fs = std::filesystem;
 
@@ -1009,6 +1011,12 @@ void FileCache::loadCacheInfoIntoMemory(std::lock_guard<std::mutex> & cache_lock
             fs::directory_iterator offset_it{key_it->path()};
             for (; offset_it != fs::directory_iterator(); ++offset_it)
             {
+                if (offset_it->is_directory())
+                {
+                    LOG_DEBUG(log, "Unexpected directory: {}. Expected a file", offset_it->path().string());
+                    continue;
+                }
+
                 auto offset_with_suffix = offset_it->path().filename().string();
                 auto delim_pos = offset_with_suffix.find('_');
                 bool parsed;

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -89,8 +89,10 @@ public:
     size_t capacity() const { return max_size; }
 
     size_t getUsedCacheSize() const;
+    size_t getTotalMaxSize() const;
 
     size_t getFileSegmentsNum() const;
+    size_t getTotalMaxElements() const;
 
     static bool isReadOnly();
 

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -80,7 +80,7 @@ public:
 
     static Key hash(const String & path);
 
-    String getPathInLocalCache(const Key & key, size_t offset, bool is_persistent) const;
+    String getPathInLocalCache(const Key & key, size_t offset, FileSegmentKind segment_kind) const;
 
     String getPathInLocalCache(const Key & key) const;
 

--- a/src/Interpreters/Cache/FileCache.h
+++ b/src/Interpreters/Cache/FileCache.h
@@ -221,6 +221,8 @@ private:
 
     FileSegmentCell * getCell(const Key & key, size_t offset, std::lock_guard<std::mutex> & cache_lock);
 
+    /// Returns non-owened pointer to the cell stored in the `files` map.
+    /// Doesn't reserve any space.
     FileSegmentCell * addCell(
         const Key & key,
         size_t offset,

--- a/src/Interpreters/Cache/FileCacheFactory.cpp
+++ b/src/Interpreters/Cache/FileCacheFactory.cpp
@@ -31,14 +31,21 @@ const FileCacheSettings & FileCacheFactory::getSettings(const std::string & cach
 
 }
 
-FileCachePtr FileCacheFactory::get(const std::string & cache_base_path)
+FileCachePtr FileCacheFactory::tryGet(const std::string & cache_base_path)
 {
     std::lock_guard lock(mutex);
     auto it = caches_by_path.find(cache_base_path);
     if (it == caches_by_path.end())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "No cache found by path: {}", cache_base_path);
+        return nullptr;
     return it->second->cache;
+}
 
+FileCachePtr FileCacheFactory::get(const std::string & cache_base_path)
+{
+    auto file_cache_ptr = tryGet(cache_base_path);
+    if (!file_cache_ptr)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "No cache found by path: {}", cache_base_path);
+    return file_cache_ptr;
 }
 
 FileCachePtr FileCacheFactory::getOrCreate(

--- a/src/Interpreters/Cache/FileCacheFactory.h
+++ b/src/Interpreters/Cache/FileCacheFactory.h
@@ -33,6 +33,7 @@ public:
 
     FileCachePtr getOrCreate(const std::string & cache_base_path, const FileCacheSettings & file_cache_settings, const std::string & name);
 
+    FileCachePtr tryGet(const std::string & cache_base_path);
     FileCachePtr get(const std::string & cache_base_path);
 
     CacheByBasePath getAll();

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -325,6 +325,7 @@ void FileSegment::write(const char * from, size_t size, size_t offset)
 
     try
     {
+        /// if `from` is nullptr, then we just allocate and hold space by current segment and it was (or would) be written outside
         if (cache_writer && from != nullptr)
             cache_writer->write(from, size);
 

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -575,8 +575,10 @@ void FileSegment::completeBasedOnCurrentState(std::lock_guard<std::mutex> & cach
 
     if (segment_kind == FileSegmentKind::Temporary && is_last_holder)
     {
-        cache->remove(key(), offset(), cache_lock, segment_lock);
         LOG_TEST(log, "Removing temporary file segment: {}", getInfoForLogUnlocked(segment_lock));
+        detach(cache_lock, segment_lock);
+        setDownloadState(State::SKIP_CACHE);
+        cache->remove(key(), offset(), cache_lock, segment_lock);
         return;
     }
 

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -86,6 +86,7 @@ FileSegment::FileSegment(
 
 String FileSegment::getPathInLocalCache() const
 {
+    chassert(cache);
     return cache->getPathInLocalCache(key(), offset(), segment_kind);
 }
 

--- a/src/Interpreters/Cache/FileSegment.h
+++ b/src/Interpreters/Cache/FileSegment.h
@@ -184,17 +184,12 @@ public:
     void assertCorrectness() const;
 
     /**
-     * ========== Methods for _only_ file segment's `writer` ======================
-     */
-
-    void synchronousWrite(const char * from, size_t size, size_t offset);
-
-    /**
      * ========== Methods for _only_ file segment's `downloader` ==================
      */
 
     /// Try to reserve exactly `size` bytes.
     bool reserve(size_t size_to_reserve);
+    size_t tryReserve(size_t size_to_reserve, bool strict);
 
     /// Write data into reserved space.
     void write(const char * from, size_t size, size_t offset);
@@ -247,9 +242,9 @@ private:
     void assertIsDownloaderUnlocked(const std::string & operation, std::unique_lock<std::mutex> & segment_lock) const;
     void assertCorrectnessUnlocked(std::unique_lock<std::mutex> & segment_lock) const;
 
-    /// complete() without any completion state is called from destructor of
-    /// FileSegmentsHolder. complete() might check if the caller of the method
-    /// is the last alive holder of the segment. Therefore, complete() and destruction
+    /// completeWithoutStateUnlocked() is called from destructor of FileSegmentsHolder.
+    /// Function might check if the caller of the method
+    /// is the last alive holder of the segment. Therefore, completion and destruction
     /// of the file segment pointer must be done under the same cache mutex.
     void completeWithoutStateUnlocked(std::lock_guard<std::mutex> & cache_lock);
     void completeBasedOnCurrentState(std::lock_guard<std::mutex> & cache_lock, std::unique_lock<std::mutex> & segment_lock);
@@ -295,7 +290,7 @@ private:
     /// In general case, all file segments are owned by cache.
     bool is_detached = false;
 
-    bool is_downloaded{false};
+    bool is_downloaded = false;
 
     std::atomic<size_t> hits_count = 0; /// cache hits.
     std::atomic<size_t> ref_count = 0; /// Used for getting snapshot state

--- a/src/Interpreters/Cache/FileSegment.h
+++ b/src/Interpreters/Cache/FileSegment.h
@@ -308,6 +308,8 @@ struct FileSegmentsHolder : private boost::noncopyable
 
     FileSegmentsHolder(FileSegmentsHolder && other) noexcept : file_segments(std::move(other.file_segments)) {}
 
+    void reset() { file_segments.clear(); }
+
     ~FileSegmentsHolder();
 
     String toString();

--- a/src/Interpreters/Cache/FileSegment.h
+++ b/src/Interpreters/Cache/FileSegment.h
@@ -30,9 +30,38 @@ using FileSegmentPtr = std::shared_ptr<FileSegment>;
 using FileSegments = std::list<FileSegmentPtr>;
 
 
+/*
+ * FileSegmentKind is used to specify the eviction policy for file segments.
+ */
+enum class FileSegmentKind
+{
+    /* `Regular` file segment is still in cache after usage, and can be evicted
+     * (unless there're some holders).
+     */
+    Regular,
+
+    /* `Persistent` file segment can't be evicted from cache,
+     * it should be removed manually.
+     */
+    Persistent,
+
+    /* `Temporary` file segment is removed right after relesing.
+     * Also corresponding files are removed during cache loading (if any).
+     */
+    Temporary,
+};
+
+String toString(FileSegmentKind type);
+
 struct CreateFileSegmentSettings
 {
-    bool is_persistent = false;
+    FileSegmentKind type = FileSegmentKind::Regular;
+
+    CreateFileSegmentSettings() = default;
+
+    explicit CreateFileSegmentSettings(FileSegmentKind type_)
+        : type(type_)
+    {}
 };
 
 class FileSegment : private boost::noncopyable, public std::enable_shared_from_this<FileSegment>
@@ -127,7 +156,8 @@ public:
 
     size_t offset() const { return range().left; }
 
-    bool isPersistent() const { return is_persistent; }
+    FileSegmentKind getKind() const { return segment_kind; }
+    bool isPersistent() const { return segment_kind == FileSegmentKind::Persistent; }
 
     using UniqueId = std::pair<FileCacheKey, size_t>;
     UniqueId getUniqueId() const { return std::pair(key(), offset()); }
@@ -188,8 +218,13 @@ public:
      */
 
     /// Try to reserve exactly `size` bytes.
+    /// Returns true if reservation was successful, false otherwise.
     bool reserve(size_t size_to_reserve);
-    size_t tryReserve(size_t size_to_reserve, bool strict);
+
+    /// Try to reserve at max `size` bytes.
+    /// Returns actual size reserved.
+    /// In strict mode throws an error on attempt to reserve space too much space
+    size_t tryReserve(size_t size_to_reserve, bool strict = false);
 
     /// Write data into reserved space.
     void write(const char * from, size_t size, size_t offset);
@@ -295,7 +330,7 @@ private:
     std::atomic<size_t> hits_count = 0; /// cache hits.
     std::atomic<size_t> ref_count = 0; /// Used for getting snapshot state
 
-    bool is_persistent;
+    FileSegmentKind segment_kind;
 
     CurrentMetrics::Increment metric_increment{CurrentMetrics::CacheFileSegments};
 };

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -32,6 +32,7 @@
 #include <Storages/StorageS3Settings.h>
 #include <Disks/DiskLocal.h>
 #include <Disks/DiskDecorator.h>
+#include <Disks/ObjectStorages/DiskObjectStorage.h>
 #include <Disks/ObjectStorages/IObjectStorage.h>
 #include <Disks/IO/ThreadPoolRemoteFSReader.h>
 #include <Disks/IO/ThreadPoolReader.h>
@@ -102,6 +103,7 @@
 #include <Interpreters/Lemmatizers.h>
 #include <Interpreters/ClusterDiscovery.h>
 #include <Interpreters/TransactionLog.h>
+#include <Interpreters/Cache/FileCacheFactory.h>
 #include <filesystem>
 #include <re2/re2.h>
 
@@ -746,28 +748,65 @@ void Context::setPath(const String & path)
         shared->user_scripts_path = shared->path + "user_scripts/";
 }
 
-VolumePtr Context::setTemporaryStorage(const String & path, const String & policy_name, size_t max_size)
+static void setupTmpPath(Poco::Logger * log, const std::string & path)
+try
+{
+    LOG_DEBUG(log, "Setting up {} to store temporary data in it", path);
+
+    fs::create_directories(path);
+
+    /// Clearing old temporary files.
+    fs::directory_iterator dir_end;
+    for (fs::directory_iterator it(path); it != dir_end; ++it)
+    {
+        if (it->is_regular_file() && startsWith(it->path().filename(), "tmp"))
+        {
+            LOG_DEBUG(log, "Removing old temporary file {}", it->path().string());
+            fs::remove(it->path());
+        }
+        else
+            LOG_DEBUG(log, "Found unknown file in temporary path {}", it->path().string());
+    }
+}
+catch (...)
+{
+    DB::tryLogCurrentException(log, fmt::format(
+        "Caught exception while setup temporary path: {}. "
+        "It is ok to skip this exception as cleaning old temporary files is not necessary", path));
+}
+
+static VolumePtr createLocalSingleDiskVolume(const std::string & path)
+{
+    auto disk = std::make_shared<DiskLocal>("_tmp_default", path, 0);
+    VolumePtr volume = std::make_shared<SingleDiskVolume>("_tmp_default", disk, 0);
+    return volume;
+}
+
+void Context::setTemporaryStoragePath(const String & path, size_t max_size)
+{
+    shared->tmp_path = path;
+    if (!shared->tmp_path.ends_with('/'))
+        shared->tmp_path += '/';
+
+    VolumePtr volume = createLocalSingleDiskVolume(shared->tmp_path);
+
+    for (const auto & disk : volume->getDisks())
+    {
+        setupTmpPath(shared->log, disk->getPath());
+    }
+
+    shared->temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(volume, nullptr, max_size);
+}
+
+void Context::setTemporaryStoragePolicy(const String & policy_name, size_t max_size)
 {
     std::lock_guard lock(shared->storage_policies_mutex);
-    VolumePtr volume;
 
-    if (policy_name.empty())
-    {
-        shared->tmp_path = path;
-        if (!shared->tmp_path.ends_with('/'))
-            shared->tmp_path += '/';
-
-        auto disk = std::make_shared<DiskLocal>("_tmp_default", shared->tmp_path, 0);
-        volume = std::make_shared<SingleDiskVolume>("_tmp_default", disk, 0);
-    }
-    else
-    {
-        StoragePolicyPtr tmp_policy = getStoragePolicySelector(lock)->get(policy_name);
-        if (tmp_policy->getVolumes().size() != 1)
-             throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG,
-                "Policy '{}' is used temporary files, such policy should have exactly one volume", policy_name);
-        volume = tmp_policy->getVolume(0);
-    }
+     StoragePolicyPtr tmp_policy = getStoragePolicySelector(lock)->get(policy_name);
+    if (tmp_policy->getVolumes().size() != 1)
+            throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG,
+            "Policy '{}' is used temporary files, such policy should have exactly one volume", policy_name);
+    VolumePtr volume = tmp_policy->getVolume(0);
 
     if (volume->getDisks().empty())
          throw Exception("No disks volume for temporary files", ErrorCodes::NO_ELEMENTS_IN_CONFIG);
@@ -789,10 +828,33 @@ VolumePtr Context::setTemporaryStorage(const String & path, const String & polic
                 "Disk '{}' ({}) is not local and can't be used for temporary files",
                 disk_ptr->getName(), typeid(*disk_raw_ptr).name());
         }
+
+        setupTmpPath(shared->log, disk->getPath());
     }
 
-    shared->temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(volume, max_size);
-    return volume;
+    shared->temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(volume, nullptr, max_size);
+}
+
+
+void Context::setTemporaryStorageInCache(const String & cache_disk_name, size_t max_size)
+{
+    auto disk_ptr = getDisk(cache_disk_name);
+    if (!disk_ptr)
+        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Disk '{}' is not found", cache_disk_name);
+
+    const auto * disk_object_storage_ptr = dynamic_cast<const DiskObjectStorage *>(disk_ptr.get());
+    if (!disk_object_storage_ptr)
+        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Disk '{}' does not use cache", cache_disk_name);
+
+    auto file_cache = disk_object_storage_ptr->getCache();
+    if (!file_cache)
+        throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Cache '{}' is not found", file_cache->getBasePath());
+
+    LOG_DEBUG(shared->log, "Using file cache ({}) for temporary files", file_cache->getBasePath());
+
+    shared->tmp_path = file_cache->getBasePath();
+    VolumePtr volume = createLocalSingleDiskVolume(shared->tmp_path);
+    shared->temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(volume, file_cache.get(), max_size);
 }
 
 void Context::setFlagsPath(const String & path)

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -461,7 +461,9 @@ public:
 
     void addWarningMessage(const String & msg) const;
 
-    VolumePtr setTemporaryStorage(const String & path, const String & policy_name, size_t max_size);
+    void setTemporaryStorageInCache(const String & cache_disk_name, size_t max_size);
+    void setTemporaryStoragePolicy(const String & policy_name, size_t max_size);
+    void setTemporaryStoragePath(const String & path, size_t max_size);
 
     using ConfigurationPtr = Poco::AutoPtr<Poco::Util::AbstractConfiguration>;
 

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -43,6 +43,13 @@ void TemporaryDataOnDiskScope::deltaAllocAndCheck(ssize_t compressed_delta, ssiz
     stat.uncompressed_size += uncompressed_delta;
 }
 
+VolumePtr TemporaryDataOnDiskScope::getVolume() const
+{
+    if (!volume)
+        throw Exception("TemporaryDataOnDiskScope has no volume", ErrorCodes::LOGICAL_ERROR);
+    return volume;
+}
+
 TemporaryFileStream & TemporaryDataOnDisk::createStream(const Block & header, size_t max_file_size)
 {
     TemporaryFileStreamPtr tmp_stream;
@@ -54,7 +61,6 @@ TemporaryFileStream & TemporaryDataOnDisk::createStream(const Block & header, si
     std::lock_guard lock(mutex);
     return *streams.emplace_back(std::move(tmp_stream));
 }
-
 
 std::vector<TemporaryFileStream *> TemporaryDataOnDisk::getStreams() const
 {

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -7,6 +7,7 @@
 #include <Formats/NativeWriter.h>
 #include <Formats/NativeReader.h>
 #include <Core/ProtocolDefines.h>
+#include <Disks/TemporaryFileInPath.h>
 
 #include <Common/logger_useful.h>
 
@@ -43,24 +44,14 @@ void TemporaryDataOnDiskScope::deltaAllocAndCheck(ssize_t compressed_delta, ssiz
 
 TemporaryFileStream & TemporaryDataOnDisk::createStream(const Block & header, size_t max_file_size)
 {
-    DiskPtr disk;
-    if (max_file_size > 0)
-    {
-        auto reservation = volume->reserve(max_file_size);
-        if (!reservation)
-            throw Exception("Not enough space on temporary disk", ErrorCodes::NOT_ENOUGH_SPACE);
-        disk = reservation->getDisk();
-    }
+    TemporaryFileStreamPtr tmp_stream;
+    if (cache)
+        tmp_stream = TemporaryFileStream::create(cache, header, max_file_size, this);
     else
-    {
-        disk = volume->getDisk();
-    }
-
-    auto tmp_file = std::make_unique<TemporaryFileOnDisk>(disk, current_metric_scope);
+        tmp_stream = TemporaryFileStream::create(volume, header, max_file_size, this);
 
     std::lock_guard lock(mutex);
-    TemporaryFileStreamPtr & tmp_stream = streams.emplace_back(std::make_unique<TemporaryFileStream>(std::move(tmp_file), header, this));
-    return *tmp_stream;
+    return *streams.emplace_back(std::move(tmp_stream));
 }
 
 
@@ -89,12 +80,13 @@ struct TemporaryFileStream::OutputWriter
     {
     }
 
-    void write(const Block & block)
+    size_t write(const Block & block)
     {
         if (finalized)
             throw Exception("Cannot write to finalized stream", ErrorCodes::LOGICAL_ERROR);
-        out_writer.write(block);
+        size_t written_bytes = out_writer.write(block);
         num_rows += block.rows();
+        return written_bytes;
     }
 
     void finalize()
@@ -155,21 +147,65 @@ struct TemporaryFileStream::InputReader
     NativeReader in_reader;
 };
 
-TemporaryFileStream::TemporaryFileStream(TemporaryFileOnDiskHolder file_, const Block & header_, TemporaryDataOnDisk * parent_)
+TemporaryFileStreamPtr TemporaryFileStream::create(const VolumePtr & volume, const Block & header, size_t max_file_size, TemporaryDataOnDisk * parent_)
+{
+    DiskPtr disk;
+    if (max_file_size > 0)
+    {
+        auto reservation = volume->reserve(max_file_size);
+        if (!reservation)
+            throw Exception("Not enough space on temporary disk", ErrorCodes::NOT_ENOUGH_SPACE);
+        disk = reservation->getDisk();
+    }
+    else
+    {
+        disk = volume->getDisk();
+    }
+
+    auto tmp_file = std::make_unique<TemporaryFileOnDisk>(disk, parent_->getMetricScope());
+    return std::make_unique<TemporaryFileStream>(std::move(tmp_file), header, /* cache_placeholder */ nullptr, /* parent */ parent_);
+}
+
+TemporaryFileStreamPtr TemporaryFileStream::create(FileCache * cache, const Block & header, size_t max_file_size, TemporaryDataOnDisk * parent_)
+{
+    auto tmp_file = std::make_unique<TemporaryFileInPath>(fs::path(cache->getBasePath()) / "tmp");
+
+    auto cache_placeholder = std::make_unique<FileCachePlaceholder>(cache, tmp_file->getPath());
+    cache_placeholder->reserveCapacity(max_file_size);
+
+    return std::make_unique<TemporaryFileStream>(std::move(tmp_file), header,  std::move(cache_placeholder), parent_);
+}
+
+TemporaryFileStream::TemporaryFileStream(
+    TemporaryFileHolder file_,
+    const Block & header_,
+    std::unique_ptr<ISpacePlaceholder> space_holder_,
+    TemporaryDataOnDisk * parent_)
     : parent(parent_)
     , header(header_)
     , file(std::move(file_))
+    , space_holder(std::move(space_holder_))
     , out_writer(std::make_unique<OutputWriter>(file->getPath(), header))
 {
 }
 
-void TemporaryFileStream::write(const Block & block)
+size_t TemporaryFileStream::write(const Block & block)
 {
     if (!out_writer)
         throw Exception("Writing has been finished", ErrorCodes::LOGICAL_ERROR);
 
+    size_t block_size_in_memory = block.allocatedBytes();
+
+    if (space_holder)
+        space_holder->reserveCapacity(block_size_in_memory);
+
     updateAllocAndCheck();
-    out_writer->write(block);
+
+    size_t bytes_written = out_writer->write(block);
+    if (space_holder)
+        space_holder->setUsed(bytes_written);
+
+    return bytes_written;
 }
 
 TemporaryFileStream::Stat TemporaryFileStream::finishWriting()

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -51,12 +51,7 @@ public:
 
     /// TODO: remove
     /// Refactor all code that uses volume directly to use TemporaryDataOnDisk.
-    VolumePtr getVolume() const
-    {
-        if (!volume)
-            throw Exception("TemporaryDataOnDiskScope has no volume", ErrorCodes::LOGICAL_ERROR);
-        return volume;
-    }
+    VolumePtr getVolume() const;
 
 protected:
     void deltaAllocAndCheck(ssize_t compressed_delta, ssize_t uncompressed_delta);

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -6,6 +6,7 @@
 #include <Disks/TemporaryFileOnDisk.h>
 #include <Disks/IVolume.h>
 #include <Common/CurrentMetrics.h>
+#include <Disks/IO/FileCachePlaceholder.h>
 
 
 namespace CurrentMetrics
@@ -40,12 +41,12 @@ public:
         std::atomic<size_t> uncompressed_size;
     };
 
-    explicit TemporaryDataOnDiskScope(VolumePtr volume_, size_t limit_)
-        : volume(std::move(volume_)), limit(limit_)
+    explicit TemporaryDataOnDiskScope(VolumePtr volume_, FileCache * cache_, size_t limit_)
+        : volume(std::move(volume_)), cache(cache_), limit(limit_)
     {}
 
     explicit TemporaryDataOnDiskScope(TemporaryDataOnDiskScopePtr parent_, size_t limit_)
-        : parent(std::move(parent_)), volume(parent->volume), limit(limit_)
+        : parent(std::move(parent_)), volume(parent->volume), cache(parent->cache), limit(limit_)
     {}
 
     /// TODO: remove
@@ -56,7 +57,9 @@ protected:
     void deltaAllocAndCheck(ssize_t compressed_delta, ssize_t uncompressed_delta);
 
     TemporaryDataOnDiskScopePtr parent = nullptr;
+
     VolumePtr volume;
+    FileCache * cache = nullptr;
 
     StatAtomic stat;
     size_t limit = 0;
@@ -91,6 +94,7 @@ public:
     bool empty() const;
 
     const StatAtomic & getStat() const { return stat; }
+    CurrentMetrics::Value getMetricScope() const { return current_metric_scope; }
 
 private:
     mutable std::mutex mutex;
@@ -116,9 +120,14 @@ public:
         size_t num_rows = 0;
     };
 
-    TemporaryFileStream(TemporaryFileOnDiskHolder file_, const Block & header_, TemporaryDataOnDisk * parent_);
+    static TemporaryFileStreamPtr create(const VolumePtr & volume, const Block & header, size_t max_file_size, TemporaryDataOnDisk * parent_);
+    static TemporaryFileStreamPtr create(FileCache * cache, const Block & header, size_t max_file_size, TemporaryDataOnDisk * parent_);
 
-    void write(const Block & block);
+    TemporaryFileStream(TemporaryFileHolder file_, const Block & header_, std::unique_ptr<ISpacePlaceholder> space_holder, TemporaryDataOnDisk * parent_);
+
+    /// Returns number of written bytes
+    size_t write(const Block & block);
+
     Stat finishWriting();
     bool isWriteFinished() const;
 
@@ -142,7 +151,8 @@ private:
 
     Block header;
 
-    TemporaryFileOnDiskHolder file;
+    TemporaryFileHolder file;
+    std::unique_ptr<ISpacePlaceholder> space_holder;
 
     Stat stat;
 

--- a/src/Interpreters/TemporaryDataOnDisk.h
+++ b/src/Interpreters/TemporaryDataOnDisk.h
@@ -51,7 +51,12 @@ public:
 
     /// TODO: remove
     /// Refactor all code that uses volume directly to use TemporaryDataOnDisk.
-    VolumePtr getVolume() const { return volume; }
+    VolumePtr getVolume() const
+    {
+        if (!volume)
+            throw Exception("TemporaryDataOnDiskScope has no volume", ErrorCodes::LOGICAL_ERROR);
+        return volume;
+    }
 
 protected:
     void deltaAllocAndCheck(ssize_t compressed_delta, ssize_t uncompressed_delta);

--- a/src/Interpreters/tests/gtest_lru_file_cache.cpp
+++ b/src/Interpreters/tests/gtest_lru_file_cache.cpp
@@ -6,6 +6,7 @@
 #include <Common/CurrentThread.h>
 #include <Common/filesystemHelpers.h>
 #include <Interpreters/Cache/FileCacheSettings.h>
+#include <Interpreters/TemporaryDataOnDisk.h>
 #include <Common/tests/gtest_global_context.h>
 #include <Common/SipHash.h>
 #include <Common/hex.h>
@@ -14,13 +15,14 @@
 #include <IO/WriteHelpers.h>
 #include <filesystem>
 #include <thread>
+#include <DataTypes/DataTypesNumber.h>
 
 #include <Disks/IO/CachedOnDiskWriteBufferFromFile.h>
 
 namespace fs = std::filesystem;
+using namespace DB;
 
-fs::path caches_dir = fs::current_path() / "lru_cache_test";
-String cache_base_path = caches_dir / "cache1" / "";
+static constexpr auto TEST_LOG_LEVEL = "debug";
 
 void assertRange(
     [[maybe_unused]] size_t assert_n, DB::FileSegmentPtr file_segment,
@@ -55,7 +57,7 @@ String getFileSegmentPath(const String & base_path, const DB::FileCache::Key & k
     return fs::path(base_path) / key_str.substr(0, 3) / key_str / DB::toString(offset);
 }
 
-void download(DB::FileSegmentPtr file_segment)
+void download(const std::string & cache_base_path, DB::FileSegmentPtr file_segment)
 {
     const auto & key = file_segment->key();
     size_t size = file_segment->range().size();
@@ -69,30 +71,54 @@ void download(DB::FileSegmentPtr file_segment)
     file_segment->write(data.data(), size, file_segment->getCurrentWriteOffset());
 }
 
-void prepareAndDownload(DB::FileSegmentPtr file_segment)
+void prepareAndDownload(const std::string & cache_base_path, DB::FileSegmentPtr file_segment)
 {
-    // std::cerr << "Reserving: " << file_segment->range().size() << " for: " << file_segment->range().toString() << "\n";
     ASSERT_TRUE(file_segment->reserve(file_segment->range().size()));
-    download(file_segment);
+    download(cache_base_path, file_segment);
 }
 
-void complete(const DB::FileSegmentsHolder & holder)
+void complete(const std::string & cache_base_path, const DB::FileSegmentsHolder & holder)
 {
     for (const auto & file_segment : holder.file_segments)
     {
         ASSERT_TRUE(file_segment->getOrSetDownloader() == DB::FileSegment::getCallerId());
-        prepareAndDownload(file_segment);
+        prepareAndDownload(cache_base_path, file_segment);
         file_segment->completeWithState(DB::FileSegment::State::DOWNLOADED);
     }
 }
 
-
-TEST(FileCache, get)
+class FileCacheTest : public ::testing::Test
 {
-    if (fs::exists(cache_base_path))
-        fs::remove_all(cache_base_path);
-    fs::create_directories(cache_base_path);
+public:
 
+    static void setupLogs(const std::string & level)
+    {
+        Poco::AutoPtr<Poco::ConsoleChannel> channel(new Poco::ConsoleChannel(std::cerr));
+        Poco::Logger::root().setChannel(channel);
+        Poco::Logger::root().setLevel(level);
+    }
+
+    void SetUp() override
+    {
+        setupLogs(TEST_LOG_LEVEL);
+
+        if (fs::exists(cache_base_path))
+            fs::remove_all(cache_base_path);
+        fs::create_directories(cache_base_path);
+    }
+
+    void TearDown() override
+    {
+        if (fs::exists(cache_base_path))
+            fs::remove_all(cache_base_path);
+    }
+
+    fs::path caches_dir = fs::current_path() / "lru_cache_test";
+    std::string cache_base_path = caches_dir / "cache1" / "";
+};
+
+TEST_F(FileCacheTest, get)
+{
     DB::ThreadStatus thread_status;
 
     /// To work with cache need query_id and query context.
@@ -128,7 +154,7 @@ TEST(FileCache, get)
             ASSERT_TRUE(segments[0]->reserve(segments[0]->range().size()));
             assertRange(2, segments[0], DB::FileSegment::Range(0, 9), DB::FileSegment::State::DOWNLOADING);
 
-            download(segments[0]);
+            download(cache_base_path, segments[0]);
             segments[0]->completeWithState(DB::FileSegment::State::DOWNLOADED);
             assertRange(3, segments[0], DB::FileSegment::Range(0, 9), DB::FileSegment::State::DOWNLOADED);
         }
@@ -149,7 +175,7 @@ TEST(FileCache, get)
             assertRange(5, segments[1], DB::FileSegment::Range(10, 14), DB::FileSegment::State::EMPTY);
 
             ASSERT_TRUE(segments[1]->getOrSetDownloader() == DB::FileSegment::getCallerId());
-            prepareAndDownload(segments[1]);
+            prepareAndDownload(cache_base_path, segments[1]);
             segments[1]->completeWithState(DB::FileSegment::State::DOWNLOADED);
             assertRange(6, segments[1], DB::FileSegment::Range(10, 14), DB::FileSegment::State::DOWNLOADED);
         }
@@ -182,8 +208,8 @@ TEST(FileCache, get)
             assertRange(10, segments[0], DB::FileSegment::Range(10, 14), DB::FileSegment::State::DOWNLOADED);
         }
 
-        complete(cache.getOrSet(key, 17, 4, {})); /// Get [17, 20]
-        complete(cache.getOrSet(key, 24, 3, {})); /// Get [24, 26]
+        complete(cache_base_path, cache.getOrSet(key, 17, 4, {})); /// Get [17, 20]
+        complete(cache_base_path, cache.getOrSet(key, 24, 3, {})); /// Get [24, 26]
         /// completeWithState(cache.getOrSet(key, 27, 1, false)); /// Get [27, 27]
 
         /// Current cache:    [__________][_____]   [____]    [___][]
@@ -205,7 +231,7 @@ TEST(FileCache, get)
             assertRange(13, segments[2], DB::FileSegment::Range(15, 16), DB::FileSegment::State::EMPTY);
 
             ASSERT_TRUE(segments[2]->getOrSetDownloader() == DB::FileSegment::getCallerId());
-            prepareAndDownload(segments[2]);
+            prepareAndDownload(cache_base_path, segments[2]);
 
             segments[2]->completeWithState(DB::FileSegment::State::DOWNLOADED);
 
@@ -246,7 +272,7 @@ TEST(FileCache, get)
             assertRange(21, segments[3], DB::FileSegment::Range(21, 21), DB::FileSegment::State::EMPTY);
 
             ASSERT_TRUE(segments[3]->getOrSetDownloader() == DB::FileSegment::getCallerId());
-            prepareAndDownload(segments[3]);
+            prepareAndDownload(cache_base_path, segments[3]);
 
             segments[3]->completeWithState(DB::FileSegment::State::DOWNLOADED);
             ASSERT_TRUE(segments[3]->state() == DB::FileSegment::State::DOWNLOADED);
@@ -269,8 +295,8 @@ TEST(FileCache, get)
 
             ASSERT_TRUE(segments[0]->getOrSetDownloader() == DB::FileSegment::getCallerId());
             ASSERT_TRUE(segments[2]->getOrSetDownloader() == DB::FileSegment::getCallerId());
-            prepareAndDownload(segments[0]);
-            prepareAndDownload(segments[2]);
+            prepareAndDownload(cache_base_path, segments[0]);
+            prepareAndDownload(cache_base_path, segments[2]);
             segments[0]->completeWithState(DB::FileSegment::State::DOWNLOADED);
             segments[2]->completeWithState(DB::FileSegment::State::DOWNLOADED);
         }
@@ -292,8 +318,8 @@ TEST(FileCache, get)
 
             ASSERT_TRUE(s5[0]->getOrSetDownloader() == DB::FileSegment::getCallerId());
             ASSERT_TRUE(s1[0]->getOrSetDownloader() == DB::FileSegment::getCallerId());
-            prepareAndDownload(s5[0]);
-            prepareAndDownload(s1[0]);
+            prepareAndDownload(cache_base_path, s5[0]);
+            prepareAndDownload(cache_base_path, s1[0]);
             s5[0]->completeWithState(DB::FileSegment::State::DOWNLOADED);
             s1[0]->completeWithState(DB::FileSegment::State::DOWNLOADED);
 
@@ -396,7 +422,7 @@ TEST(FileCache, get)
                 cv.wait(lock, [&]{ return lets_start_download; });
             }
 
-            prepareAndDownload(segments[2]);
+            prepareAndDownload(cache_base_path, segments[2]);
             segments[2]->completeWithState(DB::FileSegment::State::DOWNLOADED);
             ASSERT_TRUE(segments[2]->state() == DB::FileSegment::State::DOWNLOADED);
 
@@ -461,7 +487,7 @@ TEST(FileCache, get)
                 ASSERT_TRUE(segments_2[1]->state() == DB::FileSegment::State::PARTIALLY_DOWNLOADED);
 
                 ASSERT_TRUE(segments_2[1]->getOrSetDownloader() == DB::FileSegment::getCallerId());
-                prepareAndDownload(segments_2[1]);
+                prepareAndDownload(cache_base_path, segments_2[1]);
                 segments_2[1]->completeWithState(DB::FileSegment::State::DOWNLOADED);
             });
 
@@ -520,19 +546,14 @@ TEST(FileCache, get)
 
 }
 
-
-TEST(FileCache, rangeWriter)
+TEST_F(FileCacheTest, rangeWriter)
 {
-    if (fs::exists(cache_base_path))
-        fs::remove_all(cache_base_path);
-    fs::create_directories(cache_base_path);
-
     DB::FileCacheSettings settings;
     settings.max_size = 25;
     settings.max_elements = 5;
     settings.max_file_segment_size = 10;
 
-    auto cache = DB::FileCache(cache_base_path, settings);
+    DB::FileCache cache(cache_base_path, settings);
     cache.initialize();
     auto key = cache.hash("key1");
 
@@ -560,4 +581,108 @@ TEST(FileCache, rangeWriter)
     ASSERT_EQ(writer.tryWrite(data.data(), 3, 22, false, false), 3);
 
     writer.finalize();
+}
+
+static Block generateBlock(size_t size = 0)
+{
+    Block block;
+    ColumnWithTypeAndName column;
+    column.name = "x";
+    column.type = std::make_shared<DataTypeUInt64>();
+
+    {
+        MutableColumnPtr mut_col = column.type->createColumn();
+        for (size_t i = 0; i < size; ++i)
+            mut_col->insert(i);
+        column.column = std::move(mut_col);
+    }
+
+    block.insert(column);
+
+    LOG_DEBUG(&Poco::Logger::get("FileCacheTest"), "generated block {} bytes", block.bytes());
+    return block;
+}
+
+static size_t readAllTemporaryData(TemporaryFileStream & stream)
+{
+    Block block;
+    size_t read_rows = 0;
+    do
+    {
+        block = stream.read();
+        read_rows += block.rows();
+    } while (block);
+    return read_rows;
+}
+
+TEST_F(FileCacheTest, temporaryData)
+{
+    DB::FileCacheSettings settings;
+    settings.max_size = 10240;
+    settings.max_file_segment_size = 1024;
+
+    DB::FileCache file_cache(cache_base_path, settings);
+    file_cache.initialize();
+
+    auto tmp_data_scope = std::make_shared<TemporaryDataOnDiskScope>(nullptr, &file_cache, 0);
+
+    auto some_data_holder = file_cache.getOrSet(file_cache.hash("some_data"), 0, 1024 * 5, CreateFileSegmentSettings{});
+
+    {
+        auto segments = fromHolder(some_data_holder);
+        ASSERT_EQ(segments.size(), 5);
+        for (auto & segment : segments)
+        {
+            ASSERT_TRUE(segment->getOrSetDownloader() == DB::FileSegment::getCallerId());
+            ASSERT_TRUE(segment->reserve(segment->range().size()));
+            download(cache_base_path, segment);
+            segment->completeWithState(DB::FileSegment::State::DOWNLOADED);
+        }
+    }
+
+    size_t size_used_before_temporary_data = file_cache.getUsedCacheSize();
+    size_t segments_used_before_temporary_data = file_cache.getFileSegmentsNum();
+    ASSERT_GT(size_used_before_temporary_data, 0);
+    ASSERT_GT(segments_used_before_temporary_data, 0);
+
+    size_t size_used_with_temporary_data;
+    size_t segments_used_with_temporary_data;
+    {
+        auto tmp_data = std::make_unique<TemporaryDataOnDisk>(tmp_data_scope);
+
+        auto & stream = tmp_data->createStream(generateBlock());
+
+        ASSERT_GT(stream.write(generateBlock(100)), 0);
+
+        EXPECT_GT(file_cache.getUsedCacheSize(), 0);
+        EXPECT_GT(file_cache.getFileSegmentsNum(), 0);
+
+        size_t used_size_before_attempt = file_cache.getUsedCacheSize();
+        /// data can't be evicted because it is still held by `some_data_holder`
+        ASSERT_THROW(stream.write(generateBlock(1000)), DB::Exception);
+
+        ASSERT_EQ(file_cache.getUsedCacheSize(), used_size_before_attempt);
+
+        some_data_holder.reset();
+
+        stream.write(generateBlock(1011));
+
+        auto stat = stream.finishWriting();
+
+        EXPECT_EQ(stat.num_rows, 1111);
+        EXPECT_EQ(readAllTemporaryData(stream), 1111);
+
+        size_used_with_temporary_data = file_cache.getUsedCacheSize();
+        segments_used_with_temporary_data = file_cache.getFileSegmentsNum();
+        EXPECT_GT(size_used_with_temporary_data, 0);
+        EXPECT_GT(segments_used_with_temporary_data, 0);
+    }
+
+    /// All temp data should be evicted after removing temporary files
+    EXPECT_LE(file_cache.getUsedCacheSize(), size_used_with_temporary_data);
+    EXPECT_LE(file_cache.getFileSegmentsNum(), segments_used_with_temporary_data);
+
+    /// Some segments reserved by `some_data_holder` was eviced by temporary data
+    EXPECT_LE(file_cache.getUsedCacheSize(), size_used_before_temporary_data);
+    EXPECT_LE(file_cache.getFileSegmentsNum(), segments_used_before_temporary_data);
 }

--- a/src/Interpreters/tests/gtest_lru_file_cache.cpp
+++ b/src/Interpreters/tests/gtest_lru_file_cache.cpp
@@ -100,7 +100,7 @@ public:
 
     void SetUp() override
     {
-        if(const char * test_log_level = std::getenv("TEST_LOG_LEVEL"))
+        if(const char * test_log_level = std::getenv("TEST_LOG_LEVEL")) // NOLINT(concurrency-mt-unsafe)
             setupLogs(test_log_level);
         else
             setupLogs(TEST_LOG_LEVEL);

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -192,7 +192,7 @@ private:
         bool force_ttl{false};
         CompressionCodecPtr compression_codec{nullptr};
         size_t sum_input_rows_upper_bound{0};
-        std::unique_ptr<TemporaryFile> rows_sources_file{nullptr};
+        std::unique_ptr<PocoTemporaryFile> rows_sources_file{nullptr};
         std::unique_ptr<WriteBufferFromFileBase> rows_sources_uncompressed_write_buf{nullptr};
         std::unique_ptr<WriteBuffer> rows_sources_write_buf{nullptr};
         std::optional<ColumnSizeEstimator> column_sizes{};
@@ -257,7 +257,7 @@ private:
         /// Begin dependencies from previous stage
         std::unique_ptr<WriteBuffer> rows_sources_write_buf{nullptr};
         std::unique_ptr<WriteBufferFromFileBase> rows_sources_uncompressed_write_buf{nullptr};
-        std::unique_ptr<TemporaryFile> rows_sources_file;
+        std::unique_ptr<PocoTemporaryFile> rows_sources_file;
         std::optional<ColumnSizeEstimator> column_sizes;
         CompressionCodecPtr compression_codec;
         DiskPtr tmp_disk{nullptr};

--- a/src/Storages/System/StorageSystemFilesystemCache.cpp
+++ b/src/Storages/System/StorageSystemFilesystemCache.cpp
@@ -24,7 +24,8 @@ NamesAndTypesList StorageSystemFilesystemCache::getNamesAndTypes()
         {"cache_hits", std::make_shared<DataTypeUInt64>()},
         {"references", std::make_shared<DataTypeUInt64>()},
         {"downloaded_size", std::make_shared<DataTypeUInt64>()},
-        {"persistent", std::make_shared<DataTypeNumber<UInt8>>()}
+        {"persistent", std::make_shared<DataTypeNumber<UInt8>>()},
+        {"kind", std::make_shared<DataTypeString>()},
     };
 }
 
@@ -45,8 +46,7 @@ void StorageSystemFilesystemCache::fillData(MutableColumns & res_columns, Contex
         for (const auto & file_segment : file_segments)
         {
             res_columns[0]->insert(cache_base_path);
-            res_columns[1]->insert(
-                cache->getPathInLocalCache(file_segment->key(), file_segment->offset(), file_segment->isPersistent()));
+            res_columns[1]->insert(file_segment->getPathInLocalCache());
 
             const auto & range = file_segment->range();
             res_columns[2]->insert(range.left);
@@ -57,6 +57,7 @@ void StorageSystemFilesystemCache::fillData(MutableColumns & res_columns, Contex
             res_columns[7]->insert(file_segment->getRefCount());
             res_columns[8]->insert(file_segment->getDownloadedSize());
             res_columns[9]->insert(file_segment->isPersistent());
+            res_columns[10]->insert(toString(file_segment->getKind()));
         }
     }
 }

--- a/src/Storages/System/StorageSystemFilesystemCache.cpp
+++ b/src/Storages/System/StorageSystemFilesystemCache.cpp
@@ -46,7 +46,11 @@ void StorageSystemFilesystemCache::fillData(MutableColumns & res_columns, Contex
         for (const auto & file_segment : file_segments)
         {
             res_columns[0]->insert(cache_base_path);
-            res_columns[1]->insert(file_segment->getPathInLocalCache());
+
+            /// Do not use `file_segment->getPathInLocalCache` here because it will lead to nullptr dereference
+            /// (because file_segments in getSnapshot doesn't have `cache` field set)
+            res_columns[1]->insert(
+                cache->getPathInLocalCache(file_segment->key(), file_segment->offset(), file_segment->getKind()));
 
             const auto & range = file_segment->range();
             res_columns[2]->insert(range.left);

--- a/tests/integration/test_temporary_data_in_cache/configs/config.d/storage_configuration.xml
+++ b/tests/integration/test_temporary_data_in_cache/configs/config.d/storage_configuration.xml
@@ -1,0 +1,39 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <local_disk>
+                <type>local</type>
+                <path>/local_disk/</path>
+            </local_disk>
+
+            <tiny_local_cache>
+                <type>cache</type>
+                <disk>local_disk</disk>
+                <path>/tiny_local_cache/</path>
+                <max_size>10M</max_size>
+                <max_file_segment_size>1M</max_file_segment_size>
+                <cache_on_write_operations>1</cache_on_write_operations>
+                <do_not_evict_index_and_mark_files>0</do_not_evict_index_and_mark_files>
+            </tiny_local_cache>
+
+            <!-- Used to check free space in `/tiny_local_cache` using `system.disks` -->
+            <!-- Entry about tiny_local_cache shows incorrect info due to it uses DiskObjectStorage under the hood -->
+            <tiny_local_cache_local_disk>
+                <type>local</type>
+                <path>/tiny_local_cache/</path>
+            </tiny_local_cache_local_disk>
+        </disks>
+
+        <policies>
+            <tiny_local_cache>
+                <volumes>
+                    <main>
+                        <disk>tiny_local_cache</disk>
+                    </main>
+                </volumes>
+            </tiny_local_cache>
+        </policies>
+    </storage_configuration>
+
+    <tmp_cache>tiny_local_cache</tmp_cache>
+</clickhouse>

--- a/tests/integration/test_temporary_data_in_cache/test.py
+++ b/tests/integration/test_temporary_data_in_cache/test.py
@@ -1,0 +1,81 @@
+# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.client import QueryRuntimeException
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/config.d/storage_configuration.xml"],
+    tmpfs=["/local_disk:size=50M", "/tiny_local_cache:size=12M"],
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_cache_evicted_by_temporary_data(start_cluster):
+    q = node.query
+    qi = lambda query: int(node.query(query).strip())
+
+    cache_size_initial = qi("SELECT sum(size) FROM system.filesystem_cache")
+    assert cache_size_initial == 0
+
+    free_space_initial = qi(
+        "SELECT free_space FROM system.disks WHERE name = 'tiny_local_cache_local_disk'"
+    )
+    assert free_space_initial > 8 * 1024 * 1024
+
+    q(
+        "CREATE TABLE t1 (x UInt64) ENGINE = MergeTree ORDER BY x SETTINGS storage_policy = 'tiny_local_cache'"
+    )
+    q("INSERT INTO t1 SELECT number FROM numbers(1024 * 1024)")
+
+    # To be sure that nothing is reading the cache and entries for t1 can be evited
+    q("OPTIMIZE TABLE t1 FINAL")
+    q("SYSTEM STOP MERGES t1")
+
+    # Read some data to fill the cache
+    q("SELECT sum(x) FROM t1")
+
+    cache_size_with_t1 = qi("SELECT sum(size) FROM system.filesystem_cache")
+    assert cache_size_with_t1 > 8 * 1024 * 1024
+
+    # Almost all disk space is occupied by t1 cache
+    free_space_with_t1 = qi(
+        "SELECT free_space FROM system.disks WHERE name = 'tiny_local_cache_local_disk'"
+    )
+    assert free_space_with_t1 < 4 * 1024 * 1024
+
+    # Try to sort the table, but fail because of lack of disk space
+    with pytest.raises(QueryRuntimeException) as exc:
+        q(
+            "SELECT ignore(*) FROM numbers(10 * 1024 * 1024) ORDER BY sipHash64(number)",
+            settings={
+                "max_bytes_before_external_group_by": "4M",
+                "max_bytes_before_external_sort": "4M",
+            },
+        )
+    assert "Cannot reserve space in file cache" in str(exc.value)
+
+    # Some data evicted from cache by temporary data
+    cache_size_after_eviction = qi("SELECT sum(size) FROM system.filesystem_cache")
+    assert cache_size_after_eviction < cache_size_with_t1
+
+    # Disk space freed, at least 3 MB, because temporary data tried to write 4 MB
+    free_space_after_eviction = qi(
+        "SELECT free_space FROM system.disks WHERE name = 'tiny_local_cache_local_disk'"
+    )
+    assert free_space_after_eviction > free_space_with_t1 + 3 * 1024 * 1024
+
+    q("DROP TABLE IF EXISTS t1")

--- a/tests/integration/test_tmp_policy/test.py
+++ b/tests/integration/test_tmp_policy/test.py
@@ -23,7 +23,7 @@ def start_cluster():
         cluster.shutdown()
 
 
-def test_different_versions(start_cluster):
+def test_disk_selection(start_cluster):
     query = "SELECT count(ignore(*)) FROM (SELECT * FROM system.numbers LIMIT 1e7) GROUP BY number"
     settings = {
         "max_bytes_before_external_group_by": 1 << 20,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Temporary data (for external sorting, aggregation, and JOINs) can share storage with the filesystem cache for remote disks and evict it, close #42158


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
