### PR TITLE
sequence state fix

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSequenceMatch.h
+++ b/src/AggregateFunctions/AggregateFunctionSequenceMatch.h
@@ -50,7 +50,7 @@ struct AggregateFunctionSequenceMatchData final
     bool sorted = true;
     PODArrayWithStackMemory<TimestampEvents, 64> events_list;
     /// sequenceMatch conditions met at least once in events_list
-    std::bitset<max_events> conditions_met;
+    Events conditions_met;
 
     void add(const Timestamp timestamp, const Events & events)
     {
@@ -100,6 +100,11 @@ struct AggregateFunctionSequenceMatchData final
 
         size_t size;
         readBinary(size, buf);
+
+        /// If we lose these flags, functionality is broken
+        /// If we serialize/deserialize these flags, we have compatibility issues
+        /// If we set these flags to 1, we have a minor performance penalty, which seems acceptable
+        conditions_met.set();
 
         events_list.clear();
         events_list.reserve(size);

--- a/tests/queries/0_stateless/02713_sequence_match_serialization_fix.reference
+++ b/tests/queries/0_stateless/02713_sequence_match_serialization_fix.reference
@@ -1,0 +1,3 @@
+serialized state is not used	1
+serialized state is used	1
+via Distributed	1

--- a/tests/queries/0_stateless/02713_sequence_match_serialization_fix.sql
+++ b/tests/queries/0_stateless/02713_sequence_match_serialization_fix.sql
@@ -1,0 +1,36 @@
+DROP TABLE IF EXISTS 02713_seqt;
+DROP TABLE IF EXISTS 02713_seqt_distr;
+
+SELECT
+    'serialized state is not used', sequenceMatch('(?1)(?2)')(time, number_ = 1, number_ = 0) AS seq
+FROM
+(
+    SELECT
+        number AS time,
+        number % 2 AS number_
+    FROM numbers_mt(100)
+);
+
+
+CREATE TABLE 02713_seqt
+ENGINE = MergeTree
+ORDER BY n AS
+SELECT
+    sequenceMatchState('(?1)(?2)')(time, number_ = 1, number_ = 0) AS seq,
+    1 AS n
+FROM
+(
+    SELECT
+        number AS time,
+        number % 2 AS number_
+    FROM numbers_mt(100)
+);
+
+
+SELECT 'serialized state is used', sequenceMatchMerge('(?1)(?2)')(seq) AS seq
+FROM 02713_seqt;
+
+
+CREATE TABLE 02713_seqt_distr ( seq AggregateFunction(sequenceMatch('(?1)(?2)'), UInt64, UInt8, UInt8) , n UInt8) ENGINE = Distributed(test_shard_localhost, currentDatabase(), '02713_seqt');
+
+SELECT 'via Distributed', sequenceMatchMerge('(?1)(?2)')(seq) AS seq FROM 02713_seqt_distr;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed that `sequenceMatch()` and `sequenceCount()` return wrong results when serialized state is used. Fixes https://github.com/ClickHouse/ClickHouse/issues/37296
