### PR TITLE
Fix changing an expired role

### DIFF
--- a/src/Access/EnabledRoles.h
+++ b/src/Access/EnabledRoles.h
@@ -44,9 +44,10 @@ private:
     friend class RoleCache;
     explicit EnabledRoles(const Params & params_);
 
-    void setRolesInfo(const std::shared_ptr<const EnabledRolesInfo> & info_, scope_guard * notifications);
-
     const Params params;
+
+    /// Called by RoleCache to store `EnabledRolesInfo` in this `EnabledRoles` after the calculation is done.
+    void setRolesInfo(const std::shared_ptr<const EnabledRolesInfo> & info_, scope_guard * notifications);
 
     std::shared_ptr<const EnabledRolesInfo> info;
     mutable std::mutex info_mutex;

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -57,7 +57,9 @@ namespace
 
 
 RoleCache::RoleCache(const AccessControl & access_control_)
-    : access_control(access_control_), cache(600000 /* 10 minutes */) {}
+    : access_control(access_control_), cache(600000 /* 10 minutes */)
+{
+}
 
 
 RoleCache::~RoleCache() = default;
@@ -70,18 +72,18 @@ RoleCache::getEnabledRoles(const std::vector<UUID> & roles, const std::vector<UU
     EnabledRoles::Params params;
     params.current_roles.insert(roles.begin(), roles.end());
     params.current_roles_with_admin_option.insert(roles_with_admin_option.begin(), roles_with_admin_option.end());
-    auto it = enabled_roles.find(params);
-    if (it != enabled_roles.end())
+    auto it = enabled_roles_by_params.find(params);
+    if (it != enabled_roles_by_params.end())
     {
-        auto from_cache = it->second.lock();
-        if (from_cache)
-            return from_cache;
-        enabled_roles.erase(it);
+        if (auto enabled_roles = it->second.enabled_roles.lock())
+            return enabled_roles;
+        enabled_roles_by_params.erase(it);
     }
 
     auto res = std::shared_ptr<EnabledRoles>(new EnabledRoles(params));
-    collectEnabledRoles(*res, nullptr);
-    enabled_roles.emplace(std::move(params), res);
+    SubscriptionsOnRoles subscriptions_on_roles;
+    collectEnabledRoles(*res, subscriptions_on_roles, nullptr);
+    enabled_roles_by_params.emplace(std::move(params), EnabledRolesWithSubscriptions{res, std::move(subscriptions_on_roles)});
     return res;
 }
 
@@ -90,21 +92,23 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
 {
     /// `mutex` is already locked.
 
-    for (auto i = enabled_roles.begin(), e = enabled_roles.end(); i != e;)
+    for (auto i = enabled_roles_by_params.begin(), e = enabled_roles_by_params.end(); i != e;)
     {
-        auto elem = i->second.lock();
-        if (!elem)
-            i = enabled_roles.erase(i);
+        auto & item = i->second;
+        if (auto enabled_roles = item.enabled_roles.lock())
+        {
+            collectEnabledRoles(*enabled_roles, item.subscriptions_on_roles, notifications);
+            ++i;
+        }
         else
         {
-            collectEnabledRoles(*elem, notifications);
-            ++i;
+            i = enabled_roles_by_params.erase(i);
         }
     }
 }
 
 
-void RoleCache::collectEnabledRoles(EnabledRoles & enabled, scope_guard * notifications)
+void RoleCache::collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsOnRoles & subscriptions_on_roles, scope_guard * notifications)
 {
     /// `mutex` is already locked.
 
@@ -112,43 +116,57 @@ void RoleCache::collectEnabledRoles(EnabledRoles & enabled, scope_guard * notifi
     auto new_info = std::make_shared<EnabledRolesInfo>();
     boost::container::flat_set<UUID> skip_ids;
 
-    auto get_role_function = [this](const UUID & id) { return getRole(id); };
+    /// We need to collect and keep not only enabled roles but also subscriptions for them to be able to recalculate EnabledRolesInfo when some of the roles change.
+    SubscriptionsOnRoles new_subscriptions_on_roles;
+    new_subscriptions_on_roles.reserve(subscriptions_on_roles.size());
 
-    for (const auto & current_role : enabled.params.current_roles)
+    auto get_role_function = [this, &subscriptions_on_roles](const UUID & id) TSA_NO_THREAD_SAFETY_ANALYSIS { return getRole(id, subscriptions_on_roles); };
+
+    for (const auto & current_role : enabled_roles.params.current_roles)
         collectRoles(*new_info, skip_ids, get_role_function, current_role, true, false);
 
-    for (const auto & current_role : enabled.params.current_roles_with_admin_option)
+    for (const auto & current_role : enabled_roles.params.current_roles_with_admin_option)
         collectRoles(*new_info, skip_ids, get_role_function, current_role, true, true);
 
+    /// Remove duplicates from `subscriptions_on_roles`.
+    std::sort(new_subscriptions_on_roles.begin(), new_subscriptions_on_roles.end());
+    new_subscriptions_on_roles.erase(std::unique(new_subscriptions_on_roles.begin(), new_subscriptions_on_roles.end()), new_subscriptions_on_roles.end());
+    subscriptions_on_roles = std::move(new_subscriptions_on_roles);
+
     /// Collect data from the collected roles.
-    enabled.setRolesInfo(new_info, notifications);
+    enabled_roles.setRolesInfo(new_info, notifications);
 }
 
 
-RolePtr RoleCache::getRole(const UUID & role_id)
+RolePtr RoleCache::getRole(const UUID & role_id, SubscriptionsOnRoles & subscriptions_on_roles)
 {
     /// `mutex` is already locked.
 
     auto role_from_cache = cache.get(role_id);
     if (role_from_cache)
+    {
+        subscriptions_on_roles.emplace_back(role_from_cache->second);
         return role_from_cache->first;
+    }
 
-    auto subscription = access_control.subscribeForChanges(role_id,
-                                                    [this, role_id](const UUID &, const AccessEntityPtr & entity)
+    auto on_role_changed_or_removed = [this, role_id](const UUID &, const AccessEntityPtr & entity)
     {
         auto changed_role = entity ? typeid_cast<RolePtr>(entity) : nullptr;
         if (changed_role)
             roleChanged(role_id, changed_role);
         else
             roleRemoved(role_id);
-    });
+    };
+
+    auto subscription_on_role = std::make_shared<scope_guard>(access_control.subscribeForChanges(role_id, on_role_changed_or_removed));
 
     auto role = access_control.tryRead<Role>(role_id);
     if (role)
     {
-        auto cache_value = Poco::SharedPtr<std::pair<RolePtr, scope_guard>>(
-            new std::pair<RolePtr, scope_guard>{role, std::move(subscription)});
+        auto cache_value = Poco::SharedPtr<std::pair<RolePtr, std::shared_ptr<scope_guard>>>(
+            new std::pair<RolePtr, std::shared_ptr<scope_guard>>{role, subscription_on_role});
         cache.add(role_id, cache_value);
+        subscriptions_on_roles.emplace_back(subscription_on_role);
         return role;
     }
 
@@ -162,6 +180,7 @@ void RoleCache::roleChanged(const UUID & role_id, const RolePtr & changed_role)
     scope_guard notifications;
 
     std::lock_guard lock{mutex};
+
     auto role_from_cache = cache.get(role_id);
     if (role_from_cache)
     {

--- a/src/Access/RoleCache.h
+++ b/src/Access/RoleCache.h
@@ -24,15 +24,29 @@ public:
         const std::vector<UUID> & current_roles_with_admin_option);
 
 private:
-    void collectEnabledRoles(scope_guard * notifications);
-    void collectEnabledRoles(EnabledRoles & enabled, scope_guard * notifications);
-    RolePtr getRole(const UUID & role_id);
+    using SubscriptionsOnRoles = std::vector<std::shared_ptr<scope_guard>>;
+
+    void collectEnabledRoles(scope_guard * notifications) TSA_REQUIRES(mutex);
+    void collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsOnRoles & subscriptions_on_roles, scope_guard * notifications) TSA_REQUIRES(mutex);
+    RolePtr getRole(const UUID & role_id, SubscriptionsOnRoles & subscriptions_on_roles) TSA_REQUIRES(mutex);
     void roleChanged(const UUID & role_id, const RolePtr & changed_role);
     void roleRemoved(const UUID & role_id);
 
     const AccessControl & access_control;
-    Poco::AccessExpireCache<UUID, std::pair<RolePtr, scope_guard>> cache;
-    std::map<EnabledRoles::Params, std::weak_ptr<EnabledRoles>> enabled_roles;
+
+    Poco::AccessExpireCache<UUID, std::pair<RolePtr, std::shared_ptr<scope_guard>>> TSA_GUARDED_BY(mutex) cache;
+
+    struct EnabledRolesWithSubscriptions
+    {
+        std::weak_ptr<EnabledRoles> enabled_roles;
+
+        /// We need to keep subscriptions for all enabled roles to be able to recalculate EnabledRolesInfo when some of the roles change.
+        /// `cache` also keeps subscriptions but that's not enough because values can be purged from the `cache` anytime.
+        SubscriptionsOnRoles subscriptions_on_roles;
+    };
+
+    std::map<EnabledRoles::Params, EnabledRolesWithSubscriptions> TSA_GUARDED_BY(mutex) enabled_roles_by_params;
+
     mutable std::mutex mutex;
 };
 


### PR DESCRIPTION
### Changelog category:
- Bug Fix

### Changelog entry:
Sometimes after changing a role that could be not reflected on the access rights of a user who uses that role. This PR fixes that.

Thank you @ilejn, @filimonov for investigating this problem.