### PR TITLE
Improve ThreadPool

### DIFF
--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -430,14 +430,14 @@ void ThreadPoolImpl<Thread>::worker(typename std::list<Thread>::iterator thread_
                 /// This thread is excessive. The worker will stop.
                 detach_thread();
                 job_finished.notify_all();
-                if (exception_from_job)
-                    new_job_or_shutdown.notify_all(); /// `shutdown` could be just set, wake up other threads so they can finish themselves.
+                if (shutdown)
+                    new_job_or_shutdown.notify_all(); /// `shutdown` was set, wake up other threads so they can finish themselves.
                 return;
             }
 
             job_finished.notify_all();
-            if (exception_from_job)
-                new_job_or_shutdown.notify_all(); /// `shutdown` could be just set, wake up other threads so they can finish themselves.
+            if (shutdown)
+                new_job_or_shutdown.notify_all(); /// `shutdown` was set, wake up other threads so they can finish themselves.
         }
     }
 }

--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -95,7 +95,6 @@ private:
     mutable std::mutex mutex;
     std::condition_variable job_finished;
     std::condition_variable new_job_or_shutdown;
-    std::condition_variable thread_finished;
 
     size_t max_threads;
     size_t max_free_threads;
@@ -103,6 +102,7 @@ private:
 
     size_t scheduled_jobs = 0;
     bool shutdown = false;
+    bool threads_remove_themselves = true;
     const bool shutdown_on_exception = true;
 
     struct JobWithPriority


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Improve class `ThreadPool`:
- `ThreadPool::setMaxThreads()` can now start new threads (if there are scheduled jobs in the queue), or finish free threads;
- `ThreadPool::setMaxFreeThreads()` can now finish free threads.

Some new tests will be added in https://github.com/ClickHouse/ClickHouse/pull/47001. Here I'm checking those changes don't break anything in existing tests.