### PR TITLE
Increase table retries in `test_cluster_copier`

### DIFF
--- a/programs/copier/ClusterCopier.cpp
+++ b/programs/copier/ClusterCopier.cpp
@@ -908,7 +908,7 @@ bool ClusterCopier::tryProcessTable(const ConnectionTimeouts & timeouts, TaskTab
     /// Exit if success
     if (task_status != TaskStatus::Finished)
     {
-        LOG_WARNING(log, "Create destination Tale Failed ");
+        LOG_WARNING(log, "Create destination table failed ");
         return false;
     }
 
@@ -1473,7 +1473,7 @@ TaskStatus ClusterCopier::processPartitionPieceTaskImpl(
 
         if (count != 0)
         {
-            LOG_INFO(log, "Partition {} piece {}is not empty. In contains {} rows.", task_partition.name, current_piece_number, count);
+            LOG_INFO(log, "Partition {} piece {} is not empty. In contains {} rows.", task_partition.name, current_piece_number, count);
             Coordination::Stat stat_shards{};
             zookeeper->get(partition_piece.getPartitionPieceShardsPath(), &stat_shards);
 

--- a/tests/integration/test_cluster_copier/test.py
+++ b/tests/integration/test_cluster_copier/test.py
@@ -565,13 +565,20 @@ def test_copy_with_recovering(started_cluster, use_sample_offset):
                 str(COPYING_FAIL_PROBABILITY),
                 "--experimental-use-sample-offset",
                 "1",
+                "--max-table-tries",
+                "10",
             ],
         )
     else:
         execute_task(
             started_cluster,
             Task1(started_cluster),
-            ["--copy-fault-probability", str(COPYING_FAIL_PROBABILITY)],
+            [
+                "--copy-fault-probability",
+                str(COPYING_FAIL_PROBABILITY),
+                "--max-table-tries",
+                "10",
+            ],
         )
 
 
@@ -606,7 +613,12 @@ def test_copy_month_to_week_partition_with_recovering(started_cluster):
     execute_task(
         started_cluster,
         Task2(started_cluster, "test2"),
-        ["--copy-fault-probability", str(COPYING_FAIL_PROBABILITY)],
+        [
+            "--copy-fault-probability",
+            str(COPYING_FAIL_PROBABILITY),
+            "--max-table-tries",
+            "10",
+        ],
     )
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Trying to fix newest issues with it like https://s3.amazonaws.com/clickhouse-test-reports/46567/66984088d6931a1023354f37a9d1b5931758c756/integration_tests__tsan__%5B6/6%5D.html

In this case, the problem is that the injected copy failure will create a dirty partition. On dirty partition we drop partition for ALL paths.
The problem occurs in following case:
We try to copy partition 1 piece 0
- shard 1 is successful
- shard 2
  - attempt 0: gets copy fault injection
  - attempt 1: cleanup dirty partition - this will drop the partition and delete ZK status for shard 1 also!
  - attempt 2: successful
 
After we are done with all partitions for each shard we verify it and notice that partition 1 piece 0 shard 1 is not successful because of the missing ZK status node.

Again, nothing wrong occurred, it's just that we need more retries for copying to succeed. We can also try lowering the probability of the fault but let's see with retries first.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
