### PR TITLE
Fix endian issue in bloom filter serialization for s390x

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
@@ -96,6 +96,9 @@ void MergeTreeIndexGranuleBloomFilter::deserializeBinary(ReadBuffer & istr, Merg
         static size_t atom_size = 8;
         size_t bytes_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
         filter = std::make_shared<BloomFilter>(bytes_size, hash_functions, 0);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        bytes_size = ((bytes_size + sizeof(BloomFilter::UnderType) - 1) / sizeof(BloomFilter::UnderType)) * sizeof(BloomFilter::UnderType);
+#endif
         istr.readStrict(reinterpret_cast<char *>(filter->getFilter().data()), bytes_size);
     }
 }
@@ -108,6 +111,9 @@ void MergeTreeIndexGranuleBloomFilter::serializeBinary(WriteBuffer & ostr) const
     static size_t atom_size = 8;
     writeVarUInt(total_rows, ostr);
     size_t bytes_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    bytes_size = ((bytes_size + sizeof(BloomFilter::UnderType) - 1) / sizeof(BloomFilter::UnderType)) * sizeof(BloomFilter::UnderType);
+#endif
     for (const auto & bloom_filter : bloom_filters)
         ostr.write(reinterpret_cast<const char *>(bloom_filter->getFilter().data()), bytes_size);
 }

--- a/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
@@ -96,6 +96,10 @@ void MergeTreeIndexGranuleBloomFilter::deserializeBinary(ReadBuffer & istr, Merg
         static size_t atom_size = 8;
         size_t bytes_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
         filter = std::make_shared<BloomFilter>(bytes_size, hash_functions, 0);
+
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        bytes_size = std::max(atom_size, bytes_size);
+#endif
         istr.readStrict(reinterpret_cast<char *>(filter->getFilter().data()), bytes_size);
     }
 }
@@ -107,7 +111,11 @@ void MergeTreeIndexGranuleBloomFilter::serializeBinary(WriteBuffer & ostr) const
 
     static size_t atom_size = 8;
     writeVarUInt(total_rows, ostr);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    size_t bytes_size = std::max(atom_size, (bits_per_row * total_rows + atom_size - 1) / atom_size);
+#else
     size_t bytes_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
+#endif
     for (const auto & bloom_filter : bloom_filters)
         ostr.write(reinterpret_cast<const char *>(bloom_filter->getFilter().data()), bytes_size);
 }

--- a/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
@@ -110,7 +110,7 @@ void MergeTreeIndexGranuleBloomFilter::serializeBinary(WriteBuffer & ostr) const
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Attempt to write empty bloom filter index.");
 
     writeVarUInt(total_rows, ostr);
-    
+
     static size_t atom_size = 8;
     size_t write_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
     for (const auto & bloom_filter : bloom_filters)

--- a/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
@@ -98,8 +98,9 @@ void MergeTreeIndexGranuleBloomFilter::deserializeBinary(ReadBuffer & istr, Merg
     for (auto & filter : bloom_filters)
     {
         filter = std::make_shared<BloomFilter>(bytes_size, hash_functions, 0);
-        if constexpr (std::endian::native == std::endian::big)
-            read_size = filter->getFilter().size() * sizeof(BloomFilter::UnderType);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        read_size = filter->getFilter().size() * sizeof(BloomFilter::UnderType);
+#endif
         istr.readStrict(reinterpret_cast<char *>(filter->getFilter().data()), read_size);
     }
 }
@@ -115,8 +116,9 @@ void MergeTreeIndexGranuleBloomFilter::serializeBinary(WriteBuffer & ostr) const
     size_t write_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
     for (const auto & bloom_filter : bloom_filters)
     {
-        if constexpr (std::endian::native == std::endian::big)
-            write_size = bloom_filter->getFilter().size() * sizeof(BloomFilter::UnderType);
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        write_size = bloom_filter->getFilter().size() * sizeof(BloomFilter::UnderType);
+#endif
         ostr.write(reinterpret_cast<const char *>(bloom_filter->getFilter().data()), write_size);
     }
 }

--- a/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
@@ -91,15 +91,16 @@ void MergeTreeIndexGranuleBloomFilter::deserializeBinary(ReadBuffer & istr, Merg
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown index version {}.", version);
 
     readVarUInt(total_rows, istr);
+
+    static size_t atom_size = 8;
+    size_t bytes_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
+    size_t read_size = bytes_size;
     for (auto & filter : bloom_filters)
     {
-        static size_t atom_size = 8;
-        size_t bytes_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
         filter = std::make_shared<BloomFilter>(bytes_size, hash_functions, 0);
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        bytes_size = ((bytes_size + sizeof(BloomFilter::UnderType) - 1) / sizeof(BloomFilter::UnderType)) * sizeof(BloomFilter::UnderType);
-#endif
-        istr.readStrict(reinterpret_cast<char *>(filter->getFilter().data()), bytes_size);
+        if constexpr (std::endian::native == std::endian::big)
+            read_size = filter->getFilter().size() * sizeof(BloomFilter::UnderType);
+        istr.readStrict(reinterpret_cast<char *>(filter->getFilter().data()), read_size);
     }
 }
 
@@ -108,14 +109,16 @@ void MergeTreeIndexGranuleBloomFilter::serializeBinary(WriteBuffer & ostr) const
     if (empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Attempt to write empty bloom filter index.");
 
-    static size_t atom_size = 8;
     writeVarUInt(total_rows, ostr);
-    size_t bytes_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    bytes_size = ((bytes_size + sizeof(BloomFilter::UnderType) - 1) / sizeof(BloomFilter::UnderType)) * sizeof(BloomFilter::UnderType);
-#endif
+    
+    static size_t atom_size = 8;
+    size_t write_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
     for (const auto & bloom_filter : bloom_filters)
-        ostr.write(reinterpret_cast<const char *>(bloom_filter->getFilter().data()), bytes_size);
+    {
+        if constexpr (std::endian::native == std::endian::big)
+            write_size = bloom_filter->getFilter().size() * sizeof(BloomFilter::UnderType);
+        ostr.write(reinterpret_cast<const char *>(bloom_filter->getFilter().data()), write_size);
+    }
 }
 
 void MergeTreeIndexGranuleBloomFilter::fillingBloomFilter(BloomFilterPtr & bf, const Block & granule_index_block, size_t index_hash_column) const

--- a/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranuleBloomFilter.cpp
@@ -96,10 +96,6 @@ void MergeTreeIndexGranuleBloomFilter::deserializeBinary(ReadBuffer & istr, Merg
         static size_t atom_size = 8;
         size_t bytes_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
         filter = std::make_shared<BloomFilter>(bytes_size, hash_functions, 0);
-
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        bytes_size = std::max(atom_size, bytes_size);
-#endif
         istr.readStrict(reinterpret_cast<char *>(filter->getFilter().data()), bytes_size);
     }
 }
@@ -111,11 +107,7 @@ void MergeTreeIndexGranuleBloomFilter::serializeBinary(WriteBuffer & ostr) const
 
     static size_t atom_size = 8;
     writeVarUInt(total_rows, ostr);
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    size_t bytes_size = std::max(atom_size, (bits_per_row * total_rows + atom_size - 1) / atom_size);
-#else
     size_t bytes_size = (bits_per_row * total_rows + atom_size - 1) / atom_size;
-#endif
     for (const auto & bloom_filter : bloom_filters)
         ostr.write(reinterpret_cast<const char *>(bloom_filter->getFilter().data()), bytes_size);
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On big-endian machines, there is an endian issue when serializing/deserializing bloom filters to skipping index files when filter bytes size is not a multiple of 8, because non-leading-zero bytes of big-endian 64 bit integer are at higher addresses.
The fix is to serialize/deserialize last whole 64 bit integer for big-endian machines(while keeping original implementation for little-endian machine for back-compatibility) instead of partial bytes of it.

### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed endian issue in bloom filter serialization for s390x.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
