### PR TITLE
Fix replace[Regexp]{One,All}() with const haystacks

### DIFF
--- a/src/Functions/FunctionStringReplace.h
+++ b/src/Functions/FunctionStringReplace.h
@@ -47,7 +47,9 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t /*input_rows_count*/) const override
     {
-        const ColumnPtr column_haystack = arguments[0].column;
+        ColumnPtr column_haystack = arguments[0].column;
+        column_haystack = column_haystack->convertToFullColumnIfConst();
+
         const ColumnPtr column_needle = arguments[1].column;
         const ColumnPtr column_replacement = arguments[2].column;
 

--- a/tests/queries/0_stateless/02536_replace_with_nonconst_needle_and_replacement.reference
+++ b/tests/queries/0_stateless/02536_replace_with_nonconst_needle_and_replacement.reference
@@ -5,13 +5,28 @@
 3	Hello World	not_found	x	Hello World
 4	Hello World	[eo]	x	Hello World
 5	Hello World	.	x	Hello World
+1	Hello World	l	x	Hexxo Worxd
+2	Hello World	ll	x	Hexo World
+3	Hello World	not_found	x	Hello World
+4	Hello World	[eo]	x	Hello World
+5	Hello World	.	x	Hello World
 - const needle, non-const replacement
 1	Hello World	l	xx	Hexxxxo Worxxd
 2	Hello World	l	x	Hexxo Worxd
 3	Hello World	l	x	Hexxo Worxd
 4	Hello World	l	x	Hexxo Worxd
 5	Hello World	l	x	Hexxo Worxd
+1	Hello World	l	xx	Hexxxxo Worxxd
+2	Hello World	l	x	Hexxo Worxd
+3	Hello World	l	x	Hexxo Worxd
+4	Hello World	l	x	Hexxo Worxd
+5	Hello World	l	x	Hexxo Worxd
 - non-const needle, non-const replacement
+1	Hello World	l	xx	Hexxxxo Worxxd
+2	Hello World	ll	x	Hexo World
+3	Hello World	not_found	x	Hello World
+4	Hello World	[eo]	x	Hello World
+5	Hello World	.	x	Hello World
 1	Hello World	l	xx	Hexxxxo Worxxd
 2	Hello World	ll	x	Hexo World
 3	Hello World	not_found	x	Hello World
@@ -24,13 +39,28 @@
 3	Hello World	not_found	x	Hello World
 4	Hello World	[eo]	x	Hello World
 5	Hello World	.	x	Hello World
+1	Hello World	l	x	Hexlo World
+2	Hello World	ll	x	Hexo World
+3	Hello World	not_found	x	Hello World
+4	Hello World	[eo]	x	Hello World
+5	Hello World	.	x	Hello World
 - const needle, non-const replacement
 1	Hello World	l	xx	Hexxlo World
 2	Hello World	l	x	Hexlo World
 3	Hello World	l	x	Hexlo World
 4	Hello World	l	x	Hexlo World
 5	Hello World	l	x	Hexlo World
+1	Hello World	l	xx	Hexxlo World
+2	Hello World	l	x	Hexlo World
+3	Hello World	l	x	Hexlo World
+4	Hello World	l	x	Hexlo World
+5	Hello World	l	x	Hexlo World
 - non-const needle, non-const replacement
+1	Hello World	l	xx	Hexxlo World
+2	Hello World	ll	x	Hexo World
+3	Hello World	not_found	x	Hello World
+4	Hello World	[eo]	x	Hello World
+5	Hello World	.	x	Hello World
 1	Hello World	l	xx	Hexxlo World
 2	Hello World	ll	x	Hexo World
 3	Hello World	not_found	x	Hello World
@@ -43,13 +73,28 @@
 3	Hello World	not_found	x	Hello World
 4	Hello World	[eo]	x	Hxllx Wxrld
 5	Hello World	.	x	xxxxxxxxxxx
+1	Hello World	l	x	Hexxo Worxd
+2	Hello World	ll	x	Hexo World
+3	Hello World	not_found	x	Hello World
+4	Hello World	[eo]	x	Hxllx Wxrld
+5	Hello World	.	x	xxxxxxxxxxx
 - const needle, non-const replacement
 1	Hello World	l	xx	Hexxxxo Worxxd
 2	Hello World	l	x	Hexxo Worxd
 3	Hello World	l	x	Hexxo Worxd
 4	Hello World	l	x	Hexxo Worxd
 5	Hello World	l	x	Hexxo Worxd
+1	Hello World	l	xx	Hexxxxo Worxxd
+2	Hello World	l	x	Hexxo Worxd
+3	Hello World	l	x	Hexxo Worxd
+4	Hello World	l	x	Hexxo Worxd
+5	Hello World	l	x	Hexxo Worxd
 - non-const needle, non-const replacement
+1	Hello World	l	xx	Hexxxxo Worxxd
+2	Hello World	ll	x	Hexo World
+3	Hello World	not_found	x	Hello World
+4	Hello World	[eo]	x	Hxllx Wxrld
+5	Hello World	.	x	xxxxxxxxxxx
 1	Hello World	l	xx	Hexxxxo Worxxd
 2	Hello World	ll	x	Hexo World
 3	Hello World	not_found	x	Hello World
@@ -62,13 +107,28 @@
 3	Hello World	not_found	x	Hello World
 4	Hello World	[eo]	x	Hxllo World
 5	Hello World	.	x	xello World
+1	Hello World	l	x	Hexlo World
+2	Hello World	ll	x	Hexo World
+3	Hello World	not_found	x	Hello World
+4	Hello World	[eo]	x	Hxllo World
+5	Hello World	.	x	xello World
 - const needle, non-const replacement
 1	Hello World	l	xx	Hexxlo World
 2	Hello World	l	x	Hexlo World
 3	Hello World	l	x	Hexlo World
 4	Hello World	l	x	Hexlo World
 5	Hello World	l	x	Hexlo World
+1	Hello World	l	xx	Hexxlo World
+2	Hello World	l	x	Hexlo World
+3	Hello World	l	x	Hexlo World
+4	Hello World	l	x	Hexlo World
+5	Hello World	l	x	Hexlo World
 - non-const needle, non-const replacement
+1	Hello World	l	xx	Hexxlo World
+2	Hello World	ll	x	Hexo World
+3	Hello World	not_found	x	Hello World
+4	Hello World	[eo]	x	Hxllo World
+5	Hello World	.	x	xello World
 1	Hello World	l	xx	Hexxlo World
 2	Hello World	ll	x	Hexo World
 3	Hello World	not_found	x	Hello World

--- a/tests/queries/0_stateless/02536_replace_with_nonconst_needle_and_replacement.sql
+++ b/tests/queries/0_stateless/02536_replace_with_nonconst_needle_and_replacement.sql
@@ -9,53 +9,63 @@ CREATE TABLE test_tab
 
 INSERT INTO test_tab VALUES (1, 'Hello World', 'l', 'xx') (2, 'Hello World', 'll', 'x') (3, 'Hello World', 'not_found', 'x') (4, 'Hello World', '[eo]', 'x') (5, 'Hello World', '.', 'x')
 
+
 SELECT '** replaceAll() **';
 
 SELECT '- non-const needle, const replacement';
 SELECT id, haystack, needle, 'x', replaceAll(haystack, needle, 'x') FROM test_tab ORDER BY id;
+SELECT id, haystack, needle, 'x', replaceAll('Hello World', needle, 'x') FROM test_tab ORDER BY id;
 
 SELECT '- const needle, non-const replacement';
 SELECT id, haystack, 'l', replacement, replaceAll(haystack, 'l', replacement) FROM test_tab ORDER BY id;
+SELECT id, haystack, 'l', replacement, replaceAll('Hello World', 'l', replacement) FROM test_tab ORDER BY id;
 
 SELECT '- non-const needle, non-const replacement';
 SELECT id, haystack, needle, replacement, replaceAll(haystack, needle, replacement) FROM test_tab ORDER BY id;
+SELECT id, haystack, needle, replacement, replaceAll('Hello World', needle, replacement) FROM test_tab ORDER BY id;
+
 
 SELECT '** replaceOne() **';
 
 SELECT '- non-const needle, const replacement';
 SELECT id, haystack, needle, 'x', replaceOne(haystack, needle, 'x') FROM test_tab ORDER BY id;
-
+SELECT id, haystack, needle, 'x', replaceOne('Hello World', needle, 'x') FROM test_tab ORDER BY id;
 
 SELECT '- const needle, non-const replacement';
 SELECT id, haystack, 'l', replacement, replaceOne(haystack, 'l', replacement) FROM test_tab ORDER BY id;
-
+SELECT id, haystack, 'l', replacement, replaceOne('Hello World', 'l', replacement) FROM test_tab ORDER BY id;
 
 SELECT '- non-const needle, non-const replacement';
 SELECT id, haystack, needle, replacement, replaceOne(haystack, needle, replacement) FROM test_tab ORDER BY id;
+SELECT id, haystack, needle, replacement, replaceOne('Hello World', needle, replacement) FROM test_tab ORDER BY id;
 
 SELECT '** replaceRegexpAll() **';
 
 SELECT '- non-const needle, const replacement';
 SELECT id, haystack, needle, 'x', replaceRegexpAll(haystack, needle, 'x') FROM test_tab ORDER BY id;
+SELECT id, haystack, needle, 'x', replaceRegexpAll('Hello World', needle, 'x') FROM test_tab ORDER BY id;
 
 SELECT '- const needle, non-const replacement';
 SELECT id, haystack, 'l', replacement, replaceRegexpAll(haystack, 'l', replacement) FROM test_tab ORDER BY id;
+SELECT id, haystack, 'l', replacement, replaceRegexpAll('Hello World', 'l', replacement) FROM test_tab ORDER BY id;
 
 SELECT '- non-const needle, non-const replacement';
 SELECT id, haystack, needle, replacement, replaceRegexpAll(haystack, needle, replacement) FROM test_tab ORDER BY id;
+SELECT id, haystack, needle, replacement, replaceRegexpAll('Hello World', needle, replacement) FROM test_tab ORDER BY id;
 
 SELECT '** replaceRegexpOne() **';
 
 SELECT '- non-const needle, const replacement';
 SELECT id, haystack, needle, 'x', replaceRegexpOne(haystack, needle, 'x') FROM test_tab ORDER BY id;
-
+SELECT id, haystack, needle, 'x', replaceRegexpOne('Hello World', needle, 'x') FROM test_tab ORDER BY id;
 
 SELECT '- const needle, non-const replacement';
 SELECT id, haystack, 'l', replacement, replaceRegexpOne(haystack, 'l', replacement) FROM test_tab ORDER BY id;
-
+SELECT id, haystack, 'l', replacement, replaceRegexpOne('Hello World', 'l', replacement) FROM test_tab ORDER BY id;
 
 SELECT '- non-const needle, non-const replacement';
 SELECT id, haystack, needle, replacement, replaceRegexpOne(haystack, needle, replacement) FROM test_tab ORDER BY id;
+SELECT id, haystack, needle, replacement, replaceRegexpOne('Hello World', needle, replacement) FROM test_tab ORDER BY id;
 
 DROP TABLE IF EXISTS test_tab;
 


### PR DESCRIPTION
Follow-up to #46589.

Enables query 

``` SQL
SELECT replaceAll('Hello, world',
    number % 2 ? 'Hello' : 'world',
    number % 3 ? 'Goodbye' : 'Greetings') AS x
FROM numbers(2)
```

announced in the [v23.4 webinar](https://presentations.clickhouse.com/release_23.4/#12) with the famous words "it works perfectly" 😉

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Functions replace[Regexp]{One,All}() now work with constant haystacks