### PR TITLE
Query plan filter push down optimization filled JOIN fix

### DIFF
--- a/src/Processors/QueryPlan/JoinStep.h
+++ b/src/Processors/QueryPlan/JoinStep.h
@@ -49,6 +49,8 @@ public:
     String getName() const override { return "FilledJoin"; }
     void transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
 
+    const JoinPtr & getJoin() const { return join; }
+
 private:
     void updateOutputStream() override;
 

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -314,11 +314,14 @@ size_t tryPushDownFilter(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes
     if (auto updated_steps = simplePushDownOverStep<DistinctStep>(parent_node, nodes, child))
         return updated_steps;
 
-    if (auto * join = typeid_cast<JoinStep *>(child.get()))
+    auto * join = typeid_cast<JoinStep *>(child.get());
+    auto * filled_join = typeid_cast<FilledJoinStep *>(child.get());
+
+    if (join || filled_join)
     {
         auto join_push_down = [&](JoinKind kind) -> size_t
         {
-            const auto & table_join = join->getJoin()->getTableJoin();
+            const auto & table_join = join ? join->getJoin()->getTableJoin() : filled_join->getJoin()->getTableJoin();
 
             /// Only inner and left(/right) join are supported. Other types may generate default values for left table keys.
             /// So, if we push down a condition like `key != 0`, not all rows may be filtered.
@@ -326,8 +329,8 @@ size_t tryPushDownFilter(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes
                 return 0;
 
             bool is_left = kind == JoinKind::Left;
-            const auto & input_header = is_left ? join->getInputStreams().front().header : join->getInputStreams().back().header;
-            const auto & res_header = join->getOutputStream().header;
+            const auto & input_header = is_left ? child->getInputStreams().front().header : child->getInputStreams().back().header;
+            const auto & res_header = child->getOutputStream().header;
             Names allowed_keys;
             const auto & source_columns = input_header.getNames();
             for (const auto & name : source_columns)
@@ -372,7 +375,7 @@ size_t tryPushDownFilter(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes
             return updated_steps;
 
         /// For full sorting merge join we push down both to the left and right tables, because left and right streams are not independent.
-        if (join->allowPushDownToRight())
+        if (join && join->allowPushDownToRight())
         {
             if (size_t updated_steps = join_push_down(JoinKind::Right))
                 return updated_steps;

--- a/tests/queries/0_stateless/02675_predicate_push_down_filled_join_fix.reference
+++ b/tests/queries/0_stateless/02675_predicate_push_down_filled_join_fix.reference
@@ -1,0 +1,33 @@
+Expression ((Project names + (Projection + )))
+Header: t1.id UInt64
+        t1.value String
+        t2.value String
+Actions: INPUT : 0 -> t1.id_0 UInt64 : 0
+         INPUT : 1 -> t1.value_1 String : 1
+         INPUT : 2 -> t2.value_2 String : 2
+         ALIAS t1.id_0 :: 0 -> t1.id UInt64 : 3
+         ALIAS t1.value_1 :: 1 -> t1.value String : 0
+         ALIAS t2.value_2 :: 2 -> t2.value String : 1
+Positions: 3 0 1
+  FilledJoin (Filled JOIN)
+  Header: t1.id_0 UInt64
+          t1.value_1 String
+          t2.value_2 String
+    Filter (( + (JOIN actions + Change column names to column identifiers)))
+    Header: t1.id_0 UInt64
+            t1.value_1 String
+    Filter column: equals(t1.id_0, 0_UInt8) (removed)
+    Actions: INPUT : 0 -> id UInt64 : 0
+             INPUT : 1 -> value String : 1
+             COLUMN Const(UInt8) -> 0_UInt8 UInt8 : 2
+             ALIAS id :: 0 -> t1.id_0 UInt64 : 3
+             ALIAS value :: 1 -> t1.value_1 String : 0
+             FUNCTION equals(t1.id_0 : 3, 0_UInt8 :: 2) -> equals(t1.id_0, 0_UInt8) UInt8 : 1
+    Positions: 1 3 0
+      ReadFromMergeTree (default.test_table)
+      Header: id UInt64
+              value String
+      ReadType: Default
+      Parts: 1
+      Granules: 1
+0	Value	JoinValue

--- a/tests/queries/0_stateless/02675_predicate_push_down_filled_join_fix.sql
+++ b/tests/queries/0_stateless/02675_predicate_push_down_filled_join_fix.sql
@@ -1,0 +1,26 @@
+SET allow_experimental_analyzer = 1;
+
+DROP TABLE IF EXISTS test_table;
+CREATE TABLE test_table
+(
+    id UInt64,
+    value String
+) ENGINE=MergeTree ORDER BY id;
+
+INSERT INTO test_table VALUES (0, 'Value');
+
+DROP TABLE IF EXISTS test_table_join;
+CREATE TABLE test_table_join
+(
+    id UInt64,
+    value String
+) ENGINE = Join(All, inner, id);
+
+INSERT INTO test_table_join VALUES (0, 'JoinValue');
+
+EXPLAIN header = 1, actions = 1 SELECT t1.id, t1.value, t2.value FROM test_table AS t1 INNER JOIN test_table_join AS t2 ON t1.id = t2.id WHERE t1.id = 0;
+
+SELECT t1.id, t1.value, t2.value FROM test_table AS t1 INNER JOIN test_table_join AS t2 ON t1.id = t2.id WHERE t1.id = 0;
+
+DROP TABLE test_table_join;
+DROP TABLE test_table;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support filter push down to left table for JOIN with StorageJoin, StorageDictionary, StorageEmbeddedRocksDB.
