### PR TITLE
Fix rust modules rebuild (previously ignores changes in cargo config.toml)

### DIFF
--- a/rust/skim/build.rs.in
+++ b/rust/skim/build.rs.in
@@ -5,4 +5,5 @@ fn main() {
     }
     build.compile("skim");
     println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=.cargo/config.toml");
 }


### PR DESCRIPTION
This leads to the problem when you switch compiler flags, for example:

    $ cmake -DSANITIZE=memory ..
    $ ninja
    $ cmake -DSANITIZE= ..
    $ ninja

And this leads to:

    ld.lld-15: error: undefined symbol: __msan_init
    >>> referenced by lib.rs.cc
    >>>               lib.rs.o:(msan.module_ctor) in archive rust/skim/RelWithDebInfo/lib_ch_rust_skim_rust.a

Reported-by: @alexey-milovidov

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)