### PR TITLE
Close GRPC channels in tests

### DIFF
--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -112,11 +112,15 @@ def get_pgsql_client(cluster, port):
             time.sleep(0.1)
 
 
+@contextlib.contextmanager
 def get_grpc_channel(cluster, port):
     host_port = cluster.get_instance_ip("instance") + f":{port}"
     channel = grpc.insecure_channel(host_port)
     grpc.channel_ready_future(channel).result(timeout=10)
-    return channel
+    try:
+        yield channel
+    finally:
+        channel.close()
 
 
 def grpc_query(channel, query_text):
@@ -238,19 +242,17 @@ def test_change_postgresql_port(cluster, zk):
 
 def test_change_grpc_port(cluster, zk):
     with default_client(cluster, zk) as client:
-        grpc_channel = get_grpc_channel(cluster, port=9100)
-        assert grpc_query(grpc_channel, "SELECT 1") == "1\n"
-        with sync_loaded_config(client.query):
-            zk.set("/clickhouse/ports/grpc", b"9090")
-        with pytest.raises(
-            grpc._channel._InactiveRpcError, match="StatusCode.UNAVAILABLE"
-        ):
-            grpc_query(grpc_channel, "SELECT 1")
-        grpc_channel.close()
+        with get_grpc_channel(cluster, port=9100) as grpc_channel:
+            assert grpc_query(grpc_channel, "SELECT 1") == "1\n"
+            with sync_loaded_config(client.query):
+                zk.set("/clickhouse/ports/grpc", b"9090")
+            with pytest.raises(
+                grpc._channel._InactiveRpcError, match="StatusCode.UNAVAILABLE"
+            ):
+                grpc_query(grpc_channel, "SELECT 1")
 
-        grpc_channel_on_new_port = get_grpc_channel(cluster, port=9090)
-        assert grpc_query(grpc_channel_on_new_port, "SELECT 1") == "1\n"
-        grpc_channel_on_new_port.close()
+        with get_grpc_channel(cluster, port=9090) as grpc_channel_on_new_port:
+            assert grpc_query(grpc_channel_on_new_port, "SELECT 1") == "1\n"
 
 
 def test_remove_tcp_port(cluster, zk):
@@ -295,16 +297,14 @@ def test_remove_postgresql_port(cluster, zk):
 
 def test_remove_grpc_port(cluster, zk):
     with default_client(cluster, zk) as client:
-        grpc_channel = get_grpc_channel(cluster, port=9100)
-        assert grpc_query(grpc_channel, "SELECT 1") == "1\n"
-        with sync_loaded_config(client.query):
-            zk.delete("/clickhouse/ports/grpc")
-        with pytest.raises(
-            grpc._channel._InactiveRpcError, match="StatusCode.UNAVAILABLE"
-        ):
-            grpc_query(grpc_channel, "SELECT 1")
-
-        grpc_channel.close()
+        with get_grpc_channel(cluster, port=9100) as grpc_channel:
+            assert grpc_query(grpc_channel, "SELECT 1") == "1\n"
+            with sync_loaded_config(client.query):
+                zk.delete("/clickhouse/ports/grpc")
+            with pytest.raises(
+                grpc._channel._InactiveRpcError, match="StatusCode.UNAVAILABLE"
+            ):
+                grpc_query(grpc_channel, "SELECT 1")
 
 
 def test_change_listen_host(cluster, zk):

--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -246,8 +246,11 @@ def test_change_grpc_port(cluster, zk):
             grpc._channel._InactiveRpcError, match="StatusCode.UNAVAILABLE"
         ):
             grpc_query(grpc_channel, "SELECT 1")
+        grpc_channel.close()
+
         grpc_channel_on_new_port = get_grpc_channel(cluster, port=9090)
         assert grpc_query(grpc_channel_on_new_port, "SELECT 1") == "1\n"
+        grpc_channel_on_new_port.close()
 
 
 def test_remove_tcp_port(cluster, zk):
@@ -300,6 +303,8 @@ def test_remove_grpc_port(cluster, zk):
             grpc._channel._InactiveRpcError, match="StatusCode.UNAVAILABLE"
         ):
             grpc_query(grpc_channel, "SELECT 1")
+
+        grpc_channel.close()
 
 
 def test_change_listen_host(cluster, zk):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Possible fix for issues like https://s3.amazonaws.com/clickhouse-test-reports/43922/de58e9c02d040d3223dcc23af4e3af112c5df056/integration_tests__asan__%5B2/6%5D.html

It seems after one of the `grpc` tests in `test_server_reload` it gets stuck after everything was processed.
I didn't see any useful logs so let's try with adding `close` statements which are recommended by client authors.

Example:
https://s3.amazonaws.com/clickhouse-test-reports/43922/de58e9c02d040d3223dcc23af4e3af112c5df056/integration_tests__asan__[2/6]/integration_run_parallel2_0.log
Here we see how all started tests PASSED except `test_server_reload/test.py::test_change_grpc_port`. In its logs we see how all the queries from the test and ZK requests were done.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
