### PR TITLE
Use /etc/default/clickhouse in systemd too

### DIFF
--- a/packages/clickhouse-server.service
+++ b/packages/clickhouse-server.service
@@ -24,6 +24,8 @@ RuntimeDirectory=%p
 ExecStart=/usr/bin/clickhouse-server --config=/etc/clickhouse-server/config.xml --pid-file=%t/%p/%p.pid
 # Minus means that this file is optional.
 EnvironmentFile=-/etc/default/%p
+# Bring back /etc/default/clickhouse for backward compatibility
+EnvironmentFile=-/etc/default/clickhouse
 LimitCORE=infinity
 LimitNOFILE=500000
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_IPC_LOCK CAP_SYS_NICE CAP_NET_BIND_SERVICE


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The `/etc/default/clickhouse` file was accidentally replaced by `/etc/default/clickhouse-server` in #45568. Bring it back