### PR TITLE
fix typo in HashJoin insertion that enables debug code in release build #46726

### DIFF
--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -495,7 +495,7 @@ size_t HashJoin::getTotalByteCount() const
     if (!data)
         return 0;
 
-#ifdef NDEBUG
+#ifndef NDEBUG
     size_t debug_blocks_allocated_size = 0;
     for (const auto & block : data->blocks)
         debug_blocks_allocated_size += block.allocatedBytes();


### PR DESCRIPTION
Fix #46726 
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

