### PR TITLE
add toUUIDOrDefault docs

### DIFF
--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -8,7 +8,7 @@ sidebar_label: Type Conversion
 
 ## Common Issues of Numeric Conversions
 
-When you convert a value from one to another data type, you should remember that in common case, it is an unsafe operation that can lead to a data loss. A data loss can occur if you try to fit value from a larger data type to a smaller data type, or if you convert values between different data types.
+When you convert a value from one to another data type, you should remember that if you try to fit a value from a larger data type to a smaller one (for example Int64 to Int32), or convert from one data type to another (for example `String` to `Int`), you could have data loss.  Test beforehand.
 
 ClickHouse has the [same behavior as C++ programs](https://en.cppreference.com/w/cpp/language/implicit_conversion).
 
@@ -45,7 +45,7 @@ SELECT toInt64(nan), toInt32(32), toInt16('16'), toInt8(8.8);
 
 Result:
 
-``` text
+```response
 ┌─────────toInt64(nan)─┬─toInt32(32)─┬─toInt16('16')─┬─toInt8(8.8)─┐
 │ -9223372036854775808 │          32 │            16 │           8 │
 └──────────────────────┴─────────────┴───────────────┴─────────────┘
@@ -65,7 +65,7 @@ SELECT toInt64OrZero('123123'), toInt8OrZero('123qwe123');
 
 Result:
 
-``` text
+```response
 ┌─toInt64OrZero('123123')─┬─toInt8OrZero('123qwe123')─┐
 │                  123123 │                         0 │
 └─────────────────────────┴───────────────────────────┘
@@ -85,7 +85,7 @@ SELECT toInt64OrNull('123123'), toInt8OrNull('123qwe123');
 
 Result:
 
-``` text
+```response
 ┌─toInt64OrNull('123123')─┬─toInt8OrNull('123qwe123')─┐
 │                  123123 │                      ᴺᵁᴸᴸ │
 └─────────────────────────┴───────────────────────────┘
@@ -105,7 +105,7 @@ SELECT toInt64OrDefault('123123', cast('-1' as Int64)), toInt8OrDefault('123qwe1
 
 Result:
 
-``` text
+```response
 ┌─toInt64OrDefault('123123', CAST('-1', 'Int64'))─┬─toInt8OrDefault('123qwe123', CAST('-1', 'Int8'))─┐
 │                                          123123 │                                               -1 │
 └─────────────────────────────────────────────────┴──────────────────────────────────────────────────┘
@@ -144,7 +144,7 @@ SELECT toUInt64(nan), toUInt32(-32), toUInt16('16'), toUInt8(8.8);
 
 Result:
 
-``` text
+```response
 ┌───────toUInt64(nan)─┬─toUInt32(-32)─┬─toUInt16('16')─┬─toUInt8(8.8)─┐
 │ 9223372036854775808 │    4294967264 │             16 │            8 │
 └─────────────────────┴───────────────┴────────────────┴──────────────┘
@@ -314,7 +314,7 @@ Type: [Date32](/docs/en/sql-reference/data-types/date32.md).
 SELECT toDate32('1955-01-01') AS value, toTypeName(value);
 ```
 
-``` text
+```response
 ┌──────value─┬─toTypeName(toDate32('1925-01-01'))─┐
 │ 1955-01-01 │ Date32                             │
 └────────────┴────────────────────────────────────┘
@@ -326,7 +326,7 @@ SELECT toDate32('1955-01-01') AS value, toTypeName(value);
 SELECT toDate32('1899-01-01') AS value, toTypeName(value);
 ```
 
-``` text
+```response
 ┌──────value─┬─toTypeName(toDate32('1899-01-01'))─┐
 │ 1900-01-01 │ Date32                             │
 └────────────┴────────────────────────────────────┘
@@ -338,7 +338,7 @@ SELECT toDate32('1899-01-01') AS value, toTypeName(value);
 SELECT toDate32(toDate('1899-01-01')) AS value, toTypeName(value);
 ```
 
-``` text
+```response
 ┌──────value─┬─toTypeName(toDate32(toDate('1899-01-01')))─┐
 │ 1970-01-01 │ Date32                                     │
 └────────────┴────────────────────────────────────────────┘
@@ -358,7 +358,7 @@ SELECT toDate32OrZero('1899-01-01'), toDate32OrZero('');
 
 Result:
 
-``` text
+```response
 ┌─toDate32OrZero('1899-01-01')─┬─toDate32OrZero('')─┐
 │                   1900-01-01 │         1900-01-01 │
 └──────────────────────────────┴────────────────────┘
@@ -378,7 +378,7 @@ SELECT toDate32OrNull('1955-01-01'), toDate32OrNull('');
 
 Result:
 
-``` text
+```response
 ┌─toDate32OrNull('1955-01-01')─┬─toDate32OrNull('')─┐
 │                   1955-01-01 │               ᴺᵁᴸᴸ │
 └──────────────────────────────┴────────────────────┘
@@ -400,7 +400,7 @@ SELECT
 
 Result:
 
-``` text
+```response
 ┌─toDate32OrDefault('1930-01-01', toDate32('2020-01-01'))─┬─toDate32OrDefault('xx1930-01-01', toDate32('2020-01-01'))─┐
 │                                              1930-01-01 │                                                2020-01-01 │
 └─────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────┘
@@ -436,7 +436,7 @@ Type: [DateTime64](/docs/en/sql-reference/data-types/datetime64.md).
 SELECT toDateTime64('1955-01-01 00:00:00.000', 3) AS value, toTypeName(value);
 ```
 
-``` text
+```response
 ┌───────────────────value─┬─toTypeName(toDateTime64('1955-01-01 00:00:00.000', 3))─┐
 │ 1955-01-01 00:00:00.000 │ DateTime64(3)                                          │
 └─────────────────────────┴────────────────────────────────────────────────────────┘
@@ -448,7 +448,7 @@ SELECT toDateTime64('1955-01-01 00:00:00.000', 3) AS value, toTypeName(value);
 SELECT toDateTime64(1546300800.000, 3) AS value, toTypeName(value);
 ```
 
-``` text
+```response
 ┌───────────────────value─┬─toTypeName(toDateTime64(1546300800., 3))─┐
 │ 2019-01-01 00:00:00.000 │ DateTime64(3)                            │
 └─────────────────────────┴──────────────────────────────────────────┘
@@ -460,7 +460,7 @@ Without the decimal point the value is still treated as Unix Timestamp in second
 SELECT toDateTime64(1546300800000, 3) AS value, toTypeName(value);
 ```
 
-``` text
+```response
 ┌───────────────────value─┬─toTypeName(toDateTime64(1546300800000, 3))─┐
 │ 2282-12-31 00:00:00.000 │ DateTime64(3)                              │
 └─────────────────────────┴────────────────────────────────────────────┘
@@ -473,7 +473,7 @@ SELECT toDateTime64(1546300800000, 3) AS value, toTypeName(value);
 SELECT toDateTime64('2019-01-01 00:00:00', 3, 'Asia/Istanbul') AS value, toTypeName(value);
 ```
 
-``` text
+```response
 ┌───────────────────value─┬─toTypeName(toDateTime64('2019-01-01 00:00:00', 3, 'Asia/Istanbul'))─┐
 │ 2019-01-01 00:00:00.000 │ DateTime64(3, 'Asia/Istanbul')                                      │
 └─────────────────────────┴─────────────────────────────────────────────────────────────────────┘
@@ -522,7 +522,7 @@ SELECT toDecimal32OrNull(toString(-1.111), 5) AS val, toTypeName(val);
 
 Result:
 
-``` text
+```response
 ┌────val─┬─toTypeName(toDecimal32OrNull(toString(-1.111), 5))─┐
 │ -1.111 │ Nullable(Decimal(9, 5))                            │
 └────────┴────────────────────────────────────────────────────┘
@@ -536,7 +536,7 @@ SELECT toDecimal32OrNull(toString(-1.111), 2) AS val, toTypeName(val);
 
 Result:
 
-``` text
+```response
 ┌──val─┬─toTypeName(toDecimal32OrNull(toString(-1.111), 2))─┐
 │ ᴺᵁᴸᴸ │ Nullable(Decimal(9, 2))                            │
 └──────┴────────────────────────────────────────────────────┘
@@ -576,7 +576,7 @@ SELECT toDecimal32OrDefault(toString(-1.111), 5) AS val, toTypeName(val);
 
 Result:
 
-``` text
+```response
 ┌────val─┬─toTypeName(toDecimal32OrDefault(toString(-1.111), 5))─┐
 │ -1.111 │ Decimal(9, 5)                                         │
 └────────┴───────────────────────────────────────────────────────┘
@@ -590,7 +590,7 @@ SELECT toDecimal32OrDefault(toString(-1.111), 2) AS val, toTypeName(val);
 
 Result:
 
-``` text
+```response
 ┌─val─┬─toTypeName(toDecimal32OrDefault(toString(-1.111), 2))─┐
 │   0 │ Decimal(9, 2)                                         │
 └─────┴───────────────────────────────────────────────────────┘
@@ -629,7 +629,7 @@ SELECT toDecimal32OrZero(toString(-1.111), 5) AS val, toTypeName(val);
 
 Result:
 
-``` text
+```response
 ┌────val─┬─toTypeName(toDecimal32OrZero(toString(-1.111), 5))─┐
 │ -1.111 │ Decimal(9, 5)                                      │
 └────────┴────────────────────────────────────────────────────┘
@@ -643,7 +643,7 @@ SELECT toDecimal32OrZero(toString(-1.111), 2) AS val, toTypeName(val);
 
 Result:
 
-``` text
+```response
 ┌──val─┬─toTypeName(toDecimal32OrZero(toString(-1.111), 2))─┐
 │ 0.00 │ Decimal(9, 2)                                      │
 └──────┴────────────────────────────────────────────────────┘
@@ -661,7 +661,7 @@ When converting dates with times to numbers or vice versa, the date with time co
 
 The date and date-with-time formats for the toDate/toDateTime functions are defined as follows:
 
-``` text
+```response
 YYYY-MM-DD
 YYYY-MM-DD hh:mm:ss
 ```
@@ -686,7 +686,7 @@ SELECT
 
 Result:
 
-``` text
+```response
 ┌───────────now_local─┬─now_yekat───────────┐
 │ 2016-06-15 00:11:21 │ 2016-06-15 02:11:21 │
 └─────────────────────┴─────────────────────┘
@@ -713,7 +713,7 @@ SELECT toFixedString('foo', 8) AS s, toStringCutToZero(s) AS s_cut;
 
 Result:
 
-``` text
+```response
 ┌─s─────────────┬─s_cut─┐
 │ foo\0\0\0\0\0 │ foo   │
 └───────────────┴───────┘
@@ -727,7 +727,7 @@ SELECT toFixedString('foo\0bar', 8) AS s, toStringCutToZero(s) AS s_cut;
 
 Result:
 
-``` text
+```response
 ┌─s──────────┬─s_cut─┐
 │ foo\0bar\0 │ foo   │
 └────────────┴───────┘
@@ -754,6 +754,10 @@ This function accepts a number or date or date with time and returns a string co
 This function accepts a number or date or date with time and returns a FixedString containing bytes representing the corresponding value in host order (little endian). Null bytes are dropped from the end. For example, a UInt32 type value of 255 is a FixedString that is one byte long.
 
 ## reinterpretAsUUID
+
+:::note
+In addition to the UUID functions listed here, there is dedicated [UUID function documentation](/docs/en/sql-reference/functions/uuid-functions.md).
+:::
 
 Accepts 16 bytes string and returns UUID containing bytes representing the corresponding value in network byte order (big-endian). If the string isn't long enough, the function works as if the string is padded with the necessary number of null bytes to the end. If the string is longer than 16 bytes, the extra bytes at the end are ignored.
 
@@ -783,7 +787,7 @@ SELECT reinterpretAsUUID(reverse(unhex('000102030405060708090a0b0c0d0e0f')));
 
 Result:
 
-``` text
+```response
 ┌─reinterpretAsUUID(reverse(unhex('000102030405060708090a0b0c0d0e0f')))─┐
 │                                  08090a0b-0c0d-0e0f-0001-020304050607 │
 └───────────────────────────────────────────────────────────────────────┘
@@ -803,7 +807,7 @@ SELECT uuid = uuid2;
 
 Result:
 
-``` text
+```response
 ┌─equals(uuid, uuid2)─┐
 │                   1 │
 └─────────────────────┘
@@ -904,7 +908,7 @@ SELECT
 
 Result:
 
-``` text
+```response
 ┌─timestamp───────────┬────────────datetime─┬───────date─┬─string──────────────┬─fixed_string──────────────┐
 │ 2016-06-15 23:00:00 │ 2016-06-15 23:00:00 │ 2016-06-15 │ 2016-06-15 23:00:00 │ 2016-06-15 23:00:00\0\0\0 │
 └─────────────────────┴─────────────────────┴────────────┴─────────────────────┴───────────────────────────┘
@@ -924,7 +928,7 @@ SELECT toTypeName(x) FROM t_null;
 
 Result:
 
-``` text
+```response
 ┌─toTypeName(x)─┐
 │ Int8          │
 │ Int8          │
@@ -939,7 +943,7 @@ SELECT toTypeName(CAST(x, 'Nullable(UInt16)')) FROM t_null;
 
 Result:
 
-``` text
+```response
 ┌─toTypeName(CAST(x, 'Nullable(UInt16)'))─┐
 │ Nullable(UInt16)                        │
 │ Nullable(UInt16)                        │
@@ -966,7 +970,7 @@ SELECT cast(-1, 'UInt8') as uint8;
 
 Result:
 
-``` text
+```response
 ┌─uint8─┐
 │   255 │
 └───────┘
@@ -980,7 +984,7 @@ SELECT accurateCast(-1, 'UInt8') as uint8;
 
 Result:
 
-``` text
+```response
 Code: 70. DB::Exception: Received from localhost:9000. DB::Exception: Value in column Int8 cannot be safely converted into type UInt8: While processing accurateCast(-1, 'UInt8') AS uint8.
 ```
 
@@ -1013,7 +1017,7 @@ SELECT toTypeName(accurateCastOrNull(5, 'UInt8'));
 
 Result:
 
-``` text
+```response
 ┌─toTypeName(accurateCastOrNull(5, 'UInt8'))─┐
 │ Nullable(UInt8)                            │
 └────────────────────────────────────────────┘
@@ -1030,7 +1034,7 @@ SELECT
 
 Result:
 
-``` text
+```response
 ┌─uint8─┬─int8─┬─fixed_string─┐
 │  ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ         │
 └───────┴──────┴──────────────┘
@@ -1067,7 +1071,7 @@ SELECT toTypeName(accurateCastOrDefault(5, 'UInt8'));
 
 Result:
 
-``` text
+```response
 ┌─toTypeName(accurateCastOrDefault(5, 'UInt8'))─┐
 │ UInt8                                         │
 └───────────────────────────────────────────────┘
@@ -1087,7 +1091,7 @@ SELECT
 
 Result:
 
-``` text
+```response
 ┌─uint8─┬─uint8_default─┬─int8─┬─int8_default─┬─fixed_string─┬─fixed_string_default─┐
 │     0 │             5 │    0 │            5 │              │ Te                   │
 └───────┴───────────────┴──────┴──────────────┴──────────────┴──────────────────────┘
@@ -1134,7 +1138,7 @@ SELECT
 
 Result:
 
-``` text
+```response
 ┌─plus(date, interval_week)─┬─plus(date, interval_to_week)─┐
 │                2019-01-08 │                   2019-01-08 │
 └───────────────────────────┴──────────────────────────────┘
@@ -1183,7 +1187,7 @@ AS parseDateTimeBestEffort;
 
 Result:
 
-``` text
+```response
 ┌─parseDateTimeBestEffort─┐
 │     2020-10-23 12:12:57 │
 └─────────────────────────┘
@@ -1198,7 +1202,7 @@ AS parseDateTimeBestEffort;
 
 Result:
 
-``` text
+```response
 ┌─parseDateTimeBestEffort─┐
 │     2018-08-18 10:22:16 │
 └─────────────────────────┘
@@ -1213,7 +1217,7 @@ AS parseDateTimeBestEffort;
 
 Result:
 
-``` text
+```response
 ┌─parseDateTimeBestEffort─┐
 │     2015-07-07 12:04:41 │
 └─────────────────────────┘
@@ -1228,7 +1232,7 @@ AS parseDateTimeBestEffort;
 
 Result:
 
-``` text
+```response
 ┌─parseDateTimeBestEffort─┐
 │     2018-10-23 10:12:12 │
 └─────────────────────────┘
@@ -1242,7 +1246,7 @@ SELECT parseDateTimeBestEffort('10 20:19');
 
 Result:
 
-``` text
+```response
 ┌─parseDateTimeBestEffort('10 20:19')─┐
 │                 2000-01-10 20:19:00 │
 └─────────────────────────────────────┘
@@ -1376,7 +1380,7 @@ SELECT toLowCardinality('1');
 
 Result:
 
-``` text
+```response
 ┌─toLowCardinality('1')─┐
 │ 1                     │
 └───────────────────────┘
@@ -1419,7 +1423,7 @@ SELECT toUnixTimestamp64Milli(dt64);
 
 Result:
 
-``` text
+```response
 ┌─toUnixTimestamp64Milli(dt64)─┐
 │                1568650812345 │
 └──────────────────────────────┘
@@ -1434,7 +1438,7 @@ SELECT toUnixTimestamp64Nano(dt64);
 
 Result:
 
-``` text
+```response
 ┌─toUnixTimestamp64Nano(dt64)─┐
 │         1568650812345678000 │
 └─────────────────────────────┘
@@ -1474,7 +1478,7 @@ SELECT fromUnixTimestamp64Milli(i64, 'UTC');
 
 Result:
 
-``` text
+```response
 ┌─fromUnixTimestamp64Milli(i64, 'UTC')─┐
 │              2009-02-13 23:31:31.011 │
 └──────────────────────────────────────┘
@@ -1510,7 +1514,7 @@ FROM numbers(3);
 
 Result:
 
-``` text
+```response
 ┌─formatRow('CSV', number, 'good')─┐
 │ 0,"good"
                          │
@@ -1535,7 +1539,7 @@ SETTINGS format_custom_result_before_delimiter='<prefix>\n', format_custom_resul
 
 Result:
 
-``` text
+```response
 ┌─formatRow('CustomSeparated', number, 'good')─┐
 │ <prefix>
 0	good
@@ -1581,7 +1585,7 @@ FROM numbers(3);
 
 Result:
 
-``` text
+```response
 ┌─formatRowNoNewline('CSV', number, 'good')─┐
 │ 0,"good"                                  │
 │ 1,"good"                                  │
@@ -1618,7 +1622,7 @@ SELECT snowflakeToDateTime(CAST('1426860702823350272', 'Int64'), 'UTC');
 
 Result:
 
-``` text
+```response
 
 ┌─snowflakeToDateTime(CAST('1426860702823350272', 'Int64'), 'UTC')─┐
 │                                              2021-08-15 10:57:56 │
@@ -1654,7 +1658,7 @@ SELECT snowflakeToDateTime64(CAST('1426860802823350272', 'Int64'), 'UTC');
 
 Result:
 
-``` text
+```response
 
 ┌─snowflakeToDateTime64(CAST('1426860802823350272', 'Int64'), 'UTC')─┐
 │                                            2021-08-15 10:58:19.841 │
@@ -1689,7 +1693,7 @@ WITH toDateTime('2021-08-15 18:57:56', 'Asia/Shanghai') AS dt SELECT dateTimeToS
 
 Result:
 
-``` text
+```response
 ┌─dateTimeToSnowflake(dt)─┐
 │     1426860702823350272 │
 └─────────────────────────┘
@@ -1723,7 +1727,7 @@ WITH toDateTime64('2021-08-15 18:57:56.492', 3, 'Asia/Shanghai') AS dt64 SELECT 
 
 Result:
 
-``` text
+```response
 ┌─dateTime64ToSnowflake(dt64)─┐
 │         1426860704886947840 │
 └─────────────────────────────┘

--- a/docs/en/sql-reference/functions/uuid-functions.md
+++ b/docs/en/sql-reference/functions/uuid-functions.md
@@ -38,7 +38,7 @@ INSERT INTO t_uuid SELECT generateUUIDv4()
 SELECT * FROM t_uuid
 ```
 
-``` text
+```response
 ┌────────────────────────────────────x─┐
 │ f4bf890f-f9dc-4332-ad5c-0c18e73f28e9 │
 └──────────────────────────────────────┘
@@ -89,7 +89,7 @@ SELECT empty(generateUUIDv4());
 
 Result:
 
-```text
+```response
 ┌─empty(generateUUIDv4())─┐
 │                       0 │
 └─────────────────────────┘
@@ -131,7 +131,7 @@ SELECT notEmpty(generateUUIDv4());
 
 Result:
 
-```text
+```response
 ┌─notEmpty(generateUUIDv4())─┐
 │                          1 │
 └────────────────────────────┘
@@ -155,10 +155,54 @@ The UUID type value.
 SELECT toUUID('61f0c404-5cb3-11e7-907b-a6006ad3dba0') AS uuid
 ```
 
-``` text
+```response
 ┌─────────────────────────────────uuid─┐
 │ 61f0c404-5cb3-11e7-907b-a6006ad3dba0 │
 └──────────────────────────────────────┘
+```
+
+## toUUIDOrDefault (x,y)
+
+**Arguments**
+
+-   `string` — String of 36 characters or FixedString(36). [String](../../sql-reference/syntax.md#string).
+-   `default` — UUID to be used as the default if the first argument cannot be converted to a UUID type. [UUID](/docs/en/sql-reference/data-types/uuid.md).
+
+**Returned value**
+
+UUID
+
+``` sql
+toUUIDOrDefault(String, UUID)
+```
+
+**Returned value**
+
+The UUID type value.
+
+**Usage examples**
+
+This first example returns the first argument converted to a UUID type as it can be converted:
+
+``` sql
+SELECT toUUIDOrDefault('61f0c404-5cb3-11e7-907b-a6006ad3dba0', cast('59f0c404-5cb3-11e7-907b-a6006ad3dba0' as UUID));
+```
+```response
+┌─toUUIDOrDefault('61f0c404-5cb3-11e7-907b-a6006ad3dba0', CAST('59f0c404-5cb3-11e7-907b-a6006ad3dba0', 'UUID'))─┐
+│ 61f0c404-5cb3-11e7-907b-a6006ad3dba0                                                                          │
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+This second example returns the second argument (the provided default UUID) as the first argument cannot be converted to a UUID type:
+
+```sql
+SELECT toUUIDOrDefault('-----61f0c404-5cb3-11e7-907b-a6006ad3dba0', cast('59f0c404-5cb3-11e7-907b-a6006ad3dba0' as UUID));
+```
+
+```response
+┌─toUUIDOrDefault('-----61f0c404-5cb3-11e7-907b-a6006ad3dba0', CAST('59f0c404-5cb3-11e7-907b-a6006ad3dba0', 'UUID'))─┐
+│ 59f0c404-5cb3-11e7-907b-a6006ad3dba0                                                                               │
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## toUUIDOrNull (x)
@@ -179,7 +223,7 @@ The Nullable(UUID) type value.
 SELECT toUUIDOrNull('61f0c404-5cb3-11e7-907b-a6006ad3dba0T') AS uuid
 ```
 
-``` text
+```response
 ┌─uuid─┐
 │ ᴺᵁᴸᴸ │
 └──────┘
@@ -203,7 +247,7 @@ The UUID type value.
 SELECT toUUIDOrZero('61f0c404-5cb3-11e7-907b-a6006ad3dba0T') AS uuid
 ```
 
-``` text
+```response
 ┌─────────────────────────────────uuid─┐
 │ 00000000-0000-0000-0000-000000000000 │
 └──────────────────────────────────────┘
@@ -236,7 +280,7 @@ SELECT
     UUIDStringToNum(uuid) AS bytes
 ```
 
-``` text
+```response
 ┌─uuid─────────────────────────────────┬─bytes────────────┐
 │ 612f3c40-5d3b-217e-707b-6a546a3d7b29 │ a/<@];!~p{jTj={) │
 └──────────────────────────────────────┴──────────────────┘
@@ -248,7 +292,7 @@ SELECT
     UUIDStringToNum(uuid, 2) AS bytes
 ```
 
-``` text
+```response
 ┌─uuid─────────────────────────────────┬─bytes────────────┐
 │ 612f3c40-5d3b-217e-707b-6a546a3d7b29 │ @</a;]~!p{jTj={) │
 └──────────────────────────────────────┴──────────────────┘
@@ -281,7 +325,7 @@ SELECT
     UUIDNumToString(toFixedString(bytes, 16)) AS uuid
 ```
 
-``` text
+```response
 ┌─bytes────────────┬─uuid─────────────────────────────────┐
 │ a/<@];!~p{jTj={) │ 612f3c40-5d3b-217e-707b-6a546a3d7b29 │
 └──────────────────┴──────────────────────────────────────┘
@@ -293,7 +337,7 @@ SELECT
     UUIDNumToString(toFixedString(bytes, 16), 2) AS uuid
 ```
 
-``` text
+```response
 ┌─bytes────────────┬─uuid─────────────────────────────────┐
 │ @</a;]~!p{jTj={) │ 612f3c40-5d3b-217e-707b-6a546a3d7b29 │
 └──────────────────┴──────────────────────────────────────┘


### PR DESCRIPTION
Add missing toUUIDOrDeault docs, and link these type conversions from the Type Conversion docs.

closes #44802 

Changes output code blocks from `text` to `response` syntax highlighting to match other docs.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

