### PR TITLE
Update sorting properties after reading in order applied

### DIFF
--- a/src/Processors/QueryPlan/DistinctStep.cpp
+++ b/src/Processors/QueryPlan/DistinctStep.cpp
@@ -103,7 +103,12 @@ void DistinctStep::transformPipeline(QueryPipelineBuilder & pipeline, const Buil
                             return nullptr;
 
                         return std::make_shared<DistinctSortedChunkTransform>(
-                            header, set_size_limits, limit_hint, distinct_sort_desc, columns, false);
+                            header,
+                            set_size_limits,
+                            limit_hint,
+                            distinct_sort_desc,
+                            columns,
+                            input_stream.sort_scope == DataStream::SortScope::Stream);
                     });
                 return;
             }

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -99,7 +99,11 @@ void updateStepsDataStreams(StepStack & steps_to_update)
 
         while (!steps_to_update.empty())
         {
-            dynamic_cast<ITransformingStep *>(steps_to_update.back())->updateInputStream(*input_stream);
+            auto * transforming_step = dynamic_cast<ITransformingStep *>(steps_to_update.back());
+            if (!transforming_step)
+                break;
+
+            transforming_step->updateInputStream(*input_stream);
             input_stream = &steps_to_update.back()->getOutputStream();
             steps_to_update.pop_back();
         }

--- a/tests/performance/distinct_in_order.xml
+++ b/tests/performance/distinct_in_order.xml
@@ -2,6 +2,7 @@
     <!-- high cardinality -->
     <create_query>CREATE TABLE distinct_cardinality_high (high UInt64, medium UInt64, low UInt64) ENGINE MergeTree() ORDER BY (high, medium)</create_query>
     <fill_query>INSERT INTO distinct_cardinality_high SELECT number % 1e6, number % 1e4, number % 1e2 FROM numbers_mt(1e8)</fill_query>
+    <fill_query>OPTIMIZE TABLE distinct_cardinality_high FINAL</fill_query>
 
     <query>SELECT DISTINCT high FROM distinct_cardinality_high FORMAT Null</query>
     <query>SELECT DISTINCT high, medium FROM distinct_cardinality_high FORMAT Null</query>
@@ -14,6 +15,7 @@
     <!-- low cardinality -->
     <create_query>CREATE TABLE distinct_cardinality_low (low UInt64, medium UInt64, high UInt64) ENGINE MergeTree() ORDER BY (low, medium)</create_query>
     <fill_query>INSERT INTO distinct_cardinality_low SELECT number % 1e2, number % 1e4, number % 1e6 FROM numbers_mt(1e8)</fill_query>
+    <fill_query>OPTIMIZE TABLE distinct_cardinality_low FINAL</fill_query>
 
     <query>SELECT DISTINCT low FROM distinct_cardinality_low FORMAT Null</query>
     <query>SELECT DISTINCT low, medium FROM distinct_cardinality_low FORMAT Null</query>

--- a/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.reference
+++ b/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.reference
@@ -59,6 +59,8 @@ Sorting (Stream): a ASC, b ASC
 -- check that reading in order optimization for ORDER BY and DISTINCT applied correctly in the same query
 -- disabled, check that sorting description for ReadFromMergeTree match ORDER BY columns
 Sorting (Stream): a ASC
+Sorting (Stream): a ASC
+Sorting (Stream): a ASC
 -- enabled, check that ReadFromMergeTree sorting description is overwritten by DISTINCT optimization i.e. it contains columns from DISTINCT clause
 Sorting (Stream): a ASC, b ASC
 Sorting (Stream): a ASC, b ASC
@@ -69,7 +71,11 @@ Sorting (Stream): a DESC, b DESC
 Sorting (Stream): a DESC, b DESC
 -- enabled, check that ReadFromMergeTree sorting description is NOT overwritten by DISTINCT optimization (1), - it contains columns from ORDER BY clause
 Sorting (Stream): a ASC, b ASC
+Sorting (Stream): a ASC, b ASC
+Sorting (Stream): a ASC, b ASC
 -- enabled, check that ReadFromMergeTree sorting description is NOT overwritten by DISTINCT optimization (2), - direction used from ORDER BY clause
+Sorting (Stream): a DESC, b DESC
+Sorting (Stream): a DESC, b DESC
 Sorting (Stream): a DESC, b DESC
 -- enabled, check that disabling other 'read in order' optimizations do not disable distinct in order optimization
 Sorting (Stream): a ASC, b ASC

--- a/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.reference
+++ b/tests/queries/0_stateless/02317_distinct_in_order_optimization_explain.reference
@@ -14,10 +14,10 @@ DistinctSortedTransform
 DistinctSortedChunkTransform
 -- distinct with primary key prefix and order by the same columns -> pre-distinct and final distinct optimization
 DistinctSortedStreamTransform
-DistinctSortedChunkTransform
+DistinctSortedStreamTransform
 -- distinct with primary key prefix and order by columns are prefix of distinct columns -> pre-distinct and final distinct optimization
 DistinctSortedTransform
-DistinctSortedChunkTransform
+DistinctSortedStreamTransform
 -- distinct with primary key prefix and order by column in distinct but non-primary key prefix -> pre-distinct and final distinct optimization
 DistinctSortedTransform
 DistinctSortedChunkTransform

--- a/tests/queries/0_stateless/02377_optimize_sorting_by_input_stream_properties_explain.reference
+++ b/tests/queries/0_stateless/02377_optimize_sorting_by_input_stream_properties_explain.reference
@@ -25,7 +25,7 @@ PartialSortingTransform × 3
 Sorting (Global): a ASC
 Sorting (Sorting for ORDER BY)
 Sorting (Global): a ASC
-Sorting (Chunk): a ASC
+Sorting (Stream): a ASC
 Sorting (Stream): a ASC
 -- QUERY: set optimize_read_in_order=1;set max_threads=3;set query_plan_remove_redundant_sorting=0;EXPLAIN PLAN actions=1, header=1, sorting=1 SELECT a FROM optimize_sorting ORDER BY a+1
 Sorting (None)
@@ -70,14 +70,14 @@ Sorting (Global): a ASC
 Sorting (None)
 Sorting (Sorting for ORDER BY)
 Sorting (Global): a ASC
-Sorting (Chunk): a ASC
+Sorting (Stream): a ASC
 Sorting (Stream): a ASC
 -- aliases DONT break sorting order
 -- QUERY: set optimize_read_in_order=1;set max_threads=3;set query_plan_remove_redundant_sorting=0;EXPLAIN PLAN actions=1, header=1, sorting=1 SELECT a, b FROM (SELECT x AS a, y AS b FROM (SELECT a AS x, b AS y FROM optimize_sorting) ORDER BY x, y)
 Sorting (Global): x ASC, y ASC
 Sorting (Sorting for ORDER BY)
 Sorting (Global): x ASC, y ASC
-Sorting (Chunk): a ASC, b ASC
+Sorting (Stream): a ASC, b ASC
 Sorting (Stream): a ASC, b ASC
 -- actions chain breaks sorting order: input(column a)->sipHash64(column a)->alias(sipHash64(column a), a)->plus(alias a, 1)
 -- QUERY: set optimize_read_in_order=1;set max_threads=3;set query_plan_remove_redundant_sorting=0;EXPLAIN PLAN actions=1, header=1, sorting=1 SELECT a, z FROM (SELECT sipHash64(a) AS a, a + 1 AS z FROM (SELECT a FROM optimize_sorting ORDER BY a + 1)) ORDER BY a + 1
@@ -94,5 +94,5 @@ Sorting (Chunk): a ASC
 Sorting (Global): a ASC
 Sorting (Sorting for ORDER BY)
 Sorting (Global): a ASC
-Sorting (Chunk): a ASC, b ASC
+Sorting (Stream): a ASC
 Sorting (Stream): a ASC

--- a/tests/queries/0_stateless/02481_aggregation_in_order_plan.reference
+++ b/tests/queries/0_stateless/02481_aggregation_in_order_plan.reference
@@ -4,5 +4,6 @@
 0	1	2	200
   Aggregating
   Order: a ASC, c ASC
+    Sorting (Stream): a ASC, b ASC, c ASC
       ReadFromMergeTree (default.tab)
       Sorting (Stream): a ASC, b ASC, c ASC

--- a/tests/queries/0_stateless/02481_aggregation_in_order_plan.sql
+++ b/tests/queries/0_stateless/02481_aggregation_in_order_plan.sql
@@ -1,3 +1,4 @@
+drop table if exists tab;
 create table tab (a Int32, b Int32, c Int32, d Int32) engine = MergeTree order by (a, b, c);
 
 insert into tab select 0, number % 3, 2 - intDiv(number, 3), (number % 3 + 1) * 10 from numbers(6);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Correct sorting properties propagation after reading in order optimization. Fixes leftovers after #42829 ([comment1](https://github.com/ClickHouse/ClickHouse/pull/42829/files#r1012078631), [comment2](https://github.com/ClickHouse/ClickHouse/pull/42829/files#r1012083875))
