### PR TITLE
Add check for submodules sanity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -269,9 +269,6 @@
 [submodule "contrib/vectorscan"]
 	path = contrib/vectorscan
 	url = https://github.com/VectorCamp/vectorscan.git
-[submodule "contrib/liburing"]
-	path = contrib/liburing
-	url = https://github.com/axboe/liburing.git
 [submodule "contrib/c-ares"]
 	path = contrib/c-ares
 	url = https://github.com/ClickHouse/c-ares

--- a/docker/test/style/process_style_check_result.py
+++ b/docker/test/style/process_style_check_result.py
@@ -19,6 +19,7 @@ def process_result(result_folder):
         "typos",
         "whitespaces",
         "workflows",
+        "submodules",
         "docs spelling",
     )
 

--- a/docker/test/style/run.sh
+++ b/docker/test/style/run.sh
@@ -10,7 +10,7 @@ echo "Check style" | ts
 echo "Check python formatting with black" | ts
 ./check-black -n              |& tee /test_output/black_output.txt
 echo "Check python type hinting with mypy" | ts
-./check-mypy -n              |& tee /test_output/mypy_output.txt
+./check-mypy -n               |& tee /test_output/mypy_output.txt
 echo "Check typos" | ts
 ./check-typos                 |& tee /test_output/typos_output.txt
 echo "Check docs spelling" | ts
@@ -19,6 +19,8 @@ echo "Check whitespaces" | ts
 ./check-whitespaces -n        |& tee /test_output/whitespaces_output.txt
 echo "Check workflows" | ts
 ./check-workflows             |& tee /test_output/workflows_output.txt
+echo "Check submodules" | ts
+./check-submodules            |& tee /test_output/submodules_output.txt
 echo "Check shell scripts with shellcheck" | ts
 ./shellcheck-run.sh           |& tee /test_output/shellcheck_output.txt
 /process_style_check_result.py || echo -e "failure\tCannot parse results" > /test_output/check_status.tsv

--- a/utils/check-style/check-submodules
+++ b/utils/check-style/check-submodules
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# The script checks if all submodules defined in $GIT_ROOT/.gitmodules exist in $GIT_ROOT/contrib
+
+set -e
+
+GIT_ROOT=$(git rev-parse --show-cdup)
+GIT_ROOT=${GIT_ROOT:-.}
+
+cd "$GIT_ROOT"
+
+# Remove keys for submodule.*.path parameters, the values are separated by \0
+# and check if the directory exists
+git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\n||' | \
+  xargs -P100 -0 --no-run-if-empty -I{} bash -c 'if ! test -d {}; then echo Directory for submodule {} is not found; exit 1; fi' 2>&1
+
+
+# And check that the submodule is fine
+git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\n||' | \
+  xargs -P100 -0 --no-run-if-empty -I{} git submodule status -q {} 2>&1


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check if `.gitmodules` is clean and sane. The current state contain one stale submodule