### PR TITLE
Randomize allow_vertical_merges_from_compact_to_wide_parts in tests

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -582,7 +582,9 @@ class MergeTreeSettingsRandomizer:
         "vertical_merge_algorithm_min_columns_to_activate": threshold_generator(
             0.4, 0.4, 1, 100
         ),
-        "allow_vertical_merges_from_compact_to_wide_parts": lambda: random.randint(0, 1),
+        "allow_vertical_merges_from_compact_to_wide_parts": lambda: random.randint(
+            0, 1
+        ),
         "min_merge_bytes_to_use_direct_io": threshold_generator(
             0.25, 0.25, 1, 10 * 1024 * 1024 * 1024
         ),

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -582,6 +582,7 @@ class MergeTreeSettingsRandomizer:
         "vertical_merge_algorithm_min_columns_to_activate": threshold_generator(
             0.4, 0.4, 1, 100
         ),
+        "allow_vertical_merges_from_compact_to_wide_parts": lambda: random.randint(0, 1),
         "min_merge_bytes_to_use_direct_io": threshold_generator(
             0.25, 0.25, 1, 10 * 1024 * 1024 * 1024
         ),


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Randomize vertical merges from compact to wide parts in tests.


AFAIK all replicas in the tests receive the same set of settings and all use recent CHs, so it should be safe to use this setting and will help testing random cases.
