### PR TITLE
Try making `test_keeper_mntr_data_size` less flaky

### DIFF
--- a/tests/integration/test_keeper_mntr_data_size/test.py
+++ b/tests/integration/test_keeper_mntr_data_size/test.py
@@ -5,8 +5,6 @@ from helpers.cluster import ClickHouseCluster
 import helpers.keeper_utils as keeper_utils
 import random
 import string
-import os
-import time
 from kazoo.client import KazooClient, KazooState
 
 
@@ -17,7 +15,6 @@ node = cluster.add_instance(
     "node",
     main_configs=["configs/enable_keeper.xml"],
     stay_alive=True,
-    with_zookeeper=True,
 )
 
 
@@ -60,10 +57,14 @@ def test_mntr_data_size_after_restart(started_cluster):
                 "/test_mntr_data_size/node" + str(i), random_string(123).encode()
             )
 
-        def get_line_with_size():
+        node_zk.stop()
+        node_zk.close()
+        node_zk = None
+
+        def get_line_from_mntr(key):
             return next(
                 filter(
-                    lambda line: "zk_approximate_data_size" in line,
+                    lambda line: key in line,
                     keeper_utils.send_4lw_cmd(started_cluster, node, "mntr").split(
                         "\n"
                     ),
@@ -71,19 +72,21 @@ def test_mntr_data_size_after_restart(started_cluster):
                 None,
             )
 
-        line_size_before = get_line_with_size()
+        line_size_before = get_line_from_mntr("zk_approximate_data_size")
+        node_count_before = get_line_from_mntr("zk_znode_count")
+        assert get_line_from_mntr("zk_ephemerals_count") == "zk_ephemerals_count\t0"
         assert line_size_before != None
-
-        node_zk.stop()
-        node_zk.close()
-        node_zk = None
 
         restart_clickhouse()
 
-        assert get_line_with_size() == line_size_before
+        def assert_mntr_stats():
+            assert get_line_from_mntr("zk_ephemerals_count") == "zk_ephemerals_count\t0"
+            assert get_line_from_mntr("zk_znode_count") == node_count_before
+            assert get_line_from_mntr("zk_approximate_data_size") == line_size_before
 
+        assert_mntr_stats()
         keeper_utils.send_4lw_cmd(started_cluster, node, "rclc")
-        assert get_line_with_size() == line_size_before
+        assert_mntr_stats()
     finally:
         try:
             if node_zk is not None:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
