### PR TITLE
Fix noisy log messages

### DIFF
--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -245,11 +245,7 @@ void KeeperDispatcher::setResponse(int64_t session_id, const Coordination::ZooKe
 
         /// Session was disconnected, just skip this response
         if (session_response_callback == session_to_response_callback.end())
-        {
-            LOG_TEST(log, "Cannot write response xid={}, op={}, session {} disconnected",
-                response->xid, response->xid == Coordination::WATCH_XID ? "Watch" : toString(response->getOpNum()), session_id);
             return;
-        }
 
         session_response_callback->second(response);
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1248,7 +1248,10 @@ bool ReplicatedMergeTreeQueue::isCoveredByFuturePartsImpl(const LogEntry & entry
 
         constexpr auto fmt_string = "Not executing log entry {} for part {} "
                                     "because it is not disjoint with part {} that is currently executing.";
-        LOG_TEST(LogToStr(out_reason, log), fmt_string, entry.znode_name, new_part_name, future_part_elem.first);
+
+        /// This message can be too noisy, do not print it more than once per second
+        if (!(entry.last_postpone_time == time(nullptr) && entry.postpone_reason.ends_with("that is currently executing.")))
+            LOG_TEST(LogToStr(out_reason, log), fmt_string, entry.znode_name, new_part_name, future_part_elem.first);
         return true;
     }
 


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fixes `00002_log_and_exception_messages_formatting` failures like this: https://s3.amazonaws.com/clickhouse-test-reports/0/f57ba896c811ab1c711d99fbd66a3e9aba34f19e/stateless_tests__release__databasereplicated__[1/2].html