### PR TITLE
tests/perf: fix dependency check during DROP

### DIFF
--- a/tests/performance/direct_dictionary.xml
+++ b/tests/performance/direct_dictionary.xml
@@ -129,10 +129,9 @@
         FORMAT Null;
     </query>
 
-    <drop_query>DROP TABLE IF EXISTS simple_key_direct_dictionary_source_table;</drop_query>
-    <drop_query>DROP TABLE IF EXISTS complex_key_direct_dictionary_source_table;</drop_query>
-
     <drop_query>DROP DICTIONARY IF EXISTS simple_key_direct_dictionary;</drop_query>
     <drop_query>DROP DICTIONARY IF EXISTS complex_key_direct_dictionary;</drop_query>
 
+    <drop_query>DROP TABLE IF EXISTS simple_key_direct_dictionary_source_table;</drop_query>
+    <drop_query>DROP TABLE IF EXISTS complex_key_direct_dictionary_source_table;</drop_query>
 </test>

--- a/tests/performance/flat_dictionary.xml
+++ b/tests/performance/flat_dictionary.xml
@@ -73,8 +73,7 @@
         FORMAT Null;
     </query>
 
-    <drop_query>DROP TABLE IF EXISTS simple_key_flat_dictionary_source_table</drop_query>
-
     <drop_query>DROP DICTIONARY IF EXISTS simple_key_flat_dictionary</drop_query>
 
+    <drop_query>DROP TABLE IF EXISTS simple_key_flat_dictionary_source_table</drop_query>
 </test>

--- a/tests/performance/hashed_array_dictionary.xml
+++ b/tests/performance/hashed_array_dictionary.xml
@@ -129,10 +129,9 @@
         FORMAT Null;
     </query>
 
-    <drop_query>DROP TABLE IF EXISTS simple_key_hashed_array_dictionary_source_table;</drop_query>
-    <drop_query>DROP TABLE IF EXISTS complex_key_hashed_array_dictionary_source_table;</drop_query>
-
     <drop_query>DROP DICTIONARY IF EXISTS simple_key_hashed_array_dictionary;</drop_query>
     <drop_query>DROP DICTIONARY IF EXISTS complex_key_hashed_array_dictionary;</drop_query>
 
+    <drop_query>DROP TABLE IF EXISTS simple_key_hashed_array_dictionary_source_table;</drop_query>
+    <drop_query>DROP TABLE IF EXISTS complex_key_hashed_array_dictionary_source_table;</drop_query>
 </test>

--- a/tests/performance/hashed_dictionary.xml
+++ b/tests/performance/hashed_dictionary.xml
@@ -129,10 +129,9 @@
         FORMAT Null;
     </query>
 
-    <drop_query>DROP TABLE IF EXISTS simple_key_hashed_dictionary_source_table;</drop_query>
-    <drop_query>DROP TABLE IF EXISTS complex_key_hashed_dictionary_source_table;</drop_query>
-
     <drop_query>DROP DICTIONARY IF EXISTS simple_key_hashed_dictionary;</drop_query>
     <drop_query>DROP DICTIONARY IF EXISTS complex_key_hashed_dictionary;</drop_query>
 
+    <drop_query>DROP TABLE IF EXISTS simple_key_hashed_dictionary_source_table;</drop_query>
+    <drop_query>DROP TABLE IF EXISTS complex_key_hashed_dictionary_source_table;</drop_query>
 </test>

--- a/tests/performance/hierarchical_dictionaries.xml
+++ b/tests/performance/hierarchical_dictionaries.xml
@@ -68,8 +68,7 @@
         SELECT {func}('hierarchical_{dictionary_layout}_dictionary', number + 1) FROM numbers(1000000) FORMAT Null;
     </query>
 
-    <drop_query>DROP TABLE IF EXISTS hierarchical_dictionary_source_table;</drop_query>
     <drop_query>DROP DICTIONARY IF EXISTS hierarchical_{dictionary_layout}_dictionary;</drop_query>
     <drop_query>DROP DICTIONARY IF EXISTS hierarchical_flat_dictionary;</drop_query>
-
+    <drop_query>DROP TABLE IF EXISTS hierarchical_dictionary_source_table;</drop_query>
 </test>

--- a/tests/performance/range_hashed_dictionary.xml
+++ b/tests/performance/range_hashed_dictionary.xml
@@ -117,10 +117,9 @@
         FORMAT Null;
     </query>
 
-    <drop_query>DROP TABLE IF EXISTS simple_key_range_hashed_dictionary_source_table;</drop_query>
-    <drop_query>DROP TABLE IF EXISTS complex_key_range_hashed_dictionary_source_table;</drop_query>
-
     <drop_query>DROP DICTIONARY IF EXISTS simple_key_range_hashed_dictionary;</drop_query>
     <drop_query>DROP DICTIONARY IF EXISTS complex_key_range_hashed_dictionary;</drop_query>
 
+    <drop_query>DROP TABLE IF EXISTS simple_key_range_hashed_dictionary_source_table;</drop_query>
+    <drop_query>DROP TABLE IF EXISTS complex_key_range_hashed_dictionary_source_table;</drop_query>
 </test>


### PR DESCRIPTION
CI [1]:

    DB::Exception: Cannot drop or rename default.hierarchical_dictionary_source_table, because some tables depend on it: default.hierarchical_hashed_array_dictionary, default.hierarchical_flat_dictionary, default.hierarchical_hashed_dictionary. Stack trace:

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/44256/8e67a361a8f14abec6717af09ee997eb25151685/performance_comparison_[1/4]/report.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)