### PR TITLE
Try to fix Logical error 'Array sizes mismatched' while parsing JSON object

### DIFF
--- a/src/DataTypes/Serializations/JSONDataParser.cpp
+++ b/src/DataTypes/Serializations/JSONDataParser.cpp
@@ -119,7 +119,7 @@ void JSONDataParser<ParserImpl>::traverseArrayElement(const Element & element, P
         if (values[i].isNull())
             continue;
 
-        UInt128 hash = PathInData::getPartsHash(paths[i]);
+        UInt128 hash = PathInData::getPartsHash(paths[i].begin(), paths[i].end());
         if (auto * found = ctx.arrays_by_path.find(hash))
         {
             auto & path_array = found->getMapped().second;
@@ -128,11 +128,11 @@ void JSONDataParser<ParserImpl>::traverseArrayElement(const Element & element, P
             /// If current element of array is part of Nested,
             /// collect its size or check it if the size of
             /// the Nested has been already collected.
-            auto nested_key = getNameOfNested(paths[i], values[i]);
-            if (!nested_key.empty())
+            auto nested_hash = getHashOfNestedPath(paths[i], values[i]);
+            if (nested_hash)
             {
                 size_t array_size = values[i].template get<const Array &>().size();
-                auto & current_nested_sizes = ctx.nested_sizes_by_key[nested_key];
+                auto & current_nested_sizes = ctx.nested_sizes_by_path[*nested_hash];
 
                 if (current_nested_sizes.size() == ctx.current_size)
                     current_nested_sizes.push_back(array_size);
@@ -151,11 +151,11 @@ void JSONDataParser<ParserImpl>::traverseArrayElement(const Element & element, P
             path_array.reserve(ctx.total_size);
             path_array.resize(ctx.current_size);
 
-            auto nested_key = getNameOfNested(paths[i], values[i]);
-            if (!nested_key.empty())
+            auto nested_hash = getHashOfNestedPath(paths[i], values[i]);
+            if (nested_hash)
             {
                 size_t array_size = values[i].template get<const Array &>().size();
-                auto & current_nested_sizes = ctx.nested_sizes_by_key[nested_key];
+                auto & current_nested_sizes = ctx.nested_sizes_by_path[*nested_hash];
 
                 if (current_nested_sizes.empty())
                 {
@@ -217,11 +217,11 @@ bool JSONDataParser<ParserImpl>::tryInsertDefaultFromNested(
         return false;
 
     /// Last element is not Null, because otherwise this path wouldn't exist.
-    auto nested_key = getNameOfNested(path, array.back());
-    if (nested_key.empty())
+    auto hash = getHashOfNestedPath(path, array.back());
+    if (!hash)
         return false;
 
-    auto * mapped = ctx.nested_sizes_by_key.find(nested_key);
+    auto * mapped = ctx.nested_sizes_by_path.find(*hash);
     if (!mapped)
         return false;
 
@@ -251,21 +251,21 @@ Field JSONDataParser<ParserImpl>::getValueAsField(const Element & element)
 }
 
 template <typename ParserImpl>
-StringRef JSONDataParser<ParserImpl>::getNameOfNested(const PathInData::Parts & path, const Field & value)
+std::optional<UInt128> JSONDataParser<ParserImpl>::getHashOfNestedPath(const PathInData::Parts & path, const Field & value)
 {
     if (value.getType() != Field::Types::Array || path.empty())
         return {};
 
-    /// Find first key that is marked as nested,
-    /// because we may have tuple of Nested and there could be
+    /// Find first key that is marked as nested and return hash of its path.
+    /// It's needed because we may have tuple of Nested and there could be
     /// several arrays with the same prefix, but with independent sizes.
     /// Consider we have array element with type `k2 Tuple(k3 Nested(...), k5 Nested(...))`
     /// Then subcolumns `k2.k3` and `k2.k5` may have indepented sizes and we should extract
     /// `k3` and `k5` keys instead of `k2`.
 
-    for (const auto & part : path)
-        if (part.is_nested)
-            return StringRef{part.key};
+    for (size_t i = 0; i != path.size(); ++i)
+        if (path[i].is_nested)
+            return PathInData::getPartsHash(path.begin(), std::next(path.begin(), i + 1));
 
     return {};
 }

--- a/src/DataTypes/Serializations/JSONDataParser.h
+++ b/src/DataTypes/Serializations/JSONDataParser.h
@@ -34,7 +34,7 @@ private:
 
     using PathPartsWithArray = std::pair<PathInData::Parts, Array>;
     using PathToArray = HashMapWithStackMemory<UInt128, PathPartsWithArray, UInt128TrivialHash, 5>;
-    using KeyToSizes = HashMapWithStackMemory<StringRef, std::vector<size_t>, StringRefHash, 5>;
+    using PathToSizes = HashMapWithStackMemory<UInt128, std::vector<size_t>, UInt128TrivialHash, 5>;
 
     struct ParseArrayContext
     {
@@ -42,7 +42,7 @@ private:
         size_t total_size = 0;
 
         PathToArray arrays_by_path;
-        KeyToSizes nested_sizes_by_key;
+        PathToSizes nested_sizes_by_path;
         Arena strings_pool;
     };
 
@@ -56,7 +56,7 @@ private:
         ParseArrayContext & ctx, const PathInData::Parts & path, Array & array);
 
     static Field getValueAsField(const Element & element);
-    static StringRef getNameOfNested(const PathInData::Parts & path, const Field & value);
+    static std::optional<UInt128> getHashOfNestedPath(const PathInData::Parts & path, const Field & value);
 
     ParserImpl parser;
 };

--- a/src/DataTypes/Serializations/PathInData.cpp
+++ b/src/DataTypes/Serializations/PathInData.cpp
@@ -54,15 +54,15 @@ PathInData & PathInData::operator=(const PathInData & other)
     return *this;
 }
 
-UInt128 PathInData::getPartsHash(const Parts & parts_)
+UInt128 PathInData::getPartsHash(const Parts::const_iterator & begin, const Parts::const_iterator & end)
 {
     SipHash hash;
-    hash.update(parts_.size());
-    for (const auto & part : parts_)
+    hash.update(std::distance(begin, end));
+    for (auto part_it = begin; part_it != end; ++part_it)
     {
-        hash.update(part.key.data(), part.key.length());
-        hash.update(part.is_nested);
-        hash.update(part.anonymous_array_level);
+        hash.update(part_it->key.data(), part_it->key.length());
+        hash.update(part_it->is_nested);
+        hash.update(part_it->anonymous_array_level);
     }
 
     UInt128 res;
@@ -104,7 +104,7 @@ void PathInData::buildParts(const Parts & other_parts)
 
 size_t PathInData::Hash::operator()(const PathInData & value) const
 {
-    auto hash = getPartsHash(value.parts);
+    auto hash = getPartsHash(value.parts.begin(), value.parts.end());
     return hash.items[0] ^ hash.items[1];
 }
 

--- a/src/DataTypes/Serializations/PathInData.h
+++ b/src/DataTypes/Serializations/PathInData.h
@@ -44,7 +44,7 @@ public:
     PathInData(const PathInData & other);
     PathInData & operator=(const PathInData & other);
 
-    static UInt128 getPartsHash(const Parts & parts_);
+    static UInt128 getPartsHash(const Parts::const_iterator & begin, const Parts::const_iterator & end);
 
     bool empty() const { return parts.empty(); }
 

--- a/tests/queries/0_stateless/02482_json_nested_arrays_with_same_keys.reference
+++ b/tests/queries/0_stateless/02482_json_nested_arrays_with_same_keys.reference
@@ -1,0 +1,1 @@
+{"list.nested.x.r":[[1,2]],"list.x.r":[[1]]}

--- a/tests/queries/0_stateless/02482_json_nested_arrays_with_same_keys.sh
+++ b/tests/queries/0_stateless/02482_json_nested_arrays_with_same_keys.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02482_json_nested_arrays_with_same_keys.sh
+++ b/tests/queries/0_stateless/02482_json_nested_arrays_with_same_keys.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02482_json_nested_arrays_with_same_keys.sh
+++ b/tests/queries/0_stateless/02482_json_nested_arrays_with_same_keys.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo '
+{
+    "obj" :
+    {
+        "list" :
+        [
+            {
+                "nested" : {
+                    "x" : [{"r" : 1}, {"r" : 2}]
+                },
+                "x" : [{"r" : 1}]
+            }
+        ]
+    }
+}' > 02482_object_data.jsonl
+
+$CLICKHOUSE_LOCAL --allow_experimental_object_type=1 -q "select * from file(02482_object_data.jsonl, auto, 'obj JSON')"
+
+rm 02482_object_data.jsonl
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix posssible logical error 'Array sizes mismatched' while parsing JSON object with arrays with same key names but with different nesting level. Closes https://github.com/ClickHouse/ClickHouse/issues/43569

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
