### PR TITLE
Fix code block in clickhouse-local.md

### DIFF
--- a/docs/en/operations/utilities/clickhouse-local.md
+++ b/docs/en/operations/utilities/clickhouse-local.md
@@ -41,9 +41,9 @@ If the file is sitting on the same machine as `clickhouse-local`, use the `file`
 ```
 
 ClickHouse knows the file uses a tab-separated format from filename extension. If you need to explicitly specify the format, simply add one of the [many ClickHouse input formats](../../interfaces/formats.md):
-    ```bash
-    ./clickhouse local -q "SELECT * FROM file('reviews.tsv', 'TabSeparated')"
-    ```
+```bash
+./clickhouse local -q "SELECT * FROM file('reviews.tsv', 'TabSeparated')"
+```
 
 The `file` table function creates a table, and you can use `DESCRIBE` to see the inferred schema:
 


### PR DESCRIPTION
Code block was with additional indent which causes wrong rendering here on GitHub and website.

### Changelog category:
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Fix indentation which causes [wrong rendering](https://clickhouse.com/docs/en/operations/utilities/clickhouse-local#query-data-in-a-csv-file-using-sql)