### PR TITLE
Rerun DocsCheck on edited PR description

### DIFF
--- a/tests/ci/cancel_and_rerun_workflow_lambda/app.py
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/app.py
@@ -13,14 +13,16 @@ import jwt
 import requests  # type: ignore
 import boto3  # type: ignore
 
-PULL_REQUEST_CI = "PullRequestCI"
+
+NEED_RERUN_ON_EDITED = {
+    "PullRequestCI",
+    "DocsCheck",
+}
 
 NEED_RERUN_OR_CANCELL_WORKFLOWS = {
-    PULL_REQUEST_CI,
-    "DocsCheck",
     "DocsReleaseChecks",
     "BackportPR",
-}
+}.union(NEED_RERUN_ON_EDITED)
 
 MAX_RETRY = 5
 
@@ -335,7 +337,7 @@ def main(event):
         most_recent_workflow = workflow_descriptions[-1]
         if (
             most_recent_workflow.status == "completed"
-            and most_recent_workflow.name == PULL_REQUEST_CI
+            and most_recent_workflow.name in NEED_RERUN_ON_EDITED
         ):
             print(
                 "The PR's body is changed and workflow is finished. "


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Rerun DocsCheck on edited PR description as well as PullRequestCI