### PR TITLE
fix #42610, dictionary minimal lifetime 1 seconds not 5

### DIFF
--- a/src/Interpreters/IExternalLoadable.cpp
+++ b/src/Interpreters/IExternalLoadable.cpp
@@ -19,18 +19,13 @@ ExternalLoadableLifetime::ExternalLoadableLifetime(const Poco::Util::AbstractCon
 
 UInt64 calculateDurationWithBackoff(pcg64 & rnd_engine, size_t error_count)
 {
-    constexpr UInt64 backoff_initial_sec = 5;
-    constexpr UInt64 backoff_max_sec = 10 * 60; /// 10 minutes
+    constexpr UInt64 backoff_max_iterations = 9; /// 2^9 = 512 seconds
 
-    if (error_count < 1)
-        error_count = 1;
+    if (error_count > backoff_max_iterations)
+        error_count = backoff_max_iterations;
 
-    /// max seconds is 600 and 2 ** 10 == 1024
-    if (error_count > 11)
-        error_count = 11;
-
-    std::uniform_int_distribution<UInt64> distribution(0, static_cast<UInt64>(std::exp2(error_count - 1)));
-    return std::min<UInt64>(backoff_max_sec, backoff_initial_sec + distribution(rnd_engine));
+    std::uniform_int_distribution<UInt64> distribution(0, static_cast<UInt64>(std::exp2(error_count)));
+    return distribution(rnd_engine);
 }
 
 }

--- a/tests/queries/0_stateless/01033_dictionaries_min_lifetime_1second.reference
+++ b/tests/queries/0_stateless/01033_dictionaries_min_lifetime_1second.reference
@@ -1,0 +1,3 @@
+1	issue
+1	no issue
+1	no issue

--- a/tests/queries/0_stateless/01033_dictionaries_min_lifetime_1second.sql
+++ b/tests/queries/0_stateless/01033_dictionaries_min_lifetime_1second.sql
@@ -1,0 +1,26 @@
+CREATE TABLE TestTbl(id UInt16, val String)
+ENGINE = ReplacingMergeTree
+ORDER BY (id) as 
+SELECT 1, 'issue';  
+
+CREATE DICTIONARY TestTblDict(id UInt16, val String)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE TestTbl DB currentDatabase()))
+LIFETIME(1)
+LAYOUT(COMPLEX_KEY_HASHED());
+
+select * FROM TestTblDict;
+
+insert into TestTbl values(1, 'no issue');
+optimize table TestTbl final;
+
+SELECT sleep(3) format Null;
+
+select * FROM TestTblDict; 
+
+SYSTEM RELOAD DICTIONARY TestTblDict;
+
+select * FROM TestTblDict; 
+
+drop dictionary TestTblDict;
+drop table TestTbl;


### PR DESCRIPTION
fixes: #42610

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix minimal dictionary lifetime to 1 seconds. It was 5 seconds because of backoff calculation issue. 
Maximum backoff now is 9 iterations - 512(2^9) seconds.
