### PR TITLE
Fix build error for big-endian platforms

### DIFF
--- a/src/Functions/FunctionsCodingULID.cpp
+++ b/src/Functions/FunctionsCodingULID.cpp
@@ -158,8 +158,9 @@ public:
         Int64 ms = 0;
         memcpy(reinterpret_cast<UInt8 *>(&ms) + 2, buffer, 6);
 
-        if constexpr (std::endian::native == std::endian::little)
-            std::reverse(reinterpret_cast<UInt8 *>(&ms), reinterpret_cast<UInt8 *>(&ms) + sizeof(Int64));
+#    if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        ms = std::byteswap(ms);
+#    endif
 
         return DecimalUtils::decimalFromComponents<DateTime64>(ms / intExp10(DATETIME_SCALE), ms % intExp10(DATETIME_SCALE), DATETIME_SCALE);
     }


### PR DESCRIPTION
Unfortunately, using `if constexpr (std::endian::native == std::endian::little)` results in a build error for big-endian platforms:
```
[build] /root/ClickHouse/src/Functions/FunctionsCodingULID.cpp:162:13: error: code will never be executed [-Werror,-Wunreachable-code]
[build]             std::reverse(reinterpret_cast<UInt8 *>(&ms), reinterpret_cast<UInt8 *>(&ms) + sizeof(Int64));
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)