### PR TITLE
tests: add missing allow_suspicious_codecs in 02536_delta_gorilla_corruption (fixes fasttest)

### DIFF
--- a/tests/queries/0_stateless/02536_delta_gorilla_corruption.sql
+++ b/tests/queries/0_stateless/02536_delta_gorilla_corruption.sql
@@ -1,6 +1,8 @@
 -- Tags: no-asan
 -- no-asan: the flaky check complains that the test sometimes runs > 60 sec on asan builds
 
+set allow_suspicious_codecs=1;
+
 select 'Original bug: the same query executed multiple times yielded different results.';
 select 'For unclear reasons this happened only in Release builds, not in Debug builds.';
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Race between #45615 and #45376
Cc: @rschu1ze