### PR TITLE
Fix test_distributed_ddl_parallel

### DIFF
--- a/tests/integration/test_distributed_ddl_parallel/test.py
+++ b/tests/integration/test_distributed_ddl_parallel/test.py
@@ -167,7 +167,7 @@ def test_smoke():
 
 def test_smoke_parallel():
     threads = []
-    for _ in range(100):
+    for _ in range(50):
         threads.append(SafeThread(target=execute_smoke_query))
     for thread in threads:
         thread.start()
@@ -178,7 +178,7 @@ def test_smoke_parallel():
 
 def test_smoke_parallel_dict_reload():
     threads = []
-    for _ in range(100):
+    for _ in range(90):
         threads.append(SafeThread(target=execute_reload_dictionary_slow_dict_3))
     for thread in threads:
         thread.start()


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/46156/9314c90b0531a49daa4912d4c2137a5cc6fb3535/integration_tests__tsan__[6/6].html

```
_____________________________ test_smoke_parallel ______________________________
[gw4] linux -- Python 3.8.10 /usr/bin/python3

    def test_smoke_parallel():
        threads = []
        for _ in range(100):
            threads.append(SafeThread(target=execute_smoke_query))
        for thread in threads:
            thread.start()
        for thread in threads:
>           thread.join(70)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

E           helpers.client.QueryRuntimeException: Client failed! Return code: 231, stderr: Received exception from server (version 23.2.1):
E           Code: 999. DB::Exception: Received from 172.16.6.8:9000. Coordination::Exception. Coordination::Exception: Operation timeout, path: /clickhouse. Stack trace:
E           
E           0. ./build_docker/../contrib/llvm-project/libcxx/include/exception:0: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, int) @ 0x228fd1de in /usr/bin/clickhouse
E           1. ./build_docker/../src/Common/Exception.cpp:91: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x13d974b8 in /usr/bin/clickhouse
E           2. ./build_docker/../contrib/llvm-project/libcxx/include/string:1499: Coordination::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, Coordination::Error, int) @ 0x1f3e28bf in /usr/bin/clickhouse
E           3. ./build_docker/../contrib/llvm-project/libcxx/include/string:1499: Coordination::Exception::Exception(Coordination::Error, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) @ 0x1f3e3159 in /usr/bin/clickhouse
E           4. ./build_docker/../src/Common/ZooKeeper/ZooKeeper.cpp:326: zkutil::ZooKeeper::createIfNotExists(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) @ 0x1f3ec8e4 in /usr/bin/clickhouse
E           5. ./build_docker/../contrib/llvm-project/libcxx/include/string:1499: zkutil::ZooKeeper::createAncestors(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) @ 0x1f3ecafa in /usr/bin/clickhouse
E           6. ./build_docker/../src/Interpreters/DDLWorker.cpp:0: DB::DDLWorker::enqueueQuery(DB::DDLLogEntry&) @ 0x1c59bae8 in /usr/bin/clickhouse
E           7. ./build_docker/../contrib/llvm-project/libcxx/include/__memory/shared_ptr.h:594: DB::executeDDLQueryOnCluster(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::Context const>, DB::DDLQueryOnClusterParams const&) @ 0x1d745d00 in /usr/bin/clickhouse
E           8. ./build_docker/../contrib/llvm-project/libcxx/include/vector:434: DB::InterpreterDropQuery::execute() @ 0x1d16e825 in /usr/bin/clickhouse
E           9. ./build_docker/../src/Interpreters/executeQuery.cpp:0: DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x1d757076 in /usr/bin/clickhouse
E           10. ./build_docker/../src/Interpreters/executeQuery.cpp:1180: DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum) @ 0x1d7534ac in /usr/bin/clickhouse
E           11. ./build_docker/../src/Server/TCPHandler.cpp:0: DB::TCPHandler::runImpl() @ 0x1ec21f0f in /usr/bin/clickhouse
E           12. ./build_docker/../src/Server/TCPHandler.cpp:1965: DB::TCPHandler::run() @ 0x1ec36d88 in /usr/bin/clickhouse
E           13. ./build_docker/../base/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x2273c203 in /usr/bin/clickhouse
E           14. ./build_docker/../contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: Poco::Net::TCPServerDispatcher::run() @ 0x2273ca73 in /usr/bin/clickhouse
E           15. ./build_docker/../base/poco/Foundation/src/ThreadPool.cpp:213: Poco::PooledThread::run() @ 0x2299697a in /usr/bin/clickhouse
E           16. ./build_docker/../base/poco/Foundation/src/Thread.cpp:56: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x22994d30 in /usr/bin/clickhouse
E           17. ./build_docker/../base/poco/Foundation/include/Poco/SharedPtr.h:277: Poco::ThreadImpl::runnableEntry(void*) @ 0x22993368 in /usr/bin/clickhouse
E           18. __tsan_thread_start_func @ 0xc268ea7 in /usr/bin/clickhouse
E           19. ? @ 0x7f7ab144d609 in ?
E           20. clone @ 0x7f7ab1372133 in ?
E           . (KEEPER_EXCEPTION)
E           (query: DROP DATABASE IF EXISTS foo ON CLUSTER cluster_b)
```

```
_______________________ test_smoke_parallel_dict_reload ________________________
[gw4] linux -- Python 3.8.10 /usr/bin/python3

    def test_smoke_parallel_dict_reload():
        threads = []
        for _ in range(100):
            threads.append(SafeThread(target=execute_reload_dictionary_slow_dict_3))
        for thread in threads:
            thread.start()
        for thread in threads:
>           thread.join(70)


E           helpers.client.QueryRuntimeException: Client failed! Return code: 202, stderr: Received exception from server (version 23.2.1):
E           Code: 202. DB::Exception: Received from 172.16.6.8:9000. DB::Exception: Too many simultaneous queries. Maximum: 100. Stack trace:
E           
E           0. ./build_docker/../contrib/llvm-project/libcxx/include/exception:0: Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, int) @ 0x228fd1de in /usr/bin/clickhouse
E           1. ./build_docker/../src/Common/Exception.cpp:91: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x13d974b8 in /usr/bin/clickhouse
E           2. DB::Exception::Exception<unsigned long&>(int, FormatStringHelperImpl<std::__1::type_identity<unsigned long&>::type>, unsigned long&) @ 0xc92370d in /usr/bin/clickhouse
E           3. ./build_docker/../src/Interpreters/ProcessList.cpp:91: DB::ProcessList::insert(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, DB::IAST const*, std::__1::shared_ptr<DB::Context>, unsigned long) @ 0x1d40f0a8 in /usr/bin/clickhouse
E           4. ./build_docker/../src/Interpreters/executeQuery.cpp:0: DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x1d754dea in /usr/bin/clickhouse
E           5. ./build_docker/../src/Interpreters/executeQuery.cpp:1180: DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum) @ 0x1d7534ac in /usr/bin/clickhouse
E           6. ./build_docker/../src/Server/TCPHandler.cpp:0: DB::TCPHandler::runImpl() @ 0x1ec21f0f in /usr/bin/clickhouse
E           7. ./build_docker/../src/Server/TCPHandler.cpp:1965: DB::TCPHandler::run() @ 0x1ec36d88 in /usr/bin/clickhouse
E           8. ./build_docker/../base/poco/Net/src/TCPServerConnection.cpp:57: Poco::Net::TCPServerConnection::start() @ 0x2273c203 in /usr/bin/clickhouse
E           9. ./build_docker/../contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: Poco::Net::TCPServerDispatcher::run() @ 0x2273ca73 in /usr/bin/clickhouse
E           10. ./build_docker/../base/poco/Foundation/src/ThreadPool.cpp:213: Poco::PooledThread::run() @ 0x2299697a in /usr/bin/clickhouse
E           11. ./build_docker/../base/poco/Foundation/src/Thread.cpp:56: Poco::(anonymous namespace)::RunnableHolder::run() @ 0x22994d30 in /usr/bin/clickhouse
E           12. ./build_docker/../base/poco/Foundation/include/Poco/SharedPtr.h:277: Poco::ThreadImpl::runnableEntry(void*) @ 0x22993368 in /usr/bin/clickhouse
E           13. __tsan_thread_start_func @ 0xc268ea7 in /usr/bin/clickhouse
E           14. ? @ 0x7f7ab144d609 in ?
E           15. clone @ 0x7f7ab1372133 in ?
E           . (TOO_MANY_SIMULTANEOUS_QUERIES)
E           (query: SYSTEM RELOAD DICTIONARY ON CLUSTER cluster_b slow_dict_3)
```