### PR TITLE
Fix error message for a broken distributed batches ("While sending batch")

### DIFF
--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -700,12 +700,14 @@ struct StorageDistributedDirectoryMonitor::BatchHeader
 
 struct StorageDistributedDirectoryMonitor::Batch
 {
+    /// File indexes for this batch.
     std::vector<UInt64> file_indices;
     size_t total_rows = 0;
     size_t total_bytes = 0;
     bool recovered = false;
 
     StorageDistributedDirectoryMonitor & parent;
+    /// Information about all available indexes (not only for the current batch).
     const std::map<UInt64, String> & file_index_to_path;
 
     bool split_batch_on_failure = true;
@@ -795,17 +797,22 @@ struct StorageDistributedDirectoryMonitor::Batch
             else
             {
                 std::vector<std::string> files;
-                for (const auto && file_info : file_index_to_path | boost::adaptors::indexed())
+                for (auto file_index_info : file_indices | boost::adaptors::indexed())
                 {
-                    if (file_info.index() > 8)
+                    if (file_index_info.index() > 8)
                     {
                         files.push_back("...");
                         break;
                     }
 
-                    files.push_back(file_info.value().second);
+                    auto file_index = file_index_info.value();
+                    auto file_path = file_index_to_path.find(file_index);
+                    if (file_path != file_index_to_path.end())
+                        files.push_back(file_path->second);
+                    else
+                        files.push_back(fmt::format("#{}.bin (deleted)", file_index));
                 }
-                e.addMessage(fmt::format("While sending batch, nums: {}, files: {}", file_index_to_path.size(), fmt::join(files, "\n")));
+                e.addMessage(fmt::format("While sending batch, size: {}, files: {}", file_indices.size(), fmt::join(files, "\n")));
 
                 throw;
             }


### PR DESCRIPTION
There was an error from the begginning that does not respect file_indices, and iterate only over file_index_to_path, while this is not correct, since there can be less files then in file_index_to_path, and this is what file_indices for.

Note, that only an error message was wrong, logic was fine. You can verify this by the logs:

    2022.12.07 11:55:50.951976 [ 39217 ] {} <Debug> default.dist.DirectoryMonitor: Sending a batch of 10 files to localhost:9000 (128.42 thousand rows, 36.32 MiB bytes).
    2022.12.07 11:55:50.953762 [ 39217 ] {} <Error> default.dist.DirectoryMonitor: Code: 516. DB::Exception: Received from localhost:9000. DB::Exception: Interserver authentication failed. Stack trace:
    ...
    : While sending batch, nums: 62, files: /work6/clickhouse/data/default/dist/shard1_replica1/66827258.bin

As you can see "Sending a batch of 10 files" but "nums: 62"

Fixes: #23856
Refs: #41813

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)