### PR TITLE
Push clickhouse-keeper as both w/ and w/o suffix `-alpine`

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -470,7 +470,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_server.py --release-type head --no-push \
             --image-repo clickhouse/clickhouse-server --image-path docker/server
-          python3 docker_server.py --release-type head --no-push --no-ubuntu \
+          python3 docker_server.py --release-type head --no-push \
             --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper
       - name: Cleanup
         if: always()

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -862,7 +862,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_server.py --release-type head \
             --image-repo clickhouse/clickhouse-server --image-path docker/server
-          python3 docker_server.py --release-type head --no-ubuntu \
+          python3 docker_server.py --release-type head \
             --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper
       - name: Cleanup
         if: always()

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -918,7 +918,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_server.py --release-type head --no-push \
             --image-repo clickhouse/clickhouse-server --image-path docker/server
-          python3 docker_server.py --release-type head --no-push --no-ubuntu \
+          python3 docker_server.py --release-type head --no-push \
             --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper
       - name: Cleanup
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         cd "$GITHUB_WORKSPACE/tests/ci"
         python3 docker_server.py --release-type auto --version "$GITHUB_TAG" \
           --image-repo clickhouse/clickhouse-server --image-path docker/server
-        python3 docker_server.py --release-type auto --version "$GITHUB_TAG" --no-ubuntu \
+        python3 docker_server.py --release-type auto --version "$GITHUB_TAG" \
           --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper
     - name: Cleanup
       if: always()

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -527,7 +527,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_server.py --release-type head --no-push \
             --image-repo clickhouse/clickhouse-server --image-path docker/server
-          python3 docker_server.py --release-type head --no-push --no-ubuntu \
+          python3 docker_server.py --release-type head --no-push \
             --image-repo clickhouse/clickhouse-keeper --image-path docker/keeper
       - name: Cleanup
         if: always()

--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -1,3 +1,6 @@
+# The Dockerfile.ubuntu exists for the tests/ci/docker_server.py script
+# If the image is built from Dockerfile.alpine, then the `-alpine` suffix is added automatically,
+# so the only purpose of Dockerfile.ubuntu is to push `latest`, `head` and so on w/o suffixes
 FROM ubuntu:20.04 AS glibc-donor
 
 ARG TARGETARCH

--- a/docker/keeper/Dockerfile.ubuntu
+++ b/docker/keeper/Dockerfile.ubuntu
@@ -1,0 +1,1 @@
+Dockerfile


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The `clickhouse/clickhouse-keeper` image used to be pushed only with tags `-alpine`, e.g. `latest-alpine`. As it was suggested in https://github.com/ClickHouse/examples/pull/2, now it will be pushed as suffixless too.

