### PR TITLE
Another fix `test_server_reload`

### DIFF
--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -150,7 +150,7 @@ def configure_from_zk(zk, querier=None):
             zk.create(path=path, value=value, makepath=True)
             has_changed = True
         except NodeExistsError:
-            if zk.get(path) != value:
+            if zk.get(path)[0] != value:
                 zk.set(path=path, value=value)
                 has_changed = True
         if has_changed and querier is not None:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)




> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
