### PR TITLE
Add new syntax to tell users and roles apart

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -3911,3 +3911,26 @@ Default value: `0`.
 :::note
 Use this setting only for backward compatibility if your use cases depend on old syntax.
 :::
+
+## enable_extended_subject_syntax {#enable_extended_subject_syntax}
+
+The `enable_extended_subject_syntax` setting causes ClickHouse to explicitly report users and roles as such
+in response to `SHOW GRANTS ...` or `SHOW ACCESS ...` queries.
+
+Example:
+
+```sql
+SET enable_extended_subject_syntax=0
+SHOW GRANTS FOR default
+┌─GRANTS FOR default────────────────────────────┐
+│ GRANT ALL ON *.* TO default WITH GRANT OPTION │
+└───────────────────────────────────────────────┘
+
+SET enable_extended_subject_syntax=1
+SHOW GRANTS FOR default
+┌─GRANTS FOR default────────────────────────────────────┐
+│ GRANT ALL ON *.* TO default AS USER WITH GRANT OPTION │
+└───────────────────────────────────────────────────────┘
+```
+
+Disabled by default.

--- a/docs/en/sql-reference/statements/alter/user.md
+++ b/docs/en/sql-reference/statements/alter/user.md
@@ -15,7 +15,7 @@ ALTER USER [IF EXISTS] name1 [ON CLUSTER cluster_name1] [RENAME TO new_name1]
     [NOT IDENTIFIED | IDENTIFIED {[WITH {no_password | plaintext_password | sha256_password | sha256_hash | double_sha1_password | double_sha1_hash}] BY {'password' | 'hash'}} | {WITH ldap SERVER 'server_name'} | {WITH kerberos [REALM 'realm']} | {WITH ssl_certificate CN 'common_name'}]
     [[ADD | DROP] HOST {LOCAL | NAME 'name' | REGEXP 'name_regexp' | IP 'address' | LIKE 'pattern'} [,...] | ANY | NONE]
     [DEFAULT ROLE role [,...] | ALL | ALL EXCEPT role [,...] ]
-    [GRANTEES {user | role | ANY | NONE} [,...] [EXCEPT {user | role} [,...]]]
+    [GRANTEES {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH | ANY | NONE} [,...] [EXCEPT {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH} [,...]]]
     [SETTINGS variable [= value] [MIN [=] min_value] [MAX [=] max_value] [READONLY | WRITABLE] | PROFILE 'profile_name'] [,...]
 ```
 
@@ -31,6 +31,7 @@ Specifies users or roles which are allowed to receive [privileges](../../../sql-
 -   `NONE` — This user can grant privileges to none.
 
 You can exclude any user or role by using the `EXCEPT` expression. For example, `ALTER USER user1 GRANTEES ANY EXCEPT user2`. It means if `user1` has some privileges granted with `GRANT OPTION` it will be able to grant those privileges to anyone except `user2`.
+If `AS {USER|ROLE|BOTH}` is not used and a user and a role with the same name exist, only the user will be affected.
 
 ## Examples
 

--- a/docs/en/sql-reference/statements/create/user.md
+++ b/docs/en/sql-reference/statements/create/user.md
@@ -16,7 +16,7 @@ CREATE USER [IF NOT EXISTS | OR REPLACE] name1 [ON CLUSTER cluster_name1]
     [HOST {LOCAL | NAME 'name' | REGEXP 'name_regexp' | IP 'address' | LIKE 'pattern'} [,...] | ANY | NONE]
     [DEFAULT ROLE role [,...]]
     [DEFAULT DATABASE database | NONE]
-    [GRANTEES {user | role | ANY | NONE} [,...] [EXCEPT {user | role} [,...]]]
+    [GRANTEES {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH | ANY | NONE} [,...] [EXCEPT {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH} [,...]]]
     [SETTINGS variable [= value] [MIN [=] min_value] [MAX [=] max_value] [READONLY | WRITABLE] | PROFILE 'profile_name'] [,...]
 ```
 
@@ -69,6 +69,7 @@ Specifies users or roles which are allowed to receive [privileges](../../../sql-
 -   `NONE` — This user can grant privileges to none.
 
 You can exclude any user or role by using the `EXCEPT` expression. For example, `CREATE USER user1 GRANTEES ANY EXCEPT user2`. It means if `user1` has some privileges granted with `GRANT OPTION` it will be able to grant those privileges to anyone except `user2`.
+If `AS {USER|ROLE|BOTH}` is not used and a user and a role with the same name exist, only the user will be affected.
 
 ## Examples
 

--- a/docs/en/sql-reference/statements/grant.md
+++ b/docs/en/sql-reference/statements/grant.md
@@ -14,7 +14,7 @@ To revoke privileges, use the [REVOKE](../../sql-reference/statements/revoke.md)
 ## Granting Privilege Syntax
 
 ``` sql
-GRANT [ON CLUSTER cluster_name] privilege[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} TO {user | role | CURRENT_USER} [,...] [WITH GRANT OPTION] [WITH REPLACE OPTION]
+GRANT [ON CLUSTER cluster_name] privilege[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} TO {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH | CURRENT_USER} [,...] [WITH GRANT OPTION] [WITH REPLACE OPTION]
 ```
 
 -   `privilege` — Type of privilege.
@@ -23,11 +23,12 @@ GRANT [ON CLUSTER cluster_name] privilege[(column_name [,...])] [,...] ON {db.ta
 
 The `WITH GRANT OPTION` clause grants `user` or `role` with permission to execute the `GRANT` query. Users can grant privileges of the same scope they have and less.
 The `WITH REPLACE OPTION` clause replace old privileges by new privileges for the `user` or `role`, if is not specified it appends privileges.
+If `AS {USER|ROLE|BOTH}` is not used and a user and a role with the same name exist, only user's permissions will be changed.
 
 ## Assigning Role Syntax
 
 ``` sql
-GRANT [ON CLUSTER cluster_name] role [,...] TO {user | another_role | CURRENT_USER} [,...] [WITH ADMIN OPTION] [WITH REPLACE OPTION]
+GRANT [ON CLUSTER cluster_name] role [,...] TO {user [AS USER] | another_role [AS ROLE] | CURRENT_USER} [,...] [WITH ADMIN OPTION] [WITH REPLACE OPTION]
 ```
 
 -   `role` — ClickHouse user role.
@@ -35,6 +36,7 @@ GRANT [ON CLUSTER cluster_name] role [,...] TO {user | another_role | CURRENT_US
 
 The `WITH ADMIN OPTION` clause grants [ADMIN OPTION](#admin-option-privilege) privilege to `user` or `role`.
 The `WITH REPLACE OPTION` clause replace old roles by new role for the `user` or `role`, if is not specified it appends roles.
+If `AS {USER|ROLE|BOTH}` is not used and a user and a role with the same name exist, only user's permissions will be changed.
 
 ## Usage
 

--- a/docs/en/sql-reference/statements/revoke.md
+++ b/docs/en/sql-reference/statements/revoke.md
@@ -13,18 +13,19 @@ Revokes privileges from users or roles.
 **Revoking privileges from users**
 
 ``` sql
-REVOKE [ON CLUSTER cluster_name] privilege[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} FROM {user | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user | CURRENT_USER} [,...]
+REVOKE [ON CLUSTER cluster_name] privilege[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} FROM {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH | CURRENT_USER} [,...]
 ```
 
 **Revoking roles from users**
 
 ``` sql
-REVOKE [ON CLUSTER cluster_name] [ADMIN OPTION FOR] role [,...] FROM {user | role | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user_name | role_name | CURRENT_USER} [,...]
+REVOKE [ON CLUSTER cluster_name] [ADMIN OPTION FOR] role [,...] FROM {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user_name [AS USER] | role_name [AS ROLE] | CURRENT_USER} [,...]
 ```
 
 ## Description
 
 To revoke some privilege you can use a privilege of a wider scope than you plan to revoke. For example, if a user has the `SELECT (x,y)` privilege, administrator can execute `REVOKE SELECT(x,y) ...`, or `REVOKE SELECT * ...`, or even `REVOKE ALL PRIVILEGES ...` query to revoke this privilege.
+If `AS {USER|ROLE|BOTH}` is not used and a user and a role with the same name exist, only user's permissions will be revoked.
 
 ### Partial Revokes
 

--- a/docs/en/sql-reference/statements/show.md
+++ b/docs/en/sql-reference/statements/show.md
@@ -229,15 +229,16 @@ SHOW DICTIONARIES FROM db LIKE '%reg%' LIMIT 2
 
 ## SHOW GRANTS
 
-Shows privileges for a user.
+Shows privileges for a user or a role.
 
 ### Syntax
 
 ``` sql
-SHOW GRANTS [FOR user1 [, user2 ...]]
+SHOW GRANTS [FOR {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH | CURRENT_USER} [,...]]
 ```
 
 If user is not specified, the query returns privileges for the current user.
+If `AS {USER|ROLE|BOTH}` is not used and a user and a role with the same name exist, only user's permissions will be returned.
 
 ## SHOW CREATE USER
 

--- a/src/Access/AccessEntityIO.cpp
+++ b/src/Access/AccessEntityIO.cpp
@@ -41,7 +41,7 @@ String serializeAccessEntity(const IAccessEntity & entity)
     ASTs queries;
     queries.push_back(InterpreterShowCreateAccessEntityQuery::getAttachQuery(entity));
     if ((entity.getType() == AccessEntityType::USER) || (entity.getType() == AccessEntityType::ROLE))
-        boost::range::push_back(queries, InterpreterShowGrantsQuery::getAttachGrantQueries(entity));
+        boost::range::push_back(queries, InterpreterShowGrantsQuery::getAttachGrantQueries(entity, false));
 
     /// Serialize the list of ATTACH queries to a string.
     WriteBufferFromOwnString buf;

--- a/src/Access/RolesOrUsersSet.h
+++ b/src/Access/RolesOrUsersSet.h
@@ -15,8 +15,8 @@ class AccessControl;
 
 
 /// Represents a set of users/roles like
-/// {user_name | role_name | CURRENT_USER | ALL | NONE} [,...]
-/// [EXCEPT {user_name | role_name | CURRENT_USER | ALL | NONE} [,...]]
+/// {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER | ALL | NONE} [,...]
+/// [EXCEPT {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER | ALL | NONE} [,...]]
 /// Similar to ASTRolesOrUsersSet, but with IDs instead of names.
 struct RolesOrUsersSet
 {

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -703,6 +703,7 @@ class IColumn;
     M(Float, insert_keeper_fault_injection_probability, 0.0f, "Approximate probability of failure for a keeper request during insert. Valid value is in interval [0.0f, 1.0f]", 0) \
     M(UInt64, insert_keeper_fault_injection_seed, 0, "0 - random seed, otherwise the setting value", 0) \
     M(Bool, force_aggregation_in_order, false, "Force use of aggregation in order on remote nodes during distributed aggregation. PLEASE, NEVER CHANGE THIS SETTING VALUE MANUALLY!", IMPORTANT) \
+    M(Bool, enable_extended_subject_syntax, false, "Explicitly report users and roles as such when returning permissions.", 0) \
     // End of COMMON_SETTINGS
     // Please add settings related to formats into the FORMAT_FACTORY_SETTINGS and move obsolete settings to OBSOLETE_SETTINGS.
 

--- a/src/Interpreters/Access/InterpreterShowAccessQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowAccessQuery.cpp
@@ -65,13 +65,14 @@ ASTs InterpreterShowAccessQuery::getCreateAndGrantQueries() const
 {
     auto entities = getEntities();
     const auto & access_control = getContext()->getAccessControl();
+    const auto ext_syn = getContext()->getSettingsRef().enable_extended_subject_syntax;
 
     ASTs create_queries, grant_queries;
     for (const auto & entity : entities)
     {
         create_queries.push_back(InterpreterShowCreateAccessEntityQuery::getCreateQuery(*entity, access_control));
         if (entity->isTypeOf(AccessEntityType::USER) || entity->isTypeOf(AccessEntityType::ROLE))
-            insertAtEnd(grant_queries, InterpreterShowGrantsQuery::getGrantQueries(*entity, access_control));
+            insertAtEnd(grant_queries, InterpreterShowGrantsQuery::getGrantQueries(*entity, access_control, ext_syn));
     }
 
     ASTs result = std::move(create_queries);

--- a/src/Interpreters/Access/InterpreterShowGrantsQuery.h
+++ b/src/Interpreters/Access/InterpreterShowGrantsQuery.h
@@ -20,8 +20,9 @@ public:
 
     BlockIO execute() override;
 
-    static ASTs getGrantQueries(const IAccessEntity & user_or_role, const AccessControl & access_control);
-    static ASTs getAttachGrantQueries(const IAccessEntity & user_or_role);
+    static ASTs
+    getGrantQueries(const IAccessEntity & user_or_role, const AccessControl & access_control, bool enable_extended_subject_syntax);
+    static ASTs getAttachGrantQueries(const IAccessEntity & user_or_role, const bool enable_extended_subject_syntax);
 
     bool ignoreQuota() const override { return true; }
     bool ignoreLimits() const override { return true; }

--- a/src/Parsers/Access/ASTGrantQuery.h
+++ b/src/Parsers/Access/ASTGrantQuery.h
@@ -10,11 +10,11 @@ namespace DB
 class ASTRolesOrUsersSet;
 
 
-/** GRANT access_type[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} TO {user_name | CURRENT_USER} [,...] [WITH GRANT OPTION]
-  * REVOKE access_type[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} FROM {user_name | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user_name | CURRENT_USER} [,...]
+/** GRANT access_type[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} TO {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER} [,...] [WITH GRANT OPTION]
+  * REVOKE access_type[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} FROM {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER} [,...]
   *
-  * GRANT role [,...] TO {user_name | role_name | CURRENT_USER} [,...] [WITH ADMIN OPTION]
-  * REVOKE [ADMIN OPTION FOR] role [,...] FROM {user_name | role_name | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user_name | role_name | CURRENT_USER} [,...]
+  * GRANT role [,...] TO {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER} [,...] [WITH ADMIN OPTION]
+  * REVOKE [ADMIN OPTION FOR] role [,...] FROM {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER} [,...]
   */
 class ASTGrantQuery : public IAST, public ASTQueryWithOnCluster
 {

--- a/src/Parsers/Access/ParserCreateUserQuery.h
+++ b/src/Parsers/Access/ParserCreateUserQuery.h
@@ -11,7 +11,7 @@ namespace DB
   *     [HOST {LOCAL | NAME 'name' | REGEXP 'name_regexp' | IP 'address' | LIKE 'pattern'} [,...] | ANY | NONE]
   *     [DEFAULT ROLE role [,...]]
   *     [SETTINGS variable [= value] [MIN [=] min_value] [MAX [=] max_value] [CONST|READONLY|WRITABLE|CHANGEABLE_IN_READONLY] | PROFILE 'profile_name'] [,...]
-  *     [GRANTEES {user | role | ANY | NONE} [,...] [EXCEPT {user | role} [,...]]]
+  *     [GRANTEES {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH | ANY | NONE} [,...] [EXCEPT {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH} [,...]]]
   *
   * ALTER USER [IF EXISTS] name
   *     [RENAME TO new_name]
@@ -19,7 +19,7 @@ namespace DB
   *     [[ADD|DROP] HOST {LOCAL | NAME 'name' | REGEXP 'name_regexp' | IP 'address' | LIKE 'pattern'} [,...] | ANY | NONE]
   *     [DEFAULT ROLE role [,...] | ALL | ALL EXCEPT role [,...] ]
   *     [SETTINGS variable [= value] [MIN [=] min_value] [MAX [=] max_value] [CONST|READONLY|WRITABLE|CHANGEABLE_IN_READONLY] | PROFILE 'profile_name'] [,...]
-  *     [GRANTEES {user | role | ANY | NONE} [,...] [EXCEPT {user | role} [,...]]]
+  *     [GRANTEES {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH | ANY | NONE} [,...] [EXCEPT {user [AS USER] | role [AS ROLE] | user_and_role AS BOTH} [,...]]]
   */
 class ParserCreateUserQuery : public IParserBase
 {

--- a/src/Parsers/Access/ParserGrantQuery.h
+++ b/src/Parsers/Access/ParserGrantQuery.h
@@ -6,8 +6,8 @@
 namespace DB
 {
 /** Parses queries like
-  * GRANT access_type[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} TO {user_name | CURRENT_USER} [,...] [WITH GRANT OPTION]
-  * REVOKE access_type[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} FROM {user_name | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user_name | CURRENT_USER} [,...]
+  * GRANT access_type[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} TO {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER} [,...] [WITH GRANT OPTION]
+  * REVOKE access_type[(column_name [,...])] [,...] ON {db.table|db.*|*.*|table|*} FROM {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER} [,...] | ALL | ALL EXCEPT {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER} [,...]
   */
 class ParserGrantQuery : public IParserBase
 {

--- a/src/Parsers/Access/ParserRolesOrUsersSet.h
+++ b/src/Parsers/Access/ParserRolesOrUsersSet.h
@@ -1,14 +1,15 @@
 #pragma once
 
 #include <Core/Types.h>
+#include <Parsers/Access/ASTRolesOrUsersSet.h>
 #include <Parsers/IParserBase.h>
 
 
 namespace DB
 {
 /** Parses a string like this:
-  * {user_name | role_name | CURRENT_USER | ALL | NONE} [,...]
-  * [EXCEPT {user_name | role_name | CURRENT_USER | ALL | NONE} [,...]]
+  * {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER | ALL | NONE} [,...]
+  * [EXCEPT {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER | ALL | NONE} [,...]]
   */
 class ParserRolesOrUsersSet : public IParserBase
 {
@@ -31,8 +32,19 @@ private:
     bool allow_current_user = false;
     bool allow_roles = false;
     bool id_mode = false;
-    bool parseBeforeExcept(IParserBase::Pos & pos, Expected & expected, bool & all, Strings & names, bool & current_user);
-    bool parseExceptAndAfterExcept(IParserBase::Pos & pos, Expected & expected, Strings & except_names, bool & except_current_user);
+    bool parseBeforeExcept(
+        IParserBase::Pos & pos,
+        Expected & expected,
+        bool & all,
+        Strings & names,
+        ASTRolesOrUsersSet::NameFilters & names_filters,
+        bool & current_user) const;
+    bool parseExceptAndAfterExcept(
+        IParserBase::Pos & pos,
+        Expected & expected,
+        Strings & except_names,
+        ASTRolesOrUsersSet::NameFilters & except_names_filters,
+        bool & except_current_user) const;
 };
 
 }

--- a/src/Parsers/Access/ParserRolesOrUsersSet.h
+++ b/src/Parsers/Access/ParserRolesOrUsersSet.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Types.h>
 #include <Parsers/IParserBase.h>
 
 
@@ -30,6 +31,8 @@ private:
     bool allow_current_user = false;
     bool allow_roles = false;
     bool id_mode = false;
+    bool parseBeforeExcept(IParserBase::Pos & pos, Expected & expected, bool & all, Strings & names, bool & current_user);
+    bool parseExceptAndAfterExcept(IParserBase::Pos & pos, Expected & expected, Strings & except_names, bool & except_current_user);
 };
 
 }

--- a/src/Parsers/Access/ParserShowGrantsQuery.h
+++ b/src/Parsers/Access/ParserShowGrantsQuery.h
@@ -6,7 +6,7 @@
 namespace DB
 {
 /** Parses queries like
-  * SHOW GRANTS [FOR user_name]
+  * SHOW GRANTS [FOR {user_name [AS USER] | role_name [AS ROLE] | user_and_role_name AS BOTH | CURRENT_USER}]
   */
 class ParserShowGrantsQuery : public IParserBase
 {

--- a/tests/queries/0_stateless/02540_user_role_ambiguity.reference
+++ b/tests/queries/0_stateless/02540_user_role_ambiguity.reference
@@ -1,0 +1,38 @@
+0
+1
+GRANT ALL ON *.* TO test_user_02540 AS USER
+GRANT SELECT ON *.* TO test_user_02540 AS ROLE
+2
+GRANT ALL ON *.* TO test_user_02540 AS USER
+3
+GRANT ALL ON *.* TO test_user_02540 AS USER
+GRANT ALL ON *.* TO test_user_02540 AS ROLE
+4
+GRANT ALL ON *.* TO test_user_02540 AS USER
+5
+GRANT ALL ON *.* TO test_user_02540 AS USER
+GRANT ALL ON *.* TO test_user_02540 AS ROLE
+6
+7
+GRANT ALL ON *.* TO test_user_02540 AS USER
+GRANT ALL ON *.* TO test_user_02540 AS ROLE
+8
+GRANT ALL ON *.* TO test_user_02540 AS USER
+9
+10
+GRANT ALL ON *.* TO test_user_02540 AS USER
+11
+GRANT ALL ON *.* TO test_user_02540 AS ROLE
+12
+GRANT ALL ON *.* TO test_user_02540 AS USER
+GRANT ALL ON *.* TO test_user_02540 AS ROLE
+13
+14
+GRANT ALL ON *.* TO test_user_02540 AS USER
+GRANT ALL ON *.* TO test_user_02540 AS ROLE
+15
+GRANT ALL ON *.* TO test_user_02540 AS USER
+GRANT ALL ON *.* TO test_user_02540 AS ROLE
+16
+GRANT ALL ON *.* TO test_user_02540
+GRANT ALL ON *.* TO test_user_02540

--- a/tests/queries/0_stateless/02540_user_role_ambiguity.sql
+++ b/tests/queries/0_stateless/02540_user_role_ambiguity.sql
@@ -1,0 +1,89 @@
+-- Tags: no-parallel
+
+SELECT value FROM system.settings where name='enable_extended_subject_syntax';
+
+SET enable_extended_subject_syntax = 1;
+
+DROP USER IF EXISTS test_user_02540;
+DROP ROLE IF EXISTS test_user_02540;
+CREATE USER test_user_02540;
+CREATE ROLE test_user_02540;
+
+GRANT ALL on *.* TO test_user_02540 AS USER;
+GRANT SELECT on *.* TO test_user_02540 AS ROLE;
+SELECT 1;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+REVOKE SELECT on *.* FROM test_user_02540 AS ROLE;
+SELECT 2;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+GRANT ALL on *.* TO test_user_02540 AS ROLE;
+SELECT 3;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+REVOKE ALL on *.* FROM default AS USER, test_user_02540 AS ROLE EXCEPT default AS USER;
+SELECT 4;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+GRANT ALL on *.* TO test_user_02540 AS ROLE;
+SELECT 5;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+REVOKE ALL on *.* FROM test_user_02540 AS ROLE, test_user_02540 AS USER;
+SELECT 6;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+GRANT ALL on *.* TO test_user_02540, test_user_02540 AS ROLE, test_user_02540 AS USER;
+SELECT 7;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+SELECT 8;
+SHOW GRANTS FOR test_user_02540;
+
+REVOKE ALL on *.* FROM test_user_02540 AS ROLE, test_user_02540 AS USER;
+SELECT 9;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+GRANT ALL on *.* TO test_user_02540, test_user_02540 AS USER;
+SELECT 10;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+REVOKE ALL on *.* FROM test_user_02540 AS ROLE, test_user_02540 AS USER;
+
+GRANT ALL on *.* TO test_user_02540, test_user_02540 AS ROLE;
+SELECT 11;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+GRANT ALL on *.* TO test_user_02540;
+SELECT 12;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+REVOKE ALL on *.* FROM test_user_02540 AS BOTH;
+SELECT 13;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+GRANT ALL on *.* TO test_user_02540 AS BOTH;
+SELECT 14;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+SELECT 15;
+SHOW GRANTS FOR test_user_02540 AS BOTH;
+
+SET enable_extended_subject_syntax = 0;
+SELECT 16;
+SHOW GRANTS FOR test_user_02540 AS USER;
+SHOW GRANTS FOR test_user_02540 AS ROLE;
+
+DROP USER IF EXISTS test_user_02540;
+DROP ROLE IF EXISTS test_user_02540;


### PR DESCRIPTION
Change parse code for RolesOrUsersSet to add new keywords to allow
users to unambiguously refer to users or roles in queries like:
- `GRANT *`
- `REVOKE *`
- `{ALTER|CREATE} USER ... GRANTEES ...`

Also add a setting (that defaults to off) to make CH use the
same syntax when replying to queries like `SHOW GRANTS`.

This is necessary because it is possible to have users and roles
with the same name.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add syntax to unambiguously refer to users or roles in queries.
Add setting to make CH unambiguously refer to users or roles in replies to queries.  

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Translations in languages other than English might be needed.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
