### PR TITLE
Revert "Fix GCS native copy (#48981)"

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -260,6 +260,7 @@ void PocoHTTPClient::makeRequestInternal(
     Poco::Logger * log = &Poco::Logger::get("AWSClient");
 
     auto uri = request.GetUri().GetURIString();
+#if 0
     auto provider_type = getProviderTypeFromURL(uri);
 
     if (provider_type == ProviderType::GCS)
@@ -269,6 +270,7 @@ void PocoHTTPClient::makeRequestInternal(
         request.DeleteHeader("amz-sdk-invocation-id");
         request.DeleteHeader("amz-sdk-request");
     }
+#endif
 
     if (enable_s3_requests_logging)
         LOG_TEST(log, "Make request to: {}", uri);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix reading from GCS storage with s3 compatibility API

### Documentation entry for user-facing changes

Partially reverts https://github.com/ClickHouse/ClickHouse/pull/48981
This PR has broken s3 disks over GCS (with s3 compat API). Reverting the header changes make them work again.

cc @antonio2368 

More details about the issue coming in a ticket
