### PR TITLE
Add MergeTree setting allow_suspicious_indices

### DIFF
--- a/src/Core/SettingsChangesHistory.h
+++ b/src/Core/SettingsChangesHistory.h
@@ -78,6 +78,7 @@ namespace SettingsChangesHistory
 /// It's used to implement `compatibility` setting (see https://github.com/ClickHouse/ClickHouse/issues/35972)
 static std::map<ClickHouseVersion, SettingsChangesHistory::SettingsChanges> settings_changes_history =
 {
+        {"22.12", {{"allow_suspicious_indices", true, false, "If true, index can defined with identical expressions"}}},
         {"22.11", {{"use_structure_from_insertion_table_in_table_functions", 0, 2, "Improve using structure from insertion table in table functions"}}},
         {"22.9", {{"force_grouping_standard_compatibility", false, true, "Make GROUPING function output the same as in SQL standard and other DBMS"}}},
         {"22.7", {{"cross_to_inner_join_rewrite", 1, 2, "Force rewrite comma join to inner"},

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -132,6 +132,7 @@ struct Settings;
     M(UInt64, concurrent_part_removal_threshold, 100, "Activate concurrent part removal (see 'max_part_removal_threads') only if the number of inactive data parts is at least this.", 0) \
     M(String, storage_policy, "default", "Name of storage disk policy", 0) \
     M(Bool, allow_nullable_key, false, "Allow Nullable types as primary keys.", 0) \
+    M(Bool, allow_suspicious_indices, false, "If true, index can defined with indentical expressions", 0) \
     M(Bool, remove_empty_parts, true, "Remove empty parts after they were pruned by TTL, mutation, or collapsing merge algorithm.", 0) \
     M(Bool, assign_part_uuids, false, "Generate UUIDs for parts. Before enabling check that all replicas support new format.", 0) \
     M(Int64, max_partitions_to_read, -1, "Limit the max number of partitions that can be accessed in one query. <= 0 means unlimited. This setting is the default that can be overridden by the query-level setting with the same name.", 0) \

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -132,7 +132,7 @@ struct Settings;
     M(UInt64, concurrent_part_removal_threshold, 100, "Activate concurrent part removal (see 'max_part_removal_threads') only if the number of inactive data parts is at least this.", 0) \
     M(String, storage_policy, "default", "Name of storage disk policy", 0) \
     M(Bool, allow_nullable_key, false, "Allow Nullable types as primary keys.", 0) \
-    M(Bool, allow_suspicious_indices, false, "If true, index can defined with indentical expressions", 0) \
+    M(Bool, allow_suspicious_indices, false, "If true, index can defined with identical expressions", 0) \
     M(Bool, remove_empty_parts, true, "Remove empty parts after they were pruned by TTL, mutation, or collapsing merge algorithm.", 0) \
     M(Bool, assign_part_uuids, false, "Generate UUIDs for parts. Before enabling check that all replicas support new format.", 0) \
     M(Int64, max_partitions_to_read, -1, "Limit the max number of partitions that can be accessed in one query. <= 0 means unlimited. This setting is the default that can be overridden by the query-level setting with the same name.", 0) \

--- a/tests/queries/0_stateless/02493_allow_suspicious_indices.sql
+++ b/tests/queries/0_stateless/02493_allow_suspicious_indices.sql
@@ -1,0 +1,9 @@
+DROP DATABASE IF EXISTS test;
+CREATE DATABASE IF NOT EXISTS test;
+CREATE TABLE test.allow_suspicious_indices (id UInt32) ENGINE = MergeTree() order by (id, id) settings allow_suspicious_indices = 1;
+DROP TABLE IF EXISTS test.allow_suspicious_indices;
+CREATE TABLE test.allow_suspicous_indices (id UInt32) ENGINE = MergeTree() order by (id, id) settings allow_suspicious_indices = 0;  -- { serverError BAD_ARGUMENTS }
+DROP TABLE IF EXISTS test.allow_suspicious_indices;
+CREATE TABLE test.allow_suspicous_indices (id UInt32, index idx (id, id) TYPE minmax GRANULARITY 1) ENGINE = MergeTree() order by id settings allow_suspicious_indices = 1;
+DROP TABLE IF EXISTS test.allow_suspicious_indices;
+CREATE TABLE test.allow_suspicious_indices (id UInt32, index idx (id, id) TYPE minmax GRANULARITY 1) ENGINE = MergeTree() order by id settings allow_suspicious_indices = 0;  -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/02493_allow_suspicious_indices.sql
+++ b/tests/queries/0_stateless/02493_allow_suspicious_indices.sql
@@ -1,9 +1,11 @@
-DROP DATABASE IF EXISTS test;
-CREATE DATABASE IF NOT EXISTS test;
-CREATE TABLE test.allow_suspicious_indices (id UInt32) ENGINE = MergeTree() order by (id, id) settings allow_suspicious_indices = 1;
-DROP TABLE IF EXISTS test.allow_suspicious_indices;
-CREATE TABLE test.allow_suspicous_indices (id UInt32) ENGINE = MergeTree() order by (id, id) settings allow_suspicious_indices = 0;  -- { serverError BAD_ARGUMENTS }
-DROP TABLE IF EXISTS test.allow_suspicious_indices;
-CREATE TABLE test.allow_suspicous_indices (id UInt32, index idx (id, id) TYPE minmax GRANULARITY 1) ENGINE = MergeTree() order by id settings allow_suspicious_indices = 1;
-DROP TABLE IF EXISTS test.allow_suspicious_indices;
-CREATE TABLE test.allow_suspicious_indices (id UInt32, index idx (id, id) TYPE minmax GRANULARITY 1) ENGINE = MergeTree() order by id settings allow_suspicious_indices = 0;  -- { serverError BAD_ARGUMENTS }
+CREATE TABLE allow_suspicious_indices (id UInt32) ENGINE = MergeTree() order by (id, id) settings allow_suspicious_indices = 1;
+DROP TABLE IF EXISTS allow_suspicious_indices;
+CREATE TABLE allow_suspicious_indices (id UInt32) ENGINE = MergeTree() order by (id, id) settings allow_suspicious_indices = 0;  -- { serverError BAD_ARGUMENTS }
+DROP TABLE IF EXISTS allow_suspicious_indices;
+CREATE TABLE allow_suspicious_indices (id UInt32, index idx (id, id) TYPE minmax GRANULARITY 1) ENGINE = MergeTree() order by id settings allow_suspicious_indices = 1;
+DROP TABLE IF EXISTS allow_suspicious_indices;
+CREATE TABLE allow_suspicious_indices (id UInt32, index idx (id, id) TYPE minmax GRANULARITY 1) ENGINE = MergeTree() order by id settings allow_suspicious_indices = 0;  -- { serverError BAD_ARGUMENTS }
+DROP TABLE IF EXISTS allow_suspicious_indices;
+CREATE TABLE allow_suspicious_indices (id UInt32) ENGINE = MergeTree() order by id + 1 settings allow_suspicious_indices = 0;
+ALTER TABLE allow_suspicious_indices ADD COLUMN `id2` UInt32, MODIFY ORDER BY (id + 1, id2 + 1, id2 + 1);
+DROP TABLE IF EXISTS allow_suspicious_indices;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add new setting `allow_suspicious_indices`. Users can set it as true to define indices with identical expressions.

Close #26467

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
