### PR TITLE
Fix another possible lock order inversion in tmp storage initialization

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -934,6 +934,11 @@ void Context::setTemporaryStorageInCache(const String & cache_disk_name, size_t 
 
     LOG_DEBUG(shared->log, "Using file cache ({}) for temporary files", file_cache->getBasePath());
 
+    auto lock = getLock();
+
+    if (shared->root_temp_data_on_disk)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Temporary storage is already set");
+
     shared->tmp_path = file_cache->getBasePath();
     VolumePtr volume = createLocalSingleDiskVolume(shared->tmp_path);
     shared->root_temp_data_on_disk = std::make_shared<TemporaryDataOnDiskScope>(volume, file_cache.get(), max_size);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Follow-up for https://github.com/ClickHouse/ClickHouse/pull/48219

Failure: https://s3.amazonaws.com/clickhouse-test-reports/0/7f5bab23e522df60e8c0f706612e4e31c2a6c587/integration_tests__tsan__[6/6]/integration_run_parallel4_0.log