### PR TITLE
Interpret `cluster_name` identifier in `s3Cluster` function as literal

### DIFF
--- a/src/TableFunctions/TableFunctionS3Cluster.cpp
+++ b/src/TableFunctions/TableFunctionS3Cluster.cpp
@@ -47,7 +47,7 @@ void TableFunctionS3Cluster::parseArguments(const ASTPtr & ast_function, Context
     ASTs & args = args_func.at(0)->children;
 
     for (auto & arg : args)
-        arg = evaluateConstantExpressionAsLiteral(arg, context);
+        arg = evaluateConstantExpressionOrIdentifierAsLiteral(arg, context);
 
     constexpr auto fmt_string = "The signature of table function {} could be the following:\n"
                                 " - cluster, url\n"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make queries like `SELECT ... FROM s3Cluster(default, ...)` work the same way as the ```SELECT ... FROM s3Cluster(`default`, ...)```