### PR TITLE
Stabilize tests for new function parseDateTimeInJodaSyntax

### DIFF
--- a/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.reference
+++ b/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.reference
@@ -3,19 +3,17 @@
 select parseDateTimeInJodaSyntax(' ', ' ', 'UTC') = toDateTime('1970-01-01', 'UTC');
 1
 -- era
-select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
-1
-select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
 1
 select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy') = toDateTime('1999-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy') = toDateTime('2000-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy', 'UTC') = toDateTime('2000-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('AD 1999 2000', 'G yyyy YYYY') = toDateTime('2000-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999 2000', 'G yyyy YYYY', 'UTC') = toDateTime('2000-01-01', 'UTC');
 1
 select parseDateTimeInJodaSyntax('AD 1999', 'G Y'); -- { serverError CANNOT_PARSE_DATETIME }
 select parseDateTimeInJodaSyntax('AD 1999', 'G YY'); -- { serverError CANNOT_PARSE_DATETIME }

--- a/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.reference
+++ b/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.reference
@@ -9,7 +9,7 @@ select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY', 'UTC') = toDateTime('1999-
 1
 select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy', 'UTC') = toDateTime('1999-01-01', 'UTC');
 1
 select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy', 'UTC') = toDateTime('2000-01-01', 'UTC');
 1

--- a/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.reference
+++ b/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.reference
@@ -3,19 +3,19 @@
 select parseDateTimeInJodaSyntax(' ', ' ', 'UTC') = toDateTime('1970-01-01', 'UTC');
 1
 -- era
-select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01');
+select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY') = toDateTime('1999-01-01');
+select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY') = toDateTime('1999-01-01');
+select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01');
+select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy') = toDateTime('1999-01-01');
+select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy') = toDateTime('1999-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy') = toDateTime('2000-01-01');
+select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy') = toDateTime('2000-01-01', 'UTC');
 1
-select parseDateTimeInJodaSyntax('AD 1999 2000', 'G yyyy YYYY') = toDateTime('2000-01-01');
+select parseDateTimeInJodaSyntax('AD 1999 2000', 'G yyyy YYYY') = toDateTime('2000-01-01', 'UTC');
 1
 select parseDateTimeInJodaSyntax('AD 1999', 'G Y'); -- { serverError CANNOT_PARSE_DATETIME }
 select parseDateTimeInJodaSyntax('AD 1999', 'G YY'); -- { serverError CANNOT_PARSE_DATETIME }

--- a/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.sql
+++ b/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.sql
@@ -3,13 +3,12 @@
 select parseDateTimeInJodaSyntax(' ', ' ', 'UTC') = toDateTime('1970-01-01', 'UTC');
 
 -- era
-select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
-select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
-select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
-select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
 select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy') = toDateTime('1999-01-01', 'UTC');
-select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy') = toDateTime('2000-01-01', 'UTC');
-select parseDateTimeInJodaSyntax('AD 1999 2000', 'G yyyy YYYY') = toDateTime('2000-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy', 'UTC') = toDateTime('2000-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999 2000', 'G yyyy YYYY', 'UTC') = toDateTime('2000-01-01', 'UTC');
 select parseDateTimeInJodaSyntax('AD 1999', 'G Y'); -- { serverError CANNOT_PARSE_DATETIME }
 select parseDateTimeInJodaSyntax('AD 1999', 'G YY'); -- { serverError CANNOT_PARSE_DATETIME }
 select parseDateTimeInJodaSyntax('AD 1999', 'G YYY'); -- { serverError CANNOT_PARSE_DATETIME }

--- a/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.sql
+++ b/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.sql
@@ -3,13 +3,13 @@
 select parseDateTimeInJodaSyntax(' ', ' ', 'UTC') = toDateTime('1970-01-01', 'UTC');
 
 -- era
-select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01');
-select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY') = toDateTime('1999-01-01');
-select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY') = toDateTime('1999-01-01');
-select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01');
-select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy') = toDateTime('1999-01-01');
-select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy') = toDateTime('2000-01-01');
-select parseDateTimeInJodaSyntax('AD 1999 2000', 'G yyyy YYYY') = toDateTime('2000-01-01');
+select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy') = toDateTime('2000-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999 2000', 'G yyyy YYYY') = toDateTime('2000-01-01', 'UTC');
 select parseDateTimeInJodaSyntax('AD 1999', 'G Y'); -- { serverError CANNOT_PARSE_DATETIME }
 select parseDateTimeInJodaSyntax('AD 1999', 'G YY'); -- { serverError CANNOT_PARSE_DATETIME }
 select parseDateTimeInJodaSyntax('AD 1999', 'G YYY'); -- { serverError CANNOT_PARSE_DATETIME }

--- a/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.sql
+++ b/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.sql
@@ -6,7 +6,7 @@ select parseDateTimeInJodaSyntax(' ', ' ', 'UTC') = toDateTime('1970-01-01', 'UT
 select parseDateTimeInJodaSyntax('AD 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
 select parseDateTimeInJodaSyntax('ad 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
 select parseDateTimeInJodaSyntax('Ad 1999', 'G YYYY', 'UTC') = toDateTime('1999-01-01', 'UTC');
-select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy') = toDateTime('1999-01-01', 'UTC');
+select parseDateTimeInJodaSyntax('AD 1999', 'G yyyy', 'UTC') = toDateTime('1999-01-01', 'UTC');
 select parseDateTimeInJodaSyntax('AD 1999 2000', 'G YYYY yyyy', 'UTC') = toDateTime('2000-01-01', 'UTC');
 select parseDateTimeInJodaSyntax('AD 1999 2000', 'G yyyy YYYY', 'UTC') = toDateTime('2000-01-01', 'UTC');
 select parseDateTimeInJodaSyntax('AD 1999', 'G Y'); -- { serverError CANNOT_PARSE_DATETIME }


### PR DESCRIPTION
failed due to time zone randomization

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)