### PR TITLE
Added batching for reads and retries for the most heavy function in backups

### DIFF
--- a/src/Backups/BackupCoordinationRemote.cpp
+++ b/src/Backups/BackupCoordinationRemote.cpp
@@ -1,3 +1,4 @@
+#include <iterator>
 #include <Backups/BackupCoordinationRemote.h>
 #include <Access/Common/AccessEntityType.h>
 #include <IO/ReadBufferFromString.h>
@@ -7,6 +8,7 @@
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/escapeForFileName.h>
 #include <Common/hex.h>
+#include "QueryPipeline/ProfileInfo.h"
 #include <Backups/BackupCoordinationStage.h>
 
 
@@ -173,6 +175,13 @@ BackupCoordinationRemote::BackupCoordinationRemote(
     , get_zookeeper(get_zookeeper_)
     , is_internal(is_internal_)
 {
+    zookeeper_retries_info = ZooKeeperRetriesInfo(
+        "BackupCoordinationRemote",
+        &Poco::Logger::get("BackupCoordinationRemote"),
+        20,
+        10,
+        1000);
+
     createRootNodes();
     stage_sync.emplace(
         zookeeper_path + "/stage", [this] { return getZooKeeper(); }, &Poco::Logger::get("BackupCoordination"));
@@ -486,19 +495,127 @@ void BackupCoordinationRemote::updateFileInfo(const FileInfo & file_info)
 
 std::vector<FileInfo> BackupCoordinationRemote::getAllFileInfos() const
 {
-    auto zk = getZooKeeper();
-    std::vector<FileInfo> file_infos;
-    Strings escaped_names = zk->getChildren(zookeeper_path + "/file_names");
-    for (const String & escaped_name : escaped_names)
+    /// There could be tons of files inside /file_names or /file_infos
+    /// Thus we use MultiRead requests for processing them
+    /// We also use [Zoo]Keeper retries and it should be safe, because
+    /// this function is called at the end after the actual copying is finished.
+
+    auto split_vector = [](Strings && vec, size_t max_batch_size) -> std::vector<Strings>
     {
-        String size_and_checksum = zk->get(zookeeper_path + "/file_names/" + escaped_name);
-        UInt64 size = deserializeSizeAndChecksum(size_and_checksum).first;
-        FileInfo file_info;
-        if (size) /// we don't keep FileInfos for empty files
-            file_info = deserializeFileInfo(zk->get(zookeeper_path + "/file_infos/" + size_and_checksum));
-        file_info.file_name = unescapeForFileName(escaped_name);
-        file_infos.emplace_back(std::move(file_info));
+        std::vector<Strings> result;
+        size_t left_border = 0;
+
+        auto move_to_result = [&](auto && begin, auto && end)
+        {
+            auto batch = Strings();
+            batch.reserve(max_batch_size);
+            std::move(begin, end, std::back_inserter(batch));
+            result.push_back(std::move(batch));
+        };
+
+        if (max_batch_size == 0)
+        {
+            move_to_result(vec.begin(), vec.end());
+            return result;
+        }
+
+        for (size_t pos = 0; pos < vec.size(); ++pos)
+        {
+            if (pos >= left_border + max_batch_size)
+            {
+                move_to_result(vec.begin() + left_border, vec.begin() + pos);
+                left_border = pos;
+            }
+        }
+
+        if (vec.begin() + left_border != vec.end())
+            move_to_result(vec.begin() + left_border, vec.end());
+
+        return result;
+    };
+
+    std::vector<Strings> batched_escaped_names;
+    {
+        ZooKeeperRetriesControl retries_ctl("getAllFileInfos::getChildren", zookeeper_retries_info);
+        retries_ctl.retryLoop([&]()
+        {
+            auto zk = getZooKeeper();
+            batched_escaped_names = split_vector(zk->getChildren(zookeeper_path + "/file_names"), 0);
+        });
     }
+
+    std::vector<FileInfo> file_infos;
+    file_infos.reserve(batched_escaped_names.size());
+
+    for (auto & batch : batched_escaped_names)
+    {
+        std::optional<zkutil::ZooKeeper::MultiGetResponse> sizes_and_checksums;
+        {
+            Strings file_names_paths;
+            file_names_paths.reserve(batch.size());
+            for (const String & escaped_name : batch)
+                file_names_paths.emplace_back(zookeeper_path + "/file_names/" + escaped_name);
+
+
+            ZooKeeperRetriesControl retries_ctl("getAllFileInfos::getSizesAndChecksums", zookeeper_retries_info);
+            retries_ctl.retryLoop([&]()
+            {
+                auto zk = getZooKeeper();
+                sizes_and_checksums = zk->get(file_names_paths);
+            });
+        }
+
+        Strings non_empty_file_names;
+        Strings non_empty_file_infos_paths;
+        std::vector<FileInfo> non_empty_files_infos;
+
+        /// Process all files and understand whether there are some empty files
+        /// Save non empty file names for further batch processing
+        {
+            std::vector<FileInfo> empty_files_infos;
+            for (size_t i = 0; i < batch.size(); ++i)
+            {
+                auto file_name = batch[i];
+                auto size_and_checksum = sizes_and_checksums.value()[i].data;
+                auto size = deserializeSizeAndChecksum(size_and_checksum).first;
+
+                if (size)
+                {
+                    /// Save it later for batch processing
+                    non_empty_file_names.emplace_back(file_name);
+                    non_empty_file_infos_paths.emplace_back(zookeeper_path + "/file_infos/" + size_and_checksum);
+                    continue;
+                }
+
+                /// File is empty
+                FileInfo empty_file_info;
+                empty_file_info.file_name = unescapeForFileName(file_name);
+                empty_files_infos.emplace_back(std::move(empty_file_info));
+            }
+
+            std::move(empty_files_infos.begin(), empty_files_infos.end(), std::back_inserter(file_infos));
+        }
+
+        std::optional<zkutil::ZooKeeper::MultiGetResponse> non_empty_file_infos_serialized;
+        ZooKeeperRetriesControl retries_ctl("getAllFileInfos::getFileInfos", zookeeper_retries_info);
+        retries_ctl.retryLoop([&]()
+        {
+            auto zk = getZooKeeper();
+            non_empty_file_infos_serialized = zk->get(non_empty_file_infos_paths);
+        });
+
+        /// Process non empty files
+        for (size_t i = 0; i < non_empty_file_names.size(); ++i)
+        {
+            FileInfo file_info;
+            file_info = deserializeFileInfo(non_empty_file_infos_serialized.value()[i].data);
+            file_info.file_name = unescapeForFileName(non_empty_file_names[i]);
+            non_empty_files_infos.emplace_back(std::move(file_info));
+        }
+
+        std::move(non_empty_files_infos.begin(), non_empty_files_infos.end(), std::back_inserter(file_infos));
+    }
+
     return file_infos;
 }
 

--- a/src/Backups/BackupCoordinationRemote.cpp
+++ b/src/Backups/BackupCoordinationRemote.cpp
@@ -579,6 +579,8 @@ std::vector<FileInfo> BackupCoordinationRemote::getAllFileInfos() const
             for (size_t i = 0; i < batch.size(); ++i)
             {
                 auto file_name = batch[i];
+                if (sizes_and_checksums.value()[i].error != Coordination::Error::ZOK)
+                    throw zkutil::KeeperException(sizes_and_checksums.value()[i].error);
                 auto size_and_checksum = sizes_and_checksums.value()[i].data;
                 auto size = deserializeSizeAndChecksum(size_and_checksum).first;
 
@@ -611,6 +613,8 @@ std::vector<FileInfo> BackupCoordinationRemote::getAllFileInfos() const
         for (size_t i = 0; i < non_empty_file_names.size(); ++i)
         {
             FileInfo file_info;
+            if (non_empty_file_infos_serialized.value()[i].error != Coordination::Error::ZOK)
+                throw zkutil::KeeperException(non_empty_file_infos_serialized.value()[i].error);
             file_info = deserializeFileInfo(non_empty_file_infos_serialized.value()[i].data);
             file_info.file_name = unescapeForFileName(non_empty_file_names[i]);
             non_empty_files_infos.emplace_back(std::move(file_info));

--- a/src/Backups/BackupCoordinationRemote.cpp
+++ b/src/Backups/BackupCoordinationRemote.cpp
@@ -540,7 +540,7 @@ std::vector<FileInfo> BackupCoordinationRemote::getAllFileInfos() const
         retries_ctl.retryLoop([&]()
         {
             auto zk = getZooKeeper();
-            batched_escaped_names = split_vector(zk->getChildren(zookeeper_path + "/file_names"), 0);
+            batched_escaped_names = split_vector(zk->getChildren(zookeeper_path + "/file_names"), 1000);
         });
     }
 

--- a/src/Backups/BackupCoordinationRemote.h
+++ b/src/Backups/BackupCoordinationRemote.h
@@ -17,7 +17,20 @@ constexpr size_t MAX_ZOOKEEPER_ATTEMPTS = 10;
 class BackupCoordinationRemote : public IBackupCoordination
 {
 public:
-    BackupCoordinationRemote(const String & root_zookeeper_path_, const String & backup_uuid_, zkutil::GetZooKeeper get_zookeeper_, bool is_internal_);
+    struct BackupKeeperSettings
+    {
+        UInt64 keeper_max_retries;
+        UInt64 keeper_retry_initial_backoff_ms;
+        UInt64 keeper_retry_max_backoff_ms;
+        UInt64 batch_size_for_keeper_multiread;
+    };
+
+    BackupCoordinationRemote(
+        const BackupKeeperSettings & keeper_settings_,
+        const String & root_zookeeper_path_,
+        const String & backup_uuid_,
+        zkutil::GetZooKeeper get_zookeeper_,
+        bool is_internal_);
     ~BackupCoordinationRemote() override;
 
     void setStage(const String & current_host, const String & new_stage, const String & message) override;
@@ -69,6 +82,7 @@ private:
     void prepareReplicatedTables() const;
     void prepareReplicatedAccess() const;
 
+    const BackupKeeperSettings keeper_settings;
     const String root_zookeeper_path;
     const String zookeeper_path;
     const String backup_uuid;

--- a/src/Backups/BackupCoordinationRemote.h
+++ b/src/Backups/BackupCoordinationRemote.h
@@ -4,6 +4,7 @@
 #include <Backups/BackupCoordinationReplicatedAccess.h>
 #include <Backups/BackupCoordinationReplicatedTables.h>
 #include <Backups/BackupCoordinationStageSync.h>
+#include <Storages/MergeTree/ZooKeeperRetries.h>
 
 
 namespace DB
@@ -74,6 +75,7 @@ private:
     const zkutil::GetZooKeeper get_zookeeper;
     const bool is_internal;
 
+    mutable ZooKeeperRetriesInfo zookeeper_retries_info;
     std::optional<BackupCoordinationStageSync> stage_sync;
 
     mutable std::mutex mutex;

--- a/src/Backups/IBackupCoordination.h
+++ b/src/Backups/IBackupCoordination.h
@@ -1,12 +1,9 @@
 #pragma once
 
 #include <optional>
-
 #include <fmt/format.h>
-#include <fmt/core.h>
-
-#include <Core/Types.h>
 #include <Common/hex.h>
+#include <Core/Types.h>
 
 
 namespace DB
@@ -91,6 +88,8 @@ public:
         /// Position in the archive.
         UInt64 pos_in_archive = static_cast<UInt64>(-1);
 
+        /// Note: this format doesn't allow to parse data back
+        /// It is useful only for debugging purposes
         [[ maybe_unused ]] String describe()
         {
             String result;

--- a/src/Backups/IBackupCoordination.h
+++ b/src/Backups/IBackupCoordination.h
@@ -1,7 +1,12 @@
 #pragma once
 
-#include <Core/Types.h>
 #include <optional>
+
+#include <fmt/format.h>
+#include <fmt/core.h>
+
+#include <Core/Types.h>
+#include <Common/hex.h>
 
 
 namespace DB
@@ -85,6 +90,20 @@ public:
 
         /// Position in the archive.
         UInt64 pos_in_archive = static_cast<UInt64>(-1);
+
+        [[ maybe_unused ]] String describe()
+        {
+            String result;
+            result += fmt::format("file_name: {};\n", file_name);
+            result += fmt::format("size: {};\n", size);
+            result += fmt::format("checksum: {};\n", getHexUIntLowercase(checksum));
+            result += fmt::format("base_size: {};\n", base_size);
+            result += fmt::format("base_checksum: {};\n", getHexUIntLowercase(checksum));
+            result += fmt::format("data_file_name: {};\n", data_file_name);
+            result += fmt::format("archive_suffix: {};\n", archive_suffix);
+            result += fmt::format("pos_in_archive: {};\n", pos_in_archive);
+            return result;
+        }
     };
 
     /// Adds file information.

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -414,6 +414,10 @@ class IColumn;
     \
     M(UInt64, backup_threads, 16, "The maximum number of threads to execute BACKUP requests.", 0) \
     M(UInt64, restore_threads, 16, "The maximum number of threads to execute RESTORE requests.", 0) \
+    M(UInt64, backup_keeper_max_retries, 20, "Max retries for keeper operations during backup", 0) \
+    M(UInt64, backup_keeper_retry_initial_backoff_ms, 100, "Initial backoff timeout for [Zoo]Keeper operations during backup", 0) \
+    M(UInt64, backup_keeper_retry_max_backoff_ms, 5000, "Max backoff timeout for [Zoo]Keeper operations during backup", 0) \
+    M(UInt64, backup_batch_size_for_keeper_multiread, 10000, "Maximum size of batch for multiread request to [Zoo]Keeper during backup", 0) \
     \
     M(Bool, log_profile_events, true, "Log query performance statistics into the query_log, query_thread_log and query_views_log.", 0) \
     M(Bool, log_query_settings, true, "Log query settings into the query_log.", 0) \


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use MultiRead request and retries for collecting metadata at final stage of backup processing. 

