### PR TITLE
Add sanity checks for writing number in variable length format

### DIFF
--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <base/types.h>
+#include <base/defines.h>
 #include <IO/ReadBuffer.h>
 #include <IO/WriteBuffer.h>
 
@@ -14,7 +15,19 @@ namespace ErrorCodes
 }
 
 
-/** Write UInt64 in variable length format (base128) NOTE Only up to 2^63 - 1 are supported. */
+/** Variable-Length Quantity (VLQ) Base-128 compression
+ *
+ * NOTE: Due to historical reasons, only up to 1<<63-1 are supported, which
+ * cannot be changed without breaking the backward compatibility.
+ * Also some drivers may support full 1<<64 range (i.e. python -
+ * clickhouse-driver), while others has the same limitations as ClickHouse
+ * (i.e. Rust - clickhouse-rs).
+ * So implementing VLQ for the whole 1<<64 range will require different set of
+ * helpers.
+ */
+constexpr size_t VAR_UINT_MAX = (1ULL<<63) - 1;
+
+/** Write UInt64 in variable length format (base128) */
 void writeVarUInt(UInt64 x, std::ostream & ostr);
 void writeVarUInt(UInt64 x, WriteBuffer & ostr);
 char * writeVarUInt(UInt64 x, char * ostr);
@@ -186,6 +199,7 @@ inline const char * readVarUInt(UInt64 & x, const char * istr, size_t size)
 
 inline void writeVarUInt(UInt64 x, WriteBuffer & ostr)
 {
+    chassert(x <= VAR_UINT_MAX);
     for (size_t i = 0; i < 9; ++i)
     {
         uint8_t byte = x & 0x7F;
@@ -205,6 +219,7 @@ inline void writeVarUInt(UInt64 x, WriteBuffer & ostr)
 
 inline void writeVarUInt(UInt64 x, std::ostream & ostr)
 {
+    chassert(x <= VAR_UINT_MAX);
     for (size_t i = 0; i < 9; ++i)
     {
         uint8_t byte = x & 0x7F;
@@ -222,6 +237,7 @@ inline void writeVarUInt(UInt64 x, std::ostream & ostr)
 
 inline char * writeVarUInt(UInt64 x, char * ostr)
 {
+    chassert(x <= VAR_UINT_MAX);
     for (size_t i = 0; i < 9; ++i)
     {
         uint8_t byte = x & 0x7F;

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1824,7 +1824,7 @@ void TCPHandler::sendData(const Block & block)
         {
             --unknown_packet_in_send_data;
             if (unknown_packet_in_send_data == 0)
-                writeVarUInt(UInt64(-1), *out);
+                writeVarUInt(VAR_UINT_MAX, *out);
         }
 
         writeVarUInt(Protocol::Server::Data, *out);


### PR DESCRIPTION
And just to double check:

    # var_uint 9223372036854775807
    ffffffffffffffff7f
    ffffffffffffffff7f
    ffffffffffffffff7f
    x: 9223372036854775807, y: 9223372036854775807
    # var_uint 9223372036854775808
    808080808080808080
    808080808080808080
    808080808080808080
    x: 9223372036854775808, y: 0

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)