### PR TITLE
Allow `disk` merge tree setting in query to override config merge tree setting `storage_policy`

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -49,22 +49,42 @@ void MergeTreeSettings::loadFromQuery(ASTStorage & storage_def, ContextPtr conte
     {
         try
         {
+            bool found_disk_setting = false;
+            bool found_storage_policy_setting = false;
+
             auto changes = storage_def.settings->changes;
             for (auto & [name, value] : changes)
             {
                 CustomType custom;
-                if (value.tryGet<CustomType>(custom) && 0 == strcmp(custom.getTypeName(), "AST"))
+                if (name == "disk")
                 {
-                    auto ast = dynamic_cast<const FieldFromASTImpl &>(custom.getImpl()).ast;
-                    if (ast && isDiskFunction(ast))
+                    if (value.tryGet<CustomType>(custom) && 0 == strcmp(custom.getTypeName(), "AST"))
                     {
-                        const auto & ast_function = assert_cast<const ASTFunction &>(*ast);
-                        auto disk_name = getOrCreateDiskFromDiskAST(ast_function, context);
-                        LOG_TRACE(&Poco::Logger::get("MergeTreeSettings"), "Created custom disk {}", disk_name);
-                        value = disk_name;
-                        break;
+                        auto ast = dynamic_cast<const FieldFromASTImpl &>(custom.getImpl()).ast;
+                        if (ast && isDiskFunction(ast))
+                        {
+                            const auto & ast_function = assert_cast<const ASTFunction &>(*ast);
+                            auto disk_name = getOrCreateDiskFromDiskAST(ast_function, context);
+                            LOG_TRACE(&Poco::Logger::get("MergeTreeSettings"), "Created custom disk {}", disk_name);
+                            value = disk_name;
+                        }
                     }
+
+                    if (has("storage_policy"))
+                        resetToDefault("storage_policy");
+
+                    found_disk_setting = true;
                 }
+                else if (name == "storage_policy")
+                    found_storage_policy_setting = true;
+
+                if (found_disk_setting && found_storage_policy_setting)
+                {
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time");
+                }
+
             }
 
             applyChanges(changes);

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -590,11 +590,6 @@ static StoragePtr create(const StorageFactory::Arguments & args)
 
         storage_settings->loadFromQuery(*args.storage_def, context);
 
-        if (storage_settings->disk.changed && storage_settings->storage_policy.changed)
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS,
-                "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time");
-
         // updates the default storage_settings with settings specified via SETTINGS arg in a query
         if (args.storage_def->settings)
         {

--- a/tests/integration/test_disk_configuration/configs/config.d/mergetree_settings.xml
+++ b/tests/integration/test_disk_configuration/configs/config.d/mergetree_settings.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <merge_tree>
+        <storage_policy>unknown</storage_policy>
+    </merge_tree>
+</clickhouse>

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -348,8 +348,7 @@ def test_merge_tree_setting_override(start_cluster):
     node.query(f"INSERT INTO {TABLE_NAME} SELECT number FROM numbers(100)")
     assert int(node.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
     assert (
-        len(list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True)))
-        > 0
+        len(list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True))) > 0
     )
 
     node.query(
@@ -366,6 +365,5 @@ def test_merge_tree_setting_override(start_cluster):
     node.query(f"INSERT INTO {TABLE_NAME} SELECT number FROM numbers(100)")
     assert int(node.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
     assert (
-        len(list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True)))
-        > 0
+        len(list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True))) > 0
     )

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -32,6 +32,16 @@ def start_cluster():
             with_minio=True,
             macros={"replica": "node2", "shard": "shard1"},
         )
+        cluster.add_instance(
+            "node3",
+            main_configs=[
+                "configs/config.d/storage_configuration.xml",
+                "configs/config.d/remote_servers.xml",
+                "configs/config.d/mergetree_settings.xml",
+            ],
+            stay_alive=True,
+            with_minio=True,
+        )
 
         cluster.start()
         yield cluster
@@ -42,19 +52,6 @@ def start_cluster():
 
 def test_merge_tree_disk_setting(start_cluster):
     node1 = cluster.instances["node1"]
-
-    assert (
-        "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time"
-        in node1.query_and_get_error(
-            f"""
-        DROP TABLE IF EXISTS {TABLE_NAME};
-        CREATE TABLE {TABLE_NAME} (a Int32)
-        ENGINE = MergeTree()
-        ORDER BY tuple()
-        SETTINGS disk = 'disk_local', storage_policy = 's3';
-    """
-        )
-    )
 
     node1.query(
         f"""
@@ -295,4 +292,80 @@ def test_merge_tree_custom_disk_setting(start_cluster):
         == node2.query(
             f"SELECT disks FROM system.storage_policies WHERE policy_name = '{policy2}'"
         ).strip()
+    )
+
+
+def test_merge_tree_setting_override(start_cluster):
+    node = cluster.instances["node3"]
+    assert (
+        "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time"
+        in node.query_and_get_error(
+            f"""
+        DROP TABLE IF EXISTS {TABLE_NAME};
+        CREATE TABLE {TABLE_NAME} (a Int32)
+        ENGINE = MergeTree()
+        ORDER BY tuple()
+        SETTINGS disk = 'kek', storage_policy = 's3';
+    """
+        )
+    )
+
+    assert "Unknown storage policy" in node.query_and_get_error(
+        f"""
+        DROP TABLE IF EXISTS {TABLE_NAME};
+        CREATE TABLE {TABLE_NAME} (a Int32)
+        ENGINE = MergeTree()
+        ORDER BY tuple();
+    """
+    )
+
+    assert "Unknown disk" in node.query_and_get_error(
+        f"""
+        DROP TABLE IF EXISTS {TABLE_NAME};
+        CREATE TABLE {TABLE_NAME} (a Int32)
+        ENGINE = MergeTree()
+        ORDER BY tuple()
+        SETTINGS disk = 'kek';
+    """
+    )
+
+    node.query(
+        f"""
+        DROP TABLE IF EXISTS {TABLE_NAME} NO DELAY;
+        CREATE TABLE {TABLE_NAME} (a Int32)
+        ENGINE = MergeTree()
+        ORDER BY tuple()
+        SETTINGS
+            disk = disk(
+                type=s3,
+                endpoint='http://minio1:9001/root/data/',
+                access_key_id='minio',
+                secret_access_key='minio123');
+    """
+    )
+
+    minio = cluster.minio_client
+    node.query(f"INSERT INTO {TABLE_NAME} SELECT number FROM numbers(100)")
+    assert int(node.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
+    assert (
+        len(list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True)))
+        > 0
+    )
+
+    node.query(
+        f"""
+        DROP TABLE IF EXISTS {TABLE_NAME} NO DELAY;
+        CREATE TABLE {TABLE_NAME} (a Int32)
+        ENGINE = MergeTree()
+        ORDER BY tuple()
+        SETTINGS disk = 's3'
+    """
+    )
+
+    minio = cluster.minio_client
+    node.query(f"INSERT INTO {TABLE_NAME} SELECT number FROM numbers(100)")
+    assert int(node.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
+    assert (
+        len(list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True)))
+        > 0
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not throw exception if `disk` setting was specified on query level, but `storage_policy` was specified in config merge tree settings section. `disk` will override setting from config.  