### PR TITLE
WIP: Refactor IAST::FormatSettings - hide `show_secrets` field

### DIFF
--- a/src/Interpreters/Cache/QueryResultCache.cpp
+++ b/src/Interpreters/Cache/QueryResultCache.cpp
@@ -136,8 +136,7 @@ bool QueryResultCache::Key::operator==(const Key & other) const
 String QueryResultCache::Key::queryStringFromAst() const
 {
     WriteBufferFromOwnString buf;
-    IAST::FormatSettings format_settings(buf, /*one_line*/ true);
-    format_settings.show_secrets = false;
+    IAST::FormatSettings format_settings(buf, /*one_line*/ true, false);
     ast->format(format_settings);
     return buf.str();
 }

--- a/src/Parsers/ASTAlterNamedCollectionQuery.cpp
+++ b/src/Parsers/ASTAlterNamedCollectionQuery.cpp
@@ -29,10 +29,8 @@ void ASTAlterNamedCollectionQuery::formatImpl(const IAST::FormatSettings & setti
                 first = false;
 
             formatSettingName(change.name, settings.ostr);
-            if (settings.show_secrets)
-                settings.ostr << " = " << applyVisitor(FieldVisitorToString(), change.value);
-            else
-                settings.ostr << " = '[HIDDEN]'";
+            settings.ostr << " = ";
+            settings.outputSecret(applyVisitor(FieldVisitorToString(), change.value));
         }
     }
     if (!delete_keys.empty())

--- a/src/Parsers/ASTCreateNamedCollectionQuery.cpp
+++ b/src/Parsers/ASTCreateNamedCollectionQuery.cpp
@@ -32,11 +32,8 @@ void ASTCreateNamedCollectionQuery::formatImpl(const IAST::FormatSettings & sett
             first = false;
 
         formatSettingName(change.name, settings.ostr);
-
-        if (settings.show_secrets)
-            settings.ostr << " = " << applyVisitor(FieldVisitorToString(), change.value);
-        else
-            settings.ostr << " = '[HIDDEN]'";
+        settings.ostr << " = ";
+        settings.outputSecret(applyVisitor(FieldVisitorToString(), change.value));
     }
 }
 

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -967,7 +967,7 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
                 || name == "replaceRegexpAll");
 
         auto secret_arguments = std::make_pair(static_cast<size_t>(-1), static_cast<size_t>(-1));
-        if (!settings.show_secrets)
+        if (!settings.shouldShowSecrets())
             secret_arguments = FunctionSecretArgumentsFinder(*this).getRange();
 
         for (size_t i = 0, size = arguments->children.size(); i < size; ++i)
@@ -977,9 +977,9 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
             if (arguments->children[i]->as<ASTSetQuery>())
                 settings.ostr << "SETTINGS ";
 
-            if (!settings.show_secrets && (secret_arguments.first <= i) && (i < secret_arguments.second))
+            if (!settings.shouldShowSecrets() && (secret_arguments.first <= i) && (i < secret_arguments.second))
             {
-                settings.ostr << "'[HIDDEN]'";
+                settings.outputSecret();
                 if (size - 1 < secret_arguments.second)
                     break; /// All other arguments should also be hidden.
                 continue;

--- a/src/Parsers/ASTFunctionWithKeyValueArguments.cpp
+++ b/src/Parsers/ASTFunctionWithKeyValueArguments.cpp
@@ -29,11 +29,11 @@ void ASTPair::formatImpl(const FormatSettings & settings, FormatState & state, F
     if (second_with_brackets)
         settings.ostr << (settings.hilite ? hilite_keyword : "") << "(";
 
-    if (!settings.show_secrets && (first == "password"))
+    if (!settings.shouldShowSecrets() && (first == "password"))
     {
         /// Hide password in the definition of a dictionary:
         /// SOURCE(CLICKHOUSE(host 'example01-01-1' port 9000 user 'default' password '[HIDDEN]' db 'default' table 'ids'))
-        settings.ostr << "'[HIDDEN]'";
+        settings.outputSecret();
     }
     else
     {

--- a/src/Parsers/Access/ASTCreateUserQuery.cpp
+++ b/src/Parsers/Access/ASTCreateUserQuery.cpp
@@ -93,7 +93,7 @@ namespace
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "AST: Unexpected authentication type {}", toString(auth_type));
         }
 
-        if (password && !settings.show_secrets)
+        if (password && !settings.shouldShowSecrets())
         {
             prefix = "";
             password.reset();

--- a/src/Parsers/IAST.cpp
+++ b/src/Parsers/IAST.cpp
@@ -171,8 +171,7 @@ String IAST::formatWithSecretsHidden(size_t max_length, bool one_line) const
 {
     WriteBufferFromOwnString buf;
 
-    FormatSettings settings{buf, one_line};
-    settings.show_secrets = false;
+    FormatSettings settings{buf, one_line, false};
     format(settings);
 
     return wipeSensitiveDataAndCutToLength(buf.str(), max_length);
@@ -249,6 +248,11 @@ void IAST::FormatSettings::writeIdentifier(const String & name) const
             break;
         }
     }
+}
+
+void IAST::FormatSettings::outputSecret(const String & secret) const
+{
+    ostr << (should_show_secrets ? secret : "'[HIDDEN]'");
 }
 
 void IAST::dumpTree(WriteBuffer & ostr, size_t indent) const

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -185,25 +185,32 @@ public:
         bool one_line;
         bool always_quote_identifiers = false;
         IdentifierQuotingStyle identifier_quoting_style = IdentifierQuotingStyle::Backticks;
-        bool show_secrets = true; /// Show secret parts of the AST (e.g. passwords, encryption keys).
+    private:
+        const bool should_show_secrets; /// Show secret parts of the AST (e.g. passwords, encryption keys).
 
+    public:
         // Newline or whitespace.
         char nl_or_ws;
 
-        FormatSettings(WriteBuffer & ostr_, bool one_line_)
-            : ostr(ostr_), one_line(one_line_)
+        FormatSettings(WriteBuffer & ostr_, bool one_line_, bool should_show_secrets_ = true)
+            : ostr(ostr_), one_line(one_line_), should_show_secrets(should_show_secrets_)
         {
             nl_or_ws = one_line ? ' ' : '\n';
         }
 
         FormatSettings(WriteBuffer & ostr_, const FormatSettings & other)
             : ostr(ostr_), hilite(other.hilite), one_line(other.one_line),
-            always_quote_identifiers(other.always_quote_identifiers), identifier_quoting_style(other.identifier_quoting_style)
+            always_quote_identifiers(other.always_quote_identifiers), identifier_quoting_style(other.identifier_quoting_style),
+            should_show_secrets(other.should_show_secrets)
         {
             nl_or_ws = one_line ? ' ' : '\n';
         }
 
         void writeIdentifier(const String & name) const;
+
+        bool shouldShowSecrets() const { return should_show_secrets; }
+
+        void outputSecret(const String & secret = "") const;
     };
 
     /// State. For example, a set of nodes can be remembered, which we already walk through.


### PR DESCRIPTION
Part of #45649, submitted separately to ease review, as it's easily decouplable from the main change.

NB: This PR should be merged after the main PR, as otherwise it will change the c-tor in non backward compatible way. WIP until the main PR is merged.

This PR is ready, although I see a few places for improvement:

I couldn't properly encapsulate in cases when a secret is not a String but requires rendering via formatImpl.

[ASTAlterNamedCollectionQuery.cpp](https://github.com/ClickHouse/ClickHouse/compare/master...murfel:ClickHouse:formatsettings-hide-showsecrets?expand=1#diff-05defa5d25a0bb178467b3dfd632fcee98de0879d81ab0b49e544bfac8defffc) and [ASTCreateNamedCollectionQuery.cpp](https://github.com/ClickHouse/ClickHouse/compare/master...murfel:ClickHouse:formatsettings-hide-showsecrets?expand=1#diff-abb10bd75ec4f2640f9475e5742f48472018231f35dd1c41f107e8d96285521c) are refactored perfectly, apart from the fact that the field is now evaluated eagerly, even when there's no need to output it. I think it's no big deal, as it's just a couple of string fields.

But there're various problems with the other 3 files.

1. [ASTFunction.cpp](https://github.com/ClickHouse/ClickHouse/compare/master...murfel:ClickHouse:formatsettings-hide-showsecrets?expand=1#diff-63929be73482623b2bc3924b5583e92712882c32c31638812efc20a5556706a0) has secret rendered via formatImpl + for some reason it only outputs one `[HIDDEN]` for a range of secrets. Shouldn't it be the same number of `[HIDDEN]` as there're secrets?

2. [ASTFunctionWithKeyValueArguments.cpp](https://github.com/ClickHouse/ClickHouse/compare/master...murfel:ClickHouse:formatsettings-hide-showsecrets?expand=1#diff-71fe055d66c18f9fe7a4a279f8cecc7bab0901c37e1dc05a8d7b2e038204c8f8) has secret rendered via formatImpl

3. [ASTCreateUserQuery.cpp](https://github.com/ClickHouse/ClickHouse/compare/master...murfel:ClickHouse:formatsettings-hide-showsecrets?expand=1#diff-7c23bec215d2369ba47e5046c66991de4a35165fce20d6e342fac134a10a2c42) outputs empty strings intsead of `[HIDDEN]`. Isn't this confusing to a user?

For 1 and 2, if we absolutely want to avoid having a `shouldShowSecret()` method, I could suggest implementing an `std::lock_guard`-style object. I would prefer not to go this route, as it's too much hassle for just two use-cases. Here it goes anyway.

Instead of this usage,
```
if (!settings.shouldShowSecrets() && (first == "password"))
    settings.outputSecret();
else
    second->formatImpl(settings, state, frame);
```

It would provide this usage:
```
if (first == "password")
{
    auto scoped_secret_writer = settings.createScopedSecretWriter();
    second->formatImpl(settings, state, frame);
}
else
{
    second->formatImpl(settings, state, frame);
}
```

And the internal implementation sketch is:

```
class ScopedSecretWriter
{
    friend class FormatSettings;
    ScopedSecretWriter(FormatSettings & settings)
    {
        settings.startSecretWriting();
    }
    ~ScopedSecretWriter()
    {
        settings.stopSecretWriting();
    }
    operator='s = delete;
    copy-ctors = delete;
};

FormatSettings
{
...
private:
    friend class ScopedSecretWriter;
    bool is_writing_secret;
    startSecretWriting()
    {
        is_writing_secret = should_hide_secrets;
    }
    stopSecretWriting()
    {
        is_writing_secret = false;
    }

public:
    ScopedSecretWriter FormatSettings::createScopedSecretWriter()
    {
        return {*this};
    }
    FormatSettings& operator<<(std::string_view str)  // NB: this operator will exist once the original PR hides `ostr`.
    {
        ostr << is_writing_secret ? "[HIDDEN]" : str;
        
        // The final implementation would be harder, as we want to allow writing
        //   one secret token via multiple calls of operator<<.
    }
};
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)