### PR TITLE
Add also last messages from stdout/stderr/debuglog in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -71,6 +71,7 @@ def stringhash(s):
     return zlib.crc32(s.encode("utf-8"))
 
 
+# First and last lines of the log
 def trim_for_log(s):
     if not s:
         return s

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -71,6 +71,13 @@ def stringhash(s):
     return zlib.crc32(s.encode("utf-8"))
 
 
+def trim_for_log(s):
+    if not s:
+        return s
+    lines = s.splitlines()
+    return "\n".join(lines[:50] + ["#" * 100] + lines[-50:])
+
+
 class HTTPError(Exception):
     def __init__(self, message=None, code=None):
         self.message = message
@@ -870,8 +877,7 @@ class TestCase:
     ):
         description = ""
 
-        if debug_log:
-            debug_log = "\n".join(debug_log.splitlines()[:100])
+        debug_log = trim_for_log(debug_log)
 
         if proc:
             if proc.returncode is None:
@@ -921,9 +927,7 @@ class TestCase:
 
                 if os.path.isfile(self.stdout_file):
                     description += ", result:\n\n"
-                    description += "\n".join(
-                        open(self.stdout_file).read().splitlines()[:100]
-                    )
+                    description += trim_for_log(open(self.stdout_file).read())
                     description += "\n"
 
                 description += f"\nstdout:\n{stdout}\n"
@@ -932,7 +936,9 @@ class TestCase:
                 )
 
         if stderr:
-            description += "\n{}\n".format("\n".join(stderr.splitlines()[:100]))
+            description += "\n"
+            description += trim_for_log(stderr)
+            description += "\n"
             description += f"\nstdout:\n{stdout}\n"
             if debug_log:
                 description += "\n"
@@ -946,7 +952,9 @@ class TestCase:
             )
 
         if "Exception" in stdout:
-            description += "\n{}\n".format("\n".join(stdout.splitlines()[:100]))
+            description += "\n"
+            description += trim_for_log(stdout)
+            description += "\n"
             if debug_log:
                 description += "\n"
                 description += debug_log


### PR DESCRIPTION
First lines not very helpful usually, since the problem usually happens at the end [1], though some tricky stuff may happens at the beginning, so let's output both.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/45654/1716af465d376f5335720b5045bcccdd9e1823aa/fast_test.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)