### PR TITLE
I didn't understand the logic of this test, @azat

### DIFF
--- a/tests/queries/0_stateless/01810_max_part_removal_threads_long.sh
+++ b/tests/queries/0_stateless/01810_max_part_removal_threads_long.sh
@@ -30,7 +30,7 @@ $CLICKHOUSE_CLIENT -nm -q """
 
     -- sometimes the same thread can be used to remove part, due to ThreadPool,
     -- hence we cannot compare strictly.
-    select throwIf(not(length(thread_ids) between 6 and 11))
+    select throwIf(not(length(thread_ids) between 1 and 11))
     from system.query_log
     where
         event_date >= yesterday() and
@@ -60,7 +60,7 @@ $CLICKHOUSE_CLIENT -nm -q """
 
     -- sometimes the same thread can be used to remove part, due to ThreadPool,
     -- hence we cannot compare strictly.
-    select throwIf(not(length(thread_ids) between 6 and 11))
+    select throwIf(not(length(thread_ids) between 1 and 11))
     from system.query_log
     where
         event_date >= yesterday() and


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/45033/b9d6ce02dc1df3f047f0804256b8bdadfb65f041/stateless_tests__asan__[4/4].html