### PR TITLE
add aliases for parts name and names

### DIFF
--- a/src/Interpreters/PartLog.cpp
+++ b/src/Interpreters/PartLog.cpp
@@ -135,6 +135,7 @@ NamesAndAliases PartLogElement::getNamesAndAliases()
     {
         {"ProfileEvents.Names", {std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())}, "mapKeys(ProfileEvents)"},
         {"ProfileEvents.Values", {std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>())}, "mapValues(ProfileEvents)"},
+        {"name", {std::make_shared<DataTypeString>()}, "part_name"},
     };
 }
 

--- a/src/Storages/System/StorageSystemPartsBase.cpp
+++ b/src/Storages/System/StorageSystemPartsBase.cpp
@@ -304,6 +304,7 @@ StorageSystemPartsBase::StorageSystemPartsBase(const StorageID & table_id_, Name
     /// Add aliases for old column names for backwards compatibility.
     add_alias("bytes", "bytes_on_disk");
     add_alias("marks_size", "marks_bytes");
+    add_alias("part_name", "name");
 
     StorageInMemoryMetadata storage_metadata;
     storage_metadata.setColumns(tmp_columns);

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -510,7 +510,8 @@ CREATE TABLE system.parts
     `last_removal_attemp_time` DateTime,
     `removal_state` String,
     `bytes` UInt64,
-    `marks_size` UInt64
+    `marks_size` UInt64,
+    `part_name` String
 )
 ENGINE = SystemParts
 COMMENT 'SYSTEM TABLE is built on the fly.'
@@ -564,7 +565,8 @@ CREATE TABLE system.parts_columns
     `subcolumns.data_uncompressed_bytes` Array(UInt64),
     `subcolumns.marks_bytes` Array(UInt64),
     `bytes` UInt64,
-    `marks_size` UInt64
+    `marks_size` UInt64,
+    `part_name` String
 )
 ENGINE = SystemPartsColumns
 COMMENT 'SYSTEM TABLE is built on the fly.'
@@ -685,7 +687,8 @@ CREATE TABLE system.projection_parts
     `rows_where_ttl_info.min` Array(DateTime),
     `rows_where_ttl_info.max` Array(DateTime),
     `bytes` UInt64,
-    `marks_size` UInt64
+    `marks_size` UInt64,
+    `part_name` String
 )
 ENGINE = SystemProjectionParts
 COMMENT 'SYSTEM TABLE is built on the fly.'
@@ -739,7 +742,8 @@ CREATE TABLE system.projection_parts_columns
     `column_data_uncompressed_bytes` UInt64,
     `column_marks_bytes` UInt64,
     `bytes` UInt64,
-    `marks_size` UInt64
+    `marks_size` UInt64,
+    `part_name` String
 )
 ENGINE = SystemProjectionPartsColumns
 COMMENT 'SYSTEM TABLE is built on the fly.'


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add aliases `name` and `part_name` form `system.parts` and `system.part_log`. Closes #48718