### PR TITLE
add uniq marker to each thread

### DIFF
--- a/tests/queries/0_stateless/02497_trace_events_stress_long.sh
+++ b/tests/queries/0_stateless/02497_trace_events_stress_long.sh
@@ -9,7 +9,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 function thread1()
 {
-    query_id="$RANDOM-$CLICKHOUSE_DATABASE"
+    query_id="$RANDOM-$CLICKHOUSE_DATABASE-$1"
 
     while true; do
         $CLICKHOUSE_CLIENT --query_id=$query_id --query "
@@ -35,10 +35,10 @@ export -f thread2
 
 TIMEOUT=10
 
-timeout $TIMEOUT bash -c thread1 >/dev/null &
-timeout $TIMEOUT bash -c thread1 >/dev/null &
-timeout $TIMEOUT bash -c thread1 >/dev/null &
-timeout $TIMEOUT bash -c thread1 >/dev/null &
+timeout $TIMEOUT bash -c "thread1 t1" >/dev/null &
+timeout $TIMEOUT bash -c "thread1 t2" >/dev/null &
+timeout $TIMEOUT bash -c "thread1 t3" >/dev/null &
+timeout $TIMEOUT bash -c "thread1 t4" >/dev/null &
 timeout $TIMEOUT bash -c thread2 >/dev/null &
 
 wait


### PR DESCRIPTION
add uniq marker to each thread in order to exclude collision in query_id with RANDOM. 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
