### PR TITLE
Add new trusted contributors

### DIFF
--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -124,6 +124,8 @@ TRUSTED_CONTRIBUTORS = {
         "tylerhannan",  # ClickHouse Employee
         "myrrc",  # Mike Kot, DoubleCloud
         "thevar1able",  # ClickHouse Employee
+        "aalexfvk",
+        "MikhailBurdukov",
     ]
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
