### PR TITLE
Suppress "Cannot flush" for Distributed tables in upgrade check

### DIFF
--- a/docker/test/upgrade/run.sh
+++ b/docker/test/upgrade/run.sh
@@ -159,6 +159,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Session expired" \
            -e "TOO_MANY_PARTS" \
            -e "Authentication failed" \
+           -e "Cannot flush" \
            -e "Container already exists" \
     /var/log/clickhouse-server/clickhouse-server.upgrade.log | zgrep -Fa "<Error>" > /test_output/upgrade_error_messages.txt \
     && echo -e "Error message in clickhouse-server.log (see upgrade_error_messages.txt)$FAIL$(head_escaped /test_output/bc_check_error_messages.txt)" \


### PR DESCRIPTION
CI reports [1]:

    2023.03.01 04:39:00.185189 [ 358842 ] {} <Error> StorageDistributed (dist_01555): Cannot flush: Code: 279. DB::NetException: All connection tries failed. Log:
    2023.03.01 04:39:00.242066 [ 358842 ] {} <Error> StorageDistributed (dist_01555): Cannot flush: Code: 279. DB::NetException: All connection tries failed. Log:

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/47042/0e0a24234aa3409bb7799cc9a4b7a72bb006a923/upgrade_check__asan_.html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)