### PR TITLE
Preset description on the tweak reset

### DIFF
--- a/tests/ci/release.py
+++ b/tests/ci/release.py
@@ -273,7 +273,9 @@ class Release:
         self, version: ClickHouseVersion, reset_tweak: bool = True
     ) -> None:
         if reset_tweak:
+            desc = version.description
             version = version.reset_tweak()
+            version.with_description(desc)
         update_cmake_version(version)
         update_contributors(raise_error=True)
         if self.dry_run:

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -58,6 +58,7 @@ class ClickHouseVersion:
         elif self._git is not None:
             self._tweak = self._git.tweak
         self._describe = ""
+        self._description = ""
 
     def update(self, part: Literal["major", "minor", "patch"]) -> "ClickHouseVersion":
         """If part is valid, returns a new version"""
@@ -126,6 +127,10 @@ class ClickHouseVersion:
         return self._describe
 
     @property
+    def description(self) -> str:
+        return self._description
+
+    @property
     def string(self):
         return ".".join(
             (str(self.major), str(self.minor), str(self.patch), str(self.tweak))
@@ -149,6 +154,7 @@ class ClickHouseVersion:
     def with_description(self, version_type):
         if version_type not in VersionType.VALID:
             raise ValueError(f"version type {version_type} not in {VersionType.VALID}")
+        self._description = version_type
         self._describe = f"v{self.string}-{version_type}"
 
     def __eq__(self, other: Any) -> bool:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the bug in the `reset_tweak` that broke the script completely.