### PR TITLE
Un-flake 01079_new_range_reader_segfault

### DIFF
--- a/tests/queries/0_stateless/01079_new_range_reader_segfault.sql
+++ b/tests/queries/0_stateless/01079_new_range_reader_segfault.sql
@@ -3,9 +3,9 @@ drop table if exists t;
 create table t (a Int) engine = MergeTree order by a;
 
 -- some magic to satisfy conditions to run optimizations in MergeTreeRangeReader
-insert into t select number < 20000 ? 0 : 1 from numbers(50000);
+insert into t select number < 20 ? 0 : 1 from numbers(50);
 alter table t add column s String default 'foo';
 
-select s from t prewhere a != 1 where rand() % 2 = 0 limit 1;
+select s from t prewhere a != 1 where rowNumberInBlock() % 2 = 0 limit 1;
 
 drop table t;

--- a/tests/queries/0_stateless/01079_new_range_reader_segfault.sql
+++ b/tests/queries/0_stateless/01079_new_range_reader_segfault.sql
@@ -3,7 +3,7 @@ drop table if exists t;
 create table t (a Int) engine = MergeTree order by a;
 
 -- some magic to satisfy conditions to run optimizations in MergeTreeRangeReader
-insert into t select number < 20 ? 0 : 1 from numbers(50);
+insert into t select number < 20000 ? 0 : 1 from numbers(50000);
 alter table t add column s String default 'foo';
 
 select s from t prewhere a != 1 where rand() % 2 = 0 limit 1;


### PR DESCRIPTION
Usage of `rand()` means that the SELECT produces with probability 0.5^20 = 0.000000953 no result. This happend in (*).

The query is designed to trigger some specific logic in MergeTreeReader. Rewriting it is not a good idea. I therefore increased the amount of test data to reduce the probability of an empty result significantly. I hope that the same logic as before is triggered.

EDIT: Instead replaced `rand()` by the more deterministic `rowNumberInBlock()`.

The test currently runs 507 times / day, this means this PR will prevent a failure in ca. 5.6 years from now. Happy 2028!

(*) https://s3.amazonaws.com/clickhouse-test-reports/0/905587b39def432667437efd92c28dde9cc0dfb2/stateless_tests__release__s3_storage__[1/2].html

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)