### PR TITLE
Fix test_merge_tree_azure_blob_storage::test_zero_copy_replication test

### DIFF
--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
@@ -2,6 +2,7 @@
 
 #if USE_AZURE_BLOB_STORAGE
 
+#include <Common/Exception.h>
 #include <optional>
 #include <re2/re2.h>
 #include <azure/identity/managed_identity_credential.hpp>
@@ -125,21 +126,22 @@ std::unique_ptr<BlobContainerClient> getAzureBlobContainerClient(
 
     auto blob_service_client = getAzureBlobStorageClientWithAuth<BlobServiceClient>(endpoint.storage_account_url, container_name, config, config_prefix);
 
-    if (!endpoint.container_already_exists.has_value())
+    try
     {
-        ListBlobContainersOptions blob_containers_list_options;
-        blob_containers_list_options.Prefix = container_name;
-        blob_containers_list_options.PageSizeHint = 1;
-        auto blob_containers = blob_service_client->ListBlobContainers().BlobContainers;
-        for (const auto & blob_container : blob_containers)
-        {
-            if (blob_container.Name == endpoint.container_name)
-                return getAzureBlobStorageClientWithAuth<BlobContainerClient>(final_url, container_name, config, config_prefix);
-        }
+        return std::make_unique<BlobContainerClient>(
+            blob_service_client->CreateBlobContainer(container_name).Value);
     }
-
-    return std::make_unique<BlobContainerClient>(
-        blob_service_client->CreateBlobContainer(container_name).Value);
+    catch (const Azure::Storage::StorageException & e)
+    {
+        /// If container_already_exists is not set (in config), ignore already exists error.
+        /// (Conflict - The specified container already exists)
+        if (!endpoint.container_already_exists.has_value() && e.StatusCode == Azure::Core::Http::HttpStatusCode::Conflict)
+        {
+            tryLogCurrentException("Container already exist, return existing container");
+            return getAzureBlobStorageClientWithAuth<BlobContainerClient>(final_url, container_name, config, config_prefix);
+        }
+        throw;
+    }
 }
 
 std::unique_ptr<AzureObjectStorageSettings> getAzureBlobStorageSettings(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, ContextPtr /*context*/)

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageAuth.cpp
@@ -137,7 +137,7 @@ std::unique_ptr<BlobContainerClient> getAzureBlobContainerClient(
         /// (Conflict - The specified container already exists)
         if (!endpoint.container_already_exists.has_value() && e.StatusCode == Azure::Core::Http::HttpStatusCode::Conflict)
         {
-            tryLogCurrentException("Container already exist, return existing container");
+            tryLogCurrentException("Container already exists, returning the existing container");
             return getAzureBlobStorageClientWithAuth<BlobContainerClient>(final_url, container_name, config, config_prefix);
         }
         throw;

--- a/tests/integration/test_merge_tree_azure_blob_storage/configs/config.d/storage_conf.xml
+++ b/tests/integration/test_merge_tree_azure_blob_storage/configs/config.d/storage_conf.xml
@@ -5,12 +5,15 @@
                 <type>azure_blob_storage</type>
                 <storage_account_url>http://azurite1:10000/devstoreaccount1</storage_account_url>
                 <container_name>cont</container_name>
-                <container_already_exists>false</container_already_exists>
                 <skip_access_check>false</skip_access_check>
                 <!-- default credentials for Azurite storage account -->
                 <account_name>devstoreaccount1</account_name>
                 <account_key>Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==</account_key>
                 <max_single_part_upload_size>100000</max_single_part_upload_size>
+                <!-- NOTE: container_already_exists is omitted to:
+                  a) create it
+                  b) ignore if it already exists, since there are two instances, that conflicts with each other
+                -->
             </blob_storage_disk>
             <hdd>
                  <type>local</type>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix test_merge_tree_azure_blob_storage::test_zero_copy_replication test, and fix TOCTOU for `container_already_exists` directive

Here is an example of an error [1]:

    2023.02.06 21:59:09.076849 [ 200 ] {} <Information> DiskObjectStorage(DiskAzureBlobStorage): Starting up disk blob_storage_disk
    2023.02.06 21:59:09.076897 [ 200 ] {} <Information> DiskObjectStorage(DiskAzureBlobStorage): Disk blob_storage_disk started up
    2023.02.06 21:59:09.077263 [ 200 ] {} <Trace> StoragePolicy (blob_storage_policy): Storage policy blob_storage_policy created, total volumes 1
    2023.02.06 21:59:09.077318 [ 200 ] {} <Information> StoragePolicySelector: Storage policy `blob_storage_policy` loaded
    ...
    2023.02.06 21:59:09.227326 [ 1 ] {} <Error> Application: std::exception. Code: 1001, type: Azure::Storage::StorageException, e.what() = 409 The specified container already exists.
    The specified container already exists.
    RequestId:73d54dcf-0c66-489c-b9b8-2b5398df9384
    Time:2023-02-06T21:59:08.225Z
    Request ID: 73d54dcf-0c66-489c-b9b8-2b5398df9384, Stack trace (when copying this message, always include the lines below):

    0. ./build_docker/../contrib/llvm-project/libcxx/include/exception:134: std::runtime_error::runtime_error() @ 0x44297b8d in /usr/bin/clickhouse
    ...
    5. ./build_docker/../contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714: DB::getAzureBlobContainerClient() @ 0x2f5b225f in /usr/bin/clickhouse
    6. ./build_docker/../src/Disks/ObjectStorages/AzureBlobStorage/registerDiskAzureBlobStorage.cpp:0:
    10. ./build_docker/../src/Interpreters/Context.cpp:0: DB::Context::getDisksMap() const @ 0x2f95af47 in /usr/bin/clickhouse
    ...
    13. ./build_docker/../contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714: DB::AsynchronousMetrics::start() @ 0x1f4d6161 in /usr/bin/clickhouse
    14. ./build_docker/../programs/server/Server.cpp:0: DB::Server::main() @ 0x1f3a5bfb in /usr/bin/clickhouse
    15. ./build_docker/../contrib/poco/Util/src/Application.cpp:0: Poco::Util::Application::run() @ 0x3c7546bf in /usr/bin/clickhouse
    16. ./build_docker/../programs/server/Server.cpp:476: DB::Server::run() @ 0x1f381f7b in /usr/bin/clickhouse
    17. ./build_docker/../contrib/poco/Util/src/ServerApplication.cpp:612: Poco::Util::ServerApplication::run(int, char**) @ 0x3c797ee0 in /usr/bin/clickhouse
    18. ./build_docker/../programs/server/Server.cpp:0: mainEntryClickHouseServer(int, char**) @ 0x1f37a262 in /usr/bin/clickhouse
    19. ./build_docker/../programs/main.cpp:0: main @ 0xe9d21ae in /usr/bin/clickhouse
    20. __libc_start_main @ 0x7f58271a1083 in ?
    21. _start @ 0xe90ef6e in /usr/bin/clickhouse
     (version 23.2.1.1)
    2023.02.06 21:59:09.227971 [ 1 ] {} <Error> Application: 409 The specified container already exists.
    The specified container already exists.
    RequestId:73d54dcf-0c66-489c-b9b8-2b5398df9384
    Time:2023-02-06T21:59:08.225Z
    Request ID: 73d54dcf-0c66-489c-b9b8-2b5398df9384

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/46045/bd4170e03c6af583a51d12d2c39fa775dcb9997b/integration_tests__asan__[6/6].html