### PR TITLE
Don't throw CURRENT_WRITE_BUFFER_IS_EXHAUSTED for normal behaviour

### DIFF
--- a/src/IO/CascadeWriteBuffer.cpp
+++ b/src/IO/CascadeWriteBuffer.cpp
@@ -1,4 +1,5 @@
 #include <IO/CascadeWriteBuffer.h>
+#include <IO/MemoryReadWriteBuffer.h>
 #include <Common/Exception.h>
 
 namespace DB
@@ -35,9 +36,9 @@ void CascadeWriteBuffer::nextImpl()
         curr_buffer->position() = position();
         curr_buffer->next();
     }
-    catch (const Exception & e)
+    catch (const MemoryWriteBuffer::CurrentBufferExhausted &)
     {
-        if (curr_buffer_num < num_sources && e.code() == ErrorCodes::CURRENT_WRITE_BUFFER_IS_EXHAUSTED)
+        if (curr_buffer_num < num_sources)
         {
             /// TODO: protocol should require set(position(), 0) before Exception
 
@@ -46,7 +47,7 @@ void CascadeWriteBuffer::nextImpl()
             curr_buffer = setNextBuffer();
         }
         else
-            throw;
+            throw Exception(ErrorCodes::CURRENT_WRITE_BUFFER_IS_EXHAUSTED, "MemoryWriteBuffer limit is exhausted");
     }
 
     set(curr_buffer->position(), curr_buffer->buffer().end() - curr_buffer->position());

--- a/src/IO/CascadeWriteBuffer.h
+++ b/src/IO/CascadeWriteBuffer.h
@@ -16,7 +16,7 @@ namespace ErrorCodes
  * (lazy_sources contains not pointers themself, but their delayed constructors)
  *
  * Firtly, CascadeWriteBuffer redirects data to first buffer of the sequence
- * If current WriteBuffer cannot receive data anymore, it throws special exception CURRENT_WRITE_BUFFER_IS_EXHAUSTED in nextImpl() body,
+ * If current WriteBuffer cannot receive data anymore, it throws special exception MemoryWriteBuffer::CurrentBufferExhausted in nextImpl() body,
  *  CascadeWriteBuffer prepare next buffer and continuously redirects data to it.
  * If there are no buffers anymore CascadeWriteBuffer throws an exception.
  *

--- a/src/IO/MemoryReadWriteBuffer.cpp
+++ b/src/IO/MemoryReadWriteBuffer.cpp
@@ -5,12 +5,6 @@
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int CURRENT_WRITE_BUFFER_IS_EXHAUSTED;
-}
-
-
 class ReadBufferFromMemoryWriteBuffer : public ReadBuffer, boost::noncopyable, private Allocator<false>
 {
 public:
@@ -118,7 +112,7 @@ void MemoryWriteBuffer::addChunk()
         if (0 == next_chunk_size)
         {
             set(position(), 0);
-            throw Exception(ErrorCodes::CURRENT_WRITE_BUFFER_IS_EXHAUSTED, "MemoryWriteBuffer limit is exhausted");
+            throw MemoryWriteBuffer::CurrentBufferExhausted();
         }
     }
 

--- a/src/IO/MemoryReadWriteBuffer.h
+++ b/src/IO/MemoryReadWriteBuffer.h
@@ -16,6 +16,12 @@ namespace DB
 class MemoryWriteBuffer : public WriteBuffer, public IReadableWriteBuffer, boost::noncopyable, private Allocator<false>
 {
 public:
+    /// Special exception to throw when the current WriteBuffer cannot receive data
+    class CurrentBufferExhausted : public std::exception
+    {
+    public:
+        const char * what() const noexcept override { return "MemoryWriteBuffer limit is exhausted"; }
+    };
 
     /// Use max_total_size_ = 0 for unlimited storage
     explicit MemoryWriteBuffer(

--- a/src/IO/tests/gtest_cascade_and_memory_write_buffer.cpp
+++ b/src/IO/tests/gtest_cascade_and_memory_write_buffer.cpp
@@ -198,7 +198,7 @@ TEST(MemoryWriteBuffer, WriteAndReread)
         if (s > 1)
         {
             MemoryWriteBuffer buf(s - 1);
-            EXPECT_THROW(buf.write(data.data(), data.size()), DB::Exception);
+            EXPECT_THROW(buf.write(data.data(), data.size()), MemoryWriteBuffer::CurrentBufferExhausted);
         }
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Don't throw CURRENT_WRITE_BUFFER_IS_EXHAUSTED for normal behaviour

### Documentation entry for user-facing changes

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/


While testing 23.3 settings `http_wait_end_of_query` and `http_response_buffer_size` I noticed the following error on system.errors only (queries finished correcly):
```
Row 1:
──────
server_shard:       1
version:            23.3.1.2778
name:               CURRENT_WRITE_BUFFER_IS_EXHAUSTED
code:               362
quantity:           20
last_error_message: MemoryWriteBuffer limit is exhausted
traceback:          DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool)
DB::MemoryWriteBuffer::addChunk()
DB::CascadeWriteBuffer::nextImpl()
DB::ParallelFormattingOutputFormat::collectorThreadFunction(std::__1::shared_ptr<DB::ThreadGroupStatus> const&)
void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPoolImpl<true>::ThreadFromGlobalPoolImpl<DB::ParallelFormattingOutputFormat::ParallelFormattingOutputFormat(DB::ParallelFormattingOutputFormat::Params)::'lambda'()>(DB::ParallelFormattingOutputFormat::ParallelFormattingOutputFormat(DB::ParallelFormattingOutputFormat::Params)::'lambda'()&&)::'lambda'(), void ()>>(std::__1::__function::__policy_storage const*)
ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>)
```

Looking at the exception it seems that CH uses `CURRENT_WRITE_BUFFER_IS_EXHAUSTED` to internally flag in `CascadeWriteBuffer` that it needs a new buffer. The problem is that using DB::Exception also reports this error to system.errors which is confusing since this is not an actual error.

Instead, use a custom exception to handle it this and only throw `CURRENT_WRITE_BUFFER_IS_EXHAUSTED` when there are no buffers anymore.

