### PR TITLE
S3 support upload object using storage class INTELLIGENT_TIERING

### DIFF
--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -1,4 +1,3 @@
-#include <aws/s3/model/StorageClass.h>
 #include "config.h"
 #include <Common/ProfileEvents.h>
 
@@ -19,6 +18,7 @@
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>
+#include <aws/s3/model/StorageClass.h>
 
 #include <utility>
 

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -474,7 +474,7 @@ void WriteBufferFromS3::fillPutRequest(Aws::S3::Model::PutObjectRequest & req)
     req.SetBody(temporary_buffer);
     if (object_metadata.has_value())
         req.SetMetadata(object_metadata.value());
-    if (settings.storageClassNameChanged())
+    if (!settings.storage_class_name.empty())
         req.SetStorageClass(Aws::S3::Model::StorageClassMapper::GetStorageClassForName(settings.storage_class_name));
 
     /// If we don't do it, AWS SDK can mistakenly set it to application/xml, see https://github.com/aws/aws-sdk-cpp/issues/1840

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -1,3 +1,4 @@
+#include <aws/s3/model/StorageClass.h>
 #include "config.h"
 #include <Common/ProfileEvents.h>
 
@@ -473,6 +474,8 @@ void WriteBufferFromS3::fillPutRequest(Aws::S3::Model::PutObjectRequest & req)
     req.SetBody(temporary_buffer);
     if (object_metadata.has_value())
         req.SetMetadata(object_metadata.value());
+    if (settings.storageClassNameChanged())
+        req.SetStorageClass(Aws::S3::Model::StorageClassMapper::GetStorageClassForName(settings.storage_class_name));
 
     /// If we don't do it, AWS SDK can mistakenly set it to application/xml, see https://github.com/aws/aws-sdk-cpp/issues/1840
     req.SetContentType("binary/octet-stream");

--- a/src/Storages/StorageS3Settings.cpp
+++ b/src/Storages/StorageS3Settings.cpp
@@ -39,7 +39,7 @@ S3Settings::RequestSettings::PartUploadSettings::PartUploadSettings(
     max_part_number = config.getUInt64(key + "max_part_number", max_part_number);
     max_single_part_upload_size = config.getUInt64(key + "max_single_part_upload_size", max_single_part_upload_size);
     max_single_operation_copy_size = config.getUInt64(key + "max_single_operation_copy_size", max_single_operation_copy_size);
-    
+
     /// This configuration is only applicable to s3. Other types of object storage are not applicable or have different meanings.
     storage_class_name = config.getString(config_prefix + ".s3_storage_class", storage_class_name);
     storage_class_name = Poco::toUpperInPlace(storage_class_name);

--- a/src/Storages/StorageS3Settings.cpp
+++ b/src/Storages/StorageS3Settings.cpp
@@ -145,11 +145,11 @@ void S3Settings::RequestSettings::PartUploadSettings::validate()
             "Setting upload_part_size_multiply_factor is too big ({}). Multiplication to max_upload_part_size ({}) will cause integer overflow",
             ReadableSize(max_part_number), ReadableSize(max_part_number_limit));
 
-    std::unordered_set<String> storage_class_names {"NOT_SET", "STANDARD", "INTELLIGENT_TIERING"};
-    if (!storage_class_names.contains(storage_class_name))
+    std::unordered_set<String> storage_class_names {"STANDARD", "INTELLIGENT_TIERING"};
+    if (!storage_class_name.empty() && !storage_class_names.contains(storage_class_name))
         throw Exception(
             ErrorCodes::INVALID_SETTING_VALUE,
-            "Setting storage_class has invalid value {} which only supports NOT_SET, STANDARD and INTELLIGENT_TIERING",
+            "Setting storage_class has invalid value {} which only supports STANDARD and INTELLIGENT_TIERING",
             storage_class_name);
 
     /// TODO: it's possible to set too small limits. We can check that max possible object size is not too small.

--- a/src/Storages/StorageS3Settings.h
+++ b/src/Storages/StorageS3Settings.h
@@ -11,6 +11,7 @@
 #include <Storages/HeaderCollection.h>
 
 #include <IO/S3Common.h>
+
 namespace Poco::Util
 {
 class AbstractConfiguration;

--- a/src/Storages/StorageS3Settings.h
+++ b/src/Storages/StorageS3Settings.h
@@ -11,7 +11,6 @@
 #include <Storages/HeaderCollection.h>
 
 #include <IO/S3Common.h>
-
 namespace Poco::Util
 {
 class AbstractConfiguration;
@@ -36,9 +35,11 @@ struct S3Settings
             size_t max_part_number = 10000;
             size_t max_single_part_upload_size = 32 * 1024 * 1024;
             size_t max_single_operation_copy_size = 5ULL * 1024 * 1024 * 1024;
+            String storage_class_name = "NOT_SET";
 
             void updateFromSettings(const Settings & settings) { updateFromSettingsImpl(settings, true); }
             void validate();
+            bool storageClassNameChanged() const { return storage_class_name != "NOT_SET"; }
 
         private:
             PartUploadSettings() = default;

--- a/src/Storages/StorageS3Settings.h
+++ b/src/Storages/StorageS3Settings.h
@@ -35,11 +35,10 @@ struct S3Settings
             size_t max_part_number = 10000;
             size_t max_single_part_upload_size = 32 * 1024 * 1024;
             size_t max_single_operation_copy_size = 5ULL * 1024 * 1024 * 1024;
-            String storage_class_name = "NOT_SET";
+            String storage_class_name;
 
             void updateFromSettings(const Settings & settings) { updateFromSettingsImpl(settings, true); }
             void validate();
-            bool storageClassNameChanged() const { return storage_class_name != "NOT_SET"; }
 
         private:
             PartUploadSettings() = default;

--- a/tests/integration/test_s3_storage_class/configs/config.d/minio.xml
+++ b/tests/integration/test_s3_storage_class/configs/config.d/minio.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+
+<!-- Using named collections 22.4+ -->
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <use_s3_storage_class>
+                <type>s3</type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>minio123</secret_access_key>
+                <s3_storage_class>STANDARD</s3_storage_class>
+            </use_s3_storage_class>
+        </disks>
+        <policies>
+            <use_s3_storage_class>
+                <volumes>
+                    <main>
+                        <disk>use_s3_storage_class</disk>
+                    </main>
+                </volumes>
+            </use_s3_storage_class>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_s3_storage_class/test.py
+++ b/tests/integration/test_s3_storage_class/test.py
@@ -1,0 +1,47 @@
+import os
+import logging
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+logging.getLogger().setLevel(logging.INFO)
+logging.getLogger().addHandler(logging.StreamHandler())
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", main_configs=["configs/config.d/minio.xml"], stay_alive=True, with_minio=True)
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_s3_storage_class_right(started_cluster):
+    node.query(
+        """
+            CREATE TABLE test_s3_storage_class
+            (
+                `id` UInt64,
+                `value` String
+            )
+            ENGINE = MergeTree
+            ORDER BY id
+            SETTINGS storage_policy='use_s3_storage_class';
+        """,
+    )
+    node.query(
+        """
+            INSERT INTO test_s3_storage_class VALUES (1, 'a');
+        """,
+    )
+    result = node.query(
+        """
+            SELECT id FROM test_s3_storage_class;
+        """
+    )
+
+    assert result == "1\n"
+

--- a/tests/integration/test_s3_storage_class/test.py
+++ b/tests/integration/test_s3_storage_class/test.py
@@ -8,7 +8,12 @@ logging.getLogger().setLevel(logging.INFO)
 logging.getLogger().addHandler(logging.StreamHandler())
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node", main_configs=["configs/config.d/minio.xml"], stay_alive=True, with_minio=True)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/config.d/minio.xml"],
+    stay_alive=True,
+    with_minio=True,
+)
 
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_s3_storage_class/test.py
+++ b/tests/integration/test_s3_storage_class/test.py
@@ -15,6 +15,7 @@ node = cluster.add_instance(
     with_minio=True,
 )
 
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -49,4 +50,3 @@ def test_s3_storage_class_right(started_cluster):
     )
 
     assert result == "1\n"
-


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
We can use `s3_storage_class` to set different tier. Such as 
```
<disks>
    <s3>
        <type>s3</type>
        <endpoint>xxx</endpoint>
        <access_key_id>xxx</access_key_id>
        <secret_access_key>xxx</secret_access_key>
        <s3_storage_class>STANDARD/INTELLIGENT_TIERING</s3_storage_class>
    </s3>
</disks>
```
Closes #44443

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
