### PR TITLE
Simplify backup coordination for file infos

### DIFF
--- a/src/Backups/BackupCoordinationFileInfos.cpp
+++ b/src/Backups/BackupCoordinationFileInfos.cpp
@@ -8,6 +8,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BACKUP_ENTRY_ALREADY_EXISTS;
+    extern const int LOGICAL_ERROR;
 }
 
 using SizeAndChecksum = std::pair<UInt64, UInt128>;
@@ -37,6 +38,14 @@ BackupFileInfos BackupCoordinationFileInfos::getFileInfosForAllHosts() const
     for (const auto * file_info : file_infos_for_all_hosts)
         res.emplace_back(*file_info);
     return res;
+}
+
+BackupFileInfo BackupCoordinationFileInfos::getFileInfoByDataFileIndex(size_t data_file_index) const
+{
+    prepare();
+    if (data_file_index == static_cast<size_t>(-1))
+        return {};
+    return *(file_infos_for_all_hosts[data_file_index]);
 }
 
 void BackupCoordinationFileInfos::prepare() const

--- a/src/Backups/BackupCoordinationFileInfos.cpp
+++ b/src/Backups/BackupCoordinationFileInfos.cpp
@@ -1,0 +1,134 @@
+#include <Backups/BackupCoordinationFileInfos.h>
+#include <Common/quoteString.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BACKUP_ENTRY_ALREADY_EXISTS;
+}
+
+using SizeAndChecksum = std::pair<UInt64, UInt128>;
+
+
+void BackupCoordinationFileInfos::addFileInfos(BackupFileInfos && file_infos_, const String & host_id_)
+{
+    if (prepared)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "addFileInfos() must not be called after preparing");
+    file_infos.emplace(host_id_, std::move(file_infos_));
+}
+
+BackupFileInfos BackupCoordinationFileInfos::getFileInfos(const String & host_id_) const
+{
+    prepare();
+    auto it = file_infos.find(host_id_);
+    if (it == file_infos.end())
+        return {};
+    return it->second;
+}
+
+BackupFileInfos BackupCoordinationFileInfos::getFileInfosForAllHosts() const
+{
+    prepare();
+    BackupFileInfos res;
+    res.reserve(file_infos_for_all_hosts.size());
+    for (const auto * file_info : file_infos_for_all_hosts)
+        res.emplace_back(*file_info);
+    return res;
+}
+
+void BackupCoordinationFileInfos::prepare() const
+{
+    if (prepared)
+        return;
+
+    /// Make a list of all file infos from all hosts.
+    size_t total_num_infos = 0;
+    for (const auto & [_, infos] : file_infos)
+        total_num_infos += infos.size();
+
+    file_infos_for_all_hosts.reserve(total_num_infos);
+    for (auto & [_, infos] : file_infos)
+        for (auto & info : infos)
+            file_infos_for_all_hosts.emplace_back(&info);
+
+    /// Sort the list of all file infos by file name (file names must be unique).
+    std::sort(
+        file_infos_for_all_hosts.begin(),
+        file_infos_for_all_hosts.end(),
+        [](const BackupFileInfo * left, const BackupFileInfo * right) { return left->file_name < right->file_name; });
+
+    auto adjacent_it = std::adjacent_find(file_infos_for_all_hosts.begin(), file_infos_for_all_hosts.end(), BackupFileInfo::EqualByFileName{});
+    if (adjacent_it != file_infos_for_all_hosts.end())
+    {
+        throw Exception(
+            ErrorCodes::BACKUP_ENTRY_ALREADY_EXISTS, "Entry {} added multiple times to backup", quoteString((*adjacent_it)->file_name));
+    }
+
+    num_files = 0;
+    total_size_of_files = 0;
+
+    if (plain_backup)
+    {
+        /// For plain backup all file infos are stored as is, without checking for duplicates or skipping empty files.
+        for (size_t i = 0; i != file_infos_for_all_hosts.size(); ++i)
+        {
+            auto & info = *(file_infos_for_all_hosts[i]);
+            info.data_file_name = info.file_name;
+            info.data_file_index = i;
+            info.base_size = 0; /// Base backup is not used while creating a plain backup
+            info.base_checksum = 0;
+            total_size_of_files += info.size;
+        }
+        num_files = file_infos_for_all_hosts.size();
+    }
+    else
+    {
+        std::map<SizeAndChecksum, size_t> data_file_index_by_checksum;
+
+        for (size_t i = 0; i != file_infos_for_all_hosts.size(); ++i)
+        {
+            auto & info = *(file_infos_for_all_hosts[i]);
+            if (info.size == info.base_size)
+            {
+                info.data_file_name.clear();
+                info.data_file_index = static_cast<size_t>(-1);
+            }
+            else
+            {
+                SizeAndChecksum size_and_checksum{info.size, info.checksum};
+                auto [it, inserted] = data_file_index_by_checksum.emplace(size_and_checksum, i);
+                if (inserted)
+                {
+                    info.data_file_name = info.file_name;
+                    info.data_file_index = i;
+                    ++num_files;
+                    total_size_of_files += info.size - info.base_size;
+                }
+                else
+                {
+                    info.data_file_index = it->second;
+                    info.data_file_name = file_infos_for_all_hosts[it->second]->data_file_name;
+                }
+            }
+        }
+    }
+
+    prepared = true;
+}
+
+size_t BackupCoordinationFileInfos::getNumFiles() const
+{
+    prepare();
+    return num_files;
+}
+
+size_t BackupCoordinationFileInfos::getTotalSizeOfFiles() const
+{
+    prepare();
+    return total_size_of_files;
+}
+
+}

--- a/src/Backups/BackupCoordinationFileInfos.h
+++ b/src/Backups/BackupCoordinationFileInfos.h
@@ -10,10 +10,10 @@
 namespace DB
 {
 
-/// Replicas use this class to coordinate lists of files they are going to write to a backup.
-/// Because different replicas shouldn't write the same file twice and or even files with different names but with the same checksum.
-/// Also the initiator of the BACKUP query uses this class to get a whole list of files written by other replica to write that list
-/// as a part of the .backup file (the backup metadata file).
+/// Hosts use this class to coordinate lists of files they are going to write to a backup.
+/// Because different hosts shouldn't write the same file twice and or even files with different names but with the same checksum.
+/// Also the initiator of the BACKUP query uses this class to get a whole list of files written by all hosts to write that list
+/// as a part of the contents of the .backup file (the backup metadata file).
 class BackupCoordinationFileInfos
 {
 public:

--- a/src/Backups/BackupCoordinationFileInfos.h
+++ b/src/Backups/BackupCoordinationFileInfos.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
-#include <Backups/BackupFileInfo.h> 
+#include <Backups/BackupFileInfo.h>
 
 
 namespace DB
@@ -29,6 +29,9 @@ public:
 
     /// Returns file infos for all hosts after preparation.
     BackupFileInfos getFileInfosForAllHosts() const;
+
+    /// Returns a file info by data file index (see BackupFileInfo::data_file_index).
+    BackupFileInfo getFileInfoByDataFileIndex(size_t data_file_index) const;
 
     /// Returns the number of files after deduplication and excluding empty files.
     size_t getNumFiles() const;

--- a/src/Backups/BackupCoordinationFileInfos.h
+++ b/src/Backups/BackupCoordinationFileInfos.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <Backups/BackupFileInfo.h> 
+
+
+namespace DB
+{
+
+/// Replicas use this class to coordinate lists of files they are going to write to a backup.
+/// Because different replicas shouldn't write the same file twice and or even files with different names but with the same checksum.
+/// Also the initiator of the BACKUP query uses this class to get a whole list of files written by other replica to write that list
+/// as a part of the .backup file (the backup metadata file).
+class BackupCoordinationFileInfos
+{
+public:
+    /// plain_backup sets that we're writing a plain backup, which means all duplicates are written as is, and empty files are written as is.
+    /// (For normal backups only the first file amongst duplicates is actually stored, and empty files are not stored).
+    BackupCoordinationFileInfos(bool plain_backup_) : plain_backup(plain_backup_) {}
+
+    /// Adds file infos for the specified host.
+    void addFileInfos(BackupFileInfos && file_infos, const String & host_id);
+
+    /// Returns file infos for the specified host after preparation.
+    BackupFileInfos getFileInfos(const String & host_id) const;
+
+    /// Returns file infos for all hosts after preparation.
+    BackupFileInfos getFileInfosForAllHosts() const;
+
+    /// Returns the number of files after deduplication and excluding empty files.
+    size_t getNumFiles() const;
+
+    /// Returns the total size of files after deduplication and excluding empty files.
+    size_t getTotalSizeOfFiles() const;
+
+private:
+    void prepare() const;
+
+    /// before preparation
+    const bool plain_backup;
+    mutable std::unordered_map<String, BackupFileInfos> file_infos;
+
+    /// after preparation
+    mutable bool prepared = false;
+    mutable std::vector<BackupFileInfo *> file_infos_for_all_hosts;
+    mutable size_t num_files;
+    mutable size_t total_size_of_files;
+};
+
+}

--- a/src/Backups/BackupCoordinationLocal.cpp
+++ b/src/Backups/BackupCoordinationLocal.cpp
@@ -34,90 +34,90 @@ Strings BackupCoordinationLocal::waitForStage(const String &, std::chrono::milli
 
 void BackupCoordinationLocal::addReplicatedPartNames(const String & table_shared_id, const String & table_name_for_logs, const String & replica_name, const std::vector<PartNameAndChecksum> & part_names_and_checksums)
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_tables_mutex};
     replicated_tables.addPartNames(table_shared_id, table_name_for_logs, replica_name, part_names_and_checksums);
 }
 
 Strings BackupCoordinationLocal::getReplicatedPartNames(const String & table_shared_id, const String & replica_name) const
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_tables_mutex};
     return replicated_tables.getPartNames(table_shared_id, replica_name);
 }
 
 
 void BackupCoordinationLocal::addReplicatedMutations(const String & table_shared_id, const String & table_name_for_logs, const String & replica_name, const std::vector<MutationInfo> & mutations)
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_tables_mutex};
     replicated_tables.addMutations(table_shared_id, table_name_for_logs, replica_name, mutations);
 }
 
 std::vector<IBackupCoordination::MutationInfo> BackupCoordinationLocal::getReplicatedMutations(const String & table_shared_id, const String & replica_name) const
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_tables_mutex};
     return replicated_tables.getMutations(table_shared_id, replica_name);
 }
 
 
 void BackupCoordinationLocal::addReplicatedDataPath(const String & table_shared_id, const String & data_path)
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_tables_mutex};
     replicated_tables.addDataPath(table_shared_id, data_path);
 }
 
 Strings BackupCoordinationLocal::getReplicatedDataPaths(const String & table_shared_id) const
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_tables_mutex};
     return replicated_tables.getDataPaths(table_shared_id);
 }
 
 
 void BackupCoordinationLocal::addReplicatedAccessFilePath(const String & access_zk_path, AccessEntityType access_entity_type, const String & file_path)
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_access_mutex};
     replicated_access.addFilePath(access_zk_path, access_entity_type, "", file_path);
 }
 
 Strings BackupCoordinationLocal::getReplicatedAccessFilePaths(const String & access_zk_path, AccessEntityType access_entity_type) const
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_access_mutex};
     return replicated_access.getFilePaths(access_zk_path, access_entity_type, "");
 }
 
 
 void BackupCoordinationLocal::addReplicatedSQLObjectsDir(const String & loader_zk_path, UserDefinedSQLObjectType object_type, const String & dir_path)
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_sql_objects_mutex};
     replicated_sql_objects.addDirectory(loader_zk_path, object_type, "", dir_path);
 }
 
 Strings BackupCoordinationLocal::getReplicatedSQLObjectsDirs(const String & loader_zk_path, UserDefinedSQLObjectType object_type) const
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{replicated_sql_objects_mutex};
     return replicated_sql_objects.getDirectories(loader_zk_path, object_type, "");
 }
 
 
 void BackupCoordinationLocal::addFileInfos(BackupFileInfos && file_infos_)
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{file_infos_mutex};
     file_infos.addFileInfos(std::move(file_infos_), "");
 }
 
 BackupFileInfos BackupCoordinationLocal::getFileInfos() const
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{file_infos_mutex};
     return file_infos.getFileInfos("");
 }
 
 BackupFileInfos BackupCoordinationLocal::getFileInfosForAllHosts() const
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{file_infos_mutex};
     return file_infos.getFileInfosForAllHosts();
 }
 
 bool BackupCoordinationLocal::startWritingFile(size_t data_file_index)
 {
-    std::lock_guard lock{mutex};
+    std::lock_guard lock{writing_files_mutex};
     return writing_files.emplace(data_file_index).second;
 }
 

--- a/src/Backups/BackupCoordinationLocal.cpp
+++ b/src/Backups/BackupCoordinationLocal.cpp
@@ -8,11 +8,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int BACKUP_ENTRY_ALREADY_EXISTS;
-}
-
 BackupCoordinationLocal::BackupCoordinationLocal(bool plain_backup_) : file_infos(plain_backup_)
 {
 }

--- a/src/Backups/BackupCoordinationLocal.cpp
+++ b/src/Backups/BackupCoordinationLocal.cpp
@@ -13,9 +13,7 @@ namespace ErrorCodes
     extern const int BACKUP_ENTRY_ALREADY_EXISTS;
 }
 
-using FileInfo = IBackupCoordination::FileInfo;
-
-BackupCoordinationLocal::BackupCoordinationLocal(bool plain_backup_) : plain_backup(plain_backup_)
+BackupCoordinationLocal::BackupCoordinationLocal(bool plain_backup_) : file_infos(plain_backup_)
 {
 }
 
@@ -104,61 +102,28 @@ Strings BackupCoordinationLocal::getReplicatedSQLObjectsDirs(const String & load
 }
 
 
-void BackupCoordinationLocal::addFileInfo(const FileInfo & file_info, bool & is_data_file_required)
+void BackupCoordinationLocal::addFileInfos(BackupFileInfos && file_infos_)
 {
-    FileInfo inserting_info = file_info;
-
     std::lock_guard lock{mutex};
-
-    if (plain_backup)
-    {
-        /// Plain backups don't use base backups and store each file as is.
-        inserting_info.base_checksum = 0;
-        inserting_info.base_size = 0;
-        is_data_file_required = true;
-    }
-    else if (file_info.size == file_info.base_size)
-    {
-        /// The file is either empty or is taken from the base backup as a whole.
-        inserting_info.data_file_name = "";
-        is_data_file_required = false;
-    }
-    else if (auto it = file_infos.find(file_info); it != file_infos.end())
-    {
-        /// The file is a duplicate of another file in this backup.
-        inserting_info.data_file_name = it->data_file_name;
-        is_data_file_required = false;
-    }
-    else
-    {
-        /// The file is not empty, not a duplicate, and doesn't exist in the base backup as a whole,
-        /// so it must be written to this backup.
-        is_data_file_required = true;
-    }
-
-    file_infos.emplace(std::move(inserting_info));
+    file_infos.addFileInfos(std::move(file_infos_), "");
 }
 
-std::vector<FileInfo> BackupCoordinationLocal::getAllFileInfos() const
+BackupFileInfos BackupCoordinationLocal::getFileInfos() const
 {
-    /// File infos are almost ready, we just need to sort them and check for duplicates.
-    std::vector<FileInfo> res;
-    {
-        std::lock_guard lock{mutex};
-        res.reserve(file_infos.size());
-        std::copy(file_infos.begin(), file_infos.end(), std::back_inserter(res));
-    }
+    std::lock_guard lock{mutex};
+    return file_infos.getFileInfos("");
+}
 
-    /// Sort file infos alphabetically and check there are no duplicates.
-    std::sort(res.begin(), res.end(), FileInfo::LessByFileName{});
+BackupFileInfos BackupCoordinationLocal::getFileInfosForAllHosts() const
+{
+    std::lock_guard lock{mutex};
+    return file_infos.getFileInfosForAllHosts();
+}
 
-    if (auto adjacent_it = std::adjacent_find(res.begin(), res.end(), FileInfo::EqualByFileName{}); adjacent_it != res.end())
-    {
-        throw Exception(
-            ErrorCodes::BACKUP_ENTRY_ALREADY_EXISTS, "Entry {} added multiple times to backup", quoteString(adjacent_it->file_name));
-    }
-
-    return res;
+bool BackupCoordinationLocal::startWritingFile(size_t data_file_index)
+{
+    std::lock_guard lock{mutex};
+    return writing_files.emplace(data_file_index).second;
 }
 
 

--- a/src/Backups/BackupCoordinationLocal.cpp
+++ b/src/Backups/BackupCoordinationLocal.cpp
@@ -118,6 +118,7 @@ BackupFileInfos BackupCoordinationLocal::getFileInfosForAllHosts() const
 bool BackupCoordinationLocal::startWritingFile(size_t data_file_index)
 {
     std::lock_guard lock{writing_files_mutex};
+    /// Return false if this function was already called with this `data_file_index`.
     return writing_files.emplace(data_file_index).second;
 }
 

--- a/src/Backups/BackupCoordinationLocal.cpp
+++ b/src/Backups/BackupCoordinationLocal.cpp
@@ -109,16 +109,6 @@ void BackupCoordinationLocal::addFileInfo(const FileInfo & file_info, bool & is_
     is_data_file_required = inserted_file_info && (file_info.size > file_info.base_size);
 }
 
-void BackupCoordinationLocal::updateFileInfo(const FileInfo & file_info)
-{
-    if (!file_info.size)
-        return; /// we don't keep FileInfos for empty files, nothing to update
-
-    std::lock_guard lock{mutex};
-    auto & dest = file_infos.at(std::pair{file_info.size, file_info.checksum});
-    dest.archive_suffix = file_info.archive_suffix;
-}
-
 std::vector<FileInfo> BackupCoordinationLocal::getAllFileInfos() const
 {
     std::lock_guard lock{mutex};
@@ -199,20 +189,6 @@ std::optional<FileInfo> BackupCoordinationLocal::getFileInfo(const SizeAndChecks
     if (it == file_infos.end())
         return std::nullopt;
     return it->second;
-}
-
-String BackupCoordinationLocal::getNextArchiveSuffix()
-{
-    std::lock_guard lock{mutex};
-    String new_archive_suffix = fmt::format("{:03}", ++current_archive_suffix); /// Outputs 001, 002, 003, ...
-    archive_suffixes.push_back(new_archive_suffix);
-    return new_archive_suffix;
-}
-
-Strings BackupCoordinationLocal::getAllArchiveSuffixes() const
-{
-    std::lock_guard lock{mutex};
-    return archive_suffixes;
 }
 
 bool BackupCoordinationLocal::hasConcurrentBackups(const std::atomic<size_t> & num_active_backups) const

--- a/src/Backups/BackupCoordinationLocal.h
+++ b/src/Backups/BackupCoordinationLocal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Backups/IBackupCoordination.h>
+#include <Backups/BackupCoordinationFileInfos.h>
 #include <Backups/BackupCoordinationReplicatedAccess.h>
 #include <Backups/BackupCoordinationReplicatedSQLObjects.h>
 #include <Backups/BackupCoordinationReplicatedTables.h>
@@ -43,20 +44,20 @@ public:
     void addReplicatedSQLObjectsDir(const String & loader_zk_path, UserDefinedSQLObjectType object_type, const String & dir_path) override;
     Strings getReplicatedSQLObjectsDirs(const String & loader_zk_path, UserDefinedSQLObjectType object_type) const override;
 
-    void addFileInfo(const FileInfo & file_info, bool & is_data_file_required) override;
-    std::vector<FileInfo> getAllFileInfos() const override;
+    void addFileInfos(BackupFileInfos && file_infos) override;
+    BackupFileInfos getFileInfos() const override;
+    BackupFileInfos getFileInfosForAllHosts() const override;
+    bool startWritingFile(size_t data_file_index) override;
 
     bool hasConcurrentBackups(const std::atomic<size_t> & num_active_backups) const override;
 
 private:
-    const bool plain_backup = false;
     mutable std::mutex mutex;
     BackupCoordinationReplicatedTables replicated_tables TSA_GUARDED_BY(mutex);
     BackupCoordinationReplicatedAccess replicated_access TSA_GUARDED_BY(mutex);
     BackupCoordinationReplicatedSQLObjects replicated_sql_objects TSA_GUARDED_BY(mutex);
-
-    /// Information about files.
-    std::multiset<FileInfo, FileInfo::LessBySizeOrChecksum> file_infos TSA_GUARDED_BY(mutex);
+    BackupCoordinationFileInfos file_infos TSA_GUARDED_BY(mutex);
+    std::unordered_set<size_t> writing_files TSA_GUARDED_BY(mutex);
 };
 
 }

--- a/src/Backups/BackupCoordinationLocal.h
+++ b/src/Backups/BackupCoordinationLocal.h
@@ -52,12 +52,17 @@ public:
     bool hasConcurrentBackups(const std::atomic<size_t> & num_active_backups) const override;
 
 private:
-    mutable std::mutex mutex;
-    BackupCoordinationReplicatedTables replicated_tables TSA_GUARDED_BY(mutex);
-    BackupCoordinationReplicatedAccess replicated_access TSA_GUARDED_BY(mutex);
-    BackupCoordinationReplicatedSQLObjects replicated_sql_objects TSA_GUARDED_BY(mutex);
-    BackupCoordinationFileInfos file_infos TSA_GUARDED_BY(mutex);
-    std::unordered_set<size_t> writing_files TSA_GUARDED_BY(mutex);
+    BackupCoordinationReplicatedTables TSA_GUARDED_BY(replicated_tables_mutex) replicated_tables;
+    BackupCoordinationReplicatedAccess TSA_GUARDED_BY(replicated_access_mutex) replicated_access;
+    BackupCoordinationReplicatedSQLObjects TSA_GUARDED_BY(replicated_sql_objects_mutex) replicated_sql_objects;
+    BackupCoordinationFileInfos TSA_GUARDED_BY(file_infos_mutex) file_infos;
+    std::unordered_set<size_t> TSA_GUARDED_BY(writing_files_mutex) writing_files;
+
+    mutable std::mutex replicated_tables_mutex;
+    mutable std::mutex replicated_access_mutex;
+    mutable std::mutex replicated_sql_objects_mutex;
+    mutable std::mutex file_infos_mutex;
+    mutable std::mutex writing_files_mutex;
 };
 
 }

--- a/src/Backups/BackupCoordinationLocal.h
+++ b/src/Backups/BackupCoordinationLocal.h
@@ -44,7 +44,6 @@ public:
     Strings getReplicatedSQLObjectsDirs(const String & loader_zk_path, UserDefinedSQLObjectType object_type) const override;
 
     void addFileInfo(const FileInfo & file_info, bool & is_data_file_required) override;
-    void updateFileInfo(const FileInfo & file_info) override;
 
     std::vector<FileInfo> getAllFileInfos() const override;
     Strings listFiles(const String & directory, bool recursive) const override;
@@ -52,9 +51,6 @@ public:
 
     std::optional<FileInfo> getFileInfo(const String & file_name) const override;
     std::optional<FileInfo> getFileInfo(const SizeAndChecksum & size_and_checksum) const override;
-
-    String getNextArchiveSuffix() override;
-    Strings getAllArchiveSuffixes() const override;
 
     bool hasConcurrentBackups(const std::atomic<size_t> & num_active_backups) const override;
 
@@ -66,8 +62,6 @@ private:
 
     std::map<String /* file_name */, SizeAndChecksum> file_names TSA_GUARDED_BY(mutex); /// Should be ordered alphabetically, see listFiles(). For empty files we assume checksum = 0.
     std::map<SizeAndChecksum, FileInfo> file_infos TSA_GUARDED_BY(mutex); /// Information about files. Without empty files.
-    Strings archive_suffixes TSA_GUARDED_BY(mutex);
-    size_t current_archive_suffix TSA_GUARDED_BY(mutex) = 0;
 };
 
 }

--- a/src/Backups/BackupCoordinationLocal.h
+++ b/src/Backups/BackupCoordinationLocal.h
@@ -7,7 +7,7 @@
 #include <Backups/BackupCoordinationReplicatedTables.h>
 #include <base/defines.h>
 #include <mutex>
-#include <set>
+#include <unordered_set>
 
 
 namespace Poco { class Logger; }

--- a/src/Backups/BackupCoordinationRemote.h
+++ b/src/Backups/BackupCoordinationRemote.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Backups/IBackupCoordination.h>
+#include <Backups/BackupCoordinationFileInfos.h>
 #include <Backups/BackupCoordinationReplicatedAccess.h>
 #include <Backups/BackupCoordinationReplicatedSQLObjects.h>
 #include <Backups/BackupCoordinationReplicatedTables.h>
@@ -68,8 +69,10 @@ public:
     void addReplicatedSQLObjectsDir(const String & loader_zk_path, UserDefinedSQLObjectType object_type, const String & dir_path) override;
     Strings getReplicatedSQLObjectsDirs(const String & loader_zk_path, UserDefinedSQLObjectType object_type) const override;
 
-    void addFileInfo(const FileInfo & file_info, bool & is_data_file_required) override;
-    std::vector<FileInfo> getAllFileInfos() const override;
+    void addFileInfos(BackupFileInfos && file_infos) override;
+    BackupFileInfos getFileInfos() const override;
+    BackupFileInfos getFileInfosForAllHosts() const override;
+    bool startWritingFile(size_t data_file_index) override;
 
     bool hasConcurrentBackups(const std::atomic<size_t> & num_active_backups) const override;
 
@@ -87,6 +90,7 @@ private:
     void prepareReplicatedTables() const;
     void prepareReplicatedAccess() const;
     void prepareReplicatedSQLObjects() const;
+    void prepareFileInfos() const;
 
     const zkutil::GetZooKeeper get_zookeeper;
     const String root_zookeeper_path;
@@ -107,6 +111,7 @@ private:
     mutable std::optional<BackupCoordinationReplicatedTables> replicated_tables;
     mutable std::optional<BackupCoordinationReplicatedAccess> replicated_access;
     mutable std::optional<BackupCoordinationReplicatedSQLObjects> replicated_sql_objects;
+    mutable std::optional<BackupCoordinationFileInfos> file_infos;
 };
 
 }

--- a/src/Backups/BackupCoordinationRemote.h
+++ b/src/Backups/BackupCoordinationRemote.h
@@ -33,6 +33,7 @@ public:
         const String & backup_uuid_,
         const Strings & all_hosts_,
         const String & current_host_,
+        bool plain_backup_,
         bool is_internal_);
 
     ~BackupCoordinationRemote() override;
@@ -68,12 +69,7 @@ public:
     Strings getReplicatedSQLObjectsDirs(const String & loader_zk_path, UserDefinedSQLObjectType object_type) const override;
 
     void addFileInfo(const FileInfo & file_info, bool & is_data_file_required) override;
-
     std::vector<FileInfo> getAllFileInfos() const override;
-    Strings listFiles(const String & directory, bool recursive) const override;
-    bool hasFiles(const String & directory) const override;
-    std::optional<FileInfo> getFileInfo(const String & file_name) const override;
-    std::optional<FileInfo> getFileInfo(const SizeAndChecksum & size_and_checksum) const override;
 
     bool hasConcurrentBackups(const std::atomic<size_t> & num_active_backups) const override;
 
@@ -100,6 +96,7 @@ private:
     const Strings all_hosts;
     const String current_host;
     const size_t current_host_index;
+    const bool plain_backup;
     const bool is_internal;
 
     mutable ZooKeeperRetriesInfo zookeeper_retries_info;

--- a/src/Backups/BackupCoordinationRemote.h
+++ b/src/Backups/BackupCoordinationRemote.h
@@ -68,16 +68,12 @@ public:
     Strings getReplicatedSQLObjectsDirs(const String & loader_zk_path, UserDefinedSQLObjectType object_type) const override;
 
     void addFileInfo(const FileInfo & file_info, bool & is_data_file_required) override;
-    void updateFileInfo(const FileInfo & file_info) override;
 
     std::vector<FileInfo> getAllFileInfos() const override;
     Strings listFiles(const String & directory, bool recursive) const override;
     bool hasFiles(const String & directory) const override;
     std::optional<FileInfo> getFileInfo(const String & file_name) const override;
     std::optional<FileInfo> getFileInfo(const SizeAndChecksum & size_and_checksum) const override;
-
-    String getNextArchiveSuffix() override;
-    Strings getAllArchiveSuffixes() const override;
 
     bool hasConcurrentBackups(const std::atomic<size_t> & num_active_backups) const override;
 

--- a/src/Backups/BackupCoordinationRemote.h
+++ b/src/Backups/BackupCoordinationRemote.h
@@ -24,7 +24,7 @@ public:
         UInt64 keeper_max_retries;
         UInt64 keeper_retry_initial_backoff_ms;
         UInt64 keeper_retry_max_backoff_ms;
-        UInt64 batch_size_for_keeper_multiread;
+        UInt64 keeper_value_max_size;
     };
 
     BackupCoordinationRemote(

--- a/src/Backups/BackupCoordinationStage.h
+++ b/src/Backups/BackupCoordinationStage.h
@@ -23,7 +23,7 @@ namespace BackupCoordinationStage
     /// Running special tasks for replicated tables which can also prepare some backup entries.
     constexpr const char * RUNNING_POST_TASKS = "running post-tasks";
 
-    /// Building file informations about all backup entries in the future backup.
+    /// Building information about all files which will be written to a backup.
     constexpr const char * BUILDING_FILE_INFOS = "building file infos";
 
     /// Writing backup entries to the backup and removing temporary hard links.

--- a/src/Backups/BackupCoordinationStage.h
+++ b/src/Backups/BackupCoordinationStage.h
@@ -23,6 +23,9 @@ namespace BackupCoordinationStage
     /// Running special tasks for replicated tables which can also prepare some backup entries.
     constexpr const char * RUNNING_POST_TASKS = "running post-tasks";
 
+    /// Building file informations about all backup entries in the future backup.
+    constexpr const char * BUILDING_FILE_INFOS = "building file infos";
+
     /// Writing backup entries to the backup and removing temporary hard links.
     constexpr const char * WRITING_BACKUP = "writing backup";
 

--- a/src/Backups/BackupEntriesCollector.cpp
+++ b/src/Backups/BackupEntriesCollector.cpp
@@ -123,7 +123,6 @@ BackupEntries BackupEntriesCollector::run()
     runPostTasks();
 
     /// No more backup entries or tasks are allowed after this point.
-    setStage(Stage::WRITING_BACKUP);
 
     return std::move(backup_entries);
 }

--- a/src/Backups/BackupFileInfo.cpp
+++ b/src/Backups/BackupFileInfo.cpp
@@ -1,0 +1,283 @@
+#include <Backups/BackupFileInfo.h>
+
+#include <Backups/IBackup.h>
+#include <Backups/IBackupEntry.h>
+#include <Common/CurrentThread.h>
+#include <Common/logger_useful.h>
+#include <Common/scope_guard_safe.h>
+#include <Common/setThreadName.h>
+#include <IO/HashingReadBuffer.h>
+
+
+namespace DB
+{
+
+namespace
+{
+    using SizeAndChecksum = std::pair<UInt64, UInt128>;
+
+    std::optional<SizeAndChecksum> getInfoAboutFileFromBaseBackupIfExists(const BackupPtr & base_backup, const std::string & file_path)
+    {
+        if (base_backup && base_backup->fileExists(file_path))
+            return base_backup->getFileSizeAndChecksum(file_path);
+
+        return std::nullopt;
+    }
+
+    enum class CheckBackupResult
+    {
+        HasPrefix,
+        HasFull,
+        HasNothing,
+    };
+
+    CheckBackupResult checkBaseBackupForFile(const SizeAndChecksum & base_backup_info, const BackupFileInfo & new_entry_info)
+    {
+        /// We cannot reuse base backup because our file is smaller
+        /// than file stored in previous backup
+        if (new_entry_info.size < base_backup_info.first)
+            return CheckBackupResult::HasNothing;
+
+        if (base_backup_info.first == new_entry_info.size)
+            return CheckBackupResult::HasFull;
+
+        return CheckBackupResult::HasPrefix;
+
+    }
+
+    struct ChecksumsForNewEntry
+    {
+        UInt128 full_checksum;
+        UInt128 prefix_checksum;
+    };
+
+    /// Calculate checksum for backup entry if it's empty.
+    /// Also able to calculate additional checksum of some prefix.
+    ChecksumsForNewEntry calculateNewEntryChecksumsIfNeeded(const BackupEntryPtr & entry, size_t prefix_size)
+    {
+        if (prefix_size > 0)
+        {
+            auto read_buffer = entry->getReadBuffer();
+            HashingReadBuffer hashing_read_buffer(*read_buffer);
+            hashing_read_buffer.ignore(prefix_size);
+            auto prefix_checksum = hashing_read_buffer.getHash();
+            if (entry->getChecksum() == std::nullopt)
+            {
+                hashing_read_buffer.ignoreAll();
+                auto full_checksum = hashing_read_buffer.getHash();
+                return ChecksumsForNewEntry{full_checksum, prefix_checksum};
+            }
+            else
+            {
+                return ChecksumsForNewEntry{*(entry->getChecksum()), prefix_checksum};
+            }
+        }
+        else
+        {
+            if (entry->getChecksum() == std::nullopt)
+            {
+                auto read_buffer = entry->getReadBuffer();
+                HashingReadBuffer hashing_read_buffer(*read_buffer);
+                hashing_read_buffer.ignoreAll();
+                return ChecksumsForNewEntry{hashing_read_buffer.getHash(), 0};
+            }
+            else
+            {
+                return ChecksumsForNewEntry{*(entry->getChecksum()), 0};
+            }
+        }
+    }
+
+    /// We store entries' file names in the backup without leading slashes.
+    String removeLeadingSlash(const String & path)
+    {
+        if (path.starts_with('/'))
+            return path.substr(1);
+        return path;
+    }
+}
+
+
+/// Note: this format doesn't allow to parse data back
+/// It is useful only for debugging purposes
+String BackupFileInfo::describe() const
+{
+    String result;
+    result += fmt::format("file_name: {};\n", file_name);
+    result += fmt::format("size: {};\n", size);
+    result += fmt::format("checksum: {};\n", getHexUIntLowercase(checksum));
+    result += fmt::format("base_size: {};\n", base_size);
+    result += fmt::format("base_checksum: {};\n", getHexUIntLowercase(checksum));
+    result += fmt::format("data_file_name: {};\n", data_file_name);
+    result += fmt::format("data_file_index: {};\n", data_file_index);
+    return result;
+}
+
+
+BackupFileInfo buildFileInfoForBackupEntry(const String & file_name, const BackupEntryPtr & backup_entry, const BackupPtr & base_backup, Poco::Logger * log)
+{
+    auto adjusted_path = removeLeadingSlash(file_name);
+
+    BackupFileInfo info;
+    info.file_name = adjusted_path;
+    info.data_file_name = info.file_name;
+    info.size = backup_entry->getSize();
+
+    if (!info.size)
+    {
+        /// Empty file.
+        return info;
+    }
+
+    if (!log)
+        log = &Poco::Logger::get("FileInfoFromBackupEntry");
+
+    std::optional<SizeAndChecksum> base_backup_file_info = getInfoAboutFileFromBaseBackupIfExists(base_backup, adjusted_path);
+
+    /// We have info about this file in base backup
+    /// If file has no checksum -- calculate and fill it.
+    if (base_backup_file_info.has_value())
+    {
+        LOG_TRACE(log, "File {} found in base backup, checking for equality", adjusted_path);
+        CheckBackupResult check_base = checkBaseBackupForFile(*base_backup_file_info, info);
+
+        /// File with the same name but smaller size exist in previous backup
+        if (check_base == CheckBackupResult::HasPrefix)
+        {
+            auto checksums = calculateNewEntryChecksumsIfNeeded(backup_entry, base_backup_file_info->first);
+            info.checksum = checksums.full_checksum;
+
+            /// We have prefix of this file in backup with the same checksum.
+            /// In ClickHouse this can happen for StorageLog for example.
+            if (checksums.prefix_checksum == base_backup_file_info->second)
+            {
+                LOG_TRACE(log, "Found prefix of file {} in the base backup, will write rest of the file to current backup", adjusted_path);
+                info.base_size = base_backup_file_info->first;
+                info.base_checksum = base_backup_file_info->second;
+            }
+            else
+            {
+                LOG_TRACE(log, "Prefix of file {} doesn't match the file in the base backup", adjusted_path);
+            }
+        }
+        else
+        {
+            /// We have full file or have nothing, first of all let's get checksum
+            /// of current file
+            auto checksums = calculateNewEntryChecksumsIfNeeded(backup_entry, 0);
+            info.checksum = checksums.full_checksum;
+
+            if (info.checksum == base_backup_file_info->second)
+            {
+                LOG_TRACE(log, "Found whole file {} in base backup", adjusted_path);
+                assert(check_base == CheckBackupResult::HasFull);
+                assert(info.size == base_backup_file_info->first);
+
+                info.base_size = base_backup_file_info->first;
+                info.base_checksum = base_backup_file_info->second;
+                /// Actually we can add this info to coordination and exist,
+                /// but we intentionally don't do it, otherwise control flow
+                /// of this function will be very complex.
+            }
+            else
+            {
+                LOG_TRACE(log, "Whole file {} in base backup doesn't match by checksum", adjusted_path);
+            }
+        }
+    }
+    else
+    {
+        auto checksums = calculateNewEntryChecksumsIfNeeded(backup_entry, 0);
+        info.checksum = checksums.full_checksum;
+    }
+
+    /// We don't have info about this file_name (sic!) in base backup,
+    /// however file could be renamed, so we will check one more time using size and checksum
+    if (base_backup && base_backup->fileExists(std::pair{info.size, info.checksum}))
+    {
+        LOG_TRACE(log, "Found a file in the base backup with the same size and checksum as {}", adjusted_path);
+        info.base_size = info.size;
+        info.base_checksum = info.checksum;
+    }
+
+    if (base_backup && !info.base_size)
+        LOG_TRACE(log, "Nothing found for file {} in base backup", adjusted_path);
+
+    return info;
+}
+
+BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entries, const BackupPtr & base_backup, ThreadPool & thread_pool)
+{
+    BackupFileInfos infos;
+    infos.resize(backup_entries.size());
+
+    size_t num_active_jobs = 0;
+    std::mutex mutex;
+    std::condition_variable event;
+    std::exception_ptr exception;
+
+    auto thread_group = CurrentThread::getGroup();
+    Poco::Logger * log = &Poco::Logger::get("FileInfosFromBackupEntries");
+
+    for (size_t i = 0; i != backup_entries.size(); ++i)
+    {
+        {
+            std::lock_guard lock{mutex};
+            if (exception)
+                break;
+            ++num_active_jobs;
+        }
+
+        auto job = [&mutex, &num_active_jobs, &event, &exception, &infos, &backup_entries, &base_backup, &thread_group, i, log](bool async)
+        {
+            SCOPE_EXIT_SAFE({
+                std::lock_guard lock{mutex};
+                if (!--num_active_jobs)
+                    event.notify_all();
+                if (async)
+                    CurrentThread::detachFromGroupIfNotDetached();
+            });
+
+            try
+            {
+                const auto & name = backup_entries[i].first;
+                const auto & entry = backup_entries[i].second;
+
+                if (async && thread_group)
+                    CurrentThread::attachToGroup(thread_group);
+
+                if (async)
+                    setThreadName("BackupWorker");
+
+                {
+                    std::lock_guard lock{mutex};
+                    if (exception)
+                        return;
+                }
+
+                infos[i] = buildFileInfoForBackupEntry(name, entry, base_backup, log);
+                infos[i].data_file_index = i;
+            }
+            catch (...)
+            {
+                std::lock_guard lock{mutex};
+                if (!exception)
+                    exception = std::current_exception();
+            }
+        };
+
+        if (!thread_pool.trySchedule([job] { job(true); }))
+            job(false);
+    }
+
+    {
+        std::unique_lock lock{mutex};
+        event.wait(lock, [&] { return !num_active_jobs; });
+        if (exception)
+            std::rethrow_exception(exception);
+    }
+
+    return infos;
+}
+
+}

--- a/src/Backups/BackupFileInfo.cpp
+++ b/src/Backups/BackupFileInfo.cpp
@@ -120,8 +120,10 @@ BackupFileInfo buildFileInfoForBackupEntry(const String & file_name, const Backu
 
     BackupFileInfo info;
     info.file_name = adjusted_path;
-    info.data_file_name = info.file_name;
     info.size = backup_entry->getSize();
+
+    /// We don't set `info.data_file_name` and `info.data_file_index` in this function because they're set during backup coordination
+    /// (see the class BackupCoordinationFileInfos).
 
     if (!info.size)
     {
@@ -256,7 +258,6 @@ BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entr
                 }
 
                 infos[i] = buildFileInfoForBackupEntry(name, entry, base_backup, log);
-                infos[i].data_file_index = i;
             }
             catch (...)
             {

--- a/src/Backups/BackupFileInfo.h
+++ b/src/Backups/BackupFileInfo.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <Core/Types.h>
+#include <Common/ThreadPool.h>
+
+
+namespace DB
+{
+
+class IBackup;
+class IBackupEntry;
+using BackupPtr = std::shared_ptr<const IBackup>;
+using BackupEntryPtr = std::shared_ptr<const IBackupEntry>;
+using BackupEntries = std::vector<std::pair<String, BackupEntryPtr>>;
+
+
+/// Information about a file stored in a backup.
+struct BackupFileInfo
+{
+    String file_name;
+
+    UInt64 size = 0;
+    UInt128 checksum{0};
+
+    /// for incremental backups
+    UInt64 base_size = 0;
+    UInt128 base_checksum{0};
+
+    /// Name of the data file. An empty string means there is no data file (that can happen if the file is empty or was taken from the base backup as a whole). 
+    /// Both `data_file_name` and `data_file_index` are adjusted during backup coordination.
+    String data_file_name;
+
+    /// Index of the data file. -1 means there is no data file.
+    size_t data_file_index = static_cast<size_t>(-1);
+
+    struct LessByFileName
+    {
+        bool operator()(const BackupFileInfo & lhs, const BackupFileInfo & rhs) const { return (lhs.file_name < rhs.file_name); }
+    };
+
+    struct EqualByFileName
+    {
+        bool operator()(const BackupFileInfo & lhs, const BackupFileInfo & rhs) const { return (lhs.file_name == rhs.file_name); }
+        bool operator()(const BackupFileInfo * lhs, const BackupFileInfo * rhs) const { return (lhs->file_name == rhs->file_name); }
+    };
+
+    struct LessBySizeOrChecksum
+    {
+        bool operator()(const BackupFileInfo & lhs, const BackupFileInfo & rhs) const
+        {
+            return (lhs.size < rhs.size) || (lhs.size == rhs.size && lhs.checksum < rhs.checksum);
+        }
+    };
+
+    /// Note: this format doesn't allow to parse data back.
+    /// Must be used only for debugging purposes.
+    String describe() const;
+};
+
+using BackupFileInfos = std::vector<BackupFileInfo>;
+
+/// Builds a BackupFileInfo for a specified backup entry.
+BackupFileInfo buildFileInfoForBackupEntry(const String & file_name, const BackupEntryPtr & backup_entry, const BackupPtr & base_backup, Poco::Logger * log);
+
+/// Builds a vector of BackupFileInfos for specified backup entries.
+BackupFileInfos buildFileInfosForBackupEntries(const BackupEntries & backup_entries, const BackupPtr & base_backup, ThreadPool & thread_pool);
+
+}

--- a/src/Backups/BackupFileInfo.h
+++ b/src/Backups/BackupFileInfo.h
@@ -26,11 +26,12 @@ struct BackupFileInfo
     UInt64 base_size = 0;
     UInt128 base_checksum{0};
 
-    /// Name of the data file. An empty string means there is no data file (that can happen if the file is empty or was taken from the base backup as a whole). 
-    /// Both `data_file_name` and `data_file_index` are adjusted during backup coordination.
+    /// Name of the data file. An empty string means there is no data file (that can happen if the file is empty or was taken from the base backup as a whole).
+    /// This field can be adjusted during backup coordination.
     String data_file_name;
 
     /// Index of the data file. -1 means there is no data file.
+    /// This field is adjusted during backup coordination.
     size_t data_file_index = static_cast<size_t>(-1);
 
     struct LessByFileName

--- a/src/Backups/BackupFileInfo.h
+++ b/src/Backups/BackupFileInfo.h
@@ -27,16 +27,17 @@ struct BackupFileInfo
     UInt128 base_checksum{0};
 
     /// Name of the data file. An empty string means there is no data file (that can happen if the file is empty or was taken from the base backup as a whole).
-    /// This field can be adjusted during backup coordination.
+    /// This field is set during backup coordination (see the class BackupCoordinationFileInfos).
     String data_file_name;
 
     /// Index of the data file. -1 means there is no data file.
-    /// This field is adjusted during backup coordination.
+    /// This field is set during backup coordination (see the class BackupCoordinationFileInfos).
     size_t data_file_index = static_cast<size_t>(-1);
 
     struct LessByFileName
     {
         bool operator()(const BackupFileInfo & lhs, const BackupFileInfo & rhs) const { return (lhs.file_name < rhs.file_name); }
+        bool operator()(const BackupFileInfo * lhs, const BackupFileInfo * rhs) const { return (lhs->file_name < rhs->file_name); }
     };
 
     struct EqualByFileName

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -34,7 +34,6 @@ namespace ErrorCodes
     extern const int BACKUP_DAMAGED;
     extern const int NO_BASE_BACKUP;
     extern const int WRONG_BASE_BACKUP;
-    extern const int BACKUP_ENTRY_ALREADY_EXISTS;
     extern const int BACKUP_ENTRY_NOT_FOUND;
     extern const int BACKUP_IS_EMPTY;
     extern const int FAILED_TO_SYNC_BACKUP_OR_RESTORE;

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -81,7 +81,7 @@ public:
                           WriteMode write_mode, const WriteSettings & write_settings) const override;
     void writeFile(const String & file_name, BackupEntryPtr entry) override;
     void finalizeWriting() override;
-    bool supportsWritingInMultipleThreads() const override { return !use_archives; }
+    bool supportsWritingInMultipleThreads() const override { return !use_archive; }
 
 private:
     using FileInfo = IBackupCoordination::FileInfo;
@@ -89,7 +89,9 @@ private:
 
     void open(const ContextPtr & context);
     void close();
-    void closeArchives();
+
+    void openArchive();
+    void closeArchive();
 
     /// Writes the file ".backup" containing backup's metadata.
     void writeBackupMetadata();
@@ -106,16 +108,12 @@ private:
 
     void removeAllFilesAfterFailure();
 
-    String getArchiveNameWithSuffix(const String & suffix) const;
-    std::shared_ptr<IArchiveReader> getArchiveReader(const String & suffix) const;
-    std::shared_ptr<IArchiveWriter> getArchiveWriter(const String & suffix);
-
     /// Calculates and sets `compressed_size`.
     void setCompressedSize();
 
     const String backup_name_for_logging;
+    const bool use_archive;
     const ArchiveParams archive_params;
-    const bool use_archives;
     const OpenMode open_mode;
     std::shared_ptr<IBackupWriter> writer;
     std::shared_ptr<IBackupReader> reader;
@@ -137,9 +135,8 @@ private:
     std::optional<BackupInfo> base_backup_info;
     std::shared_ptr<const IBackup> base_backup;
     std::optional<UUID> base_backup_uuid;
-    mutable std::unordered_map<String /* archive_suffix */, std::shared_ptr<IArchiveReader>> archive_readers;
-    std::pair<String, std::shared_ptr<IArchiveWriter>> archive_writers[2];
-    String current_archive_suffix;
+    std::shared_ptr<IArchiveReader> archive_reader;
+    std::shared_ptr<IArchiveWriter> archive_writer;
     String lock_file_name;
     bool writing_finalized = false;
     bool deduplicate_files = true;

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -65,11 +65,12 @@ namespace
                 toString(*backup_settings.backup_uuid),
                 all_hosts,
                 backup_settings.host_id,
+                !backup_settings.deduplicate_files,
                 backup_settings.internal);
         }
         else
         {
-            return std::make_shared<BackupCoordinationLocal>();
+            return std::make_shared<BackupCoordinationLocal>(!backup_settings.deduplicate_files);
         }
     }
 

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -105,8 +105,11 @@ private:
         ContextMutablePtr mutable_context,
         bool called_async);
 
+    /// Builds file infos for specified backup entries.
+    void buildFileInfosForBackupEntries(const BackupPtr & backup, const BackupEntries & backup_entries, std::shared_ptr<IBackupCoordination> backup_coordination);
+
     /// Write backup entries to an opened backup.
-    void writeBackupEntries(const OperationID & backup_id, BackupMutablePtr backup, BackupEntries && backup_entries, ThreadPool & thread_pool, bool internal);
+    void writeBackupEntries(BackupMutablePtr backup, BackupEntries && backup_entries, const OperationID & backup_id, std::shared_ptr<IBackupCoordination> backup_coordination, bool internal);
 
     OperationID startRestoring(const ASTPtr & query, ContextMutablePtr context);
 

--- a/src/Backups/IBackup.h
+++ b/src/Backups/IBackup.h
@@ -10,8 +10,9 @@
 namespace DB
 {
 class IBackupEntry;
-class IDisk;
 using BackupEntryPtr = std::shared_ptr<const IBackupEntry>;
+struct BackupFileInfo;
+class IDisk;
 using DiskPtr = std::shared_ptr<IDisk>;
 class SeekableReadBuffer;
 
@@ -41,6 +42,9 @@ public:
 
     /// Returns UUID of the backup.
     virtual UUID getUUID() const = 0;
+
+    /// Returns the base backup (can be null).
+    virtual std::shared_ptr<const IBackup> getBaseBackup() const = 0;
 
     /// Returns the number of files stored in the backup. Compare with getNumEntries().
     virtual size_t getNumFiles() const = 0;
@@ -111,7 +115,7 @@ public:
                                   WriteMode write_mode = WriteMode::Rewrite, const WriteSettings & write_settings = {}) const = 0;
 
     /// Puts a new entry to the backup.
-    virtual void writeFile(const String & file_name, BackupEntryPtr entry) = 0;
+    virtual void writeFile(const BackupFileInfo & file_info, BackupEntryPtr entry) = 0;
 
     /// Finalizes writing the backup, should be called after all entries have been successfully written.
     virtual void finalizeWriting() = 0;

--- a/src/Backups/IBackupCoordination.h
+++ b/src/Backups/IBackupCoordination.h
@@ -100,26 +100,32 @@ public:
             result += fmt::format("data_file_name: {};\n", data_file_name);
             return result;
         }
+
+        struct LessByFileName
+        {
+            bool operator()(const FileInfo & lhs, const FileInfo & rhs) const { return (lhs.file_name < rhs.file_name); }
+        };
+
+        struct EqualByFileName
+        {
+            bool operator()(const FileInfo & lhs, const FileInfo & rhs) const { return (lhs.file_name == rhs.file_name); }
+        };
+
+        struct LessBySizeOrChecksum
+        {
+            bool operator()(const FileInfo & lhs, const FileInfo & rhs) const
+            {
+                return (lhs.size < rhs.size) || (lhs.size == rhs.size && lhs.checksum < rhs.checksum);
+            }
+        };
+
+        using SizeAndChecksum = std::pair<UInt64, UInt128>;
     };
 
     /// Adds file information.
     /// If specified checksum+size are new for this IBackupContentsInfo the function sets `is_data_file_required`.
     virtual void addFileInfo(const FileInfo & file_info, bool & is_data_file_required) = 0;
-
-    void addFileInfo(const FileInfo & file_info)
-    {
-        bool is_data_file_required;
-        addFileInfo(file_info, is_data_file_required);
-    }
-
     virtual std::vector<FileInfo> getAllFileInfos() const = 0;
-    virtual Strings listFiles(const String & directory, bool recursive) const = 0;
-    virtual bool hasFiles(const String & directory) const = 0;
-
-    using SizeAndChecksum = std::pair<UInt64, UInt128>;
-
-    virtual std::optional<FileInfo> getFileInfo(const String & file_name) const = 0;
-    virtual std::optional<FileInfo> getFileInfo(const SizeAndChecksum & size_and_checksum) const = 0;
 
     /// This function is used to check if concurrent backups are running
     /// other than the backup passed to the function

--- a/src/Backups/IBackupCoordination.h
+++ b/src/Backups/IBackupCoordination.h
@@ -87,12 +87,6 @@ public:
         /// Name of the data file.
         String data_file_name;
 
-        /// Suffix of an archive if the backup is stored as a series of archives.
-        String archive_suffix;
-
-        /// Position in the archive.
-        UInt64 pos_in_archive = static_cast<UInt64>(-1);
-
         /// Note: this format doesn't allow to parse data back
         /// It is useful only for debugging purposes
         [[ maybe_unused ]] String describe()
@@ -104,8 +98,6 @@ public:
             result += fmt::format("base_size: {};\n", base_size);
             result += fmt::format("base_checksum: {};\n", getHexUIntLowercase(checksum));
             result += fmt::format("data_file_name: {};\n", data_file_name);
-            result += fmt::format("archive_suffix: {};\n", archive_suffix);
-            result += fmt::format("pos_in_archive: {};\n", pos_in_archive);
             return result;
         }
     };
@@ -120,9 +112,6 @@ public:
         addFileInfo(file_info, is_data_file_required);
     }
 
-    /// Updates some fields (currently only `archive_suffix`) of a stored file's information.
-    virtual void updateFileInfo(const FileInfo & file_info) = 0;
-
     virtual std::vector<FileInfo> getAllFileInfos() const = 0;
     virtual Strings listFiles(const String & directory, bool recursive) const = 0;
     virtual bool hasFiles(const String & directory) const = 0;
@@ -131,12 +120,6 @@ public:
 
     virtual std::optional<FileInfo> getFileInfo(const String & file_name) const = 0;
     virtual std::optional<FileInfo> getFileInfo(const SizeAndChecksum & size_and_checksum) const = 0;
-
-    /// Generates a new archive suffix, e.g. "001", "002", "003", ...
-    virtual String getNextArchiveSuffix() = 0;
-
-    /// Returns the list of all the archive suffixes which were generated.
-    virtual Strings getAllArchiveSuffixes() const = 0;
 
     /// This function is used to check if concurrent backups are running
     /// other than the backup passed to the function

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -418,6 +418,7 @@ class IColumn;
     M(UInt64, backup_keeper_max_retries, 20, "Max retries for keeper operations during backup", 0) \
     M(UInt64, backup_keeper_retry_initial_backoff_ms, 100, "Initial backoff timeout for [Zoo]Keeper operations during backup", 0) \
     M(UInt64, backup_keeper_retry_max_backoff_ms, 5000, "Max backoff timeout for [Zoo]Keeper operations during backup", 0) \
+    M(UInt64, backup_keeper_value_max_size, 1048576, "Maximum size of data of a [Zoo]Keeper's node during backup", 0) \
     M(UInt64, backup_batch_size_for_keeper_multiread, 10000, "Maximum size of batch for multiread request to [Zoo]Keeper during backup", 0) \
     \
     M(Bool, log_profile_events, true, "Log query performance statistics into the query_log, query_thread_log and query_views_log.", 0) \

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -429,6 +429,39 @@ def test_replicated_database_async():
     assert node2.query("SELECT * FROM mydb.tbl2 ORDER BY y") == TSV(["a", "bb"])
 
 
+# By default `backup_keeper_value_max_size` is 1 MB, but in this test we'll set it to 50 bytes just to check it works.
+def test_keeper_value_max_size():
+    node1.query(
+        "CREATE TABLE tbl ON CLUSTER 'cluster' ("
+        "x UInt32"
+        ") ENGINE=ReplicatedMergeTree('/clickhouse/tables/tbl/', '{replica}')"
+        "ORDER BY x"
+    )
+
+    node1.query("INSERT INTO tbl VALUES (111)")
+    node2.query("INSERT INTO tbl VALUES (222)")
+
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
+    node1.query("SYSTEM STOP REPLICATED SENDS ON CLUSTER 'cluster' tbl")
+
+    node1.query("INSERT INTO tbl VALUES (333)")
+    node2.query("INSERT INTO tbl VALUES (444)")
+
+    backup_name = new_backup_name()
+    node1.query(
+        f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}",
+        settings={"backup_keeper_value_max_size": 50},
+    )
+
+    node1.query(f"DROP TABLE tbl ON CLUSTER 'cluster' NO DELAY")
+
+    node1.query(f"RESTORE TABLE tbl ON CLUSTER 'cluster' FROM {backup_name}")
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl")
+
+    assert node1.query("SELECT * FROM tbl ORDER BY x") == TSV([111, 222, 333, 444])
+    assert node2.query("SELECT * FROM tbl ORDER BY x") == TSV([111, 222, 333, 444])
+
+
 @pytest.mark.parametrize(
     "interface, on_cluster", [("native", True), ("http", True), ("http", False)]
 )


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Decrease the number of zookeeper nodes created and read during a backup process.
Build all file infos before writing anything to backup (that will allow to show progress for on cluster backups properly).
Remove some obsolete code.
