### PR TITLE
Use docker images cache from merged PRs in master and release branches

### DIFF
--- a/tests/ci/docker_images_check.py
+++ b/tests/ci/docker_images_check.py
@@ -441,11 +441,15 @@ def main():
 
     result_images = {}
     images_processing_result = []
+    additional_cache = ""
+    if pr_info.release_pr or pr_info.merged_pr:
+        additional_cache = str(pr_info.release_pr or pr_info.merged_pr)
+
     for image in changed_images:
         # If we are in backport PR, then pr_info.release_pr is defined
         # We use it as tag to reduce rebuilding time
         images_processing_result += process_image_with_parents(
-            image, image_versions, pr_info.release_pr, args.push
+            image, image_versions, additional_cache, args.push
         )
         result_images[image.repo] = result_version
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use built docker images from PRs in the following CI to reduce build time