### PR TITLE
Fix `grep`

### DIFF
--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -348,7 +348,7 @@ if [ -f core.gz ]; then
     CORE_LINK='<a href="core.gz">core.gz</a>'
 fi
 
-grep -F '<Fatal>' server.log > fatal.log ||:
+grep --text -F '<Fatal>' server.log > fatal.log ||:
 
 pigz server.log
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/44812/ea04181d11827fd552a86ca4d9c07e1d531e6ca3/fuzzer_astfuzzerdebug/report.html

We should probably replace `grep` with `rg` everywhere.