### PR TITLE
Vectorize filter generation of ColumnNullable in FilterDescription

### DIFF
--- a/src/Columns/FilterDescription.cpp
+++ b/src/Columns/FilterDescription.cpp
@@ -80,7 +80,12 @@ FilterDescription::FilterDescription(const IColumn & column_)
 
         size_t size = res.size();
         for (size_t i = 0; i < size; ++i)
-            res[i] = res[i] && !null_map[i];
+        {
+            auto has_val = static_cast<UInt8>(!!res[i]);
+            auto not_null = static_cast<UInt8>(!null_map[i]);
+            /// Instead of the logical AND operator(&&), the bitwise one(&) is utilized for the auto vectorization.
+            res[i] = has_val & not_null;
+        }
 
         data = &res;
         data_holder = std::move(mutable_holder);


### PR DESCRIPTION
This commit achieved the data parallelism for filter generations of the nullable columns by replacing the logical AND operator with the bitwise one, which could be auto-vectorized by the compiler.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This change could effectively reduce the overhead of obtaining the filter from ColumnNullable(UInt8) and improve the overall query performance. To evaluate the impact of this change, we adopted TPC-H benchmark but revised the column types from non-nullable to nullable, and we measured the QPS of its queries as the performance indicator.

We found with this change, **Q07** and **Q10**, which spend 1.3% and 2.9% of total cycles in _FilterDescription_, could be improved by **1.80%** and **1.95%** respectively.


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
