### PR TITLE
Rerun PullRequestCI on changed description body

### DIFF
--- a/tests/ci/cancel_and_rerun_workflow_lambda/app.py
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/app.py
@@ -303,7 +303,7 @@ def main(event):
     pull_request = event_data["pull_request"]
     labels = {label["name"] for label in pull_request["labels"]}
     print("PR has labels", labels)
-    if action == "closed" or "do not test" in labels:
+    if action == "closed" or (action == "labeled" and "do not test" in labels):
         print("PR merged/closed or manually labeled 'do not test' will kill workflows")
         workflow_descriptions = get_workflows_description_for_pull_request(
             pull_request, token

--- a/tests/ci/cancel_and_rerun_workflow_lambda/app.py
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/app.py
@@ -13,8 +13,10 @@ import jwt
 import requests  # type: ignore
 import boto3  # type: ignore
 
+PULL_REQUEST_CI = "PullRequestCI"
+
 NEED_RERUN_OR_CANCELL_WORKFLOWS = {
-    "PullRequestCI",
+    PULL_REQUEST_CI,
     "DocsCheck",
     "DocsReleaseChecks",
     "BackportPR",
@@ -114,7 +116,16 @@ def _exec_get_with_retry(url: str, token: str) -> dict:
 
 WorkflowDescription = namedtuple(
     "WorkflowDescription",
-    ["url", "run_id", "head_sha", "status", "rerun_url", "cancel_url", "conclusion"],
+    [
+        "url",
+        "run_id",
+        "name",
+        "head_sha",
+        "status",
+        "rerun_url",
+        "cancel_url",
+        "conclusion",
+    ],
 )
 
 
@@ -169,6 +180,7 @@ def get_workflows_description_for_pull_request(
                 WorkflowDescription(
                     url=workflow["url"],
                     run_id=workflow["id"],
+                    name=workflow["name"],
                     head_sha=workflow["head_sha"],
                     status=workflow["status"],
                     rerun_url=workflow["rerun_url"],
@@ -229,6 +241,7 @@ def get_workflow_description_fallback(
         WorkflowDescription(
             url=wf["url"],
             run_id=wf["id"],
+            name=workflow["name"],
             head_sha=wf["head_sha"],
             status=wf["status"],
             rerun_url=wf["rerun_url"],
@@ -246,6 +259,7 @@ def get_workflow_description(workflow_url, token) -> WorkflowDescription:
     return WorkflowDescription(
         url=workflow["url"],
         run_id=workflow["id"],
+        name=workflow["name"],
         head_sha=workflow["head_sha"],
         status=workflow["status"],
         rerun_url=workflow["rerun_url"],
@@ -268,8 +282,8 @@ def _exec_post_with_retry(url, token):
     raise Exception("Cannot execute POST request with retry")
 
 
-def exec_workflow_url(urls_to_cancel, token):
-    for url in urls_to_cancel:
+def exec_workflow_url(urls_to_post, token):
+    for url in urls_to_post:
         print("Post for workflow workflow using url", url)
         _exec_post_with_retry(url, token)
         print("Workflow post finished")
@@ -307,6 +321,29 @@ def main(event):
                 urls_to_cancel.append(workflow_description.cancel_url)
         print(f"Found {len(urls_to_cancel)} workflows to cancel")
         exec_workflow_url(urls_to_cancel, token)
+        return
+    elif action == "edited":
+        print("PR is edited, check if it needs to rerun")
+        workflow_descriptions = get_workflows_description_for_pull_request(
+            pull_request, token
+        )
+        workflow_descriptions = (
+            workflow_descriptions
+            or get_workflow_description_fallback(pull_request, token)
+        )
+        workflow_descriptions.sort(key=lambda x: x.run_id)
+        most_recent_workflow = workflow_descriptions[-1]
+        if (
+            most_recent_workflow.status == "completed"
+            and most_recent_workflow.name == PULL_REQUEST_CI
+        ):
+            print(
+                "The PR's body is changed and workflow is finished. "
+                "Rerun to check the description"
+            )
+            exec_workflow_url([most_recent_workflow.rerun_url], token)
+            print("Rerun finished, exiting")
+            return
     elif action == "synchronize":
         print("PR is synchronized, going to stop old actions")
         workflow_descriptions = get_workflows_description_for_pull_request(
@@ -339,8 +376,8 @@ def main(event):
             print("Not found any workflows")
             return
 
-        sorted_workflows = list(sorted(workflow_descriptions, key=lambda x: x.run_id))
-        most_recent_workflow = sorted_workflows[-1]
+        workflow_descriptions.sort(key=lambda x: x.run_id)
+        most_recent_workflow = workflow_descriptions[-1]
         print("Latest workflow", most_recent_workflow)
         if (
             most_recent_workflow.status != "completed"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Rerun finished PullRequestCI workflows if the PR body was changed to check the description