### PR TITLE
Vectorize AssociativeGenericApplierImpl::apply

### DIFF
--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -16,6 +16,7 @@
 #include <Functions/FunctionUnaryArithmetic.h>
 #include <Common/FieldVisitors.h>
 
+#include <cstring>
 #include <algorithm>
 
 
@@ -94,7 +95,7 @@ void convertAnyColumnToBool(const IColumn * column, UInt8Container & res)
 }
 
 
-template <class Op, typename Func>
+template <class Op, bool IsTernary, typename Func>
 bool extractConstColumns(ColumnRawPtrs & in, UInt8 & res, Func && func)
 {
     bool has_res = false;
@@ -112,7 +113,10 @@ bool extractConstColumns(ColumnRawPtrs & in, UInt8 & res, Func && func)
 
         if (has_res)
         {
-            res = Op::apply(res, x);
+            if constexpr (IsTernary)
+                res = Op::ternaryApply(res, x);
+            else
+                res = Op::apply(res, x);
         }
         else
         {
@@ -129,7 +133,7 @@ bool extractConstColumns(ColumnRawPtrs & in, UInt8 & res, Func && func)
 template <class Op>
 inline bool extractConstColumnsAsBool(ColumnRawPtrs & in, UInt8 & res)
 {
-    return extractConstColumns<Op>(
+    return extractConstColumns<Op, false>(
         in, res,
         [](const Field & value)
         {
@@ -141,7 +145,7 @@ inline bool extractConstColumnsAsBool(ColumnRawPtrs & in, UInt8 & res)
 template <class Op>
 inline bool extractConstColumnsAsTernary(ColumnRawPtrs & in, UInt8 & res_3v)
 {
-    return extractConstColumns<Op>(
+    return extractConstColumns<Op, true>(
         in, res_3v,
         [](const Field & value)
         {
@@ -192,47 +196,55 @@ private:
 };
 
 
-/// A helper class used by AssociativeGenericApplierImpl
-/// Allows for on-the-fly conversion of any data type into intermediate ternary representation
-using TernaryValueGetter = std::function<Ternary::ResultType (size_t)>;
-
 template <typename ... Types>
-struct ValueGetterBuilderImpl;
+struct TernaryValueBuilderImpl;
 
 template <typename Type, typename ...Types>
-struct ValueGetterBuilderImpl<Type, Types...>
+struct TernaryValueBuilderImpl<Type, Types...>
 {
-    static TernaryValueGetter build(const IColumn * x)
+    static void build(const IColumn * x, UInt8* __restrict ternary_column_data)
     {
+        size_t size = x->size();
         if (x->onlyNull())
         {
-            return [](size_t){ return Ternary::Null; };
+            memset(ternary_column_data, Ternary::Null, size);
         }
         else if (const auto * nullable_column = typeid_cast<const ColumnNullable *>(x))
         {
             if (const auto * nested_column = typeid_cast<const ColumnVector<Type> *>(nullable_column->getNestedColumnPtr().get()))
             {
-                return [
-                    &null_data = nullable_column->getNullMapData(),
-                    &column_data = nested_column->getData()](size_t i)
+                const auto& null_data = nullable_column->getNullMapData();
+                const auto& column_data = nested_column->getData();
+
+                for (size_t i = 0; i < size; ++i)
                 {
-                    return Ternary::makeValue(column_data[i], null_data[i]);
-                };
+                    auto has_value = static_cast<UInt8>(column_data[i] != 0);
+                    auto is_null = !!null_data[i];
+
+                    ternary_column_data[i] = ((has_value << 1) | is_null) & (1 << !is_null);
+                }
             }
             else
-                return ValueGetterBuilderImpl<Types...>::build(x);
+                TernaryValueBuilderImpl<Types...>::build(x, ternary_column_data);
         }
         else if (const auto column = typeid_cast<const ColumnVector<Type> *>(x))
-            return [&column_data = column->getData()](size_t i) { return Ternary::makeValue(column_data[i]); };
+        {
+            auto &column_data = column->getData();
+
+            for (size_t i = 0; i < size; ++i)
+            {
+                ternary_column_data[i] = (column_data[i] != 0) << 1;
+            }
+        }
         else
-            return ValueGetterBuilderImpl<Types...>::build(x);
+            TernaryValueBuilderImpl<Types...>::build(x, ternary_column_data);
     }
 };
 
 template <>
-struct ValueGetterBuilderImpl<>
+struct TernaryValueBuilderImpl<>
 {
-    static TernaryValueGetter build(const IColumn * x)
+    [[noreturn]] static void build(const IColumn * x, UInt8 * /* nullable_ternary_column_data */)
     {
         throw Exception(
                 std::string("Unknown numeric column of type: ") + demangle(typeid(*x).name()),
@@ -240,12 +252,12 @@ struct ValueGetterBuilderImpl<>
     }
 };
 
-using ValueGetterBuilder =
-        ValueGetterBuilderImpl<UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, Float32, Float64>;
+using TernaryValueBuilder =
+        TernaryValueBuilderImpl<UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, Float32, Float64>;
 
-/// This class together with helper class ValueGetterBuilder can be used with columns of arbitrary data type
-/// Allows for on-the-fly conversion of any type of data into intermediate ternary representation
-/// and eliminates the need to materialize data columns in intermediate representation
+/// This class together with helper class TernaryValueBuilder can be used with columns of arbitrary data type
+/// Converts column of any data type into an intermediate UInt8Column of ternary representation for the
+/// vectorized ternary logic evaluation.
 template <typename Op, size_t N>
 class AssociativeGenericApplierImpl
 {
@@ -254,20 +266,19 @@ class AssociativeGenericApplierImpl
 public:
     /// Remembers the last N columns from `in`.
     explicit AssociativeGenericApplierImpl(const ColumnRawPtrs & in)
-        : val_getter{ValueGetterBuilder::build(in[in.size() - N])}, next{in} {}
+        : vec(in[in.size() - N]->size()), next{in}
+        {
+            TernaryValueBuilder::build(in[in.size() - N], vec.data());
+        }
 
     /// Returns a combination of values in the i-th row of all columns stored in the constructor.
     inline ResultValueType apply(const size_t i) const
     {
-        const auto a = val_getter(i);
-        if constexpr (Op::isSaturable())
-            return Op::isSaturatedValueTernary(a) ? a : Op::apply(a, next.apply(i));
-        else
-            return Op::apply(a, next.apply(i));
+        return Op::ternaryApply(vec[i], next.apply(i));
     }
 
 private:
-    const TernaryValueGetter val_getter;
+    UInt8Container vec;
     const AssociativeGenericApplierImpl<Op, N - 1> next;
 };
 
@@ -280,12 +291,15 @@ class AssociativeGenericApplierImpl<Op, 1>
 public:
     /// Remembers the last N columns from `in`.
     explicit AssociativeGenericApplierImpl(const ColumnRawPtrs & in)
-        : val_getter{ValueGetterBuilder::build(in[in.size() - 1])} {}
+        : vec(UInt8Container(in[in.size() - 1]->size()))
+        {
+            TernaryValueBuilder::build(in[in.size() - 1], vec.data());
+        }
 
-    inline ResultValueType apply(const size_t i) const { return val_getter(i); }
+    inline ResultValueType apply(const size_t i) const { return vec[i]; }
 
 private:
-    const TernaryValueGetter val_getter;
+    UInt8Container vec;
 };
 
 
@@ -318,7 +332,12 @@ struct OperationApplier
         for (size_t i = 0; i < size; ++i)
         {
             if constexpr (CarryResult)
-                result_data[i] = Op::apply(result_data[i], operation_applier_impl.apply(i));
+            {
+                if constexpr (std::is_same_v<OperationApplierImpl<Op, N>, AssociativeApplierImpl<Op, N>>)
+                    result_data[i] = Op::apply(result_data[i], operation_applier_impl.apply(i));
+                else
+                    result_data[i] = Op::ternaryApply(result_data[i], operation_applier_impl.apply(i));
+            }
             else
                 result_data[i] = operation_applier_impl.apply(i);
         }

--- a/src/Functions/FunctionsLogical.cpp
+++ b/src/Functions/FunctionsLogical.cpp
@@ -216,12 +216,31 @@ struct TernaryValueBuilderImpl<Type, Types...>
                 const auto& null_data = nullable_column->getNullMapData();
                 const auto& column_data = nested_column->getData();
 
-                for (size_t i = 0; i < size; ++i)
+                if constexpr (sizeof(Type) == 1)
                 {
-                    auto has_value = static_cast<UInt8>(column_data[i] != 0);
-                    auto is_null = !!null_data[i];
+                    for (size_t i = 0; i < size; ++i)
+                    {
+                        auto has_value = static_cast<UInt8>(column_data[i] != 0);
+                        auto is_null = !!null_data[i];
 
-                    ternary_column_data[i] = ((has_value << 1) | is_null) & (1 << !is_null);
+                        ternary_column_data[i] = ((has_value << 1) | is_null) & (1 << !is_null);
+                    }
+                }
+                else
+                {
+                    for (size_t i = 0; i < size; ++i)
+                    {
+                        auto has_value = static_cast<UInt8>(column_data[i] != 0);
+                        ternary_column_data[i] = has_value;
+                    }
+
+                    for (size_t i = 0; i < size; ++i)
+                    {
+                        auto has_value = ternary_column_data[i];
+                        auto is_null = !!null_data[i];
+
+                        ternary_column_data[i] = ((has_value << 1) | is_null) & (1 << !is_null);
+                    }
                 }
             }
             else

--- a/src/Functions/tests/gtest_ternary_logic.cpp
+++ b/src/Functions/tests/gtest_ternary_logic.cpp
@@ -1,0 +1,354 @@
+#include <algorithm>
+#include <cstring>
+#include <vector>
+#include <string>
+#include <type_traits>
+#include <gtest/gtest.h>
+#include <Columns/ColumnNothing.h>
+#include <Columns/ColumnsNumber.h>
+#include <Functions/FunctionsLogical.h>
+
+// I know that inclusion of .cpp is not good at all
+#include <Functions/FunctionsLogical.cpp> // NOLINT
+
+using namespace DB;
+using TernaryValues = std::vector<Ternary::ResultType>;
+
+struct LinearCongruentialGenerator
+{
+    /// Constants from `man lrand48_r`.
+    static constexpr UInt64 a = 0x5DEECE66D;
+    static constexpr UInt64 c = 0xB;
+
+    /// And this is from `head -c8 /dev/urandom | xxd -p`
+    UInt64 current = 0x09826f4a081cee35ULL;
+
+    UInt32 next()
+    {
+        current = current * a + c;
+        return static_cast<UInt32>(current >> 16);
+    }
+};
+
+void generateRandomTernaryValue(LinearCongruentialGenerator & gen, Ternary::ResultType * output, size_t size, double false_ratio, double null_ratio)
+{
+    /// The LinearCongruentialGenerator generates nonnegative integers uniformly distributed over the interval [0, 2^32).
+    /// See https://linux.die.net/man/3/nrand48
+
+    double false_percentile = false_ratio;
+    double null_percentile = false_ratio + null_ratio;
+
+    false_percentile = false_percentile > 1 ? 1 : false_percentile;
+    null_percentile = null_percentile > 1 ? 1 : null_percentile;
+
+    UInt32 false_threshold = static_cast<UInt32>(static_cast<double>(std::numeric_limits<UInt32>::max()) * false_percentile);
+    UInt32 null_threshold = static_cast<UInt32>(static_cast<double>(std::numeric_limits<UInt32>::max()) * null_percentile);
+
+    for (Ternary::ResultType * end = output + size; output != end; ++output)
+    {
+        UInt32 val = gen.next();
+        *output = val < false_threshold ? Ternary::False : (val < null_threshold ? Ternary::Null : Ternary::True);
+    }
+}
+
+template<typename T>
+ColumnPtr createColumnNullable(const Ternary::ResultType * ternary_values, size_t size)
+{
+    auto nested_column = ColumnVector<T>::create(size);
+    auto null_map = ColumnUInt8::create(size);
+    auto & nested_column_data = nested_column->getData();
+    auto & null_map_data = null_map->getData();
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (ternary_values[i] == Ternary::Null)
+        {
+            null_map_data[i] = 1;
+            nested_column_data[i] = 0;
+        }
+        else if (ternary_values[i] == Ternary::True)
+        {
+            null_map_data[i] = 0;
+            nested_column_data[i] = 100;
+        }
+        else
+        {
+            null_map_data[i] = 0;
+            nested_column_data[i] = 0;
+        }
+    }
+
+    return ColumnNullable::create(std::move(nested_column), std::move(null_map));
+}
+
+template<typename T>
+ColumnPtr createColumnVector(const Ternary::ResultType * ternary_values, size_t size)
+{
+    auto column = ColumnVector<T>::create(size);
+    auto & column_data = column->getData();
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (ternary_values[i] == Ternary::True)
+        {
+            column_data[i] = 100;
+        }
+        else
+        {
+            column_data[i] = 0;
+        }
+    }
+
+    return column;
+}
+
+template<typename ColumnType, typename T>
+ColumnPtr createRandomColumn(LinearCongruentialGenerator & gen, TernaryValues & ternary_values)
+{
+    size_t size = ternary_values.size();
+    Ternary::ResultType * ternary_data = ternary_values.data();
+
+    if constexpr (std::is_same_v<ColumnType, ColumnNullable>)
+    {
+        generateRandomTernaryValue(gen, ternary_data, size, 0.3, 0.7);
+        return createColumnNullable<T>(ternary_data, size);
+    }
+    else if constexpr (std::is_same_v<ColumnType, ColumnVector<UInt8>>)
+    {
+        generateRandomTernaryValue(gen, ternary_data, size, 0.5, 0);
+        return createColumnVector<T>(ternary_data, size);
+    }
+    else
+    {
+        auto nested_col = ColumnNothing::create(size);
+        auto null_map = ColumnUInt8::create(size);
+
+        memset(ternary_data, Ternary::Null, size);
+
+        return ColumnNullable::create(std::move(nested_col), std::move(null_map));
+    }
+}
+
+/* The truth table of ternary And and Or operations:
+ * +-------+-------+---------+--------+
+ * |   a   |   b   | a And b | a Or b |
+ * +-------+-------+---------+--------+
+ * | False | False | False   | False  |
+ * | False | Null  | False   | Null   |
+ * | False | True  | False   | True   |
+ * | Null  | False | False   | Null   |
+ * | Null  | Null  | Null    | Null   |
+ * | Null  | True  | Null    | True   |
+ * | True  | False | False   | True   |
+ * | True  | Null  | Null    | True   |
+ * | True  | True  | True    | True   |
+ * +-------+-------+---------+--------+
+ *
+ * https://en.wikibooks.org/wiki/Structured_Query_Language/NULLs_and_the_Three_Valued_Logic
+ */
+template <typename Op, typename T>
+bool testTernaryLogicTruthTable()
+{
+    constexpr size_t size = 9;
+
+    Ternary::ResultType col_a_ternary[] = {Ternary::False, Ternary::False, Ternary::False, Ternary::Null, Ternary::Null, Ternary::Null, Ternary::True, Ternary::True, Ternary::True};
+    Ternary::ResultType col_b_ternary[] = {Ternary::False, Ternary::Null, Ternary::True, Ternary::False, Ternary::Null, Ternary::True,Ternary::False, Ternary::Null, Ternary::True};
+    Ternary::ResultType and_expected_ternary[] = {Ternary::False, Ternary::False, Ternary::False, Ternary::False, Ternary::Null, Ternary::Null,Ternary::False, Ternary::Null, Ternary::True};
+    Ternary::ResultType or_expected_ternary[] = {Ternary::False, Ternary::Null, Ternary::True, Ternary::Null, Ternary::Null, Ternary::True,Ternary::True, Ternary::True, Ternary::True};
+    Ternary::ResultType * expected_ternary;
+
+
+    if constexpr (std::is_same_v<Op, AndImpl>)
+    {
+        expected_ternary = and_expected_ternary;
+    }
+    else
+    {
+        expected_ternary = or_expected_ternary;
+    }
+
+    auto col_a = createColumnNullable<T>(col_a_ternary, size);
+    auto col_b = createColumnNullable<T>(col_b_ternary, size);
+    ColumnRawPtrs arguments = {col_a.get(), col_b.get()};
+
+    auto col_res = ColumnUInt8::create(size);
+    auto & col_res_data = col_res->getData();
+
+    OperationApplier<Op, AssociativeGenericApplierImpl>::apply(arguments, col_res->getData(), false);
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (col_res_data[i] != expected_ternary[i]) return false;
+    }
+
+    return true;
+}
+
+template <typename Op, typename LeftColumn, typename RightColumn>
+bool testTernaryLogicOfTwoColumns(size_t size)
+{
+    LinearCongruentialGenerator gen;
+
+    TernaryValues left_column_ternary(size);
+    TernaryValues right_column_ternary(size);
+    TernaryValues expected_ternary(size);
+
+    ColumnPtr left = createRandomColumn<LeftColumn, UInt8>(gen, left_column_ternary);
+    ColumnPtr right = createRandomColumn<RightColumn, UInt8>(gen, right_column_ternary);
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        /// Given that False is less than Null and Null is less than True, the And operation can be implemented
+        /// with std::min, and the Or operation can be implemented with std::max.
+        if constexpr (std::is_same_v<Op, AndImpl>)
+        {
+            expected_ternary[i] = std::min(left_column_ternary[i], right_column_ternary[i]);
+        }
+        else
+        {
+            expected_ternary[i] = std::max(left_column_ternary[i], right_column_ternary[i]);
+        }
+    }
+
+    ColumnRawPtrs arguments = {left.get(), right.get()};
+
+    auto col_res = ColumnUInt8::create(size);
+    auto & col_res_data = col_res->getData();
+
+    OperationApplier<Op, AssociativeGenericApplierImpl>::apply(arguments, col_res->getData(), false);
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (col_res_data[i] != expected_ternary[i]) return false;
+    }
+
+    return true;
+}
+
+TEST(TernaryLogicTruthTable, NestedUInt8)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, UInt8>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, UInt8>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTruthTable, NestedUInt16)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, UInt16>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, UInt16>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTruthTable, NestedUInt32)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, UInt32>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, UInt32>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTruthTable, NestedUInt64)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, UInt64>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, UInt64>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTruthTable, NestedInt8)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, Int8>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, Int8>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTruthTable, NestedInt16)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, Int16>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, Int16>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTruthTable, NestedInt32)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, Int32>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, Int32>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTruthTable, NestedInt64)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, Int64>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, Int64>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTruthTable, NestedFloat32)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, Float32>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, Float32>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTruthTable, NestedFloat64)
+{
+    bool test_1 = testTernaryLogicTruthTable<AndImpl, Float64>();
+    bool test_2 = testTernaryLogicTruthTable<OrImpl, Float64>();
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTwoColumns, TwoNullable)
+{
+    bool test_1 = testTernaryLogicOfTwoColumns<AndImpl, ColumnNullable, ColumnNullable>(100 /*size*/);
+    bool test_2 = testTernaryLogicOfTwoColumns<OrImpl, ColumnNullable, ColumnNullable>(100 /*size*/);
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTwoColumns, TwoVector)
+{
+    bool test_1 = testTernaryLogicOfTwoColumns<AndImpl, ColumnUInt8, ColumnUInt8>(100 /*size*/);
+    bool test_2 = testTernaryLogicOfTwoColumns<OrImpl, ColumnUInt8, ColumnUInt8>(100 /*size*/);
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTwoColumns, TwoNothing)
+{
+    bool test_1 = testTernaryLogicOfTwoColumns<AndImpl, ColumnNothing, ColumnNothing>(100 /*size*/);
+    bool test_2 = testTernaryLogicOfTwoColumns<OrImpl, ColumnNothing, ColumnNothing>(100 /*size*/);
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTwoColumns, NullableVector)
+{
+    bool test_1 = testTernaryLogicOfTwoColumns<AndImpl, ColumnNullable, ColumnUInt8>(100 /*size*/);
+    bool test_2 = testTernaryLogicOfTwoColumns<OrImpl, ColumnNullable, ColumnUInt8>(100 /*size*/);
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTwoColumns, NullableNothing)
+{
+    bool test_1 = testTernaryLogicOfTwoColumns<AndImpl, ColumnNullable, ColumnNothing>(100 /*size*/);
+    bool test_2 = testTernaryLogicOfTwoColumns<OrImpl, ColumnNullable, ColumnNothing>(100 /*size*/);
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}
+
+TEST(TernaryLogicTwoColumns, VectorNothing)
+{
+    bool test_1 = testTernaryLogicOfTwoColumns<AndImpl, ColumnUInt8, ColumnNothing>(100 /*size*/);
+    bool test_2 = testTernaryLogicOfTwoColumns<OrImpl, ColumnUInt8, ColumnNothing>(100 /*size*/);
+    ASSERT_EQ(test_1, true);
+    ASSERT_EQ(test_2, true);
+}


### PR DESCRIPTION
This commit achieved the auto-vectorization by redefining numerical values of ternary representations and corresponding implementations of And/Or operators, caching the intermediate ternary values in a continuous range of memory for the SIMD instructions to consume, and removing the short-circuit for the ternary logic evaluation.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
As a follow-up of #42214, this PR tries to optimize the column-wise ternary logic evaluation by achieving auto-vectorization. In the performance test of this [microbenchmark](https://github.com/ZhiguoZh/ClickHouse/blob/20221123-ternary-logic-opt-example/src/Functions/examples/associative_applier_perf.cpp), we've observed a peak **performance gain** of **21x** on the ICX device (Intel Xeon Platinum 8380 CPU).

This change is very similar to the one we introduced in #42214. However, we found that simply removing the short-circuit could not efficiently vectorize the ternary logic evaluation. Two major causes are identified in our analysis:
1. To share the exact And/Or operator implementation with binary one, the ternary value is defined as: True(0xFF), Null(0x01) and False(0x00). And to determine the ternary values with data (Zero/Non-zero) and null map column (if the entry is Null), the original implementation utilized the if-else clause, which hinders the generation of vectorized code.
2. Unlike the binary logic functions, whose operand is simply ColumnUInt8, the ternary logic functions would take as arguments the ColumnNullables which contain a ColumnUInt8 null map column and a Column{UInt8, UInt16, UInt32, UInt64, …} data column. The ClickHouse implemented getter functions for each type of data column. As a result, the getter functions would be called for each entries in the columns, and at the same time hinder the vectorization.

To overcome the above problems, we firstly redefined the ternary representations which are feasible for vectorization, we then replaced the getter functions with intermediate columns containing the ternary values for the SIMD instructions to consume, and we finally removed the short-circuit evaluation to ensure all rows share the exact code path.

Meanwhile, this optimization need an **O(m*n)** memory cost for the intermediate ternary values of **n** columns with **m** elements.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
