### PR TITLE
Add tests as examples with errors of date(time) and string comparison that we should eliminate

### DIFF
--- a/tests/queries/0_stateless/02513_date_string_comparison.reference
+++ b/tests/queries/0_stateless/02513_date_string_comparison.reference
@@ -1,0 +1,27 @@
+Date
+2
+2
+2
+2
+DateTime
+3
+3
+3
+3
+3
+Date String
+2
+2
+2
+DateTime String
+3
+3
+3
+Date LC
+2
+2
+2
+DateTime LC
+3
+3
+3

--- a/tests/queries/0_stateless/02513_date_string_comparison.sql
+++ b/tests/queries/0_stateless/02513_date_string_comparison.sql
@@ -1,0 +1,65 @@
+CREATE TABLE datetime_date_table (
+    col_date Date,
+    col_datetime DateTime,
+    col_datetime64 DateTime64(3),
+    col_date_string String,
+    col_datetime_string String,
+    col_datetime64_string DateTime64,
+    col_date_lc LowCardinality(String),
+    col_datetime_lc LowCardinality(String),
+    col_datetime64_lc LowCardinality(String),
+    PRIMARY KEY col_date
+) ENGINE = MergeTree;
+
+INSERT INTO datetime_date_table VALUES ('2020-03-04', '2020-03-04 10:23:45', '2020-03-04 10:23:45.123', '2020-03-04', '2020-03-04 10:23:45', '2020-03-04 10:23:45.123', '2020-03-04', '2020-03-04 10:23:45', '2020-03-04 10:23:45.123');
+INSERT INTO datetime_date_table VALUES ('2020-03-05', '2020-03-05 12:23:45', '2020-03-05 12:23:45.123', '2020-03-05', '2020-03-05 12:23:45', '2020-03-05 12:23:45.123', '2020-03-05', '2020-03-05 12:23:45', '2020-03-05 12:23:45.123');
+INSERT INTO datetime_date_table VALUES ('2020-04-05', '2020-04-05 00:10:45', '2020-04-05 00:10:45.123', '2020-04-05', '2020-04-05 00:10:45', '2020-04-05 00:10:45.123', '2020-04-05', '2020-04-05 00:10:45', '2020-04-05 00:10:45.123');
+
+SELECT 'Date';
+SELECT count() FROM datetime_date_table WHERE col_date > '2020-03-04';
+SELECT count() FROM datetime_date_table WHERE col_date > '2020-03-04'::Date;
+SELECT count() FROM datetime_date_table WHERE col_date > '2020-03-04 10:20:45'; -- { serverError TYPE_MISMATCH }
+SELECT count() FROM datetime_date_table WHERE col_date > '2020-03-04 10:20:45'::DateTime;
+SELECT count() FROM datetime_date_table WHERE col_date > '2020-03-04 10:20:45.100'; -- { serverError TYPE_MISMATCH }
+SELECT count() FROM datetime_date_table WHERE col_date > '2020-03-04 10:20:45.100'::DateTime64(3);
+
+SELECT 'DateTime';
+SELECT count() FROM datetime_date_table WHERE col_datetime > '2020-03-04';
+SELECT count() FROM datetime_date_table WHERE col_datetime > '2020-03-04'::Date;
+SELECT count() FROM datetime_date_table WHERE col_datetime > '2020-03-04 10:20:45';
+SELECT count() FROM datetime_date_table WHERE col_datetime > '2020-03-04 10:20:45'::DateTime;
+SELECT count() FROM datetime_date_table WHERE col_datetime > '2020-03-04 10:20:45.100'; -- { serverError TYPE_MISMATCH }
+SELECT count() FROM datetime_date_table WHERE col_datetime > '2020-03-04 10:20:45.100'::DateTime64(3);
+
+SELECT 'Date String';
+SELECT count() FROM datetime_date_table WHERE col_date_string > '2020-03-04';
+SELECT count() FROM datetime_date_table WHERE col_date_string > '2020-03-04'::Date; -- { serverError NO_COMMON_TYPE }
+SELECT count() FROM datetime_date_table WHERE col_date_string > '2020-03-04 10:20:45';
+SELECT count() FROM datetime_date_table WHERE col_date_string > '2020-03-04 10:20:45'::DateTime; -- { serverError NO_COMMON_TYPE }
+SELECT count() FROM datetime_date_table WHERE col_date_string > '2020-03-04 10:20:45.100';
+SELECT count() FROM datetime_date_table WHERE col_date_string > '2020-03-04 10:20:45.100'::DateTime64(3); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT 'DateTime String';
+SELECT count() FROM datetime_date_table WHERE col_datetime_string > '2020-03-04';
+SELECT count() FROM datetime_date_table WHERE col_datetime_string > '2020-03-04'::Date; -- { serverError NO_COMMON_TYPE }
+SELECT count() FROM datetime_date_table WHERE col_datetime_string > '2020-03-04 10:20:45';
+SELECT count() FROM datetime_date_table WHERE col_datetime_string > '2020-03-04 10:20:45'::DateTime; -- { serverError NO_COMMON_TYPE }
+SELECT count() FROM datetime_date_table WHERE col_datetime_string > '2020-03-04 10:20:45.100';
+SELECT count() FROM datetime_date_table WHERE col_datetime_string > '2020-03-04 10:20:45.100'::DateTime64(3); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT 'Date LC';
+SELECT count() FROM datetime_date_table WHERE col_date_lc > '2020-03-04';
+SELECT count() FROM datetime_date_table WHERE col_date_lc > '2020-03-04'::Date; -- { serverError NO_COMMON_TYPE }
+SELECT count() FROM datetime_date_table WHERE col_date_lc > '2020-03-04 10:20:45';
+SELECT count() FROM datetime_date_table WHERE col_date_lc > '2020-03-04 10:20:45'::DateTime; -- { serverError NO_COMMON_TYPE }
+SELECT count() FROM datetime_date_table WHERE col_date_lc > '2020-03-04 10:20:45.100';
+SELECT count() FROM datetime_date_table WHERE col_date_lc > '2020-03-04 10:20:45.100'::DateTime64(3); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT 'DateTime LC';
+SELECT count() FROM datetime_date_table WHERE col_datetime_lc > '2020-03-04';
+SELECT count() FROM datetime_date_table WHERE col_datetime_lc > '2020-03-04'::Date;  -- { serverError NO_COMMON_TYPE }
+SELECT count() FROM datetime_date_table WHERE col_datetime_lc > '2020-03-04 10:20:45';
+SELECT count() FROM datetime_date_table WHERE col_datetime_lc > '2020-03-04 10:20:45'::DateTime; -- { serverError NO_COMMON_TYPE }
+SELECT count() FROM datetime_date_table WHERE col_datetime_lc > '2020-03-04 10:20:45.100';
+SELECT count() FROM datetime_date_table WHERE col_datetime_lc > '2020-03-04 10:20:45.100'::DateTime64(3); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Currently we forbid String to Date conversion on comparison which makes it hard to work with string columns storing Date(time)s.
We can use corresponding date type as common type. Or convert date to string. 

It may be a feature that is controlled by flag(use string or date as common), but something tells be that ANSI SQL allows that comparisons.
PS it is also hilarious that we report it with 3 errors (NO_COMMON_TYPE, TYPE_MISMATCH, ILLEGAL_TYPE_OF_ARGUMENT) in different cases. 

Tests should be green now, so we can merge this PR and track changes in linked issue

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
