### PR TITLE
Allow passing password in URL for play.html

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -517,7 +517,7 @@
     let previous_query = '';
 
     const current_url = new URL(window.location);
-    const opened_locally = document.location.href.startsWith("file://");
+    const opened_locally = location.protocol == 'file:';
 
     const server_address = current_url.searchParams.get('url');
     if (server_address) {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -517,11 +517,12 @@
     let previous_query = '';
 
     const current_url = new URL(window.location);
+    const opened_locally = document.location.href.startsWith("file://");
 
     const server_address = current_url.searchParams.get('url');
     if (server_address) {
         document.getElementById('url').value = server_address;
-    } else if (location.protocol != 'file:') {
+    } else if (!opened_locally) {
         /// Substitute the address of the server where the page is served.
         document.getElementById('url').value = location.origin;
     }
@@ -530,6 +531,18 @@
     const user_from_url = current_url.searchParams.get('user');
     if (user_from_url) {
         document.getElementById('user').value = user_from_url;
+    }
+
+    const pass_from_url = current_url.searchParams.get('password');
+    if (pass_from_url) {
+        document.getElementById('password').value = pass_from_url;
+        if (!opened_locally) {
+            let replaced_pass = current_url.searchParams;
+            replaced_pass.delete('password');
+            window.history.replaceState(null, '',
+                window.location.origin + window.location.pathname + '?'
+                + replaced_pass.toString() + window.location.hash);
+        }
     }
 
     function postImpl(posted_request_num, query)
@@ -548,7 +561,7 @@
             '&max_result_rows=1000&max_result_bytes=10000000&result_overflow_mode=break';
 
         // If play.html is opened locally, append username and password to the URL parameter to avoid CORS issue.
-        if (document.location.href.startsWith("file://")) {
+        if (opened_locally) {
             url += '&user=' + encodeURIComponent(user) +
             '&password=' + encodeURIComponent(password)
         }
@@ -557,7 +570,7 @@
 
         xhr.open('POST', url, true);
         // If play.html is open normally, use Basic auth to prevent username and password being exposed in URL parameters
-        if (!document.location.href.startsWith("file://")) {
+        if (!opened_locally) {
             xhr.setRequestHeader("Authorization", "Basic " + btoa(user+":"+password));
         }
         xhr.onreadystatechange = function()

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -536,6 +536,7 @@
     const pass_from_url = current_url.searchParams.get('password');
     if (pass_from_url) {
         document.getElementById('password').value = pass_from_url;
+	/// Browsers don't allow manipulating history for the 'file:' protocol.
         if (!opened_locally) {
             let replaced_pass = current_url.searchParams;
             replaced_pass.delete('password');


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Allow `?password=pass` in URL. Password is replaced in browser history.