### PR TITLE
Trim refs/tags/ from GITHUB_TAG in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ jobs:
     steps:
     - name: Deploy packages and assets
       run: |
-        curl '${{ secrets.PACKAGES_RELEASE_URL }}/release/${{ github.ref }}?binary=binary_darwin&binary=binary_darwin_aarch64&sync=true' -d ''
+        GITHUB_TAG="${GITHUB_REF#refs/tags/}"
+        curl '${{ secrets.PACKAGES_RELEASE_URL }}/release/'"${GITHUB_TAG}"'?binary=binary_darwin&binary=binary_darwin_aarch64&sync=true' -d ''
   ############################################################################################
   ##################################### Docker images  #######################################
   ############################################################################################


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix issues like in https://github.com/ClickHouse/ClickHouse/actions/runs/4010659215/jobs/6887411997#step:3:2