### PR TITLE
add docs for UNDROP TABLE

### DIFF
--- a/docs/en/sql-reference/statements/drop.md
+++ b/docs/en/sql-reference/statements/drop.md
@@ -22,6 +22,10 @@ DROP DATABASE [IF EXISTS] db [ON CLUSTER cluster] [SYNC]
 
 Deletes the table.
 
+:::tip
+Also see [UNDROP TABLE](/docs/en/sql-reference/statements/undrop.md)
+:::
+
 Syntax:
 
 ``` sql

--- a/docs/en/sql-reference/statements/undrop.md
+++ b/docs/en/sql-reference/statements/undrop.md
@@ -8,7 +8,7 @@ sidebar_label: UNDROP
 Cancels the dropping of the table.
 
 Beginning with ClickHouse version 23.3 it is possible to UNDROP a table 
-thin 8 minutes of issuing the DROP TABLE statement.  Dropped tables are listed in 
+within 8 minutes of issuing the DROP TABLE statement.  Dropped tables are listed in 
 a system table called `system.dropped_tables`.
 
 :::note

--- a/docs/en/sql-reference/statements/undrop.md
+++ b/docs/en/sql-reference/statements/undrop.md
@@ -1,0 +1,97 @@
+---
+slug: /en/sql-reference/statements/undrop
+sidebar_label: UNDROP
+---
+
+# UNDROP TABLE
+
+Cancels the dropping of the table.
+
+Beginning with ClickHouse version 23.3 it is possible to UNDROP a table 
+thin 8 minutes of issuing the DROP TABLE statement.  Dropped tables are listed in 
+a system table called `system.dropped_tables`.
+
+:::note
+UNDROP TABLE is experimental.  To use it add this setting: 
+```sql
+set allow_experimental_undrop_table_query = 1;
+```
+:::
+
+:::tip
+Also see [DROP TABLE](/docs/en/sql-reference/statements/drop.md)
+:::
+
+Syntax:
+
+``` sql
+UNDROP [TEMPORARY] TABLE [IF EXISTS] [db.]name [ON CLUSTER cluster] [SYNC]
+```
+
+**Example**
+
+``` sql
+set allow_experimental_undrop_table_query = 1;
+```
+
+```sql
+CREATE TABLE undropMe
+(
+    `id` UInt8
+)
+ENGINE = MergeTree
+ORDER BY id
+```
+
+```sql
+DROP TABLE undropMe
+```
+```sql
+SELECT *
+FROM system.dropped_tables
+FORMAT Vertical
+```
+```response
+Row 1:
+──────
+index:                 0
+database:              default
+table:                 undropMe
+uuid:                  aa696a1a-1d70-4e60-a841-4c80827706cc
+engine:                MergeTree
+metadata_dropped_path: /var/lib/clickhouse/metadata_dropped/default.undropMe.aa696a1a-1d70-4e60-a841-4c80827706cc.sql
+table_dropped_time:    2023-04-05 14:12:12
+
+1 row in set. Elapsed: 0.001 sec. 
+```
+```sql
+UNDROP TABLE undropMe
+```
+```response
+Ok.
+```
+```sql
+SELECT *
+FROM system.dropped_tables
+FORMAT Vertical
+```
+```response
+Ok.
+
+0 rows in set. Elapsed: 0.001 sec. 
+```
+```sql
+DESCRIBE TABLE undropMe
+FORMAT Vertical
+```
+```response
+Row 1:
+──────
+name:               id
+type:               UInt8
+default_type:       
+default_expression: 
+comment:            
+codec_expression:   
+ttl_expression:     
+```

--- a/docs/en/sql-reference/statements/undrop.md
+++ b/docs/en/sql-reference/statements/undrop.md
@@ -25,7 +25,7 @@ Also see [DROP TABLE](/docs/en/sql-reference/statements/drop.md)
 Syntax:
 
 ``` sql
-UNDROP [TEMPORARY] TABLE [IF EXISTS] [db.]name [ON CLUSTER cluster] [SYNC]
+UNDROP TABLE [db.]name [UUID '<uuid>'] [ON CLUSTER cluster]
 ```
 
 **Example**

--- a/docs/en/sql-reference/statements/undrop.md
+++ b/docs/en/sql-reference/statements/undrop.md
@@ -11,6 +11,8 @@ Beginning with ClickHouse version 23.3 it is possible to UNDROP a table in an At
 within `database_atomic_delay_before_drop_table_sec` (8 minutes by default) of issuing the DROP TABLE statement.  Dropped tables are listed in 
 a system table called `system.dropped_tables`.
 
+If you have a materialized view without a `TO` clause associated with the dropped table, then you will also have to UNDROP the inner table of that view.
+
 :::note
 UNDROP TABLE is experimental.  To use it add this setting: 
 ```sql

--- a/docs/en/sql-reference/statements/undrop.md
+++ b/docs/en/sql-reference/statements/undrop.md
@@ -7,7 +7,7 @@ sidebar_label: UNDROP
 
 Cancels the dropping of the table.
 
-Beginning with ClickHouse version 23.3 it is possible to UNDROP a table 
+Beginning with ClickHouse version 23.3 it is possible to UNDROP a table in an Atomic database
 within `database_atomic_delay_before_drop_table_sec` (8 minutes by default) of issuing the DROP TABLE statement.  Dropped tables are listed in 
 a system table called `system.dropped_tables`.
 

--- a/docs/en/sql-reference/statements/undrop.md
+++ b/docs/en/sql-reference/statements/undrop.md
@@ -8,7 +8,7 @@ sidebar_label: UNDROP
 Cancels the dropping of the table.
 
 Beginning with ClickHouse version 23.3 it is possible to UNDROP a table 
-within 8 minutes of issuing the DROP TABLE statement.  Dropped tables are listed in 
+within `database_atomic_delay_before_drop_table_sec` (8 minutes by default) of issuing the DROP TABLE statement.  Dropped tables are listed in 
 a system table called `system.dropped_tables`.
 
 :::note


### PR DESCRIPTION
Reviewers: Please check my syntax line.  I found this in a comment in the Parsers header file:
```
UNDROP TABLE [db.]name [UUID uuid]
```

But I copied the syntax line from DROP TABLE.  Let me know which one is correct and please tell me how to figure it out for myself in the future.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

closes https://github.com/ClickHouse/clickhouse-docs/issues/969

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
