### PR TITLE
Fix some expect tests leftovers and enable them in fasttest

### DIFF
--- a/src/Client/ReplxxLineReader.cpp
+++ b/src/Client/ReplxxLineReader.cpp
@@ -432,6 +432,7 @@ ReplxxLineReader::ReplxxLineReader(
     };
 
     rx.bind_key(Replxx::KEY::control('R'), interactive_history_search);
+#endif
 
     /// Rebind regular incremental search to C-T.
     ///
@@ -443,7 +444,6 @@ ReplxxLineReader::ReplxxLineReader(
         uint32_t reverse_search = Replxx::KEY::control('R');
         return rx.invoke(Replxx::ACTION::HISTORY_INCREMENTAL_SEARCH, reverse_search);
     });
-#endif
 }
 
 ReplxxLineReader::~ReplxxLineReader()

--- a/tests/queries/0_stateless/01179_insert_values_semicolon.expect
+++ b/tests/queries/0_stateless/01179_insert_values_semicolon.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: long
 
 set basedir [file dirname $argv0]
 set basename [file tail $argv0]

--- a/tests/queries/0_stateless/01180_client_syntax_errors.expect
+++ b/tests/queries/0_stateless/01180_client_syntax_errors.expect
@@ -31,6 +31,7 @@ expect "Syntax error: failed at position 93 ('UInt64'):*"
 send -- "select (1, 2\r"
 expect "Syntax error: failed at position 8 ('('):"
 expect "Unmatched parentheses: ("
+expect ":) "
 
 send -- "\4"
 expect eof

--- a/tests/queries/0_stateless/01300_client_save_history_when_terminated_long.expect
+++ b/tests/queries/0_stateless/01300_client_save_history_when_terminated_long.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: long
 
 set basedir [file dirname $argv0]
 set basename [file tail $argv0]

--- a/tests/queries/0_stateless/01565_query_loop_after_client_error.expect
+++ b/tests/queries/0_stateless/01565_query_loop_after_client_error.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: long
 
 # This is a separate test, because we want to test the interactive mode.
 # https://github.com/ClickHouse/ClickHouse/issues/19353

--- a/tests/queries/0_stateless/01910_client_replxx_container_overflow_long.expect
+++ b/tests/queries/0_stateless/01910_client_replxx_container_overflow_long.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: long
 
 set basedir [file dirname $argv0]
 set basename [file tail $argv0]

--- a/tests/queries/0_stateless/02003_memory_limit_in_client.expect
+++ b/tests/queries/0_stateless/02003_memory_limit_in_client.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-fasttest
 
 # This is a test for system.warnings. Testing in interactive mode is necessary,
 # as we want to see certain warnings from client

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-parallel
 
 set basedir [file dirname $argv0]
 set basename [file tail $argv0]

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_client_with_queries_file.expect
@@ -15,15 +15,13 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-system "$basedir/helpers/02112_prepare.sh"
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT --disable_suggestion --interactive --queries-file $basedir/file_02112"
+system "echo \"drop table if exists t; create table t(i String) engine=Memory; insert into t select 'test string'\" > $env(CLICKHOUSE_TMP)/file_02112"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT --disable_suggestion --interactive --queries-file $env(CLICKHOUSE_TMP)/file_02112"
 expect ":) "
 
-send -- "select * from t format TSV\r"
-expect "1"
+send -- "select i from t format TSV\r"
+expect "test string"
 expect ":) "
 
 send ""
 expect eof
-
-system "$basedir/helpers/02112_clean.sh"

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
@@ -15,15 +15,13 @@ expect_after {
     -i $any_spawn_id timeout { exit 1 }
 }
 
-system "$basedir/helpers/02112_prepare.sh"
-spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_LOCAL --disable_suggestion --interactive --queries-file $basedir/file_02112"
+system "echo \"drop table if exists t; create table t(i String) engine=Memory; insert into t select 'test string'\" > $env(CLICKHOUSE_TMP)/file_02112"
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_LOCAL --disable_suggestion --interactive --queries-file $env(CLICKHOUSE_TMP)/file_02112"
 expect ":) "
 
-send -- "select * from t format TSV\r"
-expect "1"
+send -- "select \* from t format TSV\r"
+expect "test string"
 expect ":) "
 
 send ""
 expect eof
-
-system "$basedir/helpers/02112_clean.sh"

--- a/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
+++ b/tests/queries/0_stateless/02112_delayed_clickhouse_local_with_queries_file.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: no-parallel
 
 set basedir [file dirname $argv0]
 set basename [file tail $argv0]

--- a/tests/queries/0_stateless/02116_interactive_hello.expect
+++ b/tests/queries/0_stateless/02116_interactive_hello.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: long
 
 set basedir [file dirname $argv0]
 set basename [file tail $argv0]

--- a/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
+++ b/tests/queries/0_stateless/02160_client_autocomplete_parse_query.expect
@@ -44,9 +44,8 @@ expect ":) "
 
 # Generate UIUD to avoid matching old database/tables/columns from previous test runs.
 send -- "select 'begin-' || replace(toString(generateUUIDv4()), '-', '') || '-end' format TSV\r"
-expect -re TSV.*TSV.*begin-(.*)-end.*
+expect -re "TSV.*TSV.*begin-(.*)-end.*:\\) "
 set uuid $expect_out(1,string)
-expect ":) "
 
 # CREATE DATABASE
 send -- "create database new_${uuid}_database\r"

--- a/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.expect
+++ b/tests/queries/0_stateless/02310_clickhouse_client_INSERT_progress_profile_events.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: long
 
 # This is the regression for the concurrent access in ProgressIndication,
 # so it is important to read enough rows here (10e6).

--- a/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
+++ b/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect -f
-# Tags: long
 
 # This is the regression for the concurrent access in ProgressIndication,
 # so it is important to read enough rows here (10e6).

--- a/tests/queries/0_stateless/helpers/02112_clean.sh
+++ b/tests/queries/0_stateless/helpers/02112_clean.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-FILE=${CURDIR}/../file_02112
-rm "$FILE"

--- a/tests/queries/0_stateless/helpers/02112_prepare.sh
+++ b/tests/queries/0_stateless/helpers/02112_prepare.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-FILE=${CURDIR}/../file_02112
-echo "drop table if exists t;create table t(i Int32) engine=Memory; insert into t select 1" > "$FILE"


### PR DESCRIPTION
Those tests was simply broken and timed out without failing the test
before this PRs:
- #46911
- #46857
- #46779, #46636, #46619

So after those fixes they should be fast and fasttest compatible.

And also fix few more tests
- `02160_client_autocomplete_parse_query`
- `02112_delayed_clickhouse_client_with_queries_file`
- `02112_delayed_clickhouse_local_with_queries_file`
- `01180_client_syntax_errors`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)