### PR TITLE
Temporarily disable one rabbitmq flaky test

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -3000,6 +3000,7 @@ def test_format_with_prefix_and_suffix(rabbitmq_cluster):
         == "<prefix>\n0\t0\n<suffix>\n<prefix>\n10\t100\n<suffix>\n"
     )
 
+
 @pytest.mark.skip(reason="FIXME: broken")
 def test_max_rows_per_message(rabbitmq_cluster):
     num_rows = 5

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -3000,7 +3000,7 @@ def test_format_with_prefix_and_suffix(rabbitmq_cluster):
         == "<prefix>\n0\t0\n<suffix>\n<prefix>\n10\t100\n<suffix>\n"
     )
 
-
+@pytest.mark.skip(reason="FIXME: broken")
 def test_max_rows_per_message(rabbitmq_cluster):
     num_rows = 5
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


I cannot fix it quickly, strange error, need to debug, so will temporarily disable.
```
        instance.query(
            f"INSERT INTO test.rabbit select number*10 as key, number*100 as value from numbers({num_rows}) settings format_custom_result_before_delimiter='<prefix>\n', format_custom_result_after_delimiter='<suffix>\n'"
        )
    
        insert_messages = []
    
        def onReceived(channel, method, properties, body):
            insert_messages.append(body.decode())
            if len(insert_messages) == 2:
                channel.stop_consuming()
    
        consumer.basic_consume(onReceived, queue_name)
>       consumer.start_consuming()

test_storage_rabbitmq/test.py:3052: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3/dist-packages/pika/adapters/blocking_connection.py:1756: in start_consuming
    self.connection.process_data_events(time_limit=None)
/usr/lib/python3/dist-packages/pika/adapters/blocking_connection.py:707: in process_data_events
    self._flush_output(common_terminator)
/usr/lib/python3/dist-packages/pika/adapters/blocking_connection.py:455: in _flush_output
    self._impl.ioloop.poll()
/usr/lib/python3/dist-packages/pika/adapters/select_connection.py:245: in poll
    self._poller.poll()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pika.adapters.select_connection.EPollPoller object at 0x7fcb1c01f0d0>

    def poll(self):
        """Wait for events of interest on registered file descriptors until an
        event of interest occurs or next timer deadline or _MAX_POLL_TIMEOUT,
        whichever is sooner, and dispatch the corresponding event handlers.
    
        """
        while True:
            try:
>               events = self._poll.poll(self._get_next_deadline())
E               Failed: Timeout >900.0s

```