### PR TITLE
Decrease scale_down ratio for faster deflation

### DIFF
--- a/tests/ci/autoscale_runners_lambda/app.py
+++ b/tests/ci/autoscale_runners_lambda/app.py
@@ -59,11 +59,11 @@ def get_scales(runner_type: str) -> Tuple[int, int]:
     "returns the multipliers for scaling down and up ASG by types"
     # Scaling down is quicker on the lack of running jobs than scaling up on
     # queue
-    scale_down = 3
+    scale_down = 2
     scale_up = 5
     if runner_type == "style-checker":
         # the style checkers have so many noise, so it scales up too quickly
-        scale_down = 2
+        scale_down = 1
         scale_up = 10
     return scale_down, scale_up
 

--- a/tests/ci/autoscale_runners_lambda_test.py
+++ b/tests/ci/autoscale_runners_lambda_test.py
@@ -70,6 +70,9 @@ class TestSetCapacity(unittest.TestCase):
             TestCase("w/reserve", 1, 13, 20, [Queue("queued", 17, "w/reserve")], -1),
             # Increase capacity
             TestCase("increase", 1, 13, 20, [Queue("queued", 23, "increase")], 15),
+            TestCase(
+                "style-checker", 1, 13, 20, [Queue("queued", 33, "style-checker")], 15
+            ),
             TestCase("increase", 1, 13, 20, [Queue("queued", 18, "increase")], 14),
             TestCase("increase", 1, 13, 20, [Queue("queued", 183, "increase")], 20),
             TestCase(
@@ -85,10 +88,20 @@ class TestSetCapacity(unittest.TestCase):
             ),
             TestCase("lower-min", 10, 5, 20, [Queue("queued", 5, "lower-min")], 10),
             # Decrease capacity
-            TestCase("w/reserve", 1, 13, 20, [Queue("queued", 5, "w/reserve")], 11),
+            TestCase("w/reserve", 1, 13, 20, [Queue("queued", 5, "w/reserve")], 9),
+            TestCase(
+                "style-checker", 1, 13, 20, [Queue("queued", 5, "style-checker")], 5
+            ),
             TestCase("w/reserve", 1, 23, 20, [Queue("queued", 17, "w/reserve")], 20),
-            TestCase("decrease", 1, 13, 20, [Queue("in_progress", 3, "decrease")], 10),
-            TestCase("decrease", 1, 13, 20, [Queue("in_progress", 5, "decrease")], 11),
+            TestCase("decrease", 1, 13, 20, [Queue("in_progress", 3, "decrease")], 8),
+            TestCase(
+                "style-checker",
+                1,
+                13,
+                20,
+                [Queue("in_progress", 5, "style-checker")],
+                5,
+            ),
         )
         for t in test_cases:
             self.client.data_helper(t.name, t.min_size, t.desired_capacity, t.max_size)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Another small improvement for quick deflation. Already running