### PR TITLE
Don't use type conversion with String query parameters

### DIFF
--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -103,6 +103,9 @@ void ReplaceQueryParameterVisitor::visitQueryParameter(ASTPtr & ast)
     else
         literal = temp_column[0];
 
+    /// If it's a String, substitute it in the form of a string literal without CAST
+    /// to enable substitutions in simple queries that don't support expressions
+    /// (such as CREATE USER).
     if (typeid_cast<const DataTypeString *>(data_type.get()))
         ast = std::make_shared<ASTLiteral>(literal);
     else

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -102,7 +102,10 @@ void ReplaceQueryParameterVisitor::visitQueryParameter(ASTPtr & ast)
     else
         literal = temp_column[0];
 
-    ast = addTypeConversionToAST(std::make_shared<ASTLiteral>(literal), type_name);
+    if (typeid_cast<const DataTypeString *>(&data_type))
+        ast = std::make_shared<ASTLiteral>(literal);
+    else
+        ast = addTypeConversionToAST(std::make_shared<ASTLiteral>(literal), type_name);
 
     /// Keep the original alias.
     ast->setAlias(alias);

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -1,6 +1,7 @@
 #include <Columns/IColumn.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypeString.h>
 #include <Formats/FormatSettings.h>
 #include <IO/ReadBufferFromString.h>
 #include <Interpreters/IdentifierSemantic.h>
@@ -102,7 +103,7 @@ void ReplaceQueryParameterVisitor::visitQueryParameter(ASTPtr & ast)
     else
         literal = temp_column[0];
 
-    if (typeid_cast<const DataTypeString *>(&data_type))
+    if (typeid_cast<const DataTypeString *>(data_type.get()))
         ast = std::make_shared<ASTLiteral>(literal);
     else
         ast = addTypeConversionToAST(std::make_shared<ASTLiteral>(literal), type_name);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
It is needed to implement query parameters in `CREATE USER` query and it makes more sense in general.