### PR TITLE
Fix flaky 01175_distributed_ddl_output_mode_long

### DIFF
--- a/tests/queries/0_stateless/01175_distributed_ddl_output_mode_long.sh
+++ b/tests/queries/0_stateless/01175_distributed_ddl_output_mode_long.sh
@@ -37,7 +37,7 @@ RAND_COMMENT="01175_DDL_$RANDOM"
 LOG_COMMENT="${CLICKHOUSE_LOG_COMMENT}_$RAND_COMMENT"
 
 CLICKHOUSE_CLIENT_WITH_SETTINGS=${CLICKHOUSE_CLIENT/--log_comment ${CLICKHOUSE_LOG_COMMENT}/--log_comment ${LOG_COMMENT}}
-CLICKHOUSE_CLIENT_WITH_SETTINGS+=" --output_format_parallel_formatting=0 "
+CLICKHOUSE_CLIENT_WITH_SETTINGS+=" --output_format_parallel_formatting=0 --database_atomic_wait_for_drop_and_detach_synchronously=0 "
 
 CLIENT=${CLICKHOUSE_CLIENT_WITH_SETTINGS}
 CLIENT+=" --distributed_ddl_task_timeout=$TIMEOUT "

--- a/tests/queries/0_stateless/01175_distributed_ddl_output_mode_long.sh
+++ b/tests/queries/0_stateless/01175_distributed_ddl_output_mode_long.sh
@@ -22,7 +22,7 @@ function run_until_out_contains()
     PATTERN=$1
     shift
 
-    for ((i=MIN_TIMEOUT; i<10; i++))
+    for ((i=MIN_TIMEOUT; i<33; i=i*2))
     do
         "$@" --distributed_ddl_task_timeout="$i" > "$TMP_OUT" 2>&1
         if grep -q "$PATTERN" "$TMP_OUT"


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/43458/ad749610757dd446844181920b025eeda28ebc7d/stateless_tests__release__s3_storage__[2/2].html
https://pastila.nl/?00b8574d/ee6c864300d2f21b8ed4c6253ca4f7f1