### PR TITLE
A few improvements to AST Fuzzer

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -384,7 +384,7 @@ th { cursor: pointer; }
 <tr>
   <td>AST Fuzzer</td>
   <td>$(cat status.txt)</td>
-  <td style="white-space: pre;">$(clickhouse-local --input-format RawBLOB --output-format RawBLOB --query "SELECT encodeXMLComponent(*) FROM table" < description.txt)</td>
+  <td style="white-space: pre;">$(clickhouse-local --input-format RawBLOB --output-format RawBLOB --query "SELECT encodeXMLComponent(*) FROM table" < description.txt || cat description.txt)</td>
 </tr>
 </table>
 </body>

--- a/tests/ci/ast_fuzzer_check.py
+++ b/tests/ci/ast_fuzzer_check.py
@@ -124,20 +124,12 @@ if __name__ == "__main__":
     s3_helper = S3Helper()
     for f in paths:
         try:
-            paths[f] = s3_helper.upload_test_report_to_s3(paths[f], s3_prefix + "/" + f)
+            paths[f] = s3_helper.upload_test_report_to_s3(paths[f], s3_prefix + f)
         except Exception as ex:
             logging.info("Exception uploading file %s text %s", f, ex)
             paths[f] = ""
 
     report_url = GITHUB_RUN_URL
-    if paths["run.log"]:
-        report_url = paths["run.log"]
-    if paths["main.log"]:
-        report_url = paths["main.log"]
-    if paths["server.log.gz"]:
-        report_url = paths["server.log.gz"]
-    if paths["fuzzer.log"]:
-        report_url = paths["fuzzer.log"]
     if paths["report.html"]:
         report_url = paths["report.html"]
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


1. Remove double `/` in the path. s3 keys are sensitive to that, and it is confusing.
2. It will expose either the HTML or the GitHub Actions task as the URL but no other random files.
3. Just in case, fallback if clickhouse-local cannot run when generating HTML.