### PR TITLE
Add `X-ClickHouse-Query-Id` header in all queries

### DIFF
--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -11,7 +11,15 @@ namespace DB
 class ReadBuffer;
 class WriteBuffer;
 
-using SetResultDetailsFunc = std::function<void(const String &, const String &, const String &, const String &)>;
+struct QueryResultDetails
+{
+    String query_id;
+    std::optional<String> content_type;
+    std::optional<String> format;
+    std::optional<String> timezone;
+};
+
+using SetResultDetailsFunc = std::function<void(const QueryResultDetails &)>;
 
 /// Parse and execute a query.
 void executeQuery(

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -819,12 +819,20 @@ void HTTPHandler::processQuery(
     customizeContext(request, context);
 
     executeQuery(*in, *used_output.out_maybe_delayed_and_compressed, /* allow_into_outfile = */ false, context,
-        [&response, this] (const String & current_query_id, const String & content_type, const String & format, const String & timezone)
+        [&response, this] (const QueryResultDetails & details)
         {
-            response.setContentType(content_type_override.value_or(content_type));
-            response.add("X-ClickHouse-Query-Id", current_query_id);
-            response.add("X-ClickHouse-Format", format);
-            response.add("X-ClickHouse-Timezone", timezone);
+            response.add("X-ClickHouse-Query-Id", details.query_id);
+
+            if (content_type_override)
+                response.setContentType(*content_type_override);
+            else if (details.content_type)
+                response.setContentType(*details.content_type);
+
+            if (details.format)
+                response.add("X-ClickHouse-Format", *details.format);
+
+            if (details.timezone)
+                response.add("X-ClickHouse-Timezone", *details.timezone);
         }
     );
 

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -354,9 +354,13 @@ void MySQLHandler::comQuery(ReadBuffer & payload)
 
         auto set_result_details = [&with_output](const QueryResultDetails & details)
         {
-            if (details.format && *details.format != "MySQLWire")
-                throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "MySQL protocol does not support custom output formats");
-            with_output = true;
+            if (details.format)
+            {
+                if (*details.format != "MySQLWire")
+                    throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "MySQL protocol does not support custom output formats");
+
+                with_output = true;
+            }
         };
 
         executeQuery(should_replace ? replacement : payload, *out, false, query_context, set_result_details, format_settings);

--- a/src/Server/MySQLHandler.cpp
+++ b/src/Server/MySQLHandler.cpp
@@ -352,9 +352,9 @@ void MySQLHandler::comQuery(ReadBuffer & payload)
         format_settings.mysql_wire.max_packet_size = max_packet_size;
         format_settings.mysql_wire.sequence_id = &sequence_id;
 
-        auto set_result_details = [&with_output](const String &, const String &, const String &format, const String &)
+        auto set_result_details = [&with_output](const QueryResultDetails & details)
         {
-            if (format != "MySQLWire")
+            if (details.format && *details.format != "MySQLWire")
                 throw Exception(ErrorCodes::UNSUPPORTED_METHOD, "MySQL protocol does not support custom output formats");
             with_output = true;
         };

--- a/tests/queries/0_stateless/02564_query_id_header.reference
+++ b/tests/queries/0_stateless/02564_query_id_header.reference
@@ -1,5 +1,22 @@
-X-ClickHouse-Query-Id
-X-ClickHouse-Query-Id
-X-ClickHouse-Query-Id
-X-ClickHouse-Query-Id
-X-ClickHouse-Query-Id
+CREATE TABLE t_query_id_header (a UInt64) ENGINE = Memory
+< Content-Type: text/plain; charset=UTF-8
+< X-ClickHouse-Query-Id: query_id
+< X-ClickHouse-Timezone: timezone
+INSERT INTO t_query_id_header VALUES (1)
+< Content-Type: text/plain; charset=UTF-8
+< X-ClickHouse-Query-Id: query_id
+< X-ClickHouse-Timezone: timezone
+EXISTS TABLE t_query_id_header
+< Content-Type: text/tab-separated-values; charset=UTF-8
+< X-ClickHouse-Format: TabSeparated
+< X-ClickHouse-Query-Id: query_id
+< X-ClickHouse-Timezone: timezone
+SELECT * FROM t_query_id_header
+< Content-Type: text/tab-separated-values; charset=UTF-8
+< X-ClickHouse-Format: TabSeparated
+< X-ClickHouse-Query-Id: query_id
+< X-ClickHouse-Timezone: timezone
+DROP TABLE t_query_id_header
+< Content-Type: text/plain; charset=UTF-8
+< X-ClickHouse-Query-Id: query_id
+< X-ClickHouse-Timezone: timezone

--- a/tests/queries/0_stateless/02564_query_id_header.reference
+++ b/tests/queries/0_stateless/02564_query_id_header.reference
@@ -1,0 +1,5 @@
+X-ClickHouse-Query-Id
+X-ClickHouse-Query-Id
+X-ClickHouse-Query-Id
+X-ClickHouse-Query-Id
+X-ClickHouse-Query-Id

--- a/tests/queries/0_stateless/02564_query_id_header.sh
+++ b/tests/queries/0_stateless/02564_query_id_header.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_query_id_header"
+
+${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "CREATE TABLE t_query_id_header (a UInt64) ENGINE = Memory" 2>&1 | grep -o "X-ClickHouse-Query-Id"
+${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "INSERT INTO t_query_id_header VALUES (1)" 2>&1 | grep -o "X-ClickHouse-Query-Id"
+${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "EXISTS TABLE t_query_id_header" 2>&1 | grep -o "X-ClickHouse-Query-Id"
+${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "SELECT * FROM t_query_id_header" 2>&1 | grep -o "X-ClickHouse-Query-Id"
+${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "DROP TABLE t_query_id_header" 2>&1 | grep -o "X-ClickHouse-Query-Id"

--- a/tests/queries/0_stateless/02564_query_id_header.sh
+++ b/tests/queries/0_stateless/02564_query_id_header.sh
@@ -4,10 +4,27 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+CLICKHOUSE_TIMEZONE_ESCAPED=$($CLICKHOUSE_CLIENT --query="SELECT timezone()" | sed 's/[]\/$*.^+:()[]/\\&/g')
+
+function run_and_check_headers()
+{
+    query=$1
+    query_id="${CLICKHOUSE_DATABASE}_${RANDOM}"
+
+    echo "$query"
+
+    ${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}&query_id=$query_id" -d "$1" 2>&1 \
+        | grep -e "< X-ClickHouse-Query-Id" -e "< X-ClickHouse-Timezone" -e "< X-ClickHouse-Format" -e "< Content-Type" \
+        | sed "s/$CLICKHOUSE_TIMEZONE_ESCAPED/timezone/" \
+        | sed "s/$query_id/query_id/" \
+        | sed "s/\r$//" \
+        | sort
+}
+
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_query_id_header"
 
-${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "CREATE TABLE t_query_id_header (a UInt64) ENGINE = Memory" 2>&1 | grep -o "X-ClickHouse-Query-Id"
-${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "INSERT INTO t_query_id_header VALUES (1)" 2>&1 | grep -o "X-ClickHouse-Query-Id"
-${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "EXISTS TABLE t_query_id_header" 2>&1 | grep -o "X-ClickHouse-Query-Id"
-${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "SELECT * FROM t_query_id_header" 2>&1 | grep -o "X-ClickHouse-Query-Id"
-${CLICKHOUSE_CURL} -sS -v "${CLICKHOUSE_URL}" -d "DROP TABLE t_query_id_header" 2>&1 | grep -o "X-ClickHouse-Query-Id"
+run_and_check_headers "CREATE TABLE t_query_id_header (a UInt64) ENGINE = Memory"
+run_and_check_headers "INSERT INTO t_query_id_header VALUES (1)"
+run_and_check_headers "EXISTS TABLE t_query_id_header"
+run_and_check_headers "SELECT * FROM t_query_id_header"
+run_and_check_headers "DROP TABLE t_query_id_header"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Now `X-ClickHouse-Query-Id` and `X-ClickHouse-Timezone` headers are added to response in all queries via http protocol. Previously it was done only for `SELECT` queries.