### PR TITLE
Fix multipart upload for large S3 object

### DIFF
--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -166,7 +166,8 @@ void BackupWriterS3::copyObjectImpl(
 
     auto outcome = client->CopyObject(request);
 
-    if (!outcome.IsSuccess() && outcome.GetError().GetExceptionName() == "EntityTooLarge")
+    if (!outcome.IsSuccess() && (outcome.GetError().GetExceptionName() == "EntityTooLarge"
+            || outcome.GetError().GetExceptionName() == "InvalidRequest"))
     { // Can't come here with MinIO, MinIO allows single part upload for large objects.
         copyObjectMultipartImpl(src_bucket, src_key, dst_bucket, dst_key, head, metadata);
         return;

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -480,7 +480,8 @@ void S3ObjectStorage::copyObjectImpl(
 
     auto outcome = client_ptr->CopyObject(request);
 
-    if (!outcome.IsSuccess() && outcome.GetError().GetExceptionName() == "EntityTooLarge")
+    if (!outcome.IsSuccess() && (outcome.GetError().GetExceptionName() == "EntityTooLarge"
+            || outcome.GetError().GetExceptionName() == "InvalidRequest"))
     { // Can't come here with MinIO, MinIO allows single part upload for large objects.
         copyObjectMultipartImpl(src_bucket, src_key, dst_bucket, dst_key, head, metadata);
         return;


### PR DESCRIPTION
### Changelog category:

- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Fix using multipart upload for large S3 objects in AWS S3.

AWS S3 implementation returns "InvalidRequest" message when ClickHouse tries to copy large S3 object.
Code checked only "EntityTooLarge" message before (for Yandex.Cloud S3 implementation)

```2022.11.16 18:11:24.580575 [ 111299 ] {} <Error> Failed to run async task: Code: 499. DB::Exception: Unable to parse ExceptionName: InvalidRequest Message: The specified copy source is larger than the ma
ximum allowable size for a copy source: 5368709120 (Code: 100). (S3_ERROR), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0x78d553a in /usr/bin/clickhouse
1. DB::S3ObjectStorage::copyObjectImpl(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::al
locator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >
 const&, std::__1::optional<Aws::S3::Model::HeadObjectResult>, std::__1::optional<std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_stri
ng<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pa
ir<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > > >) const @ 0x11
6470f5 in /usr/bin/clickhouse
2. DB::S3ObjectStorage::copyObjectToAnotherObjectStorage(DB::StoredObject const&, DB::StoredObject const&, DB::IObjectStorage&, std::__1::optional<std::__1::map<std::__1::basic_string<char, std::__1::cha
r_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>
, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::cha
r_traits<char>, std::__1::allocator<char> > > > > >) @ 0x11646330 in /usr/bin/clickhouse
3. DB::DiskObjectStorageRemoteMetadataRestoreHelper::processRestoreFiles(DB::IObjectStorage*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::vecto
r<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > cons
t&) const @ 0x115f1a69 in /usr/bin/clickhouse
4. ? @ 0x115e0598 in /usr/bin/clickhouse
5. ThreadPoolImpl<ThreadFromGlobalPoolImpl<false> >::worker(std::__1::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0x797b4ac in /usr/bin/clickhouse
6. void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlo
balPoolImpl<false> >::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'(), void ()> >(std::__1::__function::__policy_storage co
nst*) @ 0x797e1d7 in /usr/bin/clickhouse
7. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x79779ec in /usr/bin/clickhouse
8. ? @ 0x797d0fe in /usr/bin/clickhouse
9. start_thread @ 0x76db in /lib/x86_64-linux-gnu/libpthread-2.27.so
10. clone @ 0x12161f in /lib/x86_64-linux-gnu/libc-2.27.so
 (version 22.9.4.32 (official build))
```
