### PR TITLE
Try fixing `test_keeper_snapshot_small_distance` with ZK restart

### DIFF
--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -4,7 +4,8 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 import helpers.keeper_utils as keeper_utils
 from multiprocessing.dummy import Pool
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient, KazooRetry
+from kazoo.handlers.threading import KazooTimeoutError
 import random
 import string
 import os
@@ -37,6 +38,11 @@ def clear_zookeeper(node):
 def restart_and_clear_zookeeper(node):
     stop_zookeeper(node)
     clear_zookeeper(node)
+    start_zookeeper(node)
+
+
+def restart_zookeeper(node):
+    stop_zookeeper(node)
     start_zookeeper(node)
 
 
@@ -104,11 +110,25 @@ def get_fake_zk(node, timeout=30.0):
 
 
 def get_genuine_zk(node, timeout=30.0):
-    _genuine_zk_instance = KazooClient(
-        hosts=cluster.get_instance_ip(node.name) + ":2181", timeout=timeout
-    )
-    _genuine_zk_instance.start()
-    return _genuine_zk_instance
+    CONNECTION_RETRIES = 100
+    for i in range(CONNECTION_RETRIES):
+        try:
+            _genuine_zk_instance = KazooClient(
+                hosts=cluster.get_instance_ip(node.name) + ":2181",
+                timeout=timeout,
+                connection_retry=KazooRetry(max_tries=20),
+            )
+            _genuine_zk_instance.start()
+            return _genuine_zk_instance
+        except KazooTimeoutError:
+            if i == CONNECTION_RETRIES - 1:
+                raise
+
+            print(
+                "Failed to connect to ZK cluster because of timeout. Restarting cluster and trying again."
+            )
+            time.sleep(0.2)
+            restart_zookeeper(node)
 
 
 def test_snapshot_and_load(started_cluster):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Same solution as for `test_keeper_zookeeper_converter` (https://github.com/ClickHouse/ClickHouse/pull/44363)
Based on the [logs](https://s3.amazonaws.com/clickhouse-test-reports/0/3223c5311134935c85e13848b6504c9dd8faf0f7/integration_tests__tsan__[1/4].html) the problem looks the same.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
