### PR TITLE
Fix macOs compilation due to sprintf

### DIFF
--- a/base/poco/Util/src/SystemConfiguration.cpp
+++ b/base/poco/Util/src/SystemConfiguration.cpp
@@ -89,7 +89,9 @@ bool SystemConfiguration::getRaw(const std::string& key, std::string& value) con
 			Poco::Environment::NodeId id;
 			Poco::Environment::nodeId(id);
 			char result[13];
-			std::sprintf(result, "%02x%02x%02x%02x%02x%02x",
+			std::snprintf(result, 
+                sizeof(result),
+                "%02x%02x%02x%02x%02x%02x",
 				id[0],
 				id[1],
 				id[2],


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

sprintf is deprecated in macOs, removing in favor of snprintf to fix compilation.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
