### PR TITLE
Avoid loading toolchain files multiple times

### DIFF
--- a/cmake/darwin/toolchain-aarch64.cmake
+++ b/cmake/darwin/toolchain-aarch64.cmake
@@ -1,3 +1,6 @@
+# See linux/toolchain-x86_64.cmake for details about multiple load of toolchain file.
+include_guard(GLOBAL)
+
 set (CMAKE_SYSTEM_NAME "Darwin")
 set (CMAKE_SYSTEM_PROCESSOR "aarch64")
 set (CMAKE_C_COMPILER_TARGET "aarch64-apple-darwin")

--- a/cmake/darwin/toolchain-x86_64.cmake
+++ b/cmake/darwin/toolchain-x86_64.cmake
@@ -1,3 +1,6 @@
+# See linux/toolchain-x86_64.cmake for details about multiple load of toolchain file.
+include_guard(GLOBAL)
+
 set (CMAKE_SYSTEM_NAME "Darwin")
 set (CMAKE_SYSTEM_PROCESSOR "x86_64")
 set (CMAKE_C_COMPILER_TARGET "x86_64-apple-darwin")

--- a/cmake/freebsd/toolchain-aarch64.cmake
+++ b/cmake/freebsd/toolchain-aarch64.cmake
@@ -1,3 +1,6 @@
+# See linux/toolchain-x86_64.cmake for details about multiple load of toolchain file.
+include_guard(GLOBAL)
+
 set (CMAKE_SYSTEM_NAME "FreeBSD")
 set (CMAKE_SYSTEM_PROCESSOR "aarch64")
 set (CMAKE_C_COMPILER_TARGET "aarch64-unknown-freebsd12")

--- a/cmake/freebsd/toolchain-ppc64le.cmake
+++ b/cmake/freebsd/toolchain-ppc64le.cmake
@@ -1,3 +1,6 @@
+# See linux/toolchain-x86_64.cmake for details about multiple load of toolchain file.
+include_guard(GLOBAL)
+
 set (CMAKE_SYSTEM_NAME "FreeBSD")
 set (CMAKE_SYSTEM_PROCESSOR "ppc64le")
 set (CMAKE_C_COMPILER_TARGET "powerpc64le-unknown-freebsd13")

--- a/cmake/freebsd/toolchain-x86_64.cmake
+++ b/cmake/freebsd/toolchain-x86_64.cmake
@@ -1,3 +1,6 @@
+# See linux/toolchain-x86_64.cmake for details about multiple load of toolchain file.
+include_guard(GLOBAL)
+
 set (CMAKE_SYSTEM_NAME "FreeBSD")
 set (CMAKE_SYSTEM_PROCESSOR "x86_64")
 set (CMAKE_C_COMPILER_TARGET "x86_64-pc-freebsd11")

--- a/cmake/linux/toolchain-aarch64.cmake
+++ b/cmake/linux/toolchain-aarch64.cmake
@@ -1,3 +1,6 @@
+# See linux/toolchain-x86_64.cmake for details about multiple load of toolchain file.
+include_guard(GLOBAL)
+
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set (CMAKE_SYSTEM_NAME "Linux")

--- a/cmake/linux/toolchain-ppc64le.cmake
+++ b/cmake/linux/toolchain-ppc64le.cmake
@@ -1,3 +1,6 @@
+# See linux/toolchain-x86_64.cmake for details about multiple load of toolchain file.
+include_guard(GLOBAL)
+
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set (CMAKE_SYSTEM_NAME "Linux")

--- a/cmake/linux/toolchain-riscv64.cmake
+++ b/cmake/linux/toolchain-riscv64.cmake
@@ -1,3 +1,6 @@
+# See linux/toolchain-x86_64.cmake for details about multiple load of toolchain file.
+include_guard(GLOBAL)
+
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set (CMAKE_SYSTEM_NAME "Linux")

--- a/cmake/linux/toolchain-x86_64-musl.cmake
+++ b/cmake/linux/toolchain-x86_64-musl.cmake
@@ -1,3 +1,6 @@
+# See linux/toolchain-x86_64.cmake for details about multiple load of toolchain file.
+include_guard(GLOBAL)
+
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set (CMAKE_SYSTEM_NAME "Linux")

--- a/cmake/linux/toolchain-x86_64.cmake
+++ b/cmake/linux/toolchain-x86_64.cmake
@@ -1,18 +1,15 @@
-if (_CLICKHOUSE_TOOLCHAIN_FILE_LOADED)
-    # During first run of cmake the toolchain file will be loaded twice,
-    # - /usr/share/cmake-3.23/Modules/CMakeDetermineSystem.cmake
-    # - /bld/CMakeFiles/3.23.2/CMakeSystem.cmake
-    #
-    # But once you already have non-empty cmake cache it will be loaded only
-    # once:
-    # - /bld/CMakeFiles/3.23.2/CMakeSystem.cmake
-    #
-    # This has no harm except for double load of toolchain will add
-    # --gcc-toolchain multiple times that will not allow ccache to reuse the
-    # cache.
-    return()
-endif()
-set (_CLICKHOUSE_TOOLCHAIN_FILE_LOADED ON)
+# During first run of cmake the toolchain file will be loaded twice,
+# - /usr/share/cmake-3.23/Modules/CMakeDetermineSystem.cmake
+# - /bld/CMakeFiles/3.23.2/CMakeSystem.cmake
+#
+# But once you already have non-empty cmake cache it will be loaded only
+# once:
+# - /bld/CMakeFiles/3.23.2/CMakeSystem.cmake
+#
+# This has no harm except for double load of toolchain will add
+# --gcc-toolchain multiple times that will not allow ccache to reuse the
+# cache.
+include_guard(GLOBAL)
 
 set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 


### PR DESCRIPTION
Previously, in #39387, this protection had been added only for linux x86_64.

And use include_guard() instead of manual if()+set().

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)