### PR TITLE
Fix postgres database setting

### DIFF
--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -319,7 +319,7 @@ DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String
         if (auto named_collection = tryGetNamedCollectionWithOverrides(engine_args, context))
         {
             configuration = StoragePostgreSQL::processNamedCollectionResult(*named_collection, false);
-            use_table_cache = named_collection->getOrDefault<UInt64>("use_tables_cache", 0);
+            use_table_cache = named_collection->getOrDefault<UInt64>("use_table_cache", 0);
         }
         else
         {

--- a/src/Storages/StoragePostgreSQL.cpp
+++ b/src/Storages/StoragePostgreSQL.cpp
@@ -416,7 +416,7 @@ StoragePostgreSQL::Configuration StoragePostgreSQL::processNamedCollectionResult
         required_arguments.insert("table");
 
     validateNamedCollection<ValidateKeysMultiset<ExternalDatabaseEqualKeysSet>>(
-        named_collection, required_arguments, {"schema", "on_conflict", "addresses_expr", "host", "hostname", "port", "use_tables_cache"});
+        named_collection, required_arguments, {"schema", "on_conflict", "addresses_expr", "host", "hostname", "port", "use_table_cache"});
 
     configuration.addresses_expr = named_collection.getOrDefault<String>("addresses_expr", "");
     if (configuration.addresses_expr.empty())

--- a/tests/integration/test_postgresql_database_engine/test.py
+++ b/tests/integration/test_postgresql_database_engine/test.py
@@ -330,7 +330,7 @@ def test_predefined_connection_configuration(started_cluster):
     node1.query(
         """
         DROP DATABASE postgres_database;
-        CREATE DATABASE postgres_database ENGINE = PostgreSQL(postgres1, use_tables_cache=1);
+        CREATE DATABASE postgres_database ENGINE = PostgreSQL(postgres1, use_table_cache=1);
         """
     )
     assert (


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
PR #49100 uses the incorrect setting `use_tables_cache`. The correct value is `use_table_cache`.

### Changelog category (leave one):
Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix PostgreSQL database settings use_table_cache not working with named collections since 23.3. Closes #48914.
