### PR TITLE
Fix DROP COLUMN with ReplicatedMergeTree containing projections

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
@@ -456,6 +456,14 @@ StorageInMemoryMetadata ReplicatedMergeTreeTableMetadata::Diff::getNewMetadata(c
         new_metadata.table_ttl = TTLTableDescription::getTTLForTableFromAST(
             new_metadata.table_ttl.definition_ast, new_metadata.columns, context, new_metadata.primary_key);
 
+    if (!projections_changed)
+    {
+        ProjectionsDescription recalculated_projections;
+        for (const auto & projection : new_metadata.projections)
+            recalculated_projections.add(ProjectionDescription::getProjectionFromAST(projection.definition_ast, new_metadata.columns, context));
+        new_metadata.projections = std::move(recalculated_projections);
+    }
+
     return new_metadata;
 }
 

--- a/tests/queries/0_stateless/02691_drop_column_with_projections_replicated.sql
+++ b/tests/queries/0_stateless/02691_drop_column_with_projections_replicated.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS 02691_drop_column_replicated;
+
+CREATE TABLE 02691_drop_column_replicated (col1 Int64, col2 Int64, PROJECTION 02691_drop_column_replicated (SELECT * ORDER BY col1 ))
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test/02691_drop_column', 'r1')
+ORDER BY col1;
+
+INSERT INTO 02691_drop_column_replicated VALUES (1, 2);
+
+ALTER TABLE 02691_drop_column_replicated DROP COLUMN col2 SETTINGS alter_sync = 2;
+
+DROP TABLE 02691_drop_column_replicated;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix DROP COLUMN for `ReplicatedMergeTree` tables with projections.

Possible fix for https://github.com/ClickHouse/ClickHouse/issues/43107 ? cc @amosbird 
EDIT: In the issue it's actually a problem with regular MergeTree.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
