### PR TITLE
Add necessary dependency for sanitizers

### DIFF
--- a/docker/test/util/Dockerfile
+++ b/docker/test/util/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
         gdb \
         git \
         gperf \
+        libclang-rt-${LLVM_VERSION}-dev \
         lld-${LLVM_VERSION} \
         llvm-${LLVM_VERSION} \
         llvm-${LLVM_VERSION}-dev \


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix broken sanitizers builds