### PR TITLE
Increase the limit on the number of opened files in `clickhouse-local`

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -6,7 +6,6 @@
 #include <sys/types.h>
 #include <pwd.h>
 #include <unistd.h>
-#include <Poco/Version.h>
 #include <Poco/Net/HTTPServer.h>
 #include <Poco/Net/NetException.h>
 #include <Poco/Util/HelpFormatter.h>

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -224,9 +224,9 @@ namespace detail
 
         enum class InitializeError
         {
-            RETRIABLE_ERROR,
+            RETRYABLE_ERROR,
             /// If error is not retriable, `exception` variable must be set.
-            NON_RETRIABLE_ERROR,
+            NON_RETRYABLE_ERROR,
             /// Allows to skip not found urls for globs
             SKIP_NOT_FOUND_URL,
             NONE,
@@ -398,7 +398,7 @@ namespace detail
                 }
                 else if (!isRetriableError(http_status))
                 {
-                    initialization_error = InitializeError::NON_RETRIABLE_ERROR;
+                    initialization_error = InitializeError::NON_RETRYABLE_ERROR;
                     exception = std::current_exception();
                 }
                 else
@@ -409,7 +409,7 @@ namespace detail
         }
 
         /**
-         * Throws if error is retriable, otherwise sets initialization_error = NON_RETRIABLE_ERROR and
+         * Throws if error is retryable, otherwise sets initialization_error = NON_RETRYABLE_ERROR and
          * saves exception into `exception` variable. In case url is not found and skip_not_found_url == true,
          * sets initialization_error = SKIP_NOT_FOUND_URL, otherwise throws.
          */
@@ -453,9 +453,9 @@ namespace detail
 
                     /// Retry 200OK
                     if (response.getStatus() == Poco::Net::HTTPResponse::HTTPStatus::HTTP_OK)
-                        initialization_error = InitializeError::RETRIABLE_ERROR;
+                        initialization_error = InitializeError::RETRYABLE_ERROR;
                     else
-                        initialization_error = InitializeError::NON_RETRIABLE_ERROR;
+                        initialization_error = InitializeError::NON_RETRYABLE_ERROR;
 
                     return;
                 }
@@ -544,7 +544,7 @@ namespace detail
                     {
                         initialize();
 
-                        if (initialization_error == InitializeError::NON_RETRIABLE_ERROR)
+                        if (initialization_error == InitializeError::NON_RETRYABLE_ERROR)
                         {
                             assert(exception);
                             break;
@@ -553,7 +553,7 @@ namespace detail
                         {
                             return false;
                         }
-                        else if (initialization_error == InitializeError::RETRIABLE_ERROR)
+                        else if (initialization_error == InitializeError::RETRYABLE_ERROR)
                         {
                             LOG_ERROR(
                                 log,

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -582,10 +582,13 @@ namespace detail
                 }
                 catch (const Poco::Exception & e)
                 {
-                    /**
-                     * Retry request unconditionally if nothing has been read yet.
-                     * Otherwise if it is GET method retry with range header.
-                     */
+                    /// Too many open files - non-retryable.
+                    if (e.code() == POCO_EMFILE)
+                        throw;
+
+                    /** Retry request unconditionally if nothing has been read yet.
+                      * Otherwise if it is GET method retry with range header.
+                      */
                     bool can_retry_request = !offset_from_begin_pos || method == Poco::Net::HTTPRequest::HTTP_GET;
                     if (!can_retry_request)
                         throw;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Increase the limit for opened files in `clickhouse-local`. It will be able to read from `web` tables on servers with a huge number of CPU cores. Do not back off reading from the URL table engine in case of too many opened files. This closes #46852.