### PR TITLE
Follow-up #47755

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -63,8 +63,9 @@ The check results does not matter at this step - you can safely ignore them.
 
 ### Note
 
-This pull-request will be merged automatically as it reaches the mergeable state, \
-**do not merge it manually**.
+This pull-request will be merged automatically as it reaches the mergeable state.
+
+# Do NOT merge it manually
 
 ### If the PR was closed and then reopened
 


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Follow-up #47755

(yes, that looks stupid, but that's how it works)