### PR TITLE
Reimplement interserver mode to avoid replay attacks

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -216,6 +216,7 @@ void Connection::disconnect()
         socket->close();
     socket = nullptr;
     connected = false;
+    nonce.reset();
 }
 
 
@@ -323,6 +324,14 @@ void Connection::receiveHello()
                 readStringBinary(exception_message, *in);
                 password_complexity_rules.push_back({std::move(original_pattern), std::move(exception_message)});
             }
+        }
+        if (server_revision >= DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2)
+        {
+            chassert(!nonce.has_value());
+
+            UInt64 read_nonce;
+            readIntBinary(read_nonce, *in);
+            nonce.emplace(read_nonce);
         }
     }
     else if (packet_type == Protocol::Server::Exception)
@@ -584,6 +593,9 @@ void Connection::sendQuery(
         {
 #if USE_SSL
             std::string data(salt);
+            // For backward compatibility
+            if (nonce.has_value())
+                data += std::to_string(nonce.value());
             data += cluster_secret;
             data += query;
             data += query_id;
@@ -593,8 +605,8 @@ void Connection::sendQuery(
             std::string hash = encodeSHA256(data);
             writeStringBinary(hash, *out);
 #else
-        throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
-                        "Inter-server secret support is disabled, because ClickHouse was built without SSL library");
+            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
+                            "Inter-server secret support is disabled, because ClickHouse was built without SSL library");
 #endif
         }
         else

--- a/src/Client/Connection.h
+++ b/src/Client/Connection.h
@@ -167,7 +167,10 @@ private:
     /// For inter-server authorization
     String cluster;
     String cluster_secret;
+    /// For DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET
     String salt;
+    /// For DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2
+    std::optional<UInt64> nonce;
 
     /// Address is resolved during the first connection (or the following reconnects)
     /// Use it only for logging purposes

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -35,7 +35,6 @@
 
 #define DBMS_MERGE_TREE_PART_INFO_VERSION 1
 
-/// Minimum revision supporting interserver secret.
 #define DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET 54441
 
 #define DBMS_MIN_REVISION_WITH_X_FORWARDED_FOR_IN_CLIENT_INFO 54443
@@ -54,7 +53,7 @@
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-#define DBMS_TCP_PROTOCOL_VERSION 54461
+#define DBMS_TCP_PROTOCOL_VERSION 54462
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME 54449
 
@@ -72,3 +71,5 @@
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_SERVER_QUERY_TIME_IN_PROGRESS 54460
 
 #define DBMS_MIN_PROTOCOL_VERSION_WITH_PASSWORD_COMPLEXITY_RULES 54461
+
+#define DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2 54462

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -41,6 +41,7 @@
 #include <Compression/CompressionFactory.h>
 #include <Common/logger_useful.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/thread_local_rng.h>
 #include <fmt/format.h>
 
 #include <Processors/Executors/PullingAsyncPipelineExecutor.h>
@@ -1279,6 +1280,18 @@ void TCPHandler::sendHello()
             writeStringBinary(exception_message, *out);
         }
     }
+    if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2)
+    {
+        chassert(!nonce.has_value());
+        /// Contains lots of stuff (including time), so this should be enough for NONCE.
+        nonce.emplace(thread_local_rng());
+        writeIntBinary(nonce.value(), *out);
+    }
+    else
+    {
+        LOG_WARNING(LogFrequencyLimiter(log, 10),
+            "Using deprecated interserver protocol because the client is too old. Consider upgrading all nodes in cluster.");
+    }
     out->next();
 }
 
@@ -1459,20 +1472,30 @@ void TCPHandler::receiveQuery()
     if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS)
         passed_params.read(*in, settings_format);
 
-    /// TODO Unify interserver authentication (and make sure that it's secure enough)
     if (is_interserver_mode)
     {
         client_info.interface = ClientInfo::Interface::TCP_INTERSERVER;
 #if USE_SSL
         String cluster_secret = server.context()->getCluster(cluster)->getSecret();
+
         if (salt.empty() || cluster_secret.empty())
         {
-            auto exception = Exception(ErrorCodes::AUTHENTICATION_FAILED, "Interserver authentication failed");
-            session->onAuthenticationFailure(/* user_name */ std::nullopt, socket().peerAddress(), exception);
+            auto exception = Exception(ErrorCodes::AUTHENTICATION_FAILED, "Interserver authentication failed (no salt/cluster secret)");
+            session->onAuthenticationFailure(/* user_name= */ std::nullopt, socket().peerAddress(), exception);
+            throw exception; /// NOLINT
+        }
+
+        if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2 && !nonce.has_value())
+        {
+            auto exception = Exception(ErrorCodes::AUTHENTICATION_FAILED, "Interserver authentication failed (no nonce)");
+            session->onAuthenticationFailure(/* user_name= */ std::nullopt, socket().peerAddress(), exception);
             throw exception; /// NOLINT
         }
 
         std::string data(salt);
+        // For backward compatibility
+        if (nonce.has_value())
+            data += std::to_string(nonce.value());
         data += cluster_secret;
         data += state.query;
         data += state.query_id;

--- a/src/Server/TCPHandler.h
+++ b/src/Server/TCPHandler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <Poco/Net/TCPServerConnection.h>
 
 #include <base/getFQDNOrHostName.h>
@@ -188,7 +189,10 @@ private:
 
     /// For inter-server secret (remote_server.*.secret)
     bool is_interserver_mode = false;
+    /// For DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET
     String salt;
+    /// For DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2
+    std::optional<UInt64> nonce;
     String cluster;
 
     std::mutex task_callback_mutex;

--- a/tests/integration/test_distributed_inter_server_secret/configs/remote_servers.xml
+++ b/tests/integration/test_distributed_inter_server_secret/configs/remote_servers.xml
@@ -24,5 +24,17 @@
                 <priority>1</priority>
             </node>
         </secure>
+
+        <secure_backward>
+            <secret>foo_backward</secret>
+            <node>
+                <host>n1</host>
+                <port>9000</port>
+            </node>
+            <node>
+                <host>backward</host>
+                <port>9000</port>
+            </node>
+        </secure_backward>
     </remote_servers>
 </clickhouse>

--- a/tests/integration/test_distributed_inter_server_secret/configs/remote_servers_backward.xml
+++ b/tests/integration/test_distributed_inter_server_secret/configs/remote_servers_backward.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+    <remote_servers>
+        <secure_disagree>
+            <secret>backward</secret>
+            <node>
+                <host>n1</host>
+                <port>9000</port>
+            </node>
+            <node>
+                <host>backward</host>
+                <port>9000</port>
+            </node>
+        </secure_disagree>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_distributed_inter_server_secret/test.py
+++ b/tests/integration/test_distributed_inter_server_secret/test.py
@@ -12,18 +12,28 @@ from helpers.cluster import ClickHouseCluster
 cluster = ClickHouseCluster(__file__)
 
 
-def make_instance(name, cfg):
+def make_instance(name, cfg, *args, **kwargs):
     return cluster.add_instance(
         name,
         with_zookeeper=True,
         main_configs=["configs/remote_servers.xml", cfg],
         user_configs=["configs/users.xml"],
+        *args,
+        **kwargs,
     )
 
 
 # _n1/_n2 contains cluster with different <secret> -- should fail
 n1 = make_instance("n1", "configs/remote_servers_n1.xml")
 n2 = make_instance("n2", "configs/remote_servers_n2.xml")
+backward = make_instance(
+    "backward",
+    "configs/remote_servers_backward.xml",
+    image="clickhouse/clickhouse-server",
+    # version without DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2
+    tag="23.2.3",
+    with_installed_binary=True,
+)
 
 users = pytest.mark.parametrize(
     "user,password",
@@ -52,6 +62,12 @@ def bootstrap():
             """
         CREATE TABLE dist_secure AS data
         Engine=Distributed(secure, currentDatabase(), data, key)
+        """
+        )
+        n.query(
+            """
+        CREATE TABLE dist_secure_backward AS data
+        Engine=Distributed(secure_backward, currentDatabase(), data, key)
         """
         )
         n.query(
@@ -408,4 +424,32 @@ def test_per_user_protocol_settings_secure_cluster(user, password):
     )
     assert int(get_query_setting_on_shard(n1, id_, "max_memory_usage_for_user")) == int(
         1e9
+    )
+
+
+@users
+def test_user_secure_cluster_with_backward(user, password):
+    id_ = "with-backward-query-dist_secure-" + user
+    query_with_id(
+        n1, id_, "SELECT * FROM dist_secure_backward", user=user, password=password
+    )
+    assert get_query_user_info(n1, id_) == [user, user]
+    assert get_query_user_info(backward, id_) == [user, user]
+
+
+@users
+def test_user_secure_cluster_from_backward(user, password):
+    id_ = "from-backward-query-dist_secure-" + user
+    query_with_id(
+        backward,
+        id_,
+        "SELECT * FROM dist_secure_backward",
+        user=user,
+        password=password,
+    )
+    assert get_query_user_info(n1, id_) == [user, user]
+    assert get_query_user_info(backward, id_) == [user, user]
+
+    assert n1.contains_in_log(
+        "Using deprecated interserver protocol because the client is too old. Consider upgrading all nodes in cluster."
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Reimplement interserver mode to avoid replay attacks (note, that change is backward compatible with older servers)

Previous implementation (`DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET`) accepts the salt from the client, which make it useless.

Re implement the protocol to send the salt by the server and use it in the client instead.

Fixes: #39903 (cc @tavplubix @alexey-milovidov @vitlibar )
Follow-up for: #13156