### PR TITLE
Extend aggregate function `first_value` and `last_value` 

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/first_value.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/first_value.md
@@ -9,7 +9,7 @@ Selects the first encountered value, similar to `any`, but could accept NULL.
 
 ## examples
 
-```sq;
+```sql
 insert into test_data (a,b) values (1,null), (2,3), (4, 5), (6,null)
 ```
 

--- a/docs/en/sql-reference/aggregate-functions/reference/first_value.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/first_value.md
@@ -46,6 +46,7 @@ select first_value(b) respect nulls from test_data
 ```
 
 ```text
+
 ┌─first_value_respect_nulls(b)─┐
 │                         ᴺᵁᴸᴸ │
 └──────────────────────────────┘

--- a/docs/en/sql-reference/aggregate-functions/reference/first_value.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/first_value.md
@@ -1,0 +1,52 @@
+---
+slug: /en/sql-reference/aggregate-functions/reference/first_value
+sidebar_position: 7
+---
+
+# first_value
+
+Selects the first encountered value, similar to `any`, but could accept NULL.
+
+## examples
+
+```sq;
+insert into test_data (a,b) values (1,null), (2,3), (4, 5), (6.null)
+```
+
+### example1
+The NULL value is ignored at default.
+```sql
+select first_value(b) from test_data
+```
+
+```text
+┌─first_value(b)─┐
+│              3 │
+└────────────────┘
+```
+
+### example2
+The NULL value is ignored.
+```sql
+select first_value(false)(b) from test_data
+```
+
+```text
+┌─first_value(false)(b)─┐
+│                     3 │
+└───────────────────────┘
+```
+
+### example3
+The NULL value is accepted.
+```sql
+select first_value(true)(b) from test_data
+```
+
+```text
+┌─first_value(true)(b)─┐
+│                 ᴺᵁᴸᴸ │
+└──────────────────────┘
+```
+
+

--- a/docs/en/sql-reference/aggregate-functions/reference/first_value.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/first_value.md
@@ -10,7 +10,7 @@ Selects the first encountered value, similar to `any`, but could accept NULL.
 ## examples
 
 ```sq;
-insert into test_data (a,b) values (1,null), (2,3), (4, 5), (6.null)
+insert into test_data (a,b) values (1,null), (2,3), (4, 5), (6,null)
 ```
 
 ### example1
@@ -20,33 +20,35 @@ select first_value(b) from test_data
 ```
 
 ```text
-┌─first_value(b)─┐
-│              3 │
-└────────────────┘
+┌─first_value_ignore_nulls(b)─┐
+│                           3 │
+└─────────────────────────────┘
+
 ```
 
 ### example2
 The NULL value is ignored.
 ```sql
-select first_value(false)(b) from test_data
+select first_value(b) ignore nulls sfrom test_data
 ```
 
 ```text
-┌─first_value(false)(b)─┐
-│                     3 │
-└───────────────────────┘
+┌─first_value_ignore_nulls(b)─┐
+│                           3 │
+└─────────────────────────────┘
+
 ```
 
 ### example3
 The NULL value is accepted.
 ```sql
-select first_value(true)(b) from test_data
+select first_value(b) respect nulls from test_data
 ```
 
 ```text
-┌─first_value(true)(b)─┐
-│                 ᴺᵁᴸᴸ │
-└──────────────────────┘
+┌─first_value_respect_nulls(b)─┐
+│                         ᴺᵁᴸᴸ │
+└──────────────────────────────┘
 ```
 
 

--- a/docs/en/sql-reference/aggregate-functions/reference/index.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/index.md
@@ -26,6 +26,8 @@ ClickHouse-specific aggregate functions:
 
 - [anyHeavy](../../../sql-reference/aggregate-functions/reference/anyheavy.md)
 - [anyLast](../../../sql-reference/aggregate-functions/reference/anylast.md)
+- [first_value](../../../sql-reference/aggregate-functions/reference/first_value.md)
+- [last_value](../../../sql-reference/aggregate-functions/reference/last_value.md)
 - [argMin](../../../sql-reference/aggregate-functions/reference/argmin.md)
 - [argMax](../../../sql-reference/aggregate-functions/reference/argmax.md)
 - [avgWeighted](../../../sql-reference/aggregate-functions/reference/avgweighted.md)

--- a/docs/en/sql-reference/aggregate-functions/reference/last_value.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/last_value.md
@@ -1,0 +1,53 @@
+---
+slug: /en/sql-reference/aggregate-functions/reference/last_value
+sidebar_position: 8
+---
+
+# first_value
+
+Selects the last encountered value, similar to `anyLast`, but could accept NULL.
+
+
+## examples
+
+```sq;
+insert into test_data (a,b) values (1,null), (2,3), (4, 5), (6.null)
+```
+
+### example1
+The NULL value is ignored at default.
+```sql
+select last_value(b) from test_data
+```
+
+```text
+┌─last_value(b)─┐
+│             5 │
+└───────────────┘
+```
+
+### example2
+The NULL value is ignored.
+```sql
+select last_value(false)(b) from test_data
+```
+
+```text
+┌─last_value(false)(b)─┐
+│                    5 │
+└──────────────────────┘
+```
+
+### example3
+The NULL value is accepted.
+```sql
+select last_value(true)(b) from test_data
+```
+
+```text
+┌─last_value(true)(b)─┐
+│                ᴺᵁᴸᴸ │
+└─────────────────────┘
+```
+
+

--- a/docs/en/sql-reference/aggregate-functions/reference/last_value.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/last_value.md
@@ -10,7 +10,7 @@ Selects the last encountered value, similar to `anyLast`, but could accept NULL.
 
 ## examples
 
-```sq;
+```sql
 insert into test_data (a,b) values (1,null), (2,3), (4, 5), (6,null)
 ```
 

--- a/docs/en/sql-reference/aggregate-functions/reference/last_value.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/last_value.md
@@ -11,7 +11,7 @@ Selects the last encountered value, similar to `anyLast`, but could accept NULL.
 ## examples
 
 ```sq;
-insert into test_data (a,b) values (1,null), (2,3), (4, 5), (6.null)
+insert into test_data (a,b) values (1,null), (2,3), (4, 5), (6,null)
 ```
 
 ### example1
@@ -21,33 +21,33 @@ select last_value(b) from test_data
 ```
 
 ```text
-┌─last_value(b)─┐
-│             5 │
-└───────────────┘
+┌─last_value_ignore_nulls(b)─┐
+│                          5 │
+└────────────────────────────┘
 ```
 
 ### example2
 The NULL value is ignored.
 ```sql
-select last_value(false)(b) from test_data
+select last_value(b) ignore nulls from test_data
 ```
 
 ```text
-┌─last_value(false)(b)─┐
-│                    5 │
-└──────────────────────┘
+┌─last_value_ignore_nulls(b)─┐
+│                          5 │
+└────────────────────────────┘
 ```
 
 ### example3
 The NULL value is accepted.
 ```sql
-select last_value(true)(b) from test_data
+select last_value(b) respect nulls from test_data
 ```
 
 ```text
-┌─last_value(true)(b)─┐
-│                ᴺᵁᴸᴸ │
-└─────────────────────┘
+┌─last_value_respect_nulls(b)─┐
+│                        ᴺᵁᴸᴸ │
+└─────────────────────────────┘
 ```
 
 

--- a/src/AggregateFunctions/AggregateFunctionAny.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAny.cpp
@@ -14,9 +14,12 @@ AggregateFunctionPtr createAggregateFunctionAny(const std::string & name, const 
     return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionAnyData>(name, argument_types, parameters, settings));
 }
 
+template <bool RespectNulls = false, bool NullIsGreater = false>
 AggregateFunctionPtr createAggregateFunctionNullableAny(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
 {
-    return AggregateFunctionPtr(createAggregateFunctionSingleNullableValue<AggregateFunctionsSingleValue, AggregateFunctionAnyData>(name, argument_types, parameters, settings));
+    return AggregateFunctionPtr(
+        createAggregateFunctionSingleNullableValue<AggregateFunctionsSingleValue, AggregateFunctionAnyData, RespectNulls, NullIsGreater>(
+            name, argument_types, parameters, settings));
 }
 
 AggregateFunctionPtr createAggregateFunctionAnyLast(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
@@ -24,9 +27,14 @@ AggregateFunctionPtr createAggregateFunctionAnyLast(const std::string & name, co
     return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionAnyLastData>(name, argument_types, parameters, settings));
 }
 
+template <bool RespectNulls = false, bool NullIsGreater = false>
 AggregateFunctionPtr createAggregateFunctionNullableAnyLast(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
 {
-    return AggregateFunctionPtr(createAggregateFunctionSingleNullableValue<AggregateFunctionsSingleValue, AggregateFunctionAnyLastData>(name, argument_types, parameters, settings));
+    return AggregateFunctionPtr(createAggregateFunctionSingleNullableValue<
+                                AggregateFunctionsSingleValue,
+                                AggregateFunctionAnyLastData,
+                                RespectNulls,
+                                NullIsGreater>(name, argument_types, parameters, settings));
 }
 
 AggregateFunctionPtr createAggregateFunctionAnyHeavy(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
@@ -46,10 +54,22 @@ void registerAggregateFunctionsAny(AggregateFunctionFactory & factory)
 
     // Synonyms for use as window functions.
     factory.registerFunction("first_value",
-        { createAggregateFunctionNullableAny, properties },
+        { createAggregateFunctionAny, properties },
+        AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("first_value_respect_nulls",
+        { createAggregateFunctionNullableAny<true>, properties },
+        AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("first_value_ignore_nulls",
+        { createAggregateFunctionNullableAny<false>, properties },
         AggregateFunctionFactory::CaseInsensitive);
     factory.registerFunction("last_value",
-        { createAggregateFunctionNullableAnyLast, properties },
+        { createAggregateFunctionAnyLast, properties },
+        AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("last_value_respect_nulls",
+        { createAggregateFunctionNullableAnyLast<true>, properties },
+        AggregateFunctionFactory::CaseInsensitive);
+    factory.registerFunction("last_value_ignore_nulls",
+        { createAggregateFunctionNullableAnyLast<false>, properties },
         AggregateFunctionFactory::CaseInsensitive);
 }
 

--- a/src/AggregateFunctions/AggregateFunctionAny.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAny.cpp
@@ -14,11 +14,12 @@ AggregateFunctionPtr createAggregateFunctionAny(const std::string & name, const 
     return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionAnyData>(name, argument_types, parameters, settings));
 }
 
-template <bool RespectNulls = false, bool NullIsGreater = false>
-AggregateFunctionPtr createAggregateFunctionNullableAny(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
+template <bool RespectNulls = false>
+AggregateFunctionPtr createAggregateFunctionNullableAny(
+    const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
 {
     return AggregateFunctionPtr(
-        createAggregateFunctionSingleNullableValue<AggregateFunctionsSingleValue, AggregateFunctionAnyData, RespectNulls, NullIsGreater>(
+        createAggregateFunctionSingleNullableValue<AggregateFunctionsSingleValue, AggregateFunctionAnyData, RespectNulls>(
             name, argument_types, parameters, settings));
 }
 
@@ -27,14 +28,13 @@ AggregateFunctionPtr createAggregateFunctionAnyLast(const std::string & name, co
     return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionAnyLastData>(name, argument_types, parameters, settings));
 }
 
-template <bool RespectNulls = false, bool NullIsGreater = false>
+template <bool RespectNulls = false>
 AggregateFunctionPtr createAggregateFunctionNullableAnyLast(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
 {
     return AggregateFunctionPtr(createAggregateFunctionSingleNullableValue<
                                 AggregateFunctionsSingleValue,
                                 AggregateFunctionAnyLastData,
-                                RespectNulls,
-                                NullIsGreater>(name, argument_types, parameters, settings));
+                                RespectNulls>(name, argument_types, parameters, settings));
 }
 
 AggregateFunctionPtr createAggregateFunctionAnyHeavy(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
@@ -59,17 +59,11 @@ void registerAggregateFunctionsAny(AggregateFunctionFactory & factory)
     factory.registerFunction("first_value_respect_nulls",
         { createAggregateFunctionNullableAny<true>, properties },
         AggregateFunctionFactory::CaseInsensitive);
-    factory.registerFunction("first_value_ignore_nulls",
-        { createAggregateFunctionNullableAny<false>, properties },
-        AggregateFunctionFactory::CaseInsensitive);
     factory.registerFunction("last_value",
         { createAggregateFunctionAnyLast, properties },
         AggregateFunctionFactory::CaseInsensitive);
     factory.registerFunction("last_value_respect_nulls",
         { createAggregateFunctionNullableAnyLast<true>, properties },
-        AggregateFunctionFactory::CaseInsensitive);
-    factory.registerFunction("last_value_ignore_nulls",
-        { createAggregateFunctionNullableAnyLast<false>, properties },
         AggregateFunctionFactory::CaseInsensitive);
 }
 

--- a/src/AggregateFunctions/AggregateFunctionAny.cpp
+++ b/src/AggregateFunctions/AggregateFunctionAny.cpp
@@ -14,9 +14,19 @@ AggregateFunctionPtr createAggregateFunctionAny(const std::string & name, const 
     return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionAnyData>(name, argument_types, parameters, settings));
 }
 
+AggregateFunctionPtr createAggregateFunctionNullableAny(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
+{
+    return AggregateFunctionPtr(createAggregateFunctionSingleNullableValue<AggregateFunctionsSingleValue, AggregateFunctionAnyData>(name, argument_types, parameters, settings));
+}
+
 AggregateFunctionPtr createAggregateFunctionAnyLast(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
 {
     return AggregateFunctionPtr(createAggregateFunctionSingleValue<AggregateFunctionsSingleValue, AggregateFunctionAnyLastData>(name, argument_types, parameters, settings));
+}
+
+AggregateFunctionPtr createAggregateFunctionNullableAnyLast(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
+{
+    return AggregateFunctionPtr(createAggregateFunctionSingleNullableValue<AggregateFunctionsSingleValue, AggregateFunctionAnyLastData>(name, argument_types, parameters, settings));
 }
 
 AggregateFunctionPtr createAggregateFunctionAnyHeavy(const std::string & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
@@ -36,10 +46,10 @@ void registerAggregateFunctionsAny(AggregateFunctionFactory & factory)
 
     // Synonyms for use as window functions.
     factory.registerFunction("first_value",
-        { createAggregateFunctionAny, properties },
+        { createAggregateFunctionNullableAny, properties },
         AggregateFunctionFactory::CaseInsensitive);
     factory.registerFunction("last_value",
-        { createAggregateFunctionAnyLast, properties },
+        { createAggregateFunctionNullableAnyLast, properties },
         AggregateFunctionFactory::CaseInsensitive);
 }
 

--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -106,7 +106,7 @@ AggregateFunctionPtr AggregateFunctionFactory::get(
         // nullability themselves. Another special case is functions from Nothing
         // that are rewritten to AggregateFunctionNothing, in this case
         // nested_function is nullptr.
-        if (!nested_function || !nested_function->isOnlyWindowFunction())
+        if (!nested_function->getResultType()->isNullable() && (!nested_function || !nested_function->isOnlyWindowFunction()))
             return combinator->transformAggregateFunction(nested_function, out_properties, types_without_low_cardinality, parameters);
     }
 

--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -106,7 +106,7 @@ AggregateFunctionPtr AggregateFunctionFactory::get(
         // nullability themselves. Another special case is functions from Nothing
         // that are rewritten to AggregateFunctionNothing, in this case
         // nested_function is nullptr.
-        if ((!nested_function || !nested_function->isOnlyWindowFunction()))
+        if (!nested_function || !nested_function->isOnlyWindowFunction())
             return combinator->transformAggregateFunction(nested_function, out_properties, types_without_low_cardinality, parameters);
     }
 

--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -106,7 +106,7 @@ AggregateFunctionPtr AggregateFunctionFactory::get(
         // nullability themselves. Another special case is functions from Nothing
         // that are rewritten to AggregateFunctionNothing, in this case
         // nested_function is nullptr.
-        if (!nested_function->getResultType()->isNullable() && (!nested_function || !nested_function->isOnlyWindowFunction()))
+        if ((!nested_function || !nested_function->isOnlyWindowFunction()))
             return combinator->transformAggregateFunction(nested_function, out_properties, types_without_low_cardinality, parameters);
     }
 

--- a/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -1478,6 +1478,17 @@ public:
         this->data(place).insertResultInto(to);
     }
 
+    AggregateFunctionPtr getOwnNullAdapter(
+        const AggregateFunctionPtr & nested_function,
+        const DataTypes & /*arguments*/,
+        const Array & /*params*/,
+        const AggregateFunctionProperties & /*properties*/) const override
+    {
+        if (Data::is_nullable)
+            return nested_function;
+        return nullptr;
+    }
+
 #if USE_EMBEDDED_COMPILER
 
     bool isCompilable() const override

--- a/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
+++ b/src/AggregateFunctions/AggregateFunctionMinMaxAny.h
@@ -766,7 +766,7 @@ static_assert(
 
 
 /// For any other value types.
-template <bool IS_NULLABLE = false, bool IS_NULL_GREATER = false>
+template <bool IS_NULLABLE = false>
 struct SingleValueDataGeneric
 {
 private:
@@ -778,7 +778,6 @@ private:
 public:
     static constexpr bool is_nullable = IS_NULLABLE;
     static constexpr bool is_any = false;
-    static constexpr bool is_null_greater = IS_NULL_GREATER;
 
     bool has() const
     {
@@ -881,26 +880,13 @@ public:
             {
                 Field new_value;
                 column.get(row_num, new_value);
-                if constexpr (!is_null_greater)
+                if (!value.isNull() && (new_value.isNull() || new_value < value))
                 {
-                    if (!value.isNull() && (new_value.isNull() || new_value < value))
-                    {
-                        value = new_value;
-                        return true;
-                    }
-                    else
-                        return false;
+                    value = new_value;
+                    return true;
                 }
                 else
-                {
-                    if ((value.isNull() && !new_value.isNull()) || (!new_value.isNull() && new_value < value))
-                    {
-                        value = new_value;
-                        return true;
-                    }
-
                     return false;
-                }
             }
             else
             {
@@ -928,24 +914,12 @@ public:
                 change(to, arena);
                 return true;
             }
-            if constexpr (!is_null_greater)
+            if (to.value.isNull() || (!value.isNull() && to.value < value))
             {
-                if (to.value.isNull() || (!value.isNull() && to.value < value))
-                {
-                    value = to.value;
-                    return true;
-                }
-                return false;
+                value = to.value;
+                return true;
             }
-            else
-            {
-                if ((value.isNull() && !to.value.isNull()) || (!to.value.isNull() || to.value < value))
-                {
-                    value = to.value;
-                    return true;
-                }
-                return false;
-            }
+            return false;
         }
         else
         {
@@ -972,24 +946,12 @@ public:
             {
                 Field new_value;
                 column.get(row_num, new_value);
-                if constexpr (is_null_greater)
+                if (!value.isNull() && (new_value.isNull() || value < new_value))
                 {
-                    if (!value.isNull() && (new_value.isNull() || value < new_value))
-                    {
-                        value = new_value;
-                        return true;
-                    }
-                    return false;
+                    value = new_value;
+                    return true;
                 }
-                else
-                {
-                    if ((value.isNull() && !new_value.isNull()) || (!new_value.isNull() && value < new_value))
-                    {
-                        value = new_value;
-                        return true;
-                    }
-                    return false;
-                }
+                return false;
             }
             else
             {
@@ -1012,25 +974,12 @@ public:
             return false;
         if constexpr (is_nullable)
         {
-            if constexpr (is_null_greater)
+            if (!value.isNull() && (to.value.isNull() || value < to.value))
             {
-                if (!value.isNull() && (to.value.isNull() || value < to.value))
-                {
-                    value = to.value;
-                    return true;
-                }
-                return false;
+                value = to.value;
+                return true;
             }
-            else
-            {
-                if ((value.isNull() && !to.value.isNull()) || (!to.value.isNull() && value < to.value))
-                {
-                    value = to.value;
-                    return true;
-                }
-                return false;
-
-            }
+            return false;
         }
         else
         {

--- a/src/AggregateFunctions/HelpersMinMaxAny.h
+++ b/src/AggregateFunctions/HelpersMinMaxAny.h
@@ -11,10 +11,6 @@
 
 namespace DB
 {
-namespace ErrorCodes
-{
-    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
-}
 struct Settings;
 
 /// min, max, any, anyLast, anyHeavy, etc...
@@ -51,29 +47,23 @@ static IAggregateFunction * createAggregateFunctionSingleValue(const String & na
     return new AggregateFunctionTemplate<Data<SingleValueDataGeneric<>>>(argument_type);
 }
 
-template <template <typename> class AggregateFunctionTemplate, template <typename> class Data, bool RespectNulls = false, bool NullIsGreater = false>
+template <template <typename> class AggregateFunctionTemplate, template <typename> class Data, bool RespectNulls = false>
 static IAggregateFunction * createAggregateFunctionSingleNullableValue(const String & name, const DataTypes & argument_types, const Array & parameters, const Settings * settings)
 {
     assertNoParameters(name, parameters);
     assertUnary(name, argument_types);
-    if (parameters.size() > 2)
-        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "name's parameter size must not be larger  then 2");
 
     const DataTypePtr & argument_type = argument_types[0];
     WhichDataType which(argument_type);
-    // if the resule value could be null(excluding the case that no row is matched),
+    // If the result value could be null (excluding the case that no row is matched),
     // use SingleValueDataGeneric.
     if constexpr (!RespectNulls)
     {
         return createAggregateFunctionSingleValue<AggregateFunctionTemplate, Data>(name, argument_types, Array(), settings);
     }
-    else if constexpr (NullIsGreater)
-    {
-        return new AggregateFunctionTemplate<Data<SingleValueDataGeneric<true, true>>>(argument_type);
-    }
     else
     {
-        return new AggregateFunctionTemplate<Data<SingleValueDataGeneric<true, false>>>(argument_type);
+        return new AggregateFunctionTemplate<Data<SingleValueDataGeneric<true>>>(argument_type);
     }
     UNREACHABLE();
 }

--- a/src/AggregateFunctions/HelpersMinMaxAny.h
+++ b/src/AggregateFunctions/HelpersMinMaxAny.h
@@ -153,7 +153,7 @@ static IAggregateFunction * createAggregateFunctionArgMinMax(const String & name
     if (which.idx == TypeIndex::String)
         return createAggregateFunctionArgMinMaxSecond<MinMaxData, SingleValueDataString>(res_type, val_type);
 
-    return createAggregateFunctionArgMinMaxSecond<MinMaxData, SingleValueDataGeneric<false>>(res_type, val_type);
+    return createAggregateFunctionArgMinMaxSecond<MinMaxData, SingleValueDataGeneric<>>(res_type, val_type);
 }
 
 }

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1,4 +1,5 @@
 #include <string_view>
+#include <unordered_map>
 
 #include <Parsers/ExpressionListParsers.h>
 #include <Parsers/ParserSetQuery.h>
@@ -25,6 +26,7 @@
 
 #include <Common/logger_useful.h>
 #include <Parsers/queryToString.h>
+#include <Parsers/CommonParsers.h>
 
 using namespace std::literals;
 
@@ -1085,6 +1087,8 @@ public:
 
             ParserKeyword filter("FILTER");
             ParserKeyword over("OVER");
+            ParserKeyword respect_nulls("RESPECT NULLS");
+            ParserKeyword ignore_nulls("IGNORE NULLS");
 
             if (filter.ignore(pos, expected))
             {
@@ -1099,6 +1103,17 @@ public:
                 if (!filter_parser.parse(pos, function_node_as_iast, expected))
                     return false;
             }
+
+            NullsAction nulls_action = NullsAction::DEFAULT;
+            if (respect_nulls.ignore(pos, expected))
+            {
+                nulls_action = NullsAction::RESPECT_NULLS;
+            }
+            if (ignore_nulls.ignore(pos, expected))
+            {
+                nulls_action = NullsAction::IGNORE_NULLS;
+            }
+            function_node->name = transformFunctionNameForRepectNulls(function_node->name, nulls_action);
 
             if (over.ignore(pos, expected))
             {
@@ -1132,6 +1147,24 @@ private:
 
     bool allow_function_parameters;
     bool is_compound_name;
+
+    enum NullsAction
+    {
+        DEFAULT = 0,
+        RESPECT_NULLS = 1,
+        IGNORE_NULLS = 2,
+    };
+    static String transformFunctionNameForRepectNulls(const String & original_function_name, NullsAction nulls_action)
+    {
+        static std::unordered_map<String, std::vector<String>> renamed_functions_with_nulls = {
+            {"first_value", {"first_value_ignore_nulls", "first_value_respect_nulls", "first_value_ignore_nulls"}},
+            {"last_value", {"last_value_ignore_nulls", "last_value_respect_nulls", "last_value_ignore_nulls"}},
+        };
+        auto it = renamed_functions_with_nulls.find(original_function_name);
+        if (it == renamed_functions_with_nulls.end())
+            return original_function_name;
+        return it->second[nulls_action];
+    }
 };
 
 /// Layer for priority brackets and tuple function
@@ -2353,7 +2386,6 @@ bool ParserExpressionImpl::parse(std::unique_ptr<Layer> start, IParser::Pos & po
         {
             if (!layers.back()->parse(pos, expected, next))
                 break;
-
             if (layers.back()->isFinished())
             {
                 if (layers.size() == 1)

--- a/tests/queries/0_stateless/02662_first_last_value.reference
+++ b/tests/queries/0_stateless/02662_first_last_value.reference
@@ -1,0 +1,20 @@
+-- { echo }
+
+-- create table
+drop table if exists test;
+create table test(`a` Nullable(Int32), `b` Nullable(Int32)) ENGINE = Memory;
+insert into test (a,b) values (1,null), (2,3), (4, 5), (6,null);
+-- first value
+select first_value(b) from test;
+3
+select first_value(false)(b) from test;
+3
+select first_value(true)(b) from test;
+\N
+-- last value
+select last_value(b) from test;
+5
+select last_value(false)(b) from test;
+5
+select last_value(true)(b) from test;
+\N

--- a/tests/queries/0_stateless/02662_first_last_value.reference
+++ b/tests/queries/0_stateless/02662_first_last_value.reference
@@ -7,14 +7,14 @@ insert into test (a,b) values (1,null), (2,3), (4, 5), (6,null);
 -- first value
 select first_value(b) from test;
 3
-select first_value(false)(b) from test;
+select first_value(b) ignore nulls from test;
 3
-select first_value(true)(b) from test;
+select first_value(b) respect nulls from test;
 \N
 -- last value
 select last_value(b) from test;
 5
-select last_value(false)(b) from test;
+select last_value(b) ignore nulls from test;
 5
-select last_value(true)(b) from test;
+select last_value(true)(b) respect nulls from test;
 \N

--- a/tests/queries/0_stateless/02662_first_last_value.reference
+++ b/tests/queries/0_stateless/02662_first_last_value.reference
@@ -16,5 +16,5 @@ select last_value(b) from test;
 5
 select last_value(b) ignore nulls from test;
 5
-select last_value(true)(b) respect nulls from test;
+select last_value(b) respect nulls from test;
 \N

--- a/tests/queries/0_stateless/02662_first_last_value.sql
+++ b/tests/queries/0_stateless/02662_first_last_value.sql
@@ -13,4 +13,4 @@ select first_value(b) respect nulls from test;
 -- last value
 select last_value(b) from test;
 select last_value(b) ignore nulls from test;
-select last_value(true)(b) respect nulls from test;
+select last_value(b) respect nulls from test;

--- a/tests/queries/0_stateless/02662_first_last_value.sql
+++ b/tests/queries/0_stateless/02662_first_last_value.sql
@@ -7,10 +7,10 @@ insert into test (a,b) values (1,null), (2,3), (4, 5), (6,null);
 
 -- first value
 select first_value(b) from test;
-select first_value(false)(b) from test;
-select first_value(true)(b) from test;
+select first_value(b) ignore nulls from test;
+select first_value(b) respect nulls from test;
 
 -- last value
 select last_value(b) from test;
-select last_value(false)(b) from test;
-select last_value(true)(b) from test;
+select last_value(b) ignore nulls from test;
+select last_value(true)(b) respect nulls from test;

--- a/tests/queries/0_stateless/02662_first_last_value.sql
+++ b/tests/queries/0_stateless/02662_first_last_value.sql
@@ -1,0 +1,16 @@
+-- { echo }
+
+-- create table
+drop table if exists test;
+create table test(`a` Nullable(Int32), `b` Nullable(Int32)) ENGINE = Memory;
+insert into test (a,b) values (1,null), (2,3), (4, 5), (6,null);
+
+-- first value
+select first_value(b) from test;
+select first_value(false)(b) from test;
+select first_value(true)(b) from test;
+
+-- last value
+select last_value(b) from test;
+select last_value(false)(b) from test;
+select last_value(true)(b) from test;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

extend `first_value` and `last_value` to accept NULL.

for example
```SQL
insert into test (a,b) values (1,null), (2,3), (4, 5), (6,null);
-- same as before
select first_value(b) from test;
-- if first encountered value is NULL, return NULL
select first_value(b) respect nulls from test;
```

```
┌─first_value_ignore_nulls(b)─┐
│              3 │
└────────────────┘

┌─first_value_respect_nulls(b)─┐
│                 ᴺᵁᴸᴸ │
└──────────────────────┘
```

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
