### PR TITLE
Only log to stdout in containers

### DIFF
--- a/docker/server/docker_related_config.xml
+++ b/docker/server/docker_related_config.xml
@@ -4,9 +4,11 @@
     <listen_host>0.0.0.0</listen_host>
     <listen_try>1</listen_try>
 
-    <!--
+    <!-- send logging to stdout for containers -->
     <logger>
-        <console>1</console>
+        <console>true</console>
+        <log remove="remove"/>
+        <errorlog remove="remove"/>
     </logger>
-    -->
+
 </clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Docker containers are now configured to log to `stdout` by default.