### PR TITLE
Fix concrete columns PREWHERE support

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -593,8 +593,6 @@ InterpreterSelectQuery::InterpreterSelectQuery(
 
                 Names queried_columns = syntax_analyzer_result->requiredSourceColumns();
                 const auto & supported_prewhere_columns = storage->supportedPrewhereColumns();
-                if (supported_prewhere_columns.has_value())
-                    std::erase_if(queried_columns, [&](const auto & name) { return !supported_prewhere_columns->contains(name); });
 
                 MergeTreeWhereOptimizer{
                     current_info,
@@ -602,6 +600,7 @@ InterpreterSelectQuery::InterpreterSelectQuery(
                     std::move(column_compressed_sizes),
                     metadata_snapshot,
                     queried_columns,
+                    supported_prewhere_columns,
                     log};
             }
         }

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
@@ -39,6 +39,7 @@ public:
         std::unordered_map<std::string, UInt64> column_sizes_,
         const StorageMetadataPtr & metadata_snapshot,
         const Names & queried_columns_,
+        const std::optional<NameSet> & supported_columns_,
         Poco::Logger * log_);
 
 private:
@@ -82,6 +83,7 @@ private:
     void optimizeArbitrary(ASTSelectQuery & select) const;
 
     UInt64 getIdentifiersColumnSize(const NameSet & identifiers) const;
+    bool identifiersSupportsPrewhere(const NameSet & identifiers) const;
 
     bool isExpressionOverSortingKey(const ASTPtr & ast) const;
 
@@ -105,6 +107,7 @@ private:
 
     const StringSet table_columns;
     const Names queried_columns;
+    const std::optional<NameSet> supported_columns;
     const NameSet sorting_key_names;
     const Block block_with_constants;
     Poco::Logger * log;

--- a/tests/queries/0_stateless/02575_merge_prewhere_different_default_kind.reference
+++ b/tests/queries/0_stateless/02575_merge_prewhere_different_default_kind.reference
@@ -1,12 +1,13 @@
 -- { echoOn }
 -- for pure PREWHERE it is not addressed yet.
 SELECT * FROM m PREWHERE a = 'OK';
-OK	0
+OK	1970-01-01	0
 SELECT * FROM m PREWHERE f = 0; -- { serverError ILLEGAL_PREWHERE }
 SELECT * FROM m WHERE f = 0 SETTINGS optimize_move_to_prewhere=0;
-OK	0
+OK	1970-01-01	0
 SELECT * FROM m WHERE f = 0 SETTINGS optimize_move_to_prewhere=1;
-OK	0
+OK	1970-01-01	0
 -- { echoOn }
 SELECT * FROM m WHERE f = 0 SETTINGS optimize_move_to_prewhere=1;
-OK	0
+OK	1970-01-01	0
+OK	1970-01-01	0

--- a/tests/queries/0_stateless/02575_merge_prewhere_different_default_kind.sql
+++ b/tests/queries/0_stateless/02575_merge_prewhere_different_default_kind.sql
@@ -6,20 +6,22 @@ DROP TABLE IF EXISTS t2;
 
 CREATE TABLE m
 (
-    `a` String,
-    `f` UInt8
+    a String,
+    date Date,
+    f UInt8
 )
 ENGINE = Merge(currentDatabase(), '^(t1|t2)$');
 
 CREATE TABLE t1
 (
     a String,
+    date Date,
     f UInt8 ALIAS 0
 )
 ENGINE = MergeTree
 ORDER BY tuple()
 SETTINGS index_granularity = 8192;
-INSERT INTO t1 VALUES ('OK');
+INSERT INTO t1 (a) VALUES ('OK');
 
 -- { echoOn }
 -- for pure PREWHERE it is not addressed yet.
@@ -32,12 +34,13 @@ SELECT * FROM m WHERE f = 0 SETTINGS optimize_move_to_prewhere=1;
 CREATE TABLE t2
 (
     a String,
+    date Date,
     f UInt8,
 )
 ENGINE = MergeTree
 ORDER BY tuple()
 SETTINGS index_granularity = 8192;
-INSERT INTO t2 VALUES ('OK', 1);
+INSERT INTO t2 (a) VALUES ('OK');
 
 -- { echoOn }
 SELECT * FROM m WHERE f = 0 SETTINGS optimize_move_to_prewhere=1;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix concrete columns PREWHERE support

This is the fix for the `IStorage::supportedPrewhereColumns()` API.

Fixes: #46454 (cc @vdimir )

**Note: it should be backported to 23.2 so as #46454**