### PR TITLE
Avoid leaving symbols leftovers for query fuzzy search

### DIFF
--- a/rust/skim/src/lib.rs
+++ b/rust/skim/src/lib.rs
@@ -11,10 +11,25 @@ mod ffi {
 
 struct Item {
     text: String,
+    orig_text: String,
+}
+impl Item {
+    fn new(text: String) -> Self {
+        return Self{
+            // Text that will be shown should not contains new lines since in this case skim may
+            // live some symbols on the screen, and this looks odd.
+            text: text.replace("\n", " "),
+            orig_text: text,
+        };
+    }
 }
 impl SkimItem for Item {
     fn text(&self) -> Cow<str> {
         return Cow::Borrowed(&self.text);
+    }
+
+    fn output(&self) -> Cow<str> {
+        return Cow::Borrowed(&self.orig_text);
     }
 }
 
@@ -34,7 +49,7 @@ fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, Stri
 
     let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
     for word in words {
-        tx.send(Arc::new(Item{ text: word.to_string() })).unwrap();
+        tx.send(Arc::new(Item::new(word.to_string()))).unwrap();
     }
     // so that skim could know when to stop waiting for more items.
     drop(tx);

--- a/src/Client/ReplxxLineReader.cpp
+++ b/src/Client/ReplxxLineReader.cpp
@@ -417,6 +417,10 @@ ReplxxLineReader::ReplxxLineReader(
         {
             rx.print("skim failed: %s (consider using Ctrl-T for a regular non-fuzzy reverse search)\n", e.what());
         }
+
+        /// REPAINT before to avoid prompt overlap by the query
+        rx.invoke(Replxx::ACTION::REPAINT, code);
+
         if (!new_query.empty())
             rx.set_state(replxx::Replxx::State(new_query.c_str(), static_cast<int>(new_query.size())));
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Avoid client prompt overlap after query fuzzy search
- Avoid leaving symbols leftovers on the screen during query fuzzy search

Cc: @alexey-milovidov 