### PR TITLE
Improve json object as string inference

### DIFF
--- a/src/DataTypes/transformTypesRecursively.cpp
+++ b/src/DataTypes/transformTypesRecursively.cpp
@@ -44,7 +44,8 @@ void transformTypesRecursively(DataTypes & types, std::function<void(DataTypes &
         transformTypesRecursively(nested_types, transform_simple_types, transform_complex_types);
         for (size_t i = 0; i != types.size(); ++i)
         {
-            if (is_nullable[i])
+            /// Type could be changed so it cannot be inside Nullable anymore.
+            if (is_nullable[i] && nested_types[i]->canBeInsideNullable())
                 types[i] = makeNullable(nested_types[i]);
             else
                 types[i] = nested_types[i];

--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -421,7 +421,7 @@ String getAdditionalFormatInfoByEscapingRule(const FormatSettings & settings, Fo
             break;
         case FormatSettings::EscapingRule::JSON:
             result += fmt::format(
-                ", try_infer_numbers_from_strings={}, read_bools_as_numbers={}, try_infer_objects={}",
+                ", try_infer_numbers_from_strings={}, read_bools_as_numbers={}, read_objects_as_strings={}, read_numbers_as_strings={}, try_infer_objects={}",
                 settings.json.try_infer_numbers_from_strings,
                 settings.json.read_bools_as_numbers,
                 settings.json.read_objects_as_strings,

--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -424,6 +424,8 @@ String getAdditionalFormatInfoByEscapingRule(const FormatSettings & settings, Fo
                 ", try_infer_numbers_from_strings={}, read_bools_as_numbers={}, try_infer_objects={}",
                 settings.json.try_infer_numbers_from_strings,
                 settings.json.read_bools_as_numbers,
+                settings.json.read_objects_as_strings,
+                settings.json.read_numbers_as_strings,
                 settings.json.try_infer_objects);
             break;
         default:

--- a/src/Formats/SchemaInferenceUtils.cpp
+++ b/src/Formats/SchemaInferenceUtils.cpp
@@ -735,7 +735,7 @@ namespace
                 if (settings.json.try_infer_objects)
                     return std::make_shared<DataTypeObject>("json", true);
                 if (settings.json.read_objects_as_strings)
-                    return makeNullable(std::make_shared<DataTypeString>());
+                    return std::make_shared<DataTypeString>();
                 return nullptr;
             }
 

--- a/tests/queries/0_stateless/02499_read_json_objects_as_strings.reference
+++ b/tests/queries/0_stateless/02499_read_json_objects_as_strings.reference
@@ -1,3 +1,6 @@
 x	Nullable(String)					
 abc
 {"a" : 10, "b" : "abc"}
+x	Nullable(String)					
+{"a" : "b"}
+{"a" : 1, "b" : [1,2,3]}

--- a/tests/queries/0_stateless/02499_read_json_objects_as_strings.sql
+++ b/tests/queries/0_stateless/02499_read_json_objects_as_strings.sql
@@ -2,3 +2,5 @@
 set input_format_json_read_objects_as_strings=1;
 desc format(JSONEachRow, '{"x" : "abc"}, {"x" : {"a" : 10, "b" : "abc"}}');
 select * from format(JSONEachRow, '{"x" : "abc"}, {"x" : {"a" : 10, "b" : "abc"}}');
+desc format(JSONEachRow, '{"x" : {"a" : "b"}}, {"x" : {"a" : 1, "b" : [1,2,3]}}');
+select * from format(JSONEachRow, '{"x" : {"a" : "b"}}, {"x" : {"a" : 1, "b" : [1,2,3]}}');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve schema inference when `input_format_json_read_object_as_string` is enabled

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
