### PR TITLE
do not run wal on remote disks

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7541,7 +7541,19 @@ MergeTreeData::WriteAheadLogPtr MergeTreeData::getWriteAheadLog()
     if (!write_ahead_log)
     {
         auto reservation = reserveSpace(getSettings()->write_ahead_log_max_bytes);
-        write_ahead_log = std::make_shared<MergeTreeWriteAheadLog>(*this, reservation->getDisk());
+        for (auto disk: reservation->getDisks())
+        {
+            if (!disk->isRemote())
+            {
+                write_ahead_log = std::make_shared<MergeTreeWriteAheadLog>(*this, reservation->getDisk());
+                break;
+            }
+        }
+
+        if (!write_ahead_log)
+            throw Exception(
+                    ErrorCodes::NOT_IMPLEMENTED,
+                    "Can't store write ahead log in remote disk. It makes no sense.");
     }
 
     return write_ahead_log;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7541,11 +7541,11 @@ MergeTreeData::WriteAheadLogPtr MergeTreeData::getWriteAheadLog()
     if (!write_ahead_log)
     {
         auto reservation = reserveSpace(getSettings()->write_ahead_log_max_bytes);
-        for (auto disk: reservation->getDisks())
+        for (const auto & disk: reservation->getDisks())
         {
             if (!disk->isRemote())
             {
-                write_ahead_log = std::make_shared<MergeTreeWriteAheadLog>(*this, reservation->getDisk());
+                write_ahead_log = std::make_shared<MergeTreeWriteAheadLog>(*this, disk);
                 break;
             }
         }

--- a/tests/queries/0_stateless/01130_in_memory_parts.sql
+++ b/tests/queries/0_stateless/01130_in_memory_parts.sql
@@ -1,3 +1,5 @@
+-- Tags: no-s3-storage
+
 DROP TABLE IF EXISTS in_memory;
 CREATE TABLE in_memory (a UInt32, b UInt32)
     ENGINE = MergeTree ORDER BY a

--- a/tests/queries/0_stateless/01130_in_memory_parts_check.sql
+++ b/tests/queries/0_stateless/01130_in_memory_parts_check.sql
@@ -1,4 +1,7 @@
+-- Tags: no-s3-storage
+
 -- Part of 00961_check_table test, but with in-memory parts
+
 SET check_query_single_value_result = 0;
 DROP TABLE IF EXISTS mt_table;
 CREATE TABLE mt_table (d Date, key UInt64, data String) ENGINE = MergeTree() PARTITION BY toYYYYMM(d) ORDER BY key

--- a/tests/queries/0_stateless/01130_in_memory_parts_default.sql
+++ b/tests/queries/0_stateless/01130_in_memory_parts_default.sql
@@ -1,3 +1,4 @@
+-- Tags: no-s3-storage
 -- Test 01266_default_prewhere_reqq, but with in-memory parts
 DROP TABLE IF EXISTS t1;
 

--- a/tests/queries/0_stateless/01130_in_memory_parts_nested.sql
+++ b/tests/queries/0_stateless/01130_in_memory_parts_nested.sql
@@ -9,8 +9,8 @@ INSERT INTO nested SELECT number, number % 2, range(number % 10) FROM system.num
 
 ALTER TABLE nested ADD COLUMN n.b Array(UInt64);
 SELECT DISTINCT n.b FROM nested PREWHERE filter;
-SELECT DISTINCT n.b FROM nested PREWHERE filter SETTINGS max_block_size = 10;
 SELECT DISTINCT n.b FROM nested PREWHERE filter SETTINGS max_block_size = 123;
+SELECT DISTINCT n.b FROM nested PREWHERE filter SETTINGS max_block_size = 1234;
 
 ALTER TABLE nested ADD COLUMN n.c Array(UInt64) DEFAULT arrayMap(x -> x * 2, n.a);
 SELECT DISTINCT n.c FROM nested PREWHERE filter;

--- a/tests/queries/0_stateless/01130_in_memory_parts_nested.sql
+++ b/tests/queries/0_stateless/01130_in_memory_parts_nested.sql
@@ -1,3 +1,4 @@
+-- Tags: no-s3-storage
 -- Test 00576_nested_and_prewhere, but with in-memory parts.
 DROP TABLE IF EXISTS nested;
 

--- a/tests/queries/0_stateless/01130_in_memory_parts_partitons.sql
+++ b/tests/queries/0_stateless/01130_in_memory_parts_partitons.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-s3-storage
 
 DROP TABLE IF EXISTS t2;
 

--- a/tests/queries/0_stateless/01475_read_subcolumns_storages.sh
+++ b/tests/queries/0_stateless/01475_read_subcolumns_storages.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-s3-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01508_race_condition_rename_clear_zookeeper_long.sh
+++ b/tests/queries/0_stateless/01508_race_condition_rename_clear_zookeeper_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: race, zookeeper
+# Tags: race, zookeeper, no-s3-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01600_parts_types_metrics_long.sh
+++ b/tests/queries/0_stateless/01600_parts_types_metrics_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-s3-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/01643_merge_tree_fsync_smoke.sql
+++ b/tests/queries/0_stateless/01643_merge_tree_fsync_smoke.sql
@@ -1,3 +1,5 @@
+-- Tags: no-s3-storage
+
 drop table if exists data_01643;
 
 select 'default';

--- a/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.sql
+++ b/tests/queries/0_stateless/01643_replicated_merge_tree_fsync_smoke.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel
+-- Tags: no-parallel, no-s3-storage
 -- no-parallel -- for flaky check and to avoid "Removing leftovers from table" (for other tables)
 
 -- Temporarily skip warning 'table was created by another server at the same moment, will retry'

--- a/tests/queries/0_stateless/02410_inmemory_wal_cleanup.sql
+++ b/tests/queries/0_stateless/02410_inmemory_wal_cleanup.sql
@@ -1,3 +1,5 @@
+-- Tags: no-s3-storage
+
 -- { echo }
 
 DROP TABLE IF EXISTS in_memory;

--- a/tests/queries/0_stateless/02423_drop_memory_parts.sql
+++ b/tests/queries/0_stateless/02423_drop_memory_parts.sql
@@ -1,3 +1,5 @@
+-- Tags: no-s3-storage
+
 DROP TABLE IF EXISTS table_in_memory;
 
 CREATE TABLE table_in_memory


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

I have found out [here](https://github.com/ClickHouse/ClickHouse/pull/44869) that CH uses wal on S3 disk in tests.

It makes not much sence. It's better to write compact parts instead. Furthermore  CH do not use such combination in real work.
In test I see that wal needs to be sync often in order to fulfill the assignment and be robust with restarts.
It is not possible to sync writing in S3. It is possible either finish the file or continue writing in it without fixation of written file part. Interesting fact: rotation works for fixation written file part much better Instead of sync.

I'm going to collect what test is failed and turn them off for s3-disks and other remote disks.



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
