### PR TITLE
Add snapshot creation retry in Keeper tests using ZooKeeper

### DIFF
--- a/tests/integration/test_keeper_snapshot_small_distance/test.py
+++ b/tests/integration/test_keeper_snapshot_small_distance/test.py
@@ -36,6 +36,41 @@ def stop_zookeeper(node):
         time.sleep(0.2)
 
 
+def generate_zk_snapshot(node):
+    for _ in range(100):
+        stop_zookeeper(node)
+        start_zookeeper(node)
+        time.sleep(2)
+        stop_zookeeper(node)
+
+        # get last snapshot
+        last_snapshot = node.exec_in_container(
+            [
+                "bash",
+                "-c",
+                "find /zookeeper/version-2 -name 'snapshot.*' -printf '%T@ %p\n' | sort -n | awk 'END {print $2}'",
+            ]
+        ).strip()
+
+        print(f"Latest snapshot: {last_snapshot}")
+
+        try:
+            # verify last snapshot
+            # zkSnapShotToolkit is a tool to inspect generated snapshots - if it's broken, an exception is thrown
+            node.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    f"/opt/zookeeper/bin/zkSnapShotToolkit.sh {last_snapshot}",
+                ]
+            )
+            return
+        except Exception as err:
+            print(f"Got error while reading snapshot: {err}")
+
+    raise Exception("Failed to generate a ZooKeeper snapshot")
+
+
 def clear_zookeeper(node):
     node.exec_in_container(["bash", "-c", "rm -fr /zookeeper/*"])
 
@@ -88,20 +123,6 @@ def start_clickhouse(node):
     keeper_utils.wait_until_connected(cluster, node)
 
 
-def copy_zookeeper_data(make_zk_snapshots, node):
-    stop_zookeeper(node)
-
-    if make_zk_snapshots:  # force zookeeper to create snapshot
-        start_zookeeper(node)
-        stop_zookeeper(node)
-
-    stop_clickhouse(node)
-    clear_clickhouse_data(node)
-    convert_zookeeper_data(node)
-    start_zookeeper(node)
-    start_clickhouse(node)
-
-
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -150,6 +171,7 @@ def test_snapshot_and_load(started_cluster):
     try:
         restart_and_clear_zookeeper(node1)
         genuine_connection = get_genuine_zk(node1)
+
         for node in [node1, node2, node3]:
             print("Stop and clear", node.name, "with dockerid", node.docker_id)
             stop_clickhouse(node)
@@ -160,9 +182,7 @@ def test_snapshot_and_load(started_cluster):
 
         print("Data loaded to zookeeper")
 
-        stop_zookeeper(node1)
-        start_zookeeper(node1)
-        stop_zookeeper(node1)
+        generate_zk_snapshot(node1)
 
         print("Data copied to node1")
         resulted_path = convert_zookeeper_data(node1)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We can detect invalid generated snapshots by ZK with `zkSnapShotToolkit`.
I tried truncating snapshots to different sizes and ZK will correctly generate a valid one on the next restart.

### Documentation entry for user-facing changes
<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
