### PR TITLE
Disable buggy tsan assertion for integration test

### DIFF
--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -34,7 +34,8 @@ instance = cluster.add_instance(
     user_configs=["configs/default_passwd.xml"],
     with_zookeeper=True,
     # Bug in TSAN reproduces in this test https://github.com/grpc/grpc/issues/29550#issuecomment-1188085387
-    env_variables={"TSAN_OPTIONS": "report_atomic_races=0"},
+    # second_deadlock_stack -- just ordinary option we use everywhere, don't want to overwrite it
+    env_variables={"TSAN_OPTIONS": "report_atomic_races=0 second_deadlock_stack=1"},
 )
 
 

--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -33,6 +33,8 @@ instance = cluster.add_instance(
     ],
     user_configs=["configs/default_passwd.xml"],
     with_zookeeper=True,
+    # Bug in TSAN reproduces in this test https://github.com/grpc/grpc/issues/29550#issuecomment-1188085387
+    env_variables={"TSAN_OPTIONS": "report_atomic_races=0"},
 )
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Bug in tsan, suppressing it. Fixes #42734, #44188.