### PR TITLE
Fix logical error in DistributedSink

### DIFF
--- a/tests/integration/test_sharding_key_from_default_column/test.py
+++ b/tests/integration/test_sharding_key_from_default_column/test.py
@@ -49,14 +49,14 @@ def test_default_column():
             "INSERT INTO TABLE dist (x) VALUES (1), (2), (3), (4)", settings=settings
         )
         node1.query("SYSTEM FLUSH DISTRIBUTED dist")
-        assert node1.query("SELECT x, y, z FROM local") == TSV(
+        assert node1.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[2, 102, 104], [4, 104, 108]]
         )
-        assert node2.query("SELECT x, y, z FROM local") == TSV(
+        assert node2.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[1, 101, 102], [3, 103, 106]]
         )
-        assert node1.query("SELECT x, y, z FROM dist") == TSV(
-            [[2, 102, 104], [4, 104, 108], [1, 101, 102], [3, 103, 106]]
+        assert node1.query("SELECT x, y, z FROM dist ORDER BY x") == TSV(
+            [[1, 101, 102], [2, 102, 104], [3, 103, 106], [4, 104, 108]]
         )
 
         # INSERT INTO TABLE dist (x, y)
@@ -66,12 +66,12 @@ def test_default_column():
             settings=settings,
         )
         node1.query("SYSTEM FLUSH DISTRIBUTED dist")
-        assert node1.query("SELECT x, y, z FROM local") == TSV([[2, 22, 24]])
-        assert node2.query("SELECT x, y, z FROM local") == TSV(
+        assert node1.query("SELECT x, y, z FROM local ORDER BY x") == TSV([[2, 22, 24]])
+        assert node2.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[1, 11, 12], [3, 33, 36]]
         )
-        assert node1.query("SELECT x, y, z FROM dist") == TSV(
-            [[2, 22, 24], [1, 11, 12], [3, 33, 36]]
+        assert node1.query("SELECT x, y, z FROM dist ORDER BY x") == TSV(
+            [[1, 11, 12], [2, 22, 24], [3, 33, 36]]
         )
 
 
@@ -96,14 +96,14 @@ def test_materialized_column_allow_insert_materialized():
             "INSERT INTO TABLE dist (x) VALUES (1), (2), (3), (4)", settings=settings
         )
         node1.query("SYSTEM FLUSH DISTRIBUTED dist")
-        assert node1.query("SELECT x, y, z FROM local") == TSV(
+        assert node1.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[2, 102, 104], [4, 104, 108]]
         )
-        assert node2.query("SELECT x, y, z FROM local") == TSV(
+        assert node2.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[1, 101, 102], [3, 103, 106]]
         )
-        assert node1.query("SELECT x, y, z FROM dist") == TSV(
-            [[2, 102, 104], [4, 104, 108], [1, 101, 102], [3, 103, 106]]
+        assert node1.query("SELECT x, y, z FROM dist ORDER BY x") == TSV(
+            [[1, 101, 102], [2, 102, 104], [3, 103, 106], [4, 104, 108]]
         )
 
         # INSERT INTO TABLE dist (x, y)
@@ -113,12 +113,12 @@ def test_materialized_column_allow_insert_materialized():
             settings=settings,
         )
         node1.query("SYSTEM FLUSH DISTRIBUTED dist")
-        assert node1.query("SELECT x, y, z FROM local") == TSV([[2, 22, 24]])
-        assert node2.query("SELECT x, y, z FROM local") == TSV(
+        assert node1.query("SELECT x, y, z FROM local ORDER BY x") == TSV([[2, 22, 24]])
+        assert node2.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[1, 11, 12], [3, 33, 36]]
         )
-        assert node1.query("SELECT x, y, z FROM dist") == TSV(
-            [[2, 22, 24], [1, 11, 12], [3, 33, 36]]
+        assert node1.query("SELECT x, y, z FROM dist ORDER BY x") == TSV(
+            [[1, 11, 12], [2, 22, 24], [3, 33, 36]]
         )
 
 
@@ -143,14 +143,14 @@ def test_materialized_column_disallow_insert_materialized():
             "INSERT INTO TABLE dist (x) VALUES (1), (2), (3), (4)", settings=settings
         )
         node1.query("SYSTEM FLUSH DISTRIBUTED dist")
-        assert node1.query("SELECT x, y, z FROM local") == TSV(
+        assert node1.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[2, 202, -200], [4, 204, -200]]
         )
-        assert node2.query("SELECT x, y, z FROM local") == TSV(
+        assert node2.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[1, 201, -200], [3, 203, -200]]
         )
-        assert node1.query("SELECT x, y, z FROM dist") == TSV(
-            [[2, 202, -200], [4, 204, -200], [1, 201, -200], [3, 203, -200]]
+        assert node1.query("SELECT x, y, z FROM dist ORDER BY x") == TSV(
+            [[1, 201, -200], [2, 202, -200], [3, 203, -200], [4, 204, -200]]
         )
 
         # INSERT INTO TABLE dist (x, y)
@@ -183,12 +183,12 @@ def test_materialized_column_disallow_insert_materialized_different_shards():
             "INSERT INTO TABLE dist (x) VALUES (1), (2), (3), (4)", settings=settings
         )
         node1.query("SYSTEM FLUSH DISTRIBUTED dist")
-        assert node1.query("SELECT x, y, z FROM local") == TSV(
+        assert node1.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[1, 201, -200], [3, 203, -200]]
         )
-        assert node2.query("SELECT x, y, z FROM local") == TSV(
+        assert node2.query("SELECT x, y, z FROM local ORDER BY x") == TSV(
             [[2, 202, -200], [4, 204, -200]]
         )
-        assert node1.query("SELECT x, y, z FROM dist") == TSV(
-            [[1, 201, -200], [3, 203, -200], [2, 202, -200], [4, 204, -200]]
+        assert node1.query("SELECT x, y, z FROM dist ORDER BY x") == TSV(
+            [[1, 201, -200], [2, 202, -200], [3, 203, -200], [4, 204, -200]]
         )


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


https://s3.amazonaws.com/clickhouse-test-reports/0/868b639df1443e8127bd0bcb8c557a6eff01097c/stateless_tests__msan__[3/3].html
```
2023.03.23 02:06:34.814832 [ 8559 ] {22a1e338-0155-4386-80bd-6d86410a3216} <Fatal> : Logical error: 'Pipeline for PushingPipelineExecutor was finished before all data was inserted'.
2023.03.23 02:06:34.815919 [ 58345 ] {} <Fatal> BaseDaemon: ########################################
2023.03.23 02:06:34.816344 [ 58345 ] {} <Fatal> BaseDaemon: (version 23.3.1.1 (official build), build id: FE9C50FE5FC22183460064C4DEC0501DB8483FAD) (from thread 8559) (query_id: 22a1e338-0155-4386-80bd-6d86410a3216) (query: insert into function remote('127.2', currentDatabase(), in_02232) select * from numbers(1e6)) Received signal Aborted (6)
2023.03.23 02:06:34.816715 [ 58345 ] {} <Fatal> BaseDaemon: 
2023.03.23 02:06:34.817158 [ 58345 ] {} <Fatal> BaseDaemon: Stack trace: 0x7f8edc4a900b 0x7f8edc488859 0x293000f1 0x2930143f 0xe85365a 0x4b86ae0d 0x4b86b021 0x4a007f2c 0x29687f25 0x296956c9 0x29695549 0x2967e60d 0x2968d523 0x7f8edc660609 0x7f8edc585133
2023.03.23 02:06:34.817646 [ 58345 ] {} <Fatal> BaseDaemon: 4. gsignal @ 0x7f8edc4a900b in ?
2023.03.23 02:06:34.818032 [ 58345 ] {} <Fatal> BaseDaemon: 5. abort @ 0x7f8edc488859 in ?
2023.03.23 02:06:35.146669 [ 58345 ] {} <Fatal> BaseDaemon: 6. ./build_docker/../src/Common/Exception.cpp:0: DB::abortOnFailedAssertion(String const&) @ 0x293000f1 in /usr/bin/clickhouse
2023.03.23 02:06:35.482079 [ 58345 ] {} <Fatal> BaseDaemon: 7.1. inlined from ./build_docker/../src/Common/Exception.cpp:0: DB::handle_error_code(String const&, int, bool, std::vector<void*, std::allocator<void*>> const&)
2023.03.23 02:06:35.482598 [ 58345 ] {} <Fatal> BaseDaemon: 7. ./build_docker/../src/Common/Exception.cpp:92: DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x2930143f in /usr/bin/clickhouse
2023.03.23 02:06:44.268605 [ 58345 ] {} <Fatal> BaseDaemon: 8. DB::Exception::Exception<char const (&) [79], void>(int, char const (&) [79]) @ 0xe85365a in /usr/bin/clickhouse
2023.03.23 02:06:44.397450 [ 58345 ] {} <Fatal> BaseDaemon: 9. ./build_docker/../src/Processors/Executors/PushingPipelineExecutor.cpp:0: DB::PushingPipelineExecutor::push(DB::Chunk) @ 0x4b86ae0d in /usr/bin/clickhouse
2023.03.23 02:06:44.524142 [ 58345 ] {} <Fatal> BaseDaemon: 10. ./build_docker/../src/Processors/Executors/PushingPipelineExecutor.cpp:0: DB::PushingPipelineExecutor::push(DB::Block) @ 0x4b86b021 in /usr/bin/clickhouse
2023.03.23 02:06:45.171017 [ 58345 ] {} <Fatal> BaseDaemon: 11.1. inlined from ./build_docker/../src/Core/Block.h:27: ~Block
2023.03.23 02:06:45.171161 [ 58345 ] {} <Fatal> BaseDaemon: 11.2. inlined from ./build_docker/../src/Storages/Distributed/DistributedSink.cpp:400: operator()
2023.03.23 02:06:45.171472 [ 58345 ] {} <Fatal> BaseDaemon: 11.3. inlined from ./build_docker/../contrib/llvm-project/libcxx/include/__functional/invoke.h:394: decltype(std::declval<DB::DistributedSink::runWritingJob(DB::DistributedSink::JobReplica&, DB::Block const&, unsigned long)::$_0&>()()) std::__invoke[abi:v15000]<DB::DistributedSink::runWritingJob(DB::DistributedSink::JobReplica&, DB::Block const&, unsigned long)::$_0&>(DB::DistributedSink::runWritingJob(DB::DistributedSink::JobReplica&, DB::Block const&, unsigned long)::$_0&)
2023.03.23 02:06:45.171705 [ 58345 ] {} <Fatal> BaseDaemon: 11.4. inlined from ./build_docker/../contrib/llvm-project/libcxx/include/__functional/invoke.h:479: void std::__invoke_void_return_wrapper<void, true>::__call<DB::DistributedSink::runWritingJob(DB::DistributedSink::JobReplica&, DB::Block const&, unsigned long)::$_0&>(DB::DistributedSink::runWritingJob(DB::DistributedSink::JobReplica&, DB::Block const&, unsigned long)::$_0&)
2023.03.23 02:06:45.171887 [ 58345 ] {} <Fatal> BaseDaemon: 11.5. inlined from ./build_docker/../contrib/llvm-project/libcxx/include/__functional/function.h:235: std::__function::__default_alloc_func<DB::DistributedSink::runWritingJob(DB::DistributedSink::JobReplica&, DB::Block const&, unsigned long)::$_0, void ()>::operator()[abi:v15000]()
2023.03.23 02:06:45.171978 [ 58345 ] {} <Fatal> BaseDaemon: 11. ./build_docker/../contrib/llvm-project/libcxx/include/__functional/function.h:716: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<DB::DistributedSink::runWritingJob(DB::DistributedSink::JobReplica&, DB::Block const&, unsigned long)::$_0, void ()>>(std::__function::__policy_storage const*) @ 0x4a007f2c in /usr/bin/clickhouse
2023.03.23 02:06:45.368778 [ 58345 ] {} <Fatal> BaseDaemon: 12.1. inlined from ./build_docker/../base/base/wide_integer_impl.h:786: bool wide::integer<128ul, unsigned int>::_impl::operator_eq<wide::integer<128ul, unsigned int>>(wide::integer<128ul, unsigned int> const&, wide::integer<128ul, unsigned int> const&)
2023.03.23 02:06:45.368945 [ 58345 ] {} <Fatal> BaseDaemon: 12.2. inlined from ./build_docker/../base/base/wide_integer_impl.h:1453: bool wide::operator==<128ul, unsigned int, 128ul, unsigned int>(wide::integer<128ul, unsigned int> const&, wide::integer<128ul, unsigned int> const&)
2023.03.23 02:06:45.369058 [ 58345 ] {} <Fatal> BaseDaemon: 12.3. inlined from ./build_docker/../base/base/strong_typedef.h:42: StrongTypedef<wide::integer<128ul, unsigned int>, DB::UUIDTag>::operator==(StrongTypedef<wide::integer<128ul, unsigned int>, DB::UUIDTag> const&) const
2023.03.23 02:06:45.369138 [ 58345 ] {} <Fatal> BaseDaemon: 12.4. inlined from ./build_docker/../src/Common/OpenTelemetryTraceContext.h:63: DB::OpenTelemetry::Span::isTraceEnabled() const
2023.03.23 02:06:45.369207 [ 58345 ] {} <Fatal> BaseDaemon: 12. ./build_docker/../src/Common/ThreadPool.cpp:317: ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::worker(std::__list_iterator<ThreadFromGlobalPoolImpl<false>, void*>) @ 0x29687f25 in /usr/bin/clickhouse
2023.03.23 02:06:45.522467 [ 58345 ] {} <Fatal> BaseDaemon: 13. ./build_docker/../src/Common/ThreadPool.h:211: ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::function<void ()>, long, std::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'()::operator()() @ 0x296956c9 in /usr/bin/clickhouse
2023.03.23 02:06:45.764784 [ 58345 ] {} <Fatal> BaseDaemon: 14. ./build_docker/../contrib/llvm-project/libcxx/include/__functional/function.h:717: void std::__function::__policy_invoker<void ()>::__call_impl<std::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<false>::ThreadFromGlobalPoolImpl<void ThreadPoolImpl<ThreadFromGlobalPoolImpl<false>>::scheduleImpl<void>(std::function<void ()>, long, std::optional<unsigned long>, bool)::'lambda0'()>(void&&)::'lambda'(), void ()>>(std::__function::__policy_storage const*) @ 0x29695549 in /usr/bin/clickhouse
2023.03.23 02:06:45.939152 [ 58345 ] {} <Fatal> BaseDaemon: 15. ./build_docker/../contrib/llvm-project/libcxx/include/__functional/function.h:0: ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x2967e60d in /usr/bin/clickhouse
2023.03.23 02:06:46.161330 [ 58345 ] {} <Fatal> BaseDaemon: 16. ./build_docker/../src/Common/ThreadPool.cpp:0: void* std::__thread_proxy[abi:v15000]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, long, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x2968d523 in /usr/bin/clickhouse
2023.03.23 02:06:46.161470 [ 58345 ] {} <Fatal> BaseDaemon: 17. ? @ 0x7f8edc660609 in ?
2023.03.23 02:06:46.161549 [ 58345 ] {} <Fatal> BaseDaemon: 18. clone @ 0x7f8edc585133 in ?
2023.03.23 02:06:49.071204 [ 58345 ] {} <Fatal> BaseDaemon: Integrity check of the executable successfully passed (checksum: E837822AE67A0F0E9014C4338B6CD52C)
2023.03.23 02:07:02.160241 [ 656 ] {} <Fatal> Application: Child process was terminated by signal 6.
```


I have no idea what it means and why it's a logical error, but the probable reason is that some task was added to the pool after `pool->wait()` returned.