### PR TITLE
Revert change to ld64.lld linker on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ endif ()
 
 if (NOT CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE")
     # Can be lld or ld-lld or lld-13 or /path/to/lld.
-    if (LINKER_NAME MATCHES "lld" AND OS_LINUX)
+    if (LINKER_NAME MATCHES "lld")
         set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gdb-index")
         message (STATUS "Adding .gdb-index via --gdb-index linker option.")
     endif ()
@@ -212,7 +212,7 @@ endif ()
 
 # Create BuildID when using lld. For other linkers it is created by default.
 # (NOTE: LINKER_NAME can be either path or name, and in different variants)
-if (LINKER_NAME MATCHES "lld" AND OS_LINUX)
+if (LINKER_NAME MATCHES "lld")
     # SHA1 is not cryptographically secure but it is the best what lld is offering.
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=sha1")
 endif ()
@@ -349,17 +349,7 @@ set (CMAKE_ASM_FLAGS_DEBUG               "${CMAKE_ASM_FLAGS_DEBUG} -O0 ${DEBUG_I
 if (COMPILER_CLANG)
     if (OS_DARWIN)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-U,_inside_main")
-
-        # The LLVM MachO linker (ld64.lld, used in native builds) generates by default unwind info in 'compact' format which the internal
-        # unwinder doesn't support and the server will not come up ('invalid compact unwind encoding'). Disable it. You will see warning
-        # during the build "ld64.lld: warning: Option `-no_compact_unwind' is undocumented. Should lld implement it?". Yes, ld64.lld does
-        # not document the option, likely for compat with Apple's system ld after which ld64.lld is modeled after and which also does not
-        # document it.
-        if (NOT CMAKE_CROSSCOMPILING)
-            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no_compact_unwind")
-        endif ()
     endif()
 
     # Display absolute paths in error messages. Otherwise KDevelop fails to navigate to correct file and opens a new file instead.

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -61,17 +61,13 @@ if (NOT LINKER_NAME)
     if (COMPILER_GCC)
         find_program (LLD_PATH NAMES "ld.lld")
     elseif (COMPILER_CLANG)
-        # llvm lld is a generic driver.
-        # Invoke ld.lld (Unix), ld64.lld (macOS), lld-link (Windows), wasm-ld (WebAssembly) instead
         if (OS_LINUX)
             if (NOT ARCH_S390X) # s390x doesnt support lld
                 find_program (LLD_PATH NAMES "ld.lld-${COMPILER_VERSION_MAJOR}" "ld.lld")
             endif ()
-        elseif (OS_DARWIN)
-            find_program (LLD_PATH NAMES "ld64.lld-${COMPILER_VERSION_MAJOR}" "ld64.lld")
         endif ()
     endif ()
-    if (OS_LINUX OR OS_DARWIN)
+    if (OS_LINUX)
         if (LLD_PATH)
             if (COMPILER_GCC)
                 # GCC driver requires one of supported linker names like "lld".


### PR DESCRIPTION
This reverts PRs #42470, #47673 and #47744. The problem was that after the switch to ld64.lld, server binaries build in Debug mode on Mac no longer came up, see the discussion after (*). My attempt to fix it with `-Wl,-no_compact_unwind` didn't help (#47673).

I also tried
- `-Wl,-keep_dwarf_unwind`,
- `-unwindlib` (to use the OS unwinder),
- the unwinder in contrib (CMake variable `EXCEPTION_HANDLING_LIBRARY`) but w/o success. Just tons of wasted time.

Rolling back to lld as linker on Mac. This will bring back many linker warnings (#42282) but I rather accept that (temporarily, maybe someone can figure out how to fix them) than have a broken Debug binary.

(*) https://github.com/ClickHouse/ClickHouse/pull/42470#issuecomment-1312344068

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Restore ability of native macos debug server build to start (this time for real)