### PR TITLE
Partially reimplement Parquet encoder to make it faster and parallelizable

### DIFF
--- a/contrib/arrow-cmake/CMakeLists.txt
+++ b/contrib/arrow-cmake/CMakeLists.txt
@@ -502,9 +502,10 @@ target_include_directories(_parquet SYSTEM BEFORE
         "${ClickHouse_SOURCE_DIR}/contrib/arrow/cpp/src"
         "${CMAKE_CURRENT_SOURCE_DIR}/cpp/src")
 target_link_libraries(_parquet
-    PUBLIC _arrow
-    PRIVATE
+    PUBLIC
+        _arrow
         ch_contrib::thrift
+    PRIVATE
         boost::headers_only
         boost::regex
         OpenSSL::Crypto OpenSSL::SSL)

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -812,6 +812,11 @@ bool Client::processWithFuzzing(const String & full_query)
         }
         catch (...)
         {
+            if (!ast_to_process)
+                fmt::print(stderr,
+                    "Error while forming new query: {}\n",
+                    getCurrentExceptionMessage(true));
+
             // Some functions (e.g. protocol parsers) don't throw, but
             // set last_exception instead, so we'll also do it here for
             // uniformity.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,6 +267,10 @@ add_object_library(clickhouse_processors_queryplan Processors/QueryPlan)
 add_object_library(clickhouse_processors_queryplan_optimizations Processors/QueryPlan/Optimizations)
 add_object_library(clickhouse_user_defined_functions Functions/UserDefined)
 
+if (USE_PARQUET)
+    add_object_library(clickhouse_processors_formats_impl_parquet Processors/Formats/Impl/Parquet)
+endif()
+
 if (TARGET ch_contrib::nuraft)
     add_object_library(clickhouse_coordination Coordination)
 endif()

--- a/src/Common/CurrentMetrics.cpp
+++ b/src/Common/CurrentMetrics.cpp
@@ -149,8 +149,10 @@
     M(RestartReplicaThreadsActive, "Number of threads in the RESTART REPLICA thread pool running a task.") \
     M(QueryPipelineExecutorThreads, "Number of threads in the PipelineExecutor thread pool.") \
     M(QueryPipelineExecutorThreadsActive, "Number of threads in the PipelineExecutor thread pool running a task.") \
-    M(ParquetDecoderThreads, "Number of threads in the ParquetBlockInputFormat thread pool running a task.") \
-    M(ParquetDecoderThreadsActive, "Number of threads in the ParquetBlockInputFormat thread pool.") \
+    M(ParquetDecoderThreads, "Number of threads in the ParquetBlockInputFormat thread pool.") \
+    M(ParquetDecoderThreadsActive, "Number of threads in the ParquetBlockInputFormat thread pool running a task.") \
+    M(ParquetEncoderThreads, "Number of threads in ParquetBlockOutputFormat thread pool.") \
+    M(ParquetEncoderThreadsActive, "Number of threads in ParquetBlockOutputFormat thread pool running a task.") \
     M(OutdatedPartsLoadingThreads, "Number of threads in the threadpool for loading Outdated data parts.") \
     M(OutdatedPartsLoadingThreadsActive, "Number of active threads in the threadpool for loading Outdated data parts.") \
     M(DistributedBytesToInsert, "Number of pending bytes to process for asynchronous insertion into Distributed tables. Number of bytes for every shard is summed.") \

--- a/src/Common/PODArray.cpp
+++ b/src/Common/PODArray.cpp
@@ -15,4 +15,14 @@ template class PODArray<Int8, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADD
 template class PODArray<Int16, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
 template class PODArray<Int32, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
 template class PODArray<Int64, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
+
+template class PODArray<UInt8, 4096, Allocator<false>, 0, 0>;
+template class PODArray<UInt16, 4096, Allocator<false>, 0, 0>;
+template class PODArray<UInt32, 4096, Allocator<false>, 0, 0>;
+template class PODArray<UInt64, 4096, Allocator<false>, 0, 0>;
+
+template class PODArray<Int8, 4096, Allocator<false>, 0, 0>;
+template class PODArray<Int16, 4096, Allocator<false>, 0, 0>;
+template class PODArray<Int32, 4096, Allocator<false>, 0, 0>;
+template class PODArray<Int64, 4096, Allocator<false>, 0, 0>;
 }

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -783,4 +783,15 @@ extern template class PODArray<Int8, 4096, Allocator<false>, PADDING_FOR_SIMD - 
 extern template class PODArray<Int16, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
 extern template class PODArray<Int32, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
 extern template class PODArray<Int64, 4096, Allocator<false>, PADDING_FOR_SIMD - 1, PADDING_FOR_SIMD>;
+
+extern template class PODArray<UInt8, 4096, Allocator<false>, 0, 0>;
+extern template class PODArray<UInt16, 4096, Allocator<false>, 0, 0>;
+extern template class PODArray<UInt32, 4096, Allocator<false>, 0, 0>;
+extern template class PODArray<UInt64, 4096, Allocator<false>, 0, 0>;
+
+extern template class PODArray<Int8, 4096, Allocator<false>, 0, 0>;
+extern template class PODArray<Int16, 4096, Allocator<false>, 0, 0>;
+extern template class PODArray<Int32, 4096, Allocator<false>, 0, 0>;
+extern template class PODArray<Int64, 4096, Allocator<false>, 0, 0>;
+
 }

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -953,6 +953,10 @@ class IColumn;
     M(ParquetVersion, output_format_parquet_version, "2.latest", "Parquet format version for output format. Supported versions: 1.0, 2.4, 2.6 and 2.latest (default)", 0) \
     M(ParquetCompression, output_format_parquet_compression_method, "lz4", "Compression method for Parquet output format. Supported codecs: snappy, lz4, brotli, zstd, gzip, none (uncompressed)", 0) \
     M(Bool, output_format_parquet_compliant_nested_types, true, "In parquet file schema, use name 'element' instead of 'item' for list elements. This is a historical artifact of Arrow library implementation. Generally increases compatibility, except perhaps with some old versions of Arrow.", 0) \
+    M(Bool, output_format_parquet_use_custom_encoder, true, "Use experimental faster Parquet encoder implementation.", 0) \
+    M(Bool, output_format_parquet_parallel_encoding, true, "Do Parquet encoding in multiple threads. Requires output_format_parquet_use_custom_encoder.", 0) \
+    M(UInt64, output_format_parquet_data_page_size, 1024 * 1024, "Target page size in bytes, before compression.", 0) \
+    M(UInt64, output_format_parquet_batch_size, 1024, "Check page size every this many rows. Consider decreasing if you have columns with average values size above a few KBs.", 0) \
     M(String, output_format_avro_codec, "", "Compression codec used for output. Possible values: 'null', 'deflate', 'snappy'.", 0) \
     M(UInt64, output_format_avro_sync_interval, 16 * 1024, "Sync interval in bytes.", 0) \
     M(String, output_format_avro_string_column_pattern, "", "For Avro format: regexp of String columns to select as AVRO string.", 0) \

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -130,6 +130,10 @@ FormatSettings getFormatSettings(ContextPtr context, const Settings & settings)
     format_settings.parquet.max_block_size = settings.input_format_parquet_max_block_size;
     format_settings.parquet.output_compression_method = settings.output_format_parquet_compression_method;
     format_settings.parquet.output_compliant_nested_types = settings.output_format_parquet_compliant_nested_types;
+    format_settings.parquet.use_custom_encoder = settings.output_format_parquet_use_custom_encoder;
+    format_settings.parquet.parallel_encoding = settings.output_format_parquet_parallel_encoding;
+    format_settings.parquet.data_page_size = settings.output_format_parquet_data_page_size;
+    format_settings.parquet.write_batch_size = settings.output_format_parquet_batch_size;
     format_settings.pretty.charset = settings.output_format_pretty_grid_charset.toString() == "ASCII" ? FormatSettings::Pretty::Charset::ASCII : FormatSettings::Pretty::Charset::UTF8;
     format_settings.pretty.color = settings.output_format_pretty_color;
     format_settings.pretty.max_column_pad_width = settings.output_format_pretty_max_column_pad_width;
@@ -434,7 +438,7 @@ OutputFormatPtr FormatFactory::getOutputFormatParallelIfPossible(
         return format;
     }
 
-    return getOutputFormat(name, buf, sample, context, _format_settings);
+    return getOutputFormat(name, buf, sample, context, format_settings);
 }
 
 
@@ -453,6 +457,7 @@ OutputFormatPtr FormatFactory::getOutputFormat(
         context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Format, name);
 
     auto format_settings = _format_settings ? *_format_settings : getFormatSettings(context);
+    format_settings.max_threads = context->getSettingsRef().max_threads;
 
     /** TODO: Materialization is needed, because formats can use the functions `IDataType`,
       *  which only work with full columns.

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -100,6 +100,8 @@ struct FormatSettings
 
     UInt64 max_parser_depth = DBMS_DEFAULT_MAX_PARSER_DEPTH;
 
+    size_t max_threads = 1;
+
     enum class ArrowCompression
     {
         NONE,
@@ -233,10 +235,14 @@ struct FormatSettings
         bool output_string_as_string = false;
         bool output_fixed_string_as_fixed_byte_array = true;
         bool preserve_order = false;
+        bool use_custom_encoder = true;
+        bool parallel_encoding = true;
         UInt64 max_block_size = 8192;
         ParquetVersion output_version;
         ParquetCompression output_compression_method = ParquetCompression::SNAPPY;
         bool output_compliant_nested_types = true;
+        size_t data_page_size = 1024 * 1024;
+        size_t write_batch_size = 1024;
     } parquet;
 
     struct Pretty

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -684,9 +684,6 @@ namespace DB
         bool output_fixed_string_as_fixed_byte_array,
         std::unordered_map<String, MutableColumnPtr> & dictionary_values)
     {
-        const String column_type_name = column_type->getFamilyName();
-        WhichDataType which(column_type);
-
         switch (column_type->getTypeId())
         {
             case TypeIndex::Nullable:
@@ -796,7 +793,7 @@ namespace DB
                 FOR_INTERNAL_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
             default:
-                throw Exception(ErrorCodes::UNKNOWN_TYPE, "Internal type '{}' of a column '{}' is not supported for conversion into {} data format.", column_type_name, column_name, format_name);
+                throw Exception(ErrorCodes::UNKNOWN_TYPE, "Internal type '{}' of a column '{}' is not supported for conversion into {} data format.", column_type->getFamilyName(), column_name, format_name);
         }
     }
 

--- a/src/Processors/Formats/Impl/Parquet/PrepareForWrite.cpp
+++ b/src/Processors/Formats/Impl/Parquet/PrepareForWrite.cpp
@@ -1,0 +1,618 @@
+#include "Processors/Formats/Impl/Parquet/Write.h"
+
+#include <Columns/MaskOperations.h>
+#include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnTuple.h>
+#include <Columns/ColumnLowCardinality.h>
+#include <Columns/ColumnMap.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesDecimal.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeFixedString.h>
+
+
+/// This file deals with schema conversion and with repetition and definition levels.
+
+/// Schema conversion is pretty straightforward.
+
+/// "Repetition and definition levels" are a somewhat tricky way of encoding information about
+/// optional fields and lists.
+///
+/// If you don't want to learn how these work, feel free to skip the updateRepDefLevels* functions.
+/// All you need to know is:
+///  * values for nulls are not encoded, so we have to filter nullable columns,
+///  * information about all array lengths and nulls is encoded in the arrays `def` and `rep`,
+///    which need to be encoded next to the data,
+///  * `def` and `rep` arrays can be longer than `primitive_column`, because they include nulls and
+///    empty arrays; the values in primitive_column correspond to positions where def[i] == max_def.
+///
+/// If you do want to learn it, dremel paper: https://research.google/pubs/pub36632/
+/// Instead of reading the whole paper, try staring at figures 2-3 for a while - it might be enough.
+/// (Why does Parquet do all this instead of just storing array lengths and null masks? I'm not
+/// really sure.)
+///
+/// We calculate the levels recursively, from inner to outer columns.
+/// This means scanning the whole array for each Array/Nullable nesting level, which is probably not
+/// the most efficient way to do it. But there's usually at most one nesting level, so it's fine.
+///
+/// Most of this is moot because ClickHouse doesn't support nullable arrays or tuples right now, so
+/// almost none of the tricky cases can happen. We implement it in full generality anyway (mostly
+/// because I only learned the previous sentence after writing most of the code).
+
+
+namespace DB::ErrorCodes
+{
+    extern const int UNKNOWN_TYPE;
+    extern const int TOO_DEEP_RECURSION; // I'm 14 and this is deep
+    extern const int UNKNOWN_COMPRESSION_METHOD;
+    extern const int LOGICAL_ERROR;
+}
+
+namespace DB::Parquet
+{
+
+/// Thrift structs that Parquet uses for various metadata inside the parquet file.
+namespace parq = parquet::format;
+
+namespace
+{
+
+void assertNoDefOverflow(ColumnChunkWriteState & s)
+{
+    if (s.max_def == UINT8_MAX)
+        throw Exception(ErrorCodes::TOO_DEEP_RECURSION,
+            "Column has more than 255 levels of nested Array/Nullable. Impressive! Unfortunately, "
+            "this is not supported by this Parquet encoder (but is supported by Parquet, if you "
+            "really need this for some reason).");
+}
+
+void updateRepDefLevelsAndFilterColumnForNullable(ColumnChunkWriteState & s, const NullMap & null_map)
+{
+    /// Increment definition levels for non-nulls.
+    /// Filter the column to contain only non-null values.
+
+    assertNoDefOverflow(s);
+    ++s.max_def;
+
+    /// Normal case: no arrays or nullables inside this nullable.
+    if (s.max_def == 1)
+    {
+        chassert(s.def.empty());
+        s.def.resize(null_map.size());
+        for (size_t i = 0; i < s.def.size(); ++i)
+            s.def[i] = !null_map[i];
+
+        /// We could be more efficient with this:
+        ///  * Instead of doing the filter() here, we could defer it to writeColumnChunkBody(), at
+        ///    least in the simple case of Nullable(Primitive). Then it'll parallelize if the table
+        ///    consists of one big tuple.
+        ///  * Instead of filtering explicitly, we could build filtering into the data encoder.
+        ///  * Instead of filling out the `def` values above, we could point to null_map and build
+        ///    the '!' into the encoder.
+        /// None of these seem worth the complexity right now.
+        s.primitive_column = s.primitive_column->filter(s.def, /*result_size_hint*/ -1);
+
+        return;
+    }
+
+    /// Weird general case: Nullable(Array), Nullable(Nullable), or any arbitrary nesting like that.
+    /// This is currently not allowed in ClickHouse, but let's support it anyway just in case.
+
+    IColumn::Filter filter;
+    size_t row_idx = static_cast<size_t>(-1);
+    for (size_t i = 0; i < s.def.size(); ++i)
+    {
+        row_idx += s.max_rep == 0 || s.rep[i] == 0;
+        if (s.def[i] == s.max_def - 1)
+            filter.push_back(!null_map[row_idx]);
+        s.def[i] += !null_map[row_idx];
+    }
+    s.primitive_column = s.primitive_column->filter(filter, /*result_size_hint*/ -1);
+}
+
+void updateRepDefLevelsForArray(ColumnChunkWriteState & s, const IColumn::Offsets & offsets)
+{
+    /// Increment all definition levels.
+    /// For non-first elements of arrays, increment repetition levels.
+    /// For empty arrays, insert a zero into repetition and definition levels arrays.
+
+    assertNoDefOverflow(s);
+    ++s.max_def;
+    ++s.max_rep;
+
+    /// Common case: no arrays or nullables inside this array.
+    if (s.max_rep == 1 && s.max_def == 1)
+    {
+        s.def.resize_fill(s.primitive_column->size(), 1);
+        s.rep.resize_fill(s.primitive_column->size(), 1);
+        size_t i = 0;
+        for (ssize_t row = 0; row < static_cast<ssize_t>(offsets.size()); ++row)
+        {
+            size_t n = offsets[row] - offsets[row - 1];
+            if (n)
+            {
+                s.rep[i] = 0;
+                i += n;
+            }
+            else
+            {
+                s.def.push_back(1);
+                s.rep.push_back(1);
+                s.def[i] = 0;
+                s.rep[i] = 0;
+                i += 1;
+            }
+        }
+        return;
+    }
+
+    /// General case: Array(Array), Array(Nullable), or any arbitrary nesting like that.
+
+    for (auto & x : s.def)
+        ++x;
+
+    if (s.max_rep == 1)
+        s.rep.resize_fill(s.def.size(), 1);
+    else
+        for (auto & x : s.rep)
+            ++x;
+
+    PaddedPODArray<UInt8> mask(s.def.size(), 1); // for inserting zeroes to rep and def
+    size_t i = 0; // in the input (s.def/s.rep)
+    size_t empty_arrays = 0;
+    for (ssize_t row = 0; row < static_cast<ssize_t>(offsets.size()); ++row)
+    {
+        size_t n = offsets[row] - offsets[row - 1];
+        if (n)
+        {
+            /// Un-increment the first rep of the array.
+            /// Skip n "items" in the nested column; first element of each item has rep = 1
+            /// (we incremented it above).
+            chassert(s.rep[i] == 1);
+            --s.rep[i];
+            do
+            {
+                ++i;
+                if (i == s.rep.size())
+                {
+                    --n;
+                    chassert(n == 0);
+                    break;
+                }
+                n -= s.rep[i] == 1;
+            } while (n);
+        }
+        else
+        {
+            mask.push_back(1);
+            mask[i + empty_arrays] = 0;
+            ++empty_arrays;
+        }
+    }
+
+    if (empty_arrays != 0)
+    {
+        expandDataByMask(s.def, mask, false);
+        expandDataByMask(s.rep, mask, false);
+    }
+}
+
+parq::CompressionCodec::type compressionMethodToParquet(CompressionMethod c)
+{
+    switch (c)
+    {
+        case CompressionMethod::None: return parq::CompressionCodec::UNCOMPRESSED;
+        case CompressionMethod::Snappy: return parq::CompressionCodec::SNAPPY;
+        case CompressionMethod::Gzip: return parq::CompressionCodec::GZIP;
+        case CompressionMethod::Brotli: return parq::CompressionCodec::BROTLI;
+        case CompressionMethod::Lz4: return parq::CompressionCodec::LZ4_RAW;
+        case CompressionMethod::Zstd: return parq::CompressionCodec::ZSTD;
+
+        default:
+            throw Exception(ErrorCodes::UNKNOWN_COMPRESSION_METHOD, "Compression method {} is not supported by Parquet", toContentEncodingName(c));
+    }
+}
+
+/// Depth-first traversal of the schema tree for this column.
+void prepareColumnRecursive(
+    ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
+    ColumnChunkWriteStates & states, SchemaElements & schemas);
+
+void preparePrimitiveColumn(ColumnPtr column, DataTypePtr type, const std::string & name,
+    const WriteOptions & options, ColumnChunkWriteStates & states, SchemaElements & schemas)
+{
+    /// Add physical column info.
+    auto & state = states.emplace_back();
+    state.primitive_column = column;
+    state.compression = options.compression;
+
+    state.column_chunk.__isset.meta_data = true;
+    state.column_chunk.meta_data.__set_path_in_schema({name});
+    state.column_chunk.meta_data.__set_codec(compressionMethodToParquet(state.compression));
+
+    /// Add logical schema leaf.
+    auto & schema = schemas.emplace_back();
+    schema.__set_repetition_type(parq::FieldRepetitionType::REQUIRED);
+    schema.__set_name(name);
+
+    /// Convert the type enums.
+
+    using T = parq::Type;
+    using C = parq::ConvertedType;
+
+    auto types = [&](T::type type_, std::optional<C::type> converted = std::nullopt, std::optional<parq::LogicalType> logical = std::nullopt)
+    {
+        state.column_chunk.meta_data.__set_type(type_);
+        schema.__set_type(type_);
+        if (converted)
+            schema.__set_converted_type(*converted);
+        if (logical)
+            schema.__set_logicalType(*logical);
+    };
+
+    auto int_type = [](Int8 bits, bool signed_)
+    {
+        parq::LogicalType t;
+        t.__isset.INTEGER = true;
+        t.INTEGER.__set_bitWidth(bits);
+        t.INTEGER.__set_isSigned(signed_);
+        return t;
+    };
+
+    auto fixed_string = [&](size_t size, std::optional<C::type> converted = std::nullopt, std::optional<parq::LogicalType> logical = std::nullopt)
+    {
+        state.column_chunk.meta_data.__set_type(parq::Type::FIXED_LEN_BYTE_ARRAY);
+        schema.__set_type(parq::Type::FIXED_LEN_BYTE_ARRAY);
+        schema.__set_type_length(static_cast<Int32>(size));
+        if (converted)
+            schema.__set_converted_type(*converted);
+        if (logical)
+            schema.__set_logicalType(*logical);
+    };
+
+    auto decimal = [&](Int32 bytes, UInt32 precision, UInt32 scale)
+    {
+        state.column_chunk.meta_data.__set_type(parq::Type::FIXED_LEN_BYTE_ARRAY);
+        schema.__set_type(parq::Type::FIXED_LEN_BYTE_ARRAY);
+        schema.__set_type_length(bytes);
+        schema.__set_scale(static_cast<Int32>(scale));
+        schema.__set_precision(static_cast<Int32>(precision));
+        schema.__set_converted_type(parq::ConvertedType::DECIMAL);
+        parq::DecimalType d;
+        d.__set_scale(static_cast<Int32>(scale));
+        d.__set_precision(static_cast<Int32>(precision));
+        parq::LogicalType t;
+        t.__set_DECIMAL(d);
+        schema.__set_logicalType(t);
+    };
+
+    switch (type->getTypeId())
+    {
+        case TypeIndex::UInt8:  types(T::INT32, C::UINT_8 , int_type(8 , false)); break;
+        case TypeIndex::UInt16: types(T::INT32, C::UINT_16, int_type(16, false)); break;
+        case TypeIndex::UInt32: types(T::INT32, C::UINT_32, int_type(32, false)); break;
+        case TypeIndex::UInt64: types(T::INT64, C::UINT_64, int_type(64, false)); break;
+        case TypeIndex::Int8:   types(T::INT32, C::INT_8  , int_type(8 , true)); break;
+        case TypeIndex::Int16:  types(T::INT32, C::INT_16 , int_type(16, true)); break;
+        case TypeIndex::Int32:  types(T::INT32); break;
+        case TypeIndex::Int64:  types(T::INT64); break;
+        case TypeIndex::Float32: types(T::FLOAT); break;
+        case TypeIndex::Float64: types(T::DOUBLE); break;
+
+        /// These don't have suitable parquet logical types, so we write them as plain numbers.
+        /// (Parquet has "enums" but they're just strings, with nowhere to declare all possible enum
+        /// values in advance as part of the data type.)
+        case TypeIndex::Enum8:    types(T::INT32, C::INT_8  , int_type(8 , true)); break; //  Int8
+        case TypeIndex::Enum16:   types(T::INT32, C::INT_16 , int_type(16, true)); break; //  Int16
+        case TypeIndex::IPv4:     types(T::INT32, C::UINT_32, int_type(32, false)); break; // UInt32
+        case TypeIndex::Date:     types(T::INT32, C::UINT_16, int_type(16, false)); break; // UInt16
+        case TypeIndex::DateTime: types(T::INT32, C::UINT_32, int_type(32, false)); break; // UInt32
+
+        case TypeIndex::Date32:
+        {
+            parq::LogicalType t;
+            t.__set_DATE({});
+            types(T::INT32, C::DATE, t);
+            break;
+        }
+
+        case TypeIndex::DateTime64:
+        {
+            std::optional<parq::ConvertedType::type> converted;
+            std::optional<parq::TimeUnit> unit;
+            switch (assert_cast<const DataTypeDateTime64 &>(*type).getScale())
+            {
+                case 3:
+                    converted = parq::ConvertedType::TIMESTAMP_MILLIS;
+                    unit.emplace().__set_MILLIS({});
+                    break;
+                case 6:
+                    converted = parq::ConvertedType::TIMESTAMP_MICROS;
+                    unit.emplace().__set_MICROS({});
+                    break;
+                case 9:
+                    unit.emplace().__set_NANOS({});
+                    break;
+            }
+
+            std::optional<parq::LogicalType> t;
+            if (unit)
+            {
+                parq::TimestampType tt;
+                tt.__set_isAdjustedToUTC(true);
+                tt.__set_unit(*unit);
+                t.emplace().__set_TIMESTAMP(tt);
+            }
+            types(T::INT64, converted, t);
+            break;
+        }
+
+        case TypeIndex::String:
+        case TypeIndex::FixedString:
+        {
+            if (options.output_fixed_string_as_fixed_byte_array &&
+                type->getTypeId() == TypeIndex::FixedString)
+            {
+                fixed_string(assert_cast<const DataTypeFixedString &>(*type).getN());
+            }
+            else if (options.output_string_as_string)
+            {
+                parq::LogicalType t;
+                t.__set_STRING({});
+                types(T::BYTE_ARRAY, C::UTF8, t);
+            }
+            else
+            {
+                types(T::BYTE_ARRAY);
+            }
+            break;
+        }
+
+        /// Parquet doesn't have logical types for these.
+        case TypeIndex::UInt128: fixed_string(16); break;
+        case TypeIndex::UInt256: fixed_string(32); break;
+        case TypeIndex::Int128:  fixed_string(16); break;
+        case TypeIndex::Int256:  fixed_string(32); break;
+        case TypeIndex::IPv6:    fixed_string(16); break;
+
+        case TypeIndex::Decimal32:  decimal(4 , getDecimalPrecision(*type), getDecimalScale(*type)); break;
+        case TypeIndex::Decimal64:  decimal(8 , getDecimalPrecision(*type), getDecimalScale(*type)); break;
+        case TypeIndex::Decimal128: decimal(16, getDecimalPrecision(*type), getDecimalScale(*type)); break;
+        case TypeIndex::Decimal256: decimal(32, getDecimalPrecision(*type), getDecimalScale(*type)); break;
+
+        default:
+            throw Exception(ErrorCodes::UNKNOWN_TYPE, "Internal type '{}' of column '{}' is not supported for conversion into Parquet data format.", type->getFamilyName(), name);
+    }
+}
+
+void prepareColumnNullable(
+    ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
+    ColumnChunkWriteStates & states, SchemaElements & schemas)
+{
+    const ColumnNullable * column_nullable = assert_cast<const ColumnNullable *>(column.get());
+    ColumnPtr nested_column = column_nullable->getNestedColumnPtr();
+    DataTypePtr nested_type = assert_cast<const DataTypeNullable *>(type.get())->getNestedType();
+    const NullMap & null_map = column_nullable->getNullMapData();
+
+    size_t child_states_begin = states.size();
+    size_t child_schema_idx = schemas.size();
+
+    prepareColumnRecursive(nested_column, nested_type, name, options, states, schemas);
+
+    if (schemas[child_schema_idx].repetition_type == parq::FieldRepetitionType::REQUIRED)
+    {
+        /// Normal case: we just slap a FieldRepetitionType::OPTIONAL onto the nested column.
+        schemas[child_schema_idx].repetition_type = parq::FieldRepetitionType::OPTIONAL;
+    }
+    else
+    {
+        /// Weird case: Nullable(Nullable(...)). Or Nullable(Tuple(Nullable(...))), etc.
+        /// This is probably not allowed in ClickHouse, but let's support it just in case.
+        auto & schema = *schemas.insert(schemas.begin() + child_schema_idx, {});
+        schema.__set_repetition_type(parq::FieldRepetitionType::OPTIONAL);
+        schema.__set_name("nullable");
+        schema.__set_num_children(1);
+        for (size_t i = child_states_begin; i < states.size(); ++i)
+        {
+            Strings & path = states[i].column_chunk.meta_data.path_in_schema;
+            path.insert(path.begin(), schema.name + ".");
+        }
+    }
+
+    for (size_t i = child_states_begin; i < states.size(); ++i)
+    {
+        auto & s = states[i];
+        updateRepDefLevelsAndFilterColumnForNullable(s, null_map);
+    }
+}
+
+void prepareColumnTuple(
+    ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
+    ColumnChunkWriteStates & states, SchemaElements & schemas)
+{
+    const auto * column_tuple = assert_cast<const ColumnTuple *>(column.get());
+    const auto * type_tuple = assert_cast<const DataTypeTuple *>(type.get());
+
+    auto & tuple_schema = schemas.emplace_back();
+    tuple_schema.__set_repetition_type(parq::FieldRepetitionType::REQUIRED);
+    tuple_schema.__set_name(name);
+    tuple_schema.__set_num_children(static_cast<Int32>(type_tuple->getElements().size()));
+
+    size_t child_states_begin = states.size();
+
+    for (size_t i = 0; i < type_tuple->getElements().size(); ++i)
+        prepareColumnRecursive(column_tuple->getColumnPtr(i), type_tuple->getElement(i), type_tuple->getNameByPosition(i + 1), options, states, schemas);
+
+    for (size_t i = child_states_begin; i < states.size(); ++i)
+    {
+        Strings & path = states[i].column_chunk.meta_data.path_in_schema;
+        /// O(nesting_depth^2), but who cares.
+        path.insert(path.begin(), name);
+    }
+}
+
+void prepareColumnArray(
+    ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
+    ColumnChunkWriteStates & states, SchemaElements & schemas)
+{
+    const auto * column_array = assert_cast<const ColumnArray *>(column.get());
+    ColumnPtr nested_column = column_array->getDataPtr();
+    DataTypePtr nested_type = assert_cast<const DataTypeArray *>(type.get())->getNestedType();
+    const auto & offsets = column_array->getOffsets();
+
+    /// Schema for lists https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
+    ///
+    /// required group `name` (List):
+    ///   repeated group "list":
+    ///     <recurse into nested type> "element"
+
+    /// Add the groups schema.
+
+    schemas.emplace_back();
+    schemas.emplace_back();
+    auto & list_schema = schemas[schemas.size() - 2];
+    auto & item_schema = schemas[schemas.size() - 1];
+
+    list_schema.__set_repetition_type(parq::FieldRepetitionType::REQUIRED);
+    list_schema.__set_name(name);
+    list_schema.__set_num_children(1);
+    list_schema.__set_converted_type(parq::ConvertedType::LIST);
+    list_schema.__isset.logicalType = true;
+    list_schema.logicalType.__set_LIST({});
+
+    item_schema.__set_repetition_type(parq::FieldRepetitionType::REPEATED);
+    item_schema.__set_name("list");
+    item_schema.__set_num_children(1);
+
+    std::array<std::string, 2> path_prefix = {list_schema.name, item_schema.name};
+    size_t child_states_begin = states.size();
+
+    /// Recurse.
+    prepareColumnRecursive(nested_column, nested_type, "element", options, states, schemas);
+
+    /// Update repetition+definition levels and fully-qualified column names (x -> myarray.list.x).
+    for (size_t i = child_states_begin; i < states.size(); ++i)
+    {
+        Strings & path = states[i].column_chunk.meta_data.path_in_schema;
+        path.insert(path.begin(), path_prefix.begin(), path_prefix.end());
+
+        updateRepDefLevelsForArray(states[i], offsets);
+    }
+}
+
+void prepareColumnMap(
+    ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
+    ColumnChunkWriteStates & states, SchemaElements & schemas)
+{
+    const auto * column_map = assert_cast<const ColumnMap *>(column.get());
+    const auto * column_array = &column_map->getNestedColumn();
+    const auto & offsets = column_array->getOffsets();
+    ColumnPtr column_tuple = column_array->getDataPtr();
+
+    const auto * map_type = assert_cast<const DataTypeMap *>(type.get());
+    DataTypePtr tuple_type = std::make_shared<DataTypeTuple>(map_type->getKeyValueTypes(), Strings{"key", "value"});
+
+    /// Map is an array of tuples
+    /// https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps
+    ///
+    /// required group `name` (Map):
+    ///   repeated group "key_value":
+    ///     reqiured <...> "key"
+    ///     <...> "value"
+
+    auto & map_schema = schemas.emplace_back();
+    map_schema.__set_repetition_type(parq::FieldRepetitionType::REQUIRED);
+    map_schema.__set_name(name);
+    map_schema.__set_num_children(1);
+    map_schema.__set_converted_type(parq::ConvertedType::MAP);
+    map_schema.__set_logicalType({});
+    map_schema.logicalType.__set_MAP({});
+
+    size_t tuple_schema_idx = schemas.size();
+    size_t child_states_begin = states.size();
+
+    prepareColumnTuple(column_tuple, tuple_type, "key_value", options, states, schemas);
+
+    schemas[tuple_schema_idx].__set_repetition_type(parq::FieldRepetitionType::REPEATED);
+    schemas[tuple_schema_idx].__set_converted_type(parq::ConvertedType::MAP_KEY_VALUE);
+
+    for (size_t i = child_states_begin; i < states.size(); ++i)
+    {
+        Strings & path = states[i].column_chunk.meta_data.path_in_schema;
+        path.insert(path.begin(), name);
+
+        updateRepDefLevelsForArray(states[i], offsets);
+    }
+}
+
+void prepareColumnRecursive(
+    ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
+    ColumnChunkWriteStates & states, SchemaElements & schemas)
+{
+    switch (type->getTypeId())
+    {
+        case TypeIndex::Nullable: prepareColumnNullable(column, type, name, options, states, schemas); break;
+        case TypeIndex::Array: prepareColumnArray(column, type, name, options, states, schemas); break;
+        case TypeIndex::Tuple: prepareColumnTuple(column, type, name, options, states, schemas); break;
+        case TypeIndex::Map: prepareColumnMap(column, type, name, options, states, schemas); break;
+        case TypeIndex::LowCardinality:
+        {
+            auto nested_type = assert_cast<const DataTypeLowCardinality &>(*type).getDictionaryType();
+            if (nested_type->isNullable())
+                prepareColumnNullable(
+                    column->convertToFullColumnIfLowCardinality(), nested_type, name, options, states, schemas);
+            else
+                /// Use nested data type, but keep ColumnLowCardinality. The encoder can deal with it.
+                preparePrimitiveColumn(column, nested_type, name, options, states, schemas);
+            break;
+        }
+        default:
+            preparePrimitiveColumn(column, type, name, options, states, schemas);
+            break;
+    }
+}
+
+}
+
+SchemaElements convertSchema(const Block & sample, const WriteOptions & options)
+{
+    SchemaElements schema;
+    auto & root = schema.emplace_back();
+    root.__set_name("schema");
+    root.__set_num_children(static_cast<Int32>(sample.columns()));
+
+    for (auto & c : sample)
+        prepareColumnForWrite(c.column, c.type, c.name, options, nullptr, &schema);
+
+    return schema;
+}
+
+void prepareColumnForWrite(
+    ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
+    ColumnChunkWriteStates * out_columns_to_write, SchemaElements * out_schema)
+{
+    if (column->size() == 0 && out_columns_to_write != nullptr)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty column passed to Parquet encoder");
+
+    ColumnChunkWriteStates states;
+    SchemaElements schemas;
+    prepareColumnRecursive(column, type, name, options, states, schemas);
+
+    if (out_columns_to_write)
+        for (auto & s : states)
+            out_columns_to_write->push_back(std::move(s));
+    if (out_schema)
+        out_schema->insert(out_schema->end(), schemas.begin(), schemas.end());
+
+    if (column->empty())
+        states.clear();
+}
+
+}

--- a/src/Processors/Formats/Impl/Parquet/ThriftUtil.cpp
+++ b/src/Processors/Formats/Impl/Parquet/ThriftUtil.cpp
@@ -1,0 +1,35 @@
+#include <Processors/Formats/Impl/Parquet/ThriftUtil.h>
+#include <thrift/protocol/TCompactProtocol.h>
+
+namespace DB::Parquet
+{
+
+class WriteBufferTransport : public apache::thrift::transport::TTransport
+{
+public:
+    WriteBuffer & out;
+    size_t bytes = 0;
+
+    explicit WriteBufferTransport(WriteBuffer & out_) : out(out_) {}
+
+    void write(const uint8_t* buf, uint32_t len)
+    {
+        out.write(reinterpret_cast<const char *>(buf), len);
+        bytes += len;
+    }
+};
+
+template <typename T>
+size_t serializeThriftStruct(const T & obj, WriteBuffer & out)
+{
+    auto trans = std::make_shared<WriteBufferTransport>(out);
+    auto proto = apache::thrift::protocol::TCompactProtocolFactoryT<WriteBufferTransport>().getProtocol(trans);
+    obj.write(proto.get());
+    return trans->bytes;
+}
+
+template size_t serializeThriftStruct<parquet::format::PageHeader>(const parquet::format::PageHeader &, WriteBuffer & out);
+template size_t serializeThriftStruct<parquet::format::ColumnChunk>(const parquet::format::ColumnChunk &, WriteBuffer & out);
+template size_t serializeThriftStruct<parquet::format::FileMetaData>(const parquet::format::FileMetaData &, WriteBuffer & out);
+
+}

--- a/src/Processors/Formats/Impl/Parquet/ThriftUtil.h
+++ b/src/Processors/Formats/Impl/Parquet/ThriftUtil.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <generated/parquet_types.h> // in contrib/arrow/cpp/src/ , generated from parquet.thrift
+#include <IO/WriteBuffer.h>
+
+namespace DB::Parquet
+{
+
+/// Returns number of bytes written.
+template <typename T>
+size_t serializeThriftStruct(const T & obj, WriteBuffer & out);
+
+extern template size_t serializeThriftStruct<parquet::format::PageHeader>(const parquet::format::PageHeader &, WriteBuffer & out);
+extern template size_t serializeThriftStruct<parquet::format::ColumnChunk>(const parquet::format::ColumnChunk &, WriteBuffer & out);
+extern template size_t serializeThriftStruct<parquet::format::FileMetaData>(const parquet::format::FileMetaData &, WriteBuffer & out);
+
+}

--- a/src/Processors/Formats/Impl/Parquet/Write.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Write.cpp
@@ -1,0 +1,816 @@
+#include "Processors/Formats/Impl/Parquet/Write.h"
+#include "Processors/Formats/Impl/Parquet/ThriftUtil.h"
+#include <parquet/encoding.h>
+#include <parquet/schema.h>
+#include <arrow/util/rle_encoding.h>
+#include <lz4.h>
+#include <Columns/MaskOperations.h>
+#include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnDecimal.h>
+#include <Columns/ColumnTuple.h>
+#include <Columns/ColumnMap.h>
+#include <IO/WriteHelpers.h>
+#include "config_version.h"
+
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_COMPRESS;
+    extern const int LIMIT_EXCEEDED;
+    extern const int LOGICAL_ERROR;
+}
+
+namespace DB::Parquet
+{
+
+namespace parq = parquet::format;
+
+namespace
+{
+
+template <typename T, typename SourceType>
+struct StatisticsNumeric
+{
+    T min = std::numeric_limits<T>::max();
+    T max = std::numeric_limits<T>::min();
+
+    void add(SourceType x)
+    {
+        min = std::min(min, static_cast<T>(x));
+        max = std::max(max, static_cast<T>(x));
+    }
+
+    void merge(const StatisticsNumeric & s)
+    {
+        min = std::min(min, s.min);
+        max = std::max(max, s.max);
+    }
+
+    void clear() { *this = {}; }
+
+    parq::Statistics get(const WriteOptions &)
+    {
+        parq::Statistics s;
+        s.__isset.min_value = s.__isset.max_value = true;
+        s.min_value.resize(sizeof(T));
+        s.max_value.resize(sizeof(T));
+        memcpy(s.min_value.data(), &min, sizeof(T));
+        memcpy(s.max_value.data(), &max, sizeof(T));
+
+        if constexpr (std::is_signed<T>::value)
+        {
+            s.__set_min(s.min_value);
+            s.__set_max(s.max_value);
+        }
+        return s;
+    }
+};
+
+struct StatisticsFixedString
+{
+    size_t fixed_string_size = UINT64_MAX;
+    const uint8_t * min = nullptr;
+    const uint8_t * max = nullptr;
+
+    void add(parquet::FixedLenByteArray a)
+    {
+        chassert(fixed_string_size != UINT64_MAX);
+        addMin(a.ptr);
+        addMax(a.ptr);
+    }
+
+    void merge(const StatisticsFixedString & s)
+    {
+        chassert(fixed_string_size == UINT64_MAX || fixed_string_size == s.fixed_string_size);
+        fixed_string_size = s.fixed_string_size;
+        if (s.min == nullptr)
+            return;
+        addMin(s.min);
+        addMax(s.max);
+    }
+
+    void clear() { min = max = nullptr; }
+
+    parq::Statistics get(const WriteOptions & options)
+    {
+        parq::Statistics s;
+        if (min == nullptr || fixed_string_size > options.max_statistics_size)
+            return s;
+        s.__set_min_value(std::string(reinterpret_cast<const char *>(min), fixed_string_size));
+        s.__set_max_value(std::string(reinterpret_cast<const char *>(max), fixed_string_size));
+        return s;
+    }
+
+    void addMin(const uint8_t * p)
+    {
+        if (min == nullptr || memcmp(p, min, fixed_string_size) < 0)
+            min = p;
+    }
+    void addMax(const uint8_t * p)
+    {
+        if (max == nullptr || memcmp(p, max, fixed_string_size) > 0)
+            max = p;
+    }
+};
+
+struct StatisticsString
+{
+    parquet::ByteArray min;
+    parquet::ByteArray max;
+
+    void add(parquet::ByteArray x)
+    {
+        addMin(x);
+        addMax(x);
+    }
+
+    void merge(const StatisticsString & s)
+    {
+        if (s.min.ptr == nullptr)
+            return;
+        addMin(s.min);
+        addMax(s.max);
+    }
+
+    void clear() { *this = {}; }
+
+    parq::Statistics get(const WriteOptions & options)
+    {
+        parq::Statistics s;
+        if (min.ptr == nullptr)
+            return s;
+        if (static_cast<size_t>(min.len) <= options.max_statistics_size)
+            s.__set_min_value(std::string(reinterpret_cast<const char *>(min.ptr), static_cast<size_t>(min.len)));
+        if (static_cast<size_t>(max.len) <= options.max_statistics_size)
+            s.__set_max_value(std::string(reinterpret_cast<const char *>(max.ptr), static_cast<size_t>(max.len)));
+        return s;
+    }
+
+    void addMin(parquet::ByteArray x)
+    {
+        if (min.ptr == nullptr || compare(x, min) < 0)
+            min = x;
+    }
+
+    void addMax(parquet::ByteArray x)
+    {
+        if (max.ptr == nullptr || compare(x, max) > 0)
+            max = x;
+    }
+
+    static int compare(parquet::ByteArray a, parquet::ByteArray b)
+    {
+        int t = memcmp(a.ptr, b.ptr, std::min(a.len, b.len));
+        if (t != 0)
+            return t;
+        return a.len - b.len;
+    }
+};
+
+/// The column usually needs to be converted to one of Parquet physical types, e.g. UInt16 -> Int32
+/// or [element of ColumnString] -> std::string_view.
+/// We do this conversion in small batches rather than all at once, just before encoding the batch,
+/// in hopes of getting better performance through cache locality.
+/// The Coverter* structs below are responsible for that.
+/// When conversion is not needed, getBatch() will just return pointer into original data.
+
+template <typename Col, typename To, typename MinMaxType = typename std::conditional<
+        std::is_signed<typename Col::Container::value_type>::value,
+        To,
+        typename std::make_unsigned<To>::type>::type>
+struct ConverterNumeric
+{
+    using Statistics = StatisticsNumeric<MinMaxType, To>;
+
+    const Col & column;
+    PODArray<To> buf;
+
+    explicit ConverterNumeric(const ColumnPtr & c) : column(assert_cast<const Col &>(*c)) {}
+
+    const To * getBatch(size_t offset, size_t count)
+    {
+        if constexpr (sizeof(*column.getData().data()) == sizeof(To))
+            return reinterpret_cast<const To *>(column.getData().data() + offset);
+        else
+        {
+            buf.resize(count);
+            for (size_t i = 0; i < count; ++i)
+                buf[i] = static_cast<To>(column.getData()[offset + i]);
+            return buf.data();
+        }
+    }
+};
+
+struct ConverterString
+{
+    using Statistics = StatisticsString;
+
+    const ColumnString & column;
+    PODArray<parquet::ByteArray> buf;
+
+    explicit ConverterString(const ColumnPtr & c) : column(assert_cast<const ColumnString &>(*c)) {}
+
+    const parquet::ByteArray * getBatch(size_t offset, size_t count)
+    {
+        buf.resize(count);
+        for (size_t i = 0; i < count; ++i)
+        {
+            StringRef s = column.getDataAt(offset + i);
+            buf[i] = parquet::ByteArray(static_cast<UInt32>(s.size), reinterpret_cast<const uint8_t *>(s.data));
+        }
+        return buf.data();
+    }
+};
+
+struct ConverterFixedString
+{
+    using Statistics = StatisticsFixedString;
+
+    const ColumnFixedString & column;
+    PODArray<parquet::FixedLenByteArray> buf;
+
+    explicit ConverterFixedString(const ColumnPtr & c) : column(assert_cast<const ColumnFixedString &>(*c)) {}
+
+    const parquet::FixedLenByteArray * getBatch(size_t offset, size_t count)
+    {
+        buf.resize(count);
+        for (size_t i = 0; i < count; ++i)
+            buf[i].ptr = reinterpret_cast<const uint8_t *>(column.getChars().data() + (offset + i) * column.getN());
+        return buf.data();
+    }
+
+    size_t fixedStringSize() { return column.getN(); }
+};
+
+struct ConverterFixedStringAsString
+{
+    using Statistics = StatisticsString;
+
+    const ColumnFixedString & column;
+    PODArray<parquet::ByteArray> buf;
+
+    explicit ConverterFixedStringAsString(const ColumnPtr & c) : column(assert_cast<const ColumnFixedString &>(*c)) {}
+
+    const parquet::ByteArray * getBatch(size_t offset, size_t count)
+    {
+        buf.resize(count);
+        for (size_t i = 0; i < count; ++i)
+            buf[i] = parquet::ByteArray(static_cast<UInt32>(column.getN()), reinterpret_cast<const uint8_t *>(column.getChars().data() + (offset + i) * column.getN()));
+        return buf.data();
+    }
+};
+
+template <typename T>
+struct ConverterNumberAsFixedString
+{
+    /// Calculate min/max statistics for little-endian fixed strings, not numbers, because parquet
+    /// doesn't know it's numbers.
+    using Statistics = StatisticsFixedString;
+
+    const ColumnVector<T> & column;
+    PODArray<parquet::FixedLenByteArray> buf;
+
+    explicit ConverterNumberAsFixedString(const ColumnPtr & c) : column(assert_cast<const ColumnVector<T> &>(*c)) {}
+
+    const parquet::FixedLenByteArray * getBatch(size_t offset, size_t count)
+    {
+        buf.resize(count);
+        for (size_t i = 0; i < count; ++i)
+            buf[i].ptr = reinterpret_cast<const uint8_t *>(column.getData().data() + offset + i);
+        return buf.data();
+    }
+
+    size_t fixedStringSize() { return sizeof(T); }
+};
+
+/// Like ConverterNumberAsFixedString, but converts to big-endian. Because that's the byte order
+/// Parquet uses for decimal types and literally nothing else, for some reason.
+template <typename T>
+struct ConverterDecimal
+{
+    using Statistics = StatisticsFixedString;
+
+    const ColumnDecimal<T> & column;
+    PODArray<uint8_t> data_buf;
+    PODArray<parquet::FixedLenByteArray> ptr_buf;
+
+    explicit ConverterDecimal(const ColumnPtr & c) : column(assert_cast<const ColumnDecimal<T> &>(*c)) {}
+
+    const parquet::FixedLenByteArray * getBatch(size_t offset, size_t count)
+    {
+        data_buf.resize(count * sizeof(T));
+        ptr_buf.resize(count);
+        memcpy(data_buf.data(), reinterpret_cast<const char *>(column.getData().data() + offset), count * sizeof(T));
+        for (size_t i = 0; i < count; ++i)
+        {
+            std::reverse(data_buf.data() + i * sizeof(T), data_buf.data() + (i + 1) * sizeof(T));
+            ptr_buf[i].ptr = data_buf.data() + i * sizeof(T);
+        }
+        return ptr_buf.data();
+    }
+
+    size_t fixedStringSize() { return sizeof(T); }
+};
+
+/// Returns either `source` or `scratch`.
+PODArray<char> & compress(PODArray<char> & source, PODArray<char> & scratch, CompressionMethod method)
+{
+    /// We could use wrapWriteBufferWithCompressionMethod() for everything, but I worry about the
+    /// overhead of creating a bunch of WriteBuffers on each page (thousands of values).
+    switch (method)
+    {
+        case CompressionMethod::None:
+            return source;
+
+        case CompressionMethod::Lz4:
+        {
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wold-style-cast"
+
+            size_t max_dest_size = LZ4_COMPRESSBOUND(source.size());
+
+            #pragma clang diagnostic pop
+
+            if (max_dest_size > std::numeric_limits<int>::max())
+                throw Exception(ErrorCodes::CANNOT_COMPRESS, "Cannot compress column of size {}", formatReadableSizeWithBinarySuffix(source.size()));
+
+            scratch.resize(max_dest_size);
+
+            int compressed_size = LZ4_compress_default(
+                source.data(),
+                scratch.data(),
+                static_cast<int>(source.size()),
+                static_cast<int>(max_dest_size));
+
+            scratch.resize(static_cast<size_t>(compressed_size));
+            return scratch;
+        }
+
+        default:
+        {
+            auto dest_buf = std::make_unique<WriteBufferFromVector<PODArray<char>>>(scratch);
+            auto compressed_buf = wrapWriteBufferWithCompressionMethod(
+                std::move(dest_buf),
+                method,
+                /*level*/ 3,
+                source.size(),
+                /*existing_memory*/ source.data());
+            chassert(compressed_buf->position() == source.data());
+            chassert(compressed_buf->available() == source.size());
+            compressed_buf->position() += source.size();
+            compressed_buf->finalize();
+            return scratch;
+        }
+    }
+}
+
+void encodeRepDefLevelsRLE(const UInt8 * data, size_t size, UInt8 max_level, PODArray<char> & out)
+{
+    using arrow::util::RleEncoder;
+
+    chassert(max_level > 0);
+    size_t offset = out.size();
+    size_t prefix_size = sizeof(Int32);
+
+    int bit_width = bitScanReverse(max_level) + 1;
+    int max_rle_size = RleEncoder::MaxBufferSize(bit_width, static_cast<int>(size)) +
+                       RleEncoder::MinBufferSize(bit_width);
+
+    out.resize(offset + prefix_size + max_rle_size);
+
+    RleEncoder encoder(reinterpret_cast<uint8_t *>(out.data() + offset + prefix_size), max_rle_size, bit_width);
+    for (size_t i = 0; i < size; ++i)
+        encoder.Put(data[i]);
+    encoder.Flush();
+    Int32 len = encoder.len();
+
+    memcpy(out.data() + offset, &len, prefix_size);
+    out.resize(offset + prefix_size + len);
+}
+
+void addToEncodingsUsed(ColumnChunkWriteState & s, parq::Encoding::type e)
+{
+    if (!std::count(s.column_chunk.meta_data.encodings.begin(), s.column_chunk.meta_data.encodings.end(), e))
+        s.column_chunk.meta_data.encodings.push_back(e);
+}
+
+void writePage(const parq::PageHeader & header, const PODArray<char> & compressed, ColumnChunkWriteState & s, WriteBuffer & out)
+{
+    size_t header_size = serializeThriftStruct(header, out);
+    out.write(compressed.data(), compressed.size());
+
+    /// Remember first data page and first dictionary page.
+    if (header.__isset.data_page_header && s.column_chunk.meta_data.data_page_offset == -1)
+        s.column_chunk.meta_data.__set_data_page_offset(s.column_chunk.meta_data.total_compressed_size);
+    if (header.__isset.dictionary_page_header && !s.column_chunk.meta_data.__isset.dictionary_page_offset)
+        s.column_chunk.meta_data.__set_dictionary_page_offset(s.column_chunk.meta_data.total_compressed_size);
+
+    s.column_chunk.meta_data.total_uncompressed_size += header.uncompressed_page_size + header_size;
+    s.column_chunk.meta_data.total_compressed_size += header.compressed_page_size + header_size;
+}
+
+template <typename ParquetDType, typename Converter>
+void writeColumnImpl(
+    ColumnChunkWriteState & s, const WriteOptions & options, WriteBuffer & out, Converter && converter)
+{
+    size_t num_values = s.max_def > 0 ? s.def.size() : s.primitive_column->size();
+    auto encoding = options.encoding;
+
+    typename Converter::Statistics page_statistics;
+    typename Converter::Statistics total_statistics;
+
+    /// We start with dictionary encoding, then switch to `encoding` (non-dictionary) if the
+    /// dictionary gets too big. That's how arrow does it too.
+    bool initially_used_dictionary = options.use_dictionary_encoding;
+    bool currently_using_dictionary = initially_used_dictionary;
+
+    std::optional<parquet::ColumnDescriptor> fixed_string_descr;
+    if constexpr (std::is_same<ParquetDType, parquet::FLBAType>::value)
+    {
+        /// This just communicates one number to MakeTypedEncoder(): the fixed string length.
+        fixed_string_descr.emplace(parquet::schema::PrimitiveNode::Make(
+            "", parquet::Repetition::REQUIRED, parquet::Type::FIXED_LEN_BYTE_ARRAY,
+            parquet::ConvertedType::NONE, static_cast<int>(converter.fixedStringSize())), 0, 0);
+
+        page_statistics.fixed_string_size = converter.fixedStringSize();
+    }
+
+    /// Could use an arena here (by passing a custom MemoryPool), to reuse memory across pages.
+    /// Alternatively, we could avoid using arrow's dictionary encoding code and leverage
+    /// ColumnLowCardinality instead. It would work basically the same way as what this function
+    /// currently does: add values to the ColumnRowCardinality (instead of `encoder`) in batches,
+    /// checking dictionary size after each batch; if it gets big, flush the dictionary and the
+    /// indices and switch to non-dictionary encoding. Feels like it could even be slightly less code.
+    auto encoder = parquet::MakeTypedEncoder<ParquetDType>(
+        // ignored if using dictionary
+        static_cast<parquet::Encoding::type>(encoding),
+        currently_using_dictionary, fixed_string_descr ? &*fixed_string_descr : nullptr);
+
+    struct PageData
+    {
+        parq::PageHeader header;
+        PODArray<char> data;
+    };
+    std::vector<PageData> dict_encoded_pages; // can't write them out until we have full dictionary
+
+    /// Reused across pages to reduce number of allocations and improve locality.
+    PODArray<char> encoded;
+    PODArray<char> compressed_maybe;
+
+    /// Start of current page.
+    size_t def_offset = 0; // index in def and rep
+    size_t data_offset = 0; // index in primitive_column
+
+    auto flush_page = [&](size_t def_count, size_t data_count)
+    {
+        encoded.clear();
+
+        /// Concatenate encoded rep, def, and data.
+
+        if (s.max_rep > 0)
+            encodeRepDefLevelsRLE(s.rep.data() + def_offset, def_count, s.max_rep, encoded);
+        if (s.max_def > 0)
+            encodeRepDefLevelsRLE(s.def.data() + def_offset, def_count, s.max_def, encoded);
+
+        std::shared_ptr<parquet::Buffer> values = encoder->FlushValues(); // resets it for next page
+
+        encoded.resize(encoded.size() + values->size());
+        memcpy(encoded.data() + encoded.size() - values->size(), values->data(), values->size());
+        values.reset();
+
+        if (encoded.size() > INT32_MAX)
+            throw Exception(ErrorCodes::CANNOT_COMPRESS, "Uncompressed page is too big: {}", encoded.size());
+
+        size_t uncompressed_size = encoded.size();
+        auto & compressed = compress(encoded, compressed_maybe, s.compression);
+
+        if (compressed.size() > INT32_MAX)
+            throw Exception(ErrorCodes::CANNOT_COMPRESS, "Compressed page is too big: {}", compressed.size());
+
+        parq::PageHeader header;
+        header.__set_type(parq::PageType::DATA_PAGE);
+        header.__set_uncompressed_page_size(static_cast<int>(uncompressed_size));
+        header.__set_compressed_page_size(static_cast<int>(compressed.size()));
+        header.__isset.data_page_header = true;
+        auto & d = header.data_page_header;
+        d.__set_num_values(static_cast<Int32>(def_count));
+        d.__set_encoding(currently_using_dictionary ? parq::Encoding::RLE_DICTIONARY : encoding);
+        d.__set_definition_level_encoding(parq::Encoding::RLE);
+        d.__set_repetition_level_encoding(parq::Encoding::RLE);
+        /// We could also put checksum in `header.crc`, but apparently no one uses it:
+        /// https://issues.apache.org/jira/browse/PARQUET-594
+
+        if (options.write_page_statistics)
+        {
+            d.__set_statistics(page_statistics.get(options));
+
+            if (s.max_def == 1 && s.max_rep == 0)
+                d.statistics.__set_null_count(static_cast<Int64>(def_count - data_count));
+        }
+
+        total_statistics.merge(page_statistics);
+        page_statistics.clear();
+
+        if (currently_using_dictionary)
+        {
+            dict_encoded_pages.push_back({.header = std::move(header)});
+            std::swap(dict_encoded_pages.back().data, compressed);
+        }
+        else
+        {
+            writePage(header, compressed, s, out);
+        }
+
+        def_offset += def_count;
+        data_offset += data_count;
+    };
+
+    auto flush_dict = [&] -> bool
+    {
+        auto * dict_encoder = dynamic_cast<parquet::DictEncoder<ParquetDType> *>(encoder.get());
+        int dict_size = dict_encoder->dict_encoded_size();
+
+        encoded.resize(static_cast<size_t>(dict_size));
+        dict_encoder->WriteDict(reinterpret_cast<uint8_t *>(encoded.data()));
+
+        auto & compressed = compress(encoded, compressed_maybe, s.compression);
+
+        if (compressed.size() > INT32_MAX)
+            throw Exception(ErrorCodes::CANNOT_COMPRESS, "Compressed dictionary page is too big: {}", compressed.size());
+
+        parq::PageHeader header;
+        header.__set_type(parq::PageType::DICTIONARY_PAGE);
+        header.__set_uncompressed_page_size(dict_size);
+        header.__set_compressed_page_size(static_cast<int>(compressed.size()));
+        header.__isset.dictionary_page_header = true;
+        header.dictionary_page_header.__set_num_values(dict_encoder->num_entries());
+        header.dictionary_page_header.__set_encoding(parq::Encoding::PLAIN);
+
+        writePage(header, compressed, s, out);
+
+        for (auto & p : dict_encoded_pages)
+            writePage(p.header, p.data, s, out);
+
+        dict_encoded_pages.clear();
+        encoder.reset();
+
+        return true;
+    };
+
+    auto is_dict_too_big = [&] {
+        auto * dict_encoder = dynamic_cast<parquet::DictEncoder<ParquetDType> *>(encoder.get());
+        int dict_size = dict_encoder->dict_encoded_size();
+        return static_cast<size_t>(dict_size) >= options.dictionary_size_limit;
+    };
+
+    while (def_offset < num_values)
+    {
+        /// Pick enough data for a page.
+        size_t next_def_offset = def_offset;
+        size_t next_data_offset = data_offset;
+        while (true)
+        {
+            /// Bite off a batch of defs and corresponding data values.
+            size_t def_count = std::min(options.write_batch_size, num_values - next_def_offset);
+            size_t data_count = 0;
+            if (s.max_def == 0)
+                data_count = def_count;
+            else
+                for (size_t i = 0; i < def_count; ++i)
+                    data_count += s.def[next_def_offset + i] == s.max_def;
+
+            /// Encode the data (but not the levels yet), so that we can estimate its encoded size.
+            const typename ParquetDType::c_type * converted = converter.getBatch(next_data_offset, data_count);
+
+            if (options.write_page_statistics || options.write_column_chunk_statistics)
+                for (size_t i = 0; i < data_count; ++i)
+                    page_statistics.add(converted[i]);
+
+            encoder->Put(converted, static_cast<int>(data_count));
+
+            next_def_offset += def_count;
+            next_data_offset += data_count;
+
+            if (currently_using_dictionary && is_dict_too_big())
+            {
+                /// Fallback to non-dictionary encoding.
+                flush_page(next_def_offset - def_offset, next_data_offset - data_offset);
+                flush_dict();
+
+                currently_using_dictionary = false;
+                encoder = parquet::MakeTypedEncoder<ParquetDType>(
+                    static_cast<parquet::Encoding::type>(encoding));
+                break;
+            }
+
+            if (next_def_offset == num_values ||
+                static_cast<size_t>(encoder->EstimatedDataEncodedSize()) >= options.data_page_size)
+            {
+                flush_page(next_def_offset - def_offset, next_data_offset - data_offset);
+                break;
+            }
+        }
+    }
+
+    if (currently_using_dictionary)
+        flush_dict();
+
+    chassert(data_offset == s.primitive_column->size());
+
+    if (options.write_column_chunk_statistics)
+    {
+        s.column_chunk.meta_data.__set_statistics(total_statistics.get(options));
+
+        if (s.max_def == 1 && s.max_rep == 0)
+            s.column_chunk.meta_data.statistics.__set_null_count(static_cast<Int64>(def_offset - data_offset));
+    }
+
+    /// Report which encodings we've used.
+    if (s.max_rep > 0 || s.max_def > 0)
+        addToEncodingsUsed(s, parq::Encoding::RLE); // levels
+    if (!currently_using_dictionary)
+        addToEncodingsUsed(s, encoding); // non-dictionary encoding
+    if (initially_used_dictionary)
+    {
+        addToEncodingsUsed(s, parq::Encoding::PLAIN); // dictionary itself
+        addToEncodingsUsed(s, parq::Encoding::RLE_DICTIONARY); // ids
+    }
+}
+
+}
+
+void writeColumnChunkBody(ColumnChunkWriteState & s, const WriteOptions & options, WriteBuffer & out)
+{
+    s.column_chunk.meta_data.__set_num_values(s.max_def > 0 ? s.def.size() : s.primitive_column->size());
+
+    /// We'll be updating these as we go.
+    s.column_chunk.meta_data.__set_encodings({});
+    s.column_chunk.meta_data.__set_total_compressed_size(0);
+    s.column_chunk.meta_data.__set_total_uncompressed_size(0);
+    s.column_chunk.meta_data.__set_data_page_offset(-1);
+
+    s.primitive_column = s.primitive_column->convertToFullColumnIfLowCardinality();
+
+    switch (s.primitive_column->getDataType())
+    {
+        /// Numeric conversion to Int32 or Int64.
+        #define N(source_type, parquet_dtype) \
+            writeColumnImpl<parquet::parquet_dtype>(s, options, out, \
+                ConverterNumeric<ColumnVector<source_type>, parquet::parquet_dtype::c_type>( \
+                    s.primitive_column))
+
+        case TypeIndex::UInt8  : N(UInt8 , Int32Type); break;
+        case TypeIndex::UInt16 : N(UInt16, Int32Type); break;
+        case TypeIndex::UInt32 : N(UInt32, Int32Type); break;
+        case TypeIndex::UInt64 : N(UInt64, Int64Type); break;
+        case TypeIndex::Int8   : N(Int8  , Int32Type); break;
+        case TypeIndex::Int16  : N(Int16 , Int32Type); break;
+        case TypeIndex::Int32  : N(Int32 , Int32Type); break;
+        case TypeIndex::Int64  : N(Int64 , Int64Type); break;
+
+        case TypeIndex::Enum8:      N(Int8  , Int32Type); break;
+        case TypeIndex::Enum16:     N(Int16 , Int32Type); break;
+        case TypeIndex::Date:       N(UInt16, Int32Type); break;
+        case TypeIndex::Date32:     N(Int32 , Int32Type); break;
+        case TypeIndex::DateTime:   N(UInt32, Int32Type); break;
+
+        #undef N
+
+        case TypeIndex::Float32:
+            writeColumnImpl<parquet::FloatType>(
+                s, options, out, ConverterNumeric<ColumnVector<Float32>, Float32, Float32>(
+                    s.primitive_column));
+            break;
+
+        case TypeIndex::Float64:
+            writeColumnImpl<parquet::DoubleType>(
+                s, options, out, ConverterNumeric<ColumnVector<Float64>, Float64, Float64>(
+                    s.primitive_column));
+            break;
+
+        case TypeIndex::DateTime64:
+            writeColumnImpl<parquet::Int64Type>(
+                s, options, out, ConverterNumeric<ColumnDecimal<DateTime64>, Int64, Int64>(
+                    s.primitive_column));
+            break;
+
+        case TypeIndex::IPv4:
+            writeColumnImpl<parquet::Int32Type>(
+                s, options, out, ConverterNumeric<ColumnVector<IPv4>, Int32, UInt32>(
+                    s.primitive_column));
+            break;
+
+        case TypeIndex::String:
+            writeColumnImpl<parquet::ByteArrayType>(
+                s, options, out, ConverterString(s.primitive_column));
+            break;
+
+        case TypeIndex::FixedString:
+            if (options.output_fixed_string_as_fixed_byte_array)
+                writeColumnImpl<parquet::FLBAType>(
+                s, options, out, ConverterFixedString(s.primitive_column));
+            else
+                writeColumnImpl<parquet::ByteArrayType>(
+                s, options, out, ConverterFixedStringAsString(s.primitive_column));
+            break;
+
+        #define F(source_type) \
+            writeColumnImpl<parquet::FLBAType>( \
+                s, options, out, ConverterNumberAsFixedString<source_type>(s.primitive_column))
+        case TypeIndex::UInt128: F(UInt128); break;
+        case TypeIndex::UInt256: F(UInt256); break;
+        case TypeIndex::Int128:  F(Int128); break;
+        case TypeIndex::Int256:  F(Int256); break;
+        case TypeIndex::IPv6:    F(IPv6); break;
+        #undef F
+
+        #define D(source_type) \
+            writeColumnImpl<parquet::FLBAType>( \
+                s, options, out, ConverterDecimal<source_type>(s.primitive_column))
+        case TypeIndex::Decimal32:  D(Decimal32); break;
+        case TypeIndex::Decimal64:  D(Decimal64); break;
+        case TypeIndex::Decimal128: D(Decimal128); break;
+        case TypeIndex::Decimal256: D(Decimal256); break;
+        #undef D
+
+        default:
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected column type: {}", s.primitive_column->getFamilyName());
+    }
+
+    /// Free some memory.
+    s.primitive_column = {};
+    s.def = {};
+    s.rep = {};
+}
+
+void writeFileHeader(WriteBuffer & out)
+{
+    /// Write the magic bytes. We're a wizard now.
+    out.write("PAR1", 4);
+}
+
+parq::ColumnChunk finalizeColumnChunkAndWriteFooter(
+    size_t offset_in_file, ColumnChunkWriteState s, const WriteOptions &, WriteBuffer & out)
+{
+    if (s.column_chunk.meta_data.data_page_offset != -1)
+        s.column_chunk.meta_data.data_page_offset += offset_in_file;
+    if (s.column_chunk.meta_data.__isset.dictionary_page_offset)
+        s.column_chunk.meta_data.dictionary_page_offset += offset_in_file;
+    s.column_chunk.file_offset = offset_in_file + s.column_chunk.meta_data.total_compressed_size;
+
+    serializeThriftStruct(s.column_chunk, out);
+
+    return std::move(s.column_chunk);
+}
+
+parq::RowGroup makeRowGroup(std::vector<parq::ColumnChunk> column_chunks, size_t num_rows)
+{
+    parq::RowGroup r;
+    r.__set_num_rows(num_rows);
+    r.__set_columns(std::move(column_chunks));
+    r.__set_total_compressed_size(0);
+    for (auto & c : r.columns)
+    {
+        r.total_byte_size += c.meta_data.total_uncompressed_size;
+        r.total_compressed_size += c.meta_data.total_compressed_size;
+    }
+    if (!r.columns.empty())
+    {
+        auto & m = r.columns[0].meta_data;
+        r.__set_file_offset(m.__isset.dictionary_page_offset ? m.dictionary_page_offset : m.data_page_offset);
+    }
+    return r;
+}
+
+void writeFileFooter(std::vector<parq::RowGroup> row_groups, SchemaElements schema, const WriteOptions & options, WriteBuffer & out)
+{
+    parq::FileMetaData meta;
+    meta.version = 2;
+    meta.schema = std::move(schema);
+    meta.row_groups = std::move(row_groups);
+    for (auto & r : meta.row_groups)
+        meta.num_rows += r.num_rows;
+    meta.__set_created_by(VERSION_NAME " " VERSION_DESCRIBE);
+
+    if (options.write_page_statistics || options.write_column_chunk_statistics)
+    {
+        meta.__set_column_orders({});
+        for (auto & s : meta.schema)
+            if (!s.__isset.num_children)
+                meta.column_orders.emplace_back();
+        for (auto & c : meta.column_orders)
+            c.__set_TYPE_ORDER({});
+    }
+
+    size_t footer_size = serializeThriftStruct(meta, out);
+
+    if (footer_size > INT32_MAX)
+        throw Exception(ErrorCodes::LIMIT_EXCEEDED, "Parquet file metadata too big: {}", footer_size);
+
+    writeIntBinary(static_cast<int>(footer_size), out);
+    out.write("PAR1", 4);
+}
+
+}

--- a/src/Processors/Formats/Impl/Parquet/Write.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Write.cpp
@@ -651,6 +651,10 @@ void writeColumnImpl(
             const typename ParquetDType::c_type * converted = converter.getBatch(next_data_offset, data_count);
 
             if (options.write_page_statistics || options.write_column_chunk_statistics)
+/// Workaround for clang bug: https://github.com/llvm/llvm-project/issues/63630
+#ifdef MEMORY_SANITIZER
+#pragma clang loop vectorize(disable)
+#endif
                 for (size_t i = 0; i < data_count; ++i)
                     page_statistics.add(converted[i]);
 

--- a/src/Processors/Formats/Impl/Parquet/Write.h
+++ b/src/Processors/Formats/Impl/Parquet/Write.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <Processors/Formats/Impl/Parquet/ThriftUtil.h>
+#include <Columns/IColumn.h>
+#include <DataTypes/IDataType.h>
+#include <Common/PODArray.h>
+#include <IO/CompressionMethod.h>
+
+namespace DB::Parquet
+{
+
+/// A good resource for learning how Parquet format works is
+/// contrib/arrow/cpp/src/parquet/parquet.thrift
+
+struct WriteOptions
+{
+    bool output_string_as_string = false;
+    bool output_fixed_string_as_fixed_byte_array = true;
+
+    CompressionMethod compression = CompressionMethod::Lz4;
+
+    size_t data_page_size = 1024 * 1024;
+    size_t write_batch_size = 1024;
+
+    bool use_dictionary_encoding = true;
+    size_t dictionary_size_limit = 1024 * 1024;
+    /// If using dictionary, this encoding is used as a fallback when dictionary gets too big.
+    /// Otherwise, this is used for everything.
+    parquet::format::Encoding::type encoding = parquet::format::Encoding::PLAIN;
+
+    bool write_page_statistics = true;
+    bool write_column_chunk_statistics = true;
+    size_t max_statistics_size = 4096;
+};
+
+/// Information about a primitive column (leaf of the schema tree) to write to Parquet file.
+struct ColumnChunkWriteState
+{
+    /// After writeColumnChunkBody(), offsets in this struct are relative to the start of column chunk.
+    /// Then finalizeColumnChunkAndWriteFooter() fixes them up before writing to file.
+    parquet::format::ColumnChunk column_chunk;
+
+    ColumnPtr primitive_column;
+    CompressionMethod compression; // must match what's inside column_chunk
+
+    /// Repetition and definition levels. Produced by prepareColumnForWrite().
+    /// def is empty iff max_def == 0, which means no arrays or nullables.
+    /// rep is empty iff max_rep == 0, which means no arrays.
+    PaddedPODArray<UInt8> def; // definition levels
+    PaddedPODArray<UInt8> rep; // repetition levels
+    /// Max possible levels, according to schema. Actual max in def/rep may be smaller.
+    UInt8 max_def = 0;
+    UInt8 max_rep = 0;
+
+    ColumnChunkWriteState() = default;
+    /// Prevent accidental copying.
+    ColumnChunkWriteState(ColumnChunkWriteState &&) = default;
+    ColumnChunkWriteState & operator=(ColumnChunkWriteState &&) = default;
+
+    /// Estimated memory usage.
+    size_t allocatedBytes() const
+    {
+        size_t r = def.allocated_bytes() + rep.allocated_bytes();
+        if (primitive_column)
+            r += primitive_column->allocatedBytes();
+        return r;
+    }
+};
+
+using SchemaElements = std::vector<parquet::format::SchemaElement>;
+using ColumnChunkWriteStates = std::vector<ColumnChunkWriteState>;
+
+/// Parquet file consists of row groups, which consist of column chunks.
+///
+/// Column chunks can be encoded mostly independently of each other, in parallel.
+/// But there are two small complications:
+///  1. One ClickHouse column can translate to multiple leaf columns in parquet.
+///     E.g. tuples and maps.
+///     If all primitive columns are in one big tuple, we'd like to encode them in parallel too,
+///     even though they're one top-level ClickHouse column.
+///  2. At the end of each encoded column chunk there's a footer (struct ColumnMetaData) that
+///     contains some absolute offsets in the file. We can't encode it until we know the exact
+///     position in the file where the column chunk will go. So these footers have to be serialized
+///     sequentially, after we know sizes of all previous column chunks.
+///
+/// With that in mind, here's how to write a parquet file:
+///
+/// (1) writeFileHeader()
+/// (2) For each row group:
+///  | (3) For each ClickHouse column:
+///  |    (4) Call prepareColumnForWrite().
+///  |        It'll produce one or more ColumnChunkWriteStates, corresponding to primitive columns that
+///  |        we need to write.
+///  |        It'll also produce SchemaElements as a byproduct, describing the logical types and
+///  |        groupings of the physical columns (e.g. tuples, arrays, maps).
+///  | (5) For each ColumnChunkWriteState:
+///  |    (6) Call writeColumnChunkBody() to write the actual data to the given WriteBuffer.
+///  |    (7) Call finalizeColumnChunkAndWriteFooter() to write the footer of the column chunk.
+///  | (8) Call makeRowGroup() using the ColumnChunk metadata structs from previous step.
+/// (9) Call writeFileFooter() using the row groups from previous step and SchemaElements from
+///     convertSchema().
+///
+/// Steps (4) and (6) can be parallelized, both within and across row groups.
+
+/// Parquet schema is a tree of SchemaElements, flattened into a list in depth-first order.
+/// Leaf nodes correspond to physical columns of primitive types. Inner nodes describe logical
+/// groupings of those columns, e.g. tuples or structs.
+SchemaElements convertSchema(const Block & sample, const WriteOptions & options);
+
+void prepareColumnForWrite(
+    ColumnPtr column, DataTypePtr type, const std::string & name, const WriteOptions & options,
+    ColumnChunkWriteStates * out_columns_to_write, SchemaElements * out_schema = nullptr);
+
+void writeFileHeader(WriteBuffer & out);
+
+/// Encodes a column chunk, without the footer.
+/// The ColumnChunkWriteState-s should then passed to finalizeColumnChunkAndWriteFooter().
+void writeColumnChunkBody(ColumnChunkWriteState & s, const WriteOptions & options, WriteBuffer & out);
+
+/// Unlike most of the column chunk data, the footer (`ColumnMetaData`) needs to know its absolute
+/// offset in the file. So we encode it separately, after all previous row groups and column chunks
+/// have been encoded.
+/// (If you're wondering if the 8-byte offset values can be patched inside the encoded blob - no,
+/// they're varint-encoded and can't be padded to a fixed length.)
+/// `offset_in_file` is the absolute position in the file where the writeColumnChunkBody()'s output
+/// starts.
+/// Returns a ColumnChunk to add to the RowGroup.
+parquet::format::ColumnChunk finalizeColumnChunkAndWriteFooter(
+    size_t offset_in_file, ColumnChunkWriteState s, const WriteOptions & options, WriteBuffer & out);
+
+parquet::format::RowGroup makeRowGroup(std::vector<parquet::format::ColumnChunk> column_chunks, size_t num_rows);
+
+void writeFileFooter(std::vector<parquet::format::RowGroup> row_groups, SchemaElements schema, const WriteOptions & options, WriteBuffer & out);
+
+}

--- a/src/Processors/Formats/Impl/Parquet/Write.h
+++ b/src/Processors/Formats/Impl/Parquet/Write.h
@@ -42,6 +42,7 @@ struct ColumnChunkWriteState
 
     ColumnPtr primitive_column;
     CompressionMethod compression; // must match what's inside column_chunk
+    bool is_bool = false;
 
     /// Repetition and definition levels. Produced by prepareColumnForWrite().
     /// def is empty iff max_def == 0, which means no arrays or nullables.

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -59,7 +59,12 @@ ParquetBlockInputFormat::ParquetBlockInputFormat(
         pool = std::make_unique<ThreadPool>(CurrentMetrics::ParquetDecoderThreads, CurrentMetrics::ParquetDecoderThreadsActive, max_decoding_threads);
 }
 
-ParquetBlockInputFormat::~ParquetBlockInputFormat() = default;
+ParquetBlockInputFormat::~ParquetBlockInputFormat()
+{
+    is_stopped = true;
+    if (pool)
+        pool->wait();
+}
 
 void ParquetBlockInputFormat::initializeIfNeeded()
 {

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -3,13 +3,22 @@
 #if USE_PARQUET
 
 #include <Formats/FormatFactory.h>
+#include <IO/WriteBufferFromVector.h>
 #include <parquet/arrow/writer.h>
 #include "ArrowBufferedStreams.h"
 #include "CHColumnToArrowColumn.h"
 
 
+namespace CurrentMetrics
+{
+    extern const Metric ParquetEncoderThreads;
+    extern const Metric ParquetEncoderThreadsActive;
+}
+
 namespace DB
 {
+
+using namespace Parquet;
 
 namespace ErrorCodes
 {
@@ -67,11 +76,219 @@ namespace
 ParquetBlockOutputFormat::ParquetBlockOutputFormat(WriteBuffer & out_, const Block & header_, const FormatSettings & format_settings_)
     : IOutputFormat(header_, out_), format_settings{format_settings_}
 {
+    if (format_settings.parquet.use_custom_encoder)
+    {
+        if (format_settings.parquet.parallel_encoding && format_settings.max_threads > 1)
+            pool = std::make_unique<ThreadPool>(
+                CurrentMetrics::ParquetEncoderThreads, CurrentMetrics::ParquetEncoderThreadsActive,
+                format_settings.max_threads);
+
+        using C = FormatSettings::ParquetCompression;
+        switch (format_settings.parquet.output_compression_method)
+        {
+            case C::NONE: options.compression = CompressionMethod::None; break;
+            case C::SNAPPY: options.compression = CompressionMethod::Snappy; break;
+            case C::ZSTD: options.compression = CompressionMethod::Zstd; break;
+            case C::LZ4: options.compression = CompressionMethod::Lz4; break;
+            case C::GZIP: options.compression = CompressionMethod::Gzip; break;
+            case C::BROTLI: options.compression = CompressionMethod::Brotli; break;
+        }
+        options.output_string_as_string = format_settings.parquet.output_string_as_string;
+        options.output_fixed_string_as_fixed_byte_array = format_settings.parquet.output_fixed_string_as_fixed_byte_array;
+        options.data_page_size = format_settings.parquet.data_page_size;
+        options.write_batch_size = format_settings.parquet.write_batch_size;
+
+        schema = convertSchema(header_, options);
+    }
 }
 
-void ParquetBlockOutputFormat::consumeStaged()
+ParquetBlockOutputFormat::~ParquetBlockOutputFormat()
 {
-    const size_t columns_num = staging_chunks.at(0).getNumColumns();
+    if (pool)
+    {
+        is_stopped = true;
+        pool->wait();
+    }
+}
+
+void ParquetBlockOutputFormat::consume(Chunk chunk)
+{
+    /// Poll background tasks.
+    if (pool)
+    {
+        std::unique_lock lock(mutex);
+        while (true)
+        {
+            /// If some row groups are ready to be written to the file, write them.
+            reapCompletedRowGroups(lock);
+
+            if (background_exception)
+                std::rethrow_exception(background_exception);
+
+            if (is_stopped)
+                return;
+
+            /// If there's too much work in flight, wait for some of it to complete.
+            if (row_groups.size() < 2)
+                break;
+            if (bytes_in_flight <= format_settings.parquet.row_group_bytes * 4 &&
+                task_queue.size() <= format_settings.max_threads * 4)
+                break;
+
+            condvar.wait(lock);
+        }
+    }
+
+    /// Do something like SquashingTransform to produce big enough row groups.
+    /// Because the real SquashingTransform is only used for INSERT, not for SELECT ... INTO OUTFILE.
+    /// The latter doesn't even have a pipeline where a transform could be inserted, so it's more
+    /// convenient to do the squashing here. It's also parallelized here.
+
+    if (chunk.getNumRows() != 0)
+    {
+        staging_rows += chunk.getNumRows();
+        staging_bytes += chunk.bytes();
+        staging_chunks.push_back(std::move(chunk));
+    }
+
+    const size_t target_rows = std::max(static_cast<UInt64>(1), format_settings.parquet.row_group_rows);
+
+    if (staging_rows < target_rows &&
+        staging_bytes < format_settings.parquet.row_group_bytes)
+        return;
+
+    /// In the rare case that more than `row_group_rows` rows arrived in one chunk, split the
+    /// staging chunk into multiple row groups.
+    if (staging_rows >= target_rows * 2)
+    {
+        /// Increase row group size slightly (by < 2x) to avoid a small row group at the end.
+        size_t num_row_groups = std::max(static_cast<UInt64>(1), staging_rows / target_rows);
+        size_t row_group_size = (staging_rows - 1) / num_row_groups + 1; // round up
+
+        Chunk concatenated = std::move(staging_chunks[0]);
+        for (size_t i = 1; i < staging_chunks.size(); ++i)
+            concatenated.append(staging_chunks[i]);
+        staging_chunks.clear();
+
+        for (size_t offset = 0; offset < staging_rows; offset += row_group_size)
+        {
+            size_t count = std::min(row_group_size, staging_rows - offset);
+            MutableColumns columns = concatenated.cloneEmptyColumns();
+            for (size_t i = 0; i < columns.size(); ++i)
+                columns[i]->insertRangeFrom(*concatenated.getColumns()[i], offset, count);
+
+            Chunks piece;
+            piece.emplace_back(std::move(columns), count, concatenated.getChunkInfo());
+            writeRowGroup(std::move(piece));
+        }
+    }
+    else
+    {
+        writeRowGroup(std::move(staging_chunks));
+    }
+
+    staging_chunks.clear();
+    staging_rows = 0;
+    staging_bytes = 0;
+}
+
+void ParquetBlockOutputFormat::finalizeImpl()
+{
+    if (!staging_chunks.empty())
+        writeRowGroup(std::move(staging_chunks));
+
+    if (format_settings.parquet.use_custom_encoder)
+    {
+        if (pool)
+        {
+            std::unique_lock lock(mutex);
+
+            /// Wait for background work to complete.
+            while (true)
+            {
+                reapCompletedRowGroups(lock);
+
+                if (background_exception)
+                    std::rethrow_exception(background_exception);
+
+                if (is_stopped)
+                    return;
+
+                if (row_groups.empty())
+                    break;
+
+                condvar.wait(lock);
+            }
+        }
+
+        if (row_groups_complete.empty())
+            writeFileHeader(out);
+        writeFileFooter(std::move(row_groups_complete), schema, options, out);
+    }
+    else
+    {
+        if (!file_writer)
+        {
+            Block header = materializeBlock(getPort(PortKind::Main).getHeader());
+            std::vector<Chunk> chunks;
+            chunks.push_back(Chunk(header.getColumns(), 0));
+            writeRowGroup(std::move(chunks));
+        }
+
+        if (file_writer)
+        {
+            auto status = file_writer->Close();
+            if (!status.ok())
+                throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Error while closing a table: {}", status.ToString());
+        }
+    }
+}
+
+void ParquetBlockOutputFormat::resetFormatterImpl()
+{
+    if (pool)
+    {
+        is_stopped = true;
+        pool->wait();
+        is_stopped = false;
+    }
+
+    background_exception = nullptr;
+    threads_running = 0;
+    task_queue.clear();
+    row_groups.clear();
+    file_writer.reset();
+    row_groups_complete.clear();
+    staging_chunks.clear();
+    staging_rows = 0;
+    staging_bytes = 0;
+}
+
+void ParquetBlockOutputFormat::onCancel()
+{
+    is_stopped = true;
+}
+
+void ParquetBlockOutputFormat::writeRowGroup(std::vector<Chunk> chunks)
+{
+    if (pool)
+        writeRowGroupInParallel(std::move(chunks));
+    else if (!format_settings.parquet.use_custom_encoder)
+        writeUsingArrow(std::move(chunks));
+    else
+    {
+        Chunk concatenated = std::move(chunks[0]);
+        for (size_t i = 1; i < chunks.size(); ++i)
+            concatenated.append(chunks[i]);
+        chunks.clear();
+
+        writeRowGroupInOneThread(std::move(concatenated));
+    }
+}
+
+void ParquetBlockOutputFormat::writeUsingArrow(std::vector<Chunk> chunks)
+{
+    const size_t columns_num = chunks.at(0).getNumColumns();
     std::shared_ptr<arrow::Table> arrow_table;
 
     if (!ch_column_to_arrow_column)
@@ -85,7 +302,7 @@ void ParquetBlockOutputFormat::consumeStaged()
             format_settings.parquet.output_fixed_string_as_fixed_byte_array);
     }
 
-    ch_column_to_arrow_column->chChunkToArrowTable(arrow_table, staging_chunks, columns_num);
+    ch_column_to_arrow_column->chChunkToArrowTable(arrow_table, chunks, columns_num);
 
     if (!file_writer)
     {
@@ -112,64 +329,228 @@ void ParquetBlockOutputFormat::consumeStaged()
         file_writer = std::move(result.ValueOrDie());
     }
 
-    // TODO: calculate row_group_size depending on a number of rows and table size
-
-    // allow slightly bigger than row_group_size to avoid a very small tail row group
-    auto status = file_writer->WriteTable(*arrow_table, std::max<size_t>(format_settings.parquet.row_group_rows, staging_rows));
+    auto status = file_writer->WriteTable(*arrow_table, INT64_MAX);
 
     if (!status.ok())
         throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Error while writing a table: {}", status.ToString());
 }
 
-void ParquetBlockOutputFormat::consume(Chunk chunk)
+void ParquetBlockOutputFormat::writeRowGroupInOneThread(Chunk chunk)
 {
-    /// Do something like SquashingTransform to produce big enough row groups.
-    /// Because the real SquashingTransform is only used for INSERT, not for SELECT ... INTO OUTFILE.
-    /// The latter doesn't even have a pipeline where a transform could be inserted, so it's more
-    /// convenient to do the squashing here.
-    staging_rows += chunk.getNumRows();
-    staging_bytes += chunk.bytes();
-    staging_chunks.push_back(std::move(chunk));
-    chassert(staging_chunks.back().getNumColumns() == staging_chunks.front().getNumColumns());
-    if (staging_rows < format_settings.parquet.row_group_rows &&
-        staging_bytes < format_settings.parquet.row_group_bytes)
-    {
+    if (chunk.getNumRows() == 0)
         return;
-    }
-    else
+
+    const Block & header = getPort(PortKind::Main).getHeader();
+    Parquet::ColumnChunkWriteStates columns_to_write;
+    chassert(header.columns() == chunk.getNumColumns());
+    for (size_t i = 0; i < header.columns(); ++i)
+        prepareColumnForWrite(
+            chunk.getColumns()[i], header.getByPosition(i).type, header.getByPosition(i).name,
+            options, &columns_to_write);
+
+    if (row_groups_complete.empty())
+        writeFileHeader(out);
+
+    std::vector<parquet::format::ColumnChunk> column_chunks;
+    for (auto & s : columns_to_write)
     {
-        consumeStaged();
-        staging_chunks.clear();
-        staging_rows = 0;
-        staging_bytes = 0;
+        size_t offset = out.count();
+        writeColumnChunkBody(s, options, out);
+        auto c = finalizeColumnChunkAndWriteFooter(offset, std::move(s), options, out);
+        column_chunks.push_back(std::move(c));
+    }
+
+    auto r = makeRowGroup(std::move(column_chunks), chunk.getNumRows());
+    row_groups_complete.push_back(std::move(r));
+}
+
+void ParquetBlockOutputFormat::writeRowGroupInParallel(std::vector<Chunk> chunks)
+{
+    std::unique_lock lock(mutex);
+
+    const Block & header = getPort(PortKind::Main).getHeader();
+
+    RowGroupState & r = row_groups.emplace_back();
+    r.column_chunks.resize(header.columns());
+    r.tasks_in_flight = r.column_chunks.size();
+
+    std::vector<Columns> columnses;
+    for (auto & chunk : chunks)
+    {
+        chassert(header.columns() == chunk.getNumColumns());
+        r.num_rows += chunk.getNumRows();
+        columnses.push_back(chunk.detachColumns());
+    }
+
+    for (size_t i = 0; i < header.columns(); ++i)
+    {
+        Task & t = task_queue.emplace_back(&r, i, this);
+        t.column_type = header.getByPosition(i).type;
+        t.column_name = header.getByPosition(i).name;
+
+        /// Defer concatenating the columns to the threads.
+        size_t bytes = 0;
+        for (size_t j = 0; j < chunks.size(); ++j)
+        {
+            auto & col = columnses[j][i];
+            bytes += col->allocatedBytes();
+            t.column_pieces.push_back(std::move(col));
+        }
+        t.mem.set(bytes);
+    }
+
+    startMoreThreadsIfNeeded(lock);
+}
+
+void ParquetBlockOutputFormat::reapCompletedRowGroups(std::unique_lock<std::mutex> & lock)
+{
+    while (!row_groups.empty() && row_groups.front().tasks_in_flight == 0 && !is_stopped)
+    {
+        RowGroupState & r = row_groups.front();
+
+        /// Write to the file.
+
+        lock.unlock();
+
+        if (row_groups_complete.empty())
+            writeFileHeader(out);
+
+        std::vector<parquet::format::ColumnChunk> metadata;
+        for (auto & cols : r.column_chunks)
+        {
+            for (ColumnChunk & col : cols)
+            {
+                size_t offset = out.count();
+
+                out.write(col.serialized.data(), col.serialized.size());
+                auto m = finalizeColumnChunkAndWriteFooter(offset, std::move(col.state), options, out);
+
+                metadata.push_back(std::move(m));
+            }
+        }
+
+        row_groups_complete.push_back(makeRowGroup(std::move(metadata), r.num_rows));
+
+        lock.lock();
+
+        row_groups.pop_front();
     }
 }
 
-void ParquetBlockOutputFormat::finalizeImpl()
+void ParquetBlockOutputFormat::startMoreThreadsIfNeeded(const std::unique_lock<std::mutex> &)
 {
-    if (!file_writer && staging_chunks.empty())
+    /// Speculate that all current are already working on tasks.
+    size_t to_add = std::min(task_queue.size(), format_settings.max_threads - threads_running);
+    for (size_t i = 0; i < to_add; ++i)
     {
-        Block header = materializeBlock(getPort(PortKind::Main).getHeader());
+        auto job = [this, thread_group = CurrentThread::getGroup()]()
+        {
+            if (thread_group)
+                CurrentThread::attachToGroupIfDetached(thread_group);
+            SCOPE_EXIT_SAFE(if (thread_group) CurrentThread::detachFromGroupIfNotDetached(););
 
-        consume(Chunk(header.getColumns(), 0)); // this will make staging_chunks non-empty
+            try
+            {
+                setThreadName("ParquetEncoder");
+
+                threadFunction();
+            }
+            catch (...)
+            {
+                std::lock_guard lock(mutex);
+                background_exception = std::current_exception();
+                condvar.notify_all();
+                --threads_running;
+            }
+        };
+
+        if (threads_running == 0)
+        {
+            /// First thread. We need it to succeed; otherwise we may get stuck.
+            pool->scheduleOrThrowOnError(job);
+            ++threads_running;
+        }
+        else
+        {
+            /// More threads. This may be called from inside the thread pool, so avoid waiting;
+            /// otherwise it may deadlock.
+            if (!pool->trySchedule(job))
+                break;
+        }
     }
-
-    if (!staging_chunks.empty())
-    {
-        consumeStaged();
-        staging_chunks.clear();
-        staging_rows = 0;
-        staging_bytes = 0;
-    }
-
-    auto status = file_writer->Close();
-    if (!status.ok())
-        throw Exception(ErrorCodes::UNKNOWN_EXCEPTION, "Error while closing a table: {}", status.ToString());
 }
 
-void ParquetBlockOutputFormat::resetFormatterImpl()
+void ParquetBlockOutputFormat::threadFunction()
 {
-    file_writer.reset();
+    std::unique_lock lock(mutex);
+
+    while (true)
+    {
+        if (task_queue.empty() || is_stopped)
+        {
+            /// The check and the decrement need to be in the same critical section, to make sure
+            /// we never get stuck with tasks but no threads.
+            --threads_running;
+            return;
+        }
+
+        auto task = std::move(task_queue.front());
+        task_queue.pop_front();
+
+        if (task.column_type)
+        {
+            lock.unlock();
+
+            IColumn::MutablePtr concatenated = IColumn::mutate(std::move(task.column_pieces[0]));
+            for (size_t i = 1; i < task.column_pieces.size(); ++i)
+            {
+                auto & c = task.column_pieces[i];
+                concatenated->insertRangeFrom(*c, 0, c->size());
+                c.reset();
+            }
+            task.column_pieces.clear();
+
+            std::vector<ColumnChunkWriteState> subcolumns;
+            prepareColumnForWrite(
+                std::move(concatenated), task.column_type, task.column_name, options, &subcolumns);
+
+            lock.lock();
+
+            for (size_t i = 0; i < subcolumns.size(); ++i)
+            {
+                task.row_group->column_chunks[task.column_idx].emplace_back(this);
+                task.row_group->tasks_in_flight += 1;
+
+                auto & t = task_queue.emplace_back(task.row_group, task.column_idx, this);
+                t.subcolumn_idx = i;
+                t.state = std::move(subcolumns[i]);
+                t.mem.set(t.state.allocatedBytes());
+            }
+
+            startMoreThreadsIfNeeded(lock);
+        }
+        else
+        {
+            lock.unlock();
+
+            PODArray<char> serialized;
+            {
+                WriteBufferFromVector buf(serialized);
+                writeColumnChunkBody(task.state, options, buf);
+            }
+
+            lock.lock();
+
+            auto & c = task.row_group->column_chunks[task.column_idx][task.subcolumn_idx];
+            c.state = std::move(task.state);
+            c.serialized = std::move(serialized);
+            c.mem.set(c.serialized.size() + c.state.allocatedBytes());
+        }
+
+        --task.row_group->tasks_in_flight;
+
+        condvar.notify_all();
+    }
 }
 
 void registerOutputFormatParquet(FormatFactory & factory)

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
@@ -138,6 +138,7 @@ private:
     Parquet::WriteOptions options;
     Parquet::SchemaElements schema;
     std::vector<parquet::format::RowGroup> row_groups_complete;
+    size_t base_offset = 0;
 
 
     std::mutex mutex;

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.h
@@ -2,8 +2,11 @@
 #include "config.h"
 
 #if USE_PARQUET
-#    include <Processors/Formats/IOutputFormat.h>
-#    include <Formats/FormatSettings.h>
+
+#include <Processors/Formats/IOutputFormat.h>
+#include <Processors/Formats/Impl/Parquet/Write.h>
+#include <Formats/FormatSettings.h>
+#include <Common/ThreadPool.h>
 
 namespace arrow
 {
@@ -28,25 +31,128 @@ class ParquetBlockOutputFormat : public IOutputFormat
 {
 public:
     ParquetBlockOutputFormat(WriteBuffer & out_, const Block & header_, const FormatSettings & format_settings_);
+    ~ParquetBlockOutputFormat() override;
 
     String getName() const override { return "ParquetBlockOutputFormat"; }
 
     String getContentType() const override { return "application/octet-stream"; }
 
 private:
-    void consumeStaged();
+    struct MemoryToken
+    {
+        ParquetBlockOutputFormat * parent;
+        size_t bytes = 0;
+
+        explicit MemoryToken(ParquetBlockOutputFormat * p, size_t b = 0) : parent(p)
+        {
+            set(b);
+        }
+
+        MemoryToken(MemoryToken && t)
+          : parent(std::exchange(t.parent, nullptr)), bytes(std::exchange(t.bytes, 0)) {}
+
+        MemoryToken & operator=(MemoryToken && t)
+        {
+            parent = std::exchange(t.parent, nullptr);
+            bytes = std::exchange(t.bytes, 0);
+            return *this;
+        }
+
+        ~MemoryToken()
+        {
+            set(0);
+        }
+
+        void set(size_t new_size)
+        {
+            if (new_size == bytes)
+                return;
+            parent->bytes_in_flight += new_size - bytes; // overflow is fine
+            bytes = new_size;
+        }
+    };
+
+    struct ColumnChunk
+    {
+        Parquet::ColumnChunkWriteState state;
+        PODArray<char> serialized;
+
+        MemoryToken mem;
+
+        ColumnChunk(ParquetBlockOutputFormat * p) : mem(p) {}
+    };
+
+    struct RowGroupState
+    {
+        size_t tasks_in_flight = 0;
+        std::vector<std::vector<ColumnChunk>> column_chunks;
+        size_t num_rows = 0;
+    };
+
+    struct Task
+    {
+        RowGroupState * row_group;
+        size_t column_idx;
+        size_t subcolumn_idx = 0;
+
+        MemoryToken mem;
+
+        /// If not null, we need to call prepareColumnForWrite().
+        /// Otherwise we need to call writeColumnChunkBody().
+        DataTypePtr column_type;
+        std::string column_name;
+        std::vector<ColumnPtr> column_pieces;
+
+        Parquet::ColumnChunkWriteState state;
+
+        Task(RowGroupState * rg, size_t ci, ParquetBlockOutputFormat * p)
+            : row_group(rg), column_idx(ci), mem(p) {}
+    };
+
     void consume(Chunk) override;
     void finalizeImpl() override;
     void resetFormatterImpl() override;
+    void onCancel() override;
 
+    void writeRowGroup(std::vector<Chunk> chunks);
+    void writeUsingArrow(std::vector<Chunk> chunks);
+    void writeRowGroupInOneThread(Chunk chunk);
+    void writeRowGroupInParallel(std::vector<Chunk> chunks);
+
+    void threadFunction();
+    void startMoreThreadsIfNeeded(const std::unique_lock<std::mutex> & lock);
+
+    /// Called in single-threaded fashion. Writes to the file.
+    void reapCompletedRowGroups(std::unique_lock<std::mutex> & lock);
+
+    const FormatSettings format_settings;
+
+    /// Chunks to squash together to form a row group.
     std::vector<Chunk> staging_chunks;
     size_t staging_rows = 0;
     size_t staging_bytes = 0;
 
-    const FormatSettings format_settings;
-
     std::unique_ptr<parquet::arrow::FileWriter> file_writer;
     std::unique_ptr<CHColumnToArrowColumn> ch_column_to_arrow_column;
+
+    Parquet::WriteOptions options;
+    Parquet::SchemaElements schema;
+    std::vector<parquet::format::RowGroup> row_groups_complete;
+
+
+    std::mutex mutex;
+    std::condition_variable condvar; // wakes up consume()
+    std::unique_ptr<ThreadPool> pool;
+
+    std::atomic_bool is_stopped{false};
+    std::exception_ptr background_exception = nullptr;
+
+    /// Invariant: if there's at least one task then there's at least one thread.
+    size_t threads_running = 0;
+    std::atomic<size_t> bytes_in_flight{0};
+
+    std::deque<Task> task_queue;
+    std::deque<RowGroupState> row_groups;
 };
 
 }

--- a/tests/queries/0_stateless/02581_parquet_arrow_orc_compressions.sh
+++ b/tests/queries/0_stateless/02581_parquet_arrow_orc_compressions.sh
@@ -5,6 +5,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+set -o pipefail
+
 $CLICKHOUSE_LOCAL -q "select * from numbers(10) format Parquet settings output_format_parquet_compression_method='none'" | $CLICKHOUSE_LOCAL --input-format=Parquet -q "select count() from table"
 $CLICKHOUSE_LOCAL -q "select * from numbers(10) format Parquet settings output_format_parquet_compression_method='lz4'" | $CLICKHOUSE_LOCAL --input-format=Parquet -q "select count() from table"
 $CLICKHOUSE_LOCAL -q "select * from numbers(10) format Parquet settings output_format_parquet_compression_method='snappy'" | $CLICKHOUSE_LOCAL --input-format=Parquet -q "select count() from table"

--- a/tests/queries/0_stateless/02735_parquet_encoder.reference
+++ b/tests/queries/0_stateless/02735_parquet_encoder.reference
@@ -1,0 +1,55 @@
+u8	Nullable(UInt8)					
+u16	Nullable(UInt16)					
+u32	Nullable(UInt32)					
+u64	Nullable(UInt64)					
+i8	Nullable(Int8)					
+i16	Nullable(Int16)					
+i32	Nullable(Int32)					
+i64	Nullable(Int64)					
+date	Nullable(UInt16)					
+date32	Nullable(Date32)					
+datetime	Nullable(UInt32)					
+datetime64	Nullable(DateTime64(3, \'UTC\'))					
+enum8	Nullable(Int8)					
+enum16	Nullable(Int16)					
+float32	Nullable(Float32)					
+float64	Nullable(Float64)					
+str	Nullable(String)					
+fstr	Nullable(FixedString(12))					
+u128	Nullable(FixedString(16))					
+u256	Nullable(FixedString(32))					
+i128	Nullable(FixedString(16))					
+i256	Nullable(FixedString(32))					
+decimal32	Nullable(Decimal(9, 3))					
+decimal64	Nullable(Decimal(18, 10))					
+decimal128	Nullable(Decimal(38, 20))					
+decimal256	Nullable(Decimal(76, 40))					
+ipv4	Nullable(UInt32)					
+ipv6	Nullable(FixedString(16))					
+0
+0
+0
+0
+1	2	1
+1	2	2
+1	3	3
+1	1000000	1
+3914219105369203805
+4	1000000	1
+(1000000,0,NULL,'100','299')
+(1000000,0,NULL,'0','-1294970296')
+(1000000,0,NULL,'-2147483296','2147481000')
+(100000,900000,NULL,'100009','999999')
+[(2,0,NULL,'','[]')]
+1	1
+0	1
+16159458007063698496
+16159458007063698496
+BYTE_ARRAY	String
+FIXED_LEN_BYTE_ARRAY	None
+BYTE_ARRAY	None
+BYTE_ARRAY	None
+BYTE_ARRAY	String
+never	gonna
+give	you
+up

--- a/tests/queries/0_stateless/02735_parquet_encoder.sql
+++ b/tests/queries/0_stateless/02735_parquet_encoder.sql
@@ -1,0 +1,168 @@
+-- Tags: no-fasttest
+
+set output_format_parquet_use_custom_encoder = 1;
+set output_format_parquet_row_group_size = 1000;
+set output_format_parquet_data_page_size = 800;
+set output_format_parquet_batch_size = 100;
+set output_format_parquet_row_group_size_bytes = 1000000000;
+set engine_file_truncate_on_insert=1;
+
+-- Write random data to parquet file, then read from it and check that it matches what we wrote.
+-- Do this for all kinds of data types: primitive, Nullable(primitive), Array(primitive),
+-- Array(Nullable(primitive)), Array(Array(primitive)), Map(primitive, primitive), etc.
+
+drop table if exists basic_types_02735;
+create temporary table basic_types_02735 as select * from generateRandom('
+    u8 UInt8,
+    u16 UInt16,
+    u32 UInt32,
+    u64 UInt64,
+    i8 Int8,
+    i16 Int16,
+    i32 Int32,
+    i64 Int64,
+    date Date,
+    date32 Date32,
+    datetime DateTime,
+    datetime64 DateTime64,
+    enum8 Enum8(''x'' = 1, ''y'' = 2, ''z'' = 3),
+    enum16 Enum16(''xx'' = 1000, ''yy'' = 2000, ''zz'' = 3000),
+    float32 Float32,
+    float64 Float64,
+    str String,
+    fstr FixedString(12),
+    u128 UInt128,
+    u256 UInt256,
+    i128 Int128,
+    i256 Int256,
+    decimal32 Decimal32(3),
+    decimal64 Decimal64(10),
+    decimal128 Decimal128(20),
+    decimal256 Decimal256(40),
+    ipv4 IPv4,
+    ipv6 IPv6') limit 10101;
+insert into function file(basic_types_02735.parquet) select * from basic_types_02735;
+desc file(basic_types_02735.parquet);
+select (select sum(cityHash64(*)) from basic_types_02735) - (select sum(cityHash64(*)) from file(basic_types_02735.parquet));
+drop table basic_types_02735;
+
+
+drop table if exists nullables_02735;
+create temporary table nullables_02735 as select * from generateRandom('
+    u16 Nullable(UInt16),
+    i64 Nullable(Int64),
+    datetime64 Nullable(DateTime64),
+    enum8 Nullable(Enum8(''x'' = 1, ''y'' = 2, ''z'' = 3)),
+    float64 Nullable(Float64),
+    str Nullable(String),
+    fstr Nullable(FixedString(12)),
+    i256 Nullable(Int256),
+    decimal256 Nullable(Decimal256(40)),
+    ipv6 Nullable(IPv6)') limit 10000;
+insert into function file(nullables_02735.parquet) select * from nullables_02735;
+select (select sum(cityHash64(*)) from nullables_02735) - (select sum(cityHash64(*)) from file(nullables_02735.parquet));
+drop table nullables_02735;
+
+
+-- TODO: When cityHash64() fully supports Nullable: https://github.com/ClickHouse/ClickHouse/pull/48625
+--       the next two blocks can be simplified: arrays_out_02735 intermediate table is not needed,
+--       a.csv and b.csv are not needed.
+
+drop table if exists arrays_02735;
+drop table if exists arrays_out_02735;
+create table arrays_02735 engine = Memory as select * from generateRandom('
+    u32 Array(UInt32),
+    i8 Array(Int8),
+    datetime Array(DateTime),
+    enum16 Array(Enum16(''xx'' = 1000, ''yy'' = 2000, ''zz'' = 3000)),
+    float32 Array(Float32),
+    str Array(String),
+    fstr Array(FixedString(12)),
+    u128 Array(UInt128),
+    decimal64 Array(Decimal64(10)),
+    ipv4 Array(IPv4),
+    msi Map(String, Int16),
+    tup Tuple(FixedString(3), Array(String), Map(Int8, Date))') limit 10000;
+insert into function file(arrays_02735.parquet) select * from arrays_02735;
+create temporary table arrays_out_02735 as arrays_02735;
+insert into arrays_out_02735 select * from file(arrays_02735.parquet);
+select (select sum(cityHash64(*)) from arrays_02735) - (select sum(cityHash64(*)) from arrays_out_02735);
+--select (select sum(cityHash64(*)) from arrays_02735) -
+--       (select sum(cityHash64(u32, i8, datetime, enum16, float32, str, fstr, arrayMap(x->reinterpret(x, 'UInt128'), u128), decimal64, ipv4, msi, tup)) from file(arrays_02735.parquet));
+drop table arrays_02735;
+drop table arrays_out_02735;
+
+
+drop table if exists madness_02735;
+create temporary table madness_02735 as select * from generateRandom('
+    aa Array(Array(UInt32)),
+    aaa Array(Array(Array(UInt32))),
+    an Array(Nullable(String)),
+    aan Array(Array(Nullable(FixedString(10)))),
+    l LowCardinality(String),
+    ln LowCardinality(Nullable(FixedString(11))),
+    al Array(LowCardinality(UInt128)),
+    aaln Array(Array(LowCardinality(Nullable(String)))),
+    mln Map(LowCardinality(String), Nullable(Int8)),
+    t Tuple(Map(FixedString(5), Tuple(Array(UInt16), Nullable(UInt16), Array(Tuple(Int8, Decimal64(10))))), Tuple(kitchen UInt64, sink String)),
+    n Nested(hello UInt64, world Tuple(first String, second FixedString(1)))
+    ') limit 10000;
+insert into function file(madness_02735.parquet) select * from madness_02735;
+insert into function file(a.csv) select * from madness_02735 order by tuple(*);
+insert into function file(b.csv) select aa, aaa, an, aan, l, ln, arrayMap(x->reinterpret(x, 'UInt128'), al) as al_, aaln, mln, t, n.hello, n.world from file(madness_02735.parquet) order by tuple(aa, aaa, an, aan, l, ln, al_, aaln, mln, t, n.hello, n.world);
+select (select sum(cityHash64(*)) from file(a.csv, LineAsString)) - (select sum(cityHash64(*)) from file(b.csv, LineAsString));
+--select (select sum(cityHash64(*)) from madness_02735) -
+--       (select sum(cityHash64(aa, aaa, an, aan, l, ln, map(x->reinterpret(x, 'UInt128'), al), aaln, mln, t, n.hello, n.world)) from file(madness_02735.parquet));
+drop table madness_02735;
+
+
+-- Merging input blocks into bigger row groups.
+insert into function file(squash_02735.parquet) select '012345' union all select '543210' settings max_block_size = 1;
+select num_columns, num_rows, num_row_groups from file(squash_02735.parquet, ParquetMetadata);
+
+-- Row group size limit in bytes.
+insert into function file(row_group_bytes_02735.parquet) select '012345' union all select '543210' settings max_block_size = 1, output_format_parquet_row_group_size_bytes = 5;
+select num_columns, num_rows, num_row_groups from file(row_group_bytes_02735.parquet, ParquetMetadata);
+
+-- Row group size limit in rows.
+insert into function file(tiny_row_groups_02735.parquet) select * from numbers(3) settings output_format_parquet_row_group_size = 1;
+select num_columns, num_rows, num_row_groups from file(tiny_row_groups_02735.parquet, ParquetMetadata);
+
+-- 1M unique 8-byte values should exceed dictionary_size_limit (1 MB).
+insert into function file(big_column_chunk_02735.parquet) select number from numbers(1000000) settings output_format_parquet_row_group_size = 1000000;
+select num_columns, num_rows, num_row_groups from file(big_column_chunk_02735.parquet, ParquetMetadata);
+select sum(cityHash64(number)) from file(big_column_chunk_02735.parquet);
+
+-- Check statistics: signed vs unsigned, null count. Use enough rows to produce multiple pages.
+insert into function file(statistics_02735.parquet) select 100 + number%200 as a, toUInt32(number * 3000) as u, toInt32(number * 3000) as i, if(number % 10 == 9, toString(number), null) as s from numbers(1000000) settings output_format_parquet_row_group_size = 1000000;
+select num_columns, num_rows, num_row_groups from file(statistics_02735.parquet, ParquetMetadata);
+select tupleElement(c, 'statistics') from file(statistics_02735.parquet, ParquetMetadata) array join tupleElement(row_groups[1], 'columns') as c;
+
+-- Statistics string length limit (max_statistics_size).
+insert into function file(long_string_02735.parquet) select toString(range(number * 2000)) from numbers(2);
+select tupleElement(tupleElement(row_groups[1], 'columns'), 'statistics') from file(long_string_02735.parquet, ParquetMetadata);
+
+-- Compression setting.
+insert into function file(compressed_02735.parquet) select concat('aaaaaaaaaaaaaaaa', toString(number)) as s from numbers(1000) settings output_format_parquet_row_group_size = 10000, output_format_parquet_compression_method='zstd';
+select total_compressed_size < 10000, total_uncompressed_size > 15000 from file(compressed_02735.parquet, ParquetMetadata);
+insert into function file(compressed_02735.parquet) select concat('aaaaaaaaaaaaaaaa', toString(number)) as s from numbers(1000) settings output_format_parquet_row_group_size = 10000, output_format_parquet_compression_method='none';
+select total_compressed_size < 10000, total_uncompressed_size > 15000 from file(compressed_02735.parquet, ParquetMetadata);
+
+-- Single-threaded encoding and Arrow encoder.
+drop table if exists other_encoders_02735;
+create temporary table other_encoders_02735 as select number, number*2 from numbers(10000);
+insert into function file(single_thread_02735.parquet) select * from other_encoders_02735 settings max_threads = 1;
+select sum(cityHash64(*)) from file(single_thread_02735.parquet);
+insert into function file(arrow_02735.parquet) select * from other_encoders_02735 settings output_format_parquet_use_custom_encoder = 0;
+select sum(cityHash64(*)) from file(arrow_02735.parquet);
+
+-- String -> binary vs string; FixedString -> fixed-length-binary vs binary vs string.
+insert into function file(strings1_02735.parquet) select 'never', toFixedString('gonna', 5) settings output_format_parquet_string_as_string = 1, output_format_parquet_fixed_string_as_fixed_byte_array = 1;
+select columns.5, columns.6 from file(strings1_02735.parquet, ParquetMetadata) array join columns;
+insert into function file(strings2_02735.parquet) select 'give', toFixedString('you', 3) settings output_format_parquet_string_as_string = 0, output_format_parquet_fixed_string_as_fixed_byte_array = 0;
+select columns.5, columns.6 from file(strings2_02735.parquet, ParquetMetadata) array join columns;
+insert into function file(strings3_02735.parquet) select toFixedString('up', 2) settings output_format_parquet_string_as_string = 1, output_format_parquet_fixed_string_as_fixed_byte_array = 0;
+select columns.5, columns.6 from file(strings3_02735.parquet, ParquetMetadata) array join columns;
+select * from file(strings1_02735.parquet);
+select * from file(strings2_02735.parquet);
+select * from file(strings3_02735.parquet);

--- a/tests/queries/0_stateless/02735_parquet_encoder.sql
+++ b/tests/queries/0_stateless/02735_parquet_encoder.sql
@@ -1,4 +1,4 @@
--- Tags: no-fasttest
+-- Tags: no-fasttest, no-parallel
 
 set output_format_parquet_use_custom_encoder = 1;
 set output_format_parquet_row_group_size = 1000;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Writing parquet files is 10x faster, it's multi-threaded now. Almost the same speed as reading.