### PR TITLE
use Meilisearch 1.0 in test

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_meili.yml
+++ b/docker/test/integration/runner/compose/docker_compose_meili.yml
@@ -1,13 +1,13 @@
 version: '2.3'
 services:
     meili1:
-        image: getmeili/meilisearch:v0.27.0 
+        image: getmeili/meilisearch:v1.0
         restart: always
         ports:
             - ${MEILI_EXTERNAL_PORT:-7700}:${MEILI_INTERNAL_PORT:-7700}
 
     meili_secure:
-        image: getmeili/meilisearch:v0.27.0 
+        image: getmeili/meilisearch:v1.0
         restart: always
         ports:
             - ${MEILI_SECURE_EXTERNAL_PORT:-7700}:${MEILI_SECURE_INTERNAL_PORT:-7700}


### PR DESCRIPTION
Meilisearch version 1.0 has been released, we should test against that version

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Meilisearch version 1.0 has been released, we should test against that version

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
Once the tests pass I will
