### PR TITLE
Update s2.md, typo in reference docs

### DIFF
--- a/docs/en/sql-reference/functions/geo/s2.md
+++ b/docs/en/sql-reference/functions/geo/s2.md
@@ -304,7 +304,7 @@ Result:
 └──────────────┘
 ```
 
-## s2RectUinion
+## s2RectUnion
 
 Returns the smallest rectangle containing the union of this rectangle and the given rectangle. In the S2 system, a rectangle is represented by a type of S2Region called a `S2LatLngRect` that represents a rectangle in latitude-longitude space.
 


### PR DESCRIPTION
Small typo in s2CapUnion

### Changelog category (leave one):

- Documentation (changelog entry is not required)
