### PR TITLE
Fix `fromUnixTimestamp64Nano` example

### DIFF
--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -1455,7 +1455,7 @@ Converts an `Int64` to a `DateTime64` value with fixed sub-second precision and 
 **Syntax**
 
 ``` sql
-fromUnixTimestamp64Milli(value [, ti])
+fromUnixTimestamp64Nano(value [, ti])
 ```
 
 **Arguments**

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -1416,21 +1416,6 @@ toUnixTimestamp64Nano(value)
 
 Query:
 
-```sql
-WITH toDateTime64('2019-09-16 19:20:12.345678910', 6) AS dt64
-SELECT toUnixTimestamp64Milli(dt64);
-```
-
-Result:
-
-```response
-┌─toUnixTimestamp64Milli(dt64)─┐
-│                1568650812345 │
-└──────────────────────────────┘
-```
-
-Query:
-
 ``` sql
 WITH toDateTime64('2019-09-16 19:20:12.345678910', 6) AS dt64
 SELECT toUnixTimestamp64Nano(dt64);

--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -1401,7 +1401,7 @@ The output value is a timestamp in UTC, not in the timezone of `DateTime64`.
 **Syntax**
 
 ```sql
-toUnixTimestamp64Milli(value)
+toUnixTimestamp64Nano(value)
 ```
 
 **Arguments**
@@ -1472,16 +1472,16 @@ fromUnixTimestamp64Nano(value [, ti])
 Query:
 
 ``` sql
-WITH CAST(1234567891011, 'Int64') AS i64
-SELECT fromUnixTimestamp64Milli(i64, 'UTC');
+WITH CAST(1673982906788569020, 'Int64') AS i64
+SELECT fromUnixTimestamp64Nano(i64, 'UTC');
 ```
 
 Result:
 
 ```response
-┌─fromUnixTimestamp64Milli(i64, 'UTC')─┐
-│              2009-02-13 23:31:31.011 │
-└──────────────────────────────────────┘
+┌─fromUnixTimestamp64Nano(i64, 'UTC')─┐
+│       2023-01-17 19:15:06.788569020 │
+└─────────────────────────────────────┘
 ```
 
 ## formatRow


### PR DESCRIPTION
It was a copy/paste mistake from `fromUnixTimestamp64Milli`

### Changelog category (leave one):
- Documentation (changelog entry is not required)