### PR TITLE
Mark query cache as non-experimental

### DIFF
--- a/docs/en/operations/caches.md
+++ b/docs/en/operations/caches.md
@@ -23,6 +23,6 @@ Additional cache types:
 - [Dictionaries](../sql-reference/dictionaries/index.md) data cache.
 - Schema inference cache.
 - [Filesystem cache](storing-data.md) over S3, Azure, Local and other disks.
-- [(Experimental) Query cache](query-cache.md).
+- [Query cache](query-cache.md).
 
 To drop one of the caches, use [SYSTEM DROP ... CACHE](../sql-reference/statements/system.md#drop-mark-cache) statements.

--- a/docs/en/operations/query-cache.md
+++ b/docs/en/operations/query-cache.md
@@ -1,10 +1,10 @@
 ---
 slug: /en/operations/query-cache
 sidebar_position: 65
-sidebar_label: Query Cache [experimental]
+sidebar_label: Query Cache
 ---
 
-# Query Cache [experimental]
+# Query Cache
 
 The query cache allows to compute `SELECT` queries just once and to serve further executions of the same query directly from the cache.
 Depending on the type of the queries, this can dramatically reduce latency and resource consumption of the ClickHouse server.
@@ -29,21 +29,10 @@ Transactionally inconsistent caching is traditionally provided by client tools o
 the same caching logic and configuration is often duplicated. With ClickHouse's query cache, the caching logic moves to the server side.
 This reduces maintenance effort and avoids redundancy.
 
-:::note
-The query cache is an experimental feature that should not be used in production. There are known cases (e.g. in distributed query
-processing) where wrong results are returned.
-:::
-
 ## Configuration Settings and Usage
 
-As long as the result cache is experimental it must be activated using the following configuration setting:
-
-```sql
-SET allow_experimental_query_cache = true;
-```
-
-Afterwards, setting [use_query_cache](settings/settings.md#use-query-cache) can be used to control whether a specific query or all queries
-of the current session should utilize the query cache. For example, the first execution of query
+Setting [use_query_cache](settings/settings.md#use-query-cache) can be used to control whether a specific query or all queries of the
+current session should utilize the query cache. For example, the first execution of query
 
 ```sql
 SELECT some_expensive_calculation(column_1, column_2)

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -720,7 +720,6 @@ class IColumn;
     M(Bool, allow_experimental_nlp_functions, false, "Enable experimental functions for natural language processing.", 0) \
     M(Bool, allow_experimental_hash_functions, false, "Enable experimental hash functions (hashid, etc)", 0) \
     M(Bool, allow_experimental_object_type, false, "Allow Object and JSON data types", 0) \
-    M(Bool, allow_experimental_query_cache, false, "Enable experimental query cache", 0) \
     M(String, insert_deduplication_token, "", "If not empty, used for duplicate detection instead of data digest", 0) \
     M(String, ann_index_select_query_params, "", "Parameters passed to ANN indexes in SELECT queries, the format is 'param1=x, param2=y, ...'", 0) \
     M(UInt64, max_limit_for_ann_queries, 1000000, "Maximum limit value for using ANN indexes is used to prevent memory overflow in search queries for indexes", 0) \

--- a/src/Interpreters/Cache/QueryCache.cpp
+++ b/src/Interpreters/Cache/QueryCache.cpp
@@ -79,9 +79,7 @@ public:
 
             auto is_query_cache_related_setting = [](const auto & change)
             {
-                return change.name == "allow_experimental_query_cache"
-                    || change.name.starts_with("query_cache")
-                    || change.name.ends_with("query_cache");
+                return change.name.starts_with("query_cache_") || change.name.ends_with("_query_cache");
             };
 
             std::erase_if(set_clause->changes, is_query_cache_related_setting);

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -643,9 +643,7 @@ static std::tuple<ASTPtr, BlockIO> executeQueryImpl(
             }
         }
 
-        bool can_use_query_cache =
-            settings.allow_experimental_query_cache && settings.use_query_cache && !internal
-            && !ast->as<ASTExplainQuery>();
+        bool can_use_query_cache = settings.use_query_cache && !internal && !ast->as<ASTExplainQuery>();
 
         if (!async_insert)
         {

--- a/tests/ci/stress.py
+++ b/tests/ci/stress.py
@@ -45,7 +45,6 @@ def get_options(i, upgrade_check):
             client_options.append("max_rows_in_join=1000")
 
     if i > 0 and random.random() < 1 / 3:
-        client_options.append("allow_experimental_query_cache=1")
         client_options.append("use_query_cache=1")
 
     if i % 5 == 1:

--- a/tests/queries/0_stateless/02494_query_cache_case_agnostic_matching.sql
+++ b/tests/queries/0_stateless/02494_query_cache_case_agnostic_matching.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 -- Start with empty query cache (QC) and query log
 SYSTEM DROP QUERY CACHE;
 DROP TABLE system.query_log SYNC;

--- a/tests/queries/0_stateless/02494_query_cache_compression.sql
+++ b/tests/queries/0_stateless/02494_query_cache_compression.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 DROP TABLE IF EXISTS t;
 

--- a/tests/queries/0_stateless/02494_query_cache_drop_cache.sql
+++ b/tests/queries/0_stateless/02494_query_cache_drop_cache.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 -- (it's silly to use what will be tested below but we have to assume other tests cluttered the query cache)
 SYSTEM DROP QUERY CACHE;
 

--- a/tests/queries/0_stateless/02494_query_cache_eligible_queries.sql
+++ b/tests/queries/0_stateless/02494_query_cache_eligible_queries.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 DROP TABLE IF EXISTS eligible_test;
 DROP TABLE IF EXISTS eligible_test2;

--- a/tests/queries/0_stateless/02494_query_cache_events.sql
+++ b/tests/queries/0_stateless/02494_query_cache_events.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 -- Start with empty query cache QC and query log
 SYSTEM DROP QUERY CACHE;
 DROP TABLE system.query_log SYNC;

--- a/tests/queries/0_stateless/02494_query_cache_exception_handling.sql
+++ b/tests/queries/0_stateless/02494_query_cache_exception_handling.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 
 -- If an exception is thrown during query execution, no entry must be created in the query cache

--- a/tests/queries/0_stateless/02494_query_cache_explain.sql
+++ b/tests/queries/0_stateless/02494_query_cache_explain.sql
@@ -2,7 +2,6 @@
 -- Tag no-parallel: Messes with internal cache
 
 SET allow_experimental_analyzer = 1;
-SET allow_experimental_query_cache = true;
 
 SYSTEM DROP QUERY CACHE;
 

--- a/tests/queries/0_stateless/02494_query_cache_min_query_duration.sql
+++ b/tests/queries/0_stateless/02494_query_cache_min_query_duration.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 
 -- This creates an entry in the query cache ...

--- a/tests/queries/0_stateless/02494_query_cache_min_query_runs.sql
+++ b/tests/queries/0_stateless/02494_query_cache_min_query_runs.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 
 -- Cache the query after the 1st query invocation

--- a/tests/queries/0_stateless/02494_query_cache_nondeterministic_functions.sql
+++ b/tests/queries/0_stateless/02494_query_cache_nondeterministic_functions.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 
 -- rand() is non-deterministic, with default settings no entry in the query cache should be created

--- a/tests/queries/0_stateless/02494_query_cache_normalize_ast.sql
+++ b/tests/queries/0_stateless/02494_query_cache_normalize_ast.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 -- Start with empty query cache (QC) and query log.
 SYSTEM DROP QUERY CACHE;
 DROP TABLE system.query_log SYNC;

--- a/tests/queries/0_stateless/02494_query_cache_passive_usage.sql
+++ b/tests/queries/0_stateless/02494_query_cache_passive_usage.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 -- Start with empty query cache (QC).
 SYSTEM DROP QUERY CACHE;
 

--- a/tests/queries/0_stateless/02494_query_cache_secrets.sql
+++ b/tests/queries/0_stateless/02494_query_cache_secrets.sql
@@ -2,8 +2,6 @@
 -- Tag no-fasttest: Depends on OpenSSL
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 
 -- Cache a result of a query with secret in the query cache

--- a/tests/queries/0_stateless/02494_query_cache_sparse_columns.sql
+++ b/tests/queries/0_stateless/02494_query_cache_sparse_columns.sql
@@ -12,7 +12,6 @@ SYSTEM STOP MERGES t_cache_sparse;
 INSERT INTO t_cache_sparse SELECT number, number FROM numbers(10000);
 INSERT INTO t_cache_sparse SELECT number, 0 FROM numbers(10000);
 
-SET allow_experimental_query_cache = 1;
 SET use_query_cache = 1;
 SET max_threads = 1;
 

--- a/tests/queries/0_stateless/02494_query_cache_squash_partial_results.sql
+++ b/tests/queries/0_stateless/02494_query_cache_squash_partial_results.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 DROP TABLE IF EXISTS t;
 

--- a/tests/queries/0_stateless/02494_query_cache_totals_extremes.sql
+++ b/tests/queries/0_stateless/02494_query_cache_totals_extremes.sql
@@ -1,8 +1,6 @@
 -- Tags: no-parallel
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 DROP TABLE IF EXISTS tbl;
 

--- a/tests/queries/0_stateless/02494_query_cache_ttl_long.sql
+++ b/tests/queries/0_stateless/02494_query_cache_ttl_long.sql
@@ -3,8 +3,6 @@
 -- Tag long: Test runtime is > 6 sec
 -- Tag no-parallel: Messes with internal cache
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 
 -- Cache query result into query cache with a TTL of 3 sec

--- a/tests/queries/0_stateless/02494_query_cache_user_quotas.sql
+++ b/tests/queries/0_stateless/02494_query_cache_user_quotas.sql
@@ -5,8 +5,6 @@
 -- be used in a settings profile, together with a readonly constraint. For simplicity, test both settings stand-alone in a stateless test
 -- instead of an integration test - the relevant logic will still be covered by that.
 
-SET allow_experimental_query_cache = true;
-
 SYSTEM DROP QUERY CACHE;
 
 SET query_cache_max_size_in_bytes = 1;


### PR DESCRIPTION
This PR marks the query cache as non-experimental. Must only be merged after these items:
- #45912
- #47724
- ~~#48717~~ #48853
- Fix for #48385
- (optional: #48284)

### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The query cache can now be used for production workloads