### PR TITLE
Enable int type for repeat function's argument

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -330,7 +330,7 @@ repeat(s, n)
 **Arguments**
 
 -   `s` — The string to repeat. [String](../../sql-reference/data-types/string.md).
--   `n` — The number of times to repeat the string. [UInt](../../sql-reference/data-types/int-uint.md).
+-   `n` — The number of times to repeat the string. [UInt or Int](../../sql-reference/data-types/int-uint.md).
 
 **Returned value**
 

--- a/tests/queries/0_stateless/01013_repeat_function.reference
+++ b/tests/queries/0_stateless/01013_repeat_function.reference
@@ -1,7 +1,7 @@
 abcabcabcabcabcabcabcabcabcabc
 abcabcabc
-sdfggsdfgg
-xywq
+
+
 
 abcabcabcabcabcabcabcabcabcabcabcabc
 sdfggsdfggsdfggsdfggsdfggsdfggsdfggsdfggsdfggsdfgg
@@ -20,8 +20,8 @@ sdfggsdfggsdfggsdfggsdfggsdfggsdfggsdfggsdfggsdfgg
 xywqxywqxywqxywqxywqxywqxywqxywqxywqxywq
 plkfplkfplkfplkfplkfplkfplkfplkfplkfplkf
 abcabcabc
-abcabc
-abc
+
+
 
 abcabcabcabcabcabcabcabcabcabcabcabc
 abcabcabcabcabcabcabcabcabcabc

--- a/tests/queries/0_stateless/01013_repeat_function.sql
+++ b/tests/queries/0_stateless/01013_repeat_function.sql
@@ -3,20 +3,20 @@ DROP TABLE IF EXISTS defaults;
 CREATE TABLE defaults
 (
     strings String,
-    u8 UInt8,
+    i8 Int8,
     u16 UInt16,
     u32 UInt32,
     u64 UInt64
 )ENGINE = Memory();
 
-INSERT INTO defaults values ('abc', 3, 12, 4, 56) ('sdfgg', 2, 10, 21, 200) ('xywq', 1, 4, 9, 5) ('plkf', 0, 5, 7,77);
+INSERT INTO defaults values ('abc', 3, 12, 4, 56) ('sdfgg', -2, 10, 21, 200) ('xywq', -1, 4, 9, 5) ('plkf', 0, 5, 7,77);
 
-SELECT repeat(strings, u8) FROM defaults;
+SELECT repeat(strings, i8) FROM defaults;
 SELECT repeat(strings, u16) FROM defaults;
 SELECT repeat(strings, u32) from defaults;
 SELECT repeat(strings, u64) FROM defaults;
 SELECT repeat(strings, 10) FROM defaults;
-SELECT repeat('abc', u8) FROM defaults;
+SELECT repeat('abc', i8) FROM defaults;
 SELECT repeat('abc', u16) FROM defaults;
 SELECT repeat('abc', u32) FROM defaults;
 SELECT repeat('abc', u64) FROM defaults;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Currently the funtion repeat's second argument must be unsigned integer type,  which can not accept a integer value like -1. And this is different from the spark function, so I fix this here to make it same as spark. And it tested as below

```
create table defaults(u8 Int8, u16 UInt16, u32 UInt32, u64 UInt64) ENGINE=Memory();

INSERT INTO defaults values (-3, 12, 4, 56) (0, 10, 21, 200) (1, 4, 9, 5) (0, 5, 7,77);

:) select repeat('abc',u8) from defaults;

SELECT repeat('abc', u8)
FROM defaults

Query id: 1f1708d8-d82b-4381-82bf-7ee80ef3ecd4

┌─repeat('abc', u8)─┐
│                   │
│                   │
│ abc               │
│                   │
└───────────────────┘
↙ Progress: 0.00 rows, 0.00 B (0.00 rows/s., 0.00 B/s.) 
```
when the repeat time argument is negative, the result will be a empty string.



