### PR TITLE
Slightly better error message

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1210,7 +1210,7 @@ protected:
     {
         auto it = data_parts_by_info.find(part->info);
         if (it == data_parts_by_info.end() || (*it).get() != part.get())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Part {} doesn't exist", part->name);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Part {} doesn't exist (info: {})", part->name, part->info.getPartNameForLogs());
 
         if (!data_parts_by_state_and_info.modify(data_parts_indexes.project<TagByStateAndInfo>(it), getStateModifier(state)))
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't modify {}", (*it)->getNameWithState());


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Because I got schizophrenic logs for `Logical error: \'Part all_6_6_0 doesn\'t exist\'.`: 
https://s3.amazonaws.com/clickhouse-test-reports/0/ed503780603a70e25ef235dfd4d83793a021d1e5/stress_test__debug_.html
```
rg -Faz "test_knqme73z.r2" clickhouse-server.stress.log.zst | grep -Fa "data_parts_indexes"
2023.03.19 20:08:41.999033 [ 2536 ] {9cf0c40d-8d72-45da-9e08-e61d01764968} <Test> test_knqme73z.r2 (a3282af5-f8fa-44f5-85ec-d9d6761f09d4): loadDataParts: clearing data_parts_indexes (had 0 parts)
2023.03.19 20:08:57.319368 [ 2991 ] {844f3128-10f1-402b-a8a6-d34e6933f751} <Test> test_knqme73z.r2 (a3282af5-f8fa-44f5-85ec-d9d6761f09d4): preparePartForCommit: inserting all_1_1_0 (state PreActive) into data_parts_indexes
2023.03.19 20:08:57.401574 [ 2945 ] {b2ce8423-cf28-47cd-9880-f37e305cf89a} <Test> test_knqme73z.r2 (a3282af5-f8fa-44f5-85ec-d9d6761f09d4): preparePartForCommit: inserting all_6_6_0 (state PreActive) into data_parts_indexes
2023.03.19 20:08:57.418590 [ 2837 ] {1ce30136-93bf-4de6-8795-0fc81bd33f8c} <Test> test_knqme73z.r2 (a3282af5-f8fa-44f5-85ec-d9d6761f09d4): preparePartForCommit: inserting all_7_7_0 (state PreActive) into data_parts_indexes
2023.03.19 20:08:57.431209 [ 2557 ] {c17abbf5-9793-4468-8f07-819017394a67} <Test> test_knqme73z.r2 (a3282af5-f8fa-44f5-85ec-d9d6761f09d4): preparePartForCommit: inserting all_16_16_0 (state PreActive) into data_parts_indexes
2023.03.19 20:08:57.433864 [ 4423 ] {2b23e6e4-2f07-4d0f-b0e8-d5a2b7b15196} <Test> test_knqme73z.r2 (a3282af5-f8fa-44f5-85ec-d9d6761f09d4): preparePartForCommit: inserting all_18_18_0 (state PreActive) into data_parts_indexes
2023.03.19 20:08:57.537305 [ 2837 ] {1ce30136-93bf-4de6-8795-0fc81bd33f8c} <Test> test_knqme73z.r2 (a3282af5-f8fa-44f5-85ec-d9d6761f09d4): removePartsFromWorkingSetImmediatelyAndSetTemporaryState: removing all_7_7_0 (state Temporary) from data_parts_indexes
```

It was added, it was never removed, but it does not exist... What if `name` and `info` became inconsistent due to retries? 