### PR TITLE
Documentation: Update debian setup, remove apt-key

### DIFF
--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -118,9 +118,9 @@ It is recommended to use official pre-compiled `deb` packages for Debian or Ubun
 #### Setup the Debian repository
 ``` bash
 sudo apt-get install -y apt-transport-https ca-certificates dirmngr
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/clickhouse-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8919F6BD2B48D754
 
-echo "deb https://packages.clickhouse.com/deb stable main" | sudo tee \
+echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" | sudo tee \
     /etc/apt/sources.list.d/clickhouse.list
 sudo apt-get update
 ```

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -118,7 +118,10 @@ It is recommended to use official pre-compiled `deb` packages for Debian or Ubun
 #### Setup the Debian repository
 ``` bash
 sudo apt-get install -y apt-transport-https ca-certificates dirmngr
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/clickhouse-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8919F6BD2B48D754
+GNUPGHOME=$(mktemp -d)
+sudo GNUPGHOME="$GNUPGHOME" gpg --no-default-keyring --keyring /usr/share/keyrings/clickhouse-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8919F6BD2B48D754
+sudo rm -r "$GNUPGHOME"
+sudo chmod +r /usr/share/keyrings/clickhouse-keyring.gpg
 
 echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb stable main" | sudo tee \
     /etc/apt/sources.list.d/clickhouse.list


### PR DESCRIPTION
`apt-key` is deprecated and will be removed, see https://manpages.debian.org/bullseye/apt/apt-key.8.en.html#DESCRIPTION

Therefore I would propose to change the setup instructions on the docs. I left the “Deprecated Method” and “Migration Method” as it was, because I wasn't sure if this is supposed to stay for reference.

Further information:
 - https://wiki.debian.org/DebianRepository/UseThirdParty
 - https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html
   → “To import OpenPGP keys directly from a keyserver to a file in /usr/share/keyrings:”
 - https://askubuntu.com/a/1303285

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)