### PR TITLE
Fix double whitespace in comment in test

### DIFF
--- a/tests/queries/0_stateless/01081_PartialSortingTransform_full_column.sql
+++ b/tests/queries/0_stateless/01081_PartialSortingTransform_full_column.sql
@@ -6,7 +6,7 @@ select 1 from remote('127.{1,2}', currentDatabase(), test_01081) lhs join system
 
 -- With multiple blocks triggers:
 --
---     Code: 171. DB::Exception: Received from localhost:9000. DB::Exception: Received from 127.2:9000. DB::Exception: Block structure mismatch in  function connect between PartialSortingTransform and LazyOutputFormat stream: different columns:
+--     Code: 171. DB::Exception: Received from localhost:9000. DB::Exception: Received from 127.2:9000. DB::Exception: Block structure mismatch in function connect between PartialSortingTransform and LazyOutputFormat stream: different columns:
 --     _dummy Int Int32(size = 0), 1 UInt8 UInt8(size = 0)
 --     _dummy Int Int32(size = 0), 1 UInt8 Const(size = 0, UInt8(size = 1)).
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


This fixes #29541.