### PR TITLE
Check referential dependencies on DROP TABLE

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -641,6 +641,7 @@ class IColumn;
     \
     M(Bool, force_remove_data_recursively_on_drop, false, "Recursively remove data on DROP query. Avoids 'Directory not empty' error, but may silently remove detached data", 0) \
     M(Bool, check_table_dependencies, true, "Check that DDL query (such as DROP TABLE or RENAME) will not break dependencies", 0) \
+    M(Bool, check_referential_table_dependencies, false, "Check that DDL query (such as DROP TABLE or RENAME) will not break referential dependencies", 0) \
     M(Bool, use_local_cache_for_remote_storage, true, "Use local cache for remote storage like HDFS or S3, it's used for remote table engine only", 0) \
     \
     M(Bool, allow_unrestricted_reads_from_keeper, false, "Allow unrestricted (without condition on path) reads from system.zookeeper table, can be handy, but is not safe for zookeeper", 0) \

--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -522,11 +522,13 @@ void DatabaseAtomic::renameDatabase(ContextPtr query_context, const String & new
 {
     /// CREATE, ATTACH, DROP, DETACH and RENAME DATABASE must hold DDLGuard
 
-    if (query_context->getSettingsRef().check_table_dependencies)
+    bool check_ref_deps = query_context->getSettingsRef().check_referential_table_dependencies;
+    bool check_loading_deps = !check_ref_deps && query_context->getSettingsRef().check_table_dependencies;
+    if (check_ref_deps || check_loading_deps)
     {
         std::lock_guard lock(mutex);
         for (auto & table : tables)
-            DatabaseCatalog::instance().checkTableCanBeRemovedOrRenamed({database_name, table.first});
+            DatabaseCatalog::instance().checkTableCanBeRemovedOrRenamed({database_name, table.first}, check_ref_deps, check_loading_deps);
     }
 
     try

--- a/src/Databases/DatabaseMemory.cpp
+++ b/src/Databases/DatabaseMemory.cpp
@@ -2,6 +2,7 @@
 #include <Common/logger_useful.h>
 #include <Databases/DatabaseMemory.h>
 #include <Databases/DatabasesCommon.h>
+#include <Databases/DDLDependencyVisitor.h>
 #include <Databases/DDLLoadingDependencyVisitor.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
@@ -143,8 +144,10 @@ void DatabaseMemory::alterTable(ContextPtr local_context, const StorageID & tabl
 
     applyMetadataChangesToCreateQuery(it->second, metadata);
 
-    auto new_dependencies = getLoadingDependenciesFromCreateQuery(local_context->getGlobalContext(), table_id.getQualifiedName(), it->second);
-    DatabaseCatalog::instance().updateDependencies(table_id, new_dependencies);
+    /// The create query of the table has been just changed, we need to update dependencies too.
+    auto ref_dependencies = getDependenciesFromCreateQuery(local_context->getGlobalContext(), table_id.getQualifiedName(), it->second);
+    auto loading_dependencies = getLoadingDependenciesFromCreateQuery(local_context->getGlobalContext(), table_id.getQualifiedName(), it->second);
+    DatabaseCatalog::instance().updateDependencies(table_id, ref_dependencies, loading_dependencies);
 }
 
 std::vector<std::pair<ASTPtr, StoragePtr>> DatabaseMemory::getTablesForBackup(const FilterByNameFunction & filter, const ContextPtr & local_context) const

--- a/src/Databases/TablesLoader.h
+++ b/src/Databases/TablesLoader.h
@@ -69,6 +69,7 @@ private:
     ParsedTablesMetadata metadata;
     TablesDependencyGraph referential_dependencies;
     TablesDependencyGraph loading_dependencies;
+    TablesDependencyGraph all_loading_dependencies;
     Poco::Logger * log;
     std::atomic<size_t> tables_processed{0};
     AtomicStopwatch stopwatch;

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -224,6 +224,7 @@ void DatabaseCatalog::shutdownImpl()
     }) == uuid_map.end());
     databases.clear();
     referential_dependencies.clear();
+    loading_dependencies.clear();
     view_dependencies.clear();
 }
 
@@ -471,10 +472,13 @@ void DatabaseCatalog::updateDatabaseName(const String & old_name, const String &
     databases.erase(it);
     databases.emplace(new_name, db);
 
+    /// Update dependencies.
     for (const auto & table_name : tables_in_database)
     {
-        auto dependencies = referential_dependencies.removeDependencies(StorageID{old_name, table_name}, /* remove_isolated_tables= */ true);
-        referential_dependencies.addDependencies(StorageID{new_name, table_name}, dependencies);
+        auto removed_ref_deps = referential_dependencies.removeDependencies(StorageID{old_name, table_name}, /* remove_isolated_tables= */ true);
+        auto removed_loading_deps = loading_dependencies.removeDependencies(StorageID{old_name, table_name}, /* remove_isolated_tables= */ true);
+        referential_dependencies.addDependencies(StorageID{new_name, table_name}, removed_ref_deps);
+        loading_dependencies.addDependencies(StorageID{new_name, table_name}, removed_loading_deps);
     }
 }
 
@@ -645,6 +649,7 @@ std::unique_ptr<DatabaseCatalog> DatabaseCatalog::database_catalog;
 DatabaseCatalog::DatabaseCatalog(ContextMutablePtr global_context_)
     : WithMutableContext(global_context_)
     , referential_dependencies{"ReferentialDeps"}
+    , loading_dependencies{"LoadingDeps"}
     , view_dependencies{"ViewDeps"}
     , log(&Poco::Logger::get("DatabaseCatalog"))
 {
@@ -1040,53 +1045,107 @@ void DatabaseCatalog::waitTableFinallyDropped(const UUID & uuid)
     });
 }
 
-void DatabaseCatalog::addDependencies(const StorageID & table_id, const std::vector<StorageID> & dependencies)
+void DatabaseCatalog::addDependencies(
+    const StorageID & table_id,
+    const std::vector<StorageID> & new_referential_dependencies,
+    const std::vector<StorageID> & new_loading_dependencies)
 {
+    if (new_referential_dependencies.empty() && new_loading_dependencies.empty())
+        return;
     std::lock_guard lock{databases_mutex};
-    referential_dependencies.addDependencies(table_id, dependencies);
+    if (!new_referential_dependencies.empty())
+        referential_dependencies.addDependencies(table_id, new_referential_dependencies);
+    if (!new_loading_dependencies.empty())
+        loading_dependencies.addDependencies(table_id, new_loading_dependencies);
 }
 
-void DatabaseCatalog::addDependencies(const QualifiedTableName & table_name, const TableNamesSet & dependencies)
+void DatabaseCatalog::addDependencies(
+    const QualifiedTableName & table_name,
+    const TableNamesSet & new_referential_dependencies,
+    const TableNamesSet & new_loading_dependencies)
 {
+    if (new_referential_dependencies.empty() && new_loading_dependencies.empty())
+        return;
     std::lock_guard lock{databases_mutex};
-    referential_dependencies.addDependencies(table_name, dependencies);
+    if (!new_referential_dependencies.empty())
+        referential_dependencies.addDependencies(table_name, new_referential_dependencies);
+    if (!new_loading_dependencies.empty())
+        loading_dependencies.addDependencies(table_name, new_loading_dependencies);
 }
 
-void DatabaseCatalog::addDependencies(const TablesDependencyGraph & extra_graph)
+void DatabaseCatalog::addDependencies(
+    const TablesDependencyGraph & new_referential_dependencies, const TablesDependencyGraph & new_loading_dependencies)
 {
     std::lock_guard lock{databases_mutex};
-    referential_dependencies.mergeWith(extra_graph);
+    referential_dependencies.mergeWith(new_referential_dependencies);
+    loading_dependencies.mergeWith(new_loading_dependencies);
 }
 
-std::vector<StorageID> DatabaseCatalog::getDependencies(const StorageID & table_id) const
+std::vector<StorageID> DatabaseCatalog::getReferentialDependencies(const StorageID & table_id) const
 {
     std::lock_guard lock{databases_mutex};
     return referential_dependencies.getDependencies(table_id);
 }
 
-std::vector<StorageID> DatabaseCatalog::getDependents(const StorageID & table_id) const
+std::vector<StorageID> DatabaseCatalog::getReferentialDependents(const StorageID & table_id) const
 {
     std::lock_guard lock{databases_mutex};
     return referential_dependencies.getDependents(table_id);
 }
 
-std::vector<StorageID> DatabaseCatalog::removeDependencies(const StorageID & table_id, bool check_dependencies, bool is_drop_database)
+std::vector<StorageID> DatabaseCatalog::getLoadingDependencies(const StorageID & table_id) const
 {
     std::lock_guard lock{databases_mutex};
-    if (check_dependencies)
-        checkTableCanBeRemovedOrRenamedUnlocked(table_id, is_drop_database);
-    return referential_dependencies.removeDependencies(table_id, /* remove_isolated_tables= */ true);
+    return loading_dependencies.getDependencies(table_id);
 }
 
-void DatabaseCatalog::checkTableCanBeRemovedOrRenamed(const StorageID & table_id, bool is_drop_database) const
+std::vector<StorageID> DatabaseCatalog::getLoadingDependents(const StorageID & table_id) const
 {
     std::lock_guard lock{databases_mutex};
-    return checkTableCanBeRemovedOrRenamedUnlocked(table_id, is_drop_database);
+    return loading_dependencies.getDependents(table_id);
 }
 
-void DatabaseCatalog::checkTableCanBeRemovedOrRenamedUnlocked(const StorageID & removing_table, bool is_drop_database) const
+std::pair<std::vector<StorageID>, std::vector<StorageID>> DatabaseCatalog::removeDependencies(
+    const StorageID & table_id, bool check_referential_dependencies, bool check_loading_dependencies, bool is_drop_database)
 {
-    const auto & dependents = referential_dependencies.getDependents(removing_table);
+    std::lock_guard lock{databases_mutex};
+    checkTableCanBeRemovedOrRenamedUnlocked(table_id, check_referential_dependencies, check_loading_dependencies, is_drop_database);
+    return {referential_dependencies.removeDependencies(table_id, /* remove_isolated_tables= */ true),
+            loading_dependencies.removeDependencies(table_id, /* remove_isolated_tables= */ true)};
+}
+
+void DatabaseCatalog::updateDependencies(
+    const StorageID & table_id, const TableNamesSet & new_referential_dependencies, const TableNamesSet & new_loading_dependencies)
+{
+    std::lock_guard lock{databases_mutex};
+    referential_dependencies.removeDependencies(table_id, /* remove_isolated_tables= */ true);
+    loading_dependencies.removeDependencies(table_id, /* remove_isolated_tables= */ true);
+    if (!new_referential_dependencies.empty())
+        referential_dependencies.addDependencies(table_id, new_referential_dependencies);
+    if (!new_loading_dependencies.empty())
+        loading_dependencies.addDependencies(table_id, new_loading_dependencies);
+}
+
+void DatabaseCatalog::checkTableCanBeRemovedOrRenamed(
+    const StorageID & table_id, bool check_referential_dependencies, bool check_loading_dependencies, bool is_drop_database) const
+{
+    if (!check_referential_dependencies && !check_loading_dependencies)
+        return;
+    std::lock_guard lock{databases_mutex};
+    return checkTableCanBeRemovedOrRenamedUnlocked(table_id, check_referential_dependencies, check_loading_dependencies, is_drop_database);
+}
+
+void DatabaseCatalog::checkTableCanBeRemovedOrRenamedUnlocked(
+    const StorageID & removing_table, bool check_referential_dependencies, bool check_loading_dependencies, bool is_drop_database) const
+{
+    chassert(!check_referential_dependencies || !check_loading_dependencies); /// These flags must not be both set.
+    std::vector<StorageID> dependents;
+    if (check_referential_dependencies)
+        dependents = referential_dependencies.getDependents(removing_table);
+    else if (check_loading_dependencies)
+        dependents = loading_dependencies.getDependents(removing_table);
+    else
+        return;
 
     if (!is_drop_database)
     {
@@ -1106,13 +1165,6 @@ void DatabaseCatalog::checkTableCanBeRemovedOrRenamedUnlocked(const StorageID & 
     if (!from_other_databases.empty())
         throw Exception(ErrorCodes::HAVE_DEPENDENT_OBJECTS, "Cannot drop or rename {}, because some tables depend on it: {}",
                         removing_table, fmt::join(from_other_databases, ", "));
-}
-
-void DatabaseCatalog::updateDependencies(const StorageID & table_id, const TableNamesSet & new_dependencies)
-{
-    std::lock_guard lock{databases_mutex};
-    referential_dependencies.removeDependencies(table_id, /* remove_isolated_tables= */ true);
-    referential_dependencies.addDependencies(table_id, new_dependencies);
 }
 
 void DatabaseCatalog::cleanupStoreDirectoryTask()

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1243,9 +1243,9 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
 
     /// If table has dependencies - add them to the graph
     QualifiedTableName qualified_name{database_name, create.getTable()};
-    TableNamesSet dependencies = getLoadingDependenciesFromCreateQuery(getContext()->getGlobalContext(), qualified_name, query_ptr);
-    if (!dependencies.empty())
-        DatabaseCatalog::instance().addDependencies(qualified_name, dependencies);
+    auto ref_dependencies = getDependenciesFromCreateQuery(getContext()->getGlobalContext(), qualified_name, query_ptr);
+    auto loading_dependencies = getLoadingDependenciesFromCreateQuery(getContext()->getGlobalContext(), qualified_name, query_ptr);
+    DatabaseCatalog::instance().addDependencies(qualified_name, ref_dependencies, loading_dependencies);
 
     return fillTableIfNeeded(create);
 }

--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -124,10 +124,17 @@ BlockIO InterpreterRenameQuery::executeToTables(const ASTRenameQuery & rename, c
         }
         else
         {
-            std::vector<StorageID> dependencies;
+            StorageID from_table_id{elem.from_database_name, elem.from_table_name};
+            StorageID to_table_id{elem.to_database_name, elem.to_table_name};
+            std::vector<StorageID> ref_dependencies;
+            std::vector<StorageID> loading_dependencies;
+
             if (!exchange_tables)
-                dependencies = database_catalog.removeDependencies(StorageID(elem.from_database_name, elem.from_table_name),
-                                                                   getContext()->getSettingsRef().check_table_dependencies);
+            {
+                bool check_ref_deps = getContext()->getSettingsRef().check_referential_table_dependencies;
+                bool check_loading_deps = !check_ref_deps && getContext()->getSettingsRef().check_table_dependencies;
+                std::tie(ref_dependencies, loading_dependencies) = database_catalog.removeDependencies(from_table_id, check_ref_deps, check_loading_deps);
+            }
 
             database->renameTable(
                 getContext(),
@@ -137,8 +144,7 @@ BlockIO InterpreterRenameQuery::executeToTables(const ASTRenameQuery & rename, c
                 exchange_tables,
                 rename.dictionary);
 
-            if (!dependencies.empty())
-                DatabaseCatalog::instance().addDependencies(StorageID(elem.to_database_name, elem.to_table_name), dependencies);
+            DatabaseCatalog::instance().addDependencies(to_table_id, ref_dependencies, loading_dependencies);
         }
     }
 

--- a/src/Interpreters/loadMetadata.cpp
+++ b/src/Interpreters/loadMetadata.cpp
@@ -348,6 +348,7 @@ static void maybeConvertOrdinaryDatabaseToAtomic(ContextMutablePtr context, cons
             InterpreterSystemQuery::startStopActionInDatabase(action, /* start */ false, database_name, database, context, log);
 
         local_context->setSetting("check_table_dependencies", false);
+        local_context->setSetting("check_referential_table_dependencies", false);
         convertOrdinaryDatabaseToAtomic(log, local_context, database, database_name, tmp_name);
 
         LOG_INFO(log, "Will start background operations after renaming tables in database {}", database_name);

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -491,8 +491,8 @@ protected:
 
                 if (columns_mask[src_index] || columns_mask[src_index + 1] || columns_mask[src_index + 2] || columns_mask[src_index + 3])
                 {
-                    auto dependencies = DatabaseCatalog::instance().getDependencies(StorageID{database_name, table_name});
-                    auto dependents = DatabaseCatalog::instance().getDependents(StorageID{database_name, table_name});
+                    auto dependencies = DatabaseCatalog::instance().getLoadingDependencies(StorageID{database_name, table_name});
+                    auto dependents = DatabaseCatalog::instance().getLoadingDependents(StorageID{database_name, table_name});
 
                     Array dependencies_databases;
                     Array dependencies_tables;

--- a/tests/queries/0_stateless/02552_check_referential_table_dependencies.sql
+++ b/tests/queries/0_stateless/02552_check_referential_table_dependencies.sql
@@ -1,0 +1,29 @@
+DROP TABLE IF EXISTS mv;
+DROP TABLE IF EXISTS src;
+DROP TABLE IF EXISTS dst;
+
+CREATE TABLE src (x UInt8) ENGINE = Memory;
+CREATE TABLE dst (x UInt8) ENGINE = Memory;
+CREATE MATERIALIZED VIEW mv TO dst AS SELECT x FROM src;
+
+SET check_referential_table_dependencies = 1;
+
+-- Can't drop because of referential dependencies
+DROP TABLE src; -- { serverError HAVE_DEPENDENT_OBJECTS }
+DROP TABLE dst; -- { serverError HAVE_DEPENDENT_OBJECTS }
+
+-- Ok to drop in the correct order
+DROP TABLE mv;
+DROP TABLE src;
+DROP TABLE dst;
+
+-- Check again with check_referential_table_dependencies = 0
+CREATE TABLE src (x UInt8) ENGINE = Memory;
+CREATE TABLE dst (x UInt8) ENGINE = Memory;
+CREATE MATERIALIZED VIEW mv TO dst AS SELECT x FROM src;
+
+SET check_referential_table_dependencies = 0;
+
+DROP TABLE src;
+DROP TABLE dst;
+DROP TABLE mv;


### PR DESCRIPTION
### Changelog category:
- Improvement

### Changelog entry:
Add setting `check_referential_table_dependencies` to check referential dependencies on `DROP TABLE`.
This PR solves https://github.com/ClickHouse/ClickHouse/issues/38326
