### PR TITLE
Improve inferring arrays with nulls in JSON formats

### DIFF
--- a/tests/queries/0_stateless/02416_json_tuple_to_array_schema_inference.reference
+++ b/tests/queries/0_stateless/02416_json_tuple_to_array_schema_inference.reference
@@ -1,0 +1,3 @@
+x	Array(Array(Nullable(Int64)))					
+x	Tuple(Array(Array(Nullable(Int64))), Nullable(Int64))					
+x	Map(String, Array(Nullable(Int64)))					

--- a/tests/queries/0_stateless/02416_json_tuple_to_array_schema_inference.sql
+++ b/tests/queries/0_stateless/02416_json_tuple_to_array_schema_inference.sql
@@ -1,0 +1,4 @@
+desc format(JSONEachRow, '{"x" : [[42, null], [24, null]]}');
+desc format(JSONEachRow, '{"x" : [[[42, null], []], 24]}');
+desc format(JSONEachRow, '{"x" : {"key" : [42, null]}}');
+


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Improve inferring arrays with nulls in JSON formats.