### PR TITLE
Fix `ReadonlyReplica` metric

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -386,7 +386,7 @@ void ReplicatedMergeTreeRestartingThread::setReadonly(bool on_shutdown)
         CurrentMetrics::add(CurrentMetrics::ReadonlyReplica);
 
     /// Replica was already readonly, but we should decrement the metric, because we are detaching/dropping table.
-    /// if first pass wasn't done we don't have to decrement because it wasn't incemented in the first place
+    /// if first pass wasn't done we don't have to decrement because it wasn't incremented in the first place
     /// the task should be deactivated if it's full shutdown so no race is present
     if (!first_time && on_shutdown)
     {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -386,8 +386,13 @@ void ReplicatedMergeTreeRestartingThread::setReadonly(bool on_shutdown)
         CurrentMetrics::add(CurrentMetrics::ReadonlyReplica);
 
     /// Replica was already readonly, but we should decrement the metric, because we are detaching/dropping table.
-    if (on_shutdown)
+    /// if first pass wasn't done we don't have to decrement because it wasn't incemented in the first place
+    /// the task should be deactivated if it's full shutdown so no race is present
+    if (!first_time && on_shutdown)
+    {
         CurrentMetrics::sub(CurrentMetrics::ReadonlyReplica);
+        assert(CurrentMetrics::get(CurrentMetrics::ReadonlyReplica) >= 0);
+    }
 }
 
 void ReplicatedMergeTreeRestartingThread::setNotReadonly()
@@ -397,7 +402,10 @@ void ReplicatedMergeTreeRestartingThread::setNotReadonly()
     /// because we don't want to change this metric if replication is started successfully.
     /// So we should not decrement it when replica stopped being readonly on startup.
     if (storage.is_readonly.compare_exchange_strong(old_val, false) && !first_time)
+    {
         CurrentMetrics::sub(CurrentMetrics::ReadonlyReplica);
+        assert(CurrentMetrics::get(CurrentMetrics::ReadonlyReplica) >= 0);
+    }
 }
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prevent `ReadonlyReplica` metric from having negative values.

cc @tavplubix 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
