### PR TITLE
Fix deadlock in attach thread

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
@@ -191,7 +191,7 @@ void ReplicatedMergeTreeAttachThread::runImpl()
 
 void ReplicatedMergeTreeAttachThread::finalizeInitialization() TSA_NO_THREAD_SAFETY_ANALYSIS
 {
-    storage.startupImpl();
+    storage.startupImpl(/* from_attach_thread */ true);
     storage.initialization_done = true;
     LOG_INFO(log, "Table is initialized");
 }

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -10,11 +10,6 @@
 #include <boost/algorithm/string/replace.hpp>
 
 
-namespace ProfileEvents
-{
-    extern const Event ReplicaPartialShutdown;
-}
-
 namespace CurrentMetrics
 {
     extern const Metric ReadonlyReplica;
@@ -335,34 +330,11 @@ void ReplicatedMergeTreeRestartingThread::activateReplica()
 void ReplicatedMergeTreeRestartingThread::partialShutdown(bool part_of_full_shutdown)
 {
     setReadonly(part_of_full_shutdown);
-    ProfileEvents::increment(ProfileEvents::ReplicaPartialShutdown);
-
-    storage.partial_shutdown_called = true;
-    storage.partial_shutdown_event.set();
-    storage.replica_is_active_node = nullptr;
-
-    LOG_TRACE(log, "Waiting for threads to finish");
-    storage.merge_selecting_task->deactivate();
-    storage.queue_updating_task->deactivate();
-    storage.mutations_updating_task->deactivate();
-    storage.mutations_finalizing_task->deactivate();
-
-    storage.cleanup_thread.stop();
-    storage.part_check_thread.stop();
-
-    /// Stop queue processing
-    {
-        auto fetch_lock = storage.fetcher.blocker.cancel();
-        auto merge_lock = storage.merger_mutator.merges_blocker.cancel();
-        auto move_lock = storage.parts_mover.moves_blocker.cancel();
-        storage.background_operations_assignee.finish();
-    }
-
-    LOG_TRACE(log, "Threads finished");
+    storage.partialShutdown();
 }
 
 
-void ReplicatedMergeTreeRestartingThread::shutdown()
+void ReplicatedMergeTreeRestartingThread::shutdown(bool part_of_full_shutdown)
 {
     /// Stop restarting_thread before stopping other tasks - so that it won't restart them again.
     need_stop = true;
@@ -370,7 +342,7 @@ void ReplicatedMergeTreeRestartingThread::shutdown()
     LOG_TRACE(log, "Restarting thread finished");
 
     /// Stop other tasks.
-    partialShutdown(/* part_of_full_shutdown */ true);
+    partialShutdown(part_of_full_shutdown);
 }
 
 void ReplicatedMergeTreeRestartingThread::setReadonly(bool on_shutdown)

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.h
@@ -28,7 +28,7 @@ public:
 
     void wakeup() { task->schedule(); }
 
-    void shutdown();
+    void shutdown(bool part_of_full_shutdown);
 
 private:
     StorageReplicatedMergeTree & storage;

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -109,6 +109,7 @@ public:
 
     void startup() override;
     void shutdown() override;
+    void partialShutdown();
     void flush() override;
     ~StorageReplicatedMergeTree() override;
 
@@ -858,7 +859,7 @@ private:
     /// If somebody already holding the lock -- return std::nullopt.
     std::optional<ZeroCopyLock> tryCreateZeroCopyExclusiveLock(const String & part_name, const DiskPtr & disk) override;
 
-    void startupImpl();
+    void startupImpl(bool from_attach_thread);
 };
 
 String getPartNamePossiblyFake(MergeTreeDataFormatVersion format_version, const MergeTreePartInfo & part_info);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't want to backport it because changes are significant. Deadlock looks like this:
```
Thread 192 (Thread 0x7efca807d700 (LWP 1751)):
#0  0x00007efdd62a4170 in __lll_lock_wait () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007efdd629c0a3 in pthread_mutex_lock () from /lib/x86_64-linux-gnu/libpthread.so.0
#2  0x000000000bf103b3 in pthread_mutex_lock ()
#3  0x0000000025f482ba in std::__1::__libcpp_mutex_lock[abi:v15000](pthread_mutex_t*) (__m=0x7b340110d218) at ../contrib/llvm-project/libcxx/include/__threading_support:304
#4  std::__1::mutex::lock (this=0x7b340110d218) at ../contrib/llvm-project/libcxx/src/mutex.cpp:38
#5  0x000000001bdf9229 in std::__1::lock_guard<std::__1::mutex>::lock_guard[abi:v15000](std::__1::mutex&) (__m=..., this=<optimized out>) at ../contrib/llvm-project/libcxx/include/__mutex_base:94
#6  DB::BackgroundSchedulePoolTaskInfo::deactivate (this=0x7b340110d1c8) at ../src/Core/BackgroundSchedulePool.cpp:45
#7  0x000000001e6d6969 in DB::ReplicatedMergeTreeAttachThread::shutdown (this=0x7b8400b66918) at ../src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp:33
#8  0x000000001e06c706 in DB::StorageReplicatedMergeTree::shutdown (this=this@entry=0x7b8400b65820) at ../src/Storages/StorageReplicatedMergeTree.cpp:4329
#9  0x000000001e06c531 in DB::StorageReplicatedMergeTree::startupImpl (this=0x7b8400b65820) at ../src/Storages/StorageReplicatedMergeTree.cpp:4294
#10 0x000000001e6d9d8c in DB::ReplicatedMergeTreeAttachThread::finalizeInitialization (this=this@entry=0x7b8400b66918) at ../src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp:194
#11 0x000000001e6d6cf6 in DB::ReplicatedMergeTreeAttachThread::run (this=0x7b8400b66918) at ../src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp:51
#12 0x000000001e6da442 in DB::ReplicatedMergeTreeAttachThread::ReplicatedMergeTreeAttachThread(DB::StorageReplicatedMergeTree&)::$_0::operator()() const (this=<optimized out>) at ../src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp:19
#13 std::__1::__invoke[abi:v15000]<DB::ReplicatedMergeTreeAttachThread::ReplicatedMergeTreeAttachThread(DB::StorageReplicatedMergeTree&)::$_0&> (__f=...) at ../contrib/llvm-project/libcxx/include/__functional/invoke.h:394
#14 std::__1::__invoke_void_return_wrapper<void, true>::__call<DB::ReplicatedMergeTreeAttachThread::ReplicatedMergeTreeAttachThread(DB::StorageReplicatedMergeTree&)::$_0&>(DB::ReplicatedMergeTreeAttachThread::ReplicatedMergeTreeAttachThread(DB::StorageReplicatedMergeTree&)::$_0&) (__args=...) at ../contrib/llvm-project/libcxx/include/__functional/invoke.h:479
#15 std::__1::__function::__default_alloc_func<DB::ReplicatedMergeTreeAttachThread::ReplicatedMergeTreeAttachThread(DB::StorageReplicatedMergeTree&)::$_0, void ()>::operator()[abi:v15000]() (this=<optimized out>) at ../contrib/llvm-project/libcxx/include/__functional/function.h:235
#16 std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::ReplicatedMergeTreeAttachThread::ReplicatedMergeTreeAttachThread(DB::StorageReplicatedMergeTree&)::$_0, void ()> >(std::__1::__function::__policy_storage const*) (__buf=0x7b340110d1f8) at ../contrib/llvm-project/libcxx/include/__functional/function.h:716
#17 0x000000001bdf973f in std::__1::__function::__policy_func<void ()>::operator()[abi:v15000]() const (this=0x7b340110d1f8) at ../contrib/llvm-project/libcxx/include/__functional/function.h:848
#18 std::__1::function<void ()>::operator()() const (this=0x7b340110d1f8) at ../contrib/llvm-project/libcxx/include/__functional/function.h:1187
#19 DB::BackgroundSchedulePoolTaskInfo::execute (this=0x7b340110d1c8) at ../src/Core/BackgroundSchedulePool.cpp:98
#20 0x000000001bdfc3f3 in DB::BackgroundSchedulePool::threadFunction (this=this@entry=0x7b4800007f80) at ../src/Core/BackgroundSchedulePool.cpp:297
#21 0x000000001bdfce66 in DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2::operator()() const (this=<optimized out>) at ../src/Core/BackgroundSchedulePool.cpp:152
#22 std::__1::__invoke[abi:v15000]<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&> (__f=...) at ../contrib/llvm-project/libcxx/include/__functional/invoke.h:394
#23 std::__1::__apply_tuple_impl[abi:v15000]<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&, std::__1::tuple<>&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&, std::__1::tuple<>&, std::__1::__tuple_indices<>) (__f=..., __t=...) at ../contrib/llvm-project/libcxx/include/tuple:1789
#24 std::__1::apply[abi:v15000]<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&, std::__1::tuple<>&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&, std::__1::tuple<>&) (__f=..., __t=...) at ../contrib/llvm-project/libcxx/include/tuple:1798
#25 ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&&)::{lambda()#1}::operator()() (this=0x7b08000b3d00) at ../src/Common/ThreadPool.h:196
#26 std::__1::__invoke[abi:v15000]<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&&)::{lambda()#1}&> (__f=...) at ../contrib/llvm-project/libcxx/include/__functional/invoke.h:394
#27 std::__1::__invoke_void_return_wrapper<void, true>::__call<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&&)::{lambda()#1}&>(ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&&)::{lambda()#1}&) (__args=...) at ../contrib/llvm-project/libcxx/include/__functional/invoke.h:479
#28 std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&&)::{lambda()#1}, void ()>::operator()[abi:v15000]() (this=0x7b08000b3d00) at ../contrib/llvm-project/libcxx/include/__functional/function.h:235
#29 std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_2&&)::{lambda()#1}, void ()> >(std::__1::__function::__policy_storage const*) (__buf=<optimized out>) at ../contrib/llvm-project/libcxx/include/__functional/function.h:716
#30 0x00000000140f6d91 in std::__1::__function::__policy_func<void ()>::operator()[abi:v15000]() const (this=0x7efca8074ef0) at ../contrib/llvm-project/libcxx/include/__functional/function.h:848
#31 std::__1::function<void ()>::operator()() const (this=0x7efca8074ef0) at ../contrib/llvm-project/libcxx/include/__functional/function.h:1187
#32 ThreadPoolImpl<std::__1::thread>::worker (this=this@entry=0x7b3c000069f0, thread_it=...) at ../src/Common/ThreadPool.cpp:295
#33 0x00000000140fb592 in ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::{lambda()#2}::operator()() const (this=<optimized out>) at ../src/Common/ThreadPool.cpp:144
#34 std::__1::__invoke[abi:v15000]<ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::{lambda()#2}> (__f=...) at ../contrib/llvm-project/libcxx/include/__functional/invoke.h:394
#35 std::__1::__thread_execute[abi:v15000]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::{lambda()#2}>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::{lambda()#2}>&, std::__1::__tuple_indices<>) (__t=...) at ../contrib/llvm-project/libcxx/include/thread:284
#36 std::__1::__thread_proxy[abi:v15000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::{lambda()#2}> >(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::{lambda()#2}>) (__vp=0x7b08000b3ce0) at ../contrib/llvm-project/libcxx/include/thread:295
#37 0x000000000bef25a7 in __tsan_thread_start_func ()
#38 0x00007efdd6299609 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#39 0x00007efdd61be133 in clone () from /lib/x86_64-linux-gnu/libc.so.6
```
