### PR TITLE
Better handling of values too large for VarInt encoding

### DIFF
--- a/src/Common/SpaceSaving.h
+++ b/src/Common/SpaceSaving.h
@@ -97,8 +97,8 @@ public:
         void write(WriteBuffer & wb) const
         {
             writeBinary(key, wb);
-            writeVarUIntOverflow(count, wb);
-            writeVarUIntOverflow(error, wb);
+            writeVarUInt(count, wb);
+            writeVarUInt(error, wb);
         }
 
         void read(ReadBuffer & rb)

--- a/src/IO/Progress.cpp
+++ b/src/IO/Progress.cpp
@@ -28,13 +28,13 @@ void ProgressValues::read(ReadBuffer & in, UInt64 server_revision)
 
 void ProgressValues::write(WriteBuffer & out, UInt64 client_revision) const
 {
-    writeVarUIntOverflow(read_rows, out);
-    writeVarUIntOverflow(read_bytes, out);
-    writeVarUIntOverflow(total_rows_to_read, out);
+    writeVarUInt(read_rows, out);
+    writeVarUInt(read_bytes, out);
+    writeVarUInt(total_rows_to_read, out);
     if (client_revision >= DBMS_MIN_REVISION_WITH_CLIENT_WRITE_INFO)
     {
-        writeVarUIntOverflow(written_rows, out);
-        writeVarUIntOverflow(written_bytes, out);
+        writeVarUInt(written_rows, out);
+        writeVarUInt(written_bytes, out);
     }
     if (client_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_SERVER_QUERY_TIME_IN_PROGRESS)
     {

--- a/src/IO/VarInt.h
+++ b/src/IO/VarInt.h
@@ -193,6 +193,9 @@ inline const char * readVarUInt(UInt64 & x, const char * istr, size_t size)
 
 [[noreturn]] inline void throwValueTooLargeForVarIntEncodingException(UInt64 x)
 {
+    /// Under practical circumstances, we should virtually never end up here but AST Fuzzer manages to create superlarge input integers
+    /// which trigger this exception. Intentionally not throwing LOGICAL_ERROR or calling abort() or [ch]assert(false), so AST Fuzzer
+    /// can swallow the exception and continue to run.
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Value {} is too large for VarInt encoding", x);
 }
 

--- a/src/IO/examples/var_uint.cpp
+++ b/src/IO/examples/var_uint.cpp
@@ -22,28 +22,28 @@ int main(int argc, char ** argv)
     std::cout << std::hex << std::showbase << "Input: " << x << std::endl;
 
     Poco::HexBinaryEncoder hex(std::cout);
-    std::cout << "writeVarUIntOverflow(std::ostream): 0x";
-    DB::writeVarUIntOverflow(x, hex);
+    std::cout << "writeVarUInt(std::ostream): 0x";
+    DB::writeVarUInt(x, hex);
     std::cout << std::endl;
 
     std::string s;
 
     {
         DB::WriteBufferFromString wb(s);
-        DB::writeVarUIntOverflow(x, wb);
+        DB::writeVarUInt(x, wb);
         wb.next();
     }
 
-    std::cout << "writeVarUIntOverflow(WriteBuffer): 0x";
+    std::cout << "writeVarUInt(WriteBuffer): 0x";
     hex << s;
     std::cout << std::endl;
 
     s.clear();
     s.resize(9);
 
-    s.resize(DB::writeVarUIntOverflow(x, s.data()) - s.data());
+    s.resize(DB::writeVarUInt(x, s.data()) - s.data());
 
-    std::cout << "writeVarUIntOverflow(char *): 0x";
+    std::cout << "writeVarUInt(char *): 0x";
     hex << s;
     std::cout << std::endl;
 
@@ -52,7 +52,7 @@ int main(int argc, char ** argv)
     DB::ReadBufferFromString rb(s);
     DB::readVarUInt(y, rb);
 
-    std::cerr << "Input: " << x << ", readVarUInt(writeVarUIntOverflow()): " << y << std::endl;
+    std::cerr << "Input: " << x << ", readVarUInt(writeVarUInt()): " << y << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
PR #48154 introduced a sanity check in the form of a debug assertion that the input values for VarInt encoding are not too big. Such values should be exceptionally rare in practice but the AST fuzzer managed to trigger the assertion regardless.

The strategy to deal with such values until now was to bypass the check by limiting the value to the maximum allowed value (see #48412). Because a new AST Fuzzer failure appeared (#48497) and there may be more failures in future, this PR changes the sanity check from an assert to an exception which the AST Fuzzer ignores.

@azat 

Fixes: #48497

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)