### PR TITLE
Remove SETTINGS from Youtube dataset

### DIFF
--- a/docs/en/getting-started/example-datasets/youtube-dislikes.md
+++ b/docs/en/getting-started/example-datasets/youtube-dislikes.md
@@ -122,8 +122,7 @@ SELECT
     super_titles,
     ifNull(uploader_badges, '') AS uploader_badges,
     ifNull(video_badges, '') AS video_badges
-FROM s3Cluster(
-    'default',
+FROM s3(
     'https://clickhouse-public-datasets.s3.amazonaws.com/youtube/original/files/*.zst',
     'JSONLines'
 )
@@ -134,7 +133,6 @@ Some comments about our `INSERT` command:
 - The `parseDateTimeBestEffortUSOrZero` function is handy when the incoming date fields may not be in the proper format. If `fetch_date` does not get parsed properly, it will be set to `0`
 - The `upload_date` column contains valid dates, but it also contains strings like "4 hours ago" - which is certainly not a valid date. We decided to store the original value in `upload_date_str` and attempt to parse it with `toDate(parseDateTimeBestEffortUSOrZero(upload_date::String))`. If the parsing fails we just get `0`
 - We used `ifNull` to avoid getting `NULL` values in our table. If an incoming value is `NULL`, the `ifNull` function is setting the value to an empty string
-- It takes a long time to download the data, so we added a `SETTINGS` clause to spread out the work over more threads while making sure the block sizes stayed fairly large
 
 4. Open a new tab in the SQL Console of ClickHouse Cloud (or a new `clickhouse-client` window) and watch the count increase. It will take a while to insert 4.56B rows, depending on your server resources. (Without any tweaking of settings, it takes about 4.5 hours.)
 

--- a/docs/en/getting-started/example-datasets/youtube-dislikes.md
+++ b/docs/en/getting-started/example-datasets/youtube-dislikes.md
@@ -127,12 +127,6 @@ FROM s3Cluster(
     'https://clickhouse-public-datasets.s3.amazonaws.com/youtube/original/files/*.zst',
     'JSONLines'
 )
-SETTINGS
-   max_download_threads = 24,
-   max_insert_threads = 64,
-   max_insert_block_size = 100000000,
-   min_insert_block_size_rows = 100000000,
-   min_insert_block_size_bytes = 500000000;
 ```
 
 Some comments about our `INSERT` command:


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

The current settings may not work on instances with lower amounts of memory, and it also assumes you have a cluster named `default`. we want the command to work for everyone OOTB, so I changed it to `s3` and removed the SETTINGS.

It will take longer to insert the dataset, but it will work more universally now.