### PR TITLE
Remove misleading comment and block

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeBackgroundExecutor.cpp
@@ -217,13 +217,10 @@ void MergeTreeBackgroundExecutor<Queue>::routine(TaskRuntimeDataPtr item)
 
         if (item->is_currently_deleting)
         {
-            /// This is significant to order the destructors.
-            {
-                NOEXCEPT_SCOPE({
-                    ALLOW_ALLOCATIONS_IN_SCOPE;
-                    item->task.reset();
-                });
-            }
+            NOEXCEPT_SCOPE({
+                ALLOW_ALLOCATIONS_IN_SCOPE;
+                item->task.reset();
+            });
             item->is_done.set();
             item = nullptr;
             return;


### PR DESCRIPTION
It is no longer "significant" after `NOEXCEPT_SCOPE` macro rework #39229

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)