### PR TITLE
Use "exact" matching for fuzzy search

### DIFF
--- a/rust/skim/src/lib.rs
+++ b/rust/skim/src/lib.rs
@@ -10,22 +10,25 @@ mod ffi {
 }
 
 struct Item {
-    text: String,
+    text_no_newlines: String,
     orig_text: String,
 }
 impl Item {
     fn new(text: String) -> Self {
         return Self{
+            // Text that will be printed by skim, and will be used for matching.
+            //
             // Text that will be shown should not contains new lines since in this case skim may
             // live some symbols on the screen, and this looks odd.
-            text: text.replace("\n", " "),
+            text_no_newlines: text.replace("\n", " "),
+            // This will be used when the match had been selected.
             orig_text: text,
         };
     }
 }
 impl SkimItem for Item {
     fn text(&self) -> Cow<str> {
-        return Cow::Borrowed(&self.text);
+        return Cow::Borrowed(&self.text_no_newlines);
     }
 
     fn output(&self) -> Cow<str> {
@@ -44,6 +47,24 @@ fn skim(prefix: &CxxString, words: &CxxVector<CxxString>) -> Result<String, Stri
         .query(Some(prefix.to_str().unwrap()))
         .tac(true)
         .tiebreak(Some("-score".to_string()))
+        // Exact mode performs better for SQL.
+        //
+        // Default fuzzy search is too smart for SQL, it even takes into account the case, which
+        // should not be accounted (you don't want to type "SELECT" instead of "select" to find the
+        // query).
+        //
+        // Exact matching seems better algorithm for SQL, it is not 100% exact, it splits by space,
+        // and apply separate matcher actually for each word.
+        // Note, that if you think that "space is not enough" as the delimiter, then you should
+        // first know that this is the delimiter only for the input query, so to match
+        // "system.query_log" you can use "sy qu log"
+        // Also it should be more common for users who did not know how to use fuzzy search.
+        // (also you can disable exact mode by prepending "'" char).
+        //
+        // Also it ignores the case correctly, i.e. it does not have penalty for case mismatch,
+        // like fuzzy algorithms (take a look at SkimScoreConfig::penalty_case_mismatch).
+        .exact(true)
+        .case(CaseMatching::Ignore)
         .build()
         .unwrap();
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use "exact" matching for fuzzy search, which has correct case ignorance and more appropriate algorithm for matching SQL queries.

Right now fuzzy search is too smart for SQL, it even takes into account
the case, which should not be accounted (you don't want to type "SELECT"
instead of "select" to find the query).

And to tell the truth, I think too smart fuzzy searching for SQL queries
is not required, and is only harming.

Exact matching seems better algorithm for SQL, it is not 100% exact, it
splits by space, and apply separate matcher actually for each word.
Note, that if you think that "space is not enough" as the delimiter,
then you should first know that this is the delimiter only for the
input query, so to match "system.query_log" you can use "sy qu log"
(also you can disable exact mode by prepending "'" char).

But it ignores the case by default, and the behaviour what is expected
from the CaseMatching::Ignore.

<details>

<summary>TL;DR;</summary>

Just for the history I will describe what had been tried.

At first I tried CaseMatching::Ignore - it does not helps for
SkimV1/SkimV2/Clangd matches.

So I converted lines from the history and input query, to the lower
case. However this does not work for UPPER CASE, since only initial
portion of the query had been converted to the lower.

Then I've looked into skim/fuzzy-matcher crates code, and look for the
reason why CaseMatching::Ignore does not work, and found that there is
still a penalty for case mismatch, but there is no way to pass it from
the user code, so I've tried guerrilla to monkey patch the library's
code and it works:

    // Avoid penalty for case mismatch (even with CaseMatching::Ignore)
    let _guard = guerrilla::patch0(SkimScoreConfig::default, || {
        let score_match = 16;
        let gap_start = -3;
        let gap_extension = -1;
        let bonus_first_char_multiplier = 2;

        return SkimScoreConfig{
            score_match,
            gap_start,
            gap_extension,
            bonus_first_char_multiplier,
            bonus_head: score_match / 2,
            bonus_break: score_match / 2 + gap_extension,
            bonus_camel: score_match / 2 + 2 * gap_extension,
            bonus_consecutive: -(gap_start + gap_extension),
            // penalty_case_mismatch: gap_extension * 2,
            penalty_case_mismatch: 0,
        };
    });

But this does not sounds like a trivial code, so I decided, to look
around, and realized that "exact" matching should do what is required
for the completion of queries (at least from my point of view).

</details>