### PR TITLE
Add check for running workflows to merge_pr.py

### DIFF
--- a/docs/tools/.gitignore
+++ b/docs/tools/.gitignore
@@ -1,3 +1,2 @@
-build
 __pycache__
 *.pyc


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check that there no another workflow runs for the PR in automerge script.