### PR TITLE
Fix race on Outdated parts loading

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3948,6 +3948,9 @@ void MergeTreeData::forcefullyMovePartToDetachedAndRemoveFromMemory(const MergeT
     else
         LOG_INFO(log, "Renaming {} to {}_{} and forgetting it.", part_to_detach->getDataPartStorage().getPartDirectory(), prefix, part_to_detach->name);
 
+    if (restore_covered)
+        waitForOutdatedPartsToBeLoaded();
+
     auto lock = lockParts();
     bool removed_active_part = false;
     bool restored_active_part = false;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed a race condition between asynchronous loading of `Outdated` parts and detaching of unexpected parts in `ReplicatedMergeTree`. In rare cases, it could lead to "part is lost forever" errors.
