### PR TITLE
Add HTTP session reuse within a single ReadWriteBufferFromHTTP

### DIFF
--- a/src/IO/HTTPCommon.cpp
+++ b/src/IO/HTTPCommon.cpp
@@ -90,7 +90,6 @@ namespace
 
         ProfileEvents::increment(ProfileEvents::CreatedHTTPConnections);
 
-        /// doesn't work properly without patch
         session->setKeepAlive(keep_alive);
         return session;
     }

--- a/src/IO/HTTPCommon.h
+++ b/src/IO/HTTPCommon.h
@@ -59,10 +59,15 @@ using HTTPSessionPtr = std::shared_ptr<Poco::Net::HTTPClientSession>;
 /// All pooled sessions don't have this tag attached after being taken from a pool.
 /// If the request and the response were fully written/read, the client code should add this tag
 /// explicitly by calling `markSessionForReuse()`.
+/// Note that HTTP response may contain extra bytes after the last byte of the payload. Specifically,
+/// when chunked encoding is used, there's an empty chunk at the end. Those extra bytes must also be
+/// read before the session can be reused.  So we usually put an `istr->ignore(INT64_MAX)` call
+/// before `markSessionForReuse()`.
 struct HTTPSessionReuseTag
 {
 };
 
+void markSessionForReuse(Poco::Net::HTTPSession & session);
 void markSessionForReuse(HTTPSessionPtr session);
 void markSessionForReuse(PooledHTTPSessionPtr session);
 

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -1,4 +1,4 @@
-#include "ReadWriteBufferFromHTTP.h"
+#include <IO/ReadWriteBufferFromHTTP.h>
 
 #include <IO/HTTPCommon.h>
 
@@ -23,20 +23,21 @@ namespace ErrorCodes
 
 template <typename TSessionFactory>
 UpdatableSession<TSessionFactory>::UpdatableSession(const Poco::URI & uri, UInt64 max_redirects_, std::shared_ptr<TSessionFactory> session_factory_)
-    : max_redirects{max_redirects_}
+    : session_factory(std::move(session_factory_))
+    , max_redirects{max_redirects_}
     , initial_uri(uri)
-    , session_factory(std::move(session_factory_))
 {
     session = session_factory->buildNewSession(uri);
 }
 
 template <typename TSessionFactory>
-typename UpdatableSession<TSessionFactory>::SessionPtr UpdatableSession<TSessionFactory>::getSession() { return session; }
+typename UpdatableSession<TSessionFactory>::SessionPtr & UpdatableSession<TSessionFactory>::getSession() { return session; }
 
 template <typename TSessionFactory>
 void UpdatableSession<TSessionFactory>::updateSession(const Poco::URI & uri)
 {
     ++redirects;
+    session = {};
     if (redirects <= max_redirects)
         session = session_factory->buildNewSession(uri);
     else
@@ -363,6 +364,11 @@ void ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::call(UpdatableSessionPtr 
     }
 }
 
+/**
+ * Throws if error is retryable, otherwise sets initialization_error = NON_RETRYABLE_ERROR and
+ * saves exception into `exception` variable. In case url is not found and skip_not_found_url == true,
+ * sets initialization_error = SKIP_NOT_FOUND_URL, otherwise throws.
+ */
 template <typename UpdatableSessionPtr>
 void ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::initialize()
 {
@@ -441,8 +447,9 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
     if ((read_range.end && getOffset() > read_range.end.value()) ||
         (file_info && file_info->file_size && getOffset() >= file_info->file_size.value()))
     {
+        impl->tryIgnore(UINT64_MAX);
         /// Response was fully read.
-        markSessionForReuse(session->getSession());
+        markSessionForReuse(*session->getSession());
         ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPPreservedSessions);
         return false;
     }
@@ -472,8 +479,8 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
     {
         retry_with_range_header = true;
         impl.reset();
-        auto http_session = session->getSession();
-        http_session->reset();
+        if (session)
+            session->getSession()->reset();
         if (!last_attempt)
         {
             sleepForMilliseconds(milliseconds_to_wait);
@@ -569,7 +576,7 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
     if (!result)
     {
         /// Eof is reached, i.e response was fully read.
-        markSessionForReuse(session->getSession());
+        markSessionForReuse(*session->getSession());
         ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPPreservedSessions);
         return false;
     }
@@ -627,8 +634,9 @@ size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::readBigAt(char * to, si
 
             if (!cancelled)
             {
+                result_istr->ignore(INT64_MAX);
                 /// Response was fully read.
-                markSessionForReuse(sess);
+                markSessionForReuse(*sess);
                 ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPPreservedSessions);
             }
 
@@ -843,19 +851,58 @@ HTTPFileInfo ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::parseFileInfo(con
 
 }
 
-SessionFactory::SessionFactory(const ConnectionTimeouts & timeouts_)
+
+LocallyPooledSessionFactory::LocallyPooledSessionFactory(const ConnectionTimeouts & timeouts_)
     : timeouts(timeouts_) {}
 
-SessionFactory::SessionType SessionFactory::buildNewSession(const Poco::URI & uri)
+LocallyPooledSessionFactory::SessionType LocallyPooledSessionFactory::buildNewSession(const Poco::URI & uri)
 {
-    return makeHTTPSession(uri, timeouts);
+    {
+        std::unique_lock lock(mutex);
+
+        if (uri != current_uri)
+        {
+            available.clear();
+            current_uri = uri;
+        }
+
+        if (!available.empty())
+        {
+            auto s = std::move(available.back());
+            available.pop_back();
+            return EntryPtr { .e = std::make_shared<Entry>(this, current_uri, s) };
+        }
+    }
+
+    auto s = makeHTTPSession(uri, timeouts);
+    s->setKeepAlive(true);
+    return EntryPtr { .e = std::make_shared<Entry>(this, uri, s) };
 }
+
+void LocallyPooledSessionFactory::returnSessionToPool(HTTPSessionPtr s, Poco::URI uri)
+{
+    std::unique_lock lock(mutex);
+
+    if (uri != current_uri)
+        return;
+
+    const auto & session_data = s->sessionData();
+    if (session_data.empty() || !Poco::AnyCast<HTTPSessionReuseTag>(&session_data))
+    {
+        LOG_TRACE(&Poco::Logger::get("LocallyPooledSessionFactory"),
+            "Not reusing session for {}", uri.toString());
+        return;
+    }
+
+    available.push_back(std::move(s));
+}
+
 
 ReadWriteBufferFromHTTP::ReadWriteBufferFromHTTP(
     Poco::URI uri_,
     const std::string & method_,
     OutStreamCallback out_stream_callback_,
-    const ConnectionTimeouts & timeouts,
+    const ConnectionTimeouts & timeouts_,
     const Poco::Net::HTTPBasicCredentials & credentials_,
     const UInt64 max_redirects,
     size_t buffer_size_,
@@ -866,8 +913,8 @@ ReadWriteBufferFromHTTP::ReadWriteBufferFromHTTP(
     bool use_external_buffer_,
     bool skip_not_found_url_,
     std::optional<HTTPFileInfo> file_info_)
-    : Parent(
-        std::make_shared<SessionType>(uri_, max_redirects, std::make_shared<SessionFactory>(timeouts)),
+    : detail::ReadWriteBufferFromHTTPBase<std::shared_ptr<SessionType>>(
+        std::make_shared<SessionType>(uri_, max_redirects, std::make_shared<LocallyPooledSessionFactory>(timeouts_)),
         uri_,
         credentials_,
         method_,
@@ -911,9 +958,9 @@ PooledReadWriteBufferFromHTTP::PooledReadWriteBufferFromHTTP(
         buffer_size_) {}
 
 
-template class UpdatableSession<SessionFactory>;
+template class UpdatableSession<LocallyPooledSessionFactory>;
 template class UpdatableSession<PooledSessionFactory>;
-template class detail::ReadWriteBufferFromHTTPBase<std::shared_ptr<UpdatableSession<SessionFactory>>>;
+template class detail::ReadWriteBufferFromHTTPBase<std::shared_ptr<UpdatableSession<LocallyPooledSessionFactory>>>;
 template class detail::ReadWriteBufferFromHTTPBase<std::shared_ptr<UpdatableSession<PooledSessionFactory>>>;
 
 }

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -943,10 +943,12 @@ private:
                 Poco::JSON::Parser parser;
                 auto json_body = parser.parse(*response_body).extract<Poco::JSON::Object::Ptr>();
 
+                response_body->ignore(INT64_MAX);
                 /// Response was fully read.
                 markSessionForReuse(session);
 
                 auto schema = json_body->getValue<std::string>("schema");
+
                 LOG_TRACE((&Poco::Logger::get("AvroConfluentRowInputFormat")), "Successfully fetched schema id = {}\n{}", id, schema);
                 return avro::compileJsonSchemaFromString(schema);
             }


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
 * Better performance of url() table function in any format (through connection pooling).

Added some limited HTTP session pooling for StorageURL. Sessions are now reused by all (non-concurrent) read operations on the same ReadBuffer. This makes `SELECT count(*)` from remote (different region) parquet files 2.5x faster!

Inverted how `attachSessionData()` is used for marking whether HTTP sessions can be reused. Sessions were considered reusable by default, and ReadWriteBufferFromHTTP had to mark them as non-reusable on any error. It was missing some cases because there are lots of them. This PR flips it - the sessions are not reusable unless marked as reusable, which ReadWriteBufferFromHTTP does after receiving full response successfully. It seems silly that any of this needs to be done at all, instead of HTTPClientSession doing this tracking internally; but this was less work than changing HTTPClientSession.

We should add similar pooling for StorageS3, but that'll take more work: there's no simple way to attach the pool to a ReadBufferFromS3 instance, so it's either a global pool (with more care for eviction policy and correctness) or some hacks to indirectly pass a pool pointer to PocoHTTPClient.