### PR TITLE
Fix order by in test_storage_delta

### DIFF
--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -251,8 +251,10 @@ def test_checkpoint(started_cluster):
     assert (
         instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY 1").strip()
         == instance.query(
+            "SELECT * FROM ("
             "SELECT number, toString(number + 1) FROM numbers(5) "
-            "UNION ALL SELECT number, toString(number + 1) FROM numbers(10, 15) ORDER BY 1"
+            "UNION ALL SELECT number, toString(number + 1) FROM numbers(10, 15) "
+            ") ORDER BY 1"
         ).strip()
     )
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


Sometimes a bit flaky: https://s3.amazonaws.com/clickhouse-test-reports/0/799e0535a9439f57c9d7979bf2ae0ebba2b978f4/integration_tests__release__[3/4]/integration_run_parallel3_0.log


```
explain plan
SELECT number, toString(number + 1) FROM numbers(5)
UNION ALL SELECT number, toString(number + 1) FROM numbers(10, 15)
ORDER BY 1;

┌─explain────────────────────────────────────────────────────────┐
│ Union                                                          │
│   Expression ((Projection + Before ORDER BY))                  │
│     ReadFromStorage (SystemNumbers)                            │
│   Expression ((Projection + Before ORDER BY [lifted up part])) │
│     Sorting (Sorting for ORDER BY)                             │
│       Expression (Before ORDER BY)                             │
│         ReadFromStorage (SystemNumbers)                        │
└────────────────────────────────────────────────────────────────┘


explain plan
SELECT * FROM (
    SELECT number, toString(number + 1) FROM numbers(5)
    UNION ALL SELECT number, toString(number + 1) FROM numbers(10, 15)
) ORDER BY 1;

┌─explain───────────────────────────────────────────────────────────────┐
│ Expression (Projection)                                               │
│   Sorting (Sorting for ORDER BY)                                      │
│     Union                                                             │
│       Expression ((Before ORDER BY + (Projection + Before ORDER BY))) │
│         ReadFromStorage (SystemNumbers)                               │
│       Expression (( + (Projection + Before ORDER BY)))                │
│         ReadFromStorage (SystemNumbers)                               │
└───────────────────────────────────────────────────────────────────────┘

```
