### PR TITLE
Determine the hosts order in `SHOW CLUSTER` query

### DIFF
--- a/src/Interpreters/InterpreterShowTablesQuery.cpp
+++ b/src/Interpreters/InterpreterShowTablesQuery.cpp
@@ -87,7 +87,7 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
         rewritten_query << " WHERE cluster = " << DB::quote << query.cluster_str;
 
         /// (*)
-        rewritten_query << " ORDER BY cluster";
+        rewritten_query << " ORDER BY cluster, shard_num, replica_num, host_name, host_address, port";
 
         return rewritten_query.str();
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Determine the hosts' order in `SHOW CLUSTER` query, a followup for #48127 and #46240 
