### PR TITLE
Fix http xz compression issue for s390x

### DIFF
--- a/contrib/xz-cmake/CMakeLists.txt
+++ b/contrib/xz-cmake/CMakeLists.txt
@@ -94,6 +94,10 @@ if (ARCH_AMD64 OR ARCH_AARCH64)
     add_compile_definitions(TUKLIB_FAST_UNALIGNED_ACCESS=1)
 endif ()
 
+if (ARCH_S390X)
+    add_compile_definitions(WORDS_BIGENDIAN)
+endif ()
+
 find_package(Threads REQUIRED)
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On s390x, the xz library was built with DWORDS_BIGENDIAN turned off, which causes the compression decoding failure.
The fix is to turn the flag on in CMakeLists.txt.

### Changelog category (leave one):
- Build Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed http xz compression issue for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
