### PR TITLE
Disable Analyzer in fuzz and stress tests

### DIFF
--- a/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
@@ -2,6 +2,7 @@
     <profiles>
         <default>
             <max_execution_time>10</max_execution_time>
+
             <!--
                 Don't let the fuzzer change this setting (I've actually seen it
                 do this before).
@@ -14,6 +15,11 @@
                 <max_memory_usage>
                     <max>10G</max>
                 </max_memory_usage>
+
+                <!-- Analyzer is unstable, not ready for testing. -->
+                <allow_experimental_analyzer>
+                    <readonly/>
+                </allow_experimental_analyzer>
             </constraints>
         </default>
     </profiles>

--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -123,6 +123,22 @@ EOL
     <core_path>$PWD</core_path>
 </clickhouse>
 EOL
+
+    # Analyzer is not yet ready for testing
+    cat > /etc/clickhouse-server/users.d/no_analyzer.xml <<EOL
+<clickhouse>
+    <profiles>
+        <default>
+            <constraints>
+                <allow_experimental_analyzer>
+                    <readonly/>
+                </allow_experimental_analyzer>
+            </constraints>
+        </default>
+    </profiles>
+</clickhouse>
+EOL
+
 }
 
 function stop()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Stress and fuzz tests found issues with Analyzer in almost every PR. It prevents merging good pull requests.