### PR TITLE
Use LLVM 16

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,8 +123,8 @@ jobs:
       SONAR_SCANNER_VERSION: 4.7.0.2747
       SONAR_SERVER_URL: "https://sonarcloud.io"
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
-      CC: clang-15
-      CXX: clang++-15
+      CC: clang-16
+      CXX: clang++-16
     steps:
       - name: Check out repository code
         uses: ClickHouse/checkout@v1

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -341,17 +341,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--compiler",
         choices=(
-            "clang-15",
-            "clang-15-darwin",
-            "clang-15-darwin-aarch64",
-            "clang-15-aarch64",
-            "clang-15-aarch64-v80compat",
-            "clang-15-ppc64le",
-            "clang-15-amd64-compat",
-            "clang-15-freebsd",
-            "gcc-11",
+            "clang-16",
+            "clang-16-darwin",
+            "clang-16-darwin-aarch64",
+            "clang-16-aarch64",
+            "clang-16-aarch64-v80compat",
+            "clang-16-ppc64le",
+            "clang-16-amd64-compat",
+            "clang-16-freebsd",
         ),
-        default="clang-15",
+        default="clang-16",
         help="a compiler to use",
     )
     parser.add_argument(

--- a/docker/test/codebrowser/Dockerfile
+++ b/docker/test/codebrowser/Dockerfile
@@ -31,7 +31,7 @@ RUN arch=${TARGETARCH:-amd64} \
         arm64) rarch=aarch64 ;; \
         *) exit 1 ;; \
     esac \
-    && ln -rsf /usr/lib/$rarch-linux-gnu/libclang-15.so.15 /usr/lib/$rarch-linux-gnu/libclang-15.so.1
+    && ln -rsf /usr/lib/$rarch-linux-gnu/libclang-16.so.15 /usr/lib/$rarch-linux-gnu/libclang-16.so.1
 
 # repo versions doesn't work correctly with C++17
 # also we push reports to s3, so we add index.html to subfolder urls

--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -9,7 +9,7 @@ trap 'kill $(jobs -pr) ||:' EXIT
 stage=${stage:-}
 
 # Compiler version, normally set by Dockerfile
-export LLVM_VERSION=${LLVM_VERSION:-13}
+export LLVM_VERSION=${LLVM_VERSION:-16}
 
 # A variable to pass additional flags to CMake.
 # Here we explicitly default it to nothing so that bash doesn't complain about

--- a/docker/test/fuzzer/run-fuzzer.sh
+++ b/docker/test/fuzzer/run-fuzzer.sh
@@ -15,7 +15,7 @@ stage=${stage:-}
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "$script_dir"
 repo_dir=ch
-BINARY_TO_DOWNLOAD=${BINARY_TO_DOWNLOAD:="clang-15_debug_none_unsplitted_disable_False_binary"}
+BINARY_TO_DOWNLOAD=${BINARY_TO_DOWNLOAD:="clang-16_debug_none_unsplitted_disable_False_binary"}
 BINARY_URL_TO_DOWNLOAD=${BINARY_URL_TO_DOWNLOAD:="https://clickhouse-builds.s3.amazonaws.com/$PR_TO_TEST/$SHA_TO_TEST/clickhouse_build_check/$BINARY_TO_DOWNLOAD/clickhouse"}
 
 function git_clone_with_retry

--- a/docker/test/keeper-jepsen/run.sh
+++ b/docker/test/keeper-jepsen/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 
-CLICKHOUSE_PACKAGE=${CLICKHOUSE_PACKAGE:="https://clickhouse-builds.s3.amazonaws.com/$PR_TO_TEST/$SHA_TO_TEST/clickhouse_build_check/clang-15_relwithdebuginfo_none_unsplitted_disable_False_binary/clickhouse"}
+CLICKHOUSE_PACKAGE=${CLICKHOUSE_PACKAGE:="https://clickhouse-builds.s3.amazonaws.com/$PR_TO_TEST/$SHA_TO_TEST/clickhouse_build_check/clang-16_relwithdebuginfo_none_unsplitted_disable_False_binary/clickhouse"}
 CLICKHOUSE_REPO_PATH=${CLICKHOUSE_REPO_PATH:=""}
 
 

--- a/docker/test/server-jepsen/run.sh
+++ b/docker/test/server-jepsen/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 
-CLICKHOUSE_PACKAGE=${CLICKHOUSE_PACKAGE:="https://clickhouse-builds.s3.amazonaws.com/$PR_TO_TEST/$SHA_TO_TEST/clickhouse_build_check/clang-15_relwithdebuginfo_none_unsplitted_disable_False_binary/clickhouse"}
+CLICKHOUSE_PACKAGE=${CLICKHOUSE_PACKAGE:="https://clickhouse-builds.s3.amazonaws.com/$PR_TO_TEST/$SHA_TO_TEST/clickhouse_build_check/clang-16_relwithdebuginfo_none_unsplitted_disable_False_binary/clickhouse"}
 CLICKHOUSE_REPO_PATH=${CLICKHOUSE_REPO_PATH:=""}
 
 

--- a/docker/test/util/Dockerfile
+++ b/docker/test/util/Dockerfile
@@ -6,7 +6,7 @@ ARG apt_archive="http://archive.ubuntu.com"
 RUN sed -i "s|http://archive.ubuntu.com|$apt_archive|g" /etc/apt/sources.list
 
 # 15.0.2
-ENV DEBIAN_FRONTEND=noninteractive LLVM_VERSION=15
+ENV DEBIAN_FRONTEND=noninteractive LLVM_VERSION=16
 
 RUN apt-get update \
     && apt-get install \

--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -45,8 +45,8 @@ For other Linux distribution - check the availability of the [prebuild packages]
 #### Use the latest clang for Builds
 
 ``` bash
-export CC=clang-15
-export CXX=clang++-15
+export CC=clang-16
+export CXX=clang++-16
 ```
 
 In this example we use version 15 that is the latest as of Sept 2022.
@@ -159,4 +159,3 @@ The CI checks build the binaries on each commit to [ClickHouse](https://github.c
 1. Find the type of package for your operating system that you need and download the files.
 
 ![build artifact check](images/find-build-artifact.png)
-

--- a/docs/en/development/continuous-integration.md
+++ b/docs/en/development/continuous-integration.md
@@ -102,7 +102,7 @@ Builds ClickHouse in various configurations for use in further steps. You have t
 
 ### Report Details
 
-- **Compiler**: `clang-15`, optionally with the name of a target platform
+- **Compiler**: `clang-16`, optionally with the name of a target platform
 - **Build type**: `Debug` or `RelWithDebInfo` (cmake).
 - **Sanitizer**: `none` (without sanitizers), `address` (ASan), `memory` (MSan), `undefined` (UBSan), or `thread` (TSan).
 - **Status**: `success` or `fail`

--- a/docs/en/development/developer-instruction.md
+++ b/docs/en/development/developer-instruction.md
@@ -146,7 +146,7 @@ While inside the `build` directory, configure your build by running CMake. Befor
     export CC=clang CXX=clang++
     cmake ..
 
-If you installed clang using the automatic installation script above, also specify the version of clang installed in the first command, e.g. `export CC=clang-15 CXX=clang++-15`. The clang version will be in the script output.
+If you installed clang using the automatic installation script above, also specify the version of clang installed in the first command, e.g. `export CC=clang-16 CXX=clang++-16`. The clang version will be in the script output.
 
 The `CC` variable specifies the compiler for C (short for C Compiler), and `CXX` variable instructs which C++ compiler is to be used for building.
 

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -8,7 +8,7 @@ BuildConfig = Dict[str, ConfValue]
 CI_CONFIG = {
     "build_config": {
         "package_release": {
-            "compiler": "clang-15",
+            "compiler": "clang-16",
             "build_type": "",
             "sanitizer": "",
             "package_type": "deb",
@@ -18,7 +18,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "coverity": {
-            "compiler": "clang-15",
+            "compiler": "clang-16",
             "build_type": "",
             "sanitizer": "",
             "package_type": "coverity",
@@ -27,7 +27,7 @@ CI_CONFIG = {
             "official": False,
         },
         "package_aarch64": {
-            "compiler": "clang-15-aarch64",
+            "compiler": "clang-16-aarch64",
             "build_type": "",
             "sanitizer": "",
             "package_type": "deb",
@@ -37,7 +37,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "package_asan": {
-            "compiler": "clang-15",
+            "compiler": "clang-16",
             "build_type": "",
             "sanitizer": "address",
             "package_type": "deb",
@@ -45,7 +45,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "package_ubsan": {
-            "compiler": "clang-15",
+            "compiler": "clang-16",
             "build_type": "",
             "sanitizer": "undefined",
             "package_type": "deb",
@@ -53,7 +53,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "package_tsan": {
-            "compiler": "clang-15",
+            "compiler": "clang-16",
             "build_type": "",
             "sanitizer": "thread",
             "package_type": "deb",
@@ -61,7 +61,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "package_msan": {
-            "compiler": "clang-15",
+            "compiler": "clang-16",
             "build_type": "",
             "sanitizer": "memory",
             "package_type": "deb",
@@ -69,7 +69,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "package_debug": {
-            "compiler": "clang-15",
+            "compiler": "clang-16",
             "build_type": "debug",
             "sanitizer": "",
             "package_type": "deb",
@@ -77,7 +77,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "binary_release": {
-            "compiler": "clang-15",
+            "compiler": "clang-16",
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",
@@ -85,7 +85,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "binary_tidy": {
-            "compiler": "clang-15",
+            "compiler": "clang-16",
             "build_type": "debug",
             "sanitizer": "",
             "package_type": "binary",
@@ -94,7 +94,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "binary_darwin": {
-            "compiler": "clang-15-darwin",
+            "compiler": "clang-16-darwin",
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",
@@ -103,7 +103,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "binary_aarch64": {
-            "compiler": "clang-15-aarch64",
+            "compiler": "clang-16-aarch64",
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",
@@ -111,7 +111,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "binary_aarch64_v80compat": {
-            "compiler": "clang-15-aarch64-v80compat",
+            "compiler": "clang-16-aarch64-v80compat",
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",
@@ -120,7 +120,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "binary_freebsd": {
-            "compiler": "clang-15-freebsd",
+            "compiler": "clang-16-freebsd",
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",
@@ -129,7 +129,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "binary_darwin_aarch64": {
-            "compiler": "clang-15-darwin-aarch64",
+            "compiler": "clang-16-darwin-aarch64",
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",
@@ -138,7 +138,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "binary_ppc64le": {
-            "compiler": "clang-15-ppc64le",
+            "compiler": "clang-16-ppc64le",
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",
@@ -147,7 +147,7 @@ CI_CONFIG = {
             "with_coverage": False,
         },
         "binary_amd64_compat": {
-            "compiler": "clang-15-amd64-compat",
+            "compiler": "clang-16-amd64-compat",
             "build_type": "",
             "sanitizer": "",
             "package_type": "binary",


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
ClickHouse starts to use LLVM (and Clang, LLD, and other tools) version 16 instead of 15.