### PR TITLE
Allow full read from system database

### DIFF
--- a/src/Access/User.cpp
+++ b/src/Access/User.cpp
@@ -18,7 +18,7 @@ bool User::equal(const IAccessEntity & other) const
     return (auth_data == other_user.auth_data) && (allowed_client_hosts == other_user.allowed_client_hosts)
         && (access == other_user.access) && (granted_roles == other_user.granted_roles) && (default_roles == other_user.default_roles)
         && (settings == other_user.settings) && (grantees == other_user.grantees) && (default_database == other_user.default_database)
-        && (allow_full_read_from_system_tables == other_user.allow_full_read_from_system_tables);
+        && (allow_full_read_from_system_databases == other_user.allow_full_read_from_system_databases);
 }
 
 void User::setName(const String & name_)

--- a/src/Access/User.cpp
+++ b/src/Access/User.cpp
@@ -17,7 +17,8 @@ bool User::equal(const IAccessEntity & other) const
     const auto & other_user = typeid_cast<const User &>(other);
     return (auth_data == other_user.auth_data) && (allowed_client_hosts == other_user.allowed_client_hosts)
         && (access == other_user.access) && (granted_roles == other_user.granted_roles) && (default_roles == other_user.default_roles)
-        && (settings == other_user.settings) && (grantees == other_user.grantees) && (default_database == other_user.default_database);
+        && (settings == other_user.settings) && (grantees == other_user.grantees) && (default_database == other_user.default_database)
+        && (allow_full_read_from_system_tables == other_user.allow_full_read_from_system_tables);
 }
 
 void User::setName(const String & name_)

--- a/src/Access/User.h
+++ b/src/Access/User.h
@@ -24,6 +24,8 @@ struct User : public IAccessEntity
     RolesOrUsersSet grantees = RolesOrUsersSet::AllTag{};
     String default_database;
 
+    bool allow_full_read_from_system_tables = false;
+
     bool equal(const IAccessEntity & other) const override;
     std::shared_ptr<IAccessEntity> clone() const override { return cloneImpl<User>(); }
     static constexpr const auto TYPE = AccessEntityType::USER;

--- a/src/Access/User.h
+++ b/src/Access/User.h
@@ -24,7 +24,7 @@ struct User : public IAccessEntity
     RolesOrUsersSet grantees = RolesOrUsersSet::AllTag{};
     String default_database;
 
-    bool allow_full_read_from_system_tables = false;
+    bool allow_full_read_from_system_databases = false;
 
     bool equal(const IAccessEntity & other) const override;
     std::shared_ptr<IAccessEntity> clone() const override { return cloneImpl<User>(); }

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -248,6 +248,8 @@ namespace
         String default_database = config.getString(user_config + ".default_database", "");
         user->default_database = default_database;
 
+        user->allow_full_read_from_system_tables = config.getBool(user_config + ".allow_full_read_from_system_tables", false);
+
         return user;
     }
 

--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -248,7 +248,7 @@ namespace
         String default_database = config.getString(user_config + ".default_database", "");
         user->default_database = default_database;
 
-        user->allow_full_read_from_system_tables = config.getBool(user_config + ".allow_full_read_from_system_tables", false);
+        user->allow_full_read_from_system_databases = config.getBool(user_config + ".allow_full_read_from_system_databases", false);
 
         return user;
     }

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -92,7 +92,7 @@ protected:
         size_t rows_count = 0;
 
         const auto user = access->getUser();
-        const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+        const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
         while (rows_count < max_block_size && db_table_num < total_tables)
         {

--- a/src/Storages/System/StorageSystemColumns.cpp
+++ b/src/Storages/System/StorageSystemColumns.cpp
@@ -12,6 +12,7 @@
 #include <Storages/VirtualColumnUtils.h>
 #include <Parsers/queryToString.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Databases/IDatabase.h>
 #include <Processors/Sources/NullSource.h>
 #include <Interpreters/Context.h>
@@ -90,7 +91,8 @@ protected:
         MutableColumns res_columns = getPort().getHeader().cloneEmptyColumns();
         size_t rows_count = 0;
 
-        const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_COLUMNS);
+        const auto user = access->getUser();
+        const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
         while (rows_count < max_block_size && db_table_num < total_tables)
         {

--- a/src/Storages/System/StorageSystemDataSkippingIndices.cpp
+++ b/src/Storages/System/StorageSystemDataSkippingIndices.cpp
@@ -1,5 +1,6 @@
 #include <Storages/System/StorageSystemDataSkippingIndices.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Columns/ColumnString.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -64,7 +65,8 @@ protected:
         MutableColumns res_columns = getPort().getHeader().cloneEmptyColumns();
 
         const auto access = context->getAccess();
-        const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES);
+        const auto user = access->getUser();
+        const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
         size_t rows_count = 0;
         while (rows_count < max_block_size)

--- a/src/Storages/System/StorageSystemDataSkippingIndices.cpp
+++ b/src/Storages/System/StorageSystemDataSkippingIndices.cpp
@@ -66,7 +66,7 @@ protected:
 
         const auto access = context->getAccess();
         const auto user = access->getUser();
-        const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+        const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
         size_t rows_count = 0;
         while (rows_count < max_block_size)

--- a/src/Storages/System/StorageSystemDatabases.cpp
+++ b/src/Storages/System/StorageSystemDatabases.cpp
@@ -3,6 +3,7 @@
 #include <DataTypes/DataTypeUUID.h>
 #include <Interpreters/Context.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Storages/System/StorageSystemDatabases.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Common/logger_useful.h>
@@ -71,7 +72,8 @@ static String getEngineFull(const DatabasePtr & database)
 void StorageSystemDatabases::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo &) const
 {
     const auto access = context->getAccess();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_DATABASES);
+    const auto user = access->getUser();
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_DATABASES) && !user->allow_full_read_from_system_tables;
 
     const auto databases = DatabaseCatalog::instance().getDatabases();
     for (const auto & [database_name, database] : databases)

--- a/src/Storages/System/StorageSystemDatabases.cpp
+++ b/src/Storages/System/StorageSystemDatabases.cpp
@@ -73,7 +73,7 @@ void StorageSystemDatabases::fillData(MutableColumns & res_columns, ContextPtr c
 {
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_DATABASES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_DATABASES) && !user->allow_full_read_from_system_databases;
 
     const auto databases = DatabaseCatalog::instance().getDatabases();
     for (const auto & [database_name, database] : databases)

--- a/src/Storages/System/StorageSystemDistributionQueue.cpp
+++ b/src/Storages/System/StorageSystemDistributionQueue.cpp
@@ -8,6 +8,7 @@
 #include <Storages/StorageDistributed.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Common/typeid_cast.h>
 #include <Interpreters/Context.h>
 #include <Databases/IDatabase.h>
@@ -109,7 +110,8 @@ NamesAndTypesList StorageSystemDistributionQueue::getNamesAndTypes()
 void StorageSystemDistributionQueue::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo & query_info) const
 {
     const auto access = context->getAccess();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES);
+    const auto user = access->getUser();
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
     std::map<String, std::map<String, StoragePtr>> tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())

--- a/src/Storages/System/StorageSystemDistributionQueue.cpp
+++ b/src/Storages/System/StorageSystemDistributionQueue.cpp
@@ -111,7 +111,7 @@ void StorageSystemDistributionQueue::fillData(MutableColumns & res_columns, Cont
 {
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
     std::map<String, std::map<String, StoragePtr>> tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())

--- a/src/Storages/System/StorageSystemMerges.cpp
+++ b/src/Storages/System/StorageSystemMerges.cpp
@@ -41,7 +41,7 @@ void StorageSystemMerges::fillData(MutableColumns & res_columns, ContextPtr cont
 {
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
     for (const auto & merge : context->getMergeList().get())
     {

--- a/src/Storages/System/StorageSystemMerges.cpp
+++ b/src/Storages/System/StorageSystemMerges.cpp
@@ -2,6 +2,7 @@
 #include <Storages/MergeTree/MergeList.h>
 #include <Storages/System/StorageSystemMerges.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 
 
 namespace DB
@@ -39,7 +40,8 @@ NamesAndTypesList StorageSystemMerges::getNamesAndTypes()
 void StorageSystemMerges::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo &) const
 {
     const auto access = context->getAccess();
-    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES);
+    const auto user = access->getUser();
+    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
     for (const auto & merge : context->getMergeList().get())
     {

--- a/src/Storages/System/StorageSystemMoves.cpp
+++ b/src/Storages/System/StorageSystemMoves.cpp
@@ -27,7 +27,7 @@ void StorageSystemMoves::fillData(MutableColumns & res_columns, ContextPtr conte
 {
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
     for (const auto & move : context->getMovesList().get())
     {

--- a/src/Storages/System/StorageSystemMoves.cpp
+++ b/src/Storages/System/StorageSystemMoves.cpp
@@ -2,6 +2,7 @@
 #include <Storages/MergeTree/MovesList.h>
 #include <Storages/System/StorageSystemMoves.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 
 
 namespace DB
@@ -25,7 +26,8 @@ NamesAndTypesList StorageSystemMoves::getNamesAndTypes()
 void StorageSystemMoves::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo &) const
 {
     const auto access = context->getAccess();
-    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES);
+    const auto user = access->getUser();
+    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
     for (const auto & move : context->getMovesList().get())
     {

--- a/src/Storages/System/StorageSystemMutations.cpp
+++ b/src/Storages/System/StorageSystemMutations.cpp
@@ -40,7 +40,7 @@ void StorageSystemMutations::fillData(MutableColumns & res_columns, ContextPtr c
 {
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
     /// Collect a set of *MergeTree tables.
     std::map<String, std::map<String, StoragePtr>> merge_tree_tables;

--- a/src/Storages/System/StorageSystemMutations.cpp
+++ b/src/Storages/System/StorageSystemMutations.cpp
@@ -7,6 +7,7 @@
 #include <Storages/MergeTree/MergeTreeMutationStatus.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Databases/IDatabase.h>
 #include <Interpreters/Context.h>
 
@@ -38,7 +39,8 @@ NamesAndTypesList StorageSystemMutations::getNamesAndTypes()
 void StorageSystemMutations::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo & query_info) const
 {
     const auto access = context->getAccess();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES);
+    const auto user = access->getUser();
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
     /// Collect a set of *MergeTree tables.
     std::map<String, std::map<String, StoragePtr>> merge_tree_tables;

--- a/src/Storages/System/StorageSystemPartMovesBetweenShards.cpp
+++ b/src/Storages/System/StorageSystemPartMovesBetweenShards.cpp
@@ -1,4 +1,5 @@
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Columns/ColumnString.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDateTime.h>
@@ -45,7 +46,8 @@ NamesAndTypesList StorageSystemPartMovesBetweenShards::getNamesAndTypes()
 void StorageSystemPartMovesBetweenShards::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo & query_info) const
 {
     const auto access = context->getAccess();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES);
+    const auto user = access->getUser();
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
     std::map<String, std::map<String, StoragePtr>> replicated_tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())

--- a/src/Storages/System/StorageSystemPartMovesBetweenShards.cpp
+++ b/src/Storages/System/StorageSystemPartMovesBetweenShards.cpp
@@ -47,7 +47,7 @@ void StorageSystemPartMovesBetweenShards::fillData(MutableColumns & res_columns,
 {
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
     std::map<String, std::map<String, StoragePtr>> replicated_tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())

--- a/src/Storages/System/StorageSystemPartsBase.cpp
+++ b/src/Storages/System/StorageSystemPartsBase.cpp
@@ -10,6 +10,7 @@
 #include <Storages/StorageMaterializedMySQL.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Databases/IDatabase.h>
 #include <Parsers/queryToString.h>
 #include <Parsers/ASTIdentifier.h>
@@ -94,7 +95,8 @@ StoragesInfoStream::StoragesInfoStream(const SelectQueryInfo & query_info, Conte
     MutableColumnPtr active_column_mut = ColumnUInt8::create();
 
     const auto access = context->getAccess();
-    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES);
+    const auto user = access->getUser();
+    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
     {
         Databases databases = DatabaseCatalog::instance().getDatabases();

--- a/src/Storages/System/StorageSystemPartsBase.cpp
+++ b/src/Storages/System/StorageSystemPartsBase.cpp
@@ -96,7 +96,7 @@ StoragesInfoStream::StoragesInfoStream(const SelectQueryInfo & query_info, Conte
 
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
     {
         Databases databases = DatabaseCatalog::instance().getDatabases();

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -83,7 +83,7 @@ Pipe StorageSystemReplicas::read(
 
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
     /// We collect a set of replicated tables.
     std::map<String, std::map<String, StoragePtr>> replicated_tables;

--- a/src/Storages/System/StorageSystemReplicas.cpp
+++ b/src/Storages/System/StorageSystemReplicas.cpp
@@ -7,6 +7,7 @@
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Databases/IDatabase.h>
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <Common/typeid_cast.h>
@@ -81,7 +82,8 @@ Pipe StorageSystemReplicas::read(
     storage_snapshot->check(column_names);
 
     const auto access = context->getAccess();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES);
+    const auto user = access->getUser();
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
     /// We collect a set of replicated tables.
     std::map<String, std::map<String, StoragePtr>> replicated_tables;

--- a/src/Storages/System/StorageSystemReplicatedFetches.cpp
+++ b/src/Storages/System/StorageSystemReplicatedFetches.cpp
@@ -35,7 +35,7 @@ void StorageSystemReplicatedFetches::fillData(MutableColumns & res_columns, Cont
 {
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
     for (const auto & fetch : context->getReplicatedFetchList().get())
     {

--- a/src/Storages/System/StorageSystemReplicatedFetches.cpp
+++ b/src/Storages/System/StorageSystemReplicatedFetches.cpp
@@ -4,6 +4,7 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/Context.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 
 namespace DB
 {
@@ -33,7 +34,8 @@ NamesAndTypesList StorageSystemReplicatedFetches::getNamesAndTypes()
 void StorageSystemReplicatedFetches::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo &) const
 {
     const auto access = context->getAccess();
-    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES);
+    const auto user = access->getUser();
+    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
     for (const auto & fetch : context->getReplicatedFetchList().get())
     {

--- a/src/Storages/System/StorageSystemReplicationQueue.cpp
+++ b/src/Storages/System/StorageSystemReplicationQueue.cpp
@@ -53,7 +53,7 @@ void StorageSystemReplicationQueue::fillData(MutableColumns & res_columns, Conte
 {
     const auto access = context->getAccess();
     const auto user = access->getUser();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
     std::map<String, std::map<String, StoragePtr>> replicated_tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())

--- a/src/Storages/System/StorageSystemReplicationQueue.cpp
+++ b/src/Storages/System/StorageSystemReplicationQueue.cpp
@@ -9,6 +9,7 @@
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Storages/VirtualColumnUtils.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Common/typeid_cast.h>
 #include <Databases/IDatabase.h>
 
@@ -51,7 +52,8 @@ NamesAndTypesList StorageSystemReplicationQueue::getNamesAndTypes()
 void StorageSystemReplicationQueue::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo & query_info) const
 {
     const auto access = context->getAccess();
-    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES);
+    const auto user = access->getUser();
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
     std::map<String, std::map<String, StoragePtr>> replicated_tables;
     for (const auto & db : DatabaseCatalog::instance().getDatabases())

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -8,6 +8,7 @@
 #include <Storages/VirtualColumnUtils.h>
 #include <Databases/IDatabase.h>
 #include <Access/ContextAccess.h>
+#include <Access/User.h>
 #include <Interpreters/Context.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
@@ -140,7 +141,8 @@ protected:
         MutableColumns res_columns = getPort().getHeader().cloneEmptyColumns();
 
         const auto access = context->getAccess();
-        const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES);
+        const auto user = access->getUser();
+        const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
 
         size_t rows_count = 0;
         while (rows_count < max_block_size)

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -142,7 +142,7 @@ protected:
 
         const auto access = context->getAccess();
         const auto user = access->getUser();
-        const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_tables;
+        const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_TABLES) && !user->allow_full_read_from_system_databases;
 
         size_t rows_count = 0;
         while (rows_count < max_block_size)

--- a/tests/integration/test_full_read_from_system_tables/configs/another_user.xml
+++ b/tests/integration/test_full_read_from_system_tables/configs/another_user.xml
@@ -1,0 +1,29 @@
+<clickhouse>
+    <users>
+        <another>
+            <password/>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+            <allow_databases>
+                <database>system</database>
+            </allow_databases>
+            <allow_full_read_from_system_tables>1</allow_full_read_from_system_tables>
+        </another>
+
+        <restricted>
+            <password/>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+            <allow_databases>
+                <database>system</database>
+            </allow_databases>
+            <allow_full_read_from_system_tables>0</allow_full_read_from_system_tables>
+        </restricted>
+    </users>
+</clickhouse>

--- a/tests/integration/test_full_read_from_system_tables/configs/another_user.xml
+++ b/tests/integration/test_full_read_from_system_tables/configs/another_user.xml
@@ -10,7 +10,7 @@
             <allow_databases>
                 <database>system</database>
             </allow_databases>
-            <allow_full_read_from_system_tables>1</allow_full_read_from_system_tables>
+            <allow_full_read_from_system_databases>1</allow_full_read_from_system_databases>
         </another>
 
         <restricted>
@@ -23,7 +23,7 @@
             <allow_databases>
                 <database>system</database>
             </allow_databases>
-            <allow_full_read_from_system_tables>0</allow_full_read_from_system_tables>
+            <allow_full_read_from_system_databases>0</allow_full_read_from_system_databases>
         </restricted>
     </users>
 </clickhouse>

--- a/tests/integration/test_full_read_from_system_tables/test.py
+++ b/tests/integration/test_full_read_from_system_tables/test.py
@@ -1,0 +1,38 @@
+import pytest
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import TSV
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    user_configs=[
+        "configs/another_user.xml",
+    ],
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        node.query("CREATE DATABASE mydb")
+        node.query("CREATE TABLE mydb.table1(x UInt32) ENGINE=Log")
+        node.query("CREATE TABLE mydb.table2(x UInt32) ENGINE=Log")
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def test_full_read_from_system_tables():
+    assert node.query("SELECT name FROM system.tables WHERE database = 'mydb'") == TSV([
+        'table1',
+        'table2',
+    ])
+
+    assert node.query("SELECT name FROM system.tables WHERE database = 'mydb'", user="another") == TSV([
+        'table1',
+        'table2',
+    ])
+
+    assert node.query("SELECT name FROM system.tables WHERE database = 'mydb'", user="restricted") == TSV([])

--- a/tests/integration/test_full_read_from_system_tables/test.py
+++ b/tests/integration/test_full_read_from_system_tables/test.py
@@ -25,14 +25,22 @@ def started_cluster():
 
 
 def test_full_read_from_system_tables():
-    assert node.query("SELECT name FROM system.tables WHERE database = 'mydb'") == TSV([
-        'table1',
-        'table2',
-    ])
+    assert node.query("SELECT name FROM system.tables WHERE database = 'mydb'") == TSV(
+        [
+            "table1",
+            "table2",
+        ]
+    )
 
-    assert node.query("SELECT name FROM system.tables WHERE database = 'mydb'", user="another") == TSV([
-        'table1',
-        'table2',
-    ])
+    assert node.query(
+        "SELECT name FROM system.tables WHERE database = 'mydb'", user="another"
+    ) == TSV(
+        [
+            "table1",
+            "table2",
+        ]
+    )
 
-    assert node.query("SELECT name FROM system.tables WHERE database = 'mydb'", user="restricted") == TSV([])
+    assert node.query(
+        "SELECT name FROM system.tables WHERE database = 'mydb'", user="restricted"
+    ) == TSV([])


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add `allow_full_read_from_system_databases` user setting, which allows reading all rows from system tables even without grants to related tables. This setting doesn't grant read on `system.*` by itself!

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


Example of usage:
```
<users>
  <user_name>
    <allow_full_read_from_system_databases>1</allow_full_read_from_system_databases>
    <allow_databases>
        <database>system</database>
    </allow_databases>
    
    <!-- ... -->
  </user_name>
</users>
```

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
