### PR TITLE
Sort output of SHOW <INFO> statements

### DIFF
--- a/src/Interpreters/InterpreterShowEngineQuery.cpp
+++ b/src/Interpreters/InterpreterShowEngineQuery.cpp
@@ -12,7 +12,7 @@ namespace DB
 
 BlockIO InterpreterShowEnginesQuery::execute()
 {
-    return executeQuery("SELECT * FROM system.table_engines", getContext(), true);
+    return executeQuery("SELECT * FROM system.table_engines ORDER BY name", getContext(), true);
 }
 
 }

--- a/src/Interpreters/InterpreterShowTablesQuery.cpp
+++ b/src/Interpreters/InterpreterShowTablesQuery.cpp
@@ -71,11 +71,11 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
                 << DB::quote << query.like;
         }
 
-        if (query.limit_length)
-            rewritten_query << " LIMIT " << query.limit_length;
-
         /// (*)
         rewritten_query << " ORDER BY cluster";
+
+        if (query.limit_length)
+            rewritten_query << " LIMIT " << query.limit_length;
 
         return rewritten_query.str();
     }

--- a/tests/queries/0_stateless/01293_show_settings.reference
+++ b/tests/queries/0_stateless/01293_show_settings.reference
@@ -3,6 +3,6 @@ connect_timeout	Seconds	10
 connect_timeout_with_failover_ms	Milliseconds	2000
 connect_timeout_with_failover_secure_ms	Milliseconds	3000
 external_storage_connect_timeout_sec	UInt64	10
+filesystem_prefetch_max_memory_usage	UInt64	1073741824
 max_untracked_memory	UInt64	1048576
 memory_profiler_step	UInt64	1048576
-filesystem_prefetch_max_memory_usage	UInt64	1073741824


### PR DESCRIPTION
Sorting of results of `SHOW <INFO>` (e.g. `SHOW TABLES`, `SHOW ENGINES`, ...) is strictly speaking not necessary, but
1. sorted output is more user-friendly,
2. SQL currently does not allow to sort the output of `SHOW <INFO>` otherwise, e.g. `SELECT * FROM (SHOW <INFO> ...) ORDER BY` is rejected.
3. SQL tests can take advantage of that.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The output of some SHOW ... statements is now sorted