### PR TITLE
Enable return null and complext type for JSON_VALUE function

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -4049,12 +4049,12 @@ SELECT sum(number) FROM numbers(10000000000) SETTINGS partial_result_on_first_ca
 Possible values: `true`, `false`
 
 Default value: `false`
-## function_return_type_allow_nullable
+## function_json_value_return_type_allow_nullable
 
 Control whether allow to return `NULL` when value is not exist for JSON_VALUE function.
 
 ```sql
-SELECT JSON_VALUE('{"hello":"world"}', '$.b') settings function_return_type_allow_nullable=true;
+SELECT JSON_VALUE('{"hello":"world"}', '$.b') settings function_json_value_return_type_allow_nullable=true;
 
 ┌─JSON_VALUE('{"hello":"world"}', '$.b')─┐
 │ ᴺᵁᴸᴸ                                   │

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -4049,3 +4049,44 @@ SELECT sum(number) FROM numbers(10000000000) SETTINGS partial_result_on_first_ca
 Possible values: `true`, `false`
 
 Default value: `false`
+## function_return_type_allow_nullable
+
+Control whether allow to return `NULL` when value is not exist for JSON_VALUE function.
+
+```sql
+SELECT JSON_VALUE('{"hello":"world"}', '$.b') settings function_return_type_allow_nullable=true;
+
+┌─JSON_VALUE('{"hello":"world"}', '$.b')─┐
+│ ᴺᵁᴸᴸ                                   │
+└────────────────────────────────────────┘
+
+1 row in set. Elapsed: 0.001 sec.
+```
+
+Possible values:
+
+-   true — Allow.
+-   false — Disallow.
+
+Default value: `false`.
+
+## function_json_value_return_type_allow_complex
+
+Control whether allow to return complex type (such as: struct, array, map) for json_value function.
+
+```sql
+SELECT JSON_VALUE('{"hello":{"world":"!"}}', '$.hello') settings function_json_value_return_type_allow_complex=true
+
+┌─JSON_VALUE('{"hello":{"world":"!"}}', '$.hello')─┐
+│ {"world":"!"}                                    │
+└──────────────────────────────────────────────────┘
+
+1 row in set. Elapsed: 0.001 sec.
+```
+
+Possible values:
+
+-   true — Allow.
+-   false — Disallow.
+
+Default value: `false`.

--- a/docs/en/sql-reference/functions/json-functions.md
+++ b/docs/en/sql-reference/functions/json-functions.md
@@ -401,7 +401,7 @@ Before version 21.11 the order of arguments was wrong, i.e. JSON_QUERY(path, jso
 
 Parses a JSON and extract a value as JSON scalar.
 
-If the value does not exist, an empty string will be returned.
+If the value does not exist, NULL will be returned.
 
 Example:
 

--- a/docs/en/sql-reference/functions/json-functions.md
+++ b/docs/en/sql-reference/functions/json-functions.md
@@ -401,7 +401,7 @@ Before version 21.11 the order of arguments was wrong, i.e. JSON_QUERY(path, jso
 
 Parses a JSON and extract a value as JSON scalar.
 
-If the value does not exist, NULL will be returned.
+If the value does not exist, an empty string will be returned.
 
 Example:
 

--- a/docs/en/sql-reference/functions/json-functions.md
+++ b/docs/en/sql-reference/functions/json-functions.md
@@ -401,7 +401,7 @@ Before version 21.11 the order of arguments was wrong, i.e. JSON_QUERY(path, jso
 
 Parses a JSON and extract a value as JSON scalar.
 
-If the value does not exist, an empty string will be returned.
+If the value does not exist, an empty string will be returned by default, and by SET `function_return_type_allow_nullable` = `true`, `NULL` will be returned. If the value is complex type (such as: struct, array, map), an empty string will be returned by default, and by SET `function_json_value_return_type_allow_complex` = `true`, the complex value will be returned.
 
 Example:
 
@@ -410,6 +410,8 @@ SELECT JSON_VALUE('{"hello":"world"}', '$.hello');
 SELECT JSON_VALUE('{"array":[[0, 1, 2, 3, 4, 5], [0, -1, -2, -3, -4, -5]]}', '$.array[*][0 to 2, 4]');
 SELECT JSON_VALUE('{"hello":2}', '$.hello');
 SELECT toTypeName(JSON_VALUE('{"hello":2}', '$.hello'));
+select JSON_VALUE('{"hello":"world"}', '$.b') settings function_return_type_allow_nullable=true;
+select JSON_VALUE('{"hello":{"world":"!"}}', '$.hello') settings function_json_value_return_type_allow_complex=true;
 ```
 
 Result:

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -941,15 +941,10 @@ class IColumn;
     M(Bool, input_format_bson_skip_fields_with_unsupported_types_in_schema_inference, false, "Skip fields with unsupported types while schema inference for format BSON.", 0) \
     \
     M(Bool, regexp_dict_allow_other_sources, false, "Allow regexp_tree dictionary to use sources other than yaml source.", 0) \
-<<<<<<< f971b544e138dfd1166e073cded75fe8640d78ae
     M(Bool, regexp_dict_allow_hyperscan, true, "Allow regexp_tree dictionary using Hyperscan library.", 0) \
     \
     M(Bool, dictionary_use_async_executor, false, "Execute a pipeline for reading from a dictionary with several threads. It's supported only by DIRECT dictionary with CLICKHOUSE source.", 0) \
-
-=======
     M(Bool, regexp_dict_allow_hyperscan, false, "Allow regexp_tree dictionary using Hyperscan library.", 0) \
-    M(Bool, function_return_type_allow_nullable, false, "Allow function to return nullable type.", 0) \
->>>>>>> enable nullable return type
 
 // End of FORMAT_FACTORY_SETTINGS
 // Please add settings non-related to formats into the COMMON_SETTINGS above.

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -722,6 +722,8 @@ class IColumn;
     M(Bool, force_aggregation_in_order, false, "Force use of aggregation in order on remote nodes during distributed aggregation. PLEASE, NEVER CHANGE THIS SETTING VALUE MANUALLY!", IMPORTANT) \
     M(UInt64, http_max_request_param_data_size, 10_MiB, "Limit on size of request data used as a query parameter in predefined HTTP requests.", 0) \
     M(Bool, allow_experimental_undrop_table_query, false, "Allow to use undrop query to restore dropped table in a limited time", 0) \
+    M(Bool, function_json_value_return_type_allow_nullable, false, "Allow function to return nullable type.", 0) \
+    M(Bool, function_json_value_return_type_allow_complex, false, "Allow function to return complex type, such as: struct, array, map.", 0) \
     // End of COMMON_SETTINGS
     // Please add settings related to formats into the FORMAT_FACTORY_SETTINGS and move obsolete settings to OBSOLETE_SETTINGS.
 
@@ -944,7 +946,6 @@ class IColumn;
     M(Bool, regexp_dict_allow_hyperscan, true, "Allow regexp_tree dictionary using Hyperscan library.", 0) \
     \
     M(Bool, dictionary_use_async_executor, false, "Execute a pipeline for reading from a dictionary with several threads. It's supported only by DIRECT dictionary with CLICKHOUSE source.", 0) \
-    M(Bool, regexp_dict_allow_hyperscan, false, "Allow regexp_tree dictionary using Hyperscan library.", 0) \
 
 // End of FORMAT_FACTORY_SETTINGS
 // Please add settings non-related to formats into the COMMON_SETTINGS above.

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -941,10 +941,15 @@ class IColumn;
     M(Bool, input_format_bson_skip_fields_with_unsupported_types_in_schema_inference, false, "Skip fields with unsupported types while schema inference for format BSON.", 0) \
     \
     M(Bool, regexp_dict_allow_other_sources, false, "Allow regexp_tree dictionary to use sources other than yaml source.", 0) \
+<<<<<<< f971b544e138dfd1166e073cded75fe8640d78ae
     M(Bool, regexp_dict_allow_hyperscan, true, "Allow regexp_tree dictionary using Hyperscan library.", 0) \
     \
     M(Bool, dictionary_use_async_executor, false, "Execute a pipeline for reading from a dictionary with several threads. It's supported only by DIRECT dictionary with CLICKHOUSE source.", 0) \
 
+=======
+    M(Bool, regexp_dict_allow_hyperscan, false, "Allow regexp_tree dictionary using Hyperscan library.", 0) \
+    M(Bool, function_return_type_allow_nullable, false, "Allow function to return nullable type.", 0) \
+>>>>>>> enable nullable return type
 
 // End of FORMAT_FACTORY_SETTINGS
 // Please add settings non-related to formats into the COMMON_SETTINGS above.

--- a/src/Functions/FunctionSQLJSON.h
+++ b/src/Functions/FunctionSQLJSON.h
@@ -42,8 +42,7 @@ public:
     class Executor
     {
     public:
-        static ColumnPtr run(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, uint32_t parse_depth, 
-            const bool & return_type_allow_complex)
+        static ColumnPtr run(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, uint32_t parse_depth, const bool & return_type_allow_complex)
         {
             MutableColumnPtr to{result_type->createColumn()};
             to->reserve(input_rows_count);

--- a/src/Functions/FunctionSQLJSON.h
+++ b/src/Functions/FunctionSQLJSON.h
@@ -156,7 +156,7 @@ public:
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        if constexpr (has_static_member_function_getReturnType<Impl<DummyJSONParser>, DataTypePtr(const char *, const ColumnsWithTypeAndName &, const bool &)>::value) 
+        if constexpr (has_static_member_function_getReturnType<Impl<DummyJSONParser>, DataTypePtr(const char *, const ColumnsWithTypeAndName &, const bool &)>::value)
         {
             return Impl<DummyJSONParser>::getReturnType(Name::name, arguments, getContext()->getSettingsRef().function_return_type_allow_nullable);
         }

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -17,7 +17,7 @@ SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello');
 ["world","world2"]
 SELECT JSON_VALUE('{"hello":{"world":"!"}}', '$.hello');
 {"world":"!"}
-SELECT JSON_VALUE('{hello:world}', '$.hello');
+SELECT JSON_VALUE('{hello:world}', '$.hello'); -- invalid json => default value (empty string)
 
 SELECT JSON_VALUE('', '$.hello');
 
@@ -32,7 +32,7 @@ select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
 ☺
 select JSON_VALUE('{"a":"b"}', '$.b') settings function_return_type_allow_nullable=true;
-null
+\N
 SELECT '--JSON_QUERY--';
 --JSON_QUERY--
 SELECT JSON_QUERY('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -1,8 +1,8 @@
 -- { echo }
 SELECT '--JSON_VALUE--';
 --JSON_VALUE--
-SELECT JSON_VALUE('{"hello":1}', '$');
-{"hello":1}
+SELECT JSON_VALUE('{"hello":1}', '$'); -- root is a complex object => default value (empty string)
+
 SELECT JSON_VALUE('{"hello":1}', '$.hello');
 1
 SELECT JSON_VALUE('{"hello":1.2}', '$.hello');
@@ -14,9 +14,9 @@ world
 SELECT JSON_VALUE('{"hello":null}', '$.hello');
 null
 SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello');
-["world","world2"]
+
 SELECT JSON_VALUE('{"hello":{"world":"!"}}', '$.hello');
-{"world":"!"}
+
 SELECT JSON_VALUE('{hello:world}', '$.hello'); -- invalid json => default value (empty string)
 
 SELECT JSON_VALUE('', '$.hello');
@@ -31,8 +31,12 @@ select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 \n\0
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
 ☺
-select JSON_VALUE('{"a":"b"}', '$.b') settings function_return_type_allow_nullable=true;
+select JSON_VALUE('{"hello":"world"}', '$.b') settings function_return_type_allow_nullable=true;
 \N
+select JSON_VALUE('{"hello":{"world":"!"}}', '$.hello') settings function_json_value_return_type_allow_complex=true;
+{"world":"!"}
+SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello') settings function_json_value_return_type_allow_complex=true;
+["world","world2"]
 SELECT '--JSON_QUERY--';
 --JSON_QUERY--
 SELECT JSON_QUERY('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -31,7 +31,7 @@ select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 \n\0
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
 ☺
-select JSON_VALUE('{"a":"b"}', "$.b");
+select JSON_VALUE('{"a":"b"}', '$.b');
 null
 SELECT '--JSON_QUERY--';
 --JSON_QUERY--

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -1,8 +1,8 @@
 -- { echo }
 SELECT '--JSON_VALUE--';
 --JSON_VALUE--
-SELECT JSON_VALUE('{"hello":1}', '$'); -- root is a complex object => default value (empty string)
-
+SELECT JSON_VALUE('{"hello":1}', '$');
+{"hello":1}
 SELECT JSON_VALUE('{"hello":1}', '$.hello');
 1
 SELECT JSON_VALUE('{"hello":1.2}', '$.hello');
@@ -14,13 +14,13 @@ world
 SELECT JSON_VALUE('{"hello":null}', '$.hello');
 null
 SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello');
-
+["world","world2"]
 SELECT JSON_VALUE('{"hello":{"world":"!"}}', '$.hello');
-
-SELECT JSON_VALUE('{hello:world}', '$.hello'); -- invalid json => default value (empty string)
-
+{"world":"!"}
+SELECT JSON_VALUE('{hello:world}', '$.hello');
+null
 SELECT JSON_VALUE('', '$.hello');
-
+null
 SELECT JSON_VALUE('{"foo foo":"bar"}', '$."foo foo"');
 bar
 SELECT JSON_VALUE('{"hello":"\\uD83C\\uDF3A \\uD83C\\uDF38 \\uD83C\\uDF37 Hello, World \\uD83C\\uDF37 \\uD83C\\uDF38 \\uD83C\\uDF3A"}', '$.hello');
@@ -31,6 +31,8 @@ select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 \n\0
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
 ☺
+select JSON_VALUE('{"a":"b"}', "$.b");
+null
 SELECT '--JSON_QUERY--';
 --JSON_QUERY--
 SELECT JSON_QUERY('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -31,7 +31,7 @@ select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 \n\0
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
 ☺
-select JSON_VALUE('{"hello":"world"}', '$.b') settings function_return_type_allow_nullable=true;
+select JSON_VALUE('{"hello":"world"}', '$.b') settings function_json_value_return_type_allow_nullable=true;
 \N
 select JSON_VALUE('{"hello":{"world":"!"}}', '$.hello') settings function_json_value_return_type_allow_complex=true;
 {"world":"!"}

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -18,9 +18,9 @@ SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello');
 SELECT JSON_VALUE('{"hello":{"world":"!"}}', '$.hello');
 {"world":"!"}
 SELECT JSON_VALUE('{hello:world}', '$.hello');
-null
+
 SELECT JSON_VALUE('', '$.hello');
-null
+
 SELECT JSON_VALUE('{"foo foo":"bar"}', '$."foo foo"');
 bar
 SELECT JSON_VALUE('{"hello":"\\uD83C\\uDF3A \\uD83C\\uDF38 \\uD83C\\uDF37 Hello, World \\uD83C\\uDF37 \\uD83C\\uDF38 \\uD83C\\uDF3A"}', '$.hello');
@@ -31,7 +31,7 @@ select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 \n\0
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
 ☺
-select JSON_VALUE('{"a":"b"}', '$.b');
+select JSON_VALUE('{"a":"b"}', '$.b') settings function_return_type_allow_nullable=true;
 null
 SELECT '--JSON_QUERY--';
 --JSON_QUERY--

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -17,7 +17,7 @@ SELECT JSON_VALUE('{"hello":"\\uD83C\\uDF3A \\uD83C\\uDF38 \\uD83C\\uDF37 Hello,
 SELECT JSON_VALUE('{"a":"Hello \\"World\\" \\\\"}', '$.a');
 select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
-select JSON_VALUE('{"a":"b"}', "$.b");
+select JSON_VALUE('{"a":"b"}', '$.b');
 
 SELECT '--JSON_QUERY--';
 SELECT JSON_QUERY('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -17,7 +17,7 @@ SELECT JSON_VALUE('{"hello":"\\uD83C\\uDF3A \\uD83C\\uDF38 \\uD83C\\uDF37 Hello,
 SELECT JSON_VALUE('{"a":"Hello \\"World\\" \\\\"}', '$.a');
 select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
-select JSON_VALUE('{"a":"b"}', '$.b');
+select JSON_VALUE('{"a":"b"}', '$.b') settings function_return_type_allow_nullable=true;
 
 SELECT '--JSON_QUERY--';
 SELECT JSON_QUERY('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -17,7 +17,9 @@ SELECT JSON_VALUE('{"hello":"\\uD83C\\uDF3A \\uD83C\\uDF38 \\uD83C\\uDF37 Hello,
 SELECT JSON_VALUE('{"a":"Hello \\"World\\" \\\\"}', '$.a');
 select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
-select JSON_VALUE('{"a":"b"}', '$.b') settings function_return_type_allow_nullable=true;
+select JSON_VALUE('{"hello":"world"}', '$.b') settings function_return_type_allow_nullable=true;
+select JSON_VALUE('{"hello":{"world":"!"}}', '$.hello') settings function_json_value_return_type_allow_complex=true;
+SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello') settings function_json_value_return_type_allow_complex=true;
 
 SELECT '--JSON_QUERY--';
 SELECT JSON_QUERY('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -17,6 +17,7 @@ SELECT JSON_VALUE('{"hello":"\\uD83C\\uDF3A \\uD83C\\uDF38 \\uD83C\\uDF37 Hello,
 SELECT JSON_VALUE('{"a":"Hello \\"World\\" \\\\"}', '$.a');
 select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
+select JSON_VALUE('{"a":"b"}', "$.b");
 
 SELECT '--JSON_QUERY--';
 SELECT JSON_QUERY('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -17,7 +17,7 @@ SELECT JSON_VALUE('{"hello":"\\uD83C\\uDF3A \\uD83C\\uDF38 \\uD83C\\uDF37 Hello,
 SELECT JSON_VALUE('{"a":"Hello \\"World\\" \\\\"}', '$.a');
 select JSON_VALUE('{"a":"\\n\\u0000"}', '$.a');
 select JSON_VALUE('{"a":"\\u263a"}', '$.a');
-select JSON_VALUE('{"hello":"world"}', '$.b') settings function_return_type_allow_nullable=true;
+select JSON_VALUE('{"hello":"world"}', '$.b') settings function_json_value_return_type_allow_nullable=true;
 select JSON_VALUE('{"hello":{"world":"!"}}', '$.hello') settings function_json_value_return_type_allow_complex=true;
 SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello') settings function_json_value_return_type_allow_complex=true;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Currently, the JSON_VALUE function is similar as spark's get_json_object function, which support to get value from json string by a path like '$.key'. But still has something different
- 1.  in spark's get_json_object will return null while the path is not exist, but in JSON_VALUE will return empty string;
- 2.  in spark's get_json_object will return a complext type value, such as a json object/array value, but in JSON_VALUE will return  empty string.

So we make the change to let these 2 function act same by add some configs to set return null if needed. And it test as below

SELECT JSON_VALUE('{"a":{"c":"d"},"b":[1,2,3]}', '$.b');
┌─JSON_VALUE('{"a":{"c":"d"},"b":[1,2,3]}', '$.b')─┐
│ [1,2,3]                                                                
└────────   ────────────────────┘

SELECT JSON_VALUE('{"a":{"c":"d"}}', '$');
┌─JSON_VALUE('{"a":{"c":"d"}}', '$')─┐
│ {"a":{"c":"d"}}                                
└─────────  ────────────┘

SELECT JSON_VALUE('{"a":{"c":"d"},"b":[1,2,3]}', '$.s') settings function_return_type_allow_nullable=true
┌─JSON_VALUE('{"a":{"c":"d"},"b":[1,2,3]}', '$.s')─┐
│ ᴺᵁᴸᴸ                                                              
└────────────────────────────┘

