### PR TITLE
Proper includes for ConnectionTimeoutsContext.h

### DIFF
--- a/programs/copier/ClusterCopier.cpp
+++ b/programs/copier/ClusterCopier.cpp
@@ -6,7 +6,6 @@
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/setThreadName.h>
-#include <IO/ConnectionTimeoutsContext.h>
 #include <Interpreters/InterpreterInsertQuery.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <Parsers/ASTFunction.h>

--- a/src/BridgeHelper/IBridgeHelper.h
+++ b/src/BridgeHelper/IBridgeHelper.h
@@ -6,7 +6,6 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Common/ShellCommand.h>
 #include <Common/logger_useful.h>
-#include <IO/ConnectionTimeoutsContext.h>
 
 
 namespace DB

--- a/src/BridgeHelper/LibraryBridgeHelper.cpp
+++ b/src/BridgeHelper/LibraryBridgeHelper.cpp
@@ -1,5 +1,7 @@
 #include "LibraryBridgeHelper.h"
 
+#include <IO/ConnectionTimeoutsContext.h>
+
 namespace DB
 {
 

--- a/src/Disks/IO/ReadBufferFromWebServer.cpp
+++ b/src/Disks/IO/ReadBufferFromWebServer.cpp
@@ -4,7 +4,6 @@
 #include <base/sleep.h>
 #include <Core/Types.h>
 #include <IO/ReadWriteBufferFromHTTP.h>
-#include <IO/ConnectionTimeoutsContext.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
 #include <thread>

--- a/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Web/WebObjectStorage.cpp
@@ -3,7 +3,6 @@
 #include <Common/logger_useful.h>
 #include <Common/escapeForFileName.h>
 
-#include <IO/ConnectionTimeoutsContext.h>
 #include <IO/ReadWriteBufferFromHTTP.h>
 #include <IO/SeekAvoidingReadBuffer.h>
 #include <IO/ReadHelpers.h>

--- a/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -7,7 +7,6 @@
 #include <Common/ProfileEvents.h>
 #include <Common/checkStackSize.h>
 #include <TableFunctions/TableFunctionFactory.h>
-#include <IO/ConnectionTimeoutsContext.h>
 #include <Interpreters/RequiredSourceColumnsVisitor.h>
 #include <DataTypes/ObjectUtils.h>
 

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -6,7 +6,6 @@
 #include <Columns/ColumnNullable.h>
 #include <Processors/Transforms/buildPushingToViewsChain.h>
 #include <DataTypes/DataTypeNullable.h>
-#include <IO/ConnectionTimeoutsContext.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <Interpreters/InterpreterWatchQuery.h>
 #include <Interpreters/QueryLog.h>

--- a/src/Storages/HDFS/StorageHDFSCluster.cpp
+++ b/src/Storages/HDFS/StorageHDFSCluster.cpp
@@ -8,6 +8,7 @@
 #include <Client/Connection.h>
 #include <Core/QueryProcessingStage.h>
 #include <DataTypes/DataTypeString.h>
+#include <IO/ConnectionTimeoutsContext.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/getHeaderForProcessingStage.h>
 #include <Interpreters/SelectQueryOptions.h>

--- a/src/Storages/StorageS3Cluster.cpp
+++ b/src/Storages/StorageS3Cluster.cpp
@@ -8,6 +8,7 @@
 #include "Client/Connection.h"
 #include "Core/QueryProcessingStage.h"
 #include <DataTypes/DataTypeString.h>
+#include <IO/ConnectionTimeoutsContext.h>
 #include <IO/WriteBufferFromS3.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

ConnectionTimeouts declares several static functions (`getTCPTimeoutsWithoutFailover`, `getTCPTimeoutsWithFailover` and `getHTTPTimeouts`) but those are then declared in a different file (`ConnectionTimeoutsContext.h`) as inline. That means that any file that wants to use any of those functions must include the other file, but this was not always the case. Also, some files where including the file and not using the functions so I've removed the include there.

No idea how this was working without the include to be honest (maybe the compiler wasn't actually inlining the functions and the definition was always found?).