### PR TITLE
Remove trash from `MOVE PARTITION` command

### DIFF
--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -403,12 +403,6 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                     command->move_destination_type = DataDestinationType::DISK;
                 else if (s_to_volume.ignore(pos))
                     command->move_destination_type = DataDestinationType::VOLUME;
-                else if (s_to_table.ignore(pos))
-                {
-                    if (!parseDatabaseAndTableName(pos, expected, command->to_database, command->to_table))
-                        return false;
-                    command->move_destination_type = DataDestinationType::TABLE;
-                }
                 else if (s_to_shard.ignore(pos))
                 {
                     command->move_destination_type = DataDestinationType::SHARD;
@@ -416,14 +410,11 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 else
                     return false;
 
-                if (command->move_destination_type != DataDestinationType::TABLE)
-                {
-                    ASTPtr ast_space_name;
-                    if (!parser_string_literal.parse(pos, ast_space_name, expected))
-                        return false;
+                ASTPtr ast_space_name;
+                if (!parser_string_literal.parse(pos, ast_space_name, expected))
+                    return false;
 
-                    command->move_destination_name = ast_space_name->as<ASTLiteral &>().value.get<const String &>();
-                }
+                command->move_destination_name = ast_space_name->as<ASTLiteral &>().value.get<const String &>();
             }
             else if (s_move_partition.ignore(pos, expected))
             {

--- a/tests/queries/0_stateless/00975_move_partition_merge_tree.sql
+++ b/tests/queries/0_stateless/00975_move_partition_merge_tree.sql
@@ -21,6 +21,7 @@ SELECT count() FROM test_move_partition_src;
 SELECT count() FROM test_move_partition_dest;
 
 ALTER TABLE test_move_partition_src MOVE PARTITION 1 TO TABLE test_move_partition_dest;
+ALTER TABLE test_move_partition_src MOVE PART '0_1_1_0' TO TABLE test_move_partition_dest;  -- { clientError SYNTAX_ERROR }
 
 SELECT count() FROM test_move_partition_src;
 SELECT count() FROM test_move_partition_dest;


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed a LOGICAL_ERROR on an attempt to execute `ALTER ... MOVE PART ... TO TABLE`. This type of query was never actually supported. 


https://pastila.nl/?00b49041/a93c2bda8191148bbbfea24e840a8107
