### PR TITLE
Make `test_replicated_merge_tree_s3_restore` less flaky

### DIFF
--- a/tests/integration/test_replicated_merge_tree_s3_restore/test.py
+++ b/tests/integration/test_replicated_merge_tree_s3_restore/test.py
@@ -251,7 +251,7 @@ def test_restore_another_bucket_path(cluster, db_atomic, zero_copy):
     node_another_bucket = cluster.instances["node_another_bucket"]
 
     create_restore_file(node_another_bucket, bucket="root")
-    node_another_bucket.restart_clickhouse()
+    node_another_bucket.restart_clickhouse(stop_start_wait_sec=120)
     create_table(
         node_another_bucket, "test", schema, attach=True, db_atomic=db_atomic, uuid=uuid
     )


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/46156/9314c90b0531a49daa4912d4c2137a5cc6fb3535/integration_tests__tsan__[4/6].html

It looks like a deadlock at the first glance, but actually `DiskObjectStorageRemoteMetadataRestoreHelper` is just working too slowly sometimes. 