### PR TITLE
One more attempt to fix race in TCPHandler

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -402,14 +402,11 @@ void TCPHandler::runImpl()
                     {
                         auto callback = [this]()
                         {
-                            {
-                                std::lock_guard task_callback_lock(task_callback_mutex);
+                            std::lock_guard lock1(task_callback_mutex);
+                            std::lock_guard lock2(fatal_error_mutex);
 
-                                if (isQueryCancelled())
-                                    return true;
-                            }
-
-                            std::lock_guard lock(fatal_error_mutex);
+                            if (isQueryCancelled())
+                                return true;
 
                             sendProgress();
                             sendSelectProfileEvents();
@@ -424,6 +421,9 @@ void TCPHandler::runImpl()
                 }
 
                 state.io.onFinish();
+
+                std::lock_guard lock(task_callback_mutex);
+
                 /// Send final progress after calling onFinish(), since it will update the progress.
                 ///
                 /// NOTE: we cannot send Progress for regular INSERT (with VALUES)
@@ -446,8 +446,11 @@ void TCPHandler::runImpl()
             if (state.is_connection_closed)
                 break;
 
-            sendLogs();
-            sendEndOfStream();
+            {
+                std::lock_guard lock1(task_callback_mutex);
+                sendLogs();
+                sendEndOfStream();
+            }
 
             /// QueryState should be cleared before QueryScope, since otherwise
             /// the MemoryTracker will be wrong for possible deallocations.
@@ -796,6 +799,8 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
             }
         }
 
+        std::lock_guard lock(task_callback_mutex);
+
         /** If data has run out, we will send the profiling data and total values to
           * the last zero block to be able to use
           * this information in the suffix output of stream.
@@ -820,6 +825,7 @@ void TCPHandler::processOrdinaryQueryWithProcessors()
         last_sent_snapshots.clear();
     }
 
+    std::lock_guard lock(task_callback_mutex);
     sendProgress();
 }
 


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This PR #44955 uncovers hidden and previously existed issues with s3Cluster table function (and also parallel replicas). The problem looks like 
```
E           helpers.client.QueryRuntimeException: Client failed! Return code: 62, stderr: Received exception from server (version 22.13.1):
E           Code: 62. DB::Exception: Received from 172.16.16.11:9000. DB::Exception: Syntax error (data type): failed at position 1 (''): String�Memo. Unrecognized token: '': while receiving packet from s0_0_1:9000: While executing Remote. Stack trace:
```
And this is because a race condition in writing data to a single connection with at least 2 threads. Previous PR doesn't fully solve it. https://github.com/ClickHouse/ClickHouse/pull/45123
I've executed `test_s3_cluster/test.py::test_distributed_insert_select_with_replicated` 1000 times locally, everything should be Okay now. 
