### PR TITLE
Do not check read result consistency when unwinding

### DIFF
--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -516,11 +516,13 @@ void MergeTreeRangeReader::ReadResult::optimize(const FilterWithCachedCount & cu
 
     LOG_TEST(log, "ReadResult::optimize() before: {}", dumpInfo());
 
-    SCOPE_EXIT(checkInternalConsistency());
-
-    SCOPE_EXIT({
-        LOG_TEST(log, "ReadResult::optimize() after: {}", dumpInfo());
-    });
+    SCOPE_EXIT(
+        if (!std::uncaught_exceptions())
+        {
+            checkInternalConsistency();
+            LOG_TEST(log, "ReadResult::optimize() after: {}", dumpInfo());
+        }
+    );
 
     if (total_zero_rows_in_tails == filter.size())
     {
@@ -924,10 +926,11 @@ MergeTreeRangeReader::ReadResult MergeTreeRangeReader::read(size_t max_rows, Mar
 
     ReadResult read_result(log);
 
-    SCOPE_EXIT({
-        LOG_TEST(log, "read() returned {}, sample block {}",
-            read_result.dumpInfo(), this->result_sample_block.dumpNames());
-    });
+    SCOPE_EXIT(
+        if (!std::uncaught_exceptions())
+            LOG_TEST(log, "read() returned {}, sample block {}",
+                read_result.dumpInfo(), this->result_sample_block.dumpNames());
+    );
 
     if (prev_reader)
     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fixes #44951

### Documentation entry for user-facing changes
<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
