### PR TITLE
Do not compare empty const columns in checkBlockStructure

### DIFF
--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -91,14 +91,20 @@ static ReturnType checkColumnStructure(const ColumnWithTypeAndName & actual, con
                 expected.dumpStructure()),
             code);
 
-    if (isColumnConst(*actual.column) && isColumnConst(*expected.column))
+    if (isColumnConst(*actual.column) && isColumnConst(*expected.column)
+        && actual.column->size() > 0 && expected.column->size() > 0) /// don't check values in empty columns
     {
         Field actual_value = assert_cast<const ColumnConst &>(*actual.column).getField();
         Field expected_value = assert_cast<const ColumnConst &>(*expected.column).getField();
 
         if (actual_value != expected_value)
-            return onError<ReturnType>("Block structure mismatch in " + std::string(context_description) + " stream: different values of constants, actual: "
-                + applyVisitor(FieldVisitorToString(), actual_value) + ", expected: " + applyVisitor(FieldVisitorToString(), expected_value),
+            return onError<ReturnType>(
+                fmt::format(
+                    "Block structure mismatch in {} stream: different values of constants in column '{}': actual: {}, expected: {}",
+                    context_description,
+                    actual.name,
+                    applyVisitor(FieldVisitorToString(), actual_value),
+                    applyVisitor(FieldVisitorToString(), expected_value)),
                 code);
     }
 

--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -92,7 +92,7 @@ static ReturnType checkColumnStructure(const ColumnWithTypeAndName & actual, con
             code);
 
     if (isColumnConst(*actual.column) && isColumnConst(*expected.column)
-        && actual.column->size() > 0 && expected.column->size() > 0) /// don't check values in empty columns
+        && !actual.column->empty() && !expected.column->empty()) /// don't check values in empty columns
     {
         Field actual_value = assert_cast<const ColumnConst &>(*actual.column).getField();
         Field expected_value = assert_cast<const ColumnConst &>(*expected.column).getField();

--- a/tests/queries/0_stateless/02531_semi_join_null_const_bug.sql
+++ b/tests/queries/0_stateless/02531_semi_join_null_const_bug.sql
@@ -1,0 +1,11 @@
+SET join_use_nulls = 1;
+
+SELECT b.id
+FROM (
+    SELECT toLowCardinality(0 :: UInt32) AS id
+    GROUP BY []
+) AS a
+SEMI LEFT JOIN (
+    SELECT toLowCardinality(1 :: UInt64) AS id
+) AS b
+USING (id);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix logical error in SEMI JOIN & join_use_nulls in some cases, close https://github.com/ClickHouse/ClickHouse/issues/45163, close https://github.com/ClickHouse/ClickHouse/issues/45209

