### PR TITLE
Slight improvements to coordinator logging

### DIFF
--- a/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
+++ b/src/Storages/MergeTree/ParallelReplicasReadingCoordinator.cpp
@@ -131,7 +131,7 @@ public:
 
 DefaultCoordinator::~DefaultCoordinator()
 {
-    LOG_INFO(log, "Coordination done: {}", toString(stats));
+    LOG_DEBUG(log, "Coordination done: {}", toString(stats));
 }
 
 void DefaultCoordinator::updateReadingState(const InitialAllRangesAnnouncement & announcement)
@@ -214,7 +214,7 @@ void DefaultCoordinator::finalizeReadingState()
         description += fmt::format("Replicas: ({}) --- ", fmt::join(part.replicas, ","));
     }
 
-    LOG_INFO(log, "Reading state is fully initialized: {}", description);
+    LOG_DEBUG(log, "Reading state is fully initialized: {}", description);
 }
 
 
@@ -228,7 +228,7 @@ void DefaultCoordinator::handleInitialAllRangesAnnouncement(InitialAllRangesAnno
     stats[announcement.replica_num].number_of_requests +=1;
 
     ++sent_initial_requests;
-    LOG_INFO(log, "{} {}", sent_initial_requests, replicas_count);
+    LOG_DEBUG(log, "Sent initial requests: {} Replicas count: {}", sent_initial_requests, replicas_count);
     if (sent_initial_requests == replicas_count)
         finalizeReadingState();
 }
@@ -334,7 +334,7 @@ public:
     {}
     ~InOrderCoordinator() override
     {
-        LOG_INFO(log, "Coordination done: {}", toString(stats));
+        LOG_DEBUG(log, "Coordination done: {}", toString(stats));
     }
 
     ParallelReadResponse handleRequest([[ maybe_unused ]]  ParallelReadRequest request) override;
@@ -349,7 +349,7 @@ public:
 template <CoordinationMode mode>
 void InOrderCoordinator<mode>::handleInitialAllRangesAnnouncement(InitialAllRangesAnnouncement announcement)
 {
-    LOG_TRACE(log, "Received an announecement {}", announcement.describe());
+    LOG_TRACE(log, "Received an announcement {}", announcement.describe());
 
     /// To get rid of duplicates
     for (const auto & part: announcement.description)

--- a/src/Storages/MergeTree/RangesInDataPart.cpp
+++ b/src/Storages/MergeTree/RangesInDataPart.cpp
@@ -1,12 +1,23 @@
 #include <Storages/MergeTree/RangesInDataPart.h>
 
-#include <Storages/MergeTree/IMergeTreeDataPart.h>
-
-#include "IO/VarInt.h"
+#include <fmt/format.h>
 
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
+#include <Storages/MergeTree/IMergeTreeDataPart.h>
+#include "IO/VarInt.h"
 
+template <>
+struct fmt::formatter<DB::RangesInDataPartDescription>
+{
+    static constexpr auto parse(format_parse_context & ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const DB::RangesInDataPartDescription & range, FormatContext & ctx)
+    {
+        return format_to(ctx.out(), "{}", range.describe());
+    }
+};
 
 namespace DB
 {
@@ -26,8 +37,7 @@ void RangesInDataPartDescription::serialize(WriteBuffer & out) const
 String RangesInDataPartDescription::describe() const
 {
     String result;
-    result += fmt::format("Part: {}, ", info.getPartNameV1());
-    result += fmt::format("Ranges: [{}], ", fmt::join(ranges, ","));
+    result += fmt::format("part {} with ranges [{}]", info.getPartNameV1(), fmt::join(ranges, ","));
     return result;
 }
 
@@ -46,10 +56,7 @@ void RangesInDataPartsDescription::serialize(WriteBuffer & out) const
 
 String RangesInDataPartsDescription::describe() const
 {
-    String result;
-    for (const auto & desc : *this)
-        result += desc.describe() + ",";
-    return result;
+    return fmt::format("{} parts: [{}]", this->size(), fmt::join(*this, ", "));
 }
 
 void RangesInDataPartsDescription::deserialize(ReadBuffer & in)

--- a/src/Storages/MergeTree/RequestResponse.cpp
+++ b/src/Storages/MergeTree/RequestResponse.cpp
@@ -88,10 +88,7 @@ void ParallelReadResponse::serialize(WriteBuffer & out) const
 
 String ParallelReadResponse::describe() const
 {
-    String result;
-    result += fmt::format("finish: {} \n", finish);
-    result += description.describe();
-    return result;
+    return fmt::format("{}. Finish: {}", description.describe(), finish);
 }
 
 void ParallelReadResponse::deserialize(ReadBuffer & in)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

* Changed some logs from INFO to DEBUG as they appear in each request and became too verbose.
* Improved the formatting about coordinator requests:

Before:
```
2023.04.26 15:20:12.364621 [ 2251619 ] {b498fdbc-cc76-4fb8-8766-1f4de2a9da1d} <Trace> DefaultCoordinator: Handling request from replica 0, minimal marks size is 768
2023.04.26 15:20:12.364645 [ 2251619 ] {b498fdbc-cc76-4fb8-8766-1f4de2a9da1d} <Trace> DefaultCoordinator: Going to respond to replica 0 with finish: false 
Part: all_906_941_2, Ranges: [(3840, 4608)], ,
2023.04.26 15:20:12.369189 [ 2251652 ] {b498fdbc-cc76-4fb8-8766-1f4de2a9da1d} <Trace> DefaultCoordinator: Handling request from replica 1, minimal marks size is 768
2023.04.26 15:20:12.369227 [ 2251652 ] {b498fdbc-cc76-4fb8-8766-1f4de2a9da1d} <Trace> DefaultCoordinator: Going to respond to replica 1 with finish: false 
Part: all_906_941_2, Ranges: [(4608, 4887)], ,Part: all_977_982_1, Ranges: [(0, 768)], ,
```

After:
```
2023.04.26 15:17:50.723934 [ 2249549 ] {a8a60c53-f7b7-408b-815f-93b3da07174f} <Trace> DefaultCoordinator: Handling request from replica 0, minimal marks size is 768
2023.04.26 15:17:50.723957 [ 2249549 ] {a8a60c53-f7b7-408b-815f-93b3da07174f} <Trace> DefaultCoordinator: Going to respond to replica 0 with 1 parts: [part all_631_835_3 with ranges [(23808, 24576)]]. Finish: false
2023.04.26 15:17:50.739538 [ 2249545 ] {a8a60c53-f7b7-408b-815f-93b3da07174f} <Trace> DefaultCoordinator: Handling request from replica 1, minimal marks size is 768
2023.04.26 15:17:50.739690 [ 2249545 ] {a8a60c53-f7b7-408b-815f-93b3da07174f} <Trace> DefaultCoordinator: Going to respond to replica 1 with 2 parts: [part all_631_835_3 with ranges [(27648, 27826)], part all_906_941_2 with ranges [(0, 768)]]. Finish: false
```