### PR TITLE
Fix #36971: Watchdog: exit with non-zero code if child process exits

### DIFF
--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -1125,15 +1125,20 @@ void BaseDaemon::setupWatchdog()
             logger().information("Child process no longer exists.");
             _exit(WEXITSTATUS(status));
         }
-        else if (WIFEXITED(status))
+
+        if (WIFEXITED(status))
         {
             logger().information(fmt::format("Child process exited normally with code {}.", WEXITSTATUS(status)));
             _exit(WEXITSTATUS(status));
         }
 
+        int exit_code;
+
         if (WIFSIGNALED(status))
         {
             int sig = WTERMSIG(status);
+
+            exit_code = 128 + sig;
 
             if (sig == SIGKILL)
             {
@@ -1146,12 +1151,14 @@ void BaseDaemon::setupWatchdog()
                 logger().fatal(fmt::format("Child process was terminated by signal {}.", sig));
 
                 if (sig == SIGINT || sig == SIGTERM || sig == SIGQUIT)
-                    _exit(128 + sig);
+                    _exit(exit_code);
             }
         }
         else
         {
+            // According to POSIX, this should never happen.
             logger().fatal("Child process was not exited normally by unknown reason.");
+            exit_code = 42;
         }
 
         if (restart)
@@ -1161,7 +1168,7 @@ void BaseDaemon::setupWatchdog()
                 memcpy(argv0, original_process_name.c_str(), original_process_name.size());
         }
         else
-            _exit(WEXITSTATUS(status));
+            _exit(exit_code);
     }
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Exit with none-zero exit code if ClickHouse server was killed by SIGKILL.
Fixes #36971.

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
