### PR TITLE
Infer numbers starting from zero as strings in TSV

### DIFF
--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -315,14 +315,14 @@ DataTypePtr tryInferDataTypeByEscapingRule(const String & field, const FormatSet
             if (field == format_settings.bool_false_representation || field == format_settings.bool_true_representation)
                 return DataTypeFactory::instance().get("Bool");
 
+            if (auto date_type = tryInferDateOrDateTimeFromString(field, format_settings))
+                return date_type;
+
             /// Special case when we have number that starts with 0. In TSV we don't parse such numbers,
             /// see readIntTextUnsafe in ReadHelpers.h. If we see data started with 0, we can determine it
             /// as a String, so parsing won't fail.
-            if (field[0] == '0')
+            if (field[0] == '0' && field.size() != 1)
                 return std::make_shared<DataTypeString>();
-
-            if (auto date_type = tryInferDateOrDateTimeFromString(field, format_settings))
-                return date_type;
 
             auto type = tryInferDataTypeForSingleField(field, format_settings);
             if (!type)

--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -315,6 +315,12 @@ DataTypePtr tryInferDataTypeByEscapingRule(const String & field, const FormatSet
             if (field == format_settings.bool_false_representation || field == format_settings.bool_true_representation)
                 return DataTypeFactory::instance().get("Bool");
 
+            /// Special case when we have number that starts with 0. In TSV we don't parse such numbers,
+            /// see readIntTextUnsafe in ReadHelpers.h. If we see data started with 0, we can determine it
+            /// as a String, so parsing won't fail.
+            if (field[0] == '0')
+                return std::make_shared<DataTypeString>();
+
             if (auto date_type = tryInferDateOrDateTimeFromString(field, format_settings))
                 return date_type;
 

--- a/tests/queries/0_stateless/02514_tsv_zero_started_number.reference
+++ b/tests/queries/0_stateless/02514_tsv_zero_started_number.reference
@@ -1,0 +1,1 @@
+Nullable(String)	0123

--- a/tests/queries/0_stateless/02514_tsv_zero_started_number.sql
+++ b/tests/queries/0_stateless/02514_tsv_zero_started_number.sql
@@ -1,0 +1,2 @@
+select toTypeName(*), * from format(TSV, '0123');
+


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Infer numbers starting from zero as strings in TSV as we cannot parse them as integer
