### PR TITLE
Preserve error in system.distribution_queue on SYSTEM FLUSH DISTRIBUTED

### DIFF
--- a/tests/queries/0_stateless/01555_system_distribution_queue_mask.reference
+++ b/tests/queries/0_stateless/01555_system_distribution_queue_mask.reference
@@ -1,3 +1,5 @@
+masked flush only
+3,"default:*@127%2E0%2E0%2E1:9000,default:*@127%2E0%2E0%2E2:9000","AUTHENTICATION_FAILED",1
 masked
 3,"default:*@127%2E0%2E0%2E1:9000,default:*@127%2E0%2E0%2E2:9000","AUTHENTICATION_FAILED",1
 no masking

--- a/tests/queries/0_stateless/01555_system_distribution_queue_mask.sql
+++ b/tests/queries/0_stateless/01555_system_distribution_queue_mask.sql
@@ -10,6 +10,20 @@ drop table if exists data_01555;
 create table data_01555 (key Int) Engine=Null();
 
 --
+-- masked flush only
+--
+SELECT 'masked flush only';
+create table dist_01555 (key Int) Engine=Distributed(test_cluster_with_incorrect_pw, currentDatabase(), data_01555, key);
+
+insert into dist_01555 values (1)(2);
+system stop distributed sends dist_01555;
+-- since test_cluster_with_incorrect_pw contains incorrect password ignore error
+system flush distributed dist_01555; -- { serverError 516 }
+select length(splitByChar('*', data_path)), replaceRegexpOne(data_path, '^.*/([^/]*)/' , '\\1'), extract(last_exception, 'AUTHENTICATION_FAILED'), dateDiff('s', last_exception_time, now()) < 5 from system.distribution_queue where database = currentDatabase() and table = 'dist_01555' format CSV;
+
+drop table dist_01555;
+
+--
 -- masked
 --
 SELECT 'masked';

--- a/tests/queries/0_stateless/01555_system_distribution_queue_mask.sql
+++ b/tests/queries/0_stateless/01555_system_distribution_queue_mask.sql
@@ -29,7 +29,6 @@ SELECT 'no masking';
 create table dist_01555 (key Int) Engine=Distributed(test_shard_localhost, currentDatabase(), data_01555, key);
 
 insert into dist_01555 values (1)(2);
--- since test_cluster_with_incorrect_pw contains incorrect password ignore error
 system flush distributed dist_01555;
 select length(splitByChar('*', data_path)), replaceRegexpOne(data_path, '^.*/([^/]*)/' , '\\1') from system.distribution_queue where database = currentDatabase() and table = 'dist_01555' format CSV;
 

--- a/tests/queries/0_stateless/01555_system_distribution_queue_mask.sql
+++ b/tests/queries/0_stateless/01555_system_distribution_queue_mask.sql
@@ -14,9 +14,9 @@ create table data_01555 (key Int) Engine=Null();
 --
 SELECT 'masked flush only';
 create table dist_01555 (key Int) Engine=Distributed(test_cluster_with_incorrect_pw, currentDatabase(), data_01555, key);
+system stop distributed sends dist_01555;
 
 insert into dist_01555 values (1)(2);
-system stop distributed sends dist_01555;
 -- since test_cluster_with_incorrect_pw contains incorrect password ignore error
 system flush distributed dist_01555; -- { serverError 516 }
 select length(splitByChar('*', data_path)), replaceRegexpOne(data_path, '^.*/([^/]*)/' , '\\1'), extract(last_exception, 'AUTHENTICATION_FAILED'), dateDiff('s', last_exception_time, now()) < 5 from system.distribution_queue where database = currentDatabase() and table = 'dist_01555' format CSV;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Preserve error in `system.distribution_queue` on `SYSTEM FLUSH DISTRIBUTED`

After refactoring in https://github.com/ClickHouse/ClickHouse/pull/45491 this behaviour had been changed, hence
`01555_system_distribution_queue_mask` became flaky, since if the flush
had not happened before SYSTEM FLUSH DISTRIBUTED the error was not saved
into the system.distribution_queue.

Cc: @hanfei1991 

Fixes: #47297