### PR TITLE
Fix SipHash hashing and byte order in GenerateRandom for s389x

### DIFF
--- a/src/Common/SipHash.h
+++ b/src/Common/SipHash.h
@@ -164,7 +164,16 @@ public:
     template <typename T>
     ALWAYS_INLINE void update(const T & x)
     {
-        update(reinterpret_cast<const char *>(&x), sizeof(x)); /// NOLINT
+        if constexpr (std::endian::native == std::endian::big)
+        {
+            T rev_x = x;
+            char *start = reinterpret_cast<char *>(&rev_x);
+            char *end = start + sizeof(T);
+            std::reverse(start, end);
+            update(reinterpret_cast<const char *>(&rev_x), sizeof(rev_x)); /// NOLINT
+        }
+        else
+            update(reinterpret_cast<const char *>(&x), sizeof(x)); /// NOLINT
     }
 
     ALWAYS_INLINE void update(const std::string & x)

--- a/src/Storages/StorageGenerateRandom.cpp
+++ b/src/Storages/StorageGenerateRandom.cpp
@@ -50,16 +50,33 @@ namespace ErrorCodes
 namespace
 {
 
-void fillBufferWithRandomData(char * __restrict data, size_t size, pcg64 & rng)
+void fillBufferWithRandomData(char * __restrict data, size_t limit, size_t size_of_type, pcg64 & rng, [[maybe_unused]] bool flip_bytes = false)
 {
+    size_t size = limit * size_of_type;
     char * __restrict end = data + size;
     while (data < end)
     {
         /// The loop can be further optimized.
         UInt64 number = rng();
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        unalignedStoreLE<UInt64>(data, number);
+#else
         unalignedStore<UInt64>(data, number);
+#endif
         data += sizeof(UInt64); /// We assume that data has at least 7-byte padding (see PaddedPODArray)
     }
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    if (flip_bytes)
+    {
+        data = end - size;
+        while (data < end)
+        {
+            char * rev_end = data + size_of_type;
+            std::reverse(data, rev_end);
+            data += size_of_type;
+        }
+    }
+#endif
 }
 
 
@@ -216,7 +233,7 @@ ColumnPtr fillColumnWithRandomData(
         {
             auto column = ColumnUInt8::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(UInt8), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(UInt8), rng);
             return column;
         }
         case TypeIndex::UInt16: [[fallthrough]];
@@ -224,7 +241,7 @@ ColumnPtr fillColumnWithRandomData(
         {
             auto column = ColumnUInt16::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(UInt16), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(UInt16), rng, true);
             return column;
         }
         case TypeIndex::Date32:
@@ -242,28 +259,28 @@ ColumnPtr fillColumnWithRandomData(
         {
             auto column = ColumnUInt32::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(UInt32), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(UInt32), rng, true);
             return column;
         }
         case TypeIndex::UInt64:
         {
             auto column = ColumnUInt64::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(UInt64), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(UInt64), rng, true);
             return column;
         }
         case TypeIndex::UInt128:
         {
             auto column = ColumnUInt128::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(UInt128), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(UInt128), rng, true);
             return column;
         }
         case TypeIndex::UInt256:
         {
             auto column = ColumnUInt256::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(UInt256), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(UInt256), rng);
             return column;
         }
         case TypeIndex::UUID:
@@ -271,63 +288,63 @@ ColumnPtr fillColumnWithRandomData(
             auto column = ColumnUUID::create();
             column->getData().resize(limit);
             /// NOTE This is slightly incorrect as random UUIDs should have fixed version 4.
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(UUID), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(UUID), rng);
             return column;
         }
         case TypeIndex::Int8:
         {
             auto column = ColumnInt8::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(Int8), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(Int8), rng);
             return column;
         }
         case TypeIndex::Int16:
         {
             auto column = ColumnInt16::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(Int16), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(Int16), rng, true);
             return column;
         }
         case TypeIndex::Int32:
         {
             auto column = ColumnInt32::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(Int32), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(Int32), rng, true);
             return column;
         }
         case TypeIndex::Int64:
         {
             auto column = ColumnInt64::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(Int64), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(Int64), rng, true);
             return column;
         }
         case TypeIndex::Int128:
         {
             auto column = ColumnInt128::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(Int128), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(Int128), rng, true);
             return column;
         }
         case TypeIndex::Int256:
         {
             auto column = ColumnInt256::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(Int256), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(Int256), rng, true);
             return column;
         }
         case TypeIndex::Float32:
         {
             auto column = ColumnFloat32::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(Float32), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(Float32), rng, true);
             return column;
         }
         case TypeIndex::Float64:
         {
             auto column = ColumnFloat64::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(Float64), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(Float64), rng, true);
             return column;
         }
         case TypeIndex::Decimal32:
@@ -335,7 +352,7 @@ ColumnPtr fillColumnWithRandomData(
             auto column = type->createColumn();
             auto & column_concrete = typeid_cast<ColumnDecimal<Decimal32> &>(*column);
             column_concrete.getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column_concrete.getData().data()), limit * sizeof(Decimal32), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column_concrete.getData().data()), limit, sizeof(Decimal32), rng, true);
             return column;
         }
         case TypeIndex::Decimal64:  /// TODO Decimal may be generated out of range.
@@ -343,7 +360,7 @@ ColumnPtr fillColumnWithRandomData(
             auto column = type->createColumn();
             auto & column_concrete = typeid_cast<ColumnDecimal<Decimal64> &>(*column);
             column_concrete.getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column_concrete.getData().data()), limit * sizeof(Decimal64), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column_concrete.getData().data()), limit, sizeof(Decimal64), rng, true);
             return column;
         }
         case TypeIndex::Decimal128:
@@ -351,7 +368,7 @@ ColumnPtr fillColumnWithRandomData(
             auto column = type->createColumn();
             auto & column_concrete = typeid_cast<ColumnDecimal<Decimal128> &>(*column);
             column_concrete.getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column_concrete.getData().data()), limit * sizeof(Decimal128), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column_concrete.getData().data()), limit, sizeof(Decimal128), rng, true);
             return column;
         }
         case TypeIndex::Decimal256:
@@ -359,7 +376,7 @@ ColumnPtr fillColumnWithRandomData(
             auto column = type->createColumn();
             auto & column_concrete = typeid_cast<ColumnDecimal<Decimal256> &>(*column);
             column_concrete.getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column_concrete.getData().data()), limit * sizeof(Decimal256), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column_concrete.getData().data()), limit, sizeof(Decimal256), rng, true);
             return column;
         }
         case TypeIndex::FixedString:
@@ -367,7 +384,7 @@ ColumnPtr fillColumnWithRandomData(
             size_t n = typeid_cast<const DataTypeFixedString &>(*type).getN();
             auto column = ColumnFixedString::create(n);
             column->getChars().resize(limit * n);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getChars().data()), limit * n, rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getChars().data()), limit, n, rng);
             return column;
         }
         case TypeIndex::DateTime64:
@@ -401,14 +418,14 @@ ColumnPtr fillColumnWithRandomData(
         {
             auto column = ColumnIPv4::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(IPv4), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(IPv4), rng);
             return column;
         }
         case TypeIndex::IPv6:
         {
             auto column = ColumnIPv6::create();
             column->getData().resize(limit);
-            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit * sizeof(IPv6), rng);
+            fillBufferWithRandomData(reinterpret_cast<char *>(column->getData().data()), limit, sizeof(IPv6), rng);
             return column;
         }
 
@@ -473,7 +490,7 @@ StorageGenerateRandom::StorageGenerateRandom(
     const String & comment,
     UInt64 max_array_length_,
     UInt64 max_string_length_,
-    std::optional<UInt64> random_seed_)
+    const std::optional<UInt64> & random_seed_)
     : IStorage(table_id_), max_array_length(max_array_length_), max_string_length(max_string_length_)
 {
     static constexpr size_t MAX_ARRAY_SIZE = 1 << 30;

--- a/src/Storages/StorageGenerateRandom.h
+++ b/src/Storages/StorageGenerateRandom.h
@@ -17,7 +17,7 @@ public:
         const String & comment,
         UInt64 max_array_length,
         UInt64 max_string_length,
-        std::optional<UInt64> random_seed);
+        const std::optional<UInt64> & random_seed);
 
     std::string getName() const override { return "GenerateRandom"; }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On s390x some functional tests fail because GenerateRandom storage engine generates different random data. The root of cause is that sipHash generates wrong hash values when hashing integers on s390x, and also the byte order of integer random data is wrong.

The PR fixed SipHash integer hashing issue and byte order issue in random integer data for s390x.

### Changelog category (leave one):
- Build Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed SipHash integer hashing issue and byte order issue in random integer data from GenerateRandom storage engine for s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
