### PR TITLE
Add CMake option for BOOST_USE_UCONTEXT

### DIFF
--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -73,18 +73,6 @@
 #    endif
 #endif
 
-#if defined(ADDRESS_SANITIZER)
-#    define BOOST_USE_ASAN 1
-#    define BOOST_USE_UCONTEXT 1
-#endif
-
-#if defined(THREAD_SANITIZER)
-#    define BOOST_USE_TSAN 1
-#    define BOOST_USE_UCONTEXT 1
-#endif
-
-/// TODO: Strange enough, there is no way to detect UB sanitizer.
-
 /// Explicitly allow undefined behaviour for certain functions. Use it as a function attribute.
 /// It is useful in case when compiler cannot see (and exploit) it, but UBSan can.
 /// Example: multiplication of signed integers with possibility of overflow when both sides are from user input.

--- a/contrib/boost-cmake/CMakeLists.txt
+++ b/contrib/boost-cmake/CMakeLists.txt
@@ -92,6 +92,8 @@ add_library (boost::system ALIAS _boost_system)
 target_include_directories (_boost_system PRIVATE ${LIBRARY_DIR})
 
 # context
+option (BOOST_USE_UCONTEXT "Use ucontext_t for context switching of boost::fiber within boost::context" OFF)
+
 enable_language(ASM)
 SET(ASM_OPTIONS "-x assembler-with-cpp")
 
@@ -100,20 +102,6 @@ set (SRCS_CONTEXT
     "${LIBRARY_DIR}/libs/context/src/posix/stack_traits.cpp"
 )
 
-if (SANITIZE AND (SANITIZE STREQUAL "address" OR SANITIZE STREQUAL "thread"))
-    add_compile_definitions(BOOST_USE_UCONTEXT)
-
-    if (SANITIZE STREQUAL "address")
-        add_compile_definitions(BOOST_USE_ASAN)
-    elseif (SANITIZE STREQUAL "thread")
-        add_compile_definitions(BOOST_USE_TSAN)
-    endif()
-
-    set (SRCS_CONTEXT ${SRCS_CONTEXT}
-            "${LIBRARY_DIR}/libs/context/src/fiber.cpp"
-            "${LIBRARY_DIR}/libs/context/src/continuation.cpp"
-    )
-endif()
 if (ARCH_AARCH64)
     set (SRCS_CONTEXT ${SRCS_CONTEXT}
         "${LIBRARY_DIR}/libs/context/src/asm/jump_arm64_aapcs_elf_gas.S"
@@ -152,9 +140,26 @@ else()
     )
 endif()
 
+if (SANITIZE OR BOOST_USE_UCONTEXT)
+    list (APPEND SRCS_CONTEXT
+        "${LIBRARY_DIR}/libs/context/src/fiber.cpp"
+        "${LIBRARY_DIR}/libs/context/src/continuation.cpp"
+    )
+endif()
+
 add_library (_boost_context ${SRCS_CONTEXT})
 add_library (boost::context ALIAS _boost_context)
 target_include_directories (_boost_context PRIVATE ${LIBRARY_DIR})
+
+if (SANITIZE OR BOOST_USE_UCONTEXT)
+    target_compile_definitions(_boost_context PUBLIC BOOST_USE_UCONTEXT)
+endif()
+
+if (SANITIZE STREQUAL "address")
+    target_compile_definitions(_boost_context PUBLIC BOOST_USE_ASAN)
+elseif (SANITIZE STREQUAL "thread")
+    target_compile_definitions(_boost_context PUBLIC BOOST_USE_TSAN)
+endif()
 
 # coroutine
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -544,7 +544,8 @@ if (TARGET ch_contrib::qpl)
 dbms_target_link_libraries(PUBLIC ch_contrib::qpl)
 endif ()
 
-dbms_target_link_libraries(PRIVATE _boost_context)
+target_link_libraries(clickhouse_common_io PUBLIC boost::context)
+dbms_target_link_libraries(PUBLIC boost::context)
 
 if (ENABLE_NLP)
     dbms_target_link_libraries (PUBLIC ch_contrib::stemmer)


### PR DESCRIPTION
The changes introduce a CMake option for toggling the `BOOST_USE_UCONTEXT` compile definition ([reference](https://www.boost.org/doc/libs/1_82_0/libs/context/doc/html/context/ff/implementations__fcontext_t__ucontext_t_and_winfiber.html)) and clean up the way it's set.

The main motivation for doing this is to give users an option to use an alternative context switching mechanism in case the default one (`fcontext_t`) doesn't work properly.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)