### PR TITLE
Improve release scripts

### DIFF
--- a/tests/ci/env_helper.py
+++ b/tests/ci/env_helper.py
@@ -39,6 +39,8 @@ _GITHUB_JOB_URL = ""
 def GITHUB_JOB_ID() -> str:
     global _GITHUB_JOB_ID
     global _GITHUB_JOB_URL
+    if GITHUB_RUN_ID == "0":
+        _GITHUB_JOB_ID = "0"
     if _GITHUB_JOB_ID:
         return _GITHUB_JOB_ID
     jobs = []

--- a/tests/ci/mark_release_ready.py
+++ b/tests/ci/mark_release_ready.py
@@ -1,24 +1,61 @@
 #!/usr/bin/env python3
 
+import argparse
+import logging
+import os
+
 from commit_status_helper import get_commit
 from env_helper import GITHUB_JOB_URL
 from get_robot_token import get_best_robot_token
 from github_helper import GitHub
 from pr_info import PRInfo
 from release import RELEASE_READY_STATUS
+from git_helper import commit as commit_arg
 
 
 def main():
-    pr_info = PRInfo()
-    gh = GitHub(get_best_robot_token(), create_cache_dir=False, per_page=100)
-    commit = get_commit(gh, pr_info.sha)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="mark the commit as ready for release",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.getenv("GITHUB_TOKEN", ""),
+        required=False,
+        help="GitHub token to authorize, required if commit is set. "
+        "Can be set as GITHUB_TOKEN env",
+    )
+    parser.add_argument(
+        "commit",
+        nargs="?",
+        type=commit_arg,
+        help="if given, used instead of one from PRInfo",
+    )
+    args = parser.parse_args()
+    url = ""
+    description = "the release can be created from the commit, manually set"
+    if not args.commit:
+        pr_info = PRInfo()
+        if pr_info.event == pr_info.default_event:
+            raise ValueError("neither launched from the CI nor commit is given")
+        args.commit = pr_info.sha
+        url = GITHUB_JOB_URL()
+        description = "the release can be created from the commit"
+        args.token = args.token or get_best_robot_token()
+
+    gh = GitHub(args.token, create_cache_dir=False, per_page=100)
+    # Get the rate limits for a quick fail
+    gh.get_rate_limit()
+    commit = get_commit(gh, args.commit)
+
     commit.create_status(
         context=RELEASE_READY_STATUS,
-        description="the release can be created from the commit",
+        description=description,
         state="success",
-        target_url=GITHUB_JOB_URL(),
+        target_url=url,
     )
 
 
 if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
     main()

--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -90,8 +90,9 @@ class Release:
         return self._git.run(cmd, cwd, **kwargs)
 
     def set_release_branch(self):
-        # Fetch release commit in case it does not exist locally
+        # Fetch release commit and tags in case they don't exist locally
         self.run(f"git fetch {self.repo.url} {self.release_commit}")
+        self.run(f"git fetch {self.repo.url} --tags")
 
         # Get the actual version for the commit before check
         with self._checkout(self.release_commit, True):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prefetch tags to avoid [wrong tweak versions](https://github.com/ClickHouse/ClickHouse/releases/tag/v22.3.16.1190-lts); don't fetch `GITHUB_JOB_ID` on default `GITHUB_RUN_ID`; allow to use `mark_release_ready.py` to manually mark ready releases (dangerous).