### PR TITLE
Fix wrong approved_at, simplify conditions

### DIFF
--- a/tests/ci/merge_pr.py
+++ b/tests/ci/merge_pr.py
@@ -38,13 +38,18 @@ class Reviews:
         self.approved_at = datetime.fromtimestamp(0)
         for r in self.reviews:
             user = r.user
-            if self._review_per_user.get(user):
-                if r.state in self.STATES:
-                    self._review_per_user[user] = r
-                    if r.state == "APPROVED":
-                        self.approved_at = max(r.submitted_at, self.approved_at)
+            if r.state not in self.STATES:
                 continue
-            self._review_per_user[user] = r
+
+            if r.state == "APPROVED":
+                self.approved_at = max(r.submitted_at, self.approved_at)
+
+            if not self._review_per_user.get(user):
+                self._review_per_user[user] = r
+                continue
+
+            if r.submitted_at < self._review_per_user[user].submitted_at:
+                self._review_per_user[user] = r
 
     def is_approved(self, team: List[NamedUser]) -> bool:
         """Checks if the PR is approved, and no changes made after the last approval"""


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix wrong condition from #41110 