### PR TITLE
use IDisk's interfaces to operate filesystem in Keeper

### DIFF
--- a/programs/keeper-converter/KeeperConverter.cpp
+++ b/programs/keeper-converter/KeeperConverter.cpp
@@ -9,6 +9,7 @@
 #include <Poco/AutoPtr.h>
 #include <Poco/Logger.h>
 #include <Common/logger_useful.h>
+#include <Disks/DiskLocal.h>
 
 
 int mainEntryClickHouseKeeperConverter(int argc, char ** argv)
@@ -51,7 +52,7 @@ int mainEntryClickHouseKeeperConverter(int argc, char ** argv)
         DB::SnapshotMetadataPtr snapshot_meta = std::make_shared<DB::SnapshotMetadata>(storage.getZXID(), 1, std::make_shared<nuraft::cluster_config>());
         DB::KeeperStorageSnapshot snapshot(&storage, snapshot_meta);
 
-        DB::KeeperSnapshotManager manager(options["output-dir"].as<std::string>(), 1, keeper_context);
+        DB::KeeperSnapshotManager manager(std::make_shared<DiskLocal>("Keeper-snapshots", options["output-dir"].as<std::string>(), 0), 1, keeper_context);
         auto snp = manager.serializeSnapshotToBuffer(snapshot);
         auto path = manager.serializeSnapshotBufferToDisk(*snp, storage.getZXID());
         std::cout << "Snapshot serialized to path:" << path << std::endl;

--- a/src/Coordination/Changelog.h
+++ b/src/Coordination/Changelog.h
@@ -86,7 +86,7 @@ class Changelog
 {
 public:
     Changelog(
-        const std::string & changelogs_dir_,
+        DiskPtr disk_,
         Poco::Logger * log_,
         LogFileSettings log_file_settings);
 
@@ -168,8 +168,8 @@ private:
     /// Clean useless log files in a background thread
     void cleanLogThread();
 
-    const std::filesystem::path changelogs_dir;
-    const std::filesystem::path changelogs_detached_dir;
+    DiskPtr disk;
+    const String changelogs_detached_dir;
     const uint64_t rotate_interval;
     Poco::Logger * log;
 

--- a/src/Coordination/KeeperLogStore.cpp
+++ b/src/Coordination/KeeperLogStore.cpp
@@ -1,18 +1,23 @@
 #include <Coordination/KeeperLogStore.h>
 #include <IO/CompressionMethod.h>
+#include <Disks/DiskLocal.h>
 
 namespace DB
 {
 
-KeeperLogStore::KeeperLogStore(
-    const std::string & changelogs_path, LogFileSettings log_file_settings)
+KeeperLogStore::KeeperLogStore(DiskPtr disk_, LogFileSettings log_file_settings)
     : log(&Poco::Logger::get("KeeperLogStore"))
-    , changelog(changelogs_path, log, log_file_settings)
+    , changelog(disk_, log, log_file_settings)
 {
     if (log_file_settings.force_sync)
         LOG_INFO(log, "force_sync enabled");
     else
         LOG_INFO(log, "force_sync disabled");
+}
+
+KeeperLogStore::KeeperLogStore(const std::string & changelogs_path, LogFileSettings log_file_settings)
+    : KeeperLogStore(std::make_shared<DiskLocal>("Keeper-logs", changelogs_path, 0), log_file_settings)
+{
 }
 
 uint64_t KeeperLogStore::start_index() const

--- a/src/Coordination/KeeperLogStore.h
+++ b/src/Coordination/KeeperLogStore.h
@@ -14,6 +14,9 @@ namespace DB
 class KeeperLogStore : public nuraft::log_store
 {
 public:
+    KeeperLogStore(DiskPtr disk_, LogFileSettings log_file_settings);
+
+    /// For gtest
     KeeperLogStore(const std::string & changelogs_path, LogFileSettings log_file_settings);
 
     /// Read log storage from filesystem starting from last_commited_log_index

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -41,14 +41,14 @@ namespace
 KeeperStateMachine::KeeperStateMachine(
     ResponsesQueue & responses_queue_,
     SnapshotsQueue & snapshots_queue_,
-    const std::string & snapshots_path_,
+    DiskPtr disk_,
     const CoordinationSettingsPtr & coordination_settings_,
     const KeeperContextPtr & keeper_context_,
     KeeperSnapshotManagerS3 * snapshot_manager_s3_,
     const std::string & superdigest_)
     : coordination_settings(coordination_settings_)
     , snapshot_manager(
-          snapshots_path_,
+          disk_,
           coordination_settings->snapshots_to_keep,
           keeper_context_,
           coordination_settings->compress_snapshots_with_zstd_format,

--- a/src/Coordination/KeeperStateMachine.h
+++ b/src/Coordination/KeeperStateMachine.h
@@ -25,7 +25,7 @@ public:
     KeeperStateMachine(
         ResponsesQueue & responses_queue_,
         SnapshotsQueue & snapshots_queue_,
-        const std::string & snapshots_path_,
+        DiskPtr disk_,
         const CoordinationSettingsPtr & coordination_settings_,
         const KeeperContextPtr & keeper_context_,
         KeeperSnapshotManagerS3 * snapshot_manager_s3_,

--- a/src/Coordination/KeeperStateManager.cpp
+++ b/src/Coordination/KeeperStateManager.cpp
@@ -7,6 +7,7 @@
 #include <Common/isLocalAddress.h>
 #include <IO/ReadHelpers.h>
 #include <Common/getMultipleKeysFromConfig.h>
+#include <Disks/DiskLocal.h>
 
 namespace DB
 {
@@ -214,8 +215,8 @@ KeeperStateManager::KeeperStateManager(
     int server_id_, const std::string & host, int port, const std::string & logs_path, const std::string & state_file_path)
     : my_server_id(server_id_)
     , secure(false)
-    , log_store(nuraft::cs_new<KeeperLogStore>(logs_path, LogFileSettings{.force_sync =false, .compress_logs = false, .rotate_interval = 5000}))
-    , server_state_path(state_file_path)
+    , log_store(nuraft::cs_new<KeeperLogStore>(std::make_shared<DiskLocal>("Keeper-logs", logs_path, 0), LogFileSettings{.force_sync =false, .compress_logs = false, .rotate_interval = 5000}))
+    , server_state_file_name(fs::path(state_file_path).filename().generic_string())
     , logger(&Poco::Logger::get("KeeperStateManager"))
 {
     auto peer_config = nuraft::cs_new<nuraft::srv_config>(my_server_id, host + ":" + std::to_string(port));
@@ -228,8 +229,9 @@ KeeperStateManager::KeeperStateManager(
 KeeperStateManager::KeeperStateManager(
     int my_server_id_,
     const std::string & config_prefix_,
-    const std::string & log_storage_path,
-    const std::string & state_file_path,
+    DiskPtr log_disk_,
+    DiskPtr state_disk_,
+    const std::string & server_state_file_name_,
     const Poco::Util::AbstractConfiguration & config,
     const CoordinationSettingsPtr & coordination_settings)
     : my_server_id(my_server_id_)
@@ -237,7 +239,7 @@ KeeperStateManager::KeeperStateManager(
     , config_prefix(config_prefix_)
     , configuration_wrapper(parseServersConfiguration(config, false))
     , log_store(nuraft::cs_new<KeeperLogStore>(
-          log_storage_path,
+          log_disk_,
           LogFileSettings
           {
             .force_sync = coordination_settings->force_sync,
@@ -246,7 +248,8 @@ KeeperStateManager::KeeperStateManager(
             .max_size = coordination_settings->max_log_file_size,
             .overallocate_size = coordination_settings->log_file_overallocate_size
           }))
-    , server_state_path(state_file_path)
+    , disk(state_disk_)
+    , server_state_file_name(server_state_file_name_)
     , logger(&Poco::Logger::get("KeeperStateManager"))
 {
 }
@@ -285,11 +288,11 @@ void KeeperStateManager::save_config(const nuraft::cluster_config & config)
     configuration_wrapper.cluster_config = nuraft::cluster_config::deserialize(*buf);
 }
 
-const std::filesystem::path & KeeperStateManager::getOldServerStatePath()
+const String & KeeperStateManager::getOldServerStatePath()
 {
     static auto old_path = [this]
     {
-        return server_state_path.parent_path() / (server_state_path.filename().generic_string() + "-OLD");
+        return server_state_file_name + "-OLD";
     }();
 
     return old_path;
@@ -310,25 +313,24 @@ void KeeperStateManager::save_state(const nuraft::srv_state & state)
 {
     const auto & old_path = getOldServerStatePath();
 
-    if (std::filesystem::exists(server_state_path))
-        std::filesystem::rename(server_state_path, old_path);
+    if (disk->exists(server_state_file_name))
+        disk->moveFile(server_state_file_name, old_path);
 
-    WriteBufferFromFile server_state_file(server_state_path, DBMS_DEFAULT_BUFFER_SIZE, O_TRUNC | O_CREAT | O_WRONLY);
+    auto server_state_file = disk->writeFile(server_state_file_name);
     auto buf = state.serialize();
 
     // calculate checksum
     SipHash hash;
     hash.update(current_server_state_version);
     hash.update(reinterpret_cast<const char *>(buf->data_begin()), buf->size());
-    writeIntBinary(hash.get64(), server_state_file);
+    writeIntBinary(hash.get64(), *server_state_file);
 
-    writeIntBinary(static_cast<uint8_t>(current_server_state_version), server_state_file);
+    writeIntBinary(static_cast<uint8_t>(current_server_state_version), *server_state_file);
 
-    server_state_file.write(reinterpret_cast<const char *>(buf->data_begin()), buf->size());
-    server_state_file.sync();
-    server_state_file.close();
+    server_state_file->write(reinterpret_cast<const char *>(buf->data_begin()), buf->size());
+    server_state_file->sync();
 
-    std::filesystem::remove(old_path);
+    disk->removeFileIfExists(old_path);
 }
 
 nuraft::ptr<nuraft::srv_state> KeeperStateManager::read_state()
@@ -339,22 +341,22 @@ nuraft::ptr<nuraft::srv_state> KeeperStateManager::read_state()
     {
         try
         {
-            ReadBufferFromFile read_buf(path);
-            auto content_size = read_buf.getFileSize();
+            auto read_buf = disk->readFile(path);
+            auto content_size = read_buf->getFileSize();
 
             if (content_size == 0)
                 return nullptr;
 
             uint64_t read_checksum{0};
-            readIntBinary(read_checksum, read_buf);
+            readIntBinary(read_checksum, *read_buf);
 
             uint8_t version;
-            readIntBinary(version, read_buf);
+            readIntBinary(version, *read_buf);
 
             auto buffer_size = content_size - sizeof read_checksum - sizeof version;
 
             auto state_buf = nuraft::buffer::alloc(buffer_size);
-            read_buf.readStrict(reinterpret_cast<char *>(state_buf->data_begin()), buffer_size);
+            read_buf->readStrict(reinterpret_cast<char *>(state_buf->data_begin()), buffer_size);
 
             SipHash hash;
             hash.update(version);
@@ -364,15 +366,15 @@ nuraft::ptr<nuraft::srv_state> KeeperStateManager::read_state()
             {
                 constexpr auto error_format = "Invalid checksum while reading state from {}. Got {}, expected {}";
 #ifdef NDEBUG
-                LOG_ERROR(logger, error_format, path.generic_string(), hash.get64(), read_checksum);
+                LOG_ERROR(logger, error_format, path, hash.get64(), read_checksum);
                 return nullptr;
 #else
-                throw Exception(ErrorCodes::CORRUPTED_DATA, error_format, path.generic_string(), hash.get64(), read_checksum);
+                throw Exception(ErrorCodes::CORRUPTED_DATA, error_format, disk->getPath() + path, hash.get64(), read_checksum);
 #endif
             }
 
             auto state = nuraft::srv_state::deserialize(*state_buf);
-            LOG_INFO(logger, "Read state from {}", path.generic_string());
+            LOG_INFO(logger, "Read state from {}", disk->getPath() + path);
             return state;
         }
         catch (const std::exception & e)
@@ -383,37 +385,34 @@ nuraft::ptr<nuraft::srv_state> KeeperStateManager::read_state()
                 throw;
             }
 
-            LOG_ERROR(logger, "Failed to deserialize state from {}", path.generic_string());
+            LOG_ERROR(logger, "Failed to deserialize state from {}", disk->getPath() + path);
             return nullptr;
         }
     };
 
-    if (std::filesystem::exists(server_state_path))
+    if (disk->exists(server_state_file_name))
     {
-        auto state = try_read_file(server_state_path);
+        auto state = try_read_file(server_state_file_name);
 
         if (state)
         {
-            if (std::filesystem::exists(old_path))
-                std::filesystem::remove(old_path);
+            disk->removeFileIfExists(old_path);
 
             return state;
         }
 
-        std::filesystem::remove(server_state_path);
+        disk->removeFile(server_state_file_name);
     }
 
-    if (std::filesystem::exists(old_path))
+    if (disk->exists(old_path))
     {
         auto state = try_read_file(old_path);
-
         if (state)
         {
-            std::filesystem::rename(old_path, server_state_path);
+            disk->moveFile(old_path, server_state_file_name);
             return state;
         }
-
-        std::filesystem::remove(old_path);
+        disk->removeFile(old_path);
     }
 
     LOG_WARNING(logger, "No state was read");

--- a/src/Coordination/KeeperStateManager.h
+++ b/src/Coordination/KeeperStateManager.h
@@ -39,7 +39,8 @@ public:
     KeeperStateManager(
         int server_id_,
         const std::string & config_prefix_,
-        const std::string & log_storage_path,
+        DiskPtr logs_disk_,
+        DiskPtr state_disk_,
         const std::string & state_file_path,
         const Poco::Util::AbstractConfiguration & config,
         const CoordinationSettingsPtr & coordination_settings);
@@ -111,7 +112,7 @@ public:
     ConfigUpdateActions getConfigurationDiff(const Poco::Util::AbstractConfiguration & config) const;
 
 private:
-    const std::filesystem::path & getOldServerStatePath();
+    const String & getOldServerStatePath();
 
     /// Wrapper struct for Keeper cluster config. We parse this
     /// info from XML files.
@@ -136,7 +137,8 @@ private:
 
     nuraft::ptr<KeeperLogStore> log_store;
 
-    const std::filesystem::path server_state_path;
+    DiskPtr disk;
+    const String server_state_file_name;
 
     Poco::Logger * logger;
 

--- a/src/IO/ZstdDeflatingAppendableWriteBuffer.cpp
+++ b/src/IO/ZstdDeflatingAppendableWriteBuffer.cpp
@@ -11,7 +11,7 @@ namespace ErrorCodes
 }
 
 ZstdDeflatingAppendableWriteBuffer::ZstdDeflatingAppendableWriteBuffer(
-    std::unique_ptr<WriteBufferFromFile> out_,
+    std::unique_ptr<WriteBufferFromFileBase> out_,
     int compression_level,
     bool append_to_existing_file_,
     size_t buf_size,

--- a/src/IO/ZstdDeflatingAppendableWriteBuffer.h
+++ b/src/IO/ZstdDeflatingAppendableWriteBuffer.h
@@ -29,7 +29,7 @@ public:
     static inline constexpr ZSTDLastBlock ZSTD_CORRECT_TERMINATION_LAST_BLOCK = {0x01, 0x00, 0x00};
 
     ZstdDeflatingAppendableWriteBuffer(
-        std::unique_ptr<WriteBufferFromFile> out_,
+        std::unique_ptr<WriteBufferFromFileBase> out_,
         int compression_level,
         bool append_to_existing_file_,
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
@@ -68,7 +68,7 @@ private:
     /// Adding zstd empty block (ZSTD_CORRECT_TERMINATION_LAST_BLOCK) to out.working_buffer
     void addEmptyBlock();
 
-    std::unique_ptr<WriteBufferFromFile> out;
+    std::unique_ptr<WriteBufferFromFileBase> out;
 
     bool append_to_existing_file = false;
     ZSTD_CCtx * cctx;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Replacing std::filesystem operations with DiskPtr APIs,  because `IDisk` is filesystem abstraction.
This way can make keeper to store logs and snapshots into more types of Disk.


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
