### PR TITLE
Fix memory leak in Aws::InitAPI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -323,4 +323,4 @@
 	url = https://github.com/awslabs/aws-c-compression.git
 [submodule "contrib/aws-s2n-tls"]
 	path = contrib/aws-s2n-tls
-	url = https://github.com/aws/s2n-tls.git
+	url = https://github.com/ClickHouse/s2n-tls.git


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix memory leaks in `Aws::InitAPI`, see [https://s3.amazonaws.com/clickhouse-test-reports/40003/723dad3610d1ba8643f634d255becd5b9d2008fb/integration_tests__asan__[2/6].html](https://s3.amazonaws.com/clickhouse-test-reports/40003/723dad3610d1ba8643f634d255becd5b9d2008fb/integration_tests__asan__%5B2/6%5D.html):

```
Direct leak of 152 byte(s) in 1 object(s) allocated from:
    #0 0xe958dee in malloc (/usr/bin/clickhouse+0xe958dee) (BuildId: 5bb74c5832b8b48b64e089f56daaea78ac0c8d42)
    #1 0x418c9873 in OPENSSL_malloc build_docker/../contrib/boringssl/crypto/mem.c:139:15
    #2 0x417acaaf in EVP_CIPHER_CTX_new build_docker/../contrib/boringssl/crypto/fipsmodule/cipher/cipher.c:76:25
    #3 0x3dadc892 in s2n_drbg_instantiate (/usr/bin/clickhouse+0x3dadc892) (BuildId: 5bb74c5832b8b48b64e089f56daaea78ac0c8d42)
    #4 0x3dadb2db in s2n_ensure_initialized_drbgs s2n_random.c
    #5 0x3dadb052 in s2n_rand_init (/usr/bin/clickhouse+0x3dadb052) (BuildId: 5bb74c5832b8b48b64e089f56daaea78ac0c8d42)
    #6 0x3dad4ef0 in s2n_init (/usr/bin/clickhouse+0x3dad4ef0) (BuildId: 5bb74c5832b8b48b64e089f56daaea78ac0c8d42)
    #7 0x3d990cdc in aws_tls_init_static_state (/usr/bin/clickhouse+0x3d990cdc) (BuildId: 5bb74c5832b8b48b64e089f56daaea78ac0c8d42)
    #8 0x3db8ca3a in aws_mqtt_library_init (/usr/bin/clickhouse+0x3db8ca3a) (BuildId: 5bb74c5832b8b48b64e089f56daaea78ac0c8d42)
    #9 0x3dae97b9 in Aws::Crt::ApiHandle::ApiHandle(aws_allocator*) (/usr/bin/clickhouse+0x3dae97b9) (BuildId: 5bb74c5832b8b48b64e089f56daaea78ac0c8d42)
    #10 0x3d1f91eb in Aws::InitializeCrt() (/usr/bin/clickhouse+0x3d1f91eb) (BuildId: 5bb74c5832b8b48b64e089f56daaea78ac0c8d42)
    #11 0x3d1f541a in Aws::InitAPI(Aws::SDKOptions const&) (/usr/bin/clickhouse+0x3d1f541a) (BuildId: 5bb74c5832b8b48b64e089f56daaea78ac0c8d42)
    #12 0x2e55c576 in DB::S3::ClientFactory::ClientFactory() build_docker/../src/IO/S3Common.cpp:717:9
    #13 0x2e55d894 in DB::S3::ClientFactory::instance() build_docker/../src/IO/S3Common.cpp:730:30
    #14 0x30052048 in DB::getClient(Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context const>, DB::S3ObjectStorageSettings const&) build_docker/../src/Disks/ObjectStorages/S3/diskSettings.cpp:116:60
    #15 0x300401e7 in DB::registerDiskS3(DB::DiskFactory&, bool)::$_0::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, Poco::Util::AbstractConfiguration const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context const>, std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::shared_ptr<DB::IDisk>, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, std::__1::shared_ptr<DB::IDisk>>>> const&) const build_docker/../src/Disks/ObjectStorages/S3/registerDiskS3.cpp:125:23
```

https://github.com/ClickHouse/ClickHouse/pull/43020#issuecomment-1371865004