### PR TITLE
Documentation S3 Cache - Add missing policy name element

### DIFF
--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -135,11 +135,13 @@ Example of configuration for versions later or equal to 22.8:
             </cache>
         </disks>
         <policies>
-            <volumes>
-                <main>
-                    <disk>cache</disk>
-                </main>
-            </volumes>
+            <s3-cache>
+                <volumes>
+                    <main>
+                        <disk>cache</disk>
+                    </main>
+                </volumes>
+            </s3-cache>
         <policies>
     </storage_configuration>
 ```

--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -161,11 +161,13 @@ Example of configuration for versions earlier than 22.8:
             </s3>
         </disks>
         <policies>
-            <volumes>
-                <main>
-                    <disk>s3</disk>
-                </main>
-            </volumes>
+            <s3-cache>
+                <volumes>
+                    <main>
+                        <disk>s3</disk>
+                    </main>
+                </volumes>
+            </s3-cache>
         <policies>
     </storage_configuration>
 ```


### PR DESCRIPTION
The S3 cache example had a list of policies, but was missing the policy name. This caused this configuration to fail.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
