### PR TITLE
Inhibit settings randomization in `01304_direct_io_long.sh`

### DIFF
--- a/tests/queries/0_stateless/01304_direct_io_long.sh
+++ b/tests/queries/0_stateless/01304_direct_io_long.sh
@@ -7,7 +7,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT --multiquery --query "
     DROP TABLE IF EXISTS bug;
-    CREATE TABLE bug (UserID UInt64, Date Date) ENGINE = MergeTree ORDER BY Date;
+    CREATE TABLE bug (UserID UInt64, Date Date) ENGINE = MergeTree ORDER BY Date
+        SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi', merge_max_block_size = 8192;
     INSERT INTO bug SELECT rand64(), '2020-06-07' FROM numbers(50000000);
     OPTIMIZE TABLE bug FINAL;"
 LOG="$CLICKHOUSE_TMP/err-$CLICKHOUSE_DATABASE"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


See https://s3.amazonaws.com/clickhouse-test-reports/46562/3a88ec0bf5f58bb1993df34378b89e3ce98dfa57/stateless_tests__tsan__s3_storage__[4/5].html