### PR TITLE
Fix data race in StorageS3

### DIFF
--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -186,7 +186,7 @@ public:
 
     size_t getTotalSize() const
     {
-        return total_size;
+        return total_size.load(std::memory_order_relaxed);
     }
 
     ~Impl()
@@ -283,7 +283,7 @@ private:
             buffer.reserve(block.rows());
             for (UInt64 idx : idxs.getData())
             {
-                total_size += temp_buffer[idx].info->size;
+                total_size.fetch_add(temp_buffer[idx].info->size, std::memory_order_relaxed);
                 buffer.emplace_back(std::move(temp_buffer[idx]));
             }
         }
@@ -291,7 +291,7 @@ private:
         {
             buffer = std::move(temp_buffer);
             for (const auto & [_, info] : buffer)
-                total_size += info->size;
+                total_size.fetch_add(info->size, std::memory_order_relaxed);
         }
 
         /// Set iterator only after the whole batch is processed
@@ -357,7 +357,7 @@ private:
     ThreadPool list_objects_pool;
     ThreadPoolCallbackRunner<ListObjectsOutcome> list_objects_scheduler;
     std::future<ListObjectsOutcome> outcome_future;
-    size_t total_size = 0;
+    std::atomic<size_t> total_size = 0;
 };
 
 StorageS3Source::DisclosedGlobIterator::DisclosedGlobIterator(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Caught by TSAN: https://s3.amazonaws.com/clickhouse-test-reports/0/f7fbaf9c995acc31e866097c6482fc2622a21fc0/integration_tests__tsan__[3/4].html
https://s3.amazonaws.com/clickhouse-test-reports/0/f7fbaf9c995acc31e866097c6482fc2622a21fc0/integration_tests__tsan__[3/4]/integration_run_parallel4_0.log


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
