### PR TITLE
Remove TOTALS handling in FillingTransform

### DIFF
--- a/src/Processors/QueryPlan/FillingStep.cpp
+++ b/src/Processors/QueryPlan/FillingStep.cpp
@@ -40,8 +40,10 @@ void FillingStep::transformPipeline(QueryPipelineBuilder & pipeline, const Build
 {
     pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type) -> ProcessorPtr
     {
-        bool on_totals = stream_type == QueryPipelineBuilder::StreamType::Totals;
-        return std::make_shared<FillingTransform>(header, sort_description, std::move(interpolate_description), on_totals);
+        if (stream_type == QueryPipelineBuilder::StreamType::Totals)
+            return nullptr;
+
+        return std::make_shared<FillingTransform>(header, sort_description, std::move(interpolate_description));
     });
 }
 

--- a/src/Processors/QueryPlan/FillingStep.cpp
+++ b/src/Processors/QueryPlan/FillingStep.cpp
@@ -41,7 +41,7 @@ void FillingStep::transformPipeline(QueryPipelineBuilder & pipeline, const Build
     pipeline.addSimpleTransform([&](const Block & header, QueryPipelineBuilder::StreamType stream_type) -> ProcessorPtr
     {
         if (stream_type == QueryPipelineBuilder::StreamType::Totals)
-            return nullptr;
+            return std::make_shared<FillingNoopTransform>(header, sort_description);
 
         return std::make_shared<FillingTransform>(header, sort_description, std::move(interpolate_description));
     });

--- a/src/Processors/Transforms/FillingTransform.cpp
+++ b/src/Processors/Transforms/FillingTransform.cpp
@@ -169,17 +169,13 @@ static bool tryConvertFields(FillColumnDescription & descr, const DataTypePtr & 
 }
 
 FillingTransform::FillingTransform(
-        const Block & header_, const SortDescription & sort_description_, InterpolateDescriptionPtr interpolate_description_, bool on_totals_)
+        const Block & header_, const SortDescription & sort_description_, InterpolateDescriptionPtr interpolate_description_)
         : ISimpleTransform(header_, transformHeader(header_, sort_description_), true)
         , sort_description(sort_description_)
         , interpolate_description(interpolate_description_)
-        , on_totals(on_totals_)
         , filling_row(sort_description_)
         , next_row(sort_description_)
 {
-    if (on_totals)
-        return;
-
     if (interpolate_description)
         interpolate_actions = std::make_shared<ExpressionActions>(interpolate_description->actions);
 
@@ -239,7 +235,7 @@ FillingTransform::FillingTransform(
 
 IProcessor::Status FillingTransform::prepare()
 {
-    if (!on_totals && input.isFinished() && !output.isFinished() && !has_input && !generate_suffix)
+    if (input.isFinished() && !output.isFinished() && !has_input && !generate_suffix)
     {
         should_insert_first = next_row < filling_row || first;
 
@@ -266,9 +262,6 @@ IProcessor::Status FillingTransform::prepare()
 
 void FillingTransform::transform(Chunk & chunk)
 {
-    if (on_totals)
-        return;
-
     if (!chunk.hasRows() && !generate_suffix)
         return;
 

--- a/src/Processors/Transforms/FillingTransform.h
+++ b/src/Processors/Transforms/FillingTransform.h
@@ -52,7 +52,6 @@ private:
     bool should_insert_first = false;
 };
 
-
 class FillingNoopTransform : public ISimpleTransform
 {
 public:

--- a/src/Processors/Transforms/FillingTransform.h
+++ b/src/Processors/Transforms/FillingTransform.h
@@ -16,7 +16,7 @@ namespace DB
 class FillingTransform : public ISimpleTransform
 {
 public:
-    FillingTransform(const Block & header_, const SortDescription & sort_description_, InterpolateDescriptionPtr interpolate_description_, bool on_totals_);
+    FillingTransform(const Block & header_, const SortDescription & sort_description_, InterpolateDescriptionPtr interpolate_description_);
 
     String getName() const override { return "FillingTransform"; }
 
@@ -33,7 +33,6 @@ private:
 
     const SortDescription sort_description; /// Contains only columns with WITH FILL.
     const InterpolateDescriptionPtr interpolate_description; /// Contains INTERPOLATE columns
-    const bool on_totals; /// FillingTransform does nothing on totals.
 
     FillingRow filling_row; /// Current row, which is used to fill gaps.
     FillingRow next_row; /// Row to which we need to generate filling rows.

--- a/src/Processors/Transforms/FillingTransform.h
+++ b/src/Processors/Transforms/FillingTransform.h
@@ -52,4 +52,17 @@ private:
     bool should_insert_first = false;
 };
 
+
+class FillingNoopTransform : public ISimpleTransform
+{
+public:
+    FillingNoopTransform(const Block & header, const SortDescription & sort_description_)
+        : ISimpleTransform(header, FillingTransform::transformHeader(header, sort_description_), true)
+    {
+    }
+
+    void transform(Chunk &) override {}
+    String getName() const override { return "FillingNoopTransform"; }
+};
+
 }


### PR DESCRIPTION
If `on_totals` is true in FillingTransform then the transform does nothing. It pollutes the code. So, instead, FillingNoopTransform is created for stream related to TOTALS, which does nothing but header transformation only.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
