### PR TITLE
Fix flaky `test_keeper_snapshots`

### DIFF
--- a/tests/integration/test_keeper_snapshots/test.py
+++ b/tests/integration/test_keeper_snapshots/test.py
@@ -57,9 +57,10 @@ def restart_clickhouse():
 
 
 def test_state_after_restart(started_cluster):
+    keeper_utils.wait_until_connected(started_cluster, node)
+    node_zk = None
+    node_zk2 = None
     try:
-        node_zk = None
-        node_zk2 = None
         node_zk = get_connection_zk("node")
 
         node_zk.create("/test_state_after_restart", b"somevalue")
@@ -108,9 +109,10 @@ def test_state_after_restart(started_cluster):
 
 
 def test_ephemeral_after_restart(started_cluster):
+    keeper_utils.wait_until_connected(started_cluster, node)
+    node_zk = None
+    node_zk2 = None
     try:
-        node_zk = None
-        node_zk2 = None
         node_zk = get_connection_zk("node")
 
         session_id = node_zk._session_id


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


```
2023-04-04 22:35:38 [ 6903 ] DEBUG : Sending request(xid=None): Connect(protocol_version=0, last_zxid_seen=0, time_out=30000, session_id=0, passwd=b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', read_only=None) (connection.py:312, _submit)
2023-04-04 22:35:38 [ 6903 ] INFO : Zookeeper connection established, state: CONNECTED (client.py:532, _session_callback)
2023-04-04 22:35:38 [ 6903 ] WARNING : Connection dropped: socket connection broken (connection.py:622, _connect_attempt)
```

It connected, but ZK clients don't support rejection in handshake we send if server is not active so Keeper just drops the connection while ZK thinks everything is okay.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
