### PR TITLE
Avoid OOM in perf tests

### DIFF
--- a/docker/test/performance-comparison/Dockerfile
+++ b/docker/test/performance-comparison/Dockerfile
@@ -1,5 +1,10 @@
 # docker build -t clickhouse/performance-comparison .
-FROM ubuntu:20.04
+
+# Using ubuntu:22.04 over 20.04 as all other images, since:
+# a) ubuntu 20.04 has too old parallel, and does not support --memsuspend
+# b) anyway for perf tests it should not be important (backward compatiblity
+#    with older ubuntu had been checked lots of times in various tests)
+FROM ubuntu:22.04
 
 # ARG for quick switch to a given ubuntu mirror
 ARG apt_archive="http://archive.ubuntu.com"


### PR DESCRIPTION
At some point perf tests started to fail for one setup on CI [1]:

    /home/ubuntu/actions-runner/_work/_temp/f8fce7b1-8bc4-49c8-a203-c96867f4420a.sh: line 5: 1882659 Killed                  python3 performance_comparison_check.py "$CHECK_NAME"
    Error: Process completed with exit code 137.

  [1]: https://github.com/ClickHouse/ClickHouse/actions/runs/4230936986/jobs/7349818625

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)