### PR TITLE
From final

### DIFF
--- a/docs/en/sql-reference/statements/select/from.md
+++ b/docs/en/sql-reference/statements/select/from.md
@@ -21,8 +21,7 @@ Subquery is another `SELECT` query that may be specified in parenthesis inside `
 
 When `FINAL` is specified, ClickHouse fully merges the data before returning the result and thus performs all data transformations that happen during merges for the given table engine.
 
-It is applicable when selecting data from tables that use the [Replicated](../../../engines/table-engines/mergetree-family/replication.md) versions of `MergeTree` engines.
--   [View](../../../engines/table-engines/special/view.md), [Buffer](../../../engines/table-engines/special/buffer.md), [Distributed](../../../engines/table-engines/special/distributed.md), and [MaterializedView](../../../engines/table-engines/special/materializedview.md) engines that operate over other engines, provided they were created over `MergeTree`-engine tables.
+It is applicable when selecting data from ReplacingMergeTree, SummingMergeTree, AggregatingMergeTree, CollapsingMergeTree and VersionedCollapsingMergeTree tables.
 
 Now `SELECT` queries with `FINAL` are executed in parallel and slightly faster. But there are drawbacks (see below). The [max_final_threads](../../../operations/settings/settings.md#max-final-threads) setting limits the number of threads used.
 

--- a/docs/en/sql-reference/statements/select/from.md
+++ b/docs/en/sql-reference/statements/select/from.md
@@ -19,6 +19,8 @@ Subquery is another `SELECT` query that may be specified in parenthesis inside `
 
 ## FINAL Modifier
 
+The FINAL modifier can be used only for a SELECT from ReplacingMergeTree, SummingMergeTree, AggregatingMergeTree, CollapsingMergeTree and VersionedCollapsingMergeTree tables. 
+
 When `FINAL` is specified, ClickHouse fully merges the data before returning the result and thus performs all data transformations that happen during merges for the given table engine.
 
 It is applicable when selecting data from tables that use the [MergeTree](../../../engines/table-engines/mergetree-family/mergetree.md)-engine family. Also supported for:

--- a/docs/en/sql-reference/statements/select/from.md
+++ b/docs/en/sql-reference/statements/select/from.md
@@ -19,13 +19,9 @@ Subquery is another `SELECT` query that may be specified in parenthesis inside `
 
 ## FINAL Modifier
 
-The FINAL modifier can be used only for a SELECT from ReplacingMergeTree, SummingMergeTree, AggregatingMergeTree, CollapsingMergeTree and VersionedCollapsingMergeTree tables. 
-
 When `FINAL` is specified, ClickHouse fully merges the data before returning the result and thus performs all data transformations that happen during merges for the given table engine.
 
-It is applicable when selecting data from tables that use the [MergeTree](../../../engines/table-engines/mergetree-family/mergetree.md)-engine family. Also supported for:
-
--   [Replicated](../../../engines/table-engines/mergetree-family/replication.md) versions of `MergeTree` engines.
+It is applicable when selecting data from tables that use the [Replicated](../../../engines/table-engines/mergetree-family/replication.md) versions of `MergeTree` engines.
 -   [View](../../../engines/table-engines/special/view.md), [Buffer](../../../engines/table-engines/special/buffer.md), [Distributed](../../../engines/table-engines/special/distributed.md), and [MaterializedView](../../../engines/table-engines/special/materializedview.md) engines that operate over other engines, provided they were created over `MergeTree`-engine tables.
 
 Now `SELECT` queries with `FINAL` are executed in parallel and slightly faster. But there are drawbacks (see below). The [max_final_threads](../../../operations/settings/settings.md#max-final-threads) setting limits the number of threads used.

--- a/docs/en/sql-reference/statements/select/from.md
+++ b/docs/en/sql-reference/statements/select/from.md
@@ -23,7 +23,9 @@ When `FINAL` is specified, ClickHouse fully merges the data before returning the
 
 It is applicable when selecting data from ReplacingMergeTree, SummingMergeTree, AggregatingMergeTree, CollapsingMergeTree and VersionedCollapsingMergeTree tables.
 
-Now `SELECT` queries with `FINAL` are executed in parallel and slightly faster. But there are drawbacks (see below). The [max_final_threads](../../../operations/settings/settings.md#max-final-threads) setting limits the number of threads used.
+`SELECT` queries with `FINAL` are executed in parallel. The [max_final_threads](../../../operations/settings/settings.md#max-final-threads) setting limits the number of threads used.
+
+There are drawbacks to using `FINAL` (see below). 
 
 ### Drawbacks
 


### PR DESCRIPTION
closes #43290

### Changelog category (leave one):
- Documentation (changelog entry is not required)

@blinkov Can you have a look at lines 26 - 30 please?  Are selects with FINAL really faster than selects without, or are they faster than selects with final were in the past (maybe selects with FINAL were not always run in parallel?

```
   26 Now `SELECT` queries with `FINAL` are executed in parallel and slightly faster.       But there are drawbacks (see below). The [max_final_threads](../../../operations      /settings/settings.md#max-final-threads) setting limits the number of threads us      ed.                                                                             
   27                                                                                 
   28 ### Drawbacks                                                                   
   29                                                                                 
   30 Queries that use `FINAL` are executed slightly slower than similar queries that 
      do not, because: 
```