### PR TITLE
Fix flaky test 02479_mysql_connect_to_self

### DIFF
--- a/tests/queries/0_stateless/02479_mysql_connect_to_self.sql
+++ b/tests/queries/0_stateless/02479_mysql_connect_to_self.sql
@@ -1,3 +1,4 @@
 -- Tags: no-fasttest
 SELECT *
 FROM mysql('127.0.0.1:9004', system, one, 'default', '')
+SETTINGS send_logs_level = 'fatal'; -- failed connection tries are ok, if it succeeded after retry.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/0/150a699dda1033a35f267689ece8f81f1cc672e6/stateless_tests__release__s3_storage_.html