### PR TITLE
Typo: "Granulesis" --> "Granules"

### DIFF
--- a/docs/en/sql-reference/statements/explain.md
+++ b/docs/en/sql-reference/statements/explain.md
@@ -283,7 +283,7 @@ With `indexes` = 1, the `Indexes` key is added. It contains an array of used ind
 -   `Initial Parts` — A number of parts before the index is applied.
 -   `Selected Parts` — A number of parts after the index is applied.
 -   `Initial Granules` — A number of granules before the index is applied.
--   `Selected Granulesis` — A number of granules after the index is applied.
+-   `Selected Granules` — A number of granules after the index is applied.
 
 Example:
 

--- a/docs/ru/sql-reference/statements/explain.md
+++ b/docs/ru/sql-reference/statements/explain.md
@@ -251,7 +251,7 @@ EXPLAIN json = 1, description = 0, header = 1 SELECT 1, 2 + dummy;
 -   `Initial Parts` — количество кусков до применения индекса.
 -   `Selected Parts` — количество кусков после применения индекса.
 -   `Initial Granules` — количество гранул до применения индекса.
--   `Selected Granulesis` — количество гранул после применения индекса.
+-   `Selected Granules` — количество гранул после применения индекса.
 
 Пример:
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)