### PR TITLE
Add new function JSONArrayLength

### DIFF
--- a/docs/en/sql-reference/functions/json-functions.md
+++ b/docs/en/sql-reference/functions/json-functions.md
@@ -471,3 +471,38 @@ Result:
 
 -   [output_format_json_quote_64bit_integers](../../operations/settings/settings.md#session_settings-output_format_json_quote_64bit_integers)
 -   [output_format_json_quote_denormals](../../operations/settings/settings.md#settings-output_format_json_quote_denormals)
+
+
+## JSONArrayLength
+
+Returns the number of elements in the outermost JSON array. The function returns NULL if input JSON string is invalid.
+
+**Syntax**
+
+``` sql
+JSONArrayLength(json)
+```
+
+Alias: `JSON_ARRAY_LENGTH(json)`.
+
+**Arguments**
+
+-   `json` — [String](../../sql-reference/data-types/string.md) with valid JSON.
+
+**Returned value**
+
+-   If `json` is a valid JSON array string, returns the number of array elements, otherwise returns NULL.
+
+Type: [Nullable(UInt64)](../../sql-reference/data-types/int-uint.md).
+
+**Example**
+
+``` sql
+SELECT
+    JSONArrayLength(''),
+    JSONArrayLength('[1,2,3]')
+
+┌─JSONArrayLength('')─┬─JSONArrayLength('[1,2,3]')─┐
+│                ᴺᵁᴸᴸ │                          3 │
+└─────────────────────┴────────────────────────────┘
+```

--- a/src/Functions/JSONArrayLength.cpp
+++ b/src/Functions/JSONArrayLength.cpp
@@ -1,0 +1,110 @@
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnVector.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Interpreters/Context.h>
+#include "config.h"
+
+#if USE_SIMDJSON
+#    include <Common/JSONParsers/SimdJSONParser.h>
+#elif USE_RAPIDJSON
+#    include <Common/JSONParsers/RapidJSONParser.h>
+#else
+#    include <Common/JSONParsers/DummyJSONParser.h>
+#endif
+
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_COLUMN;
+}
+
+namespace
+{
+    /// JSONArrayLength(json)
+    class FunctionJSONArrayLength : public IFunction
+    {
+    public:
+        static constexpr auto name = "JSONArrayLength";
+        static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionJSONArrayLength>(); }
+
+        String getName() const override { return name; }
+
+        bool isVariadic() const override { return false; }
+        bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+
+        size_t getNumberOfArguments() const override { return 1; }
+        bool useDefaultImplementationForConstants() const override { return true; }
+
+        DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+        {
+            auto args = FunctionArgumentDescriptors{
+                {"json", &isString<IDataType>, nullptr, "String"},
+            };
+
+            validateFunctionArgumentTypes(*this, arguments, args);
+            return std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt64>());
+        }
+
+        ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+        {
+            const ColumnPtr column = arguments[0].column;
+            const ColumnString * col = typeid_cast<const ColumnString *>(column.get());
+            if (!col)
+                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "First argument of function {} must be string", getName());
+
+            auto null_map = ColumnUInt8::create();
+            auto data = ColumnUInt64::create();
+            null_map->reserve(input_rows_count);
+            data->reserve(input_rows_count);
+
+#if USE_SIMDJSON
+            SimdJSONParser parser;
+            SimdJSONParser::Element element;
+#elif USE_RAPIDJSON
+            RapidJSONParser parser;
+            RapidJSONParser::Element element;
+#else
+            DummyJSONParser parser;
+            DummyJSONParser::Element element;
+#endif
+
+            for (size_t i = 0; i < input_rows_count; ++i)
+            {
+                auto str_ref = col->getDataAt(i);
+                std::string_view str_view(str_ref.data, str_ref.size);
+                bool ok = parser.parse(std::move(str_view), element);
+                if (!ok || !element.isArray())
+                {
+                    null_map->insertValue(1);
+                    data->insertDefault();
+                }
+                else
+                {
+                    auto array = element.getArray();
+                    null_map->insertValue(0);
+                    data->insertValue(array.size());
+                }
+            }
+            return ColumnNullable::create(std::move(data), std::move(null_map));
+        }
+    };
+
+}
+
+REGISTER_FUNCTION(JSONArrayLength)
+{
+    factory.registerFunction<FunctionJSONArrayLength>(Documentation{
+        "Returns the number of elements in the outermost JSON array. The function returns NULL if input JSON string is invalid."});
+
+    /// For Spark compatibility.
+    factory.registerAlias("JSON_ARRAY_LENGTH", "JSONArrayLength", FunctionFactory::CaseInsensitive);
+}
+
+}

--- a/tests/queries/0_stateless/02667_json_array_length.reference
+++ b/tests/queries/0_stateless/02667_json_array_length.reference
@@ -1,21 +1,25 @@
 -- { echoOn }
-select json_array_length(null);
+select JSONArrayLength(null);
 \N
-select json_array_length('');
+select JSONArrayLength('');
 \N
-select json_array_length('[]');
+select JSONArrayLength('[]');
 0
-select json_array_length('[1,2,3]');
+select JSONArrayLength('[1,2,3]');
 3
-select json_array_length('[[1,2],[5,6,7]]');
+select JSONArrayLength('[[1,2],[5,6,7]]');
 2
-select json_array_length('[{"a":123},{"b":"hello"}]');
+select JSONArrayLength('[{"a":123},{"b":"hello"}]');
 2
-select json_array_length('[1,2,3,[33,44],{"key":[2,3,4]}]');
+select JSONArrayLength('[1,2,3,[33,44],{"key":[2,3,4]}]');
 5
-select json_array_length('{"key":"not a json array"}');
+select JSONArrayLength('{"key":"not a json array"}');
 \N
-select json_array_length('[1,2,3,4,5');
+select JSONArrayLength('[1,2,3,4,5');
 \N
-select json_array_length(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-select json_array_length(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+select JSON_ARRAY_LENGTH('[1,2,3,4,5');
+\N
+select JSON_ARRAY_LENGTH('[1,2,3,4,5]');
+5
+select JSONArrayLength(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+select JSONArrayLength(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }

--- a/tests/queries/0_stateless/02667_json_array_length.reference
+++ b/tests/queries/0_stateless/02667_json_array_length.reference
@@ -1,0 +1,21 @@
+-- { echoOn }
+select json_array_length(null);
+\N
+select json_array_length('');
+\N
+select json_array_length('[]');
+0
+select json_array_length('[1,2,3]');
+3
+select json_array_length('[[1,2],[5,6,7]]');
+2
+select json_array_length('[{"a":123},{"b":"hello"}]');
+2
+select json_array_length('[1,2,3,[33,44],{"key":[2,3,4]}]');
+5
+select json_array_length('{"key":"not a json array"}');
+\N
+select json_array_length('[1,2,3,4,5');
+\N
+select json_array_length(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+select json_array_length(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }

--- a/tests/queries/0_stateless/02667_json_array_length.sql
+++ b/tests/queries/0_stateless/02667_json_array_length.sql
@@ -1,13 +1,16 @@
 -- { echoOn }
-select json_array_length(null);
-select json_array_length('');
-select json_array_length('[]');
-select json_array_length('[1,2,3]');
-select json_array_length('[[1,2],[5,6,7]]');
-select json_array_length('[{"a":123},{"b":"hello"}]');
-select json_array_length('[1,2,3,[33,44],{"key":[2,3,4]}]');
-select json_array_length('{"key":"not a json array"}');
-select json_array_length('[1,2,3,4,5');
+select JSONArrayLength(null);
+select JSONArrayLength('');
+select JSONArrayLength('[]');
+select JSONArrayLength('[1,2,3]');
+select JSONArrayLength('[[1,2],[5,6,7]]');
+select JSONArrayLength('[{"a":123},{"b":"hello"}]');
+select JSONArrayLength('[1,2,3,[33,44],{"key":[2,3,4]}]');
+select JSONArrayLength('{"key":"not a json array"}');
+select JSONArrayLength('[1,2,3,4,5');
 
-select json_array_length(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-select json_array_length(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+select JSON_ARRAY_LENGTH('[1,2,3,4,5');
+select JSON_ARRAY_LENGTH('[1,2,3,4,5]');
+
+select JSONArrayLength(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+select JSONArrayLength(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }

--- a/tests/queries/0_stateless/02667_json_array_length.sql
+++ b/tests/queries/0_stateless/02667_json_array_length.sql
@@ -1,0 +1,13 @@
+-- { echoOn }
+select json_array_length(null);
+select json_array_length('');
+select json_array_length('[]');
+select json_array_length('[1,2,3]');
+select json_array_length('[[1,2],[5,6,7]]');
+select json_array_length('[{"a":123},{"b":"hello"}]');
+select json_array_length('[1,2,3,[33,44],{"key":[2,3,4]}]');
+select json_array_length('{"key":"not a json array"}');
+select json_array_length('[1,2,3,4,5');
+
+select json_array_length(2); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+select json_array_length(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add new function JSONArrayLength, which returns the number of elements in the outermost JSON array. The function returns NULL if input JSON string is invalid.

``` sql
SELECT
    JSONArrayLength(''),
    JSONArrayLength('[1,2,3]')

Query id: f4734419-a640-4993-b406-238d9273f2e6

┌─JSONArrayLength('')─┬─JSONArrayLength('[1,2,3]')─┐
│                ᴺᵁᴸᴸ │                          3 │
└─────────────────────┴────────────────────────────┘

1 row in set. Elapsed: 0.001 sec. 

```