### PR TITLE
BackgroundSchedulePool should not have any query context

### DIFF
--- a/src/Core/BackgroundSchedulePool.cpp
+++ b/src/Core/BackgroundSchedulePool.cpp
@@ -252,35 +252,9 @@ void BackgroundSchedulePool::cancelDelayedTask(const TaskInfoPtr & task, std::lo
 }
 
 
-scope_guard BackgroundSchedulePool::attachToThreadGroup()
-{
-    scope_guard guard = [&]()
-        {
-            if (thread_group)
-                CurrentThread::detachQueryIfNotDetached();
-        };
-
-    std::lock_guard lock(delayed_tasks_mutex);
-
-    if (thread_group)
-    {
-        /// Put all threads to one thread pool
-        CurrentThread::attachTo(thread_group);
-    }
-    else
-    {
-        CurrentThread::initializeQuery();
-        thread_group = CurrentThread::getGroup();
-    }
-    return guard;
-}
-
-
 void BackgroundSchedulePool::threadFunction()
 {
     setThreadName(thread_name.c_str());
-
-    auto detach_thread_guard = attachToThreadGroup();
 
     while (!shutdown)
     {
@@ -310,8 +284,6 @@ void BackgroundSchedulePool::threadFunction()
 void BackgroundSchedulePool::delayExecutionThreadFunction()
 {
     setThreadName((thread_name + "/D").c_str());
-
-    auto detach_thread_guard = attachToThreadGroup();
 
     while (!shutdown)
     {

--- a/src/Core/BackgroundSchedulePool.h
+++ b/src/Core/BackgroundSchedulePool.h
@@ -90,13 +90,8 @@ private:
     /// Tasks ordered by scheduled time.
     DelayedTasks delayed_tasks;
 
-    /// Thread group used for profiling purposes
-    ThreadGroupStatusPtr thread_group;
-
     CurrentMetrics::Metric tasks_metric;
     std::string thread_name;
-
-    [[nodiscard]] scope_guard attachToThreadGroup();
 };
 
 

--- a/src/Interpreters/ConcurrentHashJoin.h
+++ b/src/Interpreters/ConcurrentHashJoin.h
@@ -3,7 +3,6 @@
 #include <condition_variable>
 #include <memory>
 #include <optional>
-#include <Core/BackgroundSchedulePool.h>
 #include <Functions/FunctionsLogical.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
@@ -4,7 +4,6 @@
 #include <Interpreters/ExpressionActionsSettings.h>
 #include <Storages/MergeTree/MergeTreeReadPool.h>
 #include <Storages/MergeTree/MergeTreeIOSettings.h>
-#include <Core/BackgroundSchedulePool.h>
 #include <IO/AsyncReadCounters.h>
 #include <queue>
 


### PR DESCRIPTION
BackgroundSchedulePool is used for some peridic jobs, not from the query context, i.e. flush of Buffer table.

And for such jobs there cannot be any query context, and more importantly it will not work correctly since that query_context will eventually expires.

And this is the reason of this failures [1].

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/46668/015991bc5e20c787851050c2eaa13f0fef3aac00/stateless_tests_flaky_check__asan_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)