### PR TITLE
Add column partitions in system.query_log to show which partitions are used for each MergeTree table

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1283,8 +1283,12 @@ void Context::addQueryAccessInfo(
         query_access_info.projections.emplace(full_quoted_table_name + "." + backQuoteIfNeed(projection_name));
     if (!view_name.empty())
         query_access_info.views.emplace(view_name);
-    for (const auto & partition_name : partition_names)
-        query_access_info.partitions.emplace(partition_name);
+
+    if (!partition_names.empty())
+    {
+        auto & partitions = query_access_info.partitions[full_quoted_table_name];
+        partitions.insert(partition_names.begin(), partition_names.end());
+    }
 }
 
 void Context::addQueryFactoriesInfo(QueryLogFactories factory_type, const String & created_object) const

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1268,7 +1268,8 @@ void Context::addQueryAccessInfo(
     const String & full_quoted_table_name,
     const Names & column_names,
     const String & projection_name,
-    const String & view_name)
+    const String & view_name,
+    const NameOrderedSet & partition_names)
 {
     if (isGlobalContext())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Global context cannot have query access info");
@@ -1282,6 +1283,8 @@ void Context::addQueryAccessInfo(
         query_access_info.projections.emplace(full_quoted_table_name + "." + backQuoteIfNeed(projection_name));
     if (!view_name.empty())
         query_access_info.views.emplace(view_name);
+    for (const auto & partition_name : partition_names)
+        query_access_info.partitions.emplace(partition_name);
 }
 
 void Context::addQueryFactoriesInfo(QueryLogFactories factory_type, const String & created_object) const

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1269,7 +1269,8 @@ void Context::addQueryAccessInfo(
     const Names & column_names,
     const String & projection_name,
     const String & view_name,
-    const NameOrderedSet & partition_names)
+    const NameOrderedSet & partition_names,
+    UInt8 is_index_by_date)
 {
     if (isGlobalContext())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Global context cannot have query access info");
@@ -1289,6 +1290,7 @@ void Context::addQueryAccessInfo(
         auto & partitions = query_access_info.partitions[full_quoted_table_name];
         partitions.insert(partition_names.begin(), partition_names.end());
     }
+    query_access_info.is_index_by_dates[full_quoted_table_name] = is_index_by_date;
 }
 
 void Context::addQueryFactoriesInfo(QueryLogFactories factory_type, const String & created_object) const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -285,6 +285,7 @@ private:
             projections = rhs.projections;
             views = rhs.views;
             partitions = rhs.partitions;
+            is_index_by_dates = rhs.is_index_by_dates;
         }
 
         QueryAccessInfo(QueryAccessInfo && rhs) = delete;
@@ -303,6 +304,7 @@ private:
             std::swap(projections, rhs.projections);
             std::swap(views, rhs.views);
             std::swap(partitions, rhs.partitions);
+            std::swap(is_index_by_dates, rhs.is_index_by_dates);
         }
 
         /// To prevent a race between copy-constructor and other uses of this structure.
@@ -314,6 +316,7 @@ private:
         std::set<std::string> views{};
         /// Key: full table name
         std::map<std::string, NameOrderedSet> partitions{};
+        std::map<std::string, UInt8> is_index_by_dates{};
     };
 
     QueryAccessInfo query_access_info;
@@ -613,7 +616,8 @@ public:
         const Names & column_names,
         const String & projection_name = {},
         const String & view_name = {},
-        const NameOrderedSet & partition_names = {});
+        const NameOrderedSet & partition_names = {},
+        UInt8 is_index_by_date = 0);
 
 
     /// Supported factories for records in query_log

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -284,6 +284,7 @@ private:
             columns = rhs.columns;
             projections = rhs.projections;
             views = rhs.views;
+            partitions = rhs.partitions;
         }
 
         QueryAccessInfo(QueryAccessInfo && rhs) = delete;
@@ -301,6 +302,7 @@ private:
             std::swap(columns, rhs.columns);
             std::swap(projections, rhs.projections);
             std::swap(views, rhs.views);
+            std::swap(partitions, rhs.partitions);
         }
 
         /// To prevent a race between copy-constructor and other uses of this structure.
@@ -310,6 +312,8 @@ private:
         std::set<std::string> columns{};
         std::set<std::string> projections{};
         std::set<std::string> views{};
+        /// Key: full table name
+        std::map<std::string, NameOrderedSet> partitions{};
     };
 
     QueryAccessInfo query_access_info;
@@ -608,7 +612,8 @@ public:
         const String & full_quoted_table_name,
         const Names & column_names,
         const String & projection_name = {},
-        const String & view_name = {});
+        const String & view_name = {},
+        const NameOrderedSet & partition_names = {});
 
 
     /// Supported factories for records in query_log

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2350,12 +2350,14 @@ void InterpreterSelectQuery::executeFetchColumns(QueryProcessingStage::Enum proc
         {
             const String view_name{};
             auto local_storage_id = storage->getStorageID();
+            auto full_table_name = local_storage_id.getFullTableName();
             context->getQueryContext()->addQueryAccessInfo(
                 backQuoteIfNeed(local_storage_id.getDatabaseName()),
-                local_storage_id.getFullTableName(),
+                full_table_name,
                 required_columns,
                 query_info.projection ? query_info.projection->desc->name : "",
-                view_name);
+                view_name,
+                query_info.query_partitions[full_table_name]);
         }
 
         /// Create step which reads from empty source if storage has no data.

--- a/src/Interpreters/QueryLog.cpp
+++ b/src/Interpreters/QueryLog.cpp
@@ -202,7 +202,7 @@ void QueryLogElement::appendToBlock(MutableColumns & columns) const
         auto & column_full_table = column_tuple.getColumn(0);
         auto & column_partition_array = column_tuple.getColumn(1);
 
-        auto fill_column = [](const std::unordered_map<String, NameOrderedSet> & data,
+        auto fill_column = [](const std::map<String, NameOrderedSet> & data,
                              IColumn & column_key,
                              ColumnArray & column_values,
                              IColumn::Offsets & column_offsets)

--- a/src/Interpreters/QueryLog.h
+++ b/src/Interpreters/QueryLog.h
@@ -67,6 +67,7 @@ struct QueryLogElement
     std::set<String> query_views;
     /// Key: full table name
     std::map<String, NameOrderedSet> query_partitions;
+    std::map<String, UInt8> query_is_index_by_dates;
 
     std::unordered_set<String> used_aggregate_functions;
     std::unordered_set<String> used_aggregate_function_combinators;

--- a/src/Interpreters/QueryLog.h
+++ b/src/Interpreters/QueryLog.h
@@ -65,8 +65,8 @@ struct QueryLogElement
     std::set<String> query_columns;
     std::set<String> query_projections;
     std::set<String> query_views;
-    /// Key: db.table
-    std::unordered_map<String, std::unordered_set<String>> query_partitions;
+    /// Key: full table name
+    std::map<String, NameOrderedSet> query_partitions;
 
     std::unordered_set<String> used_aggregate_functions;
     std::unordered_set<String> used_aggregate_function_combinators;

--- a/src/Interpreters/QueryLog.h
+++ b/src/Interpreters/QueryLog.h
@@ -65,6 +65,8 @@ struct QueryLogElement
     std::set<String> query_columns;
     std::set<String> query_projections;
     std::set<String> query_views;
+    /// Key: db.table
+    std::unordered_map<String, std::unordered_set<String>> query_partitions;
 
     std::unordered_set<String> used_aggregate_functions;
     std::unordered_set<String> used_aggregate_function_combinators;

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -862,6 +862,18 @@ void MergeTreeDataSelectExecutor::filterPartsByPartition(
             .num_parts_after = part_filter_counters.num_parts_after_partition_pruner,
             .num_granules_after = part_filter_counters.num_granules_after_partition_pruner});
     }
+
+    auto storage_id = data.getStorageID();
+    auto full_table_name = storage_id.getFullTableName();
+    auto & query_partitions = query_info.query_partitions[full_table_name];
+    for (const auto & part: parts)
+    {
+        const auto & partition = part->partition;
+        WriteBufferFromOwnString buf;
+        partition.serializeText(data, buf, FormatSettings{});
+
+        query_partitions.emplace(buf.str());
+    }
 }
 
 RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipIndexes(

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -212,6 +212,8 @@ struct SelectQueryInfo
 
     /// Key: full table name
     mutable std::map<String, NameOrderedSet> query_partitions;
+    mutable std::map<String, UInt8> is_index_by_dates;
+
 
     TreeRewriterResultPtr syntax_analyzer_result;
 

--- a/src/Storages/SelectQueryInfo.h
+++ b/src/Storages/SelectQueryInfo.h
@@ -210,6 +210,9 @@ struct SelectQueryInfo
 
     mutable ParallelReplicasReadingCoordinatorPtr coordinator;
 
+    /// Key: full table name
+    mutable std::map<String, NameOrderedSet> query_partitions;
+
     TreeRewriterResultPtr syntax_analyzer_result;
 
     /// This is an additional filer applied to current table.


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add column partitions in system.query_log to show which partitions are used for each MergeTree table
