### PR TITLE
Don't report ZK node exists to system.errors when a block was created concurrently by a different replica

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -985,7 +985,7 @@ std::vector<String> ReplicatedMergeTreeSinkImpl<async_insert>::commitPart(
         }
         else if (Coordination::isUserError(multi_code))
         {
-            String failed_op_path = zkutil::KeeperMultiException(multi_code, ops, responses).getPathForFirstFailedOp();
+            String failed_op_path = ops[zkutil::getFailedOpIndex(multi_code, responses)]->getPath();
 
             auto contains = [](const auto & block_ids, const String & path)
             {
@@ -1002,7 +1002,7 @@ std::vector<String> ReplicatedMergeTreeSinkImpl<async_insert>::commitPart(
 
             if (multi_code == Coordination::Error::ZNODEEXISTS && deduplicate_block && contains(block_id_path, failed_op_path))
             {
-                /// Block with the same id have just appeared in table (or other replica), rollback thee insertion.
+                /// Block with the same id have just appeared in table (or other replica), rollback the insertion.
                 LOG_INFO(log, "Block with ID {} already exists (it was just appeared). Renaming part {} back to {}. Will retry write.",
                     toString(block_id), part->name, temporary_part_relative_path);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Don't report ZK node exists to system.errors when a block was created concurrently by a different replica



Example (comes from a CI run):

```
version:            23.3.1.19
name:               KEEPER_EXCEPTION
code:               999
quantity:           1
last_error_message: Transaction failed (Node exists)
traceback:          DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool)
Coordination::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, Coordination::Error, int)
Coordination::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, Coordination::Error)
zkutil::KeeperMultiException::KeeperMultiException(Coordination::Error, std::__1::vector<std::__1::shared_ptr<Coordination::Request>, std::__1::allocator<std::__1::shared_ptr<Coordination::Request>>> const&, std::__1::vector<std::__1::shared_ptr<Coordination::Response>, std::__1::allocator<std::__1::shared_ptr<Coordination::Response>>> const&)
DB::ReplicatedMergeTreeSinkImpl<false>::commitPart(std::__1::shared_ptr<DB::ZooKeeperWithFaultInjection> const&, std::__1::shared_ptr<DB::IMergeTreeDataPart>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, bool)
DB::ReplicatedMergeTreeSinkImpl<false>::finishDelayedChunk(std::__1::shared_ptr<DB::ZooKeeperWithFaultInjection> const&)
DB::ReplicatedMergeTreeSinkImpl<false>::consume(DB::Chunk)
DB::SinkToStorage::onConsume(DB::Chunk)
DB::ExceptionKeepingTransform::work()
DB::ExecutionThreadContext::executeTask()
DB::PipelineExecutor::executeStepImpl(unsigned long, std::__1::atomic<bool>*)
ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>)
```

Logs:
```
2023.02.24 09:44:39.462647 [ 271 ] {8d6ebeff-b02e-4700-83bf-2b965d241acb} <Trace> d_test_177ab302399e42f5a6f72ac44d8a9990.t_c16d3a255a7f4e4d82422c9337779ae1 (c2bed6e8-68c6-4035-b2cb-ff4ab0281d36): Renaming temporary part tmp_insert_all_2_2_0 to all_1_1_0 with tid (1, 1, 00000000-0000-0000-0000-000000000000).
2023.02.24 09:44:39.463916 [ 271 ] {8d6ebeff-b02e-4700-83bf-2b965d241acb} <Information> d_test_177ab302399e42f5a6f72ac44d8a9990.t_c16d3a255a7f4e4d82422c9337779ae1 (c2bed6e8-68c6-4035-b2cb-ff4ab0281d36) (Replicated OutputStream): Block with ID all_6014107614689632743_16975405373040374011 already exists (it was just appeared). Renaming part all_1_1_0 back to tmp_insert_all_2_2_0. Will retry write.
2023.02.24 09:44:39.463942 [ 271 ] {8d6ebeff-b02e-4700-83bf-2b965d241acb} <Debug> d_test_177ab302399e42f5a6f72ac44d8a9990.t_c16d3a255a7f4e4d82422c9337779ae1 (c2bed6e8-68c6-4035-b2cb-ff4ab0281d36): Undoing transaction. Rollbacking parts state to temporary and removing from working set: all_1_1_0.
```

The problems comes from using `zkutil::KeeperMultiException` to extract the path of the first error. Creating a `zkutil::KeeperMultiException` creates a `KeeperException`, which is a DB::Exception and thus reports to system.errors. Since the exception was created only for that operation, I've replaced by the equivalent functions instead.

Closes https://github.com/ClickHouse/ClickHouse/issues/32997