### PR TITLE
Use already written part of the query for fuzzy search (pass to skim)

### DIFF
--- a/base/base/ReplxxLineReader.cpp
+++ b/base/base/ReplxxLineReader.cpp
@@ -402,10 +402,11 @@ ReplxxLineReader::ReplxxLineReader(
                 words.push_back(hs.get().text());
         }
 
+        std::string current_query(rx.get_state().text());
         std::string new_query;
         try
         {
-            new_query = std::string(skim(words));
+            new_query = std::string(skim(current_query, words));
         }
         catch (const std::exception & e)
         {

--- a/rust/skim/include/skim.h
+++ b/rust/skim/include/skim.h
@@ -87,4 +87,4 @@ private:
 } // namespace cxxbridge1
 } // namespace rust
 
-::rust::String skim(::std::vector<::std::string> const &words);
+::rust::String skim(::std::string const &prefix, ::std::vector<::std::string> const &words);

--- a/rust/skim/src/lib.rs
+++ b/rust/skim/src/lib.rs
@@ -5,7 +5,7 @@ use cxx::{CxxString, CxxVector};
 #[cxx::bridge]
 mod ffi {
     extern "Rust" {
-        fn skim(words: &CxxVector<CxxString>) -> Result<String>;
+        fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String>;
     }
 }
 
@@ -18,7 +18,7 @@ impl SkimItem for Item {
     }
 }
 
-fn skim(words: &CxxVector<CxxString>) -> Result<String, String> {
+fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, String> {
     // Let's check is terminal available. To avoid panic.
     if let Err(err) = TermInfo::from_env() {
         return Err(format!("{}", err));
@@ -26,6 +26,7 @@ fn skim(words: &CxxVector<CxxString>) -> Result<String, String> {
 
     let options = SkimOptionsBuilder::default()
         .height(Some("30%"))
+        .query(Some(prefix.to_str().unwrap()))
         .tac(true)
         .tiebreak(Some("-score".to_string()))
         .build()


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use already written part of the query for fuzzy search (pass to skim)

Reported-by: @alexey-milovidov 