### PR TITLE
Temporary enable force_sync for keeper in CI

### DIFF
--- a/tests/config/config.d/keeper_port.xml
+++ b/tests/config/config.d/keeper_port.xml
@@ -9,7 +9,8 @@
             <operation_timeout_ms>10000</operation_timeout_ms>
             <session_timeout_ms>100000</session_timeout_ms>
             <min_session_timeout_ms>10000</min_session_timeout_ms>
-            <force_sync>false</force_sync>
+            <!-- FIXME enable force_sync because of suspicious rollback without it -->
+            <force_sync>true</force_sync>
             <startup_timeout>240000</startup_timeout>
             <!-- we want all logs for complex problems investigation -->
             <reserved_log_items>1000000000000000</reserved_log_items>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
