### PR TITLE
Replace LOGICAL_ERROR to BAD_ARGUMENTS for evaluateConstantExpression.

### DIFF
--- a/base/poco/Foundation/include/Poco/Exception.h
+++ b/base/poco/Foundation/include/Poco/Exception.h
@@ -74,6 +74,8 @@ public:
     int code() const;
     /// Returns the exception code if defined.
 
+    void setErrorCode(int code) { _code = code; }
+
     virtual std::string displayText() const;
     /// Returns a string consisting of the
     /// message name and the message text.

--- a/tests/queries/0_stateless/02675_identifier_as_constant_expression_logical_error.sql
+++ b/tests/queries/0_stateless/02675_identifier_as_constant_expression_logical_error.sql
@@ -1,0 +1,1 @@
+SELECT NULL FROM cluster('test_cluster_two_shards', currentDatabase(executable('', 'JSON', 'data String', SETTINGS max_command_execution_time = 100, command_read_timeout = 1)), t) -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

To fix [this](https://s3.amazonaws.com/clickhouse-test-reports/0/3de905bb7c1c9f3976324d20cefdce8e75b7a890/fuzzer_astfuzzerubsan/report.html).

This is not a good fix, but I don't have a better idea.