### PR TITLE
Fix partition ID byte order for s390x

### DIFF
--- a/src/Storages/MergeTree/MergeTreePartition.cpp
+++ b/src/Storages/MergeTree/MergeTreePartition.cpp
@@ -261,8 +261,11 @@ String MergeTreePartition::getID(const Block & partition_key_sample) const
     hash.get128(hash_data);
     result.resize(32);
     for (size_t i = 0; i < 16; ++i)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        writeHexByteLowercase(hash_data[16 - 1 - i], &result[2 * i]);
+#else
         writeHexByteLowercase(hash_data[i], &result[2 * i]);
-
+#endif
     return result;
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
On s390x, the partition ID has reversed byte order compared to those on little-endian machines. The fix is to reverse the byte order so that partition IDs keep the same on both little-endian and big-endian machines.

### Changelog category (leave one):
- Not for changelog


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed the byte order of partition IDs on s390x so that partition IDs keep the same on both little-endian and big-endian machines. This change does not affect other platforms.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
