### PR TITLE
Update documentation example for REPLACE TABLE

### DIFF
--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -388,7 +388,7 @@ RENAME TABLE myNewTable TO myOldTable;
 Instead of above, you can use the following:
 
 ```sql
-REPLACE TABLE myOldTable SELECT * FROM myOldTable WHERE CounterID <12345;
+REPLACE TABLE myOldTable ENGINE = MergeTree() ORDER BY CounterID AS SELECT * FROM myOldTable WHERE CounterID <12345;
 ```
 
 ### Syntax


### PR DESCRIPTION
The example statement for `REPLACE TABLE` using a `SELECT` query does not run as written. The example was missing a query engine, engine options, and the `AS` keyword, all of which seem required to replace a table with the output of some query.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)
