### PR TITLE
Cleanup mess in .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -110,6 +110,7 @@ Checks: '*,
     -misc-const-correctness,
     -misc-no-recursion,
     -misc-non-private-member-variables-in-classes,
+    -misc-confusable-identifiers, # useful but slooow
 
     -modernize-avoid-c-arrays,
     -modernize-concat-nested-namespaces,
@@ -148,19 +149,6 @@ Checks: '*,
     -readability-use-anyofallof,
 
     -zirkon-*,
-
-    -misc-*, # temporarily disabled due to being too slow
-    # also disable checks in other categories which are aliases of checks in misc-*:
-    # https://releases.llvm.org/15.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/list.html
-    -cert-dcl54-cpp,                                            # alias of misc-new-delete-overloads
-    -hicpp-new-delete-operators,                                # alias of misc-new-delete-overloads
-    -cert-fio38-c,                                              # alias of misc-non-copyable-objects
-    -cert-dcl03-c,                                              # alias of misc-static-assert
-    -hicpp-static-assert,                                       # alias of misc-static-assert
-    -cert-err09-cpp,                                            # alias of misc-throw-by-value-catch-by-reference
-    -cert-err61-cpp,                                            # alias of misc-throw-by-value-catch-by-reference
-    -cppcoreguidelines-c-copy-assignment-signature,             # alias of misc-unconventional-assign-operator
-    -cppcoreguidelines-non-private-member-variables-in-classes, # alias of misc-non-private-member-variables-in-classes
 '
 
 WarningsAsErrors: '*'

--- a/base/base/find_symbols.h
+++ b/base/base/find_symbols.h
@@ -36,7 +36,7 @@
 
 namespace detail
 {
-template <char ...chars> constexpr bool is_in(char x) { return ((x == chars) || ...); }
+template <char ...chars> constexpr bool is_in(char x) { return ((x == chars) || ...); } // NOLINT(misc-redundant-expression)
 
 #if defined(__SSE2__)
 template <char s0>

--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -1981,7 +1981,7 @@ struct WindowFunctionNtile final : public WindowFunction
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function {} takes exactly one parameter", name_);
         }
         auto type_id = argument_types[0]->getTypeId();
-        if (type_id != TypeIndex::UInt8 && type_id != TypeIndex::UInt16 && type_id != TypeIndex::UInt32 && type_id != TypeIndex::UInt32 && type_id != TypeIndex::UInt64)
+        if (type_id != TypeIndex::UInt8 && type_id != TypeIndex::UInt16 && type_id != TypeIndex::UInt32 && type_id != TypeIndex::UInt64)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "ntile's argument type must be an unsigned integer (not larger then 64-bit), but got {}", argument_types[0]->getName());
         }

--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -8,13 +8,6 @@
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromFile.h>
 
-namespace
-{
-
-namespace fs = std::filesystem;
-
-}
-
 namespace CurrentMetrics
 {
     extern const Metric DistributedSend;
@@ -140,7 +133,7 @@ void DistributedAsyncInsertBatch::send()
     total_bytes = 0;
     recovered = false;
 
-    fs::resize_file(parent.current_batch_file_path, 0);
+    std::filesystem::resize_file(parent.current_batch_file_path, 0);
 }
 
 void DistributedAsyncInsertBatch::serialize()
@@ -149,7 +142,7 @@ void DistributedAsyncInsertBatch::serialize()
     String tmp_file{parent.current_batch_file_path + ".tmp"};
 
     auto dir_sync_guard = parent.getDirectorySyncGuard(parent.relative_path);
-    if (fs::exists(tmp_file))
+    if (std::filesystem::exists(tmp_file))
         LOG_ERROR(parent.log, "Temporary file {} exists. Unclean shutdown?", backQuote(tmp_file));
 
     {
@@ -161,7 +154,7 @@ void DistributedAsyncInsertBatch::serialize()
             out.sync();
     }
 
-    fs::rename(tmp_file, parent.current_batch_file_path);
+    std::filesystem::rename(tmp_file, parent.current_batch_file_path);
 }
 
 void DistributedAsyncInsertBatch::deserialize()
@@ -174,7 +167,7 @@ void DistributedAsyncInsertBatch::writeText(WriteBuffer & out)
 {
     for (const auto & file : files)
     {
-        UInt64 file_index = parse<UInt64>(fs::path(file).stem());
+        UInt64 file_index = parse<UInt64>(std::filesystem::path(file).stem());
         out << file_index << '\n';
     }
 }
@@ -185,7 +178,7 @@ void DistributedAsyncInsertBatch::readText(ReadBuffer & in)
     {
         UInt64 idx;
         in >> idx >> "\n";
-        files.push_back(fs::absolute(fmt::format("{}/{}.bin", parent.path, idx)).string());
+        files.push_back(std::filesystem::absolute(fmt::format("{}/{}.bin", parent.path, idx)).string());
     }
 
     recovered = true;


### PR DESCRIPTION
This fixes some mess I left in .clang-tidy (#43863) when clang-tidy build times were too bad and had to be reduced urgently.

Verified locally that runtime isn't affected by this PR.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)