### PR TITLE
Another fix for cluster copier

### DIFF
--- a/programs/copier/ClusterCopier.cpp
+++ b/programs/copier/ClusterCopier.cpp
@@ -1225,8 +1225,8 @@ TaskStatus ClusterCopier::iterateThroughAllPiecesInPartition(const ConnectionTim
             std::this_thread::sleep_for(retry_delay_ms);
         }
 
-        was_active_pieces = (res == TaskStatus::Active);
-        was_failed_pieces = (res == TaskStatus::Error);
+        was_active_pieces |= (res == TaskStatus::Active);
+        was_failed_pieces |= (res == TaskStatus::Error);
     }
 
     if (was_failed_pieces)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


It seems https://github.com/ClickHouse/ClickHouse/pull/46120 didn't fix the problem.
After checking logs, it simply exhausts the retries.
The first problem is that copy fault exhausts 2 attempts per partition piece number (we do 3 retries in total).
Still, we do retries on the entire partition also so we should have 3 * 3 attempts but because of a mistake a successful piece in the partition after a failed one would mark the entire partition as successful and break the partition loop (because it thinks it finished).
After the partition loop we check the partitions, find an incorrect piece and retry the entire table again. After 3 table retries we fail.

Close https://github.com/ClickHouse/ClickHouse/issues/30399 (final time I hope)

cc @nikitamikhaylov 
### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
