### PR TITLE
Fix example of colored prompt in client

### DIFF
--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -15,18 +15,26 @@
     </openSSL>
     <!--
         It's a custom prompt settings for the clickhouse-client
+
         Possible macros:
             {host}
             {port}
             {user}
             {display_name}
-        Terminal colors: https://misc.flogisoft.com/bash/tip_colors_and_formatting
-        See also: https://wiki.hackzine.org/development/misc/readline-color-prompt.html
+
+        You can also use colored prompt, like in [1].
+
+          [1]: https://misc.flogisoft.com/bash/tip_colors_and_formatting
+
+        But note, that ClickHouse does not use readline anymore, instead it uses
+        replxx. This means that you don't need the following:
+        - RL_PROMPT_START_IGNORE (\001)
+        - RL_PROMPT_END_IGNORE   (\002)
     -->
     <prompt_by_server_display_name>
         <default>{display_name} :) </default>
-        <test>{display_name} \x01\e[1;32m\x02:)\x01\e[0m\x02 </test> <!-- if it matched to the substring "test" in the server display name - -->
-        <production>{display_name} \x01\e[1;31m\x02:)\x01\e[0m\x02 </production> <!-- if it matched to the substring "production" in the server display name -->
+        <test>{display_name} \e[1;32m:)\e[0m </test> <!-- if it matched to the substring "test" in the server display name - -->
+        <production>{display_name} \e[1;31m:)\e[0m </production> <!-- if it matched to the substring "production" in the server display name -->
     </prompt_by_server_display_name>
 
     <!-- 


### PR DESCRIPTION
After switching to replxx you don't need the following anymore:
- RL_PROMPT_START_IGNORE (\001)
- RL_PROMPT_END_IGNORE   (\002)

And those symbols also breaks the client prompt (the text length calculated incorrectly, it does not interpret "\x01" as an escape sequence but instead just a bunch of bytes and shows extra whitespaces after prompt).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)