### PR TITLE
Added `last_exception_time` column into distribution_queue table

### DIFF
--- a/src/Storages/Distributed/DirectoryMonitor.cpp
+++ b/src/Storages/Distributed/DirectoryMonitor.cpp
@@ -465,6 +465,7 @@ void StorageDistributedDirectoryMonitor::run()
 
                 tryLogCurrentException(getLoggerName().data());
                 status.last_exception = std::current_exception();
+                status.last_exception_time = std::chrono::system_clock::now();
             }
         }
         else

--- a/src/Storages/Distributed/DirectoryMonitor.h
+++ b/src/Storages/Distributed/DirectoryMonitor.h
@@ -58,6 +58,7 @@ public:
     struct InternalStatus
     {
         std::exception_ptr last_exception;
+        std::chrono::system_clock::time_point last_exception_time;
 
         size_t error_count = 0;
 

--- a/src/Storages/System/StorageSystemDistributionQueue.cpp
+++ b/src/Storages/System/StorageSystemDistributionQueue.cpp
@@ -101,6 +101,7 @@ NamesAndTypesList StorageSystemDistributionQueue::getNamesAndTypes()
         { "broken_data_files",            std::make_shared<DataTypeUInt64>() },
         { "broken_data_compressed_bytes", std::make_shared<DataTypeUInt64>() },
         { "last_exception",        std::make_shared<DataTypeString>() },
+        { "last_exception_time",        std::make_shared<DataTypeDateTime>() },
     };
 }
 
@@ -190,6 +191,7 @@ void StorageSystemDistributionQueue::fillData(MutableColumns & res_columns, Cont
                 res_columns[col_num++]->insert(getExceptionMessage(status.last_exception, false));
             else
                 res_columns[col_num++]->insertDefault();
+            res_columns[col_num++]->insert(static_cast<UInt32>(std::chrono::system_clock::to_time_t(status.last_exception_time)));
         }
     }
 }

--- a/tests/queries/0_stateless/01555_system_distribution_queue_mask.reference
+++ b/tests/queries/0_stateless/01555_system_distribution_queue_mask.reference
@@ -1,4 +1,4 @@
 masked
-3,"default:*@127%2E0%2E0%2E1:9000,default:*@127%2E0%2E0%2E2:9000"
+3,"default:*@127%2E0%2E0%2E1:9000,default:*@127%2E0%2E0%2E2:9000","AUTHENTICATION_FAILED",1
 no masking
 1,"default@localhost:9000"

--- a/tests/queries/0_stateless/01555_system_distribution_queue_mask.sql
+++ b/tests/queries/0_stateless/01555_system_distribution_queue_mask.sql
@@ -18,7 +18,7 @@ create table dist_01555 (key Int) Engine=Distributed(test_cluster_with_incorrect
 insert into dist_01555 values (1)(2);
 -- since test_cluster_with_incorrect_pw contains incorrect password ignore error
 system flush distributed dist_01555; -- { serverError 516; }
-select length(splitByChar('*', data_path)), replaceRegexpOne(data_path, '^.*/([^/]*)/' , '\\1') from system.distribution_queue where database = currentDatabase() and table = 'dist_01555' format CSV;
+select length(splitByChar('*', data_path)), replaceRegexpOne(data_path, '^.*/([^/]*)/' , '\\1'), extract(last_exception, 'AUTHENTICATION_FAILED'), dateDiff('s', last_exception_time, now()) < 5 from system.distribution_queue where database = currentDatabase() and table = 'dist_01555' format CSV;
 
 drop table dist_01555;
 

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -229,7 +229,8 @@ CREATE TABLE system.distribution_queue
     `data_compressed_bytes` UInt64,
     `broken_data_files` UInt64,
     `broken_data_compressed_bytes` UInt64,
-    `last_exception` String
+    `last_exception` String,
+    `last_exception_time` DateTime
 )
 ENGINE = SystemDistributionQueue
 COMMENT 'SYSTEM TABLE is built on the fly.'


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added `last_exception_time` column into distribution_queue table
