### PR TITLE
Add SSL User Certificate authentication to the native protocol

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -10,8 +10,6 @@
 #include <Poco/Net/NetException.h>
 #include <Poco/Net/SocketAddress.h>
 #include <Poco/Util/LayeredConfiguration.h>
-#include <Poco/Net/SecureStreamSocket.h>
-#include <Poco/Net/SecureStreamSocketImpl.h>
 #include <Common/CurrentThread.h>
 #include <Common/Stopwatch.h>
 #include <Common/NetException.h>
@@ -50,6 +48,11 @@
 #include <Processors/Executors/PushingAsyncPipelineExecutor.h>
 #include <Processors/Executors/CompletedPipelineExecutor.h>
 #include <Processors/Sinks/SinkToStorage.h>
+
+#if USE_SSL
+#   include <Poco/Net/SecureStreamSocket.h>
+#   include <Poco/Net/SecureStreamSocketImpl.h>
+#endif
 
 #include "Core/Protocol.h"
 #include "Storages/MergeTree/RequestResponse.h"
@@ -1227,6 +1230,7 @@ void TCPHandler::receiveHello()
     session = makeSession();
     auto & client_info = session->getClientInfo();
 
+#if USE_SSL
     /// Authentication with SSL user certificate
     if (dynamic_cast<Poco::Net::SecureStreamSocketImpl*>(socket().impl()))
     {
@@ -1239,6 +1243,7 @@ void TCPHandler::receiveHello()
             return;
         }
     }
+#endif
 
     session->authenticate(user, password, getClientAddress(client_info));
 }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1227,7 +1227,7 @@ void TCPHandler::receiveHello()
     session = makeSession();
     auto & client_info = session->getClientInfo();
 
-    /// Authentification with SSL user certificate
+    /// Authentication with SSL user certificate
     if (dynamic_cast<Poco::Net::SecureStreamSocketImpl*>(socket().impl()))
     {
         Poco::Net::SecureStreamSocket secure_socket(socket());

--- a/tests/integration/test_ssl_cert_authentication/configs/ssl_config.xml
+++ b/tests/integration/test_ssl_cert_authentication/configs/ssl_config.xml
@@ -9,7 +9,7 @@
          You have to configure certificate to enable this interface.
          See the openSSL section below.
     -->
-    <!-- <tcp_port_secure>9440</tcp_port_secure> -->
+    <tcp_port_secure>9440</tcp_port_secure>
 
     <!-- Used with https_port and tcp_port_secure. Full ssl options list: https://github.com/ClickHouse-Extras/poco/blob/master/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h#L71 -->
     <openSSL replace="replace">

--- a/tests/integration/test_ssl_cert_authentication/test.py
+++ b/tests/integration/test_ssl_cert_authentication/test.py
@@ -1,9 +1,12 @@
 import pytest
+from helpers.client import Client
 from helpers.cluster import ClickHouseCluster
 from helpers.ssl_context import WrapSSLContextWithSNI
 import urllib.request, urllib.parse
 import ssl
 import os.path
+from os import remove
+
 
 # The test cluster is configured with certificate for that host name, see 'server-ext.cnf'.
 # The client have to verify server certificate against that name. Client uses SNI
@@ -66,6 +69,54 @@ def execute_query_https(
     return response.decode("utf-8")
 
 
+config = """<clickhouse>
+    <openSSL>
+        <client>
+            <verificationMode>none</verificationMode>
+
+            <certificateFile>{certificateFile}</certificateFile>
+            <privateKeyFile>{privateKeyFile}</privateKeyFile>
+            <caConfig>{caConfig}</caConfig>
+
+            <invalidCertificateHandler>
+                <name>AcceptCertificateHandler</name>
+            </invalidCertificateHandler>
+        </client>
+    </openSSL>
+</clickhouse>"""
+
+
+def execute_query_native(node, query, user, cert_name):
+
+    config_path = f"{SCRIPT_DIR}/configs/client.xml"
+
+    formatted = config.format(
+        certificateFile=f"{SCRIPT_DIR}/certs/{cert_name}-cert.pem",
+        privateKeyFile=f"{SCRIPT_DIR}/certs/{cert_name}-key.pem",
+        caConfig=f"{SCRIPT_DIR}/certs/ca-cert.pem",
+    )
+
+    file = open(config_path, "w")
+    file.write(formatted)
+    file.close()
+
+    client = Client(
+        node.ip_address,
+        9440,
+        command=cluster.client_bin_path,
+        secure=True,
+        config=config_path,
+    )
+
+    try:
+        result = client.query(query, user=user)
+        remove(config_path)
+        return result
+    except:
+        remove(config_path)
+        raise
+
+
 def test_https():
     assert (
         execute_query_https("SELECT currentUser()", user="john", cert_name="client1")
@@ -77,6 +128,27 @@ def test_https():
     )
     assert (
         execute_query_https("SELECT currentUser()", user="lucy", cert_name="client3")
+        == "lucy\n"
+    )
+
+
+def test_native():
+    assert (
+        execute_query_native(
+            instance, "SELECT currentUser()", user="john", cert_name="client1"
+        )
+        == "john\n"
+    )
+    assert (
+        execute_query_native(
+            instance, "SELECT currentUser()", user="lucy", cert_name="client2"
+        )
+        == "lucy\n"
+    )
+    assert (
+        execute_query_native(
+            instance, "SELECT currentUser()", user="lucy", cert_name="client3"
+        )
         == "lucy\n"
     )
 
@@ -105,6 +177,23 @@ def test_https_wrong_cert():
             enable_ssl_auth=False,
             cert_name="client1",
         )
+
+
+def test_native_wrong_cert():
+    # Wrong certificate: different user's certificate
+    with pytest.raises(Exception) as err:
+        execute_query_native(
+            instance, "SELECT currentUser()", user="john", cert_name="client2"
+        )
+    assert "AUTHENTICATION_FAILED" in str(err.value)
+
+    # Wrong certificate: self-signed certificate.
+    # In this case clickhouse-client itself will throw an error
+    with pytest.raises(Exception) as err:
+        execute_query_native(
+            instance, "SELECT currentUser()", user="john", cert_name="wrong"
+        )
+    assert "UNKNOWN_CA" in str(err.value)
 
 
 def test_https_non_ssl_auth():


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add SSL User Certificate authentication to the native protocol. Closes https://github.com/ClickHouse/ClickHouse/issues/47077.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
