### PR TITLE
Wait for ZK process to stop in tests using snapshot

### DIFF
--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -29,7 +29,10 @@ def start_zookeeper(node):
 
 def stop_zookeeper(node):
     node.exec_in_container(["bash", "-c", "/opt/zookeeper/bin/zkServer.sh stop"])
+    timeout = time.time() + 60
     while node.get_process_pid("zookeeper") != None:
+        if time.time() > timeout:
+            raise Exception("Failed to stop ZooKeeper in 60 secs")
         time.sleep(0.2)
 
 

--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -29,6 +29,8 @@ def start_zookeeper(node):
 
 def stop_zookeeper(node):
     node.exec_in_container(["bash", "-c", "/opt/zookeeper/bin/zkServer.sh stop"])
+    while node.get_process_pid("zookeeper") != None:
+        time.sleep(0.2)
 
 
 def clear_zookeeper(node):

--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -24,7 +24,10 @@ def start_zookeeper():
 
 def stop_zookeeper():
     node.exec_in_container(["bash", "-c", "/opt/zookeeper/bin/zkServer.sh stop"])
+    timeout = time.time() + 60
     while node.get_process_pid("zookeeper") != None:
+        if time.time() > timeout:
+            raise Exception("Failed to stop ZooKeeper in 60 secs")
         time.sleep(0.2)
 
 

--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -24,6 +24,8 @@ def start_zookeeper():
 
 def stop_zookeeper():
     node.exec_in_container(["bash", "-c", "/opt/zookeeper/bin/zkServer.sh stop"])
+    while node.get_process_pid("zookeeper") != None:
+        time.sleep(0.2)
 
 
 def clear_zookeeper():


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Wild guess for this problem:
https://s3.amazonaws.com/clickhouse-test-reports/0/7d7de3833bf092c51f03b6d68022d8508962564b/integration_tests__tsan__[1/4]/integration_run_parallel2_0.log

It seems generated ZK snapshot is incomplete. I checked the `zkServer.sh stop` script and it doesn't wait for process to stop it just sleeps 1 sec. Maybe the process was still writing a snapshot at the time we tried to run the converter. 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
