### PR TITLE
Add missing SYSTEM FLUSH LOGS for log messages statistics

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1946,6 +1946,8 @@ def reportCoverage(args):
 
 
 def reportLogStats(args):
+    clickhouse_execute(args, "SYSTEM FLUSH LOGS")
+
     query = """
         WITH
             120 AS mins,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/47541/3d247b8635da44bccfdeb5fcd53be7130b8d0a32/stateless_tests_bugfix_validate_check/run.log

```
2023-03-13 17:51:52 Failed to get stats about log messages: Code: 404. Code: 60. DB::Exception: Table system.text_log doesn't exist. (UNKNOWN_TABLE) (version 23.2.4.12 (official build))
```

Cc: @tavplubix 