### PR TITLE
Adapt blocks from remote for totals and extremes

### DIFF
--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -411,11 +411,11 @@ std::optional<Block> RemoteQueryExecutor::processPacket(Packet packet)
             break;
 
         case Protocol::Server::Totals:
-            totals = packet.block;
+            totals = adaptBlockStructure(packet.block, header);
             break;
 
         case Protocol::Server::Extremes:
-            extremes = packet.block;
+            extremes = adaptBlockStructure(packet.block, header);
             break;
 
         case Protocol::Server::Log:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Found by https://s3.amazonaws.com/clickhouse-test-reports/0/e68b98aac3d527575c4e907c15c78bf22b5f88a6/fuzzer_astfuzzermsan/report.html

Need to write a test where we read from remote with `Distributed` so not sure if `test_shard_localhost` will work.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
