### PR TITLE
Add a script to clone or update clickhouse-docs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 build
+clickhouse-docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,8 @@ The documentation contains information about all the aspects of the ClickHouse l
 
 At the moment, [documentation](https://clickhouse.com/docs) exists in English, Russian, and Chinese. We store the reference documentation besides the ClickHouse source code in the [GitHub repository](https://github.com/ClickHouse/ClickHouse/tree/master/docs), and user guides in a separate repo [Clickhouse/clickhouse-docs](https://github.com/ClickHouse/clickhouse-docs).
 
+To get the latter launch the `get-clickhouse-docs.sh` script.
+
 Each language lies in the corresponding folder. Files that are not translated from English are symbolic links to the English ones.
 
 <a name="how-to-contribute"/>

--- a/docs/get-clickhouse-docs.sh
+++ b/docs/get-clickhouse-docs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+# The script to clone or update the user-guides documentation repo
+# https://github.com/ClickHouse/clickhouse-docs
+
+WORKDIR=$(dirname "$0")
+WORKDIR=$(readlink -f "${WORKDIR}")
+cd "$WORKDIR"
+
+if [ -d "clickhouse-docs" ]; then
+  git -C clickhouse-docs pull
+else
+  if [ -n "$1" ]; then
+    url_type="$1"
+  else
+    read -rp "Enter the URL type (ssh | https): " url_type
+  fi
+  case "$url_type" in
+  ssh)
+    git_url=git@github.com:ClickHouse/clickhouse-docs.git
+    ;;
+  https)
+    git_url=https://github.com/ClickHouse/clickhouse-docs.git
+    ;;
+  *)
+    echo "Url type must be 'ssh' or 'https'"
+    exit 1
+    ;;
+  esac
+  git clone "$git_url" "clickhouse-docs"
+fi


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The script to get/update https://github.com/ClickHouse/clickhouse-docs repository for search across full documentation.