### PR TITLE
Hotfix for too verbose warnings in HTTP

### DIFF
--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -64,7 +64,7 @@ HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse 
     else if (getMethod() != HTTPRequest::HTTP_GET && getMethod() != HTTPRequest::HTTP_HEAD && getMethod() != HTTPRequest::HTTP_DELETE)
     {
         /// That check for has_body may be false-negative in rare cases, but it's okay
-        bool has_body = stream->hasPendingData();
+        bool has_body = in->hasPendingData();
         stream = std::move(in);
         if (!startsWith(getContentType(), "multipart/form-data") && has_body)
             LOG_WARNING(&Poco::Logger::get("HTTPServerRequest"), "Got an HTTP request with no content length "

--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -63,8 +63,10 @@ HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse 
     }
     else if (getMethod() != HTTPRequest::HTTP_GET && getMethod() != HTTPRequest::HTTP_HEAD && getMethod() != HTTPRequest::HTTP_DELETE)
     {
+        /// That check for has_body may be false-negative in rare cases, but it's okay
+        bool has_body = stream->hasPendingData();
         stream = std::move(in);
-        if (!startsWith(getContentType(), "multipart/form-data"))
+        if (!startsWith(getContentType(), "multipart/form-data") && has_body)
             LOG_WARNING(&Poco::Logger::get("HTTPServerRequest"), "Got an HTTP request with no content length "
                 "and no chunked/multipart encoding, it may be impossible to distinguish graceful EOF from abnormal connection loss");
     }


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed too many `Got an HTTP request with no content length` warnings produced by interserver HTTP communication (fetches in `ReplicatedMergeTree`)
