### PR TITLE
Update clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -232,17 +232,20 @@ def need_retry(args, stdout, stderr, total_time):
 
 
 def get_processlist(args):
-    if args.replicated_database:
-        return clickhouse_execute_json(
-            args,
-            """
-        SELECT materialize((hostName(), tcpPort())) as host, *
-        FROM clusterAllReplicas('test_cluster_database_replicated', system.processes)
-        WHERE query NOT LIKE '%system.processes%'
-        """,
-        )
-    else:
-        return clickhouse_execute_json(args, "SHOW PROCESSLIST")
+    try:
+        if args.replicated_database:
+            return clickhouse_execute_json(
+                args,
+                """
+            SELECT materialize((hostName(), tcpPort())) as host, *
+            FROM clusterAllReplicas('test_cluster_database_replicated', system.processes)
+            WHERE query NOT LIKE '%system.processes%'
+            """,
+            )
+        else:
+            return clickhouse_execute_json(args, "SHOW PROCESSLIST")
+    except Exception as e:
+        return "Failed to get processlist: " + str(e)
 
 
 def get_transactions_list(args):


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/43998/673ba769e59ecfbc66edb06dfecce40d86aedb74/stress_test__ubsan_.html

```
2023-01-05 07:37:42,617 All processes finished
2023-01-05 07:37:42,617 Compressing stress logs
2023-01-05 07:37:43,927 Logs compressed
2023-01-05 07:37:43,928 Will terminate gdb (if any)
2023-01-05 07:42:46,765 Checking if some queries hung
Using queries from '/usr/share/clickhouse-test/queries' directory
Using clickhouse-client as client program
Connecting to ClickHouse server..... OK

Running 1 stateless tests (MainProcess).

00001_select_1:                                                         [ OK ]

1 tests passed. 0 tests skipped. 0.09 s elapsed (MainProcess).
Cannot check if dataset is available, assuming it's not:  [Errno 104] Connection reset by peer
Won't run stateful tests because test data wasn't loaded.
Traceback (most recent call last):
  File "/usr/bin/clickhouse-test", line 2372, in <module>
    main(args)
  File "/usr/bin/clickhouse-test", line 1911, in main
    processlist = get_processlist(args)
  File "/usr/bin/clickhouse-test", line 245, in get_processlist
    return clickhouse_execute_json(args, "SHOW PROCESSLIST")
  File "/usr/bin/clickhouse-test", line 140, in clickhouse_execute_json
    data = clickhouse_execute_http(base_args, query, timeout, settings, "JSONEachRow")
  File "/usr/bin/clickhouse-test", line 125, in clickhouse_execute_http
    raise ex
  File "/usr/bin/clickhouse-test", line 120, in clickhouse_execute_http
    res = client.getresponse()
  File "/usr/lib/python3.8/http/client.py", line 1348, in getresponse
    response.begin()
  File "/usr/lib/python3.8/http/client.py", line 316, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.8/http/client.py", line 277, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib/python3.8/socket.py", line 669, in readinto
    return self._sock.recv_into(b)
ConnectionResetError: [Errno 104] Connection reset by peer
2023-01-05 07:43:00,181 Hung check failed with exit code 1
2023-01-05 07:43:00,182 Stress test finished
```