### PR TITLE
Fix abort in destructor of `ParallelParsingInputFormat`

### DIFF
--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
@@ -161,6 +161,12 @@ Chunk ParallelParsingInputFormat::generate()
     /// Delayed launching of segmentator thread
     if (unlikely(!parsing_started.exchange(true)))
     {
+        /// Lock 'finish_and_wait_mutex' to avoid recreation of
+        /// 'segmentator_thread' after it was joined.
+        std::lock_guard finish_and_wait_lock(finish_and_wait_mutex);
+        if (finish_and_wait_called)
+            return {};
+
         segmentator_thread = ThreadFromGlobalPool(
             &ParallelParsingInputFormat::segmentatorThreadFunction, this, CurrentThread::getGroup());
     }

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1743,7 +1743,7 @@ def test_s3_list_objects_failure(started_cluster):
 
         get_query = """
             SELECT sleep({seconds}) FROM s3('http://resolver:8083/{bucket}/test_no_list_*', 'CSV', 'c1 UInt32')
-            SETTINGS s3_list_object_keys_size = 1, max_threads = {max_threads}, enable_s3_requests_logging = 1, input_format_parallel_parsing = 0
+            SETTINGS s3_list_object_keys_size = 1, max_threads = {max_threads}, enable_s3_requests_logging = 1
             """.format(
             bucket=bucket, seconds=random.random(), max_threads=random.randint(2, 20)
         )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix rare abort in case when query is canceled and parallel parsing was used during its execution.

Fixes #42009.
