### PR TITLE
Add unit test to assert arrow lib does not abort on fatal logs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -608,6 +608,7 @@ if (ENABLE_TESTS)
         dbms
         clickhouse_common_config
         clickhouse_common_zookeeper
+        ch_contrib::parquet
         string_utils)
 
     if (TARGET ch_contrib::simdjson)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -608,7 +608,6 @@ if (ENABLE_TESTS)
         dbms
         clickhouse_common_config
         clickhouse_common_zookeeper
-        ch_contrib::parquet
         string_utils)
 
     if (TARGET ch_contrib::simdjson)
@@ -623,6 +622,9 @@ if (ENABLE_TESTS)
         target_link_libraries(unit_tests_dbms PRIVATE ch_contrib::azure_sdk)
     endif()
 
+    if (TARGET ch_contrib::parquet)
+        target_link_libraries(unit_tests_dbms PRIVATE ch_contrib::parquet)
+    endif()
 
     add_check(unit_tests_dbms)
 endif ()

--- a/src/Processors/tests/gtest_assert_arrow_log_does_not_abort.cpp
+++ b/src/Processors/tests/gtest_assert_arrow_log_does_not_abort.cpp
@@ -1,3 +1,7 @@
+#include "config.h"
+
+#if USE_ARROW || USE_PARQUET
+
 #include <gtest/gtest.h>
 #include <arrow/chunked_array.h>
 #include <vector>
@@ -19,3 +23,5 @@ TEST(ArrowLog, FatalLogShouldThrow)
 }
 
 }
+
+#endif

--- a/src/Processors/tests/gtest_assert_arrow_log_does_not_abort.cpp
+++ b/src/Processors/tests/gtest_assert_arrow_log_does_not_abort.cpp
@@ -10,6 +10,9 @@ TEST(ChunkedArray, ChunkedArrayWithZeroChunksShouldNotAbort)
     std::vector<std::shared_ptr<::arrow::Array>> empty_chunks_vector;
 
     EXPECT_ANY_THROW(::arrow::ChunkedArray{empty_chunks_vector});
+}
 
-    ::arrow::util::ArrowLog(__FILE__, __LINE__, ::arrow::util::ArrowLogLevel::ARROW_FATAL);
+TEST(ArrowLog, FatalLogShouldThrow)
+{
+    EXPECT_ANY_THROW(::arrow::util::ArrowLog(__FILE__, __LINE__, ::arrow::util::ArrowLogLevel::ARROW_FATAL));
 }

--- a/src/Processors/tests/gtest_assert_arrow_log_does_not_abort.cpp
+++ b/src/Processors/tests/gtest_assert_arrow_log_does_not_abort.cpp
@@ -3,7 +3,8 @@
 #include <vector>
 #include <arrow/util/logging.h>
 
-using namespace DB;
+namespace DB
+{
 
 TEST(ChunkedArray, ChunkedArrayWithZeroChunksShouldNotAbort)
 {
@@ -15,4 +16,6 @@ TEST(ChunkedArray, ChunkedArrayWithZeroChunksShouldNotAbort)
 TEST(ArrowLog, FatalLogShouldThrow)
 {
     EXPECT_ANY_THROW(::arrow::util::ArrowLog(__FILE__, __LINE__, ::arrow::util::ArrowLogLevel::ARROW_FATAL));
+}
+
 }

--- a/src/Processors/tests/gtest_assert_arrow_log_does_not_abort.cpp
+++ b/src/Processors/tests/gtest_assert_arrow_log_does_not_abort.cpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+#include <arrow/chunked_array.h>
+#include <vector>
+#include <arrow/util/logging.h>
+
+using namespace DB;
+
+TEST(ChunkedArray, ChunkedArrayWithZeroChunksShouldNotAbort)
+{
+    std::vector<std::shared_ptr<::arrow::Array>> empty_chunks_vector;
+
+    EXPECT_ANY_THROW(::arrow::ChunkedArray{empty_chunks_vector});
+
+    ::arrow::util::ArrowLog(__FILE__, __LINE__, ::arrow::util::ArrowLogLevel::ARROW_FATAL);
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a unit test to assert arrow fatal logging does not abort. It covers the changes in https://github.com/ClickHouse/arrow/pull/16

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
