### PR TITLE
ASTFunction: never rewrite tuple function as literal when formatting

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -1019,7 +1019,8 @@ void ASTFunction::formatImplWithoutAlias(const FormatSettings & settings, Format
 
         if (!written && arguments->children.size() >= 2 && name == "tuple"sv)
         {
-            settings.ostr << (settings.hilite ? hilite_operator : "") << '(' << (settings.hilite ? hilite_none : "");
+            settings.ostr << (settings.hilite ? hilite_operator : "") << ((frame.need_parens && !alias.empty()) ? "tuple" : "") << '('
+                          << (settings.hilite ? hilite_none : "");
             for (size_t i = 0; i < arguments->children.size(); ++i)
             {
                 if (i != 0)

--- a/tests/queries/0_stateless/02560_tuple_format.reference
+++ b/tests/queries/0_stateless/02560_tuple_format.reference
@@ -1,0 +1,4 @@
+SELECT (1, 2, 3)
+SELECT (1, 2, 3) AS x
+SELECT (1, 2, 3).1
+SELECT (tuple(1, 2, 3) AS x).1

--- a/tests/queries/0_stateless/02560_tuple_format.sh
+++ b/tests/queries/0_stateless/02560_tuple_format.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+echo "select (tuple(1, 2, 3));" | "$CLICKHOUSE_FORMAT"
+echo "select (tuple(1, 2, 3) as x);" | "$CLICKHOUSE_FORMAT"
+echo "select (tuple(1, 2, 3)).1;" | "$CLICKHOUSE_FORMAT"
+echo "select (tuple(1, 2, 3) as x).1;" | "$CLICKHOUSE_FORMAT"


### PR DESCRIPTION
It is not always safe to implicitly rewrite a `tuple` function call to a literal. Even when the tuple has more then one element

e.g.
`SELECT (tuple(1, 2))` is not equivalent to `SELECT ((1, 2))`, the latter is interpreted as `SELECT tuple((1, 2))`.

Closes #45197

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Never rewrite tuple functions as literals during formatting to avoid incorrect results.


<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
