### PR TITLE
Gorilla: prefer std::functionality over own implementation

### DIFF
--- a/src/Common/BitHelpers.h
+++ b/src/Common/BitHelpers.h
@@ -51,6 +51,7 @@ inline uint32_t getLeadingZeroBitsUnsafe(T x)
 }
 
 
+/// You might as well use std::countl_zero() over this method
 template <typename T>
 inline size_t getLeadingZeroBits(T x)
 {
@@ -68,35 +69,6 @@ template <typename T>
 inline uint32_t bitScanReverse(T x)
 {
     return (std::max<size_t>(sizeof(T), sizeof(unsigned int))) * 8 - 1 - getLeadingZeroBitsUnsafe(x);
-}
-
-// Unsafe since __builtin_ctz()-family explicitly state that result is undefined on x == 0
-template <typename T>
-inline size_t getTrailingZeroBitsUnsafe(T x)
-{
-    assert(x != 0);
-
-    if constexpr (sizeof(T) <= sizeof(unsigned int))
-    {
-        return __builtin_ctz(x);
-    }
-    else if constexpr (sizeof(T) <= sizeof(unsigned long int)) /// NOLINT
-    {
-        return __builtin_ctzl(x);
-    }
-    else
-    {
-        return __builtin_ctzll(x);
-    }
-}
-
-template <typename T>
-inline size_t getTrailingZeroBits(T x)
-{
-    if (!x)
-        return sizeof(x) * 8;
-
-    return getTrailingZeroBitsUnsafe(x);
 }
 
 /** Returns a mask that has '1' for `bits` LSB set:

--- a/src/Compression/CompressionCodecGorilla.cpp
+++ b/src/Compression/CompressionCodecGorilla.cpp
@@ -11,6 +11,7 @@
 #include <IO/ReadBufferFromMemory.h>
 #include <IO/BitHelpers.h>
 
+#include <bit>
 #include <cstring>
 #include <algorithm>
 #include <type_traits>
@@ -186,8 +187,8 @@ BinaryValueInfo getLeadingAndTrailingBits(const T & value)
 {
     constexpr UInt8 bit_size = sizeof(T) * 8;
 
-    const UInt8 lz = getLeadingZeroBits(value);
-    const UInt8 tz = getTrailingZeroBits(value);
+    const UInt8 lz = std::countl_zero(value);
+    const UInt8 tz = std::countr_zero(value);
     const UInt8 data_size = value == 0 ? 0 : static_cast<UInt8>(bit_size - lz - tz);
 
     return BinaryValueInfo{lz, data_size, tz};


### PR DESCRIPTION
Just a little cleanup, noticed while reading the code.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)