### PR TITLE
remove duplicate indentwith in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,6 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ExperimentalAutoDetectBinPacking: true
 UseTab: Never
 TabWidth: 4
-IndentWidth: 4
 Standard: Cpp11
 PointerAlignment: Middle
 MaxEmptyLinesToKeep: 2


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

The key `IndentWidth`  appears twice  in the `.clang-format`. so I remove it once.

