### PR TITLE
Support for MongoDB Replica Set URI with readPreference and host:port enum in MongoDB dictionaries

### DIFF
--- a/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
@@ -162,7 +162,7 @@ namespace MongoDB
     {
         return _address;
     }
-    inline std::string Connection::uri() const
+    inline const std::string & Connection::uri() const
     {
     	return _uri;
     }

--- a/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
@@ -91,7 +91,7 @@ namespace MongoDB
         Poco::Net::SocketAddress address() const;
         /// Returns the address of the MongoDB server.
         
-        std::string uri() const;
+        const std::string & uri() const;
         /// Returns the uri on which the connection was made.
 
         void connect(const std::string & hostAndPort);

--- a/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
@@ -18,154 +18,158 @@
 #define MongoDB_Connection_INCLUDED
 
 
-#include "Poco/Net/SocketAddress.h"
-#include "Poco/Net/StreamSocket.h"
-#include "Poco/Mutex.h"
 #include "Poco/MongoDB/RequestMessage.h"
 #include "Poco/MongoDB/ResponseMessage.h"
+#include "Poco/Mutex.h"
+#include "Poco/Net/SocketAddress.h"
+#include "Poco/Net/StreamSocket.h"
 
 
-namespace Poco {
-namespace MongoDB {
-
-
-class MongoDB_API Connection
-	/// Represents a connection to a MongoDB server
-	/// using the MongoDB wire protocol.
-	///
-	/// See https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/
-	/// for more information on the wire protocol.
+namespace Poco
 {
-public:
-	typedef Poco::SharedPtr<Connection> Ptr;
-
-	class MongoDB_API SocketFactory
-	{
-	public:
-		SocketFactory();
-			/// Creates the SocketFactory.
-
-		virtual ~SocketFactory();
-			/// Destroys the SocketFactory.
-
-		virtual Poco::Net::StreamSocket createSocket(const std::string& host, int port, Poco::Timespan connectTimeout, bool secure);
-			/// Creates a Poco::Net::StreamSocket (if secure is false), or a
-			/// Poco::Net::SecureStreamSocket (if secure is true) connected to the
-			/// given host and port number.
-			///
-			/// The default implementation will throw a Poco::NotImplementedException
-			/// if secure is true.
-	};
-
-	Connection();
-		/// Creates an unconnected Connection.
-		///
-		/// Use this when you want to connect later on.
-
-	Connection(const std::string& hostAndPort);
-		/// Creates a Connection connected to the given MongoDB instance at host:port.
-		///
-		/// The host and port must be separated with a colon.
-
-	Connection(const std::string& uri, SocketFactory& socketFactory);
-		/// Creates a Connection connected to the given MongoDB instance at the
-		/// given URI.
-		///
-		/// See the corresponding connect() method for more information.
-
-	Connection(const std::string& host, int port);
-		/// Creates a Connection connected to the given MongoDB instance at host and port.
-
-	Connection(const Poco::Net::SocketAddress& addrs);
-		/// Creates a Connection connected to the given MongoDB instance at the given address.
-
-	Connection(const Poco::Net::StreamSocket& socket);
-		/// Creates a Connection connected to the given MongoDB instance using the given socket,
-		/// which must already be connected.
-
-	virtual ~Connection();
-		/// Destroys the Connection.
-
-	Poco::Net::SocketAddress address() const;
-		/// Returns the address of the MongoDB server.
-
-    	std::string uri() const;
-        	/// Returns the uri on which the connection was made.
-
-	void connect(const std::string& hostAndPort);
-		/// Connects to the given MongoDB server.
-		///
-		/// The host and port must be separated with a colon.
-
-	void connect(const std::string& uri, SocketFactory& socketFactory);
-		/// Connects to the given MongoDB instance at the given URI.
-		///
-		/// The URI must be in standard MongoDB connection string URI format:
-		///
-		///     mongodb://<user>:<password>@hostname.com:<port>/database-name?options
-		///
-		/// The following options are supported:
-		///
-		///   - ssl: If ssl=true is specified, a custom SocketFactory subclass creating
-		///     a SecureStreamSocket must be supplied.
-		///   - connectTimeoutMS: Socket connection timeout in milliseconds.
-		///   - socketTimeoutMS: Socket send/receive timeout in milliseconds.
-		///   - authMechanism: Authentication mechanism. Only "SCRAM-SHA-1" (default)
-		///     and "MONGODB-CR" are supported.
-		///
-		/// Unknown options are silently ignored.
-		///
-		/// Will also attempt to authenticate using the specified credentials,
-		/// using Database::authenticate().
-		///
-		/// Throws a Poco::NoPermissionException if authentication fails.
-
-	void connect(const std::string& host, int port);
-		/// Connects to the given MongoDB server.
-
-	void connect(const Poco::Net::SocketAddress& addrs);
-		/// Connects to the given MongoDB server.
-
-	void connect(const Poco::Net::StreamSocket& socket);
-		/// Connects using an already connected socket.
-
-	void disconnect();
-		/// Disconnects from the MongoDB server.
-
-	void sendRequest(RequestMessage& request);
-		/// Sends a request to the MongoDB server.
-		///
-		/// Used for one-way requests without a response.
-
-	void sendRequest(RequestMessage& request, ResponseMessage& response);
-		/// Sends a request to the MongoDB server and receives the response.
-		///
-		/// Use this when a response is expected: only a "query" or "getmore"
-		/// request will return a response.
-
-protected:
-	void connect();
-
-private:
-	Poco::Net::SocketAddress _address;
-	Poco::Net::StreamSocket _socket;
-    	std::string _uri;
-};
-
-
-//
-// inlines
-//
-inline Net::SocketAddress Connection::address() const
+namespace MongoDB
 {
-	return _address;
-}
-inline std::string Connection::uri() const
+
+
+    class MongoDB_API Connection
+    /// Represents a connection to a MongoDB server
+    /// using the MongoDB wire protocol.
+    ///
+    /// See https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/
+    /// for more information on the wire protocol.
+    {
+    public:
+        typedef Poco::SharedPtr<Connection> Ptr;
+
+        class MongoDB_API SocketFactory
+        {
+        public:
+            SocketFactory();
+            /// Creates the SocketFactory.
+
+            virtual ~SocketFactory();
+            /// Destroys the SocketFactory.
+
+            virtual Poco::Net::StreamSocket createSocket(const std::string & host, int port, Poco::Timespan connectTimeout, bool secure);
+            /// Creates a Poco::Net::StreamSocket (if secure is false), or a
+            /// Poco::Net::SecureStreamSocket (if secure is true) connected to the
+            /// given host and port number.
+            ///
+            /// The default implementation will throw a Poco::NotImplementedException
+            /// if secure is true.
+        };
+
+        Connection();
+        /// Creates an unconnected Connection.
+        ///
+        /// Use this when you want to connect later on.
+
+        Connection(const std::string & hostAndPort);
+        /// Creates a Connection connected to the given MongoDB instance at host:port.
+        ///
+        /// The host and port must be separated with a colon.
+
+        Connection(const std::string & uri, SocketFactory & socketFactory);
+        /// Creates a Connection connected to the given MongoDB instance at the
+        /// given URI.
+        ///
+        /// See the corresponding connect() method for more information.
+
+        Connection(const std::string & host, int port);
+        /// Creates a Connection connected to the given MongoDB instance at host and port.
+
+        Connection(const Poco::Net::SocketAddress & addrs);
+        /// Creates a Connection connected to the given MongoDB instance at the given address.
+
+        Connection(const Poco::Net::StreamSocket & socket);
+        /// Creates a Connection connected to the given MongoDB instance using the given socket,
+        /// which must already be connected.
+
+        virtual ~Connection();
+        /// Destroys the Connection.
+
+        Poco::Net::SocketAddress address() const;
+        /// Returns the address of the MongoDB server.
+        
+        std::string uri() const;
+        /// Returns the uri on which the connection was made.
+
+        void connect(const std::string & hostAndPort);
+        /// Connects to the given MongoDB server.
+        ///
+        /// The host and port must be separated with a colon.
+
+        void connect(const std::string & uri, SocketFactory & socketFactory);
+        /// Connects to the given MongoDB instance at the given URI.
+        ///
+        /// The URI must be in standard MongoDB connection string URI format:
+        ///
+        ///     mongodb://<user>:<password>@hostname.com:<port>/database-name?options
+        ///
+        /// The following options are supported:
+        ///
+        ///   - ssl: If ssl=true is specified, a custom SocketFactory subclass creating
+        ///     a SecureStreamSocket must be supplied.
+        ///   - connectTimeoutMS: Socket connection timeout in milliseconds.
+        ///   - socketTimeoutMS: Socket send/receive timeout in milliseconds.
+        ///   - authMechanism: Authentication mechanism. Only "SCRAM-SHA-1" (default)
+        ///     and "MONGODB-CR" are supported.
+        ///
+        /// Unknown options are silently ignored.
+        ///
+        /// Will also attempt to authenticate using the specified credentials,
+        /// using Database::authenticate().
+        ///
+        /// Throws a Poco::NoPermissionException if authentication fails.
+
+        void connect(const std::string & host, int port);
+        /// Connects to the given MongoDB server.
+
+        void connect(const Poco::Net::SocketAddress & addrs);
+        /// Connects to the given MongoDB server.
+
+        void connect(const Poco::Net::StreamSocket & socket);
+        /// Connects using an already connected socket.
+
+        void disconnect();
+        /// Disconnects from the MongoDB server.
+
+        void sendRequest(RequestMessage & request);
+        /// Sends a request to the MongoDB server.
+        ///
+        /// Used for one-way requests without a response.
+
+        void sendRequest(RequestMessage & request, ResponseMessage & response);
+        /// Sends a request to the MongoDB server and receives the response.
+        ///
+        /// Use this when a response is expected: only a "query" or "getmore"
+        /// request will return a response.
+
+    protected:
+        void connect();
+
+    private:
+        Poco::Net::SocketAddress _address;
+        Poco::Net::StreamSocket _socket;
+        std::string _uri;
+    };
+
+
+    //
+    // inlines
+    //
+    inline Net::SocketAddress Connection::address() const
+    {
+        return _address;
+    }
+    inline std::string Connection::uri() const
 {
     	return _uri;
 }
 
-} } // namespace Poco::MongoDB
+
+}
+} // namespace Poco::MongoDB
 
 
 #endif // MongoDB_Connection_INCLUDED

--- a/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
@@ -18,150 +18,154 @@
 #define MongoDB_Connection_INCLUDED
 
 
-#include "Poco/MongoDB/RequestMessage.h"
-#include "Poco/MongoDB/ResponseMessage.h"
-#include "Poco/Mutex.h"
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/Net/StreamSocket.h"
+#include "Poco/Mutex.h"
+#include "Poco/MongoDB/RequestMessage.h"
+#include "Poco/MongoDB/ResponseMessage.h"
 
 
-namespace Poco
+namespace Poco {
+namespace MongoDB {
+
+
+class MongoDB_API Connection
+	/// Represents a connection to a MongoDB server
+	/// using the MongoDB wire protocol.
+	///
+	/// See https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/
+	/// for more information on the wire protocol.
 {
-namespace MongoDB
+public:
+	typedef Poco::SharedPtr<Connection> Ptr;
+
+	class MongoDB_API SocketFactory
+	{
+	public:
+		SocketFactory();
+			/// Creates the SocketFactory.
+
+		virtual ~SocketFactory();
+			/// Destroys the SocketFactory.
+
+		virtual Poco::Net::StreamSocket createSocket(const std::string& host, int port, Poco::Timespan connectTimeout, bool secure);
+			/// Creates a Poco::Net::StreamSocket (if secure is false), or a
+			/// Poco::Net::SecureStreamSocket (if secure is true) connected to the
+			/// given host and port number.
+			///
+			/// The default implementation will throw a Poco::NotImplementedException
+			/// if secure is true.
+	};
+
+	Connection();
+		/// Creates an unconnected Connection.
+		///
+		/// Use this when you want to connect later on.
+
+	Connection(const std::string& hostAndPort);
+		/// Creates a Connection connected to the given MongoDB instance at host:port.
+		///
+		/// The host and port must be separated with a colon.
+
+	Connection(const std::string& uri, SocketFactory& socketFactory);
+		/// Creates a Connection connected to the given MongoDB instance at the
+		/// given URI.
+		///
+		/// See the corresponding connect() method for more information.
+
+	Connection(const std::string& host, int port);
+		/// Creates a Connection connected to the given MongoDB instance at host and port.
+
+	Connection(const Poco::Net::SocketAddress& addrs);
+		/// Creates a Connection connected to the given MongoDB instance at the given address.
+
+	Connection(const Poco::Net::StreamSocket& socket);
+		/// Creates a Connection connected to the given MongoDB instance using the given socket,
+		/// which must already be connected.
+
+	virtual ~Connection();
+		/// Destroys the Connection.
+
+	Poco::Net::SocketAddress address() const;
+		/// Returns the address of the MongoDB server.
+
+    	std::string uri() const;
+        	/// Returns the uri on which the connection was made.
+
+	void connect(const std::string& hostAndPort);
+		/// Connects to the given MongoDB server.
+		///
+		/// The host and port must be separated with a colon.
+
+	void connect(const std::string& uri, SocketFactory& socketFactory);
+		/// Connects to the given MongoDB instance at the given URI.
+		///
+		/// The URI must be in standard MongoDB connection string URI format:
+		///
+		///     mongodb://<user>:<password>@hostname.com:<port>/database-name?options
+		///
+		/// The following options are supported:
+		///
+		///   - ssl: If ssl=true is specified, a custom SocketFactory subclass creating
+		///     a SecureStreamSocket must be supplied.
+		///   - connectTimeoutMS: Socket connection timeout in milliseconds.
+		///   - socketTimeoutMS: Socket send/receive timeout in milliseconds.
+		///   - authMechanism: Authentication mechanism. Only "SCRAM-SHA-1" (default)
+		///     and "MONGODB-CR" are supported.
+		///
+		/// Unknown options are silently ignored.
+		///
+		/// Will also attempt to authenticate using the specified credentials,
+		/// using Database::authenticate().
+		///
+		/// Throws a Poco::NoPermissionException if authentication fails.
+
+	void connect(const std::string& host, int port);
+		/// Connects to the given MongoDB server.
+
+	void connect(const Poco::Net::SocketAddress& addrs);
+		/// Connects to the given MongoDB server.
+
+	void connect(const Poco::Net::StreamSocket& socket);
+		/// Connects using an already connected socket.
+
+	void disconnect();
+		/// Disconnects from the MongoDB server.
+
+	void sendRequest(RequestMessage& request);
+		/// Sends a request to the MongoDB server.
+		///
+		/// Used for one-way requests without a response.
+
+	void sendRequest(RequestMessage& request, ResponseMessage& response);
+		/// Sends a request to the MongoDB server and receives the response.
+		///
+		/// Use this when a response is expected: only a "query" or "getmore"
+		/// request will return a response.
+
+protected:
+	void connect();
+
+private:
+	Poco::Net::SocketAddress _address;
+	Poco::Net::StreamSocket _socket;
+    	std::string _uri;
+};
+
+
+//
+// inlines
+//
+inline Net::SocketAddress Connection::address() const
 {
-
-
-    class MongoDB_API Connection
-    /// Represents a connection to a MongoDB server
-    /// using the MongoDB wire protocol.
-    ///
-    /// See https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/
-    /// for more information on the wire protocol.
-    {
-    public:
-        typedef Poco::SharedPtr<Connection> Ptr;
-
-        class MongoDB_API SocketFactory
-        {
-        public:
-            SocketFactory();
-            /// Creates the SocketFactory.
-
-            virtual ~SocketFactory();
-            /// Destroys the SocketFactory.
-
-            virtual Poco::Net::StreamSocket createSocket(const std::string & host, int port, Poco::Timespan connectTimeout, bool secure);
-            /// Creates a Poco::Net::StreamSocket (if secure is false), or a
-            /// Poco::Net::SecureStreamSocket (if secure is true) connected to the
-            /// given host and port number.
-            ///
-            /// The default implementation will throw a Poco::NotImplementedException
-            /// if secure is true.
-        };
-
-        Connection();
-        /// Creates an unconnected Connection.
-        ///
-        /// Use this when you want to connect later on.
-
-        Connection(const std::string & hostAndPort);
-        /// Creates a Connection connected to the given MongoDB instance at host:port.
-        ///
-        /// The host and port must be separated with a colon.
-
-        Connection(const std::string & uri, SocketFactory & socketFactory);
-        /// Creates a Connection connected to the given MongoDB instance at the
-        /// given URI.
-        ///
-        /// See the corresponding connect() method for more information.
-
-        Connection(const std::string & host, int port);
-        /// Creates a Connection connected to the given MongoDB instance at host and port.
-
-        Connection(const Poco::Net::SocketAddress & addrs);
-        /// Creates a Connection connected to the given MongoDB instance at the given address.
-
-        Connection(const Poco::Net::StreamSocket & socket);
-        /// Creates a Connection connected to the given MongoDB instance using the given socket,
-        /// which must already be connected.
-
-        virtual ~Connection();
-        /// Destroys the Connection.
-
-        Poco::Net::SocketAddress address() const;
-        /// Returns the address of the MongoDB server.
-
-        void connect(const std::string & hostAndPort);
-        /// Connects to the given MongoDB server.
-        ///
-        /// The host and port must be separated with a colon.
-
-        void connect(const std::string & uri, SocketFactory & socketFactory);
-        /// Connects to the given MongoDB instance at the given URI.
-        ///
-        /// The URI must be in standard MongoDB connection string URI format:
-        ///
-        ///     mongodb://<user>:<password>@hostname.com:<port>/database-name?options
-        ///
-        /// The following options are supported:
-        ///
-        ///   - ssl: If ssl=true is specified, a custom SocketFactory subclass creating
-        ///     a SecureStreamSocket must be supplied.
-        ///   - connectTimeoutMS: Socket connection timeout in milliseconds.
-        ///   - socketTimeoutMS: Socket send/receive timeout in milliseconds.
-        ///   - authMechanism: Authentication mechanism. Only "SCRAM-SHA-1" (default)
-        ///     and "MONGODB-CR" are supported.
-        ///
-        /// Unknown options are silently ignored.
-        ///
-        /// Will also attempt to authenticate using the specified credentials,
-        /// using Database::authenticate().
-        ///
-        /// Throws a Poco::NoPermissionException if authentication fails.
-
-        void connect(const std::string & host, int port);
-        /// Connects to the given MongoDB server.
-
-        void connect(const Poco::Net::SocketAddress & addrs);
-        /// Connects to the given MongoDB server.
-
-        void connect(const Poco::Net::StreamSocket & socket);
-        /// Connects using an already connected socket.
-
-        void disconnect();
-        /// Disconnects from the MongoDB server.
-
-        void sendRequest(RequestMessage & request);
-        /// Sends a request to the MongoDB server.
-        ///
-        /// Used for one-way requests without a response.
-
-        void sendRequest(RequestMessage & request, ResponseMessage & response);
-        /// Sends a request to the MongoDB server and receives the response.
-        ///
-        /// Use this when a response is expected: only a "query" or "getmore"
-        /// request will return a response.
-
-    protected:
-        void connect();
-
-    private:
-        Poco::Net::SocketAddress _address;
-        Poco::Net::StreamSocket _socket;
-    };
-
-
-    //
-    // inlines
-    //
-    inline Net::SocketAddress Connection::address() const
-    {
-        return _address;
-    }
-
-
+	return _address;
 }
-} // namespace Poco::MongoDB
+inline std::string Connection::uri() const
+{
+    	return _uri;
+}
+
+} } // namespace Poco::MongoDB
 
 
 #endif // MongoDB_Connection_INCLUDED

--- a/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/base/poco/MongoDB/include/Poco/MongoDB/Connection.h
@@ -163,9 +163,9 @@ namespace MongoDB
         return _address;
     }
     inline std::string Connection::uri() const
-{
+    {
     	return _uri;
-}
+    }
 
 
 }

--- a/base/poco/MongoDB/src/Connection.cpp
+++ b/base/poco/MongoDB/src/Connection.cpp
@@ -237,7 +237,7 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
     for (std::vector<std::string>::const_iterator it = strAddresses.cbegin();it != strAddresses.cend(); ++it)
     {
         newURI = *it;
-        Poco::URI theURI(newURI);
+        theURI = Poco::URI(newURI);
 
         std::string host = theURI.getHost();
         Poco::UInt16 port = theURI.getPort();

--- a/base/poco/MongoDB/src/Connection.cpp
+++ b/base/poco/MongoDB/src/Connection.cpp
@@ -145,69 +145,157 @@ void Connection::connect(const Poco::Net::StreamSocket& socket)
 
 void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
 {
-	Poco::URI theURI(uri);
-	if (theURI.getScheme() != "mongodb") throw Poco::UnknownURISchemeException(uri);
+    std::vector<std::string> strAddresses;
+    std::string newURI;
 
-	std::string userInfo = theURI.getUserInfo();
-	std::string host = theURI.getHost();
-	Poco::UInt16 port = theURI.getPort();
-	if (port == 0) port = 27017;
+    if (uri.find(',') != std::string::npos)
+    {
+        size_t pos;
+        size_t head = 0;
+        if ((pos = uri.find("@")) != std::string::npos)
+        {
+            head = pos + 1;
+        }
+        else if ((pos = uri.find("://")) != std::string::npos)
+        {
+            head = pos + 3;
+        }
 
-	std::string databaseName = theURI.getPath();
-	if (!databaseName.empty() && databaseName[0] == '/') databaseName.erase(0, 1);
-	if (databaseName.empty()) databaseName = "admin";
+        std::string tempstr;
+        std::string::const_iterator it = uri.begin();
+        it += head;
+        size_t tail = head;
+        for (;it != uri.end() && *it != '?' && *it != '/'; ++it)
+        {
+            tempstr += *it;
+            tail++;
+        }
 
-	bool ssl = false;
-	Poco::Timespan connectTimeout;
-	Poco::Timespan socketTimeout;
-	std::string authMechanism = Database::AUTH_SCRAM_SHA1;
+        it = tempstr.begin();
+        std::string token;
+        for (;it != tempstr.end(); ++it)
+        {
+            if (*it == ',')
+            {
+                newURI = uri.substr(0, head) + token + uri.substr(tail, uri.length());
+                strAddresses.push_back(newURI);
+                token = "";
+            }
+            else
+            {
+                token += *it;
+            }
+        }
+        newURI = uri.substr(0, head) + token + uri.substr(tail, uri.length());
+        strAddresses.push_back(newURI);
+    }
+    else
+    {
+        strAddresses.push_back(uri);
+    }
 
-	Poco::URI::QueryParameters params = theURI.getQueryParameters();
-	for (Poco::URI::QueryParameters::const_iterator it = params.begin(); it != params.end(); ++it)
-	{
-		if (it->first == "ssl")
-		{
-			ssl = (it->second == "true");
-		}
-		else if (it->first == "connectTimeoutMS")
-		{
-			connectTimeout = static_cast<Poco::Timespan::TimeDiff>(1000)*Poco::NumberParser::parse(it->second);
-		}
-		else if (it->first == "socketTimeoutMS")
-		{
-			socketTimeout = static_cast<Poco::Timespan::TimeDiff>(1000)*Poco::NumberParser::parse(it->second);
-		}
-		else if (it->first == "authMechanism")
-		{
-			authMechanism = it->second;
-		}
-	}
+    newURI = strAddresses.front();
+    Poco::URI theURI(newURI);
+    if (theURI.getScheme() != "mongodb") throw Poco::UnknownURISchemeException(uri);
 
-	connect(socketFactory.createSocket(host, port, connectTimeout, ssl));
+    std::string userInfo = theURI.getUserInfo();
+    std::string databaseName = theURI.getPath();
+    if (!databaseName.empty() && databaseName[0] == '/') databaseName.erase(0, 1);
+    if (databaseName.empty()) databaseName = "admin";
 
-	if (socketTimeout > 0)
-	{
-		_socket.setSendTimeout(socketTimeout);
-		_socket.setReceiveTimeout(socketTimeout);
-	}
+    bool ssl = false;
+    Poco::Timespan connectTimeout;
+    Poco::Timespan socketTimeout;
+    std::string authMechanism = Database::AUTH_SCRAM_SHA1;
+    std::string readPreference="primary";
 
-	if (!userInfo.empty())
-	{
-		std::string username;
-		std::string password;
-		std::string::size_type pos = userInfo.find(':');
-		if (pos != std::string::npos)
-		{
-			username.assign(userInfo, 0, pos++);
-			password.assign(userInfo, pos, userInfo.size() - pos);
-		}
-		else username = userInfo;
+    Poco::URI::QueryParameters params = theURI.getQueryParameters();
+    for (Poco::URI::QueryParameters::const_iterator it = params.begin(); it != params.end(); ++it)
+    {
+        if (it->first == "ssl")
+        {
+            ssl = (it->second == "true");
+        }
+        else if (it->first == "connectTimeoutMS")
+        {
+            connectTimeout = static_cast<Poco::Timespan::TimeDiff>(1000)*Poco::NumberParser::parse(it->second);
+        }
+        else if (it->first == "socketTimeoutMS")
+        {
+            socketTimeout = static_cast<Poco::Timespan::TimeDiff>(1000)*Poco::NumberParser::parse(it->second);
+        }
+        else if (it->first == "authMechanism")
+        {
+            authMechanism = it->second;
+        }
+        else if (it->first == "readPreference")
+        {
+            readPreference= it->second;
+        }
+    }
 
-		Database database(databaseName);
-		if (!database.authenticate(*this, username, password, authMechanism))
-			throw Poco::NoPermissionException(Poco::format("Access to MongoDB database %s denied for user %s", databaseName, username));
-	}
+    for (std::vector<std::string>::const_iterator it = strAddresses.cbegin();it != strAddresses.cend(); ++it)
+    {
+        newURI = *it;
+        Poco::URI theURI(newURI);
+
+        std::string host = theURI.getHost();
+        Poco::UInt16 port = theURI.getPort();
+        if (port == 0) port = 27017;
+
+        connect(socketFactory.createSocket(host, port, connectTimeout, ssl));
+        _uri = newURI;
+        if (socketTimeout > 0)
+        {
+            _socket.setSendTimeout(socketTimeout);
+            _socket.setReceiveTimeout(socketTimeout);
+        }
+        if (strAddresses.size() > 1)
+        {
+            Poco::MongoDB::QueryRequest request("admin.$cmd");
+            request.setNumberToReturn(1);
+            request.selector().add("isMaster", 1);
+            Poco::MongoDB::ResponseMessage response;
+
+            sendRequest(request, response);
+            _uri = newURI;
+            if (!response.documents().empty())
+            {
+                Poco::MongoDB::Document::Ptr doc = response.documents()[0];
+                if (doc->get<bool>("ismaster") && readPreference == "primary")
+                {
+                    break;
+                }
+                else if (!doc->get<bool>("ismaster") && readPreference == "secondary")
+                {
+                    break;
+                }
+                else if (it + 1 == strAddresses.cend())
+                {
+                    throw Poco::URISyntaxException(uri);
+                }
+            }
+        }
+    }
+    if (!userInfo.empty())
+    {
+        std::string username;
+        std::string password;
+        std::string::size_type pos = userInfo.find(':');
+        if (pos != std::string::npos)
+        {
+            username.assign(userInfo, 0, pos++);
+            password.assign(userInfo, pos, userInfo.size() - pos);
+        }
+        else username = userInfo;
+
+        Database database(databaseName);
+
+        if (!database.authenticate(*this, username, password, authMechanism))
+            throw Poco::NoPermissionException(Poco::format("Access to MongoDB database %s denied for user %s", databaseName, username));
+    }
 }
+
 
 
 void Connection::disconnect()

--- a/base/poco/MongoDB/src/Connection.cpp
+++ b/base/poco/MongoDB/src/Connection.cpp
@@ -297,7 +297,6 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
 }
 
 
-
 void Connection::disconnect()
 {
 	_socket.close();

--- a/src/Dictionaries/MongoDBDictionarySource.cpp
+++ b/src/Dictionaries/MongoDBDictionarySource.cpp
@@ -118,7 +118,7 @@ MongoDBDictionarySource::MongoDBDictionarySource(
         Poco::MongoDB::Connection::SocketFactory socket_factory;
         connection->connect(uri, socket_factory);
 
-        Poco::URI poco_uri(connection.uri());
+        Poco::URI poco_uri(connection->uri());
 
         // Parse database from URI. This is required for correctness -- the
         // cursor is created using database name and collection name, so we have

--- a/src/Dictionaries/MongoDBDictionarySource.cpp
+++ b/src/Dictionaries/MongoDBDictionarySource.cpp
@@ -114,7 +114,11 @@ MongoDBDictionarySource::MongoDBDictionarySource(
 {
     if (!uri.empty())
     {
-        Poco::URI poco_uri(uri);
+        // Connect with URI.
+        Poco::MongoDB::Connection::SocketFactory socket_factory;
+        connection->connect(uri, socket_factory);
+
+        Poco::URI poco_uri(connection.uri());
 
         // Parse database from URI. This is required for correctness -- the
         // cursor is created using database name and collection name, so we have
@@ -134,10 +138,6 @@ MongoDBDictionarySource::MongoDBDictionarySource(
         {
             user.resize(separator);
         }
-
-        // Connect with URI.
-        Poco::MongoDB::Connection::SocketFactory socket_factory;
-        connection->connect(uri, socket_factory);
     }
     else
     {


### PR DESCRIPTION
### Changelog category (leave one): 
- Improvement 


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md): 
- Support for connection to a replica set via a URI with a host:port enum and support for the readPreference option in MongoDB dictionaries. Example URI: mongodb://db0.example.com:27017,db1.example.com:27017,db2.example.com:27017/?replicaSet=myRepl&readPreference=primary