### PR TITLE
Fix deadlock in Keeper's changelog

### DIFF
--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -206,6 +206,10 @@ private:
     ThreadFromGlobalPool write_thread;
     ConcurrentBoundedQueue<WriteOperation> write_operations;
 
+    /// Append log completion callback tries to acquire NuRaft's global lock
+    /// Deadlock can occur if NuRaft waits for a append/flush to finish
+    /// while the lock is taken
+    /// For those reasons we call the completion callback in a different thread
     void appendCompletionThread();
 
     ThreadFromGlobalPool append_completion_thread;

--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -206,6 +206,11 @@ private:
     ThreadFromGlobalPool write_thread;
     ConcurrentBoundedQueue<WriteOperation> write_operations;
 
+    void appendCompletionThread();
+
+    ThreadFromGlobalPool append_completion_thread;
+    ConcurrentBoundedQueue<uint64_t> append_completion_queue;
+
     // last_durable_index needs to be exposed through const getter so we make mutex mutable
     mutable std::mutex durable_idx_mutex;
     std::condition_variable durable_idx_cv;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Caught by https://s3.amazonaws.com/clickhouse-test-reports/44924/abf63d0c3365ef421bc0e68ad28c108d07dec2bd/integration_tests__release__%5B4/4%5D.html
Really tricky deadlock because NuRaft takes a global lock for everything.

### Documentation entry for user-facing changes
<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
