### PR TITLE
Rename `system.marked_dropped_tables` to `dropped_tables`

### DIFF
--- a/src/Storages/System/StorageSystemDroppedTables.cpp
+++ b/src/Storages/System/StorageSystemDroppedTables.cpp
@@ -1,4 +1,4 @@
-#include <Storages/System/StorageSystemMarkedDroppedTables.h>
+#include <Storages/System/StorageSystemDroppedTables.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -13,7 +13,7 @@
 namespace DB
 {
 
-NamesAndTypesList StorageSystemMarkedDroppedTables::getNamesAndTypes()
+NamesAndTypesList StorageSystemDroppedTables::getNamesAndTypes()
 {
     NamesAndTypesList names_and_types{
         {"index", std::make_shared<DataTypeUInt32>()},
@@ -28,7 +28,7 @@ NamesAndTypesList StorageSystemMarkedDroppedTables::getNamesAndTypes()
 }
 
 
-void StorageSystemMarkedDroppedTables::fillData(MutableColumns & res_columns, ContextPtr, const SelectQueryInfo &) const
+void StorageSystemDroppedTables::fillData(MutableColumns & res_columns, ContextPtr, const SelectQueryInfo &) const
 {
     auto tables_mark_dropped = DatabaseCatalog::instance().getTablesMarkedDropped();
 

--- a/src/Storages/System/StorageSystemDroppedTables.h
+++ b/src/Storages/System/StorageSystemDroppedTables.h
@@ -6,7 +6,7 @@
 namespace DB
 {
 
-class StorageSystemMarkedDroppedTables final : public IStorageSystemOneBlock<StorageSystemMarkedDroppedTables>
+class StorageSystemDroppedTables final : public IStorageSystemOneBlock<StorageSystemDroppedTables>
 {
 public:
     std::string getName() const override { return "SystemMarkedDroppedTables"; }

--- a/src/Storages/System/attachSystemTables.cpp
+++ b/src/Storages/System/attachSystemTables.cpp
@@ -79,7 +79,7 @@
 #include <Storages/System/StorageSystemRemoteDataPaths.h>
 #include <Storages/System/StorageSystemCertificates.h>
 #include <Storages/System/StorageSystemSchemaInferenceCache.h>
-#include <Storages/System/StorageSystemMarkedDroppedTables.h>
+#include <Storages/System/StorageSystemDroppedTables.h>
 
 #ifdef OS_LINUX
 #include <Storages/System/StorageSystemStackTrace.h>
@@ -141,7 +141,7 @@ void attachSystemTablesLocal(ContextPtr context, IDatabase & system_database)
     attach<StorageSystemTimeZones>(context, system_database, "time_zones");
     attach<StorageSystemBackups>(context, system_database, "backups");
     attach<StorageSystemSchemaInferenceCache>(context, system_database, "schema_inference_cache");
-    attach<StorageSystemMarkedDroppedTables>(context, system_database, "marked_dropped_tables");
+    attach<StorageSystemDroppedTables>(context, system_database, "dropped_tables");
 #ifdef OS_LINUX
     attach<StorageSystemStackTrace>(context, system_database, "stack_trace");
 #endif

--- a/tests/queries/0_stateless/25400_marked_dropped_tables.reference
+++ b/tests/queries/0_stateless/25400_marked_dropped_tables.reference
@@ -1,4 +1,4 @@
-25400_marked_dropped_tables	MergeTree
+25400_dropped_tables	MergeTree
 index	UInt32					
 database	String					
 table	String					

--- a/tests/queries/0_stateless/25400_marked_dropped_tables.sql
+++ b/tests/queries/0_stateless/25400_marked_dropped_tables.sql
@@ -1,11 +1,11 @@
 -- Tags: no-ordinary-database
 
 SET database_atomic_wait_for_drop_and_detach_synchronously = 0;
-DROP TABLE IF EXISTS 25400_marked_dropped_tables;
+DROP TABLE IF EXISTS 25400_dropped_tables;
 
-CREATE TABLE 25400_marked_dropped_tables (id Int32) Engine=MergeTree() ORDER BY id;
-DROP TABLE 25400_marked_dropped_tables;
+CREATE TABLE 25400_dropped_tables (id Int32) Engine=MergeTree() ORDER BY id;
+DROP TABLE 25400_dropped_tables;
 
-SELECT table, engine FROM system.marked_dropped_tables WHERE database = currentDatabase() LIMIT 1;
-DESCRIBE TABLE system.marked_dropped_tables;
+SELECT table, engine FROM system.dropped_tables WHERE database = currentDatabase() LIMIT 1;
+DESCRIBE TABLE system.dropped_tables;
  


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

```
Alexey Milovidov 11:27 AM
@Alexander Tokmakov
> system.marked_dropped_tables
The name rhymes poorly. Let's rename to system.dropped_tables
```

Not for changelog because https://github.com/ClickHouse/ClickHouse/pull/47364 has not been released yet 
