### PR TITLE
Fix reading of non existing nested columns with multiple level in compact parts

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -91,8 +91,12 @@ protected:
     StorageMetadataPtr metadata_snapshot;
     MarkRanges all_mark_ranges;
 
-    using ColumnPosition = std::optional<size_t>;
-    ColumnPosition findColumnForOffsets(const NameAndTypePair & column) const;
+    /// Position and level (of nesting).
+    using ColumnPositionLevel = std::optional<std::pair<size_t, size_t>>;
+    /// In case of part of the nested column does not exists, offsets should be
+    /// read, but only the offsets for the current column, that is why it
+    /// returns pair of size_t, not just one.
+    ColumnPositionLevel findColumnForOffsets(const NameAndTypePair & column) const;
 
     NameSet partially_read_columns;
 

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.h
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.h
@@ -50,10 +50,11 @@ private:
     MergeTreeMarksLoader marks_loader;
 
     /// Positions of columns in part structure.
-    using ColumnPositions = std::vector<ColumnPosition>;
+    using ColumnPositions = std::vector<std::optional<size_t>>;
     ColumnPositions column_positions;
-    /// Should we read full column or only it's offsets
-    std::vector<bool> read_only_offsets;
+    /// Should we read full column or only it's offsets.
+    /// Element of the vector is the level of the alternative stream.
+    std::vector<std::optional<size_t>> read_only_offsets;
 
     /// For asynchronous reading from remote fs. Same meaning as in MergeTreeReaderStream.
     std::optional<size_t> last_right_offset;
@@ -64,7 +65,8 @@ private:
     void seekToMark(size_t row_index, size_t column_index);
 
     void readData(const NameAndTypePair & name_and_type, ColumnPtr & column, size_t from_mark,
-        size_t current_task_last_mark, size_t column_position, size_t rows_to_read, bool only_offsets);
+        size_t current_task_last_mark, size_t column_position, size_t rows_to_read,
+        std::optional<size_t> only_offsets_level);
 
     /// Returns maximal value of granule size in compressed file from @mark_ranges.
     /// This value is used as size of read buffer.

--- a/src/Storages/MergeTree/MergeTreeReaderInMemory.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderInMemory.cpp
@@ -42,7 +42,7 @@ MergeTreeReaderInMemory::MergeTreeReaderInMemory(
         {
             if (auto offsets_position = findColumnForOffsets(column_to_read))
             {
-                positions_for_offsets[column_to_read.name] = *offsets_position;
+                positions_for_offsets[column_to_read.name] = offsets_position->first;
                 partially_read_columns.insert(column_to_read.name);
             }
         }

--- a/tests/queries/0_stateless/02559_nested_multiple_levels_default.reference
+++ b/tests/queries/0_stateless/02559_nested_multiple_levels_default.reference
@@ -1,0 +1,6 @@
+data_compact	Compact
+[[]]
+data_memory	InMemory
+[[]]
+data_wide	Wide
+[[]]

--- a/tests/queries/0_stateless/02559_nested_multiple_levels_default.sql
+++ b/tests/queries/0_stateless/02559_nested_multiple_levels_default.sql
@@ -1,0 +1,45 @@
+DROP TABLE IF EXISTS data_compact;
+DROP TABLE IF EXISTS data_memory;
+DROP TABLE IF EXISTS data_wide;
+
+-- compact
+DROP TABLE IF EXISTS data_compact;
+CREATE TABLE data_compact
+(
+    `root.array` Array(UInt8),
+)
+ENGINE = MergeTree()
+ORDER BY tuple()
+SETTINGS min_rows_for_compact_part=0, min_bytes_for_compact_part=0, min_rows_for_wide_part=100, min_bytes_for_wide_part=1e9;
+INSERT INTO data_compact VALUES ([0]);
+ALTER TABLE data_compact ADD COLUMN root.nested_array Array(Array(UInt8));
+SELECT table, part_type FROM system.parts WHERE table = 'data_compact' AND database = currentDatabase();
+SELECT root.nested_array FROM data_compact;
+
+-- memory
+DROP TABLE IF EXISTS data_memory;
+CREATE TABLE data_memory
+(
+    `root.array` Array(UInt8),
+)
+ENGINE = MergeTree()
+ORDER BY tuple()
+SETTINGS min_rows_for_compact_part=100, min_bytes_for_compact_part=1e9, min_rows_for_wide_part=100, min_bytes_for_wide_part=1e9, in_memory_parts_enable_wal=0;
+INSERT INTO data_memory VALUES ([0]);
+ALTER TABLE data_memory ADD COLUMN root.nested_array Array(Array(UInt8));
+SELECT table, part_type FROM system.parts WHERE table = 'data_memory' AND database = currentDatabase();
+SELECT root.nested_array FROM data_memory;
+
+-- wide
+DROP TABLE IF EXISTS data_wide;
+CREATE TABLE data_wide
+(
+    `root.array` Array(UInt8),
+)
+ENGINE = MergeTree()
+ORDER BY tuple()
+SETTINGS min_rows_for_wide_part=0, min_bytes_for_wide_part=0, min_rows_for_wide_part=0, min_bytes_for_wide_part=0;
+INSERT INTO data_wide VALUES ([0]);
+ALTER TABLE data_wide ADD COLUMN root.nested_array Array(Array(UInt8));
+SELECT table, part_type FROM system.parts WHERE table = 'data_wide' AND database = currentDatabase();
+SELECT root.nested_array FROM data_wide;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix reading of non existing nested columns with multiple level in compact parts

Consider the following example:

    CREATE TABLE data (root.array_str Array(UInt8)) ENGINE = MergeTree() ORDER BY tuple();
    INSERT INTO data VALUES ([]);
    ALTER TABLE data ADD COLUMN root.nested_array Array(Array(UInt8));

In this case the first part will not have data for root.nested_array,
and thanks to #37152 it will simply read offsets column from
root.array_str, however since root.nested_array is a nested array, it
will try to read elements from the same offsets stream and if you are
lucky enough you will get one of the following errors:

- Cannot read all data. Bytes read: 1. Bytes expected: 8.: (while reading column root.nested_array): While executing MergeTreeInOrder. (CANNOT_READ_ALL_DATA)
- DB::Exception: Array size is too large: 8233460228287709730: (while reading column serp.serp_features): While executing MergeTreeInOrder.

So to address this, findColumnForOffsets() had been changed to return the level of the column too, to allow to read only those offsets.

Cc: @CurtizJ 