### PR TITLE
Fix data race in `Keeper` snapshot

### DIFF
--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -194,6 +194,9 @@ void KeeperStorageSnapshot::serialize(const KeeperStorageSnapshot & snapshot, Wr
         // write only the root system path because of digest
         if (Coordination::matchPath(path.toView(), keeper_system_path) == Coordination::PathMatchResult::IS_CHILD)
         {
+            if (counter == snapshot.snapshot_container_size - 1)
+                break;
+
             ++it;
             continue;
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fix for https://s3.amazonaws.com/clickhouse-test-reports/43450/ce532cd12dff5a0b3945b49fefe74d1998ab42b4/integration_tests__tsan__[4/6].html


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
