### PR TITLE
Stricter warnings + fix whitespaces in poco

### DIFF
--- a/base/poco/CMakeLists.txt
+++ b/base/poco/CMakeLists.txt
@@ -1,6 +1,3 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 add_subdirectory (Crypto)
 add_subdirectory (Data)
 add_subdirectory (Data/ODBC)

--- a/base/poco/Crypto/CMakeLists.txt
+++ b/base/poco/Crypto/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 if (ENABLE_SSL)
     file (GLOB SRCS src/*.cpp)
 

--- a/base/poco/Crypto/CMakeLists.txt
+++ b/base/poco/Crypto/CMakeLists.txt
@@ -1,13 +1,27 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 if (ENABLE_SSL)
     file (GLOB SRCS src/*.cpp)
 
     add_library (_poco_crypto ${SRCS})
     add_library (Poco::Crypto ALIAS _poco_crypto)
 
-    target_compile_options (_poco_crypto PRIVATE -Wno-newline-eof)
+    # TODO: remove these warning exclusions
+    target_compile_options (_poco_crypto
+        PRIVATE
+            -Wno-covered-switch-default
+            -Wno-deprecated-dynamic-exception-spec
+            -Wno-extra-semi-stmt
+            -Wno-missing-noreturn
+            -Wno-newline-eof
+            -Wno-old-style-cast
+            -Wno-shadow
+            -Wno-shorten-64-to-32
+            -Wno-sign-compare
+            -Wno-suggest-destructor-override
+            -Wno-suggest-override
+            -Wno-unreachable-code-return
+            -Wno-unused-parameter
+            -Wno-zero-as-null-pointer-constant
+    )
     target_include_directories (_poco_crypto SYSTEM PUBLIC "include")
     target_link_libraries (_poco_crypto PUBLIC Poco::Foundation OpenSSL::SSL OpenSSL::Crypto)
 

--- a/base/poco/Data/CMakeLists.txt
+++ b/base/poco/Data/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_data ${SRCS})

--- a/base/poco/Data/CMakeLists.txt
+++ b/base/poco/Data/CMakeLists.txt
@@ -1,10 +1,20 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_data ${SRCS})
 add_library (Poco::Data ALIAS _poco_data)
 
+# TODO: remove these warning exclusions
+target_compile_options (_poco_data
+    PRIVATE
+        -Wno-comma
+        -Wno-covered-switch-default
+        -Wno-deprecated-dynamic-exception-spec
+        -Wno-extra-semi-stmt
+        -Wno-old-style-cast
+        -Wno-shorten-64-to-32
+        -Wno-sign-compare
+        -Wno-unused-parameter
+        -Wno-zero-as-null-pointer-constant
+)
 target_include_directories (_poco_data SYSTEM PUBLIC "include")
 target_link_libraries (_poco_data PUBLIC Poco::Foundation)

--- a/base/poco/Data/ODBC/CMakeLists.txt
+++ b/base/poco/Data/ODBC/CMakeLists.txt
@@ -31,6 +31,8 @@ if (ENABLE_ODBC)
             -Wno-extra-semi-stmt
             -Wno-old-style-cast
             -Wno-sign-compare
+            -Wno-tautological-constant-out-of-range-compare
+            -Wno-tautological-unsigned-zero-compare
             -Wno-unused-parameter
             -Wno-unused-variable
             -Wno-zero-as-null-pointer-constant

--- a/base/poco/Data/ODBC/CMakeLists.txt
+++ b/base/poco/Data/ODBC/CMakeLists.txt
@@ -23,7 +23,18 @@ if (ENABLE_ODBC)
     add_library (_poco_data_odbc ${SRCS})
     add_library (Poco::Data::ODBC ALIAS _poco_data_odbc)
 
-    target_compile_options (_poco_data_odbc PRIVATE -Wno-unused-variable)
+    # TODO: remove these warning exclusions
+    target_compile_options (_poco_data_odbc
+        PRIVATE
+            -Wno-cast-qual
+            -Wno-deprecated-dynamic-exception-spec
+            -Wno-extra-semi-stmt
+            -Wno-old-style-cast
+            -Wno-sign-compare
+            -Wno-unused-parameter
+            -Wno-unused-variable
+            -Wno-zero-as-null-pointer-constant
+    )
     target_include_directories (_poco_data_odbc SYSTEM PUBLIC "include")
     target_link_libraries (_poco_data_odbc PUBLIC Poco::Data ch_contrib::unixodbc)
 

--- a/base/poco/Data/ODBC/include/Poco/Data/ODBC/Preparator.h
+++ b/base/poco/Data/ODBC/include/Poco/Data/ODBC/Preparator.h
@@ -570,7 +570,7 @@ private:
 		if (Utility::isError(SQLBindCol(_rStmt, 
 			(SQLUSMALLINT) pos + 1, 
 			valueType, 
-			(SQLPOINTER) pVal,  
+			(SQLPOINTER) pVal, 
 			(SQLINTEGER) dataSize, 
 			&_lengths[pos])))
 		{

--- a/base/poco/Data/include/Poco/Data/RecordSet.h
+++ b/base/poco/Data/include/Poco/Data/RecordSet.h
@@ -460,7 +460,7 @@ private:
 		}
 		else 
 		{
-			throw Poco::BadCastException(Poco::format("Type cast failed!\nColumn: %z\nTarget type:\t%s",  
+			throw Poco::BadCastException(Poco::format("Type cast failed!\nColumn: %z\nTarget type:\t%s",
 				pos,
 				std::string(typeid(T).name())));
 		}

--- a/base/poco/Foundation/CMakeLists.txt
+++ b/base/poco/Foundation/CMakeLists.txt
@@ -207,6 +207,7 @@ target_compile_options (_poco_foundation
         -Wno-sign-compare
         -Wno-suggest-destructor-override
         -Wno-suggest-override
+        -Wno-tautological-unsigned-zero-compare
         -Wno-thread-safety-analysis
         -Wno-thread-safety-negative
         -Wno-undef

--- a/base/poco/Foundation/CMakeLists.txt
+++ b/base/poco/Foundation/CMakeLists.txt
@@ -209,6 +209,7 @@ target_compile_options (_poco_foundation
         -Wno-suggest-override
         -Wno-thread-safety-analysis
         -Wno-thread-safety-negative
+        -Wno-undef
         -Wno-unreachable-code-return
         -Wno-unused-exception-parameter
         -Wno-unused-macros

--- a/base/poco/Foundation/CMakeLists.txt
+++ b/base/poco/Foundation/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Foundation (pcre)
 
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 file (GLOB SRCS_PCRE src/pcre_*.c)
 
 add_library (_poco_foundation_pcre ${SRCS_PCRE})

--- a/base/poco/Foundation/CMakeLists.txt
+++ b/base/poco/Foundation/CMakeLists.txt
@@ -1,14 +1,25 @@
 # Foundation (pcre)
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 file (GLOB SRCS_PCRE src/pcre_*.c)
 
 add_library (_poco_foundation_pcre ${SRCS_PCRE})
 add_library (Poco::Foundation::PCRE ALIAS _poco_foundation_pcre)
 
-target_compile_options (_poco_foundation_pcre PRIVATE -Wno-sign-compare)
+# TODO: remove these warning exclusions
+target_compile_options (_poco_foundation_pcre
+    PRIVATE
+        -Wno-cast-align
+        -Wno-cast-qual
+        -Wno-comma
+        -Wno-conditional-uninitialized
+        -Wno-extra-semi-stmt
+        -Wno-implicit-fallthrough
+        -Wno-reserved-identifier
+        -Wno-sign-compare
+        -Wno-unknown-pragmas
+        -Wno-unreachable-code-break
+        -Wno-unused-macros
+)
 
 # Foundation
 
@@ -172,21 +183,37 @@ set (SRCS
 add_library (_poco_foundation ${SRCS})
 add_library (Poco::Foundation ALIAS _poco_foundation)
 
+# TODO: remove these warning exclusions
 target_compile_options (_poco_foundation
     PRIVATE
+        -Wno-array-bounds
         -Wno-atomic-implicit-seq-cst
+        -Wno-cast-align
+        -Wno-cast-qual
+        -Wno-class-varargs
+        -Wno-covered-switch-default
         -Wno-deprecated
         -Wno-extra-semi-stmt
-        -Wno-zero-as-null-pointer-constant
+        -Wno-implicit-fallthrough
         -Wno-implicit-int-float-conversion
+        -Wno-misleading-indentation
+        -Wno-missing-noreturn
+        -Wno-old-style-cast
+        -Wno-redundant-parens
+        -Wno-reserved-identifier
+        -Wno-reserved-macro-identifier
+        -Wno-shadow
+        -Wno-shorten-64-to-32
+        -Wno-sign-compare
+        -Wno-suggest-destructor-override
+        -Wno-suggest-override
         -Wno-thread-safety-analysis
         -Wno-thread-safety-negative
-)
-
-target_compile_options (_poco_foundation
-    PRIVATE
-        -Wno-sign-compare
+        -Wno-unreachable-code-return
+        -Wno-unused-exception-parameter
+        -Wno-unused-macros
         -Wno-unused-parameter
+        -Wno-zero-as-null-pointer-constant
 )
 
 target_compile_definitions (_poco_foundation

--- a/base/poco/Foundation/include/Poco/HexBinaryDecoder.h
+++ b/base/poco/Foundation/include/Poco/HexBinaryDecoder.h
@@ -29,7 +29,7 @@ namespace Poco {
 class Foundation_API HexBinaryDecoderBuf: public UnbufferedStreamBuf
 	/// This streambuf decodes all hexBinary-encoded data read
 	/// from the istream connected to it.
-	/// In hexBinary encoding, each binary octet is encoded as a character tuple,  
+	/// In hexBinary encoding, each binary octet is encoded as a character tuple,
 	/// consisting of two hexadecimal digits ([0-9a-fA-F]) representing the octet code.
 	/// See also: XML Schema Part 2: Datatypes (http://www.w3.org/TR/xmlschema-2/),
 	/// section 3.2.15.
@@ -71,7 +71,7 @@ protected:
 class Foundation_API HexBinaryDecoder: public HexBinaryDecoderIOS, public std::istream
 	/// This istream decodes all hexBinary-encoded data read
 	/// from the istream connected to it.
-	/// In hexBinary encoding, each binary octet is encoded as a character tuple,  
+	/// In hexBinary encoding, each binary octet is encoded as a character tuple,
 	/// consisting of two hexadecimal digits ([0-9a-fA-F]) representing the octet code.
 	/// See also: XML Schema Part 2: Datatypes (http://www.w3.org/TR/xmlschema-2/),
 	/// section 3.2.15.

--- a/base/poco/Foundation/include/Poco/HexBinaryEncoder.h
+++ b/base/poco/Foundation/include/Poco/HexBinaryEncoder.h
@@ -29,8 +29,8 @@ namespace Poco {
 class Foundation_API HexBinaryEncoderBuf: public UnbufferedStreamBuf
 	/// This streambuf encodes all data written
 	/// to it in hexBinary encoding and forwards it to a connected
-	/// ostream. 
-	/// In hexBinary encoding, each binary octet is encoded as a character tuple,  
+	/// ostream.
+	/// In hexBinary encoding, each binary octet is encoded as a character tuple,
 	/// consisting of two hexadecimal digits ([0-9a-fA-F]) representing the octet code.
 	/// See also: XML Schema Part 2: Datatypes (http://www.w3.org/TR/xmlschema-2/),
 	/// section 3.2.15.
@@ -95,7 +95,7 @@ class Foundation_API HexBinaryEncoder: public HexBinaryEncoderIOS, public std::o
 	/// Always call close() when done
 	/// writing data, to ensure proper
 	/// completion of the encoding operation.
-	/// In hexBinary encoding, each binary octet is encoded as a character tuple,  
+	/// In hexBinary encoding, each binary octet is encoded as a character tuple,
 	/// consisting of two hexadecimal digits ([0-9a-fA-F]) representing the octet code.
 	/// See also: XML Schema Part 2: Datatypes (http://www.w3.org/TR/xmlschema-2/),
 	/// section 3.2.15.

--- a/base/poco/Foundation/include/Poco/UnicodeConverter.h
+++ b/base/poco/Foundation/include/Poco/UnicodeConverter.h
@@ -37,7 +37,7 @@ public:
 	static void convert(const std::string& utf8String, UTF32String& utf32String);
 		/// Converts the given UTF-8 encoded string into an UTF-32 encoded wide string.
 
-	static void convert(const char* utf8String,  std::size_t length, UTF32String& utf32String);
+	static void convert(const char* utf8String, std::size_t length, UTF32String& utf32String);
 		/// Converts the given UTF-8 encoded character sequence into an UTF-32 encoded wide string.
 
 	static void convert(const char* utf8String, UTF32String& utf32String);
@@ -46,7 +46,7 @@ public:
 	static void convert(const std::string& utf8String, UTF16String& utf16String);
 		/// Converts the given UTF-8 encoded string into an UTF-16 encoded wide string.
 
-	static void convert(const char* utf8String,  std::size_t length, UTF16String& utf16String);	
+	static void convert(const char* utf8String, std::size_t length, UTF16String& utf16String);	
 		/// Converts the given UTF-8 encoded character sequence into an UTF-16 encoded wide string.
 
 	static void convert(const char* utf8String, UTF16String& utf16String);	
@@ -58,7 +58,7 @@ public:
 	static void convert(const UTF32String& utf32String, std::string& utf8String);
 		/// Converts the given UTF-32 encoded wide string into an UTF-8 encoded string.
 
-	static void convert(const UTF16Char* utf16String,  std::size_t length, std::string& utf8String);
+	static void convert(const UTF16Char* utf16String, std::size_t length, std::string& utf8String);
 		/// Converts the given zero-terminated UTF-16 encoded wide character sequence into an UTF-8 encoded string.
 
 	static void convert(const UTF32Char* utf16String, std::size_t length, std::string& utf8String);

--- a/base/poco/Foundation/src/DateTimeParser.cpp
+++ b/base/poco/Foundation/src/DateTimeParser.cpp
@@ -276,11 +276,11 @@ int DateTimeParser::parseTZD(std::string::const_iterator& it, const std::string:
 		{"PDT",   -7*3600},
 		{"AKST",  -9*3600},
 		{"AKDT",  -8*3600},
-		{"HST",  -10*3600},
+		{"HST", -10*3600},
 		{"AEST",  10*3600},
 		{"AEDT",  11*3600},
-		{"ACST",   9*3600+1800},
-		{"ACDT",  10*3600+1800},
+		{"ACST", 9*3600+1800},
+		{"ACDT", 10*3600+1800},
 		{"AWST",   8*3600},
 		{"AWDT",   9*3600}
 	};

--- a/base/poco/Foundation/src/MD5Engine.cpp
+++ b/base/poco/Foundation/src/MD5Engine.cpp
@@ -224,7 +224,7 @@ void MD5Engine::transform (UInt32 state[4], const unsigned char block[64])
 	GG (c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
 	GG (b, c, d, a, x[ 0], S24, 0xe9b6c7aa); /* 20 */
 	GG (a, b, c, d, x[ 5], S21, 0xd62f105d); /* 21 */
-	GG (d, a, b, c, x[10], S22,  0x2441453); /* 22 */
+	GG (d, a, b, c, x[10], S22, 0x2441453); /* 22 */
 	GG (c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
 	GG (b, c, d, a, x[ 4], S24, 0xe7d3fbc8); /* 24 */
 	GG (a, b, c, d, x[ 9], S21, 0x21e1cde6); /* 25 */
@@ -248,7 +248,7 @@ void MD5Engine::transform (UInt32 state[4], const unsigned char block[64])
 	HH (a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
 	HH (d, a, b, c, x[ 0], S32, 0xeaa127fa); /* 42 */
 	HH (c, d, a, b, x[ 3], S33, 0xd4ef3085); /* 43 */
-	HH (b, c, d, a, x[ 6], S34,  0x4881d05); /* 44 */
+	HH (b, c, d, a, x[ 6], S34, 0x4881d05); /* 44 */
 	HH (a, b, c, d, x[ 9], S31, 0xd9d4d039); /* 45 */
 	HH (d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
 	HH (c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */

--- a/base/poco/Foundation/src/UnicodeConverter.cpp
+++ b/base/poco/Foundation/src/UnicodeConverter.cpp
@@ -86,7 +86,7 @@ void UnicodeConverter::convert(const std::string& utf8String, UTF16String& utf16
 }
 
 
-void UnicodeConverter::convert(const char* utf8String,  std::size_t length, UTF16String& utf16String)
+void UnicodeConverter::convert(const char* utf8String, std::size_t length, UTF16String& utf16String)
 {
 	if (!utf8String || !length)
 	{
@@ -130,7 +130,7 @@ void UnicodeConverter::convert(const UTF32String& utf32String, std::string& utf8
 }
 
 
-void UnicodeConverter::convert(const UTF16Char* utf16String,  std::size_t length, std::string& utf8String)
+void UnicodeConverter::convert(const UTF16Char* utf16String, std::size_t length, std::string& utf8String)
 {
 	utf8String.clear();
 	UTF8Encoding utf8Encoding;
@@ -140,7 +140,7 @@ void UnicodeConverter::convert(const UTF16Char* utf16String,  std::size_t length
 }
 
 
-void UnicodeConverter::convert(const UTF32Char* utf32String,  std::size_t length, std::string& utf8String)
+void UnicodeConverter::convert(const UTF32Char* utf32String, std::size_t length, std::string& utf8String)
 {
 	toUTF8(UTF32String(utf32String, length), utf8String);
 }

--- a/base/poco/JSON/CMakeLists.txt
+++ b/base/poco/JSON/CMakeLists.txt
@@ -1,6 +1,3 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 # Poco::JSON (pdjson)
 
 set (SRCS_PDJSON
@@ -10,12 +7,34 @@ set (SRCS_PDJSON
 add_library (_poco_json_pdjson ${SRCS_PDJSON})
 add_library (Poco::JSON::Pdjson ALIAS _poco_json_pdjson)
 
+# TODO: remove these warning exclusions
+target_compile_options (_poco_json_pdjson
+    PRIVATE
+        -Wno-cast-qual
+        -Wno-declaration-after-statement
+        -Wno-extra-semi-stmt
+        -Wno-implicit-fallthrough
+        -Wno-shorten-64-to-32
+        -Wno-unreachable-code-return
+)
+
 # Poco::JSON
 
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_json ${SRCS})
 add_library (Poco::JSON ALIAS _poco_json)
+
+# TODO: remove these warning exclusions
+target_compile_options (_poco_json
+    PRIVATE
+        -Wno-deprecated-dynamic-exception-spec
+        -Wno-sign-compare
+        -Wno-suggest-destructor-override
+        -Wno-suggest-override
+        -Wno-unused-parameter
+        -Wno-zero-as-null-pointer-constant
+)
 
 target_include_directories (_poco_json SYSTEM PUBLIC "include")
 target_link_libraries (_poco_json PUBLIC Poco::Foundation Poco::JSON::Pdjson)

--- a/base/poco/JSON/CMakeLists.txt
+++ b/base/poco/JSON/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 # Poco::JSON (pdjson)
 
 set (SRCS_PDJSON

--- a/base/poco/MongoDB/CMakeLists.txt
+++ b/base/poco/MongoDB/CMakeLists.txt
@@ -1,10 +1,15 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_mongodb ${SRCS})
 add_library (Poco::MongoDB ALIAS _poco_mongodb)
+
+# TODO: remove these warning exclusions
+target_compile_options (_poco_mongodb
+    PRIVATE
+        -Wno-old-style-cast
+        -Wno-unused-parameter
+        -Wno-zero-as-null-pointer-constant
+)
 
 target_include_directories (_poco_mongodb SYSTEM PUBLIC "include")
 target_link_libraries (_poco_mongodb PUBLIC Poco::Net)

--- a/base/poco/MongoDB/CMakeLists.txt
+++ b/base/poco/MongoDB/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_mongodb ${SRCS})

--- a/base/poco/Net/CMakeLists.txt
+++ b/base/poco/Net/CMakeLists.txt
@@ -1,6 +1,3 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_net ${SRCS})
@@ -12,17 +9,31 @@ elseif (OS_DARWIN OR OS_FREEBSD)
     target_compile_definitions (_poco_net PUBLIC POCO_HAVE_FD_POLL)
 endif ()
 
+# TODO: remove these warning exclusions
 target_compile_options (_poco_net
     PRIVATE
         -Wno-atomic-implicit-seq-cst
-        -Wno-extra-semi-stmt
-        -Wno-extra-semi
-)
-
-target_compile_options (_poco_net
-    PRIVATE
+        -Wno-cast-align
+        -Wno-cast-qual
+        -Wno-comma
+        -Wno-covered-switch-default
         -Wno-deprecated
         -Wno-extra-semi
+        -Wno-extra-semi-stmt
+        -Wno-missing-noreturn
+        -Wno-old-style-cast
+        -Wno-shadow
+        -Wno-shorten-64-to-32
+        -Wno-sign-compare
+        -Wno-suggest-destructor-override
+        -Wno-suggest-override
+        -Wno-undef
+        -Wno-unreachable-code
+        -Wno-unreachable-code-return
+        -Wno-unused-macros
+        -Wno-unused-parameter
+        -Wno-zero-as-null-pointer-constant
 )
+
 target_include_directories (_poco_net SYSTEM PUBLIC "include")
 target_link_libraries (_poco_net PUBLIC Poco::Foundation)

--- a/base/poco/Net/CMakeLists.txt
+++ b/base/poco/Net/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_net ${SRCS})

--- a/base/poco/Net/include/Poco/Net/ServerSocket.h
+++ b/base/poco/Net/include/Poco/Net/ServerSocket.h
@@ -131,7 +131,7 @@ public:
 		/// If the library has not been built with IPv6 support,
 		/// a Poco::NotImplementedException will be thrown.
 
-	virtual void bind6(const SocketAddress& address, bool reuseAddress, bool reusePort,  bool ipV6Only);
+	virtual void bind6(const SocketAddress& address, bool reuseAddress, bool reusePort, bool ipV6Only);
 		/// Binds a local IPv6 address to the socket.
 		///
 		/// This is usually only done when establishing a server

--- a/base/poco/Net/include/Poco/Net/SocketImpl.h
+++ b/base/poco/Net/include/Poco/Net/SocketImpl.h
@@ -114,7 +114,7 @@ public:
 		/// If the library has not been built with IPv6 support,
 		/// a Poco::NotImplementedException will be thrown.
 
-	virtual void bind6(const SocketAddress& address, bool reuseAddress, bool reusePort,  bool ipV6Only);
+	virtual void bind6(const SocketAddress& address, bool reuseAddress, bool reusePort, bool ipV6Only);
 		/// Bind a local IPv6 address to the socket.
 		///
 		/// This is usually only done when establishing a server

--- a/base/poco/NetSSL_OpenSSL/CMakeLists.txt
+++ b/base/poco/NetSSL_OpenSSL/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 if (ENABLE_SSL)
     file (GLOB SRCS src/*.cpp)
 

--- a/base/poco/NetSSL_OpenSSL/CMakeLists.txt
+++ b/base/poco/NetSSL_OpenSSL/CMakeLists.txt
@@ -1,12 +1,27 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 if (ENABLE_SSL)
     file (GLOB SRCS src/*.cpp)
 
     add_library (_poco_net_ssl ${SRCS})
     add_library (Poco::Net::SSL ALIAS _poco_net_ssl)
 
+    # TODO: remove these warning exclusions
+    target_compile_options (_poco_net_ssl
+        PRIVATE
+            -Wno-cast-qual
+            -Wno-covered-switch-default
+            -Wno-deprecated-copy-with-user-provided-dtor
+            -Wno-deprecated-dynamic-exception-spec
+            -Wno-extra-semi
+            -Wno-extra-semi-stmt
+            -Wno-implicit-fallthrough
+            -Wno-old-style-cast
+            -Wno-shorten-64-to-32
+            -Wno-sign-compare
+            -Wno-unused-exception-parameter
+            -Wno-unused-macros
+            -Wno-unused-parameter
+            -Wno-zero-as-null-pointer-constant
+    )
     target_include_directories (_poco_net_ssl SYSTEM PUBLIC "include")
     target_link_libraries (_poco_net_ssl PUBLIC Poco::Crypto Poco::Net Poco::Util)
 else ()

--- a/base/poco/Redis/CMakeLists.txt
+++ b/base/poco/Redis/CMakeLists.txt
@@ -1,11 +1,16 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_redis ${SRCS})
 add_library (Poco::Redis ALIAS _poco_redis)
 
-target_compile_options (_poco_redis PRIVATE -Wno-shadow)
+# TODO: remove these warning exclusions
+target_compile_options (_poco_redis
+    PRIVATE
+        -Wno-deprecated-dynamic-exception-spec
+        -Wno-shadow
+        -Wno-shorten-64-to-32
+        -Wno-sign-compare
+        -Wno-zero-as-null-pointer-constant
+)
 target_include_directories (_poco_redis SYSTEM PUBLIC "include")
 target_link_libraries (_poco_redis PUBLIC Poco::Net)

--- a/base/poco/Redis/CMakeLists.txt
+++ b/base/poco/Redis/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_redis ${SRCS})

--- a/base/poco/Util/CMakeLists.txt
+++ b/base/poco/Util/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_util ${SRCS})

--- a/base/poco/Util/CMakeLists.txt
+++ b/base/poco/Util/CMakeLists.txt
@@ -1,10 +1,20 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 file (GLOB SRCS src/*.cpp)
 
 add_library (_poco_util ${SRCS})
 add_library (Poco::Util ALIAS _poco_util)
 
+# TODO: remove these warning exclusions
+target_compile_options (_poco_util
+    PRIVATE
+        -Wno-deprecated-dynamic-exception-spec
+        -Wno-newline-eof
+        -Wno-old-style-cast
+        -Wno-shadow
+        -Wno-sign-compare
+        -Wno-suggest-destructor-override
+        -Wno-suggest-override
+        -Wno-unused-parameter
+        -Wno-zero-as-null-pointer-constant
+)
 target_include_directories (_poco_util SYSTEM PUBLIC "include")
 target_link_libraries (_poco_util PUBLIC Poco::JSON Poco::XML)

--- a/base/poco/Util/CMakeLists.txt
+++ b/base/poco/Util/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library (Poco::Util ALIAS _poco_util)
 target_compile_options (_poco_util
     PRIVATE
         -Wno-deprecated-dynamic-exception-spec
+        -Wno-extra-semi-stmt
         -Wno-newline-eof
         -Wno-old-style-cast
         -Wno-shadow

--- a/base/poco/Util/include/Poco/Util/Units.h
+++ b/base/poco/Util/include/Poco/Util/Units.h
@@ -848,7 +848,7 @@ UNIT_DISPLAY_NAME(Units::T,   "T");
 UNIT_DISPLAY_NAME(Units::H,   "H");
 UNIT_DISPLAY_NAME(Units::lx,  "lx");
 UNIT_DISPLAY_NAME(Units::Gy,  "Gy");
-UNIT_DISPLAY_NAME(Units::kat,  "kat");
+UNIT_DISPLAY_NAME(Units::kat, "kat");
 
 
 namespace Units

--- a/base/poco/Util/src/ServerApplication.cpp
+++ b/base/poco/Util/src/ServerApplication.cpp
@@ -143,7 +143,7 @@ void ServerApplication::ServiceControlHandler(DWORD control)
 	case SERVICE_CONTROL_INTERROGATE:
 		break;
 	}
-	SetServiceStatus(_serviceStatusHandle,  &_serviceStatus);
+	SetServiceStatus(_serviceStatusHandle, &_serviceStatus);
 }
 
 

--- a/base/poco/XML/CMakeLists.txt
+++ b/base/poco/XML/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
+
 # Poco::XML (expat)
 
 file (GLOB SRCS_EXPAT src/xml*.c)

--- a/base/poco/XML/CMakeLists.txt
+++ b/base/poco/XML/CMakeLists.txt
@@ -39,6 +39,7 @@ target_compile_options (_poco_xml
         -Wno-suggest-destructor-override
         -Wno-suggest-override
         -Wno-tautological-type-limit-compare
+        -Wno-tautological-unsigned-zero-compare
         -Wno-unreachable-code
         -Wno-unused-macros
         -Wno-unused-parameter

--- a/base/poco/XML/CMakeLists.txt
+++ b/base/poco/XML/CMakeLists.txt
@@ -1,12 +1,20 @@
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
-
 # Poco::XML (expat)
 
 file (GLOB SRCS_EXPAT src/xml*.c)
 
 add_library (_poco_xml_expat ${SRCS_EXPAT})
 add_library (Poco::XML::Expat ALIAS _poco_xml_expat)
+
+# TODO: remove these warning exclusions
+target_compile_options (_poco_xml_expat
+    PRIVATE
+        -Wno-cast-qual
+        -Wno-empty-translation-unit
+        -Wno-extra-semi-stmt
+        -Wno-implicit-fallthrough
+        -Wno-reserved-identifier
+        -Wno-unused-macros
+)
 
 target_include_directories (_poco_xml_expat PUBLIC "include")
 target_include_directories (_poco_xml_expat PRIVATE "../Foundation/include")
@@ -17,6 +25,24 @@ file (GLOB SRCS src/*.cpp)
 add_library (_poco_xml ${SRCS})
 add_library (Poco::XML ALIAS _poco_xml)
 
-target_compile_options (_poco_xml PRIVATE -Wno-old-style-cast)
+# TODO: remove these warning exclusions
+target_compile_options (_poco_xml
+    PRIVATE
+        -Wno-cast-qual
+        -Wno-deprecated-dynamic-exception-spec
+        -Wno-implicit-fallthrough
+        -Wno-missing-noreturn
+        -Wno-old-style-cast
+        -Wno-reserved-identifier
+        -Wno-shadow
+        -Wno-shorten-64-to-32
+        -Wno-suggest-destructor-override
+        -Wno-suggest-override
+        -Wno-tautological-type-limit-compare
+        -Wno-unreachable-code
+        -Wno-unused-macros
+        -Wno-unused-parameter
+        -Wno-zero-as-null-pointer-constant
+)
 target_include_directories (_poco_xml SYSTEM PUBLIC "include")
 target_link_libraries (_poco_xml PUBLIC Poco::Foundation Poco::XML::Expat)

--- a/base/poco/XML/include/Poco/XML/expat.h
+++ b/base/poco/XML/include/Poco/XML/expat.h
@@ -7,33 +7,33 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
    Copyright (c) 2000-2005 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
    Copyright (c) 2001-2002 Greg Stein <gstein@users.sourceforge.net>
    Copyright (c) 2002-2016 Karl Waclawek <karl@waclawek.net>
    Copyright (c) 2016-2022 Sebastian Pipping <sebastian@pipping.org>
-   Copyright (c) 2016      Cristian Rodríguez <crrodriguez@opensuse.org>
-   Copyright (c) 2016      Thomas Beutlich <tc@tbeu.de>
-   Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
-   Copyright (c) 2022      Thijs Schreijer <thijs@thijsschreijer.nl>
+   Copyright (c) 2016 Cristian Rodríguez <crrodriguez@opensuse.org>
+   Copyright (c) 2016 Thomas Beutlich <tc@tbeu.de>
+   Copyright (c) 2017 Rhodri James <rhodri@wildebeest.org.uk>
+   Copyright (c) 2022 Thijs Schreijer <thijs@thijsschreijer.nl>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/include/Poco/XML/expat_external.h
+++ b/base/poco/XML/include/Poco/XML/expat_external.h
@@ -7,32 +7,32 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
    Copyright (c) 2000-2004 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
    Copyright (c) 2001-2002 Greg Stein <gstein@users.sourceforge.net>
    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
-   Copyright (c) 2016      Cristian Rodríguez <crrodriguez@opensuse.org>
+   Copyright (c) 2016 Cristian Rodríguez <crrodriguez@opensuse.org>
    Copyright (c) 2016-2019 Sebastian Pipping <sebastian@pipping.org>
-   Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
-   Copyright (c) 2018      Yury Gribov <tetra2005@gmail.com>
+   Copyright (c) 2017 Rhodri James <rhodri@wildebeest.org.uk>
+   Copyright (c) 2018 Yury Gribov <tetra2005@gmail.com>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/ascii.h
+++ b/base/poco/XML/src/ascii.h
@@ -7,28 +7,28 @@
                                  |_| XML parser
 
    Copyright (c) 1999-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
-   Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
-   Copyright (c) 2007      Karl Waclawek <karl@waclawek.net>
-   Copyright (c) 2017      Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2002 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+   Copyright (c) 2007 Karl Waclawek <karl@waclawek.net>
+   Copyright (c) 2017 Sebastian Pipping <sebastian@pipping.org>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/asciitab.h
+++ b/base/poco/XML/src/asciitab.h
@@ -7,27 +7,27 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
-   Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
-   Copyright (c) 2017      Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2002 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+   Copyright (c) 2017 Sebastian Pipping <sebastian@pipping.org>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/iasciitab.h
+++ b/base/poco/XML/src/iasciitab.h
@@ -7,27 +7,27 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
-   Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
-   Copyright (c) 2017      Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2002 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+   Copyright (c) 2017 Sebastian Pipping <sebastian@pipping.org>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/internal.h
+++ b/base/poco/XML/src/internal.h
@@ -27,28 +27,28 @@
 
    Copyright (c) 2002-2003 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
-   Copyright (c) 2003      Greg Stein <gstein@users.sourceforge.net>
+   Copyright (c) 2003 Greg Stein <gstein@users.sourceforge.net>
    Copyright (c) 2016-2021 Sebastian Pipping <sebastian@pipping.org>
-   Copyright (c) 2018      Yury Gribov <tetra2005@gmail.com>
-   Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
+   Copyright (c) 2018 Yury Gribov <tetra2005@gmail.com>
+   Copyright (c) 2019 David Loffredo <loffredo@steptools.com>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/latin1tab.h
+++ b/base/poco/XML/src/latin1tab.h
@@ -7,27 +7,27 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
-   Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
-   Copyright (c) 2017      Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2002 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+   Copyright (c) 2017 Sebastian Pipping <sebastian@pipping.org>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/nametab.h
+++ b/base/poco/XML/src/nametab.h
@@ -10,22 +10,22 @@
    Copyright (c) 2017 Sebastian Pipping <sebastian@pipping.org>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/utf8tab.h
+++ b/base/poco/XML/src/utf8tab.h
@@ -7,27 +7,27 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
-   Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
-   Copyright (c) 2017      Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2002 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+   Copyright (c) 2017 Sebastian Pipping <sebastian@pipping.org>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/xmlparse.cpp
+++ b/base/poco/XML/src/xmlparse.cpp
@@ -7,52 +7,52 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
    Copyright (c) 2000-2006 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
    Copyright (c) 2001-2002 Greg Stein <gstein@users.sourceforge.net>
    Copyright (c) 2002-2016 Karl Waclawek <karl@waclawek.net>
    Copyright (c) 2005-2009 Steven Solie <steven@solie.ca>
-   Copyright (c) 2016      Eric Rahm <erahm@mozilla.com>
+   Copyright (c) 2016 Eric Rahm <erahm@mozilla.com>
    Copyright (c) 2016-2022 Sebastian Pipping <sebastian@pipping.org>
-   Copyright (c) 2016      Gaurav <g.gupta@samsung.com>
-   Copyright (c) 2016      Thomas Beutlich <tc@tbeu.de>
-   Copyright (c) 2016      Gustavo Grieco <gustavo.grieco@imag.fr>
-   Copyright (c) 2016      Pascal Cuoq <cuoq@trust-in-soft.com>
-   Copyright (c) 2016      Ed Schouten <ed@nuxi.nl>
+   Copyright (c) 2016 Gaurav <g.gupta@samsung.com>
+   Copyright (c) 2016 Thomas Beutlich <tc@tbeu.de>
+   Copyright (c) 2016 Gustavo Grieco <gustavo.grieco@imag.fr>
+   Copyright (c) 2016 Pascal Cuoq <cuoq@trust-in-soft.com>
+   Copyright (c) 2016 Ed Schouten <ed@nuxi.nl>
    Copyright (c) 2017-2018 Rhodri James <rhodri@wildebeest.org.uk>
-   Copyright (c) 2017      Václav Slavík <vaclav@slavik.io>
-   Copyright (c) 2017      Viktor Szakats <commit@vsz.me>
-   Copyright (c) 2017      Chanho Park <chanho61.park@samsung.com>
-   Copyright (c) 2017      Rolf Eike Beer <eike@sf-mail.de>
-   Copyright (c) 2017      Hans Wennborg <hans@chromium.org>
-   Copyright (c) 2018      Anton Maklakov <antmak.pub@gmail.com>
-   Copyright (c) 2018      Benjamin Peterson <benjamin@python.org>
-   Copyright (c) 2018      Marco Maggi <marco.maggi-ipsu@poste.it>
-   Copyright (c) 2018      Mariusz Zaborski <oshogbo@vexillium.org>
-   Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
+   Copyright (c) 2017 Václav Slavík <vaclav@slavik.io>
+   Copyright (c) 2017 Viktor Szakats <commit@vsz.me>
+   Copyright (c) 2017 Chanho Park <chanho61.park@samsung.com>
+   Copyright (c) 2017 Rolf Eike Beer <eike@sf-mail.de>
+   Copyright (c) 2017 Hans Wennborg <hans@chromium.org>
+   Copyright (c) 2018 Anton Maklakov <antmak.pub@gmail.com>
+   Copyright (c) 2018 Benjamin Peterson <benjamin@python.org>
+   Copyright (c) 2018 Marco Maggi <marco.maggi-ipsu@poste.it>
+   Copyright (c) 2018 Mariusz Zaborski <oshogbo@vexillium.org>
+   Copyright (c) 2019 David Loffredo <loffredo@steptools.com>
    Copyright (c) 2019-2020 Ben Wagner <bungeman@chromium.org>
-   Copyright (c) 2019      Vadim Zeitlin <vadim@zeitlins.org>
-   Copyright (c) 2021      Dong-hee Na <donghee.na@python.org>
-   Copyright (c) 2022      Samanta Navarro <ferivoz@riseup.net>
-   Copyright (c) 2022      Jeffrey Walton <noloader@gmail.com>
+   Copyright (c) 2019 Vadim Zeitlin <vadim@zeitlins.org>
+   Copyright (c) 2021 Dong-hee Na <donghee.na@python.org>
+   Copyright (c) 2022 Samanta Navarro <ferivoz@riseup.net>
+   Copyright (c) 2022 Jeffrey Walton <noloader@gmail.com>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/xmlrole.h
+++ b/base/poco/XML/src/xmlrole.h
@@ -7,28 +7,28 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
-   Copyright (c) 2002      Karl Waclawek <karl@waclawek.net>
-   Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
-   Copyright (c) 2017      Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2002 Karl Waclawek <karl@waclawek.net>
+   Copyright (c) 2002 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+   Copyright (c) 2017 Sebastian Pipping <sebastian@pipping.org>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/xmltok.h
+++ b/base/poco/XML/src/xmltok.h
@@ -7,29 +7,29 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
-   Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2002 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
    Copyright (c) 2002-2005 Karl Waclawek <karl@waclawek.net>
    Copyright (c) 2016-2017 Sebastian Pipping <sebastian@pipping.org>
-   Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
+   Copyright (c) 2017 Rhodri James <rhodri@wildebeest.org.uk>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/base/poco/XML/src/xmltok_impl.h
+++ b/base/poco/XML/src/xmltok_impl.h
@@ -7,26 +7,26 @@
                                  |_| XML parser
 
    Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
-   Copyright (c) 2000      Clark Cooper <coopercc@users.sourceforge.net>
+   Copyright (c) 2000 Clark Cooper <coopercc@users.sourceforge.net>
    Copyright (c) 2017-2019 Sebastian Pipping <sebastian@pipping.org>
    Licensed under the MIT license:
 
-   Permission is  hereby granted,  free of charge,  to any  person obtaining
-   a  copy  of  this  software   and  associated  documentation  files  (the
-   "Software"),  to  deal in  the  Software  without restriction,  including
-   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
    distribute, sublicense, and/or sell copies of the Software, and to permit
-   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   persons to whom the Software is furnished to do so, subject to the
    following conditions:
 
-   The above copyright  notice and this permission notice  shall be included
+   The above copyright notice and this permission notice shall be included
    in all copies or substantial portions of the Software.
 
-   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
-   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/utils/check-style/check-whitespaces
+++ b/utils/check-style/check-whitespaces
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ROOT_PATH=$(git rev-parse --show-toplevel)
-EXCLUDE_DIRS='build/|integration/|widechar_width/|glibc-compatibility/|poco/|memcpy/|consistent-hashing/|Parsers/New'
+EXCLUDE_DIRS='build/|integration/|widechar_width/|glibc-compatibility/|memcpy/|consistent-hashing/|Parsers/New'
 
 # Double whitespaces
 find $ROOT_PATH/{src,base,programs,utils} -name '*.h' -or -name '*.cpp' 2>/dev/null |


### PR DESCRIPTION
This is follow-up to #46075, also see #46076.

This PR
- Replaces the global warning suppression that previously existed for poco by fine-granular suppressions. Actually fixing the warnings is future work.
- Fixes double  whitespaces in poco and removes "poco" from the whitespace checker exclude list

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)