### PR TITLE
Fix halfMD5 and cityhash for s390x

### DIFF
--- a/src/Functions/FunctionsHashing.h
+++ b/src/Functions/FunctionsHashing.h
@@ -174,7 +174,11 @@ struct HalfMD5Impl
         MD5_Update(&ctx, reinterpret_cast<const unsigned char *>(begin), size);
         MD5_Final(buf.char_data, &ctx);
 
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        return buf.uint64_data;        /// No need to flip bytes on big endian machines
+#else
         return Poco::ByteOrder::flipBytes(static_cast<Poco::UInt64>(buf.uint64_data));        /// Compatibility with existing code. Cast need for old poco AND macos where UInt64 != uint64_t
+#endif
     }
 
     static UInt64 combineHashes(UInt64 h1, UInt64 h2)
@@ -1026,21 +1030,9 @@ private:
                 if constexpr (Impl::use_int_hash_for_pods)
                 {
                     if constexpr (std::is_same_v<ToType, UInt64>)
-                    {
-                        UInt64 v = bit_cast<UInt64>(vec_from[i]);
-
-                        /// Consider using std::byteswap() once ClickHouse builds with C++23
-                        if constexpr (std::endian::native == std::endian::big)
-                            v = __builtin_bswap64(v);
-                        h = IntHash64Impl::apply(v);
-                    }
+                        h = IntHash64Impl::apply(bit_cast<UInt64>(vec_from[i]));
                     else
-                    {
-                        UInt32 v = bit_cast<UInt32>(vec_from[i]);
-                        if constexpr (std::endian::native == std::endian::big)
-                            v = __builtin_bswap32(v);
-                        h = IntHash32Impl::apply(v);
-                    }
+                        h = IntHash32Impl::apply(bit_cast<UInt32>(vec_from[i]));
                 }
                 else
                 {
@@ -1070,20 +1062,9 @@ private:
             auto value = col_from_const->template getValue<FromType>();
             ToType hash;
             if constexpr (std::is_same_v<ToType, UInt64>)
-            {
-                UInt64 v = bit_cast<UInt64>(value);
-                /// Consider using std::byteswap() once ClickHouse builds with C++23
-                if constexpr (std::endian::native == std::endian::big)
-                    v = __builtin_bswap64(v);
-                hash = IntHash64Impl::apply(v);
-            }
+                hash = IntHash64Impl::apply(bit_cast<UInt64>(value));
             else
-            {
-                UInt32 v = bit_cast<UInt32>(value);
-                if constexpr (std::endian::native == std::endian::big)
-                    v = __builtin_bswap32(v);
-                hash = IntHash32Impl::apply(v);
-            }
+                hash = IntHash32Impl::apply(bit_cast<UInt32>(value));
 
             size_t size = vec_to.size();
             if constexpr (first)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
This PR addresses two issues on s390x:
1. Fixed halfMD5 endian issue by NOT byte-flipping result of halfMD5 function on s390x.
2. Rolled back changes which related to IntHash32Impl and IntHash64Impl in [PR 46495
](https://github.com/ClickHouse/ClickHouse/pull/46495)
The reason for rolling back is that hashing by using IntHash64/32 already works on s390x without reversing byte order of integer inputs. The changes would break hash functions like cityHash on s390x.

### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed halfMD5 and broken cityHash function for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
