### PR TITLE
Better diagnostics on server stop for the stress test

### DIFF
--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -1051,18 +1051,12 @@ namespace
         return pid;
     }
 
-    int stop(const fs::path & pid_file, bool force, bool do_not_kill, unsigned max_tries)
+    bool sendSignalAndWaitForStop(const fs::path & pid_file, int signal, unsigned max_tries, unsigned wait_ms, const char * signal_name)
     {
-        if (force && do_not_kill)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Specified flags are incompatible");
-
         int pid = isRunning(pid_file);
 
         if (!pid)
-            return 0;
-
-        int signal = force ? SIGKILL : SIGTERM;
-        const char * signal_name = force ? "kill" : "terminate";
+            return true;
 
         if (0 == kill(pid, signal))
             fmt::print("Sent {} signal to process with pid {}.\n", signal_name, pid);
@@ -1078,46 +1072,51 @@ namespace
                 fmt::print("Server stopped\n");
                 break;
             }
-            sleepForSeconds(1);
+            sleepForMilliseconds(wait_ms);
         }
 
-        if (try_num == max_tries)
+        return try_num < max_tries;
+    }
+
+    int stop(const fs::path & pid_file, bool force, bool do_not_kill, unsigned max_tries)
+    {
+        if (force && do_not_kill)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Specified flags are incompatible");
+
+        int signal = force ? SIGKILL : SIGTERM;
+        const char * signal_name = force ? "kill" : "terminate";
+
+        if (sendSignalAndWaitForStop(pid_file, signal, max_tries, 1000, signal_name))
+            return 0;
+
+        int pid = isRunning(pid_file);
+        if (!pid)
+            return 0;
+
+        if (do_not_kill)
         {
-            if (do_not_kill)
-            {
-                fmt::print("Process (pid = {}) is still running. Will not try to kill it.\n", pid);
-                return 1;
-            }
-
-            fmt::print("Will terminate forcefully (pid = {}).\n", pid);
-            if (0 == kill(pid, 9))
-                fmt::print("Sent kill signal (pid = {}).\n", pid);
-            else
-                throwFromErrno("Cannot send kill signal", ErrorCodes::SYSTEM_ERROR);
-
-            /// Wait for the process (100 seconds).
-            constexpr size_t num_kill_check_tries = 1000;
-            constexpr size_t kill_check_delay_ms = 100;
-            for (size_t i = 0; i < num_kill_check_tries; ++i)
-            {
-                fmt::print("Waiting for server to be killed\n");
-                if (!isRunning(pid_file))
-                {
-                    fmt::print("Server exited\n");
-                    break;
-                }
-                sleepForMilliseconds(kill_check_delay_ms);
-            }
-
-            if (isRunning(pid_file))
-            {
-                throw Exception(ErrorCodes::CANNOT_KILL,
-                    "The server process still exists after {} tries (delay: {} ms)",
-                    num_kill_check_tries, kill_check_delay_ms);
-            }
+            fmt::print("Process (pid = {}) is still running. Will not try to kill it.\n", pid);
+            return 1;
         }
 
-        return 0;
+        /// Send termination signal again, the server will receive it and immediately terminate.
+        fmt::print("Will send the termination signal again to force the termination (pid = {}).\n", pid);
+        if (sendSignalAndWaitForStop(pid_file, signal, std::min(10U, max_tries), 1000, signal_name))
+            return 0;
+
+        /// Send kill signal. Total wait is 100 seconds.
+        constexpr size_t num_kill_check_tries = 1000;
+        constexpr size_t kill_check_delay_ms = 100;
+        fmt::print("Will terminate forcefully (pid = {}).\n", pid);
+        if (sendSignalAndWaitForStop(pid_file, SIGKILL, num_kill_check_tries, kill_check_delay_ms, signal_name))
+            return 0;
+
+        if (!isRunning(pid_file))
+            return 0;
+
+        throw Exception(ErrorCodes::CANNOT_KILL,
+            "The server process still exists after {} tries (delay: {} ms)",
+            num_kill_check_tries, kill_check_delay_ms);
     }
 }
 

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -958,7 +958,6 @@ void BaseDaemon::handleSignal(int signal_id)
         std::lock_guard lock(signal_handler_mutex);
         {
             ++terminate_signals_counter;
-            sigint_signals_counter += signal_id == SIGINT;
             signal_event.notify_all();
         }
 
@@ -973,9 +972,9 @@ void BaseDaemon::onInterruptSignals(int signal_id)
     is_cancelled = true;
     LOG_INFO(&logger(), "Received termination signal ({})", strsignal(signal_id)); // NOLINT(concurrency-mt-unsafe) // it is not thread-safe but ok in this context
 
-    if (sigint_signals_counter >= 2)
+    if (terminate_signals_counter >= 2)
     {
-        LOG_INFO(&logger(), "Received second signal Interrupt. Immediately terminate.");
+        LOG_INFO(&logger(), "This is the second termination signal. Immediately terminate.");
         call_default_signal_handler(signal_id);
         /// If the above did not help.
         _exit(128 + signal_id);

--- a/src/Daemon/BaseDaemon.h
+++ b/src/Daemon/BaseDaemon.h
@@ -162,7 +162,6 @@ protected:
     std::mutex signal_handler_mutex;
     std::condition_variable signal_event;
     std::atomic_size_t terminate_signals_counter{0};
-    std::atomic_size_t sigint_signals_counter{0};
 
     std::string config_path;
     DB::ConfigProcessor::LoadedConfig loaded_config;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

If the `clickhouse stop` command cannot gracefully terminate the server with the TERM signal, it will send the KILL signal.
But our CI scripts cannot distinguish it from other KILL signals, such as OOM killer, and it is confusing.

We have a nice feature - if you press Ctrl+C twice, sending the INT signal twice, the server will immediately terminate using the default signal action, skipping the graceful termination.

The idea is to use a second TERM signal to terminate the server, before sending KILL. This will help to disambiguate the termination reason.

For some reason, this feature of forceful termination on a subsequent signal is only enabled for the INT signal, but not for TERM. I did not find any comments in the code about this, so the code has no excuses*, and I extended it for the TERM signal as well.

\* note: if you write a code without comments, the code will be deleted.