### PR TITLE
Fix ORDER BY <UUID> on big endian machines

### DIFF
--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -46,7 +46,22 @@ struct CompareHelper
       */
     static constexpr int compare(T a, U b, int /*nan_direction_hint*/)
     {
-        return a > b ? 1 : (a < b ? -1 : 0);
+        if constexpr (std::endian::native == std::endian::big && std::same_as<T, UUID> && std::same_as<U, UUID>)
+        {
+            UUID tmp_a = a;
+            char *start = reinterpret_cast<char *>(&tmp_a);
+            char *end = start + sizeof(tmp_a);
+            std::reverse(start, end);
+
+            UUID tmp_b = b;
+            start = reinterpret_cast<char *>(&tmp_b);
+            end = start + sizeof(tmp_b);
+            std::reverse(start, end);
+
+            return tmp_a > tmp_b ? 1 : (tmp_a < tmp_b ? -1 : 0);
+        }
+        else
+            return a > b ? 1 : (a < b ? -1 : 0);
     }
 };
 

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -58,7 +58,7 @@ struct CompareHelper
             end = start + sizeof(tmp_b);
             std::reverse(start, end);
 
-            return tmp_a > tmp_b ? 1 : (tmp_a < tmp_b ? -1 : 0);
+            return memcmp(&tmp_a, &tmp_b, sizeof(UUID));
         }
         else
             return a > b ? 1 : (a < b ? -1 : 0);


### PR DESCRIPTION
On big-endian machines like s390x, when SQL SELECT has "ORDER BY" UUID, the ordered result is different from the result on little-endian machines. This fails the functional tests like 01533_distinct_nullable_uuid.

The fix is to reverse the byte orders of UUIDs and compare the reversed UUIDs on big-endian machines so that it generates same "ORDER BY" results as those in little-endian machines.

### Changelog category (leave one):
- Not For Changelog

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed ORDER BY <UUDI> on big endian machines (e.g. s390x)