### PR TITLE
Untangle configuration of query result cache

### DIFF
--- a/docs/en/operations/query-result-cache.md
+++ b/docs/en/operations/query-result-cache.md
@@ -54,19 +54,20 @@ SETTINGS use_query_result_cache = true;
 will store the query result in the query result cache. Subsequent executions of the same query (also with parameter `use_query_result_cache
 = true`) will read the computed result from the cache and return it immediately.
 
-The way the cache is utilized can be configured in more detail using settings [use_query_result_cache_active_usage](settings/settings.md#use_query_result_cache_active_usage) and
-[use_query_result_cache_passive_usage](settings/settings.md#use_query_result_cache_active_usage) (both `true` by default). Active usage
-means that query results are stored in the cache, whereas passive usage means that the database should try to retrieve query results from
-the cache. For example, the following query will use the cache only passively, i.e. attempt to read from it but not store its result in it:
+The way the cache is utilized can be configured in more detail using settings [enable_writes_to_query_result_cache](settings/settings.md#enable-writes-to-query-result-cache)
+and [enable_reads_from_query_result_cache](settings/settings.md#enable-reads-from-query-result-cache) (both `true` by default). The first
+settings controls whether query results are stored in the cache, whereas the second parameter determines if the database should try to
+retrieve query results from the cache. For example, the following query will use the cache only passively, i.e. attempt to read from it but
+not store its result in it:
 
 ```sql
 SELECT some_expensive_calculation(column_1, column_2)
 FROM table
-SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false;
+SETTINGS use_query_result_cache = true, enable_writes_to_query_result_cache = false;
 ```
 
-For maximum control, it is generally recommended to provide settings "use_query_result_cache", "use_query_result_cache_active_usage" and
-"use_query_result_cache_passive_usage" only with specific queries. It is also possible to enable caching at user or profile level (e.g. via
+For maximum control, it is generally recommended to provide settings "use_query_result_cache", "enable_writes_to_query_result_cache" and
+"enable_reads_from_query_result_cache" only with specific queries. It is also possible to enable caching at user or profile level (e.g. via
 `SET use_query_result_cache = true`) but one should keep in mind that all `SELECT` queries including monitoring or debugging queries to
 system tables may return cached results then.
 

--- a/docs/en/operations/query-result-cache.md
+++ b/docs/en/operations/query-result-cache.md
@@ -6,14 +6,14 @@ sidebar_label: Query Result Cache [experimental]
 
 # Query Result Cache [experimental]
 
-The query result cache allows to compute SELECT queries just once and to serve further executions of the same query directly from the cache.
-Depending on the type of the queries, this can dramatically reduce latency and resource consumption of the ClickHouse server.
+The query result cache allows to compute `SELECT` queries just once and to serve further executions of the same query directly from the
+cache. Depending on the type of the queries, this can dramatically reduce latency and resource consumption of the ClickHouse server.
 
 ## Background, Design and Limitations
 
 Query result caches can generally be viewed as transactionally consistent or inconsistent.
 
-- In transactionally consistent caches, the database invalidates (discards) cached query results if the result of the SELECT query changes
+- In transactionally consistent caches, the database invalidates (discards) cached query results if the result of the `SELECT` query changes
   or potentially changes. In ClickHouse, operations which change the data include inserts/updates/deletes in/of/from tables or collapsing
   merges. Transactionally consistent caching is especially suitable for OLTP databases, for example
   [MySQL](https://dev.mysql.com/doc/refman/5.6/en/query-cache.html) (which removed query result cache after v8.0) and
@@ -22,7 +22,7 @@ Query result caches can generally be viewed as transactionally consistent or inc
   assigned a validity period after which they expire (e.g. 1 minute) and that the underlying data changes only little during this period.
   This approach is overall more suitable for OLAP databases. As an example where transactionally inconsistent caching is sufficient,
   consider an hourly sales report in a reporting tool which is simultaneously accessed by multiple users. Sales data changes typically
-  slowly enough that the database only needs to compute the report once (represented by the first SELECT query). Further queries can be
+  slowly enough that the database only needs to compute the report once (represented by the first `SELECT` query). Further queries can be
   served directly from the query result cache. In this example, a reasonable validity period could be 30 min.
 
 Transactionally inconsistent caching is traditionally provided by client tools or proxy packages interacting with the database. As a result,
@@ -36,32 +36,44 @@ processing) where wrong results are returned.
 
 ## Configuration Settings and Usage
 
-Parameter [enable_experimental_query_result_cache](settings/settings.md#enable-experimental-query-result-cache) controls whether query
-results are inserted into / retrieved from the cache for the current query or session. For example, the first execution of query
+As long as the result cache is experimental it must be activated using the following configuration setting:
 
-``` sql
-SELECT some_expensive_calculation(column_1, column_2)
-FROM table
-SETTINGS enable_experimental_query_result_cache = true;
+```sql
+SET allow_experimental_query_result_cache = true;
 ```
 
-stores the query result into the query result cache. Subsequent executions of the same query (also with parameter
-`enable_experimental_query_result_cache = true`) will read the computed result directly from the cache.
+Afterwards, setting [use_query_result_cache](settings/settings.md#use-query-result-cache) can be used to control whether a specific query or
+all queries of the current session should utilize the query result cache. For example, the first execution of query
 
-Sometimes, it is desirable to use the query result cache only passively, i.e. to allow reading from it but not writing into it (if the cache
-result is not stored yet). Parameter [enable_experimental_query_result_cache_passive_usage](settings/settings.md#enable-experimental-query-result-cache-passive-usage)
-instead of 'enable_experimental_query_result_cache' can be used for that.
+```sql
+SELECT some_expensive_calculation(column_1, column_2)
+FROM table
+SETTINGS use_query_result_cache = true;
+```
 
-For maximum control, it is generally recommended to provide settings "enable_experimental_query_result_cache" or
-"enable_experimental_query_result_cache_passive_usage" only with specific queries. It is also possible to enable caching at user or profile
-level but one should keep in mind that all SELECT queries may return a cached results, including monitoring or debugging queries to system
-tables.
+will store the query result in the query result cache. Subsequent executions of the same query (also with parameter `use_query_result_cache
+= true`) will read the computed result from the cache and return it immediately.
+
+The way the cache is utilized can be configured in more detail using settings [use_query_result_cache_active_usage](settings/settings.md#use_query_result_cache_active_usage) and
+[use_query_result_cache_passive_usage](settings/settings.md#use_query_result_cache_active_usage) (both `true` by default). Active usage
+means that query results are stored in the cache, whereas passive usage means that the database should try to retrieve query results from
+the cache. For example, the following query will use the cache only passively, i.e. attempt to read from it but not store its result in it:
+
+```sql
+SELECT some_expensive_calculation(column_1, column_2)
+FROM table
+SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false;
+```
+
+For maximum control, it is generally recommended to provide settings "use_query_result_cache", "use_query_result_cache_active_usage" and
+"use_query_result_cache_passive_usage" only with specific queries. It is also possible to enable caching at user or profile level (e.g. via
+`SET use_query_result_cache = true`) but one should keep in mind that all `SELECT` queries including monitoring or debugging queries to
+system tables may return cached results then.
 
 The query result cache can be cleared using statement `SYSTEM DROP QUERY RESULT CACHE`. The content of the query result cache is displayed
 in system table `SYSTEM.QUERY_RESULT_CACHE`. The number of query result cache hits and misses are shown as events "QueryResultCacheHits" and
-"QueryResultCacheMisses" in system table `SYSTEM.EVENTS`. Both counters are only updated for SELECT queries which run with settings
-"enable_experimental_query_result_cache = true" or "enable_experimental_query_result_cache_passive_usage = true". Other queries do not
-affect the cache miss counter.
+"QueryResultCacheMisses" in system table `SYSTEM.EVENTS`. Both counters are only updated for `SELECT` queries which run with setting
+"use_query_result_cache = true". Other queries do not affect the cache miss counter.
 
 The query result cache exists once per ClickHouse server process. However, cache results are by default not shared between users. This can
 be changed (see below) but doing so is not recommended for security reasons.
@@ -81,7 +93,7 @@ To define how long a query must run at least such that its result can be cached,
 ``` sql
 SELECT some_expensive_calculation(column_1, column_2)
 FROM table
-SETTINGS enable_experimental_query_result_cache = true, query_result_cache_min_query_duration = 5000;
+SETTINGS use_query_result_cache = true, query_result_cache_min_query_duration = 5000;
 ```
 
 is only cached if the query runs longer than 5 seconds. It is also possible to specify how often a query needs to run until its result is

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1303,8 +1303,8 @@ Default value: `3`.
 
 ## use_query_result_cache {#use-query-result-cache}
 
-If turned on, SELECT queries may utilize the [query result cache](../query-result-cache.md). Parameters [use_query_result_cache_passive_usage](#use-query-result-cache-passive-usage)
-and [use_query_result_cache_active_usage](#use-query-result-cache-active-usage) control in more detail how the cache is used.
+If turned on, SELECT queries may utilize the [query result cache](../query-result-cache.md). Parameters [enable_reads_from_query_result_cache](#enable-reads-from-query-result-cache)
+and [enable_writes_to_query_result_cache](#enable-writes-to-query-result-cache) control in more detail how the cache is used.
 
 Possible values:
 
@@ -1313,7 +1313,7 @@ Possible values:
 
 Default value: `0`.
 
-## use_query_result_cache_passive_usage {#use-query-result-cache-passive-usage}
+## enable_reads_from_query_result_cache {#enable-reads-from-query-result-cache}
 
 If turned on, results of SELECT queries are retrieved from the [query result cache](../query-result-cache.md).
 
@@ -1324,7 +1324,7 @@ Possible values:
 
 Default value: `1`.
 
-## use_query_result_cache_active_usage {#use-query-result-cache-active-usage}
+## enable_writes_to_query_result_cache {#enable-writes-to-query-result-cache}
 
 If turned on, results of SELECT queries are stored in the [query result cache](../query-result-cache.md).
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1304,7 +1304,7 @@ Default value: `3`.
 ## use_query_result_cache {#use-query-result-cache}
 
 If turned on, SELECT queries may utilize the [query result cache](../query-result-cache.md). Parameters [use_query_result_cache_passive_usage](#use-query-result-cache-passive-usage)
-and [use_query_result_cache_active_usage](#use-query-result-cache-active-usage) control how the cache can be used in more detail.
+and [use_query_result_cache_active_usage](#use-query-result-cache-active-usage) control in more detail how the cache is used.
 
 Possible values:
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1301,27 +1301,39 @@ Possible values:
 
 Default value: `3`.
 
-## enable_experimental_query_result_cache {#enable-experimental-query-result-cache}
+## use_query_result_cache {#use-query-result-cache}
 
-If turned on, results of SELECT queries are stored in and (if available) retrieved from the [query result cache](../query-result-cache.md).
+If turned on, SELECT queries may utilize the [query result cache](../query-result-cache.md). Parameters [use_query_result_cache_passive_usage](#use-query-result-cache-passive-usage)
+and [use_query_result_cache_active_usage](#use-query-result-cache-active-usage) control how the cache can be used in more detail.
+
+Possible values:
+
+- 0 - Yes
+- 1 - No
+
+Default value: `0`.
+
+## use_query_result_cache_passive_usage {#use-query-result-cache-passive-usage}
+
+If turned on, results of SELECT queries are retrieved from the [query result cache](../query-result-cache.md).
 
 Possible values:
 
 - 0 - Disabled
 - 1 - Enabled
 
-Default value: `0`.
+Default value: `1`.
 
-## enable_experimental_query_result_cache_passive_usage {#enable-experimental-query-result-cache-passive-usage}
+## use_query_result_cache_active_usage {#use-query-result-cache-active-usage}
 
-If turned on, results of SELECT queries are (if available) retrieved from the [query result cache](../query-result-cache.md).
+If turned on, results of SELECT queries are stored in the [query result cache](../query-result-cache.md).
 
 Possible values:
 
 - 0 - Disabled
 - 1 - Enabled
 
-Default value: `0`.
+Default value: `1`.
 
 ## query_result_cache_store_results_of_queries_with_nondeterministic_functions {#query-result-cache-store-results-of-queries-with-nondeterministic-functions}
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -542,7 +542,7 @@ class IColumn;
     \
     M(Bool, use_query_result_cache, false, "Enable the query result cache", 0) \
     M(Bool, enable_writes_to_query_result_cache, true, "Enable storing results of SELECT queries in the query result cache", 0) \
-    M(Bool, enable_reads_from_query_result_cache, true, "Enable retrieval of results of SELECT queries from the query result cache", 0) \
+    M(Bool, enable_reads_from_query_result_cache, true, "Enable reading results of SELECT queries from the query result cache", 0) \
     M(Bool, query_result_cache_store_results_of_queries_with_nondeterministic_functions, false, "Store results of queries with non-deterministic functions (e.g. rand(), now()) in the query result cache", 0) \
     M(UInt64, query_result_cache_min_query_runs, 0, "Minimum number a SELECT query must run before its result is stored in the query result cache", 0) \
     M(Milliseconds, query_result_cache_min_query_duration, 0, "Minimum time in milliseconds for a query to run for its result to be stored in the query result cache.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -541,7 +541,7 @@ class IColumn;
     M(Bool, describe_include_subcolumns, false, "If true, subcolumns of all table columns will be included into result of DESCRIBE query", 0) \
     \
     M(Bool, use_query_result_cache, false, "Enable the query result cache", 0) \
-    M(Bool, enable_writes_to_query_result_cache, true, "Enable storage of results of SELECT queries in the query result cache", 0) \
+    M(Bool, enable_writes_to_query_result_cache, true, "Enable storing results of SELECT queries in the query result cache", 0) \
     M(Bool, enable_reads_from_query_result_cache, true, "Enable retrieval of results of SELECT queries from the query result cache", 0) \
     M(Bool, query_result_cache_store_results_of_queries_with_nondeterministic_functions, false, "Store results of queries with non-deterministic functions (e.g. rand(), now()) in the query result cache", 0) \
     M(UInt64, query_result_cache_min_query_runs, 0, "Minimum number a SELECT query must run before its result is stored in the query result cache", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -541,8 +541,8 @@ class IColumn;
     M(Bool, describe_include_subcolumns, false, "If true, subcolumns of all table columns will be included into result of DESCRIBE query", 0) \
     \
     M(Bool, use_query_result_cache, false, "Enable the query result cache", 0) \
-    M(Bool, use_query_result_cache_active_usage, true, "Utilize the query result cache actively, i.e. store results of SELECT queries in the cache", 0) \
-    M(Bool, use_query_result_cache_passive_usage, true, "Utilize the query result cache passively, i.e. retrieve results of SELECT queries from the cache", 0) \
+    M(Bool, enable_writes_to_query_result_cache, true, "Enable storage of results of SELECT queries in the query result cache", 0) \
+    M(Bool, enable_reads_from_query_result_cache, true, "Enable retrieval of results of SELECT queries from the query result cache", 0) \
     M(Bool, query_result_cache_store_results_of_queries_with_nondeterministic_functions, false, "Store results of queries with non-deterministic functions (e.g. rand(), now()) in the query result cache", 0) \
     M(UInt64, query_result_cache_min_query_runs, 0, "Minimum number a SELECT query must run before its result is stored in the query result cache", 0) \
     M(Milliseconds, query_result_cache_min_query_duration, 0, "Minimum time in milliseconds for a query to run for its result to be stored in the query result cache.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -543,7 +543,6 @@ class IColumn;
     M(Bool, use_query_result_cache, false, "Enable the query result cache", 0) \
     M(Bool, use_query_result_cache_active_usage, true, "Utilize the query result cache actively, i.e. store results of SELECT queries in the cache", 0) \
     M(Bool, use_query_result_cache_passive_usage, true, "Utilize the query result cache passively, i.e. retrieve results of SELECT queries from the cache", 0) \
-    M(Bool, enable_experimental_query_result_cache_passive_usage, false, "Retrieve results of SELECT queries from the query result cache", 0) \
     M(Bool, query_result_cache_store_results_of_queries_with_nondeterministic_functions, false, "Store results of queries with non-deterministic functions (e.g. rand(), now()) in the query result cache", 0) \
     M(UInt64, query_result_cache_min_query_runs, 0, "Minimum number a SELECT query must run before its result is stored in the query result cache", 0) \
     M(Milliseconds, query_result_cache_min_query_duration, 0, "Minimum time in milliseconds for a query to run for its result to be stored in the query result cache.", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -540,6 +540,16 @@ class IColumn;
     M(Bool, describe_extend_object_types, false, "Deduce concrete type of columns of type Object in DESCRIBE query", 0) \
     M(Bool, describe_include_subcolumns, false, "If true, subcolumns of all table columns will be included into result of DESCRIBE query", 0) \
     \
+    M(Bool, use_query_result_cache, false, "Enable the query result cache", 0) \
+    M(Bool, use_query_result_cache_active_usage, true, "Utilize the query result cache actively, i.e. store results of SELECT queries in the cache", 0) \
+    M(Bool, use_query_result_cache_passive_usage, true, "Utilize the query result cache passively, i.e. retrieve results of SELECT queries from the cache", 0) \
+    M(Bool, enable_experimental_query_result_cache_passive_usage, false, "Retrieve results of SELECT queries from the query result cache", 0) \
+    M(Bool, query_result_cache_store_results_of_queries_with_nondeterministic_functions, false, "Store results of queries with non-deterministic functions (e.g. rand(), now()) in the query result cache", 0) \
+    M(UInt64, query_result_cache_min_query_runs, 0, "Minimum number a SELECT query must run before its result is stored in the query result cache", 0) \
+    M(Milliseconds, query_result_cache_min_query_duration, 0, "Minimum time in milliseconds for a query to run for its result to be stored in the query result cache.", 0) \
+    M(Seconds, query_result_cache_ttl, 60, "After this time in seconds entries in the query result cache become stale", 0) \
+    M(Bool, query_result_cache_share_between_users, false, "Allow other users to read entry in the query result cache", 0) \
+    \
     M(Bool, optimize_rewrite_sum_if_to_count_if, false, "Rewrite sumIf() and sum(if()) function countIf() function when logically equivalent", 0) \
     M(UInt64, insert_shard_id, 0, "If non zero, when insert into a distributed table, the data will be inserted into the shard `insert_shard_id` synchronously. Possible values range from 1 to `shards_number` of corresponding distributed table", 0) \
     \
@@ -660,6 +670,7 @@ class IColumn;
     M(Bool, allow_experimental_nlp_functions, false, "Enable experimental functions for natural language processing.", 0) \
     M(Bool, allow_experimental_hash_functions, false, "Enable experimental hash functions (hashid, etc)", 0) \
     M(Bool, allow_experimental_object_type, false, "Allow Object and JSON data types", 0) \
+    M(Bool, allow_experimental_query_result_cache, false, "Enable experimental query result cache", 0) \
     M(String, insert_deduplication_token, "", "If not empty, used for duplicate detection instead of data digest", 0) \
     M(String, ann_index_select_query_params, "", "Parameters passed to ANN indexes in SELECT queries, the format is 'param1=x, param2=y, ...'", 0) \
     M(UInt64, max_limit_for_ann_queries, 1000000, "Maximum limit value for using ANN indexes is used to prevent memory overflow in search queries for indexes", 0) \
@@ -675,13 +686,6 @@ class IColumn;
     M(UInt64, grace_hash_join_max_buckets, 1024, "Limit on the number of grace hash join buckets", 0) \
     M(Bool, optimize_distinct_in_order, true, "Enable DISTINCT optimization if some columns in DISTINCT form a prefix of sorting. For example, prefix of sorting key in merge tree or ORDER BY statement", 0) \
     M(Bool, optimize_sorting_by_input_stream_properties, true, "Optimize sorting by sorting properties of input stream", 0) \
-    M(Bool, enable_experimental_query_result_cache, false, "Store and retrieve results of SELECT queries in/from the query result cache", 0) \
-    M(Bool, enable_experimental_query_result_cache_passive_usage, false, "Retrieve results of SELECT queries from the query result cache", 0) \
-    M(Bool, query_result_cache_store_results_of_queries_with_nondeterministic_functions, false, "Store results of queries with non-deterministic functions (e.g. rand(), now()) in the query result cache", 0) \
-    M(UInt64, query_result_cache_min_query_runs, 0, "Minimum number a SELECT query must run before its result is stored in the query result cache", 0) \
-    M(Milliseconds, query_result_cache_min_query_duration, 0, "Minimum time in milliseconds for a query to run for its result to be stored in the query result cache.", 0) \
-    M(Seconds, query_result_cache_ttl, 60, "After this time in seconds entries in the query result cache become stale", 0) \
-    M(Bool, query_result_cache_share_between_users, false, "Allow other users to read entry in the query result cache", 0) \
     M(UInt64, insert_keeper_max_retries, 0, "Max retries for keeper operations during insert", 0) \
     M(UInt64, insert_keeper_retry_initial_backoff_ms, 100, "Initial backoff timeout for keeper operations during insert", 0) \
     M(UInt64, insert_keeper_retry_max_backoff_ms, 10000, "Max backoff timeout for keeper operations during insert", 0) \

--- a/src/Interpreters/Cache/QueryResultCache.cpp
+++ b/src/Interpreters/Cache/QueryResultCache.cpp
@@ -89,7 +89,7 @@ public:
     }
 
     /// TODO further improve AST cleanup, e.g. remove SETTINGS clause completely if it is empty
-    /// E.g. SELECT 1 SETTINGS enable_experimental_query_result_cache = true
+    /// E.g. SELECT 1 SETTINGS use_query_result_cache = true
     /// and  SELECT 1;
     /// currently don't match.
 };
@@ -97,11 +97,12 @@ public:
 using RemoveQueryResultCacheSettingsVisitor = InDepthNodeVisitor<RemoveQueryResultCacheSettingsMatcher, true>;
 
 /// Consider
-///   (1) SET enable_experimental_query_result_cache = true;
+///   (1) SET use_query_result_cache = true;
 ///       SELECT expensiveComputation(...) SETTINGS max_threads = 64, query_result_cache_ttl = 300;
-///       SET enable_experimental_query_result_cache = false;
+///       SET use_query_result_cache = false;
 /// and
-///   (2) SELECT expensiveComputation(...) SETTINGS max_threads = 64, enable_experimental_query_result_cache_passive_usage = true;
+///   (2) SELECT expensiveComputation(...) SETTINGS max_threads = 64, use_query_result_cache = true;
+///
 /// The SELECT queries in (1) and (2) are basically the same and the user expects that the second invocation is served from the query result
 /// cache. However, query results are indexed by their query ASTs and therefore no result will be found. Insert and retrieval behave overall
 /// more natural if settings related to the query result cache are erased from the AST key. Note that at this point the settings themselves

--- a/src/Interpreters/Cache/QueryResultCache.cpp
+++ b/src/Interpreters/Cache/QueryResultCache.cpp
@@ -80,8 +80,8 @@ public:
             auto is_query_result_cache_related_setting = [](const auto & change)
             {
                 return change.name == "allow_experimental_query_result_cache"
-                    || change.name.starts_with("use_query_result_cache")
-                    || change.name.starts_with("query_result_cache");
+                    || change.name.starts_with("query_result_cache")
+                    || change.name.ends_with("query_result_cache");
             };
 
             std::erase_if(set_clause->changes, is_query_result_cache_related_setting);

--- a/src/Interpreters/Cache/QueryResultCache.cpp
+++ b/src/Interpreters/Cache/QueryResultCache.cpp
@@ -79,7 +79,8 @@ public:
 
             auto is_query_result_cache_related_setting = [](const auto & change)
             {
-                return change.name.starts_with("enable_experimental_query_result_cache")
+                return change.name == "allow_experimental_query_result_cache"
+                    || change.name.starts_with("use_query_result_cache")
                     || change.name.starts_with("query_result_cache");
             };
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -722,7 +722,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                 auto query_result_cache = context->getQueryResultCache();
                 bool read_result_from_query_result_cache = false; /// a query must not read from *and* write to the query result cache at the same time
                 if (query_result_cache != nullptr
-                    && (settings.allow_experimental_query_result_cache && settings.use_query_result_cache && settings.use_query_result_cache_passive_usage)
+                    && (settings.allow_experimental_query_result_cache && settings.use_query_result_cache && settings.enable_reads_from_query_result_cache)
                     && res.pipeline.pulling())
                 {
                     QueryResultCache::Key key(
@@ -743,7 +743,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                 /// then add a processor on top of the pipeline which stores the result in the query result cache.
                 if (!read_result_from_query_result_cache
                     && query_result_cache != nullptr
-                    && settings.allow_experimental_query_result_cache && settings.use_query_result_cache && settings.use_query_result_cache_active_usage
+                    && settings.allow_experimental_query_result_cache && settings.use_query_result_cache && settings.enable_writes_to_query_result_cache
                     && res.pipeline.pulling()
                     && (!astContainsNonDeterministicFunctions(ast, context) || settings.query_result_cache_store_results_of_queries_with_nondeterministic_functions))
                 {
@@ -910,7 +910,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                                     ast,
                                     allow_experimental_query_result_cache = settings.allow_experimental_query_result_cache,
                                     use_query_result_cache = settings.use_query_result_cache,
-                                    use_query_result_cache_active_usage = settings.use_query_result_cache_active_usage,
+                                    enable_writes_to_query_result_cache = settings.enable_writes_to_query_result_cache,
                                     query_result_cache_store_results_of_queries_with_nondeterministic_functions = settings.query_result_cache_store_results_of_queries_with_nondeterministic_functions,
                                     log_queries,
                                     log_queries_min_type = settings.log_queries_min_type,
@@ -926,7 +926,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                 auto query_result_cache = context->getQueryResultCache();
                 if (query_result_cache != nullptr
                     && pulling_pipeline
-                    && allow_experimental_query_result_cache && use_query_result_cache && use_query_result_cache_active_usage
+                    && allow_experimental_query_result_cache && use_query_result_cache && enable_writes_to_query_result_cache
                     && (!astContainsNonDeterministicFunctions(ast, context) || query_result_cache_store_results_of_queries_with_nondeterministic_functions))
                 {
                     query_pipeline.finalizeWriteInQueryResultCache();

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -714,11 +714,15 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
 
                 res = interpreter->execute();
 
-                /// Try to read (SELECT) query result from query result cache (if it is enabled)
+                /// If
+                /// - it is a SELECT query,
+                /// - passive (read) use of the query result cache is enabled, and
+                /// - the query result cache knows the query result
+                /// then replace the pipeline by a new pipeline with a single source that is populated from the query result cache
                 auto query_result_cache = context->getQueryResultCache();
                 bool read_result_from_query_result_cache = false; /// a query must not read from *and* write to the query result cache at the same time
                 if (query_result_cache != nullptr
-                    && (settings.enable_experimental_query_result_cache || settings.enable_experimental_query_result_cache_passive_usage)
+                    && (settings.allow_experimental_query_result_cache && settings.use_query_result_cache && settings.use_query_result_cache_passive_usage)
                     && res.pipeline.pulling())
                 {
                     QueryResultCache::Key key(
@@ -733,10 +737,13 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                     }
                 }
 
-                /// Try to write (SELECT) query result into query result cache (if it is enabled)
+                /// If
+                /// - it is a SELECT query, and
+                /// - active (write) use of the query result cache is enabled
+                /// then add a processor on top of the pipeline which stores the result in the query result cache.
                 if (!read_result_from_query_result_cache
                     && query_result_cache != nullptr
-                    && settings.enable_experimental_query_result_cache
+                    && settings.allow_experimental_query_result_cache && settings.use_query_result_cache && settings.use_query_result_cache_active_usage
                     && res.pipeline.pulling()
                     && (!astContainsNonDeterministicFunctions(ast, context) || settings.query_result_cache_store_results_of_queries_with_nondeterministic_functions))
                 {
@@ -901,7 +908,9 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             auto finish_callback = [elem,
                                     context,
                                     ast,
-                                    enable_experimental_query_result_cache = settings.enable_experimental_query_result_cache,
+                                    allow_experimental_query_result_cache = settings.allow_experimental_query_result_cache,
+                                    use_query_result_cache = settings.use_query_result_cache,
+                                    use_query_result_cache_active_usage = settings.use_query_result_cache_active_usage,
                                     query_result_cache_store_results_of_queries_with_nondeterministic_functions = settings.query_result_cache_store_results_of_queries_with_nondeterministic_functions,
                                     log_queries,
                                     log_queries_min_type = settings.log_queries_min_type,
@@ -912,11 +921,12 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
                                     pulling_pipeline = pipeline.pulling(),
                                     query_span](QueryPipeline & query_pipeline) mutable
             {
-                /// Write query result into query result cache (if enabled)
+                /// If active (write) use of the query result cache is enabled and the query is eligible for result caching, then store the
+                /// query result buffered in the special-purpose cache processor (added on top of the pipeline) into the cache.
                 auto query_result_cache = context->getQueryResultCache();
                 if (query_result_cache != nullptr
                     && pulling_pipeline
-                    && enable_experimental_query_result_cache
+                    && allow_experimental_query_result_cache && use_query_result_cache && use_query_result_cache_active_usage
                     && (!astContainsNonDeterministicFunctions(ast, context) || query_result_cache_store_results_of_queries_with_nondeterministic_functions))
                 {
                     query_pipeline.finalizeWriteInQueryResultCache();

--- a/tests/queries/0_stateless/02494_query_result_cache_case_agnostic_matching.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_case_agnostic_matching.sql
@@ -1,18 +1,20 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 -- Start with empty query result cache (QRC) and query log
 SYSTEM DROP QUERY RESULT CACHE;
 DROP TABLE system.query_log SYNC;
 
 -- Insert an entry into the query result cache.
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true;
+SELECT 1 SETTINGS use_query_result_cache = true;
 -- Check that entry in QRC exists
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- Run the same SELECT but with different case (--> select). We want its result to be served from the QRC.
 SELECT '---';
-select 1 SETTINGS enable_experimental_query_result_cache = true;
+select 1 SETTINGS use_query_result_cache = true;
 
 -- There should still be just one entry in the QRC
 SELECT COUNT(*) FROM system.query_result_cache;
@@ -22,6 +24,6 @@ SYSTEM FLUSH LOGS;
 SELECT ProfileEvents['QueryResultCacheHits'], ProfileEvents['QueryResultCacheMisses']
 FROM system.query_log
 WHERE type = 'QueryFinish'
-  AND query = 'select 1 SETTINGS enable_experimental_query_result_cache = true;';
+  AND query = 'select 1 SETTINGS use_query_result_cache = true;';
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_drop_cache.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_drop_cache.sql
@@ -1,8 +1,10 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 -- Cache query result in query result cache
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true;
+SELECT 1 SETTINGS use_query_result_cache = true;
 SELECT count(*) FROM system.query_result_cache;
 
 -- No query results are cached after DROP

--- a/tests/queries/0_stateless/02494_query_result_cache_eligible_queries.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_eligible_queries.sql
@@ -1,15 +1,17 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 SYSTEM DROP QUERY RESULT CACHE;
 DROP TABLE IF EXISTS eligible_test;
 DROP TABLE IF EXISTS eligible_test2;
 
 -- enable query result cache session-wide but also force it individually in each of below statements
-SET enable_experimental_query_result_cache = true;
+SET use_query_result_cache = true;
 
 -- check that SELECT statements create entries in the query result cache ...
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true;
+SELECT 1 SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SYSTEM DROP QUERY RESULT CACHE;
@@ -17,49 +19,49 @@ SYSTEM DROP QUERY RESULT CACHE;
 -- ... and all other statements also should not create entries:
 
 -- CREATE
-CREATE TABLE eligible_test (a String) ENGINE=MergeTree ORDER BY a; --  SETTINGS enable_experimental_query_result_cache = true; -- SETTINGS rejected as unknown
+CREATE TABLE eligible_test (a String) ENGINE=MergeTree ORDER BY a; --  SETTINGS use_query_result_cache = true; -- SETTINGS rejected as unknown
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- ALTER
-ALTER TABLE eligible_test ADD COLUMN b String SETTINGS enable_experimental_query_result_cache = true;
+ALTER TABLE eligible_test ADD COLUMN b String SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- INSERT
-INSERT INTO eligible_test VALUES('a', 'b'); -- SETTINGS enable_experimental_query_result_cache = true; -- SETTINGS rejected as unknown
+INSERT INTO eligible_test VALUES('a', 'b'); -- SETTINGS use_query_result_cache = true; -- SETTINGS rejected as unknown
 SELECT COUNT(*) FROM system.query_result_cache;
-INSERT INTO eligible_test SELECT * FROM eligible_test SETTINGS enable_experimental_query_result_cache = true;
+INSERT INTO eligible_test SELECT * FROM eligible_test SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- SHOW
-SHOW TABLES SETTINGS enable_experimental_query_result_cache = true;
+SHOW TABLES SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- CHECK
-CHECK TABLE eligible_test SETTINGS enable_experimental_query_result_cache = true;
+CHECK TABLE eligible_test SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- DESCRIBE
-DESCRIBE TABLE eligible_test SETTINGS enable_experimental_query_result_cache = true;
+DESCRIBE TABLE eligible_test SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- EXISTS
-EXISTS TABLE eligible_test SETTINGS enable_experimental_query_result_cache = true;
+EXISTS TABLE eligible_test SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- KILL
-KILL QUERY WHERE query_id='3-857d-4a57-9ee0-3c7da5d60a90' SETTINGS enable_experimental_query_result_cache = true;
+KILL QUERY WHERE query_id='3-857d-4a57-9ee0-3c7da5d60a90' SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- OPTIMIZE
-OPTIMIZE TABLE eligible_test FINAL SETTINGS enable_experimental_query_result_cache = true;
+OPTIMIZE TABLE eligible_test FINAL SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- TRUNCATE
-TRUNCATE TABLE eligible_test SETTINGS enable_experimental_query_result_cache = true;
+TRUNCATE TABLE eligible_test SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 -- RENAME
-RENAME TABLE eligible_test TO eligible_test2 SETTINGS enable_experimental_query_result_cache = true;
+RENAME TABLE eligible_test TO eligible_test2 SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_events.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_events.sql
@@ -1,30 +1,32 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 -- Start with empty query result cache (QRC) and query log
 SYSTEM DROP QUERY RESULT CACHE;
 DROP TABLE system.query_log SYNC;
 
 -- Run a query with QRC on. The first execution is a QRC miss.
 SELECT '---';
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true;
+SELECT 1 SETTINGS use_query_result_cache = true;
 
 SYSTEM FLUSH LOGS;
 SELECT ProfileEvents['QueryResultCacheHits'], ProfileEvents['QueryResultCacheMisses']
 FROM system.query_log
 WHERE type = 'QueryFinish'
-  AND query = 'SELECT 1 SETTINGS enable_experimental_query_result_cache = true;';
+  AND query = 'SELECT 1 SETTINGS use_query_result_cache = true;';
 
 
 -- Run previous query again with query result cache on
 SELECT '---';
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true;
+SELECT 1 SETTINGS use_query_result_cache = true;
 
 DROP TABLE system.query_log SYNC;
 SYSTEM FLUSH LOGS;
 SELECT ProfileEvents['QueryResultCacheHits'], ProfileEvents['QueryResultCacheMisses']
 FROM system.query_log
 WHERE type = 'QueryFinish'
-  AND query = 'SELECT 1 SETTINGS enable_experimental_query_result_cache = true;';
+  AND query = 'SELECT 1 SETTINGS use_query_result_cache = true;';
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_exception_handling.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_exception_handling.sql
@@ -1,10 +1,12 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 SYSTEM DROP QUERY RESULT CACHE;
 
 -- If an exception is thrown during query execution, no entry must be created in the query result cache
-SELECT throwIf(1) SETTINGS enable_experimental_query_result_cache = true; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+SELECT throwIf(1) SETTINGS use_query_result_cache = true; -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_explain.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_explain.sql
@@ -1,19 +1,21 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 SYSTEM DROP QUERY RESULT CACHE;
 
 -- Run a silly query with a non-trivial plan and put the result into the query result cache (QRC)
-SELECT 1 + number from system.numbers LIMIT 1 SETTINGS enable_experimental_query_result_cache = true;
+SELECT 1 + number from system.numbers LIMIT 1 SETTINGS use_query_result_cache = true;
 SELECT count(*) FROM system.query_result_cache;
 
 -- EXPLAIN PLAN should show the same regardless if the result is calculated or read from the QRC
 EXPLAIN PLAN SELECT 1 + number from system.numbers LIMIT 1;
-EXPLAIN PLAN SELECT 1 + number from system.numbers LIMIT 1 SETTINGS enable_experimental_query_result_cache = true; -- (*)
+EXPLAIN PLAN SELECT 1 + number from system.numbers LIMIT 1 SETTINGS use_query_result_cache = true; -- (*)
 
 -- EXPLAIN PIPELINE should show the same regardless if the result is calculated or read from the QRC
 EXPLAIN PIPELINE SELECT 1 + number from system.numbers LIMIT 1;
-EXPLAIN PIPELINE SELECT 1 + number from system.numbers LIMIT 1 SETTINGS enable_experimental_query_result_cache = true; -- (*)
+EXPLAIN PIPELINE SELECT 1 + number from system.numbers LIMIT 1 SETTINGS use_query_result_cache = true; -- (*)
 
 -- Statements (*) must not cache their results into the QRC
 SELECT count(*) FROM system.query_result_cache;

--- a/tests/queries/0_stateless/02494_query_result_cache_min_query_duration.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_min_query_duration.sql
@@ -1,10 +1,12 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 SYSTEM DROP QUERY RESULT CACHE;
 
 -- This creates an entry in the query result cache ...
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true;
+SELECT 1 SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SYSTEM DROP QUERY RESULT CACHE;
@@ -12,7 +14,7 @@ SYSTEM DROP QUERY RESULT CACHE;
 SELECT '---';
 
 -- ... but this does not because the query executes much faster than the specified minumum query duration for caching the result
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_min_query_duration = 10000;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_min_query_duration = 10000;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_min_query_runs.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_min_query_runs.sql
@@ -1,10 +1,12 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 SYSTEM DROP QUERY RESULT CACHE;
 
 -- Cache the query result after the 1st query invocation
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_min_query_runs = 0;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_min_query_runs = 0;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SELECT '---';
@@ -12,9 +14,9 @@ SELECT '---';
 SYSTEM DROP QUERY RESULT CACHE;
 
 -- Cache the query result after the 2nd query invocation
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_min_query_runs = 1;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_min_query_runs = 1;
 SELECT COUNT(*) FROM system.query_result_cache;
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_min_query_runs = 1;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_min_query_runs = 1;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SELECT '---';
@@ -22,11 +24,11 @@ SELECT '---';
 SYSTEM DROP QUERY RESULT CACHE;
 
 -- Cache the query result after the 3rd query invocation
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_min_query_runs = 2;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_min_query_runs = 2;
 SELECT COUNT(*) FROM system.query_result_cache;
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_min_query_runs = 2;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_min_query_runs = 2;
 SELECT COUNT(*) FROM system.query_result_cache;
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_min_query_runs = 2;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_min_query_runs = 2;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_nondeterministic_functions.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_nondeterministic_functions.sql
@@ -1,16 +1,18 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 SYSTEM DROP QUERY RESULT CACHE;
 
 -- rand() is non-deterministic, with default settings no entry in the query result cache should be created
-SELECT COUNT(rand(1)) SETTINGS enable_experimental_query_result_cache = true;
+SELECT COUNT(rand(1)) SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SELECT '---';
 
 -- But an entry can be forced using a setting
-SELECT COUNT(RAND(1)) SETTINGS enable_experimental_query_result_cache = true, query_result_cache_store_results_of_queries_with_nondeterministic_functions = true;
+SELECT COUNT(RAND(1)) SETTINGS use_query_result_cache = true, query_result_cache_store_results_of_queries_with_nondeterministic_functions = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_normalize_ast.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_normalize_ast.sql
@@ -18,7 +18,7 @@ SELECT COUNT(*) FROM system.query_result_cache;
 -- Run the same SELECT but with different SETTINGS. We want its result to be served from the QRC (--> passive mode, achieve it by
 -- disabling active mode)
 SELECT '---';
-SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false, max_threads = 16;
+SELECT 1 SETTINGS use_query_result_cache = true, enable_writes_to_query_result_cache = false, max_threads = 16;
 
 -- Technically, both SELECT queries have different ASTs, leading to different QRC keys. QRC does some AST normalization (erase all
 -- QRC-related settings) such that the keys match regardless. Verify by checking that the second query caused a QRC hit.
@@ -26,6 +26,6 @@ SYSTEM FLUSH LOGS;
 SELECT ProfileEvents['QueryResultCacheHits'], ProfileEvents['QueryResultCacheMisses']
 FROM system.query_log
 WHERE type = 'QueryFinish'
-  AND query = 'SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false, max_threads = 16;';
+  AND query = 'SELECT 1 SETTINGS use_query_result_cache = true, enable_writes_to_query_result_cache = false, max_threads = 16;';
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_normalize_ast.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_normalize_ast.sql
@@ -1,21 +1,24 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 -- Start with empty query result cache (QRC) and query log.
 SYSTEM DROP QUERY RESULT CACHE;
 DROP TABLE system.query_log SYNC;
 
 -- Run query whose result gets cached in the query result cache.
--- Besides "enable_experimental_query_result_cache", pass two more knobs (one QRC-specific knob and one non-QRC-specific knob). We just care
+-- Besides "use_query_result_cache", pass two more knobs (one QRC-specific knob and one non-QRC-specific knob). We just care
 -- *that* they are passed and not about their effect.
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_store_results_of_queries_with_nondeterministic_functions = true, max_threads = 16;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_store_results_of_queries_with_nondeterministic_functions = true, max_threads = 16;
 
 -- Check that entry in QRC exists
 SELECT COUNT(*) FROM system.query_result_cache;
 
--- Run the same SELECT but with different SETTINGS. We want its result to be served from the QRC.
+-- Run the same SELECT but with different SETTINGS. We want its result to be served from the QRC (--> passive mode, achieve it by
+-- disabling active mode)
 SELECT '---';
-SELECT 1 SETTINGS enable_experimental_query_result_cache_passive_usage = true, max_threads = 16;
+SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false, max_threads = 16;
 
 -- Technically, both SELECT queries have different ASTs, leading to different QRC keys. QRC does some AST normalization (erase all
 -- QRC-related settings) such that the keys match regardless. Verify by checking that the second query caused a QRC hit.
@@ -23,6 +26,6 @@ SYSTEM FLUSH LOGS;
 SELECT ProfileEvents['QueryResultCacheHits'], ProfileEvents['QueryResultCacheMisses']
 FROM system.query_log
 WHERE type = 'QueryFinish'
-  AND query = 'SELECT 1 SETTINGS enable_experimental_query_result_cache_passive_usage = true, max_threads = 16;';
+  AND query = 'SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false, max_threads = 16;';
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_passive_usage.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_passive_usage.sql
@@ -13,7 +13,7 @@ SELECT COUNT(*) FROM system.query_result_cache;
 SELECT '-----';
 
 -- Try to retrieve query result from empty QRC using the passive mode. Do this by disabling the active mode. The cache should still be empty (no insert).
-SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false;
+SELECT 1 SETTINGS use_query_result_cache = true, enable_writes_to_query_result_cache = false;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SELECT '-----';
@@ -29,13 +29,13 @@ SELECT '-----';
 -- Get rid of log of previous SELECT
 DROP TABLE system.query_log SYNC;
 
-SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false;
+SELECT 1 SETTINGS use_query_result_cache = true, enable_writes_to_query_result_cache = false;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SYSTEM FLUSH LOGS;
 SELECT ProfileEvents['QueryResultCacheHits'], ProfileEvents['QueryResultCacheMisses']
 FROM system.query_log
 WHERE type = 'QueryFinish'
-  AND query = 'SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false;';
+  AND query = 'SELECT 1 SETTINGS use_query_result_cache = true, enable_writes_to_query_result_cache = false;';
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_passive_usage.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_passive_usage.sql
@@ -1,6 +1,8 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 -- Start with empty query result cache (QRC).
 SYSTEM DROP QUERY RESULT CACHE;
 
@@ -10,14 +12,14 @@ SELECT COUNT(*) FROM system.query_result_cache;
 
 SELECT '-----';
 
--- Try to retrieve query result from empty QRC using the passive mode. The cache should still be empty (no insert).
-SELECT 1 SETTINGS enable_experimental_query_result_cache_passive_usage = true;
+-- Try to retrieve query result from empty QRC using the passive mode. Do this by disabling the active mode. The cache should still be empty (no insert).
+SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SELECT '-----';
 
 -- Put query result into cache.
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true;
+SELECT 1 SETTINGS use_query_result_cache = true;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SELECT '-----';
@@ -27,13 +29,13 @@ SELECT '-----';
 -- Get rid of log of previous SELECT
 DROP TABLE system.query_log SYNC;
 
-SELECT 1 SETTINGS enable_experimental_query_result_cache_passive_usage = true;
+SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false;
 SELECT COUNT(*) FROM system.query_result_cache;
 
 SYSTEM FLUSH LOGS;
 SELECT ProfileEvents['QueryResultCacheHits'], ProfileEvents['QueryResultCacheMisses']
 FROM system.query_log
 WHERE type = 'QueryFinish'
-  AND query = 'SELECT 1 SETTINGS enable_experimental_query_result_cache_passive_usage = true;';
+  AND query = 'SELECT 1 SETTINGS use_query_result_cache = true, use_query_result_cache_active_usage = false;';
 
 SYSTEM DROP QUERY RESULT CACHE;

--- a/tests/queries/0_stateless/02494_query_result_cache_secrets.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_secrets.sql
@@ -2,10 +2,12 @@
 -- Tag no-fasttest: Depends on OpenSSL
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 SYSTEM DROP QUERY RESULT CACHE;
 
 -- Cache a result of a query with secret in the query result cache
-SELECT hex(encrypt('aes-128-ecb', 'plaintext', 'passwordpassword')) SETTINGS enable_experimental_query_result_cache = true;
+SELECT hex(encrypt('aes-128-ecb', 'plaintext', 'passwordpassword')) SETTINGS use_query_result_cache = true;
 
 -- The secret should not be revealed in system.query_result_cache
 SELECT query FROM system.query_result_cache;

--- a/tests/queries/0_stateless/02494_query_result_cache_ttl_long.sql
+++ b/tests/queries/0_stateless/02494_query_result_cache_ttl_long.sql
@@ -3,10 +3,12 @@
 -- Tag long: Test runtime is > 6 sec
 -- Tag no-parallel: Messes with internal cache
 
+SET allow_experimental_query_result_cache = true;
+
 SYSTEM DROP QUERY RESULT CACHE;
 
 -- Cache query result into query result cache with a TTL of 3 sec
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_ttl = 3;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_ttl = 3;
 
 -- Expect one non-stale cache entry
 SELECT COUNT(*) FROM system.query_result_cache;
@@ -20,7 +22,7 @@ SELECT stale FROM system.query_result_cache;
 SELECT '---';
 
 -- Run same query as before
-SELECT 1 SETTINGS enable_experimental_query_result_cache = true, query_result_cache_ttl = 3;
+SELECT 1 SETTINGS use_query_result_cache = true, query_result_cache_ttl = 3;
 
 -- The entry should have been refreshed (non-stale)
 SELECT COUNT(*) FROM system.query_result_cache;


### PR DESCRIPTION
This PR modularizes the configuration options for the query result cache (QRC).

1. Introduce a feature toggle `allow_experimental_query_result_cache = false` which controls whether the experimental QRC can be used at all. This configuration option will be removed once the QRC becomes non-experimental.

2. Remove the two existing configuration settings `enable_experimental_query_result_cache` and`enable_experimental_query_result_cache_passive_usage`  and replace them by three orthogonal settings:

- `use_query_result_cache = false` which controls whether a query (or all queries of the session) utilize the query result cache
- settings `use_query_result_cache_passive_usage = true` and `use_query_result_cache_active_usage = true` which control *how* a query (or all queries of the session) utilize the query result cache: "passive" use is reading from the cache, "active" use is writing to the cache.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- The experimental query result cache now provides more modular configuration settings.