### PR TITLE
skip hardlinking inverted index files in mutation

### DIFF
--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -19,6 +19,7 @@
 #include <Storages/MergeTree/MergeTreeDataWriter.h>
 #include <Storages/MutationCommands.h>
 #include <Storages/MergeTree/MergeTreeDataMergerMutator.h>
+#include <Storages/MergeTree/MergeTreeIndexInverted.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <boost/algorithm/string/replace.hpp>
 #include <Common/ProfileEventsScope.h>
@@ -551,6 +552,15 @@ static NameSet collectFilesToSkip(
         /// Since MinMax index has .idx2 extension, we need to add correct extension.
         files_to_skip.insert(index->getFileName() + index->getSerializedFileExtension());
         files_to_skip.insert(index->getFileName() + mrk_extension);
+
+        // skip all inverted index files, for they will be re-built
+        if (dynamic_cast<const MergeTreeIndexInverted *>(&*index) != nullptr)
+        {
+            files_to_skip.insert(index->getFileName() + ".gin_dict");
+            files_to_skip.insert(index->getFileName() + ".gin_post");
+            files_to_skip.insert(index->getFileName() + ".gin_sed");
+            files_to_skip.insert(index->getFileName() + ".gin_sid");
+        }
     }
 
     for (const auto & projection : projections_to_recalc)

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -553,13 +553,14 @@ static NameSet collectFilesToSkip(
         files_to_skip.insert(index->getFileName() + index->getSerializedFileExtension());
         files_to_skip.insert(index->getFileName() + mrk_extension);
 
-        // skip all inverted index files, for they will be re-built
-        if (dynamic_cast<const MergeTreeIndexInverted *>(&*index) != nullptr)
+        // Skip all inverted index files, for they will be rebuilt
+        if (dynamic_cast<const MergeTreeIndexInverted *>(index.get()))
         {
-            files_to_skip.insert(index->getFileName() + ".gin_dict");
-            files_to_skip.insert(index->getFileName() + ".gin_post");
-            files_to_skip.insert(index->getFileName() + ".gin_sed");
-            files_to_skip.insert(index->getFileName() + ".gin_sid");
+            auto index_filename = index->getFileName();
+            files_to_skip.insert(index_filename + ".gin_dict");
+            files_to_skip.insert(index_filename + ".gin_post");
+            files_to_skip.insert(index_filename + ".gin_sed");
+            files_to_skip.insert(index_filename + ".gin_sid");
         }
     }
 

--- a/tests/queries/0_stateless/02346_inverted_index_mutation.reference
+++ b/tests/queries/0_stateless/02346_inverted_index_mutation.reference
@@ -1,0 +1,3 @@
+1
+2
+I am not inverted

--- a/tests/queries/0_stateless/02346_inverted_index_mutation.sql
+++ b/tests/queries/0_stateless/02346_inverted_index_mutation.sql
@@ -1,0 +1,23 @@
+SET allow_experimental_inverted_index=1;
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t
+(
+    `timestamp` UInt64,
+    `s` String,
+    INDEX idx s TYPE inverted(3) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1;
+
+INSERT INTO t (s) VALUES ('I am inverted');
+
+SELECT data_version FROM system.parts WHERE database=currentDatabase() AND table='t' AND active=1;
+
+-- do update column synchronously
+ALTER TABLE t UPDATE s='I am not inverted' WHERE 1 SETTINGS mutations_sync=1;
+
+SELECT data_version FROM system.parts WHERE database=currentDatabase() AND table='t' AND active=1;
+
+SELECT s FROM t WHERE s LIKE '%inverted%' SETTINGS force_data_skipping_indices='idx';

--- a/tests/queries/0_stateless/02346_inverted_index_mutation.sql
+++ b/tests/queries/0_stateless/02346_inverted_index_mutation.sql
@@ -21,3 +21,5 @@ ALTER TABLE t UPDATE s='I am not inverted' WHERE 1 SETTINGS mutations_sync=1;
 SELECT data_version FROM system.parts WHERE database=currentDatabase() AND table='t' AND active=1;
 
 SELECT s FROM t WHERE s LIKE '%inverted%' SETTINGS force_data_skipping_indices='idx';
+
+DROP TABLE t;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
In mutation task, files that are not affected are hardlinked into new part, for wide part.

as I understand, If the inverted index be recalculated, their files should not be linked to the new part.

Close #47393

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix invalid segment id bug after mutation

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
