### PR TITLE
Fix compiling average example (suppress -Wframe-larger-than)

### DIFF
--- a/src/Common/examples/average.cpp
+++ b/src/Common/examples/average.cpp
@@ -473,7 +473,8 @@ Float NO_INLINE buffered(const PODArray<UInt8> & keys, const PODArray<Float> & v
     return map[0].result();
 }
 
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wframe-larger-than"
 template <size_t UNROLL_COUNT>
 Float NO_INLINE really_unrolled(const PODArray<UInt8> & keys, const PODArray<Float> & values)
 {
@@ -496,6 +497,7 @@ Float NO_INLINE really_unrolled(const PODArray<UInt8> & keys, const PODArray<Flo
 
     return map[0].result();
 }
+#pragma clang diagnostic pop
 
 
 struct State4


### PR DESCRIPTION
    FAILED: src/Common/examples/CMakeFiles/average.dir/average.cpp.o
    ...
    /src/ch/clickhouse/src/Common/examples/average.cpp:478:17: error: stack frame size (65560) exceeds limit (65536) in 'float really_unrolled<16ul>(DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 0ul, 0ul> const&, DB::PODArray<float, 4096ul, Allocator<false, false>, 0ul, 0ul> const&)' [-Werror,-Wframe-larger-than]
    Float NO_INLINE really_unrolled(const PODArray<UInt8> & keys, const PODArray<Float> & values)
                    ^
    1 error generated.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)