### PR TITLE
Fix empty result when selection from only one side of join in analyzer

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -334,6 +334,16 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(const QueryTreeNodePtr & tabl
     }
     else if (query_node || union_node)
     {
+        if (table_expression_data.getColumnNames().empty())
+        {
+            const auto & projection_columns = query_node ? query_node->getProjectionColumns() : union_node->computeProjectionColumns();
+            NamesAndTypesList projection_columns_list(projection_columns.begin(), projection_columns.end());
+            auto additional_column_to_read = ExpressionActions::getSmallestColumn(projection_columns_list);
+
+            const auto & column_identifier = planner_context->getGlobalPlannerContext()->createColumnIdentifier(additional_column_to_read, table_expression);
+            table_expression_data.addColumn(additional_column_to_read, column_identifier);
+        }
+
         auto subquery_options = select_query_options.subquery();
         Planner subquery_planner(table_expression, subquery_options, planner_context->getGlobalPlannerContext());
         /// Propagate storage limits to subquery

--- a/tests/queries/0_stateless/25339_analyzer_join_subquery_empty_column_list.reference
+++ b/tests/queries/0_stateless/25339_analyzer_join_subquery_empty_column_list.reference
@@ -1,0 +1,37 @@
+-- { echoOn }
+
+SELECT a FROM ( select 1 AS a ) AS t1, ( select 2 AS b, 3 AS c) AS t2;
+1
+SELECT a FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c) AS t2;
+1
+1
+SELECT a FROM ( select 1 AS a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+1
+1
+SELECT a FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+1
+1
+1
+1
+SELECT a FROM ( select * from ( select 1 AS a UNION ALL select 1 as a) ) AS t1, ( select * from (  select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c )) AS t2;
+1
+1
+1
+1
+SELECT b FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+2
+2
+2
+2
+SELECT c FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+3
+3
+3
+3
+SELECT 42 FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+42
+42
+42
+42
+SELECT count() FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+4

--- a/tests/queries/0_stateless/25339_analyzer_join_subquery_empty_column_list.sql
+++ b/tests/queries/0_stateless/25339_analyzer_join_subquery_empty_column_list.sql
@@ -1,0 +1,14 @@
+SET allow_experimental_analyzer = 1;
+-- { echoOn }
+
+SELECT a FROM ( select 1 AS a ) AS t1, ( select 2 AS b, 3 AS c) AS t2;
+SELECT a FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c) AS t2;
+SELECT a FROM ( select 1 AS a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+SELECT a FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+SELECT a FROM ( select * from ( select 1 AS a UNION ALL select 1 as a) ) AS t1, ( select * from (  select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c )) AS t2;
+SELECT b FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+SELECT c FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+SELECT 42 FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+SELECT count() FROM ( select 1 AS a UNION ALL select 1 as a ) AS t1, ( select 2 AS b, 3 AS c UNION ALL select 2 as b, 3 as c) AS t2;
+
+


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

The same commit on top of https://github.com/ClickHouse/ClickHouse/pull/45461 is https://github.com/ClickHouse/ClickHouse/commit/bfc521638bddc494ed1e0674881f45736ffe5c99 (branch [vdimir/analyzer_join_subquery_empty_column_list2](https://github.com/ClickHouse/ClickHouse/compare/vdimir/analyzer_join_subquery_empty_column_list2)) 