### PR TITLE
Add helping logging to auto-merge script

### DIFF
--- a/tests/ci/merge_pr.py
+++ b/tests/ci/merge_pr.py
@@ -56,6 +56,13 @@ class Reviews:
             logging.info("There aren't reviews for PR #%s", self.pr.number)
             return False
 
+        logging.info(
+            "The following users have reviewed the PR:\n  %s",
+            "\n  ".join(
+                f"{user.login}: {review.state}" for user, review in self.reviews.items()
+            ),
+        )
+
         filtered_reviews = {
             user: review
             for user, review in self.reviews.items()
@@ -125,7 +132,11 @@ class Reviews:
                 return False
             return True
 
-        logging.info("The PR #%s is not approved", self.pr.number)
+        logging.info(
+            "The PR #%s is not approved by any of %s team member",
+            self.pr.number,
+            TEAM_NAME,
+        )
         return False
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Give some more context to auto-merge script