### PR TITLE
Remove trash from stress test

### DIFF
--- a/docker/test/stress/run.sh
+++ b/docker/test/stress/run.sh
@@ -593,7 +593,7 @@ clickhouse-local --structure "test String, res String" -q "SELECT 'failure', tes
 [ -s /test_output/check_status.tsv ] || echo -e "success\tNo errors found" > /test_output/check_status.tsv
 
 # Core dumps
-find . -type f -name 'core.*' | while read core; do
+find . -type f -maxdepth 1 -name 'core.*' | while read core; do
     zstd --threads=0 $core
     mv $core.zst /test_output/
 done


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It was really funny:
[core.cpython-38.pyc.zst](https://s3.amazonaws.com/clickhouse-test-reports/0/6adf1c025f0a011023c084c6b8904b019992331e/stress_test__ubsan_/core.cpython-38.pyc.zst) [core.go.zst](https://s3.amazonaws.com/clickhouse-test-reports/0/6adf1c025f0a011023c084c6b8904b019992331e/stress_test__ubsan_/core.go.zst) [core.js.zst](https://s3.amazonaws.com/clickhouse-test-reports/0/6adf1c025f0a011023c084c6b8904b019992331e/stress_test__ubsan_/core.js.zst) [core.json.zst](https://s3.amazonaws.com/clickhouse-test-reports/0/6adf1c025f0a011023c084c6b8904b019992331e/stress_test__ubsan_/core.json.zst) [core.min.js.zst](https://s3.amazonaws.com/clickhouse-test-reports/0/6adf1c025f0a011023c084c6b8904b019992331e/stress_test__ubsan_/core.min.js.zst) [core.py.zst](https://s3.amazonaws.com/clickhouse-test-reports/0/6adf1c025f0a011023c084c6b8904b019992331e/stress_test__ubsan_/core.py.zst) [core.pyc.zst](https://s3.amazonaws.com/clickhouse-test-reports/0/6adf1c025f0a011023c084c6b8904b019992331e/stress_test__ubsan_/core.pyc.zst) [core.pyi.zst](https://s3.amazonaws.com/clickhouse-test-reports/0/6adf1c025f0a011023c084c6b8904b019992331e/stress_test__ubsan_/core.pyi.zst) [core.xml.zst](https://s3.amazonaws.com/clickhouse-test-reports/0/6adf1c025f0a011023c084c6b8904b019992331e/stress_test__ubsan_/core.xml.zst)