### PR TITLE
Fix possible cannot-read-all-data in storage FileLog

### DIFF
--- a/src/Storages/FileLog/StorageFileLog.h
+++ b/src/Storages/FileLog/StorageFileLog.h
@@ -82,6 +82,7 @@ public:
         String file_name;
         UInt64 last_writen_position = 0;
         UInt64 last_open_end = 0;
+        bool operator!() const { return file_name.empty(); }
     };
 
     using InodeToFileMeta = std::unordered_map<UInt64, FileMeta>;
@@ -202,7 +203,14 @@ private:
     void serialize(UInt64 inode, const FileMeta & file_meta) const;
 
     void deserialize();
-    void checkOffsetIsValid(const String & full_name, UInt64 offset) const;
+    void checkOffsetIsValid(const String & filename, UInt64 offset) const;
+
+    struct ReadMetadataResult
+    {
+        FileMeta metadata;
+        UInt64 inode = 0;
+    };
+    ReadMetadataResult readMetadata(const String & filename) const;
 };
 
 }


### PR DESCRIPTION
File was not properly written because of out of memory issue
```
2023.01.08 11:01:48.791711 [ 177608 ] {} <Error> void DB::StorageFileLog::threadFunc(): Code: 241. DB::Exception: Memory limit (total) exceeded: would use 52.17 GiB (attempt to allocate chunk of 4969215 bytes), maximum: 34.29 GiB. OvercommitTracker decision: Memory overcommit isn't used. Waiting time or overcommit denominator are set to zero. (MEMORY_LIMIT_EXCEEDED), Stack trace (when copying this message, always include the lines below):
8. ./build_docker/../src/Storages/FileLog/StorageFileLog.cpp:0: DB::StorageFileLog::serialize() const @ 0x14c5a359 in /usr/lib/debug/usr/bin/clickhouse.debug
9. ./build_docker/../src/Storages/FileLog/StorageFileLog.cpp:457: DB::StorageFileLog::openFilesAndSetPos() @ 0x14c5ecab in /usr/lib/debug/usr/bin/clickhouse.debug
10. ./build_docker/../contrib/llvm-project/libcxx/include/vector:666: DB::StorageFileLog::streamToViews() @ 0x14c6229a in /usr/lib/debug/usr/bin/clickhouse.debug
11. ./build_docker/../src/Storages/FileLog/StorageFileLog.cpp:590: DB::StorageFileLog::threadFunc() @ 0x14c60d08 in /usr/lib/debug/usr/bin/clickhouse.debug
```
and on server startup we tried to read it and get
```
2023.01.08 11:23:45.431662 [ 338001 ] {} <Error> DB::StorageFileLog::StorageFileLog(const DB::StorageID &, DB::ContextPtr, const DB::ColumnsDescription &, const DB::String &, const DB::String &, const DB::String &, std::unique_ptr<FileLogSettings>, const DB::String &, bool): Code: 33. DB::Exception: Read meta file store/89e/89e45767-cd48-4bad-adfc-851bc648f329/metadata/a.txt failed. (CANNOT_READ_ALL_DATA), Stack trace (when copying this message, always include the lines below):

```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible cannot-read-all-data error in storage FileLog. Closes https://github.com/ClickHouse/ClickHouse/issues/45051, https://github.com/ClickHouse/ClickHouse/issues/38257.


