### PR TITLE
Add a warning to the schema_inference_hints

### DIFF
--- a/docs/en/operations/settings/settings-formats.md
+++ b/docs/en/operations/settings/settings-formats.md
@@ -142,6 +142,10 @@ y	Nullable(String)
 z	IPv4
 ```
 
+:::warning
+If the `schema_inference_hints` is not formated properly, or if there is a typo or a wrong datatype, etc... the whole schema_inference_hints will be ignored.
+:::
+
 ## schema_inference_make_columns_nullable {#schema_inference_make_columns_nullable}
 
 Controls making inferred types `Nullable` in schema inference for formats without information about nullability.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Warned about the fact that schema_inference_hints can be discarded if it's ill-formatted. 