### PR TITLE
Improve logging for TeePopen.timeout exceeded

### DIFF
--- a/tests/ci/tee_popen.py
+++ b/tests/ci/tee_popen.py
@@ -29,11 +29,13 @@ class TeePopen:
         self.env = env or os.environ.copy()
         self._process = None  # type: Optional[Popen]
         self.timeout = timeout
+        self.timeout_exceeded = False
 
     def _check_timeout(self) -> None:
         if self.timeout is None:
             return
         sleep(self.timeout)
+        self.timeout_exceeded = True
         while self.process.poll() is None:
             logging.warning(
                 "Killing process %s, timeout %s exceeded",
@@ -62,6 +64,16 @@ class TeePopen:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.wait()
+        if self.timeout_exceeded:
+            exceeded_log = (
+                f"Command `{self.command}` has failed, "
+                f"timeout {self.timeout}s is exceeded"
+            )
+            if self.process.stdout is not None:
+                sys.stdout.write(exceeded_log)
+
+            self.log_file.write(exceeded_log)
+
         self.log_file.close()
 
     def wait(self) -> int:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix #44710 by adding a log about an exceeded timeout for TeePopen.