### PR TITLE
Do not move to prewhere in select with joins

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -560,7 +560,10 @@ InterpreterSelectQuery::InterpreterSelectQuery(
             view = nullptr;
         }
 
-        if (try_move_to_prewhere && storage && storage->canMoveConditionsToPrewhere() && query.where() && !query.prewhere())
+        if (try_move_to_prewhere
+            && storage && storage->canMoveConditionsToPrewhere()
+            && query.where() && !query.prewhere()
+            && !query.hasJoin()) /// Join may produce rows with nulls or default values, it's difficult to analyze if they affected or not.
         {
             /// PREWHERE optimization: transfer some condition from WHERE to PREWHERE if enabled and viable
             if (const auto & column_sizes = storage->getColumnSizes(); !column_sizes.empty())

--- a/tests/queries/0_stateless/02534_join_prewhere_bug_44062.reference
+++ b/tests/queries/0_stateless/02534_join_prewhere_bug_44062.reference
@@ -1,0 +1,38 @@
+-- { echoOn }
+
+SELECT * FROM test1 LEFT JOIN test2 ON test1.col1 = test2.col1
+WHERE test2.col1 IS NULL
+ORDER BY test2.col1
+;
+12321	-30	\N	\N
+SELECT * FROM test2 RIGHT JOIN test1 ON test2.col1 = test1.col1
+WHERE test2.col1 IS NULL
+ORDER BY test2.col1
+;
+\N	\N	12321	-30
+SELECT * FROM test1 LEFT JOIN test2 ON test1.col1 = test2.col1
+WHERE test2.col1 IS NOT NULL
+ORDER BY test2.col1
+;
+123	123	123	5600
+321	-32	321	5601
+SELECT * FROM test2 RIGHT JOIN test1 ON test2.col1 = test1.col1
+WHERE test2.col1 IS NOT NULL
+ORDER BY test2.col1
+;
+123	5600	123	123
+321	5601	321	-32
+SELECT test2.col1, test1.* FROM test2 RIGHT JOIN test1 ON test2.col1 = test1.col1
+WHERE test2.col1 IS NOT NULL
+ORDER BY test2.col1
+;
+123	123	123
+321	321	-32
+SELECT test2.col3, test1.* FROM test2 RIGHT JOIN test1 ON test2.col1 = test1.col1
+WHERE test2.col1 IS NOT NULL
+ORDER BY test2.col1
+;
+5600	123	123
+5601	321	-32
+DROP TABLE IF EXISTS test1;
+DROP TABLE IF EXISTS test2;

--- a/tests/queries/0_stateless/02534_join_prewhere_bug_44062.sql
+++ b/tests/queries/0_stateless/02534_join_prewhere_bug_44062.sql
@@ -1,6 +1,9 @@
 
-CREATE OR REPLACE TABLE test1 ( `col1` UInt64, `col2` Int8 ) ENGINE = MergeTree ORDER BY col1;
-CREATE OR REPLACE TABLE test2 ( `col1` UInt64, `col3` Int16 ) ENGINE = MergeTree ORDER BY col1;
+DROP TABLE IF EXISTS test1;
+DROP TABLE IF EXISTS test2;
+
+CREATE TABLE test1 ( `col1` UInt64, `col2` Int8 ) ENGINE = MergeTree ORDER BY col1;
+CREATE TABLE test2 ( `col1` UInt64, `col3` Int16 ) ENGINE = MergeTree ORDER BY col1;
 
 INSERT INTO test1 VALUES (123, 123), (12321, -30), (321, -32);
 INSERT INTO test2 VALUES (123, 5600), (321, 5601);

--- a/tests/queries/0_stateless/02534_join_prewhere_bug_44062.sql
+++ b/tests/queries/0_stateless/02534_join_prewhere_bug_44062.sql
@@ -1,0 +1,43 @@
+
+CREATE OR REPLACE TABLE test1 ( `col1` UInt64, `col2` Int8 ) ENGINE = MergeTree ORDER BY col1;
+CREATE OR REPLACE TABLE test2 ( `col1` UInt64, `col3` Int16 ) ENGINE = MergeTree ORDER BY col1;
+
+INSERT INTO test1 VALUES (123, 123), (12321, -30), (321, -32);
+INSERT INTO test2 VALUES (123, 5600), (321, 5601);
+
+SET join_use_nulls = 1;
+
+-- { echoOn }
+
+SELECT * FROM test1 LEFT JOIN test2 ON test1.col1 = test2.col1
+WHERE test2.col1 IS NULL
+ORDER BY test2.col1
+;
+
+SELECT * FROM test2 RIGHT JOIN test1 ON test2.col1 = test1.col1
+WHERE test2.col1 IS NULL
+ORDER BY test2.col1
+;
+
+SELECT * FROM test1 LEFT JOIN test2 ON test1.col1 = test2.col1
+WHERE test2.col1 IS NOT NULL
+ORDER BY test2.col1
+;
+
+SELECT * FROM test2 RIGHT JOIN test1 ON test2.col1 = test1.col1
+WHERE test2.col1 IS NOT NULL
+ORDER BY test2.col1
+;
+
+SELECT test2.col1, test1.* FROM test2 RIGHT JOIN test1 ON test2.col1 = test1.col1
+WHERE test2.col1 IS NOT NULL
+ORDER BY test2.col1
+;
+
+SELECT test2.col3, test1.* FROM test2 RIGHT JOIN test1 ON test2.col1 = test1.col1
+WHERE test2.col1 IS NOT NULL
+ORDER BY test2.col1
+;
+
+DROP TABLE IF EXISTS test1;
+DROP TABLE IF EXISTS test2;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Fixed some bugs in JOINS with WHERE by disabling "move to prewhere" optimization for it, close https://github.com/ClickHouse/ClickHouse/issues/44062
