### PR TITLE
Disable memory efficient merging for distributed aggregation when grouping sets are present

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -1776,7 +1776,8 @@ static void executeMergeAggregatedImpl(
         query_plan.getCurrentDataStream(),
         params,
         final,
-        settings.distributed_aggregation_memory_efficient && is_remote_storage,
+        /// Grouping sets don't work with distributed_aggregation_memory_efficient enabled (#43989)
+        settings.distributed_aggregation_memory_efficient && is_remote_storage && !has_grouping_sets,
         settings.max_threads,
         settings.aggregation_memory_efficient_merge_threads,
         should_produce_results_in_order_of_bucket_number,

--- a/tests/queries/0_stateless/02521_grouping_sets_plus_memory_efficient_aggr.sql
+++ b/tests/queries/0_stateless/02521_grouping_sets_plus_memory_efficient_aggr.sql
@@ -1,0 +1,3 @@
+set distributed_aggregation_memory_efficient = 1;
+
+select number as a, number+1 as b from remote('127.0.0.{1,2}', numbers_mt(1e5)) group by grouping sets ((a), (b)) format Null;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Memory efficient aggregation (setting `distributed_aggregation_memory_efficient`) is disabled when grouping sets are present in the query.