### PR TITLE
Update install.md - help users more easily find self-managed install instructions below the fold

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -9,7 +9,7 @@ slug: /en/install
 You have two options for getting up and running with ClickHouse:
 
 - **[ClickHouse Cloud](https://clickhouse.com/cloud/):** the official ClickHouse as a service, - built by, maintained, and supported by the creators of ClickHouse
-- **[Self-managed ClickHouse](https://github.com/ClickHouse/ClickHouse):** ClickHouse can run on any Linux, FreeBSD, or Mac OS X with x86_64, AArch64, or PowerPC64LE CPU architecture
+- **[Self-managed ClickHouse](#self-managed-install):** ClickHouse can run on any Linux, FreeBSD, or Mac OS X with x86_64, AArch64, or PowerPC64LE CPU architecture
 
 ## ClickHouse Cloud
 


### PR DESCRIPTION
@DanRoscigno I suggest that we change this page to link "Self-Managed ClickHouse" to the `#self-managed-install` anchor below for self-managed install tutorial. This prominent link at the top currently leads to our Github README page, which contains no install instructions. The navigation on the side is pretty hard to notice in the current understated styling vs this red link, so it's easy for users looking for download instructions to navigate away from this page unintentionally, and potentially get lost.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
