### PR TITLE
Revert "Add sanity checks for writing number in variable length format"

### DIFF
--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -2,7 +2,6 @@
 
 #include <iostream>
 #include <base/types.h>
-#include <base/defines.h>
 #include <IO/ReadBuffer.h>
 #include <IO/WriteBuffer.h>
 
@@ -15,19 +14,7 @@ namespace ErrorCodes
 }
 
 
-/** Variable-Length Quantity (VLQ) Base-128 compression
- *
- * NOTE: Due to historical reasons, only up to 1<<63-1 are supported, which
- * cannot be changed without breaking the backward compatibility.
- * Also some drivers may support full 1<<64 range (i.e. python -
- * clickhouse-driver), while others has the same limitations as ClickHouse
- * (i.e. Rust - clickhouse-rs).
- * So implementing VLQ for the whole 1<<64 range will require different set of
- * helpers.
- */
-constexpr size_t VAR_UINT_MAX = (1ULL<<63) - 1;
-
-/** Write UInt64 in variable length format (base128) */
+/** Write UInt64 in variable length format (base128) NOTE Only up to 2^63 - 1 are supported. */
 void writeVarUInt(UInt64 x, std::ostream & ostr);
 void writeVarUInt(UInt64 x, WriteBuffer & ostr);
 char * writeVarUInt(UInt64 x, char * ostr);
@@ -199,7 +186,6 @@ inline const char * readVarUInt(UInt64 & x, const char * istr, size_t size)
 
 inline void writeVarUInt(UInt64 x, WriteBuffer & ostr)
 {
-    chassert(x <= VAR_UINT_MAX);
     for (size_t i = 0; i < 9; ++i)
     {
         uint8_t byte = x & 0x7F;
@@ -219,7 +205,6 @@ inline void writeVarUInt(UInt64 x, WriteBuffer & ostr)
 
 inline void writeVarUInt(UInt64 x, std::ostream & ostr)
 {
-    chassert(x <= VAR_UINT_MAX);
     for (size_t i = 0; i < 9; ++i)
     {
         uint8_t byte = x & 0x7F;
@@ -237,7 +222,6 @@ inline void writeVarUInt(UInt64 x, std::ostream & ostr)
 
 inline char * writeVarUInt(UInt64 x, char * ostr)
 {
-    chassert(x <= VAR_UINT_MAX);
     for (size_t i = 0; i < 9; ++i)
     {
         uint8_t byte = x & 0x7F;

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1869,7 +1869,7 @@ void TCPHandler::sendData(const Block & block)
         {
             --unknown_packet_in_send_data;
             if (unknown_packet_in_send_data == 0)
-                writeVarUInt(VAR_UINT_MAX, *out);
+                writeVarUInt(UInt64(-1), *out);
         }
 
         writeVarUInt(Protocol::Server::Data, *out);


### PR DESCRIPTION
The AST fuzzer managed to trigger the new `assert` ... reverting for now

https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19uYW1lIExJS0UgJ0FTVCBmdXp6ZXIlJwogICAgQU5EIGNoZWNrX3N0YXJ0X3RpbWUgPj0gbm93KCkgLSBJTlRFUlZBTCAyNCBIT1VSCiAgICBBTkQgcHVsbF9yZXF1ZXN0X251bWJlciA9IDAKICAgIEFORCB0ZXN0X3N0YXR1cyAhPSAnU0tJUFBFRCcKICAgIEFORCB0ZXN0X3N0YXR1cyBMSUtFICdGJScKICAgIEFORCBjaGVja19zdGF0dXMgIT0gJ3N1Y2Nlc3MnCk9SREVSIEJZIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgY2hlY2tfc3RhcnRfdGltZQ==