### PR TITLE
Fix misleading log message

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -763,13 +763,17 @@ try
     fs::directory_iterator dir_end;
     for (fs::directory_iterator it(path); it != dir_end; ++it)
     {
-        if (it->is_regular_file() && startsWith(it->path().filename(), "tmp"))
+        if (it->is_regular_file())
         {
-            LOG_DEBUG(log, "Removing old temporary file {}", it->path().string());
-            fs::remove(it->path());
+            if (startsWith(it->path().filename(), "tmp"))
+            {
+                LOG_DEBUG(log, "Removing old temporary file {}", it->path().string());
+                fs::remove(it->path());
+            }
+            else
+                LOG_DEBUG(log, "Found unknown file in temporary path {}", it->path().string());
         }
-        else
-            LOG_DEBUG(log, "Found unknown file in temporary path {}", it->path().string());
+        /// We skip directories (for example, 'http_buffers' - it's used for buffering of the results) and all other file types.
     }
 }
 catch (...)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The server was printing a pointless error message:
`2022.12.25 00:18:06.484365 [ 256287 ] {} <Debug> Context: Found unknown file in temporary path /var/lib/clickhouse/tmp/http_buffers`