### PR TITLE
Improve memory usage and speed of SPARSE_HASHED/HASHED dictionaries

### DIFF
--- a/base/base/StringRef.h
+++ b/base/base/StringRef.h
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <stdexcept> // for std::logic_error
 #include <string>
+#include <type_traits>
 #include <vector>
 #include <functional>
 #include <iosfwd>
@@ -324,6 +325,17 @@ namespace ZeroTraits
 {
     inline bool check(const StringRef & x) { return 0 == x.size; }
     inline void set(StringRef & x) { x.size = 0; }
+}
+
+namespace PackedZeroTraits
+{
+    template <typename Second, template <typename, typename> class PackedPairNoInit>
+    inline bool check(const PackedPairNoInit<StringRef, Second> p)
+    { return 0 == p.key.size; }
+
+    template <typename Second, template <typename, typename> class PackedPairNoInit>
+    inline void set(PackedPairNoInit<StringRef, Second> & p)
+    { p.key.size = 0; }
 }
 
 

--- a/docs/en/sql-reference/dictionaries/index.md
+++ b/docs/en/sql-reference/dictionaries/index.md
@@ -284,6 +284,13 @@ Configuration example:
          10000 is good balance between memory and speed.
          Even for 10e10 elements and can handle all the load without starvation. -->
     <shard_load_queue_backlog>10000</shard_load_queue_backlog>
+    <!-- Maximum load factor of the hash table, with greater values, the memory
+         is utilized more efficiently (less memory is wasted) but read/performance
+         may deteriorate.
+
+         Valid values: [0.5, 0.99]
+         Default: 0.5 -->
+    <max_load_factor>0.5</max_load_factor>
   </hashed>
 </layout>
 ```
@@ -327,6 +334,7 @@ Configuration example:
   <complex_key_hashed>
     <shards>1</shards>
     <!-- <shard_load_queue_backlog>10000</shard_load_queue_backlog> -->
+    <!-- <max_load_factor>0.5</max_load_factor> -->
   </complex_key_hashed>
 </layout>
 ```

--- a/docs/en/sql-reference/dictionaries/index.md
+++ b/docs/en/sql-reference/dictionaries/index.md
@@ -267,14 +267,16 @@ or
 LAYOUT(HASHED())
 ```
 
-If `shards` greater then 1 (default is `1`) the dictionary will load data in parallel, useful if you have huge amount of elements in one dictionary.
-
 Configuration example:
 
 ``` xml
 <layout>
   <hashed>
+    <!-- If shards greater then 1 (default is `1`) the dictionary will load
+         data in parallel, useful if you have huge amount of elements in one
+         dictionary. -->
     <shards>10</shards>
+
     <!-- Size of the backlog for blocks in parallel queue.
 
          Since the bottleneck in parallel loading is rehash, and so to avoid
@@ -284,6 +286,7 @@ Configuration example:
          10000 is good balance between memory and speed.
          Even for 10e10 elements and can handle all the load without starvation. -->
     <shard_load_queue_backlog>10000</shard_load_queue_backlog>
+
     <!-- Maximum load factor of the hash table, with greater values, the memory
          is utilized more efficiently (less memory is wasted) but read/performance
          may deteriorate.
@@ -298,7 +301,7 @@ Configuration example:
 or
 
 ``` sql
-LAYOUT(HASHED(SHARDS 10 [SHARD_LOAD_QUEUE_BACKLOG 10000]))
+LAYOUT(HASHED([SHARDS 1] [SHARD_LOAD_QUEUE_BACKLOG 10000] [MAX_LOAD_FACTOR 0.5]))
 ```
 
 ### sparse_hashed
@@ -311,14 +314,18 @@ Configuration example:
 
 ``` xml
 <layout>
-  <sparse_hashed />
+  <sparse_hashed>
+    <!-- <shards>1</shards> -->
+    <!-- <shard_load_queue_backlog>10000</shard_load_queue_backlog> -->
+    <!-- <max_load_factor>0.5</max_load_factor> -->
+  </sparse_hashed>
 </layout>
 ```
 
 or
 
 ``` sql
-LAYOUT(SPARSE_HASHED())
+LAYOUT(SPARSE_HASHED([SHARDS 1] [SHARD_LOAD_QUEUE_BACKLOG 10000] [MAX_LOAD_FACTOR 0.5]))
 ```
 
 It is also possible to use `shards` for this type of dictionary, and again it is more important for `sparse_hashed` then for `hashed`, since `sparse_hashed` is slower.
@@ -332,7 +339,7 @@ Configuration example:
 ``` xml
 <layout>
   <complex_key_hashed>
-    <shards>1</shards>
+    <!-- <shards>1</shards> -->
     <!-- <shard_load_queue_backlog>10000</shard_load_queue_backlog> -->
     <!-- <max_load_factor>0.5</max_load_factor> -->
   </complex_key_hashed>
@@ -342,7 +349,7 @@ Configuration example:
 or
 
 ``` sql
-LAYOUT(COMPLEX_KEY_HASHED([SHARDS 1] [SHARD_LOAD_QUEUE_BACKLOG 10000]))
+LAYOUT(COMPLEX_KEY_HASHED([SHARDS 1] [SHARD_LOAD_QUEUE_BACKLOG 10000] [MAX_LOAD_FACTOR 0.5]))
 ```
 
 ### complex_key_sparse_hashed
@@ -354,7 +361,9 @@ Configuration example:
 ``` xml
 <layout>
   <complex_key_sparse_hashed>
-    <shards>1</shards>
+    <!-- <shards>1</shards> -->
+    <!-- <shard_load_queue_backlog>10000</shard_load_queue_backlog> -->
+    <!-- <max_load_factor>0.5</max_load_factor> -->
   </complex_key_sparse_hashed>
 </layout>
 ```
@@ -362,7 +371,7 @@ Configuration example:
 or
 
 ``` sql
-LAYOUT(COMPLEX_KEY_SPARSE_HASHED([SHARDS 1] [SHARD_LOAD_QUEUE_BACKLOG 10000]))
+LAYOUT(COMPLEX_KEY_SPARSE_HASHED([SHARDS 1] [SHARD_LOAD_QUEUE_BACKLOG 10000] [MAX_LOAD_FACTOR 0.5]))
 ```
 
 ### hashed_array

--- a/src/Common/HashTable/FixedHashTable.h
+++ b/src/Common/HashTable/FixedHashTable.h
@@ -358,7 +358,7 @@ public:
         std::pair<LookupResult, bool> res;
         emplace(Cell::getKey(x), res.first, res.second);
         if (res.second)
-            insertSetMapped(res.first->getMapped(), x);
+            res.first->setMapped(x);
 
         return res;
     }

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -9,6 +9,8 @@
 /** NOTE HashMap could only be used for memmoveable (position independent) types.
   * Example: std::string is not position independent in libstdc++ with C++11 ABI or in libc++.
   * Also, key in hash table must be of type, that zero bytes is compared equals to zero key.
+  *
+  * Please keep in sync with PackedHashMap.h
   */
 
 namespace DB
@@ -53,13 +55,13 @@ PairNoInit<std::decay_t<First>, std::decay_t<Second>> makePairNoInit(First && fi
 }
 
 
-template <typename Key, typename TMapped, typename Hash, typename TState = HashTableNoState>
+template <typename Key, typename TMapped, typename Hash, typename TState = HashTableNoState, typename Pair = PairNoInit<Key, TMapped>>
 struct HashMapCell
 {
     using Mapped = TMapped;
     using State = TState;
 
-    using value_type = PairNoInit<Key, Mapped>;
+    using value_type = Pair;
     using mapped_type = Mapped;
     using key_type = Key;
 
@@ -151,14 +153,14 @@ struct HashMapCell
 namespace std
 {
 
-    template <typename Key, typename TMapped, typename Hash, typename TState>
-    struct tuple_size<HashMapCell<Key, TMapped, Hash, TState>> : std::integral_constant<size_t, 2> { };
+    template <typename Key, typename TMapped, typename Hash, typename TState, typename Pair>
+    struct tuple_size<HashMapCell<Key, TMapped, Hash, TState, Pair>> : std::integral_constant<size_t, 2> { };
 
-    template <typename Key, typename TMapped, typename Hash, typename TState>
-    struct tuple_element<0, HashMapCell<Key, TMapped, Hash, TState>> { using type = Key; };
+    template <typename Key, typename TMapped, typename Hash, typename TState, typename Pair>
+    struct tuple_element<0, HashMapCell<Key, TMapped, Hash, TState, Pair>> { using type = Key; };
 
-    template <typename Key, typename TMapped, typename Hash, typename TState>
-    struct tuple_element<1, HashMapCell<Key, TMapped, Hash, TState>> { using type = TMapped; };
+    template <typename Key, typename TMapped, typename Hash, typename TState, typename Pair>
+    struct tuple_element<1, HashMapCell<Key, TMapped, Hash, TState, Pair>> { using type = TMapped; };
 }
 
 template <typename Key, typename TMapped, typename Hash, typename TState = HashTableNoState>

--- a/src/Common/HashTable/HashSet.h
+++ b/src/Common/HashTable/HashSet.h
@@ -41,6 +41,8 @@ public:
     using Base = HashTable<Key, TCell, Hash, Grower, Allocator>;
     using typename Base::LookupResult;
 
+    using Base::Base;
+
     void merge(const Self & rhs)
     {
         if (!this->hasZero() && rhs.hasZero())

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -771,6 +771,14 @@ public:
         alloc(grower);
     }
 
+    explicit HashTable(const Grower & grower_)
+        : grower(grower_)
+    {
+        if (Cell::need_zero_value_storage)
+            this->zeroValue()->setZero();
+        alloc(grower);
+    }
+
     HashTable(size_t reserve_for_num_elements) /// NOLINT
     {
         if (Cell::need_zero_value_storage)

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -256,11 +256,12 @@ struct HashTableGrower
     /// Set the buffer size by the number of elements in the hash table. Used when deserializing a hash table.
     void set(size_t num_elems)
     {
-        size_degree = num_elems <= 1
-             ? initial_size_degree
-             : ((initial_size_degree > static_cast<size_t>(log2(num_elems - 1)) + 2)
-                 ? initial_size_degree
-                 : (static_cast<size_t>(log2(num_elems - 1)) + 2));
+        if (num_elems <= 1)
+            size_degree = initial_size_degree;
+        else if (initial_size_degree > static_cast<size_t>(log2(num_elems - 1)) + 2)
+            size_degree = initial_size_degree;
+        else
+            size_degree = static_cast<size_t>(log2(num_elems - 1)) + 2;
     }
 
     void setBufSize(size_t buf_size_)
@@ -317,11 +318,12 @@ public:
     /// Set the buffer size by the number of elements in the hash table. Used when deserializing a hash table.
     void set(size_t num_elems)
     {
-        size_degree = num_elems <= 1
-             ? initial_size_degree
-             : ((initial_size_degree > static_cast<size_t>(log2(num_elems - 1)) + 2)
-                 ? initial_size_degree
-                 : (static_cast<size_t>(log2(num_elems - 1)) + 2));
+        if (num_elems <= 1)
+            size_degree = initial_size_degree;
+        else if (initial_size_degree > static_cast<size_t>(log2(num_elems - 1)) + 2)
+            size_degree = initial_size_degree;
+        else
+            size_degree = static_cast<size_t>(log2(num_elems - 1)) + 2;
         increaseSizeDegree(0);
     }
 

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -753,6 +753,7 @@ protected:
 
 public:
     using key_type = Key;
+    using grower_type = Grower;
     using mapped_type = typename Cell::mapped_type;
     using value_type = typename Cell::value_type;
     using cell_type = Cell;

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -270,6 +270,7 @@ struct HashTableGrower
 /** Determines the size of the hash table, and when and how much it should be resized.
   * This structure is aligned to cache line boundary and also occupies it all.
   * Precalculates some values to speed up lookups and insertion into the HashTable (and thus has bigger memory footprint than HashTableGrower).
+  * This grower assume 0.5 load factor
   */
 template <size_t initial_size_degree = 8>
 class alignas(64) HashTableGrowerWithPrecalculation

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -117,7 +117,7 @@ inline bool bitEquals(T && a, T && b)
   * 3) Hash tables that store the key and do not have a "mapped" value, e.g. the normal HashTable.
   *    GetKey returns the key, and GetMapped returns a zero void pointer. This simplifies generic
   *    code that works with mapped values: it can overload on the return type of GetMapped(), and
-  *    doesn't need other parameters. One example is insertSetMapped() function.
+  *    doesn't need other parameters. One example is Cell::setMapped() function.
   *
   * 4) Hash tables that store both the key and the "mapped" value, e.g. HashMap. Both GetKey and
   *    GetMapped are supported.
@@ -215,17 +215,6 @@ struct HashTableCell
     static void move(HashTableCell * /* old_location */, HashTableCell * /* new_location */) {}
 
 };
-
-/**
-  * A helper function for HashTable::insert() to set the "mapped" value.
-  * Overloaded on the mapped type, does nothing if it's VoidMapped.
-  */
-template <typename ValueType>
-void insertSetMapped(VoidMapped /* dest */, const ValueType & /* src */) {}
-
-template <typename MappedType, typename ValueType>
-void insertSetMapped(MappedType & dest, const ValueType & src) { dest = src.second; }
-
 
 /** Determines the size of the hash table, and when and how much it should be resized.
   * Has very small state (one UInt8) and useful for Set-s allocated in automatic memory (see uniqExact as an example).
@@ -1046,7 +1035,7 @@ public:
         }
 
         if (res.second)
-            insertSetMapped(res.first->getMapped(), x);
+            res.first->setMapped(x);
 
         return res;
     }

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -230,6 +230,8 @@ struct HashTableGrower
     /// If collision resolution chains are contiguous, we can implement erase operation by moving the elements.
     static constexpr auto performs_linear_probing_with_single_step = true;
 
+    static constexpr size_t max_size_degree = 23;
+
     /// The size of the hash table in the cells.
     size_t bufSize() const               { return 1ULL << size_degree; }
 
@@ -248,7 +250,7 @@ struct HashTableGrower
     /// Increase the size of the hash table.
     void increaseSize()
     {
-        size_degree += size_degree >= 23 ? 1 : 2;
+        size_degree += size_degree >= max_size_degree ? 1 : 2;
     }
 
     /// Set the buffer size by the number of elements in the hash table. Used when deserializing a hash table.
@@ -280,6 +282,7 @@ class alignas(64) HashTableGrowerWithPrecalculation
     UInt8 size_degree = initial_size_degree;
     size_t precalculated_mask = (1ULL << initial_size_degree) - 1;
     size_t precalculated_max_fill = 1ULL << (initial_size_degree - 1);
+    static constexpr size_t max_size_degree = 23;
 
 public:
     UInt8 sizeDegree() const { return size_degree; }
@@ -309,7 +312,7 @@ public:
     bool overflow(size_t elems) const { return elems > precalculated_max_fill; }
 
     /// Increase the size of the hash table.
-    void increaseSize() { increaseSizeDegree(size_degree >= 23 ? 1 : 2); }
+    void increaseSize() { increaseSizeDegree(size_degree >= max_size_degree ? 1 : 2); }
 
     /// Set the buffer size by the number of elements in the hash table. Used when deserializing a hash table.
     void set(size_t num_elems)

--- a/src/Common/HashTable/PackedHashMap.h
+++ b/src/Common/HashTable/PackedHashMap.h
@@ -9,7 +9,7 @@
 /// NOTE: makePairNoInit() is omitted for PackedPairNoInit since it is not
 /// required for PackedHashMap (see mergeBlockWithPipe() for details)
 template <typename First, typename Second>
-struct PackedPairNoInit
+struct __attribute__((packed)) PackedPairNoInit
 {
     First first;
     Second second;
@@ -28,7 +28,7 @@ struct PackedPairNoInit
         , second(std::forward<SecondValue>(second_))
     {
     }
-} __attribute__((packed));
+};
 
 /// The difference with ZeroTraits is that PackedZeroTraits accepts PackedPairNoInit instead of Key.
 namespace PackedZeroTraits

--- a/src/Common/HashTable/PackedHashMap.h
+++ b/src/Common/HashTable/PackedHashMap.h
@@ -30,6 +30,67 @@ struct PackedPairNoInit
     }
 } __attribute__((packed));
 
+/// The difference with ZeroTraits is that PackedZeroTraits accepts PackedPairNoInit instead of Key.
+namespace PackedZeroTraits
+{
+    template <typename First, typename Second, template <typename, typename> class PackedPairNoInit>
+    bool check(const PackedPairNoInit<First, Second> p) { return p.first == First{}; }
+
+    template <typename First, typename Second, template <typename, typename> class PackedPairNoInit>
+    void set(PackedPairNoInit<First, Second> & p) { p.first = First{}; }
+}
+
+/// setZero() should be overwritten to pass the pair instead of key, to avoid
+/// "reference binding to misaligned address" errors from UBsan.
+template <typename Key, typename TMapped, typename Hash, typename TState = HashTableNoState>
+struct PackedHashMapCell : public HashMapCell<Key, TMapped, Hash, TState, PackedPairNoInit<Key, TMapped>>
+{
+    using Base = HashMapCell<Key, TMapped, Hash, TState, PackedPairNoInit<Key, TMapped>>;
+    using State = typename Base::State;
+    using value_type = typename Base::value_type;
+    using key_type = typename Base::key_type;
+    using Mapped = typename Base::Mapped;
+
+    using Base::Base;
+
+    void setZero() { PackedZeroTraits::set(this->value); }
+
+    Key getKey() const { return this->value.first; }
+    static Key getKey(const value_type & value_) { return value_.first; }
+
+    Mapped & getMapped() { return this->value.second; }
+    Mapped getMapped() const { return this->value.second; }
+    value_type getValue() const { return this->value; }
+
+    bool keyEquals(const Key key_) const { return bitEqualsByValue(this->value.first, key_); }
+    bool keyEquals(const Key key_, size_t /*hash_*/) const { return bitEqualsByValue(this->value.first, key_); }
+    bool keyEquals(const Key key_, size_t /*hash_*/, const State & /*state*/) const { return bitEqualsByValue(this->value.first, key_); }
+
+    bool isZero(const State & state) const { return isZero(this->value.first, state); }
+    static bool isZero(const Key key, const State & /*state*/) { return ZeroTraits::check(key); }
+
+    static inline bool bitEqualsByValue(key_type a, key_type b) { return a == b; }
+
+    template <size_t I>
+    auto get() const
+    {
+        if constexpr (I == 0) return this->value.first;
+        else if constexpr (I == 1) return this->value.second;
+    }
+};
+
+namespace std
+{
+    template <typename Key, typename TMapped, typename Hash, typename TState>
+    struct tuple_size<PackedHashMapCell<Key, TMapped, Hash, TState>> : std::integral_constant<size_t, 2> { };
+
+    template <typename Key, typename TMapped, typename Hash, typename TState>
+    struct tuple_element<0, PackedHashMapCell<Key, TMapped, Hash, TState>> { using type = Key; };
+
+    template <typename Key, typename TMapped, typename Hash, typename TState>
+    struct tuple_element<1, PackedHashMapCell<Key, TMapped, Hash, TState>> { using type = TMapped; };
+}
+
 /// Packed HashMap - HashMap with structure without padding
 ///
 /// Sometimes padding in structure can be crucial, consider the following
@@ -43,4 +104,4 @@ template <
     typename Hash = DefaultHash<Key>,
     typename Grower = HashTableGrower<>,
     typename Allocator = HashTableAllocator>
-using PackedHashMap = HashMapTable<Key, HashMapCell<Key, Mapped, Hash, HashTableNoState, PackedPairNoInit<Key, Mapped>>, Hash, Grower, Allocator>;
+using PackedHashMap = HashMapTable<Key, PackedHashMapCell<Key, Mapped, Hash, HashTableNoState>, Hash, Grower, Allocator>;

--- a/src/Common/HashTable/PackedHashMap.h
+++ b/src/Common/HashTable/PackedHashMap.h
@@ -1,0 +1,46 @@
+#pragma once
+
+/// Packed versions HashMap, please keep in sync with HashMap.h
+
+#include <Common/HashTable/HashMap.h>
+
+/// A pair that does not initialize the elements, if not needed.
+///
+/// NOTE: makePairNoInit() is omitted for PackedPairNoInit since it is not
+/// required for PackedHashMap (see mergeBlockWithPipe() for details)
+template <typename First, typename Second>
+struct PackedPairNoInit
+{
+    First first;
+    Second second;
+
+    PackedPairNoInit() {} /// NOLINT
+
+    template <typename FirstValue>
+    PackedPairNoInit(FirstValue && first_, NoInitTag)
+        : first(std::forward<FirstValue>(first_))
+    {
+    }
+
+    template <typename FirstValue, typename SecondValue>
+    PackedPairNoInit(FirstValue && first_, SecondValue && second_)
+        : first(std::forward<FirstValue>(first_))
+        , second(std::forward<SecondValue>(second_))
+    {
+    }
+} __attribute__((packed));
+
+/// Packed HashMap - HashMap with structure without padding
+///
+/// Sometimes padding in structure can be crucial, consider the following
+/// example <UInt64, UInt16> as <Key, Value> in this case the padding overhead
+/// is 0.375, and this can be major in case of lots of keys.
+///
+/// Note, there is no need to provide PackedHashSet, since it cannot have padding.
+template <
+    typename Key,
+    typename Mapped,
+    typename Hash = DefaultHash<Key>,
+    typename Grower = HashTableGrower<>,
+    typename Allocator = HashTableAllocator>
+using PackedHashMap = HashMapTable<Key, HashMapCell<Key, Mapped, Hash, HashTableNoState, PackedPairNoInit<Key, Mapped>>, Hash, Grower, Allocator>;

--- a/src/Common/HashTable/TwoLevelHashTable.h
+++ b/src/Common/HashTable/TwoLevelHashTable.h
@@ -224,7 +224,7 @@ public:
         emplace(Cell::getKey(x), res.first, res.second, hash_value);
 
         if (res.second)
-            insertSetMapped(res.first->getMapped(), x);
+            res.first->setMapped(x);
 
         return res;
     }

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -32,6 +32,8 @@ namespace CurrentMetrics
 namespace DB
 {
 
+using namespace HashedDictionaryImpl;
+
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -660,6 +660,11 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::createAttributes()
                     container.max_load_factor(configuration.max_load_factor);
                 attributes.emplace_back(std::move(attribute));
             }
+
+            if constexpr (IsBuiltinHashTable<typename CollectionsHolder<ValueType>::value_type>)
+                LOG_TRACE(log, "Using builtin hash table for {} attribute", dictionary_attribute.name);
+            else
+                LOG_TRACE(log, "Using sparsehash for {} attribute", dictionary_attribute.name);
         };
 
         callOnDictionaryAttributeType(dictionary_attribute.underlying_type, type_call);

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -630,6 +630,8 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::createAttributes()
     const auto size = dict_struct.attributes.size();
     attributes.reserve(size);
 
+    HashTableGrowerWithMaxLoadFactor grower(configuration.max_load_factor);
+
     for (const auto & dictionary_attribute : dict_struct.attributes)
     {
         auto type_call = [&, this](const auto & dictionary_attribute_type)
@@ -639,8 +641,23 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::createAttributes()
             using ValueType = DictionaryValueType<AttributeType>;
 
             auto is_nullable_sets = dictionary_attribute.is_nullable ? std::make_optional<NullableSets>(configuration.shards) : std::optional<NullableSets>{};
-            Attribute attribute{dictionary_attribute.underlying_type, std::move(is_nullable_sets), CollectionsHolder<ValueType>(configuration.shards)};
-            attributes.emplace_back(std::move(attribute));
+            if constexpr (IsBuiltinHashTable<typename CollectionsHolder<ValueType>::value_type>)
+            {
+                CollectionsHolder<ValueType> collections;
+                collections.reserve(configuration.shards);
+                for (size_t i = 0; i < configuration.shards; ++i)
+                    collections.emplace_back(grower);
+
+                Attribute attribute{dictionary_attribute.underlying_type, std::move(is_nullable_sets), std::move(collections)};
+                attributes.emplace_back(std::move(attribute));
+            }
+            else
+            {
+                Attribute attribute{dictionary_attribute.underlying_type, std::move(is_nullable_sets), CollectionsHolder<ValueType>(configuration.shards)};
+                for (auto & container : std::get<CollectionsHolder<ValueType>>(attribute.containers))
+                    container.max_load_factor(configuration.max_load_factor);
+                attributes.emplace_back(std::move(attribute));
+            }
         };
 
         callOnDictionaryAttributeType(dictionary_attribute.underlying_type, type_call);
@@ -648,7 +665,9 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::createAttributes()
 
     if (unlikely(attributes.size()) == 0)
     {
-        no_attributes_containers.resize(configuration.shards);
+        no_attributes_containers.reserve(configuration.shards);
+        for (size_t i = 0; i < configuration.shards; ++i)
+            no_attributes_containers.emplace_back(grower);
     }
 
     string_arenas.resize(configuration.shards);
@@ -1136,9 +1155,14 @@ void registerDictionaryHashed(DictionaryFactory & factory)
         if (shard_load_queue_backlog <= 0)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,"{}: SHARD_LOAD_QUEUE_BACKLOG parameter should be greater then zero", full_name);
 
+        float max_load_factor = static_cast<float>(config.getDouble(config_prefix + dictionary_layout_prefix + ".max_load_factor", 0.5));
+        if (max_load_factor < 0.5 || max_load_factor > 0.99)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "{}: max_load_factor parameter should be within [0.5, 0.99], got {}", full_name, max_load_factor);
+
         HashedDictionaryConfiguration configuration{
             static_cast<UInt64>(shards),
             static_cast<UInt64>(shard_load_queue_backlog),
+            max_load_factor,
             require_nonempty,
             dict_lifetime,
         };

--- a/src/Dictionaries/HashedDictionary.cpp
+++ b/src/Dictionaries/HashedDictionary.cpp
@@ -630,7 +630,7 @@ void HashedDictionary<dictionary_key_type, sparse, sharded>::createAttributes()
     const auto size = dict_struct.attributes.size();
     attributes.reserve(size);
 
-    HashTableGrowerWithMaxLoadFactor grower(configuration.max_load_factor);
+    HashTableGrowerWithPrecalculationAndMaxLoadFactor grower(configuration.max_load_factor);
 
     for (const auto & dictionary_attribute : dict_struct.attributes)
     {

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -134,7 +134,7 @@ public:
 
 private:
     template <typename Value>
-    using CollectionsHolder = std::vector<typename HashedDictionaryMapType<dictionary_key_type, sparse, KeyType, Value>::Type>;
+    using CollectionsHolder = std::vector<typename HashedDictionaryImpl::HashedDictionaryMapType<dictionary_key_type, sparse, KeyType, Value>::Type>;
 
     using NullableSet = HashSet<KeyType, DefaultHash<KeyType>>;
     using NullableSets = std::vector<NullableSet>;
@@ -232,7 +232,7 @@ private:
 
     BlockPtr update_field_loaded_block;
     std::vector<std::unique_ptr<Arena>> string_arenas;
-    std::vector<typename HashedDictionarySetType<dictionary_key_type, sparse, KeyType>::Type> no_attributes_containers;
+    std::vector<typename HashedDictionaryImpl::HashedDictionarySetType<dictionary_key_type, sparse, KeyType>::Type> no_attributes_containers;
     DictionaryHierarchicalParentToChildIndexPtr hierarchical_index;
 };
 

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -25,6 +25,7 @@ struct HashedDictionaryConfiguration
 {
     const UInt64 shards;
     const UInt64 shard_load_queue_backlog;
+    const float max_load_factor;
     const bool require_nonempty;
     const DictionaryLifetime lifetime;
 };

--- a/src/Dictionaries/HashedDictionary.h
+++ b/src/Dictionaries/HashedDictionary.h
@@ -4,17 +4,14 @@
 #include <memory>
 #include <variant>
 #include <optional>
-#include <sparsehash/sparse_hash_map>
-#include <sparsehash/sparse_hash_set>
 
-#include <Common/HashTable/HashMap.h>
-#include <Common/HashTable/HashSet.h>
 #include <Core/Block.h>
 
 #include <Dictionaries/DictionaryStructure.h>
 #include <Dictionaries/IDictionary.h>
 #include <Dictionaries/IDictionarySource.h>
 #include <Dictionaries/DictionaryHelpers.h>
+#include <Dictionaries/HashedDictionaryCollectionType.h>
 
 /** This dictionary stores all content in a hash table in memory
   * (a separate Key -> Value map for each attribute)
@@ -136,42 +133,7 @@ public:
 
 private:
     template <typename Value>
-    using CollectionTypeNonSparse = std::conditional_t<
-        dictionary_key_type == DictionaryKeyType::Simple,
-        HashMap<UInt64, Value, DefaultHash<UInt64>>,
-        HashMapWithSavedHash<StringRef, Value, DefaultHash<StringRef>>>;
-
-    using NoAttributesCollectionTypeNonSparse = std::conditional_t<
-        dictionary_key_type == DictionaryKeyType::Simple,
-        HashSet<UInt64, DefaultHash<UInt64>>,
-        HashSetWithSavedHash<StringRef, DefaultHash<StringRef>>>;
-
-    /// Here we use sparse_hash_map with DefaultHash<> for the following reasons:
-    ///
-    /// - DefaultHash<> is used for HashMap
-    /// - DefaultHash<> (from HashTable/Hash.h> works better then std::hash<>
-    ///   in case of sequential set of keys, but with random access to this set, i.e.
-    ///
-    ///       SELECT number FROM numbers(3000000) ORDER BY rand()
-    ///
-    ///   And even though std::hash<> works better in some other cases,
-    ///   DefaultHash<> is preferred since the difference for this particular
-    ///   case is significant, i.e. it can be 10x+.
-    template <typename Value>
-    using CollectionTypeSparse = std::conditional_t<
-        dictionary_key_type == DictionaryKeyType::Simple,
-        google::sparse_hash_map<UInt64, Value, DefaultHash<KeyType>>,
-        google::sparse_hash_map<StringRef, Value, DefaultHash<KeyType>>>;
-
-    using NoAttributesCollectionTypeSparse = google::sparse_hash_set<KeyType, DefaultHash<KeyType>>;
-
-    template <typename Value>
-    using CollectionType = std::conditional_t<sparse, CollectionTypeSparse<Value>, CollectionTypeNonSparse<Value>>;
-
-    template <typename Value>
-    using CollectionsHolder = std::vector<CollectionType<Value>>;
-
-    using NoAttributesCollectionType = std::conditional_t<sparse, NoAttributesCollectionTypeSparse, NoAttributesCollectionTypeNonSparse>;
+    using CollectionsHolder = std::vector<typename HashedDictionaryMapType<dictionary_key_type, sparse, KeyType, Value>::Type>;
 
     using NullableSet = HashSet<KeyType, DefaultHash<KeyType>>;
     using NullableSets = std::vector<NullableSet>;
@@ -269,7 +231,7 @@ private:
 
     BlockPtr update_field_loaded_block;
     std::vector<std::unique_ptr<Arena>> string_arenas;
-    std::vector<NoAttributesCollectionType> no_attributes_containers;
+    std::vector<typename HashedDictionarySetType<dictionary_key_type, sparse, KeyType>::Type> no_attributes_containers;
     DictionaryHierarchicalParentToChildIndexPtr hierarchical_index;
 };
 

--- a/src/Dictionaries/HashedDictionaryCollectionTraits.h
+++ b/src/Dictionaries/HashedDictionaryCollectionTraits.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <type_traits>
+#include <sparsehash/sparse_hash_map>
+#include <Common/HashTable/Hash.h>
+#include <Common/HashTable/HashMap.h>
+#include <Common/HashTable/HashSet.h>
+#include <Common/HashTable/PackedHashMap.h>
+
+namespace DB
+{
+
+/// sparse_hash_map/sparse_hash_set
+template <typename C>
+concept IsGoogleSparseHashTable = std::is_same_v<C, google::sparse_hash_map<
+    typename C::key_type,
+    typename C::mapped_type,
+    /// HashFcn is not exported in sparse_hash_map is public type
+    DefaultHash<typename C::key_type>>>;
+
+template <typename V>
+concept IsStdMapCell = requires (V v)
+{
+    v->first;
+    v->second;
+};
+
+/// HashMap/HashMapWithSavedHash/HashSet/HashMapWithSavedHash/PackedHashMap and their Cells
+template <typename C>
+concept IsBuiltinHashTable = (
+    std::is_same_v<C, HashMapWithSavedHash<
+        typename C::key_type,
+        typename C::mapped_type,
+        DefaultHash<typename C::key_type>,
+        typename C::grower_type>> ||
+    std::is_same_v<C, HashMap<
+        typename C::key_type,
+        typename C::mapped_type,
+        DefaultHash<typename C::key_type>,
+        typename C::grower_type>> ||
+    std::is_same_v<C, PackedHashMap<
+        typename C::key_type,
+        typename C::mapped_type,
+        DefaultHash<typename C::key_type>,
+        typename C::grower_type>> ||
+    std::is_same_v<C, HashSetWithSavedHash<
+        typename C::key_type,
+        DefaultHash<typename C::key_type>,
+        typename C::grower_type>> ||
+    std::is_same_v<C, HashSet<
+        typename C::key_type,
+        DefaultHash<typename C::key_type>,
+        typename C::grower_type>>
+);
+
+template <typename V>
+concept IsBuiltinSetCell = requires (V v)
+{
+    v.getKey();
+};
+
+template <typename V>
+concept IsBuiltinMapCell = requires (V v)
+{
+    v->getKey();
+    v->getMapped();
+};
+
+// NOLINTBEGIN(*)
+
+/// google::sparse_hash_map
+template <typename T> auto getSetKeyFromCell(const T & value) { return value; }
+template <typename T> auto getKeyFromCell(const T & value) requires (IsStdMapCell<T>) { return value->first; }
+template <typename T> auto getValueFromCell(const T & value) requires (IsStdMapCell<T>) { return value->second; }
+
+/// size() - returns table size, without empty and deleted
+/// and since this is sparsehash, empty cells should not be significant,
+/// and since items cannot be removed from the dictionary, deleted is also not important.
+///
+/// NOTE: for google::sparse_hash_set value_type is Key, for sparse_hash_map
+/// value_type is std::pair<Key, Value>, and now we correctly takes into
+/// account padding in structures, if any.
+template <typename C> auto getBufferSizeInBytes(const C & c) requires (IsGoogleSparseHashTable<C>) { return c.size() * sizeof(typename C::value_type); }
+/// bucket_count() - Returns table size, that includes empty and deleted
+template <typename C> auto getBufferSizeInCells(const C & c) requires (IsGoogleSparseHashTable<C>) { return c.bucket_count(); }
+
+template <typename C> auto resizeContainer(C & c, size_t size) requires (IsGoogleSparseHashTable<C>) { return c.resize(size); }
+template <typename C> auto clearContainer(C & c) requires (IsGoogleSparseHashTable<C>) { return c.clear(); }
+
+/// HashMap
+template <typename T> auto getSetKeyFromCell(const T & value) requires (IsBuiltinSetCell<T>) { return value.getKey(); }
+template <typename T> auto getKeyFromCell(const T & value) requires (IsBuiltinMapCell<T>) { return value->getKey(); }
+template <typename T> auto getValueFromCell(const T & value) requires (IsBuiltinMapCell<T>) { return value->getMapped(); }
+
+template <typename C> auto getBufferSizeInBytes(const C & c) requires (IsBuiltinHashTable<C>) { return c.getBufferSizeInBytes(); }
+template <typename C> auto getBufferSizeInCells(const C & c) requires (IsBuiltinHashTable<C>) { return c.getBufferSizeInCells(); }
+template <typename C> auto resizeContainer(C & c, size_t size) requires (IsBuiltinHashTable<C>) { return c.reserve(size); }
+template <typename C> void clearContainer(C & c) requires (IsBuiltinHashTable<C>) { return c.clearAndShrink(); }
+
+// NOLINTEND(*)
+
+}

--- a/src/Dictionaries/HashedDictionaryCollectionTraits.h
+++ b/src/Dictionaries/HashedDictionaryCollectionTraits.h
@@ -10,6 +10,9 @@
 namespace DB
 {
 
+namespace HashedDictionaryImpl
+{
+
 /// sparse_hash_map/sparse_hash_set
 template <typename C>
 concept IsGoogleSparseHashTable = std::is_same_v<C, google::sparse_hash_map<
@@ -98,5 +101,7 @@ template <typename C> auto resizeContainer(C & c, size_t size) requires (IsBuilt
 template <typename C> void clearContainer(C & c) requires (IsBuiltinHashTable<C>) { return c.clearAndShrink(); }
 
 // NOLINTEND(*)
+
+}
 
 }

--- a/src/Dictionaries/HashedDictionaryCollectionType.h
+++ b/src/Dictionaries/HashedDictionaryCollectionType.h
@@ -88,9 +88,9 @@ constexpr bool useSparseHashForHashedDictionary()
 /// google::sparse_hash_map.
 ///
 /// Based on HashTableGrowerWithPrecalculation
+template <size_t initial_size_degree = 8>
 class alignas(64) HashTableGrowerWithPrecalculationAndMaxLoadFactor
 {
-    static constexpr size_t initial_size_degree = 8;
     UInt8 size_degree = initial_size_degree;
     size_t precalculated_mask = (1ULL << initial_size_degree) - 1;
     size_t precalculated_max_fill = 1ULL << (initial_size_degree - 1);
@@ -161,7 +161,7 @@ public:
         increaseSizeDegree(0);
     }
 };
-static_assert(sizeof(HashTableGrowerWithPrecalculationAndMaxLoadFactor) == 64);
+static_assert(sizeof(HashTableGrowerWithPrecalculationAndMaxLoadFactor<>) == 64);
 
 /// Above goes various specialisations for the hash table that will be used for
 /// HASHED/SPARSE_HASHED dictionary, it could use one of the following depends
@@ -188,8 +188,8 @@ struct HashedDictionaryMapType<dictionary_key_type, /* sparse= */ false, Key, Va
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        HashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>,
-        HashMapWithSavedHash<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>>;
+        HashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor<>>,
+        HashMapWithSavedHash<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor<>>>;
 };
 
 /// Implementations for SPARSE_HASHED layout.
@@ -223,8 +223,8 @@ struct HashedDictionarySparseMapType<dictionary_key_type, Key, Value, /* use_spa
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        PackedHashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>,
-        PackedHashMap<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>>;
+        PackedHashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor<>>,
+        PackedHashMap<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor<>>>;
 };
 template <DictionaryKeyType dictionary_key_type, typename Key, typename Value>
 struct HashedDictionaryMapType<dictionary_key_type, /* sparse= */ true, Key, Value>
@@ -247,8 +247,8 @@ struct HashedDictionarySetType<dictionary_key_type, /* sparse= */ false, Key>
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>,
-        HashSetWithSavedHash<StringRef, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>>;
+        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor<>>,
+        HashSetWithSavedHash<StringRef, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor<>>>;
 };
 
 /// Implementation for SPARSE_HASHED.
@@ -261,8 +261,8 @@ struct HashedDictionarySetType<dictionary_key_type, /* sparse= */ true, Key>
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>,
-        HashSet<StringRef, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>>;
+        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor<>>,
+        HashSet<StringRef, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor<>>>;
 };
 
 }

--- a/src/Dictionaries/HashedDictionaryCollectionType.h
+++ b/src/Dictionaries/HashedDictionaryCollectionType.h
@@ -79,14 +79,6 @@ constexpr bool useSparseHashForHashedDictionary()
 
 /// Grower with custom fill limit/load factor (instead of default 50%).
 ///
-/// It turns out that HashMap can outperform google::sparse_hash_map in case of
-/// the structure size of not big, in terms of speed *and* memory. Even 99% of
-/// max load factor was faster then google::sparse_hash_map in my simple tests
-/// (1e9 UInt64 keys with UInt16 values, randomly distributed).
-///
-/// And not to mention very high allocator memory fragmentation in
-/// google::sparse_hash_map.
-///
 /// Based on HashTableGrowerWithPrecalculation
 template <size_t initial_size_degree = 8>
 class alignas(64) HashTableGrowerWithPrecalculationAndMaxLoadFactor

--- a/src/Dictionaries/HashedDictionaryCollectionType.h
+++ b/src/Dictionaries/HashedDictionaryCollectionType.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <Dictionaries/IDictionary.h>
+#include <Common/HashTable/PackedHashMap.h>
+#include <Common/HashTable/HashMap.h>
+#include <Common/HashTable/HashSet.h>
+#include <sparsehash/sparse_hash_map>
+#include <sparsehash/sparse_hash_set>
+#include <type_traits>
+
+namespace DB
+{
+
+/// HashMap with packed structure is better than google::sparse_hash_map if the
+/// <K, V> pair is small, for the sizeof(std::pair<K, V>) == 16, RSS for hash
+/// table with 1e9 elements will be:
+///
+/// - google::sparse_hash_map             : 26GiB
+/// - HashMap                             : 35GiB
+/// - PackedHashMap                       : 22GiB
+/// - google::sparse_hash_map<packed_pair>: 17GiB
+///
+/// Also note here sizeof(std::pair<>) was used since google::sparse_hash_map
+/// uses it to store <K, V>, yes we can modify google::sparse_hash_map to work
+/// with packed analog of std::pair, but the allocator overhead is still
+/// significant, because of tons of reallocations (and those cannot be solved
+/// with reserve() due to some internals of google::sparse_hash_map) and poor
+/// jemalloc support of such pattern, which results in 33% fragmentation (in
+/// comparison with glibc).
+///
+/// Plus since google::sparse_hash_map cannot use packed structure, it will
+/// have the same memory footprint for everything from UInt8 to UInt64 values
+/// and so on.
+///
+/// Returns true hen google::sparse_hash_map should be used, otherwise
+/// PackedHashMap should be used instead.
+template <typename K, typename V>
+constexpr bool useSparseHashForHashedDictionary()
+{
+    return sizeof(PackedPairNoInit<K, V>) > 16;
+}
+
+///
+/// Map (dictionary with attributes)
+///
+
+/// Type of the hash table for the dictionary.
+template <DictionaryKeyType dictionary_key_type, bool sparse, typename Key, typename Value>
+struct HashedDictionaryMapType;
+
+/// Default implementation using builtin HashMap (for HASHED layout).
+template <DictionaryKeyType dictionary_key_type, typename Key, typename Value>
+struct HashedDictionaryMapType<dictionary_key_type, /* sparse= */ false, Key, Value>
+{
+    using Type = std::conditional_t<
+        dictionary_key_type == DictionaryKeyType::Simple,
+        HashMap<UInt64, Value, DefaultHash<UInt64>>,
+        HashMapWithSavedHash<StringRef, Value, DefaultHash<StringRef>>>;
+};
+
+/// Implementations for SPARSE_HASHED layout.
+template <DictionaryKeyType dictionary_key_type, typename Key, typename Value, bool use_sparse_hash>
+struct HashedDictionarySparseMapType;
+
+/// Implementation based on google::sparse_hash_map for SPARSE_HASHED.
+template <DictionaryKeyType dictionary_key_type, typename Key, typename Value>
+struct HashedDictionarySparseMapType<dictionary_key_type, Key, Value, /* use_sparse_hash= */ true>
+{
+    /// Here we use sparse_hash_map with DefaultHash<> for the following reasons:
+    ///
+    /// - DefaultHash<> is used for HashMap
+    /// - DefaultHash<> (from HashTable/Hash.h> works better then std::hash<>
+    ///   in case of sequential set of keys, but with random access to this set, i.e.
+    ///
+    ///       SELECT number FROM numbers(3000000) ORDER BY rand()
+    ///
+    ///   And even though std::hash<> works better in some other cases,
+    ///   DefaultHash<> is preferred since the difference for this particular
+    ///   case is significant, i.e. it can be 10x+.
+    using Type = std::conditional_t<
+        dictionary_key_type == DictionaryKeyType::Simple,
+        google::sparse_hash_map<UInt64, Value, DefaultHash<Key>>,
+        google::sparse_hash_map<StringRef, Value, DefaultHash<Key>>>;
+};
+
+/// Implementation based on PackedHashMap for SPARSE_HASHED.
+template <DictionaryKeyType dictionary_key_type, typename Key, typename Value>
+struct HashedDictionarySparseMapType<dictionary_key_type, Key, Value, /* use_sparse_hash= */ false>
+{
+    using Type = std::conditional_t<
+        dictionary_key_type == DictionaryKeyType::Simple,
+        PackedHashMap<UInt64, Value, DefaultHash<UInt64>>,
+        PackedHashMap<StringRef, Value, DefaultHash<StringRef>>>;
+};
+template <DictionaryKeyType dictionary_key_type, typename Key, typename Value>
+struct HashedDictionaryMapType<dictionary_key_type, /* sparse= */ true, Key, Value>
+    : public HashedDictionarySparseMapType<
+        dictionary_key_type, Key, Value,
+        /* use_sparse_hash= */ useSparseHashForHashedDictionary<Key, Value>()>
+{};
+
+///
+/// Set (dictionary with attributes)
+///
+
+/// Type of the hash table for the dictionary.
+template <DictionaryKeyType dictionary_key_type, bool sparse, typename Key>
+struct HashedDictionarySetType;
+
+/// Default implementation using builtin HashMap (for HASHED layout).
+template <DictionaryKeyType dictionary_key_type, typename Key>
+struct HashedDictionarySetType<dictionary_key_type, /* sparse= */ false, Key>
+{
+    using Type = std::conditional_t<
+        dictionary_key_type == DictionaryKeyType::Simple,
+        HashSet<UInt64, DefaultHash<UInt64>>,
+        HashSetWithSavedHash<StringRef, DefaultHash<StringRef>>>;
+};
+
+/// Implementation for SPARSE_HASHED.
+///
+/// NOTE: There is no implementation based on google::sparse_hash_set since
+/// PackedHashMap is more optimal anyway (see comments for
+/// useSparseHashForHashedDictionary()).
+template <DictionaryKeyType dictionary_key_type, typename Key>
+struct HashedDictionarySetType<dictionary_key_type, /* sparse= */ true, Key>
+{
+    using Type = std::conditional_t<
+        dictionary_key_type == DictionaryKeyType::Simple,
+        HashSet<UInt64, DefaultHash<UInt64>>,
+        HashSet<StringRef, DefaultHash<StringRef>>>;
+};
+
+}

--- a/src/Dictionaries/HashedDictionaryCollectionType.h
+++ b/src/Dictionaries/HashedDictionaryCollectionType.h
@@ -160,6 +160,17 @@ public:
 };
 static_assert(sizeof(HashTableGrowerWithMaxLoadFactor) == 64);
 
+/// Above goes various specialisations for the hash table that will be used for
+/// HASHED/SPARSE_HASHED dictionary, it could use one of the following depends
+/// on the layout of the dictionary and types of key/value (for more info see
+/// comments in this file):
+/// - HashMap
+/// - HashSet
+/// - HashMapWithSavedHash
+/// - HashSetWithSavedHash
+/// - PackedHashMap
+/// - google::sparse_hash_map
+
 ///
 /// Map (dictionary with attributes)
 ///

--- a/src/Dictionaries/HashedDictionaryCollectionType.h
+++ b/src/Dictionaries/HashedDictionaryCollectionType.h
@@ -85,7 +85,7 @@ constexpr bool useSparseHashForHashedDictionary()
 /// google::sparse_hash_map.
 ///
 /// Based on HashTableGrowerWithPrecalculation
-class alignas(64) HashTableGrowerWithMaxLoadFactor
+class alignas(64) HashTableGrowerWithPrecalculationAndMaxLoadFactor
 {
     static constexpr size_t initial_size_degree = 8;
     UInt8 size_degree = initial_size_degree;
@@ -103,8 +103,8 @@ public:
     /// If collision resolution chains are contiguous, we can implement erase operation by moving the elements.
     static constexpr auto performs_linear_probing_with_single_step = true;
 
-    HashTableGrowerWithMaxLoadFactor() = default;
-    explicit HashTableGrowerWithMaxLoadFactor(float max_load_factor_)
+    HashTableGrowerWithPrecalculationAndMaxLoadFactor() = default;
+    explicit HashTableGrowerWithPrecalculationAndMaxLoadFactor(float max_load_factor_)
         : max_load_factor(max_load_factor_)
     {
         increaseSizeDegree(0);
@@ -158,7 +158,7 @@ public:
         increaseSizeDegree(0);
     }
 };
-static_assert(sizeof(HashTableGrowerWithMaxLoadFactor) == 64);
+static_assert(sizeof(HashTableGrowerWithPrecalculationAndMaxLoadFactor) == 64);
 
 /// Above goes various specialisations for the hash table that will be used for
 /// HASHED/SPARSE_HASHED dictionary, it could use one of the following depends
@@ -185,8 +185,8 @@ struct HashedDictionaryMapType<dictionary_key_type, /* sparse= */ false, Key, Va
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        HashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithMaxLoadFactor>,
-        HashMapWithSavedHash<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithMaxLoadFactor>>;
+        HashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>,
+        HashMapWithSavedHash<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>>;
 };
 
 /// Implementations for SPARSE_HASHED layout.
@@ -220,8 +220,8 @@ struct HashedDictionarySparseMapType<dictionary_key_type, Key, Value, /* use_spa
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        PackedHashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithMaxLoadFactor>,
-        PackedHashMap<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithMaxLoadFactor>>;
+        PackedHashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>,
+        PackedHashMap<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>>;
 };
 template <DictionaryKeyType dictionary_key_type, typename Key, typename Value>
 struct HashedDictionaryMapType<dictionary_key_type, /* sparse= */ true, Key, Value>
@@ -244,8 +244,8 @@ struct HashedDictionarySetType<dictionary_key_type, /* sparse= */ false, Key>
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithMaxLoadFactor>,
-        HashSetWithSavedHash<StringRef, DefaultHash<StringRef>, HashTableGrowerWithMaxLoadFactor>>;
+        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>,
+        HashSetWithSavedHash<StringRef, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>>;
 };
 
 /// Implementation for SPARSE_HASHED.
@@ -258,8 +258,8 @@ struct HashedDictionarySetType<dictionary_key_type, /* sparse= */ true, Key>
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithMaxLoadFactor>,
-        HashSet<StringRef, DefaultHash<StringRef>, HashTableGrowerWithMaxLoadFactor>>;
+        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>,
+        HashSet<StringRef, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>>;
 };
 
 }

--- a/src/Dictionaries/HashedDictionaryCollectionType.h
+++ b/src/Dictionaries/HashedDictionaryCollectionType.h
@@ -12,6 +12,9 @@
 namespace DB
 {
 
+namespace HashedDictionaryImpl
+{
+
 /// Return true if the type is POD [1] for the purpose of layout (this is not
 /// the same as STL traits has).
 ///
@@ -261,5 +264,7 @@ struct HashedDictionarySetType<dictionary_key_type, /* sparse= */ true, Key>
         HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>,
         HashSet<StringRef, DefaultHash<StringRef>, HashTableGrowerWithPrecalculationAndMaxLoadFactor>>;
 };
+
+}
 
 }

--- a/src/Dictionaries/HashedDictionaryCollectionType.h
+++ b/src/Dictionaries/HashedDictionaryCollectionType.h
@@ -40,6 +40,92 @@ constexpr bool useSparseHashForHashedDictionary()
     return sizeof(PackedPairNoInit<K, V>) > 16;
 }
 
+/// Grower with custom fill limit/load factor (instead of default 50%).
+///
+/// It turns out that HashMap can outperform google::sparse_hash_map in case of
+/// the structure size of not big, in terms of speed *and* memory. Even 99% of
+/// max load factor was faster then google::sparse_hash_map in my simple tests
+/// (1e9 UInt64 keys with UInt16 values, randomly distributed).
+///
+/// And not to mention very high allocator memory fragmentation in
+/// google::sparse_hash_map.
+///
+/// Based on HashTableGrowerWithPrecalculation
+class alignas(64) HashTableGrowerWithMaxLoadFactor
+{
+    static constexpr size_t initial_size_degree = 8;
+    UInt8 size_degree = initial_size_degree;
+    size_t precalculated_mask = (1ULL << initial_size_degree) - 1;
+    size_t precalculated_max_fill = 1ULL << (initial_size_degree - 1);
+    float max_load_factor = 0.5;
+    /// HashTableGrowerWithPrecalculation has 23, but to decrease memory usage
+    /// at least slightly 19 is used here. Also note, that for dictionaries it
+    /// is not that important since they are not that frequently loaded.
+    static constexpr size_t max_size_degree_quadratic = 19;
+
+public:
+    static constexpr auto initial_count = 1ULL << initial_size_degree;
+
+    /// If collision resolution chains are contiguous, we can implement erase operation by moving the elements.
+    static constexpr auto performs_linear_probing_with_single_step = true;
+
+    HashTableGrowerWithMaxLoadFactor() = default;
+    explicit HashTableGrowerWithMaxLoadFactor(float max_load_factor_)
+        : max_load_factor(max_load_factor_)
+    {
+        increaseSizeDegree(0);
+    }
+
+    UInt8 sizeDegree() const { return size_degree; }
+
+    void increaseSizeDegree(UInt8 delta)
+    {
+        size_degree += delta;
+        precalculated_mask = (1ULL << size_degree) - 1;
+        precalculated_max_fill = static_cast<size_t>((1ULL << size_degree) * max_load_factor);
+    }
+
+    /// The size of the hash table in the cells.
+    size_t bufSize() const { return 1ULL << size_degree; }
+
+    /// From the hash value, get the cell number in the hash table.
+    size_t place(size_t x) const { return x & precalculated_mask; }
+
+    /// The next cell in the collision resolution chain.
+    size_t next(size_t pos) const { return (pos + 1) & precalculated_mask; }
+
+    /// Whether the hash table is sufficiently full. You need to increase the size of the hash table, or remove something unnecessary from it.
+    bool overflow(size_t elems) const { return elems > precalculated_max_fill; }
+
+    /// Increase the size of the hash table.
+    void increaseSize() { increaseSizeDegree(size_degree >= max_size_degree_quadratic ? 1 : 2); }
+
+    /// Set the buffer size by the number of elements in the hash table. Used when deserializing a hash table.
+    void set(size_t num_elems)
+    {
+        if (num_elems <= 1)
+            size_degree = initial_size_degree;
+        else if (initial_size_degree > static_cast<size_t>(log2(num_elems - 1)) + 2)
+            size_degree = initial_size_degree;
+        else
+        {
+            /// Slightly more optimal than HashTableGrowerWithPrecalculation
+            /// and takes into account max_load_factor.
+            size_degree = static_cast<size_t>(log2(num_elems - 1)) + 1;
+            if ((1ULL << size_degree) * max_load_factor < num_elems)
+                ++size_degree;
+        }
+        increaseSizeDegree(0);
+    }
+
+    void setBufSize(size_t buf_size_)
+    {
+        size_degree = static_cast<size_t>(log2(buf_size_ - 1) + 1);
+        increaseSizeDegree(0);
+    }
+};
+static_assert(sizeof(HashTableGrowerWithMaxLoadFactor) == 64);
+
 ///
 /// Map (dictionary with attributes)
 ///
@@ -54,8 +140,8 @@ struct HashedDictionaryMapType<dictionary_key_type, /* sparse= */ false, Key, Va
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        HashMap<UInt64, Value, DefaultHash<UInt64>>,
-        HashMapWithSavedHash<StringRef, Value, DefaultHash<StringRef>>>;
+        HashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithMaxLoadFactor>,
+        HashMapWithSavedHash<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithMaxLoadFactor>>;
 };
 
 /// Implementations for SPARSE_HASHED layout.
@@ -89,8 +175,8 @@ struct HashedDictionarySparseMapType<dictionary_key_type, Key, Value, /* use_spa
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        PackedHashMap<UInt64, Value, DefaultHash<UInt64>>,
-        PackedHashMap<StringRef, Value, DefaultHash<StringRef>>>;
+        PackedHashMap<UInt64, Value, DefaultHash<UInt64>, HashTableGrowerWithMaxLoadFactor>,
+        PackedHashMap<StringRef, Value, DefaultHash<StringRef>, HashTableGrowerWithMaxLoadFactor>>;
 };
 template <DictionaryKeyType dictionary_key_type, typename Key, typename Value>
 struct HashedDictionaryMapType<dictionary_key_type, /* sparse= */ true, Key, Value>
@@ -113,8 +199,8 @@ struct HashedDictionarySetType<dictionary_key_type, /* sparse= */ false, Key>
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        HashSet<UInt64, DefaultHash<UInt64>>,
-        HashSetWithSavedHash<StringRef, DefaultHash<StringRef>>>;
+        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithMaxLoadFactor>,
+        HashSetWithSavedHash<StringRef, DefaultHash<StringRef>, HashTableGrowerWithMaxLoadFactor>>;
 };
 
 /// Implementation for SPARSE_HASHED.
@@ -127,8 +213,8 @@ struct HashedDictionarySetType<dictionary_key_type, /* sparse= */ true, Key>
 {
     using Type = std::conditional_t<
         dictionary_key_type == DictionaryKeyType::Simple,
-        HashSet<UInt64, DefaultHash<UInt64>>,
-        HashSet<StringRef, DefaultHash<StringRef>>>;
+        HashSet<UInt64, DefaultHash<UInt64>, HashTableGrowerWithMaxLoadFactor>,
+        HashSet<StringRef, DefaultHash<StringRef>, HashTableGrowerWithMaxLoadFactor>>;
 };
 
 }

--- a/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -156,11 +156,11 @@ void buildLayoutConfiguration(
 
         const auto value_field = value_literal->value;
 
-        if (value_field.getType() != Field::Types::UInt64 && value_field.getType() != Field::Types::String)
+        if (value_field.getType() != Field::Types::UInt64 && value_field.getType() != Field::Types::Float64 && value_field.getType() != Field::Types::String)
         {
             throw DB::Exception(
                 ErrorCodes::BAD_ARGUMENTS,
-                "Dictionary layout parameter value must be an UInt64 or String, got '{}' instead",
+                "Dictionary layout parameter value must be an UInt64, Float64 or String, got '{}' instead",
                 value_field.getTypeName());
         }
 

--- a/src/Interpreters/examples/hash_map.cpp
+++ b/src/Interpreters/examples/hash_map.cpp
@@ -279,35 +279,5 @@ int main(int argc, char ** argv)
             << std::endl;
     }
 
-    if (argc < 3 || std::stol(argv[2]) == 7)
-    {
-        Stopwatch watch;
-
-        PackedHashMap<Key, Value> map;
-        PackedHashMap<Key, Value>::LookupResult it;
-        bool inserted;
-
-        for (size_t i = 0; i < n; ++i)
-        {
-            map.emplace(data[i], it, inserted);
-            if (inserted)
-            {
-                new (&it->getMapped()) Value;
-                std::swap(it->getMapped(), value);
-                INIT
-            }
-        }
-
-        watch.stop();
-        std::cerr << std::fixed << std::setprecision(2)
-            << "PackedHashMap. Size: " << map.size()
-            << ", elapsed: " << watch.elapsedSeconds()
-            << " (" << n / watch.elapsedSeconds() << " elem/sec.)"
-#ifdef DBMS_HASH_MAP_COUNT_COLLISIONS
-            << ", collisions: " << map.getCollisions()
-#endif
-            << std::endl;
-    }
-
     return 0;
 }

--- a/src/Interpreters/examples/hash_map.cpp
+++ b/src/Interpreters/examples/hash_map.cpp
@@ -15,6 +15,7 @@
 #include <IO/ReadBufferFromFile.h>
 #include <Compression/CompressedReadBuffer.h>
 #include <Common/HashTable/HashMap.h>
+#include <Common/HashTable/PackedHashMap.h>
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -275,6 +276,36 @@ int main(int argc, char ** argv)
             << "google::sparse_hash_map. Size: " << map.size()
             << ", elapsed: " << watch.elapsedSeconds()
             << " (" << n / watch.elapsedSeconds() << " elem/sec.)"
+            << std::endl;
+    }
+
+    if (argc < 3 || std::stol(argv[2]) == 7)
+    {
+        Stopwatch watch;
+
+        PackedHashMap<Key, Value> map;
+        PackedHashMap<Key, Value>::LookupResult it;
+        bool inserted;
+
+        for (size_t i = 0; i < n; ++i)
+        {
+            map.emplace(data[i], it, inserted);
+            if (inserted)
+            {
+                new (&it->getMapped()) Value;
+                std::swap(it->getMapped(), value);
+                INIT
+            }
+        }
+
+        watch.stop();
+        std::cerr << std::fixed << std::setprecision(2)
+            << "PackedHashMap. Size: " << map.size()
+            << ", elapsed: " << watch.elapsedSeconds()
+            << " (" << n / watch.elapsedSeconds() << " elem/sec.)"
+#ifdef DBMS_HASH_MAP_COUNT_COLLISIONS
+            << ", collisions: " << map.getCollisions()
+#endif
             << std::endl;
     }
 

--- a/tests/performance/hashed_dictionary_load_factor.xml
+++ b/tests/performance/hashed_dictionary_load_factor.xml
@@ -1,0 +1,92 @@
+<test>
+    <substitutions>
+        <substitution>
+            <name>layout_suffix</name>
+            <values>
+                <value>HASHED</value>
+                <value>SPARSE_HASHED</value>
+            </values>
+        </substitution>
+
+        <substitution>
+            <name>load_factor</name>
+            <values>
+                <!-- 0. will be prepended -->
+                <value>5</value>
+                <value>7</value>
+                <value>99</value>
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>
+        CREATE TABLE simple_key_dictionary_source_table
+        (
+            id UInt64,
+            value_int UInt16
+        ) ENGINE = Memory
+    </create_query>
+
+    <create_query>
+        CREATE TABLE complex_key_dictionary_source_table
+        (
+            id UInt64,
+            id_key String,
+            value_int UInt64
+        ) ENGINE = Memory
+    </create_query>
+
+    <create_query>
+        CREATE DICTIONARY IF NOT EXISTS simple_key_{layout_suffix}_dictionary_l0_{load_factor}
+        (
+            id UInt64,
+            value_int UInt64
+        )
+        PRIMARY KEY id
+        SOURCE(CLICKHOUSE(TABLE 'simple_key_dictionary_source_table'))
+        LAYOUT({layout_suffix}(MAX_LOAD_FACTOR 0.{load_factor}))
+        LIFETIME(0)
+    </create_query>
+
+    <create_query>
+        CREATE DICTIONARY IF NOT EXISTS complex_key_{layout_suffix}_dictionary_l0_{load_factor}
+        (
+            id UInt64,
+            id_key String,
+            value_int UInt64
+        )
+        PRIMARY KEY id, id_key
+        SOURCE(CLICKHOUSE(TABLE 'complex_key_dictionary_source_table'))
+        LAYOUT(COMPLEX_KEY_{layout_suffix}(MAX_LOAD_FACTOR 0.{load_factor}))
+        LIFETIME(0)
+    </create_query>
+
+    <fill_query>INSERT INTO simple_key_dictionary_source_table SELECT number, number FROM numbers(3_000_000)</fill_query>
+    <fill_query>INSERT INTO complex_key_dictionary_source_table SELECT number, toString(number), number FROM numbers(2_000_000)</fill_query>
+
+    <fill_query>SYSTEM RELOAD DICTIONARY simple_key_{layout_suffix}_dictionary_l0_{load_factor}</fill_query>
+    <fill_query>SYSTEM RELOAD DICTIONARY complex_key_{layout_suffix}_dictionary_l0_{load_factor}</fill_query>
+
+    <query>SYSTEM RELOAD DICTIONARY simple_key_{layout_suffix}_dictionary_l0_{load_factor}</query>
+    <query>SYSTEM RELOAD DICTIONARY complex_key_{layout_suffix}_dictionary_l0_{load_factor}</query>
+
+    <query>
+        WITH rand64() % 3_000_000 as key
+        SELECT dictHas('default.simple_key_{layout_suffix}_dictionary_l0_{load_factor}', key)
+        FROM numbers(3_000_000)
+        FORMAT Null
+    </query>
+
+    <query>
+        WITH (rand64() % 2_000_000, toString(rand64() % 2_000_000)) as key
+        SELECT dictHas('default.complex_key_{layout_suffix}_dictionary_l0_{load_factor}', key)
+        FROM numbers(2_000_000)
+        FORMAT Null
+    </query>
+
+    <drop_query>DROP DICTIONARY simple_key_{layout_suffix}_dictionary_l0_{load_factor}</drop_query>
+    <drop_query>DROP DICTIONARY complex_key_{layout_suffix}_dictionary_l0_{load_factor}</drop_query>
+
+    <drop_query>DROP TABLE simple_key_dictionary_source_table</drop_query>
+    <drop_query>DROP TABLE complex_key_dictionary_source_table</drop_query>
+</test>

--- a/tests/performance/hashed_dictionary_sharded.xml
+++ b/tests/performance/hashed_dictionary_sharded.xml
@@ -22,7 +22,7 @@
         CREATE TABLE simple_key_dictionary_source_table
         (
             id UInt64,
-            value_int UInt64
+            value_int UInt16
         ) ENGINE = Memory
     </create_query>
 

--- a/tests/queries/0_stateless/02740_hashed_dictionary_load_factor_smoke.reference
+++ b/tests/queries/0_stateless/02740_hashed_dictionary_load_factor_smoke.reference
@@ -1,0 +1,12 @@
+CREATE DICTIONARY default.test_sparse_dictionary_load_factor\n(\n    `key` UInt64,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE test_table))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(SPARSE_HASHED(MAX_LOAD_FACTOR 0.9))
+100000
+0
+CREATE DICTIONARY default.test_dictionary_load_factor\n(\n    `key` UInt64,\n    `value` UInt16\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE test_table))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(HASHED(MAX_LOAD_FACTOR 0.9))
+100000
+0
+CREATE DICTIONARY default.test_dictionary_load_factor_nullable\n(\n    `key` UInt64,\n    `value` Nullable(UInt16)\n)\nPRIMARY KEY key\nSOURCE(CLICKHOUSE(TABLE test_table_nullable))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(HASHED(MAX_LOAD_FACTOR 0.9))
+100000
+0
+CREATE DICTIONARY default.test_complex_dictionary_load_factor\n(\n    `key_1` UInt64,\n    `key_2` UInt64,\n    `value` UInt16\n)\nPRIMARY KEY key_1, key_2\nSOURCE(CLICKHOUSE(TABLE test_table_complex))\nLIFETIME(MIN 0 MAX 0)\nLAYOUT(COMPLEX_KEY_HASHED(MAX_LOAD_FACTOR 0.9))
+100000
+0

--- a/tests/queries/0_stateless/02740_hashed_dictionary_load_factor_smoke.sql
+++ b/tests/queries/0_stateless/02740_hashed_dictionary_load_factor_smoke.sql
@@ -1,0 +1,107 @@
+DROP TABLE IF EXISTS test_table;
+CREATE TABLE test_table
+(
+    key UInt64,
+    value UInt16
+) ENGINE=Memory() AS SELECT number, number FROM numbers(1e5);
+
+DROP TABLE IF EXISTS test_table_nullable;
+CREATE TABLE test_table_nullable
+(
+    key UInt64,
+    value Nullable(UInt16)
+) ENGINE=Memory() AS SELECT number, number % 2 == 0 ? NULL : number FROM numbers(1e5);
+
+DROP TABLE IF EXISTS test_table_string;
+CREATE TABLE test_table_string
+(
+    key String,
+    value UInt16
+) ENGINE=Memory() AS SELECT 'foo' || number::String, number FROM numbers(1e5);
+
+DROP TABLE IF EXISTS test_table_complex;
+CREATE TABLE test_table_complex
+(
+    key_1 UInt64,
+    key_2 UInt64,
+    value UInt16
+) ENGINE=Memory() AS SELECT number, number, number FROM numbers(1e5);
+
+DROP DICTIONARY IF EXISTS test_sparse_dictionary_load_factor;
+CREATE DICTIONARY test_sparse_dictionary_load_factor
+(
+    key UInt64,
+    value UInt16
+) PRIMARY KEY key
+SOURCE(CLICKHOUSE(TABLE test_table))
+LAYOUT(SPARSE_HASHED(MAX_LOAD_FACTOR 0.90))
+LIFETIME(0);
+SHOW CREATE test_sparse_dictionary_load_factor;
+SYSTEM RELOAD DICTIONARY test_sparse_dictionary_load_factor;
+SELECT element_count FROM system.dictionaries WHERE database = currentDatabase() AND name = 'test_sparse_dictionary_load_factor';
+SELECT count() FROM test_table WHERE dictGet('test_sparse_dictionary_load_factor', 'value', key) != value;
+DROP DICTIONARY test_sparse_dictionary_load_factor;
+
+DROP DICTIONARY IF EXISTS test_dictionary_load_factor;
+CREATE DICTIONARY test_dictionary_load_factor
+(
+    key UInt64,
+    value UInt16
+) PRIMARY KEY key
+SOURCE(CLICKHOUSE(TABLE test_table))
+LAYOUT(HASHED(MAX_LOAD_FACTOR 0.90))
+LIFETIME(0);
+SHOW CREATE test_dictionary_load_factor;
+SYSTEM RELOAD DICTIONARY test_dictionary_load_factor;
+SELECT element_count FROM system.dictionaries WHERE database = currentDatabase() AND name = 'test_dictionary_load_factor';
+SELECT count() FROM test_table WHERE dictGet('test_dictionary_load_factor', 'value', key) != value;
+DROP DICTIONARY test_dictionary_load_factor;
+
+DROP DICTIONARY IF EXISTS test_dictionary_load_factor_nullable;
+CREATE DICTIONARY test_dictionary_load_factor_nullable
+(
+    key UInt64,
+    value Nullable(UInt16)
+) PRIMARY KEY key
+SOURCE(CLICKHOUSE(TABLE test_table_nullable))
+LAYOUT(HASHED(MAX_LOAD_FACTOR 0.90))
+LIFETIME(0);
+SHOW CREATE test_dictionary_load_factor_nullable;
+SYSTEM RELOAD DICTIONARY test_dictionary_load_factor_nullable;
+SELECT element_count FROM system.dictionaries WHERE database = currentDatabase() AND name = 'test_dictionary_load_factor_nullable';
+SELECT count() FROM test_table_nullable WHERE dictGet('test_dictionary_load_factor_nullable', 'value', key) != value;
+DROP DICTIONARY test_dictionary_load_factor_nullable;
+
+DROP DICTIONARY IF EXISTS test_complex_dictionary_load_factor;
+CREATE DICTIONARY test_complex_dictionary_load_factor
+(
+    key_1 UInt64,
+    key_2 UInt64,
+    value UInt16
+) PRIMARY KEY key_1, key_2
+SOURCE(CLICKHOUSE(TABLE test_table_complex))
+LAYOUT(COMPLEX_KEY_HASHED(MAX_LOAD_FACTOR 0.90))
+LIFETIME(0);
+SYSTEM RELOAD DICTIONARY test_complex_dictionary_load_factor;
+SHOW CREATE test_complex_dictionary_load_factor;
+SELECT element_count FROM system.dictionaries WHERE database = currentDatabase() and name = 'test_complex_dictionary_load_factor';
+SELECT count() FROM test_table_complex WHERE dictGet('test_complex_dictionary_load_factor', 'value', (key_1, key_2)) != value;
+DROP DICTIONARY test_complex_dictionary_load_factor;
+
+DROP DICTIONARY IF EXISTS test_dictionary_load_factor_string;
+CREATE DICTIONARY test_dictionary_load_factor_string
+(
+    key String,
+    value UInt16
+) PRIMARY KEY key
+SOURCE(CLICKHOUSE(TABLE test_table_string))
+LAYOUT(HASHED(MAX_LOAD_FACTOR 1))
+LIFETIME(0);
+-- should because of MAX_LOAD_FACTOR is 1 (maximum allowed value is 0.99)
+SYSTEM RELOAD DICTIONARY test_dictionary_load_factor_string; -- { serverError BAD_ARGUMENTS }
+DROP DICTIONARY test_dictionary_load_factor_string;
+
+DROP TABLE test_table;
+DROP TABLE test_table_nullable;
+DROP TABLE test_table_string;
+DROP TABLE test_table_complex;

--- a/tests/queries/0_stateless/02741_hashed_dictionary_load_factor.reference
+++ b/tests/queries/0_stateless/02741_hashed_dictionary_load_factor.reference
@@ -1,0 +1,4 @@
+test_dictionary_hashed	1000000	0.4768	33558760
+test_dictionary_hashed_load_factor	1000000	0.9537	16781544
+test_dictionary_sparse_hashed	1000000	0.4768	20975848
+test_dictionary_sparse_hashed_load_factor	1000000	0.9537	10490088

--- a/tests/queries/0_stateless/02741_hashed_dictionary_load_factor.sql.j2
+++ b/tests/queries/0_stateless/02741_hashed_dictionary_load_factor.sql.j2
@@ -1,0 +1,39 @@
+{# vi: ft=sql #}
+
+{% for layout in ["hashed", "sparse_hashed"] %}
+DROP DICTIONARY IF EXISTS test_dictionary_{{layout}};
+DROP DICTIONARY IF EXISTS test_dictionary_{{layout}}_load_factor;
+DROP TABLE IF EXISTS test_table;
+
+CREATE TABLE test_table
+(
+    key UInt64,
+    value UInt16
+) ENGINE=Memory() AS SELECT number, number FROM numbers(1e6);
+
+CREATE DICTIONARY test_dictionary_{{layout}}
+(
+    key UInt64,
+    value UInt16
+) PRIMARY KEY key
+SOURCE(CLICKHOUSE(TABLE test_table))
+LAYOUT({{layout}}())
+LIFETIME(0);
+
+CREATE DICTIONARY test_dictionary_{{layout}}_load_factor
+(
+    key UInt64,
+    value UInt16
+) PRIMARY KEY key
+SOURCE(CLICKHOUSE(TABLE test_table))
+LAYOUT({{layout}}(MAX_LOAD_FACTOR 0.98))
+LIFETIME(0);
+
+SYSTEM RELOAD DICTIONARY test_dictionary_{{layout}};
+SYSTEM RELOAD DICTIONARY test_dictionary_{{layout}}_load_factor;
+SELECT name, element_count, round(load_factor, 4), bytes_allocated FROM system.dictionaries WHERE database = currentDatabase() ORDER BY name;
+
+DROP DICTIONARY IF EXISTS test_dictionary_{{layout}};
+DROP DICTIONARY IF EXISTS test_dictionary_{{layout}}_load_factor;
+DROP TABLE test_table;
+{% endfor %}


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Improve memory usage and speed of `SPARSE_HASHED`/`HASHED` dictionaries (e.g. `SPARSE_HASHED` now eats 2.6x less memory, and is ~2x faster)

### Documentation entry for user-facing changes
`SPARSE_HASHED` now uses a "packed" hash table for small structures (<= 16 bytes), which consumes less memory and works faster.

And you can now also configure `MAX_LOAD_FACTOR` (`[0.5, 0.9]`) for the `HASHED`/`SPARSE_HASHED` dictionary layouts, which potentially decreases their memory usage. My testing shows that even 0.99 load factor works well enough (faster then previous implementation of `SPARSE_HASHED`), while reducing memory usage up to 2x.

### TL;DR;

**Firstly**, this PR **switches `SPARSE_HASHED` layout to `HashMap`** (internal ClickHouse hash table), but **with packed structure** (to avoid wasting memory for padding). This is done only for small enough key-value pairs (otherwise `google::sparse_hash_map` outperforms `HashMap`)

Consider the following example <UInt64, UInt16> as <Key, Value>, but this pair will also have a 6 byte padding (on amd64), so this is almost **40% of space wastage**.

Another problem with sparsehash is that it is not very friendly to memory allocator (especially jemalloc, it does not like tons of small reallocs, due to slabs, redis even did some fragmentation to overcome this - https://github.com/redis/redis/pull/3720).

**Secondly**, it allows to **configure the load factor of the HASHED/SPARSE_HASHED** dictionaries now, as it turns out, HashMap/**PackedHashMap works great even with max load factor of 0.99**. By "great" I mean it least it works faster then google sparsehash, and not to mention it's friendliness to the memory allocator (it has zero fragmentation since it works with a continuous memory region).

Here are some numbers (for 1e9 elements and UInt16 value):

_(but likely I will update them, since they does not looks accurate to me)_

settings|load (sec)|read (sec)|read (million rows/s)|bytes_allocated|RSS
-|-|-|-|-|-
HASHED upstream|-|-|-|-|35GiB
SPARSE_HASHED upstream|-|-|-|-|26GiB
-|-|-|-|-|-
sparse_hash_map glibc hashbench|-|-|-|-|17.5GiB
sparse_hash_map packed allocator|4.32|101.878|231.48|-|17.7GiB
PackedHashMap 0.5|15.514|42.35|23.61|20GiB|22GiB
hashed 0.95|34.903|115.615|8.65|16GiB|18.7GiB
**PackedHashMap 0.95**|**93.6**|**19.883**|**10.68**|**10GiB**|**12.8GiB**
PackedHashMap 0.99|26.113|83.6|11.96|10GiB|12.3GiB

**As you can see PackedHashMap looks way more better then current implementation of SPARSE_HASHED: 2.6x less memory, and ~2x faster**

Refs: #6894
Refs: #40003