### PR TITLE
Fix 02343_group_by_use_nulls test in new analyzer

### DIFF
--- a/tests/queries/0_stateless/02343_group_by_use_nulls.sql
+++ b/tests/queries/0_stateless/02343_group_by_use_nulls.sql
@@ -1,3 +1,4 @@
+set optimize_group_by_function_keys=0;
 -- { echoOn }
 SELECT number, number % 2, sum(number) AS val
 FROM numbers(10)


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Set `optimize_group_by_function_keys` to zero to correct the test in the new analyzer. 