### PR TITLE
Add logging for concurrency checks for backups

### DIFF
--- a/src/Backups/BackupCoordinationLocal.cpp
+++ b/src/Backups/BackupCoordinationLocal.cpp
@@ -8,7 +8,8 @@
 namespace DB
 {
 
-BackupCoordinationLocal::BackupCoordinationLocal(bool plain_backup_) : file_infos(plain_backup_)
+BackupCoordinationLocal::BackupCoordinationLocal(bool plain_backup_)
+    : log(&Poco::Logger::get("BackupCoordinationLocal")), file_infos(plain_backup_)
 {
 }
 
@@ -125,7 +126,12 @@ bool BackupCoordinationLocal::startWritingFile(size_t data_file_index)
 
 bool BackupCoordinationLocal::hasConcurrentBackups(const std::atomic<size_t> & num_active_backups) const
 {
-    return (num_active_backups > 1);
+    if (num_active_backups > 1)
+    {
+        LOG_WARNING(log, "Found concurrent backups: num_active_backups={}", num_active_backups);
+        return true;
+    }
+    return false;
 }
 
 }

--- a/src/Backups/BackupCoordinationLocal.h
+++ b/src/Backups/BackupCoordinationLocal.h
@@ -52,6 +52,8 @@ public:
     bool hasConcurrentBackups(const std::atomic<size_t> & num_active_backups) const override;
 
 private:
+    Poco::Logger * const log;
+
     BackupCoordinationReplicatedTables TSA_GUARDED_BY(replicated_tables_mutex) replicated_tables;
     BackupCoordinationReplicatedAccess TSA_GUARDED_BY(replicated_access_mutex) replicated_access;
     BackupCoordinationReplicatedSQLObjects TSA_GUARDED_BY(replicated_sql_objects_mutex) replicated_sql_objects;

--- a/src/Backups/BackupCoordinationRemote.h
+++ b/src/Backups/BackupCoordinationRemote.h
@@ -104,6 +104,7 @@ private:
     const size_t current_host_index;
     const bool plain_backup;
     const bool is_internal;
+    Poco::Logger * const log;
 
     mutable ZooKeeperRetriesInfo zookeeper_retries_info;
     std::optional<BackupCoordinationStageSync> stage_sync;

--- a/src/Backups/RestoreCoordinationLocal.cpp
+++ b/src/Backups/RestoreCoordinationLocal.cpp
@@ -1,10 +1,14 @@
 #include <Backups/RestoreCoordinationLocal.h>
+#include <Common/logger_useful.h>
 
 
 namespace DB
 {
 
-RestoreCoordinationLocal::RestoreCoordinationLocal() = default;
+RestoreCoordinationLocal::RestoreCoordinationLocal() : log(&Poco::Logger::get("RestoreCoordinationLocal"))
+{
+}
+
 RestoreCoordinationLocal::~RestoreCoordinationLocal() = default;
 
 void RestoreCoordinationLocal::setStage(const String &, const String &)
@@ -49,7 +53,12 @@ bool RestoreCoordinationLocal::acquireReplicatedSQLObjects(const String &, UserD
 
 bool RestoreCoordinationLocal::hasConcurrentRestores(const std::atomic<size_t> & num_active_restores) const
 {
-    return (num_active_restores > 1);
+    if (num_active_restores > 1)
+    {
+        LOG_WARNING(log, "Found concurrent backups: num_active_restores={}", num_active_restores);
+        return true;
+    }
+    return false;
 }
 
 }

--- a/src/Backups/RestoreCoordinationLocal.h
+++ b/src/Backups/RestoreCoordinationLocal.h
@@ -42,6 +42,8 @@ public:
     bool hasConcurrentRestores(const std::atomic<size_t> & num_active_restores) const override;
 
 private:
+    Poco::Logger * const log;
+
     std::set<std::pair<String /* database_zk_path */, String /* table_name */>> acquired_tables_in_replicated_databases;
     std::unordered_set<String /* table_zk_path */> acquired_data_in_replicated_tables;
     mutable std::mutex mutex;

--- a/src/Backups/RestoreCoordinationRemote.h
+++ b/src/Backups/RestoreCoordinationRemote.h
@@ -59,6 +59,7 @@ private:
     const String current_host;
     const size_t current_host_index;
     const bool is_internal;
+    Poco::Logger * const log;
 
     std::optional<BackupCoordinationStageSync> stage_sync;
 


### PR DESCRIPTION
### Changelog category:
- Not for changelog

Trying to investigate test failure
[test_backup_restore_on_cluster/test_disallow_concurrency.py::test_concurrent_restores_on_same_node](https://s3.amazonaws.com/clickhouse-test-reports/48286/5206d4b9265c280415a7546d6f105bd45ccdca17/integration_tests__asan__[3/6].html)