### PR TITLE
No more retries in integration tests

### DIFF
--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -13,7 +13,7 @@ import time
 import zlib  # for crc32
 
 
-MAX_RETRY = 3
+MAX_RETRY = 1
 NUM_WORKERS = 5
 SLEEP_BETWEEN_RETRIES = 5
 PARALLEL_GROUP_SIZE = 100


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
All recent failures and flaky integration tests were real problems in code or tests itself.
Like #44843, #44840.

Issues with infrastructure https://github.com/distribution/distribution/issues/3722 we will try to fix separately like with #44848.

Creating as Draft PR to see what will fail first.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
