### PR TITLE
Fix alter formatting (minor)

### DIFF
--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -612,7 +612,10 @@ void ASTAlterQuery::formatQueryImpl(const FormatSettings & settings, FormatState
     FormatStateStacked frame_nested = frame;
     frame_nested.need_parens = false;
     frame_nested.expression_list_always_start_on_new_line = true;
-    static_cast<ASTExpressionList *>(command_list)->formatImplMultiline(settings, state, frame_nested);
+    frame_nested.expression_list_prepend_whitespace = true;
+    settings.one_line
+        ? command_list->formatImpl(settings, state, frame_nested)
+        : command_list->as<ASTExpressionList &>().formatImplMultiline(settings, state, frame_nested);
 }
 
 }

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -611,11 +611,16 @@ void ASTAlterQuery::formatQueryImpl(const FormatSettings & settings, FormatState
 
     FormatStateStacked frame_nested = frame;
     frame_nested.need_parens = false;
-    frame_nested.expression_list_always_start_on_new_line = true;
-    frame_nested.expression_list_prepend_whitespace = true;
-    settings.one_line
-        ? command_list->formatImpl(settings, state, frame_nested)
-        : command_list->as<ASTExpressionList &>().formatImplMultiline(settings, state, frame_nested);
+    if (settings.one_line)
+    {
+        frame_nested.expression_list_prepend_whitespace = true;
+        command_list->formatImpl(settings, state, frame_nested);
+    }
+    else
+    {
+        frame_nested.expression_list_always_start_on_new_line = true;
+        command_list->as<ASTExpressionList &>().formatImplMultiline(settings, state, frame_nested);
+    }
 }
 
 }

--- a/tests/queries/0_stateless/01318_alter_add_constraint_format.reference
+++ b/tests/queries/0_stateless/01318_alter_add_constraint_format.reference
@@ -1,2 +1,1 @@
-ALTER TABLE replicated_constraints1
-    ADD CONSTRAINT IF NOT EXISTS b_constraint CHECK b > 10
+ALTER TABLE replicated_constraints1 ADD CONSTRAINT IF NOT EXISTS b_constraint CHECK b > 10


### PR DESCRIPTION
Fixes half of #48056.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix alter query formatting: if --oneline is specified, format it in one line.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
