### PR TITLE
Remove database ordinary from stress test

### DIFF
--- a/docker/test/stress/stress
+++ b/docker/test/stress/stress
@@ -14,9 +14,6 @@ def get_options(i, backward_compatibility_check):
     if 0 < i:
         options.append("--order=random")
 
-    if i % 3 == 1:
-        options.append("--db-engine=Ordinary")
-
     if i % 3 == 2 and not backward_compatibility_check:
         options.append(
             '''--db-engine="Replicated('/test/db/test_{}', 's1', 'r1')"'''.format(i)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):