### PR TITLE
Make SyntaxExceptions easier to understand

### DIFF
--- a/base/poco/Foundation/src/NumberParser.cpp
+++ b/base/poco/Foundation/src/NumberParser.cpp
@@ -44,7 +44,7 @@ int NumberParser::parse(const std::string& s, char thSep)
 	if (tryParse(s, result, thSep))
 		return result;
 	else
-		throw SyntaxException("Not a valid integer", s);
+		throw SyntaxException("Not a valid integer", "'" + s + "'");
 }
 
 
@@ -60,7 +60,7 @@ unsigned NumberParser::parseUnsigned(const std::string& s, char thSep)
 	if (tryParseUnsigned(s, result, thSep))
 		return result;
 	else
-		throw SyntaxException("Not a valid unsigned integer", s);
+		throw SyntaxException("Not a valid unsigned integer", "'" + s + "'");
 }
 
 
@@ -76,7 +76,7 @@ unsigned NumberParser::parseHex(const std::string& s)
 	if (tryParseHex(s, result))
 		return result;
 	else
-		throw SyntaxException("Not a valid hexadecimal integer", s);
+		throw SyntaxException("Not a valid hexadecimal integer", "'" + s + "'");
 }
 
 
@@ -94,7 +94,7 @@ unsigned NumberParser::parseOct(const std::string& s)
 	if (tryParseOct(s, result))
 		return result;
 	else
-		throw SyntaxException("Not a valid hexadecimal integer", s);
+		throw SyntaxException("Not a valid hexadecimal integer", "'" + s + "'");
 }
 
 
@@ -112,7 +112,7 @@ Int64 NumberParser::parse64(const std::string& s, char thSep)
 	if (tryParse64(s, result, thSep))
 		return result;
 	else
-		throw SyntaxException("Not a valid integer", s);
+		throw SyntaxException("Not a valid integer", "'" + s + "'");
 }
 
 
@@ -128,7 +128,7 @@ UInt64 NumberParser::parseUnsigned64(const std::string& s, char thSep)
 	if (tryParseUnsigned64(s, result, thSep))
 		return result;
 	else
-		throw SyntaxException("Not a valid unsigned integer", s);
+		throw SyntaxException("Not a valid unsigned integer", "'" + s + "'");
 }
 
 
@@ -144,7 +144,7 @@ UInt64 NumberParser::parseHex64(const std::string& s)
 	if (tryParseHex64(s, result))
 		return result;
 	else
-		throw SyntaxException("Not a valid hexadecimal integer", s);
+		throw SyntaxException("Not a valid hexadecimal integer", "'" + s + "'");
 }
 
 
@@ -162,7 +162,7 @@ UInt64 NumberParser::parseOct64(const std::string& s)
 	if (tryParseOct64(s, result))
 		return result;
 	else
-		throw SyntaxException("Not a valid hexadecimal integer", s);
+		throw SyntaxException("Not a valid hexadecimal integer", "'" + s + "'");
 }
 
 
@@ -180,7 +180,7 @@ double NumberParser::parseFloat(const std::string& s, char decSep, char thSep)
 	if (tryParseFloat(s, result, decSep, thSep))
 		return result;
 	else
-		throw SyntaxException("Not a valid floating-point number", s);
+		throw SyntaxException("Not a valid floating-point number", "'" + s + "'");
 }
 
 
@@ -196,7 +196,7 @@ bool NumberParser::parseBool(const std::string& s)
 	if (tryParseBool(s, result))
 		return result;
 	else
-		throw SyntaxException("Not a valid bool number", s);
+		throw SyntaxException("Not a valid bool number", "'" + s + "'");
 }
 
 	


### PR DESCRIPTION
E.g. with configuration

```xml
<keeper_server>
    <server>
        <id>2 </id> <!-- note the space -->
        ...
    </server>
</keeper_server>
```
Exception message before: `Syntax error: Not a valid integer: 2 `

Exception message now: `Syntax error: Not a valid integer: '2 '`

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Exceptions thrown when numbers cannot be parsed now have an easier-to-read exception message