### PR TITLE
Update query-complexity.md

### DIFF
--- a/docs/en/operations/settings/query-complexity.md
+++ b/docs/en/operations/settings/query-complexity.md
@@ -26,7 +26,7 @@ It can take one of two values: `throw` or `break`. Restrictions on aggregation (
 
 The maximum amount of RAM to use for running a query on a single server.
 
-In the default configuration file, the maximum is 10 GB.
+The default setting is unlimited (set to `0`).
 
 The setting does not consider the volume of available memory or the total volume of memory on the machine.
 The restriction applies to a single query within a single server.


### PR DESCRIPTION
The docs say that max_memory_usage is set to 10GB in the default config, but max_memory_usage does not appear in the default config, so the default is unlimited.

Closes #48837 


### Changelog category (leave one):
- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
