### PR TITLE
Update entrypoint.sh

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -80,7 +80,7 @@ do
 done
 
 # if clickhouse user is defined - create it (user "default" already exists out of box)
-if [ -n "$CLICKHOUSE_USER" ] && [ "$CLICKHOUSE_USER" != "default" ] || [ -n "$CLICKHOUSE_PASSWORD" ]; then
+if [ -n "$CLICKHOUSE_USER" ] && [ "$CLICKHOUSE_USER" != "default" ] || [ -n "$CLICKHOUSE_PASSWORD" ] || [ "$CLICKHOUSE_ACCESS_MANAGEMENT" != "0" ]; then
     echo "$0: create new user '$CLICKHOUSE_USER' instead 'default'"
     cat <<EOT > /etc/clickhouse-server/users.d/default-user.xml
     <clickhouse>


### PR DESCRIPTION
create xml with user settings if CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT is set

create proper default user with ACCESS_MANAGEMENT if
```
docker run --rm  -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 -p 9000:9000/tcp clickhouse/clickhouse-server
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
