### PR TITLE
Add last_exception_time to replication_queue

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeMutateTaskBase.cpp
@@ -91,6 +91,7 @@ bool ReplicatedMergeMutateTaskBase::executeStep()
         auto & log_entry = selected_entry->log_entry;
 
         log_entry->exception = saved_exception;
+        log_entry->last_exception_time = time(nullptr);
 
         if (log_entry->type == ReplicatedMergeTreeLogEntryData::MUTATE_PART)
         {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeLogEntry.h
@@ -157,6 +157,7 @@ struct ReplicatedMergeTreeLogEntryData
     /// Access under queue_mutex, see ReplicatedMergeTreeQueue.
     size_t num_tries = 0;                 /// The number of attempts to perform the action (since the server started, including the running one).
     std::exception_ptr exception;         /// The last exception, in the case of an unsuccessful attempt to perform the action.
+    time_t last_exception_time = 0;       /// The time at which the last exception occurred.
     time_t last_attempt_time = 0;         /// The time at which the last attempt was attempted to complete the action.
     size_t num_postponed = 0;             /// The number of times the action was postponed.
     String postpone_reason;               /// The reason why the action was postponed, if it was postponed.

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1691,6 +1691,7 @@ bool ReplicatedMergeTreeQueue::processEntry(
     {
         std::lock_guard lock(state_mutex);
         entry->exception = saved_exception;
+        entry->last_exception_time = time(nullptr);
         return false;
     }
 

--- a/src/Storages/System/StorageSystemReplicationQueue.cpp
+++ b/src/Storages/System/StorageSystemReplicationQueue.cpp
@@ -38,6 +38,7 @@ NamesAndTypesList StorageSystemReplicationQueue::getNamesAndTypes()
         { "is_currently_executing",  std::make_shared<DataTypeUInt8>() },
         { "num_tries",               std::make_shared<DataTypeUInt32>() },
         { "last_exception",          std::make_shared<DataTypeString>() },
+        { "last_exception_time",     std::make_shared<DataTypeDateTime>() },
         { "last_attempt_time",       std::make_shared<DataTypeDateTime>() },
         { "num_postponed",           std::make_shared<DataTypeUInt32>() },
         { "postpone_reason",         std::make_shared<DataTypeString>() },
@@ -141,7 +142,8 @@ void StorageSystemReplicationQueue::fillData(MutableColumns & res_columns, Conte
             res_columns[col_num++]->insert(entry.detach);
             res_columns[col_num++]->insert(entry.currently_executing);
             res_columns[col_num++]->insert(entry.num_tries);
-            res_columns[col_num++]->insert(entry.exception ? getExceptionMessage(entry.exception, false) : "");
+            res_columns[col_num++]->insert(entry.exception ? getExceptionMessage(entry.exception, true) : "");
+            res_columns[col_num++]->insert(UInt64(entry.last_exception_time));
             res_columns[col_num++]->insert(UInt64(entry.last_attempt_time));
             res_columns[col_num++]->insert(entry.num_postponed);
             res_columns[col_num++]->insert(entry.postpone_reason);

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -920,6 +920,7 @@ CREATE TABLE system.replication_queue
     `is_currently_executing` UInt8,
     `num_tries` UInt32,
     `last_exception` String,
+    `last_exception_time` DateTime,
     `last_attempt_time` DateTime,
     `num_postponed` UInt32,
     `postpone_reason` String,


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a new column `last_exception_time` to system.replication_queue

Two changes are contained in this PR:
1. a new column `last_exception_time` is added to replication_queue to reflect the time when the last exception is raised
2.the full stack trace of the last exception is saved instead of the exception message

These changes save us a lot of time to search the text log to find out when and what the exact exception occurs.
