### PR TITLE
Add building stage to the fasttests report, respect existing status on rerun

### DIFF
--- a/docker/test/fasttest/run.sh
+++ b/docker/test/fasttest/run.sh
@@ -194,7 +194,12 @@ function build
 {
     (
         cd "$FASTTEST_BUILD"
-        time ninja clickhouse-bundle 2>&1 | ts '%Y-%m-%d %H:%M:%S' | tee "$FASTTEST_OUTPUT/build_log.txt"
+        TIMEFORMAT=$'\nreal\t%3R\nuser\t%3U\nsys\t%3S'
+        ( time ninja clickhouse-bundle) |& ts '%Y-%m-%d %H:%M:%S' | tee "$FASTTEST_OUTPUT/build_log.txt"
+        BUILD_SECONDS_ELAPSED=$(awk '/^....-..-.. ..:..:.. real\t[0-9]/ {print $4}' < "$FASTTEST_OUTPUT/build_log.txt")
+        echo "build_clickhouse_fasttest_binary: [ OK ] $BUILD_SECONDS_ELAPSED sec." \
+          | ts '%Y-%m-%d %H:%M:%S' \
+          | tee "$FASTTEST_OUTPUT/test_result.txt"
         if [ "$COPY_CLICKHOUSE_BINARY_TO_OUTPUT" -eq "1" ]; then
             cp programs/clickhouse "$FASTTEST_OUTPUT/clickhouse"
 
@@ -251,7 +256,7 @@ function run_tests
     )
     time clickhouse-test "${test_opts[@]}" -- "$FASTTEST_FOCUS" 2>&1 \
         | ts '%Y-%m-%d %H:%M:%S' \
-        | tee "$FASTTEST_OUTPUT/test_result.txt"
+        | tee -a "$FASTTEST_OUTPUT/test_result.txt"
     set -e
 
     clickhouse stop --pid-path "$FASTTEST_DATA"

--- a/tests/ci/fast_test_check.py
+++ b/tests/ci/fast_test_check.py
@@ -112,6 +112,9 @@ def main():
     rerun_helper = RerunHelper(gh, pr_info, NAME)
     if rerun_helper.is_already_finished_by_status():
         logging.info("Check is already finished according to github status, exiting")
+        status = rerun_helper.get_finished_status()
+        if status is not None and status.state != "success":
+            sys.exit(1)
         sys.exit(0)
 
     docker_image = get_image_with_version(temp_path, "clickhouse/fasttest")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve the fasttests report by adding the binary build stage to the report. Fail next reruns on non `success` existing status.