### PR TITLE
Disable ISA-L on aarch64 architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,12 @@ if (OS_DARWIN)
     set (ENABLE_CURL_BUILD OFF)
 endif ()
 
+option(ENABLE_ISAL_LIBRARY "Enable ISA-L library ON by default except on aarch64." ON)
+if (ARCH_AARCH64)
+    # Disable ISA-L libray on aarch64.
+    set (ENABLE_ISAL_LIBRARY OFF)
+endif ()
+
 if (NOT CMAKE_BUILD_TYPE_UC STREQUAL "RELEASE")
     # Can be lld or ld-lld or lld-13 or /path/to/lld.
     if (LINKER_NAME MATCHES "lld")

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -191,7 +191,9 @@ add_contrib (google-benchmark-cmake google-benchmark)
 
 add_contrib (ulid-c-cmake ulid-c)
 
-add_contrib (isa-l-cmake isa-l)
+if (ENABLE_ISAL_LIBRARY)
+    add_contrib (isa-l-cmake isa-l)
+endif()
 
 # Put all targets defined here and in subdirectories under "contrib/<immediate-subdir>" folders in GUI-based IDEs.
 # Some of third-party projects may override CMAKE_FOLDER or FOLDER property of their targets, so they would not appear

--- a/contrib/libhdfs3-cmake/CMakeLists.txt
+++ b/contrib/libhdfs3-cmake/CMakeLists.txt
@@ -172,8 +172,10 @@ if (TARGET OpenSSL::SSL)
     target_link_libraries(_hdfs3 PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 endif()
 
-target_link_libraries(_hdfs3 PRIVATE ch_contrib::isal)
-add_definitions(-DHADOOP_ISAL_LIBRARY)
+if (ENABLE_ISAL_LIBRARY)
+    target_link_libraries(_hdfs3 PRIVATE ch_contrib::isal)
+    add_definitions(-DHADOOP_ISAL_LIBRARY)
+endif()
 
 add_library(ch_contrib::hdfs ALIAS _hdfs3)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Enabling ISA-L by default except on aarch64 architectures to fix compilation

Closes #49254 