### PR TITLE
Fix `01961_roaring_memory_tracking` test, again

### DIFF
--- a/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
+++ b/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
@@ -1,4 +1,4 @@
 -- Tags: no-replicated-database
 
-SET max_memory_usage = '75M';
+SET max_memory_usage = '50M';
 SELECT cityHash64(rand() % 1000) as n, groupBitmapState(number) FROM numbers_mt(2000000000) GROUP BY n FORMAT Null; -- { serverError 241 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://github.com/ClickHouse/ClickHouse/pull/45003

```
849616:2023.01.06 23:23:16.251658 [ 15449 ] {e466a95d-16c2-413a-8659-8ee15a1a00b8} <Debug> MemoryTracker: Peak memory usage (for query): 65.88 MiB.
849617:2023.01.06 23:23:16.251697 [ 15449 ] {e466a95d-16c2-413a-8659-8ee15a1a00b8} <Debug> TCPHandler: Processed in 178.098628341 sec.
```