### PR TITLE
Support more ClickHouse types in Avro format

### DIFF
--- a/docs/en/interfaces/formats.md
+++ b/docs/en/interfaces/formats.md
@@ -1818,15 +1818,19 @@ The table below shows supported data types and how they match ClickHouse [data t
 | `bytes`, `string`, `fixed`                  | [FixedString(N)](/docs/en/sql-reference/data-types/fixedstring.md)                                                            | `fixed(N)`                    |
 | `enum`                                      | [Enum(8\16)](/docs/en/sql-reference/data-types/enum.md)                                                                       | `enum`                        |
 | `array(T)`                                  | [Array(T)](/docs/en/sql-reference/data-types/array.md)                                                                        | `array(T)`                    |
+| `map(V, K)`                                 | [Map(V, K)](/docs/en/sql-reference/data-types/map.md)                                                                         | `map(string, K)`              |
 | `union(null, T)`, `union(T, null)`          | [Nullable(T)](/docs/en/sql-reference/data-types/date.md)                                                                      | `union(null, T)`              |
 | `null`                                      | [Nullable(Nothing)](/docs/en/sql-reference/data-types/special-data-types/nothing.md)                                          | `null`                        |
 | `int (date)` \**                            | [Date](/docs/en/sql-reference/data-types/date.md), [Date32](docs/en/sql-reference/data-types/date32.md)                       | `int (date)` \**              |
 | `long (timestamp-millis)` \**               | [DateTime64(3)](/docs/en/sql-reference/data-types/datetime.md)                                                                | `long (timestamp-millis)` \** |
 | `long (timestamp-micros)` \**               | [DateTime64(6)](/docs/en/sql-reference/data-types/datetime.md)                                                                | `long (timestamp-micros)` \** |
+| `bytes (decimal)`  \**                      | [DateTime64(N)](/docs/en/sql-reference/data-types/datetime.md)                                                                | `bytes (decimal)`  \**        |
 | `int`                                       | [IPv4](/docs/en/sql-reference/data-types/domains/ipv4.md)                                                                     | `int`                         |
 | `fixed(16)`                                 | [IPv6](/docs/en/sql-reference/data-types/domains/ipv6.md)                                                                     | `fixed(16)`                   |
-| `bytes (decimal)` \**                       | [Decimal(P, S)](/docs/en/sql-reference/data-types/decimal.md)                                                                | `bytes (decimal)` \**         |
-| `string (uuid)` \**                         | [UUID](/docs/en/sql-reference/data-types/uuid.md)                                                                            | `string (uuid)` \**           |
+| `bytes (decimal)` \**                       | [Decimal(P, S)](/docs/en/sql-reference/data-types/decimal.md)                                                                 | `bytes (decimal)` \**         |
+| `string (uuid)` \**                         | [UUID](/docs/en/sql-reference/data-types/uuid.md)                                                                             | `string (uuid)` \**           |
+| `fixed(16)`                                 | [Int128/UInt128](/docs/en/sql-reference/data-types/int-uint.md)                                                               | `fixed(16)`                   |
+| `fixed(32)`                                 | [Int256/UInt256](/docs/en/sql-reference/data-types/int-uint.md)                                                               | `fixed(32)`                   |
 
 
 \* `bytes` is default, controlled by [output_format_avro_string_column_pattern](/docs/en/operations/settings/settings-formats.md/#output_format_avro_string_column_pattern)

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -40,6 +40,8 @@
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnMap.h>
 
+#include <IO/ReadBufferFromString.h>
+
 #include <Compiler.hh>
 #include <DataFile.hh>
 #include <Decoder.hh>
@@ -165,9 +167,10 @@ static AvroDeserializer::DeserializeFn createDecimalDeserializeFn(const avro::No
     if (decimal_type.getScale() != static_cast<UInt32>(logical_type.scale()) || decimal_type.getPrecision() != static_cast<UInt32>(logical_type.precision()))
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
-            "Cannot insert Avro decimal with scale {} and precision {} to ClickHouse Decimal with scale {} and precision {}",
+            "Cannot insert Avro decimal with scale {} and precision {} to ClickHouse type {} with scale {} and precision {}",
             logical_type.scale(),
             logical_type.precision(),
+            target_type->getName(),
             decimal_type.getScale(),
             decimal_type.getPrecision());
 
@@ -205,6 +208,24 @@ static std::string nodeName(avro::NodePtr node)
         return node->name().simpleName();
     else
         return avro::toString(node->type());
+}
+
+static bool canBeDeserializedFromFixed( const DataTypePtr & target_type, size_t fixed_size)
+{
+    switch (target_type->getTypeId())
+    {
+        case TypeIndex::String:
+            return true;
+        case TypeIndex::FixedString: [[fallthrough]];
+        case TypeIndex::IPv6: [[fallthrough]];
+        case TypeIndex::Int128: [[fallthrough]];
+        case TypeIndex::UInt128: [[fallthrough]];
+        case TypeIndex::Int256: [[fallthrough]];
+        case TypeIndex::UInt256:
+            return target_type->getSizeOfValueInMemory() == fixed_size;
+        default:
+            return false;
+    }
 }
 
 AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro::NodePtr & root_node, const DataTypePtr & target_type)
@@ -260,6 +281,8 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
                 return createDecimalDeserializeFn<DataTypeDecimal128>(root_node, target_type);
             if (target.isDecimal256())
                 return createDecimalDeserializeFn<DataTypeDecimal256>(root_node, target_type);
+            if (target.isDateTime64())
+                return createDecimalDeserializeFn<DataTypeDateTime64>(root_node, target_type);
             break;
         case avro::AVRO_INT:
             if (target_type->isValueRepresentedByNumber())
@@ -464,16 +487,7 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
         case avro::AVRO_FIXED:
         {
             size_t fixed_size = root_node->fixedSize();
-            if ((target.isFixedString() && target_type->getSizeOfValueInMemory() == fixed_size) || target.isString())
-            {
-                return [tmp_fixed = std::vector<uint8_t>(fixed_size)](IColumn & column, avro::Decoder & decoder) mutable
-                {
-                    decoder.decodeFixed(tmp_fixed.size(), tmp_fixed);
-                    column.insertData(reinterpret_cast<const char *>(tmp_fixed.data()), tmp_fixed.size());
-                    return true;
-                };
-            }
-            else if (target.isIPv6() && fixed_size == sizeof(IPv6))
+            if (canBeDeserializedFromFixed(target_type, fixed_size))
             {
                 return [tmp_fixed = std::vector<uint8_t>(fixed_size)](IColumn & column, avro::Decoder & decoder) mutable
                 {
@@ -525,7 +539,14 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
                 const auto & values_type = map_type.getValueType();
                 auto keys_source_type = root_node->leafAt(0);
                 auto values_source_type = root_node->leafAt(1);
-                auto keys_deserializer = createDeserializeFn(keys_source_type, keys_type);
+                auto keys_deserializer = [keys_type, this](IColumn & column, avro::Decoder & decoder)
+                {
+                    String key = decoder.decodeString();
+                    ReadBufferFromString buf(key);
+                    keys_type->getDefaultSerialization()->deserializeWholeText(column, buf, settings);
+                    return true;
+                };
+
                 auto values_deserializer = createDeserializeFn(values_source_type, values_type);
                 return [keys_deserializer, values_deserializer](IColumn & column, avro::Decoder & decoder)
                 {
@@ -810,8 +831,8 @@ AvroDeserializer::Action AvroDeserializer::createAction(const Block & header, co
     }
 }
 
-AvroDeserializer::AvroDeserializer(const Block & header, avro::ValidSchema schema, bool allow_missing_fields, bool null_as_default_)
-    : null_as_default(null_as_default_)
+AvroDeserializer::AvroDeserializer(const Block & header, avro::ValidSchema schema, bool allow_missing_fields, bool null_as_default_, const FormatSettings & settings_)
+    : null_as_default(null_as_default_), settings(settings_)
 {
     const auto & schema_root = schema.root();
     if (schema_root->type() != avro::AVRO_RECORD)
@@ -857,7 +878,7 @@ void AvroRowInputFormat::readPrefix()
 {
     file_reader_ptr = std::make_unique<avro::DataFileReaderBase>(std::make_unique<AvroInputStreamReadBufferAdapter>(*in));
     deserializer_ptr = std::make_unique<AvroDeserializer>(
-        output.getHeader(), file_reader_ptr->dataSchema(), format_settings.avro.allow_missing_fields, format_settings.null_as_default);
+        output.getHeader(), file_reader_ptr->dataSchema(), format_settings.avro.allow_missing_fields, format_settings.null_as_default, format_settings);
     file_reader_ptr->init();
 }
 
@@ -1048,7 +1069,7 @@ const AvroDeserializer & AvroConfluentRowInputFormat::getOrCreateDeserializer(Sc
     {
         auto schema = schema_registry->getSchema(schema_id);
         AvroDeserializer deserializer(
-            output.getHeader(), schema, format_settings.avro.allow_missing_fields, format_settings.null_as_default);
+            output.getHeader(), schema, format_settings.avro.allow_missing_fields, format_settings.null_as_default, format_settings);
         it = deserializer_cache.emplace(schema_id, deserializer).first;
     }
     return it->second;

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -40,8 +40,6 @@
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnMap.h>
 
-#include <IO/ReadBufferFromString.h>
-
 #include <Compiler.hh>
 #include <DataFile.hh>
 #include <Decoder.hh>
@@ -210,7 +208,7 @@ static std::string nodeName(avro::NodePtr node)
         return avro::toString(node->type());
 }
 
-static bool canBeDeserializedFromFixed( const DataTypePtr & target_type, size_t fixed_size)
+static bool canBeDeserializedFromFixed(const DataTypePtr & target_type, size_t fixed_size)
 {
     switch (target_type->getTypeId())
     {

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.h
@@ -48,7 +48,7 @@ private:
 class AvroDeserializer
 {
 public:
-    AvroDeserializer(const Block & header, avro::ValidSchema schema, bool allow_missing_fields, bool null_as_default_);
+    AvroDeserializer(const Block & header, avro::ValidSchema schema, bool allow_missing_fields, bool null_as_default_, const FormatSettings & settings_);
     void deserializeRow(MutableColumns & columns, avro::Decoder & decoder, RowReadExtension & ext) const;
 
     using DeserializeFn = std::function<bool(IColumn & column, avro::Decoder & decoder)>;
@@ -145,6 +145,8 @@ private:
     std::map<avro::Name, SkipFn> symbolic_skip_fn_map;
 
     bool null_as_default = false;
+
+    const FormatSettings & settings;
 };
 
 class AvroRowInputFormat final : public IRowInputFormat

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -33,6 +33,7 @@
 #include <Schema.hh>
 
 #include <re2/re2.h>
+#include <boost/algorithm/string.hpp>
 
 namespace DB
 {
@@ -110,6 +111,19 @@ AvroSerializer::SchemaWithSerializeFn createDecimalSchemaWithSerializeFn(const D
     }};
 }
 
+template <typename BigIntegerType>
+AvroSerializer::SchemaWithSerializeFn createBigIntegerSchemaWithSerializeFn(const DataTypePtr & data_type, size_t type_name_increment)
+{
+    auto schema = avro::FixedSchema(sizeof(BigIntegerType), boost::algorithm::to_lower_copy(data_type->getName()) + std::to_string(type_name_increment));
+    return {schema, [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
+    {
+        const auto & col = assert_cast<const ColumnVector<BigIntegerType> &>(column);
+        WriteBufferFromOwnString buf;
+        writeBinary(col.getElement(row_num), buf);
+        encoder.encodeFixed(reinterpret_cast<const uint8_t *>(buf.str().data()), buf.str().size());
+    }};
+}
+
 }
 
 AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeFn(const DataTypePtr & data_type, size_t & type_name_increment, const String & column_name)
@@ -180,6 +194,14 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
             {
                 encoder.encodeDouble(assert_cast<const ColumnFloat64 &>(column).getElement(row_num));
             }};
+        case TypeIndex::Int128:
+            return createBigIntegerSchemaWithSerializeFn<Int128>(data_type, type_name_increment);
+        case TypeIndex::UInt128:
+            return createBigIntegerSchemaWithSerializeFn<UInt128>(data_type, type_name_increment);
+        case TypeIndex::Int256:
+            return createBigIntegerSchemaWithSerializeFn<Int256>(data_type, type_name_increment);
+        case TypeIndex::UInt256:
+            return createBigIntegerSchemaWithSerializeFn<UInt256>(data_type, type_name_increment);
         case TypeIndex::Date:
         {
             auto schema = avro::IntSchema();
@@ -210,7 +232,7 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
             else if (provided_type.getScale() == 6)
                 schema.root()->setLogicalType(avro::LogicalType(avro::LogicalType::TIMESTAMP_MICROS));
             else
-                break;
+                return createDecimalSchemaWithSerializeFn<DataTypeDateTime64>(data_type);
 
             return {schema, [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
             {
@@ -386,7 +408,9 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
             const auto & nested_names = tuple_type.getElementNames();
             std::vector<SerializeFn> nested_serializers;
             nested_serializers.reserve(nested_types.size());
-            auto schema = avro::RecordSchema(column_name);
+            /// We should use unique names for records. Otherwise avro will reuse schema of this record later
+            /// for all records with the same name.
+            auto schema = avro::RecordSchema(column_name + "_" + std::to_string(type_name_increment));
             for (size_t i = 0; i != nested_types.size(); ++i)
             {
                 auto nested_mapping = createSchemaWithSerializeFn(nested_types[i], type_name_increment, nested_names[i]);
@@ -406,13 +430,13 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
         {
             const auto & map_type = assert_cast<const DataTypeMap &>(*data_type);
             const auto & keys_type = map_type.getKeyType();
-            if (!isStringOrFixedString(keys_type))
-                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Avro Maps support only keys with type String, got {}", keys_type->getName());
+            auto keys_serialization = keys_type->getDefaultSerialization();
 
-            auto keys_serializer = [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
+            auto keys_serializer = [keys_serialization, this](const IColumn & column, size_t row_num, avro::Encoder & encoder)
             {
-                const std::string_view & s = column.getDataAt(row_num).toView();
-                encoder.encodeString(std::string(s));
+                WriteBufferFromOwnString buf;
+                keys_serialization->serializeText(column, row_num, buf, settings);
+                encoder.encodeString(buf.str());
             };
 
             const auto & values_type = map_type.getValueType();
@@ -450,8 +474,8 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
 }
 
 
-AvroSerializer::AvroSerializer(const ColumnsWithTypeAndName & columns, std::unique_ptr<AvroSerializerTraits> traits_)
-    : traits(std::move(traits_))
+AvroSerializer::AvroSerializer(const ColumnsWithTypeAndName & columns, std::unique_ptr<AvroSerializerTraits> traits_, const FormatSettings & settings_)
+    : traits(std::move(traits_)), settings(settings_)
 {
     avro::RecordSchema record_schema("row");
 
@@ -507,7 +531,7 @@ AvroRowOutputFormat::AvroRowOutputFormat(
     WriteBuffer & out_, const Block & header_, const FormatSettings & settings_)
     : IRowOutputFormat(header_, out_)
     , settings(settings_)
-    , serializer(header_.getColumnsWithTypeAndName(), std::make_unique<AvroSerializerTraits>(settings))
+    , serializer(header_.getColumnsWithTypeAndName(), std::make_unique<AvroSerializerTraits>(settings), settings)
 {
 }
 

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.h
@@ -23,7 +23,7 @@ class AvroSerializerTraits;
 class AvroSerializer
 {
 public:
-    AvroSerializer(const ColumnsWithTypeAndName & columns, std::unique_ptr<AvroSerializerTraits>);
+    AvroSerializer(const ColumnsWithTypeAndName & columns, std::unique_ptr<AvroSerializerTraits>, const FormatSettings & settings_);
     const avro::ValidSchema & getSchema() const { return valid_schema; }
     void serializeRow(const Columns & columns, size_t row_num, avro::Encoder & encoder);
 
@@ -41,6 +41,7 @@ private:
     std::vector<SerializeFn> serialize_fns;
     avro::ValidSchema valid_schema;
     std::unique_ptr<AvroSerializerTraits> traits;
+    const FormatSettings & settings;
 };
 
 class AvroRowOutputFormat final : public IRowOutputFormat

--- a/tests/queries/0_stateless/02592_avro_more_types.reference
+++ b/tests/queries/0_stateless/02592_avro_more_types.reference
@@ -1,0 +1,7 @@
+c1	FixedString(16)					
+c2	FixedString(16)					
+c3	FixedString(32)					
+c4	FixedString(32)					
+c5	Map(String, Int32)					
+c6	Decimal(18, 2)					
+42	42	42	42	{42:42}	2020-01-01 00:00:00.00

--- a/tests/queries/0_stateless/02592_avro_more_types.sh
+++ b/tests/queries/0_stateless/02592_avro_more_types.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_LOCAL -q "select 42::Int128 as c1, 42::UInt128 as c2, 42::Int256 as c3, 42::UInt256 as c4, map(42, 42) as c5, toDateTime64('2020-01-01', 2) as c6 format Avro" | $CLICKHOUSE_LOCAL --input-format Avro --table test  -q "desc test"
+
+$CLICKHOUSE_LOCAL -q "select 42::Int128 as c1, 42::UInt128 as c2, 42::Int256 as c3, 42::UInt256 as c4, map(42, 42) as c5, toDateTime64('2020-01-01', 2) as c6 format Avro" | $CLICKHOUSE_LOCAL --structure "c1 Int128, c2 UInt128, c3 Int256, c4 UInt256, c5 Map(UInt32, UInt32), c6 DateTime64(2)" --input-format Avro --table test  -q "select * from test"
+
+
+


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support bin integers `(U)Int128/(U)Int256`, `Map` with any key type and `DateTime64` with any precision (not only 3 and 6).

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
