### PR TITLE
Fix bug with wrong type in Merge table and PREWHERE

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -175,7 +175,10 @@ bool StorageMerge::canMoveConditionsToPrewhere() const
         {
             const auto * src_type = column_types[column.name];
             if (src_type && !src_type->equals(*column.type))
+            {
                 can_move = false;
+                return;
+            }
         }
     });
 

--- a/tests/queries/0_stateless/02518_merge_engine_nullable_43324.sql
+++ b/tests/queries/0_stateless/02518_merge_engine_nullable_43324.sql
@@ -1,0 +1,18 @@
+
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS foo__fuzz_0;
+DROP TABLE IF EXISTS foo_merge;
+
+CREATE TABLE foo (`Id` Int32, `Val` Int32) ENGINE = MergeTree ORDER BY Id;
+CREATE TABLE foo__fuzz_0 (`Id` Int64, `Val` Nullable(Int32)) ENGINE = MergeTree ORDER BY Id;
+
+INSERT INTO foo SELECT number, number % 5 FROM numbers(10);
+INSERT INTO foo__fuzz_0 SELECT number, number % 5 FROM numbers(10);
+
+CREATE TABLE merge1 AS foo ENGINE = Merge(currentDatabase(), '^foo');
+CREATE TABLE merge2 (`Id` Int32, `Val` Int32) ENGINE = Merge(currentDatabase(), '^foo');
+CREATE TABLE merge3 (`Id` Int32, `Val` Int32) ENGINE = Merge(currentDatabase(), '^foo__fuzz_0');
+
+SELECT * FROM merge1 WHERE Val = 3 AND Val = 1;
+SELECT * FROM merge2 WHERE Val = 3 AND Val = 1;
+SELECT * FROM merge3 WHERE Val = 3 AND Val = 1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug with wrong type in Merge table and PREWHERE, close https://github.com/ClickHouse/ClickHouse/issues/43324


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
