### PR TITLE
On out-of-space `at` returns error, we must terminate still

### DIFF
--- a/tests/ci/worker/init_runner.sh
+++ b/tests/ci/worker/init_runner.sh
@@ -66,7 +66,8 @@ terminate-and-exit() {
   INSTANCE_ID=$(ec2metadata --instance-id)
   # We execute it with at to not have it as an orphan process
   # GH Runners kill all remain processes
-  echo "sleep 10; aws ec2 terminate-instances --instance-ids $INSTANCE_ID" | at now
+  echo "sleep 10; aws ec2 terminate-instances --instance-ids $INSTANCE_ID" | at now || \
+    aws ec2 terminate-instances --instance-ids "$INSTANCE_ID"  # workaround for complete out of space
   exit 0
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
`at` fails on complete out-of-space, so we need to push an `alarm` button when it's broken.