### PR TITLE
Move dmesg dumping out from runner to ci-runner.py

### DIFF
--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -983,8 +983,21 @@ if __name__ == "__main__":
     runner = ClickhouseIntegrationTestsRunner(result_path, params)
 
     logging.info("Running tests")
+
+    # Avoid overlaps with previous runs
+    logging.info("Clearing dmesg before run")
+    subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
+        "dmesg --clear", shell=True
+    )
+
     state, description, test_results, _ = runner.run_impl(repo_path, build_path)
     logging.info("Tests finished")
+
+    # Dump dmesg (to capture possible OOMs)
+    logging.info("Dumping dmesg")
+    subprocess.check_call(  # STYLE_CHECK_ALLOW_SUBPROCESS_CHECK_CALL
+        "dmesg -T", shell=True
+    )
 
     status = (state, description)
     out_results_file = os.path.join(str(runner.path()), "test_results.tsv")

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -413,11 +413,5 @@ if __name__ == "__main__":
         subprocess.check_call(f"docker kill {' '.join(containers)}", shell=True)
         print(f"Containers {containers} killed")
 
-    # Avoid overlaps with previous runs
-    subprocess.check_call("dmesg --clear", shell=True)
-
     print(("Running pytest container as: '" + cmd + "'."))
     subprocess.check_call(cmd, shell=True)
-
-    # Dump dmesg (to capture possible OOMs)
-    subprocess.check_call("dmesg -T", shell=True)


### PR DESCRIPTION
runner is used by developers to run tests, while ci-runner.py is used only by CI scripts, and to avoid requiring CAP_SYSLOG for manual dmesg clear/dump had been moved.

Also for manual runs this can be done manually.

Follow-up for: #44535

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)