### PR TITLE
Build rust modules from the binary directory

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -39,5 +39,21 @@ function(clickhouse_import_crate)
     corrosion_import_crate(NO_STD ${ARGN})
 endfunction()
 
-add_subdirectory (BLAKE3)
-add_subdirectory (skim)
+# Add crate from the build directory.
+#
+# Our crates has configuration files:
+# - config for cargo (see config.toml.in)
+# - and possibly config for build (build.rs.in)
+#
+# And to avoid overlaps different builds for one source directory, crate will
+# be copied from source directory to the binary directory.
+file(COPY ".cargo" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+function(add_rust_subdirectory src)
+    set(dst "${CMAKE_CURRENT_BINARY_DIR}/${src}")
+    message(STATUS "Copy ${src} to ${dst}")
+    file(COPY "${src}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+    add_subdirectory("${dst}" "${dst}")
+endfunction()
+
+add_rust_subdirectory (BLAKE3)
+add_rust_subdirectory (skim)


### PR DESCRIPTION
Our crates has configuration files:
- config for cargo (see config.toml.in)
- and possibly config for build (build.rs.in)

Previously it uses source directory, and it will overrides files in the source directory, which will require recompile of crates in case of multiple builds for one source directory.

To avoid overlaps different builds for one source directory, crate will be copied from source directory to the binary directory.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up for: #44623