### PR TITLE
Fix hung query in stress test

### DIFF
--- a/tests/queries/0_stateless/00057_join_aliases.sql
+++ b/tests/queries/0_stateless/00057_join_aliases.sql
@@ -3,4 +3,5 @@ SELECT * FROM (
     FROM system.numbers
     ANY LEFT JOIN (SELECT number / 3 AS n, number AS j1, 'Hello' AS j2 FROM system.numbers LIMIT 10) js2
     USING n LIMIT 10
-) ORDER BY n;
+) ORDER BY n
+SETTINGS join_algorithm = 'hash'; -- the query does not finish with merge join


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #44602