### PR TITLE
tests/integration: add missing kazoo client termination

### DIFF
--- a/tests/integration/test_keeper_auth/test.py
+++ b/tests/integration/test_keeper_auth/test.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 from helpers.cluster import ClickHouseCluster
 from kazoo.client import KazooClient, KazooState
 from kazoo.security import ACL, make_digest_acl, make_acl
@@ -162,6 +163,13 @@ def test_digest_auth_basic(started_cluster, get_zk):
     with pytest.raises(AuthFailedError):
         no_auth_connection.add_auth("world", "anyone")
 
+    # FIXME: this sleep is a workaround for the bug that is fixed by this patch [1].
+    #
+    # The problem is that after AUTH_FAILED (that is caused by the line above)
+    # there can be a race, because of which, stop() will hang indefinitely.
+    #
+    #    [1]: https://github.com/python-zk/kazoo/pull/688
+    time.sleep(5)
     no_auth_connection.stop()
     # session became broken, reconnect
     no_auth_connection = get_zk()

--- a/tests/integration/test_keeper_nodes_add/test.py
+++ b/tests/integration/test_keeper_nodes_add/test.py
@@ -46,72 +46,85 @@ def start(node):
 
 
 def test_nodes_add(started_cluster):
-    keeper_utils.wait_until_connected(cluster, node1)
-    zk_conn = get_fake_zk(node1)
+    zk_conn = None
+    zk_conn2 = None
+    zk_conn3 = None
 
-    for i in range(100):
-        zk_conn.create("/test_two_" + str(i), b"somedata")
+    try:
+        keeper_utils.wait_until_connected(cluster, node1)
+        zk_conn = get_fake_zk(node1)
 
-    p = Pool(3)
-    node2.stop_clickhouse()
-    node2.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_two_nodes_2.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper2.xml",
-    )
-    waiter = p.apply_async(start, (node2,))
-    node1.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_two_nodes_1.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
-    )
-    node1.query("SYSTEM RELOAD CONFIG")
-    waiter.wait()
-    keeper_utils.wait_until_connected(cluster, node2)
+        for i in range(100):
+            zk_conn.create("/test_two_" + str(i), b"somedata")
 
-    zk_conn2 = get_fake_zk(node2)
+        p = Pool(3)
+        node2.stop_clickhouse()
+        node2.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_two_nodes_2.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper2.xml",
+        )
+        waiter = p.apply_async(start, (node2,))
+        node1.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_two_nodes_1.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+        )
+        node1.query("SYSTEM RELOAD CONFIG")
+        waiter.wait()
+        keeper_utils.wait_until_connected(cluster, node2)
 
-    for i in range(100):
-        assert zk_conn2.exists("/test_two_" + str(i)) is not None
+        zk_conn2 = get_fake_zk(node2)
 
-    zk_conn = get_fake_zk(node1)
+        for i in range(100):
+            assert zk_conn2.exists("/test_two_" + str(i)) is not None
 
-    for i in range(100):
-        zk_conn.create("/test_three_" + str(i), b"somedata")
+        zk_conn.stop()
+        zk_conn.close()
 
-    node3.stop_clickhouse()
+        zk_conn = get_fake_zk(node1)
 
-    node3.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_3.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper3.xml",
-    )
-    waiter = p.apply_async(start, (node3,))
-    node2.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_2.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper2.xml",
-    )
-    node1.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_1.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
-    )
+        for i in range(100):
+            zk_conn.create("/test_three_" + str(i), b"somedata")
 
-    node1.query("SYSTEM RELOAD CONFIG")
-    node2.query("SYSTEM RELOAD CONFIG")
+        node3.stop_clickhouse()
 
-    waiter.wait()
-    keeper_utils.wait_until_connected(cluster, node3)
-    zk_conn3 = get_fake_zk(node3)
+        node3.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_3.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper3.xml",
+        )
+        waiter = p.apply_async(start, (node3,))
+        node2.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_2.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper2.xml",
+        )
+        node1.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_three_nodes_1.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+        )
 
-    for i in range(100):
-        assert zk_conn3.exists("/test_three_" + str(i)) is not None
+        node1.query("SYSTEM RELOAD CONFIG")
+        node2.query("SYSTEM RELOAD CONFIG")
 
-    # configs which change endpoints of server should not be allowed
-    node1.replace_in_config(
-        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
-        "node3",
-        "non_existing_node",
-    )
+        waiter.wait()
+        keeper_utils.wait_until_connected(cluster, node3)
+        zk_conn3 = get_fake_zk(node3)
 
-    node1.query("SYSTEM RELOAD CONFIG")
-    time.sleep(2)
-    assert node1.contains_in_log(
-        "Config will be ignored because a server with ID 3 is already present in the cluster"
-    )
+        for i in range(100):
+            assert zk_conn3.exists("/test_three_" + str(i)) is not None
+
+        # configs which change endpoints of server should not be allowed
+        node1.replace_in_config(
+            "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+            "node3",
+            "non_existing_node",
+        )
+
+        node1.query("SYSTEM RELOAD CONFIG")
+        time.sleep(2)
+        assert node1.contains_in_log(
+            "Config will be ignored because a server with ID 3 is already present in the cluster"
+        )
+    finally:
+        for zk in [zk_conn, zk_conn2, zk_conn3]:
+            if zk:
+                zk.stop()
+                zk.close()

--- a/tests/integration/test_keeper_nodes_move/test.py
+++ b/tests/integration/test_keeper_nodes_move/test.py
@@ -54,51 +54,62 @@ def get_fake_zk(node, timeout=30.0):
 
 
 def test_node_move(started_cluster):
-    zk_conn = get_fake_zk(node1)
+    zk_conn = None
+    zk_conn2 = None
+    zk_conn3 = None
+    zk_conn4 = None
 
-    for i in range(100):
-        zk_conn.create("/test_four_" + str(i), b"somedata")
+    try:
+        zk_conn = get_fake_zk(node1)
 
-    zk_conn2 = get_fake_zk(node2)
-    zk_conn2.sync("/test_four_0")
+        for i in range(100):
+            zk_conn.create("/test_four_" + str(i), b"somedata")
 
-    zk_conn3 = get_fake_zk(node3)
-    zk_conn3.sync("/test_four_0")
+        zk_conn2 = get_fake_zk(node2)
+        zk_conn2.sync("/test_four_0")
 
-    for i in range(100):
-        assert zk_conn2.exists("test_four_" + str(i)) is not None
-        assert zk_conn3.exists("test_four_" + str(i)) is not None
+        zk_conn3 = get_fake_zk(node3)
+        zk_conn3.sync("/test_four_0")
 
-    node4.stop_clickhouse()
-    node4.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_node4_4.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper4.xml",
-    )
-    p = Pool(3)
-    waiter = p.apply_async(start, (node4,))
-    node1.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_node4_1.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
-    )
-    node2.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_node4_2.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper2.xml",
-    )
+        for i in range(100):
+            assert zk_conn2.exists("test_four_" + str(i)) is not None
+            assert zk_conn3.exists("test_four_" + str(i)) is not None
 
-    node1.query("SYSTEM RELOAD CONFIG")
-    node2.query("SYSTEM RELOAD CONFIG")
+        node4.stop_clickhouse()
+        node4.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_node4_4.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper4.xml",
+        )
+        p = Pool(3)
+        waiter = p.apply_async(start, (node4,))
+        node1.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_node4_1.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+        )
+        node2.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_node4_2.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper2.xml",
+        )
 
-    waiter.wait()
+        node1.query("SYSTEM RELOAD CONFIG")
+        node2.query("SYSTEM RELOAD CONFIG")
 
-    zk_conn4 = get_fake_zk(node4)
-    zk_conn4.sync("/test_four_0")
+        waiter.wait()
 
-    for i in range(100):
-        assert zk_conn4.exists("/test_four_" + str(i)) is not None
+        zk_conn4 = get_fake_zk(node4)
+        zk_conn4.sync("/test_four_0")
 
-    with pytest.raises(Exception):
-        # Adding and removing nodes is async operation
-        for i in range(10):
-            zk_conn3 = get_fake_zk(node3)
-            zk_conn3.sync("/test_four_0")
-            time.sleep(i)
+        for i in range(100):
+            assert zk_conn4.exists("/test_four_" + str(i)) is not None
+
+        with pytest.raises(Exception):
+            # Adding and removing nodes is async operation
+            for i in range(10):
+                zk_conn3 = get_fake_zk(node3)
+                zk_conn3.sync("/test_four_0")
+                time.sleep(i)
+    finally:
+        for zk in [zk_conn, zk_conn2, zk_conn3, zk_conn4]:
+            if zk:
+                zk.stop()
+                zk.close()

--- a/tests/integration/test_keeper_nodes_remove/test.py
+++ b/tests/integration/test_keeper_nodes_remove/test.py
@@ -40,74 +40,94 @@ def get_fake_zk(node, timeout=30.0):
 
 
 def test_nodes_remove(started_cluster):
-    zk_conn = get_fake_zk(node1)
-
-    for i in range(100):
-        zk_conn.create("/test_two_" + str(i), b"somedata")
-
-    zk_conn2 = get_fake_zk(node2)
-    zk_conn2.sync("/test_two_0")
-
-    zk_conn3 = get_fake_zk(node3)
-    zk_conn3.sync("/test_two_0")
-
-    for i in range(100):
-        assert zk_conn2.exists("test_two_" + str(i)) is not None
-        assert zk_conn3.exists("test_two_" + str(i)) is not None
-
-    node2.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_two_nodes_2.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper2.xml",
-    )
-    node1.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_keeper_two_nodes_1.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
-    )
-
-    node1.query("SYSTEM RELOAD CONFIG")
-    node2.query("SYSTEM RELOAD CONFIG")
-
-    zk_conn2 = get_fake_zk(node2)
-
-    for i in range(100):
-        assert zk_conn2.exists("test_two_" + str(i)) is not None
-        zk_conn2.create("/test_two_" + str(100 + i), b"otherdata")
-
-    zk_conn = get_fake_zk(node1)
-    zk_conn.sync("/test_two_0")
-
-    for i in range(100):
-        assert zk_conn.exists("test_two_" + str(i)) is not None
-        assert zk_conn.exists("test_two_" + str(100 + i)) is not None
+    zk_conn = None
+    zk_conn2 = None
+    zk_conn3 = None
 
     try:
-        zk_conn3 = get_fake_zk(node3)
-        zk_conn3.sync("/test_two_0")
-        time.sleep(0.1)
-    except Exception:
-        pass
+        zk_conn = get_fake_zk(node1)
 
-    node3.stop_clickhouse()
+        for i in range(100):
+            zk_conn.create("/test_two_" + str(i), b"somedata")
 
-    node1.copy_file_to_container(
-        os.path.join(CONFIG_DIR, "enable_single_keeper1.xml"),
-        "/etc/clickhouse-server/config.d/enable_keeper1.xml",
-    )
-
-    node1.query("SYSTEM RELOAD CONFIG")
-
-    zk_conn = get_fake_zk(node1)
-    zk_conn.sync("/test_two_0")
-
-    for i in range(100):
-        assert zk_conn.exists("test_two_" + str(i)) is not None
-        assert zk_conn.exists("test_two_" + str(100 + i)) is not None
-
-    try:
         zk_conn2 = get_fake_zk(node2)
         zk_conn2.sync("/test_two_0")
-        time.sleep(0.1)
-    except Exception:
-        pass
 
-    node2.stop_clickhouse()
+        zk_conn3 = get_fake_zk(node3)
+        zk_conn3.sync("/test_two_0")
+
+        for i in range(100):
+            assert zk_conn2.exists("test_two_" + str(i)) is not None
+            assert zk_conn3.exists("test_two_" + str(i)) is not None
+
+        node2.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_two_nodes_2.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper2.xml",
+        )
+        node1.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_keeper_two_nodes_1.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+        )
+
+        node1.query("SYSTEM RELOAD CONFIG")
+        node2.query("SYSTEM RELOAD CONFIG")
+
+        zk_conn2.stop()
+        zk_conn2.close()
+        zk_conn2 = get_fake_zk(node2)
+
+        for i in range(100):
+            assert zk_conn2.exists("test_two_" + str(i)) is not None
+            zk_conn2.create("/test_two_" + str(100 + i), b"otherdata")
+
+        zk_conn.stop()
+        zk_conn.close()
+        zk_conn = get_fake_zk(node1)
+        zk_conn.sync("/test_two_0")
+
+        for i in range(100):
+            assert zk_conn.exists("test_two_" + str(i)) is not None
+            assert zk_conn.exists("test_two_" + str(100 + i)) is not None
+
+        try:
+            zk_conn3.stop()
+            zk_conn3.close()
+            zk_conn3 = get_fake_zk(node3)
+            zk_conn3.sync("/test_two_0")
+            time.sleep(0.1)
+        except Exception:
+            pass
+
+        node3.stop_clickhouse()
+
+        node1.copy_file_to_container(
+            os.path.join(CONFIG_DIR, "enable_single_keeper1.xml"),
+            "/etc/clickhouse-server/config.d/enable_keeper1.xml",
+        )
+
+        node1.query("SYSTEM RELOAD CONFIG")
+
+        zk_conn.stop()
+        zk_conn.close()
+        zk_conn = get_fake_zk(node1)
+        zk_conn.sync("/test_two_0")
+
+        for i in range(100):
+            assert zk_conn.exists("test_two_" + str(i)) is not None
+            assert zk_conn.exists("test_two_" + str(100 + i)) is not None
+
+        try:
+            zk_conn2.stop()
+            zk_conn2.close()
+            zk_conn2 = get_fake_zk(node2)
+            zk_conn2.sync("/test_two_0")
+            time.sleep(0.1)
+        except Exception:
+            pass
+
+        node2.stop_clickhouse()
+    finally:
+        for zk in [zk_conn, zk_conn2, zk_conn3]:
+            if zk:
+                zk.stop()
+                zk.close()

--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -112,45 +112,57 @@ def get_genuine_zk(node, timeout=30.0):
 
 
 def test_snapshot_and_load(started_cluster):
-    restart_and_clear_zookeeper(node1)
-    genuine_connection = get_genuine_zk(node1)
-    for node in [node1, node2, node3]:
-        print("Stop and clear", node.name, "with dockerid", node.docker_id)
-        stop_clickhouse(node)
-        clear_clickhouse_data(node)
+    genuine_connection = None
+    fake_zks = []
 
-    for i in range(1000):
-        genuine_connection.create("/test" + str(i), b"data")
+    try:
+        restart_and_clear_zookeeper(node1)
+        genuine_connection = get_genuine_zk(node1)
+        for node in [node1, node2, node3]:
+            print("Stop and clear", node.name, "with dockerid", node.docker_id)
+            stop_clickhouse(node)
+            clear_clickhouse_data(node)
 
-    print("Data loaded to zookeeper")
+        for i in range(1000):
+            genuine_connection.create("/test" + str(i), b"data")
 
-    stop_zookeeper(node1)
-    start_zookeeper(node1)
-    stop_zookeeper(node1)
+        print("Data loaded to zookeeper")
 
-    print("Data copied to node1")
-    resulted_path = convert_zookeeper_data(node1)
-    print("Resulted path", resulted_path)
-    for node in [node2, node3]:
-        print("Copy snapshot from", node1.name, "to", node.name)
-        cluster.copy_file_from_container_to_container(
-            node1, resulted_path, node, "/var/lib/clickhouse/coordination/snapshots"
-        )
+        stop_zookeeper(node1)
+        start_zookeeper(node1)
+        stop_zookeeper(node1)
 
-    print("Starting clickhouses")
+        print("Data copied to node1")
+        resulted_path = convert_zookeeper_data(node1)
+        print("Resulted path", resulted_path)
+        for node in [node2, node3]:
+            print("Copy snapshot from", node1.name, "to", node.name)
+            cluster.copy_file_from_container_to_container(
+                node1, resulted_path, node, "/var/lib/clickhouse/coordination/snapshots"
+            )
 
-    p = Pool(3)
-    result = p.map_async(start_clickhouse, [node1, node2, node3])
-    result.wait()
+        print("Starting clickhouses")
 
-    print("Loading additional data")
-    fake_zks = [get_fake_zk(node) for node in [node1, node2, node3]]
-    for i in range(1000):
-        fake_zk = random.choice(fake_zks)
-        try:
-            fake_zk.create("/test" + str(i + 1000), b"data")
-        except Exception as ex:
-            print("Got exception:" + str(ex))
+        p = Pool(3)
+        result = p.map_async(start_clickhouse, [node1, node2, node3])
+        result.wait()
 
-    print("Final")
-    fake_zks[0].create("/test10000", b"data")
+        print("Loading additional data")
+        fake_zks = [get_fake_zk(node) for node in [node1, node2, node3]]
+        for i in range(1000):
+            fake_zk = random.choice(fake_zks)
+            try:
+                fake_zk.create("/test" + str(i + 1000), b"data")
+            except Exception as ex:
+                print("Got exception:" + str(ex))
+
+        print("Final")
+        fake_zks[0].create("/test10000", b"data")
+    finally:
+        for zk in fake_zks:
+            if zk:
+                zk.stop()
+                zk.close()
+        if genuine_connection:
+            genuine_connection.stop()
+            genuine_connection.close()

--- a/tests/integration/test_keeper_three_nodes_start/test.py
+++ b/tests/integration/test_keeper_three_nodes_start/test.py
@@ -29,6 +29,8 @@ def get_fake_zk(nodename, timeout=30.0):
 
 
 def test_smoke():
+    node1_zk = None
+
     try:
         cluster.start()
 
@@ -37,3 +39,7 @@ def test_smoke():
 
     finally:
         cluster.shutdown()
+
+        if node1_zk:
+            node1_zk.stop()
+            node1_zk.close()

--- a/tests/integration/test_keeper_three_nodes_two_alive/test.py
+++ b/tests/integration/test_keeper_three_nodes_two_alive/test.py
@@ -54,11 +54,16 @@ def start(node):
 
 def delete_with_retry(node_name, path):
     for _ in range(30):
+        zk = None
         try:
-            get_fake_zk(node_name).delete(path)
+            zk = get_fake_zk(node_name)
+            zk.delete(path)
             return
         except:
             time.sleep(0.5)
+        finally:
+            zk.stop()
+            zk.close()
     raise Exception(f"Cannot delete {path} from node {node_name}")
 
 
@@ -89,9 +94,14 @@ def test_start_offline(started_cluster):
         p.map(start, [node1, node2, node3])
         delete_with_retry("node1", "/test_alive")
 
+        node1_zk.stop()
+        node1_zk.close()
+
 
 def test_start_non_existing(started_cluster):
     p = Pool(3)
+    node2_zk = None
+
     try:
         node1.stop_clickhouse()
         node2.stop_clickhouse()
@@ -134,15 +144,23 @@ def test_start_non_existing(started_cluster):
         p.map(start, [node1, node2, node3])
         delete_with_retry("node2", "/test_non_exising")
 
+        if node2_zk:
+            node2_zk.stop()
+            node2_zk.close()
+
 
 def test_restart_third_node(started_cluster):
-    node1_zk = get_fake_zk("node1")
-    node1_zk.create("/test_restart", b"aaaa")
+    try:
+        node1_zk = get_fake_zk("node1")
+        node1_zk.create("/test_restart", b"aaaa")
 
-    node3.restart_clickhouse()
-    keeper_utils.wait_until_connected(cluster, node3)
+        node3.restart_clickhouse()
+        keeper_utils.wait_until_connected(cluster, node3)
 
-    assert node3.contains_in_log(
-        "Connected to ZooKeeper (or Keeper) before internal Keeper start"
-    )
-    node1_zk.delete("/test_restart")
+        assert node3.contains_in_log(
+            "Connected to ZooKeeper (or Keeper) before internal Keeper start"
+        )
+        node1_zk.delete("/test_restart")
+    finally:
+        node1_zk.stop()
+        node1_zk.close()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- tests/integration: add missing kazoo client termination (this improve situation with logging, but ater #44618 this should not be that important)
- workaround for the bug in kazoo driver that should be fixed by this patch - python-zk/kazoo#688

Follow-up for: #44618