### PR TITLE
Suppress expected errors from test 01111 in Upgrade check

### DIFF
--- a/docker/test/upgrade/run.sh
+++ b/docker/test/upgrade/run.sh
@@ -161,7 +161,9 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Authentication failed" \
            -e "Cannot flush" \
            -e "Container already exists" \
-    /var/log/clickhouse-server/clickhouse-server.upgrade.log | zgrep -Fa "<Error>" > /test_output/upgrade_error_messages.txt \
+    clickhouse-server.upgrade.log \
+    | grep -av -e "_repl_01111_.*Mapping for table with UUID" \
+    | zgrep -Fa "<Error>" > /test_output/upgrade_error_messages.txt \
     && echo -e "Error message in clickhouse-server.log (see upgrade_error_messages.txt)$FAIL$(head_escaped /test_output/upgrade_error_messages.txt)" \
         >> /test_output/test_results.tsv \
     || echo -e "No Error messages after server upgrade$OK" >> /test_output/test_results.tsv

--- a/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
+++ b/tests/queries/0_stateless/01111_create_drop_replicated_db_stress.sh
@@ -15,7 +15,7 @@ function create_db()
         # Multiple database replicas on one server are actually not supported (until we have namespaces).
         # So CREATE TABLE queries will fail on all replicas except one. But it's still makes sense for a stress test.
         $CLICKHOUSE_CLIENT --allow_experimental_database_replicated=1 --query \
-        "create database if not exists ${CLICKHOUSE_DATABASE}_repl_$SUFFIX engine=Replicated('/test/01111/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX', '$SHARD', '$REPLICA')" \
+        "create database if not exists ${CLICKHOUSE_DATABASE}_repl_01111_$SUFFIX engine=Replicated('/test/01111/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX', '$SHARD', '$REPLICA')" \
          2>&1| grep -Fa "Exception: " | grep -Fv "REPLICA_ALREADY_EXISTS" | grep -Fiv "Will not try to start it up" | \
          grep -Fv "Coordination::Exception" | grep -Fv "already contains some data and it does not look like Replicated database path"
         sleep 0.$RANDOM


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/47314/f5cf039190d547f52d718b2a16403ce8eecad8ab/upgrade_check__msan_.html

```
2023.03.08 05:26:17.617884 [ 272623 ] {} <Error> DDLWorker(test_1_repl_13): Error on initialization of test_1_repl_13: Code: 57. DB::Exception: Mapping for table with UUID=24e3305b-836f-443c-9c5a-06992bea17a5 already exists. It happened due to UUID collision, most likely because some not random UUIDs were manually specified in CREATE queries. (TABLE_ALREADY_EXISTS), Stack trace (when copying this message, always include the lines below):
2023.03.08 05:26:17.617906 [ 272448 ] {} <Error> DDLWorker(test_1_repl_10): Error on initialization of test_1_repl_10: Code: 57. DB::Exception: Mapping for table with UUID=24e3305b-836f-443c-9c5a-06992bea17a5 already exists. It happened due to UUID collision, most likely because some not random UUIDs were manually specified in CREATE queries. (TABLE_ALREADY_EXISTS), Stack trace (when copying this message, always include the lines below):
2023.03.08 05:26:18.049806 [ 272519 ] {119800fe-2ed3-4ae0-81f4-e573939ed6e1} <Error> DDLWorker(test_1_repl_4): Query /* ddl_entry=query-0000000002 */ CREATE TABLE test_1_repl_4.rmt_18668_6180_27524 UUID '24e3305b-836f-443c-9c5a-06992bea17a5' (`n` Int32) ENGINE = ReplicatedMergeTree ORDER BY tuple() SETTINGS index_granularity = 6912, min_bytes_for_wide_part = 1073741824, ratio_of_defaults_for_sparse_serialization = 1., merge_max_block_size = 2199, prefer_fetch_merged_part_size_threshold = 10737418240, vertical_merge_algorithm_min_rows_to_activate = 1000000, vertical_merge_algorithm_min_columns_to_activate = 100, min_merge_bytes_to_use_direct_io = 116699500, index_granularity_bytes = 6995938 wasn't finished successfully: Code: 57. DB::Exception: Mapping for table with UUID=24e3305b-836f-443c-9c5a-06992bea17a5 already exists. It happened due to UUID collision, most likely because some not random UUIDs were manually specified in CREATE queries. (TABLE_ALREADY_EXISTS), Stack trace (when copying this message, always include the lines below):
2023.03.08 05:26:18.174068 [ 272519 ] {} <Error> DDLWorker(test_1_repl_4): Unexpected error, will try to restart main thread: Code: 341. DB::Exception: Unexpected error: 57
2023.03.08 05:26:27.699018 [ 272448 ] {} <Error> DDLWorker(test_1_repl_10): Error on initialization of test_1_repl_10: Code: 57. DB::Exception: Mapping for table with UUID=24e3305b-836f-443c-9c5a-06992bea17a5 already exists. It happened due to UUID collision, most likely because some not random UUIDs were manually specified in CREATE queries. (TABLE_ALREADY_EXISTS), Stack trace (when copying this message, always include the lines below):
```