### PR TITLE
(wip) Fix crash with query parameters in CREATE TABLE

### DIFF
--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -6,6 +6,7 @@
 #include <Interpreters/IdentifierSemantic.h>
 #include <Interpreters/ReplaceQueryParameterVisitor.h>
 #include <Interpreters/addTypeConversionToAST.h>
+#include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTQueryParameter.h>
@@ -37,6 +38,8 @@ void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
         visitQueryParameter(ast);
     else if (ast->as<ASTIdentifier>() || ast->as<ASTTableIdentifier>())
         visitIdentifier(ast);
+    else if (ast->as<ASTCreateQuery>())
+        return;
     else
     {
         if (auto * describe_query = dynamic_cast<ASTDescribeQuery *>(ast.get()); describe_query && describe_query->table_expression)

--- a/tests/queries/0_stateless/02667_crash_in_parameterized_order_by_in_create_table.sql
+++ b/tests/queries/0_stateless/02667_crash_in_parameterized_order_by_in_create_table.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS t;
+
+SET param_o = 'a';
+CREATE TABLE t (a Int64) ENGINE=MergeTree ORDER BY ({o:String}); -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+DROP TABLE IF EXISTS t;


### PR DESCRIPTION
Fixes: #46519

Fixes the problem but in an ugly way ... please don't merge yet (unless it is considered super urgent must-have). Need to talk to @nickitat how this can be fixed more elegantly.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Don't crash in parameterized queries SET param_o = 'a'; CREATE TABLE t (a Int64) ENGINE=MergeTree ORDER BY ({o:String});