### PR TITLE
Restricting test runs section in docs

### DIFF
--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -39,11 +39,43 @@ To add new test, create a `.sql` or `.sh` file in `queries/0_stateless` director
 
 Tests should use (create, drop, etc) only tables in `test` database that is assumed to be created beforehand; also tests can use temporary tables.
 
+### Restricting test runs
+
+A test can have one or more _test tags_ specifying restrictions for test runs.
+
+For `.sh` tests tags are placed in `.sh` files as comments, example:
+
+```bash
+#!/usr/bin/env bash
+# Tags: no-fasttest
+```
+
+For `.sql` tests tags are placed as SQL comments, example: 
+
+```sql
+-- Tags: no-fasttest
+SELECT 1
+```
+
+|Tag name | What it does | Usage example |
+|---|---|---|
+| `no-fasttest`|  Test is not run under [Fast test](continuous-integration#fast-test) | Test uses MySQL table engine which is disabled in Fast test|
+| `zookeeper` | Test requires Zookeeper or ClickHouse Keeper to run ||
+| `long` | Test's execution time is extended to 10 minutes ||
+| `no-replicated-database` |||
+| `no-parallel` |||
+| `distributed` |||
+| `no-random-settings` |||
+| `no-backward-compatibility-check` |||
+| `no-cpu-x86_64` |||
+| `no-cpu-aarch64` |||
+
+In addition to the above settings, you can use `USE_*` flags from `system.build_options` to define usage of particular ClickHouse features.
+For example, if your test uses a MySQL table, you should add a tag `use-mysql`.
+
 ### Choosing the Test Name
 
 The name of the test starts with a five-digit prefix followed by a descriptive name, such as `00422_hash_function_constexpr.sql`. To choose the prefix, find the largest prefix already present in the directory, and increment it by one. In the meantime, some other tests might be added with the same numeric prefix, but this is OK and does not lead to any problems, you don't have to change it later.
-
-Some tests are marked with `zookeeper`, `shard` or `long` in their names. `zookeeper` is for tests that are using ZooKeeper. `shard` is for tests that requires server to listen `127.0.0.*`; `distributed` or `global` have the same meaning. `long` is for tests that run slightly longer that one second. You can disable these groups of tests using `--no-zookeeper`, `--no-shard` and `--no-long` options, respectively. Make sure to add a proper prefix to your test name if it needs ZooKeeper or distributed queries.
 
 ### Checking for an Error that Must Occur
 

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -60,21 +60,23 @@ SELECT 1
 |Tag name | What it does | Usage example |
 |---|---|---|
 | `disabled`|  Test is not run ||
-| `long` | Test's execution time is extended to 10 minutes ||
-| `race` |||
-| `replica` |||
-| `shard` |||
-| `distributed` |||
-| `deadlock` |||
-| `global` |||
+| `long` | Test's execution time is extended from 1 to 10 minutes ||
+| `deadlock` | Test tests a possible deadlock or race, so it's run in a loop for a long time ||
+| `race` | Same as `deadlock`. Prefer `deadlock` ||
+| `shard` | Server is required to listen to `127.0.0.*` ||
+| `distributed` | Same as `shard`. Prefer `shard` ||
+| `global` | Same as `shard`. Prefer `shard` ||
 | `zookeeper` | Test requires Zookeeper or ClickHouse Keeper to run | Test uses `ReplicatedMergeTree` |
+| `replica` | Same as `zookeeper`. Prefer `zookeeper` ||
 | `no-fasttest`|  Test is not run under [Fast test](continuous-integration#fast-test) | Test uses `MySQL` table engine which is disabled in Fast test|
+| `no-[asan, tsan, msan, ubsan]` | Disables tests in build with [sanitizers](#sanitizers) | Test is run under QEMU which doesn't work with sanitizers |
 | `no-replicated-database` |||
 | `no-ordinary-database` |||
 | `no-parallel` | Disables running other tests in parallel with this one | Test reads from `system` tables and invariants may be broken|
+| `no-parallel-replicas` |||
 | `no-debug` |||
-| `no-polymorphic-parts` |||
 | `no-stress` |||
+| `no-polymorphic-parts` |||
 | `no-random-settings` |||
 | `no-random-merge-tree-settings` |||
 | `no-backward-compatibility-check` |||
@@ -82,7 +84,6 @@ SELECT 1
 | `no-cpu-aarch64` |||
 | `no-cpu-ppc64le` |||
 | `no-s3-storage` |||
-| `no-[asan, tsan, msan, ubsan]` | Disables tests in build with [sanitizers](#sanitizers) | Test is run under QEMU which doesn't work with sanitizers |
 
 In addition to the above settings, you can use `USE_*` flags from `system.build_options` to define usage of particular ClickHouse features.
 For example, if your test uses a MySQL table, you should add a tag `use-mysql`.

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -61,7 +61,7 @@ SELECT 1
 |---|---|---|
 | `disabled`|  Test is not run ||
 | `long` | Test's execution time is extended from 1 to 10 minutes ||
-| `deadlock` | Test tests a possible deadlock or race, so it's run in a loop for a long time ||
+| `deadlock` | Test is run in a loop for a long time ||
 | `race` | Same as `deadlock`. Prefer `deadlock` ||
 | `shard` | Server is required to listen to `127.0.0.*` ||
 | `distributed` | Same as `shard`. Prefer `shard` ||

--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -41,16 +41,16 @@ Tests should use (create, drop, etc) only tables in `test` database that is assu
 
 ### Restricting test runs
 
-A test can have one or more _test tags_ specifying restrictions for test runs.
+A test can have zero or more _test tags_ specifying restrictions for test runs.
 
-For `.sh` tests tags are placed in `.sh` files as comments, example:
+For `.sh` tests tags are written as a comment on the second line:
 
 ```bash
 #!/usr/bin/env bash
 # Tags: no-fasttest
 ```
 
-For `.sql` tests tags are placed as SQL comments, example: 
+For `.sql` tests tags are placed in the first line as a SQL comment:
 
 ```sql
 -- Tags: no-fasttest
@@ -59,16 +59,30 @@ SELECT 1
 
 |Tag name | What it does | Usage example |
 |---|---|---|
-| `no-fasttest`|  Test is not run under [Fast test](continuous-integration#fast-test) | Test uses MySQL table engine which is disabled in Fast test|
-| `zookeeper` | Test requires Zookeeper or ClickHouse Keeper to run ||
+| `disabled`|  Test is not run ||
 | `long` | Test's execution time is extended to 10 minutes ||
-| `no-replicated-database` |||
-| `no-parallel` |||
+| `race` |||
+| `replica` |||
+| `shard` |||
 | `distributed` |||
+| `deadlock` |||
+| `global` |||
+| `zookeeper` | Test requires Zookeeper or ClickHouse Keeper to run | Test uses `ReplicatedMergeTree` |
+| `no-fasttest`|  Test is not run under [Fast test](continuous-integration#fast-test) | Test uses `MySQL` table engine which is disabled in Fast test|
+| `no-replicated-database` |||
+| `no-ordinary-database` |||
+| `no-parallel` | Disables running other tests in parallel with this one | Test reads from `system` tables and invariants may be broken|
+| `no-debug` |||
+| `no-polymorphic-parts` |||
+| `no-stress` |||
 | `no-random-settings` |||
+| `no-random-merge-tree-settings` |||
 | `no-backward-compatibility-check` |||
 | `no-cpu-x86_64` |||
 | `no-cpu-aarch64` |||
+| `no-cpu-ppc64le` |||
+| `no-s3-storage` |||
+| `no-[asan, tsan, msan, ubsan]` | Disables tests in build with [sanitizers](#sanitizers) | Test is run under QEMU which doesn't work with sanitizers |
 
 In addition to the above settings, you can use `USE_*` flags from `system.build_options` to define usage of particular ClickHouse features.
 For example, if your test uses a MySQL table, you should add a tag `use-mysql`.

--- a/utils/check-style/aspell-ignore/en/aspell-dict.txt
+++ b/utils/check-style/aspell-ignore/en/aspell-dict.txt
@@ -56,6 +56,7 @@ Hostname
 IPv
 IntN
 Integrations
+invariants
 JSONAsString
 JSONAsObject
 JSONColumns
@@ -130,6 +131,7 @@ ProtobufSingle
 QTCreator
 QueryCacheHits
 QueryCacheMisses
+QEMU
 RBAC
 RawBLOB
 RedHat


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

Browse used tags: `ag "Tags: .*$" tests/queries/0_stateless --nofilename | cut -d: -f2 | tr ',' '\n' | sort | uniq`