### PR TITLE
use LowCardnality for _part and _partition_id virtual column

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
@@ -560,9 +560,11 @@ static void injectPartConstVirtualColumns(
             {
                 ColumnPtr column;
                 if (rows)
-                    column = DataTypeString().createColumnConst(rows, part->name)->convertToFullColumnIfConst();
+                    column = DataTypeLowCardinality{std::make_shared<DataTypeString>()}
+                                 .createColumnConst(rows, part->name)
+                                 ->convertToFullColumnIfConst();
                 else
-                    column = DataTypeString().createColumn();
+                    column = DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn();
 
                 inserter.insertStringColumn(column, virtual_column_name);
             }
@@ -590,9 +592,11 @@ static void injectPartConstVirtualColumns(
             {
                 ColumnPtr column;
                 if (rows)
-                    column = DataTypeString().createColumnConst(rows, part->info.partition_id)->convertToFullColumnIfConst();
+                    column = DataTypeLowCardinality{std::make_shared<DataTypeString>()}
+                                 .createColumnConst(rows, part->info.partition_id)
+                                 ->convertToFullColumnIfConst();
                 else
-                    column = DataTypeString().createColumn();
+                    column = DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn();
 
                 inserter.insertStringColumn(column, virtual_column_name);
             }

--- a/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBaseSelectProcessor.cpp
@@ -456,11 +456,6 @@ namespace
 
         bool columnExists(const String & name) const { return block.has(name); }
 
-        void insertStringColumn(const ColumnPtr & column, const String & name)
-        {
-            block.insert({column, std::make_shared<DataTypeString>(), name});
-        }
-
         void insertUInt8Column(const ColumnPtr & column, const String & name)
         {
             block.insert({column, std::make_shared<DataTypeUInt8>(), name});
@@ -474,6 +469,11 @@ namespace
         void insertUUIDColumn(const ColumnPtr & column, const String & name)
         {
             block.insert({column, std::make_shared<DataTypeUUID>(), name});
+        }
+
+        void insertLowCardinalityColumn(const ColumnPtr & column, const String & name)
+        {
+            block.insert({column, std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), name});
         }
 
         void insertPartitionValueColumn(
@@ -566,7 +566,7 @@ static void injectPartConstVirtualColumns(
                 else
                     column = DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn();
 
-                inserter.insertStringColumn(column, virtual_column_name);
+                inserter.insertLowCardinalityColumn(column, virtual_column_name);
             }
             else if (virtual_column_name == "_part_index")
             {
@@ -598,7 +598,7 @@ static void injectPartConstVirtualColumns(
                 else
                     column = DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn();
 
-                inserter.insertStringColumn(column, virtual_column_name);
+                inserter.insertLowCardinalityColumn(column, virtual_column_name);
             }
             else if (virtual_column_name == "_partition_value")
             {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -837,8 +837,14 @@ Block MergeTreeData::getSampleBlockWithVirtualColumns() const
 {
     DataTypePtr partition_value_type = getPartitionValueType();
     return {
-        ColumnWithTypeAndName(ColumnString::create(), std::make_shared<DataTypeString>(), "_part"),
-        ColumnWithTypeAndName(ColumnString::create(), std::make_shared<DataTypeString>(), "_partition_id"),
+        ColumnWithTypeAndName(
+            DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn(),
+            std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()),
+            "_part"),
+        ColumnWithTypeAndName(
+            DataTypeLowCardinality{std::make_shared<DataTypeString>()}.createColumn(),
+            std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()),
+            "_partition_id"),
         ColumnWithTypeAndName(ColumnUUID::create(), std::make_shared<DataTypeUUID>(), "_part_uuid"),
         ColumnWithTypeAndName(partition_value_type->createColumn(), partition_value_type, "_partition_value")};
 }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7550,10 +7550,10 @@ MergeTreeData::WriteAheadLogPtr MergeTreeData::getWriteAheadLog()
 NamesAndTypesList MergeTreeData::getVirtuals() const
 {
     return NamesAndTypesList{
-        NameAndTypePair("_part", std::make_shared<DataTypeString>()),
+        NameAndTypePair("_part", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())),
         NameAndTypePair("_part_index", std::make_shared<DataTypeUInt64>()),
         NameAndTypePair("_part_uuid", std::make_shared<DataTypeUUID>()),
-        NameAndTypePair("_partition_id", std::make_shared<DataTypeString>()),
+        NameAndTypePair("_partition_id", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())),
         NameAndTypePair("_partition_value", getPartitionValueType()),
         NameAndTypePair("_sample_factor", std::make_shared<DataTypeFloat64>()),
         NameAndTypePair("_part_offset", std::make_shared<DataTypeUInt64>()),

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -312,18 +312,18 @@ StorageDistributed::~StorageDistributed() = default;
 NamesAndTypesList StorageDistributed::getVirtuals() const
 {
     /// NOTE This is weird. Most of these virtual columns are part of MergeTree
-    /// tables info. But Distributed is general-purpose engine.
+    /// tables info. But Distributed is  general-purpose engine.
     return NamesAndTypesList{
         NameAndTypePair("_table", std::make_shared<DataTypeString>()),
-        NameAndTypePair("_part", std::make_shared<DataTypeString>()),
+        NameAndTypePair("_part", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())),
         NameAndTypePair("_part_index", std::make_shared<DataTypeUInt64>()),
         NameAndTypePair("_part_uuid", std::make_shared<DataTypeUUID>()),
-        NameAndTypePair("_partition_id", std::make_shared<DataTypeString>()),
+        NameAndTypePair("_partition_id", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())),
         NameAndTypePair("_sample_factor", std::make_shared<DataTypeFloat64>()),
         NameAndTypePair("_part_offset", std::make_shared<DataTypeUInt64>()),
         NameAndTypePair("_row_exists", std::make_shared<DataTypeUInt8>()),
         NameAndTypePair("_shard_num", std::make_shared<DataTypeUInt32>()), /// deprecated
-    };
+};
 }
 
 StorageDistributed::StorageDistributed(

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -312,7 +312,7 @@ StorageDistributed::~StorageDistributed() = default;
 NamesAndTypesList StorageDistributed::getVirtuals() const
 {
     /// NOTE This is weird. Most of these virtual columns are part of MergeTree
-    /// tables info. But Distributed is  general-purpose engine.
+    /// tables info. But Distributed is general-purpose engine.
     return NamesAndTypesList{
         NameAndTypePair("_table", std::make_shared<DataTypeString>()),
         NameAndTypePair("_part", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())),
@@ -323,7 +323,7 @@ NamesAndTypesList StorageDistributed::getVirtuals() const
         NameAndTypePair("_part_offset", std::make_shared<DataTypeUInt64>()),
         NameAndTypePair("_row_exists", std::make_shared<DataTypeUInt8>()),
         NameAndTypePair("_shard_num", std::make_shared<DataTypeUInt32>()), /// deprecated
-};
+    };
 }
 
 StorageDistributed::StorageDistributed(

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -314,7 +314,7 @@ NamesAndTypesList StorageDistributed::getVirtuals() const
     /// NOTE This is weird. Most of these virtual columns are part of MergeTree
     /// tables info. But Distributed is general-purpose engine.
     return NamesAndTypesList{
-        NameAndTypePair("_table", std::make_shared<DataTypeString>()),
+        NameAndTypePair("_table", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())),
         NameAndTypePair("_part", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())),
         NameAndTypePair("_part_index", std::make_shared<DataTypeUInt64>()),
         NameAndTypePair("_part_uuid", std::make_shared<DataTypeUUID>()),

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -664,7 +664,7 @@ QueryPipelineBuilderPtr ReadFromMerge::createSources(
         {
             ColumnWithTypeAndName column;
             column.name = "_database";
-            column.type = std::make_shared<DataTypeString>();
+            column.type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
             column.column = column.type->createColumnConst(0, Field(database_name));
 
             auto adding_column_dag = ActionsDAG::makeAddingColumnActions(std::move(column));
@@ -682,7 +682,7 @@ QueryPipelineBuilderPtr ReadFromMerge::createSources(
         {
             ColumnWithTypeAndName column;
             column.name = "_table";
-            column.type = std::make_shared<DataTypeString>();
+            column.type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
             column.column = column.type->createColumnConst(0, Field(table_name));
 
             auto adding_column_dag = ActionsDAG::makeAddingColumnActions(std::move(column));
@@ -980,7 +980,9 @@ void registerStorageMerge(StorageFactory & factory)
 
 NamesAndTypesList StorageMerge::getVirtuals() const
 {
-    NamesAndTypesList virtuals{{"_database", std::make_shared<DataTypeString>()}, {"_table", std::make_shared<DataTypeString>()}};
+    NamesAndTypesList virtuals{
+        {"_database", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())},
+        {"_table", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>())}};
 
     auto first_table = getFirstTable([](auto && table) { return table; });
     if (first_table)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make the `_part` and `_partition_id` virtual column be `LowCardinality(String)` type. Closes #45964.
