### PR TITLE
Fix test `02050_client_profile_events`

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1131,6 +1131,8 @@ void ClientBase::onProfileEvents(Block & block)
         {
             if (profile_events.watch.elapsedMilliseconds() >= profile_events.delay_ms)
             {
+                /// We need to restart the watch each time we flushed these events
+                profile_events.watch.restart();
                 initLogsOutputStream();
                 if (need_render_progress && tty_buf)
                     progress_indication.clearProgressOutput(*tty_buf);
@@ -1144,7 +1146,6 @@ void ClientBase::onProfileEvents(Block & block)
                 incrementProfileEventsBlock(profile_events.last_block, block);
             }
         }
-        profile_events.watch.restart();
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Test failure: https://s3.amazonaws.com/clickhouse-test-reports/0/04027ed920e76526560f5b0eb90a5b6f306671a7/stateless_tests__release_.html

It seems if we are sending packets frequently enough (time between two packets is less than delay for profile events), we  won't print anything.

CC @azat 
