### PR TITLE
Update cherrypick_pr to get mergeable state

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -208,6 +208,8 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
         self.cherrypick_pr.add_to_labels(Labels.CHERRYPICK)
         self.cherrypick_pr.add_to_labels(Labels.DO_NOT_TEST)
         self._assign_new_pr(self.cherrypick_pr)
+        # update cherrypick PR to get the state for PR.mergable
+        self.cherrypick_pr.update()
 
     def create_backport(self):
         assert self.cherrypick_pr is not None


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Updated the cherry-pick PR to get a mergeable state. It allows us not to wait for another launch of `cherry_pick.py`. See how it works in #45959