### PR TITLE
Place short return before big block, improve logging

### DIFF
--- a/tests/ci/merge_pr.py
+++ b/tests/ci/merge_pr.py
@@ -100,55 +100,52 @@ class Reviews:
             if review.state == "APPROVED"
         }
 
-        if approved:
+        if not approved:
             logging.info(
-                "The following users from %s team approved the PR: %s",
+                "The PR #%s is not approved by any of %s team member",
+                self.pr.number,
                 TEAM_NAME,
-                ", ".join(user.login for user in approved.keys()),
             )
-            # The only reliable place to get the 100% accurate last_modified
-            # info is when the commit was pushed to GitHub. The info is
-            # available as a header 'last-modified' of /{org}/{repo}/commits/{sha}.
-            # Unfortunately, it's formatted as 'Wed, 04 Jan 2023 11:05:13 GMT'
-
-            commit = self.pr.head.repo.get_commit(self.pr.head.sha)
-            if commit.stats.last_modified is None:
-                logging.warning(
-                    "Unable to get info about the commit %s", self.pr.head.sha
-                )
-                return False
-
-            last_changed = datetime.strptime(
-                commit.stats.last_modified, "%a, %d %b %Y %H:%M:%S GMT"
-            )
-
-            approved_at = max(review.submitted_at for review in approved.values())
-            if approved_at == datetime.fromtimestamp(0):
-                logging.info(
-                    "Unable to get `datetime.fromtimestamp(0)`, "
-                    "here's debug info about reviews: %s",
-                    "\n".join(pformat(review) for review in self.reviews.values()),
-                )
-            else:
-                logging.info(
-                    "The PR is approved at %s",
-                    approved_at.isoformat(),
-                )
-
-            if approved_at < last_changed:
-                logging.info(
-                    "There are changes after approve at %s",
-                    approved_at.isoformat(),
-                )
-                return False
-            return True
+            return False
 
         logging.info(
-            "The PR #%s is not approved by any of %s team member",
-            self.pr.number,
+            "The following users from %s team approved the PR: %s",
             TEAM_NAME,
+            ", ".join(user.login for user in approved.keys()),
         )
-        return False
+
+        # The only reliable place to get the 100% accurate last_modified
+        # info is when the commit was pushed to GitHub. The info is
+        # available as a header 'last-modified' of /{org}/{repo}/commits/{sha}.
+        # Unfortunately, it's formatted as 'Wed, 04 Jan 2023 11:05:13 GMT'
+        commit = self.pr.head.repo.get_commit(self.pr.head.sha)
+        if commit.stats.last_modified is None:
+            logging.warning("Unable to get info about the commit %s", self.pr.head.sha)
+            return False
+
+        last_changed = datetime.strptime(
+            commit.stats.last_modified, "%a, %d %b %Y %H:%M:%S GMT"
+        )
+        logging.info("The PR is changed at %s", last_changed.isoformat())
+
+        approved_at = max(review.submitted_at for review in approved.values())
+        if approved_at == datetime.fromtimestamp(0):
+            logging.info(
+                "Unable to get `datetime.fromtimestamp(0)`, "
+                "here's debug info about reviews: %s",
+                "\n".join(pformat(review) for review in self.reviews.values()),
+            )
+        else:
+            logging.info("The PR is approved at %s", approved_at.isoformat())
+
+        if approved_at < last_changed:
+            logging.info(
+                "There are changes done at %s after approval at %s",
+                last_changed.isoformat(),
+                approved_at.isoformat(),
+            )
+            return False
+        return True
 
 
 def get_workflows_for_head(repo: Repository, head_sha: str) -> List[WorkflowRun]:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add logging of last changes, return early on non-approved.