### PR TITLE
Temporarily disable misc-* slow clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: '*,
 
     -android-*,
 
+    -bugprone-assignment-in-if-condition,
     -bugprone-branch-clone,
     -bugprone-easily-swappable-parameters,
     -bugprone-exception-escape,
@@ -23,7 +24,6 @@ Checks: '*,
     -bugprone-narrowing-conversions,
     -bugprone-not-null-terminated-result,
     -bugprone-unchecked-optional-access,
-    -bugprone-assignment-in-if-condition,
 
     -cert-dcl16-c,
     -cert-err58-cpp,
@@ -34,7 +34,6 @@ Checks: '*,
 
     -clang-analyzer-optin.performance.Padding,
     -clang-analyzer-optin.portability.UnixAPI,
-
     -clang-analyzer-security.insecureAPI.bzero,
     -clang-analyzer-security.insecureAPI.strcpy,
 
@@ -103,12 +102,13 @@ Checks: '*,
 
     -openmp-*,
 
+    -misc-const-correctness,
     -misc-no-recursion,
     -misc-non-private-member-variables-in-classes,
-    -misc-const-correctness,
 
     -modernize-avoid-c-arrays,
     -modernize-concat-nested-namespaces,
+    -modernize-macro-to-enum,
     -modernize-pass-by-value,
     -modernize-return-braced-init-list,
     -modernize-use-auto,
@@ -117,7 +117,6 @@ Checks: '*,
     -modernize-use-nodiscard,
     -modernize-use-override,
     -modernize-use-trailing-return-type,
-    -modernize-macro-to-enum,
 
     -performance-inefficient-string-concatenation,
     -performance-no-int-to-ptr,
@@ -135,11 +134,11 @@ Checks: '*,
     -readability-magic-numbers,
     -readability-named-parameter,
     -readability-redundant-declaration,
+    -readability-simplify-boolean-expr,
     -readability-static-accessed-through-instance,
     -readability-suspicious-call-argument,
     -readability-uppercase-literal-suffix,
     -readability-use-anyofallof,
-    -readability-simplify-boolean-expr,
 
     -zirkon-*,
 '

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -146,6 +146,11 @@ Checks: '*,
 
 WarningsAsErrors: '*'
 
+# TODO: use dictionary syntax for CheckOptions when minimum clang-tidy level rose to 15
+#           some-check.SomeOption: 'some value'
+#       instead of
+#           - key:             some-check.SomeOption
+#             value:           'some value'
 CheckOptions:
   - key: readability-identifier-naming.ClassCase
     value: CamelCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -141,6 +141,19 @@ Checks: '*,
     -readability-use-anyofallof,
 
     -zirkon-*,
+
+    -misc-*, # temporarily disabled due to being too slow
+    # also disable checks in other categories which are aliases of checks in misc-*:
+    # https://releases.llvm.org/15.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/list.html
+    -cert-dcl54-cpp,                                            # alias of misc-new-delete-overloads
+    -hicpp-new-delete-operators,                                # alias of misc-new-delete-overloads
+    -cert-fio38-c,                                              # alias of misc-non-copyable-objects
+    -cert-dcl03-c,                                              # alias of misc-static-assert
+    -hicpp-static-assert,                                       # alias of misc-static-assert
+    -cert-err09-cpp,                                            # alias of misc-throw-by-value-catch-by-reference
+    -cert-err61-cpp,                                            # alias of misc-throw-by-value-catch-by-reference
+    -cppcoreguidelines-c-copy-assignment-signature,             # alias of misc-unconventional-assign-operator
+    -cppcoreguidelines-non-private-member-variables-in-classes, # alias of misc-non-private-member-variables-in-classes
 '
 
 WarningsAsErrors: '*'

--- a/cmake/clang_tidy.cmake
+++ b/cmake/clang_tidy.cmake
@@ -5,21 +5,21 @@ if (ENABLE_CLANG_TIDY)
 
     find_program (CLANG_TIDY_CACHE_PATH NAMES "clang-tidy-cache")
     if (CLANG_TIDY_CACHE_PATH)
-        find_program (_CLANG_TIDY_PATH NAMES "clang-tidy" "clang-tidy-15" "clang-tidy-14" "clang-tidy-13" "clang-tidy-12")
+        find_program (_CLANG_TIDY_PATH NAMES "clang-tidy-15" "clang-tidy-14" "clang-tidy-13" "clang-tidy-12" "clang-tidy")
 
         # Why do we use ';' here?
         # It's a cmake black magic: https://cmake.org/cmake/help/latest/prop_tgt/LANG_CLANG_TIDY.html#prop_tgt:%3CLANG%3E_CLANG_TIDY
         # The CLANG_TIDY_PATH is passed to CMAKE_CXX_CLANG_TIDY, which follows CXX_CLANG_TIDY syntax.
         set (CLANG_TIDY_PATH "${CLANG_TIDY_CACHE_PATH};${_CLANG_TIDY_PATH}" CACHE STRING "A combined command to run clang-tidy with caching wrapper")
     else ()
-        find_program (CLANG_TIDY_PATH NAMES "clang-tidy" "clang-tidy-15" "clang-tidy-14" "clang-tidy-13" "clang-tidy-12")
+        find_program (CLANG_TIDY_PATH NAMES "clang-tidy-15" "clang-tidy-14" "clang-tidy-13" "clang-tidy-12" "clang-tidy")
     endif ()
 
     if (CLANG_TIDY_PATH)
         message (STATUS
             "Using clang-tidy: ${CLANG_TIDY_PATH}.
-            The checks will be run during build process.
-            See the .clang-tidy file at the root directory to configure the checks.")
+            The checks will be run during the build process.
+            See the .clang-tidy file in the root directory to configure the checks.")
 
         set (USE_CLANG_TIDY ON)
 


### PR DESCRIPTION
Based on some local bisecting, it seems like `misc-*` checks consumes the majority of clang-tidy runtime, leading to runtimes of 5+ hours in CI.

Temporarily changed a basic header to invalidate the clang-tidy cache in CI for unbiased results.

TODO: disable individual `misc-*` check(s) instead of the whole category

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)