### PR TITLE
Fix flaky test `01961_roaring_memory_tracking` (3)

### DIFF
--- a/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
+++ b/tests/queries/0_stateless/01961_roaring_memory_tracking.sql
@@ -1,4 +1,4 @@
--- Tags: no-replicated-database
+-- Tags: no-replicated-database, no-asan, no-tsan, no-msan, no-ubsan
 
-SET max_memory_usage = '50M';
-SELECT cityHash64(rand() % 1000) as n, groupBitmapState(number) FROM numbers_mt(2000000000) GROUP BY n FORMAT Null; -- { serverError 241 }
+SET max_memory_usage = '100M';
+SELECT cityHash64(rand() % 1000) as n, groupBitmapState(number) FROM numbers_mt(200000000) GROUP BY n FORMAT Null; -- { serverError 241 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The reason for failure was different from that I thought before.
Our overrides for malloc/free are not being used with sanitizers.

That's why we are getting something like this:
```
milovidov@milovidov-desktop:~/Downloads$ rg '7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6' clickhouse-server.log 
1091954:2023.01.11 06:29:36.960230 [ 4408 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> executeQuery: (from [::1]:33764) (comment: 01961_roaring_memory_tracking.sql) SELECT cityHash64(rand() % 1000) as n, groupBitmapState(number) FROM numbers_mt(2000000000) GROUP BY n FORMAT Null; (stage: Complete)
1091962:2023.01.11 06:29:36.961231 [ 4408 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> InterpreterSelectQuery: FetchColumns -> Complete
1092000:2023.01.11 06:29:36.966390 [ 14046 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092001:2023.01.11 06:29:36.966415 [ 14046 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092002:2023.01.11 06:29:36.966476 [ 14588 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092003:2023.01.11 06:29:36.966481 [ 14276 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092004:2023.01.11 06:29:36.966497 [ 14588 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092005:2023.01.11 06:29:36.966509 [ 14276 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092008:2023.01.11 06:29:36.971542 [ 14189 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092009:2023.01.11 06:29:36.971572 [ 14189 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092028:2023.01.11 06:29:36.978002 [ 14432 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092029:2023.01.11 06:29:36.978037 [ 14149 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092030:2023.01.11 06:29:36.978041 [ 14432 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092031:2023.01.11 06:29:36.978077 [ 14149 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092032:2023.01.11 06:29:36.978095 [ 13816 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092033:2023.01.11 06:29:36.978120 [ 13816 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092052:2023.01.11 06:29:36.989918 [ 13913 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092053:2023.01.11 06:29:36.989953 [ 13913 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092054:2023.01.11 06:29:36.989958 [ 14231 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092055:2023.01.11 06:29:36.989991 [ 14231 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092056:2023.01.11 06:29:36.990021 [ 14372 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092057:2023.01.11 06:29:36.990049 [ 14372 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092058:2023.01.11 06:29:36.990169 [ 14186 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092059:2023.01.11 06:29:36.990204 [ 14186 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092060:2023.01.11 06:29:36.993938 [ 14302 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092061:2023.01.11 06:29:36.993965 [ 13746 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092062:2023.01.11 06:29:36.994002 [ 13746 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092063:2023.01.11 06:29:36.994014 [ 13861 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092064:2023.01.11 06:29:36.994046 [ 13861 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092065:2023.01.11 06:29:36.994104 [ 14605 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092066:2023.01.11 06:29:36.994131 [ 14605 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092067:2023.01.11 06:29:36.994253 [ 14099 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092068:2023.01.11 06:29:36.994275 [ 14099 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092073:2023.01.11 06:29:36.998064 [ 14166 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092074:2023.01.11 06:29:36.998095 [ 14166 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092075:2023.01.11 06:29:36.998252 [ 956 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092076:2023.01.11 06:29:36.998280 [ 956 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092079:2023.01.11 06:29:37.001502 [ 13731 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092080:2023.01.11 06:29:37.001538 [ 13731 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092081:2023.01.11 06:29:37.001597 [ 13952 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092082:2023.01.11 06:29:37.001636 [ 13952 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092083:2023.01.11 06:29:37.001778 [ 14624 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092084:2023.01.11 06:29:37.001805 [ 14624 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092085:2023.01.11 06:29:37.002044 [ 14203 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092086:2023.01.11 06:29:37.002072 [ 14203 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092087:2023.01.11 06:29:36.993972 [ 14302 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092088:2023.01.11 06:29:37.001508 [ 14583 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092089:2023.01.11 06:29:37.006158 [ 14583 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092096:2023.01.11 06:29:37.009927 [ 14597 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092097:2023.01.11 06:29:37.009941 [ 14171 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092098:2023.01.11 06:29:37.009959 [ 14597 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092099:2023.01.11 06:29:37.009972 [ 14171 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092108:2023.01.11 06:29:37.013754 [ 14639 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092109:2023.01.11 06:29:37.013787 [ 14639 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092110:2023.01.11 06:29:37.014164 [ 1162 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092111:2023.01.11 06:29:37.014193 [ 1162 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092129:2023.01.11 06:29:37.017997 [ 14362 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092130:2023.01.11 06:29:37.018027 [ 14362 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1092131:2023.01.11 06:29:37.018312 [ 14459 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> AggregatingTransform: Aggregating
1092132:2023.01.11 06:29:37.018340 [ 14459 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Aggregation method: key64
1117385:2023.01.11 06:29:50.272725 [ 14583 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> MemoryTracker: Current memory usage (total): 10.00 GiB.
1139842:2023.01.11 06:30:02.368789 [ 14149 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> MemoryTracker: Current memory usage (total): 12.00 GiB.
1197032:2023.01.11 06:30:45.207747 [ 14231 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> MemoryTracker: Current memory usage (total): 20.00 GiB.
1219723:2023.01.11 06:31:04.634029 [ 14186 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> MemoryTracker: Current memory usage (total): 23.00 GiB.
1228056:2023.01.11 06:31:09.811512 [ 14639 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> MemoryTracker: Current memory usage (total): 24.00 GiB.
1235884:2023.01.11 06:31:15.468013 [ 14171 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> MemoryTracker: Current memory usage (total): 25.01 GiB.
1236064:2023.01.11 06:31:15.745444 [ 14186 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 83876976 to 1000 rows (from 1.25 GiB) in 98.783148384 sec. (849102.072 rows/sec., 12.96 MiB/sec.)
1236065:2023.01.11 06:31:15.745533 [ 13816 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 59681504 to 1000 rows (from 910.67 MiB) in 98.7829036 sec. (604168.351 rows/sec., 9.22 MiB/sec.)
1236066:2023.01.11 06:31:15.745693 [ 14149 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 68218752 to 1000 rows (from 1.02 GiB) in 98.783087921 sec. (690591.410 rows/sec., 10.54 MiB/sec.)
1236067:2023.01.11 06:31:15.745813 [ 14639 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 66604400 to 1000 rows (from 1016.30 MiB) in 98.782999454 sec. (674249.622 rows/sec., 10.29 MiB/sec.)
1236068:2023.01.11 06:31:15.746079 [ 14588 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 96177744 to 1000 rows (from 1.43 GiB) in 98.783742846 sec. (973619.153 rows/sec., 14.86 MiB/sec.)
1236069:2023.01.11 06:31:15.746391 [ 14459 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 80747312 to 1000 rows (from 1.20 GiB) in 98.783536793 sec. (817416.693 rows/sec., 12.47 MiB/sec.)
1236070:2023.01.11 06:31:15.747062 [ 14302 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 66749104 to 1000 rows (from 1018.51 MiB) in 98.78463828 sec. (675703.279 rows/sec., 10.31 MiB/sec.)
1236071:2023.01.11 06:31:15.747426 [ 14171 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 63870896 to 1000 rows (from 974.59 MiB) in 98.784879625 sec. (646565.509 rows/sec., 9.87 MiB/sec.)
1236072:2023.01.11 06:31:15.747653 [ 13913 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 64821680 to 1000 rows (from 989.10 MiB) in 98.785277563 sec. (656187.659 rows/sec., 10.01 MiB/sec.)
1236073:2023.01.11 06:31:15.748154 [ 14203 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 77023408 to 1000 rows (from 1.15 GiB) in 98.78535355 sec. (779704.736 rows/sec., 11.90 MiB/sec.)
1236074:2023.01.11 06:31:15.748413 [ 13861 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 62920112 to 1000 rows (from 960.08 MiB) in 98.785928629 sec. (636933.953 rows/sec., 9.72 MiB/sec.)
1236075:2023.01.11 06:31:15.749133 [ 14166 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 66208240 to 1000 rows (from 1010.26 MiB) in 98.786393463 sec. (670216.187 rows/sec., 10.23 MiB/sec.)
1236076:2023.01.11 06:31:15.749270 [ 14583 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 59542848 to 1000 rows (from 908.55 MiB) in 98.78680315 sec. (602740.914 rows/sec., 9.20 MiB/sec.)
1236077:2023.01.11 06:31:15.749311 [ 1162 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 101931968 to 1000 rows (from 1.52 GiB) in 98.786473336 sec. (1031841.350 rows/sec., 15.74 MiB/sec.)
1236078:2023.01.11 06:31:15.749857 [ 14605 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 66614304 to 1000 rows (from 1016.45 MiB) in 98.787171522 sec. (674321.402 rows/sec., 10.29 MiB/sec.)
1236079:2023.01.11 06:31:15.749911 [ 956 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 72249680 to 1000 rows (from 1.08 GiB) in 98.787150944 sec. (731367.180 rows/sec., 11.16 MiB/sec.)
1236080:2023.01.11 06:31:15.749915 [ 14099 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 63999648 to 1000 rows (from 976.56 MiB) in 98.78721112 sec. (647853.576 rows/sec., 9.89 MiB/sec.)
1236081:2023.01.11 06:31:15.750011 [ 14276 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 64564176 to 1000 rows (from 985.17 MiB) in 98.787608903 sec. (653565.530 rows/sec., 9.97 MiB/sec.)
1236082:2023.01.11 06:31:15.750059 [ 14432 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 66029968 to 1000 rows (from 1007.54 MiB) in 98.78779391 sec. (668402.091 rows/sec., 10.20 MiB/sec.)
1236083:2023.01.11 06:31:15.751231 [ 14189 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 66148816 to 1000 rows (from 1009.35 MiB) in 98.788726466 sec. (669598.833 rows/sec., 10.22 MiB/sec.)
1236084:2023.01.11 06:31:15.751292 [ 13731 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 55323744 to 1000 rows (from 844.17 MiB) in 98.788706121 sec. (560020.939 rows/sec., 8.55 MiB/sec.)
1236085:2023.01.11 06:31:15.751543 [ 14372 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 68595104 to 1000 rows (from 1.02 GiB) in 98.788896778 sec. (694360.462 rows/sec., 10.60 MiB/sec.)
1236086:2023.01.11 06:31:15.751636 [ 14597 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 69298288 to 1000 rows (from 1.03 GiB) in 98.789278652 sec. (701475.797 rows/sec., 10.70 MiB/sec.)
1236087:2023.01.11 06:31:15.751695 [ 13952 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 63454928 to 1000 rows (from 968.25 MiB) in 98.788971944 sec. (642328.053 rows/sec., 9.80 MiB/sec.)
1236089:2023.01.11 06:31:15.751978 [ 14046 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 68099904 to 1000 rows (from 1.01 GiB) in 98.789452149 sec. (689343.877 rows/sec., 10.52 MiB/sec.)
1236091:2023.01.11 06:31:15.752290 [ 14362 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 69219056 to 1000 rows (from 1.03 GiB) in 98.789977989 sec. (700668.807 rows/sec., 10.69 MiB/sec.)
1236092:2023.01.11 06:31:15.752446 [ 14624 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 58096864 to 1000 rows (from 886.49 MiB) in 98.789661334 sec. (588086.478 rows/sec., 8.97 MiB/sec.)
1236094:2023.01.11 06:31:15.752963 [ 13746 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 64257152 to 1000 rows (from 980.49 MiB) in 98.790398533 sec. (650439.243 rows/sec., 9.92 MiB/sec.)
1236097:2023.01.11 06:31:15.752997 [ 14231 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> AggregatingTransform: Aggregated. 65673424 to 1000 rows (from 1002.10 MiB) in 98.790551439 sec. (664774.344 rows/sec., 10.14 MiB/sec.)
1236098:2023.01.11 06:31:15.753020 [ 14231 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Merging aggregated data
1236099:2023.01.11 06:31:15.753046 [ 14231 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Trace> Aggregator: Statistics updated for key=2483587490190430702: new sum_of_sizes=29000, median_size=1000
3012292:2023.01.11 06:38:22.512738 [ 4408 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Information> executeQuery: Read 2000000000 rows, 14.90 GiB in 525.552679 sec., 3805517.6577265626 rows/sec., 29.03 MiB/sec.
3012293:2023.01.11 06:38:22.514611 [ 4408 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> MemoryTracker: Peak memory usage (for query): 46.13 MiB.
3012294:2023.01.11 06:38:22.514636 [ 4408 ] {7ee9ce39-3e19-4dff-a9c0-2d6f1ad4cda6} <Debug> TCPHandler: Processed in 525.554924194 sec.
```

And also, the test was too slow.