### PR TITLE
Fix ZK exception error message

### DIFF
--- a/src/Storages/MergeTree/ZooKeeperRetries.h
+++ b/src/Storages/MergeTree/ZooKeeperRetries.h
@@ -215,7 +215,7 @@ private:
             throw Exception::createDeprecated(user_error.message, user_error.code);
 
         if (keeper_error.code != KeeperError::Code::ZOK)
-            throw zkutil::KeeperException(keeper_error.code, keeper_error.message);
+            throw zkutil::KeeperException(keeper_error.message, keeper_error.code);
     }
 
     void logLastError(std::string_view header)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

Seeing `Coordination::Exception: Operation timeout, path: Operation timeout.` in error messages, which is incorrect (the path part):

```
2023.03.17 19:10:40.322712 [ 9329 ] {98b5a208-5e03-43b7-bc9d-f18e36beb64c} <Error> DynamicQueryHandler: Code: 999. Coordination::Exception: Operation timeout, path: Operation timeout. (KEEPER_EXCEPTION), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked const&, int, bool) @ 0xe74c47a in /usr/bin/clickhouse
1. Coordination::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, Coordination::Error, int) @ 0x15901a70 in /usr/bin/clickhouse
2. Coordination::Exception::Exception(Coordination::Error, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) @ 0x15902197 in /usr/bin/clickhouse
3. ? @ 0x1517c1c1 in /usr/bin/clickhouse
4. ? @ 0x1517b39b in /usr/bin/clickhouse
5. DB::ReplicatedMergeTreeSinkImpl<false>::commitPart(std::__1::shared_ptr<DB::ZooKeeperWithFaultInjection> const&, std::__1::shared_ptr<DB::IMergeTreeDataPart>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, bool) @ 0x1517769d in /usr/bin/clickhouse
6. DB::ReplicatedMergeTreeSinkImpl<false>::finishDelayedChunk(std::__1::shared_ptr<DB::ZooKeeperWithFaultInjection> const&) @ 0x15174bfc in /usr/bin/clickhouse
7. DB::ReplicatedMergeTreeSinkImpl<false>::consume(DB::Chunk) @ 0x15173024 in /usr/bin/clickhouse
```

Related to https://github.com/ClickHouse/ClickHouse/pull/43122 (cc @devcrafter )
