### PR TITLE
Fix double whitespace in exception message

### DIFF
--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -114,9 +114,9 @@ bool RemoteQueryExecutorReadContext::checkTimeout(bool blocking)
     catch (DB::Exception & e)
     {
         if (last_used_socket)
-            e.addMessage(" while reading from socket ({})", last_used_socket->peerAddress().toString());
+            e.addMessage("while reading from socket ({})", last_used_socket->peerAddress().toString());
         if (e.code() == ErrorCodes::SOCKET_TIMEOUT)
-            e.addMessage(" (receive timeout {} ms)", receive_timeout_usec / 1000);
+            e.addMessage("(receive timeout is {} ms)", receive_timeout_usec / 1000);
         throw;
     }
 }

--- a/src/Storages/PartitionedSink.h
+++ b/src/Storages/PartitionedSink.h
@@ -45,7 +45,6 @@ private:
     Arena partition_keys_arena;
 
     SinkPtr getSinkForPartitionKey(StringRef partition_key);
-
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

```
Received exception from server (version 23.3.1):
Code: 209. DB::Exception: Received from localhost:9000. DB::NetException. DB::NetException: Timeout exceeded:  (receive timeout 300000 ms): While executing Remote. (SOCKET_TIMEOUT)
```