### PR TITLE
Add required PostgreSQL version number to MaterializedPostgreSQL table engine

### DIFF
--- a/docs/en/engines/table-engines/integrations/materialized-postgresql.md
+++ b/docs/en/engines/table-engines/integrations/materialized-postgresql.md
@@ -33,6 +33,8 @@ PRIMARY KEY key;
 
 3. Only database [Atomic](https://en.wikipedia.org/wiki/Atomicity_(database_systems)) is allowed.
 
+4. The `MaterializedPostgreSQL` table engine only works for PostgreSQL versions >= 11 as the implementation requires the [pg_replication_slot_advance](https://pgpedia.info/p/pg_replication_slot_advance.html) PostgreSQL function.
+
 ## Virtual columns {#virtual-columns}
 
 -   `_version` — Transaction counter. Type: [UInt64](../../../sql-reference/data-types/int-uint.md).


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

As noted in a conversation in Slack: https://clickhousedb.slack.com/archives/CU478UEQZ/p1681407045472919