### PR TITLE
Fix flaky test test_backup_restore_on_cluster

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_concurrency.py
@@ -81,6 +81,11 @@ def create_and_fill_table():
         ") ENGINE=ReplicatedMergeTree('/clickhouse/tables/tbl/', '{replica}')"
         "ORDER BY tuple()"
     )
+    assert_eq_with_retry(
+        node0,
+        "SELECT count() from clusterAllReplicas('cluster', system.tables) where table='tbl' and database='default'",
+        TSV([num_nodes]),
+    )
     for i in range(num_nodes):
         nodes[i].query(f"INSERT INTO tbl VALUES ({i})")
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix error `Table default.tbl doesn't exist` in this test which could occur [sometimes](https://s3.amazonaws.com/clickhouse-test-reports/47216/f76b97cb51ad9122dfba1acc1c2a112b8df1ce9f/integration_tests_flaky_check__asan_/integration_run_flaky_0.log).