### PR TITLE
Fix printing hung queries in clickhouse-test.

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2256,7 +2256,7 @@ def main(args):
                     "\nFound hung queries in processlist:", args, "red", attrs=["bold"]
                 )
             )
-            print(json.dumps(processlist, indent=4))
+            print(processlist)
             print(get_transactions_list(args))
 
             print_stacktraces()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


```
2023-05-01 20:03:37 Found hung queries in processlist:
2023-05-01 20:03:37 Traceback (most recent call last):
2023-05-01 20:03:37   File "/usr/bin/clickhouse-test", line 2738, in <module>
2023-05-01 20:03:37     main(args)
2023-05-01 20:03:37   File "/usr/bin/clickhouse-test", line 2259, in main
2023-05-01 20:03:37     print(json.dumps(processlist, indent=4))
2023-05-01 20:03:37   File "/usr/lib/python3.8/json/__init__.py", line 234, in dumps
2023-05-01 20:03:37     return cls(
2023-05-01 20:03:37   File "/usr/lib/python3.8/json/encoder.py", line 201, in encode
2023-05-01 20:03:37     chunks = list(chunks)
2023-05-01 20:03:37   File "/usr/lib/python3.8/json/encoder.py", line 438, in _iterencode
2023-05-01 20:03:37     o = _default(o)
2023-05-01 20:03:37   File "/usr/lib/python3.8/json/encoder.py", line 179, in default
2023-05-01 20:03:37     raise TypeError(f'Object of type {o.__class__.__name__} '
2023-05-01 20:03:37 TypeError: Object of type bytes is not JSON serializable
```

[Example](https://s3.amazonaws.com/clickhouse-test-reports/49318/631e81c53f02433f30eb4bc745a2551c4eb560c8/stateless_tests__release__analyzer_/run.log)

Looks like `get_processlist_with_stacktraces` returns data in vertical format
https://github.com/ClickHouse/ClickHouse/blob/7dab1560b159926f0eb82e55ce352c8d83fda272/tests/clickhouse-test#L299