### PR TITLE
Fix 01019_alter_materialized_view_consistent

### DIFF
--- a/tests/queries/0_stateless/01019_alter_materialized_view_consistent.sh
+++ b/tests/queries/0_stateless/01019_alter_materialized_view_consistent.sh
@@ -50,12 +50,19 @@ function insert_thread() {
 function alter_thread() {
     trap 'exit' INT
 
-    ALTER[0]="ALTER TABLE mv MODIFY QUERY SELECT v == 1 as test, v as case FROM src_a;"
-    ALTER[1]="ALTER TABLE mv MODIFY QUERY SELECT v == 2 as test, v as case FROM src_b;"
+    # Generate random ALTERs, but make sure that at least one of them is for each source table.
+    for i in {0..5}; do
+        ALTER[$i]="ALTER TABLE mv MODIFY QUERY SELECT v == 1 as test, v as case FROM src_a;"
+    done
+    ALTER[$RANDOM % 3]="ALTER TABLE mv MODIFY QUERY SELECT v == 2 as test, v as case FROM src_b;"
+    ALTER[$RANDOM % 6]="ALTER TABLE mv MODIFY QUERY SELECT v == 2 as test, v as case FROM src_b;"
+    ALTER[$RANDOM % 6]="ALTER TABLE mv MODIFY QUERY SELECT v == 2 as test, v as case FROM src_b;"
 
+    i=0
     while true; do
-        $CLICKHOUSE_CLIENT --allow_experimental_alter_materialized_view_structure=1 \
-        -q "${ALTER[$RANDOM % 2]}"
+        $CLICKHOUSE_CLIENT --allow_experimental_alter_materialized_view_structure=1 -q "${ALTER[$i % 6]}"
+        ((i=i+1))
+
         sleep "0.0$RANDOM"
 
         is_done=$($CLICKHOUSE_CLIENT -q "SELECT countIf(case = 1) > 0 AND countIf(case = 2) > 0 FROM mv;")

--- a/tests/queries/0_stateless/01019_alter_materialized_view_consistent.sh
+++ b/tests/queries/0_stateless/01019_alter_materialized_view_consistent.sh
@@ -54,6 +54,7 @@ function alter_thread() {
     for i in {0..5}; do
         ALTER[$i]="ALTER TABLE mv MODIFY QUERY SELECT v == 1 as test, v as case FROM src_a;"
     done
+    # Insert 3 ALTERs to src_b, one in the first half of the array and two in arbitrary positions.
     ALTER[$RANDOM % 3]="ALTER TABLE mv MODIFY QUERY SELECT v == 2 as test, v as case FROM src_b;"
     ALTER[$RANDOM % 6]="ALTER TABLE mv MODIFY QUERY SELECT v == 2 as test, v as case FROM src_b;"
     ALTER[$RANDOM % 6]="ALTER TABLE mv MODIFY QUERY SELECT v == 2 as test, v as case FROM src_b;"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Failure example: https://s3.amazonaws.com/clickhouse-test-reports/0/16eedb004f58a3c8507cf605f8e563df84dcf1e5/stateless_tests__debug__%5B1/3%5D.html

Alter table for `src_a` was run 12 times and not for `src_b`. We need to ensure that the set of alters involves both tables.