### PR TITLE
Remove unneeded softlink to official dev docs

### DIFF
--- a/tests/instructions/developer_instruction_en.md
+++ b/tests/instructions/developer_instruction_en.md
@@ -1,1 +1,0 @@
-../../docs/en/development/developer-instruction.md

--- a/tests/instructions/developer_instruction_ru.md
+++ b/tests/instructions/developer_instruction_ru.md
@@ -1,1 +1,0 @@
-../../docs/ru/development/developer-instruction.md


### PR DESCRIPTION
No need to mirror the dev docs in docs/en/development/developer-instruction.md into tests/instructions/. The official docs on the .com page are just fine, and we should avoid confusion.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)