### PR TITLE
Fix endian issue in CityHash for s390x

### DIFF
--- a/contrib/cityhash102/src/config.h
+++ b/contrib/cityhash102/src/config.h
@@ -68,7 +68,7 @@
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
-#if defined AC_APPLE_UNIVERSAL_BUILD
+#if defined AC_APPLE_UNIVERSAL_BUILD || defined(__s390x__)
 # if defined __BIG_ENDIAN__
 #  define WORDS_BIGENDIAN 1
 # endif

--- a/tests/queries/0_stateless/00322_disable_checksumming.sh
+++ b/tests/queries/0_stateless/00322_disable_checksumming.sh
@@ -4,5 +4,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# use big-endian version of binary data for s390x
+if [[ $(uname -a | grep s390x) ]]; then
+echo -ne '\xdb\x8a\xe9\x59\xf2\x32\x74\x50\x39\xc4\x22\xfb\xa7\x4a\xc6\x37''\x82\x13\x00\x00\x00\x09\x00\x00\x00''\x90SELECT 1\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&decompress=1" --data-binary @-
+else
 echo -ne '\x50\x74\x32\xf2\x59\xe9\x8a\xdb\x37\xc6\x4a\xa7\xfb\x22\xc4\x39''\x82\x13\x00\x00\x00\x09\x00\x00\x00''\x90SELECT 1\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&decompress=1" --data-binary @-
+fi
 echo -ne 'xxxxxxxxxxxxxxxx''\x82\x13\x00\x00\x00\x09\x00\x00\x00''\x90SELECT 1\n' | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&decompress=1&http_native_compression_disable_checksumming_on_decompress=1" --data-binary @-


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On s390x, 00322_disable_checksumming fails because of the following:
 CityHash128 returns same uint128 values on both little endian and big endian machines(after a fix in contrib/cityhash102/src/config.h), however the byte order of low and high 64 bit integers of uint128 are reversed on big endian machines compared with those on little endian machines. It means that verification of the binary checksum data generated in little endian machine will fail on big endian machine. Taking checksum in 00322_disable_checksumming as an example:
In big endian:

```
0xdb 0x8a 0xe9 0x59 0xf2 0x32 0x74 0x50
0x39 0xc4 0x22 0xfb 0xa7 0x4a 0xc6 0x37
```

In little endian:
```
0x50 0x74 0x32 0xf2 0x59 0xe9 0x8a 0xdb
0x37 0xc6 0x4a 0xa7 0xfb 0x22 0xc4 0x39	
```

The fix does the following:
- Fix  contrib/cityhash102/src/config.h so that it uses big endian version of library on big endian machine.
- In the script of functional test `00322_disable_checksumming`, use checksum generated in big endian machine for big endian machines like s390x.

### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed endian issue in CityHash for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
