### PR TITLE
Change error code on invalid background_pool_size config

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.h
@@ -21,7 +21,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
-    extern const int LOGICAL_ERROR;
+    extern const int INVALID_CONFIG_PARAMETER;
 }
 
 struct TaskRuntimeData;
@@ -172,7 +172,7 @@ public:
         , metric(metric_)
     {
         if (max_tasks_count == 0)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Task count for MergeTreeBackgroundExecutor must not be zero");
+            throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Task count for MergeTreeBackgroundExecutor must not be zero");
 
         pending.setCapacity(max_tasks_count);
         active.set_capacity(max_tasks_count);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

Since this comes from an invalid config from the user, prefer not throwing a LOGICAL_ERROR here and instead throw INVALID_CONFIG_PARAMETER.

Bad config:
```
<background_pool_size>0</background_pool_size>
```