### PR TITLE
Enforce documentation change for a new-feature PR

### DIFF
--- a/docker/docs/builder/Dockerfile
+++ b/docker/docs/builder/Dockerfile
@@ -1,4 +1,3 @@
-# rebuild in #36968
 # docker build -t clickhouse/docs-builder .
 # nodejs 17 prefers ipv6 and is broken in our environment
 FROM node:16-alpine

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -383,15 +383,16 @@ CI_CONFIG = {
 
 # checks required by Mergeable Check
 REQUIRED_CHECKS = [
-    "Fast test",
-    "Style Check",
     "ClickHouse build check",
     "ClickHouse special build check",
+    "Docs Check",
+    "Fast test",
     "Stateful tests (release)",
     "Stateless tests (release)",
-    "Unit tests (release-clang)",
+    "Style Check",
     "Unit tests (asan)",
     "Unit tests (msan)",
+    "Unit tests (release-clang)",
     "Unit tests (tsan)",
     "Unit tests (ubsan)",
 ]

--- a/tests/ci/commit_status_helper.py
+++ b/tests/ci/commit_status_helper.py
@@ -95,6 +95,7 @@ def remove_labels(gh: Github, pr_info: PRInfo, labels_names: List[str]) -> None:
     pull_request = repo.get_pull(pr_info.number)
     for label in labels_names:
         pull_request.remove_from_labels(label)
+        pr_info.labels.remove(label)
 
 
 def post_labels(gh: Github, pr_info: PRInfo, labels_names: List[str]) -> None:
@@ -102,6 +103,7 @@ def post_labels(gh: Github, pr_info: PRInfo, labels_names: List[str]) -> None:
     pull_request = repo.get_pull(pr_info.number)
     for label in labels_names:
         pull_request.add_to_labels(label)
+        pr_info.labels.add(label)
 
 
 def format_description(description: str) -> str:

--- a/tests/ci/docs_check.py
+++ b/tests/ci/docs_check.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import atexit
 import logging
 import subprocess
 import os
@@ -8,7 +9,7 @@ import sys
 from github import Github
 
 from clickhouse_helper import ClickHouseHelper, prepare_tests_results_for_clickhouse
-from commit_status_helper import post_commit_status, get_commit
+from commit_status_helper import post_commit_status, get_commit, update_mergeable_check
 from docker_pull_helper import get_image_with_version
 from env_helper import TEMP_PATH, REPO_COPY
 from get_robot_token import get_best_robot_token
@@ -56,6 +57,7 @@ def main():
     if rerun_helper.is_already_finished_by_status():
         logging.info("Check is already finished according to github status, exiting")
         sys.exit(0)
+    atexit.register(update_mergeable_check, gh, pr_info, NAME)
 
     if not pr_info.has_changes_in_documentation() and not args.force:
         logging.info("No changes in documentation")

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -13,6 +13,7 @@ from commit_status_helper import (
     remove_labels,
     set_mergeable_check,
 )
+from docs_check import NAME as DOCS_NAME
 from env_helper import GITHUB_RUN_URL, GITHUB_REPOSITORY, GITHUB_SERVER_URL
 from get_robot_token import get_best_robot_token
 from pr_info import FORCE_TESTS_LABEL, PRInfo
@@ -27,6 +28,7 @@ TRUSTED_ORG_IDS = {
 OK_SKIP_LABELS = {"release", "pr-backport", "pr-cherrypick"}
 CAN_BE_TESTED_LABEL = "can be tested"
 DO_NOT_TEST_LABEL = "do not test"
+FEATURE_LABEL = "pr-feature"
 SUBMODULE_CHANGED_LABEL = "submodule changed"
 
 # They are used in .github/PULL_REQUEST_TEMPLATE.md, keep comments there
@@ -249,7 +251,15 @@ if __name__ == "__main__":
     if pr_labels_to_remove:
         remove_labels(gh, pr_info, pr_labels_to_remove)
 
-    set_mergeable_check(commit, "skipped")
+    if FEATURE_LABEL in pr_labels_to_add:
+        print(f"The '{FEATURE_LABEL}' in the labels, expect the 'Docs Check' status")
+        commit.create_status(
+            context=DOCS_NAME,
+            description=f"expect adding docs for {FEATURE_LABEL}",
+            state="pending",
+        )
+    else:
+        set_mergeable_check(commit, "skipped")
 
     if description_error:
         print(

--- a/tests/ci/run_check.py
+++ b/tests/ci/run_check.py
@@ -251,7 +251,7 @@ if __name__ == "__main__":
     if pr_labels_to_remove:
         remove_labels(gh, pr_info, pr_labels_to_remove)
 
-    if FEATURE_LABEL in pr_labels_to_add:
+    if FEATURE_LABEL in pr_info.labels:
         print(f"The '{FEATURE_LABEL}' in the labels, expect the 'Docs Check' status")
         commit.create_status(
             context=DOCS_NAME,


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Not for changelog


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enforce changed documentation for PRs with new features. The `Docs Check` will be marked as `pending` and the `Mergeable Check` will be green only after the check is done.

Fixes #49041 