### PR TITLE
Make INSERT do more things in parallel to avoid getting bottlenecked on one thread

### DIFF
--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -241,13 +241,17 @@ Chain InterpreterInsertQuery::buildChain(
         running_group = std::make_shared<ThreadGroup>(getContext());
 
     auto sample = getSampleBlock(columns, table, metadata_snapshot);
-    return buildChainImpl(table, metadata_snapshot, sample, thread_status_holder, running_group, elapsed_counter_ms);
+
+    Chain sink = buildSink(table, metadata_snapshot, thread_status_holder, running_group, elapsed_counter_ms);
+    Chain chain = buildPreSinkChain(sink.getInputHeader(), table, metadata_snapshot, sample, thread_status_holder);
+
+    chain.appendChain(std::move(sink));
+    return chain;
 }
 
-Chain InterpreterInsertQuery::buildChainImpl(
+Chain InterpreterInsertQuery::buildSink(
     const StoragePtr & table,
     const StorageMetadataPtr & metadata_snapshot,
-    const Block & query_sample_block,
     ThreadStatusesHolderPtr thread_status_holder,
     ThreadGroupPtr running_group,
     std::atomic_uint64_t * elapsed_counter_ms)
@@ -258,14 +262,7 @@ Chain InterpreterInsertQuery::buildChainImpl(
         thread_status = nullptr;
 
     auto context_ptr = getContext();
-    const ASTInsertQuery * query = nullptr;
-    if (query_ptr)
-        query = query_ptr->as<ASTInsertQuery>();
 
-    const Settings & settings = context_ptr->getSettingsRef();
-    bool null_as_default = query && query->select && context_ptr->getSettingsRef().insert_null_as_default;
-
-    /// We create a pipeline of several streams, into which we will write data.
     Chain out;
 
     /// Keep a reference to the context to make sure it stays alive until the chain is executed and destroyed
@@ -286,16 +283,48 @@ Chain InterpreterInsertQuery::buildChainImpl(
             thread_status_holder, running_group, elapsed_counter_ms);
     }
 
+    return out;
+}
+
+Chain InterpreterInsertQuery::buildPreSinkChain(
+    const Block & subsequent_header,
+    const StoragePtr & table,
+    const StorageMetadataPtr & metadata_snapshot,
+    const Block & query_sample_block,
+    ThreadStatusesHolderPtr thread_status_holder)
+{
+    ThreadStatus * thread_status = current_thread;
+
+    if (!thread_status_holder)
+        thread_status = nullptr;
+
+    auto context_ptr = getContext();
+
+    const ASTInsertQuery * query = nullptr;
+    if (query_ptr)
+        query = query_ptr->as<ASTInsertQuery>();
+
+    const Settings & settings = context_ptr->getSettingsRef();
+    bool null_as_default = query && query->select && context_ptr->getSettingsRef().insert_null_as_default;
+
+    /// We create a pipeline of several streams, into which we will write data.
+    Chain out;
+
+    auto input_header = [&]() -> const Block &
+    {
+        return out.empty() ? subsequent_header : out.getInputHeader();
+    };
+
     /// Note that we wrap transforms one on top of another, so we write them in reverse of data processing order.
 
     /// Checking constraints. It must be done after calculation of all defaults, so we can check them on calculated columns.
     if (const auto & constraints = metadata_snapshot->getConstraints(); !constraints.empty())
         out.addSource(std::make_shared<CheckConstraintsTransform>(
-            table->getStorageID(), out.getInputHeader(), metadata_snapshot->getConstraints(), context_ptr));
+            table->getStorageID(), input_header(), metadata_snapshot->getConstraints(), context_ptr));
 
     auto adding_missing_defaults_dag = addMissingDefaults(
         query_sample_block,
-        out.getInputHeader().getNamesAndTypesList(),
+        input_header().getNamesAndTypesList(),
         metadata_snapshot->getColumns(),
         context_ptr,
         null_as_default);
@@ -316,12 +345,12 @@ Chain InterpreterInsertQuery::buildChainImpl(
         bool table_prefers_large_blocks = table->prefersLargeBlocks();
 
         out.addSource(std::make_shared<SquashingChunksTransform>(
-            out.getInputHeader(),
+            input_header(),
             table_prefers_large_blocks ? settings.min_insert_block_size_rows : settings.max_block_size,
             table_prefers_large_blocks ? settings.min_insert_block_size_bytes : 0ULL));
     }
 
-    auto counting = std::make_shared<CountingTransform>(out.getInputHeader(), thread_status, getContext()->getQuota());
+    auto counting = std::make_shared<CountingTransform>(input_header(), thread_status, getContext()->getQuota());
     counting->setProcessListElement(context_ptr->getProcessListElement());
     counting->setProgressCallback(context_ptr->getProgressCallback());
     out.addSource(std::move(counting));
@@ -362,10 +391,20 @@ BlockIO InterpreterInsertQuery::execute()
         // Distributed INSERT SELECT
         distributed_pipeline = table->distributedWrite(query, getContext());
 
-    std::vector<Chain> out_chains;
+    std::vector<Chain> presink_chains;
+    std::vector<Chain> sink_chains;
     if (!distributed_pipeline || query.watch)
     {
-        size_t out_streams_size = 1;
+        /// Number of streams works like this:
+        ///  * For the SELECT, use `max_threads`, or `max_insert_threads`, or whatever
+        ///    InterpreterSelectQuery ends up with.
+        ///  * Use `max_insert_threads` streams for various insert-preparation steps, e.g.
+        ///    materializing and squashing (too slow to do in one thread). That's `presink_chains`.
+        ///  * If the table supports parallel inserts, use the same streams for writing to IStorage.
+        ///    Otherwise ResizeProcessor them down to 1 stream.
+        ///  * If it's not an INSERT SELECT, forget all that and use one stream.
+        size_t pre_streams_size = 1;
+        size_t sink_streams_size = 1;
 
         if (query.select)
         {
@@ -441,10 +480,14 @@ BlockIO InterpreterInsertQuery::execute()
 
             pipeline.dropTotalsAndExtremes();
 
-            if (table->supportsParallelInsert() && settings.max_insert_threads > 1)
-                out_streams_size = std::min(static_cast<size_t>(settings.max_insert_threads), pipeline.getNumStreams());
+            if (settings.max_insert_threads > 1)
+            {
+                pre_streams_size = std::min(static_cast<size_t>(settings.max_insert_threads), pipeline.getNumStreams());
+                if (table->supportsParallelInsert())
+                    sink_streams_size = pre_streams_size;
+            }
 
-            pipeline.resize(out_streams_size);
+            pipeline.resize(pre_streams_size);
 
             /// Allow to insert Nullable into non-Nullable columns, NULL values will be added as defaults values.
             if (getContext()->getSettingsRef().insert_null_as_default)
@@ -476,13 +519,17 @@ BlockIO InterpreterInsertQuery::execute()
             running_group = current_thread->getThreadGroup();
         if (!running_group)
             running_group = std::make_shared<ThreadGroup>(getContext());
-        for (size_t i = 0; i < out_streams_size; ++i)
+        for (size_t i = 0; i < sink_streams_size; ++i)
         {
-            auto out = buildChainImpl(table, metadata_snapshot, query_sample_block,
-                /* thread_status_holder= */ nullptr,
-                running_group,
-                /* elapsed_counter_ms= */ nullptr);
-            out_chains.emplace_back(std::move(out));
+            auto out = buildSink(table, metadata_snapshot, /* thread_status_holder= */ nullptr,
+                running_group, /* elapsed_counter_ms= */ nullptr);
+            sink_chains.emplace_back(std::move(out));
+        }
+        for (size_t i = 0; i < pre_streams_size; ++i)
+        {
+            auto out = buildPreSinkChain(sink_chains[0].getInputHeader(), table, metadata_snapshot,
+                query_sample_block, /* thread_status_holder= */ nullptr);
+            presink_chains.emplace_back(std::move(out));
         }
     }
 
@@ -495,7 +542,7 @@ BlockIO InterpreterInsertQuery::execute()
     }
     else if (query.select || query.watch)
     {
-        const auto & header = out_chains.at(0).getInputHeader();
+        const auto & header = presink_chains.at(0).getInputHeader();
         auto actions_dag = ActionsDAG::makeConvertingActions(
                 pipeline.getHeader().getColumnsWithTypeAndName(),
                 header.getColumnsWithTypeAndName(),
@@ -516,10 +563,14 @@ BlockIO InterpreterInsertQuery::execute()
 
         size_t num_select_threads = pipeline.getNumThreads();
 
-        for (auto & chain : out_chains)
+        for (auto & chain : presink_chains)
+            resources = chain.detachResources();
+        for (auto & chain : sink_chains)
             resources = chain.detachResources();
 
-        pipeline.addChains(std::move(out_chains));
+        pipeline.addChains(std::move(presink_chains));
+        pipeline.resize(sink_chains.size());
+        pipeline.addChains(std::move(sink_chains));
 
         if (!settings.parallel_view_processing)
         {
@@ -552,7 +603,8 @@ BlockIO InterpreterInsertQuery::execute()
     }
     else
     {
-        res.pipeline = QueryPipeline(std::move(out_chains.at(0)));
+        presink_chains.at(0).appendChain(std::move(sink_chains.at(0)));
+        res.pipeline = QueryPipeline(std::move(presink_chains[0]));
         res.pipeline.setNumThreads(std::min<size_t>(res.pipeline.getNumThreads(), settings.max_threads));
 
         if (query.hasInlinedData() && !async_insert)

--- a/src/Interpreters/InterpreterInsertQuery.h
+++ b/src/Interpreters/InterpreterInsertQuery.h
@@ -66,13 +66,19 @@ private:
 
     std::vector<std::unique_ptr<ReadBuffer>> owned_buffers;
 
-    Chain buildChainImpl(
+    Chain buildSink(
         const StoragePtr & table,
         const StorageMetadataPtr & metadata_snapshot,
-        const Block & query_sample_block,
         ThreadStatusesHolderPtr thread_status_holder,
         ThreadGroupPtr running_group,
         std::atomic_uint64_t * elapsed_counter_ms);
+
+    Chain buildPreSinkChain(
+        const Block & subsequent_header,
+        const StoragePtr & table,
+        const StorageMetadataPtr & metadata_snapshot,
+        const Block & query_sample_block,
+        ThreadStatusesHolderPtr thread_status_holder);
 };
 
 

--- a/src/QueryPipeline/Chain.cpp
+++ b/src/QueryPipeline/Chain.cpp
@@ -99,6 +99,14 @@ void Chain::addSink(ProcessorPtr processor)
     processors.emplace_back(std::move(processor));
 }
 
+void Chain::appendChain(Chain chain)
+{
+    connect(getOutputPort(), chain.getInputPort());
+    processors.splice(processors.end(), std::move(chain.processors));
+    attachResources(chain.detachResources());
+    num_threads += chain.num_threads;
+}
+
 IProcessor & Chain::getSource()
 {
     checkInitialized(processors);

--- a/src/QueryPipeline/Chain.h
+++ b/src/QueryPipeline/Chain.h
@@ -7,6 +7,10 @@
 namespace DB
 {
 
+/// Has one unconnected input port and one unconnected output port.
+/// There may be other ports on the processors, but they must all be connected.
+/// The unconnected input must be on the first processor, output - on the last.
+/// The processors don't necessarily form an actual chain.
 class Chain
 {
 public:
@@ -27,6 +31,7 @@ public:
 
     void addSource(ProcessorPtr processor);
     void addSink(ProcessorPtr processor);
+    void appendChain(Chain chain);
 
     IProcessor & getSource();
     IProcessor & getSink();
@@ -44,7 +49,11 @@ public:
     void addStorageHolder(StoragePtr storage) { holder.storage_holders.emplace_back(std::move(storage)); }
     void addInterpreterContext(ContextPtr context) { holder.interpreter_context.emplace_back(std::move(context)); }
 
-    void attachResources(QueryPlanResourceHolder holder_) { holder = std::move(holder_); }
+    void attachResources(QueryPlanResourceHolder holder_)
+    {
+        /// This operator "=" actually merges holder_ into holder, doesn't replace.
+        holder = std::move(holder_);
+    }
     QueryPlanResourceHolder detachResources() { return std::move(holder); }
 
     void reset();

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -146,6 +146,8 @@ public:
     virtual bool supportsReplication() const { return false; }
 
     /// Returns true if the storage supports parallel insert.
+    /// If false, each INSERT query will call write() only once.
+    /// Different INSERT queries may write in parallel regardless of this value.
     virtual bool supportsParallelInsert() const { return false; }
 
     /// Returns true if the storage supports deduplication of inserted data blocks.

--- a/tests/queries/0_stateless/00341_squashing_insert_select2.sql
+++ b/tests/queries/0_stateless/00341_squashing_insert_select2.sql
@@ -3,6 +3,7 @@ CREATE TABLE numbers_squashed (number UInt8) ENGINE = StripeLog;
 
 SET min_insert_block_size_rows = 100;
 SET min_insert_block_size_bytes = 0;
+SET max_insert_threads = 1;
 SET max_threads = 1;
 
 INSERT INTO numbers_squashed


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Without this PR, `SELECT ... INTO OUTFILE ...` can be much faster than `INSERT INTO FUNCTION file(...) SELECT ...` (even with `max_insert_threads` = `max_threads`). The difference is that the miscellaneous INSERT-related transforms are done in one thread, especially the SquashingTransform.

Example (requires https://github.com/ClickHouse/ClickHouse/pull/49367 + https://github.com/ClickHouse/ClickHouse/pull/49121 + https://github.com/ClickHouse/ClickHouse/pull/49325):

```
INSERT INTO FUNCTION file('ds/hits5.parquet')
SETTINGS parallelize_output_from_storages = 1, input_format_parquet_preserve_order = 0, max_insert_threads = 32, max_threads = 32
SELECT *
FROM file('ds/hits.parquet')
SETTINGS parallelize_output_from_storages = 1, input_format_parquet_preserve_order = 0, max_insert_threads = 32, max_threads = 32

0 rows in set. Elapsed: 107.607 sec. Processed 100.00 million rows, 94.47 GB (929.28 thousand rows/s., 877.92 MB/s.)
```
vs
```
SELECT *
FROM file('ds/hits.parquet')
INTO OUTFILE 'ds/hits5.parquet'
SETTINGS parallelize_output_from_storages = 1, input_format_parquet_preserve_order = 0, max_threads = 32

99997497 rows in set. Elapsed: 39.099 sec. Processed 100.00 million rows, 94.47 GB (2.56 million rows/s., 2.42 GB/s.)
```

This PR makes InterpreterInsertQuery use `max_insert_threads` streams for the SquashingTransform, adding defaults, materializing, etc. Result on the same query as above:

```
INSERT INTO FUNCTION file('ds/hits5.parquet')
SETTINGS parallelize_output_from_storages = 1, input_format_parquet_preserve_order = 0, max_insert_threads = 32, max_threads = 32
SELECT *
FROM file('ds/hits.parquet')
SETTINGS parallelize_output_from_storages = 1, input_format_parquet_preserve_order = 0, max_insert_threads = 32, max_threads = 32

0 rows in set. Elapsed: 44.647 sec. Processed 100.00 million rows, 94.47 GB (2.24 million rows/s., 2.12 GB/s.)
```