### PR TITLE
Replacing final: an attempt at more cache friendly implementation. 

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -512,6 +512,7 @@ class IColumn;
     M(Bool, optimize_using_constraints, false, "Use constraints for query optimization", 0)                                                                                                                                           \
     M(Bool, optimize_substitute_columns, false, "Use constraints for column substitution", 0)                                                                                                                                         \
     M(Bool, optimize_append_index, false, "Use constraints in order to append index condition (indexHint)", 0) \
+    M(Bool, use_skip_replacing_final, false, "Use alternative replacing final implementation", 0) \
     M(Bool, normalize_function_names, true, "Normalize function names to their canonical names", 0) \
     M(Bool, allow_experimental_alter_materialized_view_structure, false, "Allow atomic alter on Materialized views. Work in progress.", 0) \
     M(Bool, enable_early_constant_folding, true, "Enable query optimization where we analyze function and subqueries results and rewrite query if there're constants there", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -512,7 +512,7 @@ class IColumn;
     M(Bool, optimize_using_constraints, false, "Use constraints for query optimization", 0)                                                                                                                                           \
     M(Bool, optimize_substitute_columns, false, "Use constraints for column substitution", 0)                                                                                                                                         \
     M(Bool, optimize_append_index, false, "Use constraints in order to append index condition (indexHint)", 0) \
-    M(Bool, use_skip_replacing_final, false, "Use alternative replacing final implementation", 0) \
+    M(Bool, use_skip_replacing_final, true, "Use alternative replacing final implementation", 0) \
     M(Bool, normalize_function_names, true, "Normalize function names to their canonical names", 0) \
     M(Bool, allow_experimental_alter_materialized_view_structure, false, "Allow atomic alter on Materialized views. Work in progress.", 0) \
     M(Bool, enable_early_constant_folding, true, "Enable query optimization where we analyze function and subqueries results and rewrite query if there're constants there", 0) \

--- a/src/Processors/Merges/Algorithms/ReplacingSortedSkipAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/ReplacingSortedSkipAlgorithm.cpp
@@ -1,0 +1,226 @@
+#include <Processors/Merges/Algorithms/ReplacingSortedSkipAlgorithm.h>
+#include <IO/WriteBuffer.h>
+
+namespace DB
+{
+
+ReplacingSortedSkipAlgorithm::ReplacingSortedSkipAlgorithm(
+    const Block & header_,
+    const Block & output_header,
+    size_t num_inputs,
+    SortDescription description_,
+    const String & version_column,
+    size_t max_block_size,
+    bool use_average_block_sizes)
+
+    :
+      cursors(num_inputs)
+    , header(std::move(header_))
+    , description(std::move(description_))
+    , chunk_allocator(num_inputs + max_row_refs)
+    , sources(num_inputs)
+    , merged_data(output_header.cloneEmptyColumns(), use_average_block_sizes, max_block_size)
+{
+    if (!version_column.empty())
+        version_column_number = header_.getPositionByName(version_column);
+}
+
+
+void ReplacingSortedSkipAlgorithm::initialize(Inputs inputs)
+{
+    for (size_t source_num = 0; source_num < inputs.size(); ++source_num)
+    {
+        if (!inputs[source_num].chunk)
+            continue;
+
+        auto & source = sources[source_num];
+
+        MutableColumnPtr column = ColumnUInt8::create();
+        column->reserve(inputs[source_num].chunk.getNumRows());
+
+        source.skip_last_row = inputs[source_num].skip_last_row;
+        source.skip_chunk = false;
+        source.chunk = chunk_allocator.alloc(inputs[source_num].chunk);
+        source.chunk->filter_column = std::move(column);
+        cursors[source_num] = SortCursorImpl(header, source.chunk->getColumns(), description, source_num, inputs[source_num].permutation);
+
+        source.chunk->all_columns = cursors[source_num].all_columns;
+        source.chunk->sort_columns = cursors[source_num].sort_columns;
+    }
+
+    queue = SortingQueue<SortCursor>(cursors);
+}
+
+void ReplacingSortedSkipAlgorithm::consume(Input & input, size_t source_num)
+{
+
+    auto & source = sources[source_num];
+    source.skip_last_row = input.skip_last_row;
+    source.chunk = chunk_allocator.alloc(input.chunk);
+    cursors[source_num].reset(source.chunk->getColumns(), header, input.permutation);
+
+    source.chunk->all_columns = cursors[source_num].all_columns;
+    source.chunk->sort_columns = cursors[source_num].sort_columns;
+
+    queue.push(cursors[source_num]);
+
+    // If the chunk last row is below all other chunks position we can pass the chunk directly
+    bool skip = true;
+
+    if (cursors[source_num].isValid() && sources[source_num].chunk->getNumRows() > 0)
+    {
+
+        detail::RowRef last_row;
+        last_row.setLast(cursors[source_num]);
+
+        for (size_t source_idx = 0; source_idx < sources.size(); ++source_idx)
+        {
+            if (source_idx == source_num || !sources[source_idx].chunk || !cursors[source_idx].isValid())
+                continue;
+
+            detail::RowRef current_row;
+            current_row.setCur(cursors[source_num]);
+
+            skip = last_row.hasLowerSortColumnsWith(current_row);
+
+            if (!skip)
+                break;
+        }
+    }
+    source.skip_chunk = skip;
+
+    if (!skip)
+    {
+        MutableColumnPtr column = ColumnUInt8::create();
+
+        column->reserve(source.chunk->getNumRows());
+        source.chunk->filter_column = std::move(column);
+    }
+}
+
+
+void ReplacingSortedSkipAlgorithm::emitChunk(detail::SharedChunkPtr &chunk, bool skip)
+{
+    if (!selected_row.empty() && chunk == selected_row.owned_chunk)
+        return;
+
+    if (skip || !chunk->filter_column)
+    {
+        chunk->addColumn(ColumnConst::create(ColumnUInt8::create(1, 1), chunk->getNumRows()));
+    }
+    else
+    {
+        chunk->addColumn(std::move(chunk->filter_column));
+    }
+    size_t rows = chunk->getNumRows();
+    merged_data.insertChunkPtr(chunk, rows);
+}
+
+IMergingAlgorithm::Status ReplacingSortedSkipAlgorithm::merge()
+{
+    if (merged_data.hasEnoughRows())
+        return Status(merged_data.pull());
+
+    /// Take the rows in needed order and put them into `merged_columns` until rows no more than `max_block_size`
+    while (queue.isValid())
+    {
+        SortCursor current = queue.current();
+
+        if (sources[current->order].skip_chunk || (current->isLast() && skipLastRowFor(current->order)))
+        {
+            bool skip = sources[current->order].skip_chunk;
+            if (!skip)
+                sources[current.impl->order].chunk->filter_column->insert(0);
+
+            emitChunk(sources[current->order].chunk, skip);
+            /// Get the next block from the corresponding source, if there is one.
+            queue.removeTop();
+            return Status(current.impl->order);
+        }
+
+        RowRef current_row;
+        setRowRef(current_row, current);
+
+        bool key_differs = selected_row.empty() || !current_row.hasEqualSortColumnsWith(selected_row);
+        if (key_differs)
+        {
+            /// if there are enough rows and the last one is calculated completely
+            if (merged_data.hasEnoughRows())
+                return Status(merged_data.pull());
+
+            /// Write the data for the previous primary key.
+            if (!selected_row.empty())
+            {
+                selected_row.owned_chunk->filter_column->insert(1);
+                if (selected_row.row_num + 1 >= selected_row.owned_chunk->getNumRows())
+                {
+                    detail::SharedChunkPtr chunk = std::move(selected_row.owned_chunk);
+                    selected_row.clear();
+                    emitChunk(chunk, false);
+                    return Status(merged_data.pull());
+                }
+            }
+
+            selected_row.clear();
+        }
+
+        /// A non-strict comparison, since we select the last row for the same version values.
+        if (version_column_number == -1
+            || selected_row.empty()
+            || current->all_columns[version_column_number]->compareAt(
+                current->getRow(), selected_row.row_num,
+                *(*selected_row.all_columns)[version_column_number],
+                /* nan_direction_hint = */ 1) >= 0)
+        {
+            if (!selected_row.empty())
+            {
+                selected_row.owned_chunk->filter_column->insert(0);
+                if (selected_row.row_num + 1 >= selected_row.owned_chunk->getNumRows())
+                {
+                    detail::SharedChunkPtr chunk = std::move(selected_row.owned_chunk);
+                    selected_row.clear();
+                    emitChunk(chunk, false);
+                    return Status(merged_data.pull());
+                }
+            }
+
+            setRowRef(selected_row, current);
+        }
+        else
+        {
+            current_row.owned_chunk->filter_column->insert(0);
+        }
+
+        if (!current->isLast())
+        {
+            queue.next();
+        }
+        else
+        {
+            emitChunk(sources[current.impl->order].chunk, false);
+            /// We get the next block from the corresponding source, if there is one.
+            queue.removeTop();
+            return Status(current.impl->order);
+        }
+    }
+
+    /// If have enough rows, return block, because it prohibited to overflow requested number of rows.
+    if (merged_data.hasEnoughRows())
+        return Status(merged_data.pull());
+
+    /// We will write the data for the last primary key.
+    if (!selected_row.empty())
+    {
+        selected_row.owned_chunk->filter_column->insert(1);
+        if (selected_row.row_num + 1 >= selected_row.owned_chunk->getNumColumns())
+        {
+            detail::SharedChunkPtr chunk = std::move(selected_row.owned_chunk);
+            selected_row.clear();
+            emitChunk(chunk, false);
+        }
+    }
+
+    return Status(merged_data.pull(), true);
+}
+
+}

--- a/src/Processors/Merges/Algorithms/ReplacingSortedSkipAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/ReplacingSortedSkipAlgorithm.h
@@ -1,0 +1,69 @@
+#pragma once
+#include <Processors/Merges/Algorithms/IMergingAlgorithm.h>
+#include <Processors/Merges/Algorithms/MergedData.h>
+#include <Processors/Transforms/ColumnGathererTransform.h>
+#include <Processors/Merges/Algorithms/RowRef.h>
+#include <Columns/ColumnsNumber.h>
+#include <Core/SortDescription.h>
+
+namespace Poco
+{
+class Logger;
+}
+
+namespace DB
+{
+
+class ReplacingSortedSkipAlgorithm final : public IMergingAlgorithm
+{
+
+public:
+    ReplacingSortedSkipAlgorithm(
+        const Block & header,
+        const Block & output_header,
+        size_t num_inputs,
+        SortDescription description_, const String & version_column,
+        size_t max_block_size,
+        bool use_average_block_sizes = false);
+
+    void initialize(Inputs inputs) override;
+    void consume(Input & input, size_t source_num) override;
+    Status merge() override;
+
+private:
+
+    SortCursorImpls cursors;
+
+    struct Source
+    {
+        detail::SharedChunkPtr chunk;
+        bool skip_last_row;
+        bool skip_chunk;
+    };
+
+    Block header;
+    SortDescription description;
+
+    /// Allocator must be destroyed after source_chunks.
+    detail::SharedChunkAllocator chunk_allocator;
+
+    /// Sources currently being merged.
+    using Sources = std::vector<Source>;
+    Sources sources;
+
+    SortingQueue<SortCursor> queue;
+    MergedData merged_data;
+
+    ssize_t version_column_number = -1;
+
+    using RowRef = detail::RowRefWithOwnedChunk;
+    static constexpr size_t max_row_refs = 2; /// last, current.
+    RowRef selected_row; /// Last row with maximum version for current primary key
+
+    void setRowRef(RowRef & row, SortCursor & cursor) { row.set(cursor, sources[cursor.impl->order].chunk); }
+    bool skipLastRowFor(size_t input_number) const { return sources[input_number].skip_last_row; }
+
+    void emitChunk(detail::SharedChunkPtr &chunk, bool skip);
+};
+
+}

--- a/src/Processors/Merges/ReplacingSortedSkipTransform.h
+++ b/src/Processors/Merges/ReplacingSortedSkipTransform.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <Processors/Merges/IMergingTransform.h>
+#include <Processors/Merges/Algorithms/ReplacingSortedSkipAlgorithm.h>
+
+
+namespace DB
+{
+
+/// Implementation of IMergingTransform via ReplacingSortedAlgorithm.
+class ReplacingSortedSkipTransform final : public IMergingTransform<ReplacingSortedSkipAlgorithm>
+{
+public:
+    static Block transformHeader(const Block &input_header)
+    {
+        Block header = input_header.cloneEmpty();
+
+        ColumnWithTypeAndName filter_column(std::make_shared<DataTypeUInt8>(), "internal_filter_final_flags");
+        header.insert(std::move(filter_column));
+
+        return header;
+    }
+
+    ReplacingSortedSkipTransform(
+        const Block & input_header, const Block &output_header, size_t num_inputs,
+        SortDescription description_, const String & version_column,
+        size_t max_block_size
+        )
+        : IMergingTransform(
+            num_inputs, input_header, output_header, /*have_all_inputs_=*/ true, /*limit_hint_=*/ 0, /*always_read_till_end_=*/ false,
+            input_header,
+            output_header,
+            num_inputs,
+            std::move(description_),
+            version_column,
+            max_block_size,
+            false)
+    {
+    }
+
+    String getName() const override { return "ReplacingSortedSkip"; }
+};
+
+}

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -256,7 +256,7 @@ private:
         const InputOrderInfoPtr & input_order_info);
 
     Pipe spreadMarkRangesAmongStreamsFinal(
-        RangesInDataParts && parts, size_t num_streams, const Names & column_names, ActionsDAGPtr & out_projection);
+        RangesInDataParts && parts, size_t num_streams, const Names & column_names, ActionsDAGPtr & out_projection , const InputOrderInfoPtr & input_order_info);
 
     ReadFromMergeTree::AnalysisResult getAnalysisResult() const;
     MergeTreeDataSelectAnalysisResultPtr analyzed_result_ptr;


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Add a skip_replacing_final merge algorithm for ReplacingMergeTree to improving cache efficiency by merging columns by columns instead of row by row. 

### Description
This PR is a draft, i'm not very proficient in C++ or clickhouse and there is a major bug somewhere, Trying to get feedback on the idea and if the optimisation is worth it. 

Currently, FINAL for ReplacingMergeTree uses an horizontal implementation. If you run FINAL with a ~5/10 columns, memcpy and moving data to MergedData chunk shows up in profile as ~40% of cpu. For a long time, i thought it was hitting memory bandwidth limitation, but in fact, it seems to be more a access latency/cache bottleneck. 

To work around this, this is an attempt at implementing merging more vertically and with less copy, while dropping the benefit that the output stream remains sorted by PK. 

There are two optimisations :
1. while merge sorting chunks, we can skip chunks if the last PK in block is lower than the current cursor, we can pass the chunk without copying it, as it is fully merged.
2. Instead of rewriting chunks row by row, we can reuse filter transform used for where, and write a boolean filter column, and then filtering chunk columns by columns, which is a lot more cache friendly. 

On tests, it seems to make no impact on single columns/small final up to twice faster when doing final on table with many columns. 