### PR TITLE
Disable the trace_log by default

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1053,13 +1053,13 @@
 
     <!-- Trace log. Stores stack traces collected by query profilers.
          See query_profiler_real_time_period_ns and query_profiler_cpu_time_period_ns settings. -->
-    <trace_log>
+    <!-- trace_log>
         <database>system</database>
         <table>trace_log</table>
 
         <partition_by>toYYYYMM(event_date)</partition_by>
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
-    </trace_log>
+    </trace_log> -->
 
     <!-- Query thread log. Has information about all threads participated in query execution.
          Used only for queries with setting log_query_threads = 1. -->


### PR DESCRIPTION
The trace_log would cause lots of spin lock hotspot by running the SSB benchmark. Disable the trace_log by default would improve the performance.

Run the SSB benchmark on ICX platform. Query 1.1, 1,2, 2.1, 2.2, 2.3, 4.2, 4.3 has gained 3%-5%. The overall geomean has gained more than 2%.

CPU: ICX 8380 x 2 sockets
Core number: 40 x 2 physical cores
Benchmark: star schema benchmark

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Performance Improvement
