### PR TITLE
Static cast std::atomic<size_t> to uint64_t to serialize.

### DIFF
--- a/utils/keeper-bench/Stats.cpp
+++ b/utils/keeper-bench/Stats.cpp
@@ -132,7 +132,7 @@ void Stats::writeJSON(DB::WriteBuffer & out, size_t concurrency, int64_t start_t
     {
         Value specific_results(kObjectType);
 
-        specific_results.AddMember("total_requests", Value(collector.requests), allocator);
+        specific_results.AddMember("total_requests", Value(static_cast<uint64_t>(collector.requests)), allocator);
 
         auto [rps, bps] = collector.getThroughput(concurrency);
         specific_results.AddMember("requests_per_second", Value(rps), allocator);


### PR DESCRIPTION
There are no viable constructors for the atomic in rapidJSON.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



