### PR TITLE
Fix Buffer's offsets mismatch logical error in stress test

### DIFF
--- a/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskWriteBufferFromFile.cpp
@@ -5,6 +5,7 @@
 #include <Common/logger_useful.h>
 #include <Interpreters/FilesystemCacheLog.h>
 #include <Interpreters/Context.h>
+#include <IO/SwapHelper.h>
 
 
 namespace ProfileEvents
@@ -20,21 +21,6 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
 }
-
-namespace
-{
-    class SwapHelper
-    {
-    public:
-        SwapHelper(WriteBuffer & b1_, WriteBuffer & b2_) : b1(b1_), b2(b2_) { b1.swap(b2); }
-        ~SwapHelper() { b1.swap(b2); }
-
-    private:
-        WriteBuffer & b1;
-        WriteBuffer & b2;
-    };
-}
-
 
 FileSegmentRangeWriter::FileSegmentRangeWriter(
     FileCache * cache_,

--- a/src/IO/BoundedReadBuffer.cpp
+++ b/src/IO/BoundedReadBuffer.cpp
@@ -42,7 +42,7 @@ bool BoundedReadBuffer::nextImpl()
         SwapHelper swap(*this, *impl);
         result = impl->next();
     }
-
+    chassert(file_offset_of_buffer_end + available() == impl->getFileOffsetOfBufferEnd());
     if (result && read_until_position)
     {
         size_t remaining_size_to_read = *read_until_position - file_offset_of_buffer_end;
@@ -58,7 +58,6 @@ bool BoundedReadBuffer::nextImpl()
         }
     }
     file_offset_of_buffer_end += available();
-    chassert(file_offset_of_buffer_end == impl->getFileOffsetOfBufferEnd());
     return result;
 }
 

--- a/src/IO/SwapHelper.h
+++ b/src/IO/SwapHelper.h
@@ -1,5 +1,4 @@
-#include <IO/WriteBuffer.h>
-#include <IO/ReadBuffer.h>
+#include <IO/BufferBase.h>
 
 namespace DB
 {

--- a/src/IO/SwapHelper.h
+++ b/src/IO/SwapHelper.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <IO/BufferBase.h>
 
 namespace DB

--- a/src/IO/SwapHelper.h
+++ b/src/IO/SwapHelper.h
@@ -1,0 +1,16 @@
+#include <IO/WriteBuffer.h>
+#include <IO/ReadBuffer.h>
+
+namespace DB
+{
+    class SwapHelper
+    {
+    public:
+        SwapHelper(BufferBase & b1_, BufferBase & b2_) : b1(b1_), b2(b2_) { b1.swap(b2); }
+        ~SwapHelper() { b1.swap(b2); }
+
+    private:
+        BufferBase & b1;
+        BufferBase & b2;
+    };
+}

--- a/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
+++ b/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
@@ -1,5 +1,6 @@
 #include <Interpreters/Cache/WriteBufferToFileSegment.h>
 #include <Interpreters/Cache/FileSegment.h>
+#include <IO/SwapHelper.h>
 
 #include <Common/logger_useful.h>
 
@@ -10,20 +11,6 @@ namespace ErrorCodes
 {
     extern const int NOT_ENOUGH_SPACE;
     extern const int LOGICAL_ERROR;
-}
-
-namespace
-{
-    class SwapHelper
-    {
-    public:
-        SwapHelper(WriteBuffer & b1_, WriteBuffer & b2_) : b1(b1_), b2(b2_) { b1.swap(b2); }
-        ~SwapHelper() { b1.swap(b2); }
-
-    private:
-        WriteBuffer & b1;
-        WriteBuffer & b2;
-    };
 }
 
 WriteBufferToFileSegment::WriteBufferToFileSegment(FileSegment * file_segment_)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


I mark this PR as not-for-changelog, because this error is related to cache over some local disk, which was implemented for testing and is not likely to be used anywhere.

Closes https://github.com/ClickHouse/ClickHouse/issues/45408. 