### PR TITLE
Add default constructor for `MultiReadResponse`

### DIFF
--- a/src/Backups/BackupCoordinationRemote.cpp
+++ b/src/Backups/BackupCoordinationRemote.cpp
@@ -552,7 +552,7 @@ std::vector<FileInfo> BackupCoordinationRemote::getAllFileInfos() const
 
     for (auto & batch : batched_escaped_names)
     {
-        std::optional<zkutil::ZooKeeper::MultiGetResponse> sizes_and_checksums;
+        zkutil::ZooKeeper::MultiGetResponse sizes_and_checksums;
         {
             Strings file_names_paths;
             file_names_paths.reserve(batch.size());
@@ -561,7 +561,7 @@ std::vector<FileInfo> BackupCoordinationRemote::getAllFileInfos() const
 
 
             ZooKeeperRetriesControl retries_ctl("getAllFileInfos::getSizesAndChecksums", zookeeper_retries_info);
-            retries_ctl.retryLoop([&]()
+            retries_ctl.retryLoop([&]
             {
                 auto zk = getZooKeeper();
                 sizes_and_checksums = zk->get(file_names_paths);
@@ -579,9 +579,9 @@ std::vector<FileInfo> BackupCoordinationRemote::getAllFileInfos() const
             for (size_t i = 0; i < batch.size(); ++i)
             {
                 auto file_name = batch[i];
-                if (sizes_and_checksums.value()[i].error != Coordination::Error::ZOK)
-                    throw zkutil::KeeperException(sizes_and_checksums.value()[i].error);
-                auto size_and_checksum = sizes_and_checksums.value()[i].data;
+                if (sizes_and_checksums[i].error != Coordination::Error::ZOK)
+                    throw zkutil::KeeperException(sizes_and_checksums[i].error);
+                const auto & size_and_checksum = sizes_and_checksums[i].data;
                 auto size = deserializeSizeAndChecksum(size_and_checksum).first;
 
                 if (size)
@@ -601,7 +601,7 @@ std::vector<FileInfo> BackupCoordinationRemote::getAllFileInfos() const
             std::move(empty_files_infos.begin(), empty_files_infos.end(), std::back_inserter(file_infos));
         }
 
-        std::optional<zkutil::ZooKeeper::MultiGetResponse> non_empty_file_infos_serialized;
+        zkutil::ZooKeeper::MultiGetResponse non_empty_file_infos_serialized;
         ZooKeeperRetriesControl retries_ctl("getAllFileInfos::getFileInfos", zookeeper_retries_info);
         retries_ctl.retryLoop([&]()
         {
@@ -613,9 +613,9 @@ std::vector<FileInfo> BackupCoordinationRemote::getAllFileInfos() const
         for (size_t i = 0; i < non_empty_file_names.size(); ++i)
         {
             FileInfo file_info;
-            if (non_empty_file_infos_serialized.value()[i].error != Coordination::Error::ZOK)
-                throw zkutil::KeeperException(non_empty_file_infos_serialized.value()[i].error);
-            file_info = deserializeFileInfo(non_empty_file_infos_serialized.value()[i].data);
+            if (non_empty_file_infos_serialized[i].error != Coordination::Error::ZOK)
+                throw zkutil::KeeperException(non_empty_file_infos_serialized[i].error);
+            file_info = deserializeFileInfo(non_empty_file_infos_serialized[i].data);
             file_info.file_name = unescapeForFileName(non_empty_file_names[i]);
             non_empty_files_infos.emplace_back(std::move(file_info));
         }

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -33,6 +33,12 @@ namespace CurrentMetrics
 namespace DB
 {
     class ZooKeeperLog;
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 }
 
 namespace zkutil

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -79,13 +79,23 @@ concept ZooKeeperResponse = std::derived_from<T, Coordination::Response>;
 template <ZooKeeperResponse ResponseType, bool try_multi>
 struct MultiReadResponses
 {
+    MultiReadResponses() = default;
+
     template <typename TResponses>
     explicit MultiReadResponses(TResponses responses_) : responses(std::move(responses_))
     {}
 
     size_t size() const
     {
-        return std::visit([](auto && resp) { return resp.size(); }, responses);
+        return std::visit(
+            [&]<typename TResponses>(const TResponses & resp) -> size_t
+            {
+                if constexpr (std::same_as<TResponses, std::monostate>)
+                    throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "No responses set for MultiRead");
+                else
+                    return resp.size();
+            },
+            responses);
     }
 
     ResponseType & operator[](size_t index)
@@ -94,8 +104,10 @@ struct MultiReadResponses
             [&]<typename TResponses>(TResponses & resp) -> ResponseType &
             {
                 if constexpr (std::same_as<TResponses, RegularResponses>)
+                {
                     return dynamic_cast<ResponseType &>(*resp[index]);
-                else
+                }
+                else if constexpr (std::same_as<TResponses, ResponsesWithFutures>)
                 {
                     if constexpr (try_multi)
                     {
@@ -106,6 +118,10 @@ struct MultiReadResponses
                             throw KeeperException(error);
                     }
                     return resp[index];
+                }
+                else
+                {
+                    throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "No responses set for MultiRead");
                 }
             },
             responses);
@@ -137,7 +153,7 @@ private:
         size_t size() const { return future_responses.size(); }
     };
 
-    std::variant<RegularResponses, ResponsesWithFutures> responses;
+    std::variant<std::monostate, RegularResponses, ResponsesWithFutures> responses;
 };
 
 /// ZooKeeper session. The interface is substantially different from the usual libzookeeper API.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
