### PR TITLE
Support `Bool` type in `JSONType` function.

### DIFF
--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -647,11 +647,12 @@ public:
             case ElementType::OBJECT:
                 type = '{';
                 break;
+            case ElementType::BOOL:
+                type = 'b';
+                break;
             case ElementType::NULL_VALUE:
                 type = 0;
                 break;
-            default:
-                return false;
         }
 
         ColumnVector<Int8> & col_vec = assert_cast<ColumnVector<Int8> &>(dest);

--- a/tests/queries/0_stateless/00918_json_functions.reference
+++ b/tests/queries/0_stateless/00918_json_functions.reference
@@ -19,6 +19,7 @@ a
 --JSONType--
 Object
 Array
+Bool
 --JSONExtract<numeric>--
 -100
 200
@@ -172,6 +173,7 @@ a
 --JSONType--
 Object
 Array
+Bool
 --JSONExtract<numeric>--
 -100
 200

--- a/tests/queries/0_stateless/00918_json_functions.sql
+++ b/tests/queries/0_stateless/00918_json_functions.sql
@@ -28,6 +28,7 @@ SELECT JSONKey('{"a": "hello", "b": [-100, 200.0, 300]}', -2);
 SELECT '--JSONType--';
 SELECT JSONType('{"a": "hello", "b": [-100, 200.0, 300]}');
 SELECT JSONType('{"a": "hello", "b": [-100, 200.0, 300]}', 'b');
+SELECT JSONType('{"a": true}', 'a');
 
 SELECT '--JSONExtract<numeric>--';
 SELECT JSONExtractInt('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', 1);
@@ -196,6 +197,7 @@ SELECT JSONKey('{"a": "hello", "b": [-100, 200.0, 300]}', -2);
 SELECT '--JSONType--';
 SELECT JSONType('{"a": "hello", "b": [-100, 200.0, 300]}');
 SELECT JSONType('{"a": "hello", "b": [-100, 200.0, 300]}', 'b');
+SELECT JSONType('{"a": true}', 'a');
 
 SELECT '--JSONExtract<numeric>--';
 SELECT JSONExtractInt('{"a": "hello", "b": [-100, 200.0, 300]}', 'b', 1);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support `Bool` type in `JSONType` function. Previously `Null` type was mistakenly returned for bool values.
