### PR TITLE
Add check for running workflows to merge_pr.py

### DIFF
--- a/docs/tools/.gitignore
+++ b/docs/tools/.gitignore
@@ -1,3 +1,2 @@
-build
 __pycache__
 *.pyc

--- a/tests/ci/merge_pr.py
+++ b/tests/ci/merge_pr.py
@@ -151,9 +151,17 @@ def parse_args() -> argparse.Namespace:
         "status and green commit statuses could be done",
     )
     parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="if set, the script won't merge the PR, just check the conditions",
+    )
+    parser.add_argument(
         "--check-approved",
         action="store_true",
         help="if set, checks that the PR is approved and no changes required",
+    )
+    parser.add_argument(
+        "--check-running-workflows", default=True, help=argparse.SUPPRESS
     )
     parser.add_argument(
         "--no-check-running-workflows",
@@ -162,6 +170,7 @@ def parse_args() -> argparse.Namespace:
         default=argparse.SUPPRESS,
         help="(dangerous) if set, skip checking for running workflows for the PR head",
     )
+    parser.add_argument("--check-green", default=True, help=argparse.SUPPRESS)
     parser.add_argument(
         "--no-check-green",
         dest="check_green",
@@ -252,7 +261,8 @@ def main():
             return
 
     logging.info("Merging the PR")
-    pr.merge()
+    if not args.dry_run:
+        pr.merge()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Check that there are no other workflow runs for the PR in automerge script.