### PR TITLE
Remove unused MergeTreeReadTask::remove_prewhere_column

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -141,7 +141,6 @@ MergeTreeReadTask::MergeTreeReadTask(
     size_t part_index_in_query_,
     const NameSet & column_name_set_,
     const MergeTreeReadTaskColumns & task_columns_,
-    bool remove_prewhere_column_,
     MergeTreeBlockSizePredictorPtr size_predictor_,
     int64_t priority_,
     std::future<MergeTreeReaderPtr> reader_,
@@ -151,7 +150,6 @@ MergeTreeReadTask::MergeTreeReadTask(
     , part_index_in_query{part_index_in_query_}
     , column_name_set{column_name_set_}
     , task_columns{task_columns_}
-    , remove_prewhere_column{remove_prewhere_column_}
     , size_predictor{size_predictor_}
     , reader(std::move(reader_))
     , pre_reader_for_step(std::move(pre_reader_for_step_))

--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.h
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.h
@@ -59,8 +59,6 @@ struct MergeTreeReadTask
     const NameSet & column_name_set;
     /// column names to read during PREWHERE and WHERE
     const MergeTreeReadTaskColumns & task_columns;
-    /// should PREWHERE column be returned to requesting side?
-    const bool remove_prewhere_column;
     /// Used to satistfy preferred_block_size_bytes limitation
     MergeTreeBlockSizePredictorPtr size_predictor;
     /// Used to save current range processing status
@@ -87,7 +85,6 @@ struct MergeTreeReadTask
         size_t part_index_in_query_,
         const NameSet & column_name_set_,
         const MergeTreeReadTaskColumns & task_columns_,
-        bool remove_prewhere_column_,
         MergeTreeBlockSizePredictorPtr size_predictor_,
         int64_t priority_ = 0,
         std::future<MergeTreeReaderPtr> reader_ = {},

--- a/src/Storages/MergeTree/MergeTreeInOrderSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeInOrderSelectProcessor.cpp
@@ -56,7 +56,6 @@ try
 
     task = std::make_unique<MergeTreeReadTask>(
         data_part, mark_ranges_for_task, part_index_in_query, column_name_set, task_columns,
-        prewhere_info && prewhere_info->remove_prewhere_column,
         std::move(size_predictor));
 
     return true;

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -509,7 +509,7 @@ MergeTreePrefetchedReadPool::ThreadsTasks MergeTreePrefetchedReadPool::createThr
 
             auto read_task = std::make_unique<MergeTreeReadTask>(
                 part.data_part, ranges_to_get_from_part, part.part_index_in_query,
-                part.column_name_set, part.task_columns, prewhere_info && prewhere_info->remove_prewhere_column,
+                part.column_name_set, part.task_columns,
                 std::move(curr_task_size_predictor));
 
             read_task->priority = priority;

--- a/src/Storages/MergeTree/MergeTreeReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPool.cpp
@@ -208,7 +208,7 @@ MergeTreeReadTaskPtr MergeTreeReadPool::getTask(size_t thread)
     return std::make_unique<MergeTreeReadTask>(
         part.data_part, ranges_to_get_from_part, part.part_index_in_query,
         per_part.column_name_set, per_part.task_columns,
-        prewhere_info && prewhere_info->remove_prewhere_column, std::move(curr_task_size_predictor));
+        std::move(curr_task_size_predictor));
 }
 
 Block MergeTreeReadPool::getHeader() const
@@ -459,7 +459,6 @@ MergeTreeReadTaskPtr MergeTreeReadPoolParallelReplicas::getTask(size_t thread)
         part.part_index_in_query,
         per_part.column_name_set,
         per_part.task_columns,
-        prewhere_info && prewhere_info->remove_prewhere_column,
         std::move(curr_task_size_predictor));
 }
 

--- a/src/Storages/MergeTree/MergeTreeReverseSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeReverseSelectProcessor.cpp
@@ -49,8 +49,7 @@ bool MergeTreeReverseSelectAlgorithm::getNewTaskOrdinaryReading()
 
     task = std::make_unique<MergeTreeReadTask>(
         data_part, mark_ranges_for_task, part_index_in_query, column_name_set,
-        task_columns, prewhere_info && prewhere_info->remove_prewhere_column,
-        std::move(size_predictor));
+        task_columns, std::move(size_predictor));
 
     return true;
 
@@ -88,8 +87,7 @@ bool MergeTreeReverseSelectAlgorithm::getNewTaskParallelReplicas()
 
     task = std::make_unique<MergeTreeReadTask>(
         data_part, mark_ranges_for_task, part_index_in_query, column_name_set,
-        task_columns, prewhere_info && prewhere_info->remove_prewhere_column,
-        std::move(size_predictor));
+        task_columns, std::move(size_predictor));
 
     return true;
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
