### PR TITLE
AST fuzzer: Fix assertion in TopK serialization

### DIFF
--- a/src/Common/SpaceSaving.h
+++ b/src/Common/SpaceSaving.h
@@ -94,8 +94,8 @@ public:
         void write(WriteBuffer & wb) const
         {
             writeBinary(key, wb);
-            writeVarUInt(count, wb);
-            writeVarUInt(error, wb);
+            writeVarUIntOverflow(count, wb);
+            writeVarUIntOverflow(error, wb);
         }
 
         void read(ReadBuffer & rb)

--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -15,25 +15,19 @@ namespace ErrorCodes
 }
 
 
-/** Variable-Length Quantity (VLQ) Base-128 compression
- *
- * NOTE: Due to historical reasons, only up to 1<<63-1 are supported, which
- * cannot be changed without breaking the backward compatibility.
- * Also some drivers may support full 1<<64 range (i.e. python -
- * clickhouse-driver), while others has the same limitations as ClickHouse
- * (i.e. Rust - clickhouse-rs).
- * So implementing VLQ for the whole 1<<64 range will require different set of
- * helpers.
- */
-constexpr UInt64 VAR_UINT_MAX = (1ULL<<63) - 1;
+/// Variable-Length Quantity (VLQ) Base-128 compression, also known as Variable Byte (VB) or Varint encoding.
 
-/** Write UInt64 in variable length format (base128) */
+/// Write UInt64 in variable length format (base128)
 void writeVarUInt(UInt64 x, std::ostream & ostr);
 void writeVarUInt(UInt64 x, WriteBuffer & ostr);
 char * writeVarUInt(UInt64 x, char * ostr);
 
+/// NOTE: Due to historical reasons, only values up to 1<<63-1 can be safely encoded/decoded (bigger values are not idempotent under
+/// encoding/decoding). This cannot be changed without breaking backward compatibility (some drivers, e.g. clickhouse-rs (Rust), have the
+/// same limitation, others support the full 1<<64 range, e.g. clickhouse-driver (Python))
+constexpr UInt64 VAR_UINT_MAX = (1ULL<<63) - 1;
 
-/** Write UInt64 in variable length format, wrap the value to VAR_UINT_MAX if it exceed VAR_UINT_MAX (to bypass sanity check) */
+/// Write UInt64 in variable length format (base128), limit the value to VAR_UINT_MAX if it exceed VAR_UINT_MAX (to bypass sanity check)
 template <typename ...Args>
 auto writeVarUIntOverflow(UInt64 x, Args && ... args)
 {
@@ -41,20 +35,20 @@ auto writeVarUIntOverflow(UInt64 x, Args && ... args)
 }
 
 
-/** Read UInt64, written in variable length format (base128) */
+/// Read UInt64, written in variable length format (base128)
 void readVarUInt(UInt64 & x, std::istream & istr);
 void readVarUInt(UInt64 & x, ReadBuffer & istr);
 const char * readVarUInt(UInt64 & x, const char * istr, size_t size);
 
 
-/** Get the length of UInt64 in VarUInt format */
+/// Get the length of UInt64 in VarUInt format
 size_t getLengthOfVarUInt(UInt64 x);
 
-/** Get the Int64 length in VarInt format */
+/// Get the Int64 length in VarInt format
 size_t getLengthOfVarInt(Int64 x);
 
 
-/** Write Int64 in variable length format (base128) */
+/// Write Int64 in variable length format (base128)
 template <typename OUT>
 inline void writeVarInt(Int64 x, OUT & ostr)
 {
@@ -67,7 +61,7 @@ inline char * writeVarInt(Int64 x, char * ostr)
 }
 
 
-/** Read Int64, written in variable length format (base128) */
+/// Read Int64, written in variable length format (base128)
 template <typename IN>
 inline void readVarInt(Int64 & x, IN & istr)
 {


### PR DESCRIPTION
Problem:
  https://s3.amazonaws.com/clickhouse-test-reports/0/fa5b2bd4a5b02336bca8837c473a7124f8ecedf2/fuzzer_astfuzzerasan/report.html

The new assertion in the Varint code was introduced with #48154. It rejects values whose serialization cannot be deserialized (and this behavior cannot be changed due to historical reasons). Such values should be exceptionally rare in practice but AST fuzzer managers to trigger them.

The fix is similar to [this fix](https://github.com/ClickHouse/ClickHouse/pull/48154/files#diff-653c0a18dfdaa86262c78dc6b25550add0487f165b4ad053e86f530388f6203a): Bypass the check by limiting the value to the maximum allowed value.

(if AST fuzzer triggers finds more violations of the assertion, we might consider throwing an exception instead)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)