### PR TITLE
Exclude cargo shared libraries from the artifacts

### DIFF
--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -107,8 +107,11 @@ fi
 mv ./programs/clickhouse* /output
 [ -x ./programs/self-extracting/clickhouse ] && mv ./programs/self-extracting/clickhouse /output
 mv ./src/unit_tests_dbms /output ||: # may not exist for some binary builds
-find . -name '*.so' -print -exec mv '{}' /output \;
-find . -name '*.so.*' -print -exec mv '{}' /output \;
+
+# Exclude cargo build directory since it may have some shared libraries
+# (even though they are not required for the clickhouse binary)
+find . -name '*.so' -not -path '*/cargo/*' -print -exec mv '{}' /output \;
+find . -name '*.so.*' -not -path '*/cargo/*' -print -exec mv '{}' /output \;
 
 prepare_combined_output () {
     local OUTPUT


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)