### PR TITLE
Respect requested columns order for select.

### DIFF
--- a/src/Interpreters/ExpressionAnalyzer.h
+++ b/src/Interpreters/ExpressionAnalyzer.h
@@ -307,7 +307,7 @@ public:
         const TreeRewriterResultPtr & syntax_analyzer_result_,
         ContextPtr context_,
         const StorageMetadataPtr & metadata_snapshot_,
-        const NameSet & required_result_columns_ = {},
+        const Names & required_result_columns_ = {},
         bool do_global_ = false,
         const SelectQueryOptions & options_ = {},
         PreparedSetsPtr prepared_sets_ = nullptr)
@@ -364,7 +364,7 @@ public:
 private:
     StorageMetadataPtr metadata_snapshot;
     /// If non-empty, ignore all expressions not from this list.
-    NameSet required_result_columns;
+    Names required_result_columns;
     SelectQueryOptions query_options;
 
     JoinPtr makeJoin(

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -568,7 +568,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
             syntax_analyzer_result,
             context,
             metadata_snapshot,
-            NameSet(required_result_column_names.begin(), required_result_column_names.end()),
+            required_result_column_names,
             !options.only_analyze,
             options,
             prepared_sets);

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -165,7 +165,9 @@ InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery(
         for (size_t query_num = 0; query_num < num_children; ++query_num)
         {
             headers[query_num] = nested_interpreters[query_num]->getSampleBlock();
-            const auto & current_required_result_column_names = required_result_column_names_for_other_selects[query_num];
+            const auto & current_required_result_column_names = (query_num == 0 && !require_full_header)
+                ? required_result_column_names
+                : required_result_column_names_for_other_selects[query_num];
             if (!current_required_result_column_names.empty())
             {
                 const auto & header_columns = headers[query_num].getNames();

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -165,6 +165,10 @@ InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery(
         for (size_t query_num = 0; query_num < num_children; ++query_num)
         {
             headers[query_num] = nested_interpreters[query_num]->getSampleBlock();
+            /// Here whe check that, in case if required_result_column_names were specified,
+            /// nested interpreter returns exaclty it. Except if query requires full header.
+            /// The code aboew is written in a way that for 0th query required_result_column_names_for_other_selects[0]
+            /// is an empty list, and we should use required_result_column_names instead.
             const auto & current_required_result_column_names = (query_num == 0 && !require_full_header)
                 ? required_result_column_names
                 : required_result_column_names_for_other_selects[query_num];

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -165,8 +165,8 @@ InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery(
         for (size_t query_num = 0; query_num < num_children; ++query_num)
         {
             headers[query_num] = nested_interpreters[query_num]->getSampleBlock();
-            /// Here whe check that, in case if required_result_column_names were specified,
-            /// nested interpreter returns exaclty it. Except if query requires full header.
+            /// Here we check that, in case if required_result_column_names were specified,
+            /// nested interpreter returns exactly it. Except if query requires full header.
             /// The code aboew is written in a way that for 0th query required_result_column_names_for_other_selects[0]
             /// is an empty list, and we should use required_result_column_names instead.
             const auto & current_required_result_column_names = (query_num == 0 && !require_full_header)

--- a/tests/queries/0_stateless/02517_union_columns_order.sql
+++ b/tests/queries/0_stateless/02517_union_columns_order.sql
@@ -1,0 +1,32 @@
+CREATE TABLE t1 (c0 Int32, PRIMARY KEY (c0)) ENGINE = MergeTree;
+SELECT DISTINCT *
+FROM
+(
+    SELECT DISTINCT
+        cos(sign(exp(t1.c0))),
+        -min2(pow(t1.c0, t1.c0), intDiv(t1.c0, t1.c0)),
+        t1.c0,
+        t1.c0,
+        erf(abs(-t1.c0))
+    FROM t1
+    WHERE t1.c0 > 0
+    UNION ALL
+    SELECT DISTINCT
+        cos(sign(exp(t1.c0))),
+        -min2(pow(t1.c0, t1.c0), intDiv(t1.c0, t1.c0)),
+        t1.c0,
+        t1.c0,
+        erf(abs(-t1.c0))
+    FROM t1
+    WHERE NOT (t1.c0 > 0)
+    UNION ALL
+    SELECT DISTINCT
+        cos(sign(exp(t1.c0))),
+        -min2(pow(t1.c0, t1.c0), intDiv(t1.c0, t1.c0)),
+        t1.c0,
+        t1.c0,
+        erf(abs(-t1.c0))
+    FROM t1
+    WHERE t1.c0 > (0 IS NULL)
+);
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error `Different order of columns in UNION subquery` for queries with `UNION`. Fixes #44866