### PR TITLE
Fix BSONEachRow parallel parsing when document size is invalid

### DIFF
--- a/src/Processors/Formats/Impl/BSONEachRowRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/BSONEachRowRowInputFormat.cpp
@@ -999,6 +999,9 @@ fileSegmentationEngineBSONEachRow(ReadBuffer & in, DB::Memory<> & memory, size_t
                 "the value setting 'min_chunk_bytes_for_parallel_parsing' or check your data manually, most likely BSON is malformed",
                 min_bytes, document_size);
 
+        if (document_size < sizeof(document_size))
+            throw ParsingException(ErrorCodes::INCORRECT_DATA, "Size of BSON document is invalid");
+
         size_t old_size = memory.size();
         memory.resize(old_size + document_size);
         memcpy(memory.data() + old_size, reinterpret_cast<char *>(&document_size), sizeof(document_size));

--- a/tests/queries/0_stateless/02589_bson_invalid_document_size.sql
+++ b/tests/queries/0_stateless/02589_bson_invalid_document_size.sql
@@ -1,0 +1,2 @@
+select * from format(BSONEachRow, 'x UInt32', x'00000000'); -- {serverError INCORRECT_DATA}
+

--- a/tests/queries/0_stateless/02589_bson_invalid_document_size.sql
+++ b/tests/queries/0_stateless/02589_bson_invalid_document_size.sql
@@ -1,2 +1,2 @@
+set input_format_parallel_parsing=1;
 select * from format(BSONEachRow, 'x UInt32', x'00000000'); -- {serverError INCORRECT_DATA}
-


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix BSONEachRow parallel parsing when document size is invalid
