### PR TITLE
Allow vertical merges from compact to wide parts [2]

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -110,8 +110,6 @@ public:
 
     virtual bool isStoredOnRemoteDiskWithZeroCopySupport() const = 0;
 
-    virtual bool supportsVerticalMerge() const { return false; }
-
     /// NOTE: Returns zeros if column files are not found in checksums.
     /// Otherwise return information about column size on disk.
     ColumnSize getColumnSize(const String & column_name) const;

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -958,6 +958,15 @@ MergeAlgorithm MergeTask::ExecuteAndFinalizeHorizontalPart::chooseMergeAlgorithm
     if (global_ctx->future_part->part_format.storage_type != MergeTreeDataPartStorageType::Full)
         return MergeAlgorithm::Horizontal;
 
+    if (!data_settings->allow_vertical_merges_from_compact_to_wide_parts)
+    {
+        for (const auto & part : global_ctx->future_part->parts)
+        {
+            if (!isWidePart(part))
+                return MergeAlgorithm::Horizontal;
+        }
+    }
+
     bool is_supported_storage =
         ctx->merging_params.mode == MergeTreeData::MergingParams::Ordinary ||
         ctx->merging_params.mode == MergeTreeData::MergingParams::Collapsing ||

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -953,10 +953,10 @@ MergeAlgorithm MergeTask::ExecuteAndFinalizeHorizontalPart::chooseMergeAlgorithm
         return MergeAlgorithm::Horizontal;
     if (ctx->need_remove_expired_values)
         return MergeAlgorithm::Horizontal;
-
-    for (const auto & part : global_ctx->future_part->parts)
-        if (!part->supportsVerticalMerge() || !isFullPartStorage(part->getDataPartStorage()))
-            return MergeAlgorithm::Horizontal;
+    if (global_ctx->future_part->part_format.part_type != MergeTreeDataPartType::Wide)
+        return MergeAlgorithm::Horizontal;
+    if (global_ctx->future_part->part_format.storage_type != MergeTreeDataPartStorageType::Full)
+        return MergeAlgorithm::Horizontal;
 
     bool is_supported_storage =
         ctx->merging_params.mode == MergeTreeData::MergingParams::Ordinary ||

--- a/src/Storages/MergeTree/MergeTreeDataPartWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWide.h
@@ -47,8 +47,6 @@ public:
 
     bool isStoredOnRemoteDiskWithZeroCopySupport() const override;
 
-    bool supportsVerticalMerge() const override { return true; }
-
     String getFileNameForColumn(const NameAndTypePair & column) const override;
 
     ~MergeTreeDataPartWide() override;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -135,6 +135,7 @@ static size_t computeIndexGranularityImpl(
 {
     size_t rows_in_block = block.rows();
     size_t index_granularity_for_block;
+
     if (!can_use_adaptive_index_granularity)
     {
         index_granularity_for_block = fixed_index_granularity_rows;
@@ -143,7 +144,9 @@ static size_t computeIndexGranularityImpl(
     {
         size_t block_size_in_memory = block.bytes();
         if (blocks_are_granules)
+        {
             index_granularity_for_block = rows_in_block;
+        }
         else if (block_size_in_memory >= index_granularity_bytes)
         {
             size_t granules_in_block = block_size_in_memory / index_granularity_bytes;
@@ -155,10 +158,14 @@ static size_t computeIndexGranularityImpl(
             index_granularity_for_block = index_granularity_bytes / size_of_row_in_bytes;
         }
     }
-    /// We should be less or equal than fixed index granularity
-    index_granularity_for_block = std::min(fixed_index_granularity_rows, index_granularity_for_block);
 
-    /// very rare case when index granularity bytes less then single row
+    /// We should be less or equal than fixed index granularity.
+    /// But if block size is a granule size then do not adjust it.
+    /// Granularity greater than fixed granularity might come from compact part.
+    if (!blocks_are_granules)
+        index_granularity_for_block = std::min(fixed_index_granularity_rows, index_granularity_for_block);
+
+    /// Very rare case when index granularity bytes less than single row.
     if (index_granularity_for_block == 0)
         index_granularity_for_block = 1;
 

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -484,15 +484,8 @@ void MergeTreeDataPartWriterWide::validateColumnOfFixedSize(const NameAndTypePai
                             column->size(), mark_num, index_granularity.getMarksCount(), index_granularity_rows);
         }
 
-        if (index_granularity_rows > data_part->index_granularity_info.fixed_index_granularity)
-        {
-            throw Exception(ErrorCodes::LOGICAL_ERROR,
-                            "Mark #{} has {} rows, but max fixed granularity is {}, index granularity size {}",
-                            mark_num, index_granularity_rows, data_part->index_granularity_info.fixed_index_granularity,
-                            index_granularity.getMarksCount());
-        }
-
         if (index_granularity_rows != index_granularity.getMarkRows(mark_num))
+        {
             throw Exception(
                             ErrorCodes::LOGICAL_ERROR,
                             "Incorrect mark rows for part {} for mark #{}"
@@ -501,6 +494,7 @@ void MergeTreeDataPartWriterWide::validateColumnOfFixedSize(const NameAndTypePai
                             mark_num, offset_in_compressed_file, offset_in_decompressed_block,
                             index_granularity.getMarkRows(mark_num), index_granularity_rows,
                             index_granularity.getMarksCount());
+        }
 
         auto column = type->createColumn();
 

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -149,6 +149,7 @@ struct Settings;
     M(UInt64, min_marks_to_honor_max_concurrent_queries, 0, "Minimal number of marks to honor the MergeTree-level's max_concurrent_queries (0 - disabled). Queries will still be limited by other max_concurrent_queries settings.", 0) \
     M(UInt64, min_bytes_to_rebalance_partition_over_jbod, 0, "Minimal amount of bytes to enable part rebalance over JBOD array (0 - disabled).", 0) \
     M(Bool, check_sample_column_is_correct, true, "Check columns or columns by hash for sampling are unsigned integer.", 0) \
+    M(Bool, allow_vertical_merges_from_compact_to_wide_parts, false, "Allows vertical merges from compact to wide parts. This settings must have the same value on all replicas", 0) \
     \
     /** Experimental/work in progress feature. Unsafe for production. */ \
     M(UInt64, part_moves_between_shards_enable, 0, "Experimental/Incomplete feature to move parts between shards. Does not take into account sharding expressions.", 0) \

--- a/tests/integration/test_backward_compatibility/test_vertical_merges_from_compact_parts.py
+++ b/tests/integration/test_backward_compatibility/test_vertical_merges_from_compact_parts.py
@@ -1,0 +1,112 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node_old = cluster.add_instance(
+    "node1",
+    image="clickhouse/clickhouse-server",
+    tag="22.8",
+    stay_alive=True,
+    with_installed_binary=True,
+    with_zookeeper=True,
+)
+node_new = cluster.add_instance(
+    "node2",
+    with_zookeeper=True,
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_vertical_merges_from_comapact_parts(start_cluster):
+    for i, node in enumerate([node_old, node_new]):
+        node.query(
+            """
+            CREATE TABLE t_vertical_merges (id UInt64, v1 UInt64, v2 UInt64)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/t_vertical_merges', '{}')
+            ORDER BY id
+            SETTINGS
+                index_granularity = 50,
+                vertical_merge_algorithm_min_rows_to_activate = 1,
+                vertical_merge_algorithm_min_columns_to_activate = 1,
+                min_bytes_for_wide_part = 0,
+                min_rows_for_wide_part = 100;
+        """.format(
+                i
+            )
+        )
+
+    node_new.query(
+        "INSERT INTO t_vertical_merges SELECT number, number, number FROM numbers(60)"
+    )
+    node_new.query(
+        "INSERT INTO t_vertical_merges SELECT number * 2, number, number FROM numbers(60)"
+    )
+    node_new.query("OPTIMIZE TABLE t_vertical_merges FINAL")
+    node_old.query("SYSTEM SYNC REPLICA t_vertical_merges")
+
+    check_query = """
+        SELECT merge_algorithm, part_type FROM system.part_log
+        WHERE event_type = 'MergeParts' AND table = 't_vertical_merges' AND part_name = '{}';
+    """
+
+    node_new.query("SYSTEM FLUSH LOGS")
+    node_old.query("SYSTEM FLUSH LOGS")
+
+    assert node_new.query(check_query.format("all_0_1_1")) == "Horizontal\tWide\n"
+    assert node_old.query(check_query.format("all_0_1_1")) == "Horizontal\tWide\n"
+
+    node_new.query(
+        "ALTER TABLE t_vertical_merges MODIFY SETTING allow_vertical_merges_from_compact_to_wide_parts = 1"
+    )
+
+    node_new.query(
+        "INSERT INTO t_vertical_merges SELECT number * 3, number, number FROM numbers(60)"
+    )
+    node_new.query("OPTIMIZE TABLE t_vertical_merges FINAL")
+    node_old.query("SYSTEM SYNC REPLICA t_vertical_merges")
+
+    node_new.query("SYSTEM FLUSH LOGS")
+    node_old.query("SYSTEM FLUSH LOGS")
+
+    assert node_old.contains_in_log(
+        "CHECKSUM_DOESNT_MATCH"
+    ) or node_new.contains_in_log("CHECKSUM_DOESNT_MATCH")
+
+    assert node_new.query(check_query.format("all_0_2_2")) == "Vertical\tWide\n"
+    assert node_old.query(check_query.format("all_0_2_2")) == "Horizontal\tWide\n"
+
+    node_old.restart_with_latest_version()
+    node_new.restart_clickhouse()
+
+    node_old.query(
+        "ALTER TABLE t_vertical_merges MODIFY SETTING allow_vertical_merges_from_compact_to_wide_parts = 1"
+    )
+
+    node_new.query(
+        "INSERT INTO t_vertical_merges SELECT number * 4, number, number FROM numbers(60)"
+    )
+    node_new.query("OPTIMIZE TABLE t_vertical_merges FINAL")
+    node_old.query("SYSTEM SYNC REPLICA t_vertical_merges")
+
+    node_new.query("SYSTEM FLUSH LOGS")
+    node_old.query("SYSTEM FLUSH LOGS")
+
+    assert not (
+        node_old.contains_in_log("CHECKSUM_DOESNT_MATCH")
+        or node_new.contains_in_log("CHECKSUM_DOESNT_MATCH")
+    )
+
+    assert node_new.query(check_query.format("all_0_3_3")) == "Vertical\tWide\n"
+    assert node_old.query(check_query.format("all_0_3_3")) == "Vertical\tWide\n"

--- a/tests/queries/0_stateless/02539_vertical_merge_compact_parts.reference
+++ b/tests/queries/0_stateless/02539_vertical_merge_compact_parts.reference
@@ -1,0 +1,2 @@
+1	2	MergeParts	Horizontal	Compact
+1	3	MergeParts	Vertical	Wide

--- a/tests/queries/0_stateless/02539_vertical_merge_compact_parts.sql
+++ b/tests/queries/0_stateless/02539_vertical_merge_compact_parts.sql
@@ -7,7 +7,8 @@ SETTINGS
     min_bytes_for_wide_part = 0,
     min_rows_for_wide_part = 100,
     vertical_merge_algorithm_min_rows_to_activate = 1,
-    vertical_merge_algorithm_min_columns_to_activate = 1;
+    vertical_merge_algorithm_min_columns_to_activate = 1,
+    allow_vertical_merges_from_compact_to_wide_parts = 1;
 
 INSERT INTO t_compact_vertical_merge SELECT number, toString(number), range(number % 10) FROM numbers(40);
 INSERT INTO t_compact_vertical_merge SELECT number, toString(number), range(number % 10) FROM numbers(40);

--- a/tests/queries/0_stateless/02539_vertical_merge_compact_parts.sql
+++ b/tests/queries/0_stateless/02539_vertical_merge_compact_parts.sql
@@ -1,0 +1,41 @@
+DROP TABLE IF EXISTS t_compact_vertical_merge;
+
+CREATE TABLE t_compact_vertical_merge (id UInt64, s LowCardinality(String), arr Array(UInt64))
+ENGINE MergeTree ORDER BY id
+SETTINGS
+    index_granularity = 16,
+    min_bytes_for_wide_part = 0,
+    min_rows_for_wide_part = 100,
+    vertical_merge_algorithm_min_rows_to_activate = 1,
+    vertical_merge_algorithm_min_columns_to_activate = 1;
+
+INSERT INTO t_compact_vertical_merge SELECT number, toString(number), range(number % 10) FROM numbers(40);
+INSERT INTO t_compact_vertical_merge SELECT number, toString(number), range(number % 10) FROM numbers(40);
+
+OPTIMIZE TABLE t_compact_vertical_merge FINAL;
+SYSTEM FLUSH LOGS;
+
+WITH splitByChar('_', part_name) AS name_parts,
+    name_parts[2]::UInt64 AS min_block,
+    name_parts[3]::UInt64 AS max_block
+SELECT min_block, max_block, event_type, merge_algorithm, part_type FROM system.part_log
+WHERE
+    database = currentDatabase() AND
+    table = 't_compact_vertical_merge' AND
+    min_block = 1 AND max_block = 2;
+
+INSERT INTO t_compact_vertical_merge SELECT number, toString(number), range(number % 10) FROM numbers(40);
+
+OPTIMIZE TABLE t_compact_vertical_merge FINAL;
+SYSTEM FLUSH LOGS;
+
+WITH splitByChar('_', part_name) AS name_parts,
+    name_parts[2]::UInt64 AS min_block,
+    name_parts[3]::UInt64 AS max_block
+SELECT min_block, max_block, event_type, merge_algorithm, part_type FROM system.part_log
+WHERE
+    database = currentDatabase() AND
+    table = 't_compact_vertical_merge' AND
+    min_block = 1 AND max_block = 3;
+
+DROP TABLE t_compact_vertical_merge;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow using Vertical merge algorithm with parts in Compact format. This will allow ClickHouse server to use much less memory for background operations. This closes #46084

Resurrected #45681.
