### PR TITLE
Fix test reference files for join using nullable column

### DIFF
--- a/tests/queries/0_stateless/01142_join_lc_and_nullable_in_key.reference
+++ b/tests/queries/0_stateless/01142_join_lc_and_nullable_in_key.reference
@@ -3,15 +3,27 @@
 1	l	\N	Nullable(String)
 2		\N	Nullable(String)
 -
+1	l	Nullable(String)	\N	Nullable(String)
+0	\N	Nullable(String)	\N	Nullable(String)
+0	\N	Nullable(String)	\N	Nullable(String)
+1	l	Nullable(String)	\N	Nullable(String)
+-
+1	l	LowCardinality(String)	\N	Nullable(String)
+0		LowCardinality(String)	\N	Nullable(String)
+0		LowCardinality(String)	\N	Nullable(String)
+1	l	LowCardinality(String)	\N	Nullable(String)
+-
 1	l	\N	Nullable(String)
-0		\N	Nullable(String)
-0		\N	Nullable(String)
+0	\N	\N	Nullable(String)
+0	\N	\N	Nullable(String)
 1	l	\N	Nullable(String)
 -
 1	l	\N	Nullable(String)
 0		\N	Nullable(String)
 0		\N	Nullable(String)
 1	l	\N	Nullable(String)
+-
+0	\N
 -
 0	
 -

--- a/tests/queries/0_stateless/01142_join_lc_and_nullable_in_key.sql
+++ b/tests/queries/0_stateless/01142_join_lc_and_nullable_in_key.sql
@@ -15,19 +15,37 @@ SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l FULL JOIN nr AS r USING (x) ORD
 
 SELECT '-';
 
-SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x;
-SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x;
-SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x;
+-- lc should be supertype for l.lc and r.lc, so expect Nullable(String)
+SELECT x, lc, toTypeName(lc), r.lc, toTypeName(r.lc) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+SELECT x, lc, toTypeName(lc), r.lc, toTypeName(r.lc) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+SELECT x, lc, toTypeName(lc), r.lc, toTypeName(r.lc) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
 
 SELECT '-';
 
-SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x;
-SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x;
-SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x;
+-- old behavior is different
+SELECT x, lc, toTypeName(lc), r.lc, toTypeName(r.lc) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+SELECT x, lc, toTypeName(lc), r.lc, toTypeName(r.lc) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+SELECT x, lc, toTypeName(lc), r.lc, toTypeName(r.lc) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
 
 SELECT '-';
 
-SELECT x, lc FROM t AS l RIGHT JOIN nr AS r USING (lc);
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+
+SELECT '-';
+
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+
+SELECT '-';
+
+SELECT x, lc FROM t AS l RIGHT JOIN nr AS r USING (lc) SETTINGS allow_experimental_analyzer = 1;
+
+SELECT '-';
+
+SELECT x, lc FROM t AS l RIGHT JOIN nr AS r USING (lc) SETTINGS allow_experimental_analyzer = 0;
 
 SELECT '-';
 

--- a/tests/queries/0_stateless/01142_merge_join_lc_and_nullable_in_key.reference
+++ b/tests/queries/0_stateless/01142_merge_join_lc_and_nullable_in_key.reference
@@ -4,6 +4,16 @@
 2		\N	Nullable(String)
 -
 1	l	\N	Nullable(String)
+0	\N	\N	Nullable(String)
+0	\N	\N	Nullable(String)
+1	l	\N	Nullable(String)
+-
+1	l	\N	Nullable(String)
+0	\N	\N	Nullable(String)
+0	\N	\N	Nullable(String)
+1	l	\N	Nullable(String)
+-
+1	l	\N	Nullable(String)
 0		\N	Nullable(String)
 0		\N	Nullable(String)
 1	l	\N	Nullable(String)

--- a/tests/queries/0_stateless/01142_merge_join_lc_and_nullable_in_key.sql
+++ b/tests/queries/0_stateless/01142_merge_join_lc_and_nullable_in_key.sql
@@ -17,15 +17,27 @@ SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l FULL JOIN nr AS r USING (x) ORD
 
 SELECT '-';
 
-SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x;
-SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x;
-SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x;
+SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
 
 SELECT '-';
 
-SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x;
-SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x;
-SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x;
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 1;
+
+SELECT '-';
+
+SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+SELECT x, lc, r.lc, toTypeName(r.lc) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+
+SELECT '-';
+
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l LEFT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l RIGHT JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
+SELECT x, lc, materialize(r.lc) y, toTypeName(y) FROM t AS l FULL JOIN nr AS r USING (lc) ORDER BY x SETTINGS allow_experimental_analyzer = 0;
 
 SELECT '-';
 

--- a/tests/queries/0_stateless/01476_right_full_join_switch.reference
+++ b/tests/queries/0_stateless/01476_right_full_join_switch.reference
@@ -3,6 +3,16 @@
 1	l	\N	LowCardinality(String)	Nullable(String)
 2		\N	LowCardinality(String)	Nullable(String)
 -
+\N	\N		Nullable(String)	LowCardinality(String)
+1	\N	l	Nullable(String)	LowCardinality(String)
+1	\N	l	Nullable(String)	LowCardinality(String)
+\N	\N		Nullable(String)	LowCardinality(String)
+-
+1	l	\N	LowCardinality(String)	Nullable(String)
+2		\N	LowCardinality(String)	Nullable(String)
+1	l	\N	LowCardinality(String)	Nullable(String)
+2		\N	LowCardinality(String)	Nullable(String)
+-
 0	\N		Nullable(String)	LowCardinality(String)
 1	\N	l	Nullable(String)	LowCardinality(String)
 0	\N		Nullable(String)	LowCardinality(String)

--- a/tests/queries/0_stateless/01476_right_full_join_switch.sql
+++ b/tests/queries/0_stateless/01476_right_full_join_switch.sql
@@ -10,8 +10,27 @@ CREATE TABLE nr (`x` Nullable(UInt32), `s` Nullable(String)) ENGINE = Memory;
 INSERT INTO t VALUES (1, 'l');
 INSERT INTO nr VALUES (2, NULL);
 
+
 SET join_use_nulls = 0;
 
+SET allow_experimental_analyzer = 1;
+
+-- t.x is supertupe for `x` from left and right since `x` is inside `USING`.
+SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l LEFT JOIN nr AS r USING (x) ORDER BY t.x;
+SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l RIGHT JOIN nr AS r USING (x) ORDER BY t.x;
+SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l FULL JOIN nr AS r USING (x) ORDER BY t.x;
+
+SELECT '-';
+
+SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l LEFT JOIN t AS r USING (x) ORDER BY t.x;
+SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l RIGHT JOIN t AS r USING (x) ORDER BY t.x;
+SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l FULL JOIN t AS r USING (x) ORDER BY t.x;
+
+SELECT '-';
+
+SET allow_experimental_analyzer = 0;
+
+-- t.x is supertupe for `x` from left and right since `x` is inside `USING`.
 SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l LEFT JOIN nr AS r USING (x) ORDER BY t.x;
 SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l RIGHT JOIN nr AS r USING (x) ORDER BY t.x;
 SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l FULL JOIN nr AS r USING (x) ORDER BY t.x;

--- a/tests/queries/0_stateless/01477_lc_in_merge_join_left_key.reference
+++ b/tests/queries/0_stateless/01477_lc_in_merge_join_left_key.reference
@@ -17,7 +17,7 @@
 1	\N	l	Nullable(String)	LowCardinality(String)
 0	\N		Nullable(String)	LowCardinality(String)
 1	\N	l	Nullable(String)	LowCardinality(String)
--
+- join_use_nulls -
 1	l	\N	LowCardinality(String)	Nullable(String)
 2	\N	\N	LowCardinality(Nullable(String))	Nullable(String)
 1	l	\N	LowCardinality(Nullable(String))	Nullable(String)
@@ -33,3 +33,47 @@
 1	l	\N	LowCardinality(Nullable(String))	Nullable(String)
 \N	\N	\N	LowCardinality(Nullable(String))	Nullable(String)
 -
+\N	\N	\N	Nullable(String)	LowCardinality(Nullable(String))
+1	\N	l	Nullable(String)	LowCardinality(String)
+1	\N	l	Nullable(String)	LowCardinality(Nullable(String))
+\N	\N	\N	Nullable(String)	LowCardinality(Nullable(String))
+- analyzer -
+1	l	\N	LowCardinality(String)	Nullable(String)
+2		\N	LowCardinality(String)	Nullable(String)
+1	l	\N	LowCardinality(String)	Nullable(String)
+2		\N	LowCardinality(String)	Nullable(String)
+-
+\N	\N		Nullable(String)	LowCardinality(String)
+1	\N	l	Nullable(String)	LowCardinality(String)
+1	\N	l	Nullable(String)	LowCardinality(String)
+\N	\N		Nullable(String)	LowCardinality(String)
+-
+1	l	\N	Nullable(String)	Nullable(String)
+0	\N	\N	Nullable(String)	Nullable(String)
+0	\N	\N	Nullable(String)	Nullable(String)
+1	l	\N	Nullable(String)	Nullable(String)
+-
+0	\N	\N	Nullable(String)	Nullable(String)
+1	\N	l	Nullable(String)	Nullable(String)
+0	\N	\N	Nullable(String)	Nullable(String)
+1	\N	l	Nullable(String)	Nullable(String)
+- join_use_nulls -
+1	l	\N	LowCardinality(String)	Nullable(String)
+2	\N	\N	LowCardinality(Nullable(String))	Nullable(String)
+1	l	\N	LowCardinality(Nullable(String))	Nullable(String)
+2	\N	\N	LowCardinality(Nullable(String))	Nullable(String)
+-
+\N	\N	\N	Nullable(String)	LowCardinality(Nullable(String))
+1	\N	l	Nullable(String)	LowCardinality(String)
+1	\N	l	Nullable(String)	LowCardinality(Nullable(String))
+\N	\N	\N	Nullable(String)	LowCardinality(Nullable(String))
+-
+1	l	\N	Nullable(String)	Nullable(String)
+\N	\N	\N	Nullable(String)	Nullable(String)
+1	l	\N	Nullable(String)	Nullable(String)
+\N	\N	\N	Nullable(String)	Nullable(String)
+-
+\N	\N	\N	Nullable(String)	Nullable(String)
+1	\N	l	Nullable(String)	Nullable(String)
+1	\N	l	Nullable(String)	Nullable(String)
+\N	\N	\N	Nullable(String)	Nullable(String)

--- a/tests/queries/0_stateless/01477_lc_in_merge_join_left_key.sql.j2
+++ b/tests/queries/0_stateless/01477_lc_in_merge_join_left_key.sql.j2
@@ -10,6 +10,14 @@ CREATE TABLE nr (`x` Nullable(UInt32), `s` Nullable(String)) ENGINE = Memory;
 INSERT INTO t VALUES (1, 'l');
 INSERT INTO nr VALUES (2, NULL);
 
+{% for allow_experimental_analyzer in [0, 1] -%}
+
+SET allow_experimental_analyzer = {{ allow_experimental_analyzer }};
+
+{% if allow_experimental_analyzer -%}
+SELECT '- analyzer -';
+{% endif -%}
+
 SET join_use_nulls = 0;
 
 SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l LEFT JOIN nr AS r USING (x) ORDER BY t.x;
@@ -36,7 +44,7 @@ SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l FULL JOIN t 
 
 SET join_use_nulls = 1;
 
-SELECT '-';
+SELECT '- join_use_nulls -';
 
 SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l LEFT JOIN nr AS r USING (x) ORDER BY t.x;
 SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l RIGHT JOIN nr AS r USING (x) ORDER BY t.x;
@@ -56,10 +64,11 @@ SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM t AS l FULL JOIN nr 
 
 SELECT '-';
 
--- TODO
--- SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l LEFT JOIN t AS r USING (s) ORDER BY t.x;
--- SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l RIGHT JOIN t AS r USING (s) ORDER BY t.x;
--- SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l FULL JOIN t AS r USING (s) ORDER BY t.x;
+SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l LEFT JOIN t AS r USING (s) ORDER BY t.x;
+SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l RIGHT JOIN t AS r USING (s) ORDER BY t.x;
+SELECT t.x, l.s, r.s, toTypeName(l.s), toTypeName(r.s) FROM nr AS l FULL JOIN t AS r USING (s) ORDER BY t.x;
+
+{% endfor %}
 
 DROP TABLE t;
 DROP TABLE nr;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


Tests fixed in this PR related to result column type after `JOIN .. USING`. We expect the column under USING to have a result type which is a super-type of the column from the left and right tables:

```sql
SELECT throwIf('Int64' != any(toTypeName(s))) FROM (
    SELECT materialize(1 :: Int32) as s
) t1 FULL JOIN (
    SELECT materialize(2 :: UInt32) as s
) t2 USING (s);
```
 
But in the current interpreter it works sometime unexpected for `LowCardinality` and `Nullable` types.

This PR covers the cases like:

```sql
-- Current : LowCardinality(String)
-- Analyzer: String
SELECT any(toTypeName(s)) FROM (SELECT materialize('a' :: LowCardinality(String)) as s) t1 FULL JOIN (SELECT materialize('b' :: String) as s) t2 USING (s);
-- Current : String
-- Analyzer: String
SELECT any(toTypeName(s)) FROM (SELECT materialize('a' :: String) as s) t1 FULL JOIN (SELECT materialize('b' :: LowCardinality(String)) as s) t2 USING (s);
-- Current : Nullable(String)
-- Analyzer: Nullable(String)
SELECT any(toTypeName(s)) FROM (SELECT materialize('a' :: Nullable(String)) as s) t1 FULL JOIN (SELECT materialize('b' :: LowCardinality(String)) as s) t2 USING (s);
-- Current : LowCardinality(String)
-- Analyzer: Nullable(String)
SELECT any(toTypeName(s)) FROM (SELECT materialize('a' :: LowCardinality(String)) as s) t1 FULL JOIN (SELECT materialize('b' :: Nullable(String)) as s) t2 USING (s);
-- Current : LowCardinality(Nullable(String))
-- Analyzer: LowCardinality(Nullable(String))
SELECT any(toTypeName(s)) FROM (SELECT materialize('a' :: LowCardinality(Nullable(String))) as s) t1 FULL JOIN (SELECT materialize('b' :: LowCardinality(String)) as s) t2 USING (s);
-- Current : LowCardinality(String)
-- Analyzer: LowCardinality(Nullable(String))
SELECT any(toTypeName(s)) FROM (SELECT materialize('a' :: LowCardinality(String)) as s) t1 FULL JOIN (SELECT materialize('b' :: LowCardinality(Nullable(String))) as s) t2 USING (s);

```