### PR TITLE
release lambda resources before detaching thread group

### DIFF
--- a/src/Interpreters/threadPoolCallbackRunner.h
+++ b/src/Interpreters/threadPoolCallbackRunner.h
@@ -25,8 +25,16 @@ ThreadPoolCallbackRunner<Result, Callback> threadPoolCallbackRunner(ThreadPool &
                 CurrentThread::attachTo(thread_group);
 
             SCOPE_EXIT_SAFE({
+                {
+                    /// Release all captutred resources before detaching thread group
+                    /// Releasing has to use proper memory tracker which has been set here before callback
+
+                    [[maybe_unused]] auto tmp = std::move(callback);
+                }
+
                 if (thread_group)
                     CurrentThread::detachQueryIfNotDetached();
+
             });
 
             setThreadName(thread_name.data());

--- a/src/Interpreters/threadPoolCallbackRunner.h
+++ b/src/Interpreters/threadPoolCallbackRunner.h
@@ -30,7 +30,6 @@ ThreadPoolCallbackRunner<Result, Callback> threadPoolCallbackRunner(ThreadPool &
                     /// Releasing has to use proper memory tracker which has been set here before callback
 
                     [[maybe_unused]] auto tmp = std::move(callback);
-                    thread_name.clear();
                 }
 
                 if (thread_group)

--- a/src/Interpreters/threadPoolCallbackRunner.h
+++ b/src/Interpreters/threadPoolCallbackRunner.h
@@ -30,6 +30,7 @@ ThreadPoolCallbackRunner<Result, Callback> threadPoolCallbackRunner(ThreadPool &
                     /// Releasing has to use proper memory tracker which has been set here before callback
 
                     [[maybe_unused]] auto tmp = std::move(callback);
+                    thread_name.clear();
                 }
 
                 if (thread_group)


### PR DESCRIPTION
Related to the https://github.com/ClickHouse/ClickHouse/pull/44869

Has been discovered that resources released too late. As a result wrong memory tracker process this deletion.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
