### PR TITLE
Ask for the password in clickhouse-client interactively

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -333,22 +333,14 @@ try
     }
     catch (const Exception & e)
     {
-        if (e.code() == DB::ErrorCodes::AUTHENTICATION_FAILED)
-        {
-            if (!config().getString("password", "").empty())
-                throw;
+        if (e.code() != DB::ErrorCodes::AUTHENTICATION_FAILED ||
+            config().has("password") ||
+            config().getBool("ask-password", false) ||
+            !is_interactive)
+            throw;
 
-            if (!is_interactive)
-                throw;
-
-            String prompt = fmt::format("Password for user ({}): ", config().getString("user", ""));
-            String password;
-            if (auto * result = readpassphrase(prompt, buf, sizeof(buf), 0))
-                password = result;
-
-            config().setString("password", password);
-            connect();
-        }
+        config().setBool("ask-password", true);
+        connect();
     }
 
     /// Show warnings at the beginning of connection.


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Ask for the password in clickhouse-client interactively in a case when the empty password is wrong. Closes https://github.com/ClickHouse/ClickHouse/issues/46702