### PR TITLE
Change default Parquet compression from snappy to lz4

### DIFF
--- a/docs/en/operations/settings/settings-formats.md
+++ b/docs/en/operations/settings/settings-formats.md
@@ -1128,7 +1128,7 @@ Default value: `2.latest`.
 
 Compression method used in output Parquet format. Supported codecs: `snappy`, `lz4`, `brotli`, `zstd`, `gzip`, `none` (uncompressed)
 
-Default value: `snappy`.
+Default value: `lz4`.
 
 ## Hive format settings {#hive-format-settings}
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)
