### PR TITLE
[FixTests] Remove wrong chassert() in UserDefinedSQLObjectsLoaderFromZooKeeper.cpp

### DIFF
--- a/src/Functions/UserDefined/UserDefinedSQLObjectsLoaderFromZooKeeper.cpp
+++ b/src/Functions/UserDefined/UserDefinedSQLObjectsLoaderFromZooKeeper.cpp
@@ -279,9 +279,9 @@ bool UserDefinedSQLObjectsLoaderFromZooKeeper::getObjectDataAndSetWatch(
         if (response.type == Coordination::Event::CHANGED)
         {
             [[maybe_unused]] bool inserted = watch_queue->emplace(object_type, object_name);
-            chassert(inserted);
+            /// `inserted` can be false if `watch_queue` was already finalized (which happens when stopWatching() is called).
         }
-        /// NOTE: Event::DELETED is processed as child event by getChildren watch
+        /// Event::DELETED is processed as child event by getChildren watch
     };
 
     Coordination::Stat entity_stat;
@@ -340,7 +340,7 @@ Strings UserDefinedSQLObjectsLoaderFromZooKeeper::getObjectNamesAndSetWatch(
     auto object_list_watcher = [watch_queue = watch_queue, object_type](const Coordination::WatchResponse &)
     {
         [[maybe_unused]] bool inserted = watch_queue->emplace(object_type, "");
-        chassert(inserted);
+        /// `inserted` can be false if `watch_queue` was already finalized (which happens when stopWatching() is called).
     };
 
     Coordination::Stat stat;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Remove wrong chassert() in UserDefinedSQLObjectsLoaderFromZooKeeper.cpp

This will fix failures in tests `test_backup_restore_on_cluster*`, for example
https://s3.amazonaws.com/clickhouse-test-reports/0/de0f964b7bb335edc3ae04703227d2bb17321cbe/integration_tests__asan__[2/3].html