### PR TITLE
Try fix some tests

### DIFF
--- a/docker/test/stateful/Dockerfile
+++ b/docker/test/stateful/Dockerfile
@@ -17,6 +17,7 @@ ENV S3_URL="https://clickhouse-datasets.s3.amazonaws.com"
 ENV DATASETS="hits visits"
 
 RUN npm install -g azurite
+RUN npm install tslib
 
 COPY run.sh /
 CMD ["/bin/bash", "/run.sh"]

--- a/docker/test/stateless/Dockerfile
+++ b/docker/test/stateless/Dockerfile
@@ -80,6 +80,7 @@ ENV MINIO_ROOT_PASSWORD="clickhouse"
 ENV EXPORT_S3_STORAGE_POLICIES=1
 
 RUN npm install -g azurite
+RUN npm install tslib
 
 COPY run.sh /
 COPY setup_minio.sh /


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Looks like the tests are failing because azure disk fails to start, so the server does not start
```
2022.12.19 14:26:02.427282 [ 710 ] {} <Error> void DB::SystemLog<DB::MetricLogElement>::flushImpl(const std::vector<LogElement> &, uint64_t) [LogElement = DB::MetricLogElement]: std::exception. Code: 1001, type: Azure::Core::Http::TransportException, e.what() = Fail to get a new connection for: httplocalhost10000. Couldn't connect to server, Stack trace (when copying this message, always include the lines below):
```
in runlog I see
```
internal/modules/cjs/loader.js:638
    throw err;
    ^

Error: Cannot find module 'tslib'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/azurite/dist/src/blob/main.js:4:17)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
+ [[ 0 == 60 ]]
```
so there is some chance that this pr can fix