### PR TITLE
Do not fetch submodules in release.py

### DIFF
--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -104,8 +104,10 @@ class Release:
 
     def set_release_info(self):
         # Fetch release commit and tags in case they don't exist locally
-        self.run(f"git fetch {self.repo.url} {self.release_commit}")
-        self.run(f"git fetch {self.repo.url} --tags")
+        self.run(
+            f"git fetch {self.repo.url} {self.release_commit} --no-recurse-submodules"
+        )
+        self.run(f"git fetch {self.repo.url} --tags --no-recurse-submodules")
 
         # Get the actual version for the commit before check
         with self._checkout(self.release_commit, True):
@@ -248,9 +250,11 @@ class Release:
 
         # Prefetch the branch to have it updated
         if self._git.branch == branch:
-            self.run("git pull")
+            self.run("git pull --no-recurse-submodules")
         else:
-            self.run(f"git fetch {self.repo.url} {branch}:{branch}")
+            self.run(
+                f"git fetch {self.repo.url} {branch}:{branch} --no-recurse-submodules"
+            )
         output = self.run(f"git branch --contains={self.release_commit} {branch}")
         if branch not in output:
             raise Exception(


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not fetch submodules to avoid possible errors.


### example

```
$ git fetch git@github.com:ClickHouse/ClickHouse.git --tags
From github.com:ClickHouse/ClickHouse
 * branch                    HEAD       -> FETCH_HEAD
Fetching submodule contrib/unixodbc
fatal: remote error: upload-pack: not our ref 6c8071b1bef4e4991e7b3023a1c1c712168a818e
Errors during submodule fetch:
	contrib/unixodbc
$ git fetch --tags --no-recurse-submodules
$
```