### PR TITLE
tests/integration: suppress exceptions during logging (due to pytest)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,12 @@ from helpers.test_tools import TSV
 from helpers.network import _NetworkManager
 
 
+# This is a workaround for a problem with logging in pytest [1].
+#
+#   [1]: https://github.com/pytest-dev/pytest/issues/5502
+logging.raiseExceptions = False
+
+
 @pytest.fixture(autouse=True, scope="session")
 def cleanup_environment():
     try:


### PR DESCRIPTION
Due to pytest play games with logging [1] it is better to ignore it.

  [1]: https://github.com/pytest-dev/pytest/issues/5502

This is due to incorrect kazoo client usage (not all clients calls stop(), **this is in progress**)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc:  @alexey-milovidov 
Cc: @quickhouse (https://github.com/ClickHouse/ClickHouse/pull/41344#issuecomment-1277794173) 