### PR TITLE
Better control over Parquet row group size

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -903,7 +903,8 @@ class IColumn;
     M(UInt64, output_format_pretty_max_value_width, 10000, "Maximum width of value to display in Pretty formats. If greater - it will be cut.", 0) \
     M(Bool, output_format_pretty_color, true, "Use ANSI escape sequences to paint colors in Pretty formats", 0) \
     M(String, output_format_pretty_grid_charset, "UTF-8", "Charset for printing grid borders. Available charsets: ASCII, UTF-8 (default one).", 0) \
-    M(UInt64, output_format_parquet_row_group_size, 1000000, "Row group size in rows.", 0) \
+    M(UInt64, output_format_parquet_row_group_size, 1000000, "Target row group size in rows.", 0) \
+    M(UInt64, output_format_parquet_row_group_size_bytes, 512 * 1024 * 1024, "Target row group size in bytes, before compression.", 0) \
     M(Bool, output_format_parquet_string_as_string, false, "Use Parquet String type instead of Binary for String columns.", 0) \
     M(Bool, output_format_parquet_fixed_string_as_fixed_byte_array, true, "Use Parquet FIXED_LENGTH_BYTE_ARRAY type instead of Binary for FixedString columns.", 0) \
     M(ParquetVersion, output_format_parquet_version, "2.latest", "Parquet format version for output format. Supported versions: 1.0, 2.4, 2.6 and 2.latest (default)", 0) \

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -110,7 +110,8 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.json.allow_object_type = context->getSettingsRef().allow_experimental_object_type;
     format_settings.null_as_default = settings.input_format_null_as_default;
     format_settings.decimal_trailing_zeros = settings.output_format_decimal_trailing_zeros;
-    format_settings.parquet.row_group_size = settings.output_format_parquet_row_group_size;
+    format_settings.parquet.row_group_rows = settings.output_format_parquet_row_group_size;
+    format_settings.parquet.row_group_bytes = settings.output_format_parquet_row_group_size_bytes;
     format_settings.parquet.output_version = settings.output_format_parquet_version;
     format_settings.parquet.import_nested = settings.input_format_parquet_import_nested;
     format_settings.parquet.case_insensitive_column_matching = settings.input_format_parquet_case_insensitive_column_matching;
@@ -734,6 +735,14 @@ void FormatFactory::markFormatSupportsSubcolumns(const String & name)
     target = true;
 }
 
+void FormatFactory::markOutputFormatPrefersLargeBlocks(const String & name)
+{
+    auto & target = dict[name].prefers_large_blocks;
+    if (target)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "FormatFactory: Format {} is already marked as preferring large blocks", name);
+    target = true;
+}
+
 bool FormatFactory::checkIfFormatSupportsSubcolumns(const String & name) const
 {
     const auto & target = getCreators(name);
@@ -792,6 +801,12 @@ bool FormatFactory::checkIfFormatHasExternalSchemaReader(const String & name) co
 bool FormatFactory::checkIfFormatHasAnySchemaReader(const String & name) const
 {
     return checkIfFormatHasSchemaReader(name) || checkIfFormatHasExternalSchemaReader(name);
+}
+
+bool FormatFactory::checkIfOutputFormatPrefersLargeBlocks(const String & name) const
+{
+    const auto & target = getCreators(name);
+    return target.prefers_large_blocks;
 }
 
 void FormatFactory::checkFormatName(const String & name) const

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -141,6 +141,7 @@ private:
         bool supports_parallel_formatting{false};
         bool supports_subcolumns{false};
         bool supports_subset_of_columns{false};
+        bool prefers_large_blocks{false};
         NonTrivialPrefixAndSuffixChecker non_trivial_prefix_and_suffix_checker;
         AppendSupportChecker append_support_checker;
         AdditionalInfoForSchemaCacheGetter additional_info_for_schema_cache_getter;
@@ -237,6 +238,7 @@ public:
     void registerExternalSchemaReader(const String & name, ExternalSchemaReaderCreator external_schema_reader_creator);
 
     void markOutputFormatSupportsParallelFormatting(const String & name);
+    void markOutputFormatPrefersLargeBlocks(const String & name);
     void markFormatSupportsSubcolumns(const String & name);
     void markFormatSupportsSubsetOfColumns(const String & name);
 
@@ -246,6 +248,7 @@ public:
     bool checkIfFormatHasSchemaReader(const String & name) const;
     bool checkIfFormatHasExternalSchemaReader(const String & name) const;
     bool checkIfFormatHasAnySchemaReader(const String & name) const;
+    bool checkIfOutputFormatPrefersLargeBlocks(const String & name) const;
 
     void registerAdditionalInfoForSchemaCacheGetter(const String & name, AdditionalInfoForSchemaCacheGetter additional_info_for_schema_cache_getter);
     String getAdditionalInfoForSchemaCache(const String & name, ContextPtr context, const std::optional<FormatSettings> & format_settings_ = std::nullopt);

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -205,7 +205,8 @@ struct FormatSettings
 
     struct
     {
-        UInt64 row_group_size = 1000000;
+        UInt64 row_group_rows = 1000000;
+        UInt64 row_group_bytes = 512 * 1024 * 1024;
         bool import_nested = false;
         bool allow_missing_columns = false;
         bool skip_columns_with_unsupported_types_in_schema_inference = false;

--- a/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockOutputFormat.cpp
@@ -134,6 +134,7 @@ void registerOutputFormatArrow(FormatFactory & factory)
             return std::make_shared<ArrowBlockOutputFormat>(buf, sample, true, format_settings);
         });
     factory.markFormatHasNoAppendSupport("ArrowStream");
+    factory.markOutputFormatPrefersLargeBlocks("ArrowStream");
 }
 
 }

--- a/src/Processors/Formats/Impl/ORCBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockOutputFormat.cpp
@@ -624,6 +624,7 @@ void registerOutputFormatORC(FormatFactory & factory)
         return std::make_shared<ORCBlockOutputFormat>(buf, sample, format_settings);
     });
     factory.markFormatHasNoAppendSupport("ORC");
+    factory.markOutputFormatPrefersLargeBlocks("ORC");
 }
 
 }

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -71,6 +71,67 @@ ParquetBlockOutputFormat::ParquetBlockOutputFormat(WriteBuffer & out_, const Blo
 
 void ParquetBlockOutputFormat::consume(Chunk chunk)
 {
+    /// Do something like SquashingTransform to produce big enough row groups.
+    /// Because the real SquashingTransform is only used for INSERT, not for SELECT ... INTO OUTFILE.
+    /// The latter doesn't even have a pipeline where a transform could be inserted, so it's more
+    /// convenient to do the squashing here.
+
+    appendToAccumulatedChunk(std::move(chunk));
+
+    if (!accumulated_chunk)
+        return;
+
+    const size_t target_rows = std::max(static_cast<UInt64>(1), format_settings.parquet.row_group_rows);
+
+    if (accumulated_chunk.getNumRows() < target_rows &&
+        accumulated_chunk.bytes() < format_settings.parquet.row_group_bytes)
+        return;
+
+    /// Increase row group size slightly (by < 2x) to avoid adding a small row groups for the
+    /// remainder of the new chunk.
+    /// E.g. suppose input chunks are 70K rows each, and max_rows = 1M. Then we'll have
+    /// getNumRows() = 1.05M. We want to write all 1.05M as one row group instead of 1M and 0.05M.
+    size_t num_row_groups = std::max(static_cast<UInt64>(1), accumulated_chunk.getNumRows() / target_rows);
+    size_t row_group_size = (accumulated_chunk.getNumRows() - 1) / num_row_groups + 1; // round up
+
+    write(std::move(accumulated_chunk), row_group_size);
+    accumulated_chunk.clear();
+}
+
+void ParquetBlockOutputFormat::finalizeImpl()
+{
+    if (accumulated_chunk)
+        write(std::move(accumulated_chunk), format_settings.parquet.row_group_rows);
+
+    if (!file_writer)
+    {
+        const Block & header = getPort(PortKind::Main).getHeader();
+        write(Chunk(header.getColumns(), 0), 1);
+    }
+
+    auto status = file_writer->Close();
+    if (!status.ok())
+        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Error while closing a table: {}", status.ToString());
+}
+
+void ParquetBlockOutputFormat::resetFormatterImpl()
+{
+    file_writer.reset();
+}
+
+void ParquetBlockOutputFormat::appendToAccumulatedChunk(Chunk chunk)
+{
+    if (!accumulated_chunk)
+    {
+        accumulated_chunk = std::move(chunk);
+        return;
+    }
+    chassert(accumulated_chunk.getNumColumns() == chunk.getNumColumns());
+    accumulated_chunk.append(chunk);
+}
+
+void ParquetBlockOutputFormat::write(Chunk chunk, size_t row_group_size)
+{
     const size_t columns_num = chunk.getNumColumns();
     std::shared_ptr<arrow::Table> arrow_table;
 
@@ -105,30 +166,10 @@ void ParquetBlockOutputFormat::consume(Chunk chunk)
         file_writer = std::move(result.ValueOrDie());
     }
 
-    // TODO: calculate row_group_size depending on a number of rows and table size
-    auto status = file_writer->WriteTable(*arrow_table, format_settings.parquet.row_group_size);
+    auto status = file_writer->WriteTable(*arrow_table, row_group_size);
 
     if (!status.ok())
         throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Error while writing a table: {}", status.ToString());
-}
-
-void ParquetBlockOutputFormat::finalizeImpl()
-{
-    if (!file_writer)
-    {
-        const Block & header = getPort(PortKind::Main).getHeader();
-
-        consume(Chunk(header.getColumns(), 0));
-    }
-
-    auto status = file_writer->Close();
-    if (!status.ok())
-        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Error while closing a table: {}", status.ToString());
-}
-
-void ParquetBlockOutputFormat::resetFormatterImpl()
-{
-    file_writer.reset();
 }
 
 void registerOutputFormatParquet(FormatFactory & factory)

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
@@ -35,6 +35,8 @@ public:
 
 private:
     void consume(Chunk) override;
+    void appendToAccumulatedChunk(Chunk chunk);
+    void write(Chunk chunk, size_t row_group_size);
     void finalizeImpl() override;
     void resetFormatterImpl() override;
 
@@ -42,6 +44,8 @@ private:
 
     std::unique_ptr<parquet::arrow::FileWriter> file_writer;
     std::unique_ptr<CHColumnToArrowColumn> ch_column_to_arrow_column;
+
+    Chunk accumulated_chunk;
 };
 
 }

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -407,6 +407,11 @@ bool StorageFile::supportsSubsetOfColumns() const
     return format_name != "Distributed" && FormatFactory::instance().checkIfFormatSupportsSubsetOfColumns(format_name);
 }
 
+bool StorageFile::prefersLargeBlocks() const
+{
+    return FormatFactory::instance().checkIfOutputFormatPrefersLargeBlocks(format_name);
+}
+
 StorageFile::StorageFile(int table_fd_, CommonArguments args)
     : StorageFile(args)
 {

--- a/src/Storages/StorageFile.h
+++ b/src/Storages/StorageFile.h
@@ -73,6 +73,8 @@ public:
     /// format to read only them. Note: this hack cannot be done with ordinary formats like TSV.
     bool supportsSubsetOfColumns() const override;
 
+    bool prefersLargeBlocks() const override;
+
     bool supportsPartitionBy() const override { return true; }
 
     ColumnsDescription getTableStructureFromFileDescriptor(ContextPtr context);

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -1003,6 +1003,11 @@ bool StorageS3::supportsSubsetOfColumns() const
     return FormatFactory::instance().checkIfFormatSupportsSubsetOfColumns(configuration.format);
 }
 
+bool StorageS3::prefersLargeBlocks() const
+{
+    return FormatFactory::instance().checkIfOutputFormatPrefersLargeBlocks(configuration.format);
+}
+
 Pipe StorageS3::read(
     const Names & column_names,
     const StorageSnapshotPtr & storage_snapshot,

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -364,6 +364,8 @@ private:
 
     bool supportsSubsetOfColumns() const override;
 
+    bool prefersLargeBlocks() const override;
+
     static std::optional<ColumnsDescription> tryGetColumnsFromCache(
         const KeysWithInfo::const_iterator & begin,
         const KeysWithInfo::const_iterator & end,

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -595,6 +595,11 @@ bool IStorageURLBase::supportsSubsetOfColumns() const
     return FormatFactory::instance().checkIfFormatSupportsSubsetOfColumns(format_name);
 }
 
+bool IStorageURLBase::prefersLargeBlocks() const
+{
+    return FormatFactory::instance().checkIfOutputFormatPrefersLargeBlocks(format_name);
+}
+
 Pipe IStorageURLBase::read(
     const Names & column_names,
     const StorageSnapshotPtr & storage_snapshot,

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -100,6 +100,8 @@ protected:
 
     bool supportsSubsetOfColumns() const override;
 
+    bool prefersLargeBlocks() const override;
+
 private:
     virtual Block getHeaderBlock(const Names & column_names, const StorageSnapshotPtr & storage_snapshot) const = 0;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Parquet writer now uses reasonable row group size when invoked through OUTFILE.

Built block squashing into ParquetBlockOutputFormat. Disabled SquashingTransform for it.