### PR TITLE
Make SYSTEM UNFREEZE query enabled by default

### DIFF
--- a/src/Storages/Freeze.cpp
+++ b/src/Storages/Freeze.cpp
@@ -130,7 +130,7 @@ BlockIO Unfreezer::systemUnfreeze(const String & backup_name)
 
     const auto & config = local_context->getConfigRef();
     static constexpr auto config_key = "enable_system_unfreeze";
-    if (!config.getBool(config_key, false))
+    if (!config.getBool(config_key, true))
     {
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Support for SYSTEM UNFREEZE query is disabled. You can enable it via '{}' server setting", config_key);
     }


### PR DESCRIPTION
Make `SYSTEM UNFREEZE` query _enabled_ by default. Since a flag `enable_system_unfreeze` that was previously added is off by default and broke backward compatibility.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make SYSTEM UNFREEZE query enabled by default.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
