### PR TITLE
Disallow concurrent backup restore test - removed SYSTEM SYNC

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_disallow_concurrency.py
@@ -156,7 +156,6 @@ def test_concurrent_backups_on_same_node():
         },
     )
     nodes[0].query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
-    nodes[0].query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
 
 
 def test_concurrent_backups_on_different_nodes():


### PR DESCRIPTION
Changelog category (leave one):
* Not for changelog (changelog entry is not required)

Removed SYSTEM SYNC from test test_concurrent_backups_on_same_node.
We see test fails due to SYSTEM SYNC taking more time than ddl timeout. (can be resolved by increasing timeout). On further investigation this command is not needed for the test, thus removed it.