### PR TITLE
Fix dependency checks

### DIFF
--- a/src/Databases/DDLDependencyVisitor.cpp
+++ b/src/Databases/DDLDependencyVisitor.cpp
@@ -360,7 +360,7 @@ namespace
                 return {};
 
             auto table = tryGetStringFromArgument(function, table_arg_idx);
-            if (!table)
+            if (!table || table->empty())
                 return {};
 
             QualifiedTableName qualified_name;

--- a/src/Databases/DDLDependencyVisitor.cpp
+++ b/src/Databases/DDLDependencyVisitor.cpp
@@ -183,10 +183,11 @@ namespace
                 /// joinGet(join_storage_table_name, `value_column`, join_keys)
                 addQualifiedNameFromArgument(function, 0);
             }
-            else if (function.name == "in" || function.name == "notIn" || function.name == "globalIn" || function.name == "globalNotIn")
+            else if (functionIsInOrGlobalInOperator(function.name))
             {
-                /// in(x, table_name) - function for evaluating (x IN table_name)
-                addQualifiedNameFromArgument(function, 1);
+                /// x IN table_name.
+                /// We set evaluate=false here because we don't want to evaluate a subquery in "x IN subquery".
+                addQualifiedNameFromArgument(function, 1, /* evaluate= */ false);
             }
             else if (function.name == "dictionary")
             {
@@ -248,7 +249,10 @@ namespace
 
             if (has_local_replicas && !table_function)
             {
-                auto maybe_qualified_name = tryGetQualifiedNameFromArgument(function, 1, /* apply_current_database= */ false);
+                /// We set `apply_current_database=false` here because if this argument is an identifier without dot,
+                /// then it's not the name of a table within the current database, it's the name of a database, and
+                /// the name of a table will be in the following argument.
+                auto maybe_qualified_name = tryGetQualifiedNameFromArgument(function, 1, /* evaluate= */ true, /* apply_current_database= */ false);
                 if (!maybe_qualified_name)
                     return;
                 auto & qualified_name = *maybe_qualified_name;
@@ -271,7 +275,7 @@ namespace
         }
 
         /// Gets an argument as a string, evaluates constants if necessary.
-        std::optional<String> tryGetStringFromArgument(const ASTFunction & function, size_t arg_idx) const
+        std::optional<String> tryGetStringFromArgument(const ASTFunction & function, size_t arg_idx, bool evaluate = true) const
         {
             if (!function.arguments)
                 return {};
@@ -281,28 +285,41 @@ namespace
                 return {};
 
             const auto & arg = args[arg_idx];
-            ASTPtr evaluated;
 
-            try
+            if (evaluate)
             {
-                evaluated = evaluateConstantExpressionOrIdentifierAsLiteral(arg, context);
+                try
+                {
+                    /// We're just searching for dependencies here, it's not safe to execute subqueries now.
+                    auto evaluated = evaluateConstantExpressionOrIdentifierAsLiteral(arg, context);
+                    const auto * literal = evaluated->as<ASTLiteral>();
+                    if (!literal || (literal->value.getType() != Field::Types::String))
+                        return {};
+                    return literal->value.safeGet<String>();
+                }
+                catch (...)
+                {
+                    return {};
+                }
             }
-            catch (...)
+            else
             {
+                if (const auto * id = arg->as<ASTIdentifier>())
+                    return id->name();
+                if (const auto * literal = arg->as<ASTLiteral>())
+                {
+                    if (literal->value.getType() == Field::Types::String)
+                        return literal->value.safeGet<String>();
+                }
                 return {};
             }
-
-            const auto * literal = evaluated->as<ASTLiteral>();
-            if (!literal || (literal->value.getType() != Field::Types::String))
-                return {};
-            return literal->value.safeGet<String>();
         }
 
         /// Gets an argument as a qualified table name.
         /// Accepts forms db_name.table_name (as an identifier) and 'db_name.table_name' (as a string).
         /// The function doesn't replace an empty database name with the current_database (the caller must do that).
-        std::optional<QualifiedTableName>
-        tryGetQualifiedNameFromArgument(const ASTFunction & function, size_t arg_idx, bool apply_current_database = true) const
+        std::optional<QualifiedTableName> tryGetQualifiedNameFromArgument(
+            const ASTFunction & function, size_t arg_idx, bool evaluate = true, bool apply_current_database = true) const
         {
             if (!function.arguments)
                 return {};
@@ -326,7 +343,7 @@ namespace
             }
             else
             {
-                auto qualified_name_as_string = tryGetStringFromArgument(function, arg_idx);
+                auto qualified_name_as_string = tryGetStringFromArgument(function, arg_idx, evaluate);
                 if (!qualified_name_as_string)
                     return {};
 
@@ -345,9 +362,9 @@ namespace
 
         /// Adds a qualified table name from an argument to the collection of dependencies.
         /// Accepts forms db_name.table_name (as an identifier) and 'db_name.table_name' (as a string).
-        void addQualifiedNameFromArgument(const ASTFunction & function, size_t arg_idx)
+        void addQualifiedNameFromArgument(const ASTFunction & function, size_t arg_idx, bool evaluate = true)
         {
-            if (auto qualified_name = tryGetQualifiedNameFromArgument(function, arg_idx))
+            if (auto qualified_name = tryGetQualifiedNameFromArgument(function, arg_idx, evaluate))
                 dependencies.emplace(std::move(qualified_name).value());
         }
 

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1331,23 +1331,16 @@ def test_tables_dependency():
     instance.query("CREATE DATABASE test2")
 
     # For this test we use random names of tables to check they're created according to their dependency (not just in alphabetic order).
-    random_table_names = [f"{chr(ord('A')+i)}" for i in range(0, 10)]
+    random_table_names = [f"{chr(ord('A')+i)}" for i in range(0, 15)]
     random.shuffle(random_table_names)
     random_table_names = [
         random.choice(["test", "test2"]) + "." + table_name
         for table_name in random_table_names
     ]
     print(f"random_table_names={random_table_names}")
-
-    t1 = random_table_names[0]
-    t2 = random_table_names[1]
-    t3 = random_table_names[2]
-    t4 = random_table_names[3]
-    t5 = random_table_names[4]
-    t6 = random_table_names[5]
-    t7 = random_table_names[6]
-    t8 = random_table_names[7]
-    t9 = random_table_names[8]
+    t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15 = tuple(
+        random_table_names
+    )
 
     # Create a materialized view and a dictionary with a local table as source.
     instance.query(
@@ -1373,11 +1366,34 @@ def test_tables_dependency():
     instance.query(f"CREATE VIEW {t7} AS SELECT sum(x) FROM (SELECT x FROM {t6})")
 
     instance.query(
-        f"CREATE TABLE {t8} AS {t2} ENGINE = Buffer({t2.split('.')[0]}, {t2.split('.')[1]}, 16, 10, 100, 10000, 1000000, 10000000, 100000000)"
+        f"CREATE DICTIONARY {t8} (x Int64, y String) PRIMARY KEY x SOURCE(CLICKHOUSE(TABLE '{t1.split('.')[1]}' DB '{t1.split('.')[0]}')) LAYOUT(FLAT()) LIFETIME(9)"
+    )
+
+    instance.query(f"CREATE TABLE {t9}(a Int64) ENGINE=Log")
+
+    instance.query(
+        f"CREATE VIEW {t10}(x Int64, y String) AS SELECT * FROM {t1} WHERE x IN {t9}"
     )
 
     instance.query(
-        f"CREATE DICTIONARY {t9} (x Int64, y String) PRIMARY KEY x SOURCE(CLICKHOUSE(TABLE '{t1.split('.')[1]}' DB '{t1.split('.')[0]}')) LAYOUT(FLAT()) LIFETIME(9)"
+        f"CREATE VIEW {t11}(x Int64, y String) AS SELECT * FROM {t2} WHERE x NOT IN (SELECT a FROM {t9})"
+    )
+
+    instance.query(
+        f"CREATE TABLE {t12} AS {t1} ENGINE = Buffer({t2.split('.')[0]}, {t2.split('.')[1]}, 16, 10, 100, 10000, 1000000, 10000000, 100000000)"
+    )
+
+    instance.query(
+        f"CREATE TABLE {t13} AS {t1} ENGINE = Buffer((SELECT '{t2.split('.')[0]}'), (SELECT '{t2.split('.')[1]}'), 16, 10, 100, 10000, 1000000, 10000000, 100000000)"
+    )
+
+    instance.query(
+        f"CREATE TABLE {t14} AS {t1} ENGINE = Buffer('', {t2.split('.')[1]}, 16, 10, 100, 10000, 1000000, 10000000, 100000000)",
+        database=t2.split(".")[0],
+    )
+
+    instance.query(
+        f"CREATE TABLE {t15} AS {t1} ENGINE = Buffer('', '', 16, 10, 100, 10000, 1000000, 10000000, 100000000)"
     )
 
     # Make backup.
@@ -1386,8 +1402,14 @@ def test_tables_dependency():
 
     # Drop everything in reversive order.
     def drop():
-        instance.query(f"DROP DICTIONARY {t9}")
-        instance.query(f"DROP TABLE {t8} NO DELAY")
+        instance.query(f"DROP TABLE {t15} NO DELAY")
+        instance.query(f"DROP TABLE {t14} NO DELAY")
+        instance.query(f"DROP TABLE {t13} NO DELAY")
+        instance.query(f"DROP TABLE {t12} NO DELAY")
+        instance.query(f"DROP TABLE {t11} NO DELAY")
+        instance.query(f"DROP TABLE {t10} NO DELAY")
+        instance.query(f"DROP TABLE {t9} NO DELAY")
+        instance.query(f"DROP DICTIONARY {t8}")
         instance.query(f"DROP TABLE {t7} NO DELAY")
         instance.query(f"DROP TABLE {t6} NO DELAY")
         instance.query(f"DROP TABLE {t5} NO DELAY")
@@ -1406,7 +1428,7 @@ def test_tables_dependency():
     # Check everything is restored.
     assert instance.query(
         "SELECT concat(database, '.', name) AS c FROM system.tables WHERE database IN ['test', 'test2'] ORDER BY c"
-    ) == TSV(sorted([t1, t2, t3, t4, t5, t6, t7, t8, t9]))
+    ) == TSV(sorted(random_table_names))
 
     # Check logs.
     instance.query("SYSTEM FLUSH LOGS")
@@ -1421,8 +1443,20 @@ def test_tables_dependency():
         f"Table {t5} has 1 dependencies: {t4} (level 2)",
         f"Table {t6} has 1 dependencies: {t4} (level 2)",
         f"Table {t7} has 1 dependencies: {t6} (level 3)",
-        f"Table {t8} has 1 dependencies: {t2} (level 1)",
-        f"Table {t9} has 1 dependencies: {t1} (level 1)",
+        f"Table {t8} has 1 dependencies: {t1} (level 1)",
+        f"Table {t9} has no dependencies (level 0)",
+        (
+            f"Table {t10} has 2 dependencies: {t1}, {t9} (level 1)",
+            f"Table {t10} has 2 dependencies: {t9}, {t1} (level 1)",
+        ),
+        (
+            f"Table {t11} has 2 dependencies: {t2}, {t9} (level 1)",
+            f"Table {t11} has 2 dependencies: {t9}, {t2} (level 1)",
+        ),
+        f"Table {t12} has 1 dependencies: {t2} (level 1)",
+        f"Table {t13} has 1 dependencies: {t2} (level 1)",
+        f"Table {t14} has 1 dependencies: {t2} (level 1)",
+        f"Table {t15} has no dependencies (level 0)",
     ]
     for expect in expect_in_logs:
         assert any(


### PR DESCRIPTION
### Changelog category:
- Not for changelog (changelog entry is not required)

Slightly fix dependency checks for `RESTORE`, add more tests.
`Buffer('', '')` and `col IN subquery` are now handled correctly