### PR TITLE
Deduplicate blocks in any hash join

### DIFF
--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -603,7 +603,12 @@ namespace
         for (size_t i = 0; i < rows; ++i)
         {
             if (has_null_map && (*null_map)[i])
+            {
+                /// nulls are not inserted into hash table,
+                /// keep them for RIGHT and FULL joins
+                is_inserted = true;
                 continue;
+            }
 
             /// Check condition for right table from ON section
             if (join_mask && !(*join_mask)[i])
@@ -861,6 +866,7 @@ bool HashJoin::addJoinedBlock(const Block & source_block_, bool check_limits)
 
             if (!multiple_disjuncts && !is_inserted)
             {
+                LOG_TRACE(log, "Skipping inserting block with {} rows", rows);
                 data->blocks_allocated_size -= stored_block->allocatedBytes();
                 data->blocks.pop_back();
             }

--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -543,16 +543,20 @@ namespace
     template <typename Map, typename KeyGetter>
     struct Inserter
     {
-        static ALWAYS_INLINE void insertOne(const HashJoin & join, Map & map, KeyGetter & key_getter, Block * stored_block, size_t i,
+        static ALWAYS_INLINE bool insertOne(const HashJoin & join, Map & map, KeyGetter & key_getter, Block * stored_block, size_t i,
                                             Arena & pool)
         {
             auto emplace_result = key_getter.emplaceKey(map, i, pool);
 
             if (emplace_result.isInserted() || join.anyTakeLastRow())
+            {
                 new (&emplace_result.getMapped()) typename Map::mapped_type(stored_block, i);
+                return true;
+            }
+            return false;
         }
 
-        static ALWAYS_INLINE void insertAll(const HashJoin &, Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool)
+        static ALWAYS_INLINE bool insertAll(const HashJoin &, Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool)
         {
             auto emplace_result = key_getter.emplaceKey(map, i, pool);
 
@@ -563,9 +567,10 @@ namespace
                 /// The first element of the list is stored in the value of the hash table, the rest in the pool.
                 emplace_result.getMapped().insert({stored_block, i}, pool);
             }
+            return true;
         }
 
-        static ALWAYS_INLINE void insertAsof(HashJoin & join, Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool,
+        static ALWAYS_INLINE bool insertAsof(HashJoin & join, Map & map, KeyGetter & key_getter, Block * stored_block, size_t i, Arena & pool,
                                              const IColumn & asof_column)
         {
             auto emplace_result = key_getter.emplaceKey(map, i, pool);
@@ -575,6 +580,7 @@ namespace
             if (emplace_result.isInserted())
                 time_series_map = new (time_series_map) typename Map::mapped_type(createAsofRowRef(asof_type, join.getAsofInequality()));
             (*time_series_map)->insert(asof_column, stored_block, i);
+            return true;
         }
     };
 
@@ -582,7 +588,7 @@ namespace
     template <JoinStrictness STRICTNESS, typename KeyGetter, typename Map, bool has_null_map>
     size_t NO_INLINE insertFromBlockImplTypeCase(
         HashJoin & join, Map & map, size_t rows, const ColumnRawPtrs & key_columns,
-        const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, UInt8ColumnDataPtr join_mask, Arena & pool)
+        const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, UInt8ColumnDataPtr join_mask, Arena & pool, bool & is_inserted)
     {
         [[maybe_unused]] constexpr bool mapped_one = std::is_same_v<typename Map::mapped_type, RowRef>;
         constexpr bool is_asof_join = STRICTNESS == JoinStrictness::Asof;
@@ -593,6 +599,7 @@ namespace
 
         auto key_getter = createKeyGetter<KeyGetter, is_asof_join>(key_columns, key_sizes);
 
+        is_inserted = false;
         for (size_t i = 0; i < rows; ++i)
         {
             if (has_null_map && (*null_map)[i])
@@ -603,11 +610,11 @@ namespace
                 continue;
 
             if constexpr (is_asof_join)
-                Inserter<Map, KeyGetter>::insertAsof(join, map, key_getter, stored_block, i, pool, *asof_column);
+                is_inserted |= Inserter<Map, KeyGetter>::insertAsof(join, map, key_getter, stored_block, i, pool, *asof_column);
             else if constexpr (mapped_one)
-                Inserter<Map, KeyGetter>::insertOne(join, map, key_getter, stored_block, i, pool);
+                is_inserted |= Inserter<Map, KeyGetter>::insertOne(join, map, key_getter, stored_block, i, pool);
             else
-                Inserter<Map, KeyGetter>::insertAll(join, map, key_getter, stored_block, i, pool);
+                is_inserted |= Inserter<Map, KeyGetter>::insertAll(join, map, key_getter, stored_block, i, pool);
         }
         return map.getBufferSizeInCells();
     }
@@ -616,32 +623,37 @@ namespace
     template <JoinStrictness STRICTNESS, typename KeyGetter, typename Map>
     size_t insertFromBlockImplType(
         HashJoin & join, Map & map, size_t rows, const ColumnRawPtrs & key_columns,
-        const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, UInt8ColumnDataPtr join_mask, Arena & pool)
+        const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, UInt8ColumnDataPtr join_mask, Arena & pool, bool & is_inserted)
     {
         if (null_map)
             return insertFromBlockImplTypeCase<STRICTNESS, KeyGetter, Map, true>(
-                join, map, rows, key_columns, key_sizes, stored_block, null_map, join_mask, pool);
+                join, map, rows, key_columns, key_sizes, stored_block, null_map, join_mask, pool, is_inserted);
         else
             return insertFromBlockImplTypeCase<STRICTNESS, KeyGetter, Map, false>(
-                join, map, rows, key_columns, key_sizes, stored_block, null_map, join_mask, pool);
+                join, map, rows, key_columns, key_sizes, stored_block, null_map, join_mask, pool, is_inserted);
     }
 
 
     template <JoinStrictness STRICTNESS, typename Maps>
     size_t insertFromBlockImpl(
         HashJoin & join, HashJoin::Type type, Maps & maps, size_t rows, const ColumnRawPtrs & key_columns,
-        const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, UInt8ColumnDataPtr join_mask, Arena & pool)
+        const Sizes & key_sizes, Block * stored_block, ConstNullMapPtr null_map, UInt8ColumnDataPtr join_mask, Arena & pool, bool & is_inserted)
     {
         switch (type)
         {
-            case HashJoin::Type::EMPTY: return 0;
-            case HashJoin::Type::CROSS: return 0; /// Do nothing. We have already saved block, and it is enough.
+            case HashJoin::Type::EMPTY:
+                [[fallthrough]];
+            case HashJoin::Type::CROSS:
+                /// Do nothing. We will only save block, and it is enough
+                is_inserted = true;
+                return 0;
 
         #define M(TYPE) \
             case HashJoin::Type::TYPE: \
                 return insertFromBlockImplType<STRICTNESS, typename KeyGetterForType<HashJoin::Type::TYPE, std::remove_reference_t<decltype(*maps.TYPE)>>::Type>(\
-                    join, *maps.TYPE, rows, key_columns, key_sizes, stored_block, null_map, join_mask, pool); \
+                    join, *maps.TYPE, rows, key_columns, key_sizes, stored_block, null_map, join_mask, pool, is_inserted); \
                     break;
+
             APPLY_FOR_JOIN_VARIANTS(M)
         #undef M
         }
@@ -816,6 +828,7 @@ bool HashJoin::addJoinedBlock(const Block & source_block_, bool check_limits)
                 }
             }
 
+            bool is_inserted = false;
             if (kind != JoinKind::Cross)
             {
                 joinDispatch(kind, strictness, data->maps[onexpr_idx], [&](auto kind_, auto strictness_, auto & map)
@@ -824,26 +837,32 @@ bool HashJoin::addJoinedBlock(const Block & source_block_, bool check_limits)
                         *this, data->type, map, rows, key_columns, key_sizes[onexpr_idx], stored_block, null_map,
                         /// If mask is false constant, rows are added to hashmap anyway. It's not a happy-flow, so this case is not optimized
                         join_mask_col.getData(),
-                        data->pool);
+                        data->pool, is_inserted);
 
                     if (multiple_disjuncts)
                         used_flags.reinit<kind_, strictness_>(stored_block);
-                    else
+                    else if (is_inserted)
                         /// Number of buckets + 1 value from zero storage
                         used_flags.reinit<kind_, strictness_>(size + 1);
                 });
             }
 
-            if (!multiple_disjuncts && save_nullmap)
+            if (!multiple_disjuncts && save_nullmap && is_inserted)
             {
                 data->blocks_nullmaps_allocated_size += null_map_holder->allocatedBytes();
                 data->blocks_nullmaps.emplace_back(stored_block, null_map_holder);
             }
 
-            if (!multiple_disjuncts && not_joined_map)
+            if (!multiple_disjuncts && not_joined_map && is_inserted)
             {
                 data->blocks_nullmaps_allocated_size += not_joined_map->allocatedBytes();
                 data->blocks_nullmaps.emplace_back(stored_block, std::move(not_joined_map));
+            }
+
+            if (!multiple_disjuncts && !is_inserted)
+            {
+                data->blocks_allocated_size -= stored_block->allocatedBytes();
+                data->blocks.pop_back();
             }
 
             if (!check_limits)

--- a/tests/queries/0_stateless/02725_any_join_single_row.reference
+++ b/tests/queries/0_stateless/02725_any_join_single_row.reference
@@ -1,0 +1,3 @@
+Join(ANY, LEFT, key)	0	1
+Join(ANY, LEFT, key)	1	1
+Join(ANY, LEFT, key)	1	1

--- a/tests/queries/0_stateless/02725_any_join_single_row.reference
+++ b/tests/queries/0_stateless/02725_any_join_single_row.reference
@@ -1,3 +1,6 @@
 Join(ANY, LEFT, key)	0	1
 Join(ANY, LEFT, key)	1	1
 Join(ANY, LEFT, key)	1	1
+1
+1
+1

--- a/tests/queries/0_stateless/02725_any_join_single_row.sql
+++ b/tests/queries/0_stateless/02725_any_join_single_row.sql
@@ -1,0 +1,26 @@
+CREATE TABLE join_test
+(
+    `key` UInt64,
+    `value` UInt64
+)
+ENGINE = Join(ANY, LEFT, key);
+
+CREATE TEMPORARY TABLE initial_table_size AS
+    SELECT engine_full, total_rows, total_bytes FROM system.tables WHERE (name = 'join_test') AND (database = currentDatabase());
+
+SELECT engine_full, total_rows, total_bytes < 100_000 FROM initial_table_size;
+
+INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(1);
+
+
+CREATE TEMPORARY TABLE one_row_table_size AS
+    SELECT engine_full, total_rows, total_bytes FROM system.tables WHERE (name = 'join_test') AND (database = currentDatabase());
+
+SELECT engine_full, total_rows, total_bytes < 2 * (SELECT total_bytes FROM initial_table_size) FROM one_row_table_size;
+
+INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(1);
+INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(1);
+INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(1);
+INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(10_000);
+
+SELECT engine_full, total_rows, total_bytes == (SELECT total_bytes FROM one_row_table_size) FROM system.tables WHERE (name = 'join_test') AND (database = currentDatabase());

--- a/tests/queries/0_stateless/02725_any_join_single_row.sql
+++ b/tests/queries/0_stateless/02725_any_join_single_row.sql
@@ -1,26 +1,41 @@
-CREATE TABLE join_test
-(
-    `key` UInt64,
-    `value` UInt64
-)
-ENGINE = Join(ANY, LEFT, key);
+DROP TABLE IF EXISTS join_test;
+DROP TABLE IF EXISTS join_test_right;
 
+CREATE TABLE join_test ( `key` UInt64, `value` UInt64 ) ENGINE = Join(ANY, LEFT, key);
+
+-- Save table size before inserting any rows
 CREATE TEMPORARY TABLE initial_table_size AS
     SELECT engine_full, total_rows, total_bytes FROM system.tables WHERE (name = 'join_test') AND (database = currentDatabase());
 
+-- Check that table size is less than 100K
 SELECT engine_full, total_rows, total_bytes < 100_000 FROM initial_table_size;
 
 INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(1);
 
-
+-- Save table size after inserting one row
 CREATE TEMPORARY TABLE one_row_table_size AS
     SELECT engine_full, total_rows, total_bytes FROM system.tables WHERE (name = 'join_test') AND (database = currentDatabase());
 
+-- Check that table size is less than 2x after inserting one row
 SELECT engine_full, total_rows, total_bytes < 2 * (SELECT total_bytes FROM initial_table_size) FROM one_row_table_size;
 
-INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(1);
-INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(1);
+-- Insert some more rows with the same key
 INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(1);
 INSERT INTO join_test (key, value) SELECT 1, number FROM numbers(10_000);
 
+-- Check that rows with the same key are not duplicated
 SELECT engine_full, total_rows, total_bytes == (SELECT total_bytes FROM one_row_table_size) FROM system.tables WHERE (name = 'join_test') AND (database = currentDatabase());
+
+-- For RIGHT join we save all rows from the right table
+CREATE TABLE join_test_right ( `key` UInt64, `value` UInt64 ) ENGINE = Join(ANY, RIGHT, key);
+
+INSERT INTO join_test_right (key, value) SELECT 1, number FROM numbers(1);
+INSERT INTO join_test_right (key, value) SELECT 1, number FROM numbers(1);
+INSERT INTO join_test_right (key, value) SELECT 1, number FROM numbers(1);
+SELECT count() == 3 FROM (SELECT 1 as key) t1 ANY RIGHT JOIN join_test_right ON t1.key = join_test_right.key;
+INSERT INTO join_test_right (key, value) SELECT 1, number FROM numbers(7);
+SELECT count() == 10 FROM (SELECT 1 as key) t1 ANY RIGHT JOIN join_test_right ON t1.key = join_test_right.key;
+SELECT count() == 10 FROM (SELECT 2 as key) t1 ANY RIGHT JOIN join_test_right ON t1.key = join_test_right.key;
+
+DROP TABLE IF EXISTS join_test;
+DROP TABLE IF EXISTS join_test_right;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Do not store blocks in `ANY` hash join if nothing is inserted

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
