### PR TITLE
Add test gtest_zk_retry_contol.cpp

### DIFF
--- a/src/Interpreters/tests/gtest_zk_retry_contol.cpp
+++ b/src/Interpreters/tests/gtest_zk_retry_contol.cpp
@@ -1,0 +1,53 @@
+#include <Storages/MergeTree/ZooKeeperRetries.h>
+
+#include <random>
+#include <Common/randomSeed.h>
+#include <pcg_random.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+static pcg64 rng(randomSeed());
+
+constexpr static size_t MAX_RETRIES = 5;
+
+static ZooKeeperRetriesInfo getRetriesInfo()
+{
+    return ZooKeeperRetriesInfo(
+        "ZkRetryControllTest",
+        &Poco::Logger::get("ZkRetryControllTest"),
+        /* max_retries_ */ MAX_RETRIES,
+        /* initial_backoff_ms_ */ 10,
+        /* max_backoff_ms_ */ 100);
+}
+
+TEST(ZkRetryControll, Simple)
+{
+    String data;
+
+    {
+        for (size_t i = 0; i < 100; ++i)
+        {
+            auto retries_info = getRetriesInfo();
+            auto retries_ctl = ZooKeeperRetriesControl("executeDDLQueryOnCluster", retries_info);
+
+            size_t retry_cnt = 0;
+            retries_ctl.retryLoop([&]()
+            {
+                retry_cnt += 1;
+
+                /// random number from 0 to MAX_RETRIES
+                size_t max_retries = rng() % (MAX_RETRIES + 1);
+                if (retry_cnt >= max_retries)
+                {
+                    data += "test";
+                    return;
+                }
+                throw zkutil::KeeperException("test", Coordination::Error::ZSESSIONEXPIRED);
+            });
+        }
+    }
+
+    ASSERT_EQ(data.size(), std::string("test").size() * 100);
+}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Trying to reproduce issue from https://github.com/ClickHouse/ClickHouse/issues/48404, not yet succeeded.