### PR TITLE
Fix misleading integration tests reports for parametrized tests

### DIFF
--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -214,10 +214,9 @@ def clear_ip_tables_and_restart_daemons():
             subprocess.check_output("sudo iptables -D DOCKER-USER 1", shell=True)
     except subprocess.CalledProcessError as err:
         logging.info(
-            "All iptables rules cleared, "
-            + str(iptables_iter)
-            + "iterations, last error: "
-            + str(err)
+            "All iptables rules cleared, %s iterations, last error: %s",
+            iptables_iter,
+            str(err),
         )
 
 

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -382,7 +382,7 @@ class ClickhouseIntegrationTestsRunner:
         cmd = (
             "cd {repo_path}/tests/integration && "
             "timeout -s 9 1h ./runner {runner_opts} {image_cmd} ' --setup-plan' "
-            "| tee {out_file_full} | grep '::' | sed 's/ (fixtures used:.*//g' | sed 's/^ *//g' | sed 's/ *$//g' | sed 's/\[.*$//g' "
+            "| tee {out_file_full} | grep '::' | sed 's/ (fixtures used:.*//g' | sed 's/^ *//g' | sed 's/ *$//g' "
             "| grep -v 'SKIPPED' | sort -u  > {out_file}".format(
                 repo_path=repo_path,
                 runner_opts=self._get_runner_opts(),
@@ -593,10 +593,7 @@ class ClickhouseIntegrationTestsRunner:
             test_names = set([])
             for test_name in tests_in_group:
                 if test_name not in counters["PASSED"]:
-                    if "[" in test_name:
-                        test_names.add(test_name[: test_name.find("[")])
-                    else:
-                        test_names.add(test_name)
+                    test_names.add(test_name)
 
             if i == 0:
                 test_data_dirs = self._find_test_data_dirs(repo_path, test_names)

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -614,7 +614,7 @@ class ClickhouseIntegrationTestsRunner:
             # -E -- (E)rror
             # -p -- (p)assed
             # -s -- (s)kipped
-            cmd = "cd {}/tests/integration && timeout -s 9 1h ./runner {} {} -t {} {} '-rfEps --run-id={} --color=no --durations=0 {}' | tee {}".format(
+            cmd = "cd {}/tests/integration && timeout -s 9 1h ./runner {} {} -t {} {} '-rfEps --run-id={} --color=no --durations=0 {}'".format(
                 repo_path,
                 self._get_runner_opts(),
                 image_cmd,
@@ -622,20 +622,23 @@ class ClickhouseIntegrationTestsRunner:
                 parallel_cmd,
                 i,
                 _get_deselect_option(self.should_skip_tests()),
-                info_path,
             )
 
             log_basename = test_group_str + "_" + str(i) + ".log"
             log_path = os.path.join(repo_path, "tests/integration", log_basename)
             with open(log_path, "w") as log:
-                logging.info("Executing cmd: %s", cmd)
-                retcode = subprocess.Popen(
-                    cmd, shell=True, stderr=log, stdout=log
-                ).wait()
-                if retcode == 0:
-                    logging.info("Run %s group successfully", test_group)
-                else:
-                    logging.info("Some tests failed")
+                with open(info_path, "w") as info:
+                    logging.info("Executing cmd: %s", cmd)
+                    retcode = subprocess.Popen(
+                        cmd,
+                        shell=True,
+                        stderr=log,
+                        stdout=info,
+                    ).wait()
+                    if retcode == 0:
+                        logging.info("Run %s group successfully", test_group)
+                    else:
+                        logging.info("Some tests failed")
 
             extra_logs_names = [log_basename]
             log_result_path = os.path.join(

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -382,7 +382,7 @@ class ClickhouseIntegrationTestsRunner:
         cmd = (
             "cd {repo_path}/tests/integration && "
             "timeout -s 9 1h ./runner {runner_opts} {image_cmd} ' --setup-plan' "
-            "| tee {out_file_full} | grep '::' | sed 's/ (fixtures used:.*//g' | sed 's/^ *//g' | sed 's/ *$//g' "
+            "| tee {out_file_full} | grep '::' | sed 's/ (fixtures used:.*//g' | sed 's/^ *//g' | sed 's/ *$//g' | sed 's/\[.*$//g' "
             "| grep -v 'SKIPPED' | sort -u  > {out_file}".format(
                 repo_path=repo_path,
                 runner_opts=self._get_runner_opts(),

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -610,7 +610,7 @@ class ClickhouseIntegrationTestsRunner:
             # -E -- (E)rror
             # -p -- (p)assed
             # -s -- (s)kipped
-            cmd = "cd {}/tests/integration && timeout -s 9 1h ./runner {} {} -t {} {} '-rfEps --run-id={} --color=no --durations=0 {}'".format(
+            cmd = "cd {}/tests/integration && timeout -s 9 1h ./runner {} {} -t {} {} '-rfEps --run-id={} --color=no --durations=0 {}' | tee {}".format(
                 repo_path,
                 self._get_runner_opts(),
                 image_cmd,
@@ -618,23 +618,15 @@ class ClickhouseIntegrationTestsRunner:
                 parallel_cmd,
                 i,
                 _get_deselect_option(self.should_skip_tests()),
+                info_path,
             )
 
             log_basename = test_group_str + "_" + str(i) + ".log"
             log_path = os.path.join(repo_path, "tests/integration", log_basename)
             with open(log_path, "w") as log:
-                with open(info_path, "w") as info:
-                    logging.info("Executing cmd: %s", cmd)
-                    retcode = subprocess.Popen(
-                        cmd,
-                        shell=True,
-                        stderr=log,
-                        stdout=info,
-                    ).wait()
-                    if retcode == 0:
-                        logging.info("Run %s group successfully", test_group)
-                    else:
-                        logging.info("Some tests failed")
+                logging.info("Executing cmd: %s", cmd)
+                # ignore retcode, since it meaningful due to pipe to tee
+                subprocess.Popen(cmd, shell=True, stderr=log, stdout=log).wait()
 
             extra_logs_names = [log_basename]
             log_result_path = os.path.join(

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -326,7 +326,7 @@ class ClickhouseIntegrationTestsRunner:
                     break
             else:
                 raise Exception("Package with {} not found".format(package))
-        logging.info("Unstripping binary")
+        # logging.info("Unstripping binary")
         # logging.info(
         #     "Unstring %s",
         #     subprocess.check_output(


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There is also one assumption the runner already, that leads to
misleading reports like in [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/44762/89c071e291980e355f2c2be42dc15047caabc9bc/integration_tests__asan__%5B4/6%5D.html

Here the test test_multiple_disks/test.py::test_jbod_overflow had been
splitted into multiple groups, however because of that one assumption
it had been runned as a whole in both groups and in one it failed but
succeeded in another.

Plus fix some other things that I've found.