### PR TITLE
Sanity assertions for closing file descriptors

### DIFF
--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -130,7 +130,11 @@
         #define chassert(x) static_cast<bool>(x) ? void(0) : ::DB::abortOnFailedAssertion(#x)
         #define UNREACHABLE() abort()
     #else
-        #define chassert(x) (void)(x)
+        /// Here sizeof() trick is used to suppress unused warning for result,
+        /// since simple "(void)x" will evaluate the expression, while
+        /// "sizeof(!(x))" will not.
+        #define NIL_EXPRESSION(x) (void)sizeof(!(x))
+        #define chassert(x) NIL_EXPRESSION(x)
         #define UNREACHABLE() __builtin_unreachable()
     #endif
 #endif

--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -127,7 +127,7 @@
 /// because SIGABRT is easier to debug than SIGTRAP (the second one makes gdb crazy)
 #if !defined(chassert)
     #if defined(ABORT_ON_LOGICAL_ERROR)
-        #define chassert(x) static_cast<bool>(x) ? void(0) : abortOnFailedAssertion(#x)
+        #define chassert(x) static_cast<bool>(x) ? void(0) : ::DB::abortOnFailedAssertion(#x)
         #define UNREACHABLE() abort()
     #else
         #define chassert(x) (void)(x)

--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -130,7 +130,7 @@
         #define chassert(x) static_cast<bool>(x) ? void(0) : abortOnFailedAssertion(#x)
         #define UNREACHABLE() abort()
     #else
-        #define chassert(x) ((void)0)
+        #define chassert(x) (void)(x)
         #define UNREACHABLE() __builtin_unreachable()
     #endif
 #endif

--- a/src/Common/CounterInFile.h
+++ b/src/Common/CounterInFile.h
@@ -16,6 +16,7 @@
 #include <IO/WriteHelpers.h>
 
 #include <Common/Exception.h>
+#include <base/defines.h>
 #include <base/types.h>
 
 
@@ -112,11 +113,13 @@ public:
         }
         catch (...)
         {
-            close(fd);
+            int err = close(fd);
+            chassert(!err || errno == EINTR);
             throw;
         }
 
-        close(fd);
+        int err = close(fd);
+        chassert(!err || errno == EINTR);
         return res;
     }
 
@@ -180,11 +183,13 @@ public:
         }
         catch (...)
         {
-            close(fd);
+            int err = close(fd);
+            chassert(!err || errno == EINTR);
             throw;
         }
 
-        close(fd);
+        int err = close(fd);
+        chassert(!err || errno == EINTR);
     }
 
 private:

--- a/src/Common/Epoll.cpp
+++ b/src/Common/Epoll.cpp
@@ -2,6 +2,7 @@
 
 #include "Epoll.h"
 #include <Common/Exception.h>
+#include <base/defines.h>
 #include <unistd.h>
 
 namespace DB
@@ -78,7 +79,10 @@ size_t Epoll::getManyReady(int max_events, epoll_event * events_out, bool blocki
 Epoll::~Epoll()
 {
     if (epoll_fd != -1)
-        close(epoll_fd);
+    {
+        int err = close(epoll_fd);
+        chassert(!err || errno == EINTR);
+    }
 }
 
 }

--- a/src/Common/EventFD.cpp
+++ b/src/Common/EventFD.cpp
@@ -3,6 +3,7 @@
 
 #include <Common/EventFD.h>
 #include <Common/Exception.h>
+#include <base/defines.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
 
@@ -55,7 +56,10 @@ bool EventFD::write(uint64_t increase) const
 EventFD::~EventFD()
 {
     if (fd != -1)
-        close(fd);
+    {
+        int err = close(fd);
+        chassert(!err || errno == EINTR);
+    }
 }
 
 }

--- a/src/Common/ProcfsMetricsProvider.cpp
+++ b/src/Common/ProcfsMetricsProvider.cpp
@@ -7,6 +7,7 @@
 #include <IO/ReadHelpers.h>
 
 #include <base/find_symbols.h>
+#include <base/defines.h>
 #include <Common/logger_useful.h>
 
 #include <cassert>
@@ -102,7 +103,8 @@ ProcfsMetricsProvider::ProcfsMetricsProvider(pid_t /*tid*/)
     thread_stat_fd = ::open(thread_stat, O_RDONLY | O_CLOEXEC);
     if (-1 == thread_stat_fd)
     {
-        ::close(thread_schedstat_fd);
+        int err = ::close(thread_schedstat_fd);
+        chassert(!err || errno == EINTR);
         throwWithFailedToOpenFile(thread_stat);
     }
     thread_io_fd = ::open(thread_io, O_RDONLY | O_CLOEXEC);

--- a/src/Common/QueryProfiler.cpp
+++ b/src/Common/QueryProfiler.cpp
@@ -6,6 +6,7 @@
 #include <Common/StackTrace.h>
 #include <Common/thread_local_rng.h>
 #include <Common/logger_useful.h>
+#include <base/defines.h>
 #include <base/phdr_cache.h>
 #include <base/errnoToString.h>
 
@@ -186,8 +187,10 @@ void QueryProfilerBase<ProfilerImpl>::tryCleanup()
 #if USE_UNWIND
     if (timer_id.has_value())
     {
-        if (timer_delete(*timer_id))
+        int err = timer_delete(*timer_id);
+        if (err)
             LOG_ERROR(log, "Failed to delete query profiler timer {}", errnoToString());
+        chassert(!err && "Failed to delete query profiler timer");
         timer_id.reset();
     }
 

--- a/src/Common/StatusFile.cpp
+++ b/src/Common/StatusFile.cpp
@@ -5,9 +5,10 @@
 #include <cerrno>
 
 #include <Common/logger_useful.h>
-#include <base/errnoToString.h>
 #include <Common/ClickHouseRevision.h>
 #include <Common/LocalDateTime.h>
+#include <base/errnoToString.h>
+#include <base/defines.h>
 
 #include <IO/ReadBufferFromFile.h>
 #include <IO/LimitReadBuffer.h>
@@ -88,7 +89,8 @@ StatusFile::StatusFile(std::string path_, FillFunction fill_)
     }
     catch (...)
     {
-        close(fd);
+        int err = close(fd);
+        chassert(!err || errno == EINTR);
         throw;
     }
 }

--- a/src/Common/TaskStatsInfoGetter.cpp
+++ b/src/Common/TaskStatsInfoGetter.cpp
@@ -1,5 +1,6 @@
 #include "TaskStatsInfoGetter.h"
 #include <Common/Exception.h>
+#include <base/defines.h>
 #include <base/types.h>
 
 #include <unistd.h>
@@ -280,7 +281,10 @@ TaskStatsInfoGetter::TaskStatsInfoGetter()
     catch (...)
     {
         if (netlink_socket_fd >= 0)
-            close(netlink_socket_fd);
+        {
+            int err = close(netlink_socket_fd);
+            chassert(!err || errno == EINTR);
+        }
         throw;
     }
 }
@@ -314,7 +318,10 @@ void TaskStatsInfoGetter::getStat(::taskstats & out_stats, pid_t tid) const
 TaskStatsInfoGetter::~TaskStatsInfoGetter()
 {
     if (netlink_socket_fd >= 0)
-        close(netlink_socket_fd);
+    {
+        int err = close(netlink_socket_fd);
+        chassert(!err || errno == EINTR);
+    }
 }
 
 }

--- a/src/Common/TimerDescriptor.cpp
+++ b/src/Common/TimerDescriptor.cpp
@@ -1,6 +1,7 @@
 #if defined(OS_LINUX)
 #include <Common/TimerDescriptor.h>
 #include <Common/Exception.h>
+#include <base/defines.h>
 
 #include <sys/timerfd.h>
 #include <fcntl.h>
@@ -36,7 +37,10 @@ TimerDescriptor::~TimerDescriptor()
 {
     /// Do not check for result cause cannot throw exception.
     if (timer_fd != -1)
-        close(timer_fd);
+    {
+        int err = close(timer_fd);
+        chassert(!err || errno == EINTR);
+    }
 }
 
 void TimerDescriptor::reset() const

--- a/src/Common/waitForPid.cpp
+++ b/src/Common/waitForPid.cpp
@@ -2,6 +2,9 @@
 #include <Common/VersionNumber.h>
 #include <Poco/Environment.h>
 #include <Common/Stopwatch.h>
+/// for abortOnFailedAssertion() via chassert() (dependency chain looks odd)
+#include <Common/Exception.h>
+#include <base/defines.h>
 
 #include <fcntl.h>
 #include <sys/wait.h>
@@ -105,7 +108,8 @@ static PollPidResult pollPid(pid_t pid, int timeout_in_ms)
     if (ready <= 0)
         return PollPidResult::FAILED;
 
-    close(pid_fd);
+    int err = close(pid_fd);
+    chassert(!err || errno == EINTR);
 
     return PollPidResult::RESTART;
 }

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -1,5 +1,6 @@
 #include <cerrno>
 #include <base/errnoToString.h>
+#include <base/defines.h>
 #include <future>
 #include <Coordination/KeeperSnapshotManager.h>
 #include <Coordination/KeeperStateMachine.h>
@@ -471,13 +472,15 @@ static int bufferFromFile(Poco::Logger * log, const std::string & path, nuraft::
     if (chunk == MAP_FAILED)
     {
         LOG_WARNING(log, "Error mmapping {}, error: {}, errno: {}", path, errnoToString(), errno);
-        ::close(fd);
+        int err = ::close(fd);
+        chassert(!err || errno == EINTR);
         return errno;
     }
     data_out = nuraft::buffer::alloc(file_size);
     data_out->put_raw(chunk, file_size);
     ::munmap(chunk, file_size);
-    ::close(fd);
+    int err = ::close(fd);
+    chassert(!err || errno == EINTR);
     return 0;
 }
 

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -588,7 +588,10 @@ void BaseDaemon::closeFDs()
             if (fd > 2 && fd != signal_pipe.fds_rw[0] && fd != signal_pipe.fds_rw[1])
             {
                 int err = ::close(fd);
-                chassert(!err || errno == EINTR);
+                /// NOTE: it is OK to ignore error here since at least one fd
+                /// is already closed (for proc_path), and there can be some
+                /// tricky cases, likely.
+                (void)err;
             }
         }
     }
@@ -606,7 +609,10 @@ void BaseDaemon::closeFDs()
             if (fd != signal_pipe.fds_rw[0] && fd != signal_pipe.fds_rw[1])
             {
                 int err = ::close(fd);
-                chassert(!err || errno == EINTR);
+                /// NOTE: it is OK to get EBADF here, since it is simply
+                /// iterator over all possible fds, without any checks does
+                /// this process has this fd or not.
+                (void)err;
             }
         }
     }

--- a/src/Dictionaries/SSDCacheDictionaryStorage.h
+++ b/src/Dictionaries/SSDCacheDictionaryStorage.h
@@ -12,6 +12,7 @@
 #include <absl/container/flat_hash_set.h>
 
 #include <base/unaligned.h>
+#include <base/defines.h>
 #include <base/sort.h>
 #include <Common/randomSeed.h>
 #include <Common/Arena.h>
@@ -768,7 +769,8 @@ private:
             if (this == &rhs)
                 return *this;
 
-            close(fd);
+            int err = ::close(fd);
+            chassert(!err || errno == EINTR);
 
             fd = rhs.fd;
             rhs.fd = -1;
@@ -777,7 +779,10 @@ private:
         ~FileDescriptor()
         {
             if (fd != -1)
-                close(fd);
+            {
+                int err = close(fd);
+                chassert(!err || errno == EINTR);
+            }
         }
 
         int fd = -1;

--- a/src/IO/AsynchronousReadBufferFromFile.cpp
+++ b/src/IO/AsynchronousReadBufferFromFile.cpp
@@ -3,6 +3,7 @@
 #include <IO/AsynchronousReadBufferFromFile.h>
 #include <IO/WriteHelpers.h>
 #include <Common/ProfileEvents.h>
+#include <base/defines.h>
 #include <cerrno>
 
 
@@ -81,7 +82,8 @@ AsynchronousReadBufferFromFile::~AsynchronousReadBufferFromFile()
     if (fd < 0)
         return;
 
-    ::close(fd);
+    int err = ::close(fd);
+    chassert(!err || errno == EINTR);
 }
 
 

--- a/src/IO/ReadBufferFromFile.cpp
+++ b/src/IO/ReadBufferFromFile.cpp
@@ -3,6 +3,7 @@
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteHelpers.h>
 #include <Common/ProfileEvents.h>
+#include <base/defines.h>
 #include <cerrno>
 
 
@@ -73,7 +74,8 @@ ReadBufferFromFile::~ReadBufferFromFile()
     if (fd < 0)
         return;
 
-    ::close(fd);
+    int err = ::close(fd);
+    chassert(!err || errno == EINTR);
 }
 
 

--- a/src/IO/WriteBufferFromFile.cpp
+++ b/src/IO/WriteBufferFromFile.cpp
@@ -72,6 +72,9 @@ WriteBufferFromFile::WriteBufferFromFile(
 
 WriteBufferFromFile::~WriteBufferFromFile()
 {
+    if (fd < 0)
+        return;
+
     finalize();
     int err = ::close(fd);
     /// Everything except for EBADF should be ignored in dtor, since all of

--- a/src/IO/WriteBufferFromFile.cpp
+++ b/src/IO/WriteBufferFromFile.cpp
@@ -3,6 +3,7 @@
 #include <cerrno>
 
 #include <Common/ProfileEvents.h>
+#include <base/defines.h>
 
 #include <IO/WriteBufferFromFile.h>
 #include <IO/WriteHelpers.h>
@@ -72,7 +73,14 @@ WriteBufferFromFile::WriteBufferFromFile(
 WriteBufferFromFile::~WriteBufferFromFile()
 {
     finalize();
-    ::close(fd);
+    int err = ::close(fd);
+    /// Everything except for EBADF should be ignored in dtor, since all of
+    /// others (EINTR/EIO/ENOSPC/EDQUOT) could be possible during writing to
+    /// fd, and then write already failed and the error had been reported to
+    /// the user/caller.
+    ///
+    /// Note, that for close() on Linux, EINTR should *not* be retried.
+    chassert(!(err && errno == EBADF));
 }
 
 void WriteBufferFromFile::finalizeImpl()

--- a/src/IO/WriteBufferFromTemporaryFile.cpp
+++ b/src/IO/WriteBufferFromTemporaryFile.cpp
@@ -55,7 +55,7 @@ ReadBufferPtr WriteBufferFromTemporaryFile::getReadBufferImpl()
 
     auto res = ReadBufferFromTemporaryWriteBuffer::createFrom(this);
 
-    /// invalidate FD to avoid close(fd) in destructor
+    /// invalidate FD to avoid close() in destructor
     setFD(-1);
     file_name = {};
 

--- a/src/Processors/Executors/PollingQueue.cpp
+++ b/src/Processors/Executors/PollingQueue.cpp
@@ -3,6 +3,7 @@
 #if defined(OS_LINUX)
 
 #include <Common/Exception.h>
+#include <base/defines.h>
 #include <sys/epoll.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -31,8 +32,11 @@ PollingQueue::PollingQueue()
 
 PollingQueue::~PollingQueue()
 {
-    close(pipe_fd[0]);
-    close(pipe_fd[1]);
+    int err;
+    err = close(pipe_fd[0]);
+    chassert(!err || errno == EINTR);
+    err = close(pipe_fd[1]);
+    chassert(!err || errno == EINTR);
 }
 
 void PollingQueue::addTask(size_t thread_number, void * data, int fd)

--- a/src/Processors/Merges/Algorithms/tests/gtest_graphite.cpp
+++ b/src/Processors/Merges/Algorithms/tests/gtest_graphite.cpp
@@ -12,6 +12,7 @@
 #include <AggregateFunctions/registerAggregateFunctions.h>
 #include <Processors/Merges/Algorithms/Graphite.h>
 #include <Common/Config/ConfigProcessor.h>
+#include <base/defines.h>
 #include <base/errnoToString.h>
 
 
@@ -57,7 +58,9 @@ static ConfigProcessor::LoadedConfig loadConfigurationFromString(std::string & s
         {
             throw std::runtime_error("unable write to temp file");
         }
-        close(fd);
+        int error = close(fd);
+        chassert(!error);
+
         auto config_path = std::string(tmp_file) + ".xml";
         if (std::rename(tmp_file, config_path.c_str()))
         {

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -1,6 +1,7 @@
 #if defined(OS_LINUX)
 
 #include <QueryPipeline/RemoteQueryExecutorReadContext.h>
+#include <base/defines.h>
 #include <Common/Exception.h>
 #include <Common/NetException.h>
 #include <Client/IConnections.h>
@@ -219,9 +220,15 @@ RemoteQueryExecutorReadContext::~RemoteQueryExecutorReadContext()
 {
     /// connection_fd is closed by Poco::Net::Socket or Epoll
     if (pipe_fd[0] != -1)
-        close(pipe_fd[0]);
+    {
+        int err = close(pipe_fd[0]);
+        chassert(!err || errno == EINTR);
+    }
     if (pipe_fd[1] != -1)
-        close(pipe_fd[1]);
+    {
+        int err = close(pipe_fd[1]);
+        chassert(!err || errno == EINTR);
+    }
 }
 
 }

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -12,6 +12,7 @@
 #include <Common/NetException.h>
 #include <Common/setThreadName.h>
 #include <Common/logger_useful.h>
+#include <base/defines.h>
 #include <chrono>
 #include <Common/PipeFDs.h>
 #include <Poco/Util/AbstractConfiguration.h>
@@ -87,14 +88,18 @@ struct SocketInterruptablePollWrapper
         socket_event.data.fd = sockfd;
         if (epoll_ctl(epollfd, EPOLL_CTL_ADD, sockfd, &socket_event) < 0)
         {
-            ::close(epollfd);
+            int err = ::close(epollfd);
+            chassert(!err || errno == EINTR);
+
             throwFromErrno("Cannot insert socket into epoll queue", ErrorCodes::SYSTEM_ERROR);
         }
         pipe_event.events = EPOLLIN | EPOLLERR | EPOLLPRI;
         pipe_event.data.fd = pipe.fds_rw[0];
         if (epoll_ctl(epollfd, EPOLL_CTL_ADD, pipe.fds_rw[0], &pipe_event) < 0)
         {
-            ::close(epollfd);
+            int err = ::close(epollfd);
+            chassert(!err || errno == EINTR);
+
             throwFromErrno("Cannot insert socket into epoll queue", ErrorCodes::SYSTEM_ERROR);
         }
 #endif
@@ -198,7 +203,8 @@ struct SocketInterruptablePollWrapper
 #if defined(POCO_HAVE_FD_EPOLL)
     ~SocketInterruptablePollWrapper()
     {
-        ::close(epollfd);
+        int err = ::close(epollfd);
+        chassert(!err || errno == EINTR);
     }
 #endif
 };

--- a/src/Storages/FileLog/DirectoryWatcherBase.cpp
+++ b/src/Storages/FileLog/DirectoryWatcherBase.cpp
@@ -2,6 +2,7 @@
 #include <Storages/FileLog/DirectoryWatcherBase.h>
 #include <Storages/FileLog/FileLogDirectoryWatcher.h>
 #include <Storages/FileLog/StorageFileLog.h>
+#include <base/defines.h>
 
 #include <filesystem>
 #include <unistd.h>
@@ -129,7 +130,8 @@ void DirectoryWatcherBase::watchFunc()
 DirectoryWatcherBase::~DirectoryWatcherBase()
 {
     stop();
-    close(fd);
+    int err = ::close(fd);
+    chassert(!err || errno == EINTR);
 }
 
 void DirectoryWatcherBase::start()

--- a/utils/check-style/check-style
+++ b/utils/check-style/check-style
@@ -372,5 +372,11 @@ find $ROOT_PATH/{src,programs,utils} -name '*.h' -or -name '*.cpp' |
     grep -vP $EXCLUDE_DIRS |
     xargs grep -P '__builtin_unreachable' && echo "Use UNREACHABLE() from defines.h instead"
 
+# Require checking return value of close(),
+# since it can hide fd misuse and break other places.
+find $ROOT_PATH/{src,programs,utils} -name '*.h' -or -name '*.cpp' |
+    grep -vP $EXCLUDE_DIRS |
+    xargs grep -e ' close(.*fd' -e ' ::close(' | grep -v = && echo "Return value of close() should be checked"
+
 # Check for existence of __init__.py files
 for i in "${ROOT_PATH}"/tests/integration/test_*; do FILE="${i}/__init__.py"; [ ! -f "${FILE}" ] && echo "${FILE} should exist for every integration test"; done

--- a/utils/self-extracting-executable/decompressor.cpp
+++ b/utils/self-extracting-executable/decompressor.cpp
@@ -264,7 +264,8 @@ int decompressFiles(int input_fd, char * path, char * name, bool & have_compress
                 perror("mkstemp");
                 return 1;
             }
-            close(fd);
+            if (0 != close(fd))
+                perror("close");
             strncpy(decompressed_suffix, file_name + strlen(file_name) - 6, 6);
             *decompressed_umask = le64toh(file_info.umask);
             have_compressed_analoge = true;


### PR DESCRIPTION
Noticed one `EINVAL` on [CI](https://s3.amazonaws.com/clickhouse-test-reports/45654/1716af465d376f5335720b5045bcccdd9e1823aa/fast_test.html) and since it may affect other code (in case of i.e. `EBADF`), added few sanity checks (and only for debug builds), for close() and related.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changes

- Check return value of close() in self-extracting-executable
- Check return value of ::close()
- Add close() return value check in check-style
- Improve chassert() macro to suppress warning in release builds
- Add sanity check of evtimer_del() in QueryProfiler