### PR TITLE
Initial implementation for play multi-statement support

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -589,7 +589,7 @@
             if (posted_request_num != request_num) {
                 return;
             } else if (this.readyState === XMLHttpRequest.DONE) {
-                renderResponse(this.status, this.response, query, request_num);
+                renderResponse(this.status, this.response, query);
 
                 /// The query is saved in browser history (in state JSON object)
                 /// as well as in URL fragment identifier.
@@ -631,7 +631,7 @@
         xhr.send(query);
     }
 
-    function renderResponse(status, response, query, request_num)
+    function renderResponse(status, response, query)
     {
         document.getElementById('hourglass').style.display = 'none';
 

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -49,6 +49,7 @@
             --link-color: #06D;
             --logo-color: #CEE;
             --logo-color-active: #BDD;
+            --highlight-color: #A9A9A9;
         }
 
         [data-theme="dark"] {
@@ -70,6 +71,7 @@
             --link-color: #4BDAF7;
             --logo-color: #222;
             --logo-color-active: #333;
+            --highlight-color: #A9A9A9;
         }
 
         *
@@ -258,6 +260,31 @@
             text-align: left;
             background-color: var(--table-header-color);
             border: 1px solid var(--border-color);
+            position: relative;
+        }
+
+        .resizer
+        {
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: 5px;
+            cursor: col-resize;
+            user-select: none;
+        }
+
+        .resizer:hover,
+        .resizing
+        {
+            border-right: 2px solid var(--highlight-color);
+        }
+
+        .resizable
+        {
+            border: 1px solid gray;
+            height: 100px;
+            width: 100px;
+            position: relative;
         }
 
         /* The row under mouse pointer is highlight for better legibility. */
@@ -494,7 +521,7 @@
     </p>
     <div class="output-title">Action History &nbsp; <a id="clear-history" onclick="clearHistory()">clear</a></div>
     <div id="action_div" style="display:none">
-        <table>
+        <table id="action-table" >
             <thead>
                 <tr>
                     <th class="row-number">№</th>
@@ -544,6 +571,9 @@
 
     // Stores statements to execute when user clicks 'Run'
     const query_queue = [];
+
+    // Stores all our previous results/actions
+    let action_history = [];
 
     const current_url = new URL(window.location);
 
@@ -595,17 +625,21 @@
             if (posted_request_num != request_num) {
                 return;
             } else if (this.readyState === XMLHttpRequest.DONE) {
-                renderResponse(this.status, this.response, query);
+                renderResponse(this.status, this.response, query, false);
 
                 /// The query is saved in browser history (in state JSON object)
                 /// as well as in URL fragment identifier.
-                if (query != previous_query) {
-                    const state = {
+                const state = {
                         query: query,
                         status: this.status,
+                        request_num: request_num,
+                        action_history: action_history,
                         response: this.response.length > 100000 ? null : this.response  /// Lower than the browser's limit.
                     };
-                    const title = "ClickHouse Query: " + query;
+
+                    // Doesn't make sense to store query when multi-statement execution is available as there might be several
+                    // queries executed. Instead store the most recent request number.
+                    const title = "ClickHouse Query #" + request_num;
 
                     let history_url = window.location.pathname + '?user=' + encodeURIComponent(user);
                     if (server_address != location.origin) {
@@ -625,7 +659,6 @@
                     if (query_queue.length){
                         postImpl(++request_num);
                     }
-                }
             } else {
                 //console.log(this);
             }
@@ -637,28 +670,50 @@
         xhr.send(query);
     }
 
-    function renderResponse(status, response, query)
+    function renderStats(response){
+        let stats = document.getElementById('stats');
+        const seconds = response.statistics.elapsed.toFixed(3);
+        const rows = response.statistics.rows_read;
+        const bytes = response.statistics.bytes_read;
+        const formatted_bytes = formatReadableBytes(bytes);
+        const formatted_rows = formatReadableRows(rows);
+        const stats_message = `Elapsed: ${seconds} sec, read ${formatted_rows} rows, ${formatted_bytes}.`;
+        stats.innerText = stats_message;
+
+        return stats_message;
+    }
+
+    function renderResponse(status, response, query, is_restore)
     {
         document.getElementById('hourglass').style.display = 'none';
 
-        if (status === 200) {
-            let json;
-            try { json = JSON.parse(response); } catch (e) {}
+        let stats;
+        let result;
+        let success = false;
 
-            if (json !== undefined && json.statistics !== undefined) {
-                renderResult(json, query);
-            } else if (Array.isArray(json) && json.length == 2 &&
-                Array.isArray(json[0]) && Array.isArray(json[1]) && json[0].length > 1 && json[0].length == json[1].length) {
+        if (status === 200) {
+            try { result = JSON.parse(response); } catch (e) {}
+
+            if (result !== undefined && result.statistics !== undefined) {
+                stats = renderStats(result);
+                renderResult(result, query, stats);
+            } else if (Array.isArray(result) && result.length == 2 &&
+                Array.isArray(result[0]) && Array.isArray(result[1]) && result[0].length > 1 && result[0].length == result[1].length) {
                 /// If user requested FORMAT JSONCompactColumns, we will render it as a chart.
-                renderChart(json, query);
+                renderChart(result, query);
             } else {
                 renderUnparsedResult(response, query);
             }
             document.getElementById('check-mark').style.display = 'inline';
+            success = true;
         } else {
             /// TODO: Proper rendering of network errors.
             renderError(response, query);
+            result = response;
         }
+
+        renderActionHistory(success, result, query, stats, is_restore);
+        setupTables();
     }
 
     function getQuerySelection()
@@ -666,13 +721,8 @@
         return (query_area.value).substring(query_area.selectionStart, query_area.selectionEnd);
     }
 
-    query_area.addEventListener('click', updateRunButtonText);
-    query_area.addEventListener('select', updateRunButtonText);
-    query_area.addEventListener('keyup', updateRunButtonText);
-    query_area.addEventListener('change', updateRunButtonText);
-    query_area.addEventListener('mouseup', updateRunButtonText);
-
-    function updateRunButtonText() {
+    function updateRunButtonText()
+    {
         setTimeout(() => {
             const selection = getQuerySelection();
             const run_button = document.getElementById('run');
@@ -682,23 +732,6 @@
                 run_button.innerText = 'Run';
             }
         }, 100);
-    }
-
-    window.onpopstate = function(event)
-    {
-        if (!event.state) {
-            return;
-        }
-        query_area.value = event.state.query;
-        if (!event.state.response) {
-            clear();
-            return;
-        }
-        renderResponse(event.state.status, event.state.response);
-    };
-
-    if (window.location.hash) {
-        query_area.value = window.atob(window.location.hash.substr(1));
     }
 
     function post()
@@ -717,6 +750,31 @@
         postImpl(request_num, query);
     }
 
+    window.onpopstate = function(event)
+    {
+        if (!event.state) {
+            return;
+        }
+        query_area.value = event.state.query;
+        if (!event.state.response) {
+            clear();
+            return;
+        }
+
+        action_history = event.state.action_history
+        renderResponse(event.state.status, event.state.response, event.state.query, true);
+    };
+
+    if (window.location.hash) {
+        query_area.value = window.atob(window.location.hash.substr(1));
+    }
+
+    query_area.addEventListener('click', updateRunButtonText);
+    query_area.addEventListener('select', updateRunButtonText);
+    query_area.addEventListener('keyup', updateRunButtonText);
+    query_area.addEventListener('change', updateRunButtonText);
+    query_area.addEventListener('mouseup', updateRunButtonText);
+
     document.getElementById('run').onclick = function()
     {
         post();
@@ -728,6 +786,67 @@
         if ((event.metaKey || event.ctrlKey) && (event.keyCode == 13 || event.keyCode == 10)) {
             post();
         }
+    }
+
+    // Allow actions table columns to be resizable
+    function setupTables()
+    {
+        const createResizableTable = function(table)
+        {
+            const cols = table.querySelectorAll('th');
+            [].forEach.call(cols, function(col)
+            {
+                // Add a resizer element to the column
+                const resizer = document.createElement('div');
+                resizer.classList.add('resizer');
+
+                // Set the height
+                resizer.style.height = `${table.offsetHeight}px`;
+
+                col.appendChild(resizer);
+
+                createResizableColumn(col, resizer);
+            });
+        };
+
+        const createResizableColumn = function(col, resizer)
+        {
+            let x = 0;
+            let w = 0;
+
+            const mouseDownHandler = function(e)
+            {
+                x = e.clientX;
+
+                const styles = window.getComputedStyle(col);
+                w = parseInt(styles.width, 10);
+
+                document.addEventListener('mousemove', mouseMoveHandler);
+                document.addEventListener('mouseup', mouseUpHandler);
+
+                resizer.classList.add('resizing');
+            };
+
+            const mouseMoveHandler = function(e)
+            {
+                const dx = e.clientX - x;
+                col.style.width = `${w + dx}px`;
+            };
+
+            const mouseUpHandler = function()
+            {
+                resizer.classList.remove('resizing');
+                document.removeEventListener('mousemove', mouseMoveHandler);
+                document.removeEventListener('mouseup', mouseUpHandler);
+            };
+
+            resizer.addEventListener('mousedown', mouseDownHandler);
+        };
+
+        setTimeout(() => {
+            createResizableTable(document.getElementById('action-table'));
+            createResizableTable(document.getElementById('data-table'));
+        }, 500);
     }
 
     /// Pressing Tab in textarea will increase indentation.
@@ -799,19 +918,9 @@
         return formatReadable(rows, 2, units);
     }
 
-    function renderResult(response, query)
+    function renderResult(response, query, stats)
     {
         clear();
-
-        let stats = document.getElementById('stats');
-        const seconds = response.statistics.elapsed.toFixed(3);
-        const rows = response.statistics.rows_read;
-        const bytes = response.statistics.bytes_read;
-        const formatted_bytes = formatReadableBytes(bytes);
-        const formatted_rows = formatReadableRows(rows);
-        const statsMessage = `Elapsed: ${seconds} sec, read ${formatted_rows} rows, ${formatted_bytes}.`;
-        stats.innerText = statsMessage;
-        renderAction(true, response, query, statsMessage);
 
         /// We can also render graphs if user performed EXPLAIN PIPELINE graph=1 or EXPLAIN AST graph = 1
         if (response.data.length > 3 && query_area.value.match(/^\s*EXPLAIN/i) && typeof(response.data[0][0]) === "string" && response.data[0][0].startsWith("digraph")) {
@@ -1013,31 +1122,45 @@
         }
 
         data.innerText = response;
-        renderAction(true, response, query);
         /// inline-block make width adjust to the size of content.
         data.style.display = 'inline-block';
     }
 
-    function renderAction(success, response, query, stats) {
-        const clearHistoryButton = document.getElementById('clear-history');
-        clearHistoryButton.style = 'display:inline-block';
+    function renderActionHistory(success, response, query, stats, is_restore)
+    {
+        const clear_history_button = document.getElementById('clear-history');
+        clear_history_button.style = 'display:inline-block';
 
-        const actionDiv  = document.getElementById('action_div');
-        actionDiv.style = 'display:block';
+        const action_div  = document.getElementById('action_div');
+        action_div.style = 'display:block';
 
         const status = success ? 'Success' : 'Error';
-        const iconClass = success ? 'check-mark' : 'cross-mark'
+        const icon_class = success ? 'check-mark' : 'cross-mark'
         const icon = success ? '✔' : '✘';
 
         const message = success ? `${response.data.length} row(s) returned` : response;
-        action_body.innerHTML += `
-                <tr>
-                    <td>${request_num}</td>
-                    <td class="status-row"><span class="${iconClass}">${icon}</span></td>
-                    <td>${query}</td>
-                    <td>${stats ? message : response}</td>
-                    <td>${stats ? stats : '-'}</td>
-                </tr>`
+
+        if (!is_restore) {
+            action_history.push({
+                request_num: request_num,
+                icon_class: icon_class,
+                icon: icon,
+                query: query,
+                message: stats ? message : response,
+                stats_message: stats ? stats : '-',
+                stats: stats
+            });
+        }
+
+        action_body.innerHTML = action_history.map(x =>
+            `<tr>
+                <td class="row-number">${x.request_num}</td>
+                <td class="status-row"><span class="${x.icon_class}">${x.icon}</span></td>
+                <td>${x.query}</td>
+                <td>${x.message}</td>
+                <td>${x.stats_message}</td>
+            </tr>`
+        ).join('');
     }
 
     function clearHistory(){
@@ -1052,7 +1175,6 @@
     function renderError(response, query)
     {
         clear();
-        renderAction(false, response, query);
         document.getElementById('error').innerText = response ? response : "No response.";
         document.getElementById('error').style.display = 'block';
         document.getElementById('logo-container').style.display = 'none';

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -125,7 +125,7 @@
             font-family: Liberation Mono, DejaVu Sans Mono, MonoLisa, Consolas, monospace;
         }
 
-        .monospace-table
+        .monospace-table tbody
         {
             /* Liberation is worse than DejaVu for block drawing characters. */
             font-family: DejaVu Sans Mono, Liberation Mono, MonoLisa, Consolas, monospace;
@@ -317,6 +317,11 @@
             color: var(--misc-text-color);
         }
 
+        .status-row {
+            width: 1%;
+            text-align: right;
+        }
+
         div.empty-result
         {
             opacity: 10%;
@@ -363,14 +368,12 @@
 
         .check-mark
         {
-            text-align: center;
             font-size: 110%;
             color: #080;
         }
 
         .cross-mark
         {
-            text-align: center;
             font-size: 110%;
             color: #C00;
         }
@@ -491,8 +494,8 @@
         <table>
             <thead>
                 <tr>
+                    <th class="row-number">№</th>
                     <th></th>
-                    <th>#</th>
                     <th>Action</th>
                     <th>Message</th>
                     <th>Stats</th>
@@ -1023,8 +1026,8 @@
         const message = success ? `${response.data.length} row(s) returned` : response;
         action_body.innerHTML += `
                 <tr>
-                    <td><span class="${iconClass}">${icon}</span></td>
                     <td>${request_num}</td>
+                    <td class="status-row"><span class="${iconClass}">${icon}</span></td>
                     <td>${query}</td>
                     <td>${stats ? message : response}</td>
                     <td>${stats ? stats : '-'}</td>

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -348,7 +348,10 @@
         }
 
         #clear-history {
+            display: none;
             cursor: pointer;
+            text-decoration: underline;
+            font-size: 0.8rem;
         }
 
         #hourglass
@@ -1015,7 +1018,10 @@
         data.style.display = 'inline-block';
     }
 
-    function renderAction(success, response, query, stats){
+    function renderAction(success, response, query, stats) {
+        const clearHistoryButton = document.getElementById('clear-history');
+        clearHistoryButton.style = 'display:inline-block';
+
         const actionDiv  = document.getElementById('action_div');
         actionDiv.style = 'display:block';
 
@@ -1038,6 +1044,9 @@
         const actionDiv  = document.getElementById('action_div');
         actionDiv.style = 'display:none';
         action_body.innerHTML = null;
+
+        const clearHistoryButton = document.getElementById('clear-history');
+        clearHistoryButton.style = 'display:none';
     }
 
     function renderError(response, query)

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -357,10 +357,22 @@
 
         #check-mark
         {
-            display: none;
+            display:none;
             padding-left: 1rem;
+        }
+
+        .check-mark
+        {
+            text-align: center;
             font-size: 110%;
             color: #080;
+        }
+
+        .cross-mark
+        {
+            text-align: center;
+            font-size: 110%;
+            color: #C00;
         }
 
         a, a:visited
@@ -460,7 +472,7 @@
             <button class="shadow" id="run">Run</button>
             <span class="hint">&nbsp;(Ctrl/Cmd+Enter)</span>
             <span id="hourglass">⧗</span>
-            <span id="check-mark">✔</span>
+            <span id="check-mark" class="check-mark">✔</span>
             <span id="stats"></span>
             <span id="toggle-dark">🌑</span><span id="toggle-light">🌞</span>
         </div>
@@ -479,7 +491,8 @@
         <table>
             <thead>
                 <tr>
-                    <th>Status</th>
+                    <th></th>
+                    <th>#</th>
                     <th>Action</th>
                     <th>Message</th>
                     <th>Stats</th>
@@ -520,6 +533,12 @@
     /// Save query in history only if it is different.
     let previous_query = '';
 
+    // Query area/editor;
+    const query_area = document.getElementById('query');
+
+    // Stores statements to execute when user clicks 'Run'
+    const query_queue = [];
+
     const current_url = new URL(window.location);
 
     const server_address = current_url.searchParams.get('url');
@@ -538,7 +557,7 @@
 
     function postImpl(posted_request_num)
     {
-        const query = queryQueue.shift();
+        const query = query_queue.shift();
         const user = document.getElementById('user').value;
         const password = document.getElementById('password').value;
 
@@ -570,7 +589,7 @@
             if (posted_request_num != request_num) {
                 return;
             } else if (this.readyState === XMLHttpRequest.DONE) {
-                renderResponse(this.status, this.response, query);
+                renderResponse(this.status, this.response, query, request_num);
 
                 /// The query is saved in browser history (in state JSON object)
                 /// as well as in URL fragment identifier.
@@ -597,7 +616,7 @@
                     document.title = title;
                     previous_query = query;
 
-                    if (queryQueue.length){
+                    if (query_queue.length){
                         postImpl(++request_num);
                     }
                 }
@@ -612,7 +631,8 @@
         xhr.send(query);
     }
 
-    function renderResponse(status, response, query) {
+    function renderResponse(status, response, query, request_num)
+    {
         document.getElementById('hourglass').style.display = 'none';
 
         if (status === 200) {
@@ -635,17 +655,9 @@
         }
     }
 
-    let query_area = document.getElementById('query');
-
-    function updateRunButtonText() {
-        setTimeout(() => {
-        const selection =  (query_area.value).substring(query_area.selectionStart,query_area.selectionEnd);
-        const runButton = document.getElementById('run');
-        if (selection && selection.length){
-            runButton.innerText = 'Run selected';
-        } else {
-            runButton.innerText = 'Run';
-        }}, 100);
+    function getQuerySelection()
+    {
+        return (query_area.value).substring(query_area.selectionStart, query_area.selectionEnd);
     }
 
     query_area.addEventListener('click', updateRunButtonText);
@@ -654,7 +666,20 @@
     query_area.addEventListener('change', updateRunButtonText);
     query_area.addEventListener('mouseup', updateRunButtonText);
 
-    window.onpopstate = function(event) {
+    function updateRunButtonText() {
+        setTimeout(() => {
+            const selection = getQuerySelection();
+            const run_button = document.getElementById('run');
+            if (selection && selection.length){
+                run_button.innerText = 'Run selected';
+            } else {
+                run_button.innerText = 'Run';
+            }
+        }, 100);
+    }
+
+    window.onpopstate = function(event)
+    {
         if (!event.state) {
             return;
         }
@@ -670,20 +695,17 @@
         query_area.value = window.atob(window.location.hash.substr(1));
     }
 
-    const queryQueue = [];
-
     function post()
     {
         ++request_num;
-        let query = query_area.value;
-        const selection = (query_area.value).substring(query_area.selectionStart,query_area.selectionEnd);
-        if (selection && selection.length){
-            const multiStatements = selection.split(';').map(x => x.trim()).filter(x => x);
-            for (const statement of multiStatements){
-                queryQueue.push(statement);
-            }
-        } else {
-            queryQueue.push(query);
+
+        const selection = getQuerySelection();
+        const queries = selection && selection.length
+            ? selection.split(';').map(x => x.trim()).filter(x => x)
+            : [query_area.value];
+
+        for (const statement of queries){
+            query_queue.push(statement);
         }
 
         postImpl(request_num, query);
@@ -995,26 +1017,18 @@
         actionDiv.style = 'display:block';
 
         const status = success ? 'Success' : 'Error';
+        const iconClass = success ? 'check-mark' : 'cross-mark'
+        const icon = success ? '✔' : '✘';
 
-        if (stats) {
-            const message = success ? `${response.data.length} row(s) returned` : response;
-            action_body.innerHTML += `
-                    <tr>
-                        <td>${status}</td>
-                        <td>${query}</td>
-                        <td>${message}</td>
-                        <td>${stats}</td>
-                    </tr>`
-        } else {
-
-            action_body.innerHTML += `
-                    <tr>
-                        <td>${status}</td>
-                        <td>${query}</td>
-                        <td>${response}</td>
-                        <td>-</td>
-                    </tr>`
-        }
+        const message = success ? `${response.data.length} row(s) returned` : response;
+        action_body.innerHTML += `
+                <tr>
+                    <td><span class="${iconClass}">${icon}</span></td>
+                    <td>${request_num}</td>
+                    <td>${query}</td>
+                    <td>${stats ? message : response}</td>
+                    <td>${stats ? stats : '-'}</td>
+                </tr>`
     }
 
     function clearHistory(){

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -212,12 +212,12 @@
             color: var(--misc-text-color);
         }
 
-        #data_div
-        {
+        .output-title {
             margin-top: 1rem;
+            font-weight: bold;
         }
 
-        #data-table
+        table
         {
             width: 100%;
             border-collapse: collapse;
@@ -255,7 +255,7 @@
         th
         {
             padding: 0.25rem 0.5rem;
-            text-align: center;
+            text-align: left;
             background-color: var(--table-header-color);
             border: 1px solid var(--border-color);
         }
@@ -340,6 +340,10 @@
             100% {
                 transform: none;
             }
+        }
+
+        #clear-history {
+            cursor: pointer;
         }
 
         #hourglass
@@ -461,6 +465,7 @@
             <span id="toggle-dark">🌑</span><span id="toggle-light">🌞</span>
         </div>
     </div>
+    <div class="output-title">Results</div>
     <div id="data_div">
         <table class="monospace-table shadow" id="data-table"></table>
         <pre class="monospace-table shadow" id="data-unparsed"></pre>
@@ -469,6 +474,21 @@
     <svg id="graph" fill="none"></svg>
     <p id="error" class="monospace shadow">
     </p>
+    <div class="output-title">Action History &nbsp; <a id="clear-history" onclick="clearHistory()">clear</a></div>
+    <div id="action_div" style="display:none">
+        <table>
+            <thead>
+                <tr>
+                    <th>Status</th>
+                    <th>Action</th>
+                    <th>Message</th>
+                    <th>Stats</th>
+                </tr>
+            </thead>
+            <tbody id="action_body">
+            </tbody>
+        </table>
+    </div>
     <p id="logo-container">
         <a href="https://clickhouse.com/">
         <svg id="logo" width="50%" viewBox="0 0 180 28" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -516,8 +536,9 @@
         document.getElementById('user').value = user_from_url;
     }
 
-    function postImpl(posted_request_num, query)
+    function postImpl(posted_request_num)
     {
+        const query = queryQueue.shift();
         const user = document.getElementById('user').value;
         const password = document.getElementById('password').value;
 
@@ -549,7 +570,7 @@
             if (posted_request_num != request_num) {
                 return;
             } else if (this.readyState === XMLHttpRequest.DONE) {
-                renderResponse(this.status, this.response);
+                renderResponse(this.status, this.response, query);
 
                 /// The query is saved in browser history (in state JSON object)
                 /// as well as in URL fragment identifier.
@@ -575,6 +596,10 @@
                     }
                     document.title = title;
                     previous_query = query;
+
+                    if (queryQueue.length){
+                        postImpl(++request_num);
+                    }
                 }
             } else {
                 //console.log(this);
@@ -587,7 +612,7 @@
         xhr.send(query);
     }
 
-    function renderResponse(status, response) {
+    function renderResponse(status, response, query) {
         document.getElementById('hourglass').style.display = 'none';
 
         if (status === 200) {
@@ -595,22 +620,39 @@
             try { json = JSON.parse(response); } catch (e) {}
 
             if (json !== undefined && json.statistics !== undefined) {
-                renderResult(json);
+                renderResult(json, query);
             } else if (Array.isArray(json) && json.length == 2 &&
                 Array.isArray(json[0]) && Array.isArray(json[1]) && json[0].length > 1 && json[0].length == json[1].length) {
                 /// If user requested FORMAT JSONCompactColumns, we will render it as a chart.
-                renderChart(json);
+                renderChart(json, query);
             } else {
-                renderUnparsedResult(response);
+                renderUnparsedResult(response, query);
             }
             document.getElementById('check-mark').style.display = 'inline';
         } else {
             /// TODO: Proper rendering of network errors.
-            renderError(response);
+            renderError(response, query);
         }
     }
 
     let query_area = document.getElementById('query');
+
+    function updateRunButtonText() {
+        setTimeout(() => {
+        const selection =  (query_area.value).substring(query_area.selectionStart,query_area.selectionEnd);
+        const runButton = document.getElementById('run');
+        if (selection && selection.length){
+            runButton.innerText = 'Run selected';
+        } else {
+            runButton.innerText = 'Run';
+        }}, 100);
+    }
+
+    query_area.addEventListener('click', updateRunButtonText);
+    query_area.addEventListener('select', updateRunButtonText);
+    query_area.addEventListener('keyup', updateRunButtonText);
+    query_area.addEventListener('change', updateRunButtonText);
+    query_area.addEventListener('mouseup', updateRunButtonText);
 
     window.onpopstate = function(event) {
         if (!event.state) {
@@ -628,10 +670,22 @@
         query_area.value = window.atob(window.location.hash.substr(1));
     }
 
+    const queryQueue = [];
+
     function post()
     {
         ++request_num;
         let query = query_area.value;
+        const selection = (query_area.value).substring(query_area.selectionStart,query_area.selectionEnd);
+        if (selection && selection.length){
+            const multiStatements = selection.split(';').map(x => x.trim()).filter(x => x);
+            for (const statement of multiStatements){
+                queryQueue.push(statement);
+            }
+        } else {
+            queryQueue.push(query);
+        }
+
         postImpl(request_num, query);
     }
 
@@ -717,7 +771,7 @@
         return formatReadable(rows, 2, units);
     }
 
-    function renderResult(response)
+    function renderResult(response, query)
     {
         clear();
 
@@ -727,7 +781,9 @@
         const bytes = response.statistics.bytes_read;
         const formatted_bytes = formatReadableBytes(bytes);
         const formatted_rows = formatReadableRows(rows);
-        stats.innerText = `Elapsed: ${seconds} sec, read ${formatted_rows} rows, ${formatted_bytes}.`;
+        const statsMessage = `Elapsed: ${seconds} sec, read ${formatted_rows} rows, ${formatted_bytes}.`;
+        stats.innerText = statsMessage;
+        renderAction(true, response, query, statsMessage);
 
         /// We can also render graphs if user performed EXPLAIN PIPELINE graph=1 or EXPLAIN AST graph = 1
         if (response.data.length > 3 && query_area.value.match(/^\s*EXPLAIN/i) && typeof(response.data[0][0]) === "string" && response.data[0][0].startsWith("digraph")) {
@@ -918,7 +974,7 @@
     }
 
     /// A function to render raw data when non-default format is specified.
-    function renderUnparsedResult(response)
+    function renderUnparsedResult(response, query)
     {
         clear();
         let data = document.getElementById('data-unparsed')
@@ -929,13 +985,48 @@
         }
 
         data.innerText = response;
+        renderAction(true, response, query);
         /// inline-block make width adjust to the size of content.
         data.style.display = 'inline-block';
     }
 
-    function renderError(response)
+    function renderAction(success, response, query, stats){
+        const actionDiv  = document.getElementById('action_div');
+        actionDiv.style = 'display:block';
+
+        const status = success ? 'Success' : 'Error';
+
+        if (stats) {
+            const message = success ? `${response.data.length} row(s) returned` : response;
+            action_body.innerHTML += `
+                    <tr>
+                        <td>${status}</td>
+                        <td>${query}</td>
+                        <td>${message}</td>
+                        <td>${stats}</td>
+                    </tr>`
+        } else {
+
+            action_body.innerHTML += `
+                    <tr>
+                        <td>${status}</td>
+                        <td>${query}</td>
+                        <td>${response}</td>
+                        <td>-</td>
+                    </tr>`
+        }
+    }
+
+    function clearHistory(){
+        const actionDiv  = document.getElementById('action_div');
+        actionDiv.style = 'display:none';
+        action_body.innerHTML = null;
+    }
+
+    function renderError(response, query)
     {
         clear();
+        renderAction(false, response, query);
         document.getElementById('error').innerText = response ? response : "No response.";
         document.getElementById('error').style.display = 'block';
         document.getElementById('logo-container').style.display = 'none';


### PR DESCRIPTION
### Draft Notes

Usable and useful in the current state but needs work on:

- Render multiple result set tables using tabs or similar.
- Determine whether to retain the existing browser back/forward button history functionality or to incorporate that into the result history table. If we retain then result history needs storing in state along with results and query so that it is restored correctly when the user interacts with the back button.

### Changelog category:
- Improvement

### Changelog entry:

- Add support to the play web front-end that allows multiple statements to be run in  a batch. 
- Allows selecting a subset of the statements from those present in the query editor and executing only those selected statements, as most SQL front-ends do.
- Adds a query/result pane to allow tracking of the results from the statements executed.

### Documentation entry for user-facing changes

- Motivation: The play front end is a very useful tool and is likely to be the first interaction that new users have when starting out with clickhouse. In it's current form it can be quite frustrating to do any serious work with as you can only have a single statement present in the query editor; resulting in the need to copy and paste from an external source.


https://user-images.githubusercontent.com/5644228/210885672-f6c401c9-58f9-4bfe-815d-7de5ffddac5e.mp4


