### PR TITLE
tests: fix test_replicated_users flakiness

### DIFF
--- a/tests/integration/test_replicated_users/test.py
+++ b/tests/integration/test_replicated_users/test.py
@@ -58,7 +58,7 @@ def test_create_replicated(started_cluster, entity):
     node1.query(f"CREATE {entity.keyword} {entity.name} {entity.options}")
     assert (
         f"cannot insert because {entity.keyword.lower()} `{entity.name}{entity.options}` already exists in replicated"
-        in node2.query_and_get_error(
+        in node2.query_and_get_error_with_retry(
             f"CREATE {entity.keyword} {entity.name} {entity.options}"
         )
     )
@@ -68,7 +68,7 @@ def test_create_replicated(started_cluster, entity):
 @pytest.mark.parametrize("entity", entities, ids=get_entity_id)
 def test_create_and_delete_replicated(started_cluster, entity):
     node1.query(f"CREATE {entity.keyword} {entity.name} {entity.options}")
-    node2.query(f"DROP {entity.keyword} {entity.name} {entity.options}")
+    node2.query_with_retry(f"DROP {entity.keyword} {entity.name} {entity.options}")
 
 
 @pytest.mark.parametrize("entity", entities, ids=get_entity_id)
@@ -93,7 +93,7 @@ def test_create_replicated_if_not_exists_on_cluster(started_cluster, entity):
 @pytest.mark.parametrize("entity", entities, ids=get_entity_id)
 def test_rename_replicated(started_cluster, entity):
     node1.query(f"CREATE {entity.keyword} {entity.name} {entity.options}")
-    node2.query(
+    node2.query_with_retry(
         f"ALTER {entity.keyword} {entity.name} {entity.options} RENAME TO {entity.name}2"
     )
     node1.query(f"DROP {entity.keyword} {entity.name}2 {entity.options}")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Alter for users/quotas/... does not wait until all replicas will be up
to date, so use *_with_retries() helperx.

CI: https://s3.amazonaws.com/clickhouse-test-reports/44922/bd885be9229cf47752c5c98392f09129261550f9/integration_tests__tsan__[6/6].html
Play: https://play.clickhouse.com/play?user=play#U0VMRUNUIGRpc3RpbmN0IHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgY2hlY2tfbmFtZSBMSUtFICdJbnRlZ3JhdGlvbiUnCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDE0IGRheQovLyAgICBBTkQgcHVsbF9yZXF1ZXN0X251bWJlciA9IDAKLy8gICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EIHRlc3Rfc3RhdHVzIExJS0UgJ0YlJwogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKYW5kIHRlc3RfbmFtZSBsaWtlICcldGVzdF9yZXBsaWNhdGVkX3VzZXJzJScKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZQ==
Cc: @vitlibar 
Refs: #27426 (cc @kmichel-aiven)