### PR TITLE
Terminate long-running offline non-busy runners in EC2

### DIFF
--- a/tests/ci/terminate_runner_lambda/app.py
+++ b/tests/ci/terminate_runner_lambda/app.py
@@ -64,19 +64,25 @@ def list_runners(access_token: str) -> RunnerDescriptions:
         "Authorization": f"token {access_token}",
         "Accept": "application/vnd.github.v3+json",
     }
+    per_page = 100
     response = requests.get(
-        "https://api.github.com/orgs/ClickHouse/actions/runners?per_page=100",
+        f"https://api.github.com/orgs/ClickHouse/actions/runners?per_page={per_page}",
         headers=headers,
     )
     response.raise_for_status()
     data = response.json()
     total_runners = data["total_count"]
+    print("Expected total runners", total_runners)
     runners = data["runners"]
 
-    total_pages = int(total_runners / 100 + 1)
+    # round to 0 for 0, 1 for 1..100, but to 2 for 101..200
+    total_pages = (total_runners - 1) // per_page + 1
+
+    print("Total pages", total_pages)
     for i in range(2, total_pages + 1):
         response = requests.get(
-            f"https://api.github.com/orgs/ClickHouse/actions/runners?page={i}&per_page=100",
+            "https://api.github.com/orgs/ClickHouse/actions/runners"
+            f"?page={i}&per_page={per_page}",
             headers=headers,
         )
         response.raise_for_status()
@@ -95,6 +101,7 @@ def list_runners(access_token: str) -> RunnerDescriptions:
             busy=runner["busy"],
         )
         result.append(desc)
+
     return result
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Terminate long-term offline runners in EC2; additionally, search for non-busy runners in the same ASG as requested to termination lambda; fix lambda by reducing the invoke time to 1.5s.