### PR TITLE
Fix minmax_count_projection with _partition_value

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -5728,6 +5728,15 @@ Block MergeTreeData::getMinMaxCountProjectionBlock(
     bool need_primary_key_max_column = false;
     const auto & primary_key_max_column_name = metadata_snapshot->minmax_count_projection->primary_key_max_column_name;
     NameSet required_columns_set(required_columns.begin(), required_columns.end());
+
+    if (required_columns_set.contains("_partition_value") && !typeid_cast<const DataTypeTuple *>(getPartitionValueType().get()))
+    {
+        throw Exception(
+            ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
+            "Missing column `_partition_value` because there is no partition column in table {}",
+            getStorageID().getTableName());
+    }
+
     if (!primary_key_max_column_name.empty())
         need_primary_key_max_column = required_columns_set.contains(primary_key_max_column_name);
 

--- a/tests/queries/0_stateless/01848_partition_value_column.sql
+++ b/tests/queries/0_stateless/01848_partition_value_column.sql
@@ -13,6 +13,7 @@ select count() from tbl where _partition_value.3 = 4 settings max_rows_to_read =
 create table tbl2(i int) engine MergeTree order by i;
 insert into tbl2 values (1);
 select _partition_value from tbl2; -- { serverError 16 }
+select _partition_value from tbl2 group by 1; -- { serverError 16 }
 
 drop table tbl;
 drop table tbl2;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check if virtual column `_partition_value` can be used when building minmax_count_projection block. This fixes https://github.com/ClickHouse/ClickHouse/issues/44979 . There is no need for changelog as the case is very rare and is only found in fuzz.

### Documentation entry for user-facing changes
<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
