### PR TITLE
Update Prometheus port to 9363

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -1318,12 +1318,12 @@ Settings:
 
 ``` xml
  <prometheus>
-        <endpoint>/metrics</endpoint>
-        <port>8001</port>
-        <metrics>true</metrics>
-        <events>true</events>
-        <asynchronous_metrics>true</asynchronous_metrics>
-    </prometheus>
+    <endpoint>/metrics</endpoint>
+    <port>9363</port>
+    <metrics>true</metrics>
+    <events>true</events>
+    <asynchronous_metrics>true</asynchronous_metrics>
+</prometheus>
 ```
 
 ## query_log {#server_configuration_parameters-query-log}


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Change Prometheus port to 9363 to align with port listed in https://clickhouse.com/docs/en/guides/sre/network-ports/

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
