### PR TITLE
[RFC] Fix rare intersecting parts in case of errors during handling broken parts

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -59,6 +59,26 @@ void ReplicatedMergeTreeQueue::setBrokenPartsToEnqueueFetchesOnLoading(Strings &
     assert(virtual_parts.size() == 0);
     broken_parts_to_enqueue_fetches_on_loading = std::move(parts_to_fetch);
 }
+void ReplicatedMergeTreeQueue::addBrokenPartToEnqueueFetchesOnLoading(const String & part)
+{
+    std::lock_guard lock(state_mutex);
+    chassert(std::find(
+        broken_parts_to_enqueue_fetches_on_loading.begin(),
+        broken_parts_to_enqueue_fetches_on_loading.end(),
+        part) == broken_parts_to_enqueue_fetches_on_loading.end());
+    broken_parts_to_enqueue_fetches_on_loading.push_back(part);
+}
+void ReplicatedMergeTreeQueue::removeBrokenPartFromEnqueueFetchesOnLoading(const String & part)
+{
+    std::lock_guard lock(state_mutex);
+    size_t erased = std::erase(broken_parts_to_enqueue_fetches_on_loading, part);
+    chassert(erased > 0);
+}
+Strings ReplicatedMergeTreeQueue::getBrokenPartsEnqueuedForForFetches()
+{
+    std::lock_guard lock(state_mutex);
+    return broken_parts_to_enqueue_fetches_on_loading;
+}
 
 void ReplicatedMergeTreeQueue::initialize(zkutil::ZooKeeperPtr zookeeper)
 {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -481,8 +481,13 @@ public:
     /// We need loaded queue to create GET_PART entry for broken (or missing) part,
     /// but queue is not loaded yet on data parts loading.
     void setBrokenPartsToEnqueueFetchesOnLoading(Strings && parts_to_fetch);
+    /// This is to temporary add a part to a list of broken parts while
+    /// manipulating parts on disk and in coordinator.
+    void addBrokenPartToEnqueueFetchesOnLoading(const String & part);
+    void removeBrokenPartFromEnqueueFetchesOnLoading(const String & part);
     /// Must be called right after queue loading.
     void createLogEntriesToFetchBrokenParts();
+    Strings getBrokenPartsEnqueuedForForFetches();
 };
 
 class ReplicatedMergeTreeMergePredicate

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -3488,22 +3488,6 @@ void StorageReplicatedMergeTree::getRemovePartFromZooKeeperOps(const String & pa
     ops.emplace_back(zkutil::makeRemoveRequest(part_path, -1));
 }
 
-void StorageReplicatedMergeTree::removePartFromZooKeeper(const String & part_name)
-{
-    auto zookeeper = getZooKeeper();
-    String part_path = fs::path(replica_path) / "parts" / part_name;
-    Coordination::Stat stat;
-
-    /// Part doesn't exist, nothing to remove
-    if (!zookeeper->exists(part_path, &stat))
-        return;
-
-    Coordination::Requests ops;
-
-    getRemovePartFromZooKeeperOps(part_name, ops, stat.numChildren > 0);
-    zookeeper->multi(ops);
-}
-
 void StorageReplicatedMergeTree::removePartAndEnqueueFetch(const String & part_name, bool storage_init)
 {
     auto zookeeper = getZooKeeper();

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -543,9 +543,6 @@ private:
     /// Set has_children to true for "old-style" parts (those with /columns and /checksums child znodes).
     void getRemovePartFromZooKeeperOps(const String & part_name, Coordination::Requests & ops, bool has_children);
 
-    /// Just removes part from ZooKeeper using previous method
-    void removePartFromZooKeeper(const String & part_name);
-
     /// Quickly removes big set of parts from ZooKeeper (using async multi queries)
     void removePartsFromZooKeeper(zkutil::ZooKeeperPtr & zookeeper, const Strings & part_names,
                                   NameSet * parts_should_be_retried = nullptr);

--- a/tests/queries/0_stateless/02369_lost_part_intersecting_merges.sh
+++ b/tests/queries/0_stateless/02369_lost_part_intersecting_merges.sh
@@ -8,8 +8,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT -q "drop table if exists rmt1 sync;"
 $CLICKHOUSE_CLIENT -q "drop table if exists rmt2 sync;"
 
-$CLICKHOUSE_CLIENT -q "create table rmt1 (n int) engine=ReplicatedMergeTree('/test/02369/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/{database}', '1') order by n;"
-$CLICKHOUSE_CLIENT -q "create table rmt2 (n int) engine=ReplicatedMergeTree('/test/02369/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/{database}', '2') order by n;"
+$CLICKHOUSE_CLIENT -q "create table rmt1 (n int) engine=ReplicatedMergeTree('/test/02369/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/{database}', '1') order by n settings cleanup_delay_period=1, cleanup_delay_period_random_add=0;"
+$CLICKHOUSE_CLIENT -q "create table rmt2 (n int) engine=ReplicatedMergeTree('/test/02369/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/{database}', '2') order by n settings cleanup_delay_period=1, cleanup_delay_period_random_add=0;"
 
 $CLICKHOUSE_CLIENT --insert_keeper_fault_injection_probability=0 -q "insert into rmt1 values (1);"
 $CLICKHOUSE_CLIENT --insert_keeper_fault_injection_probability=0 -q "insert into rmt1 values (2);"


### PR DESCRIPTION
_I came across similar issues (`Intersecting parts`) in production, hence decided to dig into the problem_

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

### Documentation entry for user-facing changes
Fix rare intersecting parts in case of errors during handling broken parts

Before this patch it was possible that session expired error during handling broken parts could lead to intersecting parts.

Here is what CI had been found [1] (with some additional clarifications in the comments):

    # Here all_0_1_1 is a broken part that had been created by 02369_lost_part_intersecting_merges
    2022.12.31 05:13:22.687083 [ 1775 ] {} <Trace> test_5yo19yin.rmt1 (ReplicatedMergeTreePartCheckThread): Part all_0_1_1 in zookeeper: true, locally: true
    2022.12.31 05:13:22.801196 [ 1775 ] {} <Error> test_5yo19yin.rmt1 (ReplicatedMergeTreePartCheckThread): Part all_0_1_1 looks broken. Removing it and will try to fetch.
    2022.12.31 05:13:22.801230 [ 1775 ] {} <Information> test_5yo19yin.rmt1: Cloning part all_0_1_1 to broken_all_0_1_1 and making it obsolete.
    2022.12.31 05:13:22.805492 [ 1775 ] {} <Test> VersionMetadata: Trying to lock removal_tid by (1, 1, 00000000-0000-0000-0000-000000000000), table: test_5yo19yin.rmt1, part: all_0_1_1
    2022.12.31 05:13:22.805562 [ 1775 ] {} <Warning> test_5yo19yin.rmt1 (ReplicatedMergeTreePartCheckThread): Checking if anyone has a part all_0_1_1 or covering part.
    2022.12.31 05:13:22.886463 [ 1775 ] {} <Error> test_5yo19yin.rmt1 (ReplicatedMergeTreePartCheckThread): void DB::ReplicatedMergeTreePartCheckThread::run(): Code: 999. Coordination::Exception: Session expired, path: Session expired. (KEEPER_EXCEPTION), Stack trace (when copying this message, always include the lines below):
    ..
    # Some error happened during handling this broken part, normal log:
    # 2023.02.28 19:54:18.168792 [ 2912 ] {} <Information> test_tc42qyhv.rmt1 (ReplicatedMergeTreePartCheckThread): Found parts with the same min block and with the same max block as the missing part all_0_1_1 on replica 2. Hoping that it will eventually appear as a result of a merge. Parts: all_0_0_0, all_1_1_0
    # 2023.02.28 19:54:18.168801 [ 2912 ] {} <Warning> test_tc42qyhv.rmt1 (ReplicatedMergeTreePartCheckThread): Part all_0_1_1 exists in ZooKeeper but not locally and not found on other replica. Removing it from ZooKeeper.
    # 2023.02.28 19:54:18.168811 [ 2912 ] {} <Debug> test_tc42qyhv.rmt1 (ReplicatedMergeTreeQueue): Removed 0 entries from queue. Waiting for 0 entries that are currently executing.
    # 2023.02.28 19:54:18.169625 [ 2912 ] {} <Trace> test_tc42qyhv.rmt1 (ReplicatedMergeTreeQueue): Insert entry queue-0000000003 to queue with type GET_PART with virtual parts [all_0_1_1]

    # and after ATTACH:
    2022.12.31 05:13:22.926378 [ 1821 ] {} <Trace> test_5yo19yin.rmt1 (ReplicatedMergeTreeQueue): Initializing parts in queue
    2022.12.31 05:13:22.926554 [ 1821 ] {} <Test> test_5yo19yin.rmt1 (ReplicatedMergeTreeQueue): Adding part all_0_0_0 to current and virtual parts
    2022.12.31 05:13:22.926577 [ 1821 ] {} <Test> test_5yo19yin.rmt1 (ReplicatedMergeTreeQueue): Adding part all_1_1_0 to current and virtual parts
    2022.12.31 05:13:22.926600 [ 1821 ] {} <Test> test_5yo19yin.rmt1 (ReplicatedMergeTreeQueue): Adding part all_0_1_1 to current and virtual parts # Here we still have part
    ...
    # But here it will been removed from ZooKeeper and no this replica nothing knows about this part and can schedule an incorrect merge, i.e. all_0_2_1
    2022.12.31 05:13:22.929130 [ 1732 ] {} <Trace> test_5yo19yin.rmt1: Found 1 old parts to remove. Parts: [all_0_1_1]
    2022.12.31 05:13:22.936244 [ 1732 ] {} <Debug> test_5yo19yin.rmt1: Removing 1 old parts from ZooKeeper
    ...
    2022.12.31 05:13:24.013627 [ 8170 ] {773f11e2-6c61-4ea2-9955-47fa14e67cc3} <Trace> test_5yo19yin.rmt1: Created log entry /test/02369/02369_lost_part_intersecting_merges_test_5yo19yin/test_5yo19yin/log/log-0000000004 for merge all_0_2_1
    2022.12.31 05:14:03.325437 [ 1665 ] {test_5yo19yin.rmt1::all_0_2_1} <Trace> test_5yo19yin.rmt1 (MergerMutator): Merged 3 parts: [all_0_0_0, all_2_2_0] -> [] # WHY?
    ...
    2022.12.31 05:13:24.019988 [ 1760 ] {} <Fatal> : Logical error: 'Part all_0_2_1 intersects previous part all_0_1_1. It is a bug or a result of manual intervention in the ZooKeeper data.'.

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/44657/80ef5326d29fec05ba94837449b9e1658eb13fa7/stress_test__ubsan_.html

Fixes: #44845
Cc: @tavplubix 