### PR TITLE
Hide too noisy log messages, fix some tests

### DIFF
--- a/base/poco/Foundation/include/Poco/Message.h
+++ b/base/poco/Foundation/include/Poco/Message.h
@@ -105,6 +105,8 @@ public:
     const std::string & getText() const;
     /// Returns the text of the message.
 
+    void appendText(const std::string & text);
+
     void setPriority(Priority prio);
     /// Sets the priority of the message.
 

--- a/base/poco/Foundation/src/Message.cpp
+++ b/base/poco/Foundation/src/Message.cpp
@@ -157,6 +157,12 @@ void Message::setText(const std::string& text)
 }
 
 
+void Message::appendText(const std::string & text)
+{
+    _text.append(text);
+}
+
+
 void Message::setPriority(Priority prio)
 {
 	_prio = prio;

--- a/src/Common/LoggingFormatStringHelpers.cpp
+++ b/src/Common/LoggingFormatStringHelpers.cpp
@@ -1,7 +1,76 @@
 #include <Common/LoggingFormatStringHelpers.h>
+#include <Common/SipHash.h>
+#include <Common/thread_local_rng.h>
 
 [[noreturn]] void functionThatFailsCompilationOfConstevalFunctions(const char * error)
 {
     throw std::runtime_error(error);
 }
 
+std::unordered_map<UInt64, std::pair<time_t, size_t>> LogFrequencyLimiterIml::logged_messages;
+time_t LogFrequencyLimiterIml::last_cleanup = 0;
+std::mutex LogFrequencyLimiterIml::mutex;
+
+void LogFrequencyLimiterIml::log(Poco::Message & message)
+{
+    std::string_view pattern = message.getFormatString();
+    if (pattern.empty())
+    {
+        /// Do not filter messages without a format string
+        if (auto * channel = logger->getChannel())
+            channel->log(message);
+        return;
+    }
+
+    SipHash hash;
+    hash.update(logger->name());
+    /// Format strings are compile-time constants, so they are uniquely identified by pointer and size
+    hash.update(pattern.data());
+    hash.update(pattern.size());
+
+    time_t now = time(nullptr);
+    size_t skipped_similar_messages = 0;
+    bool need_cleanup;
+    bool need_log;
+
+    {
+        std::lock_guard lock(mutex);
+        need_cleanup = last_cleanup + 300 <= now;
+        auto & info = logged_messages[hash.get64()];
+        need_log = info.first + min_interval_s <= now;
+        if (need_log)
+        {
+            skipped_similar_messages = info.second;
+            info.first = now;
+            info.second = 0;
+        }
+        else
+        {
+            ++info.second;
+        }
+    }
+
+    /// We don't need all threads to do cleanup, just randomize
+    if (need_cleanup && thread_local_rng() % 100 == 0)
+        cleanup();
+
+    /// The message it too frequent, skip it for now
+    /// NOTE It's not optimal because we format the message first and only then check if we need to actually write it, see LOG_IMPL macro
+    if (!need_log)
+        return;
+
+    if (skipped_similar_messages)
+        message.appendText(fmt::format(" (skipped {} similar messages)", skipped_similar_messages));
+
+    if (auto * channel = logger->getChannel())
+        channel->log(message);
+}
+
+void LogFrequencyLimiterIml::cleanup(time_t too_old_threshold_s)
+{
+    time_t now = time(nullptr);
+    time_t old = now - too_old_threshold_s;
+    std::lock_guard lock(mutex);
+    std::erase_if(logged_messages, [old](const auto & elem) { return elem.second.first < old; });
+    last_cleanup = now;
+}

--- a/src/Common/logger_useful.h
+++ b/src/Common/logger_useful.h
@@ -10,35 +10,16 @@
 
 namespace Poco { class Logger; }
 
-/// This wrapper is useful to save formatted message into a String before sending it to a logger
-class LogToStrImpl
-{
-    String & out_str;
-    Poco::Logger * logger;
-    bool propagate_to_actual_log = true;
-public:
-    LogToStrImpl(String & out_str_, Poco::Logger * logger_) : out_str(out_str_) , logger(logger_) {}
-    LogToStrImpl & operator -> () { return *this; }
-    bool is(Poco::Message::Priority priority) { propagate_to_actual_log &= logger->is(priority); return true; }
-    LogToStrImpl * getChannel() {return this; }
-    const String & name() const { return logger->name(); }
-    void log(const Poco::Message & message)
-    {
-        out_str = message.getText();
-        if (!propagate_to_actual_log)
-            return;
-        if (auto * channel = logger->getChannel())
-            channel->log(message);
-    }
-};
 
 #define LogToStr(x, y) std::make_unique<LogToStrImpl>(x, y)
+#define LogFrequencyLimiter(x, y) std::make_unique<LogFrequencyLimiterIml>(x, y)
 
 namespace
 {
     [[maybe_unused]] const ::Poco::Logger * getLogger(const ::Poco::Logger * logger) { return logger; };
     [[maybe_unused]] const ::Poco::Logger * getLogger(const std::atomic<::Poco::Logger *> & logger) { return logger.load(); };
     [[maybe_unused]] std::unique_ptr<LogToStrImpl> getLogger(std::unique_ptr<LogToStrImpl> && logger) { return logger; };
+    [[maybe_unused]] std::unique_ptr<LogFrequencyLimiterIml> getLogger(std::unique_ptr<LogFrequencyLimiterIml> && logger) { return logger; };
 }
 
 #define LOG_IMPL_FIRST_ARG(X, ...) X

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -115,7 +115,7 @@ struct TemporaryFileStream::OutputWriter
         , out_compressed_buf(*out_buf)
         , out_writer(out_compressed_buf, DBMS_TCP_PROTOCOL_VERSION, header_)
     {
-        LOG_TEST(&Poco::Logger::get("TemporaryFileStream"), "Writing to {}", path);
+        LOG_TEST(&Poco::Logger::get("TemporaryFileStream"), "Writing to temporary file {}", path);
     }
 
     OutputWriter(std::unique_ptr<WriteBufferToFileSegment> out_buf_, const Block & header_)
@@ -124,7 +124,7 @@ struct TemporaryFileStream::OutputWriter
         , out_writer(out_compressed_buf, DBMS_TCP_PROTOCOL_VERSION, header_)
     {
         LOG_TEST(&Poco::Logger::get("TemporaryFileStream"),
-            "Writing to {}",
+            "Writing to temporary file {}",
             static_cast<const WriteBufferToFileSegment *>(out_buf.get())->getFileName());
     }
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1947,9 +1947,9 @@ size_t MergeTreeData::clearOldTemporaryDirectories(size_t custom_directories_lif
                 {
                     if (temporary_parts.contains(basename))
                     {
-                        /// Actually we don't rely on temporary_directories_lifetime when removing old temporaries directoties,
+                        /// Actually we don't rely on temporary_directories_lifetime when removing old temporaries directories,
                         /// it's just an extra level of protection just in case we have a bug.
-                        LOG_INFO(log, "{} is in use (by merge/mutation/INSERT) (consider increasing temporary_directories_lifetime setting)", full_path);
+                        LOG_INFO(LogFrequencyLimiter(log, 10), "{} is in use (by merge/mutation/INSERT) (consider increasing temporary_directories_lifetime setting)", full_path);
                         continue;
                     }
                     else

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1231,8 +1231,7 @@ bool ReplicatedMergeTreeQueue::isCoveredByFuturePartsImpl(const LogEntry & entry
                                     "because it is not disjoint with part {} that is currently executing.";
 
         /// This message can be too noisy, do not print it more than once per second
-        if (!(entry.last_postpone_time == time(nullptr) && entry.postpone_reason.ends_with("that is currently executing.")))
-            LOG_TEST(LogToStr(out_reason, log), fmt_string, entry.znode_name, new_part_name, future_part_elem.first);
+        LOG_TEST(LogToStr(out_reason, LogFrequencyLimiter(log, 5)), fmt_string, entry.znode_name, new_part_name, future_part_elem.first);
         return true;
     }
 
@@ -1423,7 +1422,7 @@ bool ReplicatedMergeTreeQueue::shouldExecuteLogEntry(
         {
             constexpr auto fmt_string = "Not executing log entry {} of type {} for part {}"
                                         " because source parts size ({}) is greater than the current maximum ({}).";
-            LOG_DEBUG(LogToStr(out_postpone_reason, log), fmt_string, entry.znode_name, entry.typeToString(), entry.new_part_name,
+            LOG_DEBUG(LogToStr(out_postpone_reason, LogFrequencyLimiter(log, 5)), fmt_string, entry.znode_name, entry.typeToString(), entry.new_part_name,
                       ReadableSize(sum_parts_size_in_bytes), ReadableSize(max_source_parts_size));
 
             return false;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -2951,7 +2951,8 @@ void StorageReplicatedMergeTree::cloneReplicaIfNeeded(zkutil::ZooKeeperPtr zooke
     }
 
     if (source_replica.empty())
-        throw Exception(ErrorCodes::ALL_REPLICAS_LOST, "All replicas are lost");
+        throw Exception(ErrorCodes::ALL_REPLICAS_LOST, "All replicas are lost. "
+                        "See SYSTEM DROP REPLICA and SYSTEM RESTORE REPLICA queries, they may help");
 
     if (is_new_replica)
         LOG_INFO(log, "Will mimic {}", source_replica);

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2014,7 +2014,13 @@ def reportLogStats(args):
               'Cyclic aliases', 'Detaching {}', 'Executing {}', 'Fire events: {}', 'Found part {}', 'Loaded queue',
               'No sharding key', 'No tables', 'Query: {}', 'Removed', 'Removed part {}', 'Removing parts.',
               'Request URI: {}', 'Sending part {}', 'Sent handshake', 'Starting {}', 'Will mimic {}', 'Writing to {}',
-              'dropIfEmpty', 'loadAll {}', '{} ({}:{})', '{} -> {}', '{} {}', '{}: {}'
+              'dropIfEmpty', 'loadAll {}', '{} ({}:{})', '{} -> {}', '{} {}', '{}: {}', 'Query was cancelled',
+              'Table {} already exists', '{}%', 'Cancelled merging parts', 'All replicas are lost',
+              'Cancelled mutating parts', 'Read object: {}', 'New segment: {}', 'Unknown geometry type {}',
+              'Table {} is not replicated', '{} {}.{} already exists', 'Attempt to read after eof',
+              'Replica {} already exists', 'Convert overflow', 'key must be a tuple', 'Division by zero',
+              'No part {} in committed state', 'Files set to {}', 'Bytes set to {}', 'Sharding key {} is not used',
+              'Cannot parse datetime', 'Bad get: has {}, requested {}', 'There is no {} in {}', 'Numeric overflow'
         ) AS known_short_messages
         SELECT count() AS c, message_format_string, substr(any(message), 1, 120)
         FROM system.text_log

--- a/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
+++ b/tests/integration/test_materialized_mysql_database/materialize_with_ddl.py
@@ -2063,7 +2063,7 @@ def materialized_database_support_all_kinds_of_mysql_datatype(
     # increment synchronization check
     check_query(
         clickhouse_node,
-        "SELECT v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, hex(v25), v26, v28, v29, v30, v32 FROM test_database_datatype.t1 FORMAT TSV",
+        "SELECT v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, hex(v25), v26, v28, v29, v30, v32 FROM test_database_datatype.t1 ORDER BY v1 FORMAT TSV",
         "1\t1\t11\t9223372036854775807\t-1\t1\t11\t18446744073709551615\t-1.1\t1.1\t-1.111\t1.111\t1.1111\t2021-10-06\ttext\tvarchar\tBLOB\t2021-10-06 18:32:57\t2021-10-06 18:32:57.482786\t2021-10-06 18:32:57\t2021-10-06 18:32:57.482786"
         + "\t2021\t3020399000000\t3020399000000\t00000000010100000000000000000000000000000000000000\t10\t1\t11\tvarbinary\tRED\n"
         + "2\t2\t22\t9223372036854775807\t-2\t2\t22\t18446744073709551615\t-2.2\t2.2\t-2.22\t2.222\t2.2222\t2021-10-07\ttext\tvarchar\tBLOB\t2021-10-07 18:32:57\t2021-10-07 18:32:57.482786\t2021-10-07 18:32:57\t2021-10-07 18:32:57.482786"

--- a/tests/integration/test_replicated_merge_tree_s3_zero_copy/test.py
+++ b/tests/integration/test_replicated_merge_tree_s3_zero_copy/test.py
@@ -194,10 +194,12 @@ def test_drop_table(cluster):
     )
     node.query_with_retry(
         "system sync replica test_drop_table",
-        settings={"receive_timeout": 10},
-        retry_count=5,
+        settings={"receive_timeout": 5},
+        sleep_time=5,
+        retry_count=10,
     )
-    node2.query("drop table test_drop_table")
+    node2.query("drop table test_drop_table sync")
     assert "1000\t499500\n" == node.query(
         "select count(n), sum(n) from test_drop_table"
     )
+    node.query("drop table test_drop_table sync")

--- a/tests/queries/0_stateless/00002_log_and_exception_messages_formatting.sql
+++ b/tests/queries/0_stateless/00002_log_and_exception_messages_formatting.sql
@@ -58,6 +58,7 @@ select 'number of noisy messages', max2(count(), 10) from (select count() / (sel
 select 'incorrect patterns', max2(countDistinct(message_format_string), 15) from (
     select message_format_string, any(message) as any_message from logs
     where message not like (replaceRegexpAll(message_format_string, '{[:.0-9dfx]*}', '%') as s)
+    and message not like (s || ' (skipped % similar messages)')
     and message not like ('%Exception: '||s||'%') group by message_format_string
 ) where any_message not like '%Poco::Exception%';
 


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Messages like `{} is in use (by merge/mutation/INSERT) (consider increasing temporary_directories_lifetime setting)` are not useful at all when repeated 100500 times, let's avoid this: https://s3.amazonaws.com/clickhouse-test-reports/0/2c65f672016ed135c512614807a3eceb6bfed1b3/stateless_tests__release_.html (see `00002_log_and_exception_messages_formatting`).

Also fixes two flaky integration tests: `test_materialized_mysql_database` and `test_replicated_merge_tree_s3_zero_copy` (it's not related to logging, but I don't want to create a separate PR for this and run CI one more time)