### PR TITLE
Only valid Reviews.STATES overwrite existing reviews

### DIFF
--- a/tests/ci/merge_pr.py
+++ b/tests/ci/merge_pr.py
@@ -57,7 +57,8 @@ class Reviews:
                 self.reviews[user] = r
                 continue
 
-            if r.submitted_at < self.reviews[user].submitted_at:
+            # Keep the latest review per user
+            if self.reviews[user].submitted_at < r.submitted_at:
                 self.reviews[user] = r
 
     def is_approved(self, team: List[NamedUser]) -> bool:

--- a/tests/ci/merge_pr.py
+++ b/tests/ci/merge_pr.py
@@ -47,6 +47,16 @@ class Reviews:
                 self.reviews[user] = r
                 continue
 
+            # Do not process other statuses than STATES for existing user keys
+            if r.state not in self.STATES:
+                continue
+
+            # If the user has a status other than STATES, we overwrite it by a
+            # review w/ a proper state w/o checking the date
+            if self.reviews[user].state not in self.STATES:
+                self.reviews[user] = r
+                continue
+
             if r.submitted_at < self.reviews[user].submitted_at:
                 self.reviews[user] = r
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix unreliable merge_pr part.