### PR TITLE
Add new function JSONExtractTuple for spark's json_tuple function

### DIFF
--- a/docs/en/sql-reference/functions/json-functions.md
+++ b/docs/en/sql-reference/functions/json-functions.md
@@ -506,3 +506,20 @@ SELECT
 │                ᴺᵁᴸᴸ │                          3 │
 └─────────────────────┴────────────────────────────┘
 ```
+
+## JSONExtractTuple(json\[, indices_or_keys\]…)
+
+Parses a JSON and return multiple JSON Objects as a tuple.
+
+If the value does not exist or has a wrong type, an NULL value will be returned.
+
+Examples:
+
+``` sql
+
+SELECT JSONExtractTuple('{"a":"bc","b":"cc"}', 'a', 'c')
+
+┌─JSONExtractTuple('{"a":"bc","b":"cc"}', 'a', 'c')─┐
+│ ('bc',NULL)                                       │
+└───────────────────────────────────────────────────┘
+```

--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -140,8 +140,7 @@ public:
                 bool added_to_column = false;
                 if (document_ok)
                 {
-                    auto return_type = impl.getReturnType(Name::name, arguments);
-                    if (TypeIndex::Tuple == return_type->getTypeId())
+                    if (std::string(Name::name) == "JSONExtractTuple")
                     {
                         std::vector<std::pair<Element, bool>> elements;
                         std::string_view last_key;

--- a/tests/queries/0_stateless/00918_json_functions.reference
+++ b/tests/queries/0_stateless/00918_json_functions.reference
@@ -266,3 +266,14 @@ u
 v
 --show error: type should be const string
 --show error: index type should be integer
+
+
+--JSONExtractTuple--
+('hello')
+('hello','[-100,200,300]')
+('hello',NULL)
+(NULL,NULL)
+('\n\0')
+('☺')
+(NULL)
+(NULL)

--- a/tests/queries/0_stateless/00918_json_functions.reference
+++ b/tests/queries/0_stateless/00918_json_functions.reference
@@ -266,8 +266,6 @@ u
 v
 --show error: type should be const string
 --show error: index type should be integer
-
-
 --JSONExtractTuple--
 ('hello')
 ('hello','[-100,200,300]')

--- a/tests/queries/0_stateless/00918_json_functions.sql
+++ b/tests/queries/0_stateless/00918_json_functions.sql
@@ -300,3 +300,13 @@ WITH '{"i": 1, "f": 1.2}' AS json SELECT JSONExtract(json, 'i', JSONType(json, '
 
 SELECT '--show error: index type should be integer';
 SELECT JSONExtract('[]', JSONExtract('0', 'UInt256'), 'UInt256'); -- { serverError 43 }
+
+SELECT '--JSONExtractTuple--';
+SELECT JSONExtractTuple('{"a": "hello", "b": [-100, 200.0, 300]}', 'a');
+SELECT JSONExtractTuple('{"a": "hello", "b": [-100, 200.0, 300]}', 'a', 'b');
+SELECT JSONExtractTuple('{"a": "hello", "b": [-100, 200.0, 300]}', 'a', 'c');
+SELECT JSONExtractTuple('{"a": "hello", "b": [-100, 200.0,', 'a', 'b');
+select JSONExtractTuple('{"abc":"\\n\\u0000"}', 'abc');
+select JSONExtractTuple('{"abc":"\\u263a"}', 'abc');
+select JSONExtractTuple('{"abc":"\\u263"}', 'abc');
+select JSONExtractTuple('{"abc":"hello}', 'abc');


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Currently ck do not support to extract tuple from json, and this is supported by spark's json_tuple function. So we add a new function JSONExtractTuple to be same as spark's json_tuple. the test is below

inner :) SELECT JSONExtractTuple('{"a":"bc","b":"cc"}', 'a', 'c')

SELECT JSONExtractTuple('{"a":"bc","b":"cc"}', 'a', 'c')

Query id: 4fc07f2a-555b-400a-aaec-7639c2c5b8d3

┌─JSONExtractTuple('{"a":"bc","b":"cc"}', 'a', 'c')─┐
│ ('bc',NULL)                                                         
└─────────────────────────────┘

1 row in set. Elapsed: 0.001 sec. 
