### PR TITLE
Fix cases when clickhouse-server takes long time to start in functional tests with MSan

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1118,7 +1118,7 @@ class TestCase:
                     args, self.get_description_from_exception_info(sys.exc_info())
                 ),
             )
-        except (ConnectionRefusedError, ConnectionResetError):
+        except (ConnectionError, http.ImproperConnectionState):
             return TestResult(
                 self.name,
                 TestStatus.FAIL,
@@ -1544,7 +1544,7 @@ def check_server_started(args):
             print(" OK")
             sys.stdout.flush()
             return True
-        except (ConnectionRefusedError, ConnectionResetError):
+        except (ConnectionError, http.ImproperConnectionState):
             print(".", end="")
             sys.stdout.flush()
             retry_count -= 1
@@ -1554,7 +1554,7 @@ def check_server_started(args):
             print("\nConnection timeout, will not retry")
             break
         except Exception as e:
-            print("\nUexpected exception, will not retry: ", str(e))
+            print("\nUexpected exception, will not retry: ", type(e).__name__, ": ", str(e))
             break
 
     print("\nAll connection tries failed")
@@ -2280,7 +2280,7 @@ if __name__ == "__main__":
         if find_binary(args.binary + "-client"):
             args.client = args.binary + "-client"
 
-            print("Using " + args.client + " as client program (expecting split build)")
+            print("Using " + args.client + " as client program")
         elif find_binary(args.binary):
             args.client = args.binary + " client"
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1118,7 +1118,7 @@ class TestCase:
                     args, self.get_description_from_exception_info(sys.exc_info())
                 ),
             )
-        except (ConnectionError, http.ImproperConnectionState):
+        except (ConnectionError, http.client.ImproperConnectionState):
             return TestResult(
                 self.name,
                 TestStatus.FAIL,
@@ -1544,7 +1544,7 @@ def check_server_started(args):
             print(" OK")
             sys.stdout.flush()
             return True
-        except (ConnectionError, http.ImproperConnectionState):
+        except (ConnectionError, http.client.ImproperConnectionState):
             print(".", end="")
             sys.stdout.flush()
             retry_count -= 1


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://github.com/ClickHouse/ClickHouse/commit/7e4e94890ef6ab45b4038910aa0ba3dc9a9f3683
https://s3.amazonaws.com/clickhouse-test-reports/0/7e4e94890ef6ab45b4038910aa0ba3dc9a9f3683/stateless_tests__msan__[2/3].html
Python receives exception:
```
2022-12-29 18:12:17 Connecting to ClickHouse server...
2022-12-29 18:12:17 Uexpected exception, will not retry:  Request-sent
```
which was unexpected but should be ok (while the server is starting, it can refuse connections in arbitrary ways).