### PR TITLE
Fix exception fix in TraceCollector dtor

### DIFF
--- a/src/Interpreters/TraceCollector.cpp
+++ b/src/Interpreters/TraceCollector.cpp
@@ -31,18 +31,20 @@ TraceCollector::TraceCollector(std::shared_ptr<TraceLog> trace_log_)
 
 
 TraceCollector::~TraceCollector()
-try
 {
-    if (!thread.joinable())
-        LOG_ERROR(&Poco::Logger::get("TraceCollector"), "TraceCollector thread is malformed and cannot be joined");
-    else
-        stop();
+    try
+    {
+        if (!thread.joinable())
+            LOG_ERROR(&Poco::Logger::get("TraceCollector"), "TraceCollector thread is malformed and cannot be joined");
+        else
+            stop();
 
-    TraceSender::pipe.close();
-}
-catch (...)
-{
-    tryLogCurrentException("TraceCollector");
+        TraceSender::pipe.close();
+    }
+    catch (...)
+    {
+        tryLogCurrentException("TraceCollector");
+    }
 }
 
 


### PR DESCRIPTION
Cf. #44758

Function try blocks in ctors/dtors implicitly rethrow, making them more or less useless.

Example: https://www.onlinegdb.com/pCKQA0wTIN (click RUN)

Fortunately, this seems the only place like that in the codebase.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)