### PR TITLE
Provide more clear syntax for `fromUnixTimestamp64*` and `toUnixTimestamp64*` functions

### DIFF
--- a/docs/en/sql-reference/functions/type-conversion-functions.md
+++ b/docs/en/sql-reference/functions/type-conversion-functions.md
@@ -1402,6 +1402,8 @@ The output value is a timestamp in UTC, not in the timezone of `DateTime64`.
 
 ```sql
 toUnixTimestamp64Milli(value)
+toUnixTimestamp64Micro(value)
+toUnixTimestamp64Nano(value)
 ```
 
 **Arguments**
@@ -1455,7 +1457,9 @@ Converts an `Int64` to a `DateTime64` value with fixed sub-second precision and 
 **Syntax**
 
 ``` sql
-fromUnixTimestamp64Milli(value [, ti])
+fromUnixTimestamp64Milli(value [, timezone])
+fromUnixTimestamp64Micro(value [, timezone])
+fromUnixTimestamp64Nano(value [, timezone])
 ```
 
 **Arguments**


### PR DESCRIPTION
Better way to make docs clearer instead of https://github.com/ClickHouse/ClickHouse/pull/45374

### Changelog category (leave one):
- Documentation (changelog entry is not required)
