### PR TITLE
Clarify CREATE TABLE AS SELECT docs

### DIFF
--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -65,10 +65,10 @@ In ClickHouse Cloud please split this into two steps:
 
   ```sql
   CREATE TABLE t1
-  ENGINE = MergeTree 
+  ENGINE = MergeTree
   ORDER BY ...
-  -- highlight-next-line
-  EMPTY AS 
+  # highlight-next-line
+  EMPTY AS
   SELECT ...
   ```
 
@@ -181,7 +181,7 @@ ENGINE = engine
 PRIMARY KEY(expr1[, expr2,...]);
 ```
 
-:::warning    
+:::warning
 You can't combine both ways in one query.
 :::
 
@@ -237,7 +237,7 @@ ALTER TABLE codec_example MODIFY COLUMN float_value CODEC(Default);
 
 Codecs can be combined in a pipeline, for example, `CODEC(Delta, Default)`.
 
-:::warning    
+:::warning
 You can’t decompress ClickHouse database files with external utilities like `lz4`. Instead, use the special [clickhouse-compressor](https://github.com/ClickHouse/ClickHouse/tree/master/programs/compressor) utility.
 :::
 
@@ -323,44 +323,44 @@ Encryption codecs:
 
 #### AES_128_GCM_SIV
 
-`CODEC('AES-128-GCM-SIV')` — Encrypts data with AES-128 in [RFC 8452](https://tools.ietf.org/html/rfc8452) GCM-SIV mode. 
+`CODEC('AES-128-GCM-SIV')` — Encrypts data with AES-128 in [RFC 8452](https://tools.ietf.org/html/rfc8452) GCM-SIV mode.
 
 
 #### AES-256-GCM-SIV
 
-`CODEC('AES-256-GCM-SIV')` — Encrypts data with AES-256 in GCM-SIV mode. 
+`CODEC('AES-256-GCM-SIV')` — Encrypts data with AES-256 in GCM-SIV mode.
 
 These codecs use a fixed nonce and encryption is therefore deterministic. This makes it compatible with deduplicating engines such as [ReplicatedMergeTree](../../../engines/table-engines/mergetree-family/replication.md) but has a weakness: when the same data block is encrypted twice, the resulting ciphertext will be exactly the same so an adversary who can read the disk can see this equivalence (although only the equivalence, without getting its content).
 
-:::warning    
+:::warning
 Most engines including the "\*MergeTree" family create index files on disk without applying codecs. This means plaintext will appear on disk if an encrypted column is indexed.
 :::
 
-:::warning    
+:::warning
 If you perform a SELECT query mentioning a specific value in an encrypted column (such as in its WHERE clause), the value may appear in [system.query_log](../../../operations/system-tables/query_log.md). You may want to disable the logging.
 :::
 
 **Example**
 
 ```sql
-CREATE TABLE mytable 
+CREATE TABLE mytable
 (
     x String Codec(AES_128_GCM_SIV)
-) 
+)
 ENGINE = MergeTree ORDER BY x;
 ```
 
-:::note    
+:::note
 If compression needs to be applied, it must be explicitly specified. Otherwise, only encryption will be applied to data.
 :::
 
 **Example**
 
 ```sql
-CREATE TABLE mytable 
+CREATE TABLE mytable
 (
     x String Codec(Delta, LZ4, AES_128_GCM_SIV)
-) 
+)
 ENGINE = MergeTree ORDER BY x;
 ```
 
@@ -394,7 +394,7 @@ It’s possible to use tables with [ENGINE = Memory](../../../engines/table-engi
 
 'REPLACE' query allows you to update the table atomically.
 
-:::note    
+:::note
 This query is supported only for [Atomic](../../../engines/database-engines/atomic.md) database engine.
 :::
 
@@ -470,7 +470,7 @@ SELECT * FROM base.t1;
 
 You can add a comment to the table when you creating it.
 
-:::note    
+:::note
 The comment is supported for all table engines except [Kafka](../../../engines/table-engines/integrations/kafka.md), [RabbitMQ](../../../engines/table-engines/integrations/rabbitmq.md) and [EmbeddedRocksDB](../../../engines/table-engines/integrations/embedded-rocksdb.md).
 :::
 

--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -59,6 +59,28 @@ If the table already exists and `IF NOT EXISTS` is specified, the query won’t 
 
 There can be other clauses after the `ENGINE` clause in the query. See detailed documentation on how to create tables in the descriptions of [table engines](../../../engines/table-engines/index.md#table_engines).
 
+:::tip
+In ClickHouse Cloud please split this into two steps:
+1. Create the table structure
+
+  ```sql
+  CREATE TABLE t1
+  ENGINE = MergeTree 
+  ORDER BY ...
+  -- highlight-next-line
+  EMPTY AS 
+  SELECT ...
+  ```
+
+2. Populate the table
+
+  ```sql
+  INSERT INTO t1
+  SELECT ...
+  ```
+
+:::
+
 **Example**
 
 Query:


### PR DESCRIPTION
Documentation splitting CREATE TABLE ... AS SELECT into two steps for Cloud

![image](https://user-images.githubusercontent.com/25182304/204362581-81f17c0f-2f2a-4504-9ece-ec43cd096ebc.png)


### Changelog category (leave one):
- Documentation (changelog entry is not required)

