### PR TITLE
revert doc removal

### DIFF
--- a/docs/en/sql-reference/functions/geo/h3.md
+++ b/docs/en/sql-reference/functions/geo/h3.md
@@ -1027,6 +1027,186 @@ Result:
 └─────────────┘
 ```
 
+## h3PointDistM
+
+Returns the "great circle" or "haversine" distance between pairs of GeoCoord points (latitude/longitude) pairs in meters.
+
+**Syntax**
+
+``` sql
+h3PointDistM(lat1, lon1, lat2, lon2)
+```
+
+**Arguments**
+
+-   `lat1`, `lon1` — Latitude and Longitude of point1 in degrees. Type: [Float64](../../../sql-reference/data-types/float.md).
+-   `lat2`, `lon2` — Latitude and Longitude of point2 in degrees. Type: [Float64](../../../sql-reference/data-types/float.md).
+
+**Returned values**
+
+-  Haversine or great circle distance in meters.
+
+Type: [Float64](../../../sql-reference/data-types/float.md).
+
+**Example**
+
+Query:
+
+``` sql
+select h3PointDistM(-10.0 ,0.0, 10.0, 0.0) as h3PointDistM;
+```
+
+Result:
+
+``` text
+┌──────h3PointDistM─┐
+│ 2223901.039504589 │
+└───────────────────┘
+```
+
+## h3PointDistKm
+
+Returns the "great circle" or "haversine" distance between pairs of GeoCoord points (latitude/longitude) pairs in kilometers.
+
+**Syntax**
+
+``` sql
+h3PointDistKm(lat1, lon1, lat2, lon2)
+```
+
+**Arguments**
+
+-   `lat1`, `lon1` — Latitude and Longitude of point1 in degrees. Type: [Float64](../../../sql-reference/data-types/float.md).
+-   `lat2`, `lon2` — Latitude and Longitude of point2 in degrees. Type: [Float64](../../../sql-reference/data-types/float.md).
+
+**Returned values**
+
+-  Haversine or great circle distance in kilometers.
+
+Type: [Float64](../../../sql-reference/data-types/float.md).
+
+**Example**
+
+Query:
+
+``` sql
+select h3PointDistKm(-10.0 ,0.0, 10.0, 0.0) as h3PointDistKm;
+```
+
+Result:
+
+``` text
+┌─────h3PointDistKm─┐
+│ 2223.901039504589 │
+└───────────────────┘
+```
+
+## h3PointDistRads
+
+Returns the "great circle" or "haversine" distance between pairs of GeoCoord points (latitude/longitude) pairs in radians.
+
+**Syntax**
+
+``` sql
+h3PointDistRads(lat1, lon1, lat2, lon2)
+```
+
+**Arguments**
+
+-   `lat1`, `lon1` — Latitude and Longitude of point1 in degrees. Type: [Float64](../../../sql-reference/data-types/float.md).
+-   `lat2`, `lon2` — Latitude and Longitude of point2 in degrees. Type: [Float64](../../../sql-reference/data-types/float.md).
+
+**Returned values**
+
+-  Haversine or great circle distance in radians.
+
+Type: [Float64](../../../sql-reference/data-types/float.md).
+
+**Example**
+
+Query:
+
+``` sql
+select h3PointDistRads(-10.0 ,0.0, 10.0, 0.0) as h3PointDistRads;
+```
+
+Result:
+
+``` text
+┌────h3PointDistRads─┐
+│ 0.3490658503988659 │
+└────────────────────┘
+```
+
+## h3GetRes0Indexes
+
+Returns an array of all the resolution 0 H3 indexes.
+
+**Syntax**
+
+``` sql
+h3GetRes0Indexes()
+```
+
+**Returned values**
+
+-  Array of all the resolution 0 H3 indexes.
+
+Type: [Array](../../../sql-reference/data-types/array.md)([UInt64](../../../sql-reference/data-types/int-uint.md)).
+
+
+**Example**
+
+Query:
+
+``` sql
+select h3GetRes0Indexes as indexes ;
+```
+
+Result:
+
+``` text
+┌─indexes─────────────────────────────────────┐
+│ [576495936675512319,576531121047601151,....]│
+└─────────────────────────────────────────────┘
+```
+
+## h3GetPentagonIndexes
+
+Returns all the pentagon H3 indexes at the specified resolution.
+
+**Syntax**
+
+``` sql
+h3GetPentagonIndexes(resolution)
+```
+
+**Parameter**
+
+-   `resolution` — Index resolution. Range: `[0, 15]`. Type: [UInt8](../../../sql-reference/data-types/int-uint.md).
+
+**Returned value**
+
+-  Array of all pentagon H3 indexes.
+
+Type: [Array](../../../sql-reference/data-types/array.md)([UInt64](../../../sql-reference/data-types/int-uint.md)).
+
+**Example**
+
+Query:
+
+``` sql
+SELECT h3GetPentagonIndexes(3) AS indexes;
+```
+
+Result:
+
+``` text
+┌─indexes────────────────────────────────────────────────────────┐
+│ [590112357393367039,590464201114255359,590816044835143679,...] │
+└────────────────────────────────────────────────────────────────┘
+```
+
 ## h3Line
 
 Returns the line of indices between the two indices that are provided.


### PR DESCRIPTION
closes #44787 

Add docs back in for :
- h3PointDistM
- h3PointDistKm
- h3PointDistRads
- h3GetRes0Indexes
- h3GetPentagonIndexes

### Changelog category (leave one):

- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
