### PR TITLE
Pretty op processors IDs in EXPLAIN PIPELINE graph = 1 output

### DIFF
--- a/src/QueryPipeline/printPipeline.h
+++ b/src/QueryPipeline/printPipeline.h
@@ -17,9 +17,11 @@ void printPipeline(const Processors & processors, const Statuses & statuses, Wri
     out << "  rankdir=\"LR\";\n";
     out << "  { node [shape = rect]\n";
 
-    auto get_proc_id = [](const IProcessor & proc) -> UInt64
+    auto get_proc_id = [](const IProcessor& proc) -> std::size_t
     {
-        return reinterpret_cast<std::uintptr_t>(&proc);
+        static std::unordered_map<const void*, std::size_t> pointer_to_id;
+        auto [it, inserted] = pointer_to_id.try_emplace(&proc, pointer_to_id.size());
+        return it->second;
     };
 
     auto statuses_iter = statuses.begin();

--- a/src/QueryPipeline/printPipeline.h
+++ b/src/QueryPipeline/printPipeline.h
@@ -17,9 +17,9 @@ void printPipeline(const Processors & processors, const Statuses & statuses, Wri
     out << "  rankdir=\"LR\";\n";
     out << "  { node [shape = rect]\n";
 
-    auto get_proc_id = [](const IProcessor& proc) -> std::size_t
+    std::unordered_map<const void *, std::size_t> pointer_to_id;
+    auto get_proc_id = [&](const IProcessor & proc) -> std::size_t
     {
-        static std::unordered_map<const void*, std::size_t> pointer_to_id;
         auto [it, inserted] = pointer_to_id.try_emplace(&proc, pointer_to_id.size());
         return it->second;
     };


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/48713

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Op processors IDs are raw ptrs casted to UInt64. Print it in a prettier manner:

Example:

```
EXPLAIN PIPELINE graph = 1, compact = 0
SELECT sum(number)
FROM numbers_mt(1000000)
SETTINGS max_threads = 2
FORMAT TSV

Query id: b1b154f4-f718-496f-8f2b-37d4c2b9fa93

digraph
{
  rankdir="LR";
  { node [shape = rect]
    n0[label="NumbersMt"];
    n1[label="NumbersMt"];
    n2[label="ExpressionTransform"];
    n3[label="ExpressionTransform"];
    n4[label="AggregatingTransform"];
    n5[label="AggregatingTransform"];
    n6[label="Resize"];
    n7[label="ExpressionTransform"];
    n8[label="ExpressionTransform"];
  }
  n0 -> n2;
  n1 -> n3;
  n2 -> n4;
  n3 -> n5;
  n4 -> n6;
  n5 -> n6;
  n6 -> n7;
  n6 -> n8;
}

23 rows in set. Elapsed: 0.010 sec.
```

> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
