### PR TITLE
Follow-up to #48866

### DIFF
--- a/docs/en/sql-reference/functions/array-functions.md
+++ b/docs/en/sql-reference/functions/array-functions.md
@@ -861,7 +861,7 @@ A special function. See the section [“ArrayJoin function”](../../sql-referen
 
 ## arrayDifference
 
-Calculates the difference between adjacent array elements. Returns an array where the first element will be 0, the second is the difference between `a[1] - a[0]`, etc. The type of elements in the resulting array is determined by the type inference rules for subtraction (e.g. `UInt8` - `UInt8` = `Int16`).
+Calculates an array of differences between adjacent array elements. The first element of the result array will be 0, the second `a[1] - a[0]`, the third `a[2] - a[1]`, etc. The type of elements in the result array is determined by the type inference rules for subtraction (e.g. `UInt8` - `UInt8` = `Int16`).
 
 **Syntax**
 
@@ -875,7 +875,7 @@ arrayDifference(array)
 
 **Returned values**
 
-Returns an array of differences between adjacent elements.
+Returns an array of differences between adjacent array elements.
 
 Type: [UInt\*](https://clickhouse.com/docs/en/data_types/int_uint/#uint-ranges), [Int\*](https://clickhouse.com/docs/en/data_types/int_uint/#int-ranges), [Float\*](https://clickhouse.com/docs/en/data_types/float/).
 
@@ -1643,7 +1643,7 @@ Result:
 
 ## arrayCumSum(\[func,\] arr1, …)
 
-Returns an array of partial sums of elements in the source array (a running sum). If the `func` function is specified, then the values of the array elements are converted by `func(arr1[i], …, arrN[i])` before summing.
+Returns an array of the partial (running) sums of the elements in the source array `arr1`. If `func` is specified, then the sum is computed from applying `func` to `arr1`, `arr2`, ..., `arrN`, i.e. `func(arr1[i], …, arrN[i])`.
 
 **Syntax**
 
@@ -1657,7 +1657,7 @@ arrayCumSum(arr)
 
 **Returned value**
 
-- Returns an array of partial sums of elements in the source array.
+- Returns an array of the partial sums of the elements in the source array.
 
 Type: [UInt\*](https://clickhouse.com/docs/en/data_types/int_uint/#uint-ranges), [Int\*](https://clickhouse.com/docs/en/data_types/int_uint/#int-ranges), [Float\*](https://clickhouse.com/docs/en/data_types/float/).
 
@@ -1675,9 +1675,9 @@ SELECT arrayCumSum([1, 1, 1, 1]) AS res
 
 Note that the `arrayCumSum` is a [higher-order function](../../sql-reference/functions/index.md#higher-order-functions). You can pass a lambda function to it as the first argument.
 
-## arrayCumSumNonNegative(arr)
+## arrayCumSumNonNegative(\[func,\] arr1, …)
 
-Same as `arrayCumSum`, returns an array of partial sums of elements in the source array (a running sum). Different `arrayCumSum`, when then returned value contains a value less than zero, the value is replace with zero and the subsequent calculation is performed with zero parameters. For example:
+Same as `arrayCumSum`, returns an array of the partial (running) sums of the elements in the source array. If `func` is specified, then the sum is computed from applying `func` to `arr1`, `arr2`, ..., `arrN`, i.e. `func(arr1[i], …, arrN[i])`. Unlike `arrayCumSum`, if the current running sum is smaller than `0`, it is replaced by `0`.
 
 **Syntax**
 

--- a/src/DataTypes/IDataType.h
+++ b/src/DataTypes/IDataType.h
@@ -340,8 +340,8 @@ struct WhichDataType
     constexpr bool isUInt64() const { return idx == TypeIndex::UInt64; }
     constexpr bool isUInt128() const { return idx == TypeIndex::UInt128; }
     constexpr bool isUInt256() const { return idx == TypeIndex::UInt256; }
-    constexpr bool isUInt() const { return isUInt8() || isUInt16() || isUInt32() || isUInt64() || isUInt128() || isUInt256(); }
     constexpr bool isNativeUInt() const { return isUInt8() || isUInt16() || isUInt32() || isUInt64(); }
+    constexpr bool isUInt() const { return isNativeUInt() || isUInt128() || isUInt256(); }
 
     constexpr bool isInt8() const { return idx == TypeIndex::Int8; }
     constexpr bool isInt16() const { return idx == TypeIndex::Int16; }
@@ -349,8 +349,8 @@ struct WhichDataType
     constexpr bool isInt64() const { return idx == TypeIndex::Int64; }
     constexpr bool isInt128() const { return idx == TypeIndex::Int128; }
     constexpr bool isInt256() const { return idx == TypeIndex::Int256; }
-    constexpr bool isInt() const { return isInt8() || isInt16() || isInt32() || isInt64() || isInt128() || isInt256(); }
     constexpr bool isNativeInt() const { return isInt8() || isInt16() || isInt32() || isInt64(); }
+    constexpr bool isInt() const { return isNativeInt() || isInt128() || isInt256(); }
 
     constexpr bool isDecimal32() const { return idx == TypeIndex::Decimal32; }
     constexpr bool isDecimal64() const { return idx == TypeIndex::Decimal64; }

--- a/src/Functions/array/arrayCumSum.cpp
+++ b/src/Functions/array/arrayCumSum.cpp
@@ -33,20 +33,22 @@ struct ArrayCumSumImpl
         {
             if (which.isNativeUInt())
                 return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
+            if (which.isUInt128())
+                return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt128>());
             if (which.isUInt256())
                 return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt256>());
-            else
-                return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt128>());
+            UNREACHABLE();
         }
 
         if (which.isInt())
         {
             if (which.isNativeInt())
                 return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt64>());
+            if (which.isInt128())
+                return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt128>());
             if (which.isInt256())
                 return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt256>());
-            else
-                return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt128>());
+            UNREACHABLE();
         }
 
         if (which.isFloat())
@@ -67,8 +69,8 @@ struct ArrayCumSumImpl
 
 
     template <typename Src, typename Dst>
-    static void NO_SANITIZE_UNDEFINED
-    implConst(size_t size, const IColumn::Offset * __restrict offsets, Dst * __restrict res_values, Src src_value)
+    static void NO_SANITIZE_UNDEFINED implConst(
+        size_t size, const IColumn::Offset * __restrict offsets, Dst * __restrict res_values, Src src_value)
     {
         size_t pos = 0;
         for (const auto * end = offsets + size; offsets < end; ++offsets)
@@ -84,8 +86,8 @@ struct ArrayCumSumImpl
     }
 
     template <typename Src, typename Dst>
-    static void NO_SANITIZE_UNDEFINED
-    implVector(size_t size, const IColumn::Offset * __restrict offsets, Dst * __restrict res_values, const Src * __restrict src_values)
+    static void NO_SANITIZE_UNDEFINED implVector(
+        size_t size, const IColumn::Offset * __restrict offsets, Dst * __restrict res_values, const Src * __restrict src_values)
     {
         size_t pos = 0;
         for (const auto * end = offsets + size; offsets < end; ++offsets)

--- a/src/Functions/array/arrayCumSumNonNegative.cpp
+++ b/src/Functions/array/arrayCumSumNonNegative.cpp
@@ -34,20 +34,22 @@ struct ArrayCumSumNonNegativeImpl
         {
             if (which.isNativeUInt())
                 return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
+            if (which.isUInt128())
+                return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt128>());
             if (which.isUInt256())
                 return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt256>());
-            else
-                return std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt128>());
+            UNREACHABLE();
         }
 
         if (which.isInt())
         {
             if (which.isNativeInt())
                 return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt64>());
+            if (which.isInt128())
+                return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt128>());
             if (which.isInt256())
                 return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt256>());
-            else
-                return std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt128>());
+            UNREACHABLE();
         }
 
         if (which.isFloat())
@@ -64,14 +66,13 @@ struct ArrayCumSumNonNegativeImpl
             return std::make_shared<DataTypeArray>(nested);
         }
 
-        throw Exception(
-            ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "arrayCumSumNonNegativeImpl cannot add values of type {}", expression_return->getName());
+        throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "arrayCumSumNonNegativeImpl cannot add values of type {}", expression_return->getName());
     }
 
 
     template <typename Src, typename Dst>
-    static void NO_SANITIZE_UNDEFINED
-    implVector(size_t size, const IColumn::Offset * __restrict offsets, Dst * __restrict res_values, const Src * __restrict src_values)
+    static void NO_SANITIZE_UNDEFINED implVector(
+        size_t size, const IColumn::Offset * __restrict offsets, Dst * __restrict res_values, const Src * __restrict src_values)
     {
         size_t pos = 0;
         for (const auto * end = offsets + size; offsets < end; ++offsets)

--- a/tests/queries/0_stateless/02716_int256_arrayfunc.reference
+++ b/tests/queries/0_stateless/02716_int256_arrayfunc.reference
@@ -1,26 +1,16 @@
-[1,3]
-[1,3]
-[1,3]
-[1,3]
-[3,4,5]
-[1,2]
-Array(UInt128)
-Array(Int128)
-Array(UInt256)
-Array(Int256)
-[0,2]
-[0,2]
-[0,2]
-[0,2]
-Array(Int128)
-Array(Int128)
-Array(Int256)
-Array(Int256)
-[1,0]
-[1,0]
-[1,3]
-[1,3]
-Array(Int128)
-Array(Int256)
-Array(UInt128)
-Array(UInt256)
+[0,2]	Array(Int128)
+[0,2]	Array(Int128)
+[0,2]	Array(Int256)
+[0,2]	Array(Int256)
+---
+[1,3]	Array(UInt128)
+[1,3]	Array(Int128)
+[1,3]	Array(UInt256)
+[1,3]	Array(Int256)
+[3,4,5]	Array(UInt256)
+[1,2]	Array(Int256)
+---
+[1,3]	Array(UInt128)
+[1,0]	Array(Int128)
+[1,3]	Array(UInt256)
+[1,0]	Array(Int256)

--- a/tests/queries/0_stateless/02716_int256_arrayfunc.sql
+++ b/tests/queries/0_stateless/02716_int256_arrayfunc.sql
@@ -1,28 +1,22 @@
-SELECT arrayCumSum([CAST('1', 'Int128'), 2]);
-SELECT arrayCumSum([CAST('1', 'Int256'), 2]);
-SELECT arrayCumSum([CAST('1', 'UInt128'), 2]);
-SELECT arrayCumSum([CAST('1', 'UInt256'), 2]);
-SELECT arrayCumSum([3, CAST('1', 'Int128'),CAST('1', 'Int256')]);
-SELECT arrayCumSum([CAST('1', 'Int256'), CAST('1', 'Int128')]);
-SELECT toTypeName(arrayCumSum([CAST('1', 'UInt128'), 2]));
-SELECT toTypeName(arrayCumSum([CAST('1', 'Int128'), 2]));
-SELECT toTypeName(arrayCumSum([CAST('1', 'UInt256'), CAST('1', 'UInt128')]));
-SELECT toTypeName(arrayCumSum([CAST('1', 'Int256'), CAST('1', 'Int128')]));
+SELECT arrayDifference([toUInt128(1), 3]), toTypeName(arrayDifference([toUInt128(1), 3]));
+SELECT arrayDifference([toInt128(1), 3]), toTypeName(arrayDifference([toInt128(1), 3]));
+SELECT arrayDifference([toUInt256(1), 3]), toTypeName(arrayDifference([toUInt256(1), 3]));
+SELECT arrayDifference([toInt256(1), 3]), toTypeName(arrayDifference([toInt256(1), 3]));
 
-SELECT arrayDifference([CAST('1', 'Int256'), 3]);
-SELECT arrayDifference([CAST('1', 'UInt256'), 3]);
-SELECT arrayDifference([CAST('1', 'UInt128'), 3]);
-SELECT arrayDifference([CAST('1', 'Int128'), 3]);
-SELECT toTypeName(arrayDifference([CAST('1', 'UInt128'), 3]));
-SELECT toTypeName(arrayDifference([CAST('1', 'Int128'), 3]));
-SELECT toTypeName(arrayDifference([CAST('1', 'UInt256'), 3]));
-SELECT toTypeName(arrayDifference([CAST('1', 'Int256'), 3]));
+SELECT '---';
 
-SELECT arrayCumSumNonNegative([CAST('1', 'Int128'), -2]);
-SELECT arrayCumSumNonNegative([CAST('1', 'Int256'), -2]);
-SELECT arrayCumSumNonNegative([CAST('1', 'UInt128'), 2]);
-SELECT arrayCumSumNonNegative([CAST('1', 'UInt256'), 2]);
-SELECT toTypeName(arrayCumSumNonNegative([CAST('1', 'Int128'), -2]));
-SELECT toTypeName(arrayCumSumNonNegative([CAST('1', 'Int256'), -2]));
-SELECT toTypeName(arrayCumSumNonNegative([CAST('1', 'UInt128'), 2]));
-SELECT toTypeName(arrayCumSumNonNegative([CAST('1', 'UInt256'), 2]));
+SELECT arrayCumSum([toUInt128(1), 2]), toTypeName(arrayCumSum([toUInt128(1), 2]));
+SELECT arrayCumSum([toInt128(1), 2]), toTypeName(arrayCumSum([toInt128(1), 2]));
+SELECT arrayCumSum([toUInt256(1), 2]), toTypeName(arrayCumSum([toUInt256(1), 2]));
+SELECT arrayCumSum([toInt256(1), 2]), toTypeName(arrayCumSum([toInt256(1), 2]));
+
+SELECT arrayCumSum([3, toInt128(1), toInt256(1)]), toTypeName(arrayCumSum([toUInt256(1), toUInt128(1)]));
+SELECT arrayCumSum([toInt256(1), toInt128(1)]), toTypeName(arrayCumSum([toInt256(1), toInt128(1)]));
+
+SELECT '---';
+
+SELECT arrayCumSumNonNegative([toUInt128(1), 2]), toTypeName(arrayCumSumNonNegative([toUInt128(1), 2]));
+SELECT arrayCumSumNonNegative([toInt128(1), -2]), toTypeName(arrayCumSumNonNegative([toInt128(1), -2]));
+SELECT arrayCumSumNonNegative([toUInt256(1), 2]), toTypeName(arrayCumSumNonNegative([toUInt256(1), 2]));
+SELECT arrayCumSumNonNegative([toInt256(1), -2]), toTypeName(arrayCumSumNonNegative([toInt256(1), -2]));
+


### PR DESCRIPTION
This PR contains various clean-ups in follow-up to #48866.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)