### PR TITLE
Docs: Rewrite awkwardly phrased sentence about flush interval

### DIFF
--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -104,7 +104,7 @@ Compiled expression cache used when query/user/profile enable option [compile-ex
 
 ## FLUSH LOGS
 
-Flushes buffers of log messages to system tables (e.g. system.query_log). Allows you to not wait 7.5 seconds when debugging.
+Flushes buffered log messages to system tables, e.g. system.query_log. Mainly useful for debugging since most system tables have a default flush interval of 7.5 seconds.
 This will also create system tables even if message queue is empty.
 
 ## RELOAD CONFIG


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)