### PR TITLE
Fix performance of short queries with `Array` columns

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -471,6 +471,7 @@ void IMergeTreeDataPart::setColumns(const NamesAndTypesList & new_columns, const
     }
 
     columns_description = ColumnsDescription(columns);
+    columns_description_with_collected_nested = ColumnsDescription(Nested::collect(columns));
 }
 
 NameAndTypePair IMergeTreeDataPart::getColumn(const String & column_name) const

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -148,6 +148,7 @@ public:
 
     const NamesAndTypesList & getColumns() const { return columns; }
     const ColumnsDescription & getColumnsDescription() const { return columns_description; }
+    const ColumnsDescription & getColumnsDescriptionWithCollectedNested() const { return columns_description_with_collected_nested; }
 
     NameAndTypePair getColumn(const String & name) const;
     std::optional<NameAndTypePair> tryGetColumn(const String & column_name) const;
@@ -530,6 +531,10 @@ private:
     /// Columns description for more convenient access
     /// to columns by name and getting subcolumns.
     ColumnsDescription columns_description;
+
+    /// The same as above but after call of Nested::collect().
+    /// It is used while reading from wide parts.
+    ColumnsDescription columns_description_with_collected_nested;
 
     /// Reads part unique identifier (if exists) from uuid.txt
     void loadUUID();

--- a/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Interpreters/Context.h>
 #include <Storages/MergeTree/AlterConversions.h>
+#include <Storages/ColumnsDescription.h>
 #include <Core/NamesAndTypes.h>
 
 namespace DB
@@ -40,6 +41,10 @@ public:
     virtual DataPartStoragePtr getDataPartStorage() const = 0;
 
     virtual const NamesAndTypesList & getColumns() const = 0;
+
+    virtual const ColumnsDescription & getColumnsDescription() const = 0;
+
+    virtual const ColumnsDescription & getColumnsDescriptionWithCollectedNested() const = 0;
 
     virtual std::optional<size_t> getColumnPosition(const String & column_name) const = 0;
 

--- a/src/Storages/MergeTree/IMergeTreeReader.cpp
+++ b/src/Storages/MergeTree/IMergeTreeReader.cpp
@@ -41,8 +41,12 @@ IMergeTreeReader::IMergeTreeReader(
     , alter_conversions(data_part_info_for_read->getAlterConversions())
     /// For wide parts convert plain arrays of Nested to subcolumns
     /// to allow to use shared offset column from cache.
-    , requested_columns(data_part_info_for_read->isWidePart() ? Nested::convertToSubcolumns(columns_) : columns_)
-    , part_columns(data_part_info_for_read->isWidePart() ? Nested::collect(data_part_info_for_read->getColumns()) : data_part_info_for_read->getColumns())
+    , requested_columns(data_part_info_for_read->isWidePart()
+        ? Nested::convertToSubcolumns(columns_)
+        : columns_)
+    , part_columns(data_part_info_for_read->isWidePart()
+        ? data_part_info_for_read->getColumnsDescriptionWithCollectedNested()
+        : data_part_info_for_read->getColumnsDescription())
 {
     columns_to_read.reserve(requested_columns.size());
     serializations.reserve(requested_columns.size());

--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -104,7 +104,7 @@ private:
     NamesAndTypesList requested_columns;
 
     /// Actual columns description in part.
-    ColumnsDescription part_columns;
+    const ColumnsDescription & part_columns;
 };
 
 }

--- a/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
@@ -27,6 +27,10 @@ public:
 
     const NamesAndTypesList & getColumns() const override { return data_part->getColumns(); }
 
+    const ColumnsDescription & getColumnsDescription() const override { return data_part->getColumnsDescription(); }
+
+    const ColumnsDescription & getColumnsDescriptionWithCollectedNested() const override { return data_part->getColumnsDescriptionWithCollectedNested(); }
+
     std::optional<size_t> getColumnPosition(const String & column_name) const override { return data_part->getColumnPosition(column_name); }
 
     AlterConversions getAlterConversions() const override { return data_part->storage.getAlterConversionsForPart(data_part); }


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed performance of short `SELECT` queries that read from tables with large number of`Array`/`Map`/`Nested` columns.

Fixes #44500.
