### PR TITLE
Throw SYNTAX_ERROR on invalid ON CLUSTER

### DIFF
--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -17,7 +17,7 @@ namespace ErrorCodes
 namespace DB
 {
 
-static bool parseQueryWithOnClusterAndMaybeTable(std::shared_ptr<ASTSystemQuery> & res, IParser::Pos & pos,
+[[nodiscard]] static bool parseQueryWithOnClusterAndMaybeTable(std::shared_ptr<ASTSystemQuery> & res, IParser::Pos & pos,
                                                  Expected & expected, bool require_table, bool allow_string_literal)
 {
     /// Better form for user: SYSTEM <ACTION> table ON CLUSTER cluster
@@ -71,7 +71,7 @@ enum class SystemQueryTargetType
     Disk
 };
 
-static bool parseQueryWithOnClusterAndTarget(std::shared_ptr<ASTSystemQuery> & res, IParser::Pos & pos, Expected & expected, SystemQueryTargetType target_type)
+[[nodiscard]] static bool parseQueryWithOnClusterAndTarget(std::shared_ptr<ASTSystemQuery> & res, IParser::Pos & pos, Expected & expected, SystemQueryTargetType target_type)
 {
     /// Better form for user: SYSTEM <ACTION> target_name ON CLUSTER cluster
     /// Query rewritten form + form while executing on cluster: SYSTEM <ACTION> ON CLUSTER cluster target_name
@@ -136,7 +136,7 @@ static bool parseQueryWithOnClusterAndTarget(std::shared_ptr<ASTSystemQuery> & r
     return true;
 }
 
-static bool parseQueryWithOnCluster(std::shared_ptr<ASTSystemQuery> & res, IParser::Pos & pos,
+[[nodiscard]] static bool parseQueryWithOnCluster(std::shared_ptr<ASTSystemQuery> & res, IParser::Pos & pos,
                                     Expected & expected)
 {
     String cluster_str;
@@ -196,7 +196,8 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
         }
         case Type::DROP_REPLICA:
         {
-            parseQueryWithOnCluster(res, pos, expected);
+            if (!parseQueryWithOnCluster(res, pos, expected))
+                return false;
 
             ASTPtr ast;
             if (!ParserStringLiteral{}.parse(pos, ast, expected))
@@ -239,7 +240,8 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
         case Type::RESTART_REPLICA:
         case Type::SYNC_REPLICA:
         {
-            parseQueryWithOnCluster(res, pos, expected);
+            if (!parseQueryWithOnCluster(res, pos, expected))
+                return false;
             if (!parseDatabaseAndTableAsAST(pos, expected, res->database, res->table))
                 return false;
             break;
@@ -247,7 +249,8 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
 
         case Type::SYNC_DATABASE_REPLICA:
         {
-            parseQueryWithOnCluster(res, pos, expected);
+            if (!parseQueryWithOnCluster(res, pos, expected))
+                return false;
             if (!parseDatabaseAsAST(pos, expected, res->database))
                 return false;
             break;
@@ -310,7 +313,8 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
             }
             else
             {
-                parseQueryWithOnCluster(res, pos, expected);
+                if (!parseQueryWithOnCluster(res, pos, expected))
+                    return false;
                 if (ParserKeyword{"ON VOLUME"}.ignore(pos, expected))
                 {
                     if (!parse_on_volume())
@@ -335,13 +339,15 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
         case Type::START_REPLICATED_SENDS:
         case Type::STOP_REPLICATION_QUEUES:
         case Type::START_REPLICATION_QUEUES:
-            parseQueryWithOnCluster(res, pos, expected);
+            if (!parseQueryWithOnCluster(res, pos, expected))
+                return false;
             parseDatabaseAndTableAsAST(pos, expected, res->database, res->table);
             break;
 
         case Type::SUSPEND:
         {
-            parseQueryWithOnCluster(res, pos, expected);
+            if (!parseQueryWithOnCluster(res, pos, expected))
+                return false;
 
             ASTPtr seconds;
             if (!(ParserKeyword{"FOR"}.ignore(pos, expected)
@@ -360,7 +366,8 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
             ASTPtr ast;
             if (path_parser.parse(pos, ast, expected))
                 res->filesystem_cache_path = ast->as<ASTLiteral>()->value.safeGet<String>();
-            parseQueryWithOnCluster(res, pos, expected);
+            if (!parseQueryWithOnCluster(res, pos, expected))
+                return false;
             break;
         }
         case Type::DROP_SCHEMA_CACHE:
@@ -397,7 +404,8 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
 
         default:
         {
-            parseQueryWithOnCluster(res, pos, expected);
+            if (!parseQueryWithOnCluster(res, pos, expected))
+                return false;
             break;
         }
     }

--- a/tests/queries/0_stateless/02179_dict_reload_on_cluster.sql
+++ b/tests/queries/0_stateless/02179_dict_reload_on_cluster.sql
@@ -23,6 +23,7 @@ SELECT query_count FROM system.dictionaries WHERE database = 'dict_db_02179' AND
 
 SELECT 'SYSTEM RELOAD DICTIONARIES ON CLUSTER test_shard_localhost';
 SET distributed_ddl_output_mode='throw';
+SYSTEM RELOAD DICTIONARIES ON CLUSTER; -- { clientError SYNTAX_ERROR }
 SYSTEM RELOAD DICTIONARIES ON CLUSTER test_shard_localhost;
 SET distributed_ddl_output_mode='none';
 SELECT query_count FROM system.dictionaries WHERE database = 'dict_db_02179' AND name = 'dict';


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Some invalid `SYSTEM ... ON CLUSTER` queries worked in an unexpected way if a cluster name was not specified. It's fixed, now invalid queries throw `SYNTAX_ERROR` as they should. Fixes https://github.com/ClickHouse/ClickHouse/issues/44264