### PR TITLE
Better exception message for ZSTD

### DIFF
--- a/src/IO/ZstdDeflatingAppendableWriteBuffer.cpp
+++ b/src/IO/ZstdDeflatingAppendableWriteBuffer.cpp
@@ -23,11 +23,11 @@ ZstdDeflatingAppendableWriteBuffer::ZstdDeflatingAppendableWriteBuffer(
 {
     cctx = ZSTD_createCCtx();
     if (cctx == nullptr)
-        throw Exception(ErrorCodes::ZSTD_ENCODER_FAILED, "zstd stream encoder init failed: zstd version: {}", ZSTD_VERSION_STRING);
+        throw Exception(ErrorCodes::ZSTD_ENCODER_FAILED, "ZSTD stream encoder init failed: ZSTD version: {}", ZSTD_VERSION_STRING);
     size_t ret = ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, compression_level);
     if (ZSTD_isError(ret))
         throw Exception(ErrorCodes::ZSTD_ENCODER_FAILED,
-                        "zstd stream encoder option setting failed: error code: {}; zstd version: {}",
+                        "ZSTD stream encoder option setting failed: error code: {}; zstd version: {}",
                         ret, ZSTD_VERSION_STRING);
 
     input = {nullptr, 0, 0};
@@ -64,7 +64,7 @@ void ZstdDeflatingAppendableWriteBuffer::nextImpl()
             if (ZSTD_isError(compression_result))
                 throw Exception(
                                 ErrorCodes::ZSTD_ENCODER_FAILED,
-                                "Zstd stream encoding failed: error code: {}; zstd version: {}",
+                                "ZSTD stream decoding failed: error code: {}; ZSTD version: {}",
                                 ZSTD_getErrorName(compression_result), ZSTD_VERSION_STRING);
 
             first_write = false;
@@ -138,7 +138,7 @@ void ZstdDeflatingAppendableWriteBuffer::finalizeBefore()
     {
         if (ZSTD_isError(remaining))
             throw Exception(ErrorCodes::ZSTD_ENCODER_FAILED,
-                            "Zstd stream encoder end failed: error: '{}' zstd version: {}",
+                            "ZSTD stream encoder end failed: error: '{}' ZSTD version: {}",
                             ZSTD_getErrorName(remaining), ZSTD_VERSION_STRING);
 
         remaining = ZSTD_compressStream2(cctx, &output, &input, ZSTD_e_end);

--- a/src/IO/ZstdDeflatingWriteBuffer.cpp
+++ b/src/IO/ZstdDeflatingWriteBuffer.cpp
@@ -63,7 +63,7 @@ void ZstdDeflatingWriteBuffer::nextImpl()
             if (ZSTD_isError(compression_result))
                 throw Exception(
                                 ErrorCodes::ZSTD_ENCODER_FAILED,
-                                "Zstd stream encoding failed: error: '{}'; zstd version: {}",
+                                "ZSTD stream encoding failed: error: '{}'; zstd version: {}",
                                 ZSTD_getErrorName(compression_result), ZSTD_VERSION_STRING);
 
             out->position() = out->buffer().begin() + output.pos;

--- a/src/IO/ZstdInflatingReadBuffer.cpp
+++ b/src/IO/ZstdInflatingReadBuffer.cpp
@@ -1,4 +1,5 @@
 #include <IO/ZstdInflatingReadBuffer.h>
+#include <zstd_errors.h>
 
 
 namespace DB
@@ -56,11 +57,17 @@ bool ZstdInflatingReadBuffer::nextImpl()
 
         /// Decompress data and check errors.
         size_t ret = ZSTD_decompressStream(dctx, &output, &input);
-        if (ZSTD_isError(ret))
+        if (ZSTD_getErrorCode(ret))
+        {
             throw Exception(
-                    ErrorCodes::ZSTD_DECODER_FAILED,
-                    "Zstd stream encoding failed: error '{}'; zstd version: {}",
-                    ZSTD_getErrorName(ret), ZSTD_VERSION_STRING);
+                ErrorCodes::ZSTD_DECODER_FAILED,
+                "ZSTD stream decoding failed: error '{}'{}; ZSTD version: {}",
+                ZSTD_getErrorName(ret),
+                ZSTD_error_frameParameter_windowTooLarge == ret
+                    ? ". You can increase the maximum window size with the 'zstd_window_log_max' setting in ClickHouse. Example: 'SET zstd_window_log_max = 31'"
+                    : "",
+                ZSTD_VERSION_STRING);
+        }
 
         /// Check that something has changed after decompress (input or output position)
         assert(in->eof() || output.pos > 0 || in->position() < in->buffer().begin() + input.pos);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

See #22482