### PR TITLE
Improve empty query detection for PostgreSQL (for pgx golang driver)

### DIFF
--- a/src/Server/PostgreSQLHandler.cpp
+++ b/src/Server/PostgreSQLHandler.cpp
@@ -318,6 +318,9 @@ bool PostgreSQLHandler::isEmptyQuery(const String & query)
 {
     if (query.empty())
         return true;
+    /// golang driver pgx sends ";"
+    if (query == ";")
+        return true;
 
     Poco::RegularExpression regex(R"(\A\s*\z)");
     return regex.match(query);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve empty query detection for PostgreSQL (for pgx golang driver)

From PostgreSQL documentation [1]:

    If a completely empty (no contents other than whitespace) query string
    is received, the response is EmptyQueryResponse followed by
    ReadyForQuery.

  [1]: https://www.postgresql.org/docs/current/protocol-flow.html

So without it it will try to process the query and send "Empty query" instead, that's why it is important.

Refs: https://github.com/jackc/pgx/blob/9ae852eb583d2dced83b1d2ffe1c8803dda2c92e/conn.go#L388

_I came across this while I was looking at [rill](https://github.com/rilldata/rill-developer/)_