### PR TITLE
Fix test test_replicated_merge_tree_encryption_codec

### DIFF
--- a/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
+++ b/tests/integration/test_replicated_merge_tree_encryption_codec/test.py
@@ -64,6 +64,7 @@ def optimize_table():
 
 def check_table():
     expected = [[1, "str1"], [2, "str2"]]
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
     assert node1.query("SELECT * FROM tbl ORDER BY id") == TSV(expected)
     assert node2.query("SELECT * FROM tbl ORDER BY id") == TSV(expected)
     assert node1.query("CHECK TABLE tbl") == "1\n"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fix test `test_replicated_merge_tree_encryption_codec`, see the [failure](https://s3.amazonaws.com/clickhouse-test-reports/0/28525c7c2175f60e254a8e209ab08b16a91ea41c/integration_tests__release__[2/2].html)