### PR TITLE
move title to frontmatter

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -2,10 +2,9 @@
 slug: /en/interfaces/cli
 sidebar_position: 17
 sidebar_label: Command-Line Client
+title: Command-Line Client
 ---
 import ConnectionDetails from '@site/docs/en/_snippets/_gather_your_details_native.md';
-
-# Command-line Client
 
 ## clickhouse-client
 


### PR DESCRIPTION
cli.md gets included in the SQL Clients category, and when included the H1 title gets duplicated.  This moves the title to the frontmatter, which gets ignored on include.

### Changelog category (leave one):
- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
