### PR TITLE
Fix "AttributeError: 'BuildResult' object has no attribute 'libraries'" in BuilderReport and BuilderSpecialReport

### DIFF
--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -275,7 +275,6 @@ tr:hover td {{filter: brightness(95%);}}
 <th>Compiler</th>
 <th>Build type</th>
 <th>Sanitizer</th>
-<th>Libraries</th>
 <th>Status</th>
 <th>Build log</th>
 <th>Build time</th>
@@ -318,8 +317,6 @@ def create_build_html_report(
             row += f"<td>{build_result.sanitizer}</td>"
         else:
             row += "<td>none</td>"
-
-        row += f"<td>{build_result.libraries}</td>"
 
         if build_result.status:
             style = _get_status_style(build_result.status)


### PR DESCRIPTION
Fix for error
https://github.com/ClickHouse/ClickHouse/actions/runs/3832268360/jobs/6526191644 which is fallout of #44828.

@Felixoid 

```
Traceback (most recent call last):
  File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/ci/build_report_check.py", line 309, in <module>
    main()
  File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/ci/build_report_check.py", line 248, in main
    report = create_build_html_report(
  File "/home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/ci/report.py", line 322, in create_build_html_report
    row += f"<td>{build_result.libraries}</td>"
AttributeError: 'BuildResult' object has no attribute 'libraries'
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)