### PR TITLE
Don't choose io_uring when running test on macOS

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -11,6 +11,7 @@ import shutil
 import sys
 import os
 import os.path
+import platform
 import signal
 import re
 import copy
@@ -542,7 +543,8 @@ class SettingsRandomizer:
             0.2, 0.5, 1, 10 * 1024 * 1024 * 1024
         ),
         "local_filesystem_read_method": lambda: random.choice(
-            ["read", "pread", "mmap", "pread_threadpool", "io_uring"]
+            # io_uring is not supported on macOS, don't choose it
+            ["read", "pread", "mmap", "pread_threadpool", "io_uring"] if platform.system().lower() != "darwin" else ["read", "pread", "mmap", "pread_threadpool"]
         ),
         "remote_filesystem_read_method": lambda: random.choice(["read", "threadpool"]),
         "local_filesystem_read_prefetch": lambda: random.randint(0, 1),

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -544,7 +544,9 @@ class SettingsRandomizer:
         ),
         "local_filesystem_read_method": lambda: random.choice(
             # Allow to use uring only when running on Linux
-            ["read", "pread", "mmap", "pread_threadpool", "io_uring"] if platform.system().lower() == "linux" else ["read", "pread", "mmap", "pread_threadpool"]
+            ["read", "pread", "mmap", "pread_threadpool", "io_uring"]
+            if platform.system().lower() == "linux"
+            else ["read", "pread", "mmap", "pread_threadpool"]
         ),
         "remote_filesystem_read_method": lambda: random.choice(["read", "threadpool"]),
         "local_filesystem_read_prefetch": lambda: random.randint(0, 1),

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -543,8 +543,8 @@ class SettingsRandomizer:
             0.2, 0.5, 1, 10 * 1024 * 1024 * 1024
         ),
         "local_filesystem_read_method": lambda: random.choice(
-            # io_uring is not supported on macOS, don't choose it
-            ["read", "pread", "mmap", "pread_threadpool", "io_uring"] if platform.system().lower() != "darwin" else ["read", "pread", "mmap", "pread_threadpool"]
+            # Allow to use uring only when running on Linux
+            ["read", "pread", "mmap", "pread_threadpool", "io_uring"] if platform.system().lower() == "linux" else ["read", "pread", "mmap", "pread_threadpool"]
         ),
         "remote_filesystem_read_method": lambda: random.choice(["read", "threadpool"]),
         "local_filesystem_read_prefetch": lambda: random.randint(0, 1),


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
io_uring is not supported on macOS, don't choose it when running tests on local to avoid occassional failures