### PR TITLE
Try to stabilize test 02346_full_text_search.sql

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -684,6 +684,12 @@ void DataPartStorageOnDiskBase::clearDirectory(
         request.emplace_back(fs::path(dir) / "delete-on-destroy.txt", true);
         request.emplace_back(fs::path(dir) / "txn_version.txt", true);
 
+        /// Inverted index
+        request.emplace_back(fs::path(dir) / "skp_idx_af.gin_dict", true);
+        request.emplace_back(fs::path(dir) / "skp_idx_af.gin_post", true);
+        request.emplace_back(fs::path(dir) / "skp_idx_af.gin_seg", true);
+        request.emplace_back(fs::path(dir) / "skp_idx_af.gin_sid", true);
+
         disk->removeSharedFiles(request, !can_remove_shared_data, names_not_to_remove);
         disk->removeDirectory(dir);
     }

--- a/tests/queries/0_stateless/02346_full_text_search.sql
+++ b/tests/queries/0_stateless/02346_full_text_search.sql
@@ -1,5 +1,3 @@
--- Tags: no-ordinary-database
-
 SET allow_experimental_inverted_index = 1;
 SET log_queries = 1;
 

--- a/tests/queries/0_stateless/02346_full_text_search.sql
+++ b/tests/queries/0_stateless/02346_full_text_search.sql
@@ -1,3 +1,5 @@
+-- Tags: no-ordinary-database
+
 SET allow_experimental_inverted_index = 1;
 SET log_queries = 1;
 


### PR DESCRIPTION
Failure, e.g. https://s3.amazonaws.com/clickhouse-test-reports/0/f3fa3d868cb9957eeca6b5d5fd653234f5db5b45/stateless_tests__release__databaseordinary_.html :

    "Cannot quickly remove directory /var/lib/clickhouse/data/test_ggwgonnk/tab/delete_tmp_all_1_1_0 by removing files; fallback to recursive removal. Reason: Code: 566. DB::ErrnoException: Cannot rmdir /var/lib/clickhouse/data/test_ggwgonnk/tab/delete_tmp_all_1_1_0, errno: 39, strerror: Directory not empty. (CANNOT_RMDIR) (version 23.2.1.1427 (official build))"

The issue did not reproduce in a local debug or release builds.

I noticed that it happens only with "DatabaseOrdinary" test profiles: https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgOTYgSE9VUgogICAgQU5EIHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwCiAgICBBTkQgdGVzdF9zdGF0dXMgIT0gJ1NLSVBQRUQnCiAgICBBTkQgdGVzdF9zdGF0dXMgTElLRSAnRiUnCiAgICBBTkQgY2hlY2tfc3RhdHVzICE9ICdzdWNjZXNzJwogICAgQU5EIHBvc2l0aW9uKHRlc3RfbmFtZSwgJzAyMzQ2X2Z1bGxfdGV4dF9zZWFyY2gnKSA+IDAKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZQ==

"Ordinary" databases were deprecated in ca. 2020 and nowadays can no longer be created unless a special setting is on.

There is actually a fallback path (recursive removal) and I am not sure why this is logged as "error" instead of "warning".

For now disabling 02346_full_text_search for ordinary databases.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)