### PR TITLE
Fix systemd service  file wrong inline comment

### DIFF
--- a/packages/clickhouse-server.service
+++ b/packages/clickhouse-server.service
@@ -17,7 +17,7 @@ User=clickhouse
 Group=clickhouse
 Restart=always
 RestartSec=30
- # %p is resolved to the systemd unit name
+# %p is resolved to the systemd unit name
 RuntimeDirectory=%p 
 ExecStart=/usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml --pid-file=%t/%p/%p.pid
 # Minus means that this file is optional.

--- a/packages/clickhouse-server.service
+++ b/packages/clickhouse-server.service
@@ -17,7 +17,8 @@ User=clickhouse
 Group=clickhouse
 Restart=always
 RestartSec=30
-RuntimeDirectory=%p  # %p is resolved to the systemd unit name
+ # %p is resolved to the systemd unit name
+RuntimeDirectory=%p 
 ExecStart=/usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml --pid-file=%t/%p/%p.pid
 # Minus means that this file is optional.
 EnvironmentFile=-/etc/default/%p


### PR DESCRIPTION
There is no inline comment in systemd unit file.

the before will create some many wrong runtime directory such as `#`, `is`,  `resolved`, `to`, `the`, `systemd`, `unit`,  `name`.
And the wrong `systemd`  directory will cause systemd broken after clickhouse-server close/restart in some linux distribution.(such as ubuntu 18.04)
![image](https://user-images.githubusercontent.com/3500109/219273689-a5e5d7b2-c366-4555-a5e0-3ecee320fbd6.png)


### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix Systemd service file
