### PR TITLE
Fix bug in Keeper when a node is not created with scheme `auth` in ACL sometimes.

### DIFF
--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -61,16 +61,10 @@ String getSHA1(const String & userdata)
     return String{digest_id.begin(), digest_id.end()};
 }
 
-String generateDigest(const String & userdata)
-{
-    std::vector<String> user_password;
-    boost::split(user_password, userdata, [](char character) { return character == ':'; });
-    return user_password[0] + ":" + base64Encode(getSHA1(userdata));
-}
-
 bool fixupACL(
     const std::vector<Coordination::ACL> & request_acls,
-    const std::vector<KeeperStorage::AuthID> & current_ids,
+    int64_t session_id,
+    const KeeperStorage::UncommittedState & uncommitted_state,
     std::vector<Coordination::ACL> & result_acls)
 {
     if (request_acls.empty())
@@ -81,14 +75,18 @@ bool fixupACL(
     {
         if (request_acl.scheme == "auth")
         {
-            for (const auto & current_id : current_ids)
-            {
-                valid_found = true;
-                Coordination::ACL new_acl = request_acl;
-                new_acl.scheme = current_id.scheme;
-                new_acl.id = current_id.id;
-                result_acls.push_back(new_acl);
-            }
+            uncommitted_state.forEachAuthInSession(
+                session_id,
+                [&](const KeeperStorage::AuthID & auth_id)
+                {
+                    valid_found = true;
+                    Coordination::ACL new_acl = request_acl;
+
+                    new_acl.scheme = auth_id.scheme;
+                    new_acl.id = auth_id.id;
+
+                    result_acls.push_back(new_acl);
+                });
         }
         else if (request_acl.scheme == "world" && request_acl.id == "anyone")
         {
@@ -564,6 +562,32 @@ Coordination::ACLs KeeperStorage::UncommittedState::getACLs(StringRef path) cons
     return storage.acl_map.convertNumber(node_it->value.acl_id);
 }
 
+void KeeperStorage::UncommittedState::forEachAuthInSession(int64_t session_id, std::function<void(const AuthID &)> func) const
+{
+    const auto call_for_each_auth = [&func](const auto & auth_ids)
+    {
+        for (const auto & auth : auth_ids)
+        {
+            using TAuth = std::remove_reference_t<decltype(auth)>;
+
+            const AuthID * auth_ptr = nullptr;
+            if constexpr (std::is_pointer_v<TAuth>)
+                auth_ptr = auth;
+            else
+                auth_ptr = &auth;
+
+            func(*auth_ptr);
+        }
+    };
+
+    // for committed
+    if (storage.session_and_auth.contains(session_id))
+        call_for_each_auth(storage.session_and_auth.at(session_id));
+    // for uncommitted
+    if (session_and_auth.contains(session_id))
+        call_for_each_auth(session_and_auth.at(session_id));
+}
+
 namespace
 {
 
@@ -927,7 +951,7 @@ struct KeeperStorageCreateRequestProcessor final : public KeeperStorageRequestPr
             return {KeeperStorage::Delta{zxid, Coordination::Error::ZBADARGUMENTS}};
 
         Coordination::ACLs node_acls;
-        if (!fixupACL(request.acls, storage.session_and_auth[session_id], node_acls))
+        if (!fixupACL(request.acls, session_id, storage.uncommitted_state, node_acls))
             return {KeeperStorage::Delta{zxid, Coordination::Error::ZINVALIDACL}};
 
         if (request.is_ephemeral)
@@ -1533,10 +1557,8 @@ struct KeeperStorageSetACLRequestProcessor final : public KeeperStorageRequestPr
             return {KeeperStorage::Delta{zxid, Coordination::Error::ZBADVERSION}};
 
 
-        auto & session_auth_ids = storage.session_and_auth[session_id];
         Coordination::ACLs node_acls;
-
-        if (!fixupACL(request.acls, session_auth_ids, node_acls))
+        if (!fixupACL(request.acls, session_id, uncommitted_state, node_acls))
             return {KeeperStorage::Delta{zxid, Coordination::Error::ZINVALIDACL}};
 
         std::vector<KeeperStorage::Delta> new_deltas
@@ -1840,7 +1862,7 @@ struct KeeperStorageAuthRequestProcessor final : public KeeperStorageRequestProc
             return {KeeperStorage::Delta{zxid, Coordination::Error::ZAUTHFAILED}};
 
         std::vector<KeeperStorage::Delta> new_deltas;
-        auto auth_digest = generateDigest(auth_request.data);
+        auto auth_digest = KeeperStorage::generateDigest(auth_request.data);
         if (auth_digest == storage.superdigest)
         {
             KeeperStorage::AuthID auth{"super", ""};
@@ -2418,6 +2440,13 @@ uint64_t KeeperStorage::getTotalEphemeralNodesCount() const
 void KeeperStorage::recalculateStats()
 {
     container.recalculateDataSize();
+}
+
+String KeeperStorage::generateDigest(const String & userdata)
+{
+    std::vector<String> user_password;
+    boost::split(user_password, userdata, [](char character) { return character == ':'; });
+    return user_password[0] + ":" + base64Encode(getSHA1(userdata));
 }
 
 

--- a/src/Coordination/KeeperStorage.h
+++ b/src/Coordination/KeeperStorage.h
@@ -105,6 +105,8 @@ public:
         return first.value == second.value;
     }
 
+    static String generateDigest(const String & userdata);
+
     struct RequestForSession
     {
         int64_t session_id;
@@ -262,6 +264,8 @@ public:
 
             return check_auth(auth_it->second);
         }
+
+        void forEachAuthInSession(int64_t session_id, std::function<void(const AuthID &)> func) const;
 
         std::shared_ptr<Node> tryGetNodeFromStorage(StringRef path) const;
 

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -1579,6 +1579,113 @@ TEST_P(CoordinationTest, TestEphemeralNodeRemove)
 }
 
 
+TEST_P(CoordinationTest, TestCreateNodeWithAuthSchemeForAclWhenAuthIsPrecommitted)
+{
+    using namespace Coordination;
+    using namespace DB;
+
+    ChangelogDirTest snapshots("./snapshots");
+    CoordinationSettingsPtr settings = std::make_shared<CoordinationSettings>();
+    ResponsesQueue queue(std::numeric_limits<size_t>::max());
+    SnapshotsQueue snapshots_queue{1};
+
+    auto state_machine = std::make_shared<KeeperStateMachine>(queue, snapshots_queue, "./snapshots", settings, keeper_context, nullptr);
+    state_machine->init();
+
+    String user_auth_data = "test_user:test_password";
+    String digest = KeeperStorage::generateDigest(user_auth_data);
+
+    std::shared_ptr<ZooKeeperAuthRequest> auth_req = std::make_shared<ZooKeeperAuthRequest>();
+    auth_req->scheme = "digest";
+    auth_req->data = user_auth_data;
+
+    // Add auth data to the session
+    auto auth_entry = getLogEntryFromZKRequest(0, 1, state_machine->getNextZxid(), auth_req);
+    state_machine->pre_commit(1, auth_entry->get_buf());
+
+    // Create a node with 'auth' scheme for ACL
+    String node_path = "/hello";
+    std::shared_ptr<ZooKeeperCreateRequest> create_req = std::make_shared<ZooKeeperCreateRequest>();
+    create_req->path = node_path;
+    // When 'auth' scheme is used the creator must have been authenticated by the server (for example, using 'digest' scheme) before it can
+    // create nodes with this ACL.
+    create_req->acls = {{.permissions = 31, .scheme = "auth", .id = ""}};
+    auto create_entry = getLogEntryFromZKRequest(0, 1, state_machine->getNextZxid(), create_req);
+    state_machine->pre_commit(2, create_entry->get_buf());
+
+    const auto & uncommitted_state = state_machine->getStorage().uncommitted_state;
+    ASSERT_TRUE(uncommitted_state.nodes.contains(node_path));
+
+    // commit log entries
+    state_machine->commit(1, auth_entry->get_buf());
+    state_machine->commit(2, create_entry->get_buf());
+
+    auto node = uncommitted_state.getNode(node_path);
+    ASSERT_NE(node, nullptr);
+    auto acls = uncommitted_state.getACLs(node_path);
+    ASSERT_EQ(acls.size(), 1);
+    EXPECT_EQ(acls[0].scheme, "digest");
+    EXPECT_EQ(acls[0].id, digest);
+    EXPECT_EQ(acls[0].permissions, 31);
+}
+
+TEST_P(CoordinationTest, TestSetACLWithAuthSchemeForAclWhenAuthIsPrecommitted)
+{
+    using namespace Coordination;
+    using namespace DB;
+
+    ChangelogDirTest snapshots("./snapshots");
+    CoordinationSettingsPtr settings = std::make_shared<CoordinationSettings>();
+    ResponsesQueue queue(std::numeric_limits<size_t>::max());
+    SnapshotsQueue snapshots_queue{1};
+
+    auto state_machine = std::make_shared<KeeperStateMachine>(queue, snapshots_queue, "./snapshots", settings, keeper_context, nullptr);
+    state_machine->init();
+
+    String user_auth_data = "test_user:test_password";
+    String digest = KeeperStorage::generateDigest(user_auth_data);
+
+    std::shared_ptr<ZooKeeperAuthRequest> auth_req = std::make_shared<ZooKeeperAuthRequest>();
+    auth_req->scheme = "digest";
+    auth_req->data = user_auth_data;
+
+    // Add auth data to the session
+    auto auth_entry = getLogEntryFromZKRequest(0, 1, state_machine->getNextZxid(), auth_req);
+    state_machine->pre_commit(1, auth_entry->get_buf());
+
+    // Create a node
+    String node_path = "/hello";
+    std::shared_ptr<ZooKeeperCreateRequest> create_req = std::make_shared<ZooKeeperCreateRequest>();
+    create_req->path = node_path;
+    auto create_entry = getLogEntryFromZKRequest(0, 1, state_machine->getNextZxid(), create_req);
+    state_machine->pre_commit(2, create_entry->get_buf());
+
+    // Set ACL with 'auth' scheme for ACL
+    std::shared_ptr<ZooKeeperSetACLRequest> set_acl_req = std::make_shared<ZooKeeperSetACLRequest>();
+    set_acl_req->path = node_path;
+    // When 'auth' scheme is used the creator must have been authenticated by the server (for example, using 'digest' scheme) before it can
+    // set this ACL.
+    set_acl_req->acls = {{.permissions = 31, .scheme = "auth", .id = ""}};
+    auto set_acl_entry = getLogEntryFromZKRequest(0, 1, state_machine->getNextZxid(), set_acl_req);
+    state_machine->pre_commit(3, set_acl_entry->get_buf());
+
+    // commit all entries
+    state_machine->commit(1, auth_entry->get_buf());
+    state_machine->commit(2, create_entry->get_buf());
+    state_machine->commit(2, set_acl_entry->get_buf());
+
+    const auto & uncommitted_state = state_machine->getStorage().uncommitted_state;
+    auto node = uncommitted_state.getNode(node_path);
+
+    ASSERT_NE(node, nullptr);
+    auto acls = uncommitted_state.getACLs(node_path);
+    ASSERT_EQ(acls.size(), 1);
+    EXPECT_EQ(acls[0].scheme, "digest");
+    EXPECT_EQ(acls[0].id, digest);
+    EXPECT_EQ(acls[0].permissions, 31);
+}
+
+
 TEST_P(CoordinationTest, TestRotateIntervalChanges)
 {
     using namespace Coordination;

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -1672,7 +1672,7 @@ TEST_P(CoordinationTest, TestSetACLWithAuthSchemeForAclWhenAuthIsPrecommitted)
     // commit all entries
     state_machine->commit(1, auth_entry->get_buf());
     state_machine->commit(2, create_entry->get_buf());
-    state_machine->commit(2, set_acl_entry->get_buf());
+    state_machine->commit(3, set_acl_entry->get_buf());
 
     const auto & uncommitted_state = state_machine->getStorage().uncommitted_state;
     auto node = uncommitted_state.getNode(node_path);


### PR DESCRIPTION
When a `create_node` request is pre-processed with an ACL scheme `auth` (in this case, the creator's `AuthID` is used, and it must be added to the session beforehand), but the `add_auth` request has not been committed yet (just pre-processed), then the node will not be created eventually. 
This happens, for example, when a bunch of raft log entries arrive (which contains both `add_auth` request and `create_node`) or when logs are replayed (pre-processed) on startup. All this leads to different data on different replicas. 

If we enable the `digest_enabled` setting on our cluster then we get the error like below. On a test cluster with proposed fix and digest enabled such error is not observed.
```bash
...
2023.04.06 19:24:48.552516 [ 872749 ] {} <Fatal> KeeperStateMachine: Digest for nodes is not matching after preprocessing request of type 'Create'.
Expected digest - 14083883533763233460, actual digest - 5362865241808976005 (digest V2). Keeper will terminate to avoid inconsistencies.
Extra information about the request:
XID = 11
OpNum = Create
Additional info:
path = /clickhouse
is_ephemeral = false
is_sequential = false
2023.04.06 19:24:48.552684 [ 872750 ] {} <Fatal> BaseDaemon: (version 22.8.16.1, build id: 5FCB4C536BF0390D) (from thread 872749) Terminate called without an active exception
2023.04.06 19:24:48.552831 [ 872758 ] {} <Fatal> BaseDaemon: ########################################
2023.04.06 19:24:48.552867 [ 872758 ] {} <Fatal> BaseDaemon: (version 22.8.16.1, build id: 5FCB4C536BF0390D) (from thread 872749) (no query) Received signal Aborted (6)
2023.04.06 19:24:48.552879 [ 872758 ] {} <Fatal> BaseDaemon: 
2023.04.06 19:24:48.552900 [ 872758 ] {} <Fatal> BaseDaemon: Stack trace: 0x7fc7e3d27e87 0x7fc7e3d297f1 0xfcc86bc 0x19985e83 0x19985e02 0x1584120d 0x15840bb4 0x158401ec 0x158216d0 0x15812029 0xfc9f303 0xfc9a54a 0x17532cc6 0xfc98055 0x1754628e 0xfc96dde 0xb25d3e1 0x7fc7e3d0ac87 0xb25cb6e
2023.04.06 19:24:48.552943 [ 872758 ] {} <Fatal> BaseDaemon: 3. raise @ 0x3ee87 in /lib/x86_64-linux-gnu/libc-2.27.so
2023.04.06 19:24:48.552953 [ 872758 ] {} <Fatal> BaseDaemon: 4. abort @ 0x407f1 in /lib/x86_64-linux-gnu/libc-2.27.so
2023.04.06 19:24:48.559614 [ 872758 ] {} <Fatal> BaseDaemon: 5. ./local_build/./src/Daemon/BaseDaemon.cpp:438: terminate_handler() @ 0xfcc86bc in /tmp/clickhouse
2023.04.06 19:24:48.561465 [ 872758 ] {} <Fatal> BaseDaemon: 6. ./local_build/./contrib/libcxxabi/src/cxa_handlers.cpp:61: std::__terminate(void (*)()) @ 0x19985e83 in /tmp/clickhouse
2023.04.06 19:24:48.562694 [ 872758 ] {} <Fatal> BaseDaemon: 7. ./local_build/./contrib/libcxxabi/src/cxa_handlers.cpp:86: std::terminate() @ 0x19985e02 in /tmp/clickhouse
2023.04.06 19:24:48.582852 [ 872758 ] {} <Fatal> BaseDaemon: 8.1. inlined from ./local_build/./contrib/libcxx/include/string:1551: std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__zero()
2023.04.06 19:24:48.582883 [ 872758 ] {} <Fatal> BaseDaemon: 8.2. inlined from ./contrib/libcxx/include/string:1827: basic_string
2023.04.06 19:24:48.582893 [ 872758 ] {} <Fatal> BaseDaemon: 8. ./src/Coordination/KeeperStateMachine.cpp:126: DB::(anonymous namespace)::assertDigest(DB::KeeperStorage::Digest const&, DB::KeeperStorage::Digest const&, Coordination::ZooKeeperRequest const&, bool) @ 0x1584120d in /tmp/clickhouse
2023.04.06 19:24:48.596721 [ 872758 ] {} <Fatal> BaseDaemon: 9. ./local_build/./src/Coordination/KeeperStateMachine.cpp:0: DB::KeeperStateMachine::preprocess(DB::KeeperStorage::RequestForSession const&) @ 0x15840bb4 in /tmp/clickhouse
2023.04.06 19:24:48.609860 [ 872758 ] {} <Fatal> BaseDaemon: 10.1. inlined from ./local_build/./contrib/libcxx/include/__memory/shared_ptr.h:702: ~shared_ptr
2023.04.06 19:24:48.609906 [ 872758 ] {} <Fatal> BaseDaemon: 10.2. inlined from ./src/Coordination/KeeperStorage.h:106: ~RequestForSession
2023.04.06 19:24:48.609972 [ 872758 ] {} <Fatal> BaseDaemon: 10. ./src/Coordination/KeeperStateMachine.cpp:160: DB::KeeperStateMachine::pre_commit(unsigned long, nuraft::buffer&) @ 0x158401ec in /tmp/clickhouse
2023.04.06 19:24:48.624566 [ 872758 ] {} <Fatal> BaseDaemon: 11. ./local_build/./src/Coordination/KeeperServer.cpp:0: DB::KeeperServer::startup(Poco::Util::AbstractConfiguration const&, bool) @ 0x158216d0 in /tmp/clickhouse
2023.04.06 19:24:48.634799 [ 872758 ] {} <Fatal> BaseDaemon: 12. ./local_build/./src/Coordination/KeeperDispatcher.cpp:303: DB::KeeperDispatcher::initialize(Poco::Util::AbstractConfiguration const&, bool, bool) @ 0x15812029 in /tmp/clickhouse
2023.04.06 19:24:48.636906 [ 872758 ] {} <Fatal> BaseDaemon: 13.1. inlined from ./local_build/./contrib/libcxx/include/__mutex_base:97: ~lock_guard
2023.04.06 19:24:48.636926 [ 872758 ] {} <Fatal> BaseDaemon: 13. ./programs/keeper/TinyContext.cpp:41: DB::TinyContext::initializeKeeperDispatcher(bool) const @ 0xfc9f303 in /tmp/clickhouse
2023.04.06 19:24:48.641786 [ 872758 ] {} <Fatal> BaseDaemon: 14. ./local_build/./programs/keeper/Keeper.cpp:364: DB::Keeper::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) @ 0xfc9a54a in /tmp/clickhouse
2023.04.06 19:24:48.647375 [ 872758 ] {} <Fatal> BaseDaemon: 15. ./local_build/./contrib/poco/Util/src/Application.cpp:0: Poco::Util::Application::run() @ 0x17532cc6 in /tmp/clickhouse
2023.04.06 19:24:48.654742 [ 872758 ] {} <Fatal> BaseDaemon: 16. ./local_build/./programs/keeper/Keeper.cpp:225: DB::Keeper::run() @ 0xfc98055 in /tmp/clickhouse
2023.04.06 19:24:48.656851 [ 872758 ] {} <Fatal> BaseDaemon: 17. ./local_build/./contrib/poco/Util/src/ServerApplication.cpp:612: Poco::Util::ServerApplication::run(int, char**) @ 0x1754628e in /tmp/clickhouse
2023.04.06 19:24:48.663523 [ 872758 ] {} <Fatal> BaseDaemon: 18. ./local_build/./programs/keeper/Keeper.cpp:0: mainEntryClickHouseKeeper(int, char**) @ 0xfc96dde in /tmp/clickhouse
2023.04.06 19:24:48.665197 [ 872758 ] {} <Fatal> BaseDaemon: 19. ./local_build/./programs/main.cpp:0: main @ 0xb25d3e1 in /tmp/clickhouse
2023.04.06 19:24:48.665212 [ 872758 ] {} <Fatal> BaseDaemon: 20. __libc_start_main @ 0x21c87 in /lib/x86_64-linux-gnu/libc-2.27.so
2023.04.06 19:24:49.374052 [ 872758 ] {} <Fatal> BaseDaemon: 21. _start @ 0xb25cb6e in /tmp/clickhouse
2023.04.06 19:24:49.540519 [ 872758 ] {} <Fatal> BaseDaemon: Integrity check of the executable skipped because the reference checksum could not be read. (calculated checksum: 4BA7A2D1FF80E5C137840F8B0A9836CD)
2023.04.06 19:24:49.540553 [ 872758 ] {} <Information> SentryWriter: Not sending crash report
...
```


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug in Clickhouse-Keeper when a node is not created sometimes with scheme `auth` in ACL

