### PR TITLE
Fix writeAnyEscapedString if quote_character is a meta character

### DIFF
--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -316,6 +316,15 @@ void writeAnyEscapedString(const char * begin, const char * end, WriteBuffer & b
             pos = next_pos;
             switch (*pos)
             {
+                case quote_character:
+                {
+                    if constexpr (escape_quote_with_quote)
+                        writeChar(quote_character, buf);
+                    else
+                        writeChar('\\', buf);
+                    writeChar(quote_character, buf);
+                    break;
+                }
                 case '\b':
                     writeChar('\\', buf);
                     writeChar('b', buf);
@@ -344,15 +353,6 @@ void writeAnyEscapedString(const char * begin, const char * end, WriteBuffer & b
                     writeChar('\\', buf);
                     writeChar('\\', buf);
                     break;
-                case quote_character:
-                {
-                    if constexpr (escape_quote_with_quote)
-                        writeChar(quote_character, buf);
-                    else
-                        writeChar('\\', buf);
-                    writeChar(quote_character, buf);
-                    break;
-                }
                 default:
                     writeChar(*pos, buf);
             }


### PR DESCRIPTION
Function `writeAnyEscapedString()` should escape
- `quote_character` with itself or with a backslash, depending on template parameter `escape_quote_with_quote`
- some metacharacters with backslash.

If `quote_character` *is* a metacharacter (which is silly, admittedly), the code previously always quoted with backslash, independently of `escape_quote_with_quote`. I didn't find code doing this but better be on the safe side.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)