### PR TITLE
Trigger automerge on approved PRs

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -2,7 +2,7 @@
 name: Debug
 
 'on':
-  [push, pull_request, release, workflow_dispatch, workflow_call]
+  [push, pull_request, pull_request_review, release, workflow_dispatch, workflow_call]
 
 jobs:
   DebugInfo:

--- a/.github/workflows/pull_request_approved.yml
+++ b/.github/workflows/pull_request_approved.yml
@@ -1,0 +1,23 @@
+name: PullRequestApprovedCI
+
+env:
+  # Force the stdout and stderr streams to be unbuffered
+  PYTHONUNBUFFERED: 1
+
+on:  # yamllint disable-line rule:truthy
+  pull_request_review:
+    types:
+      - submitted
+
+jobs:
+  MergeOnApproval:
+    runs-on: [self-hosted, style-checker]
+    steps:
+      - name: Check out repository code
+        uses: ClickHouse/checkout@v1
+        with:
+          clear-repository: true
+      - name: Merge approved PR
+        run: |
+          cd "$GITHUB_WORKSPACE/tests/ci"
+          python3 merge_pr.py --check-approved


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Merge green PRs on approvals, even when tests are already done like in https://github.com/ClickHouse/ClickHouse/pull/46310#pullrequestreview-1295048563.


#### Beware
There could be dragons