### PR TITLE
Fix bad log message about MergeTree metadata cache.

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1044,8 +1044,8 @@ try
         bool continue_if_corrupted = config().getBool("merge_tree_metadata_cache.continue_if_corrupted", false);
         try
         {
-            LOG_DEBUG(
-                log, "Initializing merge tree metadata cache lru_cache_size:{} continue_if_corrupted:{}", size, continue_if_corrupted);
+            LOG_DEBUG(log, "Initializing MergeTree metadata cache, lru_cache_size: {} continue_if_corrupted: {}",
+                ReadableSize(size), continue_if_corrupted);
             global_context->initializeMergeTreeMetadataCache(path_str + "/" + "rocksdb", size);
         }
         catch (...)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

`2022.12.25 00:18:06.494169 [ 256287 ] {} <Debug> Application: Initializing merge tree metadata cache lru_cache_size:268435456 continue_if_corrupted:true`

It was entirely idiotic like it's not a ClickHouse log but something from other dbms.