### PR TITLE
Do not throw DB::Exception when folders do not exist

### DIFF
--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -352,7 +352,8 @@ time_t getModificationTime(const std::string & path)
     struct stat st;
     if (stat(path.c_str(), &st) == 0)
         return st.st_mtime;
-    DB::throwFromErrnoWithPath("Cannot check modification time for file: " + path, path, DB::ErrorCodes::CANNOT_STAT);
+    std::error_code m_ec(errno, std::generic_category());
+    throw fs::filesystem_error("Cannot check modification time for file", path, m_ec);
 }
 
 time_t getChangeTime(const std::string & path)
@@ -360,7 +361,8 @@ time_t getChangeTime(const std::string & path)
     struct stat st;
     if (stat(path.c_str(), &st) == 0)
         return st.st_ctime;
-    DB::throwFromErrnoWithPath("Cannot check change time for file: " + path, path, DB::ErrorCodes::CANNOT_STAT);
+    std::error_code m_ec(errno, std::generic_category());
+    throw fs::filesystem_error("Cannot check change time for file", path, m_ec);
 }
 
 Poco::Timestamp getModificationTimestamp(const std::string & path)

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -539,11 +539,19 @@ String DatabaseOnDisk::getObjectMetadataPath(const String & object_name) const
 time_t DatabaseOnDisk::getObjectMetadataModificationTime(const String & object_name) const
 {
     String table_metadata_path = getObjectMetadataPath(object_name);
-
-    if (fs::exists(table_metadata_path))
+    try
+    {
         return FS::getModificationTime(table_metadata_path);
-    else
-        return static_cast<time_t>(0);
+    }
+    catch (const fs::filesystem_error & e)
+    {
+        if (e.code() == std::errc::no_such_file_or_directory)
+        {
+            return static_cast<time_t>(0);
+        }
+        else
+            throw;
+    }
 }
 
 void DatabaseOnDisk::iterateMetadataFiles(ContextPtr local_context, const IteratingFunction & process_metadata_file) const


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Don't report errors in system.errors due to parts being merged concurrently with the background cleanup process. 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

Background of the problem:
If a part is merged, and its temporal folder deleted, while the background cleanup process (`ReplicatedMergeTreeCleanupThread`) is working you might see errors like this in system.errors:

```
`│ 1 │ 22.9.1.344 │ CANNOT_STAT │ 400 │ 1 │ 2022-08-25 14:37:07 │ Cannot check modification time for file: /builds/ch1/data/store/a7b/a7bf0f04-f72a-43b8-a927-e65a8d3ea017/tmp_merge_202208_0_5752_2591/, errno: 2, strerror: No such file or directory │ [171716602,171720768,171943046,338869808,358351362,360284054,360277685,333708376,333718838,333722220,172512904,172525725,140286036248073,140286035349811]`
```

Callstack:
```
DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool)
DB::throwFromErrnoWithPath(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int)
FS::getModificationTime(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
DB::DiskLocal::getLastModified(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const
DB::MergeTreeData::clearOldTemporaryDirectories(unsigned long, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&)
DB::ReplicatedMergeTreeCleanupThread::iterate()
DB::ReplicatedMergeTreeCleanupThread::run()
DB::BackgroundSchedulePoolTaskInfo::execute()
DB::BackgroundSchedulePool::threadFunction()
void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*)::$_1&&)::'lambda'(), void ()> >(std::__1::__function::__policy_storage const*)
ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>)
void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()> >(void*)
```

Logs:
```
$ ack tmp_merge_202208_0_5752_2591
clickhouse-server-2.log
195119:2022.08.25 14:37:07.395721 [ 659 ] {a7bf0f04-f72a-43b8-a927-e65a8d3ea017::202208_0_5752_2591} <Trace> test_public_a6ab51bf48224505966eb8fb9445aa7f.t_141aa486b3a542acabe25b564df39791 (a7bf0f04-f72a-43b8-a927-e65a8d3ea017): Renaming temporary part tmp_merge_202208_0_5752_2591 to 202208_0_5752_2591.

clickhouse-server-1.log
763444:2022.08.25 14:37:07.405412 [ 376 ] {a7bf0f04-f72a-43b8-a927-e65a8d3ea017::202208_0_5752_2591} <Trace> test_public_a6ab51bf48224505966eb8fb9445aa7f.t_141aa486b3a542acabe25b564df39791 (a7bf0f04-f72a-43b8-a927-e65a8d3ea017): Renaming temporary part tmp_merge_202208_0_5752_2591 to 202208_0_5752_2591.
```

This happens because the temporal folder, `tmp_merge_202208_0_5752_2591` in this case, was renamed after the merge but while the cleanup thread was active (after it got its list of folders). The error itself is not a problem, and CH is handling it correctly and ignoring it, but it creates noise if you want to monitor system.errors as any DB::Exception raised adds an event there.

The initial proposal was https://github.com/ClickHouse/ClickHouse/pull/43632 which included adding new methods (`tryGetLastModified`) that don't throw when the folder does not exist. This approach instead changes the exception to use `fs::filesystem_error` as many other methods that use std::filesystem (most of DiskLocal).

Closes https://github.com/ClickHouse/ClickHouse/pull/43632