### PR TITLE
Read Parquet files even faster, take 2

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -832,7 +832,6 @@ class IColumn;
     M(Bool, input_format_orc_case_insensitive_column_matching, false, "Ignore case when matching ORC columns with CH columns.", 0) \
     M(Bool, input_format_parquet_import_nested, false, "Allow to insert array of structs into Nested table in Parquet input format.", 0) \
     M(Bool, input_format_parquet_case_insensitive_column_matching, false, "Ignore case when matching Parquet columns with CH columns.", 0) \
-    /* TODO: Consider unifying this with https://github.com/ClickHouse/ClickHouse/issues/38755 */ \
     M(Bool, input_format_parquet_preserve_order, false, "Avoid reordering rows when reading from Parquet files. Usually makes it much slower.", 0) \
     M(Bool, input_format_allow_seeks, true, "Allow seeks while reading in ORC/Parquet/Arrow input formats", 0) \
     M(Bool, input_format_orc_allow_missing_columns, false, "Allow missing columns while reading ORC input formats", 0) \

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -221,68 +221,16 @@ template FormatSettings getFormatSettings<Settings>(ContextPtr context, const Se
 
 InputFormatPtr FormatFactory::getInput(
     const String & name,
-    ReadBuffer & buf,
+    ReadBuffer & _buf,
     const Block & sample,
     ContextPtr context,
     UInt64 max_block_size,
-    const std::optional<FormatSettings> & format_settings,
-    std::optional<size_t> max_parsing_threads) const
-{
-    return getInputImpl(
-        name,
-        nullptr,
-        &buf,
-        sample,
-        context,
-        max_block_size,
-        /* is_remote_fs */ false,
-        CompressionMethod::None,
-        format_settings,
-        /* max_download_threads */ 1,
-        max_parsing_threads);
-}
-
-InputFormatPtr FormatFactory::getInputRandomAccess(
-    const String & name,
-    SeekableReadBufferFactoryPtr buf_factory,
-    const Block & sample,
-    ContextPtr context,
-    UInt64 max_block_size,
-    bool is_remote_fs,
-    CompressionMethod compression,
-    const std::optional<FormatSettings> & format_settings,
-    std::optional<size_t> max_download_threads,
-    std::optional<size_t> max_parsing_threads) const
-{
-    return getInputImpl(
-        name,
-        std::move(buf_factory),
-        nullptr,
-        sample,
-        context,
-        max_block_size,
-        is_remote_fs,
-        compression,
-        format_settings,
-        max_download_threads,
-        max_parsing_threads);
-}
-
-InputFormatPtr FormatFactory::getInputImpl(
-    const String & name,
-    // exactly one of the following two is nullptr
-    SeekableReadBufferFactoryPtr buf_factory,
-    ReadBuffer * _buf,
-    const Block & sample,
-    ContextPtr context,
-    UInt64 max_block_size,
-    bool is_remote_fs,
-    CompressionMethod compression,
     const std::optional<FormatSettings> & _format_settings,
+    std::optional<size_t> _max_parsing_threads,
     std::optional<size_t> _max_download_threads,
-    std::optional<size_t> _max_parsing_threads) const
+    bool is_remote_fs,
+    CompressionMethod compression) const
 {
-    chassert((!_buf) != (!buf_factory));
     const auto& creators = getCreators(name);
     if (!creators.input_creator && !creators.random_access_input_creator)
         throw Exception(ErrorCodes::FORMAT_IS_NOT_SUITABLE_FOR_INPUT, "Format {} is not suitable for input", name);
@@ -302,14 +250,12 @@ InputFormatPtr FormatFactory::getInputImpl(
     if (context->hasQueryContext() && settings.log_queries)
         context->getQueryContext()->addQueryFactoriesInfo(Context::QueryLogFactories::Format, name);
 
-    // Prepare a read buffer.
+    // Add ParallelReadBuffer and decompression if needed.
 
-    std::unique_ptr<ReadBuffer> owned_buf;
-    if (buf_factory)
-        owned_buf = prepareReadBuffer(buf_factory, compression, creators, format_settings, settings, max_download_threads);
-    auto * buf = owned_buf ? owned_buf.get() : _buf;
+    auto owned_buf = wrapReadBufferIfNeeded(_buf, compression, creators, format_settings, settings, is_remote_fs, max_download_threads);
+    auto & buf = owned_buf ? *owned_buf : _buf;
 
-    // Decide whether to use parallel ParallelParsingInputFormat.
+    // Decide whether to use ParallelParsingInputFormat.
 
     bool parallel_parsing = max_parsing_threads > 1 && settings.input_format_parallel_parsing && creators.file_segmentation_engine && !creators.random_access_input_creator;
 
@@ -322,7 +268,7 @@ InputFormatPtr FormatFactory::getInputImpl(
     {
         const auto & non_trivial_prefix_and_suffix_checker = creators.non_trivial_prefix_and_suffix_checker;
         /// Disable parallel parsing for input formats with non-trivial readPrefix() and readSuffix().
-        if (non_trivial_prefix_and_suffix_checker && non_trivial_prefix_and_suffix_checker(*buf))
+        if (non_trivial_prefix_and_suffix_checker && non_trivial_prefix_and_suffix_checker(buf))
             parallel_parsing = false;
     }
 
@@ -340,7 +286,7 @@ InputFormatPtr FormatFactory::getInputImpl(
             { return input_getter(input, sample, row_input_format_params, format_settings); };
 
         ParallelParsingInputFormat::Params params{
-            *buf, sample, parser_creator, creators.file_segmentation_engine, name, max_parsing_threads,
+            buf, sample, parser_creator, creators.file_segmentation_engine, name, max_parsing_threads,
             settings.min_chunk_bytes_for_parallel_parsing, max_block_size, context->getApplicationType() == Context::ApplicationType::SERVER};
 
         format = std::make_shared<ParallelParsingInputFormat>(params);
@@ -349,7 +295,6 @@ InputFormatPtr FormatFactory::getInputImpl(
     {
         format = creators.random_access_input_creator(
             buf,
-            std::move(buf_factory),
             sample,
             format_settings,
             context->getReadSettings(),
@@ -359,7 +304,7 @@ InputFormatPtr FormatFactory::getInputImpl(
     }
     else
     {
-        format = creators.input_creator(*buf, sample, row_input_format_params, format_settings);
+        format = creators.input_creator(buf, sample, row_input_format_params, format_settings);
     }
 
     if (owned_buf)
@@ -375,26 +320,28 @@ InputFormatPtr FormatFactory::getInputImpl(
     return format;
 }
 
-std::unique_ptr<ReadBuffer> FormatFactory::prepareReadBuffer(
-    SeekableReadBufferFactoryPtr & buf_factory,
+std::unique_ptr<ReadBuffer> FormatFactory::wrapReadBufferIfNeeded(
+    ReadBuffer & buf,
     CompressionMethod compression,
     const Creators & creators,
     const FormatSettings & format_settings,
     const Settings & settings,
+    bool is_remote_fs,
     size_t max_download_threads) const
 {
     std::unique_ptr<ReadBuffer> res;
 
-    bool parallel_read = max_download_threads > 1 && buf_factory && format_settings.seekable_read;
+    bool parallel_read = is_remote_fs && max_download_threads > 1 && format_settings.seekable_read && isBufferWithFileSize(buf);
     if (creators.random_access_input_creator)
         parallel_read &= compression != CompressionMethod::None;
+    size_t file_size = 0;
 
     if (parallel_read)
     {
         try
         {
-            parallel_read = buf_factory->checkIfActuallySeekable()
-                         && buf_factory->getFileSize() >= 2 * settings.max_download_buffer_size;
+            file_size = getFileSizeFromReadBuffer(buf);
+            parallel_read = file_size >= 2 * settings.max_download_buffer_size;
         }
         catch (const Poco::Exception & e)
         {
@@ -415,22 +362,17 @@ std::unique_ptr<ReadBuffer> FormatFactory::prepareReadBuffer(
             max_download_threads,
             settings.max_download_buffer_size);
 
-        res = std::make_unique<ParallelReadBuffer>(
-            std::move(buf_factory),
-            threadPoolCallbackRunner<void>(IOThreadPool::get(), "ParallelRead"),
-            max_download_threads,
-            settings.max_download_buffer_size);
+        res = wrapInParallelReadBufferIfSupported(
+            buf, threadPoolCallbackRunner<void>(IOThreadPool::get(), "ParallelRead"),
+            max_download_threads, settings.max_download_buffer_size, file_size);
     }
 
     if (compression != CompressionMethod::None)
     {
         if (!res)
-            res = buf_factory->getReader(); // NOLINT
+            res = wrapReadBufferReference(buf);
         res = wrapReadBufferWithCompressionMethod(std::move(res), compression, static_cast<int>(settings.zstd_window_log_max));
     }
-
-    if (!creators.random_access_input_creator && !res)
-        res = buf_factory->getReader();
 
     return res;
 }

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -90,15 +90,11 @@ private:
             const FormatSettings & settings)>;
 
     // Incompatible with FileSegmentationEngine.
-    // When created using SeekableReadBufferFactoryPtr, the IInputFormat doesn't support
-    // resetParser() and setReadBuffer().
     //
     // In future we may also want to pass some information about WHERE conditions (SelectQueryInfo?)
     // and get some information about projections (min/max/count per column per row group).
     using RandomAccessInputCreator = std::function<InputFormatPtr(
-            // exactly one of these two is nullptr
-            ReadBuffer * buf,
-            SeekableReadBufferFactoryPtr buf_factory,
+            ReadBuffer & buf,
             const Block & header,
             const FormatSettings & settings,
             const ReadSettings& read_settings,
@@ -153,8 +149,10 @@ private:
 public:
     static FormatFactory & instance();
 
-    // Format parser from a single ReadBuffer.
-    // Parallelizes parsing (when possible) but not reading.
+    /// This has two tricks up its sleeve:
+    ///  * Parallel reading.
+    ///    To enable it, make sure `buf` is a SeekableReadBuffer implementing readBigAt().
+    ///  * Parallel parsing.
     InputFormatPtr getInput(
         const String & name,
         ReadBuffer & buf,
@@ -162,23 +160,13 @@ public:
         ContextPtr context,
         UInt64 max_block_size,
         const std::optional<FormatSettings> & format_settings = std::nullopt,
-        std::optional<size_t> max_parsing_threads = std::nullopt) const;
-
-    // Format parser from a random-access source (factory of seekable read buffers).
-    // Parallelizes both parsing and reading when possible.
-    // Prefer this over getInput() when reading from random-access source like file or HTTP.
-    InputFormatPtr getInputRandomAccess(
-        const String & name,
-        SeekableReadBufferFactoryPtr buf_factory,
-        const Block & sample,
-        ContextPtr context,
-        UInt64 max_block_size,
-        bool is_remote_fs,
-        CompressionMethod compression,
-        // if nullopt, getFormatSettings(context) is used
-        const std::optional<FormatSettings> & format_settings = std::nullopt,
+        std::optional<size_t> max_parsing_threads = std::nullopt,
         std::optional<size_t> max_download_threads = std::nullopt,
-        std::optional<size_t> max_parsing_threads = std::nullopt) const;
+        // affects things like buffer sizes and parallel reading
+        bool is_remote_fs = false,
+        // allows to do: buf -> parallel read -> decompression,
+        // because parallel read after decompression is not possible
+        CompressionMethod compression = CompressionMethod::None) const;
 
     /// Checks all preconditions. Returns ordinary format if parallel formatting cannot be done.
     OutputFormatPtr getOutputFormatParallelIfPossible(
@@ -272,28 +260,14 @@ private:
 
     const Creators & getCreators(const String & name) const;
 
-    InputFormatPtr getInputImpl(
-        const String & name,
-        // exactly one of the following two is nullptr
-        SeekableReadBufferFactoryPtr buf_factory,
-        ReadBuffer * buf,
-        const Block & sample,
-        ContextPtr context,
-        UInt64 max_block_size,
-        bool is_remote_fs,
-        CompressionMethod compression,
-        const std::optional<FormatSettings> & format_settings,
-        std::optional<size_t> max_download_threads,
-        std::optional<size_t> max_parsing_threads) const;
-
-    // Creates a ReadBuffer to give to an input format.
-    // Returns nullptr if we should give it the whole factory.
-    std::unique_ptr<ReadBuffer> prepareReadBuffer(
-        SeekableReadBufferFactoryPtr & buf_factory,
+    // Creates a ReadBuffer to give to an input format. Returns nullptr if we should use `buf` directly.
+    std::unique_ptr<ReadBuffer> wrapReadBufferIfNeeded(
+        ReadBuffer & buf,
         CompressionMethod compression,
         const Creators & creators,
         const FormatSettings & format_settings,
         const Settings & settings,
+        bool is_remote_fs,
         size_t max_download_threads) const;
 };
 

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -214,8 +214,6 @@ struct FormatSettings
         std::unordered_set<int> skip_row_groups = {};
         bool output_string_as_string = false;
         bool output_fixed_string_as_fixed_byte_array = true;
-        // TODO: This should probably be shared among all formats and with
-        //       https://github.com/ClickHouse/ClickHouse/issues/38755
         bool preserve_order = false;
         UInt64 max_block_size = 8192;
         ParquetVersion output_version;

--- a/src/IO/MMapReadBufferFromFileDescriptor.cpp
+++ b/src/IO/MMapReadBufferFromFileDescriptor.cpp
@@ -91,4 +91,15 @@ size_t MMapReadBufferFromFileDescriptor::getFileSize()
 {
     return getSizeFromFileDescriptor(getFD(), getFileName());
 }
+
+size_t MMapReadBufferFromFileDescriptor::readBigAt(char * to, size_t n, size_t offset, const std::function<bool(size_t)> &)
+{
+    if (offset >= mapped.getLength())
+        return 0;
+
+    n = std::min(n, mapped.getLength() - offset);
+    memcpy(to, mapped.getData() + offset, n);
+    return n;
+}
+
 }

--- a/src/IO/MMapReadBufferFromFileDescriptor.h
+++ b/src/IO/MMapReadBufferFromFileDescriptor.h
@@ -39,6 +39,9 @@ public:
     int getFD() const;
 
     size_t getFileSize() override;
+
+    size_t readBigAt(char * to, size_t n, size_t offset, const std::function<bool(size_t)> &) override;
+    bool supportsReadAt() override { return true; }
 };
 
 }

--- a/src/IO/ParallelReadBuffer.cpp
+++ b/src/IO/ParallelReadBuffer.cpp
@@ -1,4 +1,5 @@
 #include <IO/ParallelReadBuffer.h>
+#include <IO/SharedThreadPools.h>
 #include <Poco/Logger.h>
 #include <Common/logger_useful.h>
 
@@ -13,51 +14,44 @@ namespace ErrorCodes
 
 }
 
-// A subrange of the input, read by one SeekableReadBuffer.
+// A subrange of the input, read by one thread.
 struct ParallelReadBuffer::ReadWorker
 {
-    ReadWorker(std::unique_ptr<SeekableReadBuffer> reader_, size_t offset_, size_t size)
-        : reader(std::move(reader_)), offset(offset_), bytes_left(size), range_end(offset + bytes_left)
+    ReadWorker(SeekableReadBuffer & input_, size_t offset, size_t size)
+        : input(input_), start_offset(offset), segment(size)
     {
-        assert(bytes_left);
+        chassert(size);
+        chassert(segment.size() == size);
     }
 
-    auto hasSegment() const { return current_segment_index < segments.size(); }
+    bool hasBytesToConsume() const { return bytes_produced > bytes_consumed; }
+    bool hasBytesToProduce() const { return bytes_produced < segment.size(); }
 
-    auto nextSegment()
-    {
-        assert(hasSegment());
-        auto next_segment = std::move(segments[current_segment_index]);
-        ++current_segment_index;
-        offset += next_segment.size();
-        return next_segment;
-    }
+    SeekableReadBuffer & input;
+    const size_t start_offset; // start of the segment
 
-    std::unique_ptr<SeekableReadBuffer> reader;
-    // Reader thread produces segments, nextImpl() consumes them.
-    std::vector<Memory<>> segments; // segments that were produced
-    size_t current_segment_index = 0; // first segment that's not consumed
-    bool finished{false}; // no more segments will be produced
-    size_t offset; // start of segments[current_segment_idx]
-    size_t bytes_left; // bytes left to produce above segments end
-    size_t range_end; // segments end + bytes_left, i.e. how far this worker will read
-
-    //                  segments[current_segment_idx..end]           range_end
-    // |-------------|--------------------------------------|------------|
-    //             offset                                     bytes_left
+    Memory<> segment;
+    /// Reader thread produces data, nextImpl() consumes it.
+    /// segment[bytes_consumed..bytes_produced-1] is data waiting to be picked up by nextImpl()
+    /// segment[bytes_produced..] needs to be read from the input ReadBuffer
+    size_t bytes_produced = 0;
+    size_t bytes_consumed = 0;
 
     std::atomic_bool cancel{false};
     std::mutex worker_mutex;
 };
 
 ParallelReadBuffer::ParallelReadBuffer(
-    std::unique_ptr<SeekableReadBufferFactory> reader_factory_, ThreadPoolCallbackRunner<void> schedule_, size_t max_working_readers_, size_t range_step_)
+    SeekableReadBuffer & input_, ThreadPoolCallbackRunner<void> schedule_, size_t max_working_readers_, size_t range_step_, size_t file_size_)
     : SeekableReadBuffer(nullptr, 0)
     , max_working_readers(max_working_readers_)
     , schedule(std::move(schedule_))
-    , reader_factory(std::move(reader_factory_))
+    , input(input_)
+    , file_size(file_size_)
     , range_step(std::max(1ul, range_step_))
 {
+    LOG_TRACE(&Poco::Logger::get("ParallelReadBuffer"), "Parallel reading is used");
+
     try
     {
         addReaders();
@@ -71,22 +65,15 @@ ParallelReadBuffer::ParallelReadBuffer(
 
 bool ParallelReadBuffer::addReaderToPool()
 {
-    size_t file_size = reader_factory->getFileSize();
     if (next_range_start >= file_size)
         return false;
     size_t range_start = next_range_start;
     size_t size = std::min(range_step, file_size - range_start);
     next_range_start += size;
 
-    auto reader = reader_factory->getReader();
-    if (!reader)
-    {
-        return false;
-    }
+    auto worker = read_workers.emplace_back(std::make_shared<ReadWorker>(input, range_start, size));
 
-    auto worker = read_workers.emplace_back(std::make_shared<ReadWorker>(std::move(reader), range_start, size));
-
-    ++active_working_reader;
+    ++active_working_readers;
     schedule([this, my_worker = std::move(worker)]() mutable { readerThreadFunction(std::move(my_worker)); }, Priority{});
 
     return true;
@@ -116,9 +103,9 @@ off_t ParallelReadBuffer::seek(off_t offset, int whence)
     }
 
     const auto offset_is_in_range
-        = [&](const auto & worker) { return static_cast<size_t>(offset) >= worker->offset && static_cast<size_t>(offset) < worker->range_end; };
+        = [&](const auto & worker) { return static_cast<size_t>(offset) >= worker->start_offset && static_cast<size_t>(offset) < worker->start_offset + worker->segment.size(); };
 
-    while (!read_workers.empty() && (offset < current_position || !offset_is_in_range(read_workers.front())))
+    while (!read_workers.empty() && !offset_is_in_range(read_workers.front()))
     {
         read_workers.front()->cancel = true;
         read_workers.pop_front();
@@ -126,32 +113,31 @@ off_t ParallelReadBuffer::seek(off_t offset, int whence)
 
     if (!read_workers.empty())
     {
-        auto & front_worker = read_workers.front();
-        current_position = front_worker->offset;
+        auto & w = read_workers.front();
+        size_t diff = static_cast<size_t>(offset) - w->start_offset;
         while (true)
         {
-            std::unique_lock lock{front_worker->worker_mutex};
-            next_condvar.wait(lock, [&] { return emergency_stop || front_worker->hasSegment(); });
+            std::unique_lock lock{w->worker_mutex};
 
             if (emergency_stop)
                 handleEmergencyStop();
 
-            auto next_segment = front_worker->nextSegment();
-            current_position += next_segment.size();
-            if (offset < current_position)
+            if (w->bytes_produced > diff)
             {
-                current_segment = std::move(next_segment);
-                working_buffer = internal_buffer = Buffer(current_segment.data(), current_segment.data() + current_segment.size());
-                pos = working_buffer.end() - (current_position - offset);
+                working_buffer = internal_buffer = Buffer(
+                    w->segment.data() + diff, w->segment.data() + w->bytes_produced);
+                w->bytes_consumed = w->bytes_produced;
+                current_position += w->start_offset + w->bytes_consumed;
                 addReaders();
                 return offset;
             }
+
+            next_condvar.wait_for(lock, std::chrono::seconds(10));
         }
     }
 
     finishAndWait();
 
-    all_completed = false;
     read_workers.clear();
 
     next_range_start = offset;
@@ -166,23 +152,12 @@ off_t ParallelReadBuffer::seek(off_t offset, int whence)
 
 size_t ParallelReadBuffer::getFileSize()
 {
-    return reader_factory->getFileSize();
+    return file_size;
 }
 
 off_t ParallelReadBuffer::getPosition()
 {
     return current_position - available();
-}
-
-bool ParallelReadBuffer::currentWorkerReady() const
-{
-    assert(!read_workers.empty());
-    return read_workers.front()->finished || read_workers.front()->hasSegment();
-}
-
-bool ParallelReadBuffer::currentWorkerCompleted() const
-{
-    return read_workers.front()->finished && !read_workers.front()->hasSegment();
 }
 
 void ParallelReadBuffer::handleEmergencyStop()
@@ -194,106 +169,99 @@ void ParallelReadBuffer::handleEmergencyStop()
 
 bool ParallelReadBuffer::nextImpl()
 {
-    if (all_completed)
-        return false;
-
     while (true)
     {
-        std::unique_lock lock{read_workers.front()->worker_mutex};
-        next_condvar.wait(
-            lock,
-            [this]()
-            {
-                /// Check if no more readers left or current reader can be processed
-                return emergency_stop || currentWorkerReady();
-            });
-
-        bool worker_removed = false;
-        /// Remove completed units
-        while (currentWorkerCompleted() && !emergency_stop)
-        {
-            lock.unlock();
-            read_workers.pop_front();
-            worker_removed = true;
-
-            if (read_workers.empty())
-                break;
-
-            lock = std::unique_lock{read_workers.front()->worker_mutex};
-        }
-
-        if (emergency_stop)
-            handleEmergencyStop();
-
-        if (worker_removed)
-            addReaders();
-
         /// All readers processed, stop
         if (read_workers.empty())
         {
-            all_completed = true;
+            chassert(next_range_start >= file_size);
             return false;
         }
 
-        auto & front_worker = read_workers.front();
-        /// Read data from first segment of the first reader
-        if (front_worker->hasSegment())
+        auto * w = read_workers.front().get();
+
+        std::unique_lock lock{w->worker_mutex};
+
+        if (emergency_stop)
+            handleEmergencyStop(); // throws
+
+        /// Read data from front reader
+        if (w->bytes_produced > w->bytes_consumed)
         {
-            current_segment = front_worker->nextSegment();
-            if (currentWorkerCompleted())
-            {
-                lock.unlock();
-                read_workers.pop_front();
-                all_completed = !addReaderToPool() && read_workers.empty();
-            }
-            break;
+            chassert(w->start_offset + w->bytes_consumed == static_cast<size_t>(current_position));
+
+            working_buffer = internal_buffer = Buffer(
+                w->segment.data() + w->bytes_consumed, w->segment.data() + w->bytes_produced);
+            current_position += working_buffer.size();
+            w->bytes_consumed = w->bytes_produced;
+
+            return true;
         }
+
+        /// Front reader is done, remove it and add another
+        if (!w->hasBytesToProduce())
+        {
+            lock.unlock();
+            read_workers.pop_front();
+            addReaders();
+
+            continue;
+        }
+
+        /// Nothing to do right now, wait for something to change.
+        ///
+        /// The timeout is a workaround for a race condition.
+        /// emergency_stop is assigned while holding a *different* mutex from the one we're holding
+        /// (exception_mutex vs worker_mutex). So it's possible that our emergency_stop check (above)
+        /// happens before a onBackgroundException() call, but our wait(lock) happens after it.
+        /// Then the wait may get stuck forever.
+        ///
+        /// Note that using wait(lock, [&]{ return emergency_stop || ...; }) wouldn't help because
+        /// it does effectively the same "check, then wait" sequence.
+        ///
+        /// One possible proper fix would be to make onBackgroundException() lock all read_workers
+        /// mutexes too (not necessarily simultaneously - just locking+unlocking them one by one
+        /// between the emergency_stop change and the notify_all() would be enough), but then we
+        /// need another mutex to protect read_workers itself...
+        next_condvar.wait_for(lock, std::chrono::seconds(10));
     }
-    working_buffer = internal_buffer = Buffer(current_segment.data(), current_segment.data() + current_segment.size());
-    current_position += working_buffer.size();
-    return true;
+    chassert(false);
+    return false;
 }
 
 void ParallelReadBuffer::readerThreadFunction(ReadWorkerPtr read_worker)
 {
     SCOPE_EXIT({
-        if (active_working_reader.fetch_sub(1) == 1)
-            active_working_reader.notify_all();
+        if (active_working_readers.fetch_sub(1) == 1)
+            active_working_readers.notify_all();
     });
 
     try
     {
-        read_worker->reader->setReadUntilPosition(read_worker->range_end);
-        read_worker->reader->seek(read_worker->offset, SEEK_SET);
-
-        while (!emergency_stop && !read_worker->cancel)
+        auto on_progress = [&](size_t bytes_read) -> bool
         {
-            if (!read_worker->reader->next())
-                throw Exception(
-                    ErrorCodes::LOGICAL_ERROR, "Failed to read all the data from the reader, missing {} bytes", read_worker->bytes_left);
-
             if (emergency_stop || read_worker->cancel)
-                break;
+                return true;
 
-            Buffer buffer = read_worker->reader->buffer();
-            size_t bytes_to_copy = std::min(buffer.size(), read_worker->bytes_left);
-            Memory<> new_segment(bytes_to_copy);
-            memcpy(new_segment.data(), buffer.begin(), bytes_to_copy);
-            read_worker->reader->ignore(bytes_to_copy);
-            read_worker->bytes_left -= bytes_to_copy;
-            {
-                /// New data ready to be read
-                std::lock_guard lock(read_worker->worker_mutex);
-                read_worker->segments.emplace_back(std::move(new_segment));
-                read_worker->finished = read_worker->bytes_left == 0;
+            std::lock_guard lock(read_worker->worker_mutex);
+            if (bytes_read <= read_worker->bytes_produced)
+                return false;
+
+            bool need_notify = read_worker->bytes_produced == read_worker->bytes_consumed;
+            read_worker->bytes_produced = bytes_read;
+            if (need_notify)
                 next_condvar.notify_all();
-            }
 
-            if (read_worker->finished)
-            {
-                break;
-            }
-        }
+            return false;
+        };
+
+        size_t r = input.readBigAt(read_worker->segment.data(), read_worker->segment.size(), read_worker->start_offset);
+
+        if (!on_progress(r) && r < read_worker->segment.size())
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Failed to read all the data from the reader at offset {}, got {}/{} bytes",
+                read_worker->start_offset, r, read_worker->segment.size());
     }
     catch (...)
     {
@@ -315,12 +283,24 @@ void ParallelReadBuffer::finishAndWait()
 {
     emergency_stop = true;
 
-    size_t active_readers = active_working_reader.load();
+    size_t active_readers = active_working_readers.load();
     while (active_readers != 0)
     {
-        active_working_reader.wait(active_readers);
-        active_readers = active_working_reader.load();
+        active_working_readers.wait(active_readers);
+        active_readers = active_working_readers.load();
     }
+}
+
+std::unique_ptr<ParallelReadBuffer> wrapInParallelReadBufferIfSupported(
+    ReadBuffer & buf, ThreadPoolCallbackRunner<void> schedule, size_t max_working_readers,
+    size_t range_step, size_t file_size)
+{
+    auto * seekable = dynamic_cast<SeekableReadBuffer*>(&buf);
+    if (!seekable || !seekable->supportsReadAt())
+        return nullptr;
+
+    return std::make_unique<ParallelReadBuffer>(
+        *seekable, schedule, max_working_readers, range_step, file_size);
 }
 
 }

--- a/src/IO/ParallelReadBuffer.h
+++ b/src/IO/ParallelReadBuffer.h
@@ -10,18 +10,17 @@ namespace DB
 {
 
 /**
- * Reads from multiple ReadBuffers in parallel.
- * Preserves order of readers obtained from SeekableReadBufferFactory.
+ * Reads from multiple positions in a ReadBuffer in parallel.
+ * Then reassembles the data into one stream in the original order.
  *
- * It consumes multiple readers and yields data from them in order as it passed.
- * Each working reader save segments of data to internal queue.
+ * Each working reader reads its segment of data into a buffer.
  *
- * ParallelReadBuffer in nextImpl method take first available segment from first reader in deque and fed it to user.
- * When first reader finish reading, they will be removed from worker deque and data from next reader consumed.
+ * ParallelReadBuffer in nextImpl method take first available segment from first reader in deque and reports it it to user.
+ * When first reader finishes reading, they will be removed from worker deque and data from next reader consumed.
  *
  * Number of working readers limited by max_working_readers.
  */
-class ParallelReadBuffer : public SeekableReadBuffer
+class ParallelReadBuffer : public SeekableReadBuffer, public WithFileSize
 {
 private:
     /// Blocks until data occurred in the first reader or this reader indicate finishing
@@ -29,19 +28,19 @@ private:
     bool nextImpl() override;
 
 public:
-    ParallelReadBuffer(SeekableReadBufferFactoryPtr reader_factory_, ThreadPoolCallbackRunner<void> schedule_, size_t max_working_readers, size_t range_step_);
+    ParallelReadBuffer(SeekableReadBuffer & input, ThreadPoolCallbackRunner<void> schedule_, size_t max_working_readers, size_t range_step_, size_t file_size);
 
     ~ParallelReadBuffer() override { finishAndWait(); }
 
     off_t seek(off_t off, int whence) override;
-    size_t getFileSize();
+    size_t getFileSize() override;
     off_t getPosition() override;
 
-    const SeekableReadBufferFactory & getReadBufferFactory() const { return *reader_factory; }
-    SeekableReadBufferFactory & getReadBufferFactory() { return *reader_factory; }
+    const SeekableReadBuffer & getReadBuffer() const { return input; }
+    SeekableReadBuffer & getReadBuffer() { return input; }
 
 private:
-    /// Reader in progress with a list of read segments
+    /// Reader in progress with a buffer for the segment
     struct ReadWorker;
     using ReadWorkerPtr = std::shared_ptr<ReadWorker>;
 
@@ -55,28 +54,28 @@ private:
     void addReaders();
     bool addReaderToPool();
 
-    /// Process read_worker, read data and save into internal segments queue
+    /// Process read_worker, read data and save into the buffer
     void readerThreadFunction(ReadWorkerPtr read_worker);
 
     void onBackgroundException();
     void finishAndWait();
 
-    Memory<> current_segment;
-
     size_t max_working_readers;
-    std::atomic_size_t active_working_reader{0};
+    std::atomic_size_t active_working_readers{0};
 
     ThreadPoolCallbackRunner<void> schedule;
 
-    std::unique_ptr<SeekableReadBufferFactory> reader_factory;
+    SeekableReadBuffer & input;
+    size_t file_size;
     size_t range_step;
     size_t next_range_start{0};
 
     /**
      * FIFO queue of readers.
-     * Each worker contains reader itself and downloaded segments.
-     * When reader read all available data it will be removed from
-     * deque and data from next reader will be consumed to user.
+     * Each worker contains a buffer for the downloaded segment.
+     * After all data for the segment is read and delivered to the user, the reader will be removed
+     * from deque and data from next reader will be delivered.
+     * After removing from deque, call addReaders().
      */
     std::deque<ReadWorkerPtr> read_workers;
 
@@ -91,5 +90,11 @@ private:
 
     bool all_completed{false};
 };
+
+/// If `buf` is a SeekableReadBuffer with supportsReadAt() == true, creates a ParallelReadBuffer
+/// from it. Otherwise returns nullptr;
+std::unique_ptr<ParallelReadBuffer> wrapInParallelReadBufferIfSupported(
+    ReadBuffer & buf, ThreadPoolCallbackRunner<void> schedule, size_t max_working_readers,
+    size_t range_step, size_t file_size);
 
 }

--- a/src/IO/ReadBufferFromFileDescriptor.cpp
+++ b/src/IO/ReadBufferFromFileDescriptor.cpp
@@ -50,30 +50,30 @@ std::string ReadBufferFromFileDescriptor::getFileName() const
 }
 
 
-bool ReadBufferFromFileDescriptor::nextImpl()
+size_t ReadBufferFromFileDescriptor::readImpl(char * to, size_t min_bytes, size_t max_bytes, size_t offset)
 {
-    /// If internal_buffer size is empty, then read() cannot be distinguished from EOF
-    assert(!internal_buffer.empty());
+    chassert(min_bytes <= max_bytes);
 
-    /// This is a workaround of a read pass EOF bug in linux kernel with pread()
-    if (file_size.has_value() && file_offset_of_buffer_end >= *file_size)
-         return false;
+    /// This is a workaround of a read past EOF bug in linux kernel with pread()
+    if (file_size.has_value() && offset >= *file_size)
+         return 0;
 
     size_t bytes_read = 0;
-    while (!bytes_read)
+    while (bytes_read < min_bytes)
     {
         ProfileEvents::increment(ProfileEvents::ReadBufferFromFileDescriptorRead);
 
         Stopwatch watch(profile_callback ? clock_type : CLOCK_MONOTONIC);
 
         ssize_t res = 0;
+        size_t to_read = max_bytes - bytes_read;
         {
             CurrentMetrics::Increment metric_increment{CurrentMetrics::Read};
 
             if (use_pread)
-                res = ::pread(fd, internal_buffer.begin(), internal_buffer.size(), file_offset_of_buffer_end);
+                res = ::pread(fd, to + bytes_read, to_read, offset + bytes_read);
             else
-                res = ::read(fd, internal_buffer.begin(), internal_buffer.size());
+                res = ::read(fd, to + bytes_read, to_read);
         }
         if (!res)
             break;
@@ -102,18 +102,31 @@ bool ReadBufferFromFileDescriptor::nextImpl()
         if (profile_callback)
         {
             ProfileInfo info;
-            info.bytes_requested = internal_buffer.size();
+            info.bytes_requested = to_read;
             info.bytes_read = res;
             info.nanoseconds = watch.elapsed();
             profile_callback(info);
         }
     }
 
+    if (bytes_read)
+        ProfileEvents::increment(ProfileEvents::ReadBufferFromFileDescriptorReadBytes, bytes_read);
+
+    return bytes_read;
+}
+
+
+bool ReadBufferFromFileDescriptor::nextImpl()
+{
+    /// If internal_buffer size is empty, then read() cannot be distinguished from EOF
+    assert(!internal_buffer.empty());
+
+    size_t bytes_read = readImpl(internal_buffer.begin(), 1, internal_buffer.size(), file_offset_of_buffer_end);
+
     file_offset_of_buffer_end += bytes_read;
 
     if (bytes_read)
     {
-        ProfileEvents::increment(ProfileEvents::ReadBufferFromFileDescriptorReadBytes, bytes_read);
         working_buffer = internal_buffer;
         working_buffer.resize(bytes_read);
     }
@@ -257,6 +270,19 @@ bool ReadBufferFromFileDescriptor::poll(size_t timeout_microseconds) const
 size_t ReadBufferFromFileDescriptor::getFileSize()
 {
     return getSizeFromFileDescriptor(fd, getFileName());
+}
+
+bool ReadBufferFromFileDescriptor::checkIfActuallySeekable()
+{
+    struct stat stat;
+    auto res = ::fstat(fd, &stat);
+    return res == 0 && S_ISREG(stat.st_mode);
+}
+
+size_t ReadBufferFromFileDescriptor::readBigAt(char * to, size_t n, size_t offset, const std::function<bool(size_t)> &)
+{
+    chassert(use_pread);
+    return readImpl(to, n, n, offset);
 }
 
 }

--- a/src/IO/ReadBufferFromFileDescriptor.h
+++ b/src/IO/ReadBufferFromFileDescriptor.h
@@ -30,6 +30,12 @@ protected:
     /// Name or some description of file.
     std::string getFileName() const override;
 
+    /// Does the read()/pread(), with all the metric increments, error handling, throttling, etc.
+    /// Doesn't seek (`offset` must match fd's position if !use_pread).
+    /// Stops after min_bytes or eof. Returns 0 if eof.
+    /// Thread safe.
+    size_t readImpl(char * to, size_t min_bytes, size_t max_bytes, size_t offset);
+
 public:
     explicit ReadBufferFromFileDescriptor(
         int fd_,
@@ -64,6 +70,11 @@ public:
     void rewind();
 
     size_t getFileSize() override;
+
+    bool checkIfActuallySeekable() override;
+
+    size_t readBigAt(char * to, size_t n, size_t offset, const std::function<bool(size_t)> &) override;
+    bool supportsReadAt() override { return use_pread; }
 
 private:
     /// Assuming file descriptor supports 'select', check that we have data to read or wait until timeout.

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -109,9 +109,12 @@ bool ReadBufferFromS3::nextImpl()
     }
 
     size_t sleep_time_with_backoff_milliseconds = 100;
-    for (size_t attempt = 0; attempt < request_settings.max_single_read_retries && !next_result; ++attempt)
+    for (size_t attempt = 0; !next_result; ++attempt)
     {
-        Stopwatch watch;
+        bool last_attempt = attempt + 1 >= request_settings.max_single_read_retries;
+
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::ReadBufferFromS3Microseconds);
+
         try
         {
             if (!impl)
@@ -133,44 +136,11 @@ bool ReadBufferFromS3::nextImpl()
 
             /// Try to read a next portion of data.
             next_result = impl->next();
-            watch.stop();
-            ProfileEvents::increment(ProfileEvents::ReadBufferFromS3Microseconds, watch.elapsedMicroseconds());
             break;
         }
         catch (Exception & e)
         {
-            watch.stop();
-            ProfileEvents::increment(ProfileEvents::ReadBufferFromS3Microseconds, watch.elapsedMicroseconds());
-            ProfileEvents::increment(ProfileEvents::ReadBufferFromS3RequestsErrors, 1);
-
-            if (auto * s3_exception = dynamic_cast<S3Exception *>(&e))
-            {
-                /// It doesn't make sense to retry Access Denied or No Such Key
-                if (!s3_exception->isRetryableError())
-                {
-                    s3_exception->addMessage("while reading key: {}, from bucket: {}", key, bucket);
-                    throw;
-                }
-            }
-
-            /// It doesn't make sense to retry allocator errors
-            if (e.code() == ErrorCodes::CANNOT_ALLOCATE_MEMORY)
-            {
-                tryLogCurrentException(log);
-                throw;
-            }
-
-            LOG_DEBUG(
-                log,
-                "Caught exception while reading S3 object. Bucket: {}, Key: {}, Version: {}, Offset: {}, Attempt: {}, Message: {}",
-                bucket,
-                key,
-                version_id.empty() ? "Latest" : version_id,
-                getPosition(),
-                attempt,
-                e.message());
-
-            if (attempt + 1 == request_settings.max_single_read_retries)
+            if (!processException(e, getPosition(), attempt) || last_attempt)
                 throw;
 
             /// Pause before next attempt.
@@ -192,6 +162,74 @@ bool ReadBufferFromS3::nextImpl()
     offset += working_buffer.size();
     if (read_settings.remote_throttler)
         read_settings.remote_throttler->add(working_buffer.size(), ProfileEvents::RemoteReadThrottlerBytes, ProfileEvents::RemoteReadThrottlerSleepMicroseconds);
+
+    return true;
+}
+
+
+size_t ReadBufferFromS3::readBigAt(char * to, size_t n, size_t range_begin, const std::function<bool(size_t)> & progress_callback)
+{
+    if (n == 0)
+        return 0;
+
+    size_t sleep_time_with_backoff_milliseconds = 100;
+    for (size_t attempt = 0;; ++attempt)
+    {
+        bool last_attempt = attempt + 1 >= request_settings.max_single_read_retries;
+
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::ReadBufferFromS3Microseconds);
+
+        try
+        {
+            auto result = sendRequest(range_begin, range_begin + n - 1);
+            std::istream & istr = result.GetBody();
+
+            size_t bytes = copyFromIStreamWithProgressCallback(istr, to, n, progress_callback);
+
+            ProfileEvents::increment(ProfileEvents::ReadBufferFromS3Bytes, bytes);
+
+            if (read_settings.remote_throttler)
+                read_settings.remote_throttler->add(bytes, ProfileEvents::RemoteReadThrottlerBytes, ProfileEvents::RemoteReadThrottlerSleepMicroseconds);
+
+            return bytes;
+        }
+        catch (Poco::Exception & e)
+        {
+            if (!processException(e, range_begin, attempt) || last_attempt)
+                throw;
+
+            sleepForMilliseconds(sleep_time_with_backoff_milliseconds);
+            sleep_time_with_backoff_milliseconds *= 2;
+        }
+    }
+}
+
+bool ReadBufferFromS3::processException(Poco::Exception & e, size_t read_offset, size_t attempt) const
+{
+    ProfileEvents::increment(ProfileEvents::ReadBufferFromS3RequestsErrors, 1);
+
+    LOG_DEBUG(
+        log,
+        "Caught exception while reading S3 object. Bucket: {}, Key: {}, Version: {}, Offset: {}, "
+        "Attempt: {}, Message: {}",
+        bucket, key, version_id.empty() ? "Latest" : version_id, read_offset, attempt, e.message());
+
+    if (auto * s3_exception = dynamic_cast<S3Exception *>(&e))
+    {
+        /// It doesn't make sense to retry Access Denied or No Such Key
+        if (!s3_exception->isRetryableError())
+        {
+            s3_exception->addMessage("while reading key: {}, from bucket: {}", key, bucket);
+            return false;
+        }
+    }
+
+    /// It doesn't make sense to retry allocator errors
+    if (e.code() == ErrorCodes::CANNOT_ALLOCATE_MEMORY)
+    {
+        tryLogCurrentException(log);
+        return false;
+    }
 
     return true;
 }
@@ -315,44 +353,40 @@ bool ReadBufferFromS3::atEndOfRequestedRangeGuess()
 
 std::unique_ptr<ReadBuffer> ReadBufferFromS3::initialize()
 {
-    S3::GetObjectRequest req;
-    req.SetBucket(bucket);
-    req.SetKey(key);
-    if (!version_id.empty())
-    {
-        req.SetVersionId(version_id);
-    }
-
     /**
      * If remote_filesystem_read_method = 'threadpool', then for MergeTree family tables
      * exact byte ranges to read are always passed here.
      */
-    if (read_until_position)
-    {
-        if (offset >= read_until_position)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Attempt to read beyond right offset ({} > {})", offset, read_until_position - 1);
+    if (read_until_position && offset >= read_until_position)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Attempt to read beyond right offset ({} > {})", offset, read_until_position - 1);
 
-        req.SetRange(fmt::format("bytes={}-{}", offset, read_until_position - 1));
-        LOG_TEST(
-            log,
-            "Read S3 object. Bucket: {}, Key: {}, Version: {}, Range: {}-{}",
-            bucket,
-            key,
-            version_id.empty() ? "Latest" : version_id,
-            offset,
-            read_until_position - 1);
-    }
-    else
+    read_result = sendRequest(offset, read_until_position ? std::make_optional(read_until_position - 1) : std::nullopt);
+
+    size_t buffer_size = use_external_buffer ? 0 : read_settings.remote_fs_buffer_size;
+    return std::make_unique<ReadBufferFromIStream>(read_result.GetBody(), buffer_size);
+}
+
+Aws::S3::Model::GetObjectResult ReadBufferFromS3::sendRequest(size_t range_begin, std::optional<size_t> range_end_incl) const
+{
+    S3::GetObjectRequest req;
+    req.SetBucket(bucket);
+    req.SetKey(key);
+    if (!version_id.empty())
+        req.SetVersionId(version_id);
+
+    if (range_end_incl)
     {
-        if (offset)
-            req.SetRange(fmt::format("bytes={}-", offset));
+        req.SetRange(fmt::format("bytes={}-{}", range_begin, *range_end_incl));
         LOG_TEST(
-            log,
-            "Read S3 object. Bucket: {}, Key: {}, Version: {}, Offset: {}",
-            bucket,
-            key,
-            version_id.empty() ? "Latest" : version_id,
-            offset);
+            log, "Read S3 object. Bucket: {}, Key: {}, Version: {}, Range: {}-{}",
+            bucket, key, version_id.empty() ? "Latest" : version_id, range_begin, *range_end_incl);
+    }
+    else if (range_begin)
+    {
+        req.SetRange(fmt::format("bytes={}-", range_begin));
+        LOG_TEST(
+            log, "Read S3 object. Bucket: {}, Key: {}, Version: {}, Offset: {}",
+            bucket, key, version_id.empty() ? "Latest" : version_id, range_begin);
     }
 
     ProfileEvents::increment(ProfileEvents::S3GetObject);
@@ -371,9 +405,7 @@ std::unique_ptr<ReadBuffer> ReadBufferFromS3::initialize()
     {
         ResourceCost bytes_read = outcome.GetResult().GetContentLength();
         read_settings.resource_link.adjust(estimated_cost, bytes_read);
-        size_t buffer_size = use_external_buffer ? 0 : read_settings.remote_fs_buffer_size;
-        read_result = outcome.GetResultWithOwnership();
-        return std::make_unique<ReadBufferFromIStream>(read_result.GetBody(), buffer_size);
+        return outcome.GetResultWithOwnership();
     }
     else
     {
@@ -383,21 +415,6 @@ std::unique_ptr<ReadBuffer> ReadBufferFromS3::initialize()
     }
 }
 
-std::unique_ptr<SeekableReadBuffer> ReadBufferS3Factory::getReader()
-{
-    return std::make_unique<ReadBufferFromS3>(
-        client_ptr,
-        bucket,
-        key,
-        version_id,
-        request_settings,
-        read_settings.adjustBufferSize(object_size));
-}
-
-size_t ReadBufferS3Factory::getFileSize()
-{
-    return object_size;
-}
 }
 
 #endif

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -77,11 +77,21 @@ public:
 
     String getFileName() const override { return bucket + "/" + key; }
 
+    size_t readBigAt(char * to, size_t n, size_t range_begin, const std::function<bool(size_t)> & progress_callback) override;
+
+    bool supportsReadAt() override { return true; }
+
 private:
     std::unique_ptr<ReadBuffer> initialize();
 
-    // If true, if we destroy impl now, no work was wasted. Just for metrics.
+    /// If true, if we destroy impl now, no work was wasted. Just for metrics.
     bool atEndOfRequestedRangeGuess();
+
+    /// Call inside catch() block if GetObject fails. Bumps metrics, logs the error.
+    /// Returns true if the error looks retriable.
+    bool processException(Poco::Exception & e, size_t read_offset, size_t attempt) const;
+
+    Aws::S3::Model::GetObjectResult sendRequest(size_t range_begin, std::optional<size_t> range_end_incl) const;
 
     ReadSettings read_settings;
 
@@ -90,43 +100,6 @@ private:
     /// There is different seek policy for disk seek and for non-disk seek
     /// (non-disk seek is applied for seekable input formats: orc, arrow, parquet).
     bool restricted_seek;
-};
-
-/// Creates separate ReadBufferFromS3 for sequence of ranges of particular object
-class ReadBufferS3Factory : public SeekableReadBufferFactory, public WithFileName
-{
-public:
-    explicit ReadBufferS3Factory(
-        std::shared_ptr<const S3::Client> client_ptr_,
-        const String & bucket_,
-        const String & key_,
-        const String & version_id_,
-        size_t object_size_,
-        const S3Settings::RequestSettings & request_settings_,
-        const ReadSettings & read_settings_)
-        : client_ptr(client_ptr_)
-        , bucket(bucket_)
-        , key(key_)
-        , version_id(version_id_)
-        , read_settings(read_settings_)
-        , object_size(object_size_)
-        , request_settings(request_settings_)
-    {}
-
-    std::unique_ptr<SeekableReadBuffer> getReader() override;
-
-    size_t getFileSize() override;
-
-    String getFileName() const override { return bucket + "/" + key; }
-
-private:
-    std::shared_ptr<const S3::Client> client_ptr;
-    const String bucket;
-    const String key;
-    const String version_id;
-    ReadSettings read_settings;
-    size_t object_size;
-    const S3Settings::RequestSettings request_settings;
 };
 
 }

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -41,6 +41,12 @@ void UpdatableSession<TSessionFactory>::updateSession(const Poco::URI & uri)
 }
 
 template <typename TSessionFactory>
+typename UpdatableSession<TSessionFactory>::SessionPtr UpdatableSession<TSessionFactory>::createDetachedSession(const Poco::URI & uri)
+{
+    return session_factory->buildNewSession(uri);
+}
+
+template <typename TSessionFactory>
 std::shared_ptr<UpdatableSession<TSessionFactory>> UpdatableSession<TSessionFactory>::clone(const Poco::URI & uri)
 {
     return std::make_shared<UpdatableSession<TSessionFactory>>(uri, max_redirects, session_factory);
@@ -89,21 +95,11 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::withPartialContent(const 
 }
 
 template <typename UpdatableSessionPtr>
-size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getRangeBegin() const { return read_range.begin.value_or(0); }
+size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getOffset() const { return read_range.begin.value_or(0) + offset_from_begin_pos; }
 
 template <typename UpdatableSessionPtr>
-size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getOffset() const { return getRangeBegin() + offset_from_begin_pos; }
-
-template <typename UpdatableSessionPtr>
-std::istream * ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::callImpl(
-    UpdatableSessionPtr & current_session, Poco::URI uri_, Poco::Net::HTTPResponse & response,
-    const std::string & method_, bool for_object_info)
+void ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::prepareRequest(Poco::Net::HTTPRequest & request, Poco::URI uri_, std::optional<HTTPRange> range) const
 {
-    // With empty path poco will send "POST  HTTP/1.1" its bug.
-    if (uri_.getPath().empty())
-        uri_.setPath("/");
-
-    Poco::Net::HTTPRequest request(method_, uri_.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
     request.setHost(uri_.getHost()); // use original, not resolved host name in header
 
     if (out_stream_callback)
@@ -111,15 +107,8 @@ std::istream * ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::callImpl(
     else if (method == Poco::Net::HTTPRequest::HTTP_POST)
         request.setContentLength(0);    /// No callback - no body
 
-    for (auto & [header, value] : http_header_entries)
+    for (const auto & [header, value] : http_header_entries)
         request.set(header, value);
-
-    std::optional<HTTPRange> range;
-    if (!for_object_info)
-    {
-        if (withPartialContent(read_range))
-            range = HTTPRange{getOffset(), read_range.end};
-    }
 
     if (range)
     {
@@ -134,6 +123,25 @@ std::istream * ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::callImpl(
 
     if (!credentials.getUsername().empty())
         credentials.authenticate(request);
+}
+
+template <typename UpdatableSessionPtr>
+std::istream * ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::callImpl(
+    UpdatableSessionPtr & current_session, Poco::URI uri_, Poco::Net::HTTPResponse & response, const std::string & method_, bool for_object_info)
+{
+    // With empty path poco will send "POST  HTTP/1.1" its bug.
+    if (uri_.getPath().empty())
+        uri_.setPath("/");
+
+    std::optional<HTTPRange> range;
+    if (!for_object_info)
+    {
+        if (withPartialContent(read_range))
+            range = HTTPRange{getOffset(), read_range.end};
+    }
+
+    Poco::Net::HTTPRequest request(method_, uri_.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
+    prepareRequest(request, uri_, range);
 
     LOG_TRACE(log, "Sending request to {}", uri_.toString());
 
@@ -174,6 +182,14 @@ size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getFileSize()
         return *file_info->file_size;
 
     throw Exception(ErrorCodes::UNKNOWN_FILE_SIZE, "Cannot find out file size for: {}", uri.toString());
+}
+
+template <typename UpdatableSessionPtr>
+bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::supportsReadAt()
+{
+    if (!file_info)
+        file_info = getFileInfo();
+    return method == Poco::Net::HTTPRequest::HTTP_GET && file_info->seekable;
 }
 
 template <typename UpdatableSessionPtr>
@@ -405,7 +421,7 @@ void ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::initialize()
         {
             /// We could have range.begin == 0 and range.end != 0 in case of DiskWeb and failing to read with partial content
             /// will affect only performance, so a warning is enough.
-            LOG_WARNING(log, "Unable to read with range header: [{}, {}]", getRangeBegin(), *read_range.end);
+            LOG_WARNING(log, "Unable to read with range header: [{}, {}]", read_range.begin.value_or(0), *read_range.end);
         }
     }
 
@@ -538,8 +554,8 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
                 throw;
 
             /** Retry request unconditionally if nothing has been read yet.
-                 * Otherwise if it is GET method retry with range header.
-                 */
+                    * Otherwise if it is GET method retry with range header.
+                    */
             bool can_retry_request = !offset_from_begin_pos || method == Poco::Net::HTTPRequest::HTTP_GET;
             if (!can_retry_request)
                 throw;
@@ -572,6 +588,83 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
     working_buffer = internal_buffer;
     offset_from_begin_pos += working_buffer.size();
     return true;
+}
+
+template <typename UpdatableSessionPtr>
+size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::readBigAt(char * to, size_t n, size_t offset, const std::function<bool(size_t)> & progress_callback)
+{
+    /// Caller must have checked supportsReadAt().
+    /// This ensures we've sent at least one HTTP request and populated saved_uri_redirect.
+    chassert(file_info && file_info->seekable);
+
+    if (n == 0)
+        return 0;
+
+    Poco::URI uri_ = saved_uri_redirect.value_or(uri);
+    if (uri_.getPath().empty())
+        uri_.setPath("/");
+
+    size_t milliseconds_to_wait = settings.http_retry_initial_backoff_ms;
+
+    for (size_t attempt = 0;; ++attempt)
+    {
+        bool last_attempt = attempt + 1 >= settings.http_max_tries;
+
+        Poco::Net::HTTPRequest request(method, uri_.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
+        prepareRequest(request, uri_, HTTPRange { .begin = offset, .end = offset + n - 1});
+
+        LOG_TRACE(log, "Sending request to {} for range [{}, {})", uri_.toString(), offset, offset + n);
+
+        auto sess = session->createDetachedSession(uri_);
+
+        Poco::Net::HTTPResponse response;
+        std::istream * result_istr;
+
+        try
+        {
+            sess->sendRequest(request);
+            result_istr = receiveResponse(*sess, request, response, /*allow_redirects*/ false);
+
+            if (response.getStatus() != Poco::Net::HTTPResponse::HTTPStatus::HTTP_PARTIAL_CONTENT &&
+                (offset != 0 || offset + n < *file_info->file_size))
+                throw Exception(
+                    ErrorCodes::HTTP_RANGE_NOT_SATISFIABLE,
+                    "Expected 206 Partial Content, got {} when reading {} range [{}, {})",
+                    toString(response.getStatus()), uri_.toString(), offset, offset + n);
+
+            bool cancelled;
+            size_t r = copyFromIStreamWithProgressCallback(*result_istr, to, n, progress_callback, &cancelled);
+
+            return r;
+        }
+        catch (const Poco::Exception & e)
+        {
+            sess->attachSessionData(e.message());
+
+            LOG_ERROR(
+                log,
+                "HTTP request (positioned) to `{}` with range [{}, {}) failed at try {}/{}: {}",
+                uri_.toString(), offset, offset + n, attempt + 1, settings.http_max_tries,
+                e.what());
+
+            /// Decide whether to retry.
+
+            if (last_attempt)
+                throw;
+
+            /// Too many open files - non-retryable.
+            if (e.code() == POCO_EMFILE)
+                throw;
+
+            if (const auto * h = dynamic_cast<const HTTPException*>(&e);
+                h && !isRetriableError(static_cast<Poco::Net::HTTPResponse::HTTPStatus>(h->getHTTPStatus())))
+                throw;
+
+            sleepForMilliseconds(milliseconds_to_wait);
+            milliseconds_to_wait = std::min(milliseconds_to_wait * 2, settings.http_retry_max_backoff_ms);
+            continue;
+        }
+    }
 }
 
 template <typename UpdatableSessionPtr>
@@ -793,75 +886,6 @@ ReadWriteBufferFromHTTP::ReadWriteBufferFromHTTP(
         skip_not_found_url_,
         file_info_) {}
 
-RangedReadWriteBufferFromHTTPFactory::RangedReadWriteBufferFromHTTPFactory(
-    Poco::URI uri_,
-    std::string method_,
-    OutStreamCallback out_stream_callback_,
-    ConnectionTimeouts timeouts_,
-    const Poco::Net::HTTPBasicCredentials & credentials_,
-    UInt64 max_redirects_,
-    size_t buffer_size_,
-    ReadSettings settings_,
-    HTTPHeaderEntries http_header_entries_,
-    const RemoteHostFilter * remote_host_filter_,
-    bool delay_initialization_,
-    bool use_external_buffer_,
-    bool skip_not_found_url_)
-    : uri(uri_)
-    , method(std::move(method_))
-    , out_stream_callback(out_stream_callback_)
-    , timeouts(std::move(timeouts_))
-    , credentials(credentials_)
-    , max_redirects(max_redirects_)
-    , buffer_size(buffer_size_)
-    , settings(std::move(settings_))
-    , http_header_entries(std::move(http_header_entries_))
-    , remote_host_filter(remote_host_filter_)
-    , delay_initialization(delay_initialization_)
-    , use_external_buffer(use_external_buffer_)
-    , skip_not_found_url(skip_not_found_url_) {}
-
-std::unique_ptr<SeekableReadBuffer> RangedReadWriteBufferFromHTTPFactory::getReader()
-{
-    return std::make_unique<ReadWriteBufferFromHTTP>(
-        uri,
-        method,
-        out_stream_callback,
-        timeouts,
-        credentials,
-        max_redirects,
-        buffer_size,
-        settings,
-        http_header_entries,
-        remote_host_filter,
-        delay_initialization,
-        use_external_buffer,
-        skip_not_found_url,
-        file_info);
-}
-
-size_t RangedReadWriteBufferFromHTTPFactory::getFileSize()
-{
-    auto s = getFileInfo().file_size;
-    if (!s)
-        throw Exception(ErrorCodes::UNKNOWN_FILE_SIZE, "Cannot find out file size for: {}", uri.toString());
-    return *s;
-}
-
-bool RangedReadWriteBufferFromHTTPFactory::checkIfActuallySeekable()
-{
-    return getFileInfo().seekable;
-}
-
-HTTPFileInfo RangedReadWriteBufferFromHTTPFactory::getFileInfo()
-{
-    if (!file_info)
-        file_info = static_cast<ReadWriteBufferFromHTTP*>(getReader().get())->getFileInfo();
-    return *file_info;
-}
-
-String RangedReadWriteBufferFromHTTPFactory::getFileName() const { return uri.toString(); }
-
 
 PooledSessionFactory::PooledSessionFactory(
     const ConnectionTimeouts & timeouts_, size_t per_endpoint_pool_size_)
@@ -890,6 +914,7 @@ PooledReadWriteBufferFromHTTP::PooledReadWriteBufferFromHTTP(
         method_,
         out_stream_callback_,
         buffer_size_) {}
+
 
 template class UpdatableSession<SessionFactory>;
 template class UpdatableSession<PooledSessionFactory>;

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -42,6 +42,9 @@ public:
 
     void updateSession(const Poco::URI & uri);
 
+    /// Thread safe.
+    SessionPtr createDetachedSession(const Poco::URI & uri);
+
     std::shared_ptr<UpdatableSession<TSessionFactory>> clone(const Poco::URI & uri);
 
 private:
@@ -110,13 +113,15 @@ namespace detail
 
         bool withPartialContent(const HTTPRange & range) const;
 
-        size_t getRangeBegin() const;
-
         size_t getOffset() const;
+
+        void prepareRequest(Poco::Net::HTTPRequest & request, Poco::URI uri_, std::optional<HTTPRange> range) const;
 
         std::istream * callImpl(UpdatableSessionPtr & current_session, Poco::URI uri_, Poco::Net::HTTPResponse & response, const std::string & method_, bool for_object_info = false);
 
         size_t getFileSize() override;
+
+        bool supportsReadAt() override;
 
         bool checkIfActuallySeekable() override;
 
@@ -170,6 +175,8 @@ namespace detail
         void initialize();
 
         bool nextImpl() override;
+
+        size_t readBigAt(char * to, size_t n, size_t offset, const std::function<bool(size_t)> & progress_callback) override;
 
         off_t getPosition() override;
 
@@ -237,53 +244,6 @@ public:
         std::optional<HTTPFileInfo> file_info_ = std::nullopt);
 };
 
-class RangedReadWriteBufferFromHTTPFactory : public SeekableReadBufferFactory, public WithFileName
-{
-    using OutStreamCallback = ReadWriteBufferFromHTTP::OutStreamCallback;
-
-public:
-    RangedReadWriteBufferFromHTTPFactory(
-        Poco::URI uri_,
-        std::string method_,
-        OutStreamCallback out_stream_callback_,
-        ConnectionTimeouts timeouts_,
-        const Poco::Net::HTTPBasicCredentials & credentials_,
-        UInt64 max_redirects_ = 0,
-        size_t buffer_size_ = DBMS_DEFAULT_BUFFER_SIZE,
-        ReadSettings settings_ = {},
-        HTTPHeaderEntries http_header_entries_ = {},
-        const RemoteHostFilter * remote_host_filter_ = nullptr,
-        bool delay_initialization_ = true,
-        bool use_external_buffer_ = false,
-        bool skip_not_found_url_ = false);
-
-    std::unique_ptr<SeekableReadBuffer> getReader() override;
-
-    size_t getFileSize() override;
-
-    bool checkIfActuallySeekable() override;
-
-    HTTPFileInfo getFileInfo();
-
-    String getFileName() const override;
-
-private:
-    Poco::URI uri;
-    std::string method;
-    OutStreamCallback out_stream_callback;
-    ConnectionTimeouts timeouts;
-    const Poco::Net::HTTPBasicCredentials & credentials;
-    UInt64 max_redirects;
-    size_t buffer_size;
-    ReadSettings settings;
-    HTTPHeaderEntries http_header_entries;
-    const RemoteHostFilter * remote_host_filter;
-    std::optional<HTTPFileInfo> file_info;
-    bool delay_initialization;
-    bool use_external_buffer;
-    bool skip_not_found_url;
-};
-
 class PooledSessionFactory
 {
 public:
@@ -292,7 +252,9 @@ public:
 
     using SessionType = PooledHTTPSessionPtr;
 
+    /// Thread safe.
     SessionType buildNewSession(const Poco::URI & uri);
+
 private:
     ConnectionTimeouts timeouts;
     size_t per_endpoint_pool_size;
@@ -314,6 +276,7 @@ public:
         const UInt64 max_redirects = 0,
         size_t max_connections_per_endpoint = DEFAULT_COUNT_OF_HTTP_CONNECTIONS_PER_ENDPOINT);
 };
+
 
 extern template class UpdatableSession<SessionFactory>;
 extern template class UpdatableSession<PooledSessionFactory>;

--- a/src/IO/SeekableReadBuffer.cpp
+++ b/src/IO/SeekableReadBuffer.cpp
@@ -3,6 +3,10 @@
 
 namespace DB
 {
+namespace ErrorCodes
+{
+    extern const int CANNOT_READ_FROM_ISTREAM;
+}
 
 namespace
 {
@@ -58,6 +62,48 @@ std::unique_ptr<SeekableReadBuffer> wrapSeekableReadBufferReference(SeekableRead
 std::unique_ptr<SeekableReadBuffer> wrapSeekableReadBufferPointer(SeekableReadBufferPtr ptr)
 {
     return std::make_unique<SeekableReadBufferWrapper<SeekableReadBufferPtr>>(*ptr, SeekableReadBufferPtr{ptr});
+}
+
+size_t copyFromIStreamWithProgressCallback(std::istream & istr, char * to, size_t n, const std::function<bool(size_t)> & progress_callback, bool * out_cancelled)
+{
+    const size_t chunk = DBMS_DEFAULT_BUFFER_SIZE;
+    if (out_cancelled)
+        *out_cancelled = false;
+
+    size_t copied = 0;
+    while (copied < n)
+    {
+        size_t to_copy = std::min(chunk, n - copied);
+        istr.read(to + copied, to_copy);
+        size_t gcount = istr.gcount();
+
+        copied += gcount;
+
+        bool cancelled = false;
+        if (gcount && progress_callback)
+            cancelled = progress_callback(copied);
+
+        if (gcount != to_copy)
+        {
+            if (!istr.eof())
+                throw Exception(
+                    ErrorCodes::CANNOT_READ_FROM_ISTREAM,
+                    "{} at offset {}",
+                    istr.fail() ? "Cannot read from istream" : "Unexpected state of istream",
+                    copied);
+
+            break;
+        }
+
+        if (cancelled)
+        {
+            if (out_cancelled != nullptr)
+                *out_cancelled = true;
+            break;
+        }
+    }
+
+    return copied;
 }
 
 }

--- a/src/IO/SeekableReadBuffer.h
+++ b/src/IO/SeekableReadBuffer.h
@@ -59,39 +59,41 @@ public:
     ///  * Sometimes when we create such buffer we don't know in advance whether we'll need it to be
     ///    seekable or not. So we don't want to pay the price for this check in advance.
     virtual bool checkIfActuallySeekable() { return true; }
+
+    /// Unbuffered positional read.
+    /// Doesn't affect the buffer state (position, working_buffer, etc).
+    ///
+    /// `progress_callback` may be called periodically during the read, reporting that to[0..m-1]
+    /// has been filled. If it returns true, reading is stopped, and readBigAt() returns bytes read
+    /// so far. Called only from inside readBigAt(), from the same thread, with increasing m.
+    ///
+    /// Stops either after n bytes, or at end of file, or on exception. Returns number of bytes read.
+    /// If offset is past the end of file, may return 0 or throw exception.
+    ///
+    /// Caller needs to be careful:
+    ///  * supportsReadAt() must be checked (called and return true) before calling readBigAt().
+    ///    Otherwise readBigAt() may crash.
+    ///  * Thread safety: multiple readBigAt() calls may be performed in parallel.
+    ///    But readBigAt() may not be called in parallel with any other methods
+    ///    (e.g. next() or supportsReadAt()).
+    ///  * Performance: there's no buffering. Each readBigAt() call typically translates into actual
+    ///    IO operation (e.g. HTTP request). Don't use it for small adjacent reads.
+    virtual size_t readBigAt(char * /*to*/, size_t /*n*/, size_t /*offset*/, const std::function<bool(size_t m)> & /*progress_callback*/ = nullptr)
+        { throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method readBigAt() not implemented"); }
+
+    /// Checks if readBigAt() is allowed. May be slow, may throw (e.g. it may do an HTTP request or an fstat).
+    virtual bool supportsReadAt() { return false; }
 };
 
-/// Useful for reading in parallel.
-/// The created read buffers may outlive the factory.
-///
-/// There are 2 ways to use this:
-///  (1) Never call seek() or getFileSize(), read the file sequentially.
-///      For HTTP, this usually translates to just one HTTP request.
-///  (2) Call checkIfActuallySeekable(), then:
-///       a. If it returned false, go to (1). seek() and getFileSize() are not available (throw if called).
-///       b. If it returned true, seek() and getFileSize() are available, knock yourself out.
-///      For HTTP, checkIfActuallySeekable() sends a HEAD request and returns false if the web server
-///      doesn't support ranges (or doesn't support HEAD requests).
-class SeekableReadBufferFactory : public WithFileSize
-{
-public:
-    ~SeekableReadBufferFactory() override = default;
-
-    // We usually call setReadUntilPosition() and seek() on the returned buffer before reading.
-    // So it's recommended that the returned implementation be lazy, i.e. don't start reading
-    // before the first call to nextImpl().
-    virtual std::unique_ptr<SeekableReadBuffer> getReader() = 0;
-
-    virtual bool checkIfActuallySeekable() { return true; }
-};
 
 using SeekableReadBufferPtr = std::shared_ptr<SeekableReadBuffer>;
-
-using SeekableReadBufferFactoryPtr = std::unique_ptr<SeekableReadBufferFactory>;
 
 /// Wraps a reference to a SeekableReadBuffer into an unique pointer to SeekableReadBuffer.
 /// This function is like wrapReadBufferReference() but for SeekableReadBuffer.
 std::unique_ptr<SeekableReadBuffer> wrapSeekableReadBufferReference(SeekableReadBuffer & ref);
 std::unique_ptr<SeekableReadBuffer> wrapSeekableReadBufferPointer(SeekableReadBufferPtr ptr);
+
+/// Helper for implementing readBigAt().
+size_t copyFromIStreamWithProgressCallback(std::istream & istr, char * to, size_t n, const std::function<bool(size_t)> & progress_callback, bool * out_cancelled = nullptr);
 
 }

--- a/src/IO/WithFileName.cpp
+++ b/src/IO/WithFileName.cpp
@@ -19,7 +19,7 @@ String getFileNameFromReadBuffer(const ReadBuffer & in)
     if (const auto * compressed = dynamic_cast<const CompressedReadBufferWrapper *>(&in))
         return getFileName(compressed->getWrappedReadBuffer());
     else if (const auto * parallel = dynamic_cast<const ParallelReadBuffer *>(&in))
-        return getFileName(parallel->getReadBufferFactory());
+        return getFileName(parallel->getReadBuffer());
     else if (const auto * peekable = dynamic_cast<const PeekableReadBuffer *>(&in))
         return getFileNameFromReadBuffer(peekable->getSubBuffer());
     else

--- a/src/IO/WithFileSize.cpp
+++ b/src/IO/WithFileSize.cpp
@@ -33,10 +33,6 @@ size_t getFileSizeFromReadBuffer(ReadBuffer & in)
     {
         return getFileSize(compressed->getWrappedReadBuffer());
     }
-    else if (auto * parallel = dynamic_cast<ParallelReadBuffer *>(&in))
-    {
-        return getFileSize(parallel->getReadBufferFactory());
-    }
 
     return getFileSize(in);
 }
@@ -50,10 +46,6 @@ bool isBufferWithFileSize(const ReadBuffer & in)
     else if (const auto * compressed = dynamic_cast<const CompressedReadBufferWrapper *>(&in))
     {
         return isBufferWithFileSize(compressed->getWrappedReadBuffer());
-    }
-    else if (const auto * parallel = dynamic_cast<const ParallelReadBuffer *>(&in))
-    {
-        return dynamic_cast<const WithFileSize *>(&parallel->getReadBufferFactory()) != nullptr;
     }
 
     return dynamic_cast<const WithFileSize *>(&in) != nullptr;

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.h
@@ -15,7 +15,6 @@ namespace DB
 {
 
 class ArrowColumnToCHColumn;
-class SeekableReadBufferFactory;
 
 // Parquet files contain a metadata block with the following information:
 //  * list of columns,
@@ -48,9 +47,7 @@ class ParquetBlockInputFormat : public IInputFormat
 {
 public:
     ParquetBlockInputFormat(
-        // exactly one of these two is nullptr
-        ReadBuffer * buf,
-        std::unique_ptr<SeekableReadBufferFactory> buf_factory,
+        ReadBuffer & buf,
         const Block & header,
         const FormatSettings & format_settings,
         size_t max_decoding_threads,
@@ -234,7 +231,6 @@ private:
         };
     };
 
-    std::unique_ptr<SeekableReadBufferFactory> buf_factory;
     const FormatSettings format_settings;
     const std::unordered_set<int> & skip_row_groups;
     size_t max_decoding_threads;

--- a/src/Storages/StorageS3.cpp
+++ b/src/Storages/StorageS3.cpp
@@ -575,31 +575,11 @@ StorageS3Source::ReaderHolder StorageS3Source::createReader()
     size_t object_size = info ? info->size : S3::getObjectSize(*client, bucket, current_key, version_id, request_settings);
     auto compression_method = chooseCompressionMethod(current_key, compression_hint);
 
-    InputFormatPtr input_format;
-    std::unique_ptr<ReadBuffer> owned_read_buf;
-
-    auto read_buf_or_factory = createS3ReadBuffer(current_key, object_size);
-    if (read_buf_or_factory.buf_factory)
-    {
-        input_format = FormatFactory::instance().getInputRandomAccess(
-            format,
-            std::move(read_buf_or_factory.buf_factory),
-            sample_block,
-            getContext(),
-            max_block_size,
-            /* is_remote_fs */ true,
-            compression_method,
-            format_settings);
-    }
-    else
-    {
-        owned_read_buf = wrapReadBufferWithCompressionMethod(
-            std::move(read_buf_or_factory.buf),
-            compression_method,
-            static_cast<int>(getContext()->getSettingsRef().zstd_window_log_max));
-        input_format = FormatFactory::instance().getInput(
-            format, *owned_read_buf, sample_block, getContext(), max_block_size, format_settings);
-    }
+    auto read_buf = createS3ReadBuffer(current_key, object_size);
+    auto input_format = FormatFactory::instance().getInput(
+            format, *read_buf, sample_block, getContext(), max_block_size,
+            format_settings, std::nullopt, std::nullopt,
+            /* is_remote_fs */ true, compression_method);
 
     QueryPipelineBuilder builder;
     builder.init(Pipe(input_format));
@@ -614,7 +594,7 @@ StorageS3Source::ReaderHolder StorageS3Source::createReader()
     auto pipeline = std::make_unique<QueryPipeline>(QueryPipelineBuilder::getPipeline(std::move(builder)));
     auto current_reader = std::make_unique<PullingPipelineExecutor>(*pipeline);
 
-    return ReaderHolder{fs::path(bucket) / current_key, std::move(owned_read_buf), std::move(pipeline), std::move(current_reader)};
+    return ReaderHolder{fs::path(bucket) / current_key, std::move(read_buf), std::move(pipeline), std::move(current_reader)};
 }
 
 std::future<StorageS3Source::ReaderHolder> StorageS3Source::createReaderAsync()
@@ -622,7 +602,7 @@ std::future<StorageS3Source::ReaderHolder> StorageS3Source::createReaderAsync()
     return create_reader_scheduler([this] { return createReader(); }, Priority{});
 }
 
-StorageS3Source::ReadBufferOrFactory StorageS3Source::createS3ReadBuffer(const String & key, size_t object_size)
+std::unique_ptr<ReadBuffer> StorageS3Source::createS3ReadBuffer(const String & key, size_t object_size)
 {
     auto read_settings = getContext()->getReadSettings().adjustBufferSize(object_size);
     read_settings.enable_filesystem_cache = false;
@@ -635,12 +615,13 @@ StorageS3Source::ReadBufferOrFactory StorageS3Source::createS3ReadBuffer(const S
     if (object_too_small && read_settings.remote_fs_method == RemoteFSReadMethod::threadpool)
     {
         LOG_TRACE(log, "Downloading object of size {} from S3 with initial prefetch", object_size);
-        return {.buf = createAsyncS3ReadBuffer(key, read_settings, object_size)};
+        return createAsyncS3ReadBuffer(key, read_settings, object_size);
     }
 
-    auto factory = std::make_unique<ReadBufferS3Factory>(
-        client, bucket, key, version_id, object_size, request_settings, read_settings);
-    return {.buf_factory = std::move(factory)};
+    return std::make_unique<ReadBufferFromS3>(
+        client, bucket, key, version_id, request_settings, read_settings,
+        /*use_external_buffer*/ false, /*offset_*/ 0, /*read_until_position_*/ 0,
+        /*restricted_seek_*/ false, object_size);
 }
 
 std::unique_ptr<ReadBuffer> StorageS3Source::createAsyncS3ReadBuffer(

--- a/src/Storages/StorageS3.h
+++ b/src/Storages/StorageS3.h
@@ -204,12 +204,6 @@ private:
         std::unique_ptr<PullingPipelineExecutor> reader;
     };
 
-    struct ReadBufferOrFactory
-    {
-        std::unique_ptr<ReadBuffer> buf;
-        SeekableReadBufferFactoryPtr buf_factory;
-    };
-
     ReaderHolder reader;
 
     std::vector<NameAndTypePair> requested_virtual_columns;
@@ -230,7 +224,7 @@ private:
     ReaderHolder createReader();
     std::future<ReaderHolder> createReaderAsync();
 
-    ReadBufferOrFactory createS3ReadBuffer(const String & key, size_t object_size);
+    std::unique_ptr<ReadBuffer> createS3ReadBuffer(const String & key, size_t object_size);
     std::unique_ptr<ReadBuffer> createAsyncS3ReadBuffer(const String & key, const ReadSettings & read_settings, size_t object_size);
 };
 

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -248,7 +248,7 @@ StorageURLSource::StorageURLSource(
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Got empty url list");
 
         auto first_option = uri_options.begin();
-        auto [actual_uri, buf_factory] = getFirstAvailableURIAndReadBuffer(
+        auto [actual_uri, buf] = getFirstAvailableURIAndReadBuffer(
             first_option,
             uri_options.end(),
             context,
@@ -262,10 +262,11 @@ StorageURLSource::StorageURLSource(
             uri_options.size() == 1);
 
         curr_uri = actual_uri;
+        read_buf = std::move(buf);
 
         try
         {
-            total_size += buf_factory->getFileSize();
+            total_size += getFileSizeFromReadBuffer(*read_buf);
         }
         catch (...)
         {
@@ -273,16 +274,17 @@ StorageURLSource::StorageURLSource(
         }
 
         // TODO: Pass max_parsing_threads and max_download_threads adjusted for num_streams.
-        auto input_format = FormatFactory::instance().getInputRandomAccess(
+        auto input_format = FormatFactory::instance().getInput(
             format,
-            std::move(buf_factory),
+            *read_buf,
             sample_block,
             context,
             max_block_size,
-            /* is_remote_fs */ true,
-            compression_method,
             format_settings,
-            download_threads);
+            download_threads,
+            /*max_download_threads*/ std::nullopt,
+            /* is_remote_fs */ true,
+            compression_method);
 
         QueryPipelineBuilder builder;
         builder.init(Pipe(input_format));
@@ -348,7 +350,7 @@ Chunk StorageURLSource::generate()
     return {};
 }
 
-std::tuple<Poco::URI, SeekableReadBufferFactoryPtr> StorageURLSource::getFirstAvailableURIAndReadBuffer(
+std::tuple<Poco::URI, std::unique_ptr<ReadWriteBufferFromHTTP>> StorageURLSource::getFirstAvailableURIAndReadBuffer(
     std::vector<String>::const_iterator & option,
     const std::vector<String>::const_iterator & end,
     ContextPtr context,
@@ -376,40 +378,38 @@ std::tuple<Poco::URI, SeekableReadBufferFactoryPtr> StorageURLSource::getFirstAv
         setCredentials(credentials, request_uri);
 
         const auto settings = context->getSettings();
-        auto res = std::make_unique<RangedReadWriteBufferFromHTTPFactory>(
-            request_uri,
-            http_method,
-            callback,
-            timeouts,
-            credentials,
-            settings.max_http_get_redirects,
-            settings.max_read_buffer_size,
-            read_settings,
-            headers,
-            &context->getRemoteHostFilter(),
-            delay_initialization,
-            /* use_external_buffer */ false,
-            /* skip_url_not_found_error */ skip_url_not_found_error);
 
-        if (options > 1)
+        try
         {
-            // Send a HEAD request to check availability.
-            try
-            {
-                res->getFileInfo();
-            }
-            catch (...)
-            {
-                if (first_exception_message.empty())
-                    first_exception_message = getCurrentExceptionMessage(false);
+            auto res = std::make_unique<ReadWriteBufferFromHTTP>(
+                request_uri,
+                http_method,
+                callback,
+                timeouts,
+                credentials,
+                settings.max_http_get_redirects,
+                settings.max_read_buffer_size,
+                read_settings,
+                headers,
+                &context->getRemoteHostFilter(),
+                delay_initialization,
+                /* use_external_buffer */ false,
+                /* skip_url_not_found_error */ skip_url_not_found_error);
 
-                tryLogCurrentException(__PRETTY_FUNCTION__);
-
-                continue;
-            }
+            return std::make_tuple(request_uri, std::move(res));
         }
+        catch (...)
+        {
+            if (options == 1)
+                throw;
 
-        return std::make_tuple(request_uri, std::move(res));
+            if (first_exception_message.empty())
+                first_exception_message = getCurrentExceptionMessage(false);
+
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+
+            continue;
+        }
     }
 
     throw Exception(ErrorCodes::NETWORK_ERROR, "All uri ({}) options are unreachable: {}", options, first_exception_message);
@@ -598,7 +598,7 @@ ColumnsDescription IStorageURLBase::getTableStructureFromData(
         if (it == urls_to_check.cend())
             return nullptr;
 
-        auto [_, buf_factory] = StorageURLSource::getFirstAvailableURIAndReadBuffer(
+        auto [_, buf] = StorageURLSource::getFirstAvailableURIAndReadBuffer(
             it,
             urls_to_check.cend(),
             context,
@@ -612,7 +612,7 @@ ColumnsDescription IStorageURLBase::getTableStructureFromData(
             false);
         ++it;
         return wrapReadBufferWithCompressionMethod(
-            buf_factory->getReader(),
+            std::move(buf),
             compression_method,
             static_cast<int>(context->getSettingsRef().zstd_window_log_max));
     };

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -183,7 +183,7 @@ public:
 
     static Block getHeader(Block sample_block, const std::vector<NameAndTypePair> & requested_virtual_columns);
 
-    static std::tuple<Poco::URI, SeekableReadBufferFactoryPtr> getFirstAvailableURIAndReadBuffer(
+    static std::tuple<Poco::URI, std::unique_ptr<ReadWriteBufferFromHTTP>> getFirstAvailableURIAndReadBuffer(
         std::vector<String>::const_iterator & option,
         const std::vector<String>::const_iterator & end,
         ContextPtr context,
@@ -205,6 +205,7 @@ private:
     std::shared_ptr<IteratorWrapper> uri_iterator;
     Poco::URI curr_uri;
 
+    std::unique_ptr<ReadBuffer> read_buf;
     std::unique_ptr<QueryPipeline> pipeline;
     std::unique_ptr<PullingPipelineExecutor> reader;
 

--- a/tests/integration/test_redirect_url_storage/test.py
+++ b/tests/integration/test_redirect_url_storage/test.py
@@ -151,7 +151,7 @@ def test_url_reconnect(started_cluster):
             result = node1.query(
                 "select sum(cityHash64(id)) from url('http://hdfs1:50075/webhdfs/v1/storage_big?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV', 'id Int32') settings http_max_tries = 10, http_retry_max_backoff_ms=1000"
             )
-            assert (int(result), 6581218782194912115)
+            assert int(result) == 6581218782194912115
 
         thread = threading.Thread(target=select)
         thread.start()
@@ -161,5 +161,5 @@ def test_url_reconnect(started_cluster):
 
         thread.join()
 
-        assert (int(result), 6581218782194912115)
+        assert int(result) == 6581218782194912115
         assert node1.contains_in_log("Timeout: connect timed out")


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
* Better performance when reading local Parquet files (through parallel reading).

Parquet's parallel random reads from local file are now actually parallel (pread() calls or memcpy from mmap), instead of locking two mutexes for no reason.

In https://github.com/ClickHouse/ClickHouse/pull/47964 I refactored things to use SeekableReadBufferFactory in more places, as *the* abstraction for random-access "files" (local/http/s3). I think that was a mistake. This PR re-refactors everything in the opposite direction: it adds a thread-safe positioned-read method in SeekableReadBuffer and uses it whenever parallel random reading is needed (ParallelReadBuffer and ParquetBlockInputFormat). This turned out better than the factory stuff, I think: less (?) code, fewer boilerplate objects, less useless extra cpu work (like maintaining a pool of ReadBuffers to reuse), less awkward code like `if`s everywhere for buffer vs factory. The factory is removed altogether.

Also fixed a confusing error message when getting HTTP 404 error: it used to say "Not a Parquet file" because asArrowFileLoadIntoMemory() was catching exceptions too eagerly.