### PR TITLE
Improve local running of cherry_pick.py

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -225,7 +225,7 @@ Merge it only if you intend to backport changes to the target branch, otherwise 
         )
         git_runner(f"{self.git_prefix} reset --soft {merge_base}")
         title = f"Backport #{self.pr.number} to {self.name}: {self.pr.title}"
-        git_runner(f"{self.git_prefix} commit -a --allow-empty -F -", input=title)
+        git_runner(f"{self.git_prefix} commit --allow-empty -F -", input=title)
 
         # Push with force, create the backport PR, lable and assign it
         git_runner(

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -467,7 +467,8 @@ def clear_repo():
 
 @contextmanager
 def stash():
-    need_stash = bool(git_runner("git diff HEAD"))
+    # diff.ignoreSubmodules=all don't show changed submodules
+    need_stash = bool(git_runner("git -c diff.ignoreSubmodules=all diff HEAD"))
     if need_stash:
         git_runner("git stash push --no-keep-index -m 'running cherry_pick.py'")
     try:


### PR DESCRIPTION
Formerly all changed files were committed, and it caused changed submodules to be committed as well

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes #45979; avoid accidental commit of changed submodules; do not consider changed submodules in `need_stash`; always update local release branches to avoid stale backport PRs