### PR TITLE
Correctly check types when using N-gram bloom filter index

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexFullText.cpp
@@ -468,6 +468,10 @@ bool MergeTreeConditionFullText::traverseTreeEquals(
                 {
                     key_column_num = map_keys_key_column_num;
                     key_exists = true;
+
+                    auto const_data_type = WhichDataType(const_type);
+                    if (!const_data_type.isStringOrFixedString() && !const_data_type.isArray())
+                        return false;
                 }
                 else
                 {

--- a/tests/queries/0_stateless/02538_ngram_bf_index_with_null.sql
+++ b/tests/queries/0_stateless/02538_ngram_bf_index_with_null.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS 02538_bf_ngrambf_map_values_test;
+
+CREATE TABLE 02538_bf_ngrambf_map_values_test (`row_id` Int128, `map` Map(String, String), `map_fixed` Map(FixedString(2), String),
+INDEX map_values_ngrambf mapKeys(map) TYPE ngrambf_v1(4, 256, 2, 0) GRANULARITY 1,
+INDEX map_fixed_values_ngrambf mapKeys(map_fixed) TYPE ngrambf_v1(4, 256, 2, 0) GRANULARITY 1)
+ENGINE = MergeTree
+ORDER BY row_id
+SETTINGS index_granularity = 1;
+
+INSERT INTO 02538_bf_ngrambf_map_values_test VALUES (1, {'a': 'a'}, {'b': 'b'});
+
+SELECT * FROM 02538_bf_ngrambf_map_values_test PREWHERE (map['']) = 'V2V\0V2V2V2V2V2V2' WHERE (map[NULL]) = 'V2V\0V2V2V2V2V2V2V2V\0V2V2V2V2V2V2V2V\0V2V2V2V2V2V2V2V\0V2V2V2V2V2V2' SETTINGS force_data_skipping_indices = 'map_values_ngrambf';
+
+DROP TABLE 02538_bf_ngrambf_map_values_test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Correctly check types when using N-gram bloom filter index to avoid invalid reads.


Caught by fuzzer https://s3.amazonaws.com/clickhouse-test-reports/0/8926af91f3a06fe4638e57a0cc1d5fda6d55a065/fuzzer_astfuzzerubsan/report.html

Closes #45509.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
