### PR TITLE
refine regexp tree dictionary

### DIFF
--- a/src/Dictionaries/RegExpTreeDictionary.cpp
+++ b/src/Dictionaries/RegExpTreeDictionary.cpp
@@ -99,6 +99,17 @@ struct RegExpTreeDictionary::RegexTreeNode
         return searcher.Match(haystack, 0, size, re2_st::RE2::Anchor::UNANCHORED, nullptr, 0);
     }
 
+    /// check if this node can cover all the attributes from the query.
+    bool containsAll(const std::unordered_map<String, const DictionaryAttribute &> & matching_attributes) const
+    {
+        for (const auto & [key, value] : matching_attributes)
+        {
+            if (!attributes.contains(key))
+                return false;
+        }
+        return true;
+    }
+
     struct AttributeValue
     {
         Field field;
@@ -498,6 +509,8 @@ std::unordered_map<String, ColumnPtr> RegExpTreeDictionary::match(
             if (node_ptr->match(reinterpret_cast<const char *>(keys_data.data()) + offset, length))
             {
                 match_result.insertNodeID(node_ptr->id);
+                if (node_ptr->containsAll(attributes))
+                    break;
             }
         }
 

--- a/src/Dictionaries/RegExpTreeDictionary.cpp
+++ b/src/Dictionaries/RegExpTreeDictionary.cpp
@@ -509,7 +509,8 @@ std::unordered_map<String, ColumnPtr> RegExpTreeDictionary::match(
             if (node_ptr->match(reinterpret_cast<const char *>(keys_data.data()) + offset, length))
             {
                 match_result.insertNodeID(node_ptr->id);
-                if (node_ptr->containsAll(attributes))
+                /// When this node is leaf and contains all the required attributes, it means a match.
+                if (node_ptr->containsAll(attributes) && node_ptr->children.empty())
                     break;
             }
         }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

if a tree node can cover all the attributes, we can safely break the loop.
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
