### PR TITLE
Minor cleanup in stress/run.sh

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1544,8 +1544,11 @@ def check_server_started(args):
             print(" OK")
             sys.stdout.flush()
             return True
-        except (ConnectionError, http.client.ImproperConnectionState):
-            print(".", end="")
+        except (ConnectionError, http.client.ImproperConnectionState) as e:
+            if args.hung_check:
+                print("Connection error, will retry: ", str(e))
+            else:
+                print(".", end="")
             sys.stdout.flush()
             retry_count -= 1
             sleep(0.5)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Follow up to https://github.com/ClickHouse/ClickHouse/pull/44197 after 22.12 is released 