### PR TITLE
Fix mbm with aio on top of query plan

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -448,10 +448,6 @@ InterpreterSelectQuery::InterpreterSelectQuery(
         }
     }
 
-    /// FIXME: Memory bound aggregation may cause another reading algorithm to be used on remote replicas
-    if (settings.allow_experimental_parallel_reading_from_replicas && settings.enable_memory_bound_merging_of_aggregation_results)
-        context->setSetting("enable_memory_bound_merging_of_aggregation_results", false);
-
     if (joined_tables.tablesCount() > 1 && settings.allow_experimental_parallel_reading_from_replicas)
     {
         LOG_WARNING(log, "Joins are not supported with parallel replicas. Query will be executed without using them.");

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2502,24 +2502,8 @@ void InterpreterSelectQuery::executeAggregation(QueryPlan & query_plan, const Ac
 
     if (!group_by_info && settings.force_aggregation_in_order)
     {
-        /// Not the most optimal implementation here, but this branch handles very marginal case.
-
         group_by_sort_description = getSortDescriptionFromGroupBy(getSelectQuery());
-
-        auto sorting_step = std::make_unique<SortingStep>(
-            query_plan.getCurrentDataStream(),
-            group_by_sort_description,
-            0 /* LIMIT */,
-            SortingStep::Settings(*context),
-            settings.optimize_sorting_by_input_stream_properties);
-        sorting_step->setStepDescription("Enforced sorting for aggregation in order");
-
-        query_plan.addStep(std::move(sorting_step));
-
-        group_by_info = std::make_shared<InputOrderInfo>(
-            group_by_sort_description, group_by_sort_description.size(), 1 /* direction */, 0 /* limit */);
-
-        sort_description_for_merging = group_by_info->sort_description_for_merging;
+        sort_description_for_merging = group_by_sort_description;
     }
 
     auto merge_threads = max_streams;
@@ -2546,7 +2530,8 @@ void InterpreterSelectQuery::executeAggregation(QueryPlan & query_plan, const Ac
         std::move(sort_description_for_merging),
         std::move(group_by_sort_description),
         should_produce_results_in_order_of_bucket_number,
-        settings.enable_memory_bound_merging_of_aggregation_results);
+        settings.enable_memory_bound_merging_of_aggregation_results,
+        !group_by_info && settings.force_aggregation_in_order);
     query_plan.addStep(std::move(aggregating_step));
 }
 

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -313,7 +313,8 @@ void addAggregationStep(QueryPlan & query_plan,
         std::move(sort_description_for_merging),
         std::move(group_by_sort_description),
         query_analysis_result.aggregation_should_produce_results_in_order_of_bucket_number,
-        settings.enable_memory_bound_merging_of_aggregation_results);
+        settings.enable_memory_bound_merging_of_aggregation_results,
+        settings.force_aggregation_in_order);
     query_plan.addStep(std::move(aggregating_step));
 }
 

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -339,6 +339,8 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
 
     if (!sort_description_for_merging.empty())
     {
+        /// We don't rely here on input_stream.sort_description because it is not correctly propagated for now in all cases
+        /// see https://github.com/ClickHouse/ClickHouse/pull/45892#discussion_r1094503048
         if (explicit_sorting_required_for_aggregation_in_order)
         {
             /// We don't really care about optimality of this sorting, because it's required only in fairly marginal cases.

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -5,12 +5,14 @@
 #include <DataTypes/DataTypeFixedString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionFactory.h>
+#include <IO/Operators.h>
 #include <Interpreters/Aggregator.h>
 #include <Interpreters/Context.h>
 #include <Processors/Merges/AggregatingSortedTransform.h>
 #include <Processors/Merges/FinishAggregatingInOrderTransform.h>
 #include <Processors/QueryPlan/AggregatingStep.h>
 #include <Processors/QueryPlan/IQueryPlanStep.h>
+#include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/Transforms/AggregatingInOrderTransform.h>
 #include <Processors/Transforms/AggregatingTransform.h>
 #include <Processors/Transforms/CopyTransform.h>
@@ -18,7 +20,6 @@
 #include <Processors/Transforms/MemoryBoundMerging.h>
 #include <Processors/Transforms/MergingAggregatedMemoryEfficientTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
-#include <IO/Operators.h>
 #include <Common/JSONBuilder.h>
 
 namespace DB
@@ -101,7 +102,8 @@ AggregatingStep::AggregatingStep(
     SortDescription sort_description_for_merging_,
     SortDescription group_by_sort_description_,
     bool should_produce_results_in_order_of_bucket_number_,
-    bool memory_bound_merging_of_aggregation_results_enabled_)
+    bool memory_bound_merging_of_aggregation_results_enabled_,
+    bool explicit_sorting_required_for_aggregation_in_order_)
     : ITransformingStep(
         input_stream_,
         appendGroupingColumn(params_.getHeader(input_stream_.header, final_), params_.keys, !grouping_sets_params_.empty(), group_by_use_nulls_),
@@ -120,11 +122,13 @@ AggregatingStep::AggregatingStep(
     , group_by_sort_description(std::move(group_by_sort_description_))
     , should_produce_results_in_order_of_bucket_number(should_produce_results_in_order_of_bucket_number_)
     , memory_bound_merging_of_aggregation_results_enabled(memory_bound_merging_of_aggregation_results_enabled_)
+    , explicit_sorting_required_for_aggregation_in_order(explicit_sorting_required_for_aggregation_in_order_)
 {
     if (memoryBoundMergingWillBeUsed())
     {
         output_stream->sort_description = group_by_sort_description;
         output_stream->sort_scope = DataStream::SortScope::Global;
+        output_stream->has_single_port = true;
     }
 }
 
@@ -139,6 +143,8 @@ void AggregatingStep::applyOrder(SortDescription sort_description_for_merging_, 
         output_stream->sort_scope = DataStream::SortScope::Global;
         output_stream->has_single_port = true;
     }
+
+    explicit_sorting_required_for_aggregation_in_order = false;
 }
 
 void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings & settings)
@@ -333,6 +339,13 @@ void AggregatingStep::transformPipeline(QueryPipelineBuilder & pipeline, const B
 
     if (!sort_description_for_merging.empty())
     {
+        if (explicit_sorting_required_for_aggregation_in_order)
+        {
+            /// We don't really care about optimality of this sorting, because it's required only in fairly marginal cases.
+            SortingStep::fullSortStreams(
+                pipeline, SortingStep::Settings(params.max_block_size), sort_description_for_merging, 0 /* limit */);
+        }
+
         if (pipeline.getNumStreams() > 1)
         {
             /** The pipeline is the following:

--- a/src/Processors/QueryPlan/AggregatingStep.h
+++ b/src/Processors/QueryPlan/AggregatingStep.h
@@ -40,7 +40,8 @@ public:
         SortDescription sort_description_for_merging_,
         SortDescription group_by_sort_description_,
         bool should_produce_results_in_order_of_bucket_number_,
-        bool memory_bound_merging_of_aggregation_results_enabled_);
+        bool memory_bound_merging_of_aggregation_results_enabled_,
+        bool explicit_sorting_required_for_aggregation_in_order_);
 
     static Block appendGroupingColumn(Block block, const Names & keys, bool has_grouping, bool use_nulls);
 
@@ -56,6 +57,7 @@ public:
     const Aggregator::Params & getParams() const { return params; }
 
     bool inOrder() const { return !sort_description_for_merging.empty(); }
+    bool explicitSortingRequired() const { return explicit_sorting_required_for_aggregation_in_order; }
     bool isGroupingSets() const { return !grouping_sets_params.empty(); }
     void applyOrder(SortDescription sort_description_for_merging_, SortDescription group_by_sort_description_);
     bool memoryBoundMergingWillBeUsed() const;
@@ -84,6 +86,7 @@ private:
     /// These settings are used to determine if we should resize pipeline to 1 at the end.
     bool should_produce_results_in_order_of_bucket_number;
     bool memory_bound_merging_of_aggregation_results_enabled;
+    bool explicit_sorting_required_for_aggregation_in_order;
 
     Processors aggregating_in_order;
     Processors aggregating_sorted;

--- a/src/Processors/QueryPlan/MergingAggregatedStep.cpp
+++ b/src/Processors/QueryPlan/MergingAggregatedStep.cpp
@@ -73,11 +73,14 @@ MergingAggregatedStep::MergingAggregatedStep(
     }
 }
 
-void MergingAggregatedStep::updateInputSortDescription(SortDescription sort_description, DataStream::SortScope sort_scope)
+void MergingAggregatedStep::applyOrder(SortDescription sort_description, DataStream::SortScope sort_scope)
 {
     auto & input_stream = input_streams.front();
     input_stream.sort_scope = sort_scope;
     input_stream.sort_description = sort_description;
+
+    /// Columns might be reordered during optimisation, so we better to update sort description.
+    group_by_sort_description = std::move(sort_description);
 
     if (memoryBoundMergingWillBeUsed() && should_produce_results_in_order_of_bucket_number)
     {

--- a/src/Processors/QueryPlan/MergingAggregatedStep.h
+++ b/src/Processors/QueryPlan/MergingAggregatedStep.h
@@ -33,7 +33,7 @@ public:
     void describeActions(JSONBuilder::JSONMap & map) const override;
     void describeActions(FormatSettings & settings) const override;
 
-    void updateInputSortDescription(SortDescription input_sort_description, DataStream::SortScope sort_scope);
+    void applyOrder(SortDescription input_sort_description, DataStream::SortScope sort_scope);
 
     bool memoryBoundMergingWillBeUsed() const;
 
@@ -48,7 +48,7 @@ private:
     size_t memory_efficient_merge_threads;
     const size_t max_block_size;
     const size_t memory_bound_merging_max_block_bytes;
-    const SortDescription group_by_sort_description;
+    SortDescription group_by_sort_description;
 
     /// These settings are used to determine if we should resize pipeline to 1 at the end.
     const bool should_produce_results_in_order_of_bucket_number;

--- a/src/Processors/QueryPlan/Optimizations/enableMemoryBoundMerging.cpp
+++ b/src/Processors/QueryPlan/Optimizations/enableMemoryBoundMerging.cpp
@@ -88,7 +88,7 @@ void enableMemoryBoundMerging(QueryPlan::Node & node, QueryPlan::Nodes &)
             reading->enforceAggregationInOrder();
     }
 
-    root_mergine_aggeregated->updateInputSortDescription(sort_description, DataStream::SortScope::Stream);
+    root_mergine_aggeregated->applyOrder(sort_description, DataStream::SortScope::Stream);
 }
 
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -1168,7 +1168,7 @@ void optimizeAggregationInOrder(QueryPlan::Node & node, QueryPlan::Nodes &)
     if (!aggregating)
         return;
 
-    if (aggregating->inOrder() || aggregating->isGroupingSets())
+    if ((aggregating->inOrder() && !aggregating->explicitSortingRequired()) || aggregating->isGroupingSets())
         return;
 
     /// TODO: maybe add support for UNION later.

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -182,7 +182,8 @@ void SortingStep::mergingSorted(QueryPipelineBuilder & pipeline, const SortDescr
     }
 }
 
-void SortingStep::mergeSorting(QueryPipelineBuilder & pipeline, const SortDescription & result_sort_desc, UInt64 limit_)
+void SortingStep::mergeSorting(
+    QueryPipelineBuilder & pipeline, const Settings & sort_settings, const SortDescription & result_sort_desc, UInt64 limit_)
 {
     bool increase_sort_description_compile_attempts = true;
 
@@ -200,6 +201,10 @@ void SortingStep::mergeSorting(QueryPipelineBuilder & pipeline, const SortDescri
             if (increase_sort_description_compile_attempts)
                 increase_sort_description_compile_attempts = false;
 
+            auto tmp_data_on_disk = sort_settings.tmp_data
+                ? std::make_unique<TemporaryDataOnDisk>(sort_settings.tmp_data, CurrentMetrics::TemporaryFilesForSort)
+                : std::unique_ptr<TemporaryDataOnDisk>();
+
             return std::make_shared<MergeSortingTransform>(
                 header,
                 result_sort_desc,
@@ -209,12 +214,17 @@ void SortingStep::mergeSorting(QueryPipelineBuilder & pipeline, const SortDescri
                 sort_settings.max_bytes_before_remerge / pipeline.getNumStreams(),
                 sort_settings.remerge_lowered_memory_bytes_ratio,
                 sort_settings.max_bytes_before_external_sort,
-                std::make_unique<TemporaryDataOnDisk>(sort_settings.tmp_data, CurrentMetrics::TemporaryFilesForSort),
+                std::move(tmp_data_on_disk),
                 sort_settings.min_free_disk_space);
         });
 }
 
-void SortingStep::fullSort(QueryPipelineBuilder & pipeline, const SortDescription & result_sort_desc, const UInt64 limit_, const bool skip_partial_sort)
+void SortingStep::fullSortStreams(
+    QueryPipelineBuilder & pipeline,
+    const Settings & sort_settings,
+    const SortDescription & result_sort_desc,
+    const UInt64 limit_,
+    const bool skip_partial_sort)
 {
     if (!skip_partial_sort || limit_)
     {
@@ -241,7 +251,13 @@ void SortingStep::fullSort(QueryPipelineBuilder & pipeline, const SortDescriptio
             });
     }
 
-    mergeSorting(pipeline, result_sort_desc, limit_);
+    mergeSorting(pipeline, sort_settings, result_sort_desc, limit_);
+}
+
+void SortingStep::fullSort(
+    QueryPipelineBuilder & pipeline, const SortDescription & result_sort_desc, const UInt64 limit_, const bool skip_partial_sort)
+{
+    fullSortStreams(pipeline, sort_settings, result_sort_desc, limit_, skip_partial_sort);
 
     /// If there are several streams, then we merge them into one
     if (pipeline.getNumStreams() > 1)

--- a/src/Processors/QueryPlan/SortingStep.h
+++ b/src/Processors/QueryPlan/SortingStep.h
@@ -73,11 +73,20 @@ public:
     Type getType() const { return type; }
     const Settings & getSettings() const { return sort_settings; }
 
+    static void fullSortStreams(
+        QueryPipelineBuilder & pipeline,
+        const Settings & sort_settings,
+        const SortDescription & result_sort_desc,
+        UInt64 limit_,
+        bool skip_partial_sort = false);
+
 private:
     void updateOutputStream() override;
 
+    static void
+    mergeSorting(QueryPipelineBuilder & pipeline, const Settings & sort_settings, const SortDescription & result_sort_desc, UInt64 limit_);
+
     void mergingSorted(QueryPipelineBuilder & pipeline, const SortDescription & result_sort_desc, UInt64 limit_);
-    void mergeSorting(QueryPipelineBuilder & pipeline, const SortDescription & result_sort_desc, UInt64 limit_);
     void finishSorting(
         QueryPipelineBuilder & pipeline, const SortDescription & input_sort_desc, const SortDescription & result_sort_desc, UInt64 limit_);
     void fullSort(

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -413,7 +413,8 @@ QueryPlanPtr MergeTreeDataSelectExecutor::read(
                     std::move(sort_description_for_merging),
                     std::move(group_by_sort_description),
                     should_produce_results_in_order_of_bucket_number,
-                    settings.enable_memory_bound_merging_of_aggregation_results);
+                    settings.enable_memory_bound_merging_of_aggregation_results,
+                    !group_by_info && settings.force_aggregation_in_order);
                 query_plan->addStep(std::move(aggregating_step));
             };
 

--- a/tests/queries/0_stateless/02404_memory_bound_merging.reference
+++ b/tests/queries/0_stateless/02404_memory_bound_merging.reference
@@ -113,22 +113,21 @@ ExpressionTransform
             (Expression)
             ExpressionTransform × 4
               (MergingAggregated)
-              Resize 1 → 4
-                SortingAggregatedTransform 4 → 1
-                  MergingAggregatedBucketTransform × 4
-                    Resize 1 → 4
-                      GroupingAggregatedTransform 6 → 1
-                        (Union)
-                          (Aggregating)
-                          MergingAggregatedBucketTransform × 4
-                            Resize 1 → 4
-                              FinishAggregatingInOrderTransform 4 → 1
-                                AggregatingInOrderTransform × 4
-                                  (Expression)
-                                  ExpressionTransform × 4
-                                    (ReadFromMergeTree)
-                                    MergeTreeInOrder × 4 0 → 1
-                          (ReadFromRemoteParallelReplicas)
+              MergingAggregatedBucketTransform × 4
+                Resize 1 → 4
+                  FinishAggregatingInOrderTransform 3 → 1
+                    (Union)
+                      (Aggregating)
+                      SortingAggregatedForMemoryBoundMergingTransform 4 → 1
+                        MergingAggregatedBucketTransform × 4
+                          Resize 1 → 4
+                            FinishAggregatingInOrderTransform 4 → 1
+                              AggregatingInOrderTransform × 4
+                                (Expression)
+                                ExpressionTransform × 4
+                                  (ReadFromMergeTree)
+                                  MergeTreeInOrder × 4 0 → 1
+                      (ReadFromRemoteParallelReplicas)
 select a, count() from pr_t group by a order by a limit 5 offset 500;
 500	1000
 501	1000

--- a/tests/queries/1_stateful/00177_memory_bound_merging.reference
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.reference
@@ -15,7 +15,7 @@ ExpressionTransform × 16
   (MergingAggregated)
   MergingAggregatedBucketTransform × 16
     Resize 1 → 16
-      FinishAggregatingInOrderTransform 2 → 1
+      FinishAggregatingInOrderTransform 3 → 1
         (Union)
           (Aggregating)
           SortingAggregatedForMemoryBoundMergingTransform 16 → 1

--- a/tests/queries/1_stateful/00177_memory_bound_merging.reference
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.reference
@@ -10,24 +10,10 @@ http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-18	http:/
 http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-19	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
 http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-20	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
 1
-(Expression)
-ExpressionTransform × 16
-  (MergingAggregated)
-  MergingAggregatedBucketTransform × 16
-    Resize 1 → 16
-      FinishAggregatingInOrderTransform 3 → 1
-        (Union)
-          (Aggregating)
-          SortingAggregatedForMemoryBoundMergingTransform 16 → 1
-            MergingAggregatedBucketTransform × 16
-              Resize 1 → 16
-                FinishAggregatingInOrderTransform 2 → 1
-                  AggregatingInOrderTransform × 2
-                    (Expression)
-                    ExpressionTransform × 2
-                      (Filter)
-                      FilterTransform × 2
-                        (ReadFromMergeTree)
-                        ExpressionTransform × 2
-                          MergeTreeInOrder × 2 0 → 1
-          (ReadFromRemoteParallelReplicas)
+MergingAggregatedBucketTransform
+FinishAggregatingInOrderTransform
+SortingAggregatedForMemoryBoundMergingTransform
+MergingAggregatedBucketTransform
+FinishAggregatingInOrderTransform
+AggregatingInOrderTransform
+MergeTreeInOrder

--- a/tests/queries/1_stateful/00177_memory_bound_merging.reference
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.reference
@@ -1,0 +1,12 @@
+http://auto.ru/chatay-baranta_bound-in-tanks.ru/forumyazan	2014-03-20	http://auto.ru/chatay-baranta_bound-in-tanks.ru/forumyazan
+http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-17	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
+http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-18	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
+http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-19	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
+http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-20	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
+1
+http://auto.ru/chatay-baranta_bound-in-tanks.ru/forumyazan	2014-03-20	http://auto.ru/chatay-baranta_bound-in-tanks.ru/forumyazan
+http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-17	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
+http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-18	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
+http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-19	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
+http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-20	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
+1

--- a/tests/queries/1_stateful/00177_memory_bound_merging.reference
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.reference
@@ -10,3 +10,24 @@ http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-18	http:/
 http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-19	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
 http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny	2014-03-20	http://auto.ru/chatay-baranta_bound-in-thankYou=ru/tver/zhanny
 1
+(Expression)
+ExpressionTransform × 16
+  (MergingAggregated)
+  MergingAggregatedBucketTransform × 16
+    Resize 1 → 16
+      FinishAggregatingInOrderTransform 2 → 1
+        (Union)
+          (Aggregating)
+          SortingAggregatedForMemoryBoundMergingTransform 16 → 1
+            MergingAggregatedBucketTransform × 16
+              Resize 1 → 16
+                FinishAggregatingInOrderTransform 2 → 1
+                  AggregatingInOrderTransform × 2
+                    (Expression)
+                    ExpressionTransform × 2
+                      (Filter)
+                      FilterTransform × 2
+                        (ReadFromMergeTree)
+                        ExpressionTransform × 2
+                          MergeTreeInOrder × 2 0 → 1
+          (ReadFromRemoteParallelReplicas)

--- a/tests/queries/1_stateful/00177_memory_bound_merging.sh
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.sh
@@ -23,7 +23,7 @@ test1() {
     query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
     $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
         SELECT URL, EventDate, max(URL)
-        FROM remote('127.0.0.{1,2}', test.hits)
+        FROM remote(test_cluster_one_shard_two_replicas, test.hits)
         WHERE CounterID = 1704509 AND UserID = 4322253409885123546
         GROUP BY CounterID, URL, EventDate, EventDate
         ORDER BY URL, EventDate
@@ -36,7 +36,7 @@ test2() {
     query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
     $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
         SELECT URL, EventDate, max(URL)
-        FROM remote('127.0.0.{1,2}', test.hits)
+        FROM remote(test_cluster_one_shard_two_replicas, test.hits)
         WHERE CounterID = 1704509 AND UserID = 4322253409885123546
         GROUP BY URL, EventDate, EventDate
         ORDER BY URL, EventDate
@@ -47,11 +47,11 @@ test2() {
 
 test3() {
     $CLICKHOUSE_CLIENT -nq "
-        SET max_threads = 16, prefer_localhost_replica = 1, read_in_order_two_level_merge_threshold = 1000;
+        SET max_threads = 16, prefer_localhost_replica = 1, read_in_order_two_level_merge_threshold = 1000, query_plan_aggregation_in_order = 1;
 
         EXPLAIN PIPELINE
         SELECT URL, EventDate, max(URL)
-        FROM remote('127.0.0.{1,2}', test.hits)
+        FROM remote(test_cluster_one_shard_two_replicas, test.hits)
         WHERE CounterID = 1704509 AND UserID = 4322253409885123546
         GROUP BY URL, EventDate
         SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, allow_experimental_parallel_reading_from_replicas = 1, max_parallel_replicas = 3, use_hedged_requests = 0"

--- a/tests/queries/1_stateful/00177_memory_bound_merging.sh
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.sh
@@ -45,5 +45,18 @@ test2() {
     check_replicas_read_in_order $query_id
 }
 
+test3() {
+    $CLICKHOUSE_CLIENT -nq "
+        SET max_threads = 16, prefer_localhost_replica = 1, read_in_order_two_level_merge_threshold = 1000;
+
+        EXPLAIN PIPELINE
+        SELECT URL, EventDate, max(URL)
+        FROM remote('127.0.0.{1,2}', test, hits)
+        WHERE CounterID = 1704509 AND UserID = 4322253409885123546
+        GROUP BY URL, EventDate
+        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, allow_experimental_parallel_reading_from_replicas = 1, max_parallel_replicas = 3, use_hedged_requests = 0"
+}
+
 test1
 test2
+test3

--- a/tests/queries/1_stateful/00177_memory_bound_merging.sh
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.sh
@@ -21,7 +21,9 @@ check_replicas_read_in_order() {
 
 test1() {
     query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
-    $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
+    $CLICKHOUSE_CLIENT --query_id="$query_id" -nq "
+        SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
+
         SELECT URL, EventDate, max(URL)
         FROM remote(test_cluster_one_shard_two_replicas, test.hits)
         WHERE CounterID = 1704509 AND UserID = 4322253409885123546
@@ -34,7 +36,9 @@ test1() {
 
 test2() {
     query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
-    $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
+    $CLICKHOUSE_CLIENT --query_id="$query_id" -nq "
+        SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
+
         SELECT URL, EventDate, max(URL)
         FROM remote(test_cluster_one_shard_two_replicas, test.hits)
         WHERE CounterID = 1704509 AND UserID = 4322253409885123546
@@ -47,11 +51,12 @@ test2() {
 
 test3() {
     $CLICKHOUSE_CLIENT -nq "
-        SET max_threads = 16, prefer_localhost_replica = 1, read_in_order_two_level_merge_threshold = 1000, query_plan_aggregation_in_order = 1;
+        SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
+        SET max_threads = 16, prefer_localhost_replica = 1, read_in_order_two_level_merge_threshold = 1000, query_plan_aggregation_in_order = 1, distributed_aggregation_memory_efficient = 1;
 
         EXPLAIN PIPELINE
         SELECT URL, EventDate, max(URL)
-        FROM remote(test_cluster_one_shard_two_replicas, test.hits)
+        FROM test.hits
         WHERE CounterID = 1704509 AND UserID = 4322253409885123546
         GROUP BY URL, EventDate
         SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, allow_experimental_parallel_reading_from_replicas = 1, max_parallel_replicas = 3, use_hedged_requests = 0"

--- a/tests/queries/1_stateful/00177_memory_bound_merging.sh
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.sh
@@ -54,12 +54,16 @@ test3() {
         SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
         SET max_threads = 16, prefer_localhost_replica = 1, read_in_order_two_level_merge_threshold = 1000, query_plan_aggregation_in_order = 1, distributed_aggregation_memory_efficient = 1;
 
-        EXPLAIN PIPELINE
-        SELECT URL, EventDate, max(URL)
-        FROM test.hits
-        WHERE CounterID = 1704509 AND UserID = 4322253409885123546
-        GROUP BY URL, EventDate
-        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, allow_experimental_parallel_reading_from_replicas = 1, max_parallel_replicas = 3, use_hedged_requests = 0"
+        SELECT replaceRegexpOne(explain, '^ *(\w+).*', '\\1')
+        FROM (
+            EXPLAIN PIPELINE
+            SELECT URL, EventDate, max(URL)
+            FROM test.hits
+            WHERE CounterID = 1704509 AND UserID = 4322253409885123546
+            GROUP BY URL, EventDate
+            SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, allow_experimental_parallel_reading_from_replicas = 1, max_parallel_replicas = 3, use_hedged_requests = 0
+        )
+        WHERE explain LIKE '%Aggr%Transform%' OR explain LIKE '%InOrder%'"
 }
 
 test1

--- a/tests/queries/1_stateful/00177_memory_bound_merging.sh
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2154
+
+unset CLICKHOUSE_LOG_COMMENT
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+
+check_replicas_read_in_order() {
+    $CLICKHOUSE_CLIENT -nq "
+        SYSTEM FLUSH LOGS;
+
+        SELECT COUNT() > 0
+        FROM system.text_log
+        WHERE query_id IN (SELECT query_id FROM system.query_log WHERE query_id != '$1' AND initial_query_id = '$1' AND event_date >= yesterday())
+            AND event_date >= yesterday() AND logger_name = 'MergeTreeInOrderSelectProcessor'"
+}
+
+test1() {
+    query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
+    $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
+        SELECT URL, EventDate, max(URL)
+        FROM remote('127.0.0.{1,2}', test, hits)
+        WHERE CounterID = 1704509 AND UserID = 4322253409885123546
+        GROUP BY CounterID, URL, EventDate, EventDate
+        ORDER BY URL, EventDate
+        LIMIT 5 OFFSET 10
+        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, allow_experimental_parallel_reading_from_replicas = 1, max_parallel_replicas = 3, use_hedged_requests = 0"
+    check_replicas_read_in_order $query_id
+}
+
+test2() {
+    query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
+    $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
+        SELECT URL, EventDate, max(URL)
+        FROM remote('127.0.0.{1,2}', test, hits)
+        WHERE CounterID = 1704509 AND UserID = 4322253409885123546
+        GROUP BY URL, EventDate, EventDate
+        ORDER BY URL, EventDate
+        LIMIT 5 OFFSET 10
+        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, allow_experimental_parallel_reading_from_replicas = 1, max_parallel_replicas = 3, use_hedged_requests = 0, query_plan_aggregation_in_order = 1"
+    check_replicas_read_in_order $query_id
+}
+
+test1
+test2

--- a/tests/queries/1_stateful/00177_memory_bound_merging.sh
+++ b/tests/queries/1_stateful/00177_memory_bound_merging.sh
@@ -23,7 +23,7 @@ test1() {
     query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
     $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
         SELECT URL, EventDate, max(URL)
-        FROM remote('127.0.0.{1,2}', test, hits)
+        FROM remote('127.0.0.{1,2}', test.hits)
         WHERE CounterID = 1704509 AND UserID = 4322253409885123546
         GROUP BY CounterID, URL, EventDate, EventDate
         ORDER BY URL, EventDate
@@ -36,7 +36,7 @@ test2() {
     query_id="query_id_memory_bound_merging_$RANDOM$RANDOM"
     $CLICKHOUSE_CLIENT --query_id="$query_id" -q "
         SELECT URL, EventDate, max(URL)
-        FROM remote('127.0.0.{1,2}', test, hits)
+        FROM remote('127.0.0.{1,2}', test.hits)
         WHERE CounterID = 1704509 AND UserID = 4322253409885123546
         GROUP BY URL, EventDate, EventDate
         ORDER BY URL, EventDate
@@ -51,7 +51,7 @@ test3() {
 
         EXPLAIN PIPELINE
         SELECT URL, EventDate, max(URL)
-        FROM remote('127.0.0.{1,2}', test, hits)
+        FROM remote('127.0.0.{1,2}', test.hits)
         WHERE CounterID = 1704509 AND UserID = 4322253409885123546
         GROUP BY URL, EventDate
         SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, allow_experimental_parallel_reading_from_replicas = 1, max_parallel_replicas = 3, use_hedged_requests = 0"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improved how memory bound merging and aggregation in order on top query plan interact. Previously we fell back to explicit sorting for AIO in some cases when it wasn't actually needed. So it is a perf issue, not a correctness one.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

When initiator choses AIO it sends special setting `force_aggregation_in_order` to remote nodes. Previously it led to insertion of explicit sorting step into the plan if `group_by_info == nullptr` (e.g. when `query_plan_aggregation_in_order == true`). In this case optimisation on top of plan wasn't applied because it doesn't expect `SortingStep` in between `AggregatingStep` and `Read*Step`. It led to not using reading in order and we were need to sort  explicitly.
Now we will not insert `SortingStep` (sorting transforms will be added by `AggregatingStep` if needed) and should correctly initiate reading in order.