### PR TITLE
Complain about missing Yasm at configure time at of build time

### DIFF
--- a/contrib/libhdfs3-cmake/CMakeLists.txt
+++ b/contrib/libhdfs3-cmake/CMakeLists.txt
@@ -105,6 +105,9 @@ set(SRCS
 
 if (ARCH_AMD64)
     find_program(YASM_PATH NAMES yasm)
+    if (NOT YASM_PATH)
+        message(FATAL_ERROR "Please install the Yasm assembler")
+    endif ()
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crc_iscsi_v_pcl.o
         COMMAND ${YASM_PATH} -f x64 -f elf64 -X gnu -g dwarf2 -D LINUX -o ${CMAKE_CURRENT_BINARY_DIR}/crc_iscsi_v_pcl.o ${HDFS3_SOURCE_DIR}/common/crc_iscsi_v_pcl.asm


### PR DESCRIPTION
I made a local build with ENABLE_LIBRARIES=1 and got funny errors at build time about yasm was not found. Running this check now earlier during CMake configure.

Follow-up to #44949

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)