### PR TITLE
Fix OOM in Fuzzer

### DIFF
--- a/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/docker/test/fuzzer/query-fuzzer-tweaks-users.xml
@@ -2,6 +2,7 @@
     <profiles>
         <default>
             <max_execution_time>10</max_execution_time>
+            <max_memory_usage>10G</max_memory_usage>
 
             <!--
                 Otherwise we will get the TOO_MANY_SIMULTANEOUS_QUERIES errors,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/0/9b380cce153065de05100d8f4468388ccb87d8af/fuzzer_astfuzzermsan/report.html

After the introduction of memory overcommit, the `max_memory_usage` is unlimited by default, so the "max" constraint also does not work.

This closes #37831.