### PR TITLE
Use uniq file names in 02149_* tests to avoid SIGBUS in stress tests

### DIFF
--- a/tests/queries/0_stateless/02149_external_schema_inference.sh
+++ b/tests/queries/0_stateless/02149_external_schema_inference.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 USER_FILES_PATH=$(clickhouse-client --query "select _path,_file from file('nonexist.txt', 'CSV', 'val1 char')" 2>&1 | grep Exception | awk '{gsub("/nonexist.txt","",$9); print $9}')
-FILE_NAME=test_02149.data
+FILE_NAME=test_$CLICKHOUSE_TEST_UNIQUE_NAME.data
 DATA_FILE=$USER_FILES_PATH/$FILE_NAME
 
 touch $DATA_FILE

--- a/tests/queries/0_stateless/02149_schema_inference.sh
+++ b/tests/queries/0_stateless/02149_schema_inference.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 USER_FILES_PATH=$(clickhouse-client --query "select _path,_file from file('nonexist.txt', 'CSV', 'val1 char')" 2>&1 | grep Exception | awk '{gsub("/nonexist.txt","",$9); print $9}')
-FILE_NAME=test_02149.data
+FILE_NAME=test_$CLICKHOUSE_TEST_UNIQUE_NAME.data
 DATA_FILE=${USER_FILES_PATH:?}/$FILE_NAME
 
 touch $DATA_FILE

--- a/tests/queries/0_stateless/02149_schema_inference_formats_with_schema.sh
+++ b/tests/queries/0_stateless/02149_schema_inference_formats_with_schema.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 
 USER_FILES_PATH=$(clickhouse-client --query "select _path,_file from file('nonexist.txt', 'CSV', 'val1 char')" 2>&1 | grep Exception | awk '{gsub("/nonexist.txt","",$9); print $9}')
-FILE_NAME=test_02149.data
+FILE_NAME=test_$CLICKHOUSE_TEST_UNIQUE_NAME.data
 DATA_FILE=$USER_FILES_PATH/$FILE_NAME
 
 for format in Arrow ArrowStream Parquet ORC Native TSVWithNamesAndTypes TSVRawWithNamesAndTypes CSVWithNamesAndTypes JSONCompactEachRowWithNamesAndTypes JSONCompactStringsEachRowWithNamesAndTypes RowBinaryWithNamesAndTypes CustomSeparatedWithNamesAndTypes


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/45225