### PR TITLE
Move memory deallocation out of critical section of ThreadGroupStatus::mutex

### DIFF
--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -342,11 +342,14 @@ void ThreadStatus::detachQuery(bool exit_if_already_detached, bool thread_exits)
     query_id.clear();
     query_context.reset();
 
+    /// The memory of thread_group->finished_threads_counters_memory is temporarily moved to this vector, which is deallocated out of critical section.
+    std::vector<ThreadGroupStatus::ProfileEventsCountersAndMemory> move_to_temp;
+
     /// Avoid leaking of ThreadGroupStatus::finished_threads_counters_memory
     /// (this is in case someone uses system thread but did not call getProfileEventsCountersAndMemoryForThreads())
     {
         std::lock_guard guard(thread_group->mutex);
-        auto stats = std::move(thread_group->finished_threads_counters_memory);
+        move_to_temp = std::move(thread_group->finished_threads_counters_memory);
     }
 
     thread_group.reset();


### PR DESCRIPTION
This commit optimizes the lock contention for ThreadGroupStatus::mutex by further shrinking the critical section for releasing the memory of ThreadGroupStatus:: finished_threads_counters_memory.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Performance Improvement

The performance experiments of SSB (Star Schema Benchmark) on the ICX device (Intel Xeon Platinum 8380 CPU, 80 cores, 160 threads) shows that this change could effectively decrease the lock contention for ThreadGroupStatus::mutex by **2%**, and increase the CPU utilization.

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
> Original changelog
In the original implementation, the memory of ThreadGroupStatus:: finished_threads_counters_memory is released by moving it to a temporary std::vector, which soon expired and gets destructed. This method is viable, however not straightforward enough. To enhance the code readability, this commit releases the memory in the vector by firstly resizing it to 0 and then shrinking the capacity accordingly.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
