### PR TITLE
IBM's s390x architecture: Issue #2053 - conversion of 256 bit to 128 bit

### DIFF
--- a/base/base/wide_integer_impl.h
+++ b/base/base/wide_integer_impl.h
@@ -360,7 +360,7 @@ struct integer<Bits, Signed>::_impl
         constexpr const unsigned to_copy = min_bits / base_bits;
 
         for (unsigned i = 0; i < to_copy; ++i)
-            self.items[little(i)] = rhs.items[little(i)];
+            self.items[little(i)] = rhs.items[integer<Bits2, Signed2>::_impl::little(i)];
 
         if constexpr (Bits > Bits2)
         {


### PR DESCRIPTION
In method `writeDecimalFractional()` in src/IO/WriteHelpers.h, the following function has conversion issue when converting 256 bit to 128 bit:

`void writeDecimalFractional(const T & x, UInt32 scale, WriteBuffer & ostr, bool trailing_zeros)`
This method  calls wide_integer_from_wide_integer() in base/base/wide_integer_impl.h
`wide_integer_from_wide_integer()` doesn't work on big-endian machine which results an output of `0.0`

Fix:
- casted the variable to `integer<Bits2, Signed2>` which  resulted in the expected output


### Changelog category (leave one):
Build Improvement

### Changelog entry:
Fixed Functional Test 00900_long_parquet for S390x

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
