### PR TITLE
Respect PK for aggregate projection.

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
@@ -582,6 +582,9 @@ bool optimizeUseAggregateProjections(QueryPlan::Node & node, QueryPlan::Nodes & 
     ContextPtr context = reading->getContext();
     MergeTreeDataSelectExecutor reader(reading->getMergeTreeData());
 
+    auto ordinary_reading_select_result = reading->selectRangesToRead(parts);
+    size_t ordinary_reading_marks = ordinary_reading_select_result->marks();
+
     /// Selecting best candidate.
     for (auto & candidate : candidates.real)
     {
@@ -597,12 +600,18 @@ bool optimizeUseAggregateProjections(QueryPlan::Node & node, QueryPlan::Nodes & 
         if (!analyzed)
             continue;
 
+        if (candidate.sum_marks > ordinary_reading_marks)
+            continue;
+
         if (best_candidate == nullptr || best_candidate->sum_marks > candidate.sum_marks)
             best_candidate = &candidate;
     }
 
     if (!best_candidate)
+    {
+        reading->setAnalyzedResult(std::move(ordinary_reading_select_result));
         return false;
+    }
 
     QueryPlanStepPtr projection_reading;
     bool has_ordinary_parts;

--- a/tests/queries/0_stateless/02725_agg_projection_resprect_PK.reference
+++ b/tests/queries/0_stateless/02725_agg_projection_resprect_PK.reference
@@ -1,0 +1,2 @@
+      ReadFromMergeTree (p1)
+          Granules: 1/12

--- a/tests/queries/0_stateless/02725_agg_projection_resprect_PK.sql
+++ b/tests/queries/0_stateless/02725_agg_projection_resprect_PK.sql
@@ -1,0 +1,31 @@
+-- Tags: no-random-merge-tree-settings
+
+DROP TABLE IF EXISTS t0;
+
+CREATE TABLE t0
+(
+    c1 Int64,
+    c2 Int64,
+    c3 Int64,
+    PROJECTION p1
+    (
+        SELECT
+            c1,
+            c2,
+            sum(c3)
+        GROUP BY
+            c2,
+            c1
+    )
+)
+ENGINE = MergeTree ORDER BY (c1, c2);
+
+INSERT INTO t0 SELECT
+    number,
+    -number,
+    number
+FROM numbers_mt(1e5);
+
+select * from (EXPLAIN indexes = 1 SELECT c1, sum(c3) FROM t0 GROUP BY c1) where explain like '%ReadFromMergeTree%';
+select * from (EXPLAIN indexes = 1 SELECT c1, sum(c3) FROM t0 WHERE c1 = 100 GROUP BY c1) where explain like '%Granules%';
+

--- a/tests/queries/0_stateless/02725_agg_projection_resprect_PK.sql
+++ b/tests/queries/0_stateless/02725_agg_projection_resprect_PK.sql
@@ -29,3 +29,4 @@ FROM numbers_mt(1e5);
 select * from (EXPLAIN indexes = 1 SELECT c1, sum(c3) FROM t0 GROUP BY c1) where explain like '%ReadFromMergeTree%';
 select * from (EXPLAIN indexes = 1 SELECT c1, sum(c3) FROM t0 WHERE c1 = 100 GROUP BY c1) where explain like '%Granules%';
 
+DROP TABLE t0;

--- a/tests/queries/0_stateless/02725_agg_projection_resprect_PK.sql
+++ b/tests/queries/0_stateless/02725_agg_projection_resprect_PK.sql
@@ -18,7 +18,7 @@ CREATE TABLE t0
             c1
     )
 )
-ENGINE = MergeTree ORDER BY (c1, c2);
+ENGINE = MergeTree ORDER BY (c1, c2) settings min_bytes_for_wide_part = 10485760, min_rows_for_wide_part = 0;
 
 INSERT INTO t0 SELECT
     number,


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use aggregate projection only if it reads fewer granules than normal reading. It should help in case if query hits the PK of the table, but not the projection. Fixes #49150

This will fix only 23.3+