### PR TITLE
fix race of async-insert-blockids-cache

### DIFF
--- a/src/Storages/MergeTree/AsyncBlockIDsCache.cpp
+++ b/src/Storages/MergeTree/AsyncBlockIDsCache.cpp
@@ -31,10 +31,11 @@ std::vector<String> AsyncBlockIDsCache::getChildren()
 {
     auto zookeeper = storage.getZooKeeper();
 
-    auto watch_callback = [&](const Coordination::WatchResponse &)
+    auto watch_callback = [last_time = this->last_updatetime.load()
+                           , update_min_interval = this->update_min_interval
+                           , task = task->shared_from_this()](const Coordination::WatchResponse &)
     {
         auto now = std::chrono::steady_clock::now();
-        auto last_time = last_updatetime.load();
         if (now - last_time < update_min_interval)
         {
             std::chrono::milliseconds sleep_time = std::chrono::duration_cast<std::chrono::milliseconds>(update_min_interval - (now - last_time));


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
when the callback in the cache is called, it is possible that this cache is destructed. To keep it safe, we capture members by value. It's also safe for task schedule because it will be deactivated before storage is destroyed. Resolve #45548 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
