### PR TITLE
Increase ddl timeout for DROP statement in backup restore tests

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -167,7 +167,7 @@ def test_concurrent_backups_on_different_nodes():
         f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}"
     )
     assert_eq_with_retry(
-        nodes[0],
+        nodes[1],
         f"SELECT status FROM system.backups WHERE status == 'BACKUP_CREATED' AND id = '{id}'",
         "BACKUP_CREATED",
     )

--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -82,10 +82,12 @@ def drop_after_test():
     try:
         yield
     finally:
-        node0.query("DROP TABLE IF EXISTS tbl ON CLUSTER 'cluster' NO DELAY",
-                    settings={
-                        "distributed_ddl_task_timeout": 360,
-                    })
+        node0.query(
+            "DROP TABLE IF EXISTS tbl ON CLUSTER 'cluster' NO DELAY",
+            settings={
+                "distributed_ddl_task_timeout": 360,
+            },
+        )
 
 
 backup_id_counter = 0
@@ -140,10 +142,12 @@ def test_concurrent_backups_on_same_node():
 
     # This restore part is added to confirm creating an internal backup & restore work
     # even when a concurrent backup is stopped
-    nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY",
-                   settings={
-                       "distributed_ddl_task_timeout": 360,
-                   })
+    nodes[0].query(
+        f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY",
+        settings={
+            "distributed_ddl_task_timeout": 360,
+        },
+    )
     nodes[0].query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
     nodes[0].query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
 
@@ -195,10 +199,12 @@ def test_concurrent_restores_on_same_node():
         "BACKUP_CREATED",
     )
 
-    nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY",
-                   settings={
-                       "distributed_ddl_task_timeout": 360,
-                   })
+    nodes[0].query(
+        f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY",
+        settings={
+            "distributed_ddl_task_timeout": 360,
+        },
+    )
     restore_id = (
         nodes[0]
         .query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")
@@ -236,10 +242,12 @@ def test_concurrent_restores_on_different_node():
         "BACKUP_CREATED",
     )
 
-    nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY",
-                   settings={
-                       "distributed_ddl_task_timeout": 360,
-                   })
+    nodes[0].query(
+        f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY",
+        settings={
+            "distributed_ddl_task_timeout": 360,
+        },
+    )
     restore_id = (
         nodes[0]
         .query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")

--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -82,8 +82,10 @@ def drop_after_test():
     try:
         yield
     finally:
-        node0.query("DROP TABLE IF EXISTS tbl ON CLUSTER 'cluster' NO DELAY")
-        node0.query("DROP DATABASE IF EXISTS mydb ON CLUSTER 'cluster' NO DELAY")
+        node0.query("DROP TABLE IF EXISTS tbl ON CLUSTER 'cluster' NO DELAY",
+                    settings={
+                        "distributed_ddl_task_timeout": 360,
+                    })
 
 
 backup_id_counter = 0
@@ -138,7 +140,10 @@ def test_concurrent_backups_on_same_node():
 
     # This restore part is added to confirm creating an internal backup & restore work
     # even when a concurrent backup is stopped
-    nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY")
+    nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY",
+                   settings={
+                       "distributed_ddl_task_timeout": 360,
+                   })
     nodes[0].query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
     nodes[0].query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
 
@@ -158,8 +163,13 @@ def test_concurrent_backups_on_different_nodes():
         f"SELECT status FROM system.backups WHERE status == 'CREATING_BACKUP' AND id = '{id}'",
         "CREATING_BACKUP",
     )
-    assert "Concurrent backups not supported" in nodes[2].query_and_get_error(
+    assert "Concurrent backups not supported" in nodes[0].query_and_get_error(
         f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}"
+    )
+    assert_eq_with_retry(
+        nodes[0],
+        f"SELECT status FROM system.backups WHERE status == 'BACKUP_CREATED' AND id = '{id}'",
+        "BACKUP_CREATED",
     )
 
 
@@ -185,7 +195,10 @@ def test_concurrent_restores_on_same_node():
         "BACKUP_CREATED",
     )
 
-    nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY")
+    nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY",
+                   settings={
+                       "distributed_ddl_task_timeout": 360,
+                   })
     restore_id = (
         nodes[0]
         .query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")
@@ -223,7 +236,10 @@ def test_concurrent_restores_on_different_node():
         "BACKUP_CREATED",
     )
 
-    nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY")
+    nodes[0].query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY",
+                   settings={
+                       "distributed_ddl_task_timeout": 360,
+                   })
     restore_id = (
         nodes[0]
         .query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name} ASYNC")


### PR DESCRIPTION
Changelog category (leave one):
* Not for changelog (changelog entry is not required)

Increased ddl timeout during DROP of table and updated node for concurrent backups on different node