### PR TITLE
Try to fix flaky `test_storage_kafka::test_kafka_produce_key_timestamp`

### DIFF
--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -2271,7 +2271,11 @@ def test_kafka_produce_key_timestamp(kafka_cluster):
     )
 
     topic_name = "insert3"
-    kafka_create_topic(admin_client, topic_name)
+    topic_config = {
+        # default retention, since predefined timestamp_ms is used.
+        "retention.ms": "-1",
+    }
+    kafka_create_topic(admin_client, topic_name, config=topic_config)
 
     instance.query(
         """


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/49155d96146f25728ab2fc8454ac3a957d3ae263/integration_tests__release__[2/2].html
Based on the logs, no errors occurred, we just got starting offset of 1 instead of 0.
We manually set the timestamp of messages so my guess is that the message was deleted before it was consumed.



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
