### PR TITLE
Fix memory order in number_mt

### DIFF
--- a/src/Storages/System/StorageSystemNumbers.cpp
+++ b/src/Storages/System/StorageSystemNumbers.cpp
@@ -79,7 +79,7 @@ protected:
         if (block_size == 0)
             return {};
 
-        UInt64 curr = state->counter.fetch_add(block_size, std::memory_order_acquire);
+        UInt64 curr = state->counter.fetch_add(block_size, std::memory_order_relaxed);
 
         if (curr >= max_counter)
             return {};


### PR DESCRIPTION
Just noticed that memory ordering is not correct semantically. Actually, there is no difference on x86 since its memory model. The PR is labeled as performance - to run performance tests on Aarch64, but guess the difference will not be really visible there.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Using correct memory order for counter in `numebers_mt()`