### PR TITLE
Fix reading from storage `File` compressed files with `zlib` and `gzip` compression

### DIFF
--- a/src/IO/ZlibInflatingReadBuffer.cpp
+++ b/src/IO/ZlibInflatingReadBuffer.cpp
@@ -6,6 +6,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ZLIB_INFLATE_FAILED;
+    extern const int ARGUMENT_OUT_OF_BOUND;
 }
 
 ZlibInflatingReadBuffer::ZlibInflatingReadBuffer(
@@ -17,6 +18,11 @@ ZlibInflatingReadBuffer::ZlibInflatingReadBuffer(
     : CompressedReadBufferWrapper(std::move(in_), buf_size, existing_memory, alignment)
     , eof_flag(false)
 {
+    if (buf_size > max_buffer_size)
+        throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+            "Zlib does not support decompression with buffer size greater than {}, got buffer size: {}",
+            max_buffer_size, buf_size);
+
     zstr.zalloc = nullptr;
     zstr.zfree = nullptr;
     zstr.opaque = nullptr;
@@ -31,10 +37,7 @@ ZlibInflatingReadBuffer::ZlibInflatingReadBuffer(
         window_bits += 16;
     }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
     int rc = inflateInit2(&zstr, window_bits);
-#pragma GCC diagnostic pop
 
     if (rc != Z_OK)
         throw Exception(ErrorCodes::ZLIB_INFLATE_FAILED, "inflateInit2 failed: {}; zlib version: {}.", zError(rc), ZLIB_VERSION);
@@ -61,16 +64,20 @@ bool ZlibInflatingReadBuffer::nextImpl()
         {
             in->nextIfAtEnd();
             zstr.next_in = reinterpret_cast<unsigned char *>(in->position());
-            zstr.avail_in = static_cast<unsigned>(in->buffer().end() - in->position());
+            zstr.avail_in = static_cast<BufferSizeType>(std::min(in->buffer().end() - in->position(), static_cast<Int64>(max_buffer_size)));
         }
+
         /// init output bytes (place, where decompressed data will be)
         zstr.next_out = reinterpret_cast<unsigned char *>(internal_buffer.begin());
-        zstr.avail_out = static_cast<unsigned>(internal_buffer.size());
+        zstr.avail_out = static_cast<BufferSizeType>(internal_buffer.size());
 
+        size_t old_total_in = zstr.total_in;
         int rc = inflate(&zstr, Z_NO_FLUSH);
 
         /// move in stream on place, where reading stopped
-        in->position() = in->buffer().end() - zstr.avail_in;
+        size_t bytes_read = zstr.total_in - old_total_in;
+        in->position() += bytes_read;
+
         /// change size of working buffer (it's size equal to internal_buffer size without unused uncompressed values)
         working_buffer.resize(internal_buffer.size() - zstr.avail_out);
 
@@ -94,9 +101,10 @@ bool ZlibInflatingReadBuffer::nextImpl()
                 return true;
             }
         }
+
         /// If it is not end and not OK, something went wrong, throw exception
         if (rc != Z_OK)
-            throw Exception(ErrorCodes::ZLIB_INFLATE_FAILED, "inflateReset failed: {}", zError(rc));
+            throw Exception(ErrorCodes::ZLIB_INFLATE_FAILED, "inflate failed: {}", zError(rc));
     }
     while (working_buffer.empty());
 

--- a/src/IO/ZlibInflatingReadBuffer.cpp
+++ b/src/IO/ZlibInflatingReadBuffer.cpp
@@ -64,7 +64,9 @@ bool ZlibInflatingReadBuffer::nextImpl()
         {
             in->nextIfAtEnd();
             zstr.next_in = reinterpret_cast<unsigned char *>(in->position());
-            zstr.avail_in = static_cast<BufferSizeType>(std::min(in->buffer().end() - in->position(), static_cast<Int64>(max_buffer_size)));
+            zstr.avail_in = static_cast<BufferSizeType>(std::min(
+                static_cast<UInt64>(in->buffer().end() - in->position()),
+                static_cast<UInt64>(max_buffer_size)));
         }
 
         /// init output bytes (place, where decompressed data will be)

--- a/src/IO/ZlibInflatingReadBuffer.h
+++ b/src/IO/ZlibInflatingReadBuffer.h
@@ -4,6 +4,7 @@
 #include <IO/CompressedReadBufferWrapper.h>
 #include <IO/CompressionMethod.h>
 
+#include <limits>
 #include <zlib.h>
 
 
@@ -33,6 +34,11 @@ private:
 
     z_stream zstr;
     bool eof_flag;
+
+    /// Limit size of buffer because zlib uses
+    /// UInt32 for sizes of internal buffers.
+    using BufferSizeType =  decltype(zstr.avail_in);
+    static constexpr auto max_buffer_size = std::numeric_limits<BufferSizeType>::max();
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed reading of files greater than 4GB compressed with `gzip` or `zlib` from storage `File`, table function `file` and with `INFILE` client option and setting `storage_file_read_method='mmap'` (enabled by default since version 23.1). 

Fixes #47756.