### PR TITLE
use http request body in predefined http handlers

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -712,6 +712,7 @@ class IColumn;
     M(Float, insert_keeper_fault_injection_probability, 0.0f, "Approximate probability of failure for a keeper request during insert. Valid value is in interval [0.0f, 1.0f]", 0) \
     M(UInt64, insert_keeper_fault_injection_seed, 0, "0 - random seed, otherwise the setting value", 0) \
     M(Bool, force_aggregation_in_order, false, "Force use of aggregation in order on remote nodes during distributed aggregation. PLEASE, NEVER CHANGE THIS SETTING VALUE MANUALLY!", IMPORTANT) \
+    M(UInt64, http_max_request_param_data_size, 10_MiB, "Limit on size of request data used as a query parameter in predefined HTTP requests.", 0) \
     // End of COMMON_SETTINGS
     // Please add settings related to formats into the FORMAT_FACTORY_SETTINGS and move obsolete settings to OBSOLETE_SETTINGS.
 

--- a/src/IO/copyData.cpp
+++ b/src/IO/copyData.cpp
@@ -10,6 +10,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ATTEMPT_TO_READ_AFTER_EOF;
+    extern const int CANNOT_READ_ALL_DATA;
 }
 
 namespace
@@ -89,6 +90,13 @@ void copyData(ReadBuffer & from, WriteBuffer & to, size_t bytes, const std::atom
 void copyData(ReadBuffer & from, WriteBuffer & to, size_t bytes, std::function<void()> cancellation_hook)
 {
     copyDataImpl(from, to, true, bytes, cancellation_hook, nullptr);
+}
+
+void copyDataMaxBytes(ReadBuffer & from, WriteBuffer & to, size_t max_bytes)
+{
+    copyDataImpl(from, to, false, max_bytes, nullptr, nullptr);
+    if (!from.eof())
+        throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Cannot read all data, max readable size reached.");
 }
 
 void copyDataWithThrottler(ReadBuffer & from, WriteBuffer & to, const std::atomic<int> & is_cancelled, ThrottlerPtr throttler)

--- a/src/IO/copyData.h
+++ b/src/IO/copyData.h
@@ -27,6 +27,9 @@ void copyData(ReadBuffer & from, WriteBuffer & to, size_t bytes, const std::atom
 void copyData(ReadBuffer & from, WriteBuffer & to, std::function<void()> cancellation_hook);
 void copyData(ReadBuffer & from, WriteBuffer & to, size_t bytes, std::function<void()> cancellation_hook);
 
+/// Copies at most `max_bytes` bytes from ReadBuffer to WriteBuffer. If there are more bytes, then throws an exception.
+void copyDataMaxBytes(ReadBuffer & from, WriteBuffer & to, size_t max_bytes);
+
 /// Same as above but also use throttler to limit maximum speed
 void copyDataWithThrottler(ReadBuffer & from, WriteBuffer & to, const std::atomic<int> & is_cancelled, ThrottlerPtr throttler);
 void copyDataWithThrottler(ReadBuffer & from, WriteBuffer & to, size_t bytes, const std::atomic<int> & is_cancelled, ThrottlerPtr throttler);

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -74,7 +74,10 @@ void ReplaceQueryParameterVisitor::visitQueryParameter(ASTPtr & ast)
     IColumn & temp_column = *temp_column_ptr;
     ReadBufferFromString read_buffer{value};
     FormatSettings format_settings;
-    data_type->getDefaultSerialization()->deserializeTextEscaped(temp_column, read_buffer, format_settings);
+    if (ast_param.name == "_request_body")
+        data_type->getDefaultSerialization()->deserializeWholeText(temp_column, read_buffer, format_settings);
+    else
+        data_type->getDefaultSerialization()->deserializeTextEscaped(temp_column, read_buffer, format_settings);
 
     if (!read_buffer.eof())
         throw Exception(ErrorCodes::BAD_QUERY_PARAMETER,

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -36,7 +36,7 @@ public:
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response) override;
 
     /// This method is called right before the query execution.
-    virtual void customizeContext(HTTPServerRequest & /* request */, ContextMutablePtr /* context */) {}
+    virtual void customizeContext(HTTPServerRequest & /* request */, ContextMutablePtr /* context */, ReadBuffer & /* body */) {}
 
     virtual bool customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value) = 0;
 
@@ -163,7 +163,7 @@ public:
         , const CompiledRegexPtr & url_regex_, const std::unordered_map<String, CompiledRegexPtr> & header_name_with_regex_
         , const std::optional<std::string> & content_type_override_);
 
-    virtual void customizeContext(HTTPServerRequest & request, ContextMutablePtr context) override;
+    void customizeContext(HTTPServerRequest & request, ContextMutablePtr context, ReadBuffer & body) override;
 
     std::string getQuery(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context) override;
 

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -147,6 +147,16 @@ def test_predefined_query_handler():
         assert b"max_final_threads\t1\nmax_threads\t1\n" == res2.content
         assert "application/generic+one" == res2.headers["content-type"]
 
+        cluster.instance.query("CREATE TABLE test_table (id UInt32, data String) Engine=TinyLog")
+        res3 = cluster.instance.http_request(
+            "test_predefined_handler_post_body?id=100",
+            method="POST",
+            data="TEST".encode("utf8")
+        )
+        assert res3.status_code == 200
+        assert cluster.instance.query("SELECT * FROM test_table") == "100\tTEST\n"
+        cluster.instance.query("DROP TABLE test_table")
+
 
 def test_fixed_static_handler():
     with contextlib.closing(

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -147,11 +147,13 @@ def test_predefined_query_handler():
         assert b"max_final_threads\t1\nmax_threads\t1\n" == res2.content
         assert "application/generic+one" == res2.headers["content-type"]
 
-        cluster.instance.query("CREATE TABLE test_table (id UInt32, data String) Engine=TinyLog")
+        cluster.instance.query(
+            "CREATE TABLE test_table (id UInt32, data String) Engine=TinyLog"
+        )
         res3 = cluster.instance.http_request(
             "test_predefined_handler_post_body?id=100",
             method="POST",
-            data="TEST".encode("utf8")
+            data="TEST".encode("utf8"),
         )
         assert res3.status_code == 200
         assert cluster.instance.query("SELECT * FROM test_table") == "100\tTEST\n"

--- a/tests/integration/test_http_handlers_config/test_predefined_handler/config.xml
+++ b/tests/integration/test_http_handlers_config/test_predefined_handler/config.xml
@@ -21,5 +21,13 @@
                 <content_type>application/generic+one</content_type>
             </handler>
         </rule>
+        <rule>
+            <methods>POST</methods>
+            <url>/test_predefined_handler_post_body</url>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>INSERT INTO test_table(id, data) SELECT {id:UInt32}, {_request_body:String}</query>
+            </handler>
+        </rule>
     </http_handlers>
 </clickhouse>


### PR DESCRIPTION
adds a new "virtual" parameter `_request_body`
which can be used in http rules, see below

tremendously helps in producing arbitrary REST interfaces

for example:

```xml
<http_handlers>
  <rule>
    <methods>POST</methods>
    <url>/ingest</url>
    <handler>
      <type>predefined_query_handler</type>
      <query>INSERT INTO events(id, data) SELECT {id:UInt32}, {_request_body:String}</query>
    </handler>
  </rule>
</http_handlers>
```

usage:

```sh
curl http://localhost:8123/ingest?id=100 --data '{"event":"track","userId": 123456}'
```

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
use _request_body parameter to configure predefined http queries

### Documentation entry for user-facing changes

adds a new "virtual" parameter `_request_body` to `predefined_query_handler` rules

for example:

```xml
<http_handlers>
  <rule>
    <methods>POST</methods>
    <url>/ingest</url>
    <handler>
      <type>predefined_query_handler</type>
      <query>INSERT INTO events(id, data) SELECT {id:UInt32}, {_request_body:String}</query>
    </handler>
  </rule>
</http_handlers>
```
