### PR TITLE
Do not cancel created prs

### DIFF
--- a/tests/ci/cancel_and_rerun_workflow_lambda/app.py
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/app.py
@@ -304,6 +304,12 @@ def main(event):
     pull_request = event_data["pull_request"]
     labels = {label["name"] for label in pull_request["labels"]}
     print("PR has labels", labels)
+    if action == "opened" or (
+        action == "labeled" and pull_request["created_at"] == pull_request["updated_at"]
+    ):
+        print("Freshly opened PR, nothing to do")
+        return
+
     if action == "closed" or (action == "labeled" and "do not test" in labels):
         print("PR merged/closed or manually labeled 'do not test' will kill workflows")
         workflow_descriptions = get_workflows_description_for_pull_request(

--- a/tests/ci/cancel_and_rerun_workflow_lambda/app.py
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/app.py
@@ -329,7 +329,8 @@ def main(event):
         print(f"Found {len(urls_to_cancel)} workflows to cancel")
         exec_workflow_url(urls_to_cancel, token)
         return
-    elif action == "edited":
+
+    if action == "edited":
         print("PR is edited, check if it needs to rerun")
         workflow_descriptions = get_workflows_description_for_pull_request(
             pull_request, token
@@ -351,7 +352,8 @@ def main(event):
             exec_workflow_url([most_recent_workflow.rerun_url], token)
             print("Rerun finished, exiting")
             return
-    elif action == "synchronize":
+
+    if action == "synchronize":
         print("PR is synchronized, going to stop old actions")
         workflow_descriptions = get_workflows_description_for_pull_request(
             pull_request, token
@@ -370,7 +372,9 @@ def main(event):
                 urls_to_cancel.append(workflow_description.cancel_url)
         print(f"Found {len(urls_to_cancel)} workflows to cancel")
         exec_workflow_url(urls_to_cancel, token)
-    elif action == "labeled" and event_data["label"]["name"] == "can be tested":
+        return
+
+    if action == "labeled" and event_data["label"]["name"] == "can be tested":
         print("PR marked with can be tested label, rerun workflow")
         workflow_descriptions = get_workflows_description_for_pull_request(
             pull_request, token
@@ -407,9 +411,9 @@ def main(event):
                 break
             print("Still have strange status")
             time.sleep(3)
+        return
 
-    else:
-        print("Nothing to do")
+    print("Nothing to do")
 
 
 def handler(event, _):


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now the freshly created actions with labels are canceled, this PR tries to address it.