### PR TITLE
Fix stress test

### DIFF
--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -655,7 +655,7 @@ bool FileCache::tryReserve(FileSegment & file_segment, size_t size)
     {
         auto locked_key = deletion_info.getMetadata().tryLock();
         if (!locked_key)
-            continue;
+            continue; /// key could become invalid after we released the key lock above, just skip it.
 
         for (auto it = deletion_info.begin(); it != deletion_info.end();)
         {

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -655,11 +655,8 @@ bool FileCache::tryReserve(FileSegment & file_segment, size_t size)
     {
         auto locked_key = deletion_info.getMetadata().tryLock();
         if (!locked_key)
-        {
-            /// key could become invalid after we released the key lock above, just skip it.
-            chassert(locked_key->getKeyState() != KeyMetadata::KeyState::ACTIVE);
             continue;
-        }
+
         for (auto it = deletion_info.begin(); it != deletion_info.end();)
         {
             chassert((*it)->releasable());


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

the failure was introduced in a PR which was merged today, so "not for changelog"