### PR TITLE
Get rid of global Git object

### DIFF
--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -32,8 +32,6 @@ from version_helper import (
 
 RELEASE_READY_STATUS = "Ready for release"
 
-git = Git()
-
 
 class Repo:
     VALID = ("ssh", "https", "origin")
@@ -79,7 +77,7 @@ class Release:
         self.release_commit = release_commit
         assert release_type in self.BIG + self.SMALL
         self.release_type = release_type
-        self._git = git
+        self._git = Git()
         self._version = get_version_from_repo(git=self._git)
         self._release_branch = ""
         self._rollback_stack = []  # type: List[str]


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix issue with mark_release_ready.py in master with shallow checkout https://github.com/ClickHouse/ClickHouse/actions/runs/3704735733/jobs/6278684689#step:5:13