### PR TITLE
Rename setting `max_query_cache_size`

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -623,7 +623,7 @@ static constexpr UInt64 operator""_GiB(unsigned long long value)
     M(Bool, read_from_filesystem_cache_if_exists_otherwise_bypass_cache, false, "Allow to use the filesystem cache in passive mode - benefit from the existing cache entries, but don't put more entries into the cache. If you set this setting for heavy ad-hoc queries and leave it disabled for short real-time queries, this will allows to avoid cache threshing by too heavy queries and to improve the overall system efficiency.", 0) \
     M(Bool, enable_filesystem_cache_on_lower_level, true, "If read buffer supports caching inside threadpool, allow it to do it, otherwise cache outside ot threadpool. Do not use this setting, it is needed for testing", 0) \
     M(Bool, skip_download_if_exceeds_query_cache, true, "Skip download from remote filesystem if exceeds query cache size", 0) \
-    M(UInt64, max_query_cache_size, (128UL * 1024 * 1024 * 1024), "Max remote filesystem cache size that can be used by a single query", 0) \
+    M(UInt64, filesystem_cache_max_download_size, (128UL * 1024 * 1024 * 1024), "Max remote filesystem cache size that can be downloaded by a single query", 0) \
     M(Bool, throw_on_error_from_cache_on_write_operations, false, "Ignore error from cache when caching on write operations (INSERT, merges)", 0) \
     \
     M(Bool, load_marks_asynchronously, false, "Load MergeTree marks asynchronously", 0) \

--- a/src/IO/ReadSettings.h
+++ b/src/IO/ReadSettings.h
@@ -90,7 +90,7 @@ struct ReadSettings
     /// they will do it. But this behaviour can be changed with this setting.
     bool enable_filesystem_cache_on_lower_level = true;
 
-    size_t max_query_cache_size = (128UL * 1024 * 1024 * 1024);
+    size_t filesystem_cache_max_download_size = (128UL * 1024 * 1024 * 1024);
     bool skip_download_if_exceeds_query_cache = true;
 
     size_t remote_read_min_bytes_for_seek = DBMS_DEFAULT_BUFFER_SIZE;

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -1399,7 +1399,7 @@ FileCache::QueryContextPtr FileCache::getOrSetQueryContext(
     if (context)
         return context;
 
-    auto query_context = std::make_shared<QueryContext>(settings.max_query_cache_size, settings.skip_download_if_exceeds_query_cache);
+    auto query_context = std::make_shared<QueryContext>(settings.filesystem_cache_max_download_size, settings.skip_download_if_exceeds_query_cache);
     auto query_iter = query_map.emplace(query_id, query_context).first;
     return query_iter->second;
 }
@@ -1408,10 +1408,10 @@ FileCache::QueryContextHolder FileCache::getQueryContextHolder(const String & qu
 {
     std::lock_guard cache_lock(mutex);
 
-    if (!enable_filesystem_query_cache_limit || settings.max_query_cache_size == 0)
+    if (!enable_filesystem_query_cache_limit || settings.filesystem_cache_max_download_size == 0)
         return {};
 
-    /// if enable_filesystem_query_cache_limit is true, and max_query_cache_size large than zero,
+    /// if enable_filesystem_query_cache_limit is true, and filesystem_cache_max_download_size large than zero,
     /// we create context query for current query.
     auto context = getOrSetQueryContext(query_id, settings, cache_lock);
     return QueryContextHolder(query_id, this, context);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3813,7 +3813,7 @@ ReadSettings Context::getReadSettings() const
     res.enable_filesystem_cache_log = settings.enable_filesystem_cache_log;
     res.enable_filesystem_cache_on_lower_level = settings.enable_filesystem_cache_on_lower_level;
 
-    res.max_query_cache_size = settings.max_query_cache_size;
+    res.filesystem_cache_max_download_size = settings.filesystem_cache_max_download_size;
     res.skip_download_if_exceeds_query_cache = settings.skip_download_if_exceeds_query_cache;
 
     res.remote_read_min_bytes_for_seek = settings.remote_read_min_bytes_for_seek;

--- a/tests/queries/0_stateless/02240_filesystem_query_cache.reference
+++ b/tests/queries/0_stateless/02240_filesystem_query_cache.reference
@@ -3,7 +3,7 @@
 SYSTEM DROP FILESYSTEM CACHE;
 SET enable_filesystem_cache_on_write_operations=0;
 SET skip_download_if_exceeds_query_cache=1;
-SET max_query_cache_size=128;
+SET filesystem_cache_max_download_size=128;
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache_4', min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false;
 INSERT INTO test SELECT number, toString(number) FROM numbers(100);

--- a/tests/queries/0_stateless/02240_filesystem_query_cache.sql
+++ b/tests/queries/0_stateless/02240_filesystem_query_cache.sql
@@ -5,7 +5,7 @@
 SYSTEM DROP FILESYSTEM CACHE;
 SET enable_filesystem_cache_on_write_operations=0;
 SET skip_download_if_exceeds_query_cache=1;
-SET max_query_cache_size=128;
+SET filesystem_cache_max_download_size=128;
 
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (key UInt32, value String) Engine=MergeTree() ORDER BY key SETTINGS storage_policy='s3_cache_4', min_bytes_for_wide_part = 10485760, compress_marks=false, compress_primary_key=false;


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Rename setting `max_query_cache_size` to `filesystem_cache_max_download_size`.