### PR TITLE
Add Keeper 4LW for cleaning resources

### DIFF
--- a/programs/keeper/CMakeLists.txt
+++ b/programs/keeper/CMakeLists.txt
@@ -128,6 +128,7 @@ if (BUILD_STANDALONE_KEEPER)
             ch_contrib::lz4
             ch_contrib::zstd
             ch_contrib::cityhash
+            ch_contrib::jemalloc
             common ch_contrib::double_conversion
             ch_contrib::dragonbox_to_chars
             pcg_random

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -36,7 +36,7 @@ void CoordinationSettings::loadFromConfig(const String & config_elem, const Poco
 }
 
 
-const String KeeperConfigurationAndSettings::DEFAULT_FOUR_LETTER_WORD_CMD = "conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rcvr,apiv,csnp,lgif,rqld,rclc";
+const String KeeperConfigurationAndSettings::DEFAULT_FOUR_LETTER_WORD_CMD = "conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,rcvr,apiv,csnp,lgif,rqld,rclc,clrs";
 
 KeeperConfigurationAndSettings::KeeperConfigurationAndSettings()
     : server_id(NOT_EXIST)

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -148,6 +148,9 @@ void FourLetterCommandFactory::registerCommands(KeeperDispatcher & keeper_dispat
         FourLetterCommandPtr recalculate_command = std::make_shared<RecalculateCommand>(keeper_dispatcher);
         factory.registerCommand(recalculate_command);
 
+        FourLetterCommandPtr clean_resources_command = std::make_shared<CleanResourcesCommand>(keeper_dispatcher);
+        factory.registerCommand(clean_resources_command);
+
         factory.initializeAllowList(keeper_dispatcher);
         factory.setInitialize(true);
     }
@@ -521,6 +524,12 @@ String RequestLeaderCommand::run()
 String RecalculateCommand::run()
 {
     keeper_dispatcher.recalculateStorageStats();
+    return "ok";
+}
+
+String CleanResourcesCommand::run()
+{
+    keeper_dispatcher.cleanResources();
     return "ok";
 }
 

--- a/src/Coordination/FourLetterCommand.h
+++ b/src/Coordination/FourLetterCommand.h
@@ -377,7 +377,6 @@ struct RequestLeaderCommand : public IFourLetterCommand
     ~RequestLeaderCommand() override = default;
 };
 
-/// Request to be leader.
 struct RecalculateCommand : public IFourLetterCommand
 {
     explicit RecalculateCommand(KeeperDispatcher & keeper_dispatcher_)
@@ -388,6 +387,18 @@ struct RecalculateCommand : public IFourLetterCommand
     String name() override { return "rclc"; }
     String run() override;
     ~RecalculateCommand() override = default;
+};
+
+struct CleanResourcesCommand : public IFourLetterCommand
+{
+    explicit CleanResourcesCommand(KeeperDispatcher & keeper_dispatcher_)
+        : IFourLetterCommand(keeper_dispatcher_)
+    {
+    }
+
+    String name() override { return "clrs"; }
+    String run() override;
+    ~CleanResourcesCommand() override = default;
 };
 
 }

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -9,7 +9,7 @@
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/checkStackSize.h>
 #include <Common/CurrentMetrics.h>
-
+#include <Common/ProfileEvents.h>
 
 #include <future>
 #include <chrono>
@@ -17,10 +17,24 @@
 #include <iterator>
 #include <limits>
 
+#if USE_JEMALLOC
+#    include <jemalloc/jemalloc.h>
+
+#define STRINGIFY_HELPER(x) #x
+#define STRINGIFY(x) STRINGIFY_HELPER(x)
+
+#endif
+
 namespace CurrentMetrics
 {
     extern const Metric KeeperAliveConnections;
     extern const Metric KeeperOutstandingRequets;
+}
+
+namespace ProfileEvents
+{
+    extern const Event MemoryAllocatorPurge;
+    extern const Event MemoryAllocatorPurgeTimeMicroseconds;
 }
 
 namespace fs = std::filesystem;
@@ -751,6 +765,17 @@ Keeper4LWInfo KeeperDispatcher::getKeeper4LWInfo() const
         result.alive_connections_count = session_to_response_callback.size();
     }
     return result;
+}
+
+void KeeperDispatcher::cleanResources()
+{
+#if USE_JEMALLOC
+    LOG_TRACE(&Poco::Logger::get("KeeperDispatcher"), "Purging unused memory");
+    Stopwatch watch;
+    mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".purge", nullptr, nullptr, nullptr, 0);
+    ProfileEvents::increment(ProfileEvents::MemoryAllocatorPurge);
+    ProfileEvents::increment(ProfileEvents::MemoryAllocatorPurgeTimeMicroseconds, watch.elapsedMicroseconds());
+#endif
 }
 
 }

--- a/src/Coordination/KeeperDispatcher.h
+++ b/src/Coordination/KeeperDispatcher.h
@@ -230,6 +230,8 @@ public:
     {
         return server->recalculateStorageStats();
     }
+
+    static void cleanResources();
 };
 
 }

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -682,6 +682,9 @@ def test_cmd_rqld(started_cluster):
 
 
 def test_cmd_clrs(started_cluster):
+    if node1.is_built_with_sanitizer():
+        return
+
     def get_memory_purges():
         return node1.query(
             "SELECT value FROM system.events WHERE event = 'MemoryAllocatorPurge' SETTINGS system_events_show_zero_values = 1"

--- a/tests/integration/test_keeper_four_word_command/test.py
+++ b/tests/integration/test_keeper_four_word_command/test.py
@@ -679,3 +679,41 @@ def test_cmd_rqld(started_cluster):
                     + " does not become leader after 30s, maybe there is something wrong."
                 )
         assert keeper_utils.is_leader(cluster, node)
+
+
+def test_cmd_clrs(started_cluster):
+    def get_memory_purges():
+        return node1.query(
+            "SELECT value FROM system.events WHERE event = 'MemoryAllocatorPurge' SETTINGS system_events_show_zero_values = 1"
+        )
+
+    zk = None
+    try:
+        wait_nodes()
+
+        zk = get_fake_zk(node1.name, timeout=30.0)
+
+        paths = [f"/clrs_{i}" for i in range(10000)]
+
+        # we only count the events because we cannot reliably test memory usage of Keeper
+        # but let's create and delete nodes so the first purge needs to release some memory
+        create_transaction = zk.transaction()
+        for path in paths:
+            create_transaction.create(path)
+        create_transaction.commit()
+
+        delete_transaction = zk.transaction()
+        for path in paths:
+            delete_transaction.delete(path)
+        delete_transaction.commit()
+
+        # repeat multiple times to make sure MemoryAllocatorPurge isn't increased because of other reasons
+        for _ in range(5):
+            prev_purges = int(get_memory_purges())
+            keeper_utils.send_4lw_cmd(cluster, node1, cmd="clrs")
+            current_purges = int(get_memory_purges())
+            assert current_purges > prev_purges
+            prev_purges = current_purges
+
+    finally:
+        destroy_zk_client(zk)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Keeper improvement: Add new 4LW `clrs` to clean resources used by Keeper (e.g. release unused memory).

- [x] Add test

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
