### PR TITLE
Assign release PRs

### DIFF
--- a/.github/workflows/tags_stable.yml
+++ b/.github/workflows/tags_stable.yml
@@ -61,6 +61,7 @@ jobs:
         committer: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
         commit-message: Update version_date.tsv and changelogs after ${{ env.GITHUB_TAG }}
         branch: auto/${{ env.GITHUB_TAG }}
+        assignees: ${{ github.event.sender.login }}  # assign the PR to the tag pusher
         delete-branch: true
         title: Update version_date.tsv and changelogs after ${{ env.GITHUB_TAG }}
         labels: do not test

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -388,7 +388,8 @@ class Release:
             body_file = get_abs_path(".github/PULL_REQUEST_TEMPLATE.md")
             self.run(
                 f"gh pr create --repo {self.repo} --title 'Update version after "
-                f"release' --head {helper_branch} --body-file '{body_file}'"
+                f"release' --head {helper_branch} --body-file '{body_file}' "
+                "--label 'do not test' --assignee @me"
             )
             # Here the testing part is done
             yield


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Assign release-related PRs to the author