### PR TITLE
Fix flaky test 01054_window_view_proc_tumble_to

### DIFF
--- a/tests/queries/0_stateless/01054_window_view_proc_tumble_to.sh
+++ b/tests/queries/0_stateless/01054_window_view_proc_tumble_to.sh
@@ -18,7 +18,7 @@ CREATE TABLE dst(count UInt64) Engine=MergeTree ORDER BY tuple();
 CREATE TABLE mt(a Int32, timestamp DateTime) ENGINE=MergeTree ORDER BY tuple();
 CREATE WINDOW VIEW wv TO dst AS SELECT count(a) AS count FROM mt GROUP BY tumble(timestamp, INTERVAL '5' SECOND, 'US/Samoa') AS wid;
 
-INSERT INTO mt VALUES (1, now('US/Samoa') + 1);
+INSERT INTO mt VALUES (1, now('US/Samoa') + 5);
 EOF
 
 for _ in {1..100}; do


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Not for changelog

hopefully closes #48694

The issue is caused **presumably** by the fact that timestamp precision is coarse enough so insertion is too late (on the boundary of the window) for window view to catch it up.
The increased ahead time in `INSERT` will cause this test to run slower up to 5 seconds - this ahead time probably can be lowered to 2 seconds but not less.