### PR TITLE
Fix BACKUP TO S3 for Google Cloud Storage

### DIFF
--- a/src/Backups/BackupIO.h
+++ b/src/Backups/BackupIO.h
@@ -29,6 +29,7 @@ public:
     virtual UInt64 getFileSize(const String & file_name) = 0;
     virtual bool fileContentsEqual(const String & file_name, const String & expected_file_contents) = 0;
     virtual std::unique_ptr<WriteBuffer> writeFile(const String & file_name) = 0;
+    virtual void removeFile(const String & file_name) = 0;
     virtual void removeFiles(const Strings & file_names) = 0;
     virtual DataSourceDescription getDataSourceDescription() const = 0;
     virtual void copyFileThroughBuffer(std::unique_ptr<SeekableReadBuffer> && source, const String & file_name);

--- a/src/Backups/BackupIO_Disk.cpp
+++ b/src/Backups/BackupIO_Disk.cpp
@@ -75,6 +75,13 @@ std::unique_ptr<WriteBuffer> BackupWriterDisk::writeFile(const String & file_nam
     return disk->writeFile(file_path);
 }
 
+void BackupWriterDisk::removeFile(const String & file_name)
+{
+    disk->removeFileIfExists(path / file_name);
+    if (disk->isDirectory(path) && disk->isDirectoryEmpty(path))
+        disk->removeDirectory(path);
+}
+
 void BackupWriterDisk::removeFiles(const Strings & file_names)
 {
     for (const auto & file_name : file_names)

--- a/src/Backups/BackupIO_Disk.h
+++ b/src/Backups/BackupIO_Disk.h
@@ -34,6 +34,7 @@ public:
     UInt64 getFileSize(const String & file_name) override;
     bool fileContentsEqual(const String & file_name, const String & expected_file_contents) override;
     std::unique_ptr<WriteBuffer> writeFile(const String & file_name) override;
+    void removeFile(const String & file_name) override;
     void removeFiles(const Strings & file_names) override;
     DataSourceDescription getDataSourceDescription() const override;
 

--- a/src/Backups/BackupIO_File.cpp
+++ b/src/Backups/BackupIO_File.cpp
@@ -72,6 +72,13 @@ std::unique_ptr<WriteBuffer> BackupWriterFile::writeFile(const String & file_nam
     return std::make_unique<WriteBufferFromFile>(file_path);
 }
 
+void BackupWriterFile::removeFile(const String & file_name)
+{
+    fs::remove(path / file_name);
+    if (fs::is_directory(path) && fs::is_empty(path))
+        fs::remove(path);
+}
+
 void BackupWriterFile::removeFiles(const Strings & file_names)
 {
     for (const auto & file_name : file_names)

--- a/src/Backups/BackupIO_File.h
+++ b/src/Backups/BackupIO_File.h
@@ -31,6 +31,7 @@ public:
     UInt64 getFileSize(const String & file_name) override;
     bool fileContentsEqual(const String & file_name, const String & expected_file_contents) override;
     std::unique_ptr<WriteBuffer> writeFile(const String & file_name) override;
+    void removeFile(const String & file_name) override;
     void removeFiles(const Strings & file_names) override;
     DataSourceDescription getDataSourceDescription() const override;
     bool supportNativeCopy(DataSourceDescription data_source_description) const override;

--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -357,7 +357,48 @@ std::unique_ptr<WriteBuffer> BackupWriterS3::writeFile(const String & file_name)
         threadPoolCallbackRunner<void>(IOThreadPool::get(), "BackupWriterS3"));
 }
 
+void BackupWriterS3::removeFile(const String & file_name)
+{
+    Aws::S3::Model::DeleteObjectRequest request;
+    request.SetBucket(s3_uri.bucket);
+    request.SetKey(fs::path(s3_uri.key) / file_name);
+    auto outcome = client->DeleteObject(request);
+    if (!outcome.IsSuccess())
+        throw Exception(outcome.GetError().GetMessage(), ErrorCodes::S3_ERROR);
+}
+
 void BackupWriterS3::removeFiles(const Strings & file_names)
+{
+    try
+    {
+        if (!supports_batch_delete.has_value() || supports_batch_delete.value() == true)
+        {
+            removeFilesBatch(file_names);
+            supports_batch_delete = true;
+        }
+        else
+        {
+            for (const auto & file_name : file_names)
+                removeFile(file_name);
+        }
+    }
+    catch (const Exception &)
+    {
+        if (!supports_batch_delete.has_value())
+        {
+            supports_batch_delete = false;
+            LOG_TRACE(log, "DeleteObjects is not supported. Retrying with plain DeleteObject.");
+
+            for (const auto & file_name : file_names)
+                removeFile(file_name);
+        }
+        else
+            throw;
+    }
+
+}
+
+void BackupWriterS3::removeFilesBatch(const Strings & file_names)
 {
     /// One call of DeleteObjects() cannot remove more than 1000 keys.
     size_t chunk_size_limit = 1000;

--- a/src/Backups/BackupIO_S3.h
+++ b/src/Backups/BackupIO_S3.h
@@ -54,6 +54,7 @@ public:
     UInt64 getFileSize(const String & file_name) override;
     bool fileContentsEqual(const String & file_name, const String & expected_file_contents) override;
     std::unique_ptr<WriteBuffer> writeFile(const String & file_name) override;
+    void removeFile(const String & file_name) override;
     void removeFiles(const Strings & file_names) override;
 
     DataSourceDescription getDataSourceDescription() const override;
@@ -79,11 +80,14 @@ private:
         const Aws::S3::Model::HeadObjectResult & head,
         const std::optional<ObjectAttributes> & metadata = std::nullopt) const;
 
+    void removeFilesBatch(const Strings & file_names);
+
     S3::URI s3_uri;
     std::shared_ptr<Aws::S3::S3Client> client;
     ReadSettings read_settings;
     S3Settings::RequestSettings request_settings;
     Poco::Logger * log;
+    std::optional<bool> supports_batch_delete;
 };
 
 }

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -506,7 +506,7 @@ void BackupImpl::removeLockFile()
         return; /// Internal backup must not remove the lock file (it's still used by the initiator).
 
     if (checkLockFile(false))
-        writer->removeFiles({lock_file_name});
+        writer->removeFile(lock_file_name);
 }
 
 Strings BackupImpl::listFiles(const String & directory, bool recursive) const


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `BACKUP TO S3` for Google Cloud Storage

GCS does not support batch delete, regular S3 disk has a check for batch delete and a fallback to regular delete if it not supported, but for BACKUPs I think that it is OK to use non-batch delete always.

Follow-up for: #42333 (cc @vitlibar )