### PR TITLE
Fix flaky `test_keeper_three_nodes_two_alive`

### DIFF
--- a/tests/integration/test_keeper_three_nodes_two_alive/configs/enable_keeper1.xml
+++ b/tests/integration/test_keeper_three_nodes_two_alive/configs/enable_keeper1.xml
@@ -26,6 +26,7 @@
                 <id>3</id>
                 <hostname>node3</hostname>
                 <port>9234</port>
+                <start_as_follower>1</start_as_follower>
             </server>
         </raft_configuration>
     </keeper_server>

--- a/tests/integration/test_keeper_three_nodes_two_alive/configs/enable_keeper2.xml
+++ b/tests/integration/test_keeper_three_nodes_two_alive/configs/enable_keeper2.xml
@@ -26,6 +26,7 @@
                 <id>3</id>
                 <hostname>node3</hostname>
                 <port>9234</port>
+                <start_as_follower>1</start_as_follower>
             </server>
         </raft_configuration>
     </keeper_server>

--- a/tests/integration/test_keeper_three_nodes_two_alive/configs/enable_keeper3.xml
+++ b/tests/integration/test_keeper_three_nodes_two_alive/configs/enable_keeper3.xml
@@ -26,6 +26,7 @@
                 <id>3</id>
                 <hostname>node3</hostname>
                 <port>9234</port>
+                <start_as_follower>1</start_as_follower>
             </server>
         </raft_configuration>
     </keeper_server>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/88556603f573fdf6df07b213f6161b7e1c10d58c/integration_tests__release__[1/2].html
It's really hard for this to happen because all of this should be true:
- the test `test_restart_third_node` should run first
- node 3 should become leader
- node 1 and node 2 do leader election 3 times because of PRE-VOTE timing (really slim chance of happening)

Not allowing node 3 to become leader should avoid leader re-election on restart.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
