### PR TITLE
Non-significant change

### DIFF
--- a/src/DataTypes/registerDataTypeDateTime.cpp
+++ b/src/DataTypes/registerDataTypeDateTime.cpp
@@ -64,7 +64,7 @@ static DataTypePtr create(const ASTPtr & arguments)
         return std::make_shared<DataTypeDateTime>();
 
     const auto scale = getArgument<UInt64, ArgumentKind::Optional>(arguments, 0, "scale", "DateTime");
-    const auto timezone = getArgument<String, ArgumentKind::Optional>(arguments, !!scale, "timezone", "DateTime");
+    const auto timezone = getArgument<String, ArgumentKind::Optional>(arguments, scale ? 1 : 0, "timezone", "DateTime");
 
     if (!scale && !timezone)
         throw Exception::createDeprecated(getExceptionMessage(" has wrong type: ", 0, "scale", "DateTime", Field::Types::Which::UInt64),


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


The usage of `!!` implies that the author wants to get a boolean value.
But he wanted to get the index of the argument, which is either zero or one, but not boolean.