### PR TITLE
Call std::condition_variable::notify_* without lock in ThreadPool

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -156,8 +156,9 @@ ReturnType ThreadPoolImpl<Thread>::scheduleImpl(Job job, ssize_t priority, std::
                      propagate_opentelemetry_tracing_context ? DB::OpenTelemetry::CurrentContext() : DB::OpenTelemetry::TracingContextOnThread());
 
         ++scheduled_jobs;
-        new_job_or_shutdown.notify_one();
     }
+
+    new_job_or_shutdown.notify_one();
 
     return static_cast<ReturnType>(true);
 }


### PR DESCRIPTION
Calling notify_* functions with lock held would let the notified thread immediately block again, and increase the lock contention. This commit moves the calls of notify_* functions out of critical sections of ThreadPool, whose lock (ThreadPoolImpl::mutex) is most extensively contended in some workloads.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The performance experiments of SSB (Star Schema Benchmark) on the ICX device (Intel Xeon Platinum 8380 CPU, 80 cores, 160 threads) shows that this change could effectively decrease the lock contention for ThreadPoolImpl::mutex by **75%**, increasing the CPU utilization and improving the overall performance by **2.4%**.

https://en.cppreference.com/w/cpp/thread/condition_variable/notify_all
https://en.cppreference.com/w/cpp/thread/condition_variable/notify_one

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
