### PR TITLE
Set content-length for empty POST requests

### DIFF
--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -159,6 +159,8 @@ namespace detail
 
             if (out_stream_callback)
                 request.setChunkedTransferEncoding(true);
+            else if (method == Poco::Net::HTTPRequest::HTTP_POST)
+                request.setContentLength(0);    /// No callback - no body
 
             for (auto & [header, value] : http_header_entries)
                 request.set(header, value);

--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -63,11 +63,9 @@ HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse 
     }
     else if (getMethod() != HTTPRequest::HTTP_GET && getMethod() != HTTPRequest::HTTP_HEAD && getMethod() != HTTPRequest::HTTP_DELETE)
     {
-        /// That check for has_body may be false-negative in rare cases, but it's okay
-        bool has_body = in->hasPendingData();
         stream = std::move(in);
-        if (!startsWith(getContentType(), "multipart/form-data") && has_body)
-            LOG_WARNING(&Poco::Logger::get("HTTPServerRequest"), "Got an HTTP request with no content length "
+        if (!startsWith(getContentType(), "multipart/form-data"))
+            LOG_WARNING(LogFrequencyLimiter(&Poco::Logger::get("HTTPServerRequest"), 10), "Got an HTTP request with no content length "
                 "and no chunked/multipart encoding, it may be impossible to distinguish graceful EOF from abnormal connection loss");
     }
     else


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Replaces https://github.com/ClickHouse/ClickHouse/pull/47903
Fixes https://github.com/ClickHouse/ClickHouse/issues/47893
Fixes https://github.com/ClickHouse/ClickHouse/issues/47888