### PR TITLE
Do not pollute logs in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -76,7 +76,10 @@ def trim_for_log(s):
     if not s:
         return s
     lines = s.splitlines()
-    return "\n".join(lines[:50] + ["#" * 100] + lines[-50:])
+    if len(lines) > 100:
+        return "\n".join(lines[:50] + ["#" * 100] + lines[-50:])
+    else:
+        return "\n".join(lines)
 
 
 class HTTPError(Exception):

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -942,7 +942,9 @@ class TestCase:
             description += "\n"
             description += trim_for_log(stderr)
             description += "\n"
-            description += f"\nstdout:\n{stdout}\n"
+            description += "\nstdout:\n"
+            description += trim_for_log(stdout)
+            description += "\n"
             if debug_log:
                 description += "\n"
                 description += debug_log


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

In case of there are less then 100 lines, there is no need to split
lines with '#', and in fact, it will only looks it odd and hard to
interpret.

Follow-up for: #46090