### PR TITLE
Fix order by positional arg in case unneeded columns pruning

### DIFF
--- a/tests/queries/0_stateless/02006_test_positional_arguments.reference
+++ b/tests/queries/0_stateless/02006_test_positional_arguments.reference
@@ -119,9 +119,25 @@ select b from (select 5 as a, 'Hello' as b order by 1);
 Hello
 drop table if exists tp2;
 create table tp2(first_col String, second_col Int32) engine = MergeTree() order by tuple();
+insert into tp2 select 'bbb', 1;
+insert into tp2 select 'aaa', 2;
 select count(*) from (select first_col, count(second_col) from tp2 group by 1);
-0
+2
 select total from (select first_col, count(second_col) as total from tp2 group by 1);
+1
+1
+select first_col from (select first_col, second_col as total from tp2 order by 1 desc);
+bbb
+aaa
+select first_col from (select first_col, second_col as total from tp2 order by 2 desc);
+aaa
+bbb
+select max from (select max(first_col) as max, second_col as total from tp2 group by 2) order by 1;
+aaa
+bbb
+with res as (select first_col from (select first_col, second_col as total from tp2 order by 2 desc) limit 1)
+select * from res;
+aaa
 drop table if exists test;
 create table test
 (

--- a/tests/queries/0_stateless/02006_test_positional_arguments.sql
+++ b/tests/queries/0_stateless/02006_test_positional_arguments.sql
@@ -51,8 +51,15 @@ select b from (select 5 as a, 'Hello' as b order by 1);
 
 drop table if exists tp2;
 create table tp2(first_col String, second_col Int32) engine = MergeTree() order by tuple();
+insert into tp2 select 'bbb', 1;
+insert into tp2 select 'aaa', 2;
 select count(*) from (select first_col, count(second_col) from tp2 group by 1);
 select total from (select first_col, count(second_col) as total from tp2 group by 1);
+select first_col from (select first_col, second_col as total from tp2 order by 1 desc);
+select first_col from (select first_col, second_col as total from tp2 order by 2 desc);
+select max from (select max(first_col) as max, second_col as total from tp2 group by 2) order by 1;
+with res as (select first_col from (select first_col, second_col as total from tp2 order by 2 desc) limit 1)
+select * from res;
 
 drop table if exists test;
 create table test


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix order by positional arg in case unneeded columns pruning. Closes https://github.com/ClickHouse/ClickHouse/issues/43964.
