### PR TITLE
Disable setting in 02343_group_by_use_nulls_distributed (for new analyzer)

### DIFF
--- a/tests/queries/0_stateless/02343_group_by_use_nulls_distributed.sql
+++ b/tests/queries/0_stateless/02343_group_by_use_nulls_distributed.sql
@@ -1,3 +1,5 @@
+set optimize_group_by_function_keys=0;
+
 -- { echoOn }
 SELECT number, number % 2, sum(number) AS val
 FROM remote('127.0.0.{2,3}', numbers(10))


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)
