### PR TITLE
Use only PRs to our repository in pr_info on push

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -2,7 +2,7 @@
 import json
 import logging
 import os
-from typing import Dict, Set, Union
+from typing import Dict, List, Set, Union
 
 from unidiff import PatchSet  # type: ignore
 
@@ -47,15 +47,22 @@ def get_pr_for_commit(sha, ref):
     try:
         response = get_with_retries(try_get_pr_url, sleep=RETRY_SLEEP)
         data = response.json()
+        our_prs = []  # type: List[Dict]
         if len(data) > 1:
             print("Got more than one pr for commit", sha)
         for pr in data:
+            # We need to check if the PR is created in our repo, because
+            # https://github.com/kaynewu/ClickHouse/pull/2
+            # has broke our PR search once in a while
+            if pr["base"]["repo"]["full_name"] != GITHUB_REPOSITORY:
+                continue
             # refs for pushes looks like refs/head/XX
             # refs for RPs looks like XX
             if pr["head"]["ref"] in ref:
                 return pr
+            our_prs.append(pr)
         print("Cannot find PR with required ref", ref, "returning first one")
-        first_pr = data[0]
+        first_pr = our_prs[0]
         return first_pr
     except Exception as ex:
         print("Cannot fetch PR info from commit", ex)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix search for PRs by ref name for cases when the PR is created __*from*__ our repository to another one.