### PR TITLE
Throw an exception for non-parametric functions in new analyzer

### DIFF
--- a/tests/broken_tests.txt
+++ b/tests/broken_tests.txt
@@ -134,6 +134,5 @@
 00725_join_on_bug_1
 00636_partition_key_parts_pruning
 00261_storage_aliases_and_array_join
-02701_non_parametric_function
 01825_type_json_multiple_files
 01281_group_by_limit_memory_tracking


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fixes `02701_non_parametric_function` test with the new analyzer after #48115.
