### PR TITLE
Fix GCS native copy

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -124,7 +124,11 @@ Client::Client(
     auto * endpoint_provider = dynamic_cast<Aws::S3::Endpoint::S3DefaultEpProviderBase *>(accessEndpointProvider().get());
     endpoint_provider->GetBuiltInParameters().GetParameter("Region").GetString(explicit_region);
     endpoint_provider->GetBuiltInParameters().GetParameter("Endpoint").GetString(initial_endpoint);
-    detect_region = explicit_region == Aws::Region::AWS_GLOBAL && initial_endpoint.find(".amazonaws.com") != std::string::npos;
+
+    provider_type = getProviderTypeFromURL(initial_endpoint);
+    LOG_TRACE(log, "Provider type: {}", toString(provider_type));
+
+    detect_region = provider_type == ProviderType::AWS && explicit_region == Aws::Region::AWS_GLOBAL;
 
     cache = std::make_shared<ClientCache>();
     ClientCacheRegistry::instance().registerClient(cache);
@@ -135,6 +139,7 @@ Client::Client(const Client & other)
     , initial_endpoint(other.initial_endpoint)
     , explicit_region(other.explicit_region)
     , detect_region(other.detect_region)
+    , provider_type(other.provider_type)
     , max_redirects(other.max_redirects)
     , log(&Poco::Logger::get("S3Client"))
 {
@@ -176,6 +181,8 @@ void Client::insertRegionOverride(const std::string & bucket, const std::string 
 Model::HeadObjectOutcome Client::HeadObject(const HeadObjectRequest & request) const
 {
     const auto & bucket = request.GetBucket();
+
+    request.setProviderType(provider_type);
 
     if (auto region = getRegionForBucket(bucket); !region.empty())
     {
@@ -315,6 +322,7 @@ std::invoke_result_t<RequestFn, RequestType>
 Client::doRequest(const RequestType & request, RequestFn request_fn) const
 {
     const auto & bucket = request.GetBucket();
+    request.setProviderType(provider_type);
 
     if (auto region = getRegionForBucket(bucket); !region.empty())
     {
@@ -387,6 +395,11 @@ Client::doRequest(const RequestType & request, RequestFn request_fn) const
     throw Exception(ErrorCodes::TOO_MANY_REDIRECTS, "Too many redirects");
 }
 
+ProviderType Client::getProviderType() const
+{
+    return provider_type;
+}
+
 std::string Client::getRegionForBucket(const std::string & bucket, bool force_detect) const
 {
     std::lock_guard lock(cache->region_cache_mutex);
@@ -395,7 +408,6 @@ std::string Client::getRegionForBucket(const std::string & bucket, bool force_de
 
     if (!force_detect && !detect_region)
         return "";
-
 
     LOG_INFO(log, "Resolving region for bucket {}", bucket);
     Aws::S3::Model::HeadBucketRequest req;

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -11,6 +11,7 @@
 #include <IO/S3/Requests.h>
 #include <IO/S3/PocoHTTPClient.h>
 #include <IO/S3/Credentials.h>
+#include <IO/S3/ProviderType.h>
 
 #include <aws/core/Aws.h>
 #include <aws/core/client/DefaultRetryStrategy.h>
@@ -160,6 +161,8 @@ public:
 
     using Aws::S3::S3Client::EnableRequestProcessing;
     using Aws::S3::S3Client::DisableRequestProcessing;
+
+    ProviderType getProviderType() const;
 private:
     Client(size_t max_redirects_,
            const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentials_provider,
@@ -205,6 +208,8 @@ private:
 
     std::string explicit_region;
     mutable bool detect_region = true;
+
+    ProviderType provider_type{ProviderType::UNKNOWN};
 
     mutable std::shared_ptr<ClientCache> cache;
 

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -15,6 +15,7 @@
 #include <IO/HTTPCommon.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
+#include <IO/S3/ProviderType.h>
 
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/HttpResponse.h>
@@ -187,7 +188,7 @@ namespace
     bool checkRequestCanReturn2xxAndErrorInBody(Aws::Http::HttpRequest & request)
     {
         auto query_params = request.GetQueryStringParameters();
-        if (request.HasHeader("x-amz-copy-source"))
+        if (request.HasHeader("x-amz-copy-source") || request.HasHeader("x-goog-copy-source"))
         {
             /// CopyObject https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
             if (query_params.empty())
@@ -259,6 +260,16 @@ void PocoHTTPClient::makeRequestInternal(
     Poco::Logger * log = &Poco::Logger::get("AWSClient");
 
     auto uri = request.GetUri().GetURIString();
+    auto provider_type = getProviderTypeFromURL(uri);
+
+    if (provider_type == ProviderType::GCS)
+    {
+        /// some GCS requests don't like S3 specific headers that the client sets
+        request.DeleteHeader("x-amz-api-version");
+        request.DeleteHeader("amz-sdk-invocation-id");
+        request.DeleteHeader("amz-sdk-request");
+    }
+
     if (enable_s3_requests_logging)
         LOG_TEST(log, "Make request to: {}", uri);
 

--- a/src/IO/S3/ProviderType.cpp
+++ b/src/IO/S3/ProviderType.cpp
@@ -1,0 +1,41 @@
+#include <IO/S3/ProviderType.h>
+
+#if USE_AWS_S3
+
+namespace DB::S3
+{
+
+std::string_view toString(ProviderType provider_type)
+{
+    using enum ProviderType;
+
+    switch (provider_type)
+    {
+        case AWS:
+            return "AWS";
+        case GCS:
+            return "GCS";
+        case UNKNOWN:
+            return "Unknown";
+    }
+}
+
+bool supportsMultiPartCopy(ProviderType provider_type)
+{
+    return provider_type != ProviderType::GCS;
+}
+
+ProviderType getProviderTypeFromURL(const std::string & url)
+{
+    if (url.find(".amazonaws.com") != std::string::npos)
+        return ProviderType::AWS;
+
+    if (url.find("storage.googleapis.com") != std::string::npos)
+        return ProviderType::GCS;
+
+    return ProviderType::UNKNOWN;
+}
+
+}
+
+#endif

--- a/src/IO/S3/ProviderType.cpp
+++ b/src/IO/S3/ProviderType.cpp
@@ -2,6 +2,8 @@
 
 #if USE_AWS_S3
 
+#include <string>
+
 namespace DB::S3
 {
 

--- a/src/IO/S3/ProviderType.h
+++ b/src/IO/S3/ProviderType.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "config.h"
+
+#if USE_AWS_S3
+
+#include <string_view>
+#include <cstdint>
+
+namespace DB::S3
+{
+
+enum class ProviderType : uint8_t
+{
+    AWS,
+    GCS,
+    UNKNOWN
+};
+
+std::string_view toString(ProviderType provider_type);
+
+bool supportsMultiPartCopy(ProviderType provider_type);
+
+ProviderType getProviderTypeFromURL(const std::string & url);
+
+}
+
+#endif

--- a/src/IO/S3/Requests.cpp
+++ b/src/IO/S3/Requests.cpp
@@ -1,0 +1,55 @@
+#include <IO/S3/Requests.h>
+
+#if USE_AWS_S3
+
+#include <Common/logger_useful.h>
+
+namespace DB::S3
+{
+
+Aws::Http::HeaderValueCollection CopyObjectRequest::GetRequestSpecificHeaders() const
+{
+    auto headers = Model::CopyObjectRequest::GetRequestSpecificHeaders();
+    if (provider_type != ProviderType::GCS)
+        return headers;
+
+    /// GCS supports same headers as S3 but with a prefix x-goog instead of x-amz
+    /// we have to replace all the prefixes client set internally
+    const auto replace_with_gcs_header = [&](const std::string & amz_header, const std::string & gcs_header)
+    {
+        if (const auto it = headers.find(amz_header); it != headers.end())
+        {
+            auto header_value = std::move(it->second);
+            headers.erase(it);
+            headers.emplace(gcs_header, std::move(header_value));
+        }
+    };
+
+    replace_with_gcs_header("x-amz-copy-source", "x-goog-copy-source");
+    replace_with_gcs_header("x-amz-metadata-directive", "x-goog-metadata-directive");
+    replace_with_gcs_header("x-amz-storage-class", "x-goog-storage-class");
+
+    /// replace all x-amz-meta- headers
+    std::vector<std::pair<std::string, std::string>> new_meta_headers;
+    for (auto it = headers.begin(); it != headers.end();)
+    {
+        if (it->first.starts_with("x-amz-meta-"))
+        {
+            auto value = std::move(it->second);
+            auto header = "x-goog" + it->first.substr(/* x-amz */ 5);
+            new_meta_headers.emplace_back(std::pair{std::move(header), std::move(value)});
+            it = headers.erase(it);
+        }
+        else
+            ++it;
+    }
+
+    for (auto & [header, value] : new_meta_headers)
+        headers.emplace(std::move(header), std::move(value));
+
+    return headers;
+}
+
+}
+
+#endif

--- a/src/IO/S3/Requests.h
+++ b/src/IO/S3/Requests.h
@@ -5,6 +5,7 @@
 #if USE_AWS_S3
 
 #include <IO/S3/URI.h>
+#include <IO/S3/ProviderType.h>
 
 #include <aws/core/endpoint/EndpointParameter.h>
 #include <aws/s3/model/HeadObjectRequest.h>
@@ -61,9 +62,21 @@ public:
         return uri_override;
     }
 
+    void setProviderType(ProviderType provider_type_) const
+    {
+        provider_type = provider_type_;
+    }
+
 protected:
     mutable std::string region_override;
     mutable std::optional<S3::URI> uri_override;
+    mutable ProviderType provider_type{ProviderType::UNKNOWN};
+};
+
+class CopyObjectRequest : public ExtendedRequest<Model::CopyObjectRequest>
+{
+public:
+    Aws::Http::HeaderValueCollection GetRequestSpecificHeaders() const override;
 };
 
 using HeadObjectRequest = ExtendedRequest<Model::HeadObjectRequest>;
@@ -78,7 +91,6 @@ using UploadPartRequest = ExtendedRequest<Model::UploadPartRequest>;
 using UploadPartCopyRequest = ExtendedRequest<Model::UploadPartCopyRequest>;
 
 using PutObjectRequest = ExtendedRequest<Model::PutObjectRequest>;
-using CopyObjectRequest = ExtendedRequest<Model::CopyObjectRequest>;
 using DeleteObjectRequest = ExtendedRequest<Model::DeleteObjectRequest>;
 using DeleteObjectsRequest = ExtendedRequest<Model::DeleteObjectsRequest>;
 

--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -4,10 +4,12 @@
 
 #include <Common/ProfileEvents.h>
 #include <Common/typeid_cast.h>
+#include <Interpreters/Context.h>
 #include <IO/LimitSeekableReadBuffer.h>
 #include <IO/S3/getObjectInfo.h>
 #include <IO/SeekableReadBuffer.h>
 #include <IO/StdStreamFromReadBuffer.h>
+#include <IO/ReadBufferFromS3.h>
 
 #include <IO/S3/Requests.h>
 
@@ -405,7 +407,7 @@ namespace
     {
     public:
         CopyDataToFileHelper(
-            const std::function<std::unique_ptr<SeekableReadBuffer>()> & create_read_buffer_,
+            const CreateReadBuffer & create_read_buffer_,
             size_t offset_,
             size_t size_,
             const std::shared_ptr<const S3::Client> & client_ptr_,
@@ -584,15 +586,35 @@ namespace
             , src_key(src_key_)
             , offset(src_offset_)
             , size(src_size_)
+            , supports_multipart_copy(S3::supportsMultiPartCopy(client_ptr_->getProviderType()))
         {
         }
 
         void performCopy()
         {
             if (size <= upload_settings.max_single_operation_copy_size)
+            {
                 performSingleOperationCopy();
+            }
+            else if (!supports_multipart_copy)
+            {
+                LOG_INFO(&Poco::Logger::get("copyS3File"), "Multipart upload using copy is not supported, will use regular upload");
+                copyDataToS3File(
+                    getSourceObjectReadBuffer(),
+                    offset,
+                    size,
+                    client_ptr,
+                    dest_bucket,
+                    dest_key,
+                    request_settings,
+                    object_metadata,
+                    schedule,
+                    for_disk_s3);
+            }
             else
+            {
                 performMultipartUploadCopy();
+            }
 
             if (request_settings.check_objects_after_upload)
                 checkObjectAfterUpload();
@@ -603,6 +625,15 @@ namespace
         const String & src_key;
         size_t offset;
         size_t size;
+        bool supports_multipart_copy;
+
+        CreateReadBuffer getSourceObjectReadBuffer()
+        {
+            return [&]
+            {
+                return std::make_unique<ReadBufferFromS3>(client_ptr, src_bucket, src_key, "", request_settings, Context::getGlobalContextInstance()->getReadSettings());
+            };
+        }
 
         void performSingleOperationCopy()
         {
@@ -652,18 +683,39 @@ namespace
                     break;
                 }
 
-                if (outcome.GetError().GetExceptionName() == "EntityTooLarge" || outcome.GetError().GetExceptionName() == "InvalidRequest")
+                if (outcome.GetError().GetExceptionName() == "EntityTooLarge" || outcome.GetError().GetExceptionName() == "InvalidRequest" || outcome.GetError().GetExceptionName() == "InvalidArgument")
                 {
                     // Can't come here with MinIO, MinIO allows single part upload for large objects.
                     LOG_INFO(
                         log,
-                        "Single operation copy failed with error {} for Bucket: {}, Key: {}, Object size: {}, will retry with multipart upload copy",
+                        "Single operation copy failed with error {} for Bucket: {}, Key: {}, Object size: {}, will retry with multipart "
+                        "upload copy",
                         outcome.GetError().GetExceptionName(),
                         dest_bucket,
                         dest_key,
                         size);
-                    performMultipartUploadCopy();
-                    break;
+
+                    if (!supports_multipart_copy)
+                    {
+                        LOG_INFO(log, "Multipart upload using copy is not supported, will try regular upload");
+                        copyDataToS3File(
+                            getSourceObjectReadBuffer(),
+                            offset,
+                            size,
+                            client_ptr,
+                            dest_bucket,
+                            dest_key,
+                            request_settings,
+                            object_metadata,
+                            schedule,
+                            for_disk_s3);
+                        break;
+                    }
+                    else
+                    {
+                        performMultipartUploadCopy();
+                        break;
+                    }
                 }
 
                 if ((outcome.GetError().GetErrorType() == Aws::S3::S3Errors::NO_SUCH_KEY) && (retries < max_retries))

--- a/src/IO/S3/copyS3File.h
+++ b/src/IO/S3/copyS3File.h
@@ -15,6 +15,8 @@ namespace DB
 {
 class SeekableReadBuffer;
 
+using CreateReadBuffer = std::function<std::unique_ptr<SeekableReadBuffer>()>;
+
 /// Copies a file from S3 to S3.
 /// The same functionality can be done by using the function copyData() and the classes ReadBufferFromS3 and WriteBufferFromS3
 /// however copyS3File() is faster and spends less network traffic and memory.
@@ -30,7 +32,7 @@ void copyS3File(
     const S3Settings::RequestSettings & settings,
     const std::optional<std::map<String, String>> & object_metadata = std::nullopt,
     ThreadPoolCallbackRunner<void> schedule_ = {},
-    bool for_disk_s3 =  false);
+    bool for_disk_s3 = false);
 
 /// Copies data from any seekable source to S3.
 /// The same functionality can be done by using the function copyData() and the class WriteBufferFromS3
@@ -38,7 +40,7 @@ void copyS3File(
 /// The callback `create_read_buffer` can be called from multiple threads in parallel, so that should be thread-safe.
 /// The parameters `offset` and `size` specify a part in the source to copy.
 void copyDataToS3File(
-    const std::function<std::unique_ptr<SeekableReadBuffer>()> & create_read_buffer,
+    const CreateReadBuffer & create_read_buffer,
     size_t offset,
     size_t size,
     const std::shared_ptr<const S3::Client> & dest_s3_client,
@@ -47,7 +49,7 @@ void copyDataToS3File(
     const S3Settings::RequestSettings & settings,
     const std::optional<std::map<String, String>> & object_metadata = std::nullopt,
     ThreadPoolCallbackRunner<void> schedule_ = {},
-    bool for_disk_s3 =  false);
+    bool for_disk_s3 = false);
 
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Correctly set headers for native copy operations on GCS.

GCS doesn't support multipart copy, only single object copy.
There is a possibility that we can remove the limitation for object size when it comes to copy, because, based on my tests, it's possible to copy files `> 5GB` using a single request.

There is a problem of copying an object which was created with a multipart upload. If copy is called on such object this error will be produced:
```
Rewriting objects created via Multipart Upload is not implemented yet. As a workaround, you can use compose to overwrite the object (by specifying nhsa6s1smucz.us-central1.gcs.gcp.clickhouse-staging.com/file.csv as both the source and output of compose) prior to rewrite
```

`ComposeRequest` will be added in future PRs but there is a problem of getting random 503 error codes when I try to call it on completed multipart upload. 

Until that is fixed, with this PR, we are sure that the copying will fallback to manual data copying inside CH instead of simply failing.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
