### PR TITLE
Fix possible aborts in arrow lib

### DIFF
--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
@@ -11,6 +11,7 @@
 #include <IO/copyData.h>
 #include <IO/PeekableReadBuffer.h>
 #include <arrow/buffer.h>
+#include <arrow/util/future.h>
 #include <arrow/io/memory.h>
 #include <arrow/result.h>
 #include <Core/Settings.h>
@@ -93,6 +94,12 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> RandomAccessFileFromSeekableReadBu
         RETURN_NOT_OK(buffer->Resize(bytes_read));
 
     return buffer;
+}
+
+arrow::Future<std::shared_ptr<arrow::Buffer>> RandomAccessFileFromSeekableReadBuffer::ReadAsync(const arrow::io::IOContext &, int64_t position, int64_t nbytes)
+{
+    /// Just a stub to to avoid using internal arrow thread pool
+    return arrow::Future<std::shared_ptr<arrow::Buffer>>::MakeFinished(ReadAt(position, nbytes));
 }
 
 arrow::Status RandomAccessFileFromSeekableReadBuffer::Seek(int64_t position)

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.h
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.h
@@ -62,6 +62,9 @@ public:
 
     arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override;
 
+    /// Override async reading to not use internal arrow thread pool.
+    arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext&, int64_t position, int64_t nbytes) override;
+
     arrow::Status Seek(int64_t position) override;
 
 private:

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.h
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.h
@@ -63,6 +63,8 @@ public:
     arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override;
 
     /// Override async reading to avoid using internal arrow thread pool.
+    /// In our code we don't use async reading, so implementation is sync,
+    /// we just call ReadAt and return future with rady value.
     arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext&, int64_t position, int64_t nbytes) override;
 
     arrow::Status Seek(int64_t position) override;

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.h
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.h
@@ -62,7 +62,7 @@ public:
 
     arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override;
 
-    /// Override async reading to not use internal arrow thread pool.
+    /// Override async reading to avoid using internal arrow thread pool.
     arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext&, int64_t position, int64_t nbytes) override;
 
     arrow::Status Seek(int64_t position) override;

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.h
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.h
@@ -64,7 +64,7 @@ public:
 
     /// Override async reading to avoid using internal arrow thread pool.
     /// In our code we don't use async reading, so implementation is sync,
-    /// we just call ReadAt and return future with rady value.
+    /// we just call ReadAt and return future with ready value.
     arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext&, int64_t position, int64_t nbytes) override;
 
     arrow::Status Seek(int64_t position) override;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Don't use internal arrow thread pool, update contrib to include changes from https://github.com/ClickHouse/arrow/pull/16
Closes https://github.com/ClickHouse/ClickHouse/issues/44912