### PR TITLE
The position of the log message about the server environment was wrong

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -703,6 +703,13 @@ try
     global_context->addWarningMessage("Server was built with sanitizer. It will work slowly.");
 #endif
 
+    const auto memory_amount = getMemoryAmount();
+
+    LOG_INFO(log, "Available RAM: {}; physical cores: {}; logical cores: {}.",
+        formatReadableSizeWithBinarySuffix(memory_amount),
+        getNumberOfPhysicalCPUCores(),  // on ARM processors it can show only enabled at current moment cores
+        std::thread::hardware_concurrency());
+
     sanityChecks(*this);
 
     // Initialize global thread pool. Do it before we fetch configs from zookeeper
@@ -775,8 +782,6 @@ try
     }
 
     Settings::checkNoSettingNamesAtTopLevel(config(), config_path);
-
-    const auto memory_amount = getMemoryAmount();
 
 #if defined(OS_LINUX)
     std::string executable_path = getExecutablePath();
@@ -1717,13 +1722,6 @@ try
 
         main_config_reloader->start();
         access_control.startPeriodicReloading();
-
-        {
-            LOG_INFO(log, "Available RAM: {}; physical cores: {}; logical cores: {}.",
-                formatReadableSizeWithBinarySuffix(memory_amount),
-                getNumberOfPhysicalCPUCores(),  // on ARM processors it can show only enabled at current moment cores
-                std::thread::hardware_concurrency());
-        }
 
         /// try to load dictionaries immediately, throw on error and die
         try


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It prevented me to read the logs of backward compatibility checks.