### PR TITLE
Add ability to override connection settings based on connection names

### DIFF
--- a/programs/client/Client.h
+++ b/programs/client/Client.h
@@ -47,6 +47,7 @@ protected:
 private:
     void printChangedSettings() const;
     void showWarnings();
+    void parseConnectionsCredentials();
     std::vector<String> loadWarningMessages();
 };
 }

--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -57,4 +57,28 @@
 
         The same can be done on user-level configuration, just create & adjust: ~/.clickhouse-client/config.xml
     -->
+
+
+    <!-- Analog of .netrc -->
+    <![CDATA[
+    <connections_credentials>
+        <connection>
+            <!-- Name of the connection, host option for the client.
+                 "host" is not the same as "hostname" since you may want to have different settings for one host,
+                 and in this case you can add "prod" and "prod_readonly".
+
+                 Default: "hostname" will be used. -->
+            <name>default</name>
+            <!-- Host that will be used for connection. -->
+            <hostname>127.0.0.1</hostname>
+            <port>9000</port>
+            <secure>1</secure>
+            <user>default</user>
+            <password></password>
+            <database></database>
+            <!-- '~' is expanded to HOME, like in any shell -->
+            <history_file></history_file>
+        </connection>
+    </connections_credentials>
+    ]]>
 </config>

--- a/tests/queries/0_stateless/02550_client_connections_credentials.reference
+++ b/tests/queries/0_stateless/02550_client_connections_credentials.reference
@@ -1,0 +1,17 @@
+hostname
+Not found address of host: MySQL.
+port
+Connection refused (localhost:0).
+9000
+secure
+1
+database
+system
+user
+MySQL: Authentication failed
+default
+password
+default: Authentication failed: password is incorrect, or there is no user with such name.
+default
+history_file
+Cannot create file: /no/such/dir/.history

--- a/tests/queries/0_stateless/02550_client_connections_credentials.sh
+++ b/tests/queries/0_stateless/02550_client_connections_credentials.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Overrides
+TEST_DATABASE=$CLICKHOUSE_DATABASE
+TEST_HOST=${CLICKHOUSE_HOST:-"localhost"}
+TEST_PORT=${CLICKHOUSE_PORT_TCP:-9000}
+CLICKHOUSE_DATABASE="system"
+CLICKHOUSE_HOST=""
+CLICKHOUSE_PORT_TCP=""
+
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CONFIG=$CLICKHOUSE_TMP/client.xml
+cat > $CONFIG <<EOL
+<clickhouse>
+    <host>$TEST_HOST</host>
+    <port>$TEST_PORT</port>
+    <database>$TEST_DATABASE</database>
+
+    <connections_credentials>
+        <connection>
+            <name>test_hostname</name>
+            <hostname>MySQL</hostname>
+        </connection>
+
+        <connection>
+            <name>test_port</name>
+            <hostname>$TEST_HOST</hostname>
+            <port>0</port>
+        </connection>
+
+        <connection>
+            <name>test_secure</name>
+            <hostname>$TEST_HOST</hostname>
+            <secure>1</secure>
+        </connection>
+
+        <connection>
+            <name>test_database</name>
+            <hostname>$TEST_HOST</hostname>
+            <database>$CLICKHOUSE_DATABASE</database>
+        </connection>
+
+        <connection>
+            <name>test_user</name>
+            <hostname>$TEST_HOST</hostname>
+            <user>MySQL</user>
+        </connection>
+
+        <connection>
+            <name>test_password</name>
+            <hostname>$TEST_HOST</hostname>
+            <password>MySQL</password>
+        </connection>
+
+        <connection>
+            <name>test_history_file</name>
+            <hostname>$TEST_HOST</hostname>
+            <history_file>/no/such/dir/.history</history_file>
+        </connection>
+    </connections_credentials>
+</clickhouse>
+EOL
+
+echo 'hostname'
+$CLICKHOUSE_CLIENT --config $CONFIG --host test_hostname -q 'select 1' |& grep -F -o 'Not found address of host: MySQL.'
+echo 'port'
+$CLICKHOUSE_CLIENT --config $CONFIG --host test_port -q 'select tcpPort()' |& grep -F -o 'Connection refused (localhost:0).'
+$CLICKHOUSE_CLIENT --config $CONFIG --host test_port --port $TEST_PORT -q 'select tcpPort()'
+echo 'secure'
+$CLICKHOUSE_CLIENT --config $CONFIG --host test_secure -q 'select tcpPort()' |& grep -c -F -o -e OPENSSL_internal:WRONG_VERSION_NUMBER -e 'tcp_secure protocol is disabled because poco library was built without NetSSL support.'
+echo 'database'
+$CLICKHOUSE_CLIENT --config $CONFIG --host test_database -q 'select currentDatabase()'
+echo 'user'
+$CLICKHOUSE_CLIENT --config $CONFIG --host test_user -q 'select currentUser()' |& grep -F -o 'MySQL: Authentication failed'
+$CLICKHOUSE_CLIENT --config $CONFIG --host test_user --user default -q 'select currentUser()'
+echo 'password'
+$CLICKHOUSE_CLIENT --config $CONFIG --host test_password -q 'select currentUser()' |& grep -F -o 'default: Authentication failed: password is incorrect, or there is no user with such name.'
+$CLICKHOUSE_CLIENT --config $CONFIG --host test_password --password "" -q 'select currentUser()'
+echo 'history_file'
+$CLICKHOUSE_CLIENT --progress off --interactive --config $CONFIG --host test_history_file -q 'select 1' </dev/null |& grep -F -o 'Cannot create file: /no/such/dir/.history'
+
+rm -f "${CONFIG:?}"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add ability to override connection settings based on connection names (that said that now you can forget about storing password for each connection, you can simply put everything into `~/.clickhouse-client/config.xml` and even use different history files for them, which can be also useful)

This is somehow analog of .netrc [1].

  [1]: https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html

The follow options can be overwritten on a per-hostname/connection basis:
- hostname
- port
- secure
- user
- password
- database
- history_file

Also note, that you can have multiple settings for one hostname, can be useful to distinguish readonly from non-readonly for example.