### PR TITLE
Give users option of overwriting

### DIFF
--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -60,12 +60,21 @@ fi
 clickhouse_download_filename_prefix="clickhouse"
 clickhouse="$clickhouse_download_filename_prefix"
 
-i=0
-while [ -f "$clickhouse" ]
-do
-    clickhouse="${clickhouse_download_filename_prefix}.${i}"
-    i=$(($i+1))
-done
+if [ -f "$clickhouse" ]
+then
+    read -p "ClickHouse binary ${clickhouse} already exists. Overwrite? [y/N] " answer
+    if [ "$answer" = "y" -o "$answer" = "Y" ]
+    then
+        rm -f "$clickhouse"
+    else
+        i=0
+        while [ -f "$clickhouse" ]
+        do
+            clickhouse="${clickhouse_download_filename_prefix}.${i}"
+            i=$(($i+1))
+        done
+    fi
+fi
 
 URL="https://builds.clickhouse.com/master/${DIR}/clickhouse"
 echo

--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -85,9 +85,9 @@ echo
 echo "Successfully downloaded the ClickHouse binary, you can run it as:
     ./${clickhouse}"
 
-if [ "${OS}" = "Linux" ]
-then
-    echo
-    echo "You can also install it:
-    sudo ./${clickhouse} install"
-fi
+#if [ "${OS}" = "Linux" ]
+#then
+    #echo
+    #echo "You can also install it:
+    #sudo ./${clickhouse} install"
+#fi


### PR DESCRIPTION
Some people do not like the way the `curl | sh` download increments the filename (for example, if `clickhouse` exists in the current dir, the script will download `clickhouse.1` etc.)

This PR adds a prompt:
```
ClickHouse binary clickhouse already exists. Overwrite? [y/N] 
```
If the user responds `y` or `Y`, then the file `clickhouse` is removed and the script continues and downloads to `clickhouse`.  If the user responds with anything else, then the normal iteration over filenames occurs and the first unused filename is used for the download.  I only tested on Linux as I do not have a macOS machine.

This PR also removes the instruction on Linux to install as there is then no way to manage upgrades.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Adds a prompt to allow the removal of an existing `cickhouse` download when using "curl | sh" download of ClickHouse. Prompt is "ClickHouse binary clickhouse already exists. Overwrite? [y/N] " 

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)
(self documenting)

