### PR TITLE
Do not assume that the original query was valid when transforming JOINs

### DIFF
--- a/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
+++ b/src/Interpreters/JoinToSubqueryTransformVisitor.cpp
@@ -560,11 +560,11 @@ std::vector<TableNeededColumns> normalizeColumnNamesExtractNeeded(
                     original_long_name = ident->name();
 
                 size_t count = countTablesWithColumn(tables, short_name);
+                const auto & table = tables[*table_pos];
 
                 /// isValidIdentifierBegin retuired to be consistent with TableJoin::deduplicateAndQualifyColumnNames
                 if (count > 1 || aliases.contains(short_name) || !isValidIdentifierBegin(short_name.at(0)))
                 {
-                    const auto & table = tables[*table_pos];
                     IdentifierSemantic::setColumnLongName(*ident, table.table); /// table.column -> table_alias.column
                     const auto & unique_long_name = ident->name();
 
@@ -578,6 +578,13 @@ std::vector<TableNeededColumns> normalizeColumnNamesExtractNeeded(
                 }
                 else
                 {
+                    if (!table.hasColumn(short_name))
+                    {
+                        throw Exception(ErrorCodes::UNKNOWN_IDENTIFIER,
+                                        "There's no column '{}' in table '{}'",
+                                        ident->name(),
+                                        table.table.getQualifiedNamePrefix(false));
+                    }
                     ident->setShortName(short_name); /// table.column -> column
                     needed_columns[*table_pos].no_clashes.emplace(short_name);
                 }

--- a/tests/queries/0_stateless/02493_do_not_assume_that_the_original_query_was_valid_when_transforming_joins.sql
+++ b/tests/queries/0_stateless/02493_do_not_assume_that_the_original_query_was_valid_when_transforming_joins.sql
@@ -1,0 +1,26 @@
+CREATE TABLE table1 (column1 String) ENGINE=MergeTree() ORDER BY tuple();
+CREATE TABLE table2 (column1 String, column2 String, column3 String) ENGINE=MergeTree() ORDER BY tuple();
+CREATE TABLE table3 (column3 String) ENGINE=MergeTree() ORDER BY tuple();
+
+SELECT
+    *
+FROM
+(
+    SELECT
+        column1
+    FROM table1
+    GROUP BY
+        column1
+) AS a
+ANY LEFT JOIN
+(
+    SELECT
+        *
+    FROM table2
+) AS b ON (b.column1 = a.column1) AND (b.column2 = a.column2)
+ANY LEFT JOIN
+(
+    SELECT
+        *
+    FROM table3
+) AS c ON c.column3 = b.column3; -- {serverError UNKNOWN_IDENTIFIER}


### PR DESCRIPTION
Before this change, during the JOIN transformation, the query was rewritten in such a way that some references to non-existing columns were replaced with references to columns with the same name in other tables.

We now check that the original query was correct before making changes that may fix it accidentally.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Correctly report errors in queries even when multiple JOINs optimization is taking place.
