### PR TITLE
Add support for Date/DateTime datatypes to arrayMin/Max, arrayDifference functions

### DIFF
--- a/src/DataTypes/DataTypeDateTime64.cpp
+++ b/src/DataTypes/DataTypeDateTime64.cpp
@@ -57,14 +57,14 @@ SerializationPtr DataTypeDateTime64::doGetDefaultSerialization() const
     return std::make_shared<SerializationDateTime64>(scale, *this);
 }
 
-inline std::string getDateTimeTimezone(const IDataType & data_type)
+std::string getDateTimeTimezone(const IDataType & data_type)
 {
     if (const auto * type = typeid_cast<const DataTypeDateTime *>(&data_type))
         return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
     if (const auto * type = typeid_cast<const DataTypeDateTime64 *>(&data_type))
         return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
 
-    throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot get decimal scale from type {}", data_type.getName());
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot get time zone from type {}", data_type.getName());
 }
 
 }

--- a/src/DataTypes/DataTypeDateTime64.cpp
+++ b/src/DataTypes/DataTypeDateTime64.cpp
@@ -12,6 +12,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ARGUMENT_OUT_OF_BOUND;
+    extern const int LOGICAL_ERROR;
 }
 
 static constexpr UInt32 max_scale = 9;
@@ -54,6 +55,16 @@ bool DataTypeDateTime64::equals(const IDataType & rhs) const
 SerializationPtr DataTypeDateTime64::doGetDefaultSerialization() const
 {
     return std::make_shared<SerializationDateTime64>(scale, *this);
+}
+
+inline std::string getDateTimeTimezone(const IDataType & data_type)
+{
+    if (const auto * type = typeid_cast<const DataTypeDateTime *>(&data_type))
+        return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
+    if (const auto * type = typeid_cast<const DataTypeDateTime64 *>(&data_type))
+        return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
+
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot get decimal scale from type {}", data_type.getName());
 }
 
 }

--- a/src/DataTypes/DataTypeDateTime64.h
+++ b/src/DataTypes/DataTypeDateTime64.h
@@ -9,11 +9,6 @@ class DateLUTImpl;
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
-
 /** DateTime64 is same as DateTime, but it stores values as Int64 and has configurable sub-second part.
  *
  * `scale` determines number of decimal places for sub-second part of the DateTime64.
@@ -46,15 +41,7 @@ protected:
     SerializationPtr doGetDefaultSerialization() const override;
 };
 
-inline std::string getDateTimeTimezone(const IDataType & data_type)
-{
-    if (const auto * type = typeid_cast<const DataTypeDateTime *>(&data_type))
-        return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
-    if (const auto * type = typeid_cast<const DataTypeDateTime64 *>(&data_type))
-        return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
-
-    throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot get decimal scale from type {}", data_type.getName());
-}
+inline std::string getDateTimeTimezone(const IDataType & data_type);
 
 }
 

--- a/src/DataTypes/DataTypeDateTime64.h
+++ b/src/DataTypes/DataTypeDateTime64.h
@@ -41,5 +41,15 @@ protected:
     SerializationPtr doGetDefaultSerialization() const override;
 };
 
+inline std::string getDateTimeTimezone(const IDataType & data_type)
+{
+    if (const auto * type = typeid_cast<const DataTypeDateTime *>(&data_type))
+        return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
+    if (const auto * type = typeid_cast<const DataTypeDateTime64 *>(&data_type))
+        return type->hasExplicitTimeZone() ? type->getTimeZone().getTimeZone() : std::string();
+
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot get decimal scale from type {}", data_type.getName());
+}
+
 }
 

--- a/src/DataTypes/DataTypeDateTime64.h
+++ b/src/DataTypes/DataTypeDateTime64.h
@@ -41,7 +41,7 @@ protected:
     SerializationPtr doGetDefaultSerialization() const override;
 };
 
-inline std::string getDateTimeTimezone(const IDataType & data_type);
+std::string getDateTimeTimezone(const IDataType & data_type);
 
 }
 

--- a/src/DataTypes/DataTypeDateTime64.h
+++ b/src/DataTypes/DataTypeDateTime64.h
@@ -9,6 +9,11 @@ class DateLUTImpl;
 namespace DB
 {
 
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
 /** DateTime64 is same as DateTime, but it stores values as Int64 and has configurable sub-second part.
  *
  * `scale` determines number of decimal places for sub-second part of the DateTime64.

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -556,6 +556,7 @@ inline bool isNullableOrLowCardinalityNullable(const DataTypePtr & data_type)
 template <typename DataType> constexpr bool IsDataTypeDecimal = false;
 template <typename DataType> constexpr bool IsDataTypeNumber = false;
 template <typename DataType> constexpr bool IsDataTypeDateOrDateTime = false;
+template <typename DataType> constexpr bool IsDataTypeDate = false;
 template <typename DataType> constexpr bool IsDataTypeEnum = false;
 
 template <typename DataType> constexpr bool IsDataTypeDecimalOrNumber = IsDataTypeDecimal<DataType> || IsDataTypeNumber<DataType>;
@@ -580,6 +581,8 @@ template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDate> = true;
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDate32> = true;
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDateTime> = true;
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDateTime64> = true;
+template <> inline constexpr bool IsDataTypeDate<DataTypeDateTime> = true;
+template <> inline constexpr bool IsDataTypeDate<DataTypeDateTime64> = true;
 
 template <typename T>
 class DataTypeEnum;

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -577,12 +577,13 @@ template <> inline constexpr bool IsDataTypeDecimal<DataTypeDateTime64> = true;
 
 template <typename T> constexpr bool IsDataTypeNumber<DataTypeNumber<T>> = true;
 
+template <> inline constexpr bool IsDataTypeDate<DataTypeDate> = true;
+template <> inline constexpr bool IsDataTypeDate<DataTypeDate32> = true;
+
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDate> = true;
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDate32> = true;
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDateTime> = true;
 template <> inline constexpr bool IsDataTypeDateOrDateTime<DataTypeDateTime64> = true;
-template <> inline constexpr bool IsDataTypeDate<DataTypeDateTime> = true;
-template <> inline constexpr bool IsDataTypeDate<DataTypeDateTime64> = true;
 
 template <typename T>
 class DataTypeEnum;

--- a/src/Functions/array/arrayAggregation.cpp
+++ b/src/Functions/array/arrayAggregation.cpp
@@ -399,6 +399,7 @@ struct ArrayAggregateImpl
             executeType<Decimal128>(mapped, offsets, res) ||
             executeType<Decimal256>(mapped, offsets, res) ||
             executeType<DateTime64>(mapped, offsets, res))
+        {
             return res;
         }
         else

--- a/src/Functions/array/arrayDifference.cpp
+++ b/src/Functions/array/arrayDifference.cpp
@@ -35,10 +35,10 @@ struct ArrayDifferenceImpl
         if (which.isUInt8() || which.isInt8())
             return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt16>());
 
-        if (which.isUInt16() || which.isInt16())
+        if (which.isUInt16() || which.isInt16() || which.isDate())
             return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt32>());
 
-        if (which.isUInt32() || which.isUInt64() || which.isInt32() || which.isInt64())
+        if (which.isUInt32() || which.isUInt64() || which.isInt32() || which.isInt64() || which.isDate32() || which.isDateTime())
             return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt64>());
 
         if (which.isFloat32() || which.isFloat64())
@@ -46,6 +46,14 @@ struct ArrayDifferenceImpl
 
         if (which.isDecimal())
             return std::make_shared<DataTypeArray>(expression_return);
+
+        if (which.isDateTime64())
+        {
+            UInt32 scale = getDecimalScale(*expression_return);
+            UInt32 precision = getDecimalPrecision(*expression_return);
+
+            return std::make_shared<DataTypeArray>(std::make_shared<DataTypeDecimal<Decimal64>>(precision, scale));
+        }
 
         throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "arrayDifference cannot process values of type {}", expression_return->getName());
     }
@@ -146,7 +154,8 @@ struct ArrayDifferenceImpl
             executeType<Decimal32, Decimal32>(mapped, array, res) ||
             executeType<Decimal64, Decimal64>(mapped, array, res) ||
             executeType<Decimal128, Decimal128>(mapped, array, res) ||
-            executeType<Decimal256, Decimal256>(mapped, array, res))
+            executeType<Decimal256, Decimal256>(mapped, array, res) ||
+            executeType<DateTime64, Decimal64>(mapped, array, res))
             return res;
         else
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Unexpected column for arrayDifference: {}", mapped->getName());

--- a/tests/queries/0_stateless/01602_array_aggregation.reference
+++ b/tests/queries/0_stateless/01602_array_aggregation.reference
@@ -34,6 +34,10 @@ Table array decimal avg
 3.5
 0
 2
+2023-04-05 00:25:24	2023-04-05 00:25:23	[0,1]
+2023-04-05 00:25:24.124	2023-04-05 00:25:23.123	[0,1.001]
+2023-04-06	2023-04-05	[0,1]
+2023-04-06	2023-04-05	[0,1]
 Types of aggregation result array min
 Int8	Int16	Int32	Int64
 UInt8	UInt16	UInt32	UInt64

--- a/tests/queries/0_stateless/01602_array_aggregation.sql
+++ b/tests/queries/0_stateless/01602_array_aggregation.sql
@@ -34,6 +34,11 @@ SELECT arrayAvg(x) FROM test_aggregation;
 
 DROP TABLE test_aggregation;
 
+WITH ['2023-04-05 00:25:23', '2023-04-05 00:25:24']::Array(DateTime) AS dt SELECT arrayMax(dt), arrayMin(dt), arrayDifference(dt);
+WITH ['2023-04-05 00:25:23.123', '2023-04-05 00:25:24.124']::Array(DateTime64(3)) AS dt SELECT arrayMax(dt), arrayMin(dt), arrayDifference(dt);
+WITH ['2023-04-05', '2023-04-06']::Array(Date) AS d SELECT arrayMax(d), arrayMin(d), arrayDifference(d);
+WITH ['2023-04-05', '2023-04-06']::Array(Date32) AS d SELECT arrayMax(d), arrayMin(d), arrayDifference(d);
+
 SELECT 'Types of aggregation result array min';
 SELECT toTypeName(arrayMin([toInt8(0)])), toTypeName(arrayMin([toInt16(0)])), toTypeName(arrayMin([toInt32(0)])), toTypeName(arrayMin([toInt64(0)]));
 SELECT toTypeName(arrayMin([toUInt8(0)])), toTypeName(arrayMin([toUInt16(0)])), toTypeName(arrayMin([toUInt32(0)])), toTypeName(arrayMin([toUInt64(0)]));


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for `Date`, `Date32`, `DateTime`, `DateTime64`  data types to `arrayMin`, `arrayMax`, `arrayDifference` functions. Closes https://github.com/ClickHouse/ClickHouse/issues/21645.