### PR TITLE
add note about prod install

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -24,7 +24,7 @@ The quickest and easiest way to get up and running with ClickHouse is to create 
 ## Self-Managed Install
 
 :::tip
-For production installs of a specific release version see the [available versions](#available-installation-options) down below.
+For production installs of a specific release version see the [installation options](#available-installation-options) down below.
 :::
 
 <Tabs>

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -23,6 +23,10 @@ The quickest and easiest way to get up and running with ClickHouse is to create 
 
 ## Self-Managed Install
 
+:::tip
+For production installs of a specific release version see the [available versions](#available-installation-options) down below.
+:::
+
 <Tabs>
 <TabItem value="linux" label="Linux" default>
 


### PR DESCRIPTION

For prod use installing a master build may not be what users want, this lets them know that curl | sh is not the only choice for prod.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

