### PR TITLE
Wait for tasks finish when scheduler failed

### DIFF
--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -227,6 +227,8 @@ namespace
             catch (...)
             {
                 tryLogCurrentException(__PRETTY_FUNCTION__);
+                // Multipart upload failed because it wasn't possible to schedule all the tasks.
+                // To avoid execution of already scheduled tasks we abort MultipartUpload.
                 abortMultipartUpload();
                 waitForAllBackGroundTasks();
                 throw;

--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -66,17 +66,7 @@ namespace
         {
         }
 
-        virtual ~UploadHelper()
-        {
-            try
-            {
-                waitForAllBackGroundTasks();
-            }
-            catch (...)
-            {
-                tryLogCurrentException(__PRETTY_FUNCTION__);
-            }
-        }
+        virtual ~UploadHelper() = default;
 
     protected:
         std::shared_ptr<const S3::Client> client_ptr;
@@ -219,17 +209,27 @@ namespace
             size_t position = start_offset;
             size_t end_position = start_offset + size;
 
-            for (size_t part_number = 1; position < end_position; ++part_number)
+            try
             {
-                if (multipart_upload_aborted)
-                    break; /// No more part uploads.
+                for (size_t part_number = 1; position < end_position; ++part_number)
+                {
+                    if (multipart_upload_aborted)
+                        break; /// No more part uploads.
 
-                size_t next_position = std::min(position + normal_part_size, end_position);
-                size_t part_size = next_position - position; /// `part_size` is either `normal_part_size` or smaller if it's the final part.
+                    size_t next_position = std::min(position + normal_part_size, end_position);
+                    size_t part_size = next_position - position; /// `part_size` is either `normal_part_size` or smaller if it's the final part.
 
-                uploadPart(part_number, position, part_size);
+                    uploadPart(part_number, position, part_size);
 
-                position = next_position;
+                    position = next_position;
+                }
+            }
+            catch (...)
+            {
+                tryLogCurrentException(__PRETTY_FUNCTION__);
+                abortMultipartUpload();
+                waitForAllBackGroundTasks();
+                throw;
             }
 
             waitForAllBackGroundTasks();


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Scheduler may fail to schedule a task. If it happens, the whole MulityPartUpload should be aborted and `UploadHelper` must wait for already scheduled tasks.

Followup #46334 cc @KochetovNicolai @nikitamikhaylov 