### PR TITLE
Reorder join keys to apply read in order optimization

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -474,6 +474,7 @@ class IColumn;
     M(Bool, optimize_read_in_order, true, "Enable ORDER BY optimization for reading data in corresponding order in MergeTree tables.", 0) \
     M(Bool, optimize_read_in_window_order, true, "Enable ORDER BY optimization in window clause for reading data in corresponding order in MergeTree tables.", 0) \
     M(Bool, optimize_aggregation_in_order, false, "Enable GROUP BY optimization for aggregating data in corresponding order in MergeTree tables.", 0) \
+    M(Bool, optimize_join_in_order, true, "Enable JOIN optimization for joining data using `full_sorting_merge` algorithm in corresponding order in MergeTree tables.", 0) \
     M(UInt64, aggregation_in_order_max_block_bytes, 50000000, "Maximal size of block in bytes accumulated during aggregation in order of primary key. Lower block size allows to parallelize more final merge stage of aggregation.", 0) \
     M(UInt64, read_in_order_two_level_merge_threshold, 100, "Minimal number of parts to read to run preliminary merge step during multithread reading in order of primary key.", 0) \
     M(Bool, low_cardinality_allow_in_native_format, true, "Use LowCardinality type in Native format. Otherwise, convert LowCardinality columns to ordinary for select query, and convert ordinary columns to required LowCardinality for insert query.", 0) \

--- a/src/Core/SortDescription.h
+++ b/src/Core/SortDescription.h
@@ -40,10 +40,17 @@ struct FillColumnDescription
 /// Description of the sorting rule by one column.
 struct SortColumnDescription
 {
-    std::string column_name; /// The name of the column.
-    int direction;           /// 1 - ascending, -1 - descending.
-    int nulls_direction;     /// 1 - NULLs and NaNs are greater, -1 - less.
-                             /// To achieve NULLS LAST, set it equal to direction, to achieve NULLS FIRST, set it opposite.
+    /// Ascending: 1
+    /// Descending: -1
+    using Direction = int;
+
+    /// The name of the column by which the sorting is performed.
+    std::string column_name;
+    /// The direction of sorting.
+    Direction direction;
+    /// To achieve NULLS LAST, set nulls_direction equal to direction, to achieve NULLS FIRST, set it opposite.
+    Direction nulls_direction;
+
     std::shared_ptr<Collator> collator; /// Collator for locale-specific comparison of strings
     bool with_fill;
     FillColumnDescription fill_description;
@@ -52,8 +59,8 @@ struct SortColumnDescription
 
     explicit SortColumnDescription(
         std::string column_name_,
-        int direction_ = 1,
-        int nulls_direction_ = 1,
+        Direction direction_ = 1,
+        Direction nulls_direction_ = 1,
         const std::shared_ptr<Collator> & collator_ = nullptr,
         bool with_fill_ = false,
         const FillColumnDescription & fill_description_ = {})
@@ -83,6 +90,11 @@ struct SortColumnDescription
     bool operator != (const SortColumnDescription & other) const
     {
         return !(*this == other);
+    }
+
+    bool isDefaultDirection() const
+    {
+        return direction == 1 && nulls_direction == 1;
     }
 
     std::string dump() const { return fmt::format("{}:dir {}nulls {}", column_name, direction, nulls_direction); }

--- a/src/Interpreters/ExpressionAnalyzer.cpp
+++ b/src/Interpreters/ExpressionAnalyzer.cpp
@@ -35,6 +35,7 @@
 
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/AggregatingStep.h>
+#include <Processors/QueryPlan/SortingStep.h>
 
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <AggregateFunctions/parseAggregateFunctionParameters.h>
@@ -57,7 +58,6 @@
 #include <Core/NamesAndTypes.h>
 #include <Common/logger_useful.h>
 #include <QueryPipeline/SizeLimits.h>
-
 
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeFactory.h>
@@ -984,7 +984,7 @@ static std::shared_ptr<IJoin> chooseJoinAlgorithm(
     {
         tried_algorithms.push_back(toString(JoinAlgorithm::FULL_SORTING_MERGE));
         if (FullSortingMergeJoin::isSupported(analyzed_join))
-            return std::make_shared<FullSortingMergeJoin>(analyzed_join, right_sample_block);
+            return std::make_shared<FullSortingMergeJoin>(analyzed_join, right_sample_block, SortingStep::Settings(*context));
     }
 
     if (analyzed_join->isEnabledAlgorithm(JoinAlgorithm::GRACE_HASH))

--- a/src/Interpreters/FullSortingMergeJoin.cpp
+++ b/src/Interpreters/FullSortingMergeJoin.cpp
@@ -27,8 +27,9 @@ void FullSortingMergeJoin::permuteKeys(const std::vector<size_t> & permutation)
 {
     auto & join_on = table_join->getOnlyClause();
 
-    assert(permutation.size() == join_on.key_names_left.size() &&
-           permutation.size() == join_on.key_names_right.size());
+    if (permutation.size() != join_on.key_names_left.size() || permutation.size() != join_on.key_names_right.size())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Permutation size ({}) is not equal to number of keys ({}, {})",
+            permutation.size(), join_on.key_names_left.size(), join_on.key_names_right.size());
 
     assertIsPermutation(permutation);
 

--- a/src/Interpreters/FullSortingMergeJoin.cpp
+++ b/src/Interpreters/FullSortingMergeJoin.cpp
@@ -1,0 +1,65 @@
+#include <Interpreters/FullSortingMergeJoin.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+static void assertIsPermutation(const std::vector<size_t> & permutation)
+{
+    std::set<size_t> sorted(permutation.begin(), permutation.end());
+    if (sorted.size() != permutation.size())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Permutation is not unique");
+
+    for (size_t i = 0; i < permutation.size(); ++i)
+    {
+        if (sorted.count(i) != 1)
+        {
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Permutation is not complete");
+        }
+    }
+}
+
+void FullSortingMergeJoin::permuteKeys(const std::vector<size_t> & permutation)
+{
+    auto & join_on = table_join->getOnlyClause();
+
+    assert(permutation.size() == join_on.key_names_left.size() &&
+           permutation.size() == join_on.key_names_right.size());
+
+    assertIsPermutation(permutation);
+
+    Names new_key_names_left;
+    Names new_key_names_right;
+    for (size_t idx : permutation)
+    {
+        new_key_names_left.push_back(join_on.key_names_left[idx]);
+        new_key_names_right.push_back(join_on.key_names_right[idx]);
+    }
+    join_on.key_names_left = std::move(new_key_names_left);
+    join_on.key_names_right = std::move(new_key_names_right);
+}
+
+const Names & FullSortingMergeJoin::getKeyNames(JoinTableSide side) const
+{
+    auto & join_on = table_join->getOnlyClause();
+    return side == JoinTableSide::Left ? join_on.key_names_left : join_on.key_names_right;
+}
+
+void FullSortingMergeJoin::setPrefixSortDesctiption(const SortDescription & prefix_sort_description_, JoinTableSide side)
+{
+    if (side == JoinTableSide::Left)
+        left_prefix_sort_description = prefix_sort_description_;
+    else
+        right_prefix_sort_description = prefix_sort_description_;
+}
+
+SortDescription FullSortingMergeJoin::getPrefixSortDesctiption(JoinTableSide side) const
+{
+    return side == JoinTableSide::Left ? left_prefix_sort_description : right_prefix_sort_description;
+}
+
+}

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -38,7 +38,6 @@
 
 #include <Processors/Sources/NullSource.h>
 #include <Processors/QueryPlan/SortingStep.h>
-#include <Processors/QueryPlan/CreateSetAndFilterOnTheFlyStep.h>
 #include <Processors/QueryPlan/ReadFromPreparedSource.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
@@ -1172,62 +1171,6 @@ JoinTreeQueryPlan buildQueryPlanForJoinNode(const QueryTreeNodePtr & join_table_
     }
     else
     {
-        auto add_sorting = [&] (QueryPlan & plan, const Names & key_names, JoinTableSide join_table_side)
-        {
-            SortDescription sort_description;
-            sort_description.reserve(key_names.size());
-            for (const auto & key_name : key_names)
-                sort_description.emplace_back(key_name);
-
-            SortingStep::Settings sort_settings(*query_context);
-
-            auto sorting_step = std::make_unique<SortingStep>(
-                plan.getCurrentDataStream(),
-                std::move(sort_description),
-                0 /*limit*/,
-                sort_settings,
-                settings.optimize_sorting_by_input_stream_properties);
-            sorting_step->setStepDescription(fmt::format("Sort {} before JOIN", join_table_side));
-            plan.addStep(std::move(sorting_step));
-        };
-
-        auto crosswise_connection = CreateSetAndFilterOnTheFlyStep::createCrossConnection();
-        auto add_create_set = [&settings, crosswise_connection](QueryPlan & plan, const Names & key_names, JoinTableSide join_table_side)
-        {
-            auto creating_set_step = std::make_unique<CreateSetAndFilterOnTheFlyStep>(
-                plan.getCurrentDataStream(),
-                key_names,
-                settings.max_rows_in_set_to_optimize_join,
-                crosswise_connection,
-                join_table_side);
-            creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_table_side));
-
-            auto * step_raw_ptr = creating_set_step.get();
-            plan.addStep(std::move(creating_set_step));
-            return step_raw_ptr;
-        };
-
-        if (join_algorithm->pipelineType() == JoinPipelineType::YShaped)
-        {
-            const auto & join_clause = table_join->getOnlyClause();
-
-            bool kind_allows_filtering = isInner(join_kind) || isLeft(join_kind) || isRight(join_kind);
-            if (settings.max_rows_in_set_to_optimize_join > 0 && kind_allows_filtering)
-            {
-                auto * left_set = add_create_set(left_plan, join_clause.key_names_left, JoinTableSide::Left);
-                auto * right_set = add_create_set(right_plan, join_clause.key_names_right, JoinTableSide::Right);
-
-                if (isInnerOrLeft(join_kind))
-                    right_set->setFiltering(left_set->getSet());
-
-                if (isInnerOrRight(join_kind))
-                    left_set->setFiltering(right_set->getSet());
-            }
-
-            add_sorting(left_plan, join_clause.key_names_left, JoinTableSide::Left);
-            add_sorting(right_plan, join_clause.key_names_right, JoinTableSide::Right);
-        }
-
         auto join_pipeline_type = join_algorithm->pipelineType();
         auto join_step = std::make_unique<JoinStep>(
             left_plan.getCurrentDataStream(),

--- a/src/Planner/PlannerJoins.cpp
+++ b/src/Planner/PlannerJoins.cpp
@@ -36,6 +36,8 @@
 #include <Interpreters/ArrayJoinAction.h>
 #include <Interpreters/GraceHashJoin.h>
 
+#include <Processors/QueryPlan/SortingStep.h>
+
 #include <Planner/PlannerActionsVisitor.h>
 #include <Planner/PlannerContext.h>
 #include <Planner/Utils.h>
@@ -690,10 +692,9 @@ std::shared_ptr<IJoin> chooseJoinAlgorithm(std::shared_ptr<TableJoin> & table_jo
         return std::make_shared<HashJoin>(table_join, right_table_expression_header);
     }
 
-    if (table_join->isEnabledAlgorithm(JoinAlgorithm::FULL_SORTING_MERGE))
+    if (table_join->isEnabledAlgorithm(JoinAlgorithm::FULL_SORTING_MERGE) && FullSortingMergeJoin::isSupported(table_join))
     {
-        if (FullSortingMergeJoin::isSupported(table_join))
-            return std::make_shared<FullSortingMergeJoin>(table_join, right_table_expression_header);
+        return std::make_shared<FullSortingMergeJoin>(table_join, right_table_expression_header, SortingStep::Settings(*planner_context->getQueryContext()));
     }
 
     if (table_join->isEnabledAlgorithm(JoinAlgorithm::GRACE_HASH))

--- a/src/Processors/QueryPlan/JoinStep.cpp
+++ b/src/Processors/QueryPlan/JoinStep.cpp
@@ -98,14 +98,9 @@ void JoinStep::updateInputStream(const DataStream & new_input_stream_, size_t id
     }
 }
 
-FullSortingMergeJoin * JoinStep::getSortingJoin()
-{
-    return dynamic_cast<FullSortingMergeJoin *>(join.get());
-}
-
 std::unique_ptr<SortingStep> JoinStep::createSorting(JoinTableSide join_side)
 {
-    const auto * sorting_join = getSortingJoin();
+    const auto * sorting_join = dynamic_cast<FullSortingMergeJoin *>(join.get());
     if (!sorting_join)
         return nullptr;
 
@@ -122,15 +117,7 @@ std::unique_ptr<SortingStep> JoinStep::createSorting(JoinTableSide join_side)
     const SortDescription & prefix_sort_description = sorting_join->getPrefixSortDesctiption(join_side);
     if (!prefix_sort_description.empty())
     {
-        LOG_DEBUG(&Poco::Logger::get("JoinStep"), "Finish sort {} side of JOIN by [{}] with prefix [{}]",
-            join_side, dumpSortDescription(sort_description), dumpSortDescription(prefix_sort_description));
-
         sorting_step->convertToFinishSorting(prefix_sort_description);
-    }
-    else
-    {
-        LOG_DEBUG(&Poco::Logger::get("JoinStep"), "Sort {} side of JOIN by [{}]",
-            join_side, dumpSortDescription(sort_description));
     }
 
     sorting_step->setStepDescription(fmt::format(

--- a/src/Processors/QueryPlan/JoinStep.h
+++ b/src/Processors/QueryPlan/JoinStep.h
@@ -9,7 +9,10 @@ namespace DB
 class IJoin;
 using JoinPtr = std::shared_ptr<IJoin>;
 
-/// Join two data streams.
+class FullSortingMergeJoin;
+class SortingStep;
+
+/// Step for JOIN.
 class JoinStep : public IQueryPlanStep
 {
 public:
@@ -31,8 +34,11 @@ public:
     bool allowPushDownToRight() const;
 
     void updateInputStream(const DataStream & new_input_stream_, size_t idx);
+    std::unique_ptr<SortingStep> createSorting(JoinTableSide join_side);
 
 private:
+    FullSortingMergeJoin * getSortingJoin();
+
     JoinPtr join;
     size_t max_block_size;
     size_t max_streams;

--- a/src/Processors/QueryPlan/JoinStep.h
+++ b/src/Processors/QueryPlan/JoinStep.h
@@ -37,8 +37,6 @@ public:
     std::unique_ptr<SortingStep> createSorting(JoinTableSide join_side);
 
 private:
-    FullSortingMergeJoin * getSortingJoin();
-
     JoinPtr join;
     size_t max_block_size;
     size_t max_streams;

--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -115,6 +115,9 @@ bool optimizeUseAggregateProjections(QueryPlan::Node & node, QueryPlan::Nodes & 
 bool optimizeUseNormalProjections(Stack & stack, QueryPlan::Nodes & nodes);
 bool addPlansForSets(QueryPlan::Node & node, QueryPlan::Nodes & nodes);
 
+/// Insert sorting step before join if needed or use read in order
+void applyOrderForJoin(QueryPlan::Node & node, QueryPlan::Nodes & nodes, const QueryPlanOptimizationSettings & optimization_settings);
+
 /// Enable memory bound merging of aggregation states for remote queries
 /// in case it was enabled for local plan
 void enableMemoryBoundMerging(QueryPlan::Node & node, QueryPlan::Nodes &);

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -14,11 +14,14 @@ QueryPlanOptimizationSettings QueryPlanOptimizationSettings::fromSettings(const 
     settings.distinct_in_order = from.optimize_distinct_in_order;
     settings.read_in_order = from.optimize_read_in_order && from.query_plan_read_in_order;
     settings.aggregation_in_order = from.optimize_aggregation_in_order && from.query_plan_aggregation_in_order;
+    settings.join_in_order = from.optimize_join_in_order;
     settings.remove_redundant_sorting = from.query_plan_remove_redundant_sorting;
     settings.aggregate_partitions_independently = from.allow_aggregate_partitions_independently;
     settings.remove_redundant_distinct = from.query_plan_remove_redundant_distinct;
     settings.optimize_projection = from.optimize_use_projections && from.query_plan_optimize_projection;
     settings.force_use_projection = settings.optimize_projection && from.force_optimize_projection;
+    settings.max_rows_in_set_to_optimize_join = from.max_rows_in_set_to_optimize_join;
+
     return settings;
 }
 

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -30,6 +30,9 @@ struct QueryPlanOptimizationSettings
     /// If aggregation-in-order optimisation is enabled
     bool aggregation_in_order = false;
 
+    /// Optimize full_sorting_merge if it is possible
+    bool join_in_order = true;
+
     /// If removing redundant sorting is enabled, for example, ORDER BY clauses in subqueries
     bool remove_redundant_sorting = true;
 
@@ -41,6 +44,9 @@ struct QueryPlanOptimizationSettings
     /// If reading from projection can be applied
     bool optimize_projection = false;
     bool force_use_projection = false;
+
+    /// Insert filtering step before sorting for full_sorting_merge JOIN with specified set size.
+    size_t max_rows_in_set_to_optimize_join = 0;
 
     static QueryPlanOptimizationSettings fromSettings(const Settings & from);
     static QueryPlanOptimizationSettings fromContext(ContextPtr from);

--- a/src/Processors/QueryPlan/Optimizations/optimizeInOrderCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeInOrderCommon.cpp
@@ -1,0 +1,14 @@
+
+#include <Processors/QueryPlan/Optimizations/optimizeInOrderCommon.h>
+
+
+namespace DB::QueryPlanOptimizations
+{
+
+Poco::Logger * getLogger()
+{
+    static Poco::Logger & logger = Poco::Logger::get("QueryPlanOptimizations");
+    return &logger;
+}
+
+}

--- a/src/Processors/QueryPlan/Optimizations/optimizeInOrderCommon.h
+++ b/src/Processors/QueryPlan/Optimizations/optimizeInOrderCommon.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <Processors/QueryPlan/Optimizations/Optimizations.h>
+#include <Storages/SelectQueryInfo.h>
+
+#include <Common/logger_useful.h>
+
+#include <stack>
+
+
+/*
+ * Common functions for join/aggregation/sorting read in order optimizations.
+ */
+namespace DB::QueryPlanOptimizations
+{
+
+using StepStack = std::vector<IQueryPlanStep *>;
+
+using Positions = std::set<size_t>;
+using Permutation = std::vector<size_t>;
+
+/// Sort description for step that requires sorting (aggregation or sorting JOIN).
+/// Note: We really do need three different sort descriptions here.
+///
+/// For example, aggregation query:
+///
+///   create table tab (a Int32, b Int32, c Int32, d Int32) engine = MergeTree order by (a, b, c);
+///   select a, any(b), c, d from tab where b = 1 group by a, c, d order by c, d;
+///
+/// We would like to have:
+/// (a, b, c) - a sort description for reading from table (it's into input_order)
+/// (a, c) - a sort description for merging (an input of AggregatingInOrderTransform is sorted by this GROUP BY keys)
+/// (a, c, d) - a target sort description (GROUP BY sort description, an input of FinishAggregatingInOrderTransform is sorted by all GROUP BY keys)
+///
+/// Sort description from input_order is not actually used. ReadFromMergeTree reads only PK prefix size.
+/// We should remove it later.
+struct StepInputOrder
+{
+    InputOrderInfoPtr input_order;
+    SortDescription sort_description_for_merging;
+    SortDescription target_sort_description;
+
+    /// Map indices from target_sort_description original positions
+    std::vector<Positions> permutation;
+};
+
+/// FixedColumns are columns which values become constants after filtering.
+/// In a query "SELECT x, y, z FROM table WHERE x = 1 AND y = 'a' ORDER BY x, y, z"
+/// Fixed columns are 'x' and 'y'.
+using FixedColumns = std::unordered_set<const ActionsDAG::Node *>;
+
+QueryPlan::Node * findReadingStep(QueryPlan::Node & node, StepStack & backward_path);
+
+StepInputOrder buildInputOrderInfo(const Names & keys, QueryPlan::Node & node, QueryPlan::Node * reading_node);
+
+void requestInputOrderInfo(const InputOrderInfoPtr & input_order_info, QueryPlanStepPtr & reading_step);
+
+void updateStepsDataStreams(StepStack & steps_to_update);
+
+
+Poco::Logger * getLogger();
+
+}

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoinInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoinInOrder.cpp
@@ -1,0 +1,258 @@
+#include <Processors/QueryPlan/Optimizations/Optimizations.h>
+
+#include <Columns/IColumn.h>
+#include <Common/typeid_cast.h>
+
+#include <DataTypes/DataTypeAggregateFunction.h>
+#include <Functions/IFunction.h>
+#include <Interpreters/ActionsDAG.h>
+#include <Interpreters/ArrayJoinAction.h>
+#include <Interpreters/FullSortingMergeJoin.h>
+#include <Interpreters/InterpreterSelectQuery.h>
+#include <Interpreters/TableJoin.h>
+
+#include <Parsers/ASTWindowDefinition.h>
+
+#include <Processors/QueryPlan/AggregatingStep.h>
+#include <Processors/QueryPlan/ArrayJoinStep.h>
+#include <Processors/QueryPlan/CreateSetAndFilterOnTheFlyStep.h>
+#include <Processors/QueryPlan/CreatingSetsStep.h>
+#include <Processors/QueryPlan/CubeStep.h>
+#include <Processors/QueryPlan/DistinctStep.h>
+#include <Processors/QueryPlan/ExpressionStep.h>
+#include <Processors/QueryPlan/ITransformingStep.h>
+#include <Processors/QueryPlan/JoinStep.h>
+#include <Processors/QueryPlan/LimitStep.h>
+#include <Processors/QueryPlan/Optimizations/actionsDAGUtils.h>
+#include <Processors/QueryPlan/ReadFromMergeTree.h>
+#include <Processors/QueryPlan/SortingStep.h>
+#include <Processors/QueryPlan/TotalsHavingStep.h>
+#include <Processors/QueryPlan/UnionStep.h>
+#include <Processors/QueryPlan/WindowStep.h>
+
+#include <Storages/StorageMerge.h>
+
+#include <Processors/QueryPlan/Optimizations/optimizeInOrderCommon.h>
+
+
+namespace DB::QueryPlanOptimizations
+{
+
+static Permutation flattenPositions(const std::vector<Positions> & positions)
+{
+    Permutation res;
+    res.reserve(positions.size());
+    for (const auto & pos : positions)
+        res.insert(res.end(), pos.begin(), pos.end());
+    return res;
+}
+
+static size_t findPrefixMatchLength(const std::vector<Positions> & positions, const Permutation & flattened)
+{
+    size_t flatten_idx = 0;
+    for (size_t i = 0; i < positions.size(); ++i)
+    {
+        for (size_t e : positions[i])
+        {
+            if (e != flattened[flatten_idx])
+                return i;
+            ++flatten_idx;
+        }
+    }
+    return positions.size();
+}
+
+/// Choose order info that use longer prefix of sorting key.
+/// Returns true if lhs is better than rhs.
+static bool compareOrderInfos(const InputOrderInfoPtr & lhs, const InputOrderInfoPtr & rhs)
+{
+    size_t lhs_size = lhs ? lhs->used_prefix_of_sorting_key_size : 0;
+    size_t rhs_size = rhs ? rhs->used_prefix_of_sorting_key_size : 0;
+    return lhs_size >= rhs_size;
+}
+
+/// Cut order info to use only prefix of specified size
+static void truncateToPrefixSize(StepInputOrder & order_info, size_t prefix_size)
+{
+    if (!order_info.input_order)
+        return;
+
+    chassert(order_info.target_sort_description.size() >= order_info.sort_description_for_merging.size());
+
+    if (order_info.target_sort_description.size() <= prefix_size)
+        return;
+
+    order_info.target_sort_description.resize(prefix_size);
+    order_info.sort_description_for_merging.resize(prefix_size);
+
+    const auto & last_column_name = order_info.sort_description_for_merging[prefix_size - 1].column_name;
+
+    chassert(order_info.input_order->sort_description_for_merging.size() == order_info.input_order->used_prefix_of_sorting_key_size);
+
+    auto input_order = std::make_shared<InputOrderInfo>(*order_info.input_order);
+    for (size_t i = 0; i < input_order->sort_description_for_merging.size(); ++i)
+    {
+        if (input_order->sort_description_for_merging[i].column_name == last_column_name)
+        {
+            input_order->used_prefix_of_sorting_key_size = i + 1;
+            input_order->sort_description_for_merging.resize(input_order->used_prefix_of_sorting_key_size);
+            break;
+        }
+    }
+    order_info.input_order = std::move(input_order);
+}
+
+/// Choose order info that use longer prefix of sorting key and cut second one to use common prefix.
+/// Returns permutation that should be applied to keys.
+static Permutation findCommonOrderInfo(StepInputOrder & left_order_info, StepInputOrder & right_order_info)
+{
+    if (!left_order_info.input_order && !right_order_info.input_order)
+    {
+        LOG_TRACE(getLogger(), "Cannot read anything in order for join");
+        return {};
+    }
+
+    if (!right_order_info.input_order)
+    {
+        LOG_TRACE(getLogger(), "Can read left stream in order for join");
+        return flattenPositions(left_order_info.permutation);
+    }
+
+    if (!left_order_info.input_order)
+    {
+        LOG_TRACE(getLogger(), "Can read right stream in order for join");
+        return flattenPositions(right_order_info.permutation);
+    }
+
+    LOG_TRACE(getLogger(), "Can read both streams in order for join");
+
+    bool left_is_better = compareOrderInfos(left_order_info.input_order, right_order_info.input_order);
+    auto & lhs = left_is_better ? left_order_info : right_order_info;
+    auto & rhs = left_is_better ? right_order_info : left_order_info;
+
+    Permutation result_permutation = flattenPositions(lhs.permutation);
+    size_t prefix_size = findPrefixMatchLength(rhs.permutation, result_permutation);
+    truncateToPrefixSize(rhs, prefix_size);
+    return result_permutation;
+}
+
+static bool optimizeJoinInOrder(QueryPlan::Node & node, const std::shared_ptr<FullSortingMergeJoin> & join_ptr)
+{
+    const auto & key_names_left = join_ptr->getKeyNames(JoinTableSide::Left);
+    auto * left_child_node = node.children[0];
+
+    StepStack steps_to_update_left;
+
+    QueryPlan::Node * left_reading_node = findReadingStep(*left_child_node->children.front(), steps_to_update_left);
+    auto left_order_info = buildInputOrderInfo(key_names_left, *left_child_node, left_reading_node);
+
+    const auto & key_names_right = join_ptr->getKeyNames(JoinTableSide::Right);
+    auto * right_child_node = node.children[1];
+
+    StepStack steps_to_update_right;
+    QueryPlan::Node * right_reading_node = findReadingStep(*right_child_node->children.front(), steps_to_update_right);
+    auto right_order_info = buildInputOrderInfo(key_names_right, *right_child_node, right_reading_node);
+
+    auto keys_permuation = findCommonOrderInfo(left_order_info, right_order_info);
+    if (keys_permuation.empty())
+        return false;
+
+    LOG_TRACE(getLogger(), "Applying permutation [{}] for join keys", fmt::join(keys_permuation, ", "));
+
+    join_ptr->permuteKeys(keys_permuation);
+
+    if (left_order_info.input_order)
+    {
+        join_ptr->setPrefixSortDesctiption(left_order_info.sort_description_for_merging, JoinTableSide::Left);
+        requestInputOrderInfo(left_order_info.input_order, left_reading_node->step);
+        updateStepsDataStreams(steps_to_update_left);
+    }
+
+    if (right_order_info.input_order)
+    {
+        join_ptr->setPrefixSortDesctiption(right_order_info.sort_description_for_merging, JoinTableSide::Right);
+        requestInputOrderInfo(right_order_info.input_order, right_reading_node->step);
+        updateStepsDataStreams(steps_to_update_right);
+    }
+    return true;
+}
+
+void applyOrderForJoin(QueryPlan::Node & node, QueryPlan::Nodes & nodes, const QueryPlanOptimizationSettings & optimization_settings)
+{
+    if (node.children.size() != 2 || node.children[0]->children.size() != 1 || node.children[1]->children.size() != 1)
+        return;
+
+    auto * join_step = typeid_cast<JoinStep *>(node.step.get());
+    if (!join_step)
+        return;
+
+    auto join_ptr = std::dynamic_pointer_cast<FullSortingMergeJoin>(join_step->getJoin());
+    if (!join_ptr)
+        return;
+
+    bool is_read_in_order_optimized = false;
+    if (optimization_settings.read_in_order && optimization_settings.join_in_order)
+        is_read_in_order_optimized = optimizeJoinInOrder(node, join_ptr);
+
+    auto insert_pre_step = [&nodes, &node](size_t idx, auto step)
+    {
+        auto & sort_node = nodes.emplace_back();
+        sort_node.step = std::move(step);
+        sort_node.children.push_back(node.children[idx]);
+        node.children[idx] = &sort_node;
+    };
+
+    auto join_kind = join_ptr->getTableJoin().kind();
+    bool kind_allows_filtering = isInner(join_kind) || isLeft(join_kind) || isRight(join_kind);
+
+    auto has_non_const = [](const Block & block, const auto & keys)
+    {
+        for (const auto & key : keys)
+        {
+            const auto & column = block.getByName(key).column;
+            if (column && !isColumnConst(*column))
+                return true;
+        }
+        return false;
+    };
+
+    const auto & left_stream = node.children[0]->step->getOutputStream();
+    const auto & right_stream = node.children[1]->step->getOutputStream();
+
+    /// This optimization relies on the sorting that should buffer the whole stream before emitting any rows.
+    /// It doesn't hold such a guarantee for streams with const keys.
+    /// Note: it's also doesn't work with the read-in-order optimization.
+    /// No checks here because read in order is not applied if we have `CreateSetAndFilterOnTheFlyStep` in the pipeline between the reading and sorting steps.
+    bool has_non_const_keys = has_non_const(left_stream.header, join_ptr->getKeyNames(JoinTableSide::Left))
+        && has_non_const(right_stream.header, join_ptr->getKeyNames(JoinTableSide::Right));
+
+    size_t max_rows_in_filter_set = optimization_settings.max_rows_in_set_to_optimize_join;
+    if (!is_read_in_order_optimized && max_rows_in_filter_set > 0 && kind_allows_filtering && has_non_const_keys)
+    {
+        auto crosswise_connection = CreateSetAndFilterOnTheFlyStep::createCrossConnection();
+        auto add_create_set = [&](const DataStream & data_stream, const Names & key_names, JoinTableSide join_pos)
+        {
+            auto creating_set_step = std::make_unique<CreateSetAndFilterOnTheFlyStep>(
+                data_stream, key_names, max_rows_in_filter_set, crosswise_connection, join_pos);
+            creating_set_step->setStepDescription(fmt::format("Create set and filter {} joined stream", join_pos));
+
+            auto * step_raw_ptr = creating_set_step.get();
+            insert_pre_step(join_pos == JoinTableSide::Left ? 0 : 1, std::move(creating_set_step));
+            return step_raw_ptr;
+        };
+
+        auto * left_set = add_create_set(left_stream, join_ptr->getKeyNames(JoinTableSide::Left), JoinTableSide::Left);
+        auto * right_set = add_create_set(right_stream, join_ptr->getKeyNames(JoinTableSide::Right), JoinTableSide::Right);
+        if (isInnerOrLeft(join_kind))
+            right_set->setFiltering(left_set->getSet());
+        if (isInnerOrRight(join_kind))
+            left_set->setFiltering(right_set->getSet());
+    }
+
+    for (size_t i = 0; i < 2; ++i)
+    {
+        insert_pre_step(i, join_step->createSorting(JoinTableSide(i)));
+    }
+}
+
+}

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -39,12 +39,6 @@
 namespace DB::QueryPlanOptimizations
 {
 
-static Poco::Logger * getLogger()
-{
-    static Poco::Logger & logger = Poco::Logger::get("QueryPlanOptimizations");
-    return &logger;
-}
-
 using Positions = std::set<size_t>;
 using Permutation = std::vector<size_t>;
 
@@ -85,7 +79,7 @@ static ISourceStep * checkSupportedReadingStep(IQueryPlanStep * step)
 
 using StepStack = std::vector<IQueryPlanStep *>;
 
-static QueryPlan::Node * findReadingStep(QueryPlan::Node & node, StepStack & backward_path)
+QueryPlan::Node * findReadingStep(QueryPlan::Node & node, StepStack & backward_path)
 {
     IQueryPlanStep * step = node.step.get();
     if (auto * reading = checkSupportedReadingStep(step))

--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -118,9 +118,15 @@ void optimizeTreeSecondPass(const QueryPlanOptimizationSettings & optimization_s
             /// NOTE: frame cannot be safely used after stack was modified.
             auto & frame = stack.back();
 
+            /// insert sorting for join if needed before optimizeReadInOrder to optimize them
+            applyOrderForJoin(*frame.node, nodes, optimization_settings);
+
             if (frame.next_child == 0)
             {
                 has_reading_from_mt |= typeid_cast<const ReadFromMergeTree *>(frame.node->step.get()) != nullptr;
+
+                if (optimization_settings.read_in_order)
+                    optimizeReadInOrder(*frame.node, nodes);
 
                 if (optimization_settings.read_in_order)
                     optimizeReadInOrder(*frame.node, nodes);

--- a/src/Processors/Transforms/FinishSortingTransform.cpp
+++ b/src/Processors/Transforms/FinishSortingTransform.cpp
@@ -32,8 +32,9 @@ FinishSortingTransform::FinishSortingTransform(
     /// Check for sanity non-modified descriptions
     if (!isPrefix(description_sorted_, description_to_sort_))
         throw Exception(ErrorCodes::LOGICAL_ERROR,
-                        "Can't finish sorting. SortDescription "
-                        "of already sorted stream is not prefix of SortDescription needed to sort");
+                        "Can't finish sorting. SortDescription [{}]"
+                        " of already sorted stream is not prefix of SortDescription [{}] needed to sort",
+                        dumpSortDescription(description_sorted_), dumpSortDescription(description_to_sort_));
 
     /// The target description is modified in SortingTransform constructor.
     /// To avoid doing the same actions with description_sorted just copy it from prefix of target description.

--- a/src/QueryPipeline/QueryPipelineBuilder.cpp
+++ b/src/QueryPipeline/QueryPipelineBuilder.cpp
@@ -350,11 +350,16 @@ std::unique_ptr<QueryPipelineBuilder> QueryPipelineBuilder::joinPipelinesYShaped
 
     left->pipe.dropExtremes();
     right->pipe.dropExtremes();
+
     if (left->getNumStreams() != 1 || right->getNumStreams() != 1)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Join is supported only for pipelines with one output port");
+    {
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+                        "Sorting join algorithm is supported only for pipelines with one output port, got: {}, {}",
+                        left->getNumStreams(), right->getNumStreams());
+    }
 
     if (left->hasTotals() || right->hasTotals())
-        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Current join algorithm is supported only for pipelines without totals");
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Sorting join algorithm is supported only for pipelines without totals");
 
     Blocks inputs = {left->getHeader(), right->getHeader()};
 

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -106,11 +106,11 @@ struct FilterDAGInfo
 struct InputOrderInfo
 {
     /// Sort description for merging of already sorted streams.
-    /// Always a prefix of ORDER BY or GROUP BY description specified in query.
+    /// Always a prefix of ORDER BY or GROUP BY description or JOIN keys specified in query.
     SortDescription sort_description_for_merging;
 
     /** Size of prefix of sorting key that is already
-     * sorted before execution of sorting or aggreagation.
+     * sorted before execution of sorting, aggreagation or join.
      *
      * Contains both columns that scpecified in
      * ORDER BY or GROUP BY clause of query
@@ -121,7 +121,7 @@ struct InputOrderInfo
      * sort_description_for_merging will be equal to (c, d) and
      * used_prefix_of_sorting_key_size will be equal to 4.
      */
-    const size_t used_prefix_of_sorting_key_size;
+    size_t used_prefix_of_sorting_key_size;
 
     const int direction;
     const UInt64 limit;

--- a/tests/queries/0_stateless/02381_join_dup_columns_in_plan.reference
+++ b/tests/queries/0_stateless/02381_join_dup_columns_in_plan.reference
@@ -28,20 +28,25 @@ Header: key String
   Header: s1.key_0 String
           s2.key_2 String
           s2.value_1 String
-    Expression
+    Sorting
     Header: s1.key_0 String
-      ReadFromStorage
-      Header: dummy UInt8
-    Union
+      Expression
+      Header: s1.key_0 String
+        ReadFromStorage
+        Header: dummy UInt8
+    Sorting
     Header: s2.key_2 String
             s2.value_1 String
-      Expression
+      Union
       Header: s2.key_2 String
               s2.value_1 String
-        ReadFromStorage
-        Header: dummy UInt8
-      Expression
-      Header: s2.key_2 String
-              s2.value_1 String
-        ReadFromStorage
-        Header: dummy UInt8
+        Expression
+        Header: s2.key_2 String
+                s2.value_1 String
+          ReadFromStorage
+          Header: dummy UInt8
+        Expression
+        Header: s2.key_2 String
+                s2.value_1 String
+          ReadFromStorage
+          Header: dummy UInt8

--- a/tests/queries/0_stateless/02381_join_dup_columns_in_plan.reference
+++ b/tests/queries/0_stateless/02381_join_dup_columns_in_plan.reference
@@ -25,28 +25,23 @@ Expression
 Header: key String
         value String
   Join
-  Header: key_0 String
-          key_2 String
-          value_1 String
-    Sorting
-    Header: key_0 String
+  Header: s1.key_0 String
+          s2.key_2 String
+          s2.value_1 String
+    Expression
+    Header: s1.key_0 String
+      ReadFromStorage
+      Header: dummy UInt8
+    Union
+    Header: s2.key_2 String
+            s2.value_1 String
       Expression
-      Header: key_0 String
+      Header: s2.key_2 String
+              s2.value_1 String
         ReadFromStorage
         Header: dummy UInt8
-    Sorting
-    Header: key_2 String
-            value_1 String
-      Union
-      Header: key_2 String
-              value_1 String
-        Expression
-        Header: key_2 String
-                value_1 String
-          ReadFromStorage
-          Header: dummy UInt8
-        Expression
-        Header: key_2 String
-                value_1 String
-          ReadFromStorage
-          Header: dummy UInt8
+      Expression
+      Header: s2.key_2 String
+              s2.value_1 String
+        ReadFromStorage
+        Header: dummy UInt8

--- a/tests/queries/0_stateless/02381_join_dup_columns_in_plan.sql
+++ b/tests/queries/0_stateless/02381_join_dup_columns_in_plan.sql
@@ -8,6 +8,8 @@ USING (key);
 
 SET join_algorithm = 'full_sorting_merge';
 
+SET optimize_read_in_order = 0, query_plan_read_in_order = 0;
+
 SET max_rows_in_set_to_optimize_join = 0;
 
 EXPLAIN actions=0, description=0, header=1

--- a/tests/queries/0_stateless/02559_sorted_full_join.sh
+++ b/tests/queries/0_stateless/02559_sorted_full_join.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -mn -q "
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+DROP TABLE IF EXISTS t4;
+DROP TABLE IF EXISTS ta1;
+DROP TABLE IF EXISTS ta2;
+
+CREATE TABLE t1 (x UInt64, y UInt64, val UInt64) ENGINE = MergeTree ORDER BY (x, y) PARTITION BY (x % 2)
+AS SELECT sipHash64(number, '11') % 100, sipHash64(number, '12') % 100, sipHash64(number, '13') % 100 FROM numbers(1000);
+
+CREATE TABLE t2 (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY (a, b) PARTITION BY (a % 2)
+AS SELECT sipHash64(number, '21') % 100, sipHash64(number, '22') % 100 FROM numbers(1000);
+
+CREATE TABLE t3 (x UInt64, y UInt64) ENGINE = MergeTree ORDER BY (x, y) PARTITION BY (x % 2)
+AS SELECT sipHash64(number, '21') % 100, sipHash64(number, '22') % 100 FROM numbers(1000);
+
+CREATE TABLE t4 (y UInt64, x UInt64) ENGINE = MergeTree ORDER BY (y, x) PARTITION BY (y % 2)
+AS SELECT sipHash64(number, '21') % 100, sipHash64(number, '22') % 100 FROM numbers(1000);
+
+CREATE TABLE ta1 (a1 UInt64, a2 UInt64, a3 UInt64, a4 UInt64, a5 UInt64, a6 UInt64, a7 UInt64, a8 UInt64, a9 UInt64, a10 UInt64)
+ENGINE = MergeTree ORDER BY (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) PARTITION BY (a1 % 2)
+AS SELECT
+    sipHash64(number, 'a11') % 2, sipHash64(number, 'a12') % 2, sipHash64(number, 'a13') % 2, sipHash64(number, 'a14') % 2, sipHash64(number, 'a15') % 2,
+    sipHash64(number, 'a16') % 2, sipHash64(number, 'a17') % 2, sipHash64(number, 'a18') % 2, sipHash64(number, 'a19') % 2, sipHash64(number, 'a20') % 2
+FROM numbers(1000);
+
+CREATE TABLE ta2 (a1 UInt64, a2 UInt64, a3 UInt64, a4 UInt64, a5 UInt64, a6 UInt64, a7 UInt64, a8 UInt64, a9 UInt64, a10 UInt64)
+ENGINE = MergeTree ORDER BY (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) PARTITION BY (a1 % 2)
+AS SELECT
+    sipHash64(number, 'a21') % 2, sipHash64(number, 'a22') % 2, sipHash64(number, 'a23') % 2, sipHash64(number, 'a24') % 2, sipHash64(number, 'a25') % 2,
+    sipHash64(number, 'a26') % 2, sipHash64(number, 'a27') % 2, sipHash64(number, 'a28') % 2, sipHash64(number, 'a29') % 2, sipHash64(number, 'a30') % 2
+FROM numbers(1000);
+"
+
+CLIENT_ARGS='--join_algorithm=full_sorting_merge --optimize_sorting_by_input_stream_properties=1 --optimize_read_in_order=1 --max_threads=8 --max_block_size=128'
+
+# test_query <expected_number_of_sort_steps> <query>
+function test_query {
+    expected_result=${1}
+    query_str="${2}"
+
+    # count the number of MergeSortingTransform's in the pipeline
+    result=$( $CLICKHOUSE_CLIENT $CLIENT_ARGS -q "EXPLAIN PIPELINE ${query_str}" )
+    sort_count=$( echo "$result" | grep 'MergeSortingTransform' | wc -l )
+
+    test "$sort_count" -eq "$expected_result" || echo "fail ${BASH_LINENO[0]}: expected: $expected_result, got: $sort_count in '${query_str}'"
+
+    echo "$result" | grep -q 'FilterOnTheFly' && echo "fail ${BASH_LINENO[0]}: step FilterOnTheFly should not be present for read in order"
+}
+
+# Simple case: join by sorted prefix with length 1
+test_query 0 'SELECT * FROM t1 JOIN t3 USING (x)'
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x'
+test_query 0 'SELECT * FROM t1 JOIN t4 ON t1.x = t4.y'
+
+# Join by sorted prefix with length 2
+test_query 0 'SELECT * FROM t1 JOIN t3 USING (x, y)'
+# Keys should be deduplicated
+test_query 0 'SELECT * FROM t1 JOIN t3 USING (x, x, x, y, y, y, y, x, x, x)'
+# Keys can be reordered
+test_query 0 'SELECT * FROM t1 JOIN t3 USING (y, x)'
+
+# Reoderinbg and deduplication for ON syntax:
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.y = t3.y'
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.y = t3.y AND t1.y = t3.y AND t1.y = t3.y AND t1.x = t3.x AND t1.x = t3.x'
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.y = t3.y AND t1.x = t3.x'
+test_query 0 'SELECT * FROM t1 JOIN t4 ON t1.x = t4.y AND t1.y = t4.x'
+test_query 0 'SELECT * FROM t1 JOIN t4 ON t1.y = t4.x AND t1.x = t4.y'
+
+# Names doesn't matter (`x,y` or `a,b` in the table)
+test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.x = t2.a'
+test_query 0 'SELECT * FROM t1 JOIN t2 ON x = a'
+
+test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.x = t2.a AND t1.y = t2.b'
+test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.y = t2.b AND t1.x = t2.a'
+test_query 0 'SELECT * FROM t1 JOIN t2 ON x = a AND y = b'
+test_query 0 'SELECT * FROM t1 JOIN t2 ON y = b AND x = a'
+
+test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.x = t3.y'
+
+# USING with any order of 10 keys
+test_query 0 'SELECT * FROM ta1 JOIN ta2 USING (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)'
+test_query 0 'SELECT * FROM ta1 JOIN ta2 USING (a10, a9, a8, a7, a6, a5, a4, a3, a2, a1)'
+test_query 0 'SELECT * FROM ta1 JOIN ta2 USING (a9, a7, a8, a10, a5, a3, a6, a4, a1, a2)'
+
+# JOIN ON with 10 keys
+test_query 0 'SELECT * FROM ta1 JOIN t1 ON ta1.a1 = t1.x AND ta1.a2 = t1.x AND ta1.a3 = t1.x AND ta1.a4 = t1.x AND ta1.a5 = t1.x
+                                       AND ta1.a6 = t1.x AND ta1.a7 = t1.y AND ta1.a8 = t1.y AND ta1.a9 = t1.y AND ta1.a10 = t1.y'
+
+# sort only one stream that is joined not by prefix
+test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.val = t3.x AND t1.y = t3.y'
+test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.y AND t1.y = t3.y'
+test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.y AND t1.x = t3.y'
+
+# ta1 should be sorted, since (a2, a3) is not a sorting prefix
+test_query 1 'SELECT * FROM ta1 JOIN ta2 ON ta1.a2 = ta2.a1 AND ta1.a3 = ta2.a2 AND ta1.a2 = ta2.a3 AND ta1.a2 = ta2.a4'
+
+# two sorts for inner subqueries and two resorts since prefixes are different
+# TODO: in the case without limit first sorting can be removed, since thay have no effect
+test_query 4 '
+    SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
+        ORDER BY x DESC, y DESC ) AS t1
+    JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))
+        ORDER BY a, b DESC ) AS t2
+    ON t1.x = t2.a AND t1.y = t2.b
+    SETTINGS max_rows_in_set_to_optimize_join = 0'
+
+test_query 4 '
+    SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
+        ORDER BY x DESC, y DESC LIMIT 100 ) AS t1
+    JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))
+        ORDER BY a DESC, b DESC LIMIT 100 ) AS t2
+    ON t1.x = t2.a AND t1.y = t2.b
+    SETTINGS max_rows_in_set_to_optimize_join = 0'
+
+$CLICKHOUSE_CLIENT -mn -q "
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+DROP TABLE IF EXISTS t4;
+DROP TABLE IF EXISTS ta1;
+DROP TABLE IF EXISTS ta2;
+"

--- a/tests/queries/0_stateless/02559_sorted_full_join.sh
+++ b/tests/queries/0_stateless/02559_sorted_full_join.sh
@@ -41,57 +41,57 @@ FROM numbers(1000);
 
 CLIENT_ARGS='--join_algorithm=full_sorting_merge --optimize_sorting_by_input_stream_properties=1 --optimize_read_in_order=1 --max_threads=8 --max_block_size=128'
 
-# test_query <expected_number_of_sort_steps> <query>
+# test_query <expected_number_of_tables_to_read_in_order> <query>
 function test_query {
     expected_result=${1}
     query_str="${2}"
 
     # count the number of MergeSortingTransform's in the pipeline
     result=$( $CLICKHOUSE_CLIENT $CLIENT_ARGS -q "EXPLAIN PIPELINE ${query_str}" )
-    sort_count=$( echo "$result" | grep 'MergeSortingTransform' | wc -l )
+    read_in_order_count=$( echo "$result" | grep 'MergeTreeInOrder' | wc -l )
 
-    test "$sort_count" -eq "$expected_result" || echo "fail ${BASH_LINENO[0]}: expected: $expected_result, got: $sort_count in '${query_str}'"
+    test "$read_in_order_count" -eq "$expected_result" || echo "fail ${BASH_LINENO[0]}: expected: $expected_result, got: $sort_count in '${query_str}'"
 
     echo "$result" | grep -q 'FilterOnTheFly' && echo "fail ${BASH_LINENO[0]}: step FilterOnTheFly should not be present for read in order"
 }
 
 # Simple case: join by sorted prefix with length 1
-test_query 0 'SELECT * FROM t1 JOIN t3 USING (x)'
-test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x'
-test_query 0 'SELECT * FROM t1 JOIN t4 ON t1.x = t4.y'
+test_query 2 'SELECT * FROM t1 JOIN t3 USING (x)'
+test_query 2 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x'
+test_query 2 'SELECT * FROM t1 JOIN t4 ON t1.x = t4.y'
 
 # Join by sorted prefix with length 2
-test_query 0 'SELECT * FROM t1 JOIN t3 USING (x, y)'
+test_query 2 'SELECT * FROM t1 JOIN t3 USING (x, y)'
 # Keys should be deduplicated
-test_query 0 'SELECT * FROM t1 JOIN t3 USING (x, x, x, y, y, y, y, x, x, x)'
+test_query 2 'SELECT * FROM t1 JOIN t3 USING (x, x, x, y, y, y, y, x, x, x)'
 # Keys can be reordered
-test_query 0 'SELECT * FROM t1 JOIN t3 USING (y, x)'
+test_query 2 'SELECT * FROM t1 JOIN t3 USING (y, x)'
 
 # Reoderinbg and deduplication for ON syntax:
-test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.y = t3.y'
-test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.y = t3.y AND t1.y = t3.y AND t1.y = t3.y AND t1.x = t3.x AND t1.x = t3.x'
-test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.y = t3.y AND t1.x = t3.x'
-test_query 0 'SELECT * FROM t1 JOIN t4 ON t1.x = t4.y AND t1.y = t4.x'
-test_query 0 'SELECT * FROM t1 JOIN t4 ON t1.y = t4.x AND t1.x = t4.y'
+test_query 2 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.y = t3.y'
+test_query 2 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.y = t3.y AND t1.y = t3.y AND t1.y = t3.y AND t1.x = t3.x AND t1.x = t3.x'
+test_query 2 'SELECT * FROM t1 JOIN t3 ON t1.y = t3.y AND t1.x = t3.x'
+test_query 2 'SELECT * FROM t1 JOIN t4 ON t1.x = t4.y AND t1.y = t4.x'
+test_query 2 'SELECT * FROM t1 JOIN t4 ON t1.y = t4.x AND t1.x = t4.y'
 
 # Names doesn't matter (`x,y` or `a,b` in the table)
-test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.x = t2.a'
-test_query 0 'SELECT * FROM t1 JOIN t2 ON x = a'
+test_query 2 'SELECT * FROM t1 JOIN t2 ON t1.x = t2.a'
+test_query 2 'SELECT * FROM t1 JOIN t2 ON x = a'
 
-test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.x = t2.a AND t1.y = t2.b'
-test_query 0 'SELECT * FROM t1 JOIN t2 ON t1.y = t2.b AND t1.x = t2.a'
-test_query 0 'SELECT * FROM t1 JOIN t2 ON x = a AND y = b'
-test_query 0 'SELECT * FROM t1 JOIN t2 ON y = b AND x = a'
+test_query 2 'SELECT * FROM t1 JOIN t2 ON t1.x = t2.a AND t1.y = t2.b'
+test_query 2 'SELECT * FROM t1 JOIN t2 ON t1.y = t2.b AND t1.x = t2.a'
+test_query 2 'SELECT * FROM t1 JOIN t2 ON x = a AND y = b'
+test_query 2 'SELECT * FROM t1 JOIN t2 ON y = b AND x = a'
 
-test_query 0 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.x = t3.y'
+test_query 2 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.x AND t1.x = t3.y'
 
 # USING with any order of 10 keys
-test_query 0 'SELECT * FROM ta1 JOIN ta2 USING (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)'
-test_query 0 'SELECT * FROM ta1 JOIN ta2 USING (a10, a9, a8, a7, a6, a5, a4, a3, a2, a1)'
-test_query 0 'SELECT * FROM ta1 JOIN ta2 USING (a9, a7, a8, a10, a5, a3, a6, a4, a1, a2)'
+test_query 2 'SELECT * FROM ta1 JOIN ta2 USING (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)'
+test_query 2 'SELECT * FROM ta1 JOIN ta2 USING (a10, a9, a8, a7, a6, a5, a4, a3, a2, a1)'
+test_query 2 'SELECT * FROM ta1 JOIN ta2 USING (a9, a7, a8, a10, a5, a3, a6, a4, a1, a2)'
 
 # JOIN ON with 10 keys
-test_query 0 'SELECT * FROM ta1 JOIN t1 ON ta1.a1 = t1.x AND ta1.a2 = t1.x AND ta1.a3 = t1.x AND ta1.a4 = t1.x AND ta1.a5 = t1.x
+test_query 2 'SELECT * FROM ta1 JOIN t1 ON ta1.a1 = t1.x AND ta1.a2 = t1.x AND ta1.a3 = t1.x AND ta1.a4 = t1.x AND ta1.a5 = t1.x
                                        AND ta1.a6 = t1.x AND ta1.a7 = t1.y AND ta1.a8 = t1.y AND ta1.a9 = t1.y AND ta1.a10 = t1.y'
 
 # sort only one stream that is joined not by prefix
@@ -102,9 +102,9 @@ test_query 1 'SELECT * FROM t1 JOIN t3 ON t1.x = t3.y AND t1.x = t3.y'
 # ta1 should be sorted, since (a2, a3) is not a sorting prefix
 test_query 1 'SELECT * FROM ta1 JOIN ta2 ON ta1.a2 = ta2.a1 AND ta1.a3 = ta2.a2 AND ta1.a2 = ta2.a3 AND ta1.a2 = ta2.a4'
 
-# two sorts for inner subqueries and two resorts since prefixes are different
+# sort for inner subqueries and resort since prefixes are different
 # TODO: in the case without limit first sorting can be removed, since thay have no effect
-test_query 4 '
+test_query 0 '
     SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
         ORDER BY x DESC, y DESC ) AS t1
     JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))
@@ -112,7 +112,7 @@ test_query 4 '
     ON t1.x = t2.a AND t1.y = t2.b
     SETTINGS max_rows_in_set_to_optimize_join = 0'
 
-test_query 4 '
+test_query 0 '
     SELECT * FROM ( SELECT x, y FROM (SELECT number AS x, number AS y FROM numbers_mt(1000))
         ORDER BY x DESC, y DESC LIMIT 100 ) AS t1
     JOIN ( SELECT a, b FROM (SELECT number AS a, number AS b FROM numbers_mt(1000))

--- a/tests/queries/0_stateless/02559_sorted_full_join.sh
+++ b/tests/queries/0_stateless/02559_sorted_full_join.sh
@@ -50,7 +50,7 @@ function test_query {
     result=$( $CLICKHOUSE_CLIENT $CLIENT_ARGS -q "EXPLAIN PIPELINE ${query_str}" )
     read_in_order_count=$( echo "$result" | grep 'MergeTreeInOrder' | wc -l )
 
-    test "$read_in_order_count" -eq "$expected_result" || echo "fail ${BASH_LINENO[0]}: expected: $expected_result, got: $sort_count in '${query_str}'"
+    test "$read_in_order_count" -eq "$expected_result" || echo "fail ${BASH_LINENO[0]}: expected: $expected_result, got: $read_in_order_count in '${query_str}'"
 
     echo "$result" | grep -q 'FilterOnTheFly' && echo "fail ${BASH_LINENO[0]}: step FilterOnTheFly should not be present for read in order"
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Reorder keys in `full_sorting_join` to apply read in order optimization


Mostly this PR is a refactoring of the same optimization for an aggregation.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
