### PR TITLE
Table function null default table structure

### DIFF
--- a/src/TableFunctions/TableFunctionNull.cpp
+++ b/src/TableFunctions/TableFunctionNull.cpp
@@ -44,6 +44,9 @@ StoragePtr TableFunctionNull::executeImpl(const ASTPtr & /*ast_function*/, Conte
         columns = getActualTableStructure(context);
     else if (!structure_hint.empty())
         columns = structure_hint;
+    else
+        columns = default_structure;
+
     auto res = std::make_shared<StorageNull>(StorageID(getDatabaseName(), table_name), columns, ConstraintsDescription(), String{});
     res->startup();
     return res;

--- a/src/TableFunctions/TableFunctionNull.cpp
+++ b/src/TableFunctions/TableFunctionNull.cpp
@@ -34,14 +34,16 @@ void TableFunctionNull::parseArguments(const ASTPtr & ast_function, ContextPtr c
 
 ColumnsDescription TableFunctionNull::getActualTableStructure(ContextPtr context) const
 {
-    return parseColumnsListFromString(structure, context);
+    if (structure != "auto")
+        return parseColumnsListFromString(structure, context);
+    return default_structure;
 }
 
 StoragePtr TableFunctionNull::executeImpl(const ASTPtr & /*ast_function*/, ContextPtr context, const std::string & table_name, ColumnsDescription /*cached_columns*/) const
 {
     ColumnsDescription columns;
     if (structure != "auto")
-        columns = getActualTableStructure(context);
+        columns = parseColumnsListFromString(structure, context);
     else if (!structure_hint.empty())
         columns = structure_hint;
     else

--- a/src/TableFunctions/TableFunctionNull.h
+++ b/src/TableFunctions/TableFunctionNull.h
@@ -21,6 +21,7 @@ public:
     bool needStructureHint() const override { return structure == "auto"; }
 
     void setStructureHint(const ColumnsDescription & structure_hint_) override { structure_hint = structure_hint_; }
+
 private:
     StoragePtr executeImpl(const ASTPtr & ast_function, ContextPtr context, const String & table_name, ColumnsDescription cached_columns) const override;
     const char * getStorageTypeName() const override { return "Null"; }

--- a/src/TableFunctions/TableFunctionNull.h
+++ b/src/TableFunctions/TableFunctionNull.h
@@ -32,6 +32,6 @@ private:
     String structure = "auto";
     ColumnsDescription structure_hint;
 
-    ColumnsDescription default_structure = ColumnsDescription{NamesAndTypesList{{"dummy", std::make_shared<DataTypeUInt8>()}}};
+    const ColumnsDescription default_structure{NamesAndTypesList{{"dummy", std::make_shared<DataTypeUInt8>()}}};
 };
 }

--- a/src/TableFunctions/TableFunctionNull.h
+++ b/src/TableFunctions/TableFunctionNull.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <TableFunctions/ITableFunction.h>
 #include <Core/Types.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <TableFunctions/ITableFunction.h>
 
 
 namespace DB
@@ -29,6 +30,7 @@ private:
 
     String structure = "auto";
     ColumnsDescription structure_hint;
-};
 
+    ColumnsDescription default_structure = ColumnsDescription{NamesAndTypesList{{"dummy", std::make_shared<DataTypeUInt8>()}}};
+};
 }

--- a/tests/queries/0_stateless/02164_clickhouse_local_interactive_exception.expect
+++ b/tests/queries/0_stateless/02164_clickhouse_local_interactive_exception.expect
@@ -17,7 +17,7 @@ spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_LOCAL  --disabl
 
 expect ":) "
 send -- "insert into table function null() format TSV some trash here 123 \n 456\r"
-expect "EMPTY_LIST_OF_COLUMNS_PASSED"
+expect "CANNOT_PARSE_INPUT_ASSERTION_FAILED"
 expect ":) "
 
 send -- ""

--- a/tests/queries/0_stateless/02674_null_default_structure.reference
+++ b/tests/queries/0_stateless/02674_null_default_structure.reference
@@ -1,0 +1,1 @@
+dummy	UInt8					

--- a/tests/queries/0_stateless/02674_null_default_structure.sql
+++ b/tests/queries/0_stateless/02674_null_default_structure.sql
@@ -1,0 +1,1 @@
+SELECT * FROM null();

--- a/tests/queries/0_stateless/02674_null_default_structure.sql
+++ b/tests/queries/0_stateless/02674_null_default_structure.sql
@@ -1,2 +1,3 @@
 SELECT * FROM null();
 DESCRIBE null();
+insert into table function  null() select 1, 'str';

--- a/tests/queries/0_stateless/02674_null_default_structure.sql
+++ b/tests/queries/0_stateless/02674_null_default_structure.sql
@@ -1,1 +1,2 @@
 SELECT * FROM null();
+DESCRIBE null();


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use `dummy UInt8` for default structure of table function `null`. Closes https://github.com/ClickHouse/ClickHouse/issues/46930