### PR TITLE
Fix "Field value too long" in catboostEvaluate()

### DIFF
--- a/docker/test/performance-comparison/perf.py
+++ b/docker/test/performance-comparison/perf.py
@@ -26,6 +26,7 @@ logging.basicConfig(
 total_start_seconds = time.perf_counter()
 stage_start_seconds = total_start_seconds
 
+
 # Thread executor that does not hides exception that happens during function
 # execution, and rethrows it after join()
 class SafeThread(Thread):
@@ -157,6 +158,7 @@ for e in subst_elems:
         raise Exception(f"No values given for substitution {{{name}}}")
 
     available_parameters[name] = values
+
 
 # Takes parallel lists of templates, substitutes them with all combos of
 # parameters. The set of parameters is determined based on the first list.

--- a/docker/test/performance-comparison/report.py
+++ b/docker/test/performance-comparison/report.py
@@ -670,7 +670,6 @@ if args.report == "main":
     )
 
 elif args.report == "all-queries":
-
     print((header_template.format()))
 
     add_tested_commits()

--- a/src/Bridge/IBridge.cpp
+++ b/src/Bridge/IBridge.cpp
@@ -4,20 +4,21 @@
 #include <Poco/Net/NetException.h>
 #include <Poco/Util/HelpFormatter.h>
 
-#include <base/range.h>
-
-#include <Common/StringUtils/StringUtils.h>
 #include <Common/SensitiveDataMasker.h>
-#include "config.h"
+#include <Common/StringUtils/StringUtils.h>
 #include <Common/logger_useful.h>
-#include <base/errnoToString.h>
-#include <IO/ReadHelpers.h>
 #include <Formats/registerFormats.h>
-#include <Server/HTTP/HTTPServer.h>
+#include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/WriteHelpers.h>
+#include <Server/HTTP/HTTPServer.h>
+#include <base/errnoToString.h>
+#include <base/range.h>
+
 #include <sys/time.h>
 #include <sys/resource.h>
+
+#include "config.h"
 
 #if USE_ODBC
 #    include <Poco/Data/ODBC/Connector.h>
@@ -89,13 +90,16 @@ void IBridge::defineOptions(Poco::Util::OptionSet & options)
         Poco::Util::Option("listen-host", "", "hostname or address to listen, default 127.0.0.1").argument("listen-host").binding("listen-host"));
 
     options.addOption(
-        Poco::Util::Option("http-timeout", "", "http timeout for socket, default 1800").argument("http-timeout").binding("http-timeout"));
+        Poco::Util::Option("http-timeout", "", "http timeout for socket, default 180").argument("http-timeout").binding("http-timeout"));
 
     options.addOption(
         Poco::Util::Option("max-server-connections", "", "max connections to server, default 1024").argument("max-server-connections").binding("max-server-connections"));
 
     options.addOption(
         Poco::Util::Option("keep-alive-timeout", "", "keepalive timeout, default 10").argument("keep-alive-timeout").binding("keep-alive-timeout"));
+
+    options.addOption(
+        Poco::Util::Option("http-max-field-value-size", "", "max http field value size, default 1048576").argument("http-max-field-value-size").binding("http-max-field-value-size"));
 
     options.addOption(
         Poco::Util::Option("log-level", "", "sets log level, default info") .argument("log-level").binding("logger.level"));
@@ -117,7 +121,7 @@ void IBridge::defineOptions(Poco::Util::OptionSet & options)
     options.addOption(
         Poco::Util::Option("help", "", "produce this help message").binding("help").callback(Poco::Util::OptionCallback<Me>(this, &Me::handleHelp)));
 
-    ServerApplication::defineOptions(options); // NOLINT Don't need complex BaseDaemon's .xml config
+    ServerApplication::defineOptions(options); // Don't need complex BaseDaemon's .xml config
 }
 
 
@@ -165,6 +169,7 @@ void IBridge::initialize(Application & self)
     http_timeout = config().getUInt64("http-timeout", DEFAULT_HTTP_READ_BUFFER_TIMEOUT);
     max_server_connections = config().getUInt("max-server-connections", 1024);
     keep_alive_timeout = config().getUInt64("keep-alive-timeout", 10);
+    http_max_field_value_size = config().getUInt64("http-max-field-value-size", 1048576);
 
     struct rlimit limit;
     const UInt64 gb = 1024 * 1024 * 1024;
@@ -225,6 +230,10 @@ int IBridge::main(const std::vector<std::string> & /*args*/)
     auto shared_context = Context::createShared();
     auto context = Context::createGlobal(shared_context.get());
     context->makeGlobalContext();
+
+    auto settings = context->getSettings();
+    settings.set("http_max_field_value_size", http_max_field_value_size);
+    context->setSettings(settings);
 
     if (config().has("query_masking_rules"))
         SensitiveDataMasker::setInstance(std::make_unique<SensitiveDataMasker>(config(), "query_masking_rules"));

--- a/src/Bridge/IBridge.cpp
+++ b/src/Bridge/IBridge.cpp
@@ -121,7 +121,7 @@ void IBridge::defineOptions(Poco::Util::OptionSet & options)
     options.addOption(
         Poco::Util::Option("help", "", "produce this help message").binding("help").callback(Poco::Util::OptionCallback<Me>(this, &Me::handleHelp)));
 
-    ServerApplication::defineOptions(options); // Don't need complex BaseDaemon's .xml config
+    ServerApplication::defineOptions(options); // NOLINT Don't need complex BaseDaemon's .xml config
 }
 
 

--- a/src/Bridge/IBridge.h
+++ b/src/Bridge/IBridge.h
@@ -45,6 +45,7 @@ private:
     std::string log_level;
     unsigned max_server_connections;
     size_t http_timeout;
+    size_t http_max_field_value_size;
 
     Poco::Logger * log;
 };

--- a/src/BridgeHelper/IBridgeHelper.cpp
+++ b/src/BridgeHelper/IBridgeHelper.cpp
@@ -67,6 +67,8 @@ std::unique_ptr<ShellCommand> IBridgeHelper::startBridgeCommand()
     cmd_args.push_back(config.getString(configPrefix() + ".listen_host", DEFAULT_HOST));
     cmd_args.push_back("--http-timeout");
     cmd_args.push_back(std::to_string(getHTTPTimeout().totalMicroseconds()));
+    cmd_args.push_back("--http-max-field-value-size");
+    cmd_args.push_back("99999999999999999"); // something "big" to accept large datasets (issue 47616)
     if (config.has("logger." + configPrefix() + "_log"))
     {
         cmd_args.push_back("--log-path");

--- a/tests/ci/clickhouse_helper.py
+++ b/tests/ci/clickhouse_helper.py
@@ -141,7 +141,6 @@ def prepare_tests_results_for_clickhouse(
     report_url: str,
     check_name: str,
 ) -> List[dict]:
-
     pull_request_url = "https://github.com/ClickHouse/ClickHouse/commits/master"
     base_ref = "master"
     head_ref = "master"

--- a/tests/ci/docker_images_check.py
+++ b/tests/ci/docker_images_check.py
@@ -96,7 +96,6 @@ def get_images_dict(repo_path: str, image_file_path: str) -> ImagesDict:
 def get_changed_docker_images(
     pr_info: PRInfo, images_dict: ImagesDict
 ) -> Set[DockerImage]:
-
     if not images_dict:
         return set()
 

--- a/tests/ci/get_previous_release_tag.py
+++ b/tests/ci/get_previous_release_tag.py
@@ -51,7 +51,6 @@ def find_previous_release(
 
     for release in releases:
         if release.version < server_version:
-
             # Check if the artifact exists on GitHub.
             # It can be not true for a short period of time
             # after creating a tag for a new release before uploading the packages.

--- a/tests/ci/report.py
+++ b/tests/ci/report.py
@@ -473,7 +473,7 @@ def create_build_html_report(
     commit_url: str,
 ) -> str:
     rows = ""
-    for (build_result, build_log_url, artifact_urls) in zip(
+    for build_result, build_log_url, artifact_urls in zip(
         build_results, build_logs_urls, artifact_urls_list
     ):
         row = "<tr>"

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -63,6 +63,7 @@ DEFAULT_ENV_NAME = ".env"
 
 SANITIZER_SIGN = "=================="
 
+
 # to create docker-compose env file
 def _create_env_file(path, variables):
     logging.debug(f"Env {variables} stored in {path}")
@@ -1454,7 +1455,6 @@ class ClickHouseCluster:
         config_root_name="clickhouse",
         extra_configs=[],
     ) -> "ClickHouseInstance":
-
         """Add an instance to the cluster.
 
         name - the name of the instance directory and the value of the 'instance' macro in ClickHouse.
@@ -3089,7 +3089,6 @@ class ClickHouseInstance:
         config_root_name="clickhouse",
         extra_configs=[],
     ):
-
         self.name = name
         self.base_cmd = cluster.base_cmd
         self.docker_id = cluster.get_instance_docker_id(self.name)

--- a/tests/integration/helpers/network.py
+++ b/tests/integration/helpers/network.py
@@ -216,7 +216,6 @@ class _NetworkManager:
         container_exit_timeout=60,
         docker_api_version=os.environ.get("DOCKER_API_VERSION"),
     ):
-
         self.container_expire_timeout = container_expire_timeout
         self.container_exit_timeout = container_exit_timeout
 
@@ -232,7 +231,6 @@ class _NetworkManager:
 
     def _ensure_container(self):
         if self._container is None or self._container_expire_time <= time.time():
-
             for i in range(5):
                 if self._container is not None:
                     try:

--- a/tests/integration/helpers/pytest_xdist_logging_to_separate_files.py
+++ b/tests/integration/helpers/pytest_xdist_logging_to_separate_files.py
@@ -1,6 +1,7 @@
 import logging
 import os.path
 
+
 # Makes the parallel workers of pytest-xdist to log to separate files.
 # Without this function all workers will log to the same log file
 # and mix everything together making it much more difficult for troubleshooting.

--- a/tests/integration/test_backward_compatibility/test_detach_part_wrong_partition_id.py
+++ b/tests/integration/test_backward_compatibility/test_detach_part_wrong_partition_id.py
@@ -24,7 +24,6 @@ def start_cluster():
 
 
 def test_detach_part_wrong_partition_id(start_cluster):
-
     # Here we create table with partition by UUID.
     node_21_6.query(
         "create table tab (id UUID, value UInt32) engine = MergeTree PARTITION BY (id) order by tuple()"

--- a/tests/integration/test_catboost_evaluate/test.py
+++ b/tests/integration/test_catboost_evaluate/test.py
@@ -279,7 +279,7 @@ def testAmazonModelManyRows(ch_cluster):
     )
 
     result = instance.query(
-        "insert into amazon select number % 256, number, number, number, number, number, number, number, number, number from numbers(7500)"
+        "insert into amazon select number % 256, number, number, number, number, number, number, number, number, number from numbers(750000)"
     )
 
     # First compute prediction, then as a very crude way to fingerprint and compare the result: sum and floor

--- a/tests/integration/test_catboost_evaluate/test.py
+++ b/tests/integration/test_catboost_evaluate/test.py
@@ -288,7 +288,7 @@ def testAmazonModelManyRows(ch_cluster):
         "SELECT floor(sum(catboostEvaluate('/etc/clickhouse-server/model/amazon_model.bin', RESOURCE, MGR_ID, ROLE_ROLLUP_1, ROLE_ROLLUP_2, ROLE_DEPTNAME, ROLE_TITLE, ROLE_FAMILY_DESC, ROLE_FAMILY, ROLE_CODE))) FROM amazon"
     )
 
-    expected = "5834\n"
+    expected = "583092\n"
     assert result == expected
 
     result = instance.query("drop table if exists amazon")

--- a/tests/integration/test_cluster_copier/test_three_nodes.py
+++ b/tests/integration/test_cluster_copier/test_three_nodes.py
@@ -19,7 +19,6 @@ cluster = ClickHouseCluster(__file__)
 def started_cluster():
     global cluster
     try:
-
         for name in ["first", "second", "third"]:
             cluster.add_instance(
                 name,

--- a/tests/integration/test_cluster_copier/test_two_nodes.py
+++ b/tests/integration/test_cluster_copier/test_two_nodes.py
@@ -19,7 +19,6 @@ cluster = ClickHouseCluster(__file__)
 def started_cluster():
     global cluster
     try:
-
         for name in ["first_of_two", "second_of_two"]:
             instance = cluster.add_instance(
                 name,

--- a/tests/integration/test_composable_protocols/test.py
+++ b/tests/integration/test_composable_protocols/test.py
@@ -63,7 +63,6 @@ def netcat(hostname, port, content):
 
 
 def test_connections():
-
     client = Client(server.ip_address, 9000, command=cluster.client_bin_path)
     assert client.query("SELECT 1") == "1\n"
 

--- a/tests/integration/test_create_query_constraints/test.py
+++ b/tests/integration/test_create_query_constraints/test.py
@@ -25,7 +25,6 @@ def start_cluster():
 
 
 def test_create_query_const_constraints():
-
     instance.query("CREATE USER u_const SETTINGS max_threads = 1 CONST")
     instance.query("GRANT ALL ON *.* TO u_const")
 
@@ -57,7 +56,6 @@ def test_create_query_const_constraints():
 
 
 def test_create_query_minmax_constraints():
-
     instance.query("CREATE USER u_minmax SETTINGS max_threads = 4 MIN 2 MAX 6")
     instance.query("GRANT ALL ON *.* TO u_minmax")
 

--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/common.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/common.py
@@ -348,7 +348,6 @@ class RangedLayoutTester(BaseLayoutTester):
         self.layouts = LAYOUTS_RANGED
 
     def execute(self, layout_name, node):
-
         if layout_name not in self.layout_to_dictionary:
             raise RuntimeError("Source doesn't support layout: {}".format(layout_name))
 

--- a/tests/integration/test_disks_app_func/test.py
+++ b/tests/integration/test_disks_app_func/test.py
@@ -7,7 +7,6 @@ import pytest
 def started_cluster():
     global cluster
     try:
-
         cluster = ClickHouseCluster(__file__)
         cluster.add_instance(
             "disks_app_test", main_configs=["config.xml"], with_minio=True

--- a/tests/integration/test_distributed_ddl_parallel/test.py
+++ b/tests/integration/test_distributed_ddl_parallel/test.py
@@ -10,6 +10,7 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 
+
 # By default the exceptions that was throwed in threads will be ignored
 # (they will not mark the test as failed, only printed to stderr).
 #

--- a/tests/integration/test_fetch_memory_usage/test.py
+++ b/tests/integration/test_fetch_memory_usage/test.py
@@ -18,7 +18,6 @@ def started_cluster():
 
 
 def test_huge_column(started_cluster):
-
     if (
         node.is_built_with_thread_sanitizer()
         or node.is_built_with_memory_sanitizer()

--- a/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/scripts/stress_test.py
+++ b/tests/integration/test_host_regexp_multiple_ptr_records_concurrent/scripts/stress_test.py
@@ -13,7 +13,6 @@ number_of_iterations = 100
 
 
 def perform_request():
-
     buffer = BytesIO()
     crl = pycurl.Curl()
     crl.setopt(pycurl.INTERFACE, client_ip)

--- a/tests/integration/test_jbod_balancer/test.py
+++ b/tests/integration/test_jbod_balancer/test.py
@@ -45,7 +45,6 @@ def start_cluster():
 
 
 def check_balance(node, table):
-
     partitions = node.query(
         """
         WITH

--- a/tests/integration/test_keeper_and_access_storage/test.py
+++ b/tests/integration/test_keeper_and_access_storage/test.py
@@ -10,6 +10,7 @@ node1 = cluster.add_instance(
     "node1", main_configs=["configs/keeper.xml"], stay_alive=True
 )
 
+
 # test that server is able to start
 @pytest.fixture(scope="module")
 def started_cluster():

--- a/tests/integration/test_keeper_back_to_back/test.py
+++ b/tests/integration/test_keeper_back_to_back/test.py
@@ -546,7 +546,6 @@ def test_random_requests(started_cluster):
 
 
 def test_end_of_session(started_cluster):
-
     fake_zk1 = None
     fake_zk2 = None
     genuine_zk1 = None
@@ -685,6 +684,7 @@ def test_concurrent_watches(started_cluster):
             nonlocal watches_created
             nonlocal all_paths_created
             fake_zk.ensure_path(global_path + "/" + str(i))
+
             # new function each time
             def dumb_watch(event):
                 nonlocal dumb_watch_triggered_counter

--- a/tests/integration/test_keeper_persistent_log/test.py
+++ b/tests/integration/test_keeper_persistent_log/test.py
@@ -163,7 +163,6 @@ def test_state_duplicate_restart(started_cluster):
 
 # http://zookeeper-user.578899.n2.nabble.com/Why-are-ephemeral-nodes-written-to-disk-tp7583403p7583418.html
 def test_ephemeral_after_restart(started_cluster):
-
     try:
         node_zk = None
         node_zk2 = None

--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -114,7 +114,6 @@ def start_clickhouse():
 
 
 def copy_zookeeper_data(make_zk_snapshots):
-
     if make_zk_snapshots:  # force zookeeper to create snapshot
         generate_zk_snapshot()
     else:

--- a/tests/integration/test_merge_tree_load_parts/test.py
+++ b/tests/integration/test_merge_tree_load_parts/test.py
@@ -148,17 +148,17 @@ def test_merge_tree_load_parts_corrupted(started_cluster):
     node1.query("SYSTEM WAIT LOADING PARTS mt_load_parts_2")
 
     def check_parts_loading(node, partition, loaded, failed, skipped):
-        for (min_block, max_block) in loaded:
+        for min_block, max_block in loaded:
             part_name = f"{partition}_{min_block}_{max_block}"
             assert node.contains_in_log(f"Loading Active part {part_name}")
             assert node.contains_in_log(f"Finished loading Active part {part_name}")
 
-        for (min_block, max_block) in failed:
+        for min_block, max_block in failed:
             part_name = f"{partition}_{min_block}_{max_block}"
             assert node.contains_in_log(f"Loading Active part {part_name}")
             assert not node.contains_in_log(f"Finished loading Active part {part_name}")
 
-        for (min_block, max_block) in skipped:
+        for min_block, max_block in skipped:
             part_name = f"{partition}_{min_block}_{max_block}"
             assert not node.contains_in_log(f"Loading Active part {part_name}")
             assert not node.contains_in_log(f"Finished loading Active part {part_name}")

--- a/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
+++ b/tests/integration/test_merge_tree_s3_failover/s3_endpoint/endpoint.py
@@ -42,7 +42,6 @@ def delete(_bucket):
 
 @route("/<_bucket>/<_path:path>", ["GET", "POST", "PUT", "DELETE"])
 def server(_bucket, _path):
-
     # It's delete query for failed part
     if _path.endswith("delete"):
         response.set_header("Location", "http://minio1:9001/" + _bucket + "/" + _path)

--- a/tests/integration/test_merge_tree_settings_constraints/test.py
+++ b/tests/integration/test_merge_tree_settings_constraints/test.py
@@ -20,7 +20,6 @@ def start_cluster():
 
 
 def test_merge_tree_settings_constraints():
-
     assert "Setting storage_policy should not be changed" in instance.query_and_get_error(
         f"CREATE TABLE wrong_table (number Int64) engine = MergeTree() ORDER BY number SETTINGS storage_policy = 'secret_policy'"
     )

--- a/tests/integration/test_old_parts_finally_removed/test.py
+++ b/tests/integration/test_old_parts_finally_removed/test.py
@@ -63,7 +63,6 @@ def test_part_finally_removed(started_cluster):
     )
 
     for i in range(60):
-
         if (
             node1.query(
                 "SELECT count() from system.parts WHERE table = 'drop_outdated_part'"

--- a/tests/integration/test_partition/test.py
+++ b/tests/integration/test_partition/test.py
@@ -528,7 +528,9 @@ def test_make_clone_in_detached(started_cluster):
         ["cp", "-r", path + "all_0_0_0", path + "detached/broken_all_0_0_0"]
     )
     assert_eq_with_retry(instance, "select * from clone_in_detached", "\n")
-    assert ["broken_all_0_0_0",] == sorted(
+    assert [
+        "broken_all_0_0_0",
+    ] == sorted(
         instance.exec_in_container(["ls", path + "detached/"]).strip().split("\n")
     )
 

--- a/tests/integration/test_password_constraints/test.py
+++ b/tests/integration/test_password_constraints/test.py
@@ -17,7 +17,6 @@ def start_cluster():
 
 
 def test_complexity_rules(start_cluster):
-
     error_message = "DB::Exception: Invalid password. The password should: be at least 12 characters long, contain at least 1 numeric character, contain at least 1 lowercase character, contain at least 1 uppercase character, contain at least 1 special character"
     assert error_message in node.query_and_get_error(
         "CREATE USER u_1 IDENTIFIED WITH plaintext_password BY ''"

--- a/tests/integration/test_read_only_table/test.py
+++ b/tests/integration/test_read_only_table/test.py
@@ -49,7 +49,6 @@ def start_cluster():
 
 
 def test_restart_zookeeper(start_cluster):
-
     for table_id in range(NUM_TABLES):
         node1.query(
             f"INSERT INTO test_table_{table_id} VALUES (1), (2), (3), (4), (5);"

--- a/tests/integration/test_reload_auxiliary_zookeepers/test.py
+++ b/tests/integration/test_reload_auxiliary_zookeepers/test.py
@@ -20,7 +20,6 @@ def start_cluster():
 
 
 def test_reload_auxiliary_zookeepers(start_cluster):
-
     node.query(
         "CREATE TABLE simple (date Date, id UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/simple', 'node') ORDER BY tuple() PARTITION BY date;"
     )

--- a/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/s3_endpoint/endpoint.py
+++ b/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/s3_endpoint/endpoint.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from bottle import request, route, run, response
 
+
 # Handle for MultipleObjectsDelete.
 @route("/<_bucket>", ["POST"])
 def delete(_bucket):

--- a/tests/integration/test_s3_with_proxy/test.py
+++ b/tests/integration/test_s3_with_proxy/test.py
@@ -5,6 +5,7 @@ import time
 import pytest
 from helpers.cluster import ClickHouseCluster
 
+
 # Runs simple proxy resolver in python env container.
 def run_resolver(cluster):
     container_id = cluster.get_container_id("resolver")

--- a/tests/integration/test_ssl_cert_authentication/test.py
+++ b/tests/integration/test_ssl_cert_authentication/test.py
@@ -87,7 +87,6 @@ config = """<clickhouse>
 
 
 def execute_query_native(node, query, user, cert_name):
-
     config_path = f"{SCRIPT_DIR}/configs/client.xml"
 
     formatted = config.format(

--- a/tests/integration/test_storage_kafka/kafka_pb2.py
+++ b/tests/integration/test_storage_kafka/kafka_pb2.py
@@ -21,7 +21,6 @@ _builder.BuildTopDescriptorsAndMessages(
     DESCRIPTOR, "clickhouse_path.format_schemas.kafka_pb2", globals()
 )
 if _descriptor._USE_C_DESCRIPTORS == False:
-
     DESCRIPTOR._options = None
     _KEYVALUEPAIR._serialized_start = 46
     _KEYVALUEPAIR._serialized_end = 88

--- a/tests/integration/test_storage_kafka/message_with_repeated_pb2.py
+++ b/tests/integration/test_storage_kafka/message_with_repeated_pb2.py
@@ -21,7 +21,6 @@ _builder.BuildTopDescriptorsAndMessages(
     DESCRIPTOR, "clickhouse_path.format_schemas.message_with_repeated_pb2", globals()
 )
 if _descriptor._USE_C_DESCRIPTORS == False:
-
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b"H\001"
     _MESSAGE._serialized_start = 62

--- a/tests/integration/test_storage_kafka/social_pb2.py
+++ b/tests/integration/test_storage_kafka/social_pb2.py
@@ -21,7 +21,6 @@ _builder.BuildTopDescriptorsAndMessages(
     DESCRIPTOR, "clickhouse_path.format_schemas.social_pb2", globals()
 )
 if _descriptor._USE_C_DESCRIPTORS == False:
-
     DESCRIPTOR._options = None
     _USER._serialized_start = 47
     _USER._serialized_end = 90

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -121,7 +121,7 @@ def kafka_create_topic(
 
 def kafka_delete_topic(admin_client, topic, max_retries=50):
     result = admin_client.delete_topics([topic])
-    for (topic, e) in result.topic_error_codes:
+    for topic, e in result.topic_error_codes:
         if e == 0:
             logging.debug(f"Topic {topic} deleted")
         else:
@@ -917,9 +917,7 @@ def describe_consumer_group(kafka_cluster, name):
         member_info["client_id"] = client_id
         member_info["client_host"] = client_host
         member_topics_assignment = []
-        for (topic, partitions) in MemberAssignment.decode(
-            member_assignment
-        ).assignment:
+        for topic, partitions in MemberAssignment.decode(member_assignment).assignment:
             member_topics_assignment.append({"topic": topic, "partitions": partitions})
         member_info["assignment"] = member_topics_assignment
         res.append(member_info)
@@ -1537,7 +1535,6 @@ def test_kafka_protobuf_no_delimiter(kafka_cluster):
 
 
 def test_kafka_materialized_view(kafka_cluster):
-
     instance.query(
         """
         DROP TABLE IF EXISTS test.view;
@@ -2315,7 +2312,6 @@ def test_kafka_virtual_columns2(kafka_cluster):
 
 
 def test_kafka_produce_key_timestamp(kafka_cluster):
-
     admin_client = KafkaAdminClient(
         bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
     )
@@ -2444,7 +2440,6 @@ def test_kafka_insert_avro(kafka_cluster):
 
 
 def test_kafka_produce_consume_avro(kafka_cluster):
-
     admin_client = KafkaAdminClient(
         bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
     )
@@ -4031,7 +4026,6 @@ def test_kafka_predefined_configuration(kafka_cluster):
 
 # https://github.com/ClickHouse/ClickHouse/issues/26643
 def test_issue26643(kafka_cluster):
-
     # for backporting:
     # admin_client = KafkaAdminClient(bootstrap_servers="localhost:9092")
     admin_client = KafkaAdminClient(
@@ -4313,7 +4307,6 @@ def test_row_based_formats(kafka_cluster):
         "RowBinaryWithNamesAndTypes",
         "MsgPack",
     ]:
-
         print(format_name)
 
         kafka_create_topic(admin_client, format_name)
@@ -4438,7 +4431,6 @@ def test_block_based_formats_2(kafka_cluster):
         "ORC",
         "JSONCompactColumns",
     ]:
-
         kafka_create_topic(admin_client, format_name)
 
         instance.query(

--- a/tests/integration/test_storage_nats/nats_pb2.py
+++ b/tests/integration/test_storage_nats/nats_pb2.py
@@ -31,7 +31,6 @@ ProtoKeyValue = _reflection.GeneratedProtocolMessageType(
 _sym_db.RegisterMessage(ProtoKeyValue)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
-
     DESCRIPTOR._options = None
     _PROTOKEYVALUE._serialized_start = 45
     _PROTOKEYVALUE._serialized_end = 88

--- a/tests/integration/test_storage_postgresql_replica/test.py
+++ b/tests/integration/test_storage_postgresql_replica/test.py
@@ -706,7 +706,6 @@ def test_abrupt_connection_loss_while_heavy_replication(started_cluster):
 
 
 def test_abrupt_server_restart_while_heavy_replication(started_cluster):
-
     # FIXME (kssenii) temporary disabled
     if instance.is_built_with_sanitizer():
         pytest.skip("Temporary disabled (FIXME)")

--- a/tests/integration/test_storage_rabbitmq/rabbitmq_pb2.py
+++ b/tests/integration/test_storage_rabbitmq/rabbitmq_pb2.py
@@ -21,7 +21,6 @@ _builder.BuildTopDescriptorsAndMessages(
     DESCRIPTOR, "clickhouse_path.format_schemas.rabbitmq_pb2", globals()
 )
 if _descriptor._USE_C_DESCRIPTORS == False:
-
     DESCRIPTOR._options = None
     _KEYVALUEPROTO._serialized_start = 49
     _KEYVALUEPROTO._serialized_end = 92

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2864,7 +2864,6 @@ def test_rabbitmq_predefined_configuration(rabbitmq_cluster):
 
 
 def test_rabbitmq_msgpack(rabbitmq_cluster):
-
     instance.query(
         """
         drop table if exists rabbit_in;
@@ -2908,7 +2907,6 @@ def test_rabbitmq_msgpack(rabbitmq_cluster):
 
 
 def test_rabbitmq_address(rabbitmq_cluster):
-
     instance2.query(
         """
         drop table if exists rabbit_in;
@@ -3243,7 +3241,6 @@ def test_block_based_formats_2(rabbitmq_cluster):
         "ORC",
         "JSONCompactColumns",
     ]:
-
         print(format_name)
 
         instance.query(

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -18,6 +18,7 @@ MINIO_INTERNAL_PORT = 9001
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
+
 # Creates S3 bucket for tests and allows anonymous read-write access to it.
 def prepare_s3_bucket(started_cluster):
     # Allows read-write access for bucket without authorization.

--- a/tests/integration/test_storage_s3/test_invalid_env_credentials.py
+++ b/tests/integration/test_storage_s3/test_invalid_env_credentials.py
@@ -11,6 +11,7 @@ MINIO_INTERNAL_PORT = 9001
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
+
 # Creates S3 bucket for tests and allows anonymous read-write access to it.
 def prepare_s3_bucket(started_cluster):
     # Allows read-write access for bucket without authorization.

--- a/tests/integration/test_system_merges/test.py
+++ b/tests/integration/test_system_merges/test.py
@@ -171,7 +171,6 @@ def test_mutation_simple(started_cluster, replicated):
     starting_block = 0 if replicated else 1
 
     try:
-
         for node in nodes:
             node.query(
                 f"create table {name} (a Int64) engine={engine} order by tuple()"

--- a/tests/integration/test_ttl_move/test.py
+++ b/tests/integration/test_ttl_move/test.py
@@ -1863,7 +1863,7 @@ def test_ttl_move_if_exists(started_cluster, name, dest_type):
                 )
             )
 
-        for (node, policy) in zip(
+        for node, policy in zip(
             [node1, node2], ["only_jbod_1", "small_jbod_with_external"]
         ):
             node.query(

--- a/tests/integration/test_zero_copy_fetch/test.py
+++ b/tests/integration/test_zero_copy_fetch/test.py
@@ -16,7 +16,6 @@ cluster = ClickHouseCluster(__file__)
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
-
         cluster.add_instance(
             "node1",
             main_configs=["configs/storage_conf.xml"],

--- a/utils/changelog-simple/format-changelog.py
+++ b/utils/changelog-simple/format-changelog.py
@@ -20,6 +20,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
+
 # This function mirrors the PR description checks in ClickhousePullRequestTrigger.
 # Returns False if the PR should not be mentioned changelog.
 def parse_one_pull_request(item):

--- a/utils/keeper-overload/keeper-overload.py
+++ b/utils/keeper-overload/keeper-overload.py
@@ -166,7 +166,7 @@ def main(args):
     keeper_bench_path = args.keeper_bench_path
 
     keepers = []
-    for (port, server_id) in zip(PORTS, SERVER_IDS):
+    for port, server_id in zip(PORTS, SERVER_IDS):
         keepers.append(
             Keeper(
                 keeper_binary_path, server_id, port, workdir, args.with_thread_fuzzer


### PR DESCRIPTION
Fixes #47616

`catboostEvaluate()` uses the library-bridge to evaluate catboost ML models over a set of features (usually rows). Basically, the ClickHouse server sends the input via HTTP to the library-bridge which calculates the result and sends it back via HTTP.

Some users reported "Field value too long" errors when calling `catboostEvaluate()` on big datasets. The exception was generated on the library-bridge side when parsing the features sent by the server. Parsing is based on Poco classes and respects setting "http_max_field_value_size" which has a too small default value. For the server, this makes sense to limit memory consumption + the attack surface but for the library-bridge not so much.

The obvious fix is to raise the limit for the library-bridge. However, library-bridge doesn't read the server's XML/YAML process, it can only be configured via some command line arguments. So, what this PR does is to
- add a new cmd line argument + some logic which writes the passed value into the internal settings (wrapped by an internal context)
- pass a big enough value when the server starts the library-bridge

In case the default value is still too small, it's possible to increment it even further by starting the library-bridge manually and providing `--http-max-field-value-size=999..9`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix "Field value too long" error in catboostEvaluate() over big datasets