### PR TITLE
Fix flaky `test_store_cleanup`

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -1215,6 +1215,8 @@ void DatabaseCatalog::cleanupStoreDirectoryTask()
 
         if (affected_dirs)
             LOG_INFO(log, "Cleaned up {} directories from store/ on disk {}", affected_dirs, disk_name);
+        else
+            LOG_TEST(log, "Nothing to clean up from store/ on disk {}", disk_name);
     }
 
     (*cleanup_task)->scheduleAfter(unused_dir_cleanup_period_sec * 1000);

--- a/tests/integration/test_broken_detached_part_clean_up/test.py
+++ b/tests/integration/test_broken_detached_part_clean_up/test.py
@@ -280,6 +280,7 @@ def test_store_cleanup(started_cluster):
         "Removing unused directory", timeout=90, look_behind_lines=1000
     )
     node1.wait_for_log_line("directories from store")
+    node1.wait_for_log_line("Nothing to clean up from store/")
 
     store = node1.exec_in_container(["ls", f"{path_to_data}/store"])
     assert "100" in store


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes https://github.com/ClickHouse/ClickHouse/issues/43735
