### PR TITLE
Allow parameters in queries with partitions

### DIFF
--- a/src/Parsers/ASTPartition.h
+++ b/src/Parsers/ASTPartition.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Parsers/IAST.h>
-
+#include <optional>
 
 namespace DB
 {
@@ -11,7 +11,7 @@ class ASTPartition : public IAST
 {
 public:
     ASTPtr value;
-    size_t fields_count = 0;
+    std::optional<size_t> fields_count;
 
     String id;
     bool all = false;

--- a/src/Parsers/ParserPartition.cpp
+++ b/src/Parsers/ParserPartition.cpp
@@ -40,7 +40,7 @@ bool ParserPartition::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         if (!parser_expr.parse(pos, value, expected))
             return false;
 
-        size_t fields_count;
+        std::optional<size_t> fields_count;
 
         const auto * tuple_ast = value->as<ASTFunction>();
         bool surrounded_by_parens = false;
@@ -65,7 +65,7 @@ bool ParserPartition::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
                 fields_count = 1;
             }
         }
-        else
+        else if (!value->as<ASTQueryParameter>())
             return false;
 
         if (surrounded_by_parens)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow parameters in queries with partitions like `ALTER TABLE t DROP PARTITION`. Closes https://github.com/ClickHouse/ClickHouse/issues/49449