### PR TITLE
FillingTransform: remove unnecessary indirection when accessing columns

### DIFF
--- a/src/Interpreters/FillingRow.cpp
+++ b/src/Interpreters/FillingRow.cpp
@@ -107,39 +107,4 @@ void FillingRow::initFromDefaults(size_t from_pos)
         row[i] = getFillDescription(i).fill_from;
 }
 
-void insertFromFillingRow(MutableColumns & filling_columns, MutableColumns & interpolate_columns, MutableColumns & other_columns,
-    const FillingRow & filling_row, const Block & interpolate_block)
-{
-    for (size_t i = 0, size = filling_columns.size(); i < size; ++i)
-    {
-        if (filling_row[i].isNull())
-        {
-            filling_columns[i]->insertDefault();
-        }
-        else
-        {
-            filling_columns[i]->insert(filling_row[i]);
-        }
-    }
-
-    if (size_t size = interpolate_block.columns())
-    {
-        Columns columns = interpolate_block.getColumns();
-        for (size_t i = 0; i < size; ++i)
-            interpolate_columns[i]->insertFrom(*columns[i]->convertToFullColumnIfConst(), 0);
-    }
-    else
-        for (const auto & interpolate_column : interpolate_columns)
-            interpolate_column->insertDefault();
-
-    for (const auto & other_column : other_columns)
-        other_column->insertDefault();
-}
-
-void copyRowFromColumns(MutableColumns & dest, const Columns & source, size_t row_num)
-{
-    for (size_t i = 0, size = source.size(); i < size; ++i)
-        dest[i]->insertFrom(*source[i], row_num);
-}
-
 }

--- a/src/Interpreters/FillingRow.h
+++ b/src/Interpreters/FillingRow.h
@@ -39,8 +39,4 @@ private:
     SortDescription sort_description;
 };
 
-void insertFromFillingRow(MutableColumns & filling_columns, MutableColumns & interpolate_columns, MutableColumns & other_columns,
-    const FillingRow & filling_row, const Block & interpolate_block);
-void copyRowFromColumns(MutableColumns & dest, const Columns & source, size_t row_num);
-
 }

--- a/src/Processors/Transforms/FillingTransform.cpp
+++ b/src/Processors/Transforms/FillingTransform.cpp
@@ -277,8 +277,6 @@ void FillingTransform::interpolate(const MutableColumns & result_columns, Block 
             {
                 MutableColumnPtr column = name_type.type->createColumn();
                 const auto * res_column = result_columns[col_pos].get();
-                // auto [res_columns, pos] = res_map[col_pos];
-                // size_t size = (*res_columns)[pos]->size();
                 size_t size = res_column->size();
                 if (size == 0) /// this is the first row in current chunk
                 {
@@ -483,18 +481,16 @@ void FillingTransform::transform(Chunk & chunk)
 void FillingTransform::saveLastRow(const MutableColumns & result_columns)
 {
     last_row.clear();
-    last_row.resize(result_columns.size());
 
-    size_t num_rows = result_columns[0]->size();
+    const size_t num_rows = result_columns[0]->size();
     if (num_rows == 0)
         return;
 
-    for (size_t i = 0, size = result_columns.size(); i < size; ++i)
+    for (const auto & result_column : result_columns)
     {
-        auto column = result_columns[i]->cloneEmpty();
-        column->insertFrom(*result_columns[i], num_rows - 1);
-        last_row[i] = std::move(column);
+        auto column = result_column->cloneEmpty();
+        column->insertFrom(*result_column, num_rows - 1);
+        last_row.push_back(std::move(column));
     }
 }
-
 }

--- a/src/Processors/Transforms/FillingTransform.h
+++ b/src/Processors/Transforms/FillingTransform.h
@@ -28,10 +28,8 @@ protected:
     void transform(Chunk & Chunk) override;
 
 private:
-    void setResultColumns(Chunk & chunk, MutableColumns & fill_columns, MutableColumns & interpolate_columns, MutableColumns & other_columns) const;
-    void saveLastRow(const MutableColumns & fill_columns, const MutableColumns & interpolate_columns, const MutableColumns & other_columns);
-    void initFillingRow(const Columns & input_columns);
-    void interpolate(const std::vector<const IColumn *> & result_columns, Block & interpolate_block);
+    void saveLastRow(const MutableColumns & result_columns);
+    void interpolate(const MutableColumns& result_columns, Block & interpolate_block);
 
     const SortDescription sort_description; /// Contains only columns with WITH FILL.
     const InterpolateDescriptionPtr interpolate_description; /// Contains INTERPOLATE columns

--- a/src/Processors/Transforms/FillingTransform.h
+++ b/src/Processors/Transforms/FillingTransform.h
@@ -31,6 +31,17 @@ private:
     void saveLastRow(const MutableColumns & result_columns);
     void interpolate(const MutableColumns& result_columns, Block & interpolate_block);
 
+    using MutableColumnRawPtrs = std::vector<IColumn *>;
+    void initColumns(
+        const Columns & input_columns,
+        Columns & input_fill_columns,
+        Columns & input_interpolate_columns,
+        Columns & input_other_columns,
+        MutableColumns & output_columns,
+        MutableColumnRawPtrs & output_fill_columns,
+        MutableColumnRawPtrs & output_interpolate_columns,
+        MutableColumnRawPtrs & output_other_columns);
+
     const SortDescription sort_description; /// Contains only columns with WITH FILL.
     const InterpolateDescriptionPtr interpolate_description; /// Contains INTERPOLATE columns
 

--- a/src/Processors/Transforms/FillingTransform.h
+++ b/src/Processors/Transforms/FillingTransform.h
@@ -30,6 +30,8 @@ protected:
 private:
     void setResultColumns(Chunk & chunk, MutableColumns & fill_columns, MutableColumns & interpolate_columns, MutableColumns & other_columns) const;
     void saveLastRow(const MutableColumns & fill_columns, const MutableColumns & interpolate_columns, const MutableColumns & other_columns);
+    void initFillingRow(const Columns & input_columns);
+    void interpolate(const std::vector<const IColumn *> & result_columns, Block & interpolate_block);
 
     const SortDescription sort_description; /// Contains only columns with WITH FILL.
     const InterpolateDescriptionPtr interpolate_description; /// Contains INTERPOLATE columns


### PR DESCRIPTION
Remove unnecessary indirection when accessing columns. Instead of holding mutable pointers to result columns in several arrays (filling, interpolate, others) and maintaining additional index to find result column by position in header, the mutable pointers to result columns are held in the result columns array and referenced via `IColumn*` in arrays for fill, interpolate, other columns. It makes column access more straightforward.
In addition: unnecessary lambdas were moved to ordinary functions to make data dependencies explicit

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
