### PR TITLE
Remove unused mockSystemDatabase from gtest_transform_query_for_exter…

### DIFF
--- a/src/Storages/tests/gtest_transform_query_for_external_database.cpp
+++ b/src/Storages/tests/gtest_transform_query_for_external_database.cpp
@@ -106,21 +106,8 @@ private:
                     StorageID(db_name, table_name), ColumnsDescription{tab.columns}, ConstraintsDescription{}, String{}));
         }
         DatabaseCatalog::instance().attachDatabase(database->getDatabaseName(), database);
-        // DatabaseCatalog::instance().attachDatabase("system", mockSystemDatabase());
 
         context->setCurrentDatabase("test");
-    }
-
-    DatabasePtr mockSystemDatabase()
-    {
-        DatabasePtr database = std::make_shared<DatabaseMemory>("system", context);
-        auto tab = TableWithColumnNamesAndTypes(createDBAndTable("one", "system"), { {"dummy", std::make_shared<DataTypeUInt8>()} });
-        database->attachTable(context, tab.table.table,
-            std::make_shared<StorageMemory>(
-                StorageID(tab.table.database, tab.table.table),
-                ColumnsDescription{tab.columns}, ConstraintsDescription{}, String{}));
-
-        return database;
     }
 };
 


### PR DESCRIPTION
…nal_database

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
