### PR TITLE
Use string concatenation for XML serialization

### DIFF
--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -16,11 +16,11 @@
 #include <IO/Archives/createArchiveWriter.h>
 #include <IO/ConcatSeekableReadBuffer.h>
 #include <IO/HashingReadBuffer.h>
-#include <IO/ReadBufferFromFileBase.h>
 #include <IO/ReadHelpers.h>
 #include <IO/SeekableReadBuffer.h>
 #include <IO/WriteBufferFromFileBase.h>
 #include <IO/WriteHelpers.h>
+#include <IO/Operators.h>
 #include <IO/copyData.h>
 #include <Poco/Util/XMLConfiguration.h>
 #include <Poco/DOM/DOMParser.h>
@@ -317,11 +317,19 @@ void BackupImpl::writeBackupMetadata()
 {
     assert(!is_internal_backup);
 
-    Poco::AutoPtr<Poco::Util::XMLConfiguration> config{new Poco::Util::XMLConfiguration()};
-    config->setInt("version", CURRENT_BACKUP_VERSION);
-    config->setBool("deduplicate_files", deduplicate_files);
-    config->setString("timestamp", toString(LocalDateTime{timestamp}));
-    config->setString("uuid", toString(*uuid));
+    checkLockFile(true);
+
+    std::unique_ptr<WriteBuffer> out;
+    if (use_archives)
+        out = getArchiveWriter("")->writeFile(".backup");
+    else
+        out = writer->writeFile(".backup");
+
+    *out << "<config>";
+    *out << "<version>" << CURRENT_BACKUP_VERSION << "</version>";
+    *out << "<deduplicate_files>" << deduplicate_files << "</deduplicate_files>";
+    *out << "<timestamp>" << toString(LocalDateTime{timestamp}) << "</timestamp>";
+    *out << "<uuid>" << toString(*uuid) << "</uuid>";
 
     auto all_file_infos = coordination->getAllFileInfos();
 
@@ -336,8 +344,8 @@ void BackupImpl::writeBackupMetadata()
 
         if (base_backup_in_use)
         {
-            config->setString("base_backup", base_backup_info->toString());
-            config->setString("base_backup_uuid", toString(*base_backup_uuid));
+            *out << "<base_backup>" << xml << base_backup_info->toString() << "</base_backup>";
+            *out << "<base_backup_uuid>" << toString(*base_backup_uuid) << "</base_backup_uuid>";
         }
     }
 
@@ -346,31 +354,32 @@ void BackupImpl::writeBackupMetadata()
     num_entries = 0;
     size_of_entries = 0;
 
-    for (size_t i = 0; i != all_file_infos.size(); ++i)
+    *out << "<contents>";
+    for (const auto & info : all_file_infos)
     {
-        const auto & info = all_file_infos[i];
-        String prefix = i ? "contents.file[" + std::to_string(i) + "]." : "contents.file.";
-        config->setString(prefix + "name", info.file_name);
-        config->setUInt64(prefix + "size", info.size);
+        *out << "<file>";
+
+        *out << "<name>" << xml << info.file_name << "</name>";
+        *out << "<size>" << info.size << "</size>";
 
         if (info.size)
         {
-            config->setString(prefix + "checksum", hexChecksum(info.checksum));
+            *out << "<checksum>" << hexChecksum(info.checksum) << "</checksum>";
             if (info.base_size)
             {
-                config->setBool(prefix + "use_base", true);
+                *out << "<use_base>true</use_base>";
                 if (info.base_size != info.size)
                 {
-                    config->setUInt64(prefix + "base_size", info.base_size);
-                    config->setString(prefix + "base_checksum", hexChecksum(info.base_checksum));
+                    *out << "<base_size>" << info.base_size << "</base_size>";
+                    *out << "<base_checksum>" << hexChecksum(info.base_checksum) << "</base_checksum>";
                 }
             }
             if (!info.data_file_name.empty() && (info.data_file_name != info.file_name))
-                config->setString(prefix + "data_file", info.data_file_name);
+                *out << "<data_file>" << xml << info.data_file_name << "</data_file>";
             if (!info.archive_suffix.empty())
-                config->setString(prefix + "archive_suffix", info.archive_suffix);
+                *out << "<archive_suffix>" << xml << info.archive_suffix << "</archive_suffix>";
             if (info.pos_in_archive != static_cast<size_t>(-1))
-                config->setUInt64(prefix + "pos_in_archive", info.pos_in_archive);
+                *out << "<pos_in_archive>" << info.pos_in_archive << "</pos_in_archive>";
         }
 
         total_size += info.size;
@@ -380,23 +389,16 @@ void BackupImpl::writeBackupMetadata()
             ++num_entries;
             size_of_entries += info.size - info.base_size;
         }
+
+        *out << "</file>";
     }
+    *out << "</contents>";
 
-    std::ostringstream stream; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    config->save(stream);
-    String str = stream.str();
+    *out << "</config>";
 
-    checkLockFile(true);
-
-    std::unique_ptr<WriteBuffer> out;
-    if (use_archives)
-        out = getArchiveWriter("")->writeFile(".backup");
-    else
-        out = writer->writeFile(".backup");
-    out->write(str.data(), str.size());
     out->finalize();
 
-    uncompressed_size = size_of_entries + str.size();
+    uncompressed_size = size_of_entries + out->count();
 }
 
 

--- a/src/IO/Operators.h
+++ b/src/IO/Operators.h
@@ -30,11 +30,13 @@ enum EscapeManip        { escape };           /// For strings - escape special c
 enum QuoteManip         { quote };            /// For strings, dates, datetimes - enclose in single quotes with escaping. In the rest, as usual.
 enum DoubleQuoteManip   { double_quote };     /// For strings, dates, datetimes - enclose in double quotes with escaping. In the rest, as usual.
 enum BinaryManip        { binary };           /// Output in binary format.
+enum XMLManip           { xml };              /// Output strings with XML escaping.
 
 struct EscapeManipWriteBuffer        : std::reference_wrapper<WriteBuffer> { using std::reference_wrapper<WriteBuffer>::reference_wrapper; };
 struct QuoteManipWriteBuffer         : std::reference_wrapper<WriteBuffer> { using std::reference_wrapper<WriteBuffer>::reference_wrapper; };
 struct DoubleQuoteManipWriteBuffer   : std::reference_wrapper<WriteBuffer> { using std::reference_wrapper<WriteBuffer>::reference_wrapper; };
 struct BinaryManipWriteBuffer        : std::reference_wrapper<WriteBuffer> { using std::reference_wrapper<WriteBuffer>::reference_wrapper; };
+struct XMLManipWriteBuffer           : std::reference_wrapper<WriteBuffer> { using std::reference_wrapper<WriteBuffer>::reference_wrapper; };
 
 struct EscapeManipReadBuffer         : std::reference_wrapper<ReadBuffer> { using std::reference_wrapper<ReadBuffer>::reference_wrapper; };
 struct QuoteManipReadBuffer          : std::reference_wrapper<ReadBuffer> { using std::reference_wrapper<ReadBuffer>::reference_wrapper; };
@@ -48,11 +50,13 @@ inline EscapeManipWriteBuffer      operator<< (WriteBuffer & buf, EscapeManip)  
 inline QuoteManipWriteBuffer       operator<< (WriteBuffer & buf, QuoteManip)       { return buf; }
 inline DoubleQuoteManipWriteBuffer operator<< (WriteBuffer & buf, DoubleQuoteManip) { return buf; }
 inline BinaryManipWriteBuffer      operator<< (WriteBuffer & buf, BinaryManip)      { return buf; }
+inline XMLManipWriteBuffer         operator<< (WriteBuffer & buf, XMLManip)         { return buf; }
 
 template <typename T> WriteBuffer & operator<< (EscapeManipWriteBuffer buf,        const T & x) { writeText(x, buf.get());         return buf; }
 template <typename T> WriteBuffer & operator<< (QuoteManipWriteBuffer buf,         const T & x) { writeQuoted(x, buf.get());       return buf; }
 template <typename T> WriteBuffer & operator<< (DoubleQuoteManipWriteBuffer buf,   const T & x) { writeDoubleQuoted(x, buf.get()); return buf; }
 template <typename T> WriteBuffer & operator<< (BinaryManipWriteBuffer buf,        const T & x) { writeBinary(x, buf.get());       return buf; }
+template <typename T> WriteBuffer & operator<< (XMLManipWriteBuffer buf,           const T & x) { writeText(x, buf.get());         return buf; }
 
 inline  WriteBuffer & operator<< (EscapeManipWriteBuffer buf, const String & x)   { writeEscapedString(x, buf); return buf; }
 inline  WriteBuffer & operator<< (EscapeManipWriteBuffer buf, std::string_view x) { writeEscapedString(x, buf); return buf; }
@@ -62,6 +66,10 @@ inline  WriteBuffer & operator<< (EscapeManipWriteBuffer buf, const char * x)   
 inline WriteBuffer & operator<< (QuoteManipWriteBuffer buf,       const char * x) { writeAnyQuotedString<'\''>(x, x + strlen(x), buf.get()); return buf; }
 inline WriteBuffer & operator<< (DoubleQuoteManipWriteBuffer buf, const char * x) { writeAnyQuotedString<'"'>(x, x + strlen(x), buf.get()); return buf; }
 inline WriteBuffer & operator<< (BinaryManipWriteBuffer buf,      const char * x) { writeStringBinary(x, buf.get()); return buf; }
+
+inline  WriteBuffer & operator<< (XMLManipWriteBuffer buf, std::string_view x) { writeXMLStringForTextElementOrAttributeValue(x, buf); return buf; }
+inline  WriteBuffer & operator<< (XMLManipWriteBuffer buf, StringRef x)        { writeXMLStringForTextElementOrAttributeValue(x.toView(), buf); return buf; }
+inline  WriteBuffer & operator<< (XMLManipWriteBuffer buf, const char * x)     { writeXMLStringForTextElementOrAttributeValue(std::string_view(x), buf); return buf; }
 
 /// The manipulator calls the WriteBuffer method `next` - this makes the buffer reset. For nested buffers, the reset is not recursive.
 enum FlushManip { flush };


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Backups for large numbers of files were unbelievably slow in previous versions.