### PR TITLE
Fix crash in explain graph with StorageMerge

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -655,7 +655,7 @@ QueryPipelineBuilderPtr ReadFromMerge::createSources(
         if (real_column_names.empty())
             real_column_names.push_back(ExpressionActions::getSmallestColumn(storage_snapshot->metadata->getColumns().getAllPhysical()).name);
 
-        QueryPlan plan;
+        QueryPlan & plan = child_plans.emplace_back();
 
         StorageView * view = dynamic_cast<StorageView *>(storage.get());
         if (!view || allow_experimental_analyzer)

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -655,6 +655,8 @@ QueryPipelineBuilderPtr ReadFromMerge::createSources(
         if (real_column_names.empty())
             real_column_names.push_back(ExpressionActions::getSmallestColumn(storage_snapshot->metadata->getColumns().getAllPhysical()).name);
 
+        /// Steps for reading from child tables should have the same lifetime as the current step
+        /// because `builder` can have references to them (mainly for EXPLAIN PIPELINE).
         QueryPlan & plan = child_plans.emplace_back();
 
         StorageView * view = dynamic_cast<StorageView *>(storage.get());

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -159,6 +159,8 @@ private:
     StoragePtr storage_merge;
     StorageSnapshotPtr merge_storage_snapshot;
 
+    std::vector<QueryPlan> child_plans;
+
     SelectQueryInfo query_info;
     ContextMutablePtr context;
     QueryProcessingStage::Enum common_processed_stage;

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -159,6 +159,8 @@ private:
     StoragePtr storage_merge;
     StorageSnapshotPtr merge_storage_snapshot;
 
+    /// Store read plan for each child table.
+    /// It's needed to guarantee lifetime for child steps to be the same as for this step.
     std::vector<QueryPlan> child_plans;
 
     SelectQueryInfo query_info;

--- a/tests/queries/0_stateless/25402_storage_merge_explain_graph_crash.sql
+++ b/tests/queries/0_stateless/25402_storage_merge_explain_graph_crash.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS foo;
+DROP TABLE IF EXISTS merge1;
+
+CREATE TABLE foo (`Id` Int32, `Val` Int32) ENGINE = MergeTree ORDER BY Id;
+INSERT INTO foo SELECT number, number FROM numbers(100);
+
+CREATE TABLE merge1 AS foo ENGINE = Merge(currentDatabase(), '^foo');
+
+EXPLAIN PIPELINE graph = 1, compact = 1 SELECT * FROM merge1 FORMAT Null;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Fix crash in `EXPLAIN graph = 1 ...` with StorageMerge, close https://github.com/ClickHouse/ClickHouse/issues/48053

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
