### PR TITLE
Use `Poco::Timestamp` for both modification and change time in IDisk

### DIFF
--- a/src/Common/filesystemHelpers.cpp
+++ b/src/Common/filesystemHelpers.cpp
@@ -370,6 +370,11 @@ Poco::Timestamp getModificationTimestamp(const std::string & path)
     return Poco::Timestamp::fromEpochTime(getModificationTime(path));
 }
 
+Poco::Timestamp getChangeTimestamp(const std::string & path)
+{
+    return Poco::Timestamp::fromEpochTime(getChangeTime(path));
+}
+
 void setModificationTime(const std::string & path, time_t time)
 {
     struct utimbuf tb;

--- a/src/Common/filesystemHelpers.h
+++ b/src/Common/filesystemHelpers.h
@@ -93,6 +93,7 @@ Poco::Timestamp getModificationTimestamp(const std::string & path);
 void setModificationTime(const std::string & path, time_t time);
 /// st_ctime
 time_t getChangeTime(const std::string & path);
+Poco::Timestamp getChangeTimestamp(const std::string & path);
 
 bool isSymlink(const fs::path & path);
 fs::path readSymlink(const fs::path & path);

--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -198,7 +198,7 @@ public:
         return delegate->getLastModified(wrapped_path);
     }
 
-    time_t getLastChanged(const String & path) const override
+    Poco::Timestamp getLastChanged(const String & path) const override
     {
         auto wrapped_path = wrappedPath(path);
         return delegate->getLastChanged(wrapped_path);

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -417,9 +417,9 @@ Poco::Timestamp DiskLocal::getLastModified(const String & path) const
     return FS::getModificationTimestamp(fs::path(disk_path) / path);
 }
 
-time_t DiskLocal::getLastChanged(const String & path) const
+Poco::Timestamp DiskLocal::getLastChanged(const String & path) const
 {
-    return FS::getChangeTime(fs::path(disk_path) / path);
+    return FS::getChangeTimeTimestamp(fs::path(disk_path) / path);
 }
 
 void DiskLocal::createHardLink(const String & src_path, const String & dst_path)

--- a/src/Disks/DiskLocal.h
+++ b/src/Disks/DiskLocal.h
@@ -91,7 +91,7 @@ public:
 
     Poco::Timestamp getLastModified(const String & path) const override;
 
-    time_t getLastChanged(const String & path) const override;
+    Poco::Timestamp getLastChanged(const String & path) const override;
 
     void setReadOnly(const String & path) override;
 

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -289,7 +289,7 @@ public:
 
     /// Get last changed time of file or directory at `path`.
     /// Meaning is the same as stat.mt_ctime (e.g. different from getLastModified()).
-    virtual time_t getLastChanged(const String & path) const = 0;
+    virtual Poco::Timestamp getLastChanged(const String & path) const = 0;
 
     /// Set file at `path` as read-only.
     virtual void setReadOnly(const String & path) = 0;

--- a/src/Disks/ObjectStorages/DiskObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.cpp
@@ -401,7 +401,7 @@ Poco::Timestamp DiskObjectStorage::getLastModified(const String & path) const
     return metadata_storage->getLastModified(path);
 }
 
-time_t DiskObjectStorage::getLastChanged(const String & path) const
+Poco::Timestamp DiskObjectStorage::getLastChanged(const String & path) const
 {
     return metadata_storage->getLastChanged(path);
 }

--- a/src/Disks/ObjectStorages/DiskObjectStorage.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorage.h
@@ -130,7 +130,7 @@ public:
 
     Poco::Timestamp getLastModified(const String & path) const override;
 
-    time_t getLastChanged(const String & path) const override;
+    Poco::Timestamp getLastChanged(const String & path) const override;
 
     bool isRemote() const override { return true; }
 

--- a/src/Disks/ObjectStorages/FakeMetadataStorageFromDisk.cpp
+++ b/src/Disks/ObjectStorages/FakeMetadataStorageFromDisk.cpp
@@ -53,7 +53,7 @@ Poco::Timestamp FakeMetadataStorageFromDisk::getLastModified(const std::string &
     return disk->getLastModified(path);
 }
 
-time_t FakeMetadataStorageFromDisk::getLastChanged(const std::string & path) const
+Poco::Timestamp FakeMetadataStorageFromDisk::getLastChanged(const std::string & path) const
 {
     return disk->getLastChanged(path);
 }

--- a/src/Disks/ObjectStorages/FakeMetadataStorageFromDisk.h
+++ b/src/Disks/ObjectStorages/FakeMetadataStorageFromDisk.h
@@ -42,7 +42,7 @@ public:
 
     Poco::Timestamp getLastModified(const std::string & path) const override;
 
-    time_t getLastChanged(const std::string & path) const override;
+    Poco::Timestamp getLastChanged(const std::string & path) const override;
 
     bool supportsChmod() const override { return disk->supportsChmod(); }
 

--- a/src/Disks/ObjectStorages/IMetadataStorage.h
+++ b/src/Disks/ObjectStorages/IMetadataStorage.h
@@ -166,7 +166,7 @@ public:
 
     virtual Poco::Timestamp getLastModified(const std::string & path) const = 0;
 
-    virtual time_t getLastChanged(const std::string & /* path */) const
+    virtual Poco::Timestamp getLastChanged(const std::string & /* path */) const
     {
         throwNotImplemented();
     }

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
@@ -46,7 +46,7 @@ Poco::Timestamp MetadataStorageFromDisk::getLastModified(const std::string & pat
     return disk->getLastModified(path);
 }
 
-time_t MetadataStorageFromDisk::getLastChanged(const std::string & path) const
+Poco::Timestamp MetadataStorageFromDisk::getLastChanged(const std::string & path) const
 {
     return disk->getLastChanged(path);
 }

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
@@ -40,7 +40,7 @@ public:
 
     Poco::Timestamp getLastModified(const std::string & path) const override;
 
-    time_t getLastChanged(const std::string & path) const override;
+    Poco::Timestamp getLastChanged(const std::string & path) const override;
 
     bool supportsChmod() const override { return disk->supportsChmod(); }
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2368,7 +2368,7 @@ size_t MergeTreeData::clearOldBrokenPartsFromDetachedDirectory()
         time_t current_time = time(nullptr);
         ssize_t threshold = current_time - getSettings()->merge_tree_clear_old_broken_detached_parts_ttl_timeout_seconds;
         auto path = fs::path(relative_data_path) / "detached" / part_info.dir_name;
-        time_t last_change_time = part_info.disk->getLastChanged(path);
+        time_t last_change_time = part_info.disk->getLastChanged(path).epochTime();
         time_t last_modification_time = part_info.disk->getLastModified(path).epochTime();
         time_t last_touch_time = std::max(last_change_time, last_modification_time);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Made two methods consistent. 