### PR TITLE
Apply log_queries_cut_to_length in MergeTreeWhereOptimizer

### DIFF
--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -202,8 +202,13 @@ std::string wipeSensitiveDataAndCutToLength(const std::string & str, size_t max_
     if (auto * masker = SensitiveDataMasker::getInstance())
         masker->wipeSensitiveData(res);
 
-    if (max_length && (res.length() > max_length))
+    size_t length = res.length();
+    if (max_length && (length > max_length))
+    {
+        size_t truncated_len = length - max_length;
         res.resize(max_length);
+        res += "... (truncated " + std::to_string(truncated_len) + " chars)";
+    }
 
     return res;
 }

--- a/src/Common/SensitiveDataMasker.cpp
+++ b/src/Common/SensitiveDataMasker.cpp
@@ -205,9 +205,12 @@ std::string wipeSensitiveDataAndCutToLength(const std::string & str, size_t max_
     size_t length = res.length();
     if (max_length && (length > max_length))
     {
-        size_t truncated_len = length - max_length;
+        constexpr size_t max_extra_msg_len = sizeof("... (truncated 18446744073709551615 characters)");
+        if (max_length < max_extra_msg_len)
+            return "(removed " + std::to_string(length) + " characters)";
+        max_length -= max_extra_msg_len;
         res.resize(max_length);
-        res += "... (truncated " + std::to_string(truncated_len) + " chars)";
+        res.append("... (truncated " + std::to_string(length - max_length) +  " characters)");
     }
 
     return res;

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -44,6 +44,7 @@ MergeTreeWhereOptimizer::MergeTreeWhereOptimizer(
     , log{log_}
     , column_sizes{std::move(column_sizes_)}
     , move_all_conditions_to_prewhere(context->getSettingsRef().move_all_conditions_to_prewhere)
+    , log_queries_cut_to_length(context->getSettingsRef().log_queries_cut_to_length)
 {
     for (const auto & name : queried_columns)
     {
@@ -310,7 +311,7 @@ void MergeTreeWhereOptimizer::optimize(ASTSelectQuery & select) const
     select.setExpression(ASTSelectQuery::Expression::WHERE, reconstruct(where_conditions));
     select.setExpression(ASTSelectQuery::Expression::PREWHERE, reconstruct(prewhere_conditions));
 
-    LOG_DEBUG(log, "MergeTreeWhereOptimizer: condition \"{}\" moved to PREWHERE", select.prewhere());
+    LOG_DEBUG(log, "MergeTreeWhereOptimizer: condition \"{}\" moved to PREWHERE", select.prewhere()->formatForLogging(log_queries_cut_to_length));
 }
 
 

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
@@ -115,6 +115,7 @@ private:
     UInt64 total_size_of_queried_columns = 0;
     NameSet array_joined_names;
     const bool move_all_conditions_to_prewhere = false;
+    UInt64 log_queries_cut_to_length = 0;
 };
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
