### PR TITLE
docs for logger stream_compression

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -606,7 +606,7 @@ Keys:
 -   `size` – Size of the file. Applies to `log` and `errorlog`. Once the file reaches `size`, ClickHouse archives and renames it, and creates a new log file in its place.
 -   `count` – The number of archived log files that ClickHouse stores.
 -   `console` – Send `log` and `errorlog` to the console instead of file. To enable, set to `1` or `true`.
--   `stream_compress` – Compress `log` and `errorlog` with `lz4` compression. To enable, set to `1` or `true`.
+-   `stream_compress` – Compress `log` and `errorlog` with `lz4` stream compression. To enable, set to `1` or `true`.
 
 **Example**
 

--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -606,6 +606,7 @@ Keys:
 -   `size` – Size of the file. Applies to `log` and `errorlog`. Once the file reaches `size`, ClickHouse archives and renames it, and creates a new log file in its place.
 -   `count` – The number of archived log files that ClickHouse stores.
 -   `console` – Send `log` and `errorlog` to the console instead of file. To enable, set to `1` or `true`.
+-   `stream_compress` – Compress `log` and `errorlog` with `lz4` compression. To enable, set to `1` or `true`.
 
 **Example**
 
@@ -616,6 +617,7 @@ Keys:
     <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
     <size>1000M</size>
     <count>10</count>
+    <stream_compress>true</stream_compress>
 </logger>
 ```
 

--- a/tests/integration/test_log_lz4_streaming/configs/logs.xml
+++ b/tests/integration/test_log_lz4_streaming/configs/logs.xml
@@ -1,5 +1,5 @@
-<yandex>
+<clickhouse>
     <logger>
         <stream_compress>true</stream_compress>
     </logger>
-</yandex>
+</clickhouse>


### PR DESCRIPTION
Document logger stream_compression

closes #46203 

### Changelog category (leave one):
- Documentation (changelog entry is not required)

