### PR TITLE
Improve automatic usage of structure from insertion table in table functions file/hdfs/s3

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1250,6 +1250,7 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
             if (select_query_hint && getSettingsRef().use_structure_from_insertion_table_in_table_functions == 2)
             {
                 const auto * expression_list = select_query_hint->select()->as<ASTExpressionList>();
+                std::unordered_set<String> virtual_column_names = table_function_ptr->getVirtualsToCheckBeforeUsingStructureHint();
                 Names columns_names;
                 bool have_asterisk = false;
                 /// First, check if we have only identifiers, asterisk and literals in select expression,
@@ -1271,10 +1272,10 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
                     }
                 }
 
-                /// Check that all identifiers are column names from insertion table.
+                /// Check that all identifiers are column names from insertion table and not virtual column names from storage.
                 for (const auto & column_name : columns_names)
                 {
-                    if (!structure_hint.has(column_name))
+                    if (!structure_hint.has(column_name) || virtual_column_names.contains(column_name))
                     {
                         use_columns_from_insert_query = false;
                         break;

--- a/src/TableFunctions/ITableFunction.h
+++ b/src/TableFunctions/ITableFunction.h
@@ -64,6 +64,12 @@ public:
     /// This hint could be used not to repeat schema in function arguments.
     virtual void setStructureHint(const ColumnsDescription &) {}
 
+    /// Used for table functions that can use structure hint during INSERT INTO ... SELECT ... FROM table_function(...)
+    /// It returns possible virtual column names of corresponding storage. If select query contains
+    /// one of these columns, the structure from insertion table won't be used as a structure hint,
+    /// because we cannot determine which column from table correspond to this virtual column.
+    virtual std::unordered_set<String> getVirtualsToCheckBeforeUsingStructureHint() const { return {}; }
+
     virtual bool supportsReadingSubsetOfColumns() { return true; }
 
     /// Create storage according to the query.

--- a/src/TableFunctions/TableFunctionFile.h
+++ b/src/TableFunctions/TableFunctionFile.h
@@ -22,6 +22,11 @@ public:
 
     ColumnsDescription getActualTableStructure(ContextPtr context) const override;
 
+    std::unordered_set<String> getVirtualsToCheckBeforeUsingStructureHint() const override
+    {
+        return {"_path", "_file"};
+    }
+
 protected:
     int fd = -1;
     void parseFirstArguments(const ASTPtr & arg, const ContextPtr & context) override;

--- a/src/TableFunctions/TableFunctionHDFS.h
+++ b/src/TableFunctions/TableFunctionHDFS.h
@@ -26,6 +26,11 @@ public:
 
     ColumnsDescription getActualTableStructure(ContextPtr context) const override;
 
+    std::unordered_set<String> getVirtualsToCheckBeforeUsingStructureHint() const override
+    {
+        return {"_path", "_file"};
+    }
+
 private:
     StoragePtr getStorage(
         const String & source, const String & format_, const ColumnsDescription & columns, ContextPtr global_context,

--- a/src/TableFunctions/TableFunctionS3.h
+++ b/src/TableFunctions/TableFunctionS3.h
@@ -32,6 +32,11 @@ public:
 
     bool supportsReadingSubsetOfColumns() override;
 
+    std::unordered_set<String> getVirtualsToCheckBeforeUsingStructureHint() const override
+    {
+        return {"_path", "_file"};
+    }
+
 protected:
     friend class TableFunctionS3Cluster;
 

--- a/tests/queries/0_stateless/02483_check_virtuals_shile_using_structure_from_insertion_table.reference
+++ b/tests/queries/0_stateless/02483_check_virtuals_shile_using_structure_from_insertion_table.reference
@@ -1,0 +1,1 @@
+Hello	02483_data.LineAsString

--- a/tests/queries/0_stateless/02483_check_virtuals_shile_using_structure_from_insertion_table.sql
+++ b/tests/queries/0_stateless/02483_check_virtuals_shile_using_structure_from_insertion_table.sql
@@ -1,0 +1,8 @@
+drop table if exists test;
+create table test (line String, _file String, _path String) engine=Memory;
+insert into function file(02483_data.LineAsString) select 'Hello' settings engine_file_truncate_on_insert=1;
+set use_structure_from_insertion_table_in_table_functions=2;
+insert into test select *, _file, _path from file(02483_data.LineAsString);
+select line, _file from test;
+drop table test;
+

--- a/tests/queries/0_stateless/02483_check_virtuals_shile_using_structure_from_insertion_table.sql
+++ b/tests/queries/0_stateless/02483_check_virtuals_shile_using_structure_from_insertion_table.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel
+
 drop table if exists test;
 create table test (line String, _file String, _path String) engine=Memory;
 insert into function file(02483_data.LineAsString) select 'Hello' settings engine_file_truncate_on_insert=1;
@@ -5,4 +7,3 @@ set use_structure_from_insertion_table_in_table_functions=2;
 insert into test select *, _file, _path from file(02483_data.LineAsString);
 select line, _file from test;
 drop table test;
-


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve automatic usage of structure from insertion table in table functions file/hdfs/s3 when virtual columns present in select query, it fixes possible error `Block structure mismatch` or `number of columns mismatch`.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
