### PR TITLE
Change the cherry-pick PR body

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -52,7 +52,7 @@ class Labels:
 
 
 class ReleaseBranch:
-    CHERRYPICK_DESCRIPTION = """This pull-request is a first step of an automated \
+    CHERRYPICK_DESCRIPTION = f"""This pull-request is a first step of an automated \
     backporting.
 It contains changes like after calling a local command `git cherry-pick`.
 If you intend to continue backporting this changes, then resolve all conflicts if any.
@@ -60,13 +60,16 @@ Otherwise, if you do not want to backport them, then just close this pull-reques
 
 The check results does not matter at this step - you can safely ignore them.
 Also this pull-request will be merged automatically as it reaches the mergeable state, \
-    but you always can merge it manually.
+**do not merge it manually**.
+
+If it stuck, check the original PR for `{Labels.BACKPORTS_CREATED}` and delete it if \
+necessary.
 """
     BACKPORT_DESCRIPTION = """This pull-request is a last step of an automated \
 backporting.
 Treat it as a standard pull-request: look at the checks and resolve conflicts.
 Merge it only if you intend to backport changes to the target branch, otherwise just \
-    close it.
+close it.
 """
     REMOTE = ""
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Change the body of cherry-pick PRs, they are not supposed to be merged manually.