### PR TITLE
Print all stacktraces in hung check

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2175,6 +2175,7 @@ def main(args):
             print(json.dumps(processlist, indent=4))
             print(get_transactions_list(args))
 
+            print_stacktraces()
             exit_code.value = 1
         else:
             print(colored("\nNo queries hung.", args, "green", attrs=["bold"]))


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


I didn't notice that it was removed in https://github.com/ClickHouse/ClickHouse/pull/43396. Although in trivial cases it's more convenient to print only stacktraces of the specific threads, sometimes we need all. Example: https://s3.amazonaws.com/clickhouse-test-reports/0/30a8eb0c2f181cd96d873d8c431567fb4b3b678f/stress_test__asan_.html  