### PR TITLE
Do not remove broken detached parts on startup

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeAttachThread.cpp
@@ -179,8 +179,6 @@ void ReplicatedMergeTreeAttachThread::runImpl()
     /// don't allow to reinitialize them, delete each of them immediately.
     storage.clearOldTemporaryDirectories(0, {"tmp_", "delete_tmp_", "tmp-fetch_"});
     storage.clearOldWriteAheadLogs();
-    if (storage.getSettings()->merge_tree_enable_clear_old_broken_detached)
-        storage.clearOldBrokenPartsFromDetachedDirectory();
 
     storage.createNewZooKeeperNodes();
     storage.syncPinnedPartUUIDs();


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


```
Initialization failed, table will remain readonly. Error: Code: 233. DB::Exception: Unexpected part name: ignored_all_58400_58417_3 for format version: 1. (BAD_DATA_PART_NAME), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0xe0c66f5 in /usr/bin/clickhouse
1. ? @ 0x1451d6ac in /usr/bin/clickhouse
2. DB::MergeTreePartInfo::fromPartName(String const&, StrongTypedef<unsigned int, DB::MergeTreeDataFormatVersionTag>) @ 0x1451d183 in /usr/bin/clickhouse
3. DB::StorageReplicatedMergeTree::unlockSharedDataByID(String, String const&, String const&, String const&, String const&, std::shared_ptr<DB::ZooKeeperWithFaultInjection> const&, DB::MergeTreeSettings const&, Poco::Logger*, String const&, StrongTypedef<unsigned int, DB::MergeTreeDataFormatVersionTag>) @ 0x14018e28 in /usr/bin/clickhouse
4. DB::StorageReplicatedMergeTree::removeSharedDetachedPart(std::shared_ptr<DB::IDisk>, String const&, String const&, String const&, String const&, String const&, std::shared_ptr<DB::Context const> const&, std::shared_ptr<zkutil::ZooKeeper> const&) @ 0x1402f87f in /usr/bin/clickhouse
5. DB::StorageReplicatedMergeTree::removeDetachedPart(std::shared_ptr<DB::IDisk>, String const&, String const&) @ 0x1402f017 in /usr/bin/clickhouse
6. DB::MergeTreeData::clearOldBrokenPartsFromDetachedDirectory() @ 0x143c0d4d in /usr/bin/clickhouse
7. DB::ReplicatedMergeTreeAttachThread::runImpl() @ 0x146344fa in /usr/bin/clickhouse
8. DB::ReplicatedMergeTreeAttachThread::run() @ 0x14631b56 in /usr/bin/clickhouse
9. DB::BackgroundSchedulePoolTaskInfo::execute() @ 0x12586586 in /usr/bin/clickhouse
10. DB::BackgroundSchedulePool::threadFunction() @ 0x1258960a in /usr/bin/clickhouse
11. ? @ 0x1258a44e in /usr/bin/clickhouse
12. ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0xe19a46a in /usr/bin/clickhouse
13. ? @ 0xe19fb21 in /usr/bin/clickhouse
14. ? @ 0x7fe7a20c4b43 in ?
15. ? @ 0x7fe7a2156a00 in ?
```
