### PR TITLE
Replace mySQL dateformatter M behaviour from minutes to month name

### DIFF
--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -1241,16 +1241,16 @@ Using replacement fields, you can define a pattern for the resulting string. “
 | %k       | hour in 24h format (00-23)                              | 22         |
 | %l       | hour in 12h format (01-12)                              | 09         |
 | %m       | month as a decimal number (01-12)                       | 01         |
-| %M       | minute (00-59)                                          | 33         |
+| %M       | full month name (January-December)                      | January    |
 | %n       | new-line character (‘’)                                 |            |
 | %p       | AM or PM designation                                    | PM         |
 | %Q       | Quarter (1-4)                                           | 1          |
-| %r       | 12-hour HH:MM AM/PM time, equivalent to %H:%M %p        | 10:30 PM   |
-| %R       | 24-hour HH:MM time, equivalent to %H:%M                 | 22:33      |
+| %r       | 12-hour HH:MM AM/PM time, equivalent to %H:%i %p        | 10:30 PM   |
+| %R       | 24-hour HH:MM time, equivalent to %H:%i                 | 22:33      |
 | %s       | second (00-59)                                          | 44         |
 | %S       | second (00-59)                                          | 44         |
 | %t       | horizontal-tab character (’)                            |            |
-| %T       | ISO 8601 time format (HH:MM:SS), equivalent to %H:%M:%S | 22:33:44   |
+| %T       | ISO 8601 time format (HH:MM:SS), equivalent to %H:%i:%S | 22:33:44   |
 | %u       | ISO 8601 weekday as number with Monday as 1 (1-7)       | 2          |
 | %V       | ISO 8601 week number (01-53)                            | 01         |
 | %w       | weekday as a decimal number with Sunday as 0 (0-6)      | 2          |

--- a/src/Functions/formatDateTime.cpp
+++ b/src/Functions/formatDateTime.cpp
@@ -126,6 +126,8 @@ constexpr std::string_view monthsFull[]
 constexpr std::string_view monthsShort[]
     = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
+constexpr std::string_view dynamicDateFormatters[2] = {"M", "W"};
+
 /** formatDateTime(time, 'format')
   * Performs formatting of time, according to provided format.
   *
@@ -806,6 +808,18 @@ public:
         return res;
     }
 
+    bool containsDynamicDateFormatter(const String & format) const
+    {
+        for (auto dynamic_formatter: dynamicDateFormatters)
+        {
+            if (format.find(dynamic_formatter) != String::npos)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     template <typename DataType>
     ColumnPtr executeType(const ColumnsWithTypeAndName & arguments, const DataTypePtr &) const
     {
@@ -847,7 +861,8 @@ public:
         dst_data.resize(vec.size() * (result_size + 1));
         dst_offsets.resize(vec.size());
 
-        if constexpr (format_syntax == FormatDateTimeTraits::FormatSyntax::MySQL)
+        if (format_syntax == FormatDateTimeTraits::FormatSyntax::MySQL
+            && !containsDynamicDateFormatter(format))
         {
             /// Fill result with literals.
             {

--- a/src/Functions/formatDateTime.cpp
+++ b/src/Functions/formatDateTime.cpp
@@ -150,13 +150,13 @@ constexpr std::string_view monthsShort[]
   *
   * Performance on Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz:
   *
-  * WITH formatDateTime(now() + number, '%H:%M:%S') AS x SELECT count() FROM system.numbers WHERE NOT ignore(x);
+  * WITH formatDateTime(now() + number, '%H:%i:%S') AS x SELECT count() FROM system.numbers WHERE NOT ignore(x);
   * - 97 million rows per second per core;
   *
   * WITH formatDateTime(toDateTime('2018-01-01 00:00:00') + number, '%F %T') AS x SELECT count() FROM system.numbers WHERE NOT ignore(x)
   * - 71 million rows per second per core;
   *
-  * select count() from (select formatDateTime(t, '%m/%d/%Y %H:%M:%S') from (select toDateTime('2018-01-01 00:00:00')+number as t from numbers(100000000)));
+  * select count() from (select formatDateTime(t, '%m/%d/%Y %H:%i:%S') from (select toDateTime('2018-01-01 00:00:00')+number as t from numbers(100000000)));
   * - 53 million rows per second per core;
   *
   * select count() from (select formatDateTime(t, 'Hello %Y World') from (select toDateTime('2018-01-01 00:00:00')+number as t from numbers(100000000)));
@@ -951,13 +951,13 @@ public:
 
                 switch (*pos)
                 {
-                    // Abbreviated weekday [Mon...Sun]
+                    // Abbreviated weekday [Mon-Sun]
                     case 'a':
                         instructions.emplace_back(&Action<T>::mysqlDayOfWeekTextShort);
                         out_template += "Mon";
                         break;
 
-                    // Abbreviated month [Jan...Dec]
+                    // Abbreviated month [Jan-Dec]
                     case 'b':
                         instructions.emplace_back(&Action<T>::mysqlMonthOfYearTextShort);
                         out_template += "Jan";
@@ -987,7 +987,7 @@ public:
                         out_template += "00/00/00";
                         break;
 
-                    // Day of month, space-padded ( 1-31)  23
+                    // Day of month, space-padded (1-31)  23
                     case 'e':
                         instructions.emplace_back(&Action<T>::mysqlDayOfMonthSpacePadded);
                         out_template += " 0";
@@ -1032,6 +1032,12 @@ public:
                         out_template += "00";
                         break;
 
+                    // Full month [January-December]
+                    case 'M':
+                        instructions.emplace_back(&Action<T>::mysqlMonthOfYearTextLong);
+                        out_template += "January";
+                        break;
+
                     // ISO 8601 weekday as number with Monday as 1 (1-7)
                     case 'u':
                         instructions.emplace_back(&Action<T>::mysqlDayOfWeek);
@@ -1050,7 +1056,7 @@ public:
                         out_template += "0";
                         break;
 
-                    // Full weekday [Monday...Sunday]
+                    // Full weekday [Monday-Sunday]
                     case 'W':
                         instructions.emplace_back(&Action<T>::mysqlDayOfWeekTextLong);
                         out_template += "Monday";
@@ -1081,12 +1087,6 @@ public:
                         break;
 
                     /// Time components. If the argument is Date, not a DateTime, then this components will have default value.
-
-                    // Minute (00-59)
-                    case 'M':
-                        add_instruction_or_extra_shift(&Action<T>::mysqlMinute, 2);
-                        out_template += "00";
-                        break;
 
                     // AM or PM
                     case 'p':

--- a/tests/queries/0_stateless/00718_format_datetime.reference
+++ b/tests/queries/0_stateless/00718_format_datetime.reference
@@ -17,7 +17,7 @@ Jan	Jan
 366	366
 00	00
 01	01
-33	00
+January	January
 \n	\n
 AM	AM
 AM

--- a/tests/queries/0_stateless/00921_datetime64_compatibility_long.python
+++ b/tests/queries/0_stateless/00921_datetime64_compatibility_long.python
@@ -83,7 +83,7 @@ CAST(N as DateTime64(9, 'Europe/Minsk'))
 # CAST(N as DateTime64(12, 'Asia/Istanbul'))
 # DateTime64(18) will always fail due to zero precision, but it is Ok to test here:
 # CAST(N as DateTime64(18, 'Asia/Istanbul'))
-formatDateTime(N, '%C %d %D %e %F %H %I %j %m %M %p %R %S %T %u %V %w %y %Y %%', 'Asia/Istanbul')
+formatDateTime(N, '%C %d %D %e %F %H %I %j %m %i %p %R %S %T %u %V %w %y %Y %%', 'Asia/Istanbul')
 """.splitlines()
 
 # Expanded later to cartesian product of all arguments, using format string.

--- a/tests/queries/0_stateless/00921_datetime64_compatibility_long.reference
+++ b/tests/queries/0_stateless/00921_datetime64_compatibility_long.reference
@@ -353,7 +353,7 @@ SELECT CAST(N as DateTime64(9, \'Europe/Minsk\'))
 "DateTime64(9, 'Europe/Minsk')","2019-09-16 19:20:11.000000000"
 "DateTime64(9, 'Europe/Minsk')","2019-09-16 19:20:11.234000000"
 ------------------------------------------
-SELECT formatDateTime(N, \'%C %d %D %e %F %H %I %j %m %M %p %R %S %T %u %V %w %y %Y %%\', \'Asia/Istanbul\')
+SELECT formatDateTime(N, \'%C %d %D %e %F %H %I %j %m %i %p %R %S %T %u %V %w %y %Y %%\', \'Asia/Istanbul\')
 "String","20 16 09/16/19 16 2019-09-16 00 12 259 09 00 AM 00:00 00 00:00:00 1 38 1 19 2019 %"
 "String","20 16 09/16/19 16 2019-09-16 19 07 259 09 20 PM 19:20 11 19:20:11 1 38 1 19 2019 %"
 "String","20 16 09/16/19 16 2019-09-16 19 07 259 09 20 PM 19:20 11 19:20:11 1 38 1 19 2019 %"

--- a/tests/queries/0_stateless/01411_from_unixtime.reference
+++ b/tests/queries/0_stateless/01411_from_unixtime.reference
@@ -24,7 +24,7 @@ Jan	Jan
 366	366
 00	00
 01	01
-33	00
+January	January
 \n	\n
 AM	AM
 AM

--- a/tests/queries/0_stateless/02564_date_format.reference
+++ b/tests/queries/0_stateless/02564_date_format.reference
@@ -17,7 +17,7 @@ Jan	Jan
 366	366
 00	00
 01	01
-33	00
+January	January
 \n	\n
 AM	AM
 AM


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->


Fixes: #46184

### Changelog category:
- Backward Incompatible Change


### Changelog entry:
Replace mySQL date-formatter `%M` to return full-month name rather than minutes.
**Note: This is a *backwards incompatible* change.**

### Documentation entry for user-facing changes

- [x] Documentation has been written / updated as part of change

**Motivation**
Our current behaviour for mySQL date-formatter `%M` does not match the mySQL standard as it returns minutes `[0-59]` rather than the full month name `February`.

- Example use:
```
select DATE_FORMAT(now(), '%M');
>>> February
```


### TODO
This change is close to being complete, however, I'm running into memory leaks when formatting the output as full-month name multiple times. For example (leaks highlighted between `<>`):

```
SELECT DATE_FORMAT(toDate32('2022-03-01'), '%M%%M%M%M%M%M%M%%M%M%M%M%M%M%%M%M%M')
>>> March<ry>MarchMarchMarchMarchMarch<nu>MarchMarchMarchMarchMarch<yJ>MarchMarch
```

I'm not entirely sure how to resolve this, I would be super grateful to any guidance given! :)