### PR TITLE
Make tiny improvements

### DIFF
--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -251,7 +251,7 @@ bool ValuesBlockInputFormat::tryParseExpressionUsingTemplate(MutableColumnPtr & 
     /// Do not use this template anymore
     templates[column_idx].reset();
     buf->rollbackToCheckpoint();
-    *token_iterator = start;
+    token_iterator = start;
 
     /// It will deduce new template or fallback to slow SQL parser
     return parseExpression(*column, column_idx);

--- a/src/Processors/ISource.cpp
+++ b/src/Processors/ISource.cpp
@@ -72,7 +72,7 @@ void ISource::progress(size_t read_rows, size_t read_bytes)
 
 std::optional<ISource::ReadProgress> ISource::getReadProgress()
 {
-    if (finished && read_progress.read_bytes == 0 && read_progress.read_bytes == 0 && read_progress.total_rows_approx == 0)
+    if (finished && read_progress.read_bytes == 0 && read_progress.total_rows_approx == 0)
         return {};
 
     ReadProgressCounters res_progress;


### PR DESCRIPTION
`token_iterator` is of type `std::optional` so it's best assigned without dereferencing, because it could result in undefined behaviour if it was `std::nullopt` ([reference](https://en.cppreference.com/w/cpp/utility/optional/operator*)). The other change is simply removing a duplication from a logical expression.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)