### PR TITLE
Fix unnecessary multiple rescheduling in StorageWindowView

### DIFF
--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -189,6 +189,11 @@ namespace
 
     using ReplaceFunctionNowVisitor = InDepthNodeVisitor<OneTypeMatcher<ReplaceFunctionNowData>, true>;
 
+    inline UInt32 now()
+    {
+        return static_cast<UInt32>(Poco::Timestamp().epochMicroseconds() / 1000000);
+    }
+
     class ToIdentifierMatcher
     {
     public:
@@ -1020,7 +1025,7 @@ void StorageWindowView::threadFuncFireProc()
 
     std::lock_guard lock(fire_signal_mutex);
     /// TODO: consider using time_t instead (for every timestamp in this class)
-    UInt32 timestamp_now = static_cast<UInt32>(Poco::Timestamp().epochMicroseconds() / 1000000);
+    UInt32 timestamp_now = now();
 
     while (next_fire_signal <= timestamp_now)
     {
@@ -1195,7 +1200,7 @@ StorageWindowView::StorageWindowView(
     target_table_id = has_inner_target_table ? StorageID(table_id_.database_name, generateTargetTableName(table_id_)) : query.to_table_id;
 
     if (is_proctime)
-        next_fire_signal = getWindowUpperBound(static_cast<UInt32>(std::time(nullptr)));
+        next_fire_signal = getWindowUpperBound(now());
 
     std::exchange(has_inner_table, true);
     if (!attach_)
@@ -1464,7 +1469,7 @@ void StorageWindowView::writeIntoWindowView(
                 column.type = std::make_shared<DataTypeDateTime>();
             else
                 column.type = std::make_shared<DataTypeDateTime>(timezone);
-            column.column = column.type->createColumnConst(0, Field(std::time(nullptr)));
+            column.column = column.type->createColumnConst(0, Field(now()));
 
             auto adding_column_dag = ActionsDAG::makeAddingColumnActions(std::move(column));
             auto adding_column_actions = std::make_shared<ExpressionActions>(

--- a/src/Storages/WindowView/StorageWindowView.cpp
+++ b/src/Storages/WindowView/StorageWindowView.cpp
@@ -1020,7 +1020,7 @@ void StorageWindowView::threadFuncFireProc()
 
     std::lock_guard lock(fire_signal_mutex);
     /// TODO: consider using time_t instead (for every timestamp in this class)
-    UInt32 timestamp_now = static_cast<UInt32>(std::time(nullptr));
+    UInt32 timestamp_now = static_cast<UInt32>(Poco::Timestamp().epochMicroseconds() / 1000000);
 
     while (next_fire_signal <= timestamp_now)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Not for changelog

std::time function produces not precise enough timestamp (less than current by few milliseconds) resulting scheduled function to be unnecessary rescheduled multiple times