### PR TITLE
[RFC] Buffer parts for MergeTree

### DIFF
--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -79,6 +79,7 @@
     M(PartsWide, "Wide parts.") \
     M(PartsCompact, "Compact parts.") \
     M(PartsInMemory, "In-memory parts.") \
+    M(PartsBuffer, "Buffer parts.") \
     M(MMappedFiles, "Total number of mmapped files.") \
     M(MMappedFileBytes, "Sum size of mmapped file regions.") \
     M(AsyncDrainedConnections, "Number of connections drained asynchronously.") \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -165,6 +165,7 @@
     M(InsertedWideParts, "Number of parts inserted in Wide format.") \
     M(InsertedCompactParts, "Number of parts inserted in Compact format.") \
     M(InsertedInMemoryParts, "Number of parts inserted in InMemory format.") \
+    M(InsertedBufferParts, "Number of parts inserted in Buffer format.") \
     M(MergedIntoWideParts, "Number of parts merged into Wide format.") \
     M(MergedIntoCompactParts, "Number of parts merged into Compact format.") \
     M(MergedIntoInMemoryParts, "Number of parts in merged into InMemory format.") \

--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -10,6 +10,7 @@
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTP/HTTPServerResponse.h>
 #include <Storages/MergeTree/MergeTreeDataPartInMemory.h>
+#include <Storages/MergeTree/MergeTreeDataPartBuffer.h>
 #include <Storages/MergeTree/MergedBlockOutputStream.h>
 #include <Storages/MergeTree/ReplicatedFetchList.h>
 #include <Storages/StorageReplicatedMergeTree.h>
@@ -144,6 +145,9 @@ void Service::processQuery(const HTMLForm & params, ReadBuffer & /*body*/, Write
     try
     {
         part = findPart(part_name);
+
+        if (isBufferPart(part))
+            throw Exception(ErrorCodes::ABORTED, "Buffer parts cannot be sent ({})", part->name);
 
         CurrentMetrics::Increment metric_increment{CurrentMetrics::ReplicatedSend};
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -49,6 +49,7 @@ namespace CurrentMetrics
     extern const Metric PartsWide;
     extern const Metric PartsCompact;
     extern const Metric PartsInMemory;
+    extern const Metric PartsBuffer;
 }
 
 namespace DB
@@ -276,6 +277,9 @@ static void incrementTypeMetric(MergeTreeDataPartType type)
         case MergeTreeDataPartType::InMemory:
             CurrentMetrics::add(CurrentMetrics::PartsInMemory);
             return;
+        case MergeTreeDataPartType::Buffer:
+            CurrentMetrics::add(CurrentMetrics::PartsBuffer);
+            return;
         case MergeTreeDataPartType::Unknown:
             return;
     }
@@ -293,6 +297,9 @@ static void decrementTypeMetric(MergeTreeDataPartType type)
             return;
         case MergeTreeDataPartType::InMemory:
             CurrentMetrics::sub(CurrentMetrics::PartsInMemory);
+            return;
+        case MergeTreeDataPartType::Buffer:
+            CurrentMetrics::sub(CurrentMetrics::PartsBuffer);
             return;
         case MergeTreeDataPartType::Unknown:
             return;
@@ -2026,6 +2033,11 @@ bool isWidePart(const MergeTreeDataPartPtr & data_part)
 bool isInMemoryPart(const MergeTreeDataPartPtr & data_part)
 {
     return (data_part && data_part->getType() == MergeTreeDataPartType::InMemory);
+}
+
+bool isBufferPart(const MergeTreeDataPartPtr & data_part)
+{
+    return (data_part && data_part->getType() == MergeTreeDataPartType::Buffer);
 }
 
 std::optional<std::string> getIndexExtensionFromFilesystem(const IDataPartStorage & data_part_storage)

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -310,6 +310,7 @@ public:
     UInt64 getIndexSizeInAllocatedBytes() const;
     UInt64 getMarksCount() const;
 
+    /// TODO: mark as virtual?
     UInt64 getBytesOnDisk() const { return bytes_on_disk; }
     void setBytesOnDisk(UInt64 bytes_on_disk_) { bytes_on_disk = bytes_on_disk_; }
 
@@ -591,6 +592,7 @@ using MergeTreeMutableDataPartPtr = std::shared_ptr<IMergeTreeDataPart>;
 bool isCompactPart(const MergeTreeDataPartPtr & data_part);
 bool isWidePart(const MergeTreeDataPartPtr & data_part);
 bool isInMemoryPart(const MergeTreeDataPartPtr & data_part);
+bool isBufferPart(const MergeTreeDataPartPtr & data_part);
 inline String getIndexExtension(bool is_compressed_primary_key) { return is_compressed_primary_key ? ".cidx" : ".idx"; }
 std::optional<String> getIndexExtensionFromFilesystem(const IDataPartStorage & data_part_storage);
 bool isCompressedFromIndexExtension(const String & index_extension);

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -449,6 +449,7 @@ public:
     };
 
     StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) const override;
+    StorageSnapshotPtr getStorageSnapshotForQuery(const StorageMetadataPtr & metadata_snapshot, const ASTPtr & /*query*/, ContextPtr query_context) const override;
 
     /// Load the set of data parts from disk. Call once - immediately after the object is created.
     void loadDataParts(bool skip_sanity_checks);
@@ -488,6 +489,7 @@ public:
     DataPartsVector getDataPartsVectorForInternalUsage() const;
 
     void filterVisibleDataParts(DataPartsVector & maybe_visible_parts, CSN snapshot_version, TransactionID current_tid) const;
+    void filterOutBufferDataParts(DataPartsVector & data_parts) const;
 
     /// Returns parts that visible with current snapshot
     DataPartsVector getVisibleDataPartsVector(ContextPtr local_context) const;
@@ -644,8 +646,10 @@ public:
     /// Removes parts from data_parts, they should be in Deleting state
     void removePartsFinally(const DataPartsVector & parts);
 
-    /// When WAL is not enabled, the InMemoryParts need to be persistent.
+    /// When WAL is not enabled, the InMemory parts need to be persistent.
     void flushAllInMemoryPartsIfNeeded();
+    /// When WAL is not enabled, the Buffer parts need to be persistent.
+    void flushAllBufferPartsIfNeeded();
 
     /// Delete irrelevant parts from memory and disk.
     /// If 'force' - don't wait for old_parts_lifetime.

--- a/src/Storages/MergeTree/MergeTreeDataPartBuffer.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartBuffer.cpp
@@ -1,0 +1,190 @@
+#include <Storages/MergeTree/MergeTreeDataPartBuffer.h>
+#include <Storages/MergeTree/MergeTreeReaderBuffer.h>
+#include <Storages/MergeTree/MergedBlockOutputStream.h>
+#include <Storages/MergeTree/MergeTreeDataPartWriterBuffer.h>
+#include <Storages/MergeTree/IMergeTreeReader.h>
+#include <Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h>
+#include <Storages/MergeTree/DataPartStorageOnDisk.h>
+#include <DataTypes/NestedUtils.h>
+#include <Disks/createVolume.h>
+#include <Interpreters/Context.h>
+#include <Poco/Logger.h>
+#include <Common/logger_useful.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int DIRECTORY_ALREADY_EXISTS;
+}
+
+
+MergeTreeDataPartBuffer::MergeTreeDataPartBuffer(
+       MergeTreeData & storage_,
+        const String & name_,
+        const MutableDataPartStoragePtr & data_part_storage_,
+        const IMergeTreeDataPart * parent_part_)
+    : IMergeTreeDataPart(storage_, name_, data_part_storage_, Type::Buffer, parent_part_)
+{
+    default_codec = CompressionCodecFactory::instance().get("NONE", {});
+}
+
+MergeTreeDataPartBuffer::MergeTreeDataPartBuffer(
+        const MergeTreeData & storage_,
+        const String & name_,
+        const MergeTreePartInfo & info_,
+        const MutableDataPartStoragePtr & data_part_storage_,
+        const IMergeTreeDataPart * parent_part_)
+    : IMergeTreeDataPart(storage_, name_, info_, data_part_storage_, Type::Buffer, parent_part_)
+{
+    default_codec = CompressionCodecFactory::instance().get("NONE", {});
+}
+
+IMergeTreeDataPart::MergeTreeReaderPtr MergeTreeDataPartBuffer::getReader(
+    const NamesAndTypesList & columns_to_read,
+    const StorageMetadataPtr & metadata_snapshot,
+    const MarkRanges & mark_ranges,
+    UncompressedCache * /* uncompressed_cache */,
+    MarkCache * /* mark_cache */,
+    const MergeTreeReaderSettings & reader_settings,
+    const ValueSizeMap & /* avg_value_size_hints */,
+    const ReadBufferFromFileBase::ProfileCallback & /* profile_callback */) const
+{
+    auto read_info = std::make_shared<LoadedMergeTreeDataPartInfoForReader>(shared_from_this());
+    auto ptr = std::static_pointer_cast<const MergeTreeDataPartBuffer>(shared_from_this());
+    return std::make_unique<MergeTreeReaderBuffer>(
+        read_info, ptr, columns_to_read, metadata_snapshot, mark_ranges, reader_settings);
+}
+
+IMergeTreeDataPart::MergeTreeWriterPtr MergeTreeDataPartBuffer::getWriter(
+    const NamesAndTypesList & columns_list,
+    const StorageMetadataPtr & metadata_snapshot,
+    const std::vector<MergeTreeIndexPtr> & /* indices_to_recalc */,
+    const CompressionCodecPtr & /* default_codec */,
+    const MergeTreeWriterSettings & writer_settings,
+    const MergeTreeIndexGranularity & /* computed_index_granularity */)
+{
+    auto ptr = std::static_pointer_cast<MergeTreeDataPartBuffer>(shared_from_this());
+    return std::make_unique<MergeTreeDataPartWriterBuffer>(
+        ptr, columns_list, metadata_snapshot, writer_settings);
+}
+
+MutableDataPartStoragePtr MergeTreeDataPartBuffer::flushToDisk(const String & new_relative_path, const StorageMetadataPtr & metadata_snapshot) const
+{
+    auto reservation = storage.reserveSpace(block.bytes(), getDataPartStorage());
+    VolumePtr volume = storage.getStoragePolicy()->getVolume(0);
+    VolumePtr data_part_volume = createVolumeFromReservation(reservation, volume);
+
+    auto new_data_part_storage = std::make_shared<DataPartStorageOnDisk>(
+        data_part_volume,
+        storage.getRelativeDataPath(),
+        new_relative_path);
+
+    new_data_part_storage->beginTransaction();
+
+    auto current_full_path = getDataPartStorage().getFullPath();
+    auto new_type = storage.choosePartTypeOnDisk(block.bytes(), rows_count);
+    auto new_data_part = storage.createPart(name, new_type, info, new_data_part_storage);
+
+    new_data_part->uuid = uuid;
+    new_data_part->setColumns(columns, {});
+    new_data_part->partition.value = partition.value;
+    new_data_part->minmax_idx = minmax_idx;
+
+    if (new_data_part_storage->exists())
+    {
+        throw Exception(
+            ErrorCodes::DIRECTORY_ALREADY_EXISTS,
+            "Could not flush part {}. Part in {} already exists",
+            quoteString(current_full_path),
+            new_data_part_storage->getFullPath());
+    }
+
+    new_data_part_storage->createDirectories();
+
+    auto compression_codec = storage.getContext()->chooseCompressionCodec(0, 0);
+    auto indices = MergeTreeIndexFactory::instance().getMany(metadata_snapshot->getSecondaryIndices());
+    MergedBlockOutputStream out(new_data_part, metadata_snapshot, columns, indices, compression_codec, NO_TRANSACTION_PTR);
+    out.write(block);
+    const auto & projections = metadata_snapshot->getProjections();
+    for (const auto & [projection_name, projection] : projection_parts)
+    {
+        if (projections.has(projection_name))
+        {
+            auto projection_part_storage = new_data_part_storage->getProjection(projection_name + ".proj");
+            if (projection_part_storage->exists())
+            {
+                throw Exception(
+                    ErrorCodes::DIRECTORY_ALREADY_EXISTS,
+                    "Could not flush projection part {}. Projection part in {} already exists",
+                    projection_name,
+                    projection_part_storage->getFullPath());
+            }
+
+            auto projection_part = asBufferPart(projection);
+            auto projection_type = storage.choosePartTypeOnDisk(projection_part->block.bytes(), rows_count);
+            MergeTreePartInfo projection_info("all", 0, 0, 0);
+            auto projection_data_part
+                = storage.createPart(projection_name, projection_type, projection_info, projection_part_storage, parent_part);
+            projection_data_part->is_temp = false; // clean up will be done on parent part
+            projection_data_part->setColumns(projection->getColumns(), {});
+
+            projection_part_storage->createDirectories();
+            const auto & desc = projections.get(name);
+            auto projection_compression_codec = storage.getContext()->chooseCompressionCodec(0, 0);
+            auto projection_indices = MergeTreeIndexFactory::instance().getMany(desc.metadata->getSecondaryIndices());
+            MergedBlockOutputStream projection_out(
+                projection_data_part, desc.metadata, projection_part->columns, projection_indices,
+                projection_compression_codec, NO_TRANSACTION_PTR);
+
+            projection_out.write(projection_part->block);
+            projection_out.finalizePart(projection_data_part, false);
+            new_data_part->addProjectionPart(projection_name, std::move(projection_data_part));
+        }
+    }
+
+    out.finalizePart(new_data_part, false);
+    new_data_part_storage->commitTransaction();
+    return new_data_part_storage;
+}
+
+void MergeTreeDataPartBuffer::makeCloneInDetached(const String & prefix, const StorageMetadataPtr & metadata_snapshot) const
+{
+    String detached_path = *getRelativePathForDetachedPart(prefix, /* broken */ false);
+    flushToDisk(detached_path, metadata_snapshot);
+}
+
+void MergeTreeDataPartBuffer::renameTo(const String & new_relative_path, bool /* remove_new_dir_if_exists */)
+{
+    getDataPartStorage().setRelativePath(new_relative_path);
+}
+
+void MergeTreeDataPartBuffer::calculateEachColumnSizes(ColumnSizeByName & each_columns_size, ColumnSize & total_size) const
+{
+    auto it = checksums.files.find("data.bin");
+    if (it != checksums.files.end())
+        total_size.data_uncompressed += it->second.uncompressed_size;
+
+    for (const auto & column : columns)
+        each_columns_size[column.name].data_uncompressed += block.getByName(column.name).column->byteSize();
+}
+
+IMergeTreeDataPart::Checksum MergeTreeDataPartBuffer::calculateBlockChecksum() const
+{
+    SipHash hash;
+    IMergeTreeDataPart::Checksum checksum;
+    for (const auto & column : block)
+        column.column->updateHashFast(hash);
+
+    checksum.uncompressed_size = block.bytes();
+    hash.get128(checksum.uncompressed_hash);
+    return checksum;
+}
+
+DataPartBufferPtr asBufferPart(const MergeTreeDataPartPtr & part)
+{
+    return std::dynamic_pointer_cast<const MergeTreeDataPartBuffer>(part);
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeDataPartBuffer.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartBuffer.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <Storages/MergeTree/IMergeTreeDataPart.h>
+
+namespace DB
+{
+
+class UncompressedCache;
+
+/// FIXME: duplicate of MergeTreeReaderInMemory
+class MergeTreeDataPartBuffer : public IMergeTreeDataPart
+{
+public:
+    MergeTreeDataPartBuffer(
+        const MergeTreeData & storage_,
+        const String & name_,
+        const MergeTreePartInfo & info_,
+        const MutableDataPartStoragePtr & data_part_storage_,
+        const IMergeTreeDataPart * parent_part_ = nullptr);
+
+    MergeTreeDataPartBuffer(
+        MergeTreeData & storage_,
+        const String & name_,
+        const MutableDataPartStoragePtr & data_part_storage_,
+        const IMergeTreeDataPart * parent_part_ = nullptr);
+
+    MergeTreeReaderPtr getReader(
+        const NamesAndTypesList & columns,
+        const StorageMetadataPtr & metadata_snapshot,
+        const MarkRanges & mark_ranges,
+        UncompressedCache * uncompressed_cache,
+        MarkCache * mark_cache,
+        const MergeTreeReaderSettings & reader_settings_,
+        const ValueSizeMap & avg_value_size_hints,
+        const ReadBufferFromFileBase::ProfileCallback & profile_callback) const override;
+
+    MergeTreeWriterPtr getWriter(
+        const NamesAndTypesList & columns_list,
+        const StorageMetadataPtr & metadata_snapshot,
+        const std::vector<MergeTreeIndexPtr> & indices_to_recalc,
+        const CompressionCodecPtr & default_codec_,
+        const MergeTreeWriterSettings & writer_settings,
+        const MergeTreeIndexGranularity & computed_index_granularity) override;
+
+    bool isStoredOnDisk() const override { return false; }
+    bool isStoredOnRemoteDisk() const override { return false; }
+    bool isStoredOnRemoteDiskWithZeroCopySupport() const override { return false; }
+    bool hasColumnFiles(const NameAndTypePair & column) const override { return !!getColumnPosition(column.getNameInStorage()); }
+    String getFileNameForColumn(const NameAndTypePair & /* column */) const override { return ""; }
+    void renameTo(const String & new_relative_path, bool remove_new_dir_if_exists) override;
+    void makeCloneInDetached(const String & prefix, const StorageMetadataPtr & metadata_snapshot) const override;
+
+    MutableDataPartStoragePtr flushToDisk(const String & new_relative_path, const StorageMetadataPtr & metadata_snapshot) const;
+
+    /// Returns hash of parts's block
+    Checksum calculateBlockChecksum() const;
+
+    mutable Block block;
+
+private:
+    mutable std::condition_variable is_merged;
+
+    /// Calculates uncompressed sizes in memory.
+    void calculateEachColumnSizes(ColumnSizeByName & each_columns_size, ColumnSize & total_size) const override;
+};
+
+using DataPartBufferPtr = std::shared_ptr<const MergeTreeDataPartBuffer>;
+using MutableDataPartBufferPtr = std::shared_ptr<MergeTreeDataPartBuffer>;
+
+DataPartBufferPtr asBufferPart(const MergeTreeDataPartPtr & part);
+
+}

--- a/src/Storages/MergeTree/MergeTreeDataPartType.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartType.h
@@ -21,6 +21,11 @@ public:
         /// Format with buffering data in RAM.
         InMemory,
 
+        /// Data stored in a buffer (backed by WAL) only, so until committed:
+        /// - data from Buffer part is not available to the SELECT,
+        /// - no data in coordinator.
+        Buffer,
+
         Unknown,
     };
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterBuffer.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterBuffer.cpp
@@ -1,0 +1,89 @@
+#include <Storages/MergeTree/MergeTreeDataPartWriterBuffer.h>
+#include <Storages/MergeTree/MergeTreeDataPartBuffer.h>
+#include <Storages/MergeTree/MergeTreeWriteAheadLog.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+MergeTreeDataPartWriterBuffer::MergeTreeDataPartWriterBuffer(
+    const MutableDataPartBufferPtr & part_,
+    const NamesAndTypesList & columns_list_,
+    const StorageMetadataPtr & metadata_snapshot_,
+    const MergeTreeWriterSettings & settings_)
+    : IMergeTreeDataPartWriter(part_, columns_list_, metadata_snapshot_, settings_)
+    , part_buffer(part_) {}
+
+void MergeTreeDataPartWriterBuffer::write(
+    const Block & block, const IColumn::Permutation * permutation)
+{
+    if (part_buffer->block)
+        throw Exception("DataPartWriterBuffer supports only one write", ErrorCodes::LOGICAL_ERROR);
+
+    Block primary_key_block;
+    if (settings.rewrite_primary_key)
+        primary_key_block = getBlockAndPermute(block, metadata_snapshot->getPrimaryKeyColumns(), permutation);
+
+    Block result_block;
+    if (permutation)
+    {
+        for (const auto & col : columns_list)
+        {
+            if (primary_key_block.has(col.name))
+                result_block.insert(primary_key_block.getByName(col.name));
+            else
+            {
+                auto permuted = block.getByName(col.name);
+                permuted.column = permuted.column->permute(*permutation, 0);
+                result_block.insert(permuted);
+            }
+        }
+    }
+    else
+    {
+        for (const auto & col : columns_list)
+            result_block.insert(block.getByName(col.name));
+    }
+
+    index_granularity.appendMark(result_block.rows());
+    if (with_final_mark)
+        index_granularity.appendMark(0);
+    part_buffer->block = std::move(result_block);
+
+    if (settings.rewrite_primary_key)
+        calculateAndSerializePrimaryIndex(primary_key_block);
+}
+
+void MergeTreeDataPartWriterBuffer::calculateAndSerializePrimaryIndex(const Block & primary_index_block)
+{
+    size_t rows = primary_index_block.rows();
+    if (!rows)
+        return;
+
+    size_t primary_columns_num = primary_index_block.columns();
+    index_columns.resize(primary_columns_num);
+    for (size_t i = 0; i < primary_columns_num; ++i)
+    {
+        const auto & primary_column = *primary_index_block.getByPosition(i).column;
+        index_columns[i] = primary_column.cloneEmpty();
+        index_columns[i]->insertFrom(primary_column, 0);
+        if (with_final_mark)
+            index_columns[i]->insertFrom(primary_column, rows - 1);
+    }
+}
+
+void MergeTreeDataPartWriterBuffer::fillChecksums(IMergeTreeDataPart::Checksums & checksums)
+{
+    /// If part is empty we still need to initialize block by empty columns.
+    if (!part_buffer->block)
+        for (const auto & column : columns_list)
+            part_buffer->block.insert(ColumnWithTypeAndName{column.type, column.name});
+
+    checksums.files["data.bin"] = part_buffer->calculateBlockChecksum();
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterBuffer.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterBuffer.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <Storages/MergeTree/IMergeTreeDataPartWriter.h>
+#include <Storages/MergeTree/MergeTreeDataPartBuffer.h>
+
+namespace DB
+{
+
+/// Writes Buffer data part.
+/// FIXME: duplicate of MergeTreeReaderInMemory
+class MergeTreeDataPartWriterBuffer : public IMergeTreeDataPartWriter
+{
+public:
+    MergeTreeDataPartWriterBuffer(
+        const MutableDataPartBufferPtr & part_,
+        const NamesAndTypesList & columns_list_,
+        const StorageMetadataPtr & metadata_snapshot,
+        const MergeTreeWriterSettings & settings_);
+
+    /// You can write only one block. Buffer part can be written only at INSERT.
+    void write(const Block & block, const IColumn::Permutation * permutation) override;
+
+    void fillChecksums(IMergeTreeDataPart::Checksums & checksums) override;
+    void finish(bool /*sync*/) override {}
+
+private:
+    void calculateAndSerializePrimaryIndex(const Block & primary_index_block);
+
+    MutableDataPartBufferPtr part_buffer;
+};
+
+}

--- a/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.cpp
@@ -83,6 +83,8 @@ std::string MarkType::getFileExtension() const
             return res + "3";
         case MergeTreeDataPartType::InMemory:
             return "";
+        case MergeTreeDataPartType::Buffer:
+            return "";
         case MergeTreeDataPartType::Unknown:
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical error: unknown data part type");
     }
@@ -122,14 +124,19 @@ void MergeTreeIndexGranularityInfo::changeGranularityIfRequired(const IDataPartS
 
 size_t MergeTreeIndexGranularityInfo::getMarkSizeInBytes(size_t columns_num) const
 {
-    if (mark_type.part_type == MergeTreeDataPartType::Wide)
-        return mark_type.adaptive ? getAdaptiveMrkSizeWide() : getNonAdaptiveMrkSizeWide();
-    else if (mark_type.part_type == MergeTreeDataPartType::Compact)
-        return getAdaptiveMrkSizeCompact(columns_num);
-    else if (mark_type.part_type == MergeTreeDataPartType::InMemory)
-        return 0;
-    else
-        throw Exception("Unknown part type", ErrorCodes::UNKNOWN_PART_TYPE);
+    switch (mark_type.part_type)
+    {
+        case MergeTreeDataPartType::Wide:
+            return mark_type.adaptive ? getAdaptiveMrkSizeWide() : getNonAdaptiveMrkSizeWide();
+        case MergeTreeDataPartType::Compact:
+            return getAdaptiveMrkSizeCompact(columns_num);
+        case MergeTreeDataPartType::InMemory:
+            return 0;
+        case MergeTreeDataPartType::Buffer:
+            return 0;
+        case MergeTreeDataPartType::Unknown:
+            throw Exception("Unknown part type", ErrorCodes::UNKNOWN_PART_TYPE);
+    }
 }
 
 size_t getAdaptiveMrkSizeCompact(size_t columns_num)

--- a/src/Storages/MergeTree/MergeTreeReaderBuffer.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderBuffer.cpp
@@ -1,0 +1,117 @@
+#include <Storages/MergeTree/MergeTreeReaderBuffer.h>
+#include <Storages/MergeTree/MergeTreeDataPartBuffer.h>
+#include <Interpreters/getColumnFromBlock.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/NestedUtils.h>
+#include <Columns/ColumnArray.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_READ_ALL_DATA;
+    extern const int ARGUMENT_OUT_OF_BOUND;
+}
+
+
+MergeTreeReaderBuffer::MergeTreeReaderBuffer(
+    MergeTreeDataPartInfoForReaderPtr data_part_info_for_read_,
+    DataPartBufferPtr data_part_,
+    NamesAndTypesList columns_,
+    const StorageMetadataPtr & metadata_snapshot_,
+    MarkRanges mark_ranges_,
+    MergeTreeReaderSettings settings_)
+    : IMergeTreeReader(
+        data_part_info_for_read_,
+        columns_,
+        metadata_snapshot_,
+        nullptr,
+        nullptr,
+        mark_ranges_,
+        settings_,
+        {})
+    , part_in_memory(std::move(data_part_))
+{
+    for (const auto & column_to_read : columns_to_read)
+    {
+        /// If array of Nested column is missing in part,
+        /// we have to read its offsets if they exist.
+        if (typeid_cast<const DataTypeArray *>(column_to_read.type.get())
+            && !tryGetColumnFromBlock(part_in_memory->block, column_to_read))
+        {
+            if (auto offsets_position = findColumnForOffsets(column_to_read))
+            {
+                positions_for_offsets[column_to_read.name] = *offsets_position;
+                partially_read_columns.insert(column_to_read.name);
+            }
+        }
+    }
+}
+
+size_t MergeTreeReaderBuffer::readRows(
+    size_t from_mark, size_t /* current_task_last_mark */, bool continue_reading, size_t max_rows_to_read, Columns & res_columns)
+{
+    if (!continue_reading)
+        total_rows_read = 0;
+
+    size_t total_marks = data_part_info_for_read->getIndexGranularity().getMarksCount();
+    if (from_mark >= total_marks)
+        throw Exception("Mark " + toString(from_mark) + " is out of bound. Max mark: "
+            + toString(total_marks), ErrorCodes::ARGUMENT_OUT_OF_BOUND);
+
+    size_t num_columns = res_columns.size();
+    checkNumberOfColumns(num_columns);
+
+    size_t part_rows = part_in_memory->block.rows();
+    if (total_rows_read >= part_rows)
+        throw Exception("Cannot read data in MergeTreeReaderBuffer. Rows already read: "
+            + toString(total_rows_read) + ". Rows in part: " + toString(part_rows), ErrorCodes::CANNOT_READ_ALL_DATA);
+
+    size_t rows_to_read = std::min(max_rows_to_read, part_rows - total_rows_read);
+    for (size_t i = 0; i < num_columns; ++i)
+    {
+        const auto & column_to_read = columns_to_read[i];
+
+        /// Copy offsets, if array of Nested column is missing in part.
+        auto offsets_it = positions_for_offsets.find(column_to_read.name);
+        if (offsets_it != positions_for_offsets.end() && !column_to_read.isSubcolumn())
+        {
+            const auto & source_offsets = assert_cast<const ColumnArray &>(
+                *part_in_memory->block.getByPosition(offsets_it->second).column).getOffsets();
+
+            if (res_columns[i] == nullptr)
+                res_columns[i] = column_to_read.type->createColumn();
+
+            auto mutable_column = res_columns[i]->assumeMutable();
+            auto & res_offstes = assert_cast<ColumnArray &>(*mutable_column).getOffsets();
+            size_t start_offset = total_rows_read ? source_offsets[total_rows_read - 1] : 0;
+            for (size_t row = 0; row < rows_to_read; ++row)
+                res_offstes.push_back(source_offsets[total_rows_read + row] - start_offset);
+
+            res_columns[i] = std::move(mutable_column);
+        }
+        else if (part_in_memory->hasColumnFiles(column_to_read))
+        {
+            auto block_column = getColumnFromBlock(part_in_memory->block, column_to_read);
+            if (rows_to_read == part_rows)
+            {
+                res_columns[i] = block_column;
+            }
+            else
+            {
+                if (res_columns[i] == nullptr)
+                    res_columns[i] = column_to_read.type->createColumn();
+
+                auto mutable_column = res_columns[i]->assumeMutable();
+                mutable_column->insertRangeFrom(*block_column, total_rows_read, rows_to_read);
+                res_columns[i] = std::move(mutable_column);
+            }
+        }
+    }
+
+    total_rows_read += rows_to_read;
+    return rows_to_read;
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeReaderBuffer.h
+++ b/src/Storages/MergeTree/MergeTreeReaderBuffer.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <Core/NamesAndTypes.h>
+#include <Storages/MergeTree/IMergeTreeReader.h>
+
+
+namespace DB
+{
+
+class MergeTreeDataPartBuffer;
+using DataPartBufferPtr = std::shared_ptr<const MergeTreeDataPartBuffer>;
+
+/// Reader for Buffer parts
+/// FIXME: duplicate of MergeTreeReaderInMemory
+class MergeTreeReaderBuffer : public IMergeTreeReader
+{
+public:
+    MergeTreeReaderBuffer(
+        MergeTreeDataPartInfoForReaderPtr data_part_info_for_read_,
+        DataPartBufferPtr data_part_,
+        NamesAndTypesList columns_,
+        const StorageMetadataPtr & metadata_snapshot_,
+        MarkRanges mark_ranges_,
+        MergeTreeReaderSettings settings_);
+
+    /// Return the number of rows has been read or zero if there is no columns to read.
+    /// If continue_reading is true, continue reading from last state, otherwise seek to from_mark
+    size_t readRows(size_t from_mark, size_t current_tasl_last_mark,
+                    bool continue_reading, size_t max_rows_to_read, Columns & res_columns) override;
+
+    bool canReadIncompleteGranules() const override { return true; }
+
+private:
+    size_t total_rows_read = 0;
+    DataPartBufferPtr part_in_memory;
+
+    std::unordered_map<String, size_t> positions_for_offsets;
+};
+
+}

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -27,14 +27,25 @@ struct Settings;
     M(UInt64, index_granularity, 8192, "How many rows correspond to one primary key value.", 0) \
     \
     /** Data storing format settings. */ \
+    M(Float, ratio_of_defaults_for_sparse_serialization, 1.0, "Minimal ratio of number of default values to number of all values in column to store it in sparse serializations. If >= 1, columns will be always written in full serialization.", 0) \
+    /** Compact parts */ \
     M(UInt64, min_bytes_for_wide_part, 10485760, "Minimal uncompressed size in bytes to create part in wide format instead of compact", 0) \
     M(UInt64, min_rows_for_wide_part, 0, "Minimal number of rows to create part in wide format instead of compact", 0) \
+    /** InMemory parts */ \
     M(UInt64, min_bytes_for_compact_part, 0, "Experimental. Minimal uncompressed size in bytes to create part in compact format instead of saving it in RAM", 0) \
     M(UInt64, min_rows_for_compact_part, 0, "Experimental. Minimal number of rows to create part in compact format instead of saving it in RAM", 0) \
     M(Bool, in_memory_parts_enable_wal, true, "Whether to write blocks in Native format to write-ahead-log before creation in-memory part", 0) \
-    M(UInt64, write_ahead_log_max_bytes, 1024 * 1024 * 1024, "Rotate WAL, if it exceeds that amount of bytes", 0) \
-    M(Float, ratio_of_defaults_for_sparse_serialization, 1.0, "Minimal ratio of number of default values to number of all values in column to store it in sparse serializations. If >= 1, columns will be always written in full serialization.", 0) \
+    M(Bool, in_memory_parts_insert_sync, false, "If true insert of part with in-memory format will wait for fsync of WAL", 0) \
+    /** Buffer parts */ \
+    M(UInt64, min_bytes_for_in_memory_part, 0, "Experimental. Minimal uncompressed size in bytes to create part in InMemory format instead of using Buffer part for it.", 0) \
+    M(UInt64, min_rows_for_in_memory_part, 0, "Experimental. Minimal number of rows to create part in InMemory format instead of using Buffer part for it.", 0) \
+    M(Bool, buffer_parts_enable_wal, true, "Whether to write blocks in Native format to write-ahead-log before creation Buffer part", 0) \
+    M(Bool, buffer_parts_insert_sync, false, "If true insert of part with in-memory format will wait for fsync of WAL", 0) \
     \
+    /** WAL settings for InMemory/Buffer */ \
+    M(UInt64, write_ahead_log_max_bytes, 1024 * 1024 * 1024, "Rotate WAL, if it exceeds that amount of bytes", 0) \
+    M(UInt64, write_ahead_log_bytes_to_fsync, 100ULL * 1024 * 1024, "Amount of bytes, accumulated in WAL to do fsync.", 0) \
+    M(UInt64, write_ahead_log_interval_ms_to_fsync, 100, "Interval in milliseconds after which fsync for WAL is being done.", 0) \
     /** Merge settings. */ \
     M(UInt64, merge_max_block_size, DEFAULT_MERGE_BLOCK_SIZE, "How many rows in blocks should be formed for merge operations.", 0) \
     M(UInt64, max_bytes_to_merge_at_max_space_in_pool, 150ULL * 1024 * 1024 * 1024, "Maximum in total size of parts to merge, when there are maximum free threads in background pool (or entries in replication queue).", 0) \
@@ -53,9 +64,6 @@ struct Settings;
     M(UInt64, min_compressed_bytes_to_fsync_after_fetch, 0, "Minimal number of compressed bytes to do fsync for part after fetch (0 - disabled)", 0) \
     M(Bool, fsync_after_insert, false, "Do fsync for every inserted part. Significantly decreases performance of inserts, not recommended to use with wide parts.", 0) \
     M(Bool, fsync_part_directory, false, "Do fsync for part directory after all part operations (writes, renames, etc.).", 0) \
-    M(UInt64, write_ahead_log_bytes_to_fsync, 100ULL * 1024 * 1024, "Amount of bytes, accumulated in WAL to do fsync.", 0) \
-    M(UInt64, write_ahead_log_interval_ms_to_fsync, 100, "Interval in milliseconds after which fsync for WAL is being done.", 0) \
-    M(Bool, in_memory_parts_insert_sync, false, "If true insert of part with in-memory format will wait for fsync of WAL", 0) \
     M(UInt64, non_replicated_deduplication_window, 0, "How many last blocks of hashes should be kept on disk (0 - disabled).", 0) \
     M(UInt64, max_parts_to_merge_at_once, 100, "Max amount of parts which can be merged at once (0 - disabled). Doesn't affect OPTIMIZE FINAL query.", 0) \
     M(UInt64, merge_selecting_sleep_ms, 5000, "Sleep time for merge selecting when no part selected, a lower setting will trigger selecting tasks in background_schedule_pool frequently which result in large amount of requests to zookeeper in large-scale clusters", 0) \

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
@@ -93,6 +93,9 @@ private:
         size_t replicas_num,
         bool writing_existing_part);
 
+    /// Rename temporary part and *do not commit* to ZooKeeper (only WAL, if any).
+    void commitBufferPart(MergeTreeData::MutableDataPartPtr & part);
+
     /// Wait for quorum to be satisfied on path (quorum_path) form part (part_name)
     /// Also checks that replica still alive.
     void waitForQuorum(

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -164,6 +164,7 @@ void StorageMergeTree::flush()
         return;
 
     flushAllInMemoryPartsIfNeeded();
+    flushAllBufferPartsIfNeeded();
 }
 
 void StorageMergeTree::shutdown()

--- a/tests/queries/0_stateless/02500_mergetree_buffer_parts.reference
+++ b/tests/queries/0_stateless/02500_mergetree_buffer_parts.reference
@@ -1,0 +1,76 @@
+# vim: ft=sql
+-- { echoOn }
+
+
+-- {'name': 'mergetree', 'engine': 'MergeTree'}
+drop table if exists buffer_parts_mergetree;
+create table buffer_parts_mergetree
+    (key Int)
+    engine=MergeTree
+    order by key
+    settings min_bytes_for_in_memory_part=1e6;
+insert into buffer_parts_mergetree select * from numbers(5);
+-- check that data will not be deduplicated
+insert into buffer_parts_mergetree select * from numbers(5);
+select name, part_type, _state from system.parts where database = currentDatabase() and table = 'buffer_parts_mergetree';
+all_1_1_0	Buffer	Active
+all_2_2_0	Buffer	Active
+select * from buffer_parts_mergetree;
+-- check WAL
+detach table buffer_parts_mergetree;
+attach table buffer_parts_mergetree;
+select * from buffer_parts_mergetree;
+select name, part_type, _state from system.parts where database = currentDatabase() and table = 'buffer_parts_mergetree';
+all_1_1_0	Buffer	Active
+all_2_2_0	Buffer	Active
+-- Buffer -> Compact
+optimize table buffer_parts_mergetree;
+select name, part_type, _state from system.parts where database = currentDatabase() and table = 'buffer_parts_mergetree' and active;
+all_1_2_1	Compact	Active
+select * from buffer_parts_mergetree;
+0
+0
+1
+1
+2
+2
+3
+3
+4
+4
+-- {'name': 'replicated_mergetree', 'engine': "ReplicatedMergeTree('/tables/{database}/replicated_mergetree', 'r1')"}
+drop table if exists buffer_parts_replicated_mergetree;
+create table buffer_parts_replicated_mergetree
+    (key Int)
+    engine=ReplicatedMergeTree('/tables/{database}/replicated_mergetree', 'r1')
+    order by key
+    settings min_bytes_for_in_memory_part=1e6;
+insert into buffer_parts_replicated_mergetree select * from numbers(5);
+-- check that data will not be deduplicated
+insert into buffer_parts_replicated_mergetree select * from numbers(5);
+select name, part_type, _state from system.parts where database = currentDatabase() and table = 'buffer_parts_replicated_mergetree';
+all_1_1_0	Buffer	Active
+all_2_2_0	Buffer	Active
+select * from buffer_parts_replicated_mergetree;
+-- check WAL
+detach table buffer_parts_replicated_mergetree;
+attach table buffer_parts_replicated_mergetree;
+select * from buffer_parts_replicated_mergetree;
+select name, part_type, _state from system.parts where database = currentDatabase() and table = 'buffer_parts_replicated_mergetree';
+all_1_1_0	Buffer	Active
+all_2_2_0	Buffer	Active
+-- Buffer -> Compact
+optimize table buffer_parts_replicated_mergetree;
+select name, part_type, _state from system.parts where database = currentDatabase() and table = 'buffer_parts_replicated_mergetree' and active;
+all_1_2_1	Compact	Active
+select * from buffer_parts_replicated_mergetree;
+0
+0
+1
+1
+2
+2
+3
+3
+4
+4

--- a/tests/queries/0_stateless/02500_mergetree_buffer_parts.sql.j2
+++ b/tests/queries/0_stateless/02500_mergetree_buffer_parts.sql.j2
@@ -1,0 +1,34 @@
+# vim: ft=sql
+-- { echoOn }
+
+{% for engine_args in [
+    {'name': 'mergetree', 'engine': 'MergeTree'},
+    {'name': 'replicated_mergetree', 'engine': "ReplicatedMergeTree('/tables/{database}/replicated_mergetree', 'r1')"},
+] %}
+-- {{ engine_args }}
+drop table if exists buffer_parts_{{ engine_args.name }};
+
+create table buffer_parts_{{ engine_args.name }}
+    (key Int)
+    engine={{ engine_args.engine }}
+    order by key
+    settings min_bytes_for_in_memory_part=1e6;
+
+insert into buffer_parts_{{ engine_args.name }} select * from numbers(5);
+-- check that data will not be deduplicated
+insert into buffer_parts_{{ engine_args.name }} select * from numbers(5);
+
+select name, part_type, _state from system.parts where database = currentDatabase() and table = 'buffer_parts_{{ engine_args.name }}';
+select * from buffer_parts_{{ engine_args.name }};
+
+-- check WAL
+detach table buffer_parts_{{ engine_args.name }};
+attach table buffer_parts_{{ engine_args.name }};
+select * from buffer_parts_{{ engine_args.name }};
+select name, part_type, _state from system.parts where database = currentDatabase() and table = 'buffer_parts_{{ engine_args.name }}';
+
+-- Buffer -> Compact
+optimize table buffer_parts_{{ engine_args.name }};
+select name, part_type, _state from system.parts where database = currentDatabase() and table = 'buffer_parts_{{ engine_args.name }}' and active;
+select * from buffer_parts_{{ engine_args.name }};
+{% endfor %}


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
TBD

Buffer parts is the parts that are not visible to SELECT, and also they are not commited to ZooKeeper.

The idea behind this new part type is to make INSERT to MergeTree faster and do not require any Buffer table in front of it.

Right now neither InMemory nor Compact part does not have the same performance as Buffer in front, especially with a case of ReplicatedMergeTree (since latency for coordinator comes to play), and also the problem became worse if you have multiple partitions in one INSERT block.

### Checklist:

- [x] add Buffer part
- [x] add part_type to WAL
- [x] test
- [ ] remove copy-paste
- [ ] mutations handling (convert all parts to regular before mutations?)
- [ ] timers to flush Buffer parts to disk

### Implementation notes:

- for now WAL is global, thought can be splitted

Fixes: #40728