### PR TITLE
Optimize docker binary-builder

### DIFF
--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -76,23 +76,25 @@ ARG TARGETARCH
 ARG NFPM_VERSION=2.20.0
 
 RUN arch=${TARGETARCH:-amd64} \
-  && curl -Lo /tmp/nfpm.deb "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${arch}.deb" \
-  && dpkg -i /tmp/nfpm.deb \
-  && rm /tmp/nfpm.deb
+    && curl -Lo /tmp/nfpm.deb "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${arch}.deb" \
+    && dpkg -i /tmp/nfpm.deb \
+    && rm /tmp/nfpm.deb
 
 ARG GO_VERSION=1.18.3
 # We need go for clickhouse-diagnostics
 RUN arch=${TARGETARCH:-amd64} \
-  && curl -Lo /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" \
-  && tar -xzf /tmp/go.tgz -C /usr/local/ \
-  && rm /tmp/go.tgz
+    && curl -Lo /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" \
+    && tar -xzf /tmp/go.tgz -C /usr/local/ \
+    && rm /tmp/go.tgz
 
 ENV PATH="$PATH:/usr/local/go/bin"
 ENV GOPATH=/workdir/go
 ENV GOCACHE=/workdir/
 
-RUN curl https://raw.githubusercontent.com/matus-chochlik/ctcache/7fd516e91c17779cbc6fc18bd119313d9532dd90/clang-tidy-cache -Lo /usr/bin/clang-tidy-cache \
-  && chmod +x /usr/bin/clang-tidy-cache
+ARG CLANG_TIDY_SHA1=03644275e794b0587849bfc2ec6123d5ae0bdb1c
+RUN curl -Lo /usr/bin/clang-tidy-cache \
+        "https://raw.githubusercontent.com/matus-chochlik/ctcache/$CLANG_TIDY_SHA1/clang-tidy-cache" \
+    && chmod +x /usr/bin/clang-tidy-cache
 
 RUN mkdir /workdir && chmod 777 /workdir
 WORKDIR /workdir

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -42,7 +42,6 @@ RUN git clone --depth 1 https://github.com/tpoechtrager/cctools-port.git \
 FROM clickhouse/test-util:$FROM_TAG
 ENV CC=clang-${LLVM_VERSION}
 ENV CXX=clang++-${LLVM_VERSION}
-COPY --from=cctools /cctools /cctools
 
 # Rust toolchain and libraries
 ENV RUSTUP_HOME=/rust/rustup
@@ -102,6 +101,8 @@ ARG CLANG_TIDY_SHA1=03644275e794b0587849bfc2ec6123d5ae0bdb1c
 RUN curl -Lo /usr/bin/clang-tidy-cache \
         "https://raw.githubusercontent.com/matus-chochlik/ctcache/$CLANG_TIDY_SHA1/clang-tidy-cache" \
     && chmod +x /usr/bin/clang-tidy-cache
+
+COPY --from=cctools /cctools /cctools
 
 RUN mkdir /workdir && chmod 777 /workdir
 WORKDIR /workdir

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -86,7 +86,7 @@ RUN arch=${TARGETARCH:-amd64} \
     && dpkg -i /tmp/nfpm.deb \
     && rm /tmp/nfpm.deb
 
-ARG GO_VERSION=1.18.3
+ARG GO_VERSION=1.19.5
 # We need go for clickhouse-diagnostics
 RUN arch=${TARGETARCH:-amd64} \
     && curl -Lo /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" \

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -1,6 +1,8 @@
 # docker build -t clickhouse/binary-builder .
 ARG FROM_TAG=latest
-FROM clickhouse/test-util:$FROM_TAG
+FROM clickhouse/test-util:latest AS cctools
+# The cctools are built always from the clickhouse/test-util:latest and cached inline
+# Theoretically, it should improve rebuild speed significantly
 ENV CC=clang-${LLVM_VERSION}
 ENV CXX=clang++-${LLVM_VERSION}
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -36,6 +38,11 @@ RUN git clone --depth 1 https://github.com/tpoechtrager/cctools-port.git \
 # !!!!!!!!!!!
 # END COMPILE
 # !!!!!!!!!!!
+
+FROM clickhouse/test-util:$FROM_TAG
+ENV CC=clang-${LLVM_VERSION}
+ENV CXX=clang++-${LLVM_VERSION}
+COPY --from=cctools /cctools /cctools
 
 # Rust toolchain and libraries
 ENV RUSTUP_HOME=/rust/rustup

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -1,7 +1,41 @@
-# rebuild in #33610
 # docker build -t clickhouse/binary-builder .
 ARG FROM_TAG=latest
 FROM clickhouse/test-util:$FROM_TAG
+ENV CC=clang-${LLVM_VERSION}
+ENV CXX=clang++-${LLVM_VERSION}
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# DO NOT PUT ANYTHING BEFORE THREE NEXT `RUN` DIRECTIVES
+# THE MOST HEAVY OPERATION MUST BE THE FIRST IN THE CACHE
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# libtapi is required to support .tbh format from recent MacOS SDKs
+RUN git clone --depth 1 https://github.com/tpoechtrager/apple-libtapi.git \
+    && cd apple-libtapi \
+    && INSTALLPREFIX=/cctools ./build.sh \
+    && ./install.sh \
+    && cd .. \
+    && rm -rf apple-libtapi
+
+# Build and install tools for cross-linking to Darwin (x86-64)
+RUN git clone --depth 1 https://github.com/tpoechtrager/cctools-port.git \
+    && cd cctools-port/cctools \
+    && ./configure --prefix=/cctools --with-libtapi=/cctools \
+        --target=x86_64-apple-darwin \
+    && make install -j$(nproc) \
+    && cd ../.. \
+    && rm -rf cctools-port
+
+# Build and install tools for cross-linking to Darwin (aarch64)
+RUN git clone --depth 1 https://github.com/tpoechtrager/cctools-port.git \
+    && cd cctools-port/cctools \
+    && ./configure --prefix=/cctools --with-libtapi=/cctools \
+        --target=aarch64-apple-darwin \
+    && make install -j$(nproc) \
+    && cd ../.. \
+    && rm -rf cctools-port
+
+# !!!!!!!!!!!
+# END COMPILE
+# !!!!!!!!!!!
 
 # Rust toolchain and libraries
 ENV RUSTUP_HOME=/rust/rustup
@@ -16,57 +50,26 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
     rustup target add aarch64-apple-darwin && \
     rustup target add powerpc64le-unknown-linux-gnu
 
-RUN apt-get update && \
-    apt-get install --yes \
-        gcc-aarch64-linux-gnu \
+# NOTE: Seems like gcc-11 is too new for ubuntu20 repository
+# A cross-linker for RISC-V 64 (we need it, because LLVM's LLD does not work):
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
+    && apt-get update \
+    && apt-get install --yes \
+        binutils-riscv64-linux-gnu \
         build-essential \
+        g++-11 \
+        gcc-11 \
+        gcc-aarch64-linux-gnu \
         libc6 \
         libc6-dev \
         libc6-dev-arm64-cross \
         yasm \
-        zstd && \
-    apt-get clean
-
-ENV CC=clang-${LLVM_VERSION}
-ENV CXX=clang++-${LLVM_VERSION}
-
-# libtapi is required to support .tbh format from recent MacOS SDKs
-RUN git clone --depth 1 https://github.com/tpoechtrager/apple-libtapi.git \
-    && cd apple-libtapi \
-    && INSTALLPREFIX=/cctools ./build.sh \
-    && ./install.sh \
-    && cd .. \
-    && rm -rf apple-libtapi
-
-# Build and install tools for cross-linking to Darwin (x86-64)
-RUN git clone --depth 1 https://github.com/tpoechtrager/cctools-port.git \
-    && cd cctools-port/cctools \
-    && ./configure --prefix=/cctools --with-libtapi=/cctools \
-        --target=x86_64-apple-darwin \
-    && make install \
-    && cd ../.. \
-    && rm -rf cctools-port
-
-# Build and install tools for cross-linking to Darwin (aarch64)
-RUN git clone --depth 1 https://github.com/tpoechtrager/cctools-port.git \
-    && cd cctools-port/cctools \
-    && ./configure --prefix=/cctools --with-libtapi=/cctools \
-        --target=aarch64-apple-darwin \
-    && make install \
-    && cd ../.. \
-    && rm -rf cctools-port
+        zstd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists
 
 # Download toolchain and SDK for Darwin
 RUN wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz
-
-# NOTE: Seems like gcc-11 is too new for ubuntu20 repository
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
-    && apt-get update \
-    && apt-get install gcc-11 g++-11 --yes \
-    && apt-get clean
-
-# A cross-linker for RISC-V 64 (we need it, because LLVM's LLD does not work):
-RUN apt-get install binutils-riscv64-linux-gnu
 
 # Architecture of the image when BuildKit/buildx is used
 ARG TARGETARCH

--- a/tests/ci/docker_test.py
+++ b/tests/ci/docker_test.py
@@ -117,15 +117,13 @@ class TestDockerImageCheck(unittest.TestCase):
         self.assertEqual(versions, ["1", "1-HEAD"])
         self.assertEqual(result_version, "1-HEAD")
 
-    @patch("builtins.open")
-    @patch("subprocess.Popen")
+    @patch("docker_images_check.TeePopen")
     @patch("platform.machine")
-    def test_build_and_push_one_image(self, mock_machine, mock_popen, mock_open):
+    def test_build_and_push_one_image(self, mock_machine, mock_popen):
         mock_popen.return_value.__enter__.return_value.wait.return_value = 0
         image = di.DockerImage("path", "name", False, gh_repo_path="")
 
         result, _ = di.build_and_push_one_image(image, "version", "", True, True)
-        mock_open.assert_called_once()
         mock_popen.assert_called_once()
         mock_machine.assert_not_called()
         self.assertIn(
@@ -138,13 +136,11 @@ class TestDockerImageCheck(unittest.TestCase):
             mock_popen.call_args.args,
         )
         self.assertTrue(result)
-        mock_open.reset_mock()
         mock_popen.reset_mock()
         mock_machine.reset_mock()
 
         mock_popen.return_value.__enter__.return_value.wait.return_value = 0
         result, _ = di.build_and_push_one_image(image, "version2", "", False, True)
-        mock_open.assert_called_once()
         mock_popen.assert_called_once()
         mock_machine.assert_not_called()
         self.assertIn(
@@ -158,12 +154,10 @@ class TestDockerImageCheck(unittest.TestCase):
         )
         self.assertTrue(result)
 
-        mock_open.reset_mock()
         mock_popen.reset_mock()
         mock_machine.reset_mock()
         mock_popen.return_value.__enter__.return_value.wait.return_value = 1
         result, _ = di.build_and_push_one_image(image, "version2", "", False, False)
-        mock_open.assert_called_once()
         mock_popen.assert_called_once()
         mock_machine.assert_not_called()
         self.assertIn(
@@ -176,14 +170,12 @@ class TestDockerImageCheck(unittest.TestCase):
         )
         self.assertFalse(result)
 
-        mock_open.reset_mock()
         mock_popen.reset_mock()
         mock_machine.reset_mock()
         mock_popen.return_value.__enter__.return_value.wait.return_value = 1
         result, _ = di.build_and_push_one_image(
             image, "version2", "cached-version", False, False
         )
-        mock_open.assert_called_once()
         mock_popen.assert_called_once()
         mock_machine.assert_not_called()
         self.assertIn(
@@ -197,7 +189,6 @@ class TestDockerImageCheck(unittest.TestCase):
         )
         self.assertFalse(result)
 
-        mock_open.reset_mock()
         mock_popen.reset_mock()
         mock_machine.reset_mock()
         only_amd64_image = di.DockerImage("path", "name", True)
@@ -206,7 +197,6 @@ class TestDockerImageCheck(unittest.TestCase):
         result, _ = di.build_and_push_one_image(
             only_amd64_image, "version", "", True, True
         )
-        mock_open.assert_called_once()
         mock_popen.assert_called_once()
         mock_machine.assert_called_once()
         self.assertIn(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Move the heaviest operation to a separate stage to improve rebuild speed. As an experiment, move the `cctools` build process to another stage from the latest tests-util, which should improve the speed even more. Reduce rebuild on merging changed docker images to master. Add building logs to the main script output with TeePopen. Update the golang version to 1.19.5.