### PR TITLE
Fix squashing in query cache

### DIFF
--- a/src/Interpreters/Cache/QueryCache.cpp
+++ b/src/Interpreters/Cache/QueryCache.cpp
@@ -245,12 +245,12 @@ void QueryCache::Writer::finalizeWrite()
         for (auto & chunk : *query_result)
         {
             convertToFullIfSparse(chunk);
-            const size_t rows_chunk = chunk.getNumRows();
-            size_t rows_chunk_processed = 0;
 
+            const size_t rows_chunk = chunk.getNumRows();
             if (rows_chunk == 0)
                 continue;
 
+            size_t rows_chunk_processed = 0;
             while (true)
             {
                 if (rows_remaining_in_squashed == 0)
@@ -263,7 +263,7 @@ void QueryCache::Writer::finalizeWrite()
                 const size_t rows_to_append = std::min(rows_chunk - rows_chunk_processed, rows_remaining_in_squashed);
                 squashed_chunks.back().append(chunk, rows_chunk_processed, rows_to_append);
                 rows_chunk_processed += rows_to_append;
-                rows_remaining_in_squashed += rows_to_append;
+                rows_remaining_in_squashed -= rows_to_append;
 
                 if (rows_chunk_processed == rows_chunk)
                     break;

--- a/tests/queries/0_stateless/02494_query_cache_squash_partial_results.sql
+++ b/tests/queries/0_stateless/02494_query_cache_squash_partial_results.sql
@@ -30,24 +30,24 @@ INSERT INTO t values ('abc') ('def') ('ghi') ('jkl');
 -- Run query which reads multiple chunks (small max_block_size), cache result in query cache, force squashing of partial results
 SELECT '-- insert with enabled squashing';
 SELECT * FROM t ORDER BY c
-SETTINGS max_block_size = 2, use_query_cache = true, query_cache_squash_partial_results = true;
+SETTINGS max_block_size = 3, use_query_cache = true, query_cache_squash_partial_results = true;
 
 -- Run again to check that no bad things happen and that the result is as expected
 SELECT '-- read from cache';
 SELECT * FROM t ORDER BY c
-SETTINGS max_block_size = 2, use_query_cache = true;
+SETTINGS max_block_size = 3, use_query_cache = true;
 
 SYSTEM DROP QUERY CACHE;
 
 -- Run query which reads multiple chunks (small max_block_size), cache result in query cache, but **disable** squashing of partial results
 SELECT '-- insert with disabled squashing';
 SELECT * FROM t ORDER BY c
-SETTINGS max_block_size = 2, use_query_cache = true, query_cache_squash_partial_results = false;
+SETTINGS max_block_size = 3, use_query_cache = true, query_cache_squash_partial_results = false;
 
 -- Run again to check that no bad things happen and that the result is as expected
 SELECT '-- read from cache';
 SELECT * FROM t ORDER BY c
-SETTINGS max_block_size = 2, use_query_cache = true;
+SETTINGS max_block_size = 3, use_query_cache = true;
 
 DROP TABLE t;
 SYSTEM DROP QUERY CACHE;


### PR DESCRIPTION
The query caches squashes and splits chunks to max_block_size. Due to a bug, there was only ever one result chunk, i.e. splitting did not work.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix squashing in query cache