### PR TITLE
Link to the new TTL user guide

### DIFF
--- a/docs/en/sql-reference/statements/alter/ttl.md
+++ b/docs/en/sql-reference/statements/alter/ttl.md
@@ -6,6 +6,10 @@ sidebar_label: TTL
 
 # Manipulations with Table TTL
 
+:::note
+If you are looking for details on using TTL for managing old data, check out the [Manage Data with TTL](../../../guides/developer/ttl.md) user guide. The docs below demonstrate how to alter or remove an existing TTL rule.
+:::
+
 ## MODIFY TTL
 
 You can change [table TTL](../../../engines/table-engines/mergetree-family/mergetree.md#mergetree-table-ttl) with a request of the following form:

--- a/docs/en/sql-reference/statements/alter/ttl.md
+++ b/docs/en/sql-reference/statements/alter/ttl.md
@@ -7,7 +7,7 @@ sidebar_label: TTL
 # Manipulations with Table TTL
 
 :::note
-If you are looking for details on using TTL for managing old data, check out the [Manage Data with TTL](../../../guides/developer/ttl.md) user guide. The docs below demonstrate how to alter or remove an existing TTL rule.
+If you are looking for details on using TTL for managing old data, check out the [Manage Data with TTL](/docs/en/guides/developer/ttl.md) user guide. The docs below demonstrate how to alter or remove an existing TTL rule.
 :::
 
 ## MODIFY TTL


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Searching for `TTL` in the docs sends users to the "Manipulations with Table TTL" page, which is only useful is already have TTL rules defined. I've added a Note at the top of the page to direct people to the new user guide that explains how to define TTL rules.