### PR TITLE
Record server startup time in ProfileEvents 

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1813,8 +1813,6 @@ try
                                                                      &CurrentMetrics::MaxDDLEntryID, &CurrentMetrics::MaxPushedDDLEntryID));
         }
 
-        ProfileEvents::increment(ProfileEvents::ServerStartupMilliseconds, startup_watch.elapsedMilliseconds());
-
         {
             std::lock_guard lock(servers_lock);
             for (auto & server : servers)
@@ -1826,6 +1824,9 @@ try
             global_context->setServerCompletelyStarted();
             LOG_INFO(log, "Ready for connections.");
         }
+
+        startup_watch.stop();
+        ProfileEvents::increment(ProfileEvents::ServerStartupMilliseconds, startup_watch.elapsedMilliseconds());
 
         try
         {

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -140,6 +140,7 @@ namespace CurrentMetrics
 namespace ProfileEvents
 {
     extern const Event MainConfigLoads;
+    extern const Event ServerStartupTime;
 }
 
 namespace fs = std::filesystem;
@@ -652,6 +653,8 @@ static void sanityChecks(Server & server)
 int Server::main(const std::vector<std::string> & /*args*/)
 try
 {
+    std::chrono::system_clock::time_point startup_start_time = std::chrono::system_clock::now();
+
     Poco::Logger * log = &logger();
 
     UseSSL use_ssl;
@@ -1426,6 +1429,9 @@ try
 #endif
 
     }
+
+    std::chrono::milliseconds startup_duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - startup_start_time);
+    ProfileEvents::increment(ProfileEvents::ServerStartupTime, startup_duration.count());
 
     for (auto & server : servers_to_start_before_tables)
     {

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -450,7 +450,7 @@ The server successfully detected this situation and will download merged part fr
     M(OverflowThrow, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'throw' and exception was thrown.") \
     M(OverflowAny, "Number of times approximate GROUP BY was in effect: when aggregation was performed only on top of first 'max_rows_to_group_by' unique keys and other keys were ignored due to 'group_by_overflow_mode' = 'any'.") \
     \
-    M(ServerStartupTime, "Time elapsed from starting server to listening to sockets")\
+    M(ServerStartupMilliseconds, "Time elapsed from starting server to listening to sockets in milliseconds")\
 
 namespace ProfileEvents
 {

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -449,7 +449,8 @@ The server successfully detected this situation and will download merged part fr
     M(OverflowBreak, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'break' and the result is incomplete.") \
     M(OverflowThrow, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'throw' and exception was thrown.") \
     M(OverflowAny, "Number of times approximate GROUP BY was in effect: when aggregation was performed only on top of first 'max_rows_to_group_by' unique keys and other keys were ignored due to 'group_by_overflow_mode' = 'any'.") \
-
+    \
+    M(ServerStartupTime, "Time elapsed from starting server to listening to sockets")\
 
 namespace ProfileEvents
 {

--- a/tests/queries/0_stateless/02532_profileevents_server_startup_time.reference
+++ b/tests/queries/0_stateless/02532_profileevents_server_startup_time.reference
@@ -1,0 +1,1 @@
+ServerStartupTime

--- a/tests/queries/0_stateless/02532_profileevents_server_startup_time.reference
+++ b/tests/queries/0_stateless/02532_profileevents_server_startup_time.reference
@@ -1,1 +1,1 @@
-ServerStartupTime
+ServerStartupMilliseconds

--- a/tests/queries/0_stateless/02532_profileevents_server_startup_time.sql
+++ b/tests/queries/0_stateless/02532_profileevents_server_startup_time.sql
@@ -1,0 +1,1 @@
+SELECT event FROM system.events WHERE event = 'ServerStartupTime'

--- a/tests/queries/0_stateless/02532_profileevents_server_startup_time.sql
+++ b/tests/queries/0_stateless/02532_profileevents_server_startup_time.sql
@@ -1,1 +1,1 @@
-SELECT event FROM system.events WHERE event = 'ServerStartupTime'
+SELECT event FROM system.events WHERE event = 'ServerStartupMilliseconds'


### PR DESCRIPTION
Changelog category (leave one):
* Feature

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Record server startup time in ProfileEvents resolves #43188
Implementation:
* Added ProfileEvents::ServerStartupMilliseconds.
* Recorded time from start of main till listening to sockets.
Testing:
* Added a test 02532_profileevents_server_startup_time.sql