### PR TITLE
Added two metrics about memory usage in cgroup to asynchronous metrics

### DIFF
--- a/docs/en/operations/system-tables/asynchronous_metrics.md
+++ b/docs/en/operations/system-tables/asynchronous_metrics.md
@@ -9,6 +9,7 @@ Columns:
 
 -   `metric` ([String](../../sql-reference/data-types/string.md)) — Metric name.
 -   `value` ([Float64](../../sql-reference/data-types/float.md)) — Metric value.
+-   `description` ([String](../../sql-reference/data-types/string.md) - Metric description)
 
 **Example**
 
@@ -17,18 +18,18 @@ SELECT * FROM system.asynchronous_metrics LIMIT 10
 ```
 
 ``` text
-┌─metric──────────────────────────────────┬──────value─┐
-│ jemalloc.background_thread.run_interval │          0 │
-│ jemalloc.background_thread.num_runs     │          0 │
-│ jemalloc.background_thread.num_threads  │          0 │
-│ jemalloc.retained                       │  422551552 │
-│ jemalloc.mapped                         │ 1682989056 │
-│ jemalloc.resident                       │ 1656446976 │
-│ jemalloc.metadata_thp                   │          0 │
-│ jemalloc.metadata                       │   10226856 │
-│ UncompressedCacheCells                  │          0 │
-│ MarkCacheFiles                          │          0 │
-└─────────────────────────────────────────┴────────────┘
+┌─metric──────────────────────────────────┬──────value─┬─description────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ AsynchronousMetricsCalculationTimeSpent │ 0.00179053 │ Time in seconds spent for calculation of asynchronous metrics (this is the overhead of asynchronous metrics).                                                                                                                                              │
+│ NumberOfDetachedByUserParts             │          0 │ The total number of parts detached from MergeTree tables by users with the `ALTER TABLE DETACH` query (as opposed to unexpected, broken or ignored parts). The server does not care about detached parts and they can be removed.                          │
+│ NumberOfDetachedParts                   │          0 │ The total number of parts detached from MergeTree tables. A part can be detached by a user with the `ALTER TABLE DETACH` query or by the server itself it the part is broken, unexpected or unneeded. The server does not care about detached parts and they can be removed. │
+│ TotalRowsOfMergeTreeTables              │    2781309 │ Total amount of rows (records) stored in all tables of MergeTree family.                                                                                                                                                                                   │
+│ TotalBytesOfMergeTreeTables             │    7741926 │ Total amount of bytes (compressed, including data and indices) stored in all tables of MergeTree family.                                                                                                                                                   │
+│ NumberOfTables                          │         93 │ Total number of tables summed across the databases on the server, excluding the databases that cannot contain MergeTree tables. The excluded database engines are those who generate the set of tables on the fly, like `Lazy`, `MySQL`, `PostgreSQL`, `SQlite`. │
+│ NumberOfDatabases                       │          6 │ Total number of databases on the server.                                                                                                                                                                                                                   │
+│ MaxPartCountForPartition                │          6 │ Maximum number of parts per partition across all partitions of all tables of MergeTree family. Values larger than 300 indicates misconfiguration, overload, or massive data loading.                                                                       │
+│ ReplicasSumMergesInQueue                │          0 │ Sum of merge operations in the queue (still to be applied) across Replicated tables.                                                                                                                                                                       │
+│ ReplicasSumInsertsInQueue               │          0 │ Sum of INSERT operations in the queue (still to be replicated) across Replicated tables.                                                                                                                                                                   │
+└─────────────────────────────────────────┴────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 **See Also**

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -894,7 +894,8 @@ void AsynchronousMetrics::update(TimePoint update_time)
             readText(cgroup_mem_limit_in_bytes, *cgroupmem_limit_in_bytes);
             readText(cgroup_mem_usage_in_bytes, *cgroupmem_usage_in_bytes);
 
-            if (!cgroup_mem_limit_in_bytes || !cgroup_mem_usage_in_bytes) {
+            if (!cgroup_mem_limit_in_bytes || !cgroup_mem_usage_in_bytes)
+            {
                 break;
             }
 

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -898,8 +898,8 @@ void AsynchronousMetrics::update(TimePoint update_time)
             {
                 new_values["CgroupMemoryTotal"] = { cgroup_mem_limit_in_bytes, "The total amount of memory in cgroup, in bytes." };
                 new_values["CgroupMemoryUsed"] = { cgroup_mem_usage_in_bytes, "The amount of memory used in cgroup, in bytes." };
-            } 
-            else 
+            }
+            else
             {
                 LOG_DEBUG(log, "Cannot read statistics about the cgroup memory total and used. Total got '{}', Used got '{}'.",
                     cgroup_mem_limit_in_bytes, cgroup_mem_usage_in_bytes);

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -66,6 +66,9 @@ AsynchronousMetrics::AsynchronousMetrics(
     openFileIfExists("/proc/uptime", uptime);
     openFileIfExists("/proc/net/dev", net_dev);
 
+    openFileIfExists("/sys/fs/cgroup/memory/memory.limit_in_bytes", cgroupmem_limit_in_bytes);
+    openFileIfExists("/sys/fs/cgroup/memory/memory.usage_in_bytes", cgroupmem_usage_in_bytes);
+
     openSensors();
     openBlockDevices();
     openEDAC();
@@ -872,6 +875,31 @@ void AsynchronousMetrics::update(TimePoint update_time)
             }
 
             proc_stat_values_other = current_other_values;
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
+
+    if (cgroupmem_limit_in_bytes && cgroupmem_usage_in_bytes)
+    {
+        try {
+            cgroupmem_limit_in_bytes->rewind();
+            cgroupmem_usage_in_bytes->rewind();
+
+            uint64_t cgroup_mem_limit_in_bytes = 0;
+            uint64_t cgroup_mem_usage_in_bytes = 0;
+
+            readText(cgroup_mem_limit_in_bytes, *cgroupmem_limit_in_bytes);
+            readText(cgroup_mem_usage_in_bytes, *cgroupmem_usage_in_bytes);
+
+            if (!cgroup_mem_limit_in_bytes || !cgroup_mem_usage_in_bytes) {
+                break;
+            }
+
+            new_values["CgroupMemoryTotal"] = { cgroup_mem_limit_in_bytes, "The total amount of memory in cgroup, in bytes." };
+            new_values["CgroupMemoryUsed"] = { cgroup_mem_usage_in_bytes, "The amount of memory used in cgroup, in bytes." };
         }
         catch (...)
         {

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -894,13 +894,16 @@ void AsynchronousMetrics::update(TimePoint update_time)
             readText(cgroup_mem_limit_in_bytes, *cgroupmem_limit_in_bytes);
             readText(cgroup_mem_usage_in_bytes, *cgroupmem_usage_in_bytes);
 
-            if (!cgroup_mem_limit_in_bytes || !cgroup_mem_usage_in_bytes)
+            if (cgroup_mem_limit_in_bytes && cgroup_mem_usage_in_bytes)
             {
-                break;
+                new_values["CgroupMemoryTotal"] = { cgroup_mem_limit_in_bytes, "The total amount of memory in cgroup, in bytes." };
+                new_values["CgroupMemoryUsed"] = { cgroup_mem_usage_in_bytes, "The amount of memory used in cgroup, in bytes." };
+            } 
+            else 
+            {
+                LOG_DEBUG(log, "Cannot read statistics about the cgroup memory total and used. Total got '{}', Used got '{}'.",
+                    cgroup_mem_limit_in_bytes, cgroup_mem_usage_in_bytes);
             }
-
-            new_values["CgroupMemoryTotal"] = { cgroup_mem_limit_in_bytes, "The total amount of memory in cgroup, in bytes." };
-            new_values["CgroupMemoryUsed"] = { cgroup_mem_usage_in_bytes, "The amount of memory used in cgroup, in bytes." };
         }
         catch (...)
         {

--- a/src/Common/AsynchronousMetrics.h
+++ b/src/Common/AsynchronousMetrics.h
@@ -108,6 +108,9 @@ private:
     std::optional<ReadBufferFromFilePRead> uptime;
     std::optional<ReadBufferFromFilePRead> net_dev;
 
+    std::optional<ReadBufferFromFilePRead> cgroupmem_limit_in_bytes;
+    std::optional<ReadBufferFromFilePRead> cgroupmem_usage_in_bytes;
+
     std::vector<std::unique_ptr<ReadBufferFromFilePRead>> thermal;
 
     std::unordered_map<String /* device name */,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add total memory and used memory metrics with respect to cgroup in AsyncMetrics (https://github.com/ClickHouse/ClickHouse/issues/37983)

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)
-- Updated document

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
