### PR TITLE
Fix the 01193_metadata_loading test to match the query execution time specific to s390x

### DIFF
--- a/tests/queries/0_stateless/01193_metadata_loading.sh
+++ b/tests/queries/0_stateless/01193_metadata_loading.sh
@@ -13,6 +13,7 @@ threads=10
 count_multiplier=1
 max_time_ms=1000
 
+# In case of s390x, the query execution time seems to be approximately ~1.1 to ~1.2 secs. So, to match the query execution time, set max_time_ms=1500
 if [[ $(uname -a | grep s390x) ]]; then
     max_time_ms=1500
 fi

--- a/tests/queries/0_stateless/01193_metadata_loading.sh
+++ b/tests/queries/0_stateless/01193_metadata_loading.sh
@@ -13,6 +13,10 @@ threads=10
 count_multiplier=1
 max_time_ms=1000
 
+if [[ $(uname -a | grep s390x) ]]; then
+    max_time_ms=1500
+fi
+
 debug_or_sanitizer_build=$($CLICKHOUSE_CLIENT -q "WITH ((SELECT value FROM system.build_options WHERE name='BUILD_TYPE') AS build, (SELECT value FROM system.build_options WHERE name='CXX_FLAGS') as flags) SELECT build='Debug' OR flags LIKE '%fsanitize%' OR hasThreadFuzzer()")
 
 if [[ debug_or_sanitizer_build -eq 1 ]]; then tables=100; count_multiplier=10; max_time_ms=1500; fi


### PR DESCRIPTION
The functional test 01193_metadata_loading taking approximately ~1.1 seconds leads to the failure in s390x. Fix the test to match the query execution time specific to s390x.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the 01193_metadata_loading test to match the query execution time specific to s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
