### PR TITLE
Avoid race on joining threads in `Zookeeper`

### DIFF
--- a/src/Common/ThreadPool.h
+++ b/src/Common/ThreadPool.h
@@ -315,8 +315,8 @@ public:
     /// This method guarantees that all subsequent calls to joinIfJoinable() will be essentially noop-s after the first call to joinIfJoinable().
     void joinIfJoinable()
     {
-        bool wasnt = false;
-        if (!join_attempted.compare_exchange_strong(wasnt, true))
+        bool expected = false;
+        if (!join_attempted.compare_exchange_strong(expected, true))
             return;
 
         if (joinable())

--- a/src/Common/ThreadPool_fwd.h
+++ b/src/Common/ThreadPool_fwd.h
@@ -6,6 +6,8 @@ class ThreadPoolImpl;
 template <bool propagate_opentelemetry_context>
 class ThreadFromGlobalPoolImpl;
 
+class ConcurrentlyJoinableThreadFromGlobalPool;
+
 using ThreadFromGlobalPoolNoTracingContextPropagation = ThreadFromGlobalPoolImpl<false>;
 
 using ThreadFromGlobalPool = ThreadFromGlobalPoolImpl<true>;

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -255,8 +255,8 @@ private:
     Watches watches TSA_GUARDED_BY(watches_mutex);
     std::mutex watches_mutex;
 
-    ThreadFromGlobalPool send_thread;
-    ThreadFromGlobalPool receive_thread;
+    std::unique_ptr<ConcurrentlyJoinableThreadFromGlobalPool> send_thread;
+    std::unique_ptr<ConcurrentlyJoinableThreadFromGlobalPool> receive_thread;
 
     Poco::Logger * log;
 

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -144,7 +144,14 @@ void DDLWorker::shutdown()
 
 DDLWorker::~DDLWorker()
 {
-    DDLWorker::shutdown();
+    try
+    {
+        DDLWorker::shutdown();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "DDLWorker wasn't finished successfully");
+    }
 }
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

To avoid crash reports.