### PR TITLE
Fix farmhash for s390x

### DIFF
--- a/contrib/libfarmhash/CMakeLists.txt
+++ b/contrib/libfarmhash/CMakeLists.txt
@@ -6,6 +6,10 @@ if (MSVC)
     target_compile_definitions (_farmhash PRIVATE FARMHASH_NO_BUILTIN_EXPECT=1)
 endif ()
 
+if (ARCH_S390X)
+    add_compile_definitions(WORDS_BIGENDIAN)
+endif ()
+
 target_include_directories (_farmhash BEFORE PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(ch_contrib::farmhash ALIAS _farmhash)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On s390x, farmhash functions fail to generate correct results because libfarmhash library is built with WORDS_BIGENDIAN undefined.
The fix is fix libfarmhash's CMakeLists.txt by defining WORDS_BIGENDIAN for s390x.

### Changelog category (leave one):

- Build Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed farmhash functions for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
