### PR TITLE
Fix flaky `test_alternative_keeper_config`

### DIFF
--- a/tests/integration/test_alternative_keeper_config/test.py
+++ b/tests/integration/test_alternative_keeper_config/test.py
@@ -59,6 +59,8 @@ def test_create_insert(started_cluster):
     node2.query("INSERT INTO tbl VALUES (1, 'str1')")  # Test deduplication
     node3.query("INSERT INTO tbl VALUES (2, 'str2')")
 
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'test_cluster' tbl")
+
     for node in [node1, node2, node3]:
         expected = [[1, "str1"], [2, "str2"]]
         assert node.query("SELECT * FROM tbl ORDER BY id") == TSV(expected)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

https://s3.amazonaws.com/clickhouse-test-reports/0/4ab8b35b008abdd811e729762f2908ad4cd5dbaf/integration_tests__asan__[3/6].html

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
