### PR TITLE
Check overflow for setting `max_threads` and friends

### DIFF
--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -21,6 +21,7 @@ namespace ErrorCodes
     extern const int SIZE_OF_FIXED_STRING_DOESNT_MATCH;
     extern const int CANNOT_PARSE_BOOL;
     extern const int CANNOT_PARSE_NUMBER;
+    extern const int CANNOT_CONVERT_TYPE;
 }
 
 

--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -168,15 +168,20 @@ namespace
         if (startsWith(str, "auto"))
             return 0;
 
-        UInt64 result;
+        UInt64 result = 0;
         ReadBufferFromString in{str};
-        if (!tryReadIntText(result, in))
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Overflow while trying to read setting value from {}", str);
+        readIntText(result, in);
         return result;
     }
 
     UInt64 fieldToMaxThreads(const Field & f)
     {
+        if (f.getType() == Field::Types::String)
+            return stringToMaxThreads(f.get<const String &>());
+        if (f.getType() != Field::Types::UInt64)
+            throw Exception(ErrorCodes::CANNOT_CONVERT_TYPE, "Unsupported type of settings value. Got: {}, expected: {}",
+                fieldTypeToString(f.getType()),
+                fieldTypeToString(Field::Types::UInt64));
         return stringToMaxThreads(applyVisitor(FieldVisitorToString(), f));
     }
 }

--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -182,7 +182,7 @@ namespace
             throw Exception(ErrorCodes::CANNOT_CONVERT_TYPE, "Unsupported type of settings value. Got: {}, expected: {}",
                 fieldTypeToString(f.getType()),
                 fieldTypeToString(Field::Types::UInt64));
-        return stringToMaxThreads(applyVisitor(FieldVisitorToString(), f));
+        return f.safeGet<UInt64>();
     }
 }
 

--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -176,8 +176,6 @@ namespace
         {
             str.resize(str.size() - auto_suffix.size());
             str.erase(0, auto_prefix.size());
-
-            std::cout << "new string " << str << std::endl;
         }
 
         UInt64 result = 0;

--- a/src/Core/SettingsFields.cpp
+++ b/src/Core/SettingsFields.cpp
@@ -164,10 +164,21 @@ template struct SettingAutoWrapper<SettingFieldNumber<double>>;
 
 namespace
 {
-    UInt64 stringToMaxThreads(const String & str)
+    UInt64 stringToMaxThreads(String str)
     {
-        if (startsWith(str, "auto"))
+        if (str == "auto" || str.empty())
             return 0;
+
+        /// In this case we would like to parse the number out of string like 'auto(16)'
+        static const std::string_view auto_prefix{"'auto("};
+        static const std::string_view auto_suffix{")'"};
+        if (str.starts_with(auto_prefix) && str.ends_with(auto_suffix))
+        {
+            str.resize(str.size() - auto_suffix.size());
+            str.erase(0, auto_prefix.size());
+
+            std::cout << "new string " << str << std::endl;
+        }
 
         UInt64 result = 0;
         ReadBufferFromString in{str};

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -426,11 +426,11 @@ ReturnType readIntTextImpl(T & x, ReadBuffer & buf)
     }
 
 end:
-    if (has_sign && !has_number)
+    if (!has_number)
     {
         if constexpr (throw_exception)
             throw ParsingException(ErrorCodes::CANNOT_PARSE_NUMBER,
-                "Cannot parse number with a sign character but without any numeric character");
+                "Cannot parse number without any numeric character");
         else
             return ReturnType(false);
     }

--- a/src/Storages/MergeTree/MutateTask.cpp
+++ b/src/Storages/MergeTree/MutateTask.cpp
@@ -1894,8 +1894,8 @@ bool MutateTask::prepare()
     /// Disable all settings that can enable reading with several streams.
     /// NOTE: isStorageTouchedByMutations() above is done without this settings because it
     /// should be ok to calculate count() with multiple streams.
-    context_for_reading->setSetting("max_streams_to_max_threads_ratio", 1);
-    context_for_reading->setSetting("max_threads", 1);
+    context_for_reading->setSetting("max_streams_to_max_threads_ratio", Field(1ULL));
+    context_for_reading->setSetting("max_threads", Field(1ULL));
     context_for_reading->setSetting("allow_asynchronous_read_from_io_pool_for_merge_tree", false);
     context_for_reading->setSetting("max_streams_for_merge_tree_reading", Field(0));
     context_for_reading->setSetting("read_from_filesystem_cache_if_exists_otherwise_bypass_cache", 1);

--- a/src/Storages/StorageMemory.cpp
+++ b/src/Storages/StorageMemory.cpp
@@ -198,8 +198,8 @@ void StorageMemory::mutate(const MutationCommands & commands, ContextPtr context
     /// When max_threads > 1, the order of returning blocks is uncertain,
     /// which will lead to inconsistency after updateBlockData.
     auto new_context = Context::createCopy(context);
-    new_context->setSetting("max_streams_to_max_threads_ratio", 1);
-    new_context->setSetting("max_threads", 1);
+    new_context->setSetting("max_streams_to_max_threads_ratio", Field(1ULL));
+    new_context->setSetting("max_threads", Field(1ULL));
 
     MutationsInterpreter::Settings settings(true);
     auto interpreter = std::make_unique<MutationsInterpreter>(storage_ptr, metadata_snapshot, commands, new_context, settings);

--- a/tests/queries/0_stateless/02589_bson_invalid_document_size.sql
+++ b/tests/queries/0_stateless/02589_bson_invalid_document_size.sql
@@ -1,4 +1,3 @@
 set input_format_parallel_parsing=1;
 set max_threads=0;
-select * from format(BSONEachRow, 'x UInt32', x'00000000'); -- {serverError INCORRECT_DATA}
-
+select * from format(BSONEachRow, 'x UInt32', x'00000000'); -- {serverError CANNOT_PARSE_NUMBER}

--- a/tests/queries/0_stateless/02589_bson_invalid_document_size.sql
+++ b/tests/queries/0_stateless/02589_bson_invalid_document_size.sql
@@ -1,3 +1,3 @@
 set input_format_parallel_parsing=1;
 set max_threads=0;
-select * from format(BSONEachRow, 'x UInt32', x'00000000'); -- {serverError CANNOT_PARSE_NUMBER}
+select * from format(BSONEachRow, 'x UInt32', x'00000000'); -- {serverError INCORRECT_DATA}

--- a/tests/queries/0_stateless/02714_max_threads_overflow.sql
+++ b/tests/queries/0_stateless/02714_max_threads_overflow.sql
@@ -1,3 +1,23 @@
-SET max_threads=-1; -- { serverError 36 }
-SET max_final_threads=-1; -- { serverError 36 }
-SET max_download_threads=-1; -- { serverError 36 }
+SET max_threads='-1'; -- { serverError 72 }
+SET max_final_threads='-1'; -- { serverError 72 }
+SET max_download_threads='-1'; -- { serverError 72 }
+
+SET max_threads=-1; -- { serverError 70 }
+SET max_final_threads=-1; -- { serverError 70 }
+SET max_download_threads=-1; -- { serverError 70 }
+
+SET max_threads='nan'; -- { serverError 72 }
+SET max_final_threads='nan'; -- { serverError 72 }
+SET max_download_threads='nan'; -- { serverError 72 }
+
+SET max_threads='inf'; -- { serverError 72 }
+SET max_final_threads='inf'; -- { serverError 72 }
+SET max_download_threads='inf'; -- { serverError 72 }
+
+SET max_threads='-0+1'; -- { serverError 72 }
+SET max_final_threads='-0+1'; -- { serverError 72 }
+SET max_download_threads='-0+1'; -- { serverError 72 }
+
+SET max_threads='++'; -- { serverError 72 }
+SET max_final_threads='++'; -- { serverError 72 }
+SET max_download_threads='++'; -- { serverError 72 }

--- a/tests/queries/0_stateless/02714_max_threads_overflow.sql
+++ b/tests/queries/0_stateless/02714_max_threads_overflow.sql
@@ -1,0 +1,3 @@
+SET max_threads=-1; -- { serverError 36 }
+SET max_final_threads=-1; -- { serverError 36 }
+SET max_download_threads=-1; -- { serverError 36 }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Forbid using negative numbers for `max_threads` setting, because it overflows and allocating such a number of threads could lead to OOM on small servers or at least just inconvenient. 

