### PR TITLE
Correctly handle s3Cluster arguments

### DIFF
--- a/src/Storages/StorageS3Cluster.h
+++ b/src/Storages/StorageS3Cluster.h
@@ -32,7 +32,8 @@ public:
         const ColumnsDescription & columns_,
         const ConstraintsDescription & constraints_,
         ContextPtr context_,
-        bool structure_argument_was_provided_);
+        bool structure_argument_was_provided_,
+        bool format_argument_was_provided_);
 
     std::string getName() const override { return "S3Cluster"; }
 
@@ -59,6 +60,7 @@ private:
     NamesAndTypesList virtual_columns;
     Block virtual_block;
     bool structure_argument_was_provided;
+    bool format_argument_was_provided;
 };
 
 

--- a/src/Storages/addColumnsStructureToQueryWithClusterEngine.cpp
+++ b/src/Storages/addColumnsStructureToQueryWithClusterEngine.cpp
@@ -14,7 +14,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-static ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query)
+ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query)
 {
     auto * select_query = query->as<ASTSelectQuery>();
     if (!select_query || !select_query->tables())

--- a/src/Storages/addColumnsStructureToQueryWithClusterEngine.h
+++ b/src/Storages/addColumnsStructureToQueryWithClusterEngine.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <Parsers/IAST.h>
+#include <Parsers/ASTExpressionList.h>
 
 namespace DB
 {
+
+ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query);
 
 /// Add structure argument for queries with s3Cluster/hdfsCluster table function.
 void addColumnsStructureToQueryWithClusterEngine(ASTPtr & query, const String & structure, size_t max_arguments, const String & function_name);

--- a/src/TableFunctions/TableFunctionS3.cpp
+++ b/src/TableFunctions/TableFunctionS3.cpp
@@ -31,9 +31,15 @@ namespace ErrorCodes
 
 
 /// This is needed to avoid copy-pase. Because s3Cluster arguments only differ in additional argument (first) - cluster name
-void TableFunctionS3::parseArgumentsImpl(
-    const String & error_message, ASTs & args, ContextPtr context, StorageS3::Configuration & s3_configuration, bool get_format_from_file)
+TableFunctionS3::ArgumentParseResult TableFunctionS3::parseArgumentsImpl(
+    const String & error_message,
+    ASTs & args,
+    ContextPtr context,
+    StorageS3::Configuration & s3_configuration,
+    bool get_format_from_file)
 {
+    ArgumentParseResult result;
+
     if (auto named_collection = tryGetNamedCollectionWithOverrides(args, context))
     {
         StorageS3::processNamedCollectionResult(s3_configuration, *named_collection);
@@ -133,10 +139,16 @@ void TableFunctionS3::parseArgumentsImpl(
         s3_configuration.url = S3::URI(checkAndGetLiteralArgument<String>(args[0], "url"));
 
         if (args_to_idx.contains("format"))
+        {
             s3_configuration.format = checkAndGetLiteralArgument<String>(args[args_to_idx["format"]], "format");
+            result.has_format_argument = true;
+        }
 
         if (args_to_idx.contains("structure"))
+        {
             s3_configuration.structure = checkAndGetLiteralArgument<String>(args[args_to_idx["structure"]], "structure");
+            result.has_structure_argument = true;
+        }
 
         if (args_to_idx.contains("compression_method"))
             s3_configuration.compression_method = checkAndGetLiteralArgument<String>(args[args_to_idx["compression_method"]], "compression_method");
@@ -155,6 +167,8 @@ void TableFunctionS3::parseArgumentsImpl(
     /// For DataLake table functions, we should specify default format.
     if (s3_configuration.format == "auto" && get_format_from_file)
         s3_configuration.format = FormatFactory::instance().getFormatFromFileName(s3_configuration.url.uri.getPath(), true);
+
+    return result;
 }
 
 void TableFunctionS3::parseArguments(const ASTPtr & ast_function, ContextPtr context)

--- a/src/TableFunctions/TableFunctionS3.h
+++ b/src/TableFunctions/TableFunctionS3.h
@@ -43,7 +43,14 @@ public:
     {
         return {"_path", "_file"};
     }
-    static void parseArgumentsImpl(
+
+    struct ArgumentParseResult
+    {
+        bool has_format_argument = false;
+        bool has_structure_argument = false;
+    };
+
+    static ArgumentParseResult parseArgumentsImpl(
         const String & error_message,
         ASTs & args,
         ContextPtr context,

--- a/src/TableFunctions/TableFunctionS3Cluster.cpp
+++ b/src/TableFunctions/TableFunctionS3Cluster.cpp
@@ -45,9 +45,6 @@ void TableFunctionS3Cluster::parseArguments(const ASTPtr & ast_function, Context
 
     ASTs & args = args_func.at(0)->children;
 
-    for (auto & arg : args)
-        arg = evaluateConstantExpressionOrIdentifierAsLiteral(arg, context);
-
     constexpr auto fmt_string = "The signature of table function {} could be the following:\n"
                                 " - cluster, url\n"
                                 " - cluster, url, format\n"
@@ -61,7 +58,10 @@ void TableFunctionS3Cluster::parseArguments(const ASTPtr & ast_function, Context
     if (args.size() < 2 || args.size() > 7)
         throw Exception::createDeprecated(message, ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH);
 
-    /// This arguments are always the first
+    /// evaluate only first argument, everything else will be done TableFunctionS3
+    args[0] = evaluateConstantExpressionOrIdentifierAsLiteral(args[0], context);
+
+    /// Cluster name is always the first
     configuration.cluster_name = checkAndGetLiteralArgument<String>(args[0], "cluster_name");
 
     if (!context->tryGetCluster(configuration.cluster_name))
@@ -69,11 +69,11 @@ void TableFunctionS3Cluster::parseArguments(const ASTPtr & ast_function, Context
 
     /// Just cut the first arg (cluster_name) and try to parse s3 table function arguments as is
     ASTs clipped_args;
-    clipped_args.reserve(args.size());
+    clipped_args.reserve(args.size() - 1);
     std::copy(args.begin() + 1, args.end(), std::back_inserter(clipped_args));
 
     /// StorageS3ClusterConfiguration inherints from StorageS3::Configuration, so it is safe to upcast it.
-    TableFunctionS3::parseArgumentsImpl(message.text, clipped_args, context, static_cast<StorageS3::Configuration &>(configuration));
+    argument_parse_result = TableFunctionS3::parseArgumentsImpl(message.text, clipped_args, context, static_cast<StorageS3::Configuration &>(configuration));
 }
 
 
@@ -94,9 +94,8 @@ StoragePtr TableFunctionS3Cluster::executeImpl(
 {
     StoragePtr storage;
     ColumnsDescription columns;
-    bool structure_argument_was_provided = configuration.structure != "auto";
 
-    if (structure_argument_was_provided)
+    if (argument_parse_result.has_structure_argument)
     {
         columns = parseColumnsListFromString(configuration.structure, context);
     }
@@ -126,7 +125,8 @@ StoragePtr TableFunctionS3Cluster::executeImpl(
             columns,
             ConstraintsDescription{},
             context,
-            structure_argument_was_provided);
+            argument_parse_result.has_structure_argument,
+            argument_parse_result.has_format_argument);
     }
 
     storage->startup();

--- a/src/TableFunctions/TableFunctionS3Cluster.h
+++ b/src/TableFunctions/TableFunctionS3Cluster.h
@@ -5,6 +5,7 @@
 #if USE_AWS_S3
 
 #include <TableFunctions/ITableFunction.h>
+#include <TableFunctions/TableFunctionS3.h>
 #include <Storages/StorageS3Cluster.h>
 
 
@@ -52,6 +53,7 @@ protected:
 
     mutable StorageS3Cluster::Configuration configuration;
     ColumnsDescription structure_hint;
+    TableFunctionS3::ArgumentParseResult argument_parse_result;
 };
 
 }

--- a/tests/integration/test_s3_cluster/s3_mocks/s3_mock.py
+++ b/tests/integration/test_s3_cluster/s3_mocks/s3_mock.py
@@ -1,0 +1,25 @@
+import sys
+
+from bottle import route, run, request, response
+
+
+@route("/<_bucket>/<_path:path>")
+def server(_bucket, _path):
+    result = (
+        request.headers["MyCustomHeader"]
+        if "MyCustomHeader" in request.headers
+        else "unknown"
+    )
+    response.content_type = "text/plain"
+    response.set_header("Content-Length", len(result))
+    return result
+
+
+@route("/")
+def ping():
+    response.content_type = "text/plain"
+    response.set_header("Content-Length", 2)
+    return "OK"
+
+
+run(host="0.0.0.0", port=int(sys.argv[1]))


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Correctly handle s3Cluster arguments in all cases. E.g. `s3Cluster` now correctly works with `headers` argument.


Logic for appending arguments seems hacky and unreliable so I extracted info from argument parsing itself.

cc @nikitamikhaylov @Avogar 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
