### PR TITLE
Fix openssl/s390x build (setenv + link order)

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -696,7 +696,7 @@ try
     {
         const String config_path = config().getString("config-file", "config.xml");
         const auto config_dir = std::filesystem::path{config_path}.replace_filename("openssl.conf");
-        setenv("OPENSSL_CONF", config_dir.string(), true);
+        setenv("OPENSSL_CONF", config_dir.c_str(), true);
     }
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -577,7 +577,6 @@ if (TARGET ch_contrib::annoy)
 endif()
 
 if (TARGET ch_rust::skim)
-    # Add only -I, library is needed only for clickhouse-client/clickhouse-local
     dbms_target_include_directories(PRIVATE $<TARGET_PROPERTY:ch_rust::skim,INTERFACE_INCLUDE_DIRECTORIES>)
     dbms_target_link_libraries(PUBLIC ch_rust::skim)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -579,6 +579,7 @@ endif()
 if (TARGET ch_rust::skim)
     # Add only -I, library is needed only for clickhouse-client/clickhouse-local
     dbms_target_include_directories(PRIVATE $<TARGET_PROPERTY:ch_rust::skim,INTERFACE_INCLUDE_DIRECTORIES>)
+    dbms_target_link_libraries(PUBLIC ch_rust::skim)
 endif()
 
 include ("${ClickHouse_SOURCE_DIR}/cmake/add_check.cmake")


### PR DESCRIPTION
- Fix call to setenv (may be s390x specfic).
- Link order for rust skim must be after libdbms.a (which needs skim symbols)

```cpp
/usr/bin/s390x-linux-gnu-ld: src/libdbms.a(ReplxxLineReader.cpp.o): in function `operator()':
./build/./src/Client/ReplxxLineReader.cpp:414: undefined reference to `skim(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&)'
/usr/bin/s390x-linux-gnu-ld: ./build/./src/Client/ReplxxLineReader.cpp:414: undefined reference to `rust::cxxbridge1::String::operator std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >() const'
/usr/bin/s390x-linux-gnu-ld: ./build/./src/Client/ReplxxLineReader.cpp:414: undefined reference to `rust::cxxbridge1::String::~String()'
/usr/bin/s390x-linux-gnu-ld: ./build/./src/Client/ReplxxLineReader.cpp:414: undefined reference to `rust::cxxbridge1::String::~String()'
```
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)