### PR TITLE
Throw exception when cannot parse DataTime64

### DIFF
--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -964,9 +964,15 @@ template <typename ReturnType>
 inline ReturnType readDateTimeTextImpl(DateTime64 & datetime64, UInt32 scale, ReadBuffer & buf, const DateLUTImpl & date_lut)
 {
     time_t whole;
-    if (!readDateTimeTextImpl<bool>(whole, buf, date_lut))
+    if constexpr (std::is_same_v<ReturnType, void>)
     {
-        return ReturnType(false);
+        readDateTimeTextImpl<void>(whole, buf, date_lut);
+    }
+    else{
+        if (!readDateTimeTextImpl<bool>(whole, buf, date_lut))
+        {
+            return ReturnType(false);
+        }
     }
 
     int negative_multiplier = 1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
when parse `DataTime64` from string, throw exception if we cannot parse  the `DataTime` part of the string
fix: #48925 

