### PR TITLE
Docs: Suggest ClickHouse-native function name over MySQL-compatibility alias

### DIFF
--- a/docs/en/sql-reference/functions/date-time-functions.md
+++ b/docs/en/sql-reference/functions/date-time-functions.md
@@ -1463,28 +1463,28 @@ Result:
 └───────────────────────┘
 ```
 
-## FROM\_UNIXTIME
+## fromUnixTimestamp
 
 Function converts Unix timestamp to a calendar date and a time of a day. When there is only a single argument of [Integer](../../sql-reference/data-types/int-uint.md) type, it acts in the same way as [toDateTime](../../sql-reference/functions/type-conversion-functions.md#todatetime) and return [DateTime](../../sql-reference/data-types/datetime.md) type.
 
-FROM_UNIXTIME uses MySQL datetime format style, refer to https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format.
+fromUnixTimestamp uses MySQL datetime format style, refer to https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format.
 
-Alias: `fromUnixTimestamp`.
+Alias: `FROM_UNIXTIME`.
 
 **Example:**
 
 Query:
 
 ```sql
-SELECT FROM_UNIXTIME(423543535);
+SELECT fromUnixTimestamp(423543535);
 ```
 
 Result:
 
 ```text
-┌─FROM_UNIXTIME(423543535)─┐
-│      1983-06-04 10:58:55 │
-└──────────────────────────┘
+┌─fromUnixTimestamp(423543535)─┐
+│          1983-06-04 10:58:55 │
+└──────────────────────────────┘
 ```
 
 When there are two or three arguments, the first an [Integer](../../sql-reference/data-types/int-uint.md), [Date](../../sql-reference/data-types/date.md), [Date32](../../sql-reference/data-types/date32.md), [DateTime](../../sql-reference/data-types/datetime.md) or [DateTime64](../../sql-reference/data-types/datetime64.md), the second a constant format string and the third an optional constant time zone string — it acts in the same way as [formatDateTime](#formatdatetime) and return [String](../../sql-reference/data-types/string.md#string) type.
@@ -1492,7 +1492,7 @@ When there are two or three arguments, the first an [Integer](../../sql-referenc
 For example:
 
 ```sql
-SELECT FROM_UNIXTIME(1234334543, '%Y-%m-%d %R:%S') AS DateTime;
+SELECT fromUnixTimestamp(1234334543, '%Y-%m-%d %R:%S') AS DateTime;
 ```
 
 ```text
@@ -1505,11 +1505,12 @@ SELECT FROM_UNIXTIME(1234334543, '%Y-%m-%d %R:%S') AS DateTime;
 
 -   [fromUnixTimestampInJodaSyntax](##fromUnixTimestampInJodaSyntax)
 
-
 ## fromUnixTimestampInJodaSyntax
-Similar to FROM_UNIXTIME, except that it formats time in Joda style instead of MySQL style. Refer to https://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html.
+
+Similar to fromUnixTimestamp, except that it formats time in Joda style instead of MySQL style. Refer to https://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html.
 
 **Example:**
+
 Query:
 ``` sql
 SELECT fromUnixTimestampInJodaSyntax(1669804872, 'yyyy-MM-dd HH:mm:ss', 'UTC');
@@ -1517,11 +1518,10 @@ SELECT fromUnixTimestampInJodaSyntax(1669804872, 'yyyy-MM-dd HH:mm:ss', 'UTC');
 
 Result:
 ```
-┌─fromUnixTimestampInJodaSyntax(1669804872, 'yyyy-MM-dd HH:mm:ss', 'UTC')─┐
+┌─fromUnixTimestampInJodaSyntax(1669804872, 'yyyy-MM-dd HH:mm:ss', 'UTC')────┐
 │ 2022-11-30 10:41:12                                                        │
 └────────────────────────────────────────────────────────────────────────────┘
 ```
-
 
 ## toModifiedJulianDay
 

--- a/src/Functions/formatDateTime.cpp
+++ b/src/Functions/formatDateTime.cpp
@@ -1405,7 +1405,7 @@ REGISTER_FUNCTION(FormatDateTime)
     factory.registerAlias("DATE_FORMAT", FunctionFormatDateTime::name);
 
     factory.registerFunction<FunctionFromUnixTimestamp>();
-    factory.registerAlias("FROM_UNIXTIME", "fromUnixTimestamp");
+    factory.registerAlias("FROM_UNIXTIME", FunctionFromUnixTimestamp::name);
 
     factory.registerFunction<FunctionFormatDateTimeInJodaSyntax>();
     factory.registerFunction<FunctionFromUnixTimestampInJodaSyntax>();


### PR DESCRIPTION
For some reason, the docs suggested using the MySQL compatibility alias `FROM_UNIXTIME` instead of the "native" function `fromUnixTimestamp`. This PR reverses this.

### Changelog category (leave one):
- Documentation (changelog entry is not required)