### PR TITLE
Increase `shutdown_wait_unfinished` timeout for stress tests

### DIFF
--- a/tests/ci/stress_tests.lib
+++ b/tests/ci/stress_tests.lib
@@ -134,6 +134,13 @@ EOL
 </clickhouse>
 EOL
 
+    cat > /etc/clickhouse-server/config.d/shutdown_wait.xml <<EOL
+<clickhouse>
+    <shutdown_wait_unfinished_queries>1</shutdown_wait_unfinished_queries>
+    <shutdown_wait_unfinished>60</shutdown_wait_unfinished>
+</clickhouse>
+EOL
+
 }
 
 function stop()


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
todo

---

hung check [log](https://s3.amazonaws.com/clickhouse-test-reports/45772/f8c95eeb7e4018e91f176a0e7ea03d5d26086caa/stress_test__ubsan_/hung_check.log)
When we cannot execute query we produce an error, [code](https://github.com/ClickHouse/ClickHouse/blob/master/tests/clickhouse-test#L2044-L2051).
I'm not sure but suppose it is related to these log messages:
```
2023.03.02 09:13:04.343489 [ 677 ] {} <Trace> BaseDaemon: Received signal 15
2023.03.02 09:13:04.343520 [ 677 ] {} <Information> Application: Received termination signal (Terminated)
2023.03.02 09:13:04.343537 [ 676 ] {} <Debug> Application: Received termination signal.
2023.03.02 09:13:04.344208 [ 676 ] {} <Debug> Application: Waiting for current connections to close.
2023.03.02 09:13:05.346641 [ 676 ] {} <Information> Application: Closed all listening sockets. Waiting for 27 outstanding connections.
2023.03.02 09:13:10.249733 [ 676 ] {} <Information> Application: Closed connections. But 27 remain. Tip: To increase wait time add to config: <shutdown_wait_unfinished>60</shutdown_wait_unfinished>
2023.03.02 09:13:10.249756 [ 676 ] {} <Information> Application: Will shutdown forcefully.
```
so let's just increase this setting. also I suppose that `shutdown_wait_unfinished_queries` could also help with false positives of hung check.