### PR TITLE
Rename `runlog.log` to `run.log` in tests

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -354,7 +354,7 @@ th { cursor: pointer; }
 
 <h1>AST Fuzzer for PR #${PR_TO_TEST} @ ${SHA_TO_TEST}</h1>
 <p class="links">
-<a href="runlog.log">runlog.log</a>
+<a href="run.log">run.log</a>
 <a href="fuzzer.log">fuzzer.log</a>
 <a href="server.log.gz">server.log.gz</a>
 <a href="main.log">main.log</a>

--- a/tests/ci/ast_fuzzer_check.py
+++ b/tests/ci/ast_fuzzer_check.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     )
     logging.info("Going to run %s", run_command)
 
-    run_log_path = os.path.join(temp_path, "runlog.log")
+    run_log_path = os.path.join(temp_path, "run.log")
     with open(run_log_path, "w", encoding="utf-8") as log:
         with subprocess.Popen(
             run_command, shell=True, stderr=log, stdout=log
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     )
     s3_prefix = f"{pr_info.number}/{pr_info.sha}/fuzzer_{check_name_lower}/"
     paths = {
-        "runlog.log": run_log_path,
+        "run.log": run_log_path,
         "main.log": os.path.join(workspace_path, "main.log"),
         "server.log.gz": os.path.join(workspace_path, "server.log.gz"),
         "fuzzer.log": os.path.join(workspace_path, "fuzzer.log"),
@@ -130,8 +130,8 @@ if __name__ == "__main__":
             paths[f] = ""
 
     report_url = GITHUB_RUN_URL
-    if paths["runlog.log"]:
-        report_url = paths["runlog.log"]
+    if paths["run.log"]:
+        report_url = paths["run.log"]
     if paths["main.log"]:
         report_url = paths["main.log"]
     if paths["server.log.gz"]:

--- a/tests/ci/codebrowser_check.py
+++ b/tests/ci/codebrowser_check.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
 
     logging.info("Going to run codebrowser: %s", run_command)
 
-    run_log_path = os.path.join(TEMP_PATH, "runlog.log")
+    run_log_path = os.path.join(TEMP_PATH, "run.log")
 
     with TeePopen(run_command, run_log_path) as process:
         retcode = process.wait()

--- a/tests/ci/docs_check.py
+++ b/tests/ci/docs_check.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
         f"{docker_image}"
     )
 
-    run_log_path = os.path.join(test_output, "runlog.log")
+    run_log_path = os.path.join(test_output, "run.log")
     logging.info("Running command: '%s'", cmd)
 
     with TeePopen(cmd, run_log_path) as process:

--- a/tests/ci/docs_release.py
+++ b/tests/ci/docs_release.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     else:
         user = f"{os.geteuid()}:{os.getegid()}"
 
-    run_log_path = os.path.join(test_output, "runlog.log")
+    run_log_path = os.path.join(test_output, "run.log")
 
     with SSHKey("ROBOT_CLICKHOUSE_SSH_KEY"):
         cmd = (

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     if not os.path.exists(logs_path):
         os.makedirs(logs_path)
 
-    run_log_path = os.path.join(logs_path, "runlog.log")
+    run_log_path = os.path.join(logs_path, "run.log")
     with TeePopen(run_cmd, run_log_path, timeout=40 * 60) as process:
         retcode = process.wait()
         if retcode == 0:

--- a/tests/ci/functional_test_check.py
+++ b/tests/ci/functional_test_check.py
@@ -292,7 +292,7 @@ if __name__ == "__main__":
     if not os.path.exists(result_path):
         os.makedirs(result_path)
 
-    run_log_path = os.path.join(result_path, "runlog.log")
+    run_log_path = os.path.join(result_path, "run.log")
 
     additional_envs = get_additional_envs(
         check_name, run_by_hash_num, run_by_hash_total

--- a/tests/ci/jepsen_check.py
+++ b/tests/ci/jepsen_check.py
@@ -251,7 +251,7 @@ if __name__ == "__main__":
         )
         logging.info("Going to run jepsen: %s", cmd)
 
-        run_log_path = os.path.join(TEMP_PATH, "runlog.log")
+        run_log_path = os.path.join(TEMP_PATH, "run.log")
 
         with TeePopen(cmd, run_log_path) as process:
             retcode = process.wait()

--- a/tests/ci/performance_comparison_check.py
+++ b/tests/ci/performance_comparison_check.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
     )
     logging.info("Going to run command %s", run_command)
 
-    run_log_path = os.path.join(temp_path, "runlog.log")
+    run_log_path = os.path.join(temp_path, "run.log")
 
     popen_env = os.environ.copy()
     popen_env.update(env_extra)
@@ -198,7 +198,7 @@ if __name__ == "__main__":
         "all-query-metrics.tsv": os.path.join(
             result_path, "report/all-query-metrics.tsv"
         ),
-        "runlog.log": run_log_path,
+        "run.log": run_log_path,
     }
 
     s3_prefix = f"{pr_info.number}/{pr_info.sha}/{check_name_prefix}/"
@@ -253,8 +253,8 @@ if __name__ == "__main__":
 
     report_url = GITHUB_RUN_URL
 
-    if uploaded["runlog.log"]:
-        report_url = uploaded["runlog.log"]
+    if uploaded["run.log"]:
+        report_url = uploaded["run.log"]
 
     if uploaded["compare.log"]:
         report_url = uploaded["compare.log"]

--- a/tests/ci/sqlancer_check.py
+++ b/tests/ci/sqlancer_check.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     run_command = get_run_command(build_url, workspace_path, docker_image)
     logging.info("Going to run %s", run_command)
 
-    run_log_path = os.path.join(workspace_path, "runlog.log")
+    run_log_path = os.path.join(workspace_path, "run.log")
     with open(run_log_path, "w", encoding="utf-8") as log:
         with subprocess.Popen(
             run_command, shell=True, stderr=log, stdout=log

--- a/tests/ci/stress_check.py
+++ b/tests/ci/stress_check.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
     if not os.path.exists(result_path):
         os.makedirs(result_path)
 
-    run_log_path = os.path.join(temp_path, "runlog.log")
+    run_log_path = os.path.join(temp_path, "run.log")
 
     run_command = get_run_command(
         packages_path, result_path, repo_tests_path, server_log_path, docker_image

--- a/tests/ci/unit_tests_check.py
+++ b/tests/ci/unit_tests_check.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
 
     run_command = f"docker run --cap-add=SYS_PTRACE --volume={tests_binary_path}:/unit_tests_dbms --volume={test_output}:/test_output {docker_image}"
 
-    run_log_path = os.path.join(test_output, "runlog.log")
+    run_log_path = os.path.join(test_output, "run.log")
 
     logging.info("Going to run func tests: %s", run_command)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Otherwise, it sounds stupid, like 'libs/libzlib.lib'.