### PR TITLE
add docs for setting async_insert_max_query_number

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1563,7 +1563,7 @@ Default value: `100000`.
 
 ### async_insert_max_query_number {#async-insert-max-query-number}
 
-The maximum number of insert query in per block before being inserted. It takes effect only if [async_insert_deduplicate](#settings-async-insert-deduplicate) is enabled.
+The maximum number of insert queries per block before being inserted. This setting takes effect only if [async_insert_deduplicate](#settings-async-insert-deduplicate) is enabled.
 
 Possible values:
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -1561,6 +1561,17 @@ Possible values:
 
 Default value: `100000`.
 
+### async_insert_max_query_number {#async-insert-max-query-number}
+
+The maximum number of insert query in per block before being inserted. It takes effect only if [async_insert_deduplicate](#settings-async-insert-deduplicate) is enabled.
+
+Possible values:
+
+-   Positive integer.
+-   0 — Asynchronous insertions are disabled.
+
+Default value: `450`.
+
 ### async_insert_busy_timeout_ms {#async-insert-busy-timeout-ms}
 
 The maximum timeout in milliseconds since the first `INSERT` query before inserting collected data.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
close https://github.com/ClickHouse/ClickHouse/issues/46541

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
