### PR TITLE
fix submodule in contrib dirty

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -238,6 +238,7 @@
 [submodule "contrib/sysroot"]
 	path = contrib/sysroot
 	url = https://github.com/ClickHouse/sysroot
+	ignore = dirty
 [submodule "contrib/nlp-data"]
 	path = contrib/nlp-data
 	url = https://github.com/ClickHouse/nlp-data
@@ -332,7 +333,8 @@
 	url = https://github.com/ClickHouse/s2n-tls
 [submodule "contrib/crc32-vpmsum"]
 	path = contrib/crc32-vpmsum
-	url = https://github.com/antonblanchard/crc32-vpmsum.git
+	url = https://github.com/antonblanchard/crc32-vpmsum
 [submodule "contrib/liburing"]
 	path = contrib/liburing
 	url = https://github.com/axboe/liburing
+	ignore = dirty


### PR DESCRIPTION
Signed-off-by: Lloyd-Pottiger <yan1579196623@gmail.com>

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


When we run `git status`, we always get the following result. This because we have made some modification on submodule. It will bring inconvenience to developers, mark them as `dirty` in `.gitmodules`.
```
% git status              
On branch master
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)
        modified:   contrib/liburing (modified content)
        modified:   contrib/sysroot (modified content)
```

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
