### PR TITLE
Escape submodules in style-check

### DIFF
--- a/utils/check-style/check-submodules
+++ b/utils/check-style/check-submodules
@@ -12,9 +12,9 @@ cd "$GIT_ROOT"
 # Remove keys for submodule.*.path parameters, the values are separated by \0
 # and check if the directory exists
 git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\n||' | \
-  xargs -P100 -0 --no-run-if-empty -I{} bash -c 'if ! test -d {}; then echo Directory for submodule {} is not found; exit 1; fi' 2>&1
+  xargs -P100 -0 --no-run-if-empty -I{} bash -c 'if ! test -d '"'{}'"'; then echo Directory for submodule {} is not found; exit 1; fi' 2>&1
 
 
 # And check that the submodule is fine
 git config --file .gitmodules --null --get-regexp path | sed -z 's|.*\n||' | \
-  xargs -P100 -0 --no-run-if-empty -I{} git submodule status -q {} 2>&1
+  xargs -P100 -0 --no-run-if-empty -I{} git submodule status -q '{}' 2>&1


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prevent possible issues with submodules' paths.