### PR TITLE
Terse stacktraces: no `::__1`, `std::string` as `String`

### DIFF
--- a/base/base/TypeList.h
+++ b/base/base/TypeList.h
@@ -4,7 +4,6 @@
 #include <type_traits>
 #include <utility>
 #include "defines.h"
-#include "TypePair.h"
 
 /// General-purpose typelist. Easy on compilation times as it does not use recursion.
 template <typename ...Args>
@@ -28,7 +27,7 @@ namespace TypeListUtils /// In some contexts it's more handy to use functions in
     constexpr Root<Args...> changeRoot(TypeList<Args...>) { return {}; }
 
     template <typename F, typename ...Args>
-    constexpr void forEach(TypeList<Args...>, F && f) { (std::forward<F>(f)(Id<Args>{}), ...); }
+    constexpr void forEach(TypeList<Args...>, F && f) { (std::forward<F>(f)(TypeList<Args>{}), ...); }
 }
 
 template <typename TypeListLeft, typename TypeListRight>

--- a/base/base/TypePair.h
+++ b/base/base/TypePair.h
@@ -1,4 +1,0 @@
-#pragma once
-
-template <typename T, typename V> struct TypePair {};
-template <typename T> struct Id {};

--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -1,18 +1,21 @@
-#include <Common/StackTrace.h>
+#include "StackTrace.h"
+
+#include <base/FnTraits.h>
+#include <base/constexpr_helpers.h>
+#include <base/demangle.h>
 
 #include <Common/Dwarf.h>
 #include <Common/Elf.h>
-#include <Common/SymbolIndex.h>
 #include <Common/MemorySanitizer.h>
-#include <base/demangle.h>
+#include <Common/SymbolIndex.h>
 
 #include <atomic>
-#include <cstring>
 #include <filesystem>
+#include <map>
 #include <mutex>
 #include <sstream>
 #include <unordered_map>
-#include <map>
+#include <fmt/format.h>
 
 #include "config.h"
 
@@ -20,24 +23,23 @@
 #    include <libunwind.h>
 #endif
 
-
 namespace
 {
-    /// Currently this variable is set up once on server startup.
-    /// But we use atomic just in case, so it is possible to be modified at runtime.
-    std::atomic<bool> show_addresses = true;
+/// Currently this variable is set up once on server startup.
+/// But we use atomic just in case, so it is possible to be modified at runtime.
+std::atomic<bool> show_addresses = true;
 
-    bool shouldShowAddress(const void * addr)
-    {
-        /// If the address is less than 4096, most likely it is a nullptr dereference with offset,
-        /// and showing this offset is secure nevertheless.
-        /// NOTE: 4096 is the page size on x86 and it can be different on other systems,
-        /// but for the purpose of this branch, it does not matter.
-        if (reinterpret_cast<uintptr_t>(addr) < 4096)
-            return true;
+bool shouldShowAddress(const void * addr)
+{
+    /// If the address is less than 4096, most likely it is a nullptr dereference with offset,
+    /// and showing this offset is secure nevertheless.
+    /// NOTE: 4096 is the page size on x86 and it can be different on other systems,
+    /// but for the purpose of this branch, it does not matter.
+    if (reinterpret_cast<uintptr_t>(addr) < 4096)
+        return true;
 
-        return show_addresses.load(std::memory_order_relaxed);
-    }
+    return show_addresses.load(std::memory_order_relaxed);
+}
 }
 
 void StackTrace::setShowAddresses(bool show)
@@ -45,155 +47,129 @@ void StackTrace::setShowAddresses(bool show)
     show_addresses.store(show, std::memory_order_relaxed);
 }
 
+std::string SigsegvErrorString(const siginfo_t & info, [[maybe_unused]] const ucontext_t & context)
+{
+    using namespace std::string_literals;
+    std::string address
+        = info.si_addr == nullptr ? "NULL pointer"s : (shouldShowAddress(info.si_addr) ? fmt::format("{}", info.si_addr) : ""s);
+
+    const std::string_view access =
+#if defined(__x86_64__) && !defined(OS_FREEBSD) && !defined(OS_DARWIN) && !defined(__arm__) && !defined(__powerpc__)
+        (context.uc_mcontext.gregs[REG_ERR] & 0x02) ? "write" : "read";
+#else
+        "";
+#endif
+
+    std::string_view message;
+
+    switch (info.si_code)
+    {
+        case SEGV_ACCERR:
+            message = "Attempted access has violated the permissions assigned to the memory area";
+            break;
+        case SEGV_MAPERR:
+            message = "Address not mapped to object";
+            break;
+        default:
+            message = "Unknown si_code";
+            break;
+    }
+
+    return fmt::format("Address: {}. Access: {}. {}.", std::move(address), access, message);
+}
+
+constexpr std::string_view SigbusErrorString(int si_code)
+{
+    switch (si_code)
+    {
+        case BUS_ADRALN:
+            return "Invalid address alignment.";
+        case BUS_ADRERR:
+            return "Non-existent physical address.";
+        case BUS_OBJERR:
+            return "Object specific hardware error.";
+
+            // Linux specific
+#if defined(BUS_MCEERR_AR)
+        case BUS_MCEERR_AR:
+            return "Hardware memory error: action required.";
+#endif
+#if defined(BUS_MCEERR_AO)
+        case BUS_MCEERR_AO:
+            return "Hardware memory error: action optional.";
+#endif
+        default:
+            return "Unknown si_code.";
+    }
+}
+
+constexpr std::string_view SigfpeErrorString(int si_code)
+{
+    switch (si_code)
+    {
+        case FPE_INTDIV:
+            return "Integer divide by zero.";
+        case FPE_INTOVF:
+            return "Integer overflow.";
+        case FPE_FLTDIV:
+            return "Floating point divide by zero.";
+        case FPE_FLTOVF:
+            return "Floating point overflow.";
+        case FPE_FLTUND:
+            return "Floating point underflow.";
+        case FPE_FLTRES:
+            return "Floating point inexact result.";
+        case FPE_FLTINV:
+            return "Floating point invalid operation.";
+        case FPE_FLTSUB:
+            return "Subscript out of range.";
+        default:
+            return "Unknown si_code.";
+    }
+}
+
+constexpr std::string_view SigillErrorString(int si_code)
+{
+    switch (si_code)
+    {
+        case ILL_ILLOPC:
+            return "Illegal opcode.";
+        case ILL_ILLOPN:
+            return "Illegal operand.";
+        case ILL_ILLADR:
+            return "Illegal addressing mode.";
+        case ILL_ILLTRP:
+            return "Illegal trap.";
+        case ILL_PRVOPC:
+            return "Privileged opcode.";
+        case ILL_PRVREG:
+            return "Privileged register.";
+        case ILL_COPROC:
+            return "Coprocessor error.";
+        case ILL_BADSTK:
+            return "Internal stack error.";
+        default:
+            return "Unknown si_code.";
+    }
+}
 
 std::string signalToErrorMessage(int sig, const siginfo_t & info, [[maybe_unused]] const ucontext_t & context)
 {
-    std::stringstream error;        // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    error.exceptions(std::ios::failbit);
     switch (sig)
     {
         case SIGSEGV:
-        {
-            /// Print info about address and reason.
-            if (nullptr == info.si_addr)
-                error << "Address: NULL pointer.";
-            else if (shouldShowAddress(info.si_addr))
-                error << "Address: " << info.si_addr;
-
-#if defined(__x86_64__) && !defined(OS_FREEBSD) && !defined(OS_DARWIN) && !defined(__arm__) && !defined(__powerpc__)
-            auto err_mask = context.uc_mcontext.gregs[REG_ERR];
-            if ((err_mask & 0x02))
-                error << " Access: write.";
-            else
-                error << " Access: read.";
-#endif
-
-            switch (info.si_code)
-            {
-                case SEGV_ACCERR:
-                    error << " Attempted access has violated the permissions assigned to the memory area.";
-                    break;
-                case SEGV_MAPERR:
-                    error << " Address not mapped to object.";
-                    break;
-                default:
-                    error << " Unknown si_code.";
-                    break;
-            }
-            break;
-        }
-
+            return SigsegvErrorString(info, context);
         case SIGBUS:
-        {
-            switch (info.si_code)
-            {
-                case BUS_ADRALN:
-                    error << "Invalid address alignment.";
-                    break;
-                case BUS_ADRERR:
-                    error << "Non-existent physical address.";
-                    break;
-                case BUS_OBJERR:
-                    error << "Object specific hardware error.";
-                    break;
-
-                    // Linux specific
-#if defined(BUS_MCEERR_AR)
-                case BUS_MCEERR_AR:
-                    error << "Hardware memory error: action required.";
-                    break;
-#endif
-#if defined(BUS_MCEERR_AO)
-                case BUS_MCEERR_AO:
-                    error << "Hardware memory error: action optional.";
-                    break;
-#endif
-
-                default:
-                    error << "Unknown si_code.";
-                    break;
-            }
-            break;
-        }
-
+            return std::string{SigbusErrorString(info.si_code)};
         case SIGILL:
-        {
-            switch (info.si_code)
-            {
-                case ILL_ILLOPC:
-                    error << "Illegal opcode.";
-                    break;
-                case ILL_ILLOPN:
-                    error << "Illegal operand.";
-                    break;
-                case ILL_ILLADR:
-                    error << "Illegal addressing mode.";
-                    break;
-                case ILL_ILLTRP:
-                    error << "Illegal trap.";
-                    break;
-                case ILL_PRVOPC:
-                    error << "Privileged opcode.";
-                    break;
-                case ILL_PRVREG:
-                    error << "Privileged register.";
-                    break;
-                case ILL_COPROC:
-                    error << "Coprocessor error.";
-                    break;
-                case ILL_BADSTK:
-                    error << "Internal stack error.";
-                    break;
-                default:
-                    error << "Unknown si_code.";
-                    break;
-            }
-            break;
-        }
-
+            return std::string{SigillErrorString(info.si_code)};
         case SIGFPE:
-        {
-            switch (info.si_code)
-            {
-                case FPE_INTDIV:
-                    error << "Integer divide by zero.";
-                    break;
-                case FPE_INTOVF:
-                    error << "Integer overflow.";
-                    break;
-                case FPE_FLTDIV:
-                    error << "Floating point divide by zero.";
-                    break;
-                case FPE_FLTOVF:
-                    error << "Floating point overflow.";
-                    break;
-                case FPE_FLTUND:
-                    error << "Floating point underflow.";
-                    break;
-                case FPE_FLTRES:
-                    error << "Floating point inexact result.";
-                    break;
-                case FPE_FLTINV:
-                    error << "Floating point invalid operation.";
-                    break;
-                case FPE_FLTSUB:
-                    error << "Subscript out of range.";
-                    break;
-                default:
-                    error << "Unknown si_code.";
-                    break;
-            }
-            break;
-        }
-
+            return std::string{SigfpeErrorString(info.si_code)};
         case SIGTSTP:
-        {
-            error << "This is a signal used for debugging purposes by the user.";
-            break;
-        }
+            return "This is a signal used for debugging purposes by the user.";
+        default:
+            return "";
     }
-
-    return error.str();
 }
 
 static void * getCallerAddress(const ucontext_t & context)
@@ -207,10 +183,8 @@ static void * getCallerAddress(const ucontext_t & context)
 #    else
     return reinterpret_cast<void *>(context.uc_mcontext.gregs[REG_RIP]);
 #    endif
-
 #elif defined(OS_DARWIN) && defined(__aarch64__)
     return reinterpret_cast<void *>(context.uc_mcontext->__ss.__pc);
-
 #elif defined(OS_FREEBSD) && defined(__aarch64__)
     return reinterpret_cast<void *>(context.uc_mcontext.mc_gpregs.gp_elr);
 #elif defined(__aarch64__)
@@ -228,20 +202,17 @@ static void * getCallerAddress(const ucontext_t & context)
 #endif
 }
 
+// FIXME: looks like this is used only for Sentry but duplicates the whole algo, maybe replace?
 void StackTrace::symbolize(
-    const StackTrace::FramePointers & frame_pointers, [[maybe_unused]] size_t offset,
-    size_t size, StackTrace::Frames & frames)
+    const StackTrace::FramePointers & frame_pointers, [[maybe_unused]] size_t offset, size_t size, StackTrace::Frames & frames)
 {
 #if defined(__ELF__) && !defined(OS_FREEBSD)
-
     auto symbol_index_ptr = DB::SymbolIndex::instance();
     const DB::SymbolIndex & symbol_index = *symbol_index_ptr;
     std::unordered_map<std::string, DB::Dwarf> dwarfs;
 
     for (size_t i = 0; i < offset; ++i)
-    {
         frames[i].virtual_addr = frame_pointers[i];
-    }
 
     for (size_t i = offset; i < size; ++i)
     {
@@ -254,7 +225,7 @@ void StackTrace::symbolize(
         if (object)
         {
             current_frame.object = object->name;
-            if (std::filesystem::exists(current_frame.object.value()))
+            if (std::error_code ec; std::filesystem::exists(current_frame.object.value(), ec) && !ec)
             {
                 auto dwarf_it = dwarfs.try_emplace(object->name, object->elf).first;
 
@@ -269,32 +240,17 @@ void StackTrace::symbolize(
             }
         }
         else
-        {
             current_frame.object = "?";
-        }
 
-        const auto * symbol = symbol_index.findSymbol(current_frame.virtual_addr);
-        if (symbol)
-        {
-            int status = 0;
-            current_frame.symbol = demangle(symbol->name, status);
-        }
+        if (const auto * symbol = symbol_index.findSymbol(current_frame.virtual_addr))
+            current_frame.symbol = demangle(symbol->name);
         else
-        {
             current_frame.symbol = "?";
-        }
     }
 #else
     for (size_t i = 0; i < size; ++i)
-    {
         frames[i].virtual_addr = frame_pointers[i];
-    }
 #endif
-}
-
-StackTrace::StackTrace()
-{
-    tryCapture();
 }
 
 StackTrace::StackTrace(const ucontext_t & signal_context)
@@ -325,81 +281,97 @@ StackTrace::StackTrace(const ucontext_t & signal_context)
     }
 }
 
-StackTrace::StackTrace(NoCapture)
-{
-}
-
 void StackTrace::tryCapture()
 {
-    size = 0;
 #if USE_UNWIND
     size = unw_backtrace(frame_pointers.data(), capacity);
     __msan_unpoison(frame_pointers.data(), size * sizeof(frame_pointers[0]));
+#else
+    size = 0;
 #endif
 }
 
-size_t StackTrace::getSize() const
+// Clickhouse uses bundled libc++ so type names will be same on every system thus it's save to hardcode them
+constexpr std::pair<std::string_view, std::string_view> replacements[]
+    = {{"::__1", ""}, {"std::basic_string<char, std::char_traits<char>, std::allocator<char>>", "String"}};
+
+String collapseNames(String && haystack)
 {
-    return size;
+    // TODO: surely there is a written version already for better in place search&replace
+    for (auto [needle, to] : replacements)
+    {
+        size_t pos = 0;
+        while ((pos = haystack.find(needle, pos)) != std::string::npos)
+        {
+            haystack.replace(pos, needle.length(), to);
+            pos += to.length();
+        }
+    }
+
+    return haystack;
 }
 
-size_t StackTrace::getOffset() const
+struct StackTraceRefTriple
 {
-    return offset;
+    const StackTrace::FramePointers & pointers;
+    size_t offset;
+    size_t size;
+};
+
+struct StackTraceTriple
+{
+    StackTrace::FramePointers pointers;
+    size_t offset;
+    size_t size;
+};
+
+template <class T>
+concept MaybeRef = std::is_same_v<T, StackTraceTriple> || std::is_same_v<T, StackTraceRefTriple>;
+
+constexpr bool operator<(const MaybeRef auto & left, const MaybeRef auto & right)
+{
+    return std::tuple{left.pointers, left.size, left.offset} < std::tuple{right.pointers, right.size, right.offset};
 }
 
-const StackTrace::FramePointers & StackTrace::getFramePointers() const
+static void
+toStringEveryLineImpl([[maybe_unused]] bool fatal, const StackTraceRefTriple & stack_trace, Fn<void(std::string_view)> auto && callback)
 {
-    return frame_pointers;
-}
-
-static void toStringEveryLineImpl(
-    [[maybe_unused]] bool fatal,
-    const StackTrace::FramePointers & frame_pointers,
-    size_t offset,
-    size_t size,
-    std::function<void(const std::string &)> callback)
-{
-    if (size == 0)
+    if (stack_trace.size == 0)
         return callback("<Empty trace>");
 
 #if defined(__ELF__) && !defined(OS_FREEBSD)
-    auto symbol_index_ptr = DB::SymbolIndex::instance();
-    const DB::SymbolIndex & symbol_index = *symbol_index_ptr;
-    std::unordered_map<std::string, DB::Dwarf> dwarfs;
-
-    std::stringstream out;  // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    std::stringstream out; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
     out.exceptions(std::ios::failbit);
 
-    for (size_t i = offset; i < size; ++i)
+    using enum DB::Dwarf::LocationInfoMode;
+    const auto mode = fatal ? FULL_WITH_INLINE : FAST;
+
+    auto symbol_index_ptr = DB::SymbolIndex::instance();
+    const DB::SymbolIndex & symbol_index = *symbol_index_ptr;
+    std::unordered_map<String, DB::Dwarf> dwarfs;
+
+    for (size_t i = stack_trace.offset; i < stack_trace.size; ++i)
     {
         std::vector<DB::Dwarf::SymbolizedFrame> inline_frames;
-        const void * virtual_addr = frame_pointers[i];
+        const void * virtual_addr = stack_trace.pointers[i];
         const auto * object = symbol_index.findObject(virtual_addr);
         uintptr_t virtual_offset = object ? uintptr_t(object->address_begin) : 0;
         const void * physical_addr = reinterpret_cast<const void *>(uintptr_t(virtual_addr) - virtual_offset);
 
         out << i << ". ";
 
-        if (object)
+        if (std::error_code ec; object && std::filesystem::exists(object->name, ec) && !ec)
         {
-            if (std::filesystem::exists(object->name))
-            {
-                auto dwarf_it = dwarfs.try_emplace(object->name, object->elf).first;
+            auto dwarf_it = dwarfs.try_emplace(object->name, object->elf).first;
 
-                DB::Dwarf::LocationInfo location;
-                auto mode = fatal ? DB::Dwarf::LocationInfoMode::FULL_WITH_INLINE : DB::Dwarf::LocationInfoMode::FAST;
-                if (dwarf_it->second.findAddress(uintptr_t(physical_addr), location, mode, inline_frames))
-                    out << location.file.toString() << ":" << location.line << ": ";
-            }
+            DB::Dwarf::LocationInfo location;
+
+            if (dwarf_it->second.findAddress(uintptr_t(physical_addr), location, mode, inline_frames))
+                out << location.file.toString() << ":" << location.line << ": ";
         }
 
-        const auto * symbol = symbol_index.findSymbol(virtual_addr);
-        if (symbol)
-        {
-            int status = 0;
-            out << demangle(symbol->name, status);
-        }
+        if (const auto * const symbol = symbol_index.findSymbol(virtual_addr))
+            out << collapseNames(demangle(symbol->name));
         else
             out << "?";
 
@@ -411,64 +383,31 @@ static void toStringEveryLineImpl(
         for (size_t j = 0; j < inline_frames.size(); ++j)
         {
             const auto & frame = inline_frames[j];
-            int status = 0;
-            callback(fmt::format("{}.{}. inlined from {}:{}: {}",
-                     i, j+1, frame.location.file.toString(), frame.location.line, demangle(frame.name, status)));
+            callback(fmt::format(
+                "{}.{}. inlined from {}:{}: {}",
+                i,
+                j + 1,
+                frame.location.file.toString(),
+                frame.location.line,
+                collapseNames(demangle(frame.name))));
         }
 
         callback(out.str());
         out.str({});
     }
 #else
-    std::stringstream out;  // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    out.exceptions(std::ios::failbit);
-
-    for (size_t i = offset; i < size; ++i)
-    {
-        const void * addr = frame_pointers[i];
-        if (shouldShowAddress(addr))
-        {
-            out << i << ". " << addr;
-
-            callback(out.str());
-            out.str({});
-        }
-    }
+    for (size_t i = stack_trace.offset; i < stack_trace.size; ++i)
+        if (const void * const addr = stack_trace.pointers[i]; shouldShowAddress(addr))
+            callback(fmt::format("{}. {}", i, addr));
 #endif
 }
 
-static std::string toStringImpl(const StackTrace::FramePointers & frame_pointers, size_t offset, size_t size)
+void StackTrace::toStringEveryLine(std::function<void(std::string_view)> callback) const
 {
-    std::stringstream out;      // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    out.exceptions(std::ios::failbit);
-    toStringEveryLineImpl(false, frame_pointers, offset, size, [&](const std::string & str) { out << str << '\n'; });
-    return out.str();
+    toStringEveryLineImpl(true, {frame_pointers, offset, size}, std::move(callback));
 }
 
-void StackTrace::toStringEveryLine(std::function<void(const std::string &)> callback) const
-{
-    toStringEveryLineImpl(true, frame_pointers, offset, size, std::move(callback));
-}
-
-
-std::string StackTrace::toString() const
-{
-    return toStringStatic(frame_pointers, offset, size);
-}
-
-std::string StackTrace::toString(void ** frame_pointers_, size_t offset, size_t size)
-{
-    __msan_unpoison(frame_pointers_, size * sizeof(*frame_pointers_));
-
-    StackTrace::FramePointers frame_pointers_copy{};
-    for (size_t i = 0; i < size; ++i)
-        frame_pointers_copy[i] = frame_pointers_[i];
-
-    return toStringStatic(frame_pointers_copy, offset, size);
-}
-
-using StackTraceRepresentation = std::tuple<StackTrace::FramePointers, size_t, size_t>;
-using StackTraceCache = std::map<StackTraceRepresentation, std::string>;
+using StackTraceCache = std::map<StackTraceTriple, String, std::less<>>;
 
 static StackTraceCache & cacheInstance()
 {
@@ -478,21 +417,40 @@ static StackTraceCache & cacheInstance()
 
 static std::mutex stacktrace_cache_mutex;
 
-std::string StackTrace::toStringStatic(const StackTrace::FramePointers & frame_pointers, size_t offset, size_t size)
+String toStringCached(const StackTrace::FramePointers & pointers, size_t offset, size_t size)
 {
     /// Calculation of stack trace text is extremely slow.
     /// We use simple cache because otherwise the server could be overloaded by trash queries.
     /// Note that this cache can grow unconditionally, but practically it should be small.
     std::lock_guard lock{stacktrace_cache_mutex};
 
-    StackTraceRepresentation key{frame_pointers, offset, size};
-    auto & cache = cacheInstance();
-    if (cache.contains(key))
-        return cache[key];
+    StackTraceCache & cache = cacheInstance();
 
-    auto result = toStringImpl(frame_pointers, offset, size);
-    cache[key] = result;
-    return result;
+    if (auto it = cache.find(StackTraceRefTriple{pointers, offset, size}); it != cache.end())
+        return it->second;
+    else
+    {
+        std::stringstream out; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+        out.exceptions(std::ios::failbit);
+        toStringEveryLineImpl(false, {pointers, offset, size}, [&](std::string_view str) { out << str << '\n'; });
+
+        return cache.emplace(StackTraceTriple{pointers, offset, size}, out.str()).first->second;
+    }
+}
+
+std::string StackTrace::toString() const
+{
+    return toStringCached(frame_pointers, offset, size);
+}
+
+std::string StackTrace::toString(void ** frame_pointers_raw, size_t offset, size_t size)
+{
+    __msan_unpoison(frame_pointers_raw, size * sizeof(*frame_pointers_raw));
+
+    StackTrace::FramePointers frame_pointers;
+    std::copy_n(frame_pointers_raw, size, frame_pointers.begin());
+
+    return toStringCached(frame_pointers, offset, size);
 }
 
 void StackTrace::dropCache()

--- a/src/Common/StackTrace.cpp
+++ b/src/Common/StackTrace.cpp
@@ -291,7 +291,7 @@ void StackTrace::tryCapture()
 #endif
 }
 
-// Clickhouse uses bundled libc++ so type names will be same on every system thus it's save to hardcode them
+/// ClickHouse uses bundled libc++ so type names will be the same on every system thus it's safe to hardcode them
 constexpr std::pair<std::string_view, std::string_view> replacements[]
     = {{"::__1", ""}, {"std::basic_string<char, std::char_traits<char>, std::allocator<char>>", "String"}};
 

--- a/src/Common/StackTrace.h
+++ b/src/Common/StackTrace.h
@@ -46,26 +46,25 @@ public:
     using Frames = std::array<Frame, capacity>;
 
     /// Tries to capture stack trace
-    StackTrace();
+    inline StackTrace() { tryCapture(); }
 
     /// Tries to capture stack trace. Fallbacks on parsing caller address from
     /// signal context if no stack trace could be captured
     explicit StackTrace(const ucontext_t & signal_context);
 
     /// Creates empty object for deferred initialization
-    explicit StackTrace(NoCapture);
+    explicit inline StackTrace(NoCapture) {}
 
-    size_t getSize() const;
-    size_t getOffset() const;
-    const FramePointers & getFramePointers() const;
+    constexpr size_t getSize() const { return size; }
+    constexpr size_t getOffset() const { return offset; }
+    const FramePointers & getFramePointers() const { return frame_pointers; }
     std::string toString() const;
 
     static std::string toString(void ** frame_pointers, size_t offset, size_t size);
-    static std::string toStringStatic(const FramePointers & frame_pointers, size_t offset, size_t size);
     static void dropCache();
     static void symbolize(const FramePointers & frame_pointers, size_t offset, size_t size, StackTrace::Frames & frames);
 
-    void toStringEveryLine(std::function<void(const std::string &)> callback) const;
+    void toStringEveryLine(std::function<void(std::string_view)> callback) const;
 
     /// Displaying the addresses can be disabled for security reasons.
     /// If you turn off addresses, it will be more secure, but we will be unable to help you with debugging.

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -374,7 +374,7 @@ private:
         }
 
         /// Write symbolized stack trace line by line for better grep-ability.
-        stack_trace.toStringEveryLine([&](const std::string & s) { LOG_FATAL(log, fmt::runtime(s)); });
+        stack_trace.toStringEveryLine([&](std::string_view s) { LOG_FATAL(log, fmt::runtime(s)); });
 
 #if defined(OS_LINUX)
         /// Write information about binary checksum. It can be difficult to calculate, so do it only after printing stack trace.

--- a/src/DataTypes/DataTypeLowCardinality.cpp
+++ b/src/DataTypes/DataTypeLowCardinality.cpp
@@ -55,7 +55,7 @@ namespace
         }
 
         template <typename T>
-        void operator()(Id<T>)
+        void operator()(TypeList<T>)
         {
             if (typeid_cast<const DataTypeNumber<T> *>(&keys_type))
                 column = creator(static_cast<ColumnVector<T> *>(nullptr));

--- a/src/Functions/FunctionsEmbeddedDictionaries.h
+++ b/src/Functions/FunctionsEmbeddedDictionaries.h
@@ -166,12 +166,12 @@ public:
 
         if (arguments[0]->getName() != TypeName<T>)
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument of function {} (must be {})",
-                arguments[0]->getName(), getName(), String(TypeName<T>));
+                arguments[0]->getName(), getName(), TypeName<T>);
 
-        if (arguments.size() == 2 && arguments[1]->getName() != TypeName<String>)
+        if (arguments.size() == 2 && arguments[1]->getName() != "String")
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                            "Illegal type {} of the second ('point of view') argument of function {} (must be {})",
-                            arguments[1]->getName(), getName(), String(TypeName<T>));
+                            "Illegal type {} of the second ('point of view') argument of function {} (must be String)",
+                            arguments[1]->getName(), getName());
 
         return arguments[0];
     }
@@ -257,16 +257,16 @@ public:
 
         if (arguments[0]->getName() != TypeName<T>)
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of first argument of function {} (must be {})",
-                arguments[0]->getName(), getName(), String(TypeName<T>));
+                arguments[0]->getName(), getName(), TypeName<T>);
 
         if (arguments[1]->getName() != TypeName<T>)
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of second argument of function {} (must be {})",
-                arguments[1]->getName(), getName(), String(TypeName<T>));
+                arguments[1]->getName(), getName(), TypeName<T>);
 
-        if (arguments.size() == 3 && arguments[2]->getName() != TypeName<String>)
+        if (arguments.size() == 3 && arguments[2]->getName() != "String")
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                            "Illegal type {} of the third ('point of view') argument of function {} (must be {})",
-                            arguments[2]->getName(), getName(), String(TypeName<String>));
+                            "Illegal type {} of the third ('point of view') argument of function {} (must be String)",
+                            arguments[2]->getName(), getName());
 
         return std::make_shared<DataTypeUInt8>();
     }
@@ -390,12 +390,12 @@ public:
 
         if (arguments[0]->getName() != TypeName<T>)
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Illegal type {} of argument of function {} (must be {})",
-            arguments[0]->getName(), getName(), String(TypeName<T>));
+            arguments[0]->getName(), getName(), TypeName<T>);
 
-        if (arguments.size() == 2 && arguments[1]->getName() != TypeName<String>)
+        if (arguments.size() == 2 && arguments[1]->getName() != "String")
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                            "Illegal type {} of the second ('point of view') argument of function {} (must be {})",
-                            arguments[1]->getName(), getName(), String(TypeName<String>));
+                            "Illegal type {} of the second ('point of view') argument of function {} (must be String)",
+                            arguments[1]->getName(), getName());
 
         return std::make_shared<DataTypeArray>(arguments[0]);
     }
@@ -591,15 +591,15 @@ public:
                 "Number of arguments for function {} doesn't match: passed {}, should be 1 or 2.",
                 getName(), arguments.size());
 
-        if (arguments[0]->getName() != TypeName<UInt32>)
+        if (arguments[0]->getName() != "UInt32")
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                            "Illegal type {} of the first argument of function {} (must be {})",
-                            arguments[0]->getName(), getName(), String(TypeName<UInt32>));
+                            "Illegal type {} of the first argument of function {} (must be UInt32)",
+                            arguments[0]->getName(), getName());
 
-        if (arguments.size() == 2 && arguments[1]->getName() != TypeName<String>)
+        if (arguments.size() == 2 && arguments[1]->getName() != "String")
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                            "Illegal type {} of the second argument of function {} (must be {})",
-                            arguments[0]->getName(), getName(), String(TypeName<String>));
+                            "Illegal type {} of the second argument of function {} (must be String)",
+                            arguments[0]->getName(), getName());
 
         return std::make_shared<DataTypeString>();
     }

--- a/src/Functions/array/arrayIntersect.cpp
+++ b/src/Functions/array/arrayIntersect.cpp
@@ -107,7 +107,7 @@ private:
             : arrays(arrays_), data_type(data_type_), result(result_) {}
 
         template <class T>
-        void operator()(Id<T>);
+        void operator()(TypeList<T>);
     };
 
     struct DecimalExecutor
@@ -120,7 +120,7 @@ private:
             : arrays(arrays_), data_type(data_type_), result(result_) {}
 
         template <class T>
-        void operator()(Id<T>);
+        void operator()(TypeList<T>);
     };
 };
 
@@ -446,7 +446,7 @@ ColumnPtr FunctionArrayIntersect::executeImpl(const ColumnsWithTypeAndName & arg
 }
 
 template <class T>
-void FunctionArrayIntersect::NumberExecutor::operator()(Id<T>)
+void FunctionArrayIntersect::NumberExecutor::operator()(TypeList<T>)
 {
     using Container = ClearableHashMapWithStackMemory<T, size_t, DefaultHash<T>,
         INITIAL_SIZE_DEGREE>;
@@ -456,7 +456,7 @@ void FunctionArrayIntersect::NumberExecutor::operator()(Id<T>)
 }
 
 template <class T>
-void FunctionArrayIntersect::DecimalExecutor::operator()(Id<T>)
+void FunctionArrayIntersect::DecimalExecutor::operator()(TypeList<T>)
 {
     using Container = ClearableHashMapWithStackMemory<T, size_t, DefaultHash<T>,
         INITIAL_SIZE_DEGREE>;

--- a/src/Interpreters/CrashLog.cpp
+++ b/src/Interpreters/CrashLog.cpp
@@ -80,7 +80,7 @@ void collectCrashLog(Int32 signal, UInt64 thread_id, const String & query_id, co
         for (size_t i = stack_trace_offset; i < stack_trace_size; ++i)
             trace.push_back(reinterpret_cast<uintptr_t>(stack_trace.getFramePointers()[i]));
 
-        stack_trace.toStringEveryLine([&trace_full](const std::string & line) { trace_full.push_back(line); });
+        stack_trace.toStringEveryLine([&trace_full](std::string_view line) { trace_full.push_back(line); });
 
         CrashLogElement element{static_cast<time_t>(time / 1000000000), time, signal, thread_id, query_id, trace, trace_full};
         crash_log_owned->add(element);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Remove `::__1` part from stacktraces. Display `std::basic_string<char, ...` as `String` in stacktraces.