### PR TITLE
Check overflow in HashTable::alloc

### DIFF
--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -41,6 +41,7 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int NO_AVAILABLE_DATA;
+    extern const int CANNOT_ALLOCATE_MEMORY;
 }
 }
 

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -513,7 +513,7 @@ protected:
         if (common::mulOverflow(buffer_size, sizeof(Cell), size))
             throw DB::Exception(
                 DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY,
-                "Integer overflow trying to allocate memory for HashTable. Trying to allocate {} cells per {} bytes",
+                "Integer overflow trying to allocate memory for HashTable. Trying to allocate {} cells of {} bytes each",
                 buffer_size, sizeof(Cell));
 
         return size;

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -507,9 +507,21 @@ protected:
         return place_value;
     }
 
+    static size_t allocCheckOverflow(size_t buffer_size)
+    {
+        size_t size = 0;
+        if (common::mulOverflow(buffer_size, sizeof(Cell), size))
+            throw DB::Exception(
+                DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY,
+                "Integer overflow trying to allocate memory for HashTable. Trying to allocate {} cells per {} bytes",
+                buffer_size, sizeof(Cell));
+
+        return size;
+    }
+
     void alloc(const Grower & new_grower)
     {
-        buf = reinterpret_cast<Cell *>(Allocator::alloc(new_grower.bufSize() * sizeof(Cell)));
+        buf = reinterpret_cast<Cell *>(Allocator::alloc(allocCheckOverflow(new_grower.bufSize())));
         grower = new_grower;
     }
 
@@ -566,11 +578,11 @@ protected:
 
         if constexpr (Cell::need_to_notify_cell_during_move)
         {
-            buf = reinterpret_cast<Cell *>(Allocator::alloc(new_grower.bufSize() * sizeof(Cell)));
+            buf = reinterpret_cast<Cell *>(Allocator::alloc(allocCheckOverflow(new_grower.bufSize())));
             memcpy(reinterpret_cast<void *>(buf), reinterpret_cast<const void *>(old_buffer.get()), old_buffer_size);
         }
         else
-            buf = reinterpret_cast<Cell *>(Allocator::realloc(buf, old_buffer_size, new_grower.bufSize() * sizeof(Cell)));
+            buf = reinterpret_cast<Cell *>(Allocator::realloc(buf, old_buffer_size, allocCheckOverflow(new_grower.bufSize())));
 
         grower = new_grower;
 

--- a/tests/queries/0_stateless/02560_agg_state_deserialization_hash_table_crash.sql
+++ b/tests/queries/0_stateless/02560_agg_state_deserialization_hash_table_crash.sql
@@ -1,0 +1,2 @@
+create table tab (d Int64, s AggregateFunction(groupUniqArrayArray, Array(UInt64)), c SimpleAggregateFunction(groupUniqArrayArray, Array(UInt64))) engine = SummingMergeTree() order by d;
+INSERT INTO tab VALUES (1, 'このコー'); -- { clientError CANNOT_ALLOCATE_MEMORY }

--- a/tests/queries/0_stateless/02560_agg_state_deserialization_hash_table_crash.sql
+++ b/tests/queries/0_stateless/02560_agg_state_deserialization_hash_table_crash.sql
@@ -1,2 +1,4 @@
+DROP TABLE IF EXISTS tab;
 create table tab (d Int64, s AggregateFunction(groupUniqArrayArray, Array(UInt64)), c SimpleAggregateFunction(groupUniqArrayArray, Array(UInt64))) engine = SummingMergeTree() order by d;
 INSERT INTO tab VALUES (1, 'このコー'); -- { clientError CANNOT_ALLOCATE_MEMORY }
+DROP TABLE tab;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible crash which can be caused by an integer overflow while deserializing aggregating state of a function that stores HashTable.

Found by **WingFuzz**