### PR TITLE
Fix flakiness of test_backup_restore_on_cluster/test_disallow_concurrency

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -229,3 +229,9 @@ def test_concurrent_restores_on_different_node():
     assert "Concurrent restores not supported" in nodes[1].query_and_get_error(
         f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}"
     )
+
+    assert_eq_with_retry(
+        nodes[0],
+        f"SELECT status FROM system.backups WHERE status == 'RESTORED'",
+        "RESTORED",
+    )

--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -186,10 +186,14 @@ def test_concurrent_restores_on_same_node():
     )
 
     nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY")
-    nodes[0].query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")
+    restore_id = (
+        nodes[0]
+        .query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")
+        .split("\t")[0]
+    )
     assert_eq_with_retry(
         nodes[0],
-        f"SELECT status FROM system.backups WHERE status == 'RESTORING'",
+        f"SELECT status FROM system.backups WHERE status == 'RESTORING' AND id == '{restore_id}'",
         "RESTORING",
     )
     assert "Concurrent restores not supported" in nodes[0].query_and_get_error(
@@ -220,7 +224,11 @@ def test_concurrent_restores_on_different_node():
     )
 
     nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY")
-    nodes[0].query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")
+    restore_id = (
+        nodes[0]
+        .query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")
+        .split("\t")[0]
+    )
     assert_eq_with_retry(
         nodes[0],
         f"SELECT status FROM system.backups WHERE status == 'RESTORING'",
@@ -232,6 +240,6 @@ def test_concurrent_restores_on_different_node():
 
     assert_eq_with_retry(
         nodes[0],
-        f"SELECT status FROM system.backups WHERE status == 'RESTORED'",
+        f"SELECT status FROM system.backups WHERE status == 'RESTORED' AND id == '{restore_id}'",
         "RESTORED",
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

The problem is that if you will run first
test_concurrent_restores_on_different_node and after test_concurrent_restores_on_same_node, like in [1], the first one will leave the RESTORE and the second will fail.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/45282/5af2967f65c3293b277872a002cb5d570200c008/integration_tests__asan__[3/6].html

Cc: @SmitaRKulkarni 
Cc: @vitlibar 
Fixes: #45486