### PR TITLE
Store clusters from ClusterDiscovery in separate map

### DIFF
--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -308,7 +308,9 @@ bool ClusterDiscovery::updateCluster(ClusterInfo & cluster_info)
     LOG_DEBUG(log, "Updating system.clusters record for '{}' with {} nodes", cluster_info.name, cluster_info.nodes_info.size());
 
     auto cluster = makeCluster(cluster_info);
-    context->setCluster(cluster_info.name, cluster);
+
+    std::lock_guard lock(mutex);
+    cluster_impls[cluster_info.name] = cluster;
     return true;
 }
 
@@ -445,6 +447,21 @@ bool ClusterDiscovery::runMainThread(std::function<void()> up_to_date_callback)
     return finished;
 }
 
+ClusterPtr ClusterDiscovery::getCluster(const String & cluster_name) const
+{
+    std::lock_guard lock(mutex);
+    auto it = cluster_impls.find(cluster_name);
+    if (it == cluster_impls.end())
+        return nullptr;
+    return it->second;
+}
+
+std::unordered_map<String, ClusterPtr> ClusterDiscovery::getClusters() const
+{
+    std::lock_guard lock(mutex);
+    return cluster_impls;
+}
+
 void ClusterDiscovery::shutdown()
 {
     LOG_DEBUG(log, "Shutting down");
@@ -456,7 +473,14 @@ void ClusterDiscovery::shutdown()
 
 ClusterDiscovery::~ClusterDiscovery()
 {
-    ClusterDiscovery::shutdown();
+    try
+    {
+        ClusterDiscovery::shutdown();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "Error on ClusterDiscovery shutdown");
+    }
 }
 
 bool ClusterDiscovery::NodeInfo::parse(const String & data, NodeInfo & result)

--- a/src/Interpreters/ClusterDiscovery.h
+++ b/src/Interpreters/ClusterDiscovery.h
@@ -33,6 +33,9 @@ public:
 
     void start();
 
+    ClusterPtr getCluster(const String & cluster_name) const;
+    std::unordered_map<String, ClusterPtr> getClusters() const;
+
     ~ClusterDiscovery();
 
 private:
@@ -123,6 +126,9 @@ private:
     /// The `shared_ptr` is used because it's passed to watch callback.
     /// It prevents accessing to invalid object after ClusterDiscovery is destroyed.
     std::shared_ptr<UpdateFlags> clusters_to_update;
+
+    mutable std::mutex mutex;
+    std::unordered_map<String, ClusterPtr> cluster_impls;
 
     ThreadFromGlobalPool main_thread;
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3017,7 +3017,8 @@ std::map<String, ClusterPtr> Context::getClusters() const
 
     if (shared->cluster_discovery)
     {
-        for (const auto & [name, cluster] : shared->cluster_discovery->getClusters())
+        const auto & cluster_discovery_map = shared->cluster_discovery->getClusters();
+        for (const auto & [name, cluster] : cluster_discovery_map)
             clusters.emplace(name, cluster);
     }
     return clusters;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -926,7 +926,7 @@ public:
     void setDDLWorker(std::unique_ptr<DDLWorker> ddl_worker);
     DDLWorker & getDDLWorker() const;
 
-    std::shared_ptr<Clusters> getClusters() const;
+    std::map<String, std::shared_ptr<Cluster>> getClusters() const;
     std::shared_ptr<Cluster> getCluster(const std::string & cluster_name) const;
     std::shared_ptr<Cluster> tryGetCluster(const std::string & cluster_name) const;
     void setClustersConfig(const ConfigurationPtr & config, bool enable_discovery = false, const String & config_name = "remote_servers");
@@ -1158,6 +1158,8 @@ private:
     DiskSelectorPtr getDiskSelector(std::lock_guard<std::mutex> & lock) const;
 
     DisksMap getDisksMap(std::lock_guard<std::mutex> & lock) const;
+
+    std::shared_ptr<Clusters> getClustersImpl() const;
 
     /// Throttling
 public:

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1159,7 +1159,8 @@ private:
 
     DisksMap getDisksMap(std::lock_guard<std::mutex> & lock) const;
 
-    std::shared_ptr<Clusters> getClustersImpl() const;
+    /// Expect lock for shared->clusters_mutex
+    std::shared_ptr<Clusters> getClustersImpl(std::lock_guard<std::mutex> & lock) const;
 
     /// Throttling
 public:

--- a/src/Storages/System/StorageSystemClusters.cpp
+++ b/src/Storages/System/StorageSystemClusters.cpp
@@ -31,7 +31,7 @@ NamesAndTypesList StorageSystemClusters::getNamesAndTypes()
 
 void StorageSystemClusters::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo &) const
 {
-    for (const auto & name_and_cluster : context->getClusters()->getContainer())
+    for (const auto & name_and_cluster : context->getClusters())
         writeCluster(res_columns, name_and_cluster);
 
     const auto databases = DatabaseCatalog::instance().getDatabases();

--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -95,8 +95,29 @@ def test_cluster_discovery_startup_and_stop(start_cluster):
         [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_shards
     )
 
+    # test ON CLUSTER query
+    nodes["node0"].query(
+        "CREATE TABLE tbl ON CLUSTER 'test_auto_cluster' (x UInt64) ENGINE = MergeTree ORDER BY x"
+    )
+    nodes["node0"].query("INSERT INTO tbl VALUES (1)")
+    nodes["node1"].query("INSERT INTO tbl VALUES (2)")
+
+    assert (
+        int(
+            nodes["node_observer"]
+            .query(
+                "SELECT sum(x) FROM clusterAllReplicas(test_auto_cluster, default.tbl)"
+            )
+            .strip()
+        )
+        == 3
+    )
+
+    # Query SYSTEM DROP DNS CACHE may reload cluster configuration
+    # check that it does not affect cluster discovery
     nodes["node1"].query("SYSTEM DROP DNS CACHE")
     nodes["node0"].query("SYSTEM DROP DNS CACHE")
+
     check_shard_num(
         [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_shards
     )

--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -95,6 +95,12 @@ def test_cluster_discovery_startup_and_stop(start_cluster):
         [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_shards
     )
 
+    nodes["node1"].query("SYSTEM DROP DNS CACHE")
+    nodes["node0"].query("SYSTEM DROP DNS CACHE")
+    check_shard_num(
+        [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_shards
+    )
+
     nodes["node1"].stop_clickhouse(kill=True)
     check_nodes_count(
         [nodes["node0"], nodes["node2"], nodes["node_observer"]], total_nodes - 1


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Ref #47176

####  Context:

Clusters defined in `discovery` mode were stored in `shared->clusters` with others. But the variable `shared->clusters` is assigned in several places (e.g., on config reloading), and it's challenging to maintain it in the correct state. Current PR moves data structure to store auto-discovered clusters out of `shared->clusters`, similar to how it's done for the replicated database.