### PR TITLE
Fix false success rerun on similar prefix for another builds

### DIFF
--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -122,7 +122,8 @@ def check_for_success_run(
     build_name: str,
     build_config: BuildConfig,
 ) -> None:
-    logged_prefix = os.path.join(S3_BUILDS_BUCKET, s3_prefix)
+    # the final empty argument is necessary for distinguish build and build_suffix
+    logged_prefix = os.path.join(S3_BUILDS_BUCKET, s3_prefix, "")
     logging.info("Checking for artifacts in %s", logged_prefix)
     try:
         # TODO: theoretically, it would miss performance artifact for pr==0,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
In rare cases, we don't rebuild binaries, because another task with a similar prefix succeeded. E.g. `binary_darwin` didn't restart because `binary_darwin_aarch64`

#### Example
For failed example see https://s3.amazonaws.com/clickhouse-builds/0/613fe09ca2e635de3726c268669d6b8e179ba592/clickhouse_special_build_check/report.html

```
INFO:botocore.credentials:Found credentials from IAM Role: ec2_admin
INFO:root:Checking for artifacts in clickhouse-builds/22.9/613fe09ca2e635de3726c268669d6b8e179ba592/binary_darwin
INFO:root:Some build results found:
['22.9/613fe09ca2e635de3726c268669d6b8e179ba592/binary_darwin_aarch64/build_log.log', '22.9/613fe09ca2e635de3726c268669d6b8e179ba592/binary_darwin_aarch64/clickhouse', '22.9/613fe09ca2e635de3726c268669d6b8e179ba592/binary_darwin_aarch64/unit_tests_dbms']
```