### PR TITLE
Update changelog README

### DIFF
--- a/utils/changelog/README.md
+++ b/utils/changelog/README.md
@@ -12,8 +12,13 @@ python3 changelog.py -h
 
 Usage example:
 
-```
-git fetch --tags # changelog.py depends on having the tags available, this will fetch them
+Note: The working directory is ClickHouse/utils/changelog
+
+```bash
+export GITHUB_TOKEN="<your token>"
+
+git fetch --tags # changelog.py depends on having the tags available, this will fetch them.  
+                 # If you are working from a branch in your personal fork, then you may need `git fetch --all`
 
 python3 changelog.py --output=changelog-v22.4.1.2305-prestable.md --gh-user-or-token="$GITHUB_TOKEN" v21.6.2.7-prestable
 python3 changelog.py --output=changelog-v22.4.1.2305-prestable.md --gh-user-or-token="$USER" --gh-password="$PASSWORD" v21.6.2.7-prestable


### PR DESCRIPTION

Some people who are working on a branch of a personal fork may need to use `git fetch --all`

PAT should be exported to the shell

### Changelog category (leave one):
- Documentation (changelog entry is not required)
