### PR TITLE
parseDateTime(): Fix UB (signed integer overflow)

### DIFF
--- a/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.reference
+++ b/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.reference
@@ -342,3 +342,5 @@ select parseDateTimeInJodaSyntax('0/', 's/', 'UTC') = toDateTime('1970-01-01 00:
 select parseDateTimeInJodaSyntax('60', 's', 'UTC'); -- { serverError CANNOT_PARSE_DATETIME }
 select parseDateTimeInJodaSyntax('-1', 's', 'UTC'); -- { serverError CANNOT_PARSE_DATETIME }
 select parseDateTimeInJodaSyntax('123456789', 's', 'UTC'); -- { serverError CANNOT_PARSE_DATETIME }
+-- integer overflow in AST Fuzzer
+select parseDateTimeInJodaSyntax('19191919191919191919191919191919', 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC', 'UTC'); -- { serverError CANNOT_PARSE_DATETIME }

--- a/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.sql
+++ b/tests/queries/0_stateless/02668_parse_datetime_in_joda_syntax.sql
@@ -229,4 +229,7 @@ select parseDateTimeInJodaSyntax('60', 's', 'UTC'); -- { serverError CANNOT_PARS
 select parseDateTimeInJodaSyntax('-1', 's', 'UTC'); -- { serverError CANNOT_PARSE_DATETIME }
 select parseDateTimeInJodaSyntax('123456789', 's', 'UTC'); -- { serverError CANNOT_PARSE_DATETIME }
 
+-- integer overflow in AST Fuzzer
+select parseDateTimeInJodaSyntax('19191919191919191919191919191919', 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC', 'UTC'); -- { serverError CANNOT_PARSE_DATETIME }
+
 -- { echoOff }


### PR DESCRIPTION
Follow-up to #46815

@taiyang-li

Fixes UB found here:
- https://s3.amazonaws.com/clickhouse-test-reports/48000/62e7aca6ad43b49e4d6248beef918d128846a0cd/fuzzer_astfuzzermsan/report.html

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix signed integer overflow with overlong Joda patterns in function parseDateTimeInJodaSyntax()