### PR TITLE
Add docs for standalone ClickHouse Keeper install.

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -15,15 +15,7 @@ You have three options for getting up and running with ClickHouse:
 
 ## ClickHouse Cloud
 
-The quickest and easiest way to get up and running with ClickHouse is to create a new service in [ClickHouse Cloud](https://clickhouse.cloud/):
-
-<div class="eighty-percent">
-
-![Create a ClickHouse Cloud service](@site/docs/en/_snippets/images/createservice1.png)
-</div>
-
-Once your Cloud service is provisioned, you will be able to [connect to it](/docs/en/integrations/connect-a-client.md) and start [inserting data](/docs/en/integrations/data-ingestion.md).
-
+The quickest and easiest way to get up and running with ClickHouse is to create a new service in [ClickHouse Cloud](https://clickhouse.cloud/).
 
 ## Self-Managed Install
 
@@ -73,6 +65,7 @@ The [Quick Start](/docs/en/quick-start.mdx/#step-1-get-clickhouse) walks through
 
 It is recommended to use official pre-compiled `deb` packages for Debian or Ubuntu. Run these commands to install packages:
 
+#### Setup the Debian repository
 ``` bash
 sudo apt-get install -y apt-transport-https ca-certificates dirmngr
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754
@@ -80,9 +73,16 @@ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D7
 echo "deb https://packages.clickhouse.com/deb stable main" | sudo tee \
     /etc/apt/sources.list.d/clickhouse.list
 sudo apt-get update
+```
 
+#### Install ClickHouse server and client
+```bash
 sudo apt-get install -y clickhouse-server clickhouse-client
+```
 
+#### Start ClickHouse server
+
+```bash
 sudo service clickhouse-server start
 clickhouse-client # or "clickhouse-client --password" if you've set up a password.
 ```
@@ -128,12 +128,26 @@ You can replace `stable` with `lts` to use different [release kinds](/docs/en/fa
 
 You can also download and install packages manually from [here](https://packages.clickhouse.com/deb/pool/main/c/).
 
+#### Install ClickHouse Keeper
+```bash
+sudo apt-get install -y clickhouse-keeper
+```
+
+#### Enable and start ClickHouse Keeper
+
+```bash
+sudo systemctl enable clickhouse-keeper
+sudo systemctl start clickhouse-keeper
+sudo systemctl status clickhouse-keeper
+```
+
 #### Packages {#packages}
 
 -   `clickhouse-common-static` — Installs ClickHouse compiled binary files.
 -   `clickhouse-server` — Creates a symbolic link for `clickhouse-server` and installs the default server configuration.
 -   `clickhouse-client` — Creates a symbolic link for `clickhouse-client` and other client-related tools. and installs client configuration files.
 -   `clickhouse-common-static-dbg` — Installs ClickHouse compiled binary files with debug info.
+-   `clickhouse-keeper` - Used to install ClickHouse Keeper on dedicated ClickHouse Keeper nodes.  If you are running ClickHouse Keeper on the same server as ClickHouse server, then you do not need to install this package. Installs ClickHouse Keeper and the default ClickHouse Keeper configuration files.
 
 :::info
 If you need to install specific version of ClickHouse you have to install all packages with the same version:

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -128,7 +128,13 @@ You can replace `stable` with `lts` to use different [release kinds](/docs/en/fa
 
 You can also download and install packages manually from [here](https://packages.clickhouse.com/deb/pool/main/c/).
 
-#### Install ClickHouse Keeper
+#### Install standalone ClickHouse Keeper
+
+:::tip
+If you are going to run ClickHouse Keeper on the same server as ClickHouse server you
+do not need to install ClickHouse Keeper as it is included with ClickHouse server.  This command is only needed on standalone ClickHouse Keeper servers.
+:::
+
 ```bash
 sudo apt-get install -y clickhouse-keeper
 ```


### PR DESCRIPTION
add docs for ClickHouse Keeper standalone install

### Changelog category (leave one):
- Documentation (changelog entry is not required)

I guess this should wait until the February release, right @Felixoid ?  I did not add instructions for RPM or TGZ installs as I could not test these.