### PR TITLE
Smallish follow-up to #46057

### DIFF
--- a/src/Common/MultiVersion.h
+++ b/src/Common/MultiVersion.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <mutex>
 #include <memory>
 #include <base/defines.h>
 
@@ -33,8 +32,8 @@ public:
     MultiVersion() = default;
 
     explicit MultiVersion(std::unique_ptr<const T> && value)
+        : current_version(std::move(value))
     {
-        set(std::move(value));
     }
 
     /// Obtain current version for read-only usage. Returns shared_ptr, that manages lifetime of version.
@@ -42,6 +41,9 @@ public:
     {
         return std::atomic_load(&current_version);
     }
+
+    /// TODO: replace atomic_load/store() on shared_ptr (which is deprecated as of C++20) by C++20 std::atomic<std::shared_ptr>.
+    /// Clang 15 currently does not support it.
 
     /// Update an object with new version.
     void set(std::unique_ptr<const T> && value)


### PR DESCRIPTION
Follow-up to #46057:
- Add TODO comment to MultiVersion.h
- Ctor requires no atomic op

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)