### PR TITLE
Fix flaky test test_drop_replica_and_achieve_quorum

### DIFF
--- a/tests/integration/test_quorum_inserts/test.py
+++ b/tests/integration/test_quorum_inserts/test.py
@@ -144,25 +144,6 @@ def test_drop_replica_and_achieve_quorum(started_cluster):
         )
     )
 
-    print("Now we can insert some other data.")
-    zero.query(
-        "INSERT INTO test_drop_replica_and_achieve_quorum(a,d) VALUES (2, '2012-02-02')"
-    )
-
-    assert TSV("1\t2011-01-01\n2\t2012-02-02\n") == TSV(
-        zero.query("SELECT * FROM test_drop_replica_and_achieve_quorum ORDER BY a")
-    )
-    assert TSV("1\t2011-01-01\n2\t2012-02-02\n") == TSV(
-        first.query("SELECT * FROM test_drop_replica_and_achieve_quorum ORDER BY a")
-    )
-    assert TSV("1\t2011-01-01\n2\t2012-02-02\n") == TSV(
-        second.query("SELECT * FROM test_drop_replica_and_achieve_quorum ORDER BY a")
-    )
-
-    zero.query(
-        "DROP TABLE IF EXISTS test_drop_replica_and_achieve_quorum ON CLUSTER cluster"
-    )
-
 
 @pytest.mark.parametrize(("add_new_data"), [False, True])
 def test_insert_quorum_with_drop_partition(started_cluster, add_new_data):


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Closes https://github.com/ClickHouse/ClickHouse/issues/43795.
The problem was: we inserted data into 3 replicas with insert_quorum=2 and then try to read all data from all replicas with sometimes `select_sequential_consistency=1`. And sometimes one of the replicas doesn't contain the part (because we have 3 replicas and quorum=2). Actually this part of the test is useless, let's just remove it.