### PR TITLE
Follow-up to #41534

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -54,6 +54,7 @@ namespace ErrorCodes
     extern const int CANNOT_ASSIGN_ALTER;
     extern const int CANNOT_ALLOCATE_MEMORY;
     extern const int MEMORY_LIMIT_EXCEEDED;
+    extern const int NOT_IMPLEMENTED;
 }
 
 constexpr const char * TASK_PROCESSED_OUT_REASON = "Task has been already processed";
@@ -456,6 +457,15 @@ bool DDLWorker::tryExecuteQuery(DDLTaskBase & task, const ZooKeeperPtr & zookeep
     try
     {
         auto query_context = task.makeQueryContext(context, zookeeper);
+
+        chassert(!query_context->getCurrentTransaction());
+        if (query_context->getSettingsRef().implicit_transaction)
+        {
+            if (query_context->getSettingsRef().throw_on_unsupported_query_inside_transaction)
+                throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot begin an implicit transaction inside distributed DDL query");
+            query_context->setSetting("implicit_transaction", Field{0});
+        }
+
         if (!task.is_initial_query)
             query_scope.emplace(query_context);
         executeQuery(istr, ostr, !task.is_initial_query, query_context, {});


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Ref: https://github.com/ClickHouse/ClickHouse/pull/41534

https://s3.amazonaws.com/clickhouse-test-reports/0/5788deeadd679a8df7726e49ac99180e88852365/stress_test__debug_.html

```
 [ 24287 ] {} <Fatal> BaseDaemon: (version 23.2.1.1 (official build), build id: 4A30A6A5E910F9A9591C9C7FA914343F4E74C723) (from thread 1922) (query_id: b330a4fd-530c-4566-bcb1-5e9fa57b0f01) (query: /* ddl_entry=query-0000000002 */ DROP DATABASE IF EXISTS `02028_db`) Received signal Aborted (6)
 [ 24287 ] {} <Fatal> BaseDaemon: 
 [ 24287 ] {} <Fatal> BaseDaemon: Stack trace: 0x7f9e41d9a00b 0x7f9e41d79859 0x7f9e41d79729 0x7f9e41d8afd6 0x293d1a09 0x2a2c9da2 0x2a765d98 0x2a76b32d 0x294a23ab 0x294a1424 0x2949f664 0x294970ac 0x294b32a9 0x294b322d 0x294b317d 0x294b30b2 0x294b3015 0x294b2ff5 0x294b2fd5 0x294b2fa0 0x21b87296 0x21b84855 0x21c7c87c 0x21c83844 0x21c837f5 0x21c8371d 0x21c83202 0x7f9e41f51609 0x7f9e41e76133
 [ 24287 ] {} <Fatal> BaseDaemon: 4. raise @ 0x7f9e41d9a00b in ?
 [ 24287 ] {} <Fatal> BaseDaemon: 5. abort @ 0x7f9e41d79859 in ?
 [ 24287 ] {} <Fatal> BaseDaemon: 6. ? @ 0x7f9e41d79729 in ?
 [ 24287 ] {} <Fatal> BaseDaemon: 7. ? @ 0x7f9e41d8afd6 in ?
 [ 24287 ] {} <Fatal> BaseDaemon: 8. /build/build_docker/../src/Interpreters/Context.cpp:0: DB::Context::setCurrentTransaction(std::__1::shared_ptr<DB::MergeTreeTransaction>) @ 0x293d1a09 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 9. /build/build_docker/../src/Interpreters/InterpreterTransactionControlQuery.cpp:46: DB::InterpreterTransactionControlQuery::executeBegin(std::__1::shared_ptr<DB::Context>) @ 0x2a2c9da2 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 10. /build/build_docker/../src/Interpreters/executeQuery.cpp:658: DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, bool, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) @ 0x2a765d98 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 11. /build/build_docker/../src/Interpreters/executeQuery.cpp:1251: DB::executeQuery(DB::ReadBuffer&, DB::WriteBuffer&, bool, std::__1::shared_ptr<DB::Context>, std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> con
 [ 24287 ] {} <Fatal> BaseDaemon: 12. /build/build_docker/../src/Interpreters/DDLWorker.cpp:461: DB::DDLWorker::tryExecuteQuery(DB::DDLTaskBase&, std::__1::shared_ptr<zkutil::ZooKeeper> const&) @ 0x294a23ab in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 13. /build/build_docker/../src/Interpreters/DDLWorker.cpp:623: DB::DDLWorker::processTask(DB::DDLTaskBase&, std::__1::shared_ptr<zkutil::ZooKeeper> const&) @ 0x294a1424 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 14. /build/build_docker/../src/Interpreters/DDLWorker.cpp:415: DB::DDLWorker::scheduleTasks(bool) @ 0x2949f664 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 15. /build/build_docker/../src/Interpreters/DDLWorker.cpp:1104: DB::DDLWorker::runMainThread() @ 0x294970ac in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 16. /build/build_docker/../contrib/llvm-project/libcxx/include/__functional/invoke.h:359: decltype(*std::declval<DB::DDLWorker*&>().*std::declval<void (DB::DDLWorker::*&)()>()()) std::__1::__invoke[abi:v15000]<void (DB::DDLWorker::*&)(), DB::DDLWorker*&, void>(void (DB::DDLWorker::*&)(), DB::DDLWorker*&) @ 0x294b32a9 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 17. /build/build_docker/../contrib/llvm-project/libcxx/include/tuple:1789: decltype(auto) std::__1::__apply_tuple_impl[abi:v15000]<void (DB::DDLWorker::*&)(), std::__1::tuple<DB::DDLWorker*>&, 0ul>(void (DB::DDLWorker::*&)(), std::__1::tuple<DB::DDLWorker*>&, std::__1::__tuple_indices<0ul>) @ 0x294b322d in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 18. /build/build_docker/../contrib/llvm-project/libcxx/include/tuple:1798: decltype(auto) std::__1::apply[abi:v15000]<void (DB::DDLWorker::*&)(), std::__1::tuple<DB::DDLWorker*>&>(void (DB::DDLWorker::*&)(), std::__1::tuple<DB::DDLWorker*>&) @ 0x294b317d in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 19. /build/build_docker/../src/Common/ThreadPool.h:210: ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<void (DB::DDLWorker::*)(), DB::DDLWorker*>(void (DB::DDLWorker::*&&)(), DB::DDLWorker*&&)::\'lambda\'()::operator()() @ 0x294b30b2 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 20. /build/build_docker/../contrib/llvm-project/libcxx/include/__functional/invoke.h:394: decltype(std::declval<void (DB::DDLWorker::*)()>()(std::declval<DB::DDLWorker*>())) std::__1::__invoke[abi:v15000]<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<void (DB::DDLWorker::*)(), DB::DDLWorker*>(void (DB::DDLWorker::*&&)(), DB::DDLWorker*&&)::\'lambda\'()&>(
 [ 24287 ] {} <Fatal> BaseDaemon: 21. /build/build_docker/../contrib/llvm-project/libcxx/include/__functional/invoke.h:480: void std::__1::__invoke_void_return_wrapper<void, true>::__call<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<void (DB::DDLWorker::*)(), DB::DDLWorker*>(void (DB::DDLWorker::*&&)(), DB::DDLWorker*&&)::\'lambda\'()&>(ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoo
 [ 24287 ] {} <Fatal> BaseDaemon: 22. /build/build_docker/../contrib/llvm-project/libcxx/include/__functional/function.h:235: std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<void (DB::DDLWorker::*)(), DB::DDLWorker*>(void (DB::DDLWorker::*&&)(), DB::DDLWorker*&&)::\'lambda\'(), void ()>::operator()[abi:v15000]() @ 0x294b2fd5 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 23. /build/build_docker/../contrib/llvm-project/libcxx/include/__functional/function.h:716: void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<void (DB::DDLWorker::*)(), DB::DDLWorker*>(void (DB::DDLWorker::*&&)(), DB::DDLWorker*&&)::\'lambda\'(), void 
 [ 24287 ] {} <Fatal> BaseDaemon: 24. /build/build_docker/../contrib/llvm-project/libcxx/include/__functional/function.h:848: std::__1::__function::__policy_func<void ()>::operator()[abi:v15000]() const @ 0x21b87296 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 25. /build/build_docker/../contrib/llvm-project/libcxx/include/__functional/function.h:1187: std::__1::function<void ()>::operator()() const @ 0x21b84855 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 26. /build/build_docker/../src/Common/ThreadPool.cpp:315: ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x21c7c87c in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 27. /build/build_docker/../src/Common/ThreadPool.cpp:145: void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::\'lambda0\'()::operator()() const @ 0x21c83844 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 28. /build/build_docker/../contrib/llvm-project/libcxx/include/__functional/invoke.h:394: decltype(std::declval<void>()()) std::__1::__invoke[abi:v15000]<void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::\'lambda0\'()>(void&&) @ 0x21c837f5 in /usr/bin/clickhouse
 [ 24287 ] {} <Fatal> BaseDaemon: 29. /build/build_docker/../contrib/llvm-project/libcxx/include/thread:285: void std::__1::__thread_execute[abi:v15000]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bool)::\'lambda0\'(
 [ 24287 ] {} <Fatal> BaseDaemon: 30. /build/build_docker/../contrib/llvm-project/libcxx/include/thread:295: void* std::__1::__thread_proxy[abi:v15000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, long, std::__1::optional<unsigned long>, bo
 [ 24287 ] {} <Fatal> BaseDaemon: 31. ? @ 0x7f9e41f51609 in ?
 [ 24287 ] {} <Fatal> BaseDaemon: 32. __clone @ 0x7f9e41e76133 in ?
 [ 24287 ] {} <Fatal> BaseDaemon: Integrity check of the executable successfully passed (checksum: 36B4166990BE0383AE9957CFFA1E1736)
```