### PR TITLE
Disable 02368_cancel_write_into_hdfs in stress tests

### DIFF
--- a/tests/queries/0_stateless/02368_cancel_write_into_hdfs.sh
+++ b/tests/queries/0_stateless/02368_cancel_write_into_hdfs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-stress
+# Tags: no-fasttest, no-asan, no-tsan, no-msan, no-ubsan, no-debug
+# FIXME https://github.com/ClickHouse/ClickHouse/issues/47207
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



