### PR TITLE
Allow to convert float stored in string field to integer in `JSONExtract`

### DIFF
--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -807,6 +807,8 @@ public:
                 value = element.getBool();
                 break;
             case ElementType::INT64:
+                value = element.getInt64() != 0;
+                break;
             case ElementType::UINT64:
                 value = element.getUInt64() != 0;
                 break;

--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -704,7 +704,8 @@ public:
                     break;
                 }
                 return false;
-            case ElementType::STRING: {
+            case ElementType::STRING:
+            {
                 auto rb = ReadBufferFromMemory{element.getString()};
                 if constexpr (std::is_floating_point_v<NumberType>)
                 {
@@ -713,7 +714,16 @@ public:
                 }
                 else
                 {
-                    if (!tryReadIntText(value, rb) || !rb.eof())
+                    if (tryReadIntText(value, rb) && rb.eof())
+                        break;
+
+                    /// Try to parse float and convert it to integer.
+                    Float64 tmp_float;
+                    rb.position() = rb.buffer().begin();
+                    if (!tryReadFloatText(tmp_float, rb) || !rb.eof())
+                        return false;
+
+                    if (!accurate::convertNumeric<Float64, NumberType, false>(tmp_float, value))
                         return false;
                 }
                 break;

--- a/tests/queries/0_stateless/00918_json_functions.reference
+++ b/tests/queries/0_stateless/00918_json_functions.reference
@@ -25,6 +25,7 @@ Array
 300
 1
 0
+1
 --JSONExtractString--
 hello
 hello
@@ -177,6 +178,11 @@ Array
 300
 1
 0
+1
+-123456789012	Int64
+123456789012	UInt64
+0	UInt64
+0	Int8
 --JSONExtractString--
 hello
 hello

--- a/tests/queries/0_stateless/00918_json_functions.reference
+++ b/tests/queries/0_stateless/00918_json_functions.reference
@@ -102,6 +102,10 @@ hello
 0	UInt64
 false	Bool
 true	Bool
+-123456789012	Int64
+123456789012	UInt64
+0	UInt64
+0	Int8
 --JSONExtractKeysAndValues--
 [('a','hello'),('b','[-100,200,300]')]
 [('b',[-100,200,300])]

--- a/tests/queries/0_stateless/00918_json_functions.sql
+++ b/tests/queries/0_stateless/00918_json_functions.sql
@@ -114,6 +114,12 @@ SELECT JSONExtract('{"a":"1234567890123456789999"}', 'a', 'UInt64') as a, toType
 SELECT JSONExtract('{"a":0}', 'a', 'Bool') as a, toTypeName(a);
 SELECT JSONExtract('{"a":1}', 'a', 'Bool') as a, toTypeName(a);
 
+SELECT JSONExtract('{"a": "-123456789012.345"}', 'a', 'Int64') as a, toTypeName(a);
+SELECT JSONExtract('{"a": "123456789012.345"}', 'a', 'UInt64') as a, toTypeName(a);
+
+SELECT JSONExtract('{"a": "-2000.22"}', 'a', 'UInt64') as a, toTypeName(a);
+SELECT JSONExtract('{"a": "-2000.22"}', 'a', 'Int8') as a, toTypeName(a);
+
 SELECT '--JSONExtractKeysAndValues--';
 SELECT JSONExtractKeysAndValues('{"a": "hello", "b": [-100, 200.0, 300]}', 'String');
 SELECT JSONExtractKeysAndValues('{"a": "hello", "b": [-100, 200.0, 300]}', 'Array(Float64)');

--- a/tests/queries/0_stateless/00918_json_functions.sql
+++ b/tests/queries/0_stateless/00918_json_functions.sql
@@ -34,6 +34,7 @@ SELECT JSONExtractFloat('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', 2);
 SELECT JSONExtractUInt('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', -1);
 SELECT JSONExtractBool('{"passed": true}', 'passed');
 SELECT JSONExtractBool('"HX-=');
+SELECT JSONExtractBool('-1');
 
 SELECT '--JSONExtractString--';
 SELECT JSONExtractString('{"a": "hello", "b": [-100, 200.0, 300]}', 'a');
@@ -201,6 +202,13 @@ SELECT JSONExtractFloat('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', 2);
 SELECT JSONExtractUInt('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', -1);
 SELECT JSONExtractBool('{"passed": true}', 'passed');
 SELECT JSONExtractBool('"HX-=');
+SELECT JSONExtractBool('-1');
+
+SELECT JSONExtract('{"a": "-123456789012.345"}', 'a', 'Int64') as a, toTypeName(a);
+SELECT JSONExtract('{"a": "123456789012.345"}', 'a', 'UInt64') as a, toTypeName(a);
+
+SELECT JSONExtract('{"a": "-2000.22"}', 'a', 'UInt64') as a, toTypeName(a);
+SELECT JSONExtract('{"a": "-2000.22"}', 'a', 'Int8') as a, toTypeName(a);
 
 SELECT '--JSONExtractString--';
 SELECT JSONExtractString('{"a": "hello", "b": [-100, 200.0, 300]}', 'a');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to implicitly convert floats stored in string fields of JSON to integers in `JSONExtract` functions. E.g. `JSONExtract('{"a": "1000.111"}', 'a', 'UInt64')` -> `1000`, previously it returned 0.
