### PR TITLE
Add fields to table `system.formats`

### DIFF
--- a/src/Storages/System/StorageSystemFormats.cpp
+++ b/src/Storages/System/StorageSystemFormats.cpp
@@ -12,6 +12,8 @@ NamesAndTypesList StorageSystemFormats::getNamesAndTypes()
         {"name", std::make_shared<DataTypeString>()},
         {"is_input", std::make_shared<DataTypeUInt8>()},
         {"is_output", std::make_shared<DataTypeUInt8>()},
+        {"supports_parallel_parsing", std::make_shared<DataTypeUInt8>()},
+        {"supports_parallel_formatting", std::make_shared<DataTypeUInt8>()},
     };
 }
 
@@ -23,9 +25,14 @@ void StorageSystemFormats::fillData(MutableColumns & res_columns, ContextPtr, co
         const auto & [format_name, creators] = pair;
         UInt64 has_input_format(creators.input_creator != nullptr);
         UInt64 has_output_format(creators.output_creator != nullptr);
+        UInt64 supports_parallel_parsing(creators.file_segmentation_engine != nullptr);
+        UInt64 supports_parallel_formatting(creators.supports_parallel_formatting);
+
         res_columns[0]->insert(format_name);
         res_columns[1]->insert(has_input_format);
         res_columns[2]->insert(has_output_format);
+        res_columns[3]->insert(supports_parallel_parsing);
+        res_columns[4]->insert(supports_parallel_formatting);
     }
 }
 

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -266,7 +266,9 @@ CREATE TABLE system.formats
 (
     `name` String,
     `is_input` UInt8,
-    `is_output` UInt8
+    `is_output` UInt8,
+    `supports_parallel_parsing` UInt8,
+    `supports_parallel_formatting` UInt8
 )
 ENGINE = SystemFormats
 COMMENT 'SYSTEM TABLE is built on the fly.'

--- a/tests/queries/0_stateless/02537_system_formats.reference
+++ b/tests/queries/0_stateless/02537_system_formats.reference
@@ -1,0 +1,2 @@
+CSV	1	1	1	1
+Parquet	1	1	0	0

--- a/tests/queries/0_stateless/02537_system_formats.reference
+++ b/tests/queries/0_stateless/02537_system_formats.reference
@@ -1,2 +1,2 @@
 CSV	1	1	1	1
-Parquet	1	1	0	0
+Native	1	1	0	0

--- a/tests/queries/0_stateless/02537_system_formats.sql
+++ b/tests/queries/0_stateless/02537_system_formats.sql
@@ -1,0 +1,1 @@
+SELECT * FROM system.formats WHERE name IN ('CSV', 'Parquet') ORDER BY name;

--- a/tests/queries/0_stateless/02537_system_formats.sql
+++ b/tests/queries/0_stateless/02537_system_formats.sql
@@ -1,1 +1,1 @@
-SELECT * FROM system.formats WHERE name IN ('CSV', 'Parquet') ORDER BY name;
+SELECT * FROM system.formats WHERE name IN ('CSV', 'Native') ORDER BY name;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added fields `supports_parallel_parsing` and `supports_parallel_formatting` to table `system.formats` for better introspection.