### PR TITLE
tests: get back test_distributed_queries_stress without flakiness

### DIFF
--- a/tests/integration/test_distributed_queries_stress/configs/server_overrides.xml
+++ b/tests/integration/test_distributed_queries_stress/configs/server_overrides.xml
@@ -1,0 +1,74 @@
+<clickhouse>
+    <!-- Reduce number of threads to avoid possible OOM under ASan
+
+         NOTE: there will be still lots of threads since TCPHandler uses it's own
+         pool, so there will be at least 2x more.
+    -->
+    <background_distributed_schedule_pool_size>1</background_distributed_schedule_pool_size>
+    <background_pool_size>1</background_pool_size>
+    <background_move_pool_size>1</background_move_pool_size>
+    <background_fetches_pool_size>1</background_fetches_pool_size>
+    <background_buffer_flush_schedule_pool_size>1</background_buffer_flush_schedule_pool_size>
+    <background_schedule_pool_size>1</background_schedule_pool_size>
+    <background_merges_mutations_concurrency_ratio>1</background_merges_mutations_concurrency_ratio>
+    <merge_tree>
+        <number_of_free_entries_in_pool_to_lower_max_size_of_merge>1</number_of_free_entries_in_pool_to_lower_max_size_of_merge>
+        <number_of_free_entries_in_pool_to_execute_mutation>1</number_of_free_entries_in_pool_to_execute_mutation>
+    </merge_tree>
+    <max_thread_pool_size>200</max_thread_pool_size>
+    <max_concurrent_queries>200</max_concurrent_queries>
+
+    <query_masking_rules remove="remove"/>
+    <query_thread_log remove="remove"/>
+    <query_log remove="remove" />
+    <query_views_log remove="remove" />
+    <metric_log remove="remove"/>
+    <text_log remove="remove"/>
+    <trace_log remove="remove"/>
+    <asynchronous_metric_log remove="remove" />
+    <session_log remove="remove" />
+    <part_log remove="remove" />
+    <crash_log remove="remove" />
+    <opentelemetry_span_log remove="remove" />
+    <zookeeper_log remove="remove" />
+    <transactions_info_log remove="remove" />
+
+    <remote_servers>
+        <one_shard>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node1_r1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node1_r2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </one_shard>
+        <two_shards>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node1_r1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node1_r2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+            <shard>
+                <replica>
+                    <host>node2_r1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2_r2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </two_shards>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_distributed_queries_stress/test.py
+++ b/tests/integration/test_distributed_queries_stress/test.py
@@ -1,0 +1,132 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=line-too-long
+
+import shlex
+import itertools
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1_r1 = cluster.add_instance(
+    "node1_r1", main_configs=["configs/server_overrides.xml"]
+)
+node2_r1 = cluster.add_instance(
+    "node2_r1", main_configs=["configs/server_overrides.xml"]
+)
+node1_r2 = cluster.add_instance(
+    "node1_r2", main_configs=["configs/server_overrides.xml"]
+)
+node2_r2 = cluster.add_instance(
+    "node2_r2", main_configs=["configs/server_overrides.xml"]
+)
+
+
+def run_benchmark(payload, settings):
+    node1_r1.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "echo {} | ".format(shlex.quote(payload.strip()))
+            + " ".join(
+                [
+                    "clickhouse",
+                    "benchmark",
+                    "--concurrency=50",
+                    "--cumulative",
+                    "--delay=0",
+                    # NOTE: with current matrix even 3 seconds it huge...
+                    "--timelimit=3",
+                    # tune some basic timeouts
+                    "--hedged_connection_timeout_ms=200",
+                    "--connect_timeout_with_failover_ms=200",
+                    "--connections_with_failover_max_tries=5",
+                    *settings,
+                ]
+            ),
+        ],
+        # sometimes default 300 seconds is not enough
+        # (for example in integration flaky check)
+        timeout=600,
+    )
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        for _, instance in cluster.instances.items():
+            instance.query(
+                """
+            create table if not exists data (
+                key Int,
+                /* just to increase block size */
+                v1 UInt64,
+                v2 UInt64,
+                v3 UInt64,
+                v4 UInt64,
+                v5 UInt64,
+                v6 UInt64,
+                v7 UInt64,
+                v8 UInt64,
+                v9 UInt64,
+                v10 UInt64,
+                v11 UInt64,
+                v12 UInt64
+            ) Engine=MergeTree() order by key partition by key%5;
+            insert into data (key) select * from numbers(10);
+
+            create table if not exists dist_one           as data engine=Distributed(one_shard, currentDatabase(), data, key);
+            create table if not exists dist_one_over_dist as data engine=Distributed(one_shard, currentDatabase(), dist_one, kostikConsistentHash(key, 2));
+
+            create table if not exists dist_two as data           engine=Distributed(two_shards, currentDatabase(), data, key);
+            create table if not exists dist_two_over_dist as data engine=Distributed(two_shards, currentDatabase(), dist_two, kostikConsistentHash(key, 2));
+            """
+            )
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.mark.parametrize(
+    "table,settings",
+    itertools.product(
+        [  # tables
+            "dist_one",
+            "dist_one_over_dist",
+            "dist_two",
+            "dist_two_over_dist",
+        ],
+        [  # settings
+            *list(
+                itertools.combinations(
+                    [
+                        "",  # defaults
+                        "--prefer_localhost_replica=0",
+                        "--async_socket_for_remote=0",
+                        "--use_hedged_requests=0",
+                        "--optimize_skip_unused_shards=1",
+                        "--distributed_group_by_no_merge=2",
+                        "--optimize_distributed_group_by_sharding_key=1",
+                        # TODO: enlarge test matrix (but first those values to accept ms):
+                        #
+                        # - sleep_in_send_tables_status
+                        # - sleep_in_send_data
+                    ],
+                    2,
+                )
+            )
+            # TODO: more combinations that just 2
+        ],
+    ),
+)
+def test_stress_distributed(table, settings, started_cluster):
+    payload = f"""
+    select * from {table} where key = 0;
+    select * from {table} where key = 1;
+    select * from {table} where key = 2;
+    select * from {table} where key = 3;
+    select * from {table};
+    """
+    run_benchmark(payload, settings)


### PR DESCRIPTION
Sometimes one of containers got KILL'ed:

    2022-11-20 15:06:43 [ 317 ] DEBUG : run container_id:roottestdistributedqueriesstress_node1_r1_1 detach:False nothrow:False cmd: ['bash', '-c', "echo 'select * from dist_two where key = 0;\n    select * from dist_two where key = 1;\n    select * from dist_two where key = 2;\n    select * from dist_two where key = 3;\n    select * from dist_two;' | clickhouse benchmark --concurrency=100 --cumulative --delay=0 --timelimit=3 --hedged_connection_timeout_ms=200 --connect_timeout_with_failover_ms=200 --connections_with_failover_max_tries=5 --async_socket_for_remote=0 --distributed_group_by_no_merge=2"] (cluster.py:1745, exec_in_container)
    2022-11-20 15:06:43 [ 317 ] DEBUG : Command:['docker', 'exec', 'roottestdistributedqueriesstress_node1_r1_1', 'bash', '-c', "echo 'select * from dist_two where key = 0;\n    select * from dist_two where key = 1;\n    select * from dist_two where key = 2;\n    select * from dist_two where key = 3;\n    select * from dist_two;' | clickhouse benchmark --concurrency=100 --cumulative --delay=0 --timelimit=3 --hedged_connection_timeout_ms=200 --connect_timeout_with_failover_ms=200 --connections_with_failover_max_tries=5 --async_socket_for_remote=0 --distributed_group_by_no_merge=2"] (cluster.py:95, run_and_check)
    2022-11-20 15:08:48 [ 317 ] DEBUG : Stderr:Loaded 5 queries. (cluster.py:105, run_and_check)
    2022-11-20 15:08:48 [ 317 ] DEBUG : Exitcode:137 (cluster.py:107, run_and_check)

(Note 137 exit code is 128+KILL)

    parallel1_0_dockerd.log:time="2022-11-20T15:08:48.244758252Z" level=debug msg="Revoking external connectivity on endpoint roottestdistributedqueriesstress_node1_r1_1 (82dfd051d379869bf885f90745cd4b097c70cd04bd3b4f86e49096358112fc51)"
    parallel1_0_dockerd.log:time="2022-11-20T15:08:48.445809392Z" level=debug msg="82dfd051d379869bf885f90745cd4b097c70cd04bd3b4f86e49096358112fc51 (1c6863e).deleteSvcRecords(roottestdistributedqueriesstress_node1_r1_1, 172.16.8.2, <nil>, true) updateSvcRecord sid:82dfd051d3798
    parallel1_0_dockerd.log:time="2022-11-20T15:08:48.526045522Z" level=debug msg="Releasing addresses for endpoint roottestdistributedqueriesstress_node1_r1_1's interface on network roottestdistributedqueriesstress_default"

The problem is likely OOM, that is the problem only under ASan with lots of threads.

Fixes: #41776
Supersedes: #44573

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)