### PR TITLE
Reset downloader for cache file segment in TemporaryFileStream

### DIFF
--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -201,7 +201,7 @@ void FileSegment::resetDownloadingStateUnlocked([[maybe_unused]] std::unique_loc
 
     size_t current_downloaded_size = getDownloadedSizeUnlocked(segment_lock);
     /// range().size() can equal 0 in case of write-though cache.
-    if (current_downloaded_size != 0 && current_downloaded_size == range().size())
+    if (!is_unbound && current_downloaded_size != 0 && current_downloaded_size == range().size())
         setDownloadedUnlocked(segment_lock);
     else
         setDownloadState(State::PARTIALLY_DOWNLOADED);
@@ -343,7 +343,7 @@ void FileSegment::write(const char * from, size_t size, size_t offset)
                 ErrorCodes::LOGICAL_ERROR,
                 "Not enough space is reserved. Available: {}, expected: {}", free_reserved_size, size);
 
-        if (current_downloaded_size == range().size())
+        if (!is_unbound && current_downloaded_size == range().size())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "File segment is already fully downloaded");
 
         if (!cache_writer)
@@ -689,7 +689,8 @@ String FileSegment::getInfoForLogUnlocked(std::unique_lock<std::mutex> & segment
     info << "first non-downloaded offset: " << getFirstNonDownloadedOffsetUnlocked(segment_lock) << ", ";
     info << "caller id: " << getCallerId() << ", ";
     info << "detached: " << is_detached << ", ";
-    info << "kind: " << toString(segment_kind);
+    info << "kind: " << toString(segment_kind) << ", ";
+    info << "unbound: " << is_unbound;
 
     return info.str();
 }
@@ -785,6 +786,7 @@ FileSegmentPtr FileSegment::getSnapshot(const FileSegmentPtr & file_segment, std
     snapshot->downloaded_size = file_segment->getDownloadedSizeUnlocked(segment_lock);
     snapshot->download_state = file_segment->download_state;
     snapshot->segment_kind = file_segment->getKind();
+    snapshot->is_unbound = file_segment->is_unbound;
 
     return snapshot;
 }
@@ -905,6 +907,8 @@ String FileSegmentsHolder::toString()
         if (!ranges.empty())
             ranges += ", ";
         ranges += file_segment->range().toString();
+        if (file_segment->is_unbound)
+            ranges += "(unbound)";
     }
     return ranges;
 }

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -429,6 +429,7 @@ bool FileSegment::reserve(size_t size_to_reserve)
     {
         std::unique_lock segment_lock(mutex);
 
+
         assertNotDetachedUnlocked(segment_lock);
         assertIsDownloaderUnlocked("reserve", segment_lock);
 

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -429,7 +429,6 @@ bool FileSegment::reserve(size_t size_to_reserve)
     {
         std::unique_lock segment_lock(mutex);
 
-
         assertNotDetachedUnlocked(segment_lock);
         assertIsDownloaderUnlocked("reserve", segment_lock);
 

--- a/src/Interpreters/Cache/FileSegment.h
+++ b/src/Interpreters/Cache/FileSegment.h
@@ -159,6 +159,7 @@ public:
 
     FileSegmentKind getKind() const { return segment_kind; }
     bool isPersistent() const { return segment_kind == FileSegmentKind::Persistent; }
+    bool isUnbound() const { return is_unbound; }
 
     using UniqueId = std::pair<FileCacheKey, size_t>;
     UniqueId getUniqueId() const { return std::pair(key(), offset()); }

--- a/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
+++ b/src/Interpreters/Cache/WriteBufferToFileSegment.cpp
@@ -2,6 +2,8 @@
 #include <Interpreters/Cache/FileSegment.h>
 #include <IO/SwapHelper.h>
 
+#include <base/scope_guard.h>
+
 #include <Common/logger_useful.h>
 
 namespace DB
@@ -10,20 +12,23 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NOT_ENOUGH_SPACE;
-    extern const int LOGICAL_ERROR;
 }
 
 WriteBufferToFileSegment::WriteBufferToFileSegment(FileSegment * file_segment_)
     : WriteBufferFromFileDecorator(file_segment_->detachWriter()), file_segment(file_segment_)
 {
-    auto downloader = file_segment->getOrSetDownloader();
-    if (downloader != FileSegment::getCallerId())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Failed to set a downloader. ({})", file_segment->getInfoForLog());
 }
 
 /// If it throws an exception, the file segment will be incomplete, so you should not use it in the future.
 void WriteBufferToFileSegment::nextImpl()
 {
+    auto downloader [[maybe_unused]] = file_segment->getOrSetDownloader();
+    chassert(downloader == FileSegment::getCallerId());
+
+    SCOPE_EXIT({
+        file_segment->completePartAndResetDownloader();
+    });
+
     size_t bytes_to_write = offset();
 
     /// In case of an error, we don't need to finalize the file segment

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -137,11 +137,18 @@ struct TemporaryFileStream::OutputWriter
             static_cast<const WriteBufferToFileSegment *>(out_buf.get())->getFileName());
     }
 
-    size_t write(const Block & block)
+    size_t write(const Block & block, bool flush = false)
     {
         if (finalized)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot write to finalized stream");
         size_t written_bytes = out_writer.write(block);
+        if (flush)
+        {
+            out_compressed_buf.next();
+            out_buf->next();
+            out_writer.flush();
+        }
+
         num_rows += block.rows();
         return written_bytes;
     }
@@ -234,9 +241,12 @@ TemporaryFileStream::TemporaryFileStream(FileSegmentsHolder && segments_, const 
 {
     if (segment_holder.file_segments.size() != 1)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "TemporaryFileStream can be created only from single segment");
-    auto & segment = segment_holder.file_segments.front();
-    auto out_buf = std::make_unique<WriteBufferToFileSegment>(segment.get());
+    auto & file_segment = segment_holder.file_segments.front();
+    auto out_buf = std::make_unique<WriteBufferToFileSegment>(file_segment.get());
     out_writer = std::make_unique<OutputWriter>(std::move(out_buf), header);
+
+    /// `write` can be called from different thread, so we need to reset downloader
+    file_segment->completePartAndResetDownloader();
 }
 
 size_t TemporaryFileStream::write(const Block & block)
@@ -245,7 +255,21 @@ size_t TemporaryFileStream::write(const Block & block)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Writing has been finished");
 
     updateAllocAndCheck();
-    size_t bytes_written = out_writer->write(block);
+
+    size_t bytes_written = 0;
+    if (segment_holder.empty())
+    {
+        bytes_written = out_writer->write(block);
+    }
+    else
+    {
+        auto & file_segment = segment_holder.file_segments.front();
+        /// We need to reset downloader for each block,
+        /// without it `file_segment->reserve` can be called only by the same thread
+        file_segment->getOrSetDownloader();
+        bytes_written = out_writer->write(block, true);
+        file_segment->completePartAndResetDownloader();
+    }
     return bytes_written;
 }
 

--- a/src/Storages/System/StorageSystemFilesystemCache.cpp
+++ b/src/Storages/System/StorageSystemFilesystemCache.cpp
@@ -26,6 +26,7 @@ NamesAndTypesList StorageSystemFilesystemCache::getNamesAndTypes()
         {"downloaded_size", std::make_shared<DataTypeUInt64>()},
         {"persistent", std::make_shared<DataTypeNumber<UInt8>>()},
         {"kind", std::make_shared<DataTypeString>()},
+        {"unbound", std::make_shared<DataTypeNumber<UInt8>>()},
     };
 }
 
@@ -62,6 +63,7 @@ void StorageSystemFilesystemCache::fillData(MutableColumns & res_columns, Contex
             res_columns[8]->insert(file_segment->getDownloadedSize());
             res_columns[9]->insert(file_segment->isPersistent());
             res_columns[10]->insert(toString(file_segment->getKind()));
+            res_columns[11]->insert(file_segment->isUnbound());
         }
     }
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix logical error in `INSERT SELECT` when using `temporary_data_in_cache`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
