### PR TITLE
Fix http_skip_not_found_url with compressed files

### DIFF
--- a/src/IO/HTTPCommon.cpp
+++ b/src/IO/HTTPCommon.cpp
@@ -90,7 +90,6 @@ namespace
 
         ProfileEvents::increment(ProfileEvents::CreatedHTTPConnections);
 
-        /// doesn't work properly without patch
         session->setKeepAlive(keep_alive);
         return session;
     }

--- a/src/IO/HTTPCommon.h
+++ b/src/IO/HTTPCommon.h
@@ -59,10 +59,15 @@ using HTTPSessionPtr = std::shared_ptr<Poco::Net::HTTPClientSession>;
 /// All pooled sessions don't have this tag attached after being taken from a pool.
 /// If the request and the response were fully written/read, the client code should add this tag
 /// explicitly by calling `markSessionForReuse()`.
+/// Note that HTTP response may contain extra bytes after the last byte of the payload. Specifically,
+/// when chunked encoding is used, there's an empty chunk at the end. Those extra bytes must also be
+/// read before the session can be reused.  So we usually put an `istr->ignore(INT64_MAX)` call
+/// before `markSessionForReuse()`.
 struct HTTPSessionReuseTag
 {
 };
 
+void markSessionForReuse(Poco::Net::HTTPSession & session);
 void markSessionForReuse(HTTPSessionPtr session);
 void markSessionForReuse(PooledHTTPSessionPtr session);
 

--- a/src/IO/ReadWriteBufferFromHTTP.cpp
+++ b/src/IO/ReadWriteBufferFromHTTP.cpp
@@ -147,7 +147,7 @@ std::istream * ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::callImpl(
     Poco::Net::HTTPRequest request(method_, uri_.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
     prepareRequest(request, uri_, range);
 
-    LOG_TRACE(log, "Sending request to {}", uri_.toString());
+    LOG_TRACE(log, "Sending {} to {}", method_, uri_.toString());
 
     auto sess = current_session->getSession();
     auto & stream_out = sess->sendRequest(request);
@@ -169,11 +169,9 @@ std::istream * ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::callImpl(
 template <typename UpdatableSessionPtr>
 size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getFileSize()
 {
-    if (!file_info)
-        file_info = getFileInfo();
-
-    if (file_info->file_size)
-        return *file_info->file_size;
+    auto result = getFileInfo().file_size;
+    if (result)
+        return *result;
 
     throw Exception(ErrorCodes::UNKNOWN_FILE_SIZE, "Cannot find out file size for: {}", uri.toString());
 }
@@ -181,17 +179,13 @@ size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getFileSize()
 template <typename UpdatableSessionPtr>
 bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::supportsReadAt()
 {
-    if (!file_info)
-        file_info = getFileInfo();
-    return method == Poco::Net::HTTPRequest::HTTP_GET && file_info->seekable;
+    return method == Poco::Net::HTTPRequest::HTTP_GET && getFileInfo().seekable;
 }
 
 template <typename UpdatableSessionPtr>
 bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::checkIfActuallySeekable()
 {
-    if (!file_info)
-        file_info = getFileInfo();
-    return file_info->seekable;
+    return getFileInfo().seekable;
 }
 
 template <typename UpdatableSessionPtr>
@@ -245,7 +239,6 @@ ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::ReadWriteBufferFromHTTPBase(
     const RemoteHostFilter * remote_host_filter_,
     bool delay_initialization,
     bool use_external_buffer_,
-    bool http_skip_not_found_url_,
     std::optional<HTTPFileInfo> file_info_)
     : SeekableReadBuffer(nullptr, 0)
     , uri {uri_}
@@ -258,7 +251,6 @@ ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::ReadWriteBufferFromHTTPBase(
     , buffer_size {buffer_size_}
     , use_external_buffer {use_external_buffer_}
     , file_info(file_info_)
-    , http_skip_not_found_url(http_skip_not_found_url_)
     , settings {settings_}
     , log(&Poco::Logger::get("ReadWriteBufferFromHTTP"))
 {
@@ -348,27 +340,14 @@ void ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::call(UpdatableSessionPtr 
 
         auto http_status = response.getStatus();
 
-        if (http_status == Poco::Net::HTTPResponse::HTTPStatus::HTTP_NOT_FOUND && http_skip_not_found_url)
-        {
-            initialization_error = InitializeError::SKIP_NOT_FOUND_URL;
-        }
-        else if (!isRetriableError(http_status))
-        {
-            initialization_error = InitializeError::NON_RETRYABLE_ERROR;
-            exception = std::current_exception();
-        }
-        else
-        {
+        if (isRetriableError(http_status))
             throw;
-        }
+
+        initialization_error = InitializeError::NON_RETRYABLE_ERROR;
+        exception = std::current_exception();
     }
 }
 
-/**
- * Throws if error is retryable, otherwise sets initialization_error = NON_RETRYABLE_ERROR and
- * saves exception into `exception` variable. In case url is not found and skip_not_found_url == true,
- * sets initialization_error = SKIP_NOT_FOUND_URL, otherwise throws.
- */
 template <typename UpdatableSessionPtr>
 void ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::initialize()
 {
@@ -437,8 +416,6 @@ void ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::initialize()
 template <typename UpdatableSessionPtr>
 bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
 {
-    if (initialization_error == InitializeError::SKIP_NOT_FOUND_URL)
-        return false;
     assert(initialization_error == InitializeError::NONE);
 
     if (next_callback)
@@ -447,10 +424,14 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
     if ((read_range.end && getOffset() > read_range.end.value()) ||
         (file_info && file_info->file_size && getOffset() >= file_info->file_size.value()))
     {
-        impl->tryIgnore(UINT64_MAX);
-        /// Response was fully read.
-        markSessionForReuse(*session->getSession());
-        ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPPreservedSessions);
+        if (impl)
+        {
+            impl->tryIgnore(UINT64_MAX);
+            /// Response was fully read.
+            markSessionForReuse(*session->getSession());
+            ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPPreservedSessions);
+        }
+
         return false;
     }
 
@@ -507,10 +488,6 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
                     assert(exception);
                     break;
                 }
-                else if (initialization_error == InitializeError::SKIP_NOT_FOUND_URL)
-                {
-                    return false;
-                }
                 else if (initialization_error == InitializeError::RETRYABLE_ERROR)
                 {
                     LOG_ERROR(
@@ -545,8 +522,8 @@ bool ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::nextImpl()
                 throw;
 
             /** Retry request unconditionally if nothing has been read yet.
-                    * Otherwise if it is GET method retry with range header.
-                    */
+              * Otherwise if it is GET method retry with range header.
+              */
             bool can_retry_request = !offset_from_begin_pos || method == Poco::Net::HTTPRequest::HTTP_GET;
             if (!can_retry_request)
                 throw;
@@ -609,7 +586,7 @@ size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::readBigAt(char * to, si
         Poco::Net::HTTPRequest request(method, uri_.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
         prepareRequest(request, uri_, HTTPRange { .begin = offset, .end = offset + n - 1});
 
-        LOG_TRACE(log, "Sending request to {} for range [{}, {})", uri_.toString(), offset, offset + n);
+        LOG_TRACE(log, "Sending {} to {} for range [{}, {})", method, uri_.toString(), offset, offset + n);
 
         auto sess = session->createDetachedSession(uri_);
 
@@ -629,7 +606,7 @@ size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::readBigAt(char * to, si
                     toString(response.getStatus()), uri_.toString(), offset, offset + n);
 
             bool cancelled;
-            size_t r = copyFromIStreamWithProgressCallback(*result_istr, to, n, progress_callback, &cancelled);
+            size_t result = copyFromIStreamWithProgressCallback(*result_istr, to, n, progress_callback, &cancelled);
 
             if (!cancelled)
             {
@@ -639,7 +616,7 @@ size_t ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::readBigAt(char * to, si
                 ProfileEvents::increment(ProfileEvents::ReadWriteBufferFromHTTPPreservedSessions);
             }
 
-            return r;
+            return result;
         }
         catch (const Poco::Exception & e)
         {
@@ -788,16 +765,22 @@ const std::string & ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getCompres
 template <typename UpdatableSessionPtr>
 std::optional<time_t> ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getLastModificationTime()
 {
-    return getFileInfo().last_modified;
+    return getFileInfo(/*use_cache*/ false).last_modified;
 }
 
 template <typename UpdatableSessionPtr>
-HTTPFileInfo ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getFileInfo()
+HTTPFileInfo ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getFileInfo(bool use_cache)
 {
+    if (use_cache && file_info)
+        return *file_info;
+
+    HTTPFileInfo res;
+
     Poco::Net::HTTPResponse response;
     try
     {
         getHeadResponse(response);
+        res = parseFileInfo(response, 0);
     }
     catch (HTTPException & e)
     {
@@ -809,11 +792,15 @@ HTTPFileInfo ReadWriteBufferFromHTTPBase<UpdatableSessionPtr>::getFileInfo()
         /// like a nightmare to debug.)
         if (e.getHTTPStatus() >= 400 && e.getHTTPStatus() <= 499 &&
             e.getHTTPStatus() != Poco::Net::HTTPResponse::HTTP_TOO_MANY_REQUESTS)
-            return HTTPFileInfo{};
-
-        throw;
+            res.exception = e;
+        else
+            throw;
     }
-    return parseFileInfo(response, 0);
+
+    if (use_cache)
+        file_info = res;
+
+    return res;
 }
 
 template <typename UpdatableSessionPtr>
@@ -909,9 +896,7 @@ ReadWriteBufferFromHTTP::ReadWriteBufferFromHTTP(
     const HTTPHeaderEntries & http_header_entries_,
     const RemoteHostFilter * remote_host_filter_,
     bool delay_initialization_,
-    bool use_external_buffer_,
-    bool skip_not_found_url_,
-    std::optional<HTTPFileInfo> file_info_)
+    bool use_external_buffer_)
     : detail::ReadWriteBufferFromHTTPBase<std::shared_ptr<SessionType>>(
         std::make_shared<SessionType>(uri_, max_redirects, std::make_shared<LocallyPooledSessionFactory>(timeouts_)),
         uri_,
@@ -923,9 +908,7 @@ ReadWriteBufferFromHTTP::ReadWriteBufferFromHTTP(
         http_header_entries_,
         remote_host_filter_,
         delay_initialization_,
-        use_external_buffer_,
-        skip_not_found_url_,
-        file_info_) {}
+        use_external_buffer_) {}
 
 
 PooledSessionFactory::PooledSessionFactory(

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -63,6 +63,9 @@ struct HTTPFileInfo
     std::optional<size_t> file_size;
     std::optional<time_t> last_modified;
     bool seekable = false;
+
+    /// If we got a non-retriable error, we cache that information and don't try HEAD requests again.
+    std::optional<HTTPException> exception;
 };
 
 
@@ -106,8 +109,6 @@ namespace detail
         /// In case of redirects, save result uri to use it if we retry the request.
         std::optional<Poco::URI> saved_uri_redirect;
 
-        bool http_skip_not_found_url;
-
         ReadSettings settings;
         Poco::Logger * log;
 
@@ -132,8 +133,6 @@ namespace detail
             RETRYABLE_ERROR,
             /// If error is not retriable, `exception` variable must be set.
             NON_RETRYABLE_ERROR,
-            /// Allows to skip not found urls for globs
-            SKIP_NOT_FOUND_URL,
             NONE,
         };
 
@@ -160,7 +159,6 @@ namespace detail
             const RemoteHostFilter * remote_host_filter_ = nullptr,
             bool delay_initialization = false,
             bool use_external_buffer_ = false,
-            bool http_skip_not_found_url_ = false,
             std::optional<HTTPFileInfo> file_info_ = std::nullopt);
 
         void callWithRedirects(Poco::Net::HTTPResponse & response, const String & method_, bool throw_on_all_errors = false, bool for_object_info = false);
@@ -169,8 +167,7 @@ namespace detail
 
         /**
          * Throws if error is retryable, otherwise sets initialization_error = NON_RETRYABLE_ERROR and
-         * saves exception into `exception` variable. In case url is not found and skip_not_found_url == true,
-         * sets initialization_error = SKIP_NOT_FOUND_URL, otherwise throws.
+         * saves exception into `exception` variable.
          */
         void initialize();
 
@@ -203,7 +200,7 @@ namespace detail
 
         std::optional<time_t> getLastModificationTime();
 
-        HTTPFileInfo getFileInfo();
+        HTTPFileInfo getFileInfo(bool use_cache = true);
 
         HTTPFileInfo parseFileInfo(const Poco::Net::HTTPResponse & response, size_t requested_range_begin);
     };
@@ -284,9 +281,7 @@ public:
         const HTTPHeaderEntries & http_header_entries_ = {},
         const RemoteHostFilter * remote_host_filter_ = nullptr,
         bool delay_initialization_ = true,
-        bool use_external_buffer_ = false,
-        bool skip_not_found_url_ = false,
-        std::optional<HTTPFileInfo> file_info_ = std::nullopt);
+        bool use_external_buffer_ = false);
 };
 
 

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -943,10 +943,12 @@ private:
                 Poco::JSON::Parser parser;
                 auto json_body = parser.parse(*response_body).extract<Poco::JSON::Object::Ptr>();
 
+                response_body->ignore(INT64_MAX);
                 /// Response was fully read.
                 markSessionForReuse(session);
 
                 auto schema = json_body->getValue<std::string>("schema");
+
                 LOG_TRACE((&Poco::Logger::get("AvroConfluentRowInputFormat")), "Successfully fetched schema id = {}\n{}", id, schema);
                 return avro::compileJsonSchemaFromString(schema);
             }

--- a/src/Storages/StorageURL.h
+++ b/src/Storages/StorageURL.h
@@ -194,8 +194,7 @@ public:
         const ConnectionTimeouts & timeouts,
         Poco::Net::HTTPBasicCredentials & credentials,
         const HTTPHeaderEntries & headers,
-        bool glob_url,
-        bool delay_initialization);
+        bool skip_if_not_found);
 
 private:
     using InitializeFunc = std::function<bool()>;

--- a/tests/integration/test_redirect_url_storage/test.py
+++ b/tests/integration/test_redirect_url_storage/test.py
@@ -2,6 +2,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 
 from helpers.network import PartitionManager
+import lz4.frame
 import threading
 import time
 
@@ -68,6 +69,47 @@ def test_url_with_globs_and_failover(started_cluster):
         "select * from url('http://hdfs1:50075/webhdfs/v1/simple_storage_{0|1|2|3}_{1..3}?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV', 'data String') as data order by data"
     )
     assert result == "1\n2\n3\n" or result == "4\n5\n6\n"
+
+
+def test_url_with_globs_skip_missing(started_cluster):
+    hdfs_api = started_cluster.hdfs_api
+
+    hdfs_api.write_data("/simple_storage_2", "10\n")
+
+    result = node1.query(
+        "select * from url('http://hdfs1:50075/webhdfs/v1/simple_storage_{1..2}?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV', 'data String') as data order by data"
+    )
+    assert result == "10\n"
+
+
+def test_url_with_globs_dont_skip_missing(started_cluster):
+    hdfs_api = started_cluster.hdfs_api
+
+    hdfs_api.write_data("/simple_storage_2", "10\n")
+
+    with pytest.raises(Exception):
+        result = node1.query(
+            "select * from url('http://hdfs1:50075/webhdfs/v1/simple_storage_{1..2}?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV', 'data String') as data order by data settings http_skip_not_found_url_for_globs = 0"
+        )
+        assert result == "10\n"
+
+
+def test_url_with_globs_skip_missing_all(started_cluster):
+    result = node1.query(
+        "select count(*) from url('http://hdfs1:50075/webhdfs/v1/does_not_exist_{3..4}?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV', 'data String')"
+    )
+    assert result == "0\n"
+
+
+def test_url_with_globs_skip_missing_compressed(started_cluster):
+    hdfs_api = started_cluster.hdfs_api
+
+    hdfs_api.write_data("/simple_storage_2.lz4", lz4.frame.compress(b"10\n"))
+
+    result = node1.query(
+        "select * from url('http://hdfs1:50075/webhdfs/v1/simple_storage_{1..2}.lz4?op=OPEN&namenoderpcaddress=hdfs1:9000&offset=0', 'TSV', 'data String', 'Lz4') as data order by data"
+    )
+    assert result == "10\n"
 
 
 def test_url_with_redirect_not_allowed(started_cluster):


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
 * Fix http_skip_not_found_url_for_globs not working for compressed files.

The behavior for skipping not-found URLs for globs was kind of inconsistent, in part broken by me in https://github.com/ClickHouse/ClickHouse/pull/47964

It skipped files by pretending that they're empty. This didn't work when the file is compressed - the decompression would error out trying to decompress an empty string.

Fixed by explicitly skipping the URL if the initial HTTP request failed, without pretending that the file is empty.