### PR TITLE
Store ZK generated data in `test_keeper_snapshot_small_distance`

### DIFF
--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -62,6 +62,13 @@ def clear_clickhouse_data(node):
 
 
 def convert_zookeeper_data(node):
+    node.exec_in_container(
+        [
+            "bash",
+            "-c",
+            "tar -cvzf /var/lib/clickhouse/zk-data.tar.gz /zookeeper/version-2",
+        ]
+    )
     cmd = "/usr/bin/clickhouse keeper-converter --zookeeper-logs-dir /zookeeper/version-2/ --zookeeper-snapshots-dir  /zookeeper/version-2/ --output-dir /var/lib/clickhouse/coordination/snapshots"
     node.exec_in_container(["bash", "-c", cmd])
     return os.path.join(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


`test_keeper_snapshot_small_distance` still failing because of invalid ZK snapshot.
Cannot reproduce locally so I'll try saving snapshot.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
