### PR TITLE
Fix 01179_insert_values_semicolon test

### DIFF
--- a/tests/queries/0_stateless/01179_insert_values_semicolon.expect
+++ b/tests/queries/0_stateless/01179_insert_values_semicolon.expect
@@ -10,9 +10,9 @@ set timeout 60
 match_max 100000
 expect_after {
     # Do not ignore eof from expect
-    eof { exp_continue }
+    -i $any_spawn_id eof { exp_continue }
     # A default timeout action is to do nothing, change it to fail
-    timeout { exit 1 }
+    -i $any_spawn_id timeout { exit 1 }
 }
 
 spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_OPT --disable_suggestion"

--- a/tests/queries/0_stateless/01179_insert_values_semicolon.expect
+++ b/tests/queries/0_stateless/01179_insert_values_semicolon.expect
@@ -21,7 +21,7 @@ expect ":) "
 send -- "DROP TABLE IF EXISTS test_01179\r"
 expect "Ok."
 
-send -- "CREATE TABLE test_01179 (date DateTime) ENGINE=Memory()\r"
+send -- "CREATE TABLE test_01179 (date DateTime64(3)) ENGINE=Memory()\r"
 expect "Ok."
 
 send -- "INSERT INTO test_01179 values ('2020-01-01')\r"
@@ -30,11 +30,11 @@ expect "Ok."
 send -- "INSERT INTO test_01179 values ('2020-01-01'); \r"
 expect "Ok."
 
-send -- "INSERT INTO test_01179 values ('2020-01-01'); (1) \r"
+send -- "INSERT INTO test_01179 values ('2020-01-01 0'); (1) \r"
 expect "Cannot read data after semicolon"
 
 send -- "SELECT date, count() FROM test_01179 GROUP BY date FORMAT TSV\r"
-expect "2020-01-01 00:00:00\t3"
+expect "2020-01-01 00:00:00.000\t2"
 
 send -- "DROP TABLE test_01179\r"
 expect "Ok."


### PR DESCRIPTION
Back in #19925 a check for reading data after semicolon had been added,
but after #40474 it does not work, the test does not show the problem
because of timeout does not work without stdin before (a more generic
fix for timeouts in expect tests I will submit later).

To make this test works, the only type that I can found that will work
right now is DateTime64, other types does use peeking, or even if they
do, they will fail while parsing the query as SQL expression.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Cc: @tavplubix 
Cc: @alexey-milovidov 