### PR TITLE
Fix flaky test "01502_long_log_tinylog_deadlock_race"

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -51,7 +51,6 @@ function clone
     )
 
     ls -lath ||:
-
 }
 
 function wget_with_retry

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1001,18 +1001,28 @@ class TestCase:
             seconds_left = max(
                 args.timeout - (datetime.now() - start_time).total_seconds(), 20
             )
+            drop_database_query = "DROP DATABASE " + database
+            if args.replicated_database:
+                drop_database_query += " ON CLUSTER test_cluster_database_replicated"
+
             try:
-                drop_database_query = "DROP DATABASE " + database
-                if args.replicated_database:
-                    drop_database_query += " ON CLUSTER test_cluster_database_replicated"
-                clickhouse_execute(
-                    args,
-                    drop_database_query,
-                    timeout=seconds_left,
-                    settings={
-                        "log_comment": args.testcase_basename,
-                    },
-                )
+                # It's possible to get an error "New table appeared in database being dropped or detached. Try again."
+                for _ in range(1, 60):
+                    try:
+                        clickhouse_execute(
+                            args,
+                            drop_database_query,
+                            timeout=seconds_left,
+                            settings={
+                                "log_comment": args.testcase_basename,
+                            },
+                        )
+                    except HTTPError as e:
+                        if need_retry(args, e.message, e.message, 0):
+                            continue
+                        raise
+                    break
+
             except socket.timeout:
                 total_time = (datetime.now() - start_time).total_seconds()
                 return (

--- a/tests/queries/0_stateless/01502_long_log_tinylog_deadlock_race.sh
+++ b/tests/queries/0_stateless/01502_long_log_tinylog_deadlock_race.sh
@@ -88,3 +88,9 @@ test_with_engine Log
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t1"
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t2"
+
+# It is not enough to kill the commands running the queries, we also have to kill the queries, the server might be still running
+# to avoid the following error:
+# Code: 219. DB::Exception: New table appeared in database being dropped or detached. Try again. (DATABASE_NOT_EMPTY)
+
+$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE current_database = currentDatabase() SYNC FORMAT Null"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/0/8a2fbbe88cd5d99ab68681858e8ec43bc6846025/stateless_tests__release__databaseordinary_.html