### PR TITLE
Clarify SYSTEM RELOAD CONFIG and USERS

### DIFF
--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -114,11 +114,11 @@ This will also create system tables even if message queue is empty.
 
 ## RELOAD CONFIG
 
-Reloads ClickHouse configuration. Used when configuration is stored in ZooKeeper.
+Reloads ClickHouse configuration. Used when configuration is stored in ZooKeeper. Note that `SYSTEM RELOAD CONFIG` does not reload `USER` configuration stored in ZooKeeper, it only reloads `USER` configuration that is stored in `users.xml`.  To reload all `USER` config use `SYSTEM RELOAD USERS`
 
 ## RELOAD USERS
 
-Reloads all access storages, including: users.xml, local disk access storage, replicated (in ZooKeeper) access storage. Note that `SYSTEM RELOAD CONFIG` will only reload users.xml access storage.
+Reloads all access storages, including: users.xml, local disk access storage, replicated (in ZooKeeper) access storage. 
 
 ## SHUTDOWN
 


### PR DESCRIPTION
closes #48201
If you issue SYSTEM RELOAD USERS, then user config that is stored in config files and in Keeper is reloaded.

If you issue SYSTEM RELOAD CONFIG, then system configuration is reloaded from Keeper and config files, but user configuration is only reloaded from config files.

https://github.com/ClickHouse/ClickHouse/blob/master/src/Access/IAccessStorage.h#L51-L60

### Changelog category (leave one):
- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


