### PR TITLE
Fix ASTQualifiedAsterisk cloning

### DIFF
--- a/src/Parsers/ASTQualifiedAsterisk.h
+++ b/src/Parsers/ASTQualifiedAsterisk.h
@@ -17,8 +17,13 @@ public:
     ASTPtr clone() const override
     {
         auto clone = std::make_shared<ASTQualifiedAsterisk>(*this);
+        clone->children.clear();
 
-        if (transformers) { clone->transformers = transformers->clone(); clone->children.push_back(clone->transformers); }
+        if (transformers)
+        {
+            clone->transformers = transformers->clone();
+            clone->children.push_back(clone->transformers);
+        }
 
         clone->qualifier = qualifier->clone();
         clone->children.push_back(clone->qualifier);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


After https://github.com/ClickHouse/ClickHouse/pull/42884, a cloned ASTQualifiedAsterisk contains both the old children and the new (cloned) ones. cc @evillique 

AFAIK, this doesn't have any user visible impact but it will cause issues if you use the cloned ASTPtr children unexpectedly (since some belong to the old object and not the new one).
