### PR TITLE
Better log message

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -870,7 +870,7 @@ void ZooKeeper::finalize(bool error_send, bool error_receive, const String & rea
     if (already_started)
         return;
 
-    LOG_INFO(log, "Finalizing session {}: finalization_started={}, queue_finished={}, reason={}",
+    LOG_INFO(log, "Finalizing session {}. finalization_started: {}, queue_finished: {}, reason: '{}'",
              session_id, already_started, requests_queue.isFinished(), reason);
 
     auto expire_session_if_not_expired = [&]


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


A log message was poorly formatted, and it was difficult to read, CC @KochetovNicolai 
`2022.12.26 20:20:11.982369 [ 519223 ] {} <Information> ZooKeeperClient: Finalizing session 2074: finalization_started=false, queue_finished=false, reason=Operation timeout on Exists /clickhouse/zero_copy/zero_copy_s3/67305e9c-edbe-46a3-bccd-c62c450d308c/-2_0_97_1_193/part_exclusive_lock`

See how terrible does it look here:
`reason=Operation timeout on Exists`

Our logs should not contain poorly formatted messages, otherwise, some people may think our software is bad.