### PR TITLE
Forbid wrong create view syntax

### DIFF
--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1299,14 +1299,13 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
             return false;
     }
 
-
-    if (ParserKeyword{"TO INNER UUID"}.ignore(pos, expected))
+    if (!is_ordinary_view && ParserKeyword{"TO INNER UUID"}.ignore(pos, expected))
     {
         ParserStringLiteral literal_p;
         if (!literal_p.parse(pos, to_inner_uuid, expected))
             return false;
     }
-    else if (ParserKeyword{"TO"}.ignore(pos, expected))
+    else if (!is_ordinary_view && ParserKeyword{"TO"}.ignore(pos, expected))
     {
         // TO [db.]table
         if (!table_name_p.parse(pos, to_table, expected))

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1299,13 +1299,13 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
             return false;
     }
 
-    if (!is_ordinary_view && ParserKeyword{"TO INNER UUID"}.ignore(pos, expected))
+    if (is_materialized_view && ParserKeyword{"TO INNER UUID"}.ignore(pos, expected))
     {
         ParserStringLiteral literal_p;
         if (!literal_p.parse(pos, to_inner_uuid, expected))
             return false;
     }
-    else if (!is_ordinary_view && ParserKeyword{"TO"}.ignore(pos, expected))
+    else if (is_materialized_view && ParserKeyword{"TO"}.ignore(pos, expected))
     {
         // TO [db.]table
         if (!table_name_p.parse(pos, to_table, expected))

--- a/tests/queries/0_stateless/02554_invalid_create_view_syntax.sql
+++ b/tests/queries/0_stateless/02554_invalid_create_view_syntax.sql
@@ -1,0 +1,1 @@
+CREATE VIEW X TO Y AS SELECT 1; -- { clientError 62 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Forbid wrong create View syntax `CREATE View X TO Y AS SELECT`. Closes #4331.