### PR TITLE
Make ASTSelectQuery::formatImpl() more robust

### DIFF
--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -113,10 +113,8 @@ void ASTSelectQuery::formatImpl(const FormatSettings & s, FormatState & state, F
     if (group_by_with_cube)
         s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << (s.one_line ? "" : "    ") << "WITH CUBE" << (s.hilite ? hilite_none : "");
 
-    if (group_by_with_grouping_sets)
+    if (group_by_with_grouping_sets && groupBy())
     {
-        if (!groupBy()) /// sanity check, issue 43049
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Corrupt AST");
         auto nested_frame = frame;
         nested_frame.surround_each_list_element_with_parens = true;
         nested_frame.expression_list_prepend_whitespace = false;


### PR DESCRIPTION
Fixes #45204

The problem is that `ASTSelectQuery::group_by_with_grouping_sets == true` should imply `ASTSelectQuery::groupBy()` but sometimes this wasn't the case. I added a sanity check a few months ago but had no idea how the AST became corrupt.

All crashes/exceptions were during AST fuzzing. Looking at Client/QueryFuzzer.cpp, there is a very small chance to run into the issue. In detail:

1. In `QueryFuzzer::fuzz()`, we find that the AST is a `ASTSelectQuery` and `groupBy()` returns true.

2. With small probability, we do `select->group_by_with_grouping_sets = !select->group_by_with_grouping_sets;` where the (default false) `group_by_with_grouping_sets` flips true.

3. With small probability, we change the expression type in the following WHERE or PREWHERE if-branches.

This situation is illegal. One possibility is changing the fuzzing code to not generate it. The fuzzing code is however generic, and doesn't really care about such details. Therefore, instead add an (theoretically unnecessary) extra check to `ASTSelectQuery::formatImpl()` for robustness.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)