### PR TITLE
Fix setting TCP_KEEPIDLE of client connection for s390x

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -148,7 +148,8 @@ void Connection::connect(const ConnectionTimeouts & timeouts)
         socket->setReceiveTimeout(timeouts.receive_timeout);
         socket->setSendTimeout(timeouts.send_timeout);
         socket->setNoDelay(true);
-        if (timeouts.tcp_keep_alive_timeout.totalSeconds())
+        int tcp_keep_alive_timeout_in_sec = timeouts.tcp_keep_alive_timeout.totalSeconds();
+        if (tcp_keep_alive_timeout_in_sec)
         {
             socket->setKeepAlive(true);
             socket->setOption(IPPROTO_TCP,
@@ -157,7 +158,7 @@ void Connection::connect(const ConnectionTimeouts & timeouts)
 #else
                 TCP_KEEPIDLE  // __APPLE__
 #endif
-                , timeouts.tcp_keep_alive_timeout);
+                , tcp_keep_alive_timeout_in_sec);
         }
 
         in = std::make_shared<ReadBufferFromPocoSocket>(*socket);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
In s390x, the code for setting TCP_KEEPIDLE by using Socket::setOption(int level, int option, const Poco::Timespan& value) throws exception (Invalid Argument Exception due to errno 22).
This function passes 16 bytes of buffer which cannot be accepted by s390x.
The fix is to use Socket::setOption(int level, int option, int value), which will pass an int address of value to setsockopt(). This is also the correct way for other platforms when setting TCP_KEEPIDLE, see the similar code in:

https://clickhouse.com/codebrowser/ClickHouse/contrib/libuv/src/unix/tcp.c.html#uv__tcp_keepalive

### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixed setting TCP_KEEPIDLE of client connection for s390x.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
