### PR TITLE
Fix flaky test `roaring_memory_tracking`

### DIFF
--- a/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
+++ b/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
@@ -1,4 +1,4 @@
 -- Tags: no-replicated-database
 
-SET max_memory_usage = '100M';
+SET max_memory_usage = '75M';
 SELECT cityHash64(rand() % 1000) as n, groupBitmapState(number) FROM numbers_mt(2000000000) GROUP BY n FORMAT Null; -- { serverError 241 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #44053

Explanation: we optimized the memory usage or something else changed, and the old threshold of 100M now is too large:

```
milovidov@milovidov-desktop:~/Downloads$ rg 56346e1b-fd75-4736-b7e5-26fc381c9463 clickhouse-server.log-3 
424103:2022.12.17 23:37:50.769831 [ 2086 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> executeQuery: (from [::1]:53180) (comment: 01961_roaring_memory_tracking.sql) SELECT cityHash64(rand() % 1000) as n, groupBitmapState(number) FROM numbers_mt(2000000000) GROUP BY n FORMAT Null; (stage: Complete)
424104:2022.12.17 23:37:50.771001 [ 2086 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
424105:2022.12.17 23:37:50.777429 [ 7227 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424106:2022.12.17 23:37:50.777457 [ 1980 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424107:2022.12.17 23:37:50.777476 [ 6717 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424108:2022.12.17 23:37:50.777458 [ 7292 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424109:2022.12.17 23:37:50.777499 [ 6812 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424110:2022.12.17 23:37:50.777517 [ 6717 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424111:2022.12.17 23:37:50.777534 [ 6812 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424112:2022.12.17 23:37:50.777502 [ 6873 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424113:2022.12.17 23:37:50.777585 [ 6862 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424114:2022.12.17 23:37:50.777612 [ 6862 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424115:2022.12.17 23:37:50.777477 [ 7188 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424116:2022.12.17 23:37:50.777686 [ 7188 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424117:2022.12.17 23:37:50.777700 [ 7101 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424118:2022.12.17 23:37:50.777731 [ 7101 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424119:2022.12.17 23:37:50.777739 [ 7264 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424120:2022.12.17 23:37:50.777763 [ 7264 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424121:2022.12.17 23:37:50.777768 [ 7040 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424122:2022.12.17 23:37:50.777808 [ 7040 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424123:2022.12.17 23:37:50.777463 [ 7476 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424124:2022.12.17 23:37:50.777851 [ 6679 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424125:2022.12.17 23:37:50.777485 [ 6831 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424126:2022.12.17 23:37:50.777884 [ 6679 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424127:2022.12.17 23:37:50.777891 [ 6831 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424128:2022.12.17 23:37:50.778102 [ 7315 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424129:2022.12.17 23:37:50.778128 [ 7315 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424139:2022.12.17 23:37:50.777471 [ 7227 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424140:2022.12.17 23:37:50.777509 [ 1980 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424143:2022.12.17 23:37:50.786119 [ 6758 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424144:2022.12.17 23:37:50.786152 [ 6758 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424149:2022.12.17 23:37:50.777770 [ 6734 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424150:2022.12.17 23:37:50.777860 [ 7476 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424151:2022.12.17 23:37:50.786467 [ 6734 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424156:2022.12.17 23:37:50.790012 [ 7215 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424157:2022.12.17 23:37:50.790035 [ 7215 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424168:2022.12.17 23:37:50.777853 [ 6934 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424169:2022.12.17 23:37:50.792570 [ 6934 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424170:2022.12.17 23:37:50.794039 [ 1347 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424171:2022.12.17 23:37:50.794069 [ 1347 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424172:2022.12.17 23:37:50.777519 [ 7292 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424173:2022.12.17 23:37:50.798152 [ 7013 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424174:2022.12.17 23:37:50.798190 [ 7013 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424175:2022.12.17 23:37:50.777588 [ 6873 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424176:2022.12.17 23:37:50.804193 [ 6995 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424177:2022.12.17 23:37:50.804235 [ 6995 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424178:2022.12.17 23:37:50.804301 [ 1075 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424179:2022.12.17 23:37:50.804339 [ 1075 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424180:2022.12.17 23:37:50.809994 [ 2003 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424181:2022.12.17 23:37:50.810038 [ 2003 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424182:2022.12.17 23:37:50.810434 [ 6959 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424183:2022.12.17 23:37:50.810461 [ 6959 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424184:2022.12.17 23:37:50.814009 [ 6888 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424185:2022.12.17 23:37:50.814043 [ 6942 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424186:2022.12.17 23:37:50.814089 [ 6942 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424187:2022.12.17 23:37:50.814160 [ 6823 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424188:2022.12.17 23:37:50.814196 [ 6823 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424189:2022.12.17 23:37:50.814367 [ 6950 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424190:2022.12.17 23:37:50.814398 [ 6950 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424191:2022.12.17 23:37:50.814052 [ 6888 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424192:2022.12.17 23:37:50.814160 [ 7438 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424193:2022.12.17 23:37:50.814169 [ 6988 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424194:2022.12.17 23:37:50.817908 [ 7438 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424195:2022.12.17 23:37:50.817925 [ 6988 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424196:2022.12.17 23:37:50.821987 [ 7295 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424197:2022.12.17 23:37:50.814061 [ 7090 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424198:2022.12.17 23:37:50.822043 [ 7295 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424199:2022.12.17 23:37:50.822064 [ 7090 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424200:2022.12.17 23:37:50.826185 [ 7268 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424201:2022.12.17 23:37:50.826227 [ 7268 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424211:2022.12.17 23:37:50.831916 [ 4665 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424212:2022.12.17 23:37:50.831950 [ 4665 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424213:2022.12.17 23:37:50.831970 [ 6997 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424214:2022.12.17 23:37:50.832003 [ 6997 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424220:2022.12.17 23:37:50.832329 [ 6783 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424221:2022.12.17 23:37:50.832351 [ 4574 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424222:2022.12.17 23:37:50.832383 [ 4574 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424223:2022.12.17 23:37:50.832358 [ 6783 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424224:2022.12.17 23:37:50.832489 [ 6941 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424225:2022.12.17 23:37:50.832511 [ 6941 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424226:2022.12.17 23:37:50.832637 [ 7358 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424227:2022.12.17 23:37:50.832663 [ 7358 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424228:2022.12.17 23:37:50.836315 [ 6891 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424229:2022.12.17 23:37:50.836347 [ 6891 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424230:2022.12.17 23:37:50.832113 [ 7109 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424231:2022.12.17 23:37:50.837845 [ 7109 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424232:2022.12.17 23:37:50.837984 [ 7474 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424233:2022.12.17 23:37:50.838012 [ 7474 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424234:2022.12.17 23:37:50.838014 [ 6795 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424235:2022.12.17 23:37:50.838042 [ 6795 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424236:2022.12.17 23:37:50.838147 [ 6796 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424237:2022.12.17 23:37:50.838173 [ 6796 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424239:2022.12.17 23:37:50.842216 [ 7447 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424240:2022.12.17 23:37:50.842250 [ 7447 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424241:2022.12.17 23:37:50.846043 [ 7166 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424242:2022.12.17 23:37:50.846042 [ 7006 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424243:2022.12.17 23:37:50.846093 [ 7166 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424244:2022.12.17 23:37:50.846104 [ 7006 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424245:2022.12.17 23:37:50.846090 [ 7161 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424246:2022.12.17 23:37:50.846142 [ 7161 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424247:2022.12.17 23:37:50.846157 [ 7441 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> AggregatingTransform: Aggregating
424248:2022.12.17 23:37:50.846183 [ 7441 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Aggregation method: key64
424644:2022.12.17 23:37:51.461837 [ 6988 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424645:2022.12.17 23:37:51.461866 [ 6795 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424646:2022.12.17 23:37:51.461923 [ 7315 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424647:2022.12.17 23:37:51.461956 [ 7474 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424648:2022.12.17 23:37:51.462341 [ 7292 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424649:2022.12.17 23:37:51.462494 [ 6959 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424650:2022.12.17 23:37:51.462876 [ 6997 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424651:2022.12.17 23:37:51.462910 [ 7006 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424652:2022.12.17 23:37:51.462952 [ 7264 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424653:2022.12.17 23:37:51.462965 [ 2003 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424654:2022.12.17 23:37:51.463056 [ 6941 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424655:2022.12.17 23:37:51.463287 [ 7109 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424656:2022.12.17 23:37:51.463471 [ 7101 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424657:2022.12.17 23:37:51.463549 [ 6758 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424658:2022.12.17 23:37:51.464018 [ 6942 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424659:2022.12.17 23:37:51.464114 [ 7040 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424660:2022.12.17 23:37:51.464181 [ 7438 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424661:2022.12.17 23:37:51.464380 [ 1980 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424662:2022.12.17 23:37:51.464558 [ 6812 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424663:2022.12.17 23:37:51.464647 [ 7447 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424664:2022.12.17 23:37:51.464666 [ 6717 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424665:2022.12.17 23:37:51.464773 [ 7441 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424666:2022.12.17 23:37:51.465048 [ 6934 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424667:2022.12.17 23:37:51.465552 [ 6891 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424668:2022.12.17 23:37:51.465578 [ 7161 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424669:2022.12.17 23:37:51.465843 [ 7215 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424670:2022.12.17 23:37:51.466074 [ 6873 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424671:2022.12.17 23:37:51.466197 [ 6995 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424672:2022.12.17 23:37:51.464652 [ 6888 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424673:2022.12.17 23:37:51.466653 [ 7090 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424674:2022.12.17 23:37:51.466698 [ 1347 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424675:2022.12.17 23:37:51.467161 [ 6783 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424676:2022.12.17 23:37:51.463295 [ 7188 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424677:2022.12.17 23:37:51.467227 [ 6823 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424678:2022.12.17 23:37:51.466701 [ 7476 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424679:2022.12.17 23:37:51.467591 [ 4665 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424680:2022.12.17 23:37:51.467168 [ 7295 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424681:2022.12.17 23:37:51.467620 [ 7166 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424682:2022.12.17 23:37:51.467655 [ 7013 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424683:2022.12.17 23:37:51.467669 [ 6831 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424684:2022.12.17 23:37:51.467757 [ 6796 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424685:2022.12.17 23:37:51.467893 [ 4574 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424686:2022.12.17 23:37:51.468390 [ 6950 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424687:2022.12.17 23:37:51.468524 [ 6862 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424688:2022.12.17 23:37:51.468680 [ 7227 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424689:2022.12.17 23:37:51.469004 [ 6734 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424690:2022.12.17 23:37:51.469245 [ 7358 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424691:2022.12.17 23:37:51.469587 [ 6679 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424695:2022.12.17 23:37:51.472195 [ 1075 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
424703:2022.12.17 23:37:51.467168 [ 7268 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Converting aggregation data to two-level.
432500:2022.12.17 23:38:05.206219 [ 6783 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> MemoryTracker: Current memory usage (total): 8.18 GiB.
471595:2022.12.17 23:38:47.331593 [ 7227 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> MemoryTracker: Current memory usage (total): 15.00 GiB.
497766:2022.12.17 23:39:13.971678 [ 6997 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> MemoryTracker: Current memory usage (total): 20.00 GiB.
498604:2022.12.17 23:39:18.960174 [ 6831 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> MemoryTracker: Current memory usage (total): 21.00 GiB.
498720:2022.12.17 23:39:20.157667 [ 6862 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 44437244 to 1000 rows (from 678.06 MiB) in 89.385032159 sec. (497144.129 rows/sec., 7.59 MiB/sec.)
498721:2022.12.17 23:39:20.158293 [ 7040 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 35447436 to 1000 rows (from 540.88 MiB) in 89.385481905 sec. (396568.159 rows/sec., 6.05 MiB/sec.)
498722:2022.12.17 23:39:20.158372 [ 6988 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36293012 to 1000 rows (from 553.79 MiB) in 89.385142412 sec. (406029.582 rows/sec., 6.20 MiB/sec.)
498723:2022.12.17 23:39:20.158462 [ 7292 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 43548530 to 1000 rows (from 664.50 MiB) in 89.385924125 sec. (487196.731 rows/sec., 7.43 MiB/sec.)
498724:2022.12.17 23:39:20.158814 [ 6823 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 37071832 to 1000 rows (from 565.67 MiB) in 89.385608351 sec. (414740.501 rows/sec., 6.33 MiB/sec.)
498725:2022.12.17 23:39:20.158836 [ 6812 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36148374 to 1000 rows (from 551.58 MiB) in 89.385808059 sec. (404408.427 rows/sec., 6.17 MiB/sec.)
498726:2022.12.17 23:39:20.159751 [ 7268 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 34535104 to 1000 rows (from 526.96 MiB) in 89.38647451 sec. (386357.155 rows/sec., 5.90 MiB/sec.)
498727:2022.12.17 23:39:20.160707 [ 6795 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 41956146 to 1000 rows (from 640.20 MiB) in 89.387828787 sec. (469372.023 rows/sec., 7.16 MiB/sec.)
498728:2022.12.17 23:39:20.161292 [ 1980 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36815934 to 1000 rows (from 561.77 MiB) in 89.388331107 sec. (411865.101 rows/sec., 6.28 MiB/sec.)
498729:2022.12.17 23:39:20.161341 [ 6888 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 44092338 to 1000 rows (from 672.80 MiB) in 89.38849698 sec. (493266.354 rows/sec., 7.53 MiB/sec.)
498730:2022.12.17 23:39:20.161356 [ 6934 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 42846226 to 1000 rows (from 653.78 MiB) in 89.388272436 sec. (479327.151 rows/sec., 7.31 MiB/sec.)
498731:2022.12.17 23:39:20.161432 [ 4574 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 35781216 to 1000 rows (from 545.98 MiB) in 89.388718601 sec. (400287.828 rows/sec., 6.11 MiB/sec.)
498732:2022.12.17 23:39:20.162062 [ 7264 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36493280 to 1000 rows (from 556.84 MiB) in 89.389463947 sec. (408250.351 rows/sec., 6.23 MiB/sec.)
498733:2022.12.17 23:39:20.162109 [ 7090 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 37194218 to 1000 rows (from 567.54 MiB) in 89.389450701 sec. (416091.806 rows/sec., 6.35 MiB/sec.)
498734:2022.12.17 23:39:20.163789 [ 7101 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 44381614 to 1000 rows (from 677.21 MiB) in 89.391000266 sec. (496488.616 rows/sec., 7.58 MiB/sec.)
498735:2022.12.17 23:39:20.164567 [ 6783 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 37828400 to 1000 rows (from 577.22 MiB) in 89.391834802 sec. (423175.115 rows/sec., 6.46 MiB/sec.)
498736:2022.12.17 23:39:20.164702 [ 6941 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 40710034 to 1000 rows (from 621.19 MiB) in 89.391393291 sec. (455413.351 rows/sec., 6.95 MiB/sec.)
498737:2022.12.17 23:39:20.165338 [ 7227 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 85625696 to 1000 rows (from 1.28 GiB) in 89.392412853 sec. (957863.126 rows/sec., 14.62 MiB/sec.)
498738:2022.12.17 23:39:20.166398 [ 1075 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36059366 to 1000 rows (from 550.22 MiB) in 89.393222432 sec. (403379.194 rows/sec., 6.16 MiB/sec.)
498739:2022.12.17 23:39:20.166776 [ 7447 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 41310838 to 1000 rows (from 630.35 MiB) in 89.393387919 sec. (462124.090 rows/sec., 7.05 MiB/sec.)
498740:2022.12.17 23:39:20.167377 [ 7215 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36170626 to 1000 rows (from 551.92 MiB) in 89.39462514 sec. (404617.458 rows/sec., 6.17 MiB/sec.)
498741:2022.12.17 23:39:20.167449 [ 7315 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36170626 to 1000 rows (from 551.92 MiB) in 89.394329914 sec. (404618.794 rows/sec., 6.17 MiB/sec.)
498742:2022.12.17 23:39:20.167996 [ 6831 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36838186 to 1000 rows (from 562.11 MiB) in 89.395018061 sec. (412083.210 rows/sec., 6.29 MiB/sec.)
498743:2022.12.17 23:39:20.168772 [ 6796 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 35981484 to 1000 rows (from 549.03 MiB) in 89.395398571 sec. (402498.166 rows/sec., 6.14 MiB/sec.)
498744:2022.12.17 23:39:20.169295 [ 7013 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 38251188 to 1000 rows (from 583.67 MiB) in 89.396139548 sec. (427884.114 rows/sec., 6.53 MiB/sec.)
498745:2022.12.17 23:39:20.169461 [ 6734 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36526658 to 1000 rows (from 557.35 MiB) in 89.396392166 sec. (408592.082 rows/sec., 6.23 MiB/sec.)
498746:2022.12.17 23:39:20.169553 [ 1347 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 46784830 to 1000 rows (from 713.88 MiB) in 89.396728538 sec. (523339.397 rows/sec., 7.99 MiB/sec.)
498747:2022.12.17 23:39:20.169704 [ 7166 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 45260568 to 1000 rows (from 690.62 MiB) in 89.396929721 sec. (506287.723 rows/sec., 7.73 MiB/sec.)
498748:2022.12.17 23:39:20.169860 [ 7295 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 37594754 to 1000 rows (from 573.65 MiB) in 89.396968958 sec. (420537.233 rows/sec., 6.42 MiB/sec.)
498749:2022.12.17 23:39:20.170475 [ 6679 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 48598368 to 1000 rows (from 741.55 MiB) in 89.397374785 sec. (543621.869 rows/sec., 8.30 MiB/sec.)
498750:2022.12.17 23:39:20.170627 [ 6950 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 35425184 to 1000 rows (from 540.55 MiB) in 89.397369544 sec. (396266.514 rows/sec., 6.05 MiB/sec.)
498751:2022.12.17 23:39:20.170786 [ 6717 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 52381208 to 1000 rows (from 799.27 MiB) in 89.397789405 sec. (585934.041 rows/sec., 8.94 MiB/sec.)
498752:2022.12.17 23:39:20.170793 [ 7161 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 42723840 to 1000 rows (from 651.91 MiB) in 89.397385313 sec. (477909.279 rows/sec., 7.29 MiB/sec.)
498753:2022.12.17 23:39:20.171103 [ 6942 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 36404272 to 1000 rows (from 555.49 MiB) in 89.398245902 sec. (407214.612 rows/sec., 6.21 MiB/sec.)
498754:2022.12.17 23:39:20.171331 [ 6959 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 37939660 to 1000 rows (from 578.91 MiB) in 89.398141751 sec. (424389.806 rows/sec., 6.48 MiB/sec.)
498758:2022.12.17 23:39:20.172396 [ 7188 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 40098104 to 1000 rows (from 611.85 MiB) in 89.399382929 sec. (448527.749 rows/sec., 6.84 MiB/sec.)
498774:2022.12.17 23:39:20.179135 [ 4665 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 32966338 to 1000 rows (from 503.03 MiB) in 89.406574505 sec. (368723.868 rows/sec., 5.63 MiB/sec.)
498779:2022.12.17 23:39:20.180333 [ 6995 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 41366468 to 1000 rows (from 631.20 MiB) in 89.407686063 sec. (462672.392 rows/sec., 7.06 MiB/sec.)
498785:2022.12.17 23:39:20.182818 [ 6758 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 32788322 to 1000 rows (from 500.31 MiB) in 89.40967595 sec. (366720.063 rows/sec., 5.60 MiB/sec.)
498787:2022.12.17 23:39:20.182967 [ 6873 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 33010842 to 1000 rows (from 503.71 MiB) in 89.409918895 sec. (369207.828 rows/sec., 5.63 MiB/sec.)
498789:2022.12.17 23:39:20.183166 [ 7006 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 57109758 to 1000 rows (from 871.43 MiB) in 89.410256755 sec. (638738.329 rows/sec., 9.75 MiB/sec.)
498801:2022.12.17 23:39:20.183979 [ 7441 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 32387786 to 1000 rows (from 494.20 MiB) in 89.410559014 sec. (362236.702 rows/sec., 5.53 MiB/sec.)
498804:2022.12.17 23:39:20.184594 [ 2003 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 32710440 to 1000 rows (from 499.12 MiB) in 89.412016082 sec. (365839.419 rows/sec., 5.58 MiB/sec.)
498808:2022.12.17 23:39:20.187398 [ 7358 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 52336704 to 1000 rows (from 798.59 MiB) in 89.414039506 sec. (585329.824 rows/sec., 8.93 MiB/sec.)
498810:2022.12.17 23:39:20.188204 [ 7474 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 40465262 to 1000 rows (from 617.45 MiB) in 89.415502576 sec. (452553.090 rows/sec., 6.91 MiB/sec.)
498812:2022.12.17 23:39:20.188253 [ 7438 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 40732286 to 1000 rows (from 621.53 MiB) in 89.415011955 sec. (455541.918 rows/sec., 6.95 MiB/sec.)
498813:2022.12.17 23:39:20.188504 [ 6891 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 33478134 to 1000 rows (from 510.84 MiB) in 89.41516305 sec. (374412.268 rows/sec., 5.71 MiB/sec.)
498819:2022.12.17 23:39:20.191051 [ 7476 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 32576928 to 1000 rows (from 497.08 MiB) in 89.418107499 sec. (364321.376 rows/sec., 5.56 MiB/sec.)
498820:2022.12.17 23:39:20.191096 [ 7109 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 33455882 to 1000 rows (from 510.50 MiB) in 89.417789428 sec. (374152.417 rows/sec., 5.71 MiB/sec.)
498822:2022.12.17 23:39:20.191467 [ 6997 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> AggregatingTransform: Aggregated. 32888456 to 1000 rows (from 501.84 MiB) in 89.418785604 sec. (367802.535 rows/sec., 5.61 MiB/sec.)
498823:2022.12.17 23:39:20.191492 [ 6997 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Merging aggregated data
498825:2022.12.17 23:39:20.191659 [ 6997 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Trace> Aggregator: Statistics updated for key=2483587490190430702: new sum_of_sizes=50000, median_size=1000
604704:2022.12.17 23:40:26.882508 [ 2086 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Information> executeQuery: Read 2000000000 rows, 14.90 GiB in 156.112565954 sec., 12811268 rows/sec., 97.74 MiB/sec.
604725:2022.12.17 23:40:26.885115 [ 2086 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> MemoryTracker: Peak memory usage (for query): 86.22 MiB.
604726:2022.12.17 23:40:26.885140 [ 2086 ] {56346e1b-fd75-4736-b7e5-26fc381c9463} <Debug> TCPHandler: Processed in 156.115871097 sec.
```