### PR TITLE
Fix (benign) data race in clickhouse-client

### DIFF
--- a/src/Client/Suggest.cpp
+++ b/src/Client/Suggest.cpp
@@ -7,6 +7,7 @@
 #include <Common/typeid_cast.h>
 #include <Common/Macros.h>
 #include "Core/Protocol.h"
+#include <IO/WriteBufferFromFileDescriptor.h>
 #include <IO/Operators.h>
 #include <Functions/FunctionFactory.h>
 #include <TableFunctions/TableFunctionFactory.h>
@@ -122,11 +123,18 @@ void Suggest::load(ContextPtr context, const ConnectionParameters & connection_p
                 if (e.code() == ErrorCodes::DEADLOCK_AVOIDED)
                     continue;
 
-                std::cerr << "Cannot load data for command line suggestions: " << getCurrentExceptionMessage(false, true) << "\n";
+                /// We should not use std::cerr here, because this method works concurrently with the main thread.
+                /// WriteBufferFromFileDescriptor will write directly to the file descriptor, avoiding data race on std::cerr.
+
+                WriteBufferFromFileDescriptor out(STDERR_FILENO, 4096);
+                out << "Cannot load data for command line suggestions: " << getCurrentExceptionMessage(false, true) << "\n";
+                out.next();
             }
             catch (...)
             {
-                std::cerr << "Cannot load data for command line suggestions: " << getCurrentExceptionMessage(false, true) << "\n";
+                WriteBufferFromFileDescriptor out(STDERR_FILENO, 4096);
+                out << "Cannot load data for command line suggestions: " << getCurrentExceptionMessage(false, true) << "\n";
+                out.next();
             }
 
             break;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This closes #43035.