### PR TITLE
Fix 43622

### DIFF
--- a/src/Functions/FunctionsConversion.h
+++ b/src/Functions/FunctionsConversion.h
@@ -2148,7 +2148,13 @@ struct ToNumberMonotonicity
             return { .is_monotonic = true, .is_always_monotonic = true };
 
         /// If converting from Float, for monotonicity, arguments must fit in range of result type.
-        if (WhichDataType(type).isFloat())
+        bool is_type_float = false;
+        if (const auto * low_cardinality = typeid_cast<const DataTypeLowCardinality *>(&type))
+            is_type_float = WhichDataType(low_cardinality->getDictionaryType()).isFloat();
+        else
+            is_type_float = WhichDataType(type).isFloat();
+
+        if (is_type_float)
         {
             if (left.isNull() || right.isNull())
                 return {};

--- a/tests/queries/0_stateless/02480_suspicious_lowcard_in_key.sql
+++ b/tests/queries/0_stateless/02480_suspicious_lowcard_in_key.sql
@@ -1,0 +1,11 @@
+set allow_suspicious_low_cardinality_types=1;
+
+drop table if exists test;
+
+create table test (val LowCardinality(Float32)) engine MergeTree order by val;
+
+insert into test values (nan);
+
+select count() from test where toUInt64(val) = -1; -- { serverError 70 }
+
+drop table if exists test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix extremely rare case when user use LowCardinality(float) as primary key and it contains `nan`. This fixes https://github.com/ClickHouse/ClickHouse/issues/43622 . There is no need for changelog.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
