### PR TITLE
Ignore "session expired" errors after BC check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ website/package-lock.json
 # temporary test files
 tests/queries/0_stateless/test_*
 tests/queries/0_stateless/*.binary
+tests/queries/0_stateless/*.generated-expect

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -497,6 +497,7 @@ else
                -e "Coordination::Exception: Connection loss" \
                -e "MutateFromLogEntryTask" \
                -e "No connection to ZooKeeper, cannot get shared table ID" \
+               -e "Session expired" \
         /var/log/clickhouse-server/clickhouse-server.backward.clean.log | zgrep -Fa "<Error>" > /test_output/bc_check_error_messages.txt \
         && echo -e 'Backward compatibility check: Error message in clickhouse-server.log (see bc_check_error_messages.txt)\tFAIL' >> /test_output/test_results.tsv \
         || echo -e 'Backward compatibility check: No Error messages in clickhouse-server.log\tOK' >> /test_output/test_results.tsv

--- a/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
@@ -142,6 +142,9 @@ void ReplicatedMergeTreeAttachThread::runImpl()
 
     checkHasReplicaMetadataInZooKeeper(zookeeper, replica_path);
 
+    /// Just in case it was not removed earlier due to connection loss
+    zookeeper->tryRemove(replica_path + "/flags/force_restore_data");
+
     String replica_metadata_version;
     const bool replica_metadata_version_exists = zookeeper->tryGet(replica_path + "/metadata_version", replica_metadata_version);
     if (replica_metadata_version_exists)


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes failures like https://s3.amazonaws.com/clickhouse-test-reports/44129/fddfd356f57d63a2e14755934f566cda2ca6eb73/stress_test__debug_.html
