### PR TITLE
Provide sha512 hashsums for tgz artifacts

### DIFF
--- a/packages/build
+++ b/packages/build
@@ -111,6 +111,8 @@ EOF
         tar -czf "$TARBALL" -C "$OUTPUT_DIR" "$PKG_DIR"
     fi
 
+    sha512sum "$TARBALL" > "$TARBALL".sha512
+
     rm -r "$PKG_PATH"
 }
 

--- a/tests/ci/build_report_check.py
+++ b/tests/ci/build_report_check.py
@@ -74,7 +74,7 @@ def group_by_artifacts(build_urls: List[str]) -> Dict[str, List[str]]:
             groups["apk"].append(url)
         elif url.endswith(".rpm"):
             groups["rpm"].append(url)
-        elif url.endswith(".tgz"):
+        elif url.endswith(".tgz") or url.endswith(".tgz.sha512"):
             groups["tgz"].append(url)
         else:
             groups["binary"].append(url)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Bring sha512 sums back to the building step