### PR TITLE
Fix the CACHE_PATH creation for default value

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -488,7 +488,7 @@ def main():
         logging.getLogger("git_helper").setLevel(logging.DEBUG)
     token = args.token or get_best_robot_token()
 
-    gh = GitHub(token, per_page=100)
+    gh = GitHub(token, create_cache_dir=False, per_page=100)
     bp = Backport(gh, args.repo, args.dry_run)
     # https://github.com/python/mypy/issues/3004
     bp.gh.cache_path = f"{TEMP_PATH}/gh_cache"  # type: ignore

--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -30,10 +30,11 @@ Issues = List[Issue]
 
 
 class GitHub(github.Github):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, create_cache_dir=True, **kwargs):
         # Define meta attribute and apply setter logic
         self._cache_path = Path(CACHE_PATH)
-        self.cache_path = self.cache_path
+        if create_cache_dir:
+            self.cache_path = self.cache_path
         # And set Path
         super().__init__(*args, **kwargs)
         self._retries = 0

--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -31,8 +31,9 @@ Issues = List[Issue]
 
 class GitHub(github.Github):
     def __init__(self, *args, **kwargs):
-        # Define meta attribute
+        # Define meta attribute and apply setter logic
         self._cache_path = Path(CACHE_PATH)
+        self.cache_path = self.cache_path
         # And set Path
         super().__init__(*args, **kwargs)
         self._retries = 0

--- a/tests/ci/mark_release_ready.py
+++ b/tests/ci/mark_release_ready.py
@@ -10,7 +10,7 @@ from release import RELEASE_READY_STATUS
 
 def main():
     pr_info = PRInfo()
-    gh = GitHub(get_best_robot_token(), per_page=100)
+    gh = GitHub(get_best_robot_token(), create_cache_dir=False, per_page=100)
     commit = get_commit(gh, pr_info.sha)
     commit.create_status(
         context=RELEASE_READY_STATUS,

--- a/tests/ci/style_check.py
+++ b/tests/ci/style_check.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
     if args.push:
         checkout_head(pr_info)
 
-    gh = GitHub(get_best_robot_token())
+    gh = GitHub(get_best_robot_token(), per_page=100, create_cache_dir=False)
 
     atexit.register(update_mergeable_check, gh, pr_info, NAME)
 

--- a/utils/changelog/changelog.py
+++ b/utils/changelog/changelog.py
@@ -33,7 +33,7 @@ categories_preferred_order = (
 FROM_REF = ""
 TO_REF = ""
 SHA_IN_CHANGELOG = []  # type: List[str]
-gh = GitHub()
+gh = GitHub(create_cache_dir=False)
 CACHE_PATH = p.join(p.dirname(p.realpath(__file__)), "gh_cache")
 
 
@@ -384,7 +384,11 @@ def main():
     # Get all PRs for the given time frame
     global gh
     gh = GitHub(
-        args.gh_user_or_token, args.gh_password, per_page=100, pool_size=args.jobs
+        args.gh_user_or_token,
+        args.gh_password,
+        create_cache_dir=False,
+        per_page=100,
+        pool_size=args.jobs,
     )
     gh.cache_path = CACHE_PATH
     query = f"type:pr repo:{args.repo} is:merged"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
CACHE_PATH used to not be created for the default `cache_path` value, fix it.