### PR TITLE
Respect setting settings.schema_inference_make_columns_nullable in Parquet/ORC/Arrow formats

### DIFF
--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -184,8 +184,9 @@ NamesAndTypesList ORCSchemaReader::readSchema()
     getFileReaderAndSchema(in, file_reader, schema, format_settings, is_stopped);
     auto header = ArrowColumnToCHColumn::arrowSchemaToCHHeader(
         *schema, "ORC", format_settings.orc.skip_columns_with_unsupported_types_in_schema_inference);
-    return getNamesAndRecursivelyNullableTypes(header);
-}
+    if (format_settings.schema_inference_make_columns_nullable)
+        return getNamesAndRecursivelyNullableTypes(header);
+    return header.getNamesAndTypesList();}
 
 void registerInputFormatORC(FormatFactory & factory)
 {
@@ -211,6 +212,11 @@ void registerORCSchemaReader(FormatFactory & factory)
             return std::make_shared<ORCSchemaReader>(buf, settings);
         }
         );
+
+    factory.registerAdditionalInfoForSchemaCacheGetter("ORC", [](const FormatSettings & settings)
+    {
+        return fmt::format("schema_inference_make_columns_nullable={}", settings.schema_inference_make_columns_nullable);
+    });
 }
 
 }

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -187,7 +187,9 @@ NamesAndTypesList ParquetSchemaReader::readSchema()
     getFileReaderAndSchema(in, file_reader, schema, format_settings, is_stopped);
     auto header = ArrowColumnToCHColumn::arrowSchemaToCHHeader(
         *schema, "Parquet", format_settings.parquet.skip_columns_with_unsupported_types_in_schema_inference);
-    return getNamesAndRecursivelyNullableTypes(header);
+    if (format_settings.schema_inference_make_columns_nullable)
+        return getNamesAndRecursivelyNullableTypes(header);
+    return header.getNamesAndTypesList();
 }
 
 void registerInputFormatParquet(FormatFactory & factory)
@@ -214,6 +216,11 @@ void registerParquetSchemaReader(FormatFactory & factory)
             return std::make_shared<ParquetSchemaReader>(buf, settings);
         }
         );
+
+    factory.registerAdditionalInfoForSchemaCacheGetter("Parquet", [](const FormatSettings & settings)
+    {
+        return fmt::format("schema_inference_make_columns_nullable={}", settings.schema_inference_make_columns_nullable);
+    });
 }
 
 }

--- a/tests/queries/0_stateless/02513_parquet_orc_arrow_nullable_schema_inference.reference
+++ b/tests/queries/0_stateless/02513_parquet_orc_arrow_nullable_schema_inference.reference
@@ -1,0 +1,6 @@
+number	Nullable(UInt64)					
+number	UInt64					
+number	Nullable(Int64)					
+number	Int64					
+number	Nullable(UInt64)					
+number	UInt64					

--- a/tests/queries/0_stateless/02513_parquet_orc_arrow_nullable_schema_inference.sh
+++ b/tests/queries/0_stateless/02513_parquet_orc_arrow_nullable_schema_inference.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel, no-fasttest
+# Tags: no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/02513_parquet_orc_arrow_nullable_schema_inference.sh
+++ b/tests/queries/0_stateless/02513_parquet_orc_arrow_nullable_schema_inference.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Tags: no-parallel, no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_LOCAL -q "select * from numbers(3) format Parquet" | $CLICKHOUSE_LOCAL --input-format=Parquet --table=test -q "desc test" --schema_inference_make_columns_nullable=1;
+$CLICKHOUSE_LOCAL -q "select * from numbers(3) format Parquet" | $CLICKHOUSE_LOCAL --input-format=Parquet --table=test -q "desc test" --schema_inference_make_columns_nullable=0;
+
+$CLICKHOUSE_LOCAL -q "select * from numbers(3) format ORC" | $CLICKHOUSE_LOCAL --input-format=ORC --table=test -q "desc test" --schema_inference_make_columns_nullable=1;
+$CLICKHOUSE_LOCAL -q "select * from numbers(3) format ORC" | $CLICKHOUSE_LOCAL --input-format=ORC --table=test -q "desc test" --schema_inference_make_columns_nullable=0;
+
+$CLICKHOUSE_LOCAL -q "select * from numbers(3) format Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "desc test" --schema_inference_make_columns_nullable=1;
+$CLICKHOUSE_LOCAL -q "select * from numbers(3) format Arrow" | $CLICKHOUSE_LOCAL --input-format=Arrow --table=test -q "desc test" --schema_inference_make_columns_nullable=0;
+


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Respect setting settings.schema_inference_make_columns_nullable in Parquet/ORC/Arrow formats
Follow up after https://github.com/ClickHouse/ClickHouse/pull/44019/

