### PR TITLE
Improve the performance of column `scatter`

### DIFF
--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -95,28 +95,28 @@ const PartitionSelector::PartitionInfo & PartitionSelector::getPartitionInfo(siz
     if (partition_info.offsets_map.size() != selector.size() || partition_info.offsets_map.empty() || force_update) [[unlikely]]
     {
         auto rows = selector.size();
-        std::vector<size_t> partitions_length(buckets + 1, 0);
+        std::vector<size_t> partitions_offset(buckets + 1, 0);
         Array offsets_map(rows, 0);
         for (size_t i = 0; i < rows; ++i)
         {
-            partitions_length[selector[i]]++;
+            partitions_offset[selector[i]]++;
         }
         for (size_t i = 1; i <= buckets; ++i)
         {
-            partitions_length[i] += partitions_length[i - 1];
+            partitions_offset[i] += partitions_offset[i - 1];
         }
         for (size_t i = rows; i-- > 0;)
         {
-            offsets_map[partitions_length[selector[i]] - 1] = i;
-            partitions_length[selector[i]]--;
+            offsets_map[partitions_offset[selector[i]] - 1] = i;
+            partitions_offset[selector[i]]--;
         }
-        partition_info.partitions_length.swap(partitions_length);
+        partition_info.partitions_offset.swap(partitions_offset);
         partition_info.offsets_map.swap(offsets_map);
     }
-    
-    if (partition_info.partitions_length.size() != buckets + 1) [[unlikely]]
+
+    if (partition_info.partitions_offset.size() != buckets + 1) [[unlikely]]
     {
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "buckets({}) is not match with {}. selector size:{}", buckets, partition_info.partitions_length.size(), selector.size());
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "buckets({}) is not match with {}. selector size:{}", buckets, partition_info.partitions_offset.size(), selector.size());
     }
 
     return partition_info;

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -653,78 +653,72 @@ bool checkColumn(const IColumn * column)
 class PartitionSelector
 {
 public:
-  using Index = IColumn::ColumnIndex;
-  using Array = PaddedPODArray<Index>;
+    using Index = IColumn::ColumnIndex;
+    using Array = PaddedPODArray<Index>;
 
-  struct PartitionInfo
-  {
-    Array offsets_map;
-    std::vector<size_t> partitions_length;
-  };
+    struct PartitionInfo
+    {
+        Array offsets_map;
+        std::vector<size_t> partitions_offset;
+    };
 
-  explicit PartitionSelector(size_t num_rows) : selector(num_rows) { }
+    explicit PartitionSelector(size_t num_rows) : selector(num_rows) { }
 
-  explicit PartitionSelector(size_t num_rows, const Index & x) : selector(num_rows, x) { }
+    explicit PartitionSelector(size_t num_rows, const Index & x) : selector(num_rows, x) { }
 
-  PartitionSelector() = default;
-  PartitionSelector(PartitionSelector && other) noexcept
-  {
-    swap(other);
-  }
+    PartitionSelector() = default;
+    PartitionSelector(PartitionSelector && other) noexcept { swap(other); }
 
-  inline void reserve(size_t n) { selector.reserve(n); }
-  inline Index & operator [] (ssize_t n)
-  {
-    return selector[n];
-  }
-  inline const Index & operator [] (ssize_t n) const { return selector[n]; }
-  inline void push_back(Index && x) { selector.push_back(x); }
-  inline void emplace_back(Index && x) { selector.emplace_back(x); }
-  inline size_t size() const { return selector.size(); }
-  inline void swap(Array & rhs)
-  { 
-    selector.swap(rhs);
-    partition_info.partitions_length.clear();
-    partition_info.offsets_map.clear();
-  }
-  inline Array::iterator begin() { return selector.begin(); }
-  inline Array::iterator end() { return selector.end(); }
-  inline Array::const_iterator begin() const { return selector.begin(); }
-  inline Array::const_iterator end() const { return selector.end(); }
-  inline Array::const_iterator cbegin() const { return selector.cbegin(); }
-  inline Array::const_iterator cend() const { return selector.cend(); }
-  inline void assign(size_t n, const Index & x) { selector.assign(n, x); }
-  inline void resize(size_t n) { selector.resize(n); }
-  inline void resize_fill(size_t n) { selector.resize_fill(n); }
-  inline void resize_fill(size_t n , const Index & x) { selector.resize_fill(n, x); }
-  inline bool empty() const { return selector.empty(); }
-  inline size_t capacity() const { return selector.capacity(); }
-  inline void clear()
-  {
-    selector.clear();
-    partition_info.partitions_length.clear();
-    partition_info.offsets_map.clear();
-  }
-  inline Index * data() { return selector.data(); }
-  inline const Index * data() const { return selector.data(); }
-  PartitionSelector & operator=(PartitionSelector && other) noexcept
-  {
-    swap(other);
-    return *this;
-  }
-  inline void swap(PartitionSelector & other)
-  {
-    selector.swap(other.selector);
-    partition_info.partitions_length.swap(other.partition_info.partitions_length);
-    partition_info.offsets_map.swap(other.partition_info.offsets_map);
-  }
+    inline void reserve(size_t n) { selector.reserve(n); }
+    inline Index & operator[](ssize_t n) { return selector[n]; }
+    inline const Index & operator[](ssize_t n) const { return selector[n]; }
+    inline void push_back(Index && x) { selector.push_back(x); }
+    inline void emplace_back(Index && x) { selector.emplace_back(x); }
+    inline size_t size() const { return selector.size(); }
+    inline void swap(Array & rhs)
+    {
+        selector.swap(rhs);
+        partition_info.partitions_offset.clear();
+        partition_info.offsets_map.clear();
+    }
+    inline Array::iterator begin() { return selector.begin(); }
+    inline Array::iterator end() { return selector.end(); }
+    inline Array::const_iterator begin() const { return selector.begin(); }
+    inline Array::const_iterator end() const { return selector.end(); }
+    inline Array::const_iterator cbegin() const { return selector.cbegin(); }
+    inline Array::const_iterator cend() const { return selector.cend(); }
+    inline void assign(size_t n, const Index & x) { selector.assign(n, x); }
+    inline void resize(size_t n) { selector.resize(n); }
+    inline void resize_fill(size_t n) { selector.resize_fill(n); }
+    inline void resize_fill(size_t n, const Index & x) { selector.resize_fill(n, x); }
+    inline bool empty() const { return selector.empty(); }
+    inline size_t capacity() const { return selector.capacity(); }
+    inline void clear()
+    {
+        selector.clear();
+        partition_info.partitions_offset.clear();
+        partition_info.offsets_map.clear();
+    }
+    inline Index * data() { return selector.data(); }
+    inline const Index * data() const { return selector.data(); }
+    PartitionSelector & operator=(PartitionSelector && other) noexcept
+    {
+        swap(other);
+        return *this;
+    }
+    inline void swap(PartitionSelector & other)
+    {
+        selector.swap(other.selector);
+        partition_info.partitions_offset.swap(other.partition_info.partitions_offset);
+        partition_info.offsets_map.swap(other.partition_info.offsets_map);
+    }
 
-  const PartitionInfo & getPartitionInfo(size_t buckets, bool force_update = false) const;
+    const PartitionInfo & getPartitionInfo(size_t buckets, bool force_update = false) const;
 
 private:
-  Array selector;
-  Array map_offsets;
-  mutable PartitionInfo partition_info;
+    Array selector;
+    Array map_offsets;
+    mutable PartitionInfo partition_info;
 };
 
 /// True if column's an ColumnConst instance. It's just a syntax sugar for type check.

--- a/tests/performance/parallel_hash_join.xml
+++ b/tests/performance/parallel_hash_join.xml
@@ -1,4 +1,4 @@
 <test>
     <!-- could test the performance of column scatter -->
-    <query> select t1.x, t2.x, t1.y, t2.y from (select number as x, number % 10 as y from numbers(10000000)) as t1 any inner join (select number as x, number % 10 as y from numbers(10000000)) as t2 on t1.x = t2.x settings join_algorithm='parallel_hash' </query>
+    <query> select t1.x, t2.x, t1.y, t2.y from (select number as x, number % 10 as y from numbers(10000000)) as t1 any inner join (select number as x, number % 10 as y from numbers(10000000)) as t2 on t1.x = t2.x FORMAT Null settings join_algorithm='parallel_hash' </query>
 </test>

--- a/tests/performance/parallel_hash_join.xml
+++ b/tests/performance/parallel_hash_join.xml
@@ -1,0 +1,4 @@
+<test>
+    <!-- could test the performance of column scatter -->
+    <query> select t1.x, t2.x, t1.y, t2.y from (select number as x, number % 10 as y from numbers(10000000)) as t1 any inner join (select number as x, number % 10 as y from numbers(10000000)) as t2 on t1.x = t2.x settings join_algorithm='parallel_hash' </query>
+</test>

--- a/tests/performance/parallel_hash_join.xml
+++ b/tests/performance/parallel_hash_join.xml
@@ -1,4 +1,4 @@
 <test>
     <!-- could test the performance of column scatter -->
-    <query> select t1.x, t2.x, t1.y, t2.y from (select number as x, number % 10 as y from numbers(10000000)) as t1 any inner join (select number as x, number % 10 as y from numbers(10000000)) as t2 on t1.x = t2.x FORMAT Null settings join_algorithm='parallel_hash' </query>
+    <query> select t1.x, t2.x, t1.y, t2.y from (select number as x, number % 10 as y from numbers(10000000)) as t1 any inner join (select number as x, number % 10 as y from numbers(10000000)) as t2 on t1.x = t2.x FORMAT Null settings max_threads=8, join_algorithm='parallel_hash' </query>
 </test>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
Improve the performance of column `scatter` by writing into columns sequentially, without switching destination columns frequently which reduce cache miss.

we compare with the previous implementation as following.

query
```sql
-- column scatter is used in parallel_hash
SELECT
    t1.msgtype,
    count(*)
FROM
(
    SELECT
        rip,
        rtime,
        msgid,
        msgtype
    FROM test_data
    WHERE (day = '2023-03-06') AND (hour = '00')
) AS t1
ANY INNER JOIN
(
    SELECT
        rip,
        rtime,
        msgid,
        msgtype
    FROM test_data
    WHERE (day = '2023-03-06') AND (hour = '00')
) AS t2 ON (t1.rip = t2.rip) AND (t1.msgid = t2.msgid) AND (t1.rtime = t2.rtime) AND (t1.msgtype = t2.msgtype)
GROUP BY t1.msgtype
SETTINGS max_threads = 32, join_algorithm = 'parallel_hash'
```

result

|  threads   | before  | after |
|  ----  | ----  | ----  |
| 1 | 6 rows in set. Elapsed: 46.652 sec. Processed 37.40 million rows, 4.53 GB (801.77 thousand rows/s., 97.12 MB/s.) | 6 rows in set. Elapsed: 45.250 sec. Processed 37.40 million rows, 4.53 GB (826.61 thousand rows/s., 100.13 MB/s.) |
| 2  | 6 rows in set. Elapsed: 30.992 sec. Processed 37.40 million rows, 4.53 GB (1.21 million rows/s., 146.19 MB/s.) | 6 rows in set. Elapsed: 26.425 sec. Processed 37.40 million rows, 4.53 GB (1.42 million rows/s., 171.46 MB/s.) |
| 4 | 6 rows in set. Elapsed: 21.150 sec. Processed 37.40 million rows, 4.53 GB (1.77 million rows/s., 214.23 MB/s.) | 6 rows in set. Elapsed: 18.612 sec. Processed 37.40 million rows, 4.53 GB (2.01 million rows/s., 243.43 MB/s.) |
| 8  | 6 rows in set. Elapsed: 18.219 sec. Processed 37.40 million rows, 4.53 GB (2.05 million rows/s., 248.69 MB/s.) | 6 rows in set. Elapsed: 16.080 sec. Processed 37.40 million rows, 4.53 GB (2.33 million rows/s., 281.76 MB/s.) |
| 16 | 6 rows in set. Elapsed: 11.162 sec. Processed 37.40 million rows, 4.53 GB (3.35 million rows/s., 405.92 MB/s.) | 6 rows in set. Elapsed: 11.620 sec. Processed 37.40 million rows, 4.53 GB (3.22 million rows/s., 389.92 MB/s.) |
| 32  | 6 rows in set. Elapsed: 12.200 sec. Processed 37.40 million rows, 4.53 GB (3.07 million rows/s., 371.39 MB/s.) | 6 rows in set. Elapsed: 11.879 sec. Processed 37.40 million rows, 4.53 GB (3.15 million rows/s., 381.41 MB/s.) |

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
