### PR TITLE
Fix race in `system.parts` and `system.parts_columns`

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1851,7 +1851,7 @@ void MergeTreeData::removePartsFinally(const MergeTreeData::DataPartsVector & pa
 
             auto it = data_parts_by_info.find(part->info);
             if (it == data_parts_by_info.end())
-                throw Exception("Deleting data part " + part->name + " doesn't exist", ErrorCodes::LOGICAL_ERROR);
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Deleting data part {} doesn't exist", part->name);
 
             (*it)->assertState({DataPartState::Deleting});
 

--- a/src/Storages/MergeTree/MergeTreeDataPartState.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartState.h
@@ -3,24 +3,23 @@
 namespace DB
 {
 
-/**
-     * Part state is a stage of its lifetime. States are ordered and state of a part could be increased only.
-     * Part state should be modified under data_parts mutex.
-     *
-     * Possible state transitions:
-     * Temporary -> PreActive:       we are trying to add a fetched, inserted or merged part to active set
-     * PreActive -> Outdated:        we could not add a part to active set and are doing a rollback (for example it is duplicated part)
-     * PreActive -> Active:          we successfully added a part to active dataset
-     * PreActive -> Outdated:        a part was replaced by a covering part or DROP PARTITION
-     * Outdated -> Deleting:         a cleaner selected this part for deletion
-     * Deleting -> Outdated:         if an ZooKeeper error occurred during the deletion, we will retry deletion
-     * Active -> DeleteOnDestroy:    if part was moved to another disk
-     */
+/** Part state is a stage of its lifetime. States are ordered and state of a part could be increased only.
+  * Part state should be modified under data_parts mutex.
+  *
+  * Possible state transitions:
+  * Temporary -> PreActive:       we are trying to add a fetched, inserted or merged part to active set
+  * PreActive -> Outdated:        we could not add a part to active set and are doing a rollback (for example it is duplicated part)
+  * PreActive -> Active:          we successfully added a part to active dataset
+  * PreActive -> Outdated:        a part was replaced by a covering part or DROP PARTITION
+  * Outdated -> Deleting:         a cleaner selected this part for deletion
+  * Deleting -> Outdated:         if an ZooKeeper error occurred during the deletion, we will retry deletion
+  * Active -> DeleteOnDestroy:    if part was moved to another disk
+  */
 enum class MergeTreeDataPartState
 {
     Temporary,       /// the part is generating now, it is not in data_parts list
-    PreActive,    /// the part is in data_parts, but not used for SELECTs
-    Active,       /// active data part, used by current and upcoming SELECTs
+    PreActive,       /// the part is in data_parts, but not used for SELECTs
+    Active,          /// active data part, used by current and upcoming SELECTs
     Outdated,        /// not active data part, but could be used by only current SELECTs, could be deleted after SELECTs finishes
     Deleting,        /// not active data part with identity refcounter, it is deleting right now by a cleaner
     DeleteOnDestroy, /// part was moved to another disk and should be deleted in own destructor

--- a/src/Storages/System/StorageSystemParts.cpp
+++ b/src/Storages/System/StorageSystemParts.cpp
@@ -234,9 +234,12 @@ void StorageSystemParts::processNextStorage(
 
         if (columns_mask[src_index++])
         {
-            // The full path changes at clean up thread under deleting state, do not read it, avoid the race
-            if (part->isStoredOnDisk() && part_state != State::Deleting)
+            /// The full path changes at clean up thread, so do not read it if parts can be deleted, avoid the race.
+            if (part->isStoredOnDisk()
+                && part_state != State::Deleting && part_state != State::DeleteOnDestroy && part_state != State::Temporary)
+            {
                 columns[res_index++]->insert(part->getDataPartStorage().getFullPath());
+            }
             else
                 columns[res_index++]->insertDefault();
         }

--- a/src/Storages/System/StorageSystemPartsColumns.cpp
+++ b/src/Storages/System/StorageSystemPartsColumns.cpp
@@ -193,9 +193,12 @@ void StorageSystemPartsColumns::processNextStorage(
                 columns[res_index++]->insert(part->getDataPartStorage().getDiskName());
             if (columns_mask[src_index++])
             {
-                // The full path changes at clean up thread under deleting state, do not read it, avoid the race
-                if (part_state != State::Deleting)
+                /// The full path changes at clean up thread, so do not read it if parts can be deleted, avoid the race.
+                if (part->isStoredOnDisk()
+                    && part_state != State::Deleting && part_state != State::DeleteOnDestroy && part_state != State::Temporary)
+                {
                     columns[res_index++]->insert(part->getDataPartStorage().getFullPath());
+                }
                 else
                     columns[res_index++]->insertDefault();
             }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
A rare race condition was possible when querying the `system.parts` or `system.parts_columns` tables in the presence of parts being moved between disks. Introduced in #41145.