### PR TITLE
Fix 01710_projection_optimize_materialize flakiness

### DIFF
--- a/tests/queries/0_stateless/01710_projection_optimize_materialize.sql
+++ b/tests/queries/0_stateless/01710_projection_optimize_materialize.sql
@@ -1,3 +1,4 @@
+-- Tags: no-random-merge-tree-settings
 drop table if exists z;
 
 create table z (pk Int64, d Date, id UInt64, c UInt64) Engine MergeTree partition by d order by pk settings ratio_of_defaults_for_sparse_serialization = 1.0;


### PR DESCRIPTION
Fails with different index granularity

CI: https://s3.amazonaws.com/clickhouse-test-reports/48242/672dbf7cd894be6f5c0ac685d493371f2996229d/stateless_tests__asan__[3/4].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes: #46614 (cc @SmitaRKulkarni )