### PR TITLE
Sometimes spot instances fail more than 20 times in a row

### DIFF
--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -25,7 +25,7 @@ MAX_RETRY = 5
 
 # Number of times a check can re-run as a whole.
 # It is needed, because we are using AWS "spot" instances, that are terminated often
-MAX_WORKFLOW_RERUN = 20
+MAX_WORKFLOW_RERUN = 100
 
 WorkflowDescription = namedtuple(
     "WorkflowDescription",

--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -25,7 +25,7 @@ MAX_RETRY = 5
 
 # Number of times a check can re-run as a whole.
 # It is needed, because we are using AWS "spot" instances, that are terminated often
-MAX_WORKFLOW_RERUN = 100
+MAX_WORKFLOW_RERUN = 30
 
 WorkflowDescription = namedtuple(
     "WorkflowDescription",


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
