### PR TITLE
A non significant change (does not affect anything): add support for signed integers in the maskBits function

### DIFF
--- a/src/Common/BitHelpers.h
+++ b/src/Common/BitHelpers.h
@@ -101,22 +101,24 @@ inline size_t getTrailingZeroBits(T x)
 
 /** Returns a mask that has '1' for `bits` LSB set:
   * maskLowBits<UInt8>(3) => 00000111
+  * maskLowBits<Int8>(3) => 00000111
   */
 template <typename T>
 inline T maskLowBits(unsigned char bits)
 {
+    using unsigedT = std::make_unsigned_t<T>;
     if (bits == 0)
     {
         return 0;
     }
 
-    T result = static_cast<T>(~T{0});
+    unsigedT result = static_cast<unsigedT>(~unsigedT{0});
     if (bits < sizeof(T) * 8)
     {
-        result = static_cast<T>(result >> (sizeof(T) * 8 - bits));
+        result = static_cast<unsigedT>(result >> (sizeof(unsigedT) * 8 - bits));
     }
 
-    return result;
+    return static_cast<T>(result);
 }
 
 template <std::integral T>

--- a/src/Common/BitHelpers.h
+++ b/src/Common/BitHelpers.h
@@ -106,16 +106,16 @@ inline size_t getTrailingZeroBits(T x)
 template <typename T>
 inline T maskLowBits(unsigned char bits)
 {
-    using unsigedT = std::make_unsigned_t<T>;
+    using UnsignedT = std::make_unsigned_t<T>;
     if (bits == 0)
     {
         return 0;
     }
 
-    unsigedT result = static_cast<unsigedT>(~unsigedT{0});
+    UnsignedT result = static_cast<UnsignedT>(~UnsignedT{0});
     if (bits < sizeof(T) * 8)
     {
-        result = static_cast<unsigedT>(result >> (sizeof(unsigedT) * 8 - bits));
+        result = static_cast<UnsignedT>(result >> (sizeof(UnsignedT) * 8 - bits));
     }
 
     return static_cast<T>(result);

--- a/src/IO/tests/gtest_bit_io.cpp
+++ b/src/IO/tests/gtest_bit_io.cpp
@@ -250,6 +250,7 @@ INSTANTIATE_TEST_SUITE_P(Primes,
 
 TEST(BitHelpers, maskLowBits)
 {
+    // unsigned
     EXPECT_EQ(0b00000111, ::maskLowBits<uint8_t>(3));
     EXPECT_EQ(0b01111111, ::maskLowBits<uint8_t>(7));
     EXPECT_EQ(0b0000000001111111, ::maskLowBits<UInt16>(7));
@@ -258,8 +259,24 @@ TEST(BitHelpers, maskLowBits)
     EXPECT_EQ(0b111111111111111111111111111111111, ::maskLowBits<UInt64>(33));
     EXPECT_EQ(0b11111111111111111111111111111111111, ::maskLowBits<UInt64>(35));
 
+    // signed
+    EXPECT_EQ(static_cast<int8_t>(0b00000111), ::maskLowBits<int8_t>(3));
+    EXPECT_EQ(static_cast<int8_t>(0b01111111), ::maskLowBits<int8_t>(7));
+    EXPECT_EQ(static_cast<Int16>(0b0000000001111111), ::maskLowBits<Int16>(7));
+    EXPECT_EQ(static_cast<Int16>(0b0001111111111111), ::maskLowBits<Int16>(13));
+    EXPECT_EQ(static_cast<Int32>(0b00000111111111111111111111111111), ::maskLowBits<Int32>(27));
+    EXPECT_EQ(static_cast<Int64>(0b111111111111111111111111111111111), ::maskLowBits<Int64>(33));
+    EXPECT_EQ(static_cast<Int64>(0b11111111111111111111111111111111111), ::maskLowBits<Int64>(35));
+
+    // unsigned
     EXPECT_EQ(0xFF, ::maskLowBits<uint8_t>(8));
     EXPECT_EQ(0xFFFF, ::maskLowBits<UInt16>(16));
     EXPECT_EQ(0xFFFFFFFF, ::maskLowBits<UInt32>(32));
     EXPECT_EQ(0xFFFFFFFFFFFFFFFF, ::maskLowBits<UInt64>(64));
+
+    // signed
+    EXPECT_EQ(static_cast<int8_t>(0xFF), ::maskLowBits<int8_t>(8));
+    EXPECT_EQ(static_cast<Int16>(0xFFFF), ::maskLowBits<Int16>(16));
+    EXPECT_EQ(static_cast<Int32>(0xFFFFFFFF), ::maskLowBits<Int32>(32));
+    EXPECT_EQ(static_cast<Int64>(0xFFFFFFFFFFFFFFFF), ::maskLowBits<Int64>(64));
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Not for changelog

    maskLowBits\<UInt8\>(3) => 00000111, but maskLowBits\<Int8\>(3) => 11111111, so I fixed it.
    after I fixed it, the result is:
    maskLowBits\<UInt8\>(3) => 00000111, maskLowBits\<Int8\>(3) => 00000111


