### PR TITLE
Fix exception type in arrayElement function

### DIFF
--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -1179,11 +1179,14 @@ ColumnPtr FunctionArrayElement::perform(const ColumnsWithTypeAndName & arguments
             || (res = executeArgument<Int16>(arguments, result_type, builder, input_rows_count))
             || (res = executeArgument<Int32>(arguments, result_type, builder, input_rows_count))
             || (res = executeArgument<Int64>(arguments, result_type, builder, input_rows_count))))
-        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Second argument for function {} must have UInt or Int type.", getName());
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Second argument for function {} must have UInt or Int type", getName());
     }
     else
     {
         Field index = (*arguments[1].column)[0];
+
+        if (index.getType() != Field::Types::UInt64 && index.getType() != Field::Types::Int64)
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Second argument for function {} must have UInt or Int type", getName());
 
         if (builder)
             builder.initSink(input_rows_count);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Change exception type in arrayElement function in case of unsupported UInt/Int type from LOGICAL_ERROR to ILLEGAL_COLUMN. Closes https://github.com/ClickHouse/ClickHouse/issues/47889