### PR TITLE
Fix flakiness of test_store_cleanup in case of image rebuild

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4161,9 +4161,10 @@ class ClickHouseInstance:
         logging.debug("Copy common configuration from helpers")
         # The file is named with 0_ prefix to be processed before other configuration overloads.
         if self.copy_common_configs:
-            need_fix_log_level = self.tag != "latest"
             write_embedded_config(
-                "0_common_instance_config.xml", self.config_d_dir, need_fix_log_level
+                "0_common_instance_config.xml",
+                self.config_d_dir,
+                self.with_installed_binary,
             )
 
         write_embedded_config("0_common_instance_users.xml", users_d_dir)


### PR DESCRIPTION
The log level will be substituted from "test" to "trace" in case of the tag is not "latest", the assumption behind this I guess is that it should not try to use "test" log level for older versions.

But, it could have per-PR image in case of changes in the Dockerfile, so it is better to check for self.with_installed_binary, since actually any parameters except this will use new clickhouse binary anyway.

CI: https://s3.amazonaws.com/clickhouse-test-reports/48596/a1272e8536265929255fdf5020836f057859e425/integration_tests__tsan__[1/6].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)