### PR TITLE
Improve jsonpath support in json functions

### DIFF
--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
@@ -1,9 +1,11 @@
 #include <Functions/JSONPath/ASTs/ASTJSONPathMemberAccess.h>
 #include <Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.h>
 
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIdentifier_fwd.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/Lexer.h>
+#include <Common/StringUtils/StringUtils.h>
 
 namespace DB
 {
@@ -16,18 +18,48 @@ namespace DB
  */
 bool ParserJSONPathMemberAccess::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
-    if (pos->type != TokenType::Dot)
+    // There's a specical case, that a path member can begin with number
+    if (pos->type != TokenType::Dot && pos->type != TokenType::Number)
         return false;
+    if (pos->type != TokenType::Number)
+        ++pos;
 
-    ++pos;
-
-    if (pos->type != TokenType::BareWord && pos->type !=TokenType::QuotedIdentifier)
-        return false;
-
-    ParserIdentifier name_p;
     ASTPtr member_name;
-    if (!name_p.parse(pos, member_name, expected))
-        return false;
+
+    if (pos->type == TokenType::Number)[[unlikely]]
+    {
+        for (const auto * c = pos->begin; c != pos->end; ++c)
+        {
+            if (*c == '.' && c == pos->begin)
+                continue;
+            if (!isNumericASCII(*c))
+            {
+                return false;
+            }
+        }
+        const auto * last_begin = *pos->begin == '.' ? pos->begin + 1 : pos->begin;
+        const auto * last_end = pos->end;
+        ++pos;
+
+        if (pos.isValid() && pos->type == TokenType::BareWord && pos->begin == last_end)
+        {
+            member_name = std::make_shared<ASTIdentifier>(String(last_begin, pos->end));
+            ++pos;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    else
+    {
+        if (pos->type != TokenType::BareWord && pos->type != TokenType::QuotedIdentifier)
+            return false;
+
+        ParserIdentifier name_p;
+        if (!name_p.parse(pos, member_name, expected))
+            return false;
+    }
 
     auto member_access = std::make_shared<ASTJSONPathMemberAccess>();
     node = member_access;

--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
@@ -18,7 +18,7 @@ namespace DB
  */
 bool ParserJSONPathMemberAccess::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
-    // There's a specical case, that a path member can begin with number
+    // There's a special case, that a path member can begin with number
     if (pos->type != TokenType::Dot && pos->type != TokenType::Number)
         return false;
     if (pos->type != TokenType::Number)

--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.cpp
@@ -19,10 +19,22 @@ namespace DB
 bool ParserJSONPathMemberAccess::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     // There's a special case, that a path member can begin with number
+    // some invalid cases as following
+    //   - ".123" is parsed as a number, not a dot and a number
+    //   - ".123abc" is parsed as two parts, a number ".123" and a token "abc"
+    //   - ".abc" is parsed as two parts. a dot and a token "abc"
+    // "$..123abc" is parsed into three parts, ".", ".123" and "abc"
     if (pos->type != TokenType::Dot && pos->type != TokenType::Number)
         return false;
     if (pos->type != TokenType::Number)
+    {
         ++pos;
+        // Check the case "$..123abc"
+        if (pos->type == TokenType::Number)
+        {
+            return false;
+        }
+    }
 
     ASTPtr member_name;
 

--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberSquareBracketAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberSquareBracketAccess.cpp
@@ -22,18 +22,11 @@ bool ParserJSONPathMemberSquareBracketAccess::parseImpl(Pos & pos, ASTPtr & node
     }
     else if (pos->type == TokenType::StringLiteral)
     {
-        try
-        {
-            ReadBufferFromMemory in(pos->begin, pos->size());
-            String name;
-            readQuotedStringWithSQLStyle(name, in);
-            member_name = std::make_shared<ASTIdentifier>(name);
-            ++pos;
-        }
-        catch (const Exception &)
-        {
-            return false;
-        }
+        ReadBufferFromMemory in(pos->begin, pos->size());
+        String name;
+        readQuotedStringWithSQLStyle(name, in);
+        member_name = std::make_shared<ASTIdentifier>(name);
+        ++pos;
     }
     else
     {

--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberSquareBracketAccess.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberSquareBracketAccess.cpp
@@ -1,0 +1,51 @@
+#include "ParserJSONPathMemberSquareBracketAccess.h"
+#include <memory>
+#include <Functions/JSONPath/ASTs/ASTJSONPathMemberAccess.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/ReadHelpers.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ExpressionElementParsers.h>
+
+namespace DB
+{
+bool ParserJSONPathMemberSquareBracketAccess::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
+{
+    if (pos->type != TokenType::OpeningSquareBracket)
+        return false;
+    ++pos;
+    ASTPtr member_name;
+    if (pos->type == TokenType::BareWord || pos->type == TokenType::QuotedIdentifier)
+    {
+        ParserIdentifier name_p;
+        if (!name_p.parse(pos, member_name, expected))
+            return false;
+    }
+    else if (pos->type == TokenType::StringLiteral)
+    {
+        try
+        {
+            ReadBufferFromMemory in(pos->begin, pos->size());
+            String name;
+            readQuotedStringWithSQLStyle(name, in);
+            member_name = std::make_shared<ASTIdentifier>(name);
+            ++pos;
+        }
+        catch (const Exception &)
+        {
+            return false;
+        }
+    }
+    else
+    {
+        return false;
+    }
+    if (pos->type != TokenType::ClosingSquareBracket)
+    {
+        return false;
+    }
+    ++pos;
+    auto member_access = std::make_shared<ASTJSONPathMemberAccess>();
+    node = member_access;
+    return tryGetIdentifierNameInto(member_name, member_access->member_name);
+}
+}

--- a/src/Functions/JSONPath/Parsers/ParserJSONPathMemberSquareBracketAccess.h
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathMemberSquareBracketAccess.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <Parsers/IParserBase.h>
+// cases
+// - [ident]
+// - ['ident']
+// - ["ident"]
+namespace DB
+{
+class ParserJSONPathMemberSquareBracketAccess : public IParserBase
+{
+private:
+    const char * getName() const override { return "ParserJSONPathMemberSquareBracketAccess"; }
+    bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;
+public:
+    explicit ParserJSONPathMemberSquareBracketAccess() = default;
+};
+}

--- a/src/Functions/JSONPath/Parsers/ParserJSONPathQuery.cpp
+++ b/src/Functions/JSONPath/Parsers/ParserJSONPathQuery.cpp
@@ -2,6 +2,7 @@
 #include <Functions/JSONPath/Parsers/ParserJSONPathQuery.h>
 #include <Functions/JSONPath/Parsers/ParserJSONPathRoot.h>
 #include <Functions/JSONPath/Parsers/ParserJSONPathMemberAccess.h>
+#include <Functions/JSONPath/Parsers/ParserJSONPathMemberSquareBracketAccess.h>
 #include <Functions/JSONPath/Parsers/ParserJSONPathRange.h>
 #include <Functions/JSONPath/Parsers/ParserJSONPathStar.h>
 
@@ -19,6 +20,7 @@ bool ParserJSONPathQuery::parseImpl(Pos & pos, ASTPtr & query, Expected & expect
 {
     query = std::make_shared<ASTJSONPathQuery>();
     ParserJSONPathMemberAccess parser_jsonpath_member_access;
+    ParserJSONPathMemberSquareBracketAccess parser_jsonpath_member_square_bracket_access;
     ParserJSONPathRange parser_jsonpath_range;
     ParserJSONPathStar parser_jsonpath_star;
     ParserJSONPathRoot parser_jsonpath_root;
@@ -32,6 +34,7 @@ bool ParserJSONPathQuery::parseImpl(Pos & pos, ASTPtr & query, Expected & expect
 
     ASTPtr accessor;
     while (parser_jsonpath_member_access.parse(pos, accessor, expected)
+           || parser_jsonpath_member_square_bracket_access.parse(pos, accessor, expected)
            || parser_jsonpath_range.parse(pos, accessor, expected)
            || parser_jsonpath_star.parse(pos, accessor, expected))
     {

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -37,6 +37,16 @@ select JSON_VALUE('{"hello":{"world":"!"}}', '$.hello') settings function_json_v
 {"world":"!"}
 SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello') settings function_json_value_return_type_allow_complex=true;
 ["world","world2"]
+SELECT JSON_VALUE('{"1key":1}', '$.1key');
+1
+SELECT JSON_VALUE('{"hello":1}', '$[hello]');
+1
+SELECT JSON_VALUE('{"hello":1}', '$["hello"]');
+1
+SELECT JSON_VALUE('{"hello":1}', '$[\'hello\']');
+1
+SELECT JSON_VALUE('{"hello 1":1}', '$["hello 1"]');
+1
 SELECT '--JSON_QUERY--';
 --JSON_QUERY--
 SELECT JSON_QUERY('{"hello":1}', '$');
@@ -61,6 +71,16 @@ SELECT JSON_QUERY('', '$.hello');
 
 SELECT JSON_QUERY('{"array":[[0, 1, 2, 3, 4, 5], [0, -1, -2, -3, -4, -5]]}', '$.array[*][0 to 2, 4]');
 [0, 1, 4, 0, -1, -4]
+SELECT JSON_QUERY('{"1key":1}', '$.1key');
+[1]
+SELECT JSON_QUERY('{"hello":1}', '$[hello]');
+[1]
+SELECT JSON_QUERY('{"hello":1}', '$["hello"]');
+[1]
+SELECT JSON_QUERY('{"hello":1}', '$[\'hello\']');
+[1]
+SELECT JSON_QUERY('{"hello 1":1}', '$["hello 1"]');
+[1]
 SELECT '--JSON_EXISTS--';
 --JSON_EXISTS--
 SELECT JSON_EXISTS('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.reference
+++ b/tests/queries/0_stateless/01889_sql_json_functions.reference
@@ -47,6 +47,10 @@ SELECT JSON_VALUE('{"hello":1}', '$[\'hello\']');
 1
 SELECT JSON_VALUE('{"hello 1":1}', '$["hello 1"]');
 1
+SELECT JSON_VALUE('{"1key":1}', '$..1key'); -- { serverError 36 }
+SELECT JSON_VALUE('{"1key":1}', '$1key'); -- { serverError 36 }
+SELECT JSON_VALUE('{"1key":1}', '$key'); -- { serverError 36 }
+SELECT JSON_VALUE('{"1key":1}', '$.[key]'); -- { serverError 36 }
 SELECT '--JSON_QUERY--';
 --JSON_QUERY--
 SELECT JSON_QUERY('{"hello":1}', '$');
@@ -81,6 +85,10 @@ SELECT JSON_QUERY('{"hello":1}', '$[\'hello\']');
 [1]
 SELECT JSON_QUERY('{"hello 1":1}', '$["hello 1"]');
 [1]
+SELECT JSON_QUERY('{"1key":1}', '$..1key'); -- { serverError 36 }
+SELECT JSON_QUERY('{"1key":1}', '$1key'); -- { serverError 36 }
+SELECT JSON_QUERY('{"1key":1}', '$key'); -- { serverError 36 }
+SELECT JSON_QUERY('{"1key":1}', '$.[key]'); -- { serverError 36 }
 SELECT '--JSON_EXISTS--';
 --JSON_EXISTS--
 SELECT JSON_EXISTS('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -20,6 +20,11 @@ select JSON_VALUE('{"a":"\\u263a"}', '$.a');
 select JSON_VALUE('{"hello":"world"}', '$.b') settings function_json_value_return_type_allow_nullable=true;
 select JSON_VALUE('{"hello":{"world":"!"}}', '$.hello') settings function_json_value_return_type_allow_complex=true;
 SELECT JSON_VALUE('{"hello":["world","world2"]}', '$.hello') settings function_json_value_return_type_allow_complex=true;
+SELECT JSON_VALUE('{"1key":1}', '$.1key');
+SELECT JSON_VALUE('{"hello":1}', '$[hello]');
+SELECT JSON_VALUE('{"hello":1}', '$["hello"]');
+SELECT JSON_VALUE('{"hello":1}', '$[\'hello\']');
+SELECT JSON_VALUE('{"hello 1":1}', '$["hello 1"]');
 
 SELECT '--JSON_QUERY--';
 SELECT JSON_QUERY('{"hello":1}', '$');
@@ -33,6 +38,11 @@ SELECT JSON_QUERY('{"hello":{"world":"!"}}', '$.hello');
 SELECT JSON_QUERY( '{hello:{"world":"!"}}}', '$.hello'); -- invalid json => default value (empty string)
 SELECT JSON_QUERY('', '$.hello');
 SELECT JSON_QUERY('{"array":[[0, 1, 2, 3, 4, 5], [0, -1, -2, -3, -4, -5]]}', '$.array[*][0 to 2, 4]');
+SELECT JSON_QUERY('{"1key":1}', '$.1key');
+SELECT JSON_QUERY('{"hello":1}', '$[hello]');
+SELECT JSON_QUERY('{"hello":1}', '$["hello"]');
+SELECT JSON_QUERY('{"hello":1}', '$[\'hello\']');
+SELECT JSON_QUERY('{"hello 1":1}', '$["hello 1"]');
 
 SELECT '--JSON_EXISTS--';
 SELECT JSON_EXISTS('{"hello":1}', '$');

--- a/tests/queries/0_stateless/01889_sql_json_functions.sql
+++ b/tests/queries/0_stateless/01889_sql_json_functions.sql
@@ -25,6 +25,10 @@ SELECT JSON_VALUE('{"hello":1}', '$[hello]');
 SELECT JSON_VALUE('{"hello":1}', '$["hello"]');
 SELECT JSON_VALUE('{"hello":1}', '$[\'hello\']');
 SELECT JSON_VALUE('{"hello 1":1}', '$["hello 1"]');
+SELECT JSON_VALUE('{"1key":1}', '$..1key'); -- { serverError 36 }
+SELECT JSON_VALUE('{"1key":1}', '$1key'); -- { serverError 36 }
+SELECT JSON_VALUE('{"1key":1}', '$key'); -- { serverError 36 }
+SELECT JSON_VALUE('{"1key":1}', '$.[key]'); -- { serverError 36 }
 
 SELECT '--JSON_QUERY--';
 SELECT JSON_QUERY('{"hello":1}', '$');
@@ -43,6 +47,10 @@ SELECT JSON_QUERY('{"hello":1}', '$[hello]');
 SELECT JSON_QUERY('{"hello":1}', '$["hello"]');
 SELECT JSON_QUERY('{"hello":1}', '$[\'hello\']');
 SELECT JSON_QUERY('{"hello 1":1}', '$["hello 1"]');
+SELECT JSON_QUERY('{"1key":1}', '$..1key'); -- { serverError 36 }
+SELECT JSON_QUERY('{"1key":1}', '$1key'); -- { serverError 36 }
+SELECT JSON_QUERY('{"1key":1}', '$key'); -- { serverError 36 }
+SELECT JSON_QUERY('{"1key":1}', '$.[key]'); -- { serverError 36 }
 
 SELECT '--JSON_EXISTS--';
 SELECT JSON_EXISTS('{"hello":1}', '$');


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

support following new jsonpath format
- '$.1key', path element begins with number
- '$[key]', '$[“key”]', '$[\\\'key\\\']', '$["key 123"]', path element embraced in []


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
