### PR TITLE
Update compare.sh

### DIFF
--- a/docker/test/performance-comparison/compare.sh
+++ b/docker/test/performance-comparison/compare.sh
@@ -538,7 +538,7 @@ unset IFS
 numactl --show
 numactl --cpunodebind=all --membind=all numactl --show
 # Use less jobs to avoid OOM. Some queries can consume 8+ GB of memory.
-jobs_count=$(($(grep -c ^processor /proc/cpuinfo) / 3))
+jobs_count=$(($(grep -c ^processor /proc/cpuinfo) / 4))
 numactl --cpunodebind=all --membind=all parallel --jobs  $jobs_count --joblog analyze/parallel-log.txt --null < analyze/commands.txt 2>> analyze/errors.log
 
 clickhouse-local --query "


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


```
 2023-02-19T22:17:04.4761030Z 2023-02-20 01:17:04	 + numactl --cpunodebind=all --membind=all parallel --jobs 12 --joblog analyze/parallel-log.txt --null
2023-02-19T22:18:11.8831152Z /home/ubuntu/actions-runner/_work/_temp/0921cb20-4c12-4a1a-8e3c-393d26ed9403.sh: line 5: 2913775 Killed                  python3 performance_comparison_check.py "$CHECK_NAME"
2023-02-19T22:18:12.2363616Z ##[error]Process completed with exit code 137.
```
