### PR TITLE
Fix http external data functional test on s390x

### DIFF
--- a/tests/queries/0_stateless/00304_http_external_data.sh
+++ b/tests/queries/0_stateless/00304_http_external_data.sh
@@ -6,4 +6,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo -ne '1,Hello\n2,World\n' | ${CLICKHOUSE_CURL} -sSF 'file=@-' "${CLICKHOUSE_URL}&query=SELECT+*+FROM+file&file_format=CSV&file_types=UInt8,String";
 echo -ne '1@Hello\n2@World\n' | ${CLICKHOUSE_CURL} -sSF 'file=@-' "${CLICKHOUSE_URL}&query=SELECT+*+FROM+file&file_format=CSV&file_types=UInt8,String&format_csv_delimiter=@";
-echo -ne '\x01\x00\x00\x00\x02\x00\x00\x00' | ${CLICKHOUSE_CURL} -sSF "tmp=@-" "${CLICKHOUSE_URL}&query=SELECT+*+FROM+tmp&tmp_structure=TaskID+UInt32&tmp_format=RowBinary";
+
+# use big-endian version of binary data for s390x
+if [[ $(uname -a | grep s390x) ]]; then
+    echo -ne '\x00\x00\x00\x01\x00\x00\x00\x02' | ${CLICKHOUSE_CURL} -sSF "tmp=@-" "${CLICKHOUSE_URL}&query=SELECT+*+FROM+tmp&tmp_structure=TaskID+UInt32&tmp_format=RowBinary";
+else
+    echo -ne '\x01\x00\x00\x00\x02\x00\x00\x00' | ${CLICKHOUSE_CURL} -sSF "tmp=@-" "${CLICKHOUSE_URL}&query=SELECT+*+FROM+tmp&tmp_structure=TaskID+UInt32&tmp_format=RowBinary";
+fi


### PR DESCRIPTION
Functional test `00304_http_external_data` fails on s390x because the format of binary test data is little endian.
The fix is to add code to use big-endian version of binary test data in the functional test for s390x.

### Changelog category (leave one):
- Testing Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed functional test 00304_http_external_data for s390x.