### PR TITLE
Remove lock for duplicated parts UUIDs (allow_experimental_query_deduplication=1)

### DIFF
--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -236,11 +236,8 @@ void RemoteQueryExecutor::sendQuery(ClientInfo::QueryKind query_kind)
     ClientInfo modified_client_info = context->getClientInfo();
     modified_client_info.query_kind = query_kind;
 
-    {
-        std::lock_guard lock(duplicated_part_uuids_mutex);
-        if (!duplicated_part_uuids.empty())
-            connections->sendIgnoredPartUUIDs(duplicated_part_uuids);
-    }
+    if (!duplicated_part_uuids.empty())
+        connections->sendIgnoredPartUUIDs(duplicated_part_uuids);
 
     connections->sendQuery(timeouts, query, query_id, stage, modified_client_info, true);
 
@@ -471,7 +468,6 @@ bool RemoteQueryExecutor::setPartUUIDs(const std::vector<UUID> & uuids)
 
     if (!duplicates.empty())
     {
-        std::lock_guard lock(duplicated_part_uuids_mutex);
         duplicated_part_uuids.insert(duplicated_part_uuids.begin(), duplicates.begin(), duplicates.end());
         return false;
     }

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -255,7 +255,6 @@ private:
     std::atomic<bool> got_duplicated_part_uuids{ false };
 
     /// Parts uuids, collected from remote replicas
-    std::mutex duplicated_part_uuids_mutex;
     std::vector<UUID> duplicated_part_uuids;
 
     PoolMode pool_mode = PoolMode::GET_MANY;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

It looks redundant, since `sendQuery()` cannot be executed in parallel with `processPacket()` (hence `RemoteQueryExecutor::setPartUUIDs()`)

This likely will fix the lock-order-inversion in `RemoteQueryExecutor`, since I think it is false-positive.

Fixes: #48534
Follow-up for: #17348 (cc @xjewer)