### PR TITLE
Inhibit randomization in test `01551_mergetree_read_in_order_spread.sql`

### DIFF
--- a/tests/queries/0_stateless/01551_mergetree_read_in_order_spread.sql
+++ b/tests/queries/0_stateless/01551_mergetree_read_in_order_spread.sql
@@ -8,7 +8,7 @@ CREATE TABLE data_01551
 ) engine=AggregatingMergeTree()
 PARTITION BY key%2
 ORDER BY (key, key/2)
-SETTINGS index_granularity=10;
+SETTINGS index_granularity=10, index_granularity_bytes='10Mi';
 
 INSERT INTO data_01551 SELECT number FROM numbers(100000);
 SET max_threads=3;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/46559/9cc475d1a06bdc49186fe380041427272b99c15c/stateless_tests__asan__[3/4].html