### PR TITLE
CMake: Add best effort checks that the build machine isn't too old

### DIFF
--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -60,7 +60,7 @@ elseif (ARCH_AARCH64)
         set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=armv8.2-a+simd+crypto+dotprod+ssbs -Xclang=-target-feature -Xclang=+ldapr -Wno-unused-command-line-argument")
     endif ()
 
-    # Quick-n-dirty check: The build generates and executes intermediate binaries, e.g. protoc and llvm-tablegen. If we build on ARM for ARM
+    # Best-effort check: The build generates and executes intermediate binaries, e.g. protoc and llvm-tablegen. If we build on ARM for ARM
     # and the build machine is too old, i.e. doesn't satisfy above modern profile, then these intermediate binaries will not run (dump
     # SIGILL). Even if they could run, the build machine wouldn't be able to run the ClickHouse binary. In that case, suggest to run the
     # build with the compat profile.
@@ -119,7 +119,7 @@ elseif (ARCH_AMD64)
         SET(ENABLE_AVX512_FOR_SPEC_OP 0)
     endif()
 
-    # Same quick-n-dirty check for x86 as above for ARM, see above.
+    # Same best-effort check for x86 as above for ARM, see above.
     if (OS_LINUX AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "amd64|x86_64" AND NOT NO_SSE3_OR_HIGHER)
         # Test for flags in standard profile but not in NO_SSE3_OR_HIGHER profile.
         # /proc/cpuid for Intel Xeon 8124: "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse

--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -65,10 +65,10 @@ elseif (ARCH_AARCH64)
     # SIGILL). Even if they could run, the build machine wouldn't be able to run the ClickHouse binary. In that case, suggest to run the
     # build with the compat profile.
     if (OS_LINUX AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)" AND NOT NO_ARMV81_OR_HIGHER)
-        # CPU features in /proc/cpuinfo and compiler flags don't align :( ... pick some obvious flags contained in modern but not legacy
-        # profile (full Graviton 3 /proc/cpuinfo is "fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt
-        # fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs paca pacg dcpodp svei8mm svebf16 i8mm bf16
-        # dgh rng")
+        # CPU features in /proc/cpuinfo and compiler flags don't align :( ... pick some obvious flags contained in the modern but not in the
+        # legacy profile (full Graviton 3 /proc/cpuinfo is "fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm
+        # jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs paca pacg dcpodp svei8mm svebf16 i8mm
+        # bf16 dgh rng")
         execute_process(
             COMMAND grep -P "^(?=.*atomic)(?=.*ssbs)" /proc/cpuinfo
             OUTPUT_VARIABLE FLAGS)
@@ -119,7 +119,7 @@ elseif (ARCH_AMD64)
         SET(ENABLE_AVX512_FOR_SPEC_OP 0)
     endif()
 
-    # Same best-effort check for x86 as above for ARM, see above.
+    # Same best-effort check for x86 as above for ARM.
     if (OS_LINUX AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "amd64|x86_64" AND NOT NO_SSE3_OR_HIGHER)
         # Test for flags in standard profile but not in NO_SSE3_OR_HIGHER profile.
         # /proc/cpuid for Intel Xeon 8124: "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse

--- a/cmake/cpu_features.cmake
+++ b/cmake/cpu_features.cmake
@@ -60,6 +60,23 @@ elseif (ARCH_AARCH64)
         set (COMPILER_FLAGS "${COMPILER_FLAGS} -march=armv8.2-a+simd+crypto+dotprod+ssbs -Xclang=-target-feature -Xclang=+ldapr -Wno-unused-command-line-argument")
     endif ()
 
+    # Quick-n-dirty check: The build generates and executes intermediate binaries, e.g. protoc and llvm-tablegen. If we build on ARM for ARM
+    # and the build machine is too old, i.e. doesn't satisfy above modern profile, then these intermediate binaries will not run (dump
+    # SIGILL). Even if they could run, the build machine wouldn't be able to run the ClickHouse binary. In that case, suggest to run the
+    # build with the compat profile.
+    if (OS_LINUX AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)" AND NOT NO_ARMV81_OR_HIGHER)
+        # CPU features in /proc/cpuinfo and compiler flags don't align :( ... pick some obvious flags contained in modern but not legacy
+        # profile (full Graviton 3 /proc/cpuinfo is "fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt
+        # fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs paca pacg dcpodp svei8mm svebf16 i8mm bf16
+        # dgh rng")
+        execute_process(
+            COMMAND grep -P "^(?=.*atomic)(?=.*ssbs)" /proc/cpuinfo
+            OUTPUT_VARIABLE FLAGS)
+        if (NOT FLAGS)
+            MESSAGE(FATAL_ERROR "The build machine does not satisfy the minimum CPU requirements, try to run cmake with -DNO_ARMV81_OR_HIGHER=1")
+        endif()
+    endif()
+
 elseif (ARCH_PPC64LE)
     # By Default, build for power8 and up, allow building for power9 and up
     # Note that gcc and clang have support for x86 SSE2 intrinsics when building for PowerPC


### PR DESCRIPTION
ClickHouse can be build on ARM
- using a "modern" build profile (the default) which assumes the presense of advanced CPU flags/instructions, see [here](https://github.com/ClickHouse/ClickHouse/blob/d67a3b9faaddb1811d434b4f18923d8891bfeace/cmake/cpu_features.cmake#L19) for all details.
- or using a "compat" build profile that allows to run the generated binaries on any ARMv8 CPU including e.g. Raspberry Pi.

In issue #46769, when building on ARM for ARM, the build itself stopped with an illegal instruction dump when running `protoc`, an intermediate binary generated during the build. The problem was that the build machine is too old, i.e. only satisfies the "compat" profile, yet the intermediate binaries are (by default) compiled for the modern profile and refused to run. CMake now tries to catch this situation and suggests to build with `-DNO_ARMV81_OR_HIGHER=1` as a workaround. A similar check was added for x86.

Fixes #46769.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)