### PR TITLE
Change logging level of a verbose message to Trace

### DIFF
--- a/src/Processors/Transforms/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/AggregatingTransform.cpp
@@ -555,7 +555,7 @@ void AggregatingTransform::initGenerate()
     double elapsed_seconds = watch.elapsedSeconds();
     size_t rows = variants.sizeWithoutOverflowRow();
 
-    LOG_DEBUG(log, "Aggregated. {} to {} rows (from {}) in {} sec. ({:.3f} rows/sec., {}/sec.)",
+    LOG_TRACE(log, "Aggregated. {} to {} rows (from {}) in {} sec. ({:.3f} rows/sec., {}/sec.)",
         src_rows, rows, ReadableSize(src_bytes),
         elapsed_seconds, src_rows / elapsed_seconds,
         ReadableSize(src_bytes / elapsed_seconds));


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See https://s3.amazonaws.com/clickhouse-test-reports/46360/33037334a5f9ba1f074527b1adbf4846d0f09f07/stateless_tests__release__databasereplicated__[3/4]/run.log

See also https://github.com/ClickHouse/ClickHouse/pull/23160 