### PR TITLE
Hide arguments of custom disk merge tree setting

### DIFF
--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -108,7 +108,8 @@ struct CustomType
     {
         virtual ~CustomTypeImpl() = default;
         virtual const char * getTypeName() const = 0;
-        virtual String toString() const = 0;
+        virtual String toString(bool show_secrets) const = 0;
+        virtual bool isSecret() const = 0;
 
         virtual bool operator < (const CustomTypeImpl &) const = 0;
         virtual bool operator <= (const CustomTypeImpl &) const = 0;
@@ -120,8 +121,9 @@ struct CustomType
     CustomType() = default;
     explicit CustomType(std::shared_ptr<const CustomTypeImpl> impl_) : impl(impl_) {}
 
+    bool isSecret() const { return impl->isSecret(); }
     const char * getTypeName() const { return impl->getTypeName(); }
-    String toString() const { return impl->toString(); }
+    String toString(bool show_secrets = true) const { return impl->toString(show_secrets); }
     const CustomTypeImpl & getImpl() { return *impl; }
 
     bool operator < (const CustomType & rhs) const { return *impl < *rhs.impl; }

--- a/src/Disks/getOrCreateDiskFromAST.cpp
+++ b/src/Disks/getOrCreateDiskFromAST.cpp
@@ -7,6 +7,7 @@
 #include <Parsers/formatAST.h>
 #include <Parsers/ASTExpressionList.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/isDiskFunction.h>
 #include <Interpreters/Context.h>
 
 namespace DB
@@ -15,15 +16,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-}
-
-bool isDiskFunction(ASTPtr ast)
-{
-    if (!ast)
-        return false;
-
-    const auto * function = ast->as<ASTFunction>();
-    return function && function->name == "disk" && function->arguments->as<ASTExpressionList>();
 }
 
 std::string getOrCreateDiskFromDiskAST(const ASTFunction & function, ContextPtr context)

--- a/src/Disks/getOrCreateDiskFromAST.h
+++ b/src/Disks/getOrCreateDiskFromAST.h
@@ -15,9 +15,4 @@ class ASTFunction;
  */
 std::string getOrCreateDiskFromDiskAST(const ASTFunction & function, ContextPtr context);
 
-/*
- * Is given ast has form of a disk(<disk_configuration>) function.
- */
-bool isDiskFunction(ASTPtr ast);
-
 }

--- a/src/Parsers/ASTSetQuery.cpp
+++ b/src/Parsers/ASTSetQuery.cpp
@@ -34,7 +34,11 @@ void ASTSetQuery::formatImpl(const FormatSettings & format, FormatState &, Forma
             first = false;
 
         formatSettingName(change.name, format.ostr);
-        format.ostr << " = " << applyVisitor(FieldVisitorToString(), change.value);
+        CustomType custom;
+        if (!format.show_secrets && change.value.tryGet<CustomType>(custom) && custom.isSecret())
+            format.ostr << " = " << custom.toString(false);
+        else
+            format.ostr << " = " << applyVisitor(FieldVisitorToString(), change.value);
     }
 
     for (const auto & setting_name : default_settings)

--- a/src/Parsers/FieldFromAST.cpp
+++ b/src/Parsers/FieldFromAST.cpp
@@ -36,16 +36,16 @@ String FieldFromASTImpl::toString(bool show_secrets) const
     if (!show_secrets && isDiskFunction(ast))
     {
         auto hidden = ast->clone();
-        auto & disk_function = assert_cast<const ASTFunction &>(*hidden);
-        auto * disk_function_args_expr = assert_cast<const ASTExpressionList *>(disk_function.arguments.get());
-        auto & disk_function_args = disk_function_args_expr->children;
+        const auto & disk_function = assert_cast<const ASTFunction &>(*hidden);
+        const auto * disk_function_args_expr = assert_cast<const ASTExpressionList *>(disk_function.arguments.get());
+        const auto & disk_function_args = disk_function_args_expr->children;
 
         auto is_secret_arg = [](const std::string & arg_name)
         {
             return arg_name != "type";
         };
 
-        for (auto & arg : disk_function_args)
+        for (const auto & arg : disk_function_args)
         {
             auto * setting_function = arg->as<ASTFunction>();
             if (!setting_function || setting_function->name != "equals")

--- a/src/Parsers/FieldFromAST.cpp
+++ b/src/Parsers/FieldFromAST.cpp
@@ -1,10 +1,18 @@
 #include <Parsers/FieldFromAST.h>
+#include <Disks/getOrCreateDiskFromAST.h>
+#include <Parsers/formatAST.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTFunction.h>
+#include <Common/assert_cast.h>
+
 
 namespace DB
 {
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
 
 Field createFieldFromAST(ASTPtr ast)
@@ -15,6 +23,53 @@ Field createFieldFromAST(ASTPtr ast)
 [[noreturn]] void FieldFromASTImpl::throwNotImplemented(std::string_view method) const
 {
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Method {} not implemented for {}", method, getTypeName());
+}
+
+bool FieldFromASTImpl::isSecret() const
+{
+    return isDiskFunction(ast);
+}
+
+String FieldFromASTImpl::toString(bool show_secrets) const
+{
+    if (!show_secrets && isDiskFunction(ast))
+    {
+        auto hidden = ast->clone();
+        auto & disk_function = assert_cast<const ASTFunction &>(*hidden);
+        auto * disk_function_args_expr = assert_cast<const ASTExpressionList *>(disk_function.arguments.get());
+        auto & disk_function_args = disk_function_args_expr->children;
+
+        auto is_secret_arg = [](const std::string & arg_name)
+        {
+            return arg_name != "type";
+        };
+
+        for (auto & arg : disk_function_args)
+        {
+            auto * setting_function = arg->as<ASTFunction>();
+            if (!setting_function || setting_function->name != "equals")
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Bad format: expected equals function");
+
+            auto * function_args_expr = assert_cast<ASTExpressionList *>(setting_function->arguments.get());
+            if (!function_args_expr)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Bad format: expected arguments");
+
+            auto & function_args = function_args_expr->children;
+            if (function_args.empty())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Bad format: expected non zero number of arguments");
+
+            auto * key_identifier = function_args[0]->as<ASTIdentifier>();
+            if (!key_identifier)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Bad format: expected Identifier");
+
+            const std::string & key = key_identifier->name();
+            if (is_secret_arg(key))
+                function_args[1] = std::make_shared<ASTLiteral>("[HIDDEN]");
+        }
+        return serializeAST(*hidden);
+    }
+
+    return serializeAST(*ast);
 }
 
 }

--- a/src/Parsers/FieldFromAST.cpp
+++ b/src/Parsers/FieldFromAST.cpp
@@ -4,6 +4,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/isDiskFunction.h>
 #include <Common/assert_cast.h>
 
 

--- a/src/Parsers/FieldFromAST.h
+++ b/src/Parsers/FieldFromAST.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <Core/Field.h>
 #include <Parsers/IAST_fwd.h>
-#include <Parsers/formatAST.h>
 
 namespace DB
 {
@@ -13,7 +12,8 @@ struct FieldFromASTImpl : public CustomType::CustomTypeImpl
     explicit FieldFromASTImpl(ASTPtr ast_) : ast(ast_) {}
 
     const char * getTypeName() const override { return name; }
-    String toString() const override { return serializeAST(*ast); }
+    String toString(bool show_secrets) const override;
+    bool isSecret() const override;
 
     [[noreturn]] void throwNotImplemented(std::string_view method) const;
 

--- a/src/Parsers/isDiskFunction.cpp
+++ b/src/Parsers/isDiskFunction.cpp
@@ -1,0 +1,16 @@
+#include <Parsers/isDiskFunction.h>
+#include <Parsers/ASTFunction.h>
+
+namespace DB
+{
+
+bool isDiskFunction(ASTPtr ast)
+{
+    if (!ast)
+        return false;
+
+    const auto * function = ast->as<ASTFunction>();
+    return function && function->name == "disk" && function->arguments->as<ASTExpressionList>();
+}
+
+}

--- a/src/Parsers/isDiskFunction.h
+++ b/src/Parsers/isDiskFunction.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <Parsers/IAST_fwd.h>
+
+namespace DB
+{
+
+bool isDiskFunction(ASTPtr ast);
+
+}

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -5,6 +5,7 @@
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/FieldFromAST.h>
+#include <Parsers/isDiskFunction.h>
 #include <Core/Field.h>
 #include <Common/Exception.h>
 #include <Common/logger_useful.h>

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -262,7 +262,7 @@ def test_merge_tree_custom_disk_setting(start_cluster):
     )
 
     expected = """
-        SETTINGS disk = disk(type = s3, endpoint = \\'http://minio1:9001/root/data2/\\', access_key_id = \\'minio\\', secret_access_key = \\'minio123\\'), index_granularity = 8192
+        SETTINGS disk = disk(type = s3, endpoint = \\'[HIDDEN]\\', access_key_id = \\'[HIDDEN]\\', secret_access_key = \\'[HIDDEN]\\'), index_granularity = 8192
     """
 
     assert expected.strip() in node1.query(f"SHOW CREATE TABLE {TABLE_NAME}_4").strip()

--- a/tests/queries/0_stateless/02454_create_table_with_custom_disk.reference
+++ b/tests/queries/0_stateless/02454_create_table_with_custom_disk.reference
@@ -6,6 +6,6 @@ ENGINE = MergeTree
 ORDER BY tuple()
 SETTINGS disk = disk(type = local, path = \'/var/lib/clickhouse/disks/local/\')
 100
-CREATE TABLE default.test\n(\n    `a` Int32\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS disk = disk(type = local, path = \'/var/lib/clickhouse/disks/local/\'), index_granularity = 8192
+CREATE TABLE default.test\n(\n    `a` Int32\n)\nENGINE = MergeTree\nORDER BY tuple()\nSETTINGS disk = disk(type = local, path = \'[HIDDEN]\'), index_granularity = 8192
 a	Int32					
 200


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Hide arguments of custom disk merge tree setting. 