### PR TITLE
Set memory limit for server in AST fuzz tests

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -91,6 +91,19 @@ function configure
     cp -av --dereference "$script_dir"/query-fuzzer-tweaks-users.xml db/users.d
     cp -av --dereference "$script_dir"/allow-nullable-key.xml db/config.d
 
+    # the following memory limits configuration is copy-pasted from docker/test/stress/run.sh
+    local total_mem
+    total_mem=$(awk '/MemTotal/ { print $(NF-1) }' /proc/meminfo) # KiB
+    total_mem=$(( total_mem*1024 )) # bytes
+    local max_server_mem
+    max_server_mem=$((total_mem*75/100)) # 75%
+    echo "Setting max_server_memory_usage=$max_server_mem"
+    cat > db/config.d/max_server_memory_usage.xml <<EOL
+<clickhouse>
+    <max_server_memory_usage>${max_server_mem}</max_server_memory_usage>
+</clickhouse>
+EOL
+
     cat > db/config.d/core.xml <<EOL
 <clickhouse>
     <core_dump>

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -91,16 +91,9 @@ function configure
     cp -av --dereference "$script_dir"/query-fuzzer-tweaks-users.xml db/users.d
     cp -av --dereference "$script_dir"/allow-nullable-key.xml db/config.d
 
-    # the following memory limits configuration is copy-pasted from docker/test/stress/run.sh
-    local total_mem
-    total_mem=$(awk '/MemTotal/ { print $(NF-1) }' /proc/meminfo) # KiB
-    total_mem=$(( total_mem*1024 )) # bytes
-    local max_server_mem
-    max_server_mem=$((total_mem*75/100)) # 75%
-    echo "Setting max_server_memory_usage=$max_server_mem"
-    cat > db/config.d/max_server_memory_usage.xml <<EOL
+    cat > db/config.d/max_server_memory_usage_to_ram_ratio.xml <<EOL
 <clickhouse>
-    <max_server_memory_usage>${max_server_mem}</max_server_memory_usage>
+    <max_server_memory_usage_to_ram_ratio>0.75</max_server_memory_usage_to_ram_ratio>
 </clickhouse>
 EOL
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Memory limit for server is set now in AST fuzz tests to avoid OOMs.