### PR TITLE
Fix clang-tidy error in Keeper `Changelog`

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -157,8 +157,8 @@ public:
         assert(file_buffer && current_file_description);
 
         assert(record.header.index - getStartIndex() <= current_file_description->expectedEntriesCountInLog());
-        if (const bool log_is_complete = record.header.index - getStartIndex() == current_file_description->expectedEntriesCountInLog();
-            log_is_complete)
+        // check if log file reached the limit for amount of records it can contain
+        if (record.header.index - getStartIndex() == current_file_description->expectedEntriesCountInLog())
         {
             rotate(record.header.index);
         }

--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -157,20 +157,23 @@ public:
         assert(file_buffer && current_file_description);
 
         assert(record.header.index - getStartIndex() <= current_file_description->expectedEntriesCountInLog());
-        const bool log_is_complete = record.header.index - getStartIndex() == current_file_description->expectedEntriesCountInLog();
-
-        if (log_is_complete)
-            rotate(record.header.index);
-
-        // writing at least 1 log is requirement - we don't want empty log files
-        // we use count() that can be unreliable for more complex WriteBuffers, so we should be careful if we change the type of it in the future
-        const bool log_too_big = record.header.index != getStartIndex() && log_file_settings.max_size != 0
-            && initial_file_size + file_buffer->count() > log_file_settings.max_size;
-
-        if (log_too_big)
+        if (const bool log_is_complete = record.header.index - getStartIndex() == current_file_description->expectedEntriesCountInLog();
+            log_is_complete)
         {
-            LOG_TRACE(log, "Log file reached maximum allowed size ({} bytes), creating new log file", log_file_settings.max_size);
             rotate(record.header.index);
+        }
+        else
+        {
+            // writing at least 1 log is requirement - we don't want empty log files
+            // we use count() that can be unreliable for more complex WriteBuffers, so we should be careful if we change the type of it in the future
+            const bool log_too_big = record.header.index != getStartIndex() && log_file_settings.max_size != 0
+                && initial_file_size + file_buffer->count() > log_file_settings.max_size;
+
+            if (log_too_big)
+            {
+                LOG_TRACE(log, "Log file reached maximum allowed size ({} bytes), creating new log file", log_file_settings.max_size);
+                rotate(record.header.index);
+            }
         }
 
         if (!prealloc_done) [[unlikely]]

--- a/utils/keeper-data-dumper/main.cpp
+++ b/utils/keeper-data-dumper/main.cpp
@@ -69,7 +69,8 @@ int main(int argc, char *argv[])
 
     LOG_INFO(logger, "Last committed index: {}", last_commited_index);
 
-    DB::KeeperLogStore changelog(argv[2], 10000000, true, settings->compress_logs);
+    DB::KeeperLogStore changelog(
+        argv[2], LogFileSettings{.force_sync = true, .compress_logs = settings->compress_logs, .rotate_interval = 10000000});
     changelog.init(last_commited_index, 10000000000UL); /// collect all logs
     if (changelog.size() == 0)
         LOG_INFO(logger, "Changelog empty");


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
