### PR TITLE
Update 01565_reconnect_after_client_error to not expect explicit reconnect

### DIFF
--- a/tests/queries/0_stateless/01565_query_loop_after_client_error.expect
+++ b/tests/queries/0_stateless/01565_query_loop_after_client_error.expect
@@ -39,7 +39,6 @@ expect "\n:) "
 send -- "INSERT INTO t01565(c0, c1) VALUES (\"1\",1) ;\n"
 expect "INSERT"
 send -- "\r"
-expect "\nConnected"
 expect "\n:) "
 
 send -- "INSERT INTO t01565(c0, c1) VALUES ('1', 1) ;\n"

--- a/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
+++ b/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
@@ -24,18 +24,27 @@ spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \
 expect "\n:) "
 
 send -- "DROP TABLE IF EXISTS t01565;\n"
+# NOTE: this is important for -mn mode, you should send "\r" only after reading echoed command
+expect "DROP"
+send -- "\r"
 expect "\nOk."
 expect "\n:)"
 
 send -- "CREATE TABLE t01565 (c0 String, c1 Int32) ENGINE = Memory() ;\n"
+expect "CREATE"
+send -- "\r"
 expect "\nOk."
 expect "\n:) "
 
 send -- "INSERT INTO t01565(c0, c1) VALUES (\"1\",1) ;\n"
+expect "INSERT"
+send -- "\r"
 expect "\nConnected"
 expect "\n:) "
 
 send -- "INSERT INTO t01565(c0, c1) VALUES ('1', 1) ;\n"
+expect "INSERT"
+send -- "\r"
 expect "\nOk."
 expect "\n:) "
 

--- a/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
+++ b/tests/queries/0_stateless/01565_reconnect_after_client_error.expect
@@ -15,9 +15,9 @@ match_max 100000
 
 expect_after {
     # Do not ignore eof from expect
-    eof { exp_continue }
+    -i $any_spawn_id eof { exp_continue }
     # A default timeout action is to do nothing, change it to fail
-    timeout { exit 1 }
+    -i $any_spawn_id timeout { exit 1 }
 }
 
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion -mn --history_file=$history_file"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

There is no need in explicit reconnect in case of client errors
(#19353), so just rewrite the test to ensure that everything works.

Cc: @kssenii 