### PR TITLE
Up the log level of tables dependencies graphs

### DIFF
--- a/src/Databases/TablesDependencyGraph.cpp
+++ b/src/Databases/TablesDependencyGraph.cpp
@@ -715,7 +715,7 @@ void TablesDependencyGraph::log() const
 {
     if (nodes.empty())
     {
-        LOG_TEST(getLogger(), "No tables");
+        LOG_TRACE(getLogger(), "No tables");
         return;
     }
 
@@ -727,7 +727,7 @@ void TablesDependencyGraph::log() const
 
         String level_desc = (node->level == CYCLIC_LEVEL) ? "cyclic" : fmt::format("level {}", node->level);
 
-        LOG_TEST(getLogger(), "Table {} has {} ({})", node->storage_id, dependencies_desc, level_desc);
+        LOG_TRACE(getLogger(), "Table {} has {} ({})", node->storage_id, dependencies_desc, level_desc);
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Increase the log level of tables dependencies graphs. This PR must help the flaky test [test_backup_restore_on_cluster/test.py::test_tables_dependency](https://github.com/ClickHouse/ClickHouse/issues/42719#issuecomment-1372089395)