### PR TITLE
Disable 02028_create_select_settings with Ordinary

### DIFF
--- a/tests/queries/0_stateless/02028_create_select_settings.sql
+++ b/tests/queries/0_stateless/02028_create_select_settings.sql
@@ -1,1 +1,3 @@
+-- Tags: no-ordinary-database
+
 create table test_table engine MergeTree order by a as select a_table.a, b_table.b_arr from (select arrayJoin(range(10000)) as a) a_table cross join (select range(10000) as b_arr) b_table settings max_memory_usage = 1; -- { serverError MEMORY_LIMIT_EXCEEDED }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The test was accidentally broken in https://github.com/ClickHouse/ClickHouse/pull/45230 (https://play.clickhouse.com/play?user=play#d2l0aCAKJyUwMjAyOF9jcmVhdGVfc2VsZWN0X3NldHRpbmdzJScgYXMgbmFtZV9wYXR0ZXJuLAonMjAyMi0wOS0wMScgYXMgc3RhcnRfZGF0ZSwKKCdTdGF0ZWxlc3MgdGVzdHMgKGFzYW4pJywgJ1N0YXRlbGVzcyB0ZXN0cyAoYWRkcmVzcyknLCAnU3RhdGVsZXNzIHRlc3RzIChhZGRyZXNzLCBhY3Rpb25zKScpIGFzIGJhY2twb3J0X2FuZF9yZWxlYXNlX3NwZWNpZmljX2NoZWNrcwpzZWxlY3QgCnRvU3RhcnRPZkhvdXIoY2hlY2tfc3RhcnRfdGltZSkgYXMgZCwKY291bnQoKSwgIGdyb3VwVW5pcUFycmF5KHB1bGxfcmVxdWVzdF9udW1iZXIpLCBhbnkoY29tbWl0X3NoYSksIGFueShyZXBvcnRfdXJsKQpmcm9tIGNoZWNrcyB3aGVyZSBzdGFydF9kYXRlIDw9IGNoZWNrX3N0YXJ0X3RpbWUgYW5kIHB1bGxfcmVxdWVzdF9udW1iZXIgbm90IGluIAooc2VsZWN0IHB1bGxfcmVxdWVzdF9udW1iZXIgYXMgcHJuIGZyb20gY2hlY2tzIHdoZXJlIHBybiE9MCBhbmQgc3RhcnRfZGF0ZSA8PSBjaGVja19zdGFydF90aW1lIGFuZCBjaGVja19uYW1lIGluIGJhY2twb3J0X2FuZF9yZWxlYXNlX3NwZWNpZmljX2NoZWNrcykgCmFuZCB0ZXN0X25hbWUgbGlrZSBuYW1lX3BhdHRlcm4gCmFuZCB0ZXN0X3N0YXR1cyBpbiAoJ0ZBSUwnLCAnRkxBS1knKSBncm91cCBieSBkIG9yZGVyIGJ5IGQgZGVzYw==)


Explanation: it used to throw MEMORY_LIMIT_EXCEEDED from checkBlockStructure (https://pastila.nl/?00887559/a819ef692e7ce14ea578177a6a221879), now checkBlockStructure is not called, so the exception is thrown later when the table is partially created (https://pastila.nl/?00887559/43f522684b8676eeacf539e0bc40a563)
We could revert it, but the test was broken accidentally and the failure is related to a known issue in a deprecated feature, so I would just disable the test with Ordinary

Fixes https://github.com/ClickHouse/ClickHouse/issues/45281
