### PR TITLE
Refine removing metadata file with invalid format for DiskObjectStorage

### DIFF
--- a/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageTransaction.cpp
@@ -17,6 +17,7 @@ namespace ErrorCodes
     extern const int FILE_DOESNT_EXIST;
     extern const int BAD_FILE_TYPE;
     extern const int FILE_ALREADY_EXISTS;
+    extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
 }
 
 DiskObjectStorageTransaction::DiskObjectStorageTransaction(
@@ -275,8 +276,15 @@ struct RemoveRecursiveObjectStorageOperation final : public IDiskObjectStorageOp
                 if (e.code() == ErrorCodes::UNKNOWN_FORMAT
                     || e.code() == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF
                     || e.code() == ErrorCodes::CANNOT_READ_ALL_DATA
-                    || e.code() == ErrorCodes::CANNOT_OPEN_FILE)
+                    || e.code() == ErrorCodes::CANNOT_OPEN_FILE
+                    || e.code() == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED)
                 {
+                    LOG_DEBUG(
+                        &Poco::Logger::get("RemoveRecursiveObjectStorageOperation"),
+                        "Can't read metadata because of an exception. Just remove it from the filesystem. Path: {}, exception: {}",
+                        metadata_storage.getPath() + path_to_remove,
+                        e.message());
+
                     tx->unlinkFile(path_to_remove);
                 }
                 else


### PR DESCRIPTION
At this point it is assumed that all data files on local disk for `DiskObjectStorage` contain metadata (version, s3 object path, etc.). If the metadata file cannot be parsed when deleted, it is quietly deleted.
Added possible exception handling and logging output.

Some `SYSTEM UNFREEZE` calls fail with the exception `CANNOT_PARSE_INPUT_ASSERTION_FAILED` if it is not handled. This depends on the contents of the file `shadow/{backup_name}/revision.txt`, which for historical reasons is stored in the disk data directory, but is not stored in S3 and has no metadata format.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `SYSTEM UNFREEZE` queries failing with the exception `CANNOT_PARSE_INPUT_ASSERTION_FAILED` 

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
