### PR TITLE
Fix HDFS test

### DIFF
--- a/tests/integration/test_merge_tree_hdfs/test.py
+++ b/tests/integration/test_merge_tree_hdfs/test.py
@@ -213,7 +213,9 @@ def test_attach_detach_partition(cluster):
     assert node.query("SELECT count(*) FROM hdfs_test FORMAT Values") == "(4096)"
     wait_for_delete_empty_parts(node, "hdfs_test")
     wait_for_delete_inactive_parts(node, "hdfs_test")
-    wait_for_delete_hdfs_objects(cluster, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2)
+    wait_for_delete_hdfs_objects(
+        cluster, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
+    )
 
     node.query("ALTER TABLE hdfs_test ATTACH PARTITION '2020-01-03'")
     assert node.query("SELECT count(*) FROM hdfs_test FORMAT Values") == "(8192)"

--- a/tests/integration/test_merge_tree_hdfs/test.py
+++ b/tests/integration/test_merge_tree_hdfs/test.py
@@ -213,9 +213,7 @@ def test_attach_detach_partition(cluster):
     assert node.query("SELECT count(*) FROM hdfs_test FORMAT Values") == "(4096)"
     wait_for_delete_empty_parts(node, "hdfs_test")
     wait_for_delete_inactive_parts(node, "hdfs_test")
-
-    hdfs_objects = fs.listdir("/clickhouse")
-    assert len(hdfs_objects) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
+    wait_for_delete_hdfs_objects(cluster, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2)
 
     node.query("ALTER TABLE hdfs_test ATTACH PARTITION '2020-01-03'")
     assert node.query("SELECT count(*) FROM hdfs_test FORMAT Values") == "(8192)"
@@ -227,9 +225,7 @@ def test_attach_detach_partition(cluster):
     assert node.query("SELECT count(*) FROM hdfs_test FORMAT Values") == "(4096)"
     wait_for_delete_empty_parts(node, "hdfs_test")
     wait_for_delete_inactive_parts(node, "hdfs_test")
-
-    hdfs_objects = fs.listdir("/clickhouse")
-    assert len(hdfs_objects) == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE
+    wait_for_delete_hdfs_objects(cluster, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE)
 
     node.query("ALTER TABLE hdfs_test DETACH PARTITION '2020-01-04'")
     node.query(
@@ -239,9 +235,7 @@ def test_attach_detach_partition(cluster):
     assert node.query("SELECT count(*) FROM hdfs_test FORMAT Values") == "(0)"
     wait_for_delete_empty_parts(node, "hdfs_test")
     wait_for_delete_inactive_parts(node, "hdfs_test")
-
-    hdfs_objects = fs.listdir("/clickhouse")
-    assert len(hdfs_objects) == FILES_OVERHEAD
+    wait_for_delete_hdfs_objects(cluster, FILES_OVERHEAD)
 
 
 def test_move_partition_to_another_disk(cluster):
@@ -307,9 +301,7 @@ def test_table_manipulations(cluster):
     assert node.query("SELECT count(*) FROM hdfs_test FORMAT Values") == "(0)"
     wait_for_delete_empty_parts(node, "hdfs_test")
     wait_for_delete_inactive_parts(node, "hdfs_test")
-
-    hdfs_objects = fs.listdir("/clickhouse")
-    assert len(hdfs_objects) == FILES_OVERHEAD
+    wait_for_delete_hdfs_objects(cluster, FILES_OVERHEAD)
 
 
 def test_move_replace_partition_to_another_table(cluster):
@@ -376,7 +368,6 @@ def test_move_replace_partition_to_another_table(cluster):
     assert node.query("SELECT count(*) FROM hdfs_clone FORMAT Values") == "(8192)"
 
     # Wait for outdated partitions deletion.
-    print(1)
     wait_for_delete_hdfs_objects(
         cluster, FILES_OVERHEAD * 2 + FILES_OVERHEAD_PER_PART_WIDE * 4
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/44569/4651a538a89d7e23cc5681d0b8a299d10005ccf4/integration_tests__release__[3/4]/integration_run_parallel1_0.log and https://s3.amazonaws.com/clickhouse-test-reports/44570/d4864c7d38db04487c05b0d698afb029a4afe9be/integration_tests__release__[3/4]/integration_run_parallel1_0.log

I was almost about to delete this test and remove the HDFS support from ClickHouse. This closes #44154.
CC @CheSema 