### PR TITLE
Small update of sparkbar docs

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/reference/sparkbar.md
+++ b/docs/en/sql-reference/aggregate-functions/reference/sparkbar.md
@@ -16,12 +16,12 @@ Otherwise, values outside the interval are ignored.
 **Syntax**
 
 ``` sql
-sparkbar(width[, min_x, max_x])(x, y)
+sparkbar(buckets[, min_x, max_x])(x, y)
 ```
 
 **Parameters**
 
--   `width` — The number of segments. Type: [Integer](../../../sql-reference/data-types/int-uint.md).
+-   `buckets` — The number of segments. Type: [Integer](../../../sql-reference/data-types/int-uint.md).
 -   `min_x` — The interval start. Optional parameter.
 -   `max_x` — The interval end. Optional parameter.
 


### PR DESCRIPTION
Parameter name "width" was misleading

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)