### PR TITLE
Fix bad punctuation in log

### DIFF
--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -909,7 +909,7 @@ void BaseDaemon::initializeTerminationAndSignalProcessing()
 
 void BaseDaemon::logRevision() const
 {
-    Poco::Logger::root().information("Starting " + std::string{VERSION_FULL}
+    logger().information("Starting " + std::string{VERSION_FULL}
         + " (revision: " + std::to_string(ClickHouseRevision::getVersionRevision())
         + ", git hash: " + (git_hash.empty() ? "<unknown>" : git_hash)
         + ", build id: " + (build_id.empty() ? "<unknown>" : build_id) + ")"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The log message was formatted wrongly:

```
2022.12.26 13:31:09.946289 [ 19525 ] {} <Information> : Starting ClickHouse 22.13.1.1 (revision: 54470, git hash: 280e14456f15504c22493363c7ebf9ecf709edd8, build id: F9C53622E0BF77E19E1B81B043DCA5F69477466D), PID 19525
```

Strange whitespace before the colon.