### PR TITLE
Add an integration test for `shutdown_wait_unfinished_queries`

### DIFF
--- a/tests/integration/test_shutdown_wait_unfinished_queries/configs/config_kill.xml
+++ b/tests/integration/test_shutdown_wait_unfinished_queries/configs/config_kill.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <shutdown_wait_unfinished>30</shutdown_wait_unfinished>
+    <shutdown_wait_unfinished_queries>0</shutdown_wait_unfinished_queries>
+</clickhouse>

--- a/tests/integration/test_shutdown_wait_unfinished_queries/configs/config_wait.xml
+++ b/tests/integration/test_shutdown_wait_unfinished_queries/configs/config_wait.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <shutdown_wait_unfinished>30</shutdown_wait_unfinished>
+    <shutdown_wait_unfinished_queries>1</shutdown_wait_unfinished_queries>
+</clickhouse>

--- a/tests/integration/test_shutdown_wait_unfinished_queries/test.py
+++ b/tests/integration/test_shutdown_wait_unfinished_queries/test.py
@@ -5,10 +5,15 @@ import time
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-node_wait_queries = cluster.add_instance("node_wait_queries", main_configs=["configs/config_wait.xml"], stay_alive=True)
-node_kill_queries = cluster.add_instance("node_kill_queries", main_configs=["configs/config_kill.xml"], stay_alive=True)
+node_wait_queries = cluster.add_instance(
+    "node_wait_queries", main_configs=["configs/config_wait.xml"], stay_alive=True
+)
+node_kill_queries = cluster.add_instance(
+    "node_kill_queries", main_configs=["configs/config_kill.xml"], stay_alive=True
+)
 
 global result
+
 
 @pytest.fixture(scope="module")
 def start_cluster():
@@ -18,12 +23,15 @@ def start_cluster():
     finally:
         cluster.shutdown()
 
+
 def do_long_query(node):
     global result
 
     result = node.query_and_get_answer_with_error(
-        "SELECT sleepEachRow(1) FROM system.numbers LIMIT 10", settings={"send_logs_level": "trace"}
+        "SELECT sleepEachRow(1) FROM system.numbers LIMIT 10",
+        settings={"send_logs_level": "trace"},
     )
+
 
 def test_shutdown_wait_unfinished_queries(start_cluster):
     global result

--- a/tests/integration/test_shutdown_wait_unfinished_queries/test.py
+++ b/tests/integration/test_shutdown_wait_unfinished_queries/test.py
@@ -36,7 +36,6 @@ def test_shutdown_wait_unfinished_queries(start_cluster):
 
     long_query.join()
 
-    print(result)
     assert result[0].count("0") == 10
 
     long_query = threading.Thread(target=do_long_query, args=(node_kill_queries,))
@@ -46,5 +45,4 @@ def test_shutdown_wait_unfinished_queries(start_cluster):
     node_kill_queries.stop_clickhouse(kill=False)
 
     long_query.join()
-    print(result)
     assert "QUERY_WAS_CANCELLED" in result[1]

--- a/tests/integration/test_shutdown_wait_unfinished_queries/test.py
+++ b/tests/integration/test_shutdown_wait_unfinished_queries/test.py
@@ -1,0 +1,50 @@
+import pytest
+
+import threading
+import time
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node_wait_queries = cluster.add_instance("node_wait_queries", main_configs=["configs/config_wait.xml"], stay_alive=True)
+node_kill_queries = cluster.add_instance("node_kill_queries", main_configs=["configs/config_kill.xml"], stay_alive=True)
+
+global result
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+def do_long_query(node):
+    global result
+
+    result = node.query_and_get_answer_with_error(
+        "SELECT sleepEachRow(1) FROM system.numbers LIMIT 10", settings={"send_logs_level": "trace"}
+    )
+
+def test_shutdown_wait_unfinished_queries(start_cluster):
+    global result
+
+    long_query = threading.Thread(target=do_long_query, args=(node_wait_queries,))
+    long_query.start()
+
+    time.sleep(1)
+    node_wait_queries.stop_clickhouse(kill=False)
+
+    long_query.join()
+
+    print(result)
+    assert result[0].count("0") == 10
+
+    long_query = threading.Thread(target=do_long_query, args=(node_kill_queries,))
+    long_query.start()
+
+    time.sleep(1)
+    node_kill_queries.stop_clickhouse(kill=False)
+
+    long_query.join()
+    print(result)
+    assert "QUERY_WAS_CANCELLED" in result[1]


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Add a test for https://github.com/ClickHouse/ClickHouse/pull/49427
