### PR TITLE
Remove wrong assertion in cache

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -493,11 +493,6 @@ bool CachedOnDiskReadBufferFromFile::completeFileSegmentAndGetNext()
 
     chassert(file_offset_of_buffer_end > completed_range.right);
 
-    if (read_type == ReadType::CACHED)
-    {
-        chassert(current_file_segment->getDownloadedSize(true) == current_file_segment->range().size());
-    }
-
     file_segments->popFront();
     if (file_segments->empty())
         return false;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


it was wrong in case `file_segment->state() == FileSegment::State::PartiallyDownloadedNoContinuation`. Decided to remove it instead of adding another condition, because this assertion is not important.

Closes https://github.com/ClickHouse/ClickHouse/issues/49368.