### PR TITLE
Implement a slight improvement for the rare case when ClickHouse is run inside LXC and LXCFS is used, because LXCFS has a bug

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -683,7 +683,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
-            
+
             /// A slight improvement for the rare case when ClickHouse is run inside LXC and LXCFS is used.
             /// The LXCFS has an issue: sometimes it returns an error "Transport endpoint is not connected" on reading from the file inside `/proc`.
             /// This error was correctly logged into ClickHouse's server log, but it was a source of annoyance to some users.

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -683,6 +683,11 @@ void AsynchronousMetrics::update(TimePoint update_time)
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            
+            /// A slight improvement for the rare case when ClickHouse is run inside LXC and LXCFS is used.
+            /// The LXCFS has an issue: sometimes it returns an error "Transport endpoint is not connected" on reading from the file inside `/proc`.
+            /// This error was correctly logged into ClickHouse's server log, but it was a source of annoyance to some users.
+            /// We additionally workaround this issue by reopening a file.
             openFileIfExists("/proc/loadavg", loadavg);
         }
     }

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -683,6 +683,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            openFileIfExists("/proc/loadavg", loadavg);
         }
     }
 
@@ -700,6 +701,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            openFileIfExists("/proc/uptime", uptime);
         }
     }
 
@@ -887,6 +889,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            openFileIfExists("/proc/stat", proc_stat);
         }
     }
 
@@ -1007,6 +1010,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            openFileIfExists("/proc/meminfo", meminfo);
         }
     }
 
@@ -1059,6 +1063,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            openFileIfExists("/proc/cpuinfo", cpuinfo);
         }
     }
 
@@ -1076,6 +1081,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            openFileIfExists("/proc/sys/fs/file-nr", file_nr);
         }
     }
 
@@ -1308,6 +1314,7 @@ void AsynchronousMetrics::update(TimePoint update_time)
         catch (...)
         {
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            openFileIfExists("/proc/net/dev", net_dev);
         }
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implement a slight improvement for the rare case when ClickHouse is run inside LXC and LXCFS is used. The LXCFS has an issue: sometimes it returns an error "Transport endpoint is not connected" on reading from the file inside `/proc`. This error was correctly logged into ClickHouse's server log. We have additionally workaround this issue by reopening a file. This is a minuscule change.