### PR TITLE
Fix MergeTreeTransaction::isReadOnly

### DIFF
--- a/src/Interpreters/MergeTreeTransaction.h
+++ b/src/Interpreters/MergeTreeTransaction.h
@@ -78,6 +78,9 @@ private:
 
     bool finalized TSA_GUARDED_BY(mutex) = false;
 
+    /// Indicates if transaction was read-only before `afterFinalize`
+    bool is_read_only TSA_GUARDED_BY(mutex) = false;
+
     /// Lists of changes made by transaction
     std::unordered_set<StoragePtr> storages TSA_GUARDED_BY(mutex);
     DataPartsVector creating_parts TSA_GUARDED_BY(mutex);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes https://github.com/ClickHouse/ClickHouse/issues/47296

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
