### PR TITLE
checksum: do not check inverted index files

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
@@ -46,6 +46,10 @@ void MergeTreeDataPartChecksum::checkEqual(const MergeTreeDataPartChecksum & rhs
 
 void MergeTreeDataPartChecksum::checkSize(const IDataPartStorage & storage, const String & name) const
 {
+    /// Do not check inverted index files
+    if (name.ends_with(".gin_dict") || name.ends_with(".gin_post") || name.ends_with(".gin_seg") || name.ends_with(".gin_sid"))
+        return;
+
     if (!storage.exists(name))
         throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "{} doesn't exist", fs::path(storage.getRelativePath()) / name);
 

--- a/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartChecksum.cpp
@@ -46,7 +46,7 @@ void MergeTreeDataPartChecksum::checkEqual(const MergeTreeDataPartChecksum & rhs
 
 void MergeTreeDataPartChecksum::checkSize(const IDataPartStorage & storage, const String & name) const
 {
-    /// Do not check inverted index files
+    /// Skip inverted index files, these have a default MergeTreeDataPartChecksum with file_size == 0
     if (name.ends_with(".gin_dict") || name.ends_with(".gin_post") || name.ends_with(".gin_seg") || name.ends_with(".gin_sid"))
         return;
 

--- a/tests/queries/0_stateless/25341_inverted_idx_checksums.sql
+++ b/tests/queries/0_stateless/25341_inverted_idx_checksums.sql
@@ -1,0 +1,16 @@
+SET allow_experimental_inverted_index = 1;
+
+CREATE TABLE t
+(
+    `key` UInt64,
+    `str` String,
+    INDEX inv_idx str TYPE inverted(0) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY key;
+
+INSERT INTO t VALUES (1, 'Hello World');
+
+ALTER TABLE t DETACH PART 'all_1_1_0';
+
+ALTER TABLE t ATTACH PART 'all_1_1_0';


### PR DESCRIPTION
`MergeTreeDataPartChecksums::checkSize` will check file size while loading parts, but inverted index files only have default `MergeTreeDataPartChecksum`(file_size = 0), these parts will fail to load.
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
