### PR TITLE
More robust CI parsers

### DIFF
--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -80,10 +80,18 @@ def process_results(
         return "error", "Invalid check_status.tsv", test_results, additional_files
     state, description = status[0][0], status[0][1]
 
-    results_path = Path(result_folder) / "test_results.tsv"
-    test_results = read_test_results(results_path)
-    if len(test_results) == 0:
-        return "error", "Empty test_results.tsv", test_results, additional_files
+    try:
+        results_path = Path(result_folder) / "test_results.tsv"
+        test_results = read_test_results(results_path)
+        if len(test_results) == 0:
+            return "error", "Empty test_results.tsv", test_results, additional_files
+    except Exception as e:
+        return (
+            "error",
+            f"Cannot parse test_results.tsv ({e})",
+            test_results,
+            additional_files,
+        )
 
     return state, description, test_results, additional_files
 

--- a/tests/ci/functional_test_check.py
+++ b/tests/ci/functional_test_check.py
@@ -163,17 +163,25 @@ def process_results(
         return "error", "Invalid check_status.tsv", test_results, additional_files
     state, description = status[0][0], status[0][1]
 
-    results_path = Path(result_folder) / "test_results.tsv"
+    try:
+        results_path = Path(result_folder) / "test_results.tsv"
 
-    if results_path.exists():
-        logging.info("Found test_results.tsv")
-    else:
-        logging.info("Files in result folder %s", os.listdir(result_folder))
-        return "error", "Not found test_results.tsv", test_results, additional_files
+        if results_path.exists():
+            logging.info("Found test_results.tsv")
+        else:
+            logging.info("Files in result folder %s", os.listdir(result_folder))
+            return "error", "Not found test_results.tsv", test_results, additional_files
 
-    test_results = read_test_results(results_path)
-    if len(test_results) == 0:
-        return "error", "Empty test_results.tsv", test_results, additional_files
+        test_results = read_test_results(results_path)
+        if len(test_results) == 0:
+            return "error", "Empty test_results.tsv", test_results, additional_files
+    except Exception as e:
+        return (
+            "error",
+            f"Cannot parse test_results.tsv ({e})",
+            test_results,
+            additional_files,
+        )
 
     return state, description, test_results, additional_files
 

--- a/tests/ci/integration_test_check.py
+++ b/tests/ci/integration_test_check.py
@@ -117,10 +117,18 @@ def process_results(
         return "error", "Invalid check_status.tsv", test_results, additional_files
     state, description = status[0][0], status[0][1]
 
-    results_path = Path(result_folder) / "test_results.tsv"
-    test_results = read_test_results(results_path, False)
-    if len(test_results) == 0:
-        return "error", "Empty test_results.tsv", test_results, additional_files
+    try:
+        results_path = Path(result_folder) / "test_results.tsv"
+        test_results = read_test_results(results_path, False)
+        if len(test_results) == 0:
+            return "error", "Empty test_results.tsv", test_results, additional_files
+    except Exception as e:
+        return (
+            "error",
+            f"Cannot parse test_results.tsv ({e})",
+            test_results,
+            additional_files,
+        )
 
     return state, description, test_results, additional_files
 

--- a/tests/ci/stress_check.py
+++ b/tests/ci/stress_check.py
@@ -93,10 +93,18 @@ def process_results(
         return "error", "Invalid check_status.tsv", test_results, additional_files
     state, description = status[0][0], status[0][1]
 
-    results_path = Path(result_folder) / "test_results.tsv"
-    test_results = read_test_results(results_path, False)
-    if len(test_results) == 0:
-        raise Exception("Empty results")
+    try:
+        results_path = Path(result_folder) / "test_results.tsv"
+        test_results = read_test_results(results_path, False)
+        if len(test_results) == 0:
+            raise Exception("Empty results")
+    except Exception as e:
+        return (
+            "error",
+            f"Cannot parse test_results.tsv ({e})",
+            test_results,
+            additional_files,
+        )
 
     return state, description, test_results, additional_files
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -790,6 +790,9 @@ class TestCase:
     ):
         description = ""
 
+        if debug_log:
+            debug_log = "\n".join(debug_log.splitlines()[:100])
+
         if proc:
             if proc.returncode is None:
                 try:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1141,6 +1141,9 @@ class TestCase:
                 proc, stdout, stderr, debug_log, total_time
             )
             result.check_if_need_retry(args, stdout, stderr, self.runs_count)
+            # to avoid breaking CSV parser
+            result.description = result.description.replace('\0', '')
+
             if result.status == TestStatus.FAIL:
                 result.description = self.add_info_about_settings(
                     args, result.description


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- ci: more robust results parsers
- clickhouse-test: replace NUL byte to avoid breaking CSV parser
- clickhouse-test: trim debuglog to the first 100 lines as other logs

Bad CI report example: https://github.com/ClickHouse/ClickHouse/actions/runs/3669487007/jobs/6221215715