### PR TITLE
remove counters for threads, fix negative counters

### DIFF
--- a/src/AggregateFunctions/UniqExactSet.h
+++ b/src/AggregateFunctions/UniqExactSet.h
@@ -54,10 +54,10 @@ public:
                 {
                     SCOPE_EXIT_SAFE(
                         if (thread_group)
-                            CurrentThread::detachQueryIfNotDetached();
+                            CurrentThread::detachFromGroupIfNotDetached();
                     );
                     if (thread_group)
-                        CurrentThread::attachToIfDetached(thread_group);
+                        CurrentThread::attachToGroupIfDetached(thread_group);
                     setThreadName("UniqExactMerger");
 
                     while (true)

--- a/src/Backups/BackupUtils.cpp
+++ b/src/Backups/BackupUtils.cpp
@@ -89,13 +89,13 @@ void writeBackupEntries(BackupMutablePtr backup, BackupEntries && backup_entries
                 if (!--num_active_jobs)
                     event.notify_all();
                 if (async)
-                    CurrentThread::detachQueryIfNotDetached();
+                    CurrentThread::detachFromGroupIfNotDetached();
             );
 
             try
             {
                 if (async && thread_group)
-                    CurrentThread::attachTo(thread_group);
+                    CurrentThread::attachToGroup(thread_group);
 
                 if (async)
                     setThreadName("BackupWorker");
@@ -154,13 +154,13 @@ void restoreTablesData(DataRestoreTasks && tasks, ThreadPool & thread_pool)
                 if (!--num_active_jobs)
                     event.notify_all();
                 if (async)
-                    CurrentThread::detachQueryIfNotDetached();
+                    CurrentThread::detachFromGroupIfNotDetached();
             );
 
             try
             {
                 if (async && thread_group)
-                    CurrentThread::attachTo(thread_group);
+                    CurrentThread::attachToGroup(thread_group);
 
                 if (async)
                     setThreadName("RestoreWorker");

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -117,6 +117,11 @@ namespace ProfileEvents
     extern const Event SystemTimeMicroseconds;
 }
 
+namespace
+{
+constexpr UInt64 THREAD_GROUP_ID = 0;
+}
+
 namespace DB
 {
 
@@ -195,23 +200,19 @@ static void incrementProfileEventsBlock(Block & dst, const Block & src)
         }
     };
     std::map<Id, UInt64> rows_by_name;
+
     for (size_t src_row = 0; src_row < src.rows(); ++src_row)
     {
+        /// Filter out threads stats, use thead group stats
+        auto thread_id = src_array_thread_id[src_row];
+        if (thread_id != THREAD_GROUP_ID)
+            continue;
+
         Id id{
             src_column_name.getDataAt(src_row),
             src_column_host_name.getDataAt(src_row),
         };
         rows_by_name[id] = src_row;
-    }
-
-    /// Filter out snapshots
-    std::set<size_t> thread_id_filter_mask;
-    for (size_t i = 0; i < src_array_thread_id.size(); ++i)
-    {
-        if (src_array_thread_id[i] != 0)
-        {
-            thread_id_filter_mask.emplace(i);
-        }
     }
 
     /// Merge src into dst.
@@ -225,10 +226,6 @@ static void incrementProfileEventsBlock(Block & dst, const Block & src)
         if (auto it = rows_by_name.find(id); it != rows_by_name.end())
         {
             size_t src_row = it->second;
-            if (thread_id_filter_mask.contains(src_row))
-            {
-                continue;
-            }
 
             dst_array_current_time[dst_row] = src_array_current_time[src_row];
 
@@ -249,11 +246,6 @@ static void incrementProfileEventsBlock(Block & dst, const Block & src)
     /// Copy rows from src that dst does not contains.
     for (const auto & [id, pos] : rows_by_name)
     {
-        if (thread_id_filter_mask.contains(pos))
-        {
-            continue;
-        }
-
         for (size_t col = 0; col < src.columns(); ++col)
         {
             mutable_columns[col]->insert((*src.getByPosition(col).column)[pos]);
@@ -1080,13 +1072,18 @@ void ClientBase::onProfileEvents(Block & block)
         const auto * user_time_name = ProfileEvents::getName(ProfileEvents::UserTimeMicroseconds);
         const auto * system_time_name = ProfileEvents::getName(ProfileEvents::SystemTimeMicroseconds);
 
-        HostToThreadTimesMap thread_times;
+        HostToTimesMap thread_times;
         for (size_t i = 0; i < rows; ++i)
         {
             auto thread_id = array_thread_id[i];
             auto host_name = host_names.getDataAt(i).toString();
-            if (thread_id != 0)
-                progress_indication.addThreadIdToList(host_name, thread_id);
+
+            /// In ProfileEvents packets thread id 0 specifies common profiling information
+            /// for all threads executing current query on specific host. So instead of summing per thread
+            /// consumption it's enough to look for data with thread id 0.
+            if (thread_id != THREAD_GROUP_ID)
+                continue;
+
             auto event_name = names.getDataAt(i);
             auto value = array_values[i];
 
@@ -1095,11 +1092,11 @@ void ClientBase::onProfileEvents(Block & block)
                 continue;
 
             if (event_name == user_time_name)
-                thread_times[host_name][thread_id].user_ms = value;
+                thread_times[host_name].user_ms = value;
             else if (event_name == system_time_name)
-                thread_times[host_name][thread_id].system_ms = value;
+                thread_times[host_name].system_ms = value;
             else if (event_name == MemoryTracker::USAGE_EVENT_NAME)
-                thread_times[host_name][thread_id].memory_usage = value;
+                thread_times[host_name].memory_usage = value;
         }
         progress_indication.updateThreadEventData(thread_times);
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -203,7 +203,12 @@ static void incrementProfileEventsBlock(Block & dst, const Block & src)
 
     for (size_t src_row = 0; src_row < src.rows(); ++src_row)
     {
-        /// Filter out threads stats, use thead group stats
+        /// Filter out threads stats, use stats from thread group
+        /// Exactly stats from thread group is stored to the table system.query_log
+        /// The stats from threads are less useful.
+        /// They take more records, they need to be combined,
+        /// there even could be several records from one thread.
+        /// Server doesn't send it any more to the clients, so this code left for compatible
         auto thread_id = src_array_thread_id[src_row];
         if (thread_id != THREAD_GROUP_ID)
             continue;

--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -65,20 +65,10 @@ void CurrentThread::attachInternalTextLogsQueue(const std::shared_ptr<InternalTe
     current_thread->attachInternalTextLogsQueue(logs_queue, client_logs_level);
 }
 
-void CurrentThread::setFatalErrorCallback(std::function<void()> callback)
-{
-    /// It does not make sense to set a callback for sending logs to a client if there's no thread status
-    chassert(current_thread);
-    current_thread->setFatalErrorCallback(callback);
-}
-
 std::shared_ptr<InternalTextLogsQueue> CurrentThread::getInternalTextLogsQueue()
 {
     /// NOTE: this method could be called at early server startup stage
     if (unlikely(!current_thread))
-        return nullptr;
-
-    if (current_thread->getCurrentState() == ThreadStatus::ThreadState::Died)
         return nullptr;
 
     return current_thread->getInternalTextLogsQueue();
@@ -94,9 +84,6 @@ void CurrentThread::attachInternalProfileEventsQueue(const InternalProfileEvents
 InternalProfileEventsQueuePtr CurrentThread::getInternalProfileEventsQueue()
 {
     if (unlikely(!current_thread))
-        return nullptr;
-
-    if (current_thread->getCurrentState() == ThreadStatus::ThreadState::Died)
         return nullptr;
 
     return current_thread->getInternalProfileEventsQueue();

--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -57,14 +57,6 @@ void CurrentThread::updateProgressOut(const Progress & value)
     current_thread->progress_out.incrementPiecewiseAtomically(value);
 }
 
-void CurrentThread::attachInternalTextLogsQueue(const std::shared_ptr<InternalTextLogsQueue> & logs_queue,
-                                                LogsLevel client_logs_level)
-{
-    if (unlikely(!current_thread))
-        return;
-    current_thread->attachInternalTextLogsQueue(logs_queue, client_logs_level);
-}
-
 std::shared_ptr<InternalTextLogsQueue> CurrentThread::getInternalTextLogsQueue()
 {
     /// NOTE: this method could be called at early server startup stage
@@ -72,13 +64,6 @@ std::shared_ptr<InternalTextLogsQueue> CurrentThread::getInternalTextLogsQueue()
         return nullptr;
 
     return current_thread->getInternalTextLogsQueue();
-}
-
-void CurrentThread::attachInternalProfileEventsQueue(const InternalProfileEventsQueuePtr & queue)
-{
-    if (unlikely(!current_thread))
-        return;
-    current_thread->attachInternalProfileEventsQueue(queue);
 }
 
 InternalProfileEventsQueuePtr CurrentThread::getInternalProfileEventsQueue()
@@ -89,12 +74,29 @@ InternalProfileEventsQueuePtr CurrentThread::getInternalProfileEventsQueue()
     return current_thread->getInternalProfileEventsQueue();
 }
 
+void CurrentThread::attachInternalTextLogsQueue(const std::shared_ptr<InternalTextLogsQueue> & logs_queue,
+                                                LogsLevel client_logs_level)
+{
+    if (unlikely(!current_thread))
+        return;
+    current_thread->attachInternalTextLogsQueue(logs_queue, client_logs_level);
+}
+
+
 ThreadGroupStatusPtr CurrentThread::getGroup()
 {
     if (unlikely(!current_thread))
         return nullptr;
 
     return current_thread->getThreadGroup();
+}
+
+std::string_view CurrentThread::getQueryId()
+{
+    if (unlikely(!current_thread))
+        return {};
+
+    return current_thread->getQueryId();
 }
 
 }

--- a/src/Common/CurrentThread.h
+++ b/src/Common/CurrentThread.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
 
 namespace ProfileEvents
@@ -48,6 +49,8 @@ public:
     static void attachInternalProfileEventsQueue(const InternalProfileEventsQueuePtr & queue);
     static InternalProfileEventsQueuePtr getInternalProfileEventsQueue();
 
+    static void attachQueryForLog(const String & query_);
+
     /// Makes system calls to update ProfileEvents that contain info from rusage and taskstats
     static void updatePerformanceCounters();
 
@@ -65,24 +68,18 @@ public:
 
     /// You must call one of these methods when create a query child thread:
     /// Add current thread to a group associated with the thread group
-    static void attachTo(const ThreadGroupStatusPtr & thread_group);
+    static void attachToGroup(const ThreadGroupStatusPtr & thread_group);
     /// Is useful for a ThreadPool tasks
-    static void attachToIfDetached(const ThreadGroupStatusPtr & thread_group);
+    static void attachToGroupIfDetached(const ThreadGroupStatusPtr & thread_group);
 
     /// Non-master threads call this method in destructor automatically
-    static void detachGroupIfNotDetached();
-    static void detachQueryIfNotDetached();
+    static void detachFromGroupIfNotDetached();
 
     /// Update ProfileEvents and dumps info to system.query_thread_log
     static void finalizePerformanceCounters();
 
     /// Returns a non-empty string if the thread is attached to a query
-    static std::string_view getQueryId()
-    {
-        if (unlikely(!current_thread))
-            return {};
-        return current_thread->getQueryId();
-    }
+    static std::string_view getQueryId();
 
     /// Initializes query with current thread as master thread in constructor, and detaches it in destructor
     struct QueryScope : private boost::noncopyable

--- a/src/Common/ProgressIndication.cpp
+++ b/src/Common/ProgressIndication.cpp
@@ -15,24 +15,6 @@
 /// http://en.wikipedia.org/wiki/ANSI_escape_code
 #define CLEAR_TO_END_OF_LINE "\033[K"
 
-
-namespace
-{
-    constexpr UInt64 ALL_THREADS = 0;
-
-    UInt64 aggregateCPUUsageNs(DB::ThreadIdToTimeMap times)
-    {
-        constexpr UInt64 us_to_ns = 1000;
-        return us_to_ns * std::accumulate(times.begin(), times.end(), 0ull,
-        [](UInt64 acc, const auto & elem)
-        {
-            if (elem.first == ALL_THREADS)
-                return acc;
-            return acc + elem.second.time();
-        });
-    }
-}
-
 namespace DB
 {
 
@@ -58,7 +40,7 @@ void ProgressIndication::resetProgress()
     {
         std::lock_guard lock(profile_events_mutex);
         cpu_usage_meter.reset(getElapsedNanoseconds());
-        thread_data.clear();
+        hosts_data.clear();
     }
 }
 
@@ -71,25 +53,17 @@ void ProgressIndication::setFileProgressCallback(ContextMutablePtr context, Writ
     });
 }
 
-void ProgressIndication::addThreadIdToList(String const & host, UInt64 thread_id)
+void ProgressIndication::updateThreadEventData(HostToTimesMap & new_hosts_data)
 {
     std::lock_guard lock(profile_events_mutex);
 
-    auto & thread_to_times = thread_data[host];
-    if (thread_to_times.contains(thread_id))
-        return;
-    thread_to_times[thread_id] = {};
-}
-
-void ProgressIndication::updateThreadEventData(HostToThreadTimesMap & new_thread_data)
-{
-    std::lock_guard lock(profile_events_mutex);
+    constexpr UInt64 us_to_ns = 1000;
 
     UInt64 total_cpu_ns = 0;
-    for (auto & new_host_map : new_thread_data)
+    for (auto & new_host : new_hosts_data)
     {
-        total_cpu_ns += aggregateCPUUsageNs(new_host_map.second);
-        thread_data[new_host_map.first] = std::move(new_host_map.second);
+        total_cpu_ns += us_to_ns * new_host.second.time();
+        hosts_data[new_host.first] = new_host.second;
     }
     cpu_usage_meter.add(getElapsedNanoseconds(), total_cpu_ns);
 }
@@ -104,16 +78,10 @@ ProgressIndication::MemoryUsage ProgressIndication::getMemoryUsage() const
 {
     std::lock_guard lock(profile_events_mutex);
 
-    return std::accumulate(thread_data.cbegin(), thread_data.cend(), MemoryUsage{},
+    return std::accumulate(hosts_data.cbegin(), hosts_data.cend(), MemoryUsage{},
         [](MemoryUsage const & acc, auto const & host_data)
         {
-            UInt64 host_usage = 0;
-            // In ProfileEvents packets thread id 0 specifies common profiling information
-            // for all threads executing current query on specific host. So instead of summing per thread
-            // memory consumption it's enough to look for data with thread id 0.
-            if (auto it = host_data.second.find(ALL_THREADS); it != host_data.second.end())
-                host_usage = it->second.memory_usage;
-
+            UInt64 host_usage = host_data.second.memory_usage;
             return MemoryUsage{.total = acc.total + host_usage, .max = std::max(acc.max, host_usage)};
         });
 }

--- a/src/Common/ProgressIndication.h
+++ b/src/Common/ProgressIndication.h
@@ -24,8 +24,7 @@ struct ThreadEventData
     UInt64 memory_usage = 0;
 };
 
-using ThreadIdToTimeMap = std::unordered_map<UInt64, ThreadEventData>;
-using HostToThreadTimesMap = std::unordered_map<String, ThreadIdToTimeMap>;
+using HostToTimesMap = std::unordered_map<String, ThreadEventData>;
 
 class ProgressIndication
 {
@@ -56,9 +55,7 @@ public:
     /// How much seconds passed since query execution start.
     double elapsedSeconds() const { return getElapsedNanoseconds() / 1e9; }
 
-    void addThreadIdToList(String const & host, UInt64 thread_id);
-
-    void updateThreadEventData(HostToThreadTimesMap & new_thread_data);
+    void updateThreadEventData(HostToTimesMap & new_hosts_data);
 
 private:
     double getCPUUsage();
@@ -91,7 +88,7 @@ private:
     bool write_progress_on_update = false;
 
     EventRateMeter cpu_usage_meter{static_cast<double>(clock_gettime_ns()), 2'000'000'000 /*ns*/}; // average cpu utilization last 2 second
-    HostToThreadTimesMap thread_data;
+    HostToTimesMap hosts_data;
     /// In case of all of the above:
     /// - clickhouse-local
     /// - input_format_parallel_parsing=true
@@ -99,7 +96,7 @@ private:
     ///
     /// It is possible concurrent access to the following:
     /// - writeProgress() (class properties) (guarded with progress_mutex)
-    /// - thread_data/cpu_usage_meter (guarded with profile_events_mutex)
+    /// - hosts_data/cpu_usage_meter (guarded with profile_events_mutex)
     mutable std::mutex profile_events_mutex;
     mutable std::mutex progress_mutex;
 };

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -159,29 +159,29 @@ void ThreadStatus::attachInternalTextLogsQueue(const InternalTextLogsQueuePtr & 
     if (!thread_group)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "No thread group attached to the thread {}", thread_id);
 
-    shared_data.logs_queue_ptr = logs_queue;
-    shared_data.client_logs_level = logs_level;
+    local_data.logs_queue_ptr = logs_queue;
+    local_data.client_logs_level = logs_level;
     thread_group->attachInternalTextLogsQueue(logs_queue, logs_level);
 }
 
 InternalTextLogsQueuePtr ThreadStatus::getInternalTextLogsQueue() const
 {
-    return shared_data.logs_queue_ptr.lock();
+    return local_data.logs_queue_ptr.lock();
 }
 
 InternalProfileEventsQueuePtr ThreadStatus::getInternalProfileEventsQueue() const
 {
-    return shared_data.profile_queue_ptr.lock();
+    return local_data.profile_queue_ptr.lock();
 }
 
 const String & ThreadStatus::getQueryForLog() const
 {
-    return shared_data.query_for_logs;
+    return local_data.query_for_logs;
 }
 
 LogsLevel ThreadStatus::getClientLogsLevel() const
 {
-    return shared_data.client_logs_level;
+    return local_data.client_logs_level;
 }
 
 void ThreadStatus::flushUntrackedMemory()

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -16,11 +16,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
-
 thread_local ThreadStatus constinit * current_thread = nullptr;
 
 #if !defined(SANITIZER)
@@ -156,12 +151,11 @@ void ThreadGroupStatus::attachInternalTextLogsQueue(const InternalTextLogsQueueP
 void ThreadStatus::attachInternalTextLogsQueue(const InternalTextLogsQueuePtr & logs_queue,
                                                LogsLevel logs_level)
 {
-    if (!thread_group)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "No thread group attached to the thread {}", thread_id);
-
     local_data.logs_queue_ptr = logs_queue;
     local_data.client_logs_level = logs_level;
-    thread_group->attachInternalTextLogsQueue(logs_queue, logs_level);
+
+    if (thread_group)
+        thread_group->attachInternalTextLogsQueue(logs_queue, logs_level);
 }
 
 InternalTextLogsQueuePtr ThreadStatus::getInternalTextLogsQueue() const

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -92,6 +92,7 @@ public:
 
     SharedData getSharedData()
     {
+        /// Critical section for making the copy of shared_data
         std::lock_guard lock(mutex);
         return shared_data;
     }
@@ -170,7 +171,7 @@ private:
     using FatalErrorCallback = std::function<void()>;
     FatalErrorCallback fatal_error_callback;
 
-    ThreadGroupStatus::SharedData shared_data;
+    ThreadGroupStatus::SharedData local_data;
 
     bool performance_counters_finalized = false;
 

--- a/src/Common/logger_useful.h
+++ b/src/Common/logger_useful.h
@@ -34,7 +34,7 @@ namespace
 {                                                                                 \
     auto _logger = ::getLogger(logger);                                           \
     const bool _is_clients_log = (DB::CurrentThread::getGroup() != nullptr) &&    \
-        (DB::CurrentThread::getGroup()->client_logs_level >= (priority));         \
+        (DB::CurrentThread::get().getClientLogsLevel() >= (priority));         \
     if (_is_clients_log || _logger->is((PRIORITY)))                               \
     {                                                                             \
         std::string formatted_message = numArgs(__VA_ARGS__) > 1 ? fmt::format(__VA_ARGS__) : firstArg(__VA_ARGS__); \

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -312,12 +312,8 @@ private:
         /// It will allow client to see failure messages directly.
         if (thread_ptr)
         {
-            query_id = std::string(thread_ptr->getQueryId());
-
-            if (auto thread_group = thread_ptr->getThreadGroup())
-            {
-                query = DB::toOneLineQuery(thread_group->query);
-            }
+            query_id = thread_ptr->getQueryId();
+            query = thread_ptr->getQueryForLog();
 
             if (auto logs_queue = thread_ptr->getInternalTextLogsQueue())
             {

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -75,7 +75,7 @@ public:
             pool.scheduleOrThrowOnError([this, shard, thread_group = CurrentThread::getGroup()]
             {
                 if (thread_group)
-                    CurrentThread::attachToIfDetached(thread_group);
+                    CurrentThread::attachToGroupIfDetached(thread_group);
                 setThreadName("HashedDictLoad");
 
                 threadWorker(shard);
@@ -224,7 +224,7 @@ HashedDictionary<dictionary_key_type, sparse, sharded>::~HashedDictionary()
         pool.trySchedule([&container, thread_group = CurrentThread::getGroup()]
         {
             if (thread_group)
-                CurrentThread::attachToIfDetached(thread_group);
+                CurrentThread::attachToGroupIfDetached(thread_group);
             setThreadName("HashedDictDtor");
 
             if constexpr (sparse)

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -2309,10 +2309,10 @@ BlocksList Aggregator::prepareBlocksAndFillTwoLevelImpl(
     {
         SCOPE_EXIT_SAFE(
             if (thread_group)
-                CurrentThread::detachQueryIfNotDetached();
+                CurrentThread::detachFromGroupIfNotDetached();
         );
         if (thread_group)
-            CurrentThread::attachToIfDetached(thread_group);
+            CurrentThread::attachToGroupIfDetached(thread_group);
 
         BlocksList blocks;
         while (true)
@@ -3030,10 +3030,10 @@ void Aggregator::mergeBlocks(BucketToBlocks bucket_to_blocks, AggregatedDataVari
         {
             SCOPE_EXIT_SAFE(
                 if (thread_group)
-                    CurrentThread::detachQueryIfNotDetached();
+                    CurrentThread::detachFromGroupIfNotDetached();
             );
             if (thread_group)
-                CurrentThread::attachToIfDetached(thread_group);
+                CurrentThread::attachToGroupIfDetached(thread_group);
 
             for (Block & block : bucket_to_blocks[bucket])
             {

--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -971,11 +971,11 @@ private:
     {
         SCOPE_EXIT_SAFE(
             if (thread_group)
-                CurrentThread::detachQueryIfNotDetached();
+                CurrentThread::detachFromGroupIfNotDetached();
         );
 
         if (thread_group)
-            CurrentThread::attachTo(thread_group);
+            CurrentThread::attachToGroup(thread_group);
 
         LOG_TRACE(log, "Start loading object '{}'", name);
         try

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -576,10 +576,7 @@ QueryStatusInfo QueryStatus::getInfo(bool get_thread_list, bool get_profile_even
         res.peak_memory_usage = thread_group->memory_tracker.getPeak();
 
         if (get_thread_list)
-        {
-            std::lock_guard lock(thread_group->mutex);
-            res.thread_ids.assign(thread_group->thread_ids.begin(), thread_group->thread_ids.end());
-        }
+            res.thread_ids = thread_group->getInvolvedThreadIds();
 
         if (get_profile_events)
             res.profile_counters = std::make_shared<ProfileEvents::Counters::Snapshot>(thread_group->performance_counters.getPartiallyAtomicSnapshot());

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -203,10 +203,10 @@ ProcessList::insert(const String & query_, const IAST * ast, ContextMutablePtr q
         ProcessListForUser & user_process_list = user_process_list_it->second;
 
         /// Actualize thread group info
+        CurrentThread::attachQueryForLog(query_);
         auto thread_group = CurrentThread::getGroup();
         if (thread_group)
         {
-            std::lock_guard lock_thread_group(thread_group->mutex);
             thread_group->performance_counters.setParent(&user_process_list.user_performance_counters);
             thread_group->memory_tracker.setParent(&user_process_list.user_memory_tracker);
             if (user_process_list.user_temp_data_on_disk)
@@ -214,8 +214,6 @@ ProcessList::insert(const String & query_, const IAST * ast, ContextMutablePtr q
                 query_context->setTempDataOnDisk(std::make_shared<TemporaryDataOnDiskScope>(
                     user_process_list.user_temp_data_on_disk, settings.max_temporary_data_on_disk_size_for_query));
             }
-            thread_group->query = query_;
-            thread_group->normalized_query_hash = normalizedQueryHash<false>(query_);
 
             /// Set query-level memory trackers
             thread_group->memory_tracker.setOrRaiseHardLimit(settings.max_memory_usage);

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -84,13 +84,13 @@ void ThreadGroupStatus::attachQueryForLog(const String & query_, UInt64 normaliz
 
 void ThreadStatus::attachQueryForLog(const String & query_)
 {
-    shared_data.query_for_logs = query_;
-    shared_data.normalized_query_hash = normalizedQueryHash<false>(query_);
+    local_data.query_for_logs = query_;
+    local_data.normalized_query_hash = normalizedQueryHash<false>(query_);
 
     if (!thread_group)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "No thread group attached to the thread {}", thread_id);
 
-    thread_group->attachQueryForLog(shared_data.query_for_logs, shared_data.normalized_query_hash);
+    thread_group->attachQueryForLog(local_data.query_for_logs, local_data.normalized_query_hash);
 }
 
 void ThreadGroupStatus::attachInternalProfileEventsQueue(const InternalProfileEventsQueuePtr & profile_queue)
@@ -104,7 +104,7 @@ void ThreadStatus::attachInternalProfileEventsQueue(const InternalProfileEventsQ
     if (!thread_group)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "No thread group attached to the thread {}", thread_id);
 
-    shared_data.profile_queue_ptr = profile_queue;
+    local_data.profile_queue_ptr = profile_queue;
     thread_group->attachInternalProfileEventsQueue(profile_queue);
 }
 
@@ -167,7 +167,7 @@ void ThreadStatus::attachToGroupImpl(const ThreadGroupStatusPtr & thread_group_)
 
     fatal_error_callback = thread_group->fatal_error_callback;
 
-    shared_data = thread_group->getSharedData();
+    local_data = thread_group->getSharedData();
 
     applyQuerySettings();
     initPerformanceCounters();
@@ -196,7 +196,7 @@ void ThreadStatus::detachFromGroup()
     query_id_from_query_context.clear();
     query_context.reset();
 
-    shared_data = {};
+    local_data = {};
 
     fatal_error_callback = {};
 
@@ -447,8 +447,8 @@ void ThreadStatus::logToQueryThreadLog(QueryThreadLog & thread_log, const String
     if (thread_group)
     {
         elem.master_thread_id = thread_group->master_thread_id;
-        elem.query = shared_data.query_for_logs;
-        elem.normalized_query_hash = shared_data.normalized_query_hash;
+        elem.query = local_data.query_for_logs;
+        elem.normalized_query_hash = local_data.normalized_query_hash;
     }
 
     auto query_context_ptr = query_context.lock();

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -122,7 +122,6 @@ void CurrentThread::attachQueryForLog(const String & query_)
     current_thread->attachQueryForLog(query_);
 }
 
-
 void ThreadStatus::applyQuerySettings()
 {
     auto query_context_ptr = query_context.lock();

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -557,7 +557,7 @@ CurrentThread::QueryScope::QueryScope(ContextMutablePtr query_context, std::func
         query_context->makeQueryContext();
 
     auto group = ThreadGroupStatus::createForQuery(query_context, std::move(fatal_error_callback));
-    CurrentThread::attachToGroup(std::move(group));
+    CurrentThread::attachToGroup(group);
 }
 
 CurrentThread::QueryScope::QueryScope(ContextPtr query_context, std::function<void()> fatal_error_callback)
@@ -567,7 +567,7 @@ CurrentThread::QueryScope::QueryScope(ContextPtr query_context, std::function<vo
             ErrorCodes::LOGICAL_ERROR, "Cannot initialize query scope without query context");
 
     auto group = ThreadGroupStatus::createForQuery(query_context, std::move(fatal_error_callback));
-    CurrentThread::attachToGroup(std::move(group));
+    CurrentThread::attachToGroup(group);
 }
 
 void CurrentThread::QueryScope::logPeakMemoryUsage()

--- a/src/Interpreters/tests/gtest_lru_file_cache.cpp
+++ b/src/Interpreters/tests/gtest_lru_file_cache.cpp
@@ -131,6 +131,7 @@ TEST_F(FileCacheTest, get)
     auto query_context = DB::Context::createCopy(getContext().context);
     query_context->makeQueryContext();
     query_context->setCurrentQueryId(query_id);
+    chassert(&DB::CurrentThread::get() == &thread_status);
     DB::CurrentThread::QueryScope query_scope_holder(query_context);
 
     DB::FileCacheSettings settings;
@@ -398,8 +399,8 @@ TEST_F(FileCacheTest, get)
                 auto query_context_1 = DB::Context::createCopy(getContext().context);
                 query_context_1->makeQueryContext();
                 query_context_1->setCurrentQueryId("query_id_1");
+                chassert(&DB::CurrentThread::get() == &thread_status_1);
                 DB::CurrentThread::QueryScope query_scope_holder_1(query_context_1);
-                thread_status_1.attachQueryContext(query_context_1);
 
                 auto holder_2 = cache.getOrSet(key, 25, 5, {}); /// Get [25, 29] once again.
                 auto segments_2 = fromHolder(holder_2);
@@ -467,8 +468,8 @@ TEST_F(FileCacheTest, get)
                 auto query_context_1 = DB::Context::createCopy(getContext().context);
                 query_context_1->makeQueryContext();
                 query_context_1->setCurrentQueryId("query_id_1");
+                chassert(&DB::CurrentThread::get() == &thread_status_1);
                 DB::CurrentThread::QueryScope query_scope_holder_1(query_context_1);
-                thread_status_1.attachQueryContext(query_context_1);
 
                 auto holder_2 = cache.getOrSet(key, 3, 23, {}); /// Get [3, 25] once again
                 auto segments_2 = fromHolder(*holder);

--- a/src/Interpreters/threadPoolCallbackRunner.h
+++ b/src/Interpreters/threadPoolCallbackRunner.h
@@ -22,7 +22,7 @@ ThreadPoolCallbackRunner<Result, Callback> threadPoolCallbackRunner(ThreadPool &
         auto task = std::make_shared<std::packaged_task<Result()>>([thread_group, thread_name, callback = std::move(callback)]() mutable -> Result
         {
             if (thread_group)
-                CurrentThread::attachTo(thread_group);
+                CurrentThread::attachToGroup(thread_group);
 
             SCOPE_EXIT_SAFE({
                 {
@@ -33,7 +33,7 @@ ThreadPoolCallbackRunner<Result, Callback> threadPoolCallbackRunner(ThreadPool &
                 }
 
                 if (thread_group)
-                    CurrentThread::detachQueryIfNotDetached();
+                    CurrentThread::detachFromGroupIfNotDetached();
 
             });
 

--- a/src/Processors/Executors/CompletedPipelineExecutor.cpp
+++ b/src/Processors/Executors/CompletedPipelineExecutor.cpp
@@ -36,14 +36,14 @@ static void threadFunction(CompletedPipelineExecutor::Data & data, ThreadGroupSt
 {
     SCOPE_EXIT_SAFE(
         if (thread_group)
-            CurrentThread::detachQueryIfNotDetached();
+            CurrentThread::detachFromGroupIfNotDetached();
     );
     setThreadName("QueryCompPipeEx");
 
     try
     {
         if (thread_group)
-            CurrentThread::attachTo(thread_group);
+            CurrentThread::attachToGroup(thread_group);
 
         data.executor->execute(num_threads);
     }

--- a/src/Processors/Executors/PipelineExecutor.cpp
+++ b/src/Processors/Executors/PipelineExecutor.cpp
@@ -308,12 +308,12 @@ void PipelineExecutor::spawnThreads()
 
             SCOPE_EXIT_SAFE(
                 if (thread_group)
-                    CurrentThread::detachQueryIfNotDetached();
+                    CurrentThread::detachFromGroupIfNotDetached();
             );
             setThreadName("QueryPipelineEx");
 
             if (thread_group)
-                CurrentThread::attachTo(thread_group);
+                CurrentThread::attachToGroup(thread_group);
 
             try
             {

--- a/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PullingAsyncPipelineExecutor.cpp
@@ -71,14 +71,14 @@ static void threadFunction(PullingAsyncPipelineExecutor::Data & data, ThreadGrou
 {
     SCOPE_EXIT_SAFE(
         if (thread_group)
-            CurrentThread::detachQueryIfNotDetached();
+            CurrentThread::detachFromGroupIfNotDetached();
     );
     setThreadName("QueryPullPipeEx");
 
     try
     {
         if (thread_group)
-            CurrentThread::attachTo(thread_group);
+            CurrentThread::attachToGroup(thread_group);
 
         data.executor->execute(num_threads);
     }

--- a/src/Processors/Executors/PushingAsyncPipelineExecutor.cpp
+++ b/src/Processors/Executors/PushingAsyncPipelineExecutor.cpp
@@ -101,14 +101,14 @@ static void threadFunction(PushingAsyncPipelineExecutor::Data & data, ThreadGrou
 {
     SCOPE_EXIT_SAFE(
         if (thread_group)
-            CurrentThread::detachQueryIfNotDetached();
+            CurrentThread::detachFromGroupIfNotDetached();
     );
     setThreadName("QueryPushPipeEx");
 
     try
     {
         if (thread_group)
-            CurrentThread::attachTo(thread_group);
+            CurrentThread::attachToGroup(thread_group);
 
         data.executor->execute(num_threads);
     }

--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
@@ -100,11 +100,11 @@ namespace DB
     {
         SCOPE_EXIT_SAFE(
             if (thread_group)
-                CurrentThread::detachQueryIfNotDetached();
+                CurrentThread::detachFromGroupIfNotDetached();
         );
         setThreadName("Collector");
         if (thread_group)
-            CurrentThread::attachToIfDetached(thread_group);
+            CurrentThread::attachToGroupIfDetached(thread_group);
 
         try
         {
@@ -161,11 +161,11 @@ namespace DB
     {
         SCOPE_EXIT_SAFE(
             if (thread_group)
-                CurrentThread::detachQueryIfNotDetached();
+                CurrentThread::detachFromGroupIfNotDetached();
         );
         setThreadName("Formatter");
         if (thread_group)
-            CurrentThread::attachToIfDetached(thread_group);
+            CurrentThread::attachToGroupIfDetached(thread_group);
 
         try
         {

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.cpp
@@ -12,10 +12,10 @@ void ParallelParsingInputFormat::segmentatorThreadFunction(ThreadGroupStatusPtr 
 {
     SCOPE_EXIT_SAFE(
         if (thread_group)
-            CurrentThread::detachQueryIfNotDetached();
+            CurrentThread::detachFromGroupIfNotDetached();
     );
     if (thread_group)
-        CurrentThread::attachTo(thread_group);
+        CurrentThread::attachToGroup(thread_group);
 
     setThreadName("Segmentator");
     try
@@ -62,10 +62,10 @@ void ParallelParsingInputFormat::parserThreadFunction(ThreadGroupStatusPtr threa
 {
     SCOPE_EXIT_SAFE(
         if (thread_group)
-            CurrentThread::detachQueryIfNotDetached();
+            CurrentThread::detachFromGroupIfNotDetached();
     );
     if (thread_group)
-        CurrentThread::attachToIfDetached(thread_group);
+        CurrentThread::attachToGroupIfDetached(thread_group);
 
     const auto parser_unit_number = current_ticket_number % processing_units.size();
     auto & unit = processing_units[parser_unit_number];

--- a/src/Processors/Transforms/AggregatingTransform.h
+++ b/src/Processors/Transforms/AggregatingTransform.h
@@ -100,10 +100,10 @@ struct ManyAggregatedData
                         {
                             SCOPE_EXIT_SAFE(
                                 if (thread_group)
-                                    CurrentThread::detachQueryIfNotDetached();
+                                    CurrentThread::detachFromGroupIfNotDetached();
                             );
                             if (thread_group)
-                                CurrentThread::attachToIfDetached(thread_group);
+                                CurrentThread::attachToGroupIfDetached(thread_group);
 
                             setThreadName("AggregDestruct");
                         });

--- a/src/Processors/Transforms/buildPushingToViewsChain.cpp
+++ b/src/Processors/Transforms/buildPushingToViewsChain.cpp
@@ -286,7 +286,7 @@ Chain buildPushingToViewsChain(
         std::unique_ptr<ThreadStatus> view_thread_status_ptr = std::make_unique<ThreadStatus>();
         /// Copy of a ThreadStatus should be internal.
         view_thread_status_ptr->setInternalThread();
-        view_thread_status_ptr->attachTo(running_group);
+        view_thread_status_ptr->attachToGroup(running_group);
 
         auto * view_thread_status = view_thread_status_ptr.get();
         views_data->thread_status_holder->thread_statuses.push_front(std::move(view_thread_status_ptr));

--- a/src/Processors/Transforms/buildPushingToViewsChain.cpp
+++ b/src/Processors/Transforms/buildPushingToViewsChain.cpp
@@ -286,12 +286,7 @@ Chain buildPushingToViewsChain(
         std::unique_ptr<ThreadStatus> view_thread_status_ptr = std::make_unique<ThreadStatus>();
         /// Copy of a ThreadStatus should be internal.
         view_thread_status_ptr->setInternalThread();
-        /// view_thread_status_ptr will be moved later (on and on), so need to capture raw pointer.
-        view_thread_status_ptr->deleter = [thread_status = view_thread_status_ptr.get(), running_group]
-        {
-            thread_status->detachQuery();
-        };
-        view_thread_status_ptr->attachQuery(running_group);
+        view_thread_status_ptr->attachTo(running_group);
 
         auto * view_thread_status = view_thread_status_ptr.get();
         views_data->thread_status_holder->thread_statuses.push_front(std::move(view_thread_status_ptr));

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -501,6 +501,7 @@ void TCPHandler::runImpl()
             /// (i.e. deallocations from the Aggregator with two-level aggregation)
             state.reset();
             query_scope.reset();
+            last_sent_snapshots.clear();
             thread_trace_context.reset();
         }
         catch (const Exception & e)

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -293,12 +293,12 @@ DistributedSink::runWritingJob(JobReplica & job, const Block & current_block, si
     {
         SCOPE_EXIT_SAFE(
             if (thread_group)
-                CurrentThread::detachQueryIfNotDetached();
+                CurrentThread::detachFromGroupIfNotDetached();
         );
         OpenTelemetry::SpanHolder span(__PRETTY_FUNCTION__);
 
         if (thread_group)
-            CurrentThread::attachToIfDetached(thread_group);
+            CurrentThread::attachToGroupIfDetached(thread_group);
         setThreadName("DistrOutStrProc");
 
         ++job.blocks_started;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1395,10 +1395,10 @@ std::vector<MergeTreeData::LoadPartResult> MergeTreeData::loadDataPartsFromDisk(
             {
                 SCOPE_EXIT_SAFE(
                     if (thread_group)
-                        CurrentThread::detachQueryIfNotDetached();
+                        CurrentThread::detachFromGroupIfNotDetached();
                 );
                 if (thread_group)
-                    CurrentThread::attachToIfDetached(thread_group);
+                    CurrentThread::attachToGroupIfDetached(thread_group);
 
                 while (true)
                 {
@@ -2314,10 +2314,10 @@ void MergeTreeData::clearPartsFromFilesystemImpl(const DataPartsVector & parts_t
             {
                 SCOPE_EXIT_SAFE(
                     if (thread_group)
-                        CurrentThread::detachQueryIfNotDetached();
+                        CurrentThread::detachFromGroupIfNotDetached();
                 );
                 if (thread_group)
-                    CurrentThread::attachToIfDetached(thread_group);
+                    CurrentThread::attachToGroupIfDetached(thread_group);
 
                 asMutableDeletingPart(part)->remove();
                 if (part_names_succeed)
@@ -2375,10 +2375,10 @@ void MergeTreeData::clearPartsFromFilesystemImpl(const DataPartsVector & parts_t
         {
             SCOPE_EXIT_SAFE(
                 if (thread_group)
-                    CurrentThread::detachQueryIfNotDetached();
+                    CurrentThread::detachFromGroupIfNotDetached();
             );
             if (thread_group)
-                CurrentThread::attachToIfDetached(thread_group);
+                CurrentThread::attachToGroupIfDetached(thread_group);
 
             LOG_TRACE(log, "Removing {} parts in blocks range {}", batch.size(), range.getPartNameForLogs());
 

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1119,10 +1119,10 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
                 {
                     SCOPE_EXIT_SAFE(
                         if (thread_group)
-                            CurrentThread::detachQueryIfNotDetached();
+                            CurrentThread::detachFromGroupIfNotDetached();
                     );
                     if (thread_group)
-                        CurrentThread::attachToIfDetached(thread_group);
+                        CurrentThread::attachToGroupIfDetached(thread_group);
 
                     process_part(part_index);
                 });

--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -90,7 +90,7 @@ namespace
         const ucontext_t signal_context = *reinterpret_cast<ucontext_t *>(context);
         stack_trace = StackTrace(signal_context);
 
-        std::string_view query_id = CurrentThread::getQueryId();
+        auto query_id = CurrentThread::getQueryId();
         query_id_size = std::min(query_id.size(), max_query_id_size);
         if (!query_id.empty())
             memcpy(query_id_data, query_id.data(), query_id_size);

--- a/tests/queries/0_stateless/02675_profile_events_from_query_log_and_client.reference
+++ b/tests/queries/0_stateless/02675_profile_events_from_query_log_and_client.reference
@@ -16,8 +16,8 @@ INSERT and READ INSERT
  [ 0 ] FileOpen: 7 
 DROP
 CHECK with query_log
-QueryFinish	INSERT INTO times SELECT now() + INTERVAL 1 day;	FileOpen	7
+QueryFinish	INSERT INTO times SELECT now() + INTERVAL 1 day SETTINGS optimize_on_insert = 0;	FileOpen	7
 QueryFinish	SELECT \'1\', min(t) FROM times;	FileOpen	0
-QueryFinish	INSERT INTO times SELECT now() + INTERVAL 2 day;	FileOpen	7
+QueryFinish	INSERT INTO times SELECT now() + INTERVAL 2 day SETTINGS optimize_on_insert = 0;	FileOpen	7
 QueryFinish	SELECT \'2\', min(t) FROM times;	FileOpen	0
-QueryFinish	INSERT INTO times SELECT now() + INTERVAL 3 day;	FileOpen	7
+QueryFinish	INSERT INTO times SELECT now() + INTERVAL 3 day SETTINGS optimize_on_insert = 0;	FileOpen	7

--- a/tests/queries/0_stateless/02675_profile_events_from_query_log_and_client.reference
+++ b/tests/queries/0_stateless/02675_profile_events_from_query_log_and_client.reference
@@ -1,0 +1,23 @@
+INSERT TO S3
+ [ 0 ] S3CompleteMultipartUpload: 1 
+ [ 0 ] S3CreateMultipartUpload: 1 
+ [ 0 ] S3HeadObject: 1 
+ [ 0 ] S3ReadRequestsCount: 1 
+ [ 0 ] S3UploadPart: 1 
+ [ 0 ] S3WriteRequestsCount: 3 
+CHECK WITH query_log
+QueryFinish	S3CreateMultipartUpload	1	S3UploadPart	1	S3CompleteMultipartUpload	1	S3PutObject	0
+CREATE
+INSERT
+ [ 0 ] FileOpen: 7 
+READ
+INSERT and READ INSERT
+ [ 0 ] FileOpen: 7 
+ [ 0 ] FileOpen: 7 
+DROP
+CHECK with query_log
+QueryFinish	INSERT INTO times SELECT now() + INTERVAL 1 day;	FileOpen	7
+QueryFinish	SELECT \'1\', min(t) FROM times;	FileOpen	0
+QueryFinish	INSERT INTO times SELECT now() + INTERVAL 2 day;	FileOpen	7
+QueryFinish	SELECT \'2\', min(t) FROM times;	FileOpen	0
+QueryFinish	INSERT INTO times SELECT now() + INTERVAL 3 day;	FileOpen	7

--- a/tests/queries/0_stateless/02675_profile_events_from_query_log_and_client.sh
+++ b/tests/queries/0_stateless/02675_profile_events_from_query_log_and_client.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: needs s3
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+echo "INSERT TO S3"
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1 -nq "
+INSERT INTO TABLE FUNCTION s3('http://localhost:11111/test/profile_events.csv', 'test', 'testtest', 'CSV', 'number UInt64') SELECT number FROM numbers(1000000) SETTINGS s3_max_single_part_upload_size = 10, s3_truncate_on_insert = 1;
+" 2>&1 | grep -o -e '\ \[\ .*\ \]\ S3.*:\ .*\ ' | grep -v 'Microseconds' | sort
+
+echo "CHECK WITH query_log"
+$CLICKHOUSE_CLIENT -nq "
+SYSTEM FLUSH LOGS;
+SELECT type,
+       'S3CreateMultipartUpload', ProfileEvents['S3CreateMultipartUpload'],
+       'S3UploadPart', ProfileEvents['S3UploadPart'],
+       'S3CompleteMultipartUpload', ProfileEvents['S3CompleteMultipartUpload'],
+       'S3PutObject', ProfileEvents['S3PutObject']
+FROM system.query_log
+WHERE query LIKE '%profile_events.csv%'
+AND type = 'QueryFinish'
+AND current_database = currentDatabase()
+ORDER BY query_start_time DESC;
+"
+
+echo "CREATE"
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1  -nq "
+DROP TABLE IF EXISTS times;
+CREATE TABLE times (t DateTime) ENGINE MergeTree ORDER BY t;
+" 2>&1 | grep -o -e '\ \[\ .*\ \]\ FileOpen:\ .*\ '
+
+echo "INSERT"
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1  -nq "
+INSERT INTO times SELECT now() + INTERVAL 1 day;
+" 2>&1 | grep -o -e '\ \[\ .*\ \]\ FileOpen:\ .*\ '
+
+echo "READ"
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1  -nq "
+SELECT '1', min(t) FROM times;
+" 2>&1 | grep -o -e '\ \[\ .*\ \]\ FileOpen:\ .*\ '
+
+echo "INSERT and READ INSERT"
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1  -nq "
+INSERT INTO times SELECT now() + INTERVAL 2 day;
+SELECT '2', min(t) FROM times;
+INSERT INTO times SELECT now() + INTERVAL 3 day;
+" 2>&1 | grep -o -e '\ \[\ .*\ \]\ FileOpen:\ .*\ '
+
+echo "DROP"
+$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1  -nq "
+DROP TABLE times;
+"
+
+echo "CHECK with query_log"
+$CLICKHOUSE_CLIENT -nq "
+SYSTEM FLUSH LOGS;
+SELECT type,
+       query,
+       'FileOpen', ProfileEvents['FileOpen']
+FROM system.query_log
+WHERE current_database = currentDatabase()
+AND ( query LIKE '%SELECT % FROM times%' OR query LIKE '%INSERT INTO times%')
+AND type = 'QueryFinish'
+ORDER BY query_start_time_microseconds ASC, query DESC;
+"
+

--- a/tests/queries/0_stateless/02675_profile_events_from_query_log_and_client.sh
+++ b/tests/queries/0_stateless/02675_profile_events_from_query_log_and_client.sh
@@ -27,7 +27,7 @@ ORDER BY query_start_time DESC;
 "
 
 echo "CREATE"
-$CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1  -nq "
+$CLICKHOUSE_CLIENT -nq "
 DROP TABLE IF EXISTS times;
 CREATE TABLE times (t DateTime) ENGINE MergeTree ORDER BY t
   SETTINGS
@@ -38,7 +38,7 @@ CREATE TABLE times (t DateTime) ENGINE MergeTree ORDER BY t
     min_bytes_for_wide_part = 1000000,
     in_memory_parts_enable_wal = 0,
     ratio_of_defaults_for_sparse_serialization=1.0;
-" 2>&1 | grep -o -e '\ \[\ .*\ \]\ FileOpen:\ .*\ '
+"
 
 echo "INSERT"
 $CLICKHOUSE_CLIENT --print-profile-events --profile-events-delay-ms=-1  -nq "


### PR DESCRIPTION
Really want to commit this https://github.com/ClickHouse/ClickHouse/pull/47104
So I have to understand how it works. While I read it I found some things.

- remove collecting and sending profile counters for threads
  Thanks to that https://github.com/ClickHouse/ClickHouse/blob/master/src/Interpreters/ThreadStatusExt.cpp#L371 
I'm sure that that counters are useless. Furthermore query_log do not use those counters, it takes counters from thread group.

- I have noticed that some time client return stats from thread with thread_id not zero. Filtration had a bug.

- When client send multiline query ie "INSERT; SELECT; INSERT" with --print-profile-events option, user got negative counters. That happens because server calculate diff between counters. But some reset was missed right after select.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
