### PR TITLE
Fix MemoryTracker counters for async inserts

### DIFF
--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -115,10 +115,11 @@ MemoryTracker * CurrentThread::getUserMemoryTracker()
     if (unlikely(!current_thread))
         return nullptr;
 
-    if (auto group = current_thread->getThreadGroup())
-        return group->memory_tracker.getParent();
+    auto * tracker = current_thread->memory_tracker.getParent();
+    while (tracker && tracker->level != VariableContext::User)
+        tracker = tracker->getParent();
 
-    return nullptr;
+    return tracker;
 }
 
 void CurrentThread::flushUntrackedMemory()

--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -110,4 +110,26 @@ ThreadGroupStatusPtr CurrentThread::getGroup()
     return current_thread->getThreadGroup();
 }
 
+MemoryTracker * CurrentThread::getUserMemoryTracker()
+{
+    if (unlikely(!current_thread))
+        return nullptr;
+
+    if (auto group = current_thread->getThreadGroup())
+        return group->memory_tracker.getParent();
+
+    return nullptr;
+}
+
+void CurrentThread::flushUntrackedMemory()
+{
+    if (unlikely(!current_thread))
+        return;
+    if (current_thread->untracked_memory == 0)
+        return;
+
+    current_thread->memory_tracker.adjustWithUntrackedMemory(current_thread->untracked_memory);
+    current_thread->untracked_memory = 0;
+}
+
 }

--- a/src/Common/CurrentThread.h
+++ b/src/Common/CurrentThread.h
@@ -40,6 +40,12 @@ public:
     /// Group to which belongs current thread
     static ThreadGroupStatusPtr getGroup();
 
+    /// MemoryTracker for user that owns current thread if any
+    static MemoryTracker * getUserMemoryTracker();
+
+    /// Adjust counters in MemoryTracker hierarchy if untracked_memory is not 0.
+    static void flushUntrackedMemory();
+
     /// A logs queue used by TCPHandler to pass logs to a client
     static void attachInternalTextLogsQueue(const std::shared_ptr<InternalTextLogsQueue> & logs_queue,
                                             LogsLevel client_logs_level);

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -17,6 +17,7 @@
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/queryToString.h>
 #include <Storages/IStorage.h>
+#include <Common/CurrentThread.h>
 #include <Common/SipHash.h>
 #include <Common/FieldVisitorHash.h>
 #include <Common/DateLUT.h>
@@ -102,9 +103,10 @@ bool AsynchronousInsertQueue::InsertQuery::operator==(const InsertQuery & other)
     return query_str == other.query_str && settings == other.settings;
 }
 
-AsynchronousInsertQueue::InsertData::Entry::Entry(String && bytes_, String && query_id_)
+AsynchronousInsertQueue::InsertData::Entry::Entry(String && bytes_, String && query_id_, MemoryTracker * user_memory_tracker_)
     : bytes(std::move(bytes_))
     , query_id(std::move(query_id_))
+    , user_memory_tracker(user_memory_tracker_)
     , create_time(std::chrono::system_clock::now())
 {
 }
@@ -209,7 +211,7 @@ std::future<void> AsynchronousInsertQueue::push(ASTPtr query, ContextPtr query_c
     if (auto quota = query_context->getQuota())
         quota->used(QuotaType::WRITTEN_BYTES, bytes.size());
 
-    auto entry = std::make_shared<InsertData::Entry>(std::move(bytes), query_context->getCurrentQueryId());
+    auto entry = std::make_shared<InsertData::Entry>(std::move(bytes), query_context->getCurrentQueryId(), CurrentThread::getUserMemoryTracker());
 
     InsertQuery key{query, settings};
     InsertDataPtr data_to_process;

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -91,6 +91,9 @@ private:
         ~InsertData()
         {
             auto it = entries.begin();
+            // Entries must be destroyed in context of user who runs async insert.
+            // Each entry in the list may correspond to a different user,
+            // so we need to switch current thread's MemoryTracker parent on each iteration.
             while (it != entries.end())
             {
                 UserMemoryTrackerSwitcher switcher((*it)->user_memory_tracker);

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Parsers/IAST_fwd.h>
+#include <Common/CurrentThread.h>
 #include <Common/ThreadPool.h>
 #include <Core/Settings.h>
 #include <Poco/Logger.h>
@@ -41,6 +42,31 @@ private:
         UInt128 calculateHash() const;
     };
 
+    struct UserMemoryTrackerSwitcher
+    {
+        explicit UserMemoryTrackerSwitcher(MemoryTracker * new_tracker)
+        {
+            auto * thread_tracker = CurrentThread::getMemoryTracker();
+            prev_untracked_memory = current_thread->untracked_memory;
+            prev_memory_tracker_parent = thread_tracker->getParent();
+
+            current_thread->untracked_memory = 0;
+            thread_tracker->setParent(new_tracker);
+        }
+
+        ~UserMemoryTrackerSwitcher()
+        {
+            CurrentThread::flushUntrackedMemory();
+            auto * thread_tracker = CurrentThread::getMemoryTracker();
+
+            current_thread->untracked_memory = prev_untracked_memory;
+            thread_tracker->setParent(prev_memory_tracker_parent);
+        }
+
+        MemoryTracker * prev_memory_tracker_parent;
+        Int64 prev_untracked_memory;
+    };
+
     struct InsertData
     {
         struct Entry
@@ -48,9 +74,10 @@ private:
         public:
             const String bytes;
             const String query_id;
+            MemoryTracker * const user_memory_tracker;
             const std::chrono::time_point<std::chrono::system_clock> create_time;
 
-            Entry(String && bytes_, String && query_id_);
+            Entry(String && bytes_, String && query_id_, MemoryTracker * user_memory_tracker_);
 
             void finish(std::exception_ptr exception_ = nullptr);
             std::future<void> getFuture() { return promise.get_future(); }
@@ -60,6 +87,16 @@ private:
             std::promise<void> promise;
             std::atomic_bool finished = false;
         };
+
+        ~InsertData()
+        {
+            auto it = entries.begin();
+            while (it != entries.end())
+            {
+                UserMemoryTrackerSwitcher switcher((*it)->user_memory_tracker);
+                it = entries.erase(it);
+            }
+        }
 
         using EntryPtr = std::shared_ptr<Entry>;
 

--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -123,7 +123,7 @@ TRUSTED_CONTRIBUTORS = {
         "BoloniniD",  # Seasoned contributor, HSE
         "tonickkozlov",  # Cloudflare
         "tylerhannan",  # ClickHouse Employee
-        "myrrc", # Mike Kot, DoubleCloud
+        "myrrc",  # Mike Kot, DoubleCloud
     ]
 }
 

--- a/tests/integration/test_async_insert_memory/test.py
+++ b/tests/integration/test_async_insert_memory/test.py
@@ -1,0 +1,35 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance("node")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_memory_usage():
+    node.query(
+        "CREATE TABLE async_table(data Array(UInt64)) ENGINE=MergeTree() ORDER BY data"
+    )
+
+    response = node.get_query_request(
+        "SELECT groupArray(number + sleepEachRow(0.0001)) FROM numbers(1000000) SETTINGS max_memory_usage_for_user={}".format(30 * (2 ** 23))
+    )
+
+    INSERT_QUERY = "INSERT INTO async_table SETTINGS async_insert=1, wait_for_async_insert=1 VALUES ({})"
+    for i in range(10):
+        node.query(INSERT_QUERY.format([i in range(i * 5000000, (i + 1) * 5000000)]))
+
+    _, err = response.get_answer_and_error()
+    assert err == "", "Query failed"
+
+    node.query("DROP TABLE async_table")

--- a/tests/integration/test_async_insert_memory/test.py
+++ b/tests/integration/test_async_insert_memory/test.py
@@ -21,15 +21,20 @@ def test_memory_usage():
         "CREATE TABLE async_table(data Array(UInt64)) ENGINE=MergeTree() ORDER BY data"
     )
 
-    response = node.get_query_request(
-        "SELECT groupArray(number + sleepEachRow(0.0001)) FROM numbers(1000000) SETTINGS max_memory_usage_for_user={}".format(30 * (2 ** 23))
+    node.get_query_request(
+        "SELECT count() FROM system.numbers"
     )
 
     INSERT_QUERY = "INSERT INTO async_table SETTINGS async_insert=1, wait_for_async_insert=1 VALUES ({})"
-    for i in range(10):
-        node.query(INSERT_QUERY.format([i in range(i * 5000000, (i + 1) * 5000000)]))
+    for iter in range(10):
+        values = list(range(iter * 5000000, (iter + 1) * 5000000))
+        node.query(INSERT_QUERY.format(values))
+
+    response = node.get_query_request(
+        "SELECT groupArray(number) FROM numbers(1000000) SETTINGS max_memory_usage_for_user={}".format(30 * (2 ** 23))
+    )
 
     _, err = response.get_answer_and_error()
-    assert err == "", "Query failed"
+    assert err == "", "Query failed with error {}".format(err)
 
     node.query("DROP TABLE async_table")

--- a/tests/integration/test_async_insert_memory/test.py
+++ b/tests/integration/test_async_insert_memory/test.py
@@ -21,9 +21,7 @@ def test_memory_usage():
         "CREATE TABLE async_table(data Array(UInt64)) ENGINE=MergeTree() ORDER BY data"
     )
 
-    node.get_query_request(
-        "SELECT count() FROM system.numbers"
-    )
+    node.get_query_request("SELECT count() FROM system.numbers")
 
     INSERT_QUERY = "INSERT INTO async_table SETTINGS async_insert=1, wait_for_async_insert=1 VALUES ({})"
     for iter in range(10):
@@ -31,7 +29,9 @@ def test_memory_usage():
         node.query(INSERT_QUERY.format(values))
 
     response = node.get_query_request(
-        "SELECT groupArray(number) FROM numbers(1000000) SETTINGS max_memory_usage_for_user={}".format(30 * (2 ** 23))
+        "SELECT groupArray(number) FROM numbers(1000000) SETTINGS max_memory_usage_for_user={}".format(
+            30 * (2**23)
+        )
     )
 
     _, err = response.get_answer_and_error()


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Allocated during asynchronous inserts memory buffers were deallocated in the global context and MemoryTracker counters for corresponding user and query were not updated correctly. That led to false positive OOM exceptions.

cc @KochetovNicolai @CurtizJ 