### PR TITLE
Fix build

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskFull.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskFull.cpp
@@ -94,7 +94,7 @@ String DataPartStorageOnDiskFull::getUniqueId() const
 {
     auto disk = volume->getDisk();
     if (!disk->supportZeroCopyReplication())
-        throw Exception(fmt::format("Disk {} doesn't support zero-copy replication", disk->getName()), ErrorCodes::LOGICAL_ERROR);
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Disk {} doesn't support zero-copy replication", disk->getName());
 
     return disk->getUniqueId(fs::path(getRelativePath()) / "checksums.txt");
 }


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It was broken due to a race condition between https://github.com/ClickHouse/ClickHouse/pull/45527 and https://github.com/ClickHouse/ClickHouse/pull/45619