### PR TITLE
Prefer explicitly defined credentials for S3

### DIFF
--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -599,7 +599,13 @@ public:
     {
         auto * logger = &Poco::Logger::get("S3CredentialsProviderChain");
 
-        if (use_environment_credentials)
+        /// add explicit credentials to the front of the chain
+        /// because it's manually defined by the user
+        if (!credentials.IsEmpty())
+        {
+            AddProvider(std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(credentials));
+        }
+        else if (use_environment_credentials)
         {
             static const char AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI[] = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
             static const char AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI[] = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
@@ -693,7 +699,6 @@ public:
             }
         }
 
-        AddProvider(std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(credentials));
         /// Quite verbose provider (argues if file with credentials doesn't exist) so iut's the last one
         /// in chain.
         AddProvider(std::make_shared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>());

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -604,8 +604,10 @@ public:
         if (!credentials.IsEmpty())
         {
             AddProvider(std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(credentials));
+            return;
         }
-        else if (use_environment_credentials)
+
+        if (use_environment_credentials)
         {
             static const char AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI[] = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
             static const char AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI[] = "AWS_CONTAINER_CREDENTIALS_FULL_URI";

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1715,10 +1715,12 @@ def test_environment_credentials(started_cluster):
     # manually defined access key should override from env
     with pytest.raises(helpers.client.QueryRuntimeException) as ei:
         instance.query(
-                f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl', 'aws', 'aws123')")
+            f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl', 'aws', 'aws123')"
+        )
 
         assert ei.value.returncode == 243
         assert "HTTP response code: 403" in ei.value.stderr
+
 
 def test_s3_list_objects_failure(started_cluster):
     bucket = started_cluster.minio_bucket

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -1699,7 +1699,6 @@ def test_ast_auth_headers(started_cluster):
 
 
 def test_environment_credentials(started_cluster):
-    filename = "test.csv"
     bucket = started_cluster.minio_restricted_bucket
 
     instance = started_cluster.instances["s3_with_environment_credentials"]
@@ -1713,6 +1712,13 @@ def test_environment_credentials(started_cluster):
         ).strip()
     )
 
+    # manually defined access key should override from env
+    with pytest.raises(helpers.client.QueryRuntimeException) as ei:
+        instance.query(
+                f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl', 'aws', 'aws123')")
+
+        assert ei.value.returncode == 243
+        assert "HTTP response code: 403" in ei.value.stderr
 
 def test_s3_list_objects_failure(started_cluster):
     bucket = started_cluster.minio_bucket

--- a/tests/integration/test_storage_s3/test_invalid_env_credentials.py
+++ b/tests/integration/test_storage_s3/test_invalid_env_credentials.py
@@ -1,0 +1,126 @@
+import json
+import os
+import logging
+
+import helpers.client
+from helpers.mock_servers import start_mock_servers
+import pytest
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
+
+MINIO_INTERNAL_PORT = 9001
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+# Creates S3 bucket for tests and allows anonymous read-write access to it.
+def prepare_s3_bucket(started_cluster):
+    # Allows read-write access for bucket without authorization.
+    bucket_read_write_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "s3:GetBucketLocation",
+                "Resource": "arn:aws:s3:::root",
+            },
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::root",
+            },
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::root/*",
+            },
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "s3:PutObject",
+                "Resource": "arn:aws:s3:::root/*",
+            },
+        ],
+    }
+
+    minio_client = started_cluster.minio_client
+    minio_client.set_bucket_policy(
+        started_cluster.minio_bucket, json.dumps(bucket_read_write_policy)
+    )
+
+    started_cluster.minio_restricted_bucket = "{}-with-auth".format(
+        started_cluster.minio_bucket
+    )
+    if minio_client.bucket_exists(started_cluster.minio_restricted_bucket):
+        minio_client.remove_bucket(started_cluster.minio_restricted_bucket)
+
+    minio_client.make_bucket(started_cluster.minio_restricted_bucket)
+
+def run_s3_mocks(started_cluster):
+    script_dir = os.path.join(os.path.dirname(__file__), "s3_mocks")
+    start_mock_servers(
+        started_cluster,
+        script_dir,
+        [
+            ("mock_s3.py", "resolver", "8080"),
+            ("unstable_server.py", "resolver", "8081"),
+            ("echo.py", "resolver", "8082"),
+            ("no_list_objects.py", "resolver", "8083"),
+        ],
+    )
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "s3_with_invalid_environment_credentials",
+            with_minio=True,
+            env_variables={
+                "AWS_ACCESS_KEY_ID": "aws",
+                "AWS_SECRET_ACCESS_KEY": "aws123",
+            },
+            main_configs=["configs/use_environment_credentials.xml"],
+        )
+
+        logging.info("Starting cluster...")
+        cluster.start()
+        logging.info("Cluster started")
+
+        prepare_s3_bucket(cluster)
+        logging.info("S3 bucket created")
+        run_s3_mocks(cluster)
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def test_with_invalid_environment_credentials(started_cluster):
+    auth = "'minio','minio123'"
+    bucket = started_cluster.minio_restricted_bucket
+
+    instance = started_cluster.instances["s3_with_invalid_environment_credentials"]
+    instance.query(
+        f"insert into function s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl', {auth}) select * from numbers(100) settings s3_truncate_on_insert=1"
+    )
+
+    with pytest.raises(helpers.client.QueryRuntimeException) as ei:
+        instance.query(
+                f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl')")
+
+        assert ei.value.returncode == 243
+        assert "HTTP response code: 403" in ei.value.stderr
+
+    assert (
+        "100"
+        == instance.query(
+            f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl', {auth})"
+        ).strip()
+    )
+
+

--- a/tests/integration/test_storage_s3/test_invalid_env_credentials.py
+++ b/tests/integration/test_storage_s3/test_invalid_env_credentials.py
@@ -61,6 +61,7 @@ def prepare_s3_bucket(started_cluster):
 
     minio_client.make_bucket(started_cluster.minio_restricted_bucket)
 
+
 def run_s3_mocks(started_cluster):
     script_dir = os.path.join(os.path.dirname(__file__), "s3_mocks")
     start_mock_servers(
@@ -73,6 +74,7 @@ def run_s3_mocks(started_cluster):
             ("no_list_objects.py", "resolver", "8083"),
         ],
     )
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -100,6 +102,7 @@ def started_cluster():
     finally:
         cluster.shutdown()
 
+
 def test_with_invalid_environment_credentials(started_cluster):
     auth = "'minio','minio123'"
     bucket = started_cluster.minio_restricted_bucket
@@ -111,7 +114,8 @@ def test_with_invalid_environment_credentials(started_cluster):
 
     with pytest.raises(helpers.client.QueryRuntimeException) as ei:
         instance.query(
-                f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl')")
+            f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl')"
+        )
 
         assert ei.value.returncode == 243
         assert "HTTP response code: 403" in ei.value.stderr
@@ -122,5 +126,3 @@ def test_with_invalid_environment_credentials(started_cluster):
             f"select count() from s3('http://{started_cluster.minio_host}:{started_cluster.minio_port}/{bucket}/test_cache4.jsonl', {auth})"
         ).strip()
     )
-
-


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Prefer explicitly defined access keys for S3 clients. If `use_environment_credentials` is set to `true`, and the user has provided the access key through query or config, they will be used instead of the ones from the environment variable.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
