### PR TITLE
Fix possible deadlock with allow_asynchronous_read_from_io_pool_for_merge_tree in case of exception from ThreadPool::schedule

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSource.cpp
@@ -104,7 +104,16 @@ struct MergeTreeSource::AsyncReadingState
 
     void schedule(ThreadPool::Job job)
     {
-        callback_runner(std::move(job), 0);
+        try
+        {
+            callback_runner(std::move(job), 0);
+        }
+        catch (...)
+        {
+            /// Roll back stage in case of exception from ThreadPool::schedule
+            control->stage = Stage::NotStarted;
+            throw;
+        }
     }
 
     ChunkAndProgress getResult()


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible deadlock with `allow_asynchronous_read_from_io_pool_for_merge_tree` enabled in case of exception from `ThreadPool::schedule`.

Possible trace:
```
0. DB::Exception::Exception(DB::Exception::MessageMasked const&, int, bool) @ 0xe76755a in /usr/bin/clickhouse
1. ? @ 0xe826042 in /usr/bin/clickhouse (addr2line : GlobalThreadPool::instance())
2. ? @ 0xe826a1e in /usr/bin/clickhouse (addr2line : GlobalThreadPool::instance())
3. ? @ 0xe8226ae in /usr/bin/clickhouse (addr2line : ThreadPoolImpl<ThreadFromGlobalPoolImpl<false> >::scheduleOrThrowOnError(std::__1::function<void ()>, long))
4. ? @ 0x1339a6a5 in /usr/bin/clickhouse (addr2line : std::__1::future<void> std::__1::__function::__policy_invoker<std::__1::future<void> (std::__1::function<void ()>&&, unsigned long)>::__call_impl<std::__1::__function::__default_alloc_func<DB::threadPoolCallbackRunner<void>(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::{lambda(std::__1::function<void ()>&&, unsigned long)#1}, std::__1::future<void> (std::__1::function<void ()>&&, unsigned long)> >(std::__1::__function::__policy_storage const*, std::__1::function<void ()>&&, unsigned long))
5. std::__1::future<void> std::__1::__function::__policy_invoker<std::__1::future<void> (std::__1::function<void ()>&&, unsigned long)>::__call_impl<std::__1::__function::__default_alloc_func<std::__1::function<std::__1::future<void> (std::__1::function<void ()>&&, unsigned long)> DB::threadPoolCallbackRunner<void>(ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)::'lambda'(std::__1::function<void ()>&&, unsigned long), std::__1::future<void> (std::__1::function<void ()>&&, unsigned long)>>(std::__1::__function::__policy_storage const*, std::__1::function<void ()>&&, unsigned long) @ 0x1339a40c in /usr/bin/clickhouse
6. DB::MergeTreeSource::tryGenerate() @ 0x157fccc0 in /usr/bin/clickhouse
7. DB::ISource::work() @ 0x1544eb26 in /usr/bin/clickhouse
8. DB::ExecutionThreadContext::executeTask() @ 0x15469b86 in /usr/bin/clickhouse
9. DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*) @ 0x1545ed7c in /usr/bin/clickhouse
10. ? @ 0x15460e9d in /usr/bin/clickhouse
11. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0xe820f76 in /usr/bin/clickhouse
12. ? @ 0xe826141 in /usr/bin/clickhouse
13. ? @ 0x7f8b585f0609 in ?
14. clone @ 0x7f8b58515133 in ?

```