### PR TITLE
Fix the code to use the RapidJSONParser in case of big-endian system

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -134,7 +134,9 @@ add_contrib (aws-cmake
 )
 
 add_contrib (base64-cmake base64)
+if (NOT ARCH_S390X)
 add_contrib (simdjson-cmake simdjson)
+endif()
 add_contrib (rapidjson-cmake rapidjson)
 add_contrib (fastops-cmake fastops)
 add_contrib (libuv-cmake libuv)

--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -541,7 +541,7 @@ SerializationPtr getObjectSerialization(const String & schema_format)
 {
     if (schema_format == "json")
     {
-#if USE_SIMDJSON && __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__
+#if USE_SIMDJSON
         return std::make_shared<SerializationObject<JSONDataParser<SimdJSONParser>>>();
 #elif USE_RAPIDJSON
         return std::make_shared<SerializationObject<JSONDataParser<RapidJSONParser>>>();

--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -541,7 +541,7 @@ SerializationPtr getObjectSerialization(const String & schema_format)
 {
     if (schema_format == "json")
     {
-#if USE_SIMDJSON
+#if USE_SIMDJSON && __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__
         return std::make_shared<SerializationObject<JSONDataParser<SimdJSONParser>>>();
 #elif USE_RAPIDJSON
         return std::make_shared<SerializationObject<JSONDataParser<RapidJSONParser>>>();


### PR DESCRIPTION
By default, ClickHouse use the SimdJSONParser to parse the JSON data. In case of big-endian s390x, the library has an issue in parsing the JSON float value.

Modify the code to use the RapidJSONParser in case of big-endian system.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use the RapidJSONParser library to parse the JSON float values in case of s390x.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
