### PR TITLE
Change the color of links in dark reports a little bit

### DIFF
--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -14,7 +14,7 @@ HTML_BASE_TEST_TEMPLATE = """
     --background: hsl(190deg, 90%, 5%) linear-gradient(180deg, hsl(190deg, 90%, 10%), hsl(190deg, 90%, 0%));
     --td-background: hsl(190deg, 90%, 15%);
     --th-background: hsl(180deg, 90%, 15%);
-    --link-color: white;
+    --link-color: #FF5;
     --link-hover-color: #F40;
     --menu-background: hsl(190deg, 90%, 20%);
     --menu-hover-background: hsl(190deg, 100%, 50%);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The reports have the same color for text and links, the PR highlights it a little bit.


### Example
[old report](https://s3.amazonaws.com/clickhouse-test-reports/44883/1e4fe038f562029fc24a0e7a33e5d428ea0474f9/style_check.html) VS [new report](https://s3.amazonaws.com/clickhouse-test-reports/45077/98ee463fc1316ac68b3a0fadced4e073b262db08/style_check.html) for style check, [old](https://s3.amazonaws.com/clickhouse-test-reports/44883/1e4fe038f562029fc24a0e7a33e5d428ea0474f9/docker_image_clickhouse/clickhouse-server_building_check.html) VS [new](https://pastila.nl/?00450c7e/25eb9505c19a4db941f9a5a840a6b560.html) for docker server images