### PR TITLE
Add query-rewrite functions

### DIFF
--- a/docs/en/sql-reference/functions/string-functions.md
+++ b/docs/en/sql-reference/functions/string-functions.md
@@ -1196,3 +1196,155 @@ Result:
 Same as concatWithSeparator, the difference is that you need to ensure that concatWithSeparator(sep, expr1, expr2, expr3...) → result is injective, it will be used for optimization of GROUP BY.
 
 The function is named “injective” if it always returns different result for different values of arguments. In other words: different arguments never yield identical result.
+
+## formatQuery
+
+Formats request given to the function in multiline format.
+
+**Syntax**
+
+``` sql
+formatQuery(x)
+```
+
+**Arguments**
+
+-   `x` — char sequence. Should be correct query. [String](../../sql-reference/data-types/string.md).
+
+**Returned values**
+
+-   Formatted request.
+
+Type: [String](../../sql-reference/data-types/string.md).
+
+**Example**
+
+Query:
+
+``` sql
+SELECT formatQuery('select number from numbers(10) where number%2 order by number desc;') AS query;
+```
+
+Result:
+
+``` text
+┌─query─────────────────────────────────────────────────────────────┐
+│ SELECT number                                                     │
+│FROM numbers(10)                                                   │
+│WHERE number % 2                                                   │
+│ORDER BY number DESC                                               │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+## formatQueryOneLine
+
+Formats request given to the function in single-line format.
+
+**Syntax**
+
+``` sql
+formatQueryOneLine(x)
+```
+
+**Arguments**
+
+-   `x` — char sequence. Should be correct query. [String](../../sql-reference/data-types/string.md).
+
+**Returned values**
+
+-   Formatted request.
+
+Type: [String](../../sql-reference/data-types/string.md).
+
+**Example**
+
+Query:
+
+``` sql
+SELECT formatQueryOneLine('select number from numbers(10) where number%2 order by number desc;') AS query;
+```
+
+Result:
+
+``` text
+┌─query────────────────────────────────────────────────────────────────┐
+│ SELECT number FROM numbers(10) WHERE number % 2 ORDER BY number DESC │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## obfuscateQuery
+
+Obfuscates request given to the function to hardly readable format. Is as idempotent operation based on given seed.
+
+**Syntax**
+
+``` sql
+formatQueryOneLine(x, [, seed])
+```
+
+**Arguments**
+
+-   `x` — char sequence used for obsucation. [String](../../sql-reference/data-types/string.md).
+-   `seed` — char sequence used as seed for obfuscation. [String](../../sql-reference/data-types/string.md).
+
+**Returned values**
+
+-   Obfuscated request.
+
+Type: [String](../../sql-reference/data-types/string.md).
+
+**Example**
+
+Query:
+
+``` sql
+SELECT obfuscate('select number from numbers(10) where number%2 order by number desc;', 'World') AS query;
+```
+
+Result:
+
+``` text
+┌─query────────────────────────────────────────────────────────┐
+│ select curl from numbers(10) where curl%3 order by curl desc │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## tokenizeQuery
+
+Tokenizes request given to the function.
+
+**Syntax**
+
+``` sql
+formatQueryOneLine(x)
+```
+
+**Arguments**
+
+-   `x` — char sequence used for tokenization. [String](../../sql-reference/data-types/string.md).
+
+**Returned values**
+
+-   Token tuples, each contains 3 elements: token chars, first token char position in string (starting from 1), distance from last token char to the end of the string.
+
+Types: 
+    [String](../../sql-reference/data-types/string.md).
+    [UInt32](../data-types/int-uint.md).
+
+**Example**
+
+Result:
+
+``` sql
+SELECT tokenizeQuery('SELECT 1') as query;
+```
+
+Query:
+
+``` text
+┌─query──────────┐
+│ ('SELECT',1,2) │
+│ ('1',7,1)      │
+│ ('\0',8,0)     │
+└────────────────┘
+```

--- a/docs/ru/sql-reference/functions/string-functions.md
+++ b/docs/ru/sql-reference/functions/string-functions.md
@@ -1113,3 +1113,155 @@ A text with tags .
 The content within <b>CDATA</b>
 Do Nothing for 2 Minutes 2:00 &nbsp;
 ```
+
+## formatQuery {#formatted-query}
+
+Форматирует запрос, переданный в функцию в многострочный формат.
+
+**Синтаксис**
+
+``` sql
+formatQuery(x)
+```
+
+**Аргументы**
+
+-   `x` — последовательность символов. Дожна представлять из себя валидный запрос. [String](../../sql-reference/data-types/string.md).
+
+**Возвращаемое значение**
+
+-   Отформатированный запрос.
+
+Тип: [String](../../sql-reference/data-types/string.md).
+
+**Пример**
+
+Запрос:
+
+``` sql
+SELECT formatQuery('select number from numbers(10) where number%2 order by number desc;') AS query;
+```
+
+Результат:
+
+``` text
+┌─query─────────────────────────────────────────────────────────────┐
+│ SELECT number                                                     │
+│FROM numbers(10)                                                   │
+│WHERE number % 2                                                   │
+│ORDER BY number DESC                                               │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+## formatQueryOneLine {#formatted-query-one-line}
+
+Форматирует запрос, переданный в функцию в однострочный формат.
+
+**Синтаксис**
+
+``` sql
+formatQueryOneLine(x)
+```
+
+**Аргументы**
+
+-   `x` — последовательность символов. Дожна представлять из себя валидный запрос. [String](../../sql-reference/data-types/string.md).
+
+**Возвращаемое значение**
+
+-   Отформатированный запрос.
+
+Тип: [String](../../sql-reference/data-types/string.md).
+
+**Пример**
+
+Запрос:
+
+``` sql
+SELECT formatQueryOneLine('select number from numbers(10) where number%2 order by number desc;') AS query;
+```
+
+Результат:
+
+``` text
+┌─query────────────────────────────────────────────────────────────────┐
+│ SELECT number FROM numbers(10) WHERE number % 2 ORDER BY number DESC │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## obfuscateQuery {#obfuscated-query}
+
+Обфусцирует запрос, переданный в функцию в сложночитаемый формат. Идемпотентна по переданному seed.
+
+**Синтаксис**
+
+``` sql
+formatQueryOneLine(x, [, seed])
+```
+
+**Аргументы**
+
+-   `x` — последовательность символов. Строка для обфускации. [String](../../sql-reference/data-types/string.md).
+-   `seed` — последовательность символов. Строка, определяющая результат обфускации. [String](../../sql-reference/data-types/string.md).
+
+**Возвращаемое значение**
+
+-   Обфусцированный запрос.
+
+Тип: [String](../../sql-reference/data-types/string.md).
+
+**Пример**
+
+Запрос:
+
+``` sql
+SELECT obfuscate('select number from numbers(10) where number%2 order by number desc;', 'World') AS query;
+```
+
+Результат:
+
+``` text
+┌─query────────────────────────────────────────────────────────┐
+│ select curl from numbers(10) where curl%3 order by curl desc │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## tokenizeQuery {#tokenized-query}
+
+Токенизирует запрос, переданный в функцию.
+
+**Синтаксис**
+
+``` sql
+formatQueryOneLine(x)
+```
+
+**Аргументы**
+
+-   `x` — последовательность символов, представляющая собой запрос для токенизации. [String](../../sql-reference/data-types/string.md).
+
+**Возвращаемое значение**
+
+-   Кортежи токенов, каждый состоящий из 3 элементов: строки токена, позиция первого символа токена в строке начиная с 1, расстояние от последнего символа токена до конца строки.
+
+Типы: 
+    [String](../../sql-reference/data-types/string.md).
+    [UInt32](../data-types/int-uint.md).
+
+**Пример**
+
+Запрос:
+
+``` sql
+SELECT tokenizeQuery('SELECT 1') as query;
+```
+
+Результат:
+
+``` text
+┌─query──────────┐
+│ ('SELECT',1,2) │
+│ ('1',7,1)      │
+│ ('\0',8,0)     │
+└────────────────┘
+```

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -53,8 +53,8 @@ template <bool oneline>
 struct Format
 {
     static constexpr auto name = oneline ? "formatQueryOneLine" : "formatQuery";
-    // static constexpr size_t max_query_size = 32768;
-    // static constexpr size_t max_parser_depth = 2048;
+    static constexpr size_t max_query_size = 32768;
+    static constexpr size_t max_parser_depth = 2048;
     static void vector(const ColumnString::Chars & data,
         const ColumnString::Offsets & offsets,
         ColumnString::Chars & res_data,
@@ -67,7 +67,7 @@ struct Format
         WriteBufferFromOwnString buffer;
         ParserQuery parser(end, false);
         ASTPtr res = parseQueryAndMovePosition(
-            parser, pos, end, "query", false, 1024, 1024);
+            parser, pos, end, "query", false, max_query_size, max_parser_depth);
         /// For insert query with data(INSERT INTO ... VALUES ...), will lead to format fail,
         /// should throw exception early and make exception message more readable.
         if (const auto * insert_query = res->as<ASTInsertQuery>(); insert_query && insert_query->data)
@@ -100,7 +100,3 @@ REGISTER_FUNCTION(FormatQuery)
 }
 
 }
-
-            // auto col_to = ColumnString::create();
-            // ColumnString::Chars & data_to = col_to->getChars();
-            // ColumnString::Offsets & offsets_to = col_to->getOffsets();

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -53,6 +53,8 @@ template <bool oneline>
 struct Format
 {
     static constexpr auto name = oneline ? "formatQueryOneLine" : "formatQuery";
+    // static constexpr size_t max_query_size = 32768;
+    // static constexpr size_t max_parser_depth = 2048;
     static void vector(const ColumnString::Chars & data,
         const ColumnString::Offsets & offsets,
         ColumnString::Chars & res_data,
@@ -65,7 +67,6 @@ struct Format
         WriteBufferFromOwnString buffer;
         ParserQuery parser(end, false);
         ASTPtr res = parseQueryAndMovePosition(
-            // TODO: change to max_parser_depth and max_parser_depth consts.
             parser, pos, end, "query", false, 1024, 1024);
         /// For insert query with data(INSERT INTO ... VALUES ...), will lead to format fail,
         /// should throw exception early and make exception message more readable.
@@ -78,26 +79,18 @@ struct Format
         formatAST(*res, buffer, false, oneline);
         buffer.next();
 
-        // size_t size = offsets.size();
-        res_offsets.resize(1);
-        // Obfuscated queries are usually don't take more than x2 characters.
-        res_data.reserve(data.size() * 2);
         std::string result = buffer.str();
-        for (size_t i = 0; i < result.size(); ++i) {
-            res_data[i] = result[i];
-        }
+        // Formated queries are usually don't take more than x3 characters.
+        res_data.reserve(result.size() * 3);
+        memcpySmallAllowReadWriteOverflow15(res_data.data(), result.c_str(), result.size());
+        res_offsets.resize(1);
         res_offsets[0] = result.size() + 1;
-        // if (res_data[0]) {
-        //     throw Exception(ErrorCodes::ILLEGAL_COLUMN, "{}, {}, {}, {}, {}::: {}, {}, {}, {}.", result, res_offsets.size(), res_offsets[-1], res_offsets[0], res_offsets[1], offsets.size(), offsets[-1], offsets[0], offsets[1]);
-        // }
-
     }
     [[noreturn]] static void vectorFixed(const ColumnString::Chars &, size_t, ColumnString::Chars &)
     {
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Cannot apply function formatQuery to fixed string.");
     }
 };
-taxi corp strongbox
 }
 
 REGISTER_FUNCTION(FormatQuery)

--- a/src/Functions/formatQuery.cpp
+++ b/src/Functions/formatQuery.cpp
@@ -1,0 +1,113 @@
+#include <DataTypes/DataTypeString.h>
+#include <Columns/ColumnString.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionStringToString.h>
+#include <Parsers/queryNormalization.h>
+#include <base/find_symbols.h>
+#include <Common/StringUtils/StringUtils.h>
+
+#include <functional>
+#include <iostream>
+#include <string_view>
+#include <boost/program_options.hpp>
+
+#include <IO/ReadBufferFromFileDescriptor.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromFileDescriptor.h>
+#include <IO/WriteBufferFromOStream.h>
+#include <IO/WriteBufferFromString.h>
+#include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ParserQuery.h>
+#include <Parsers/formatAST.h>
+#include <Parsers/obfuscateQueries.h>
+#include <Parsers/parseQuery.h>
+#include <Common/ErrorCodes.h>
+#include <Common/TerminalSize.h>
+
+#include <Interpreters/Context.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/registerFunctions.h>
+#include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <AggregateFunctions/registerAggregateFunctions.h>
+#include <TableFunctions/TableFunctionFactory.h>
+#include <TableFunctions/registerTableFunctions.h>
+#include <Storages/StorageFactory.h>
+#include <Storages/registerStorages.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <Formats/FormatFactory.h>
+#include <Formats/registerFormats.h>
+
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_COLUMN;
+    extern const int INVALID_FORMAT_INSERT_QUERY_WITH_DATA;
+}
+
+namespace
+{
+
+template <bool oneline>
+struct Format
+{
+    static constexpr auto name = oneline ? "formatQueryOneLine" : "formatQuery";
+    static void vector(const ColumnString::Chars & data,
+        const ColumnString::Offsets & offsets,
+        ColumnString::Chars & res_data,
+        ColumnString::Offsets & res_offsets)
+    {
+        std::string_view query(reinterpret_cast<const char *>(data.data() + offsets[- 1]), offsets[0] - offsets[- 1] - 1);
+        const char * pos = query.data();
+        const char * end = pos + query.size();
+
+        WriteBufferFromOwnString buffer;
+        ParserQuery parser(end, false);
+        ASTPtr res = parseQueryAndMovePosition(
+            // TODO: change to max_parser_depth and max_parser_depth consts.
+            parser, pos, end, "query", false, 1024, 1024);
+        /// For insert query with data(INSERT INTO ... VALUES ...), will lead to format fail,
+        /// should throw exception early and make exception message more readable.
+        if (const auto * insert_query = res->as<ASTInsertQuery>(); insert_query && insert_query->data)
+        {
+            throw Exception(DB::ErrorCodes::INVALID_FORMAT_INSERT_QUERY_WITH_DATA,
+                "Can't format ASTInsertQuery with data, since data will be lost");
+        }
+        
+        formatAST(*res, buffer, false, oneline);
+        buffer.next();
+
+        // size_t size = offsets.size();
+        res_offsets.resize(1);
+        // Obfuscated queries are usually don't take more than x2 characters.
+        res_data.reserve(data.size() * 2);
+        std::string result = buffer.str();
+        for (size_t i = 0; i < result.size(); ++i) {
+            res_data[i] = result[i];
+        }
+        res_offsets[0] = result.size() + 1;
+        // if (res_data[0]) {
+        //     throw Exception(ErrorCodes::ILLEGAL_COLUMN, "{}, {}, {}, {}, {}::: {}, {}, {}, {}.", result, res_offsets.size(), res_offsets[-1], res_offsets[0], res_offsets[1], offsets.size(), offsets[-1], offsets[0], offsets[1]);
+        // }
+
+    }
+    [[noreturn]] static void vectorFixed(const ColumnString::Chars &, size_t, ColumnString::Chars &)
+    {
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Cannot apply function formatQuery to fixed string.");
+    }
+};
+taxi corp strongbox
+}
+
+REGISTER_FUNCTION(FormatQuery)
+{
+    factory.registerFunction<FunctionStringToString<Format<true>, Format<true>>>();
+    factory.registerFunction<FunctionStringToString<Format<false>, Format<false>>>();
+}
+
+}
+
+            // auto col_to = ColumnString::create();
+            // ColumnString::Chars & data_to = col_to->getChars();
+            // ColumnString::Offsets & offsets_to = col_to->getOffsets();

--- a/src/Functions/obfuscateQuery.cpp
+++ b/src/Functions/obfuscateQuery.cpp
@@ -1,0 +1,145 @@
+#include <DataTypes/DataTypeString.h>
+#include <Columns/ColumnString.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionStringToString.h>
+#include <Parsers/queryNormalization.h>
+#include <base/find_symbols.h>
+#include <Common/StringUtils/StringUtils.h>
+
+#include <functional>
+#include <iostream>
+#include <string_view>
+#include <boost/program_options.hpp>
+
+#include <IO/ReadBufferFromFileDescriptor.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromFileDescriptor.h>
+#include <IO/WriteBufferFromOStream.h>
+#include <IO/WriteBufferFromString.h>
+#include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ParserQuery.h>
+#include <Parsers/formatAST.h>
+#include <Parsers/obfuscateQueries.h>
+#include <Parsers/parseQuery.h>
+#include <Common/ErrorCodes.h>
+#include <Common/TerminalSize.h>
+
+#include <Interpreters/Context.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/registerFunctions.h>
+#include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <AggregateFunctions/registerAggregateFunctions.h>
+#include <TableFunctions/TableFunctionFactory.h>
+#include <TableFunctions/registerTableFunctions.h>
+#include <Storages/StorageFactory.h>
+#include <Storages/registerStorages.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <Formats/FormatFactory.h>
+#include <Formats/registerFormats.h>
+
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_COLUMN;
+}
+
+namespace
+{
+
+struct Obfuscate
+{
+    static constexpr auto name = "obfuscateQuery";
+    static void vector(const ColumnString::Chars & data,
+        const ColumnString::Offsets & offsets,
+        ColumnString::Chars & res_data,
+        ColumnString::Offsets & res_offsets)
+    {
+        WordMap obfuscated_words_map;
+        WordSet used_nouns;
+        SipHash hash_func;
+
+        // if (options.count("seed"))
+        // {
+        //     std::string seed;
+        //     hash_func.update(options["seed"].as<std::string>());
+        // }
+        std::unordered_set<std::string> additional_names;
+
+        auto all_known_storage_names = StorageFactory::instance().getAllRegisteredNames();
+        auto all_known_data_type_names = DataTypeFactory::instance().getAllRegisteredNames();
+
+        additional_names.insert(all_known_storage_names.begin(), all_known_storage_names.end());
+        additional_names.insert(all_known_data_type_names.begin(), all_known_data_type_names.end());
+
+        KnownIdentifierFunc is_known_identifier = [&](std::string_view obj_name)
+        {
+            std::string what(obj_name);
+
+            return FunctionFactory::instance().has(what)
+                || AggregateFunctionFactory::instance().isAggregateFunctionName(what)
+                || TableFunctionFactory::instance().isTableFunctionName(what)
+                || FormatFactory::instance().isOutputFormat(what)
+                || FormatFactory::instance().isInputFormat(what)
+                || additional_names.contains(what);
+        };
+
+        size_t size = offsets.size();
+        res_offsets.resize(size + 1);
+            
+        WriteBufferFromOwnString buffer;
+        std::string_view query(reinterpret_cast<const char *>(data.data() + offsets[- 1]), offsets[0] - offsets[- 1] - 1);
+        obfuscateQueries(query, buffer, obfuscated_words_map, used_nouns, hash_func, is_known_identifier);
+
+        std::string res = buffer.str();
+        // Obfuscated queries are usually don't take more than x2 characters.
+        res_data.reserve(res.size());
+        for (size_t i = 0; i < res.size(); ++i) {
+            res_data[i] = res[i];
+        }
+        res_offsets[-1] = 0;
+        res_offsets[0] = res.size() + 1;
+        // for (size_t i = 0; i < size; ++i) {
+        //     res_offsets[i] = offsets[i];
+        // }
+        // res_offsets[0] = res_data.size();
+
+        // for (size_t j = 0; j < res.size(); ++j) {
+        //     res_data[j] = res[j];
+        // }
+        // if (res_data[0]) {
+        //     throw Exception(ErrorCodes::ILLEGAL_COLUMN, "{}, {}, {}, {}, {}::: {}, {}, {}, {}.", res, res_offsets.size(), res_offsets[-1], res_offsets[0], res_offsets[1], offsets.size(), offsets[-1], offsets[0], offsets[1]);
+        // }
+        // for (size_t i = 0; i < size; ++i)
+        // {
+        //     WriteBufferFromOwnString buffer;
+        //     std::string_view query(reinterpret_cast<const char *>(data.data() + offsets[i - 1]), offsets[i] - offsets[i - 1] - 1);
+        //     obfuscateQueries(query, buffer, obfuscated_words_map, used_nouns, hash_func, is_known_identifier);
+
+        //     std::string res = buffer.str();
+        //     for (size_t j = 0; j < res.size(); ++j) {
+        //         res_data[j + offsets[i - 1]] = res[j];
+        //     }
+        //     res_offsets[i] = res_data.size();
+        // }
+        
+    }
+    [[noreturn]] static void vectorFixed(const ColumnString::Chars &, size_t, ColumnString::Chars &)
+    {
+        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Cannot apply function normalizeUTF8 to fixed string.");
+    }
+};
+
+}
+
+REGISTER_FUNCTION(ObfuscateQuery)
+{
+    factory.registerFunction<FunctionStringToString<Obfuscate, Obfuscate>>();
+}
+
+}
+
+            // auto col_to = ColumnString::create();
+            // ColumnString::Chars & data_to = col_to->getChars();
+            // ColumnString::Offsets & offsets_to = col_to->getOffsets();

--- a/src/Parsers/Lexer.h
+++ b/src/Parsers/Lexer.h
@@ -109,6 +109,21 @@ public:
             : begin(begin_), pos(begin_), end(end_), max_query_size(max_query_size_) {}
     Token nextToken();
 
+    const char * getBegin()
+    {
+        return begin;
+    }
+
+    const char * getPos()
+    {
+        return pos;
+    }
+
+    const char * getEnd()
+    {
+        return end;
+    }
+
 private:
     const char * const begin;
     const char * pos;

--- a/tests/fuzz/all.dict
+++ b/tests/fuzz/all.dict
@@ -1471,3 +1471,7 @@
 "YY"
 "YYYY"
 "zookeeperSessionUptime"
+"obfuscateQuery"
+"tokenizeQuery"
+"formatQueryOneLine"
+"formatQuery"

--- a/tests/fuzz/dictionaries/functions.dict
+++ b/tests/fuzz/dictionaries/functions.dict
@@ -1129,3 +1129,7 @@
 "quantileExactWeighted"
 "groupBitXor"
 "quantile"
+"obfuscateQuery"
+"tokenizeQuery"
+"formatQueryOneLine"
+"formatQuery"

--- a/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
+++ b/tests/queries/0_stateless/02415_all_new_functions_must_be_documented.reference
@@ -919,3 +919,7 @@ xxHash32
 xxHash64
 yesterday
 zookeeperSessionUptime
+obfuscateQuery
+tokenizeQuery
+formatQueryOneLine
+formatQuery


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Added 4 new query-rewrite functions to SQL dialect (obfuscateQuery, tokenizeQuery[OneLine], formatQuery)

### Documentation entry for user-facing changes
Feature was being developed based on #29922 ticket.

This PR adds 4 functions to obfuscate/tokenize/format query within user query.
Functions were added directly to SQL dialect - IMO it's the most straightforward and obvious way for user to use them in their queries, moreover this is consistent with query normalization functions. Implementing these functions in imitation to EXPLAIN would be too broad for such functions which mostly would be used as meta-tools for requests.

Functionality is based on already (obviously) present query tokenization used in Clickhouse and on [clickhouse-format](https://clickhouse.com/docs/en/operations/utilities/clickhouse-format) utility to be more consistent within Clickhouse already present utilities.
