### PR TITLE
Document max_concurrent_queries_for_user

### DIFF
--- a/docs/en/operations/server-configuration-parameters/settings.md
+++ b/docs/en/operations/server-configuration-parameters/settings.md
@@ -847,48 +847,6 @@ Default value: `0`.
 <max_concurrent_select_queries>100</max_concurrent_select_queries>
 ```
 
-## max_concurrent_queries_for_user {#max-concurrent-queries-for-user}
-
-The maximum number of simultaneously processed queries related to MergeTree table per user.
-
-Possible values:
-
--   Positive integer.
--   0 — No limit.
-
-Default value: `0`.
-
-**Example**
-
-``` xml
-<max_concurrent_queries_for_user>5</max_concurrent_queries_for_user>
-```
-
-## max_concurrent_queries_for_all_users {#max-concurrent-queries-for-all-users}
-
-Throw exception if the value of this setting is less or equal than the current number of simultaneously processed queries.
-
-Example: `max_concurrent_queries_for_all_users` can be set to 99 for all users and database administrator can set it to 100 for itself to run queries for investigation even when the server is overloaded.
-
-Modifying the setting for one query or user does not affect other queries.
-
-Possible values:
-
--   Positive integer.
--   0 — No limit.
-
-Default value: `0`.
-
-**Example**
-
-``` xml
-<max_concurrent_queries_for_all_users>99</max_concurrent_queries_for_all_users>
-```
-
-**See Also**
-
--   [max_concurrent_queries](#max-concurrent-queries)
-
 ## max_connections {#max-connections}
 
 The maximum number of inbound connections.

--- a/docs/en/operations/settings/settings-profiles.md
+++ b/docs/en/operations/settings/settings-profiles.md
@@ -77,3 +77,53 @@ The example specifies two profiles: `default` and `web`.
 The `default` profile has a special purpose: it must always be present and is applied when starting the server. In other words, the `default` profile contains default settings.
 
 The `web` profile is a regular profile that can be set using the `SET` query or using a URL parameter in an HTTP query.
+
+## max_concurrent_queries_for_all_users {#max-concurrent-queries-for-all-users}
+
+Throw exception if the value of this setting is less or equal than the current number of simultaneously processed queries.
+
+Example: `max_concurrent_queries_for_all_users` can be set to 99 for all users and database administrator can set it to 100 for itself to run queries for investigation even when the server is overloaded.
+
+Modifying the setting for one query or user does not affect other queries.
+
+Possible values:
+
+-   Positive integer.
+-   0 — No limit.
+
+Default value: `0`.
+
+**Example**
+
+```xml title=/etc/clickhouse-server/users.d/users.xml
+<clickhouse>
+    <profiles>
+        <default>
+          <max_concurrent_queries_for_all_users>99</max_concurrent_queries_for_all_users>
+          ...
+```
+
+## max_concurrent_queries_for_user {#max-concurrent-queries-for-user}
+
+The maximum number of simultaneously processed queries related to MergeTree table per user.
+
+Possible values:
+
+-   Positive integer.
+-   0 — No limit.
+
+Default value: `0`.
+
+**Example**
+
+```xml title=/etc/clickhouse-server/users.d/users.xml
+<clickhouse>
+    <profiles>
+        <climited-users>
+          <max_concurrent_queries_for_user>5</max_concurrent_queries_for_user>
+          ...
+```
+
+**See Also**
+
+-   [max_concurrent_queries](#max-concurrent-queries)

--- a/docs/en/operations/settings/settings-users.md
+++ b/docs/en/operations/settings/settings-users.md
@@ -131,7 +131,7 @@ To open access only from localhost, specify:
 
 ### user_name/profile {#user-nameprofile}
 
-You can assign a settings profile for the user. Settings profiles are configured in a separate section of the `users.xml` file. For more information, see [Profiles of Settings](../../operations/settings/settings-profiles.md).
+You can assign a settings profile for the user. Settings profiles are configured in a separate section of the `users.xml` file. For more information, see [setting profiles](../../operations/settings/settings-profiles.md).
 
 ### user_name/quota {#user-namequota}
 


### PR DESCRIPTION
Move user profile settings from core settings

closes #38357 

### Changelog category (leave one):
- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
