### PR TITLE
Clarify steps for reopened cherry-pick PRs

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -52,18 +52,25 @@ class Labels:
 
 
 class ReleaseBranch:
-    CHERRYPICK_DESCRIPTION = f"""This pull-request is a first step of an automated \
-    backporting.
+    CHERRYPICK_DESCRIPTION = """Original pull-request #{pr_number}
+
+This pull-request is a first step of an automated backporting.
 It contains changes like after calling a local command `git cherry-pick`.
 If you intend to continue backporting this changes, then resolve all conflicts if any.
 Otherwise, if you do not want to backport them, then just close this pull-request.
 
 The check results does not matter at this step - you can safely ignore them.
-Also this pull-request will be merged automatically as it reaches the mergeable state, \
+
+### Note
+
+This pull-request will be merged automatically as it reaches the mergeable state, \
 **do not merge it manually**.
 
-If it stuck, check the original PR for `{Labels.BACKPORTS_CREATED}` and delete it if \
-necessary.
+### If the PR was closed and then reopened
+
+If it stuck, check #{pr_number} for `{label_backports_created}` and delete it if \
+necessary. Manually merging will do nothing, since `{label_backports_created}` \
+prevents the original PR #{pr_number} from being processed.
 """
     BACKPORT_DESCRIPTION = """This pull-request is a last step of an automated \
 backporting.
@@ -203,8 +210,10 @@ close it.
 
         self.cherrypick_pr = self.pr.base.repo.create_pull(
             title=f"Cherry pick #{self.pr.number} to {self.name}: {self.pr.title}",
-            body=f"Original pull-request #{self.pr.number}\n\n"
-            f"{self.CHERRYPICK_DESCRIPTION}",
+            body=self.CHERRYPICK_DESCRIPTION.format(
+                pr_number=self.pr.number,
+                label_backports_created=Labels.BACKPORTS_CREATED,
+            ),
             base=self.backport_branch,
             head=self.cherrypick_branch,
         )


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Empathize the steps for reopened cherry-pick PRs.