### PR TITLE
Fix block structure mismatch for nullable LowCardinality column 

### DIFF
--- a/tests/queries/0_stateless/02680_lc_null_as_default.sql
+++ b/tests/queries/0_stateless/02680_lc_null_as_default.sql
@@ -1,0 +1,6 @@
+drop table if exists test_null_as_default__fuzz_46;
+SET allow_suspicious_low_cardinality_types = 1;
+CREATE TABLE test_null_as_default__fuzz_46 (a Nullable(DateTime64(3)), b LowCardinality(Float32) DEFAULT a + 1000) ENGINE = Memory;
+INSERT INTO test_null_as_default__fuzz_46 SELECT 1, NULL UNION ALL SELECT 2, NULL;
+drop table test_null_as_default__fuzz_46;
+


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix `block structure mismatch` error which could happen at `INSERT` into nullable `LowCardinality` column with default expression. Fixes #46704