### PR TITLE
Add the context to the exception message about query paramters

### DIFF
--- a/tests/queries/0_stateless/02723_param_exception_message_context.reference
+++ b/tests/queries/0_stateless/02723_param_exception_message_context.reference
@@ -1,0 +1,1 @@
+for query parameter 'x'

--- a/tests/queries/0_stateless/02723_param_exception_message_context.sh
+++ b/tests/queries/0_stateless/02723_param_exception_message_context.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+-- The exception message about unparsed parameter also tells about the name of the parameter.
+$CLICKHOUSE_CLIENT --param_x Hello --query "SELECT {x:Array(String)}" 2>&1 | rg -oF "for query parameter 'x'" | uniq

--- a/tests/queries/0_stateless/02723_param_exception_message_context.sh
+++ b/tests/queries/0_stateless/02723_param_exception_message_context.sh
@@ -5,5 +5,5 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
--- The exception message about unparsed parameter also tells about the name of the parameter.
+# The exception message about unparsed parameter also tells about the name of the parameter.
 $CLICKHOUSE_CLIENT --param_x Hello --query "SELECT {x:Array(String)}" 2>&1 | rg -oF "for query parameter 'x'" | uniq


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The exception message about the unparsed query parameter will also tell about the name of the parameter. Reimplement #48878. Close #48772