### PR TITLE
Fix `ALTER CLEAR COLUMN` with sparse columns

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -626,6 +626,12 @@ static NameToNameVector collectFilesForRenames(
         }
     }
 
+    if (!source_part->getSerializationInfos().empty()
+        && new_part->getSerializationInfos().empty())
+    {
+        rename_vector.emplace_back(IMergeTreeDataPart::SERIALIZATION_FILE_NAME, "");
+    }
+
     return rename_vector;
 }
 

--- a/tests/queries/0_stateless/02675_sparse_columns_clear_column.reference
+++ b/tests/queries/0_stateless/02675_sparse_columns_clear_column.reference
@@ -1,0 +1,6 @@
+arr	Default
+v	Sparse
+arr	Default
+arr	Default
+v	Sparse
+0	[]

--- a/tests/queries/0_stateless/02675_sparse_columns_clear_column.sql
+++ b/tests/queries/0_stateless/02675_sparse_columns_clear_column.sql
@@ -1,0 +1,34 @@
+DROP TABLE IF EXISTS t_sparse_columns_clear;
+
+CREATE TABLE t_sparse_columns_clear (arr Array(UInt64), v UInt64)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS
+    ratio_of_defaults_for_sparse_serialization = 0.9,
+    min_bytes_for_wide_part=0;
+
+INSERT INTO t_sparse_columns_clear SELECT [number], 0 FROM numbers(1000);
+
+SELECT column, serialization_kind FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_sparse_columns_clear' AND active
+ORDER BY column;
+
+SET mutations_sync = 2;
+SET alter_sync = 2;
+
+ALTER TABLE t_sparse_columns_clear CLEAR COLUMN v;
+
+SELECT column, serialization_kind FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_sparse_columns_clear' AND active
+ORDER BY column;
+
+OPTIMIZE TABLE t_sparse_columns_clear FINAL;
+
+SELECT column, serialization_kind FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_sparse_columns_clear' AND active
+ORDER BY column;
+
+DROP TABLE t_sparse_columns_clear SYNC;
+
+SYSTEM FLUSH LOGS;
+
+SELECT count(), groupArray(message) FROM system.text_log WHERE logger_name LIKE '%' || currentDatabase() || '.t_sparse_columns_clear' || '%' AND level = 'Error';


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

This PR fixes `Cannot quickly remove directory` exception in test `02286_vertical_merges_missed_column`.