### PR TITLE
Poco: POCO_HAVE_INT64 is always defined

### DIFF
--- a/base/poco/Foundation/include/Poco/BinaryReader.h
+++ b/base/poco/Foundation/include/Poco/BinaryReader.h
@@ -76,7 +76,7 @@ public:
     BinaryReader & operator>>(float & value);
     BinaryReader & operator>>(double & value);
 
-#if defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#if !defined(POCO_LONG_IS_64_BIT)
     BinaryReader & operator>>(Int64 & value);
     BinaryReader & operator>>(UInt64 & value);
 #endif
@@ -106,12 +106,10 @@ public:
     /// See BinaryWriter::write7BitEncoded() for a description
     /// of the compression algorithm.
 
-#if defined(POCO_HAVE_INT64)
     void read7BitEncoded(UInt64 & value);
     /// Reads a 64-bit unsigned integer in compressed format.
     /// See BinaryWriter::write7BitEncoded() for a description
     /// of the compression algorithm.
-#endif
 
     void readRaw(std::streamsize length, std::string & value);
     /// Reads length bytes of raw data into value.

--- a/base/poco/Foundation/include/Poco/BinaryWriter.h
+++ b/base/poco/Foundation/include/Poco/BinaryWriter.h
@@ -81,7 +81,7 @@ public:
     BinaryWriter & operator<<(float value);
     BinaryWriter & operator<<(double value);
 
-#if defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#if !defined(POCO_LONG_IS_64_BIT)
     BinaryWriter & operator<<(Int64 value);
     BinaryWriter & operator<<(UInt64 value);
 #endif
@@ -114,7 +114,6 @@ public:
     /// written out. value is then shifted by seven bits and the next byte is written.
     /// This process is repeated until the entire integer has been written.
 
-#if defined(POCO_HAVE_INT64)
     void write7BitEncoded(UInt64 value);
     /// Writes a 64-bit unsigned integer in a compressed format.
     /// The value written out seven bits at a time, starting
@@ -125,7 +124,6 @@ public:
     /// If value will not fit in seven bits, the high bit is set on the first byte and
     /// written out. value is then shifted by seven bits and the next byte is written.
     /// This process is repeated until the entire integer has been written.
-#endif
 
     void writeRaw(const std::string & rawData);
     /// Writes the string as-is to the stream.

--- a/base/poco/Foundation/include/Poco/ByteOrder.h
+++ b/base/poco/Foundation/include/Poco/ByteOrder.h
@@ -34,64 +34,50 @@ public:
     static UInt16 flipBytes(UInt16 value);
     static Int32 flipBytes(Int32 value);
     static UInt32 flipBytes(UInt32 value);
-#if defined(POCO_HAVE_INT64)
     static Int64 flipBytes(Int64 value);
     static UInt64 flipBytes(UInt64 value);
-#endif
 
     static Int16 toBigEndian(Int16 value);
     static UInt16 toBigEndian(UInt16 value);
     static Int32 toBigEndian(Int32 value);
     static UInt32 toBigEndian(UInt32 value);
-#if defined(POCO_HAVE_INT64)
     static Int64 toBigEndian(Int64 value);
     static UInt64 toBigEndian(UInt64 value);
-#endif
 
     static Int16 fromBigEndian(Int16 value);
     static UInt16 fromBigEndian(UInt16 value);
     static Int32 fromBigEndian(Int32 value);
     static UInt32 fromBigEndian(UInt32 value);
-#if defined(POCO_HAVE_INT64)
     static Int64 fromBigEndian(Int64 value);
     static UInt64 fromBigEndian(UInt64 value);
-#endif
 
     static Int16 toLittleEndian(Int16 value);
     static UInt16 toLittleEndian(UInt16 value);
     static Int32 toLittleEndian(Int32 value);
     static UInt32 toLittleEndian(UInt32 value);
-#if defined(POCO_HAVE_INT64)
     static Int64 toLittleEndian(Int64 value);
     static UInt64 toLittleEndian(UInt64 value);
-#endif
 
     static Int16 fromLittleEndian(Int16 value);
     static UInt16 fromLittleEndian(UInt16 value);
     static Int32 fromLittleEndian(Int32 value);
     static UInt32 fromLittleEndian(UInt32 value);
-#if defined(POCO_HAVE_INT64)
     static Int64 fromLittleEndian(Int64 value);
     static UInt64 fromLittleEndian(UInt64 value);
-#endif
 
     static Int16 toNetwork(Int16 value);
     static UInt16 toNetwork(UInt16 value);
     static Int32 toNetwork(Int32 value);
     static UInt32 toNetwork(UInt32 value);
-#if defined(POCO_HAVE_INT64)
     static Int64 toNetwork(Int64 value);
     static UInt64 toNetwork(UInt64 value);
-#endif
 
     static Int16 fromNetwork(Int16 value);
     static UInt16 fromNetwork(UInt16 value);
     static Int32 fromNetwork(Int32 value);
     static UInt32 fromNetwork(UInt32 value);
-#if defined(POCO_HAVE_INT64)
     static Int64 fromNetwork(Int64 value);
     static UInt64 fromNetwork(UInt64 value);
-#endif
 };
 
 
@@ -143,7 +129,6 @@ inline Int32 ByteOrder::flipBytes(Int32 value)
 }
 
 
-#if defined(POCO_HAVE_INT64)
 inline UInt64 ByteOrder::flipBytes(UInt64 value)
 {
 #    if defined(POCO_HAVE_MSC_BYTESWAP)
@@ -162,7 +147,6 @@ inline Int64 ByteOrder::flipBytes(Int64 value)
 {
     return Int64(flipBytes(UInt64(value)));
 }
-#endif // POCO_HAVE_INT64
 
 
 //
@@ -180,7 +164,6 @@ inline Int64 ByteOrder::flipBytes(Int64 value)
     }
 
 
-#if defined(POCO_HAVE_INT64)
 #    define POCO_IMPLEMENT_BYTEORDER_NOOP(op) \
         POCO_IMPLEMENT_BYTEORDER_NOOP_(op, Int16) \
         POCO_IMPLEMENT_BYTEORDER_NOOP_(op, UInt16) \
@@ -195,18 +178,6 @@ inline Int64 ByteOrder::flipBytes(Int64 value)
         POCO_IMPLEMENT_BYTEORDER_FLIP_(op, UInt32) \
         POCO_IMPLEMENT_BYTEORDER_FLIP_(op, Int64) \
         POCO_IMPLEMENT_BYTEORDER_FLIP_(op, UInt64)
-#else
-#    define POCO_IMPLEMENT_BYTEORDER_NOOP(op) \
-        POCO_IMPLEMENT_BYTEORDER_NOOP_(op, Int16) \
-        POCO_IMPLEMENT_BYTEORDER_NOOP_(op, UInt16) \
-        POCO_IMPLEMENT_BYTEORDER_NOOP_(op, Int32) \
-        POCO_IMPLEMENT_BYTEORDER_NOOP_(op, UInt32)
-#    define POCO_IMPLEMENT_BYTEORDER_FLIP(op) \
-        POCO_IMPLEMENT_BYTEORDER_FLIP_(op, Int16) \
-        POCO_IMPLEMENT_BYTEORDER_FLIP_(op, UInt16) \
-        POCO_IMPLEMENT_BYTEORDER_FLIP_(op, Int32) \
-        POCO_IMPLEMENT_BYTEORDER_FLIP_(op, UInt32)
-#endif
 
 
 #if defined(POCO_ARCH_BIG_ENDIAN)

--- a/base/poco/Foundation/include/Poco/NumberFormatter.h
+++ b/base/poco/Foundation/include/Poco/NumberFormatter.h
@@ -151,7 +151,6 @@ public:
     /// If prefix is true, "0x" prefix is prepended to the
     /// resulting string.
 
-#ifdef POCO_HAVE_INT64
 
 #    ifdef POCO_LONG_IS_64_BIT
 
@@ -255,7 +254,6 @@ public:
 
 #    endif // ifdef POCO_LONG_IS_64_BIT
 
-#endif // ifdef POCO_HAVE_INT64
 
     static std::string format(float value);
     /// Formats a float value in decimal floating-point notation,
@@ -380,7 +378,6 @@ public:
     /// right justified and zero-padded in a field having at least the
     /// specified width.
 
-#ifdef POCO_HAVE_INT64
 
 #    ifdef POCO_LONG_IS_64_BIT
 
@@ -472,7 +469,6 @@ public:
 
 #    endif // ifdef POCO_LONG_IS_64_BIT
 
-#endif // ifdef POCO_HAVE_INT64
 
     static void append(std::string & str, float value);
     /// Formats a float value in decimal floating-point notation,
@@ -673,7 +669,6 @@ inline std::string NumberFormatter::formatHex(unsigned long value, int width, bo
 }
 
 
-#ifdef POCO_HAVE_INT64
 
 #    ifdef POCO_LONG_IS_64_BIT
 
@@ -843,7 +838,6 @@ inline std::string NumberFormatter::formatHex(UInt64 value, int width, bool pref
 
 #    endif // ifdef POCO_LONG_IS_64_BIT
 
-#endif // ifdef POCO_HAVE_INT64
 
 
 inline std::string NumberFormatter::format(float value)

--- a/base/poco/Foundation/include/Poco/NumberParser.h
+++ b/base/poco/Foundation/include/Poco/NumberParser.h
@@ -80,7 +80,6 @@ public:
     /// Returns true if a valid integer has been found, false otherwise.
     /// If parsing was not successful, value is undefined.
 
-#if defined(POCO_HAVE_INT64)
 
     static Int64 parse64(const std::string & s, char thousandSeparator = ',');
     /// Parses a 64-bit integer value in decimal notation from the given string.
@@ -118,7 +117,6 @@ public:
     /// Returns true if a valid integer has been found, false otherwise.
     /// If parsing was not successful, value is undefined.
 
-#endif // defined(POCO_HAVE_INT64)
 
     static double parseFloat(const std::string & s, char decimalSeparator = '.', char thousandSeparator = ',');
     /// Parses a double value in decimal floating point notation

--- a/base/poco/Foundation/include/Poco/StreamCopier.h
+++ b/base/poco/Foundation/include/Poco/StreamCopier.h
@@ -38,7 +38,6 @@ public:
     ///
     /// Returns the number of bytes copied.
 
-#if defined(POCO_HAVE_INT64)
     static Poco::UInt64 copyStream64(std::istream & istr, std::ostream & ostr, std::size_t bufferSize = 8192);
     /// Writes all bytes readable from istr to ostr, using an internal buffer.
     ///
@@ -46,14 +45,12 @@ public:
     ///
     /// Note: the only difference to copyStream() is that a 64-bit unsigned
     /// integer is used to count the number of bytes copied.
-#endif
 
     static std::streamsize copyStreamUnbuffered(std::istream & istr, std::ostream & ostr);
     /// Writes all bytes readable from istr to ostr.
     ///
     /// Returns the number of bytes copied.
 
-#if defined(POCO_HAVE_INT64)
     static Poco::UInt64 copyStreamUnbuffered64(std::istream & istr, std::ostream & ostr);
     /// Writes all bytes readable from istr to ostr.
     ///
@@ -61,14 +58,12 @@ public:
     ///
     /// Note: the only difference to copyStreamUnbuffered() is that a 64-bit unsigned
     /// integer is used to count the number of bytes copied.
-#endif
 
     static std::streamsize copyToString(std::istream & istr, std::string & str, std::size_t bufferSize = 8192);
     /// Appends all bytes readable from istr to the given string, using an internal buffer.
     ///
     /// Returns the number of bytes copied.
 
-#if defined(POCO_HAVE_INT64)
     static Poco::UInt64 copyToString64(std::istream & istr, std::string & str, std::size_t bufferSize = 8192);
     /// Appends all bytes readable from istr to the given string, using an internal buffer.
     ///
@@ -76,7 +71,6 @@ public:
     ///
     /// Note: the only difference to copyToString() is that a 64-bit unsigned
     /// integer is used to count the number of bytes copied.
-#endif
 };
 
 

--- a/base/poco/Foundation/include/Poco/Token.h
+++ b/base/poco/Foundation/include/Poco/Token.h
@@ -84,13 +84,11 @@ public:
     virtual std::string asString() const;
     /// Returns a string representation of the token.
 
-#if defined(POCO_HAVE_INT64)
     virtual Int64 asInteger64() const;
     /// Returns a 64-bit integer representation of the token.
 
     virtual UInt64 asUnsignedInteger64() const;
     /// Returns an unsigned 64-bit integer representation of the token.
-#endif
 
     virtual int asInteger() const;
     /// Returns an integer representation of the token.

--- a/base/poco/Foundation/include/Poco/Types.h
+++ b/base/poco/Foundation/include/Poco/Types.h
@@ -46,7 +46,6 @@ typedef unsigned long UInt64;
 typedef signed long long Int64;
 typedef unsigned long long UInt64;
 #        endif
-#    define POCO_HAVE_INT64 1
 #endif
 
 

--- a/base/poco/Foundation/src/BinaryReader.cpp
+++ b/base/poco/Foundation/src/BinaryReader.cpp
@@ -170,7 +170,7 @@ BinaryReader& BinaryReader::operator >> (double& value)
 }
 
 
-#if defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#if !defined(POCO_LONG_IS_64_BIT)
 
 
 BinaryReader& BinaryReader::operator >> (Int64& value)
@@ -233,7 +233,6 @@ void BinaryReader::read7BitEncoded(UInt32& value)
 }
 
 
-#if defined(POCO_HAVE_INT64)
 
 
 void BinaryReader::read7BitEncoded(UInt64& value)
@@ -254,7 +253,6 @@ void BinaryReader::read7BitEncoded(UInt64& value)
 }
 
 
-#endif
 
 
 void BinaryReader::readRaw(std::streamsize length, std::string& value)

--- a/base/poco/Foundation/src/BinaryWriter.cpp
+++ b/base/poco/Foundation/src/BinaryWriter.cpp
@@ -212,7 +212,7 @@ BinaryWriter& BinaryWriter::operator << (double value)
 }
 
 
-#if defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#if !defined(POCO_LONG_IS_64_BIT)
 
 
 BinaryWriter& BinaryWriter::operator << (Int64 value)
@@ -303,7 +303,6 @@ void BinaryWriter::write7BitEncoded(UInt32 value)
 }
 
 
-#if defined(POCO_HAVE_INT64)
 
 
 void BinaryWriter::write7BitEncoded(UInt64 value)
@@ -319,7 +318,6 @@ void BinaryWriter::write7BitEncoded(UInt64 value)
 }
 
 
-#endif
 
 
 void BinaryWriter::writeRaw(const std::string& rawData)

--- a/base/poco/Foundation/src/NumberFormatter.cpp
+++ b/base/poco/Foundation/src/NumberFormatter.cpp
@@ -234,7 +234,6 @@ void NumberFormatter::appendHex(std::string& str, unsigned long value, int width
 }
 
 
-#ifdef POCO_HAVE_INT64
 
 #ifdef POCO_LONG_IS_64_BIT
 
@@ -424,7 +423,6 @@ void NumberFormatter::appendHex(std::string& str, UInt64 value, int width)
 
 #endif // ifdef POCO_LONG_IS_64_BIT
 
-#endif // ifdef POCO_HAVE_INT64
 
 
 void NumberFormatter::append(std::string& str, float value)

--- a/base/poco/Foundation/src/NumberParser.cpp
+++ b/base/poco/Foundation/src/NumberParser.cpp
@@ -104,7 +104,6 @@ bool NumberParser::tryParseOct(const std::string& s, unsigned& value)
 }
 
 
-#if defined(POCO_HAVE_INT64)
 
 
 Int64 NumberParser::parse64(const std::string& s, char thSep)
@@ -173,7 +172,6 @@ bool NumberParser::tryParseOct64(const std::string& s, UInt64& value)
 }
 
 
-#endif // defined(POCO_HAVE_INT64)
 
 
 double NumberParser::parseFloat(const std::string& s, char decSep, char thSep)

--- a/base/poco/Foundation/src/StreamCopier.cpp
+++ b/base/poco/Foundation/src/StreamCopier.cpp
@@ -42,7 +42,6 @@ std::streamsize StreamCopier::copyStream(std::istream& istr, std::ostream& ostr,
 }
 
 
-#if defined(POCO_HAVE_INT64)
 Poco::UInt64 StreamCopier::copyStream64(std::istream& istr, std::ostream& ostr, std::size_t bufferSize)
 {
 	poco_assert (bufferSize > 0);
@@ -64,7 +63,6 @@ Poco::UInt64 StreamCopier::copyStream64(std::istream& istr, std::ostream& ostr, 
 	}
 	return len;
 }
-#endif
 
 
 std::streamsize StreamCopier::copyToString(std::istream& istr, std::string& str, std::size_t bufferSize)
@@ -90,7 +88,6 @@ std::streamsize StreamCopier::copyToString(std::istream& istr, std::string& str,
 }
 
 
-#if defined(POCO_HAVE_INT64)
 Poco::UInt64 StreamCopier::copyToString64(std::istream& istr, std::string& str, std::size_t bufferSize)
 {
 	poco_assert (bufferSize > 0);
@@ -112,7 +109,6 @@ Poco::UInt64 StreamCopier::copyToString64(std::istream& istr, std::string& str, 
 	}
 	return len;
 }
-#endif
 
 
 std::streamsize StreamCopier::copyStreamUnbuffered(std::istream& istr, std::ostream& ostr)
@@ -130,7 +126,6 @@ std::streamsize StreamCopier::copyStreamUnbuffered(std::istream& istr, std::ostr
 }
 
 
-#if defined(POCO_HAVE_INT64)
 Poco::UInt64 StreamCopier::copyStreamUnbuffered64(std::istream& istr, std::ostream& ostr)
 {
 	char c = 0;
@@ -144,7 +139,6 @@ Poco::UInt64 StreamCopier::copyStreamUnbuffered64(std::istream& istr, std::ostre
 	}
 	return len;
 }
-#endif
 
 
 } // namespace Poco

--- a/base/poco/Foundation/src/Token.cpp
+++ b/base/poco/Foundation/src/Token.cpp
@@ -54,7 +54,6 @@ std::string Token::asString() const
 }
 
 
-#if defined(POCO_HAVE_INT64)
 Int64 Token::asInteger64() const
 {
 	return NumberParser::parse64(_value);
@@ -65,7 +64,6 @@ UInt64 Token::asUnsignedInteger64() const
 {
 	return NumberParser::parseUnsigned64(_value);
 }
-#endif
 
 
 int Token::asInteger() const

--- a/base/poco/JSON/include/Poco/JSON/Handler.h
+++ b/base/poco/JSON/include/Poco/JSON/Handler.h
@@ -74,14 +74,12 @@ namespace JSON
         /// An unsigned value is read. This will only be triggered if the
         /// value cannot fit into a signed int.
 
-#if defined(POCO_HAVE_INT64)
         virtual void value(Int64 v) = 0;
         /// A 64-bit integer value is read.
 
         virtual void value(UInt64 v) = 0;
         /// An unsigned 64-bit integer value is read. This will only be
         /// triggered if the value cannot fit into a signed 64-bit integer.
-#endif
 
         virtual void value(const std::string & value) = 0;
         /// A string value is read.

--- a/base/poco/JSON/include/Poco/JSON/ParseHandler.h
+++ b/base/poco/JSON/include/Poco/JSON/ParseHandler.h
@@ -73,14 +73,12 @@ namespace JSON
         /// An unsigned value is read. This will only be triggered if the
         /// value cannot fit into a signed int.
 
-#if defined(POCO_HAVE_INT64)
         virtual void value(Int64 v);
         /// A 64-bit integer value is read
 
         virtual void value(UInt64 v);
         /// An unsigned 64-bit integer value is read. This will only be
         /// triggered if the value cannot fit into a signed 64-bit integer.
-#endif
 
         virtual void value(const std::string & s);
         /// A string value is read.
@@ -126,7 +124,6 @@ namespace JSON
     }
 
 
-#if defined(POCO_HAVE_INT64)
     inline void ParseHandler::value(Int64 v)
     {
         setValue(v);
@@ -137,7 +134,6 @@ namespace JSON
     {
         setValue(v);
     }
-#endif
 
 
     inline void ParseHandler::value(const std::string & s)

--- a/base/poco/JSON/include/Poco/JSON/PrintHandler.h
+++ b/base/poco/JSON/include/Poco/JSON/PrintHandler.h
@@ -81,13 +81,11 @@ namespace JSON
         /// An unsigned value is read. This will only be triggered if the
         /// value cannot fit into a signed int.
 
-#if defined(POCO_HAVE_INT64)
         void value(Int64 v);
         /// A 64-bit integer value is read; it will be written to the output.
 
         void value(UInt64 v);
         /// An unsigned 64-bit integer value is read; it will be written to the output.
-#endif
 
         void value(const std::string & value);
         /// A string value is read; it will be formatted and written to the output.

--- a/base/poco/JSON/src/PrintHandler.cpp
+++ b/base/poco/JSON/src/PrintHandler.cpp
@@ -154,7 +154,6 @@ void PrintHandler::value(unsigned v)
 }
 
 
-#if defined(POCO_HAVE_INT64)
 void PrintHandler::value(Int64 v)
 {
 	arrayValue();
@@ -169,7 +168,6 @@ void PrintHandler::value(UInt64 v)
 	_out << v;
 	_objStart = false;
 }
-#endif
 
 
 void PrintHandler::value(const std::string& value)

--- a/base/poco/Net/include/Poco/Net/HTTPFixedLengthStream.h
+++ b/base/poco/Net/include/Poco/Net/HTTPFixedLengthStream.h
@@ -43,11 +43,7 @@ namespace Net
     public:
         typedef HTTPBasicStreamBuf::openmode openmode;
 
-#if defined(POCO_HAVE_INT64)
         typedef Poco::Int64 ContentLength;
-#else
-        typedef std::streamsize ContentLength;
-#endif
 
         HTTPFixedLengthStreamBuf(HTTPSession & session, ContentLength length, openmode mode);
         ~HTTPFixedLengthStreamBuf();

--- a/base/poco/Net/include/Poco/Net/HTTPMessage.h
+++ b/base/poco/Net/include/Poco/Net/HTTPMessage.h
@@ -56,7 +56,6 @@ namespace Net
         /// which may be UNKNOWN_CONTENT_LENGTH if
         /// no Content-Length header is present.
 
-#if defined(POCO_HAVE_INT64)
         void setContentLength64(Poco::Int64 length);
         /// Sets the Content-Length header.
         ///
@@ -73,7 +72,6 @@ namespace Net
         ///
         /// In contrast to getContentLength(), this method
         /// always returns a 64-bit integer for content length.
-#endif // defined(POCO_HAVE_INT64)
 
         bool hasContentLength() const;
         /// Returns true iff a Content-Length header is present.

--- a/base/poco/Net/src/HTTPClientSession.cpp
+++ b/base/poco/Net/src/HTTPClientSession.cpp
@@ -264,11 +264,7 @@ std::ostream& HTTPClientSession::sendRequest(HTTPRequest& request)
 		{
 			Poco::CountingOutputStream cs;
 			request.write(cs);
-#if POCO_HAVE_INT64
 			_pRequestStream = new HTTPFixedLengthOutputStream(*this, request.getContentLength64() + cs.chars());
-#else
-			_pRequestStream = new HTTPFixedLengthOutputStream(*this, request.getContentLength() + cs.chars());
-#endif
 			request.write(*_pRequestStream);
 		}
 		else if ((method != HTTPRequest::HTTP_PUT && method != HTTPRequest::HTTP_POST && method != HTTPRequest::HTTP_PATCH) || request.has(HTTPRequest::UPGRADE))
@@ -334,11 +330,7 @@ std::istream& HTTPClientSession::receiveResponse(HTTPResponse& response)
 	else if (response.getChunkedTransferEncoding())
 		_pResponseStream = new HTTPChunkedInputStream(*this);
 	else if (response.hasContentLength())
-#if defined(POCO_HAVE_INT64)
 		_pResponseStream = new HTTPFixedLengthInputStream(*this, response.getContentLength64());
-#else
-		_pResponseStream = new HTTPFixedLengthInputStream(*this, response.getContentLength());
-#endif
 	else
 		_pResponseStream = new HTTPInputStream(*this);
 

--- a/base/poco/Net/src/HTTPMessage.cpp
+++ b/base/poco/Net/src/HTTPMessage.cpp
@@ -89,7 +89,6 @@ std::streamsize HTTPMessage::getContentLength() const
 }
 
 
-#if defined(POCO_HAVE_INT64)	
 void HTTPMessage::setContentLength64(Poco::Int64 length)
 {
 	if (length != UNKNOWN_CONTENT_LENGTH)
@@ -108,7 +107,6 @@ Poco::Int64 HTTPMessage::getContentLength64() const
 	}
 	else return UNKNOWN_CONTENT_LENGTH;
 }
-#endif // defined(POCO_HAVE_INT64)	
 
 
 void HTTPMessage::setTransferEncoding(const std::string& transferEncoding)

--- a/base/poco/Net/src/HTTPServerRequestImpl.cpp
+++ b/base/poco/Net/src/HTTPServerRequestImpl.cpp
@@ -49,11 +49,7 @@ HTTPServerRequestImpl::HTTPServerRequestImpl(HTTPServerResponseImpl& response, H
 	if (getChunkedTransferEncoding())
 		_pStream = new HTTPChunkedInputStream(session);
 	else if (hasContentLength())
-#if defined(POCO_HAVE_INT64)
 		_pStream = new HTTPFixedLengthInputStream(session, getContentLength64());
-#else
-		_pStream = new HTTPFixedLengthInputStream(session, getContentLength());
-#endif
 	else if (getMethod() == HTTPRequest::HTTP_GET || getMethod() == HTTPRequest::HTTP_HEAD || getMethod() == HTTPRequest::HTTP_DELETE)
 		_pStream = new HTTPFixedLengthInputStream(session, 0);
 	else

--- a/base/poco/Net/src/HTTPServerResponseImpl.cpp
+++ b/base/poco/Net/src/HTTPServerResponseImpl.cpp
@@ -92,11 +92,7 @@ std::ostream& HTTPServerResponseImpl::send()
 	{
 		Poco::CountingOutputStream cs;
 		write(cs);
-#if defined(POCO_HAVE_INT64)	
 		_pStream = new HTTPFixedLengthOutputStream(_session, getContentLength64() + cs.chars());
-#else
-		_pStream = new HTTPFixedLengthOutputStream(_session, getContentLength() + cs.chars());
-#endif
 		write(*_pStream);
 	}
 	else
@@ -153,11 +149,7 @@ void HTTPServerResponseImpl::sendFile(const std::string& path, const std::string
 	Timestamp dateTime    = f.getLastModified();
 	File::FileSize length = f.getSize();
 	set("Last-Modified", DateTimeFormatter::format(dateTime, DateTimeFormat::HTTP_FORMAT));
-#if defined(POCO_HAVE_INT64)	
 	setContentLength64(length);
-#else
-	setContentLength(static_cast<int>(length));
-#endif
 	setContentType(mediaType);
 	setChunkedTransferEncoding(false);
 

--- a/base/poco/Util/include/Poco/Util/AbstractConfiguration.h
+++ b/base/poco/Util/include/Poco/Util/AbstractConfiguration.h
@@ -167,7 +167,6 @@ namespace Util
         /// If the value contains references to other properties (${<property>}), these
         /// are expanded.
 
-#if defined(POCO_HAVE_INT64)
 
         Int64 getInt64(const std::string & key) const;
         /// Returns the Int64 value of the property with the given name.
@@ -205,7 +204,6 @@ namespace Util
         /// If the value contains references to other properties (${<property>}), these
         /// are expanded.
 
-#endif // defined(POCO_HAVE_INT64)
 
         double getDouble(const std::string & key) const;
         /// Returns the double value of the property with the given name.
@@ -255,7 +253,6 @@ namespace Util
         /// Sets the property with the given key to the given value.
         /// An already existing value for the key is overwritten.
 
-#if defined(POCO_HAVE_INT64)
 
         virtual void setInt64(const std::string & key, Int64 value);
         /// Sets the property with the given key to the given value.
@@ -265,7 +262,6 @@ namespace Util
         /// Sets the property with the given key to the given value.
         /// An already existing value for the key is overwritten.
 
-#endif // defined(POCO_HAVE_INT64)
 
         virtual void setDouble(const std::string & key, double value);
         /// Sets the property with the given key to the given value.
@@ -335,12 +331,10 @@ namespace Util
         static int parseInt(const std::string & value);
         static unsigned parseUInt(const std::string & value);
 
-#if defined(POCO_HAVE_INT64)
 
         static Int64 parseInt64(const std::string & value);
         static UInt64 parseUInt64(const std::string & value);
 
-#endif // defined(POCO_HAVE_INT64)
 
         static bool parseBool(const std::string & value);
         void setRawWithEvent(const std::string & key, std::string value);

--- a/base/poco/Util/include/Poco/Util/WinRegistryKey.h
+++ b/base/poco/Util/include/Poco/Util/WinRegistryKey.h
@@ -123,7 +123,6 @@ namespace Util
         ///
         /// Throws a NotFoundException if the value does not exist.
 
-#if defined(POCO_HAVE_INT64)
 
         void setInt64(const std::string & name, Poco::Int64 value);
         /// Sets the numeric (REG_QWORD) value with the given name.
@@ -135,7 +134,6 @@ namespace Util
         ///
         /// Throws a NotFoundException if the value does not exist.
 
-#endif // POCO_HAVE_INT64
 
         void deleteValue(const std::string & name);
         /// Deletes the value with the given name.

--- a/base/poco/Util/src/AbstractConfiguration.cpp
+++ b/base/poco/Util/src/AbstractConfiguration.cpp
@@ -163,7 +163,6 @@ unsigned AbstractConfiguration::getUInt(const std::string& key, unsigned default
 }
 
 
-#if defined(POCO_HAVE_INT64)
 
 
 Int64 AbstractConfiguration::getInt64(const std::string& key) const
@@ -214,7 +213,6 @@ UInt64 AbstractConfiguration::getUInt64(const std::string& key, UInt64 defaultVa
 }
 
 
-#endif // defined(POCO_HAVE_INT64)
 
 
 double AbstractConfiguration::getDouble(const std::string& key) const
@@ -283,7 +281,6 @@ void AbstractConfiguration::setUInt(const std::string& key, unsigned int value)
 }
 
 
-#if defined(POCO_HAVE_INT64)
 
 
 void AbstractConfiguration::setInt64(const std::string& key, Int64 value)
@@ -302,7 +299,6 @@ void AbstractConfiguration::setUInt64(const std::string& key, UInt64 value)
 }
 
 
-#endif // defined(POCO_HAVE_INT64)
 
 
 void AbstractConfiguration::setDouble(const std::string& key, double value)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)