### PR TITLE
Update build.md

### DIFF
--- a/docs/en/development/build.md
+++ b/docs/en/development/build.md
@@ -118,7 +118,7 @@ sudo yum --nogpg install git cmake make clang python3 ccache yasm gawk
 git clone --recursive https://github.com/ClickHouse/ClickHouse.git
 mkdir build && cd build
 cmake ../ClickHouse
-make -j $(nproc)
+ninja
 ```
 
 Here is an example of how to build `clang` and all the llvm infrastructure from sources:


### PR DESCRIPTION
On Fedora I could not build with `make`, I had to use `ninja`.  Error:
```
❯ make -j $(nproc)
make: *** No targets specified and no makefile found.  Stop.
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
