### PR TITLE
Fix flaky test test_backup_restore_on_cluster

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/configs/lesser_timeouts.xml
+++ b/tests/integration/test_backup_restore_on_cluster/configs/lesser_timeouts.xml
@@ -2,6 +2,6 @@
     <backups>
         <on_cluster_first_sync_timeout>1000</on_cluster_first_sync_timeout>
         <consistent_metadata_snapshot_timeout>10000</consistent_metadata_snapshot_timeout>
-        <create_table_timeout>1000</create_table_timeout>
+        <create_table_timeout>3000</create_table_timeout>
     </backups>
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Increase the create table timeout for the test.
This must fix https://github.com/ClickHouse/ClickHouse/issues/44454