### PR TITLE
update security-changelog in chinese

### DIFF
--- a/docs/zh/whats-new/security-changelog.md
+++ b/docs/zh/whats-new/security-changelog.md
@@ -3,6 +3,66 @@ slug: /zh/whats-new/security-changelog
 sidebar_position: 76
 sidebar_label: 安全更新日志
 ---
+# 安全更新日志
+## 修复于ClickHouse 22.9.1.2603, 2022-09-22
+### CVE-2022-44011
+ClickHouse server中发现了一个堆缓冲区溢出问题。拥有向ClickHouse Server导入数据能力的恶意用户，可通过插入畸形CapnProto对象使ClickHouse Server对象崩溃。
+
+修复已推送至版本22.9.1.2603, 22.8.2.11，22.7.4.16，22.6.6.16，22.3.12.19
+
+作者：Kiojj(独立研究者)
+
+### CVE-2022-44010
+ClickHouse server中发现了一个堆缓冲区溢出问题。攻击者可发送一个特殊的HTTP请求至HTTP端口（默认监听在8123端口），该攻击可造成堆缓冲区溢出进而使ClickHouse server进程崩溃。执行该攻击无需认证。
+
+修复版本已推送至版本22.9.1.2603，22.8.2.11，22.7.4.16，22.6.6.16，22.3.12.19
+
+作者：Kiojj(独立研究者)
+
+## 修复于ClickHouse 21.10.2.15，2021-10-18
+### CVE-2021-43304
+在对恶意查询做语法分析时，ClickHouse的LZ4压缩编码会堆缓冲区溢出。LZ4:decompressImpl循环尤其是wildCopy<copy_amount>(op, ip, copy_end)中的随意复制操作没有验证是否会导致超出目标缓冲区限制。
+
+作者：JFrog 安全研究团队
+
+### CVE-2021-43305
+在对恶意查询做语法分析时，ClickHouse的LZ4压缩编码会堆缓冲区溢出。LZ4:decompressImpl循环尤其是wildCopy<copy_amount>(op, ip, copy_end)中的随意复制操作没有验证是否会导致超出目标缓冲区限制。
+该问题于CVE-2021-43304非常相似，但是无保护的copy操作存在于不同的wildCopy调用里。
+
+作者：JFrog 安全研究团队
+
+### CVE-2021-42387
+在对恶意查询做语法分析时，ClickHouse的LZ4:decompressImpl循环会从压缩数据中读取一个用户提供的16bit无符号值（'offset'）。这个offset后面在复制操作作为长度使用时，没有检查是否超过复制源的上限。
+
+作者：JFrog 安全研究团队
+
+### CVE-2021-42388
+在对恶意查询做语法分析时，ClickHouse的LZ4:decompressImpl循环会从压缩数据中读取一个用户提供的16bit无符号值（'offset'）。这个offset后面在复制操作作为长度使用时，没有检查是否越过复制源的下限。
+
+作者：JFrog 安全研究团队
+
+### CVE-2021-42389
+在对恶意查询做语法分析时，ClickHouse的Delta压缩编码存在除零错误。压缩缓存的首字节在取模时没有判断是否为0。
+
+作者：JFrog 安全研究团队
+
+### CVE-2021-42390
+在对恶意查询做语法分析时，ClickHouse的DeltaDouble压缩编码存在除零错误。压缩缓存的首字节在取模时没有判断是否为0。
+
+作者：JFrog 安全研究团队
+
+### CVE-2021-42391
+在对恶意查询做语法分析时，  ClickHouse的Gorilla压缩编码存在除零错误，压缩缓存的首字节取模时没有判断是否为0。
+
+作者：JFrog 安全研究团队
+
+## 修复于ClickHouse 21.4.3.21，2021-04-12
+### CVE-2021-25263
+拥有CREATE DICTIONARY权限的攻击者，可以读取许可目录之外的任意文件。
+
+修复已推送至版本20.8.18.32-lts，21.1.9.41-stable，21.2.9.41-stable，21.3.6.55-lts，21.4.3.21-stable以及更早期的版本。
+
+作者：[Vyacheslav Egoshin](https://twitter.com/vegoshin)
 
 ## 修复于ClickHouse Release 19.14.3.3, 2019-09-10 {#fixed-in-clickhouse-release-19-14-3-3-2019-09-10}
 


### PR DESCRIPTION

### Changelog category (leave one):
- Documentation (changelog entry is not required)

update security-changelog in chinese, the original one  in [official website
](https://clickhouse.com/docs/en/whats-new/security-changelog/) has missed some new infomaiton

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
