### PR TITLE
Improve `WindowTransform::updateAggregationState` by `addBatchSinglePlace`

### DIFF
--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -961,7 +961,7 @@ void WindowTransform::updateAggregationState()
             auto * arena_ptr = arena.get();
             if constexpr (enable_batch_aggregate)
             {
-                // For [rows unbouned preceding and unbounded following,
+                // For [rows unbounded preceding and unbounded following,
                 // first_row = past_the_end_row is the major case
                 if (first_row != past_the_end_row)
                     a->addBatchSinglePlace(first_row, past_the_end_row, buf, columns, arena_ptr);
@@ -1102,7 +1102,6 @@ void WindowTransform::appendChunk(Chunk & chunk)
         assertSameColumns(input_header.getColumns(), block.input_columns);
     }
 
-    // std::function<void()> update_aggregate_state;
     void (WindowTransform::*update_aggregate_state)() = nullptr;
     if (enable_aggregate_batch_add)
         update_aggregate_state = &WindowTransform::updateAggregationState<true>;

--- a/src/Processors/Transforms/WindowTransform.h
+++ b/src/Processors/Transforms/WindowTransform.h
@@ -131,6 +131,7 @@ public:
     void advanceFrameEnd();
     void advanceFrameEndRangeOffset();
 
+    template<bool enable_batch_aggregate>
     void updateAggregationState();
     void writeOutCurrentRow();
 
@@ -287,6 +288,8 @@ public:
     std::vector<size_t> partition_by_indices;
     // Indices of the ORDER BY columns in block;
     std::vector<size_t> order_by_indices;
+    // A flag to decide to use AggreageteFunction's add or addBatchSinglePlace
+    bool enable_aggregate_batch_add = false;
 
     // Per-window-function scratch spaces.
     std::vector<WindowFunctionWorkspace> workspaces;
@@ -358,6 +361,8 @@ public:
         const IColumn * reference_column, size_t reference_row,
         const Field & offset,
         bool offset_is_preceding);
+
+    void setupEnableAggregateBatchAdd();
 };
 
 }

--- a/tests/performance/window_functions.xml
+++ b/tests/performance/window_functions.xml
@@ -144,4 +144,74 @@
         format Null
     </query>
 
+    <query>
+        select a, sum(b) over (partition by a) 
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
+    <query>
+        select a, sum(b) over (partition by a order by b)
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
+    <query>
+        select a, sum(b) over (partition by a rows between unbounded preceding and current row)
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
+    <query>
+        select a, sum(b) over (partition by a order by b rows between unbounded preceding and current row)
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
+    <query>
+        select a, sum(b) over (partition by a rows between unbounded preceding and unbounded following)
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
+    <query>
+        select a, sum(b) over (partition by a order by b rows between unbounded preceding and unbounded following)
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
+    <query>
+        select a, sum(b) over (partition by a rows between unbounded preceding and 4 following)
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
+    <query>
+        select a, sum(b) over (partition by a order by b rows between unbounded preceding and 4 following)
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
+    <query>
+        select a, sum(b) over (partition by a rows between 4 preceding and 4 following)
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
+    <query>
+        select a, sum(b) over (partition by a order by b rows between 4 preceding and 4 following)
+        from
+            (select intDiv(number, 16) as a, number % 16 as b from numbers(10000000)) t
+        format Null
+    </query>
+
 </test>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Use `addBatchSinglePlace` instead of `add` in some cases to accelate `WindowTransform::updateAggregationState`

Test

```sql
insert into test_data select intDiv(number,16) as a, number % 16 as b from numbers(10000000);

-- Q1
select a, sum(b) over (partition by a) from test_data;

-- Q2
select a, sum(b) over (partition by a order by b) from test_data;

-- Q3
select a, sum(b) over (partition by a rows between unbounded preceding and current row) from test_data;

-- Q4
select a, sum(b) over (partition by a order by b rows between unbounded preceding and current row) from test_data;

-- Q5
select a, sum(b) over (partition by a rows between unbounded preceding and unbounded following) from test_data;

-- Q6
select a, sum(b) over (partition by a order by b rows between unbounded preceding and unbounded following) from test_data;

-- Q7
select a, sum(b) over (partition by a rows between unbounded preceding and 4 following) from test_data;

-- Q8
select a, sum(b) over (partition by a order by b rows between unbounded preceding and 4 following) from test_data;

-- Q9
select a, sum(b) over (partition by a rows between 4 preceding and 4 following) from test_data;

-- Q10
select a, sum(b) over (partition by a order by b rows between 4 preceding and 4 following) from test_data;

```
Result
|  query   | before | after | speedup |
|  ----  | ----  | ---- | ---- |
| Q1 | 11.73 million rows/s., 117.31 MB/s | 11.97 million rows/s., 119.73 MB/s.| - |
| Q2  | 8.81 million rows/s., 88.12 MB/s | 8.79 million rows/s., 87.93 MB/s| - |
| Q3  | 11.74 million rows/s., 117.37 MB/s | 11.75 million rows/s., 117.53 MB/s| - |
| Q4  | 11.73 million rows/s., 117.28 MB/s | 11.81 million rows/s., 118.09 MB/s| - |
| Q5  | 12.35 million rows/s., 123.53 MB/s | 13.55 million rows/s., 135.49 MB/s| +9% |
| Q6  | 12.66 million rows/s., 126.55 MB/s | 13.56 million rows/s., 135.57 MB/s.| +9% |
| Q7  | 11.03 million rows/s., 110.32 MB/s. |11.13 million rows/s., 111.28 MB/s| - |
| Q8  | 11.65 million rows/s., 116.53 MB/s | 11.66 million rows/s., 116.65 MB/s| - |
| Q9  | 7.40 million rows/s., 74.01 MB/s | 8.31 million rows/s., 83.11 MB/s| +12% |
| Q10  |7.50 million rows/s., 74.98 MB/s | 8.51 million rows/s., 85.10 MB/s| +14% |


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
