### PR TITLE
drive mat views off capable table functions

### DIFF
--- a/tests/integration/test_executable_mat_view/test.py
+++ b/tests/integration/test_executable_mat_view/test.py
@@ -1,0 +1,62 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", stay_alive=True, main_configs=[])
+
+
+def skip_test_msan(instance):
+    if instance.is_built_with_memory_sanitizer():
+        pytest.skip("Memory Sanitizer cannot work with vfork")
+
+
+def copy_file_to_container(local_path, dist_path, container_id):
+    os.system(
+        "docker cp {local} {cont_id}:{dist}".format(
+            local=local_path, cont_id=container_id, dist=dist_path
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+
+        copy_file_to_container(
+            os.path.join(SCRIPT_DIR, "user_scripts/."),
+            "/var/lib/clickhouse/user_scripts",
+            node.docker_id,
+        )
+        node.restart_clickhouse()
+
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_executable_mat_view_input_python(started_cluster):
+    skip_test_msan(node)
+
+    node.query("CREATE TABLE test_data_table (id UInt64) ENGINE=TinyLog;")
+    node.query("CREATE TABLE input_result_ (value String) ENGINE=TinyLog;")
+
+    node.query(
+        "CREATE MATERIALIZED VIEW input_result TO input_result_ AS "
+        "SELECT * FROM executable('input.py', 'TabSeparated', 'value String', (SELECT id FROM test_data_table))"
+    )
+
+    node.query("INSERT INTO test_data_table VALUES (0), (1), (2);")
+
+    assert node.query("SELECT value FROM input_result") == "Key 0\nKey 1\nKey 2\n"
+
+    node.query("DROP TABLE test_data_table")
+    node.query("DROP TABLE input_result_")

--- a/tests/integration/test_executable_mat_view/user_scripts/input.py
+++ b/tests/integration/test_executable_mat_view/user_scripts/input.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python3
+
+import sys
+
+if __name__ == "__main__":
+    for line in sys.stdin:
+        print("Key " + line, end="")
+        sys.stdout.flush()


### PR DESCRIPTION
some table functions:

- executable
- view

have a real sub-select query as a dependency
these a pretty much good for driving mat views

this commit will add support for mat views derived from these table functions

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support materialized views from some table functions: executable, view

### Documentation entry for user-facing changes

Motivation: 
Some table engines have a subquery as a dependency, ex. `(SELECT ... FROM table ...)`
These are pretty good candidates for MATERIALIZED VIEW as view can be driven from these tables.
Yet currently all table functions are forbidden to participate in MATERIALIZED VIEW

Solution:
Support these table functions (including future ones) as a MATERIALIZED VIEW dependency.
Essentially just a new directive to parser to search for good candidates inside.

Example:

```
CREATE MATERIALIZED VIEW view1 AS executable('test.py', 'value String', (SELECT * FROM table1));
```