### PR TITLE
Use default `{replica}`, `{shard}` arguments in Replicated engine

### DIFF
--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -280,22 +280,16 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
     {
         const ASTFunction * engine = engine_define->engine;
 
-        if (!engine->arguments || engine->arguments->children.empty() || engine->arguments->children.size() > 3)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Replicated database requires at least 1 argument: zookeeper path, and optionally shard name and replica name");
+        if (!engine->arguments || engine->arguments->children.size() != 3)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Replicated database requires 3 arguments: zookeeper path, shard name and replica name");
 
         auto & arguments = engine->arguments->children;
         for (auto & engine_arg : arguments)
             engine_arg = evaluateConstantExpressionOrIdentifierAsLiteral(engine_arg, context);
 
         String zookeeper_path = safeGetLiteralValue<String>(arguments[0], "Replicated");
-        String shard_name = "{shard}";
-        String replica_name = "{replica}";
-
-        if (engine->arguments->children.size() > 1)
-            shard_name = safeGetLiteralValue<String>(arguments[1], "Replicated");
-
-        if (engine->arguments->children.size() > 2)
-            replica_name = safeGetLiteralValue<String>(arguments[2], "Replicated");
+        String shard_name = safeGetLiteralValue<String>(arguments[1], "Replicated");
+        String replica_name  = safeGetLiteralValue<String>(arguments[2], "Replicated");
 
         zookeeper_path = context->getMacros()->expand(zookeeper_path);
         shard_name = context->getMacros()->expand(shard_name);

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -233,7 +233,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
     {
         throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE,
                         "MaterializedMySQL is an experimental database engine. "
-                        "Enable allow_experimental_database_materialized_mysql to use it.");
+                        "Enable allow_experimental_database_materialized_mysql to use it");
     }
 
     if (create.storage->engine->name == "Replicated"
@@ -242,7 +242,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
     {
         throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE,
                         "Replicated is an experimental database engine. "
-                        "Enable allow_experimental_database_replicated to use it.");
+                        "Enable allow_experimental_database_replicated to use it");
     }
 
     if (create.storage->engine->name == "MaterializedPostgreSQL"
@@ -251,7 +251,7 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
     {
         throw Exception(ErrorCodes::UNKNOWN_DATABASE_ENGINE,
                         "MaterializedPostgreSQL is an experimental database engine. "
-                        "Enable allow_experimental_database_materialized_postgresql to use it.");
+                        "Enable allow_experimental_database_materialized_postgresql to use it");
     }
 
     bool need_write_metadata = !create.attach || !fs::exists(metadata_file_path);

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -227,6 +227,16 @@ BlockIO InterpreterCreateQuery::createDatabase(ASTCreateQuery & create)
         metadata_path = metadata_path / "metadata" / database_name_escaped;
     }
 
+    if (create.storage->engine->name == "Replicated" && !internal && !create.attach)
+    {
+        /// Fill in default parameters
+        if (create.storage->engine->arguments->children.size() == 1)
+            create.storage->engine->arguments->children.push_back(std::make_shared<ASTLiteral>("{shard}"));
+
+        if (create.storage->engine->arguments->children.size() == 2)
+            create.storage->engine->arguments->children.push_back(std::make_shared<ASTLiteral>("{replica}"));
+    }
+
     if ((create.storage->engine->name == "MaterializeMySQL" || create.storage->engine->name == "MaterializedMySQL")
         && !getContext()->getSettingsRef().allow_experimental_database_materialized_mysql
         && !internal && !create.attach)

--- a/tests/queries/0_stateless/02710_default_replicated_parameters.reference
+++ b/tests/queries/0_stateless/02710_default_replicated_parameters.reference
@@ -1,0 +1,2 @@
+CREATE DATABASE replicated_database_params\nENGINE = Replicated(\'some/path/default/replicated_database_params\', \'{shard}\', \'{replica}\')
+CREATE DATABASE replicated_database_params\nENGINE = Replicated(\'some/path/default/replicated_database_params\', \'shard_1\', \'{replica}\')

--- a/tests/queries/0_stateless/02710_default_replicated_parameters.sql
+++ b/tests/queries/0_stateless/02710_default_replicated_parameters.sql
@@ -1,0 +1,13 @@
+-- Tags: no-parallel
+
+SET allow_experimental_database_replicated=1;
+
+DROP DATABASE IF EXISTS replicated_database_params;
+
+CREATE DATABASE replicated_database_params ENGINE = Replicated('some/path/' || currentDatabase() || '/replicated_database_params');
+SHOW CREATE DATABASE replicated_database_params;
+DROP DATABASE replicated_database_params;
+
+CREATE DATABASE replicated_database_params ENGINE = Replicated('some/path/' || currentDatabase() || '/replicated_database_params', 'shard_1');
+SHOW CREATE DATABASE replicated_database_params;
+DROP DATABASE replicated_database_params;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)