### PR TITLE
Improve `JoinUsedFlags::reinit` in full/right join

### DIFF
--- a/src/Interpreters/HashJoin.cpp
+++ b/src/Interpreters/HashJoin.cpp
@@ -79,7 +79,13 @@ namespace JoinStuff
         {
             assert(flags[nullptr].size() <= size);
             need_flags = true;
-            flags[nullptr] = std::vector<std::atomic_bool>(size);
+            // For one disjunct clause case, we don't need to reinit each time we call addJoinedBlock.
+            // and there is no value inserted in this JoinUsedFlags before addJoinedBlock finish.
+            // So we reinit only when the hash table is rehashed to a larger size.
+            if (flags.empty() || flags[nullptr].size() < size) [[unlikely]]
+            {
+                flags[nullptr] = std::vector<std::atomic_bool>(size);
+            }
         }
     }
 

--- a/tests/performance/join_used_flags.xml
+++ b/tests/performance/join_used_flags.xml
@@ -1,0 +1,6 @@
+<test>
+    <create_query>CREATE TABLE test_join_used_flags (i64 Int64, i32 Int32) ENGINE = Memory</create_query>
+    <fill_query>INSERT INTO test_join_used_flags SELECT number AS i64, rand32() AS i32 FROM numbers(20000000)</fill_query>
+    <query>SELECT l.i64, r.i64, l.i32, r.i32 FROM test_join_used_flags l RIGHT JOIN test_join_used_flags r USING i64 format Null</query>
+    <drop_query>DROP TABLE IF EXISTS test_join_used_flags</drop_query>
+</test>


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Performance Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

* Improve the performance of `RIGHT/FULL JOIN` by up to 2 times in certain scenarios, especially when joining a small left table with a large right table.

### Details

We try to run right join on a big table(50000000 rows), and found that  the overhead of `JoinUsedFlags::reinit` is high
```
  52.70%  clickhouse          [.] DB::JoinStuff::JoinUsedFlags::reinit<(DB::JoinKind)2, (DB::JoinStrictness)3>
  18.33%  clickhouse          [.] DB::(anonymous namespace)::insertFromBlockImplTypeCase<(DB::JoinStrictness)3, DB::Colu
   2.55%  clickhouse          [.] DB::ColumnString::replicate
   2.14%  [kernel]            [k] clear_page_erms
   2.11%  [kernel]            [k] _raw_spin_lock
   1.32%  [kernel]            [k] rmqueue
   1.29%  [kernel]            [k] mem_cgroup_try_charge
   1.11%  [kernel]            [k] native_irq_return_iret
   1.04%  clickhouse          [.] memcpy
   1.04%  clickhouse          [.] DB::(anonymous namespace)::ModuloByConstantImpl<unsigned long, unsigned short>::vector
   0.91%  [kernel]            [k] try_charge
   0.76%  [kernel]            [k] sync_regs
   0.70%  clickhouse          [.] DB::ConvertImpl<DB::DataTypeNumber<long>, DB::DataTypeNumber<unsigned long>, DB::NameT
   0.66%  clickhouse          [.] DB::impl_::BinaryOperation<unsigned long, char8_t, DB::MinusImpl<unsigned long, char8_
   0.63%  [kernel]            [k] get_mem_cgroup_from_mm
   0.56%  clickhouse          [.] DB::ConvertImpl<DB::DataTypeNumber<unsigned int>, DB::DataTypeNumber<unsigned long>, D
   0.55%  [kernel]            [k] prep_new_page
   0.55%  clickhouse          [.] DB::ConvertImpl<DB::DataTypeNumber<unsigned short>, DB::DataTypeNumber<unsigned long>,
   0.35%  [kernel]            [k] mem_cgroup_throttle_swaprate
   0.32%  [kernel]            [k] __pagevec_lru_add_fn
   0.29%  [kernel]            [k] __handle_mm_fault
   0.23%  [kernel]            [k] handle_mm_fault
   0.22%  [kernel]            [k] do_anonymous_page
   0.21%  clickhouse          [.] DB::TargetSpecific::Default::RandImpl::execute
   0.21%  clickhouse          [.] DB::(anonymous namespace)::NumbersSource::generate
   0.19%  clickhouse          [.] DB::HashJoin::addJoinedBlock
   0.17%  [kernel]            [k] mem_cgroup_try_charge_delay
   0.15%  [kernel]            [k] __alloc_pages_nodemask
   0.15%  [kernel]            [k] do_user_addr_fault
   0.15%  [kernel]            [k] vsnprintf
   0.14%  clickhouse          [.] HashTable<unsigned long, HashMapCell<unsigned long, DB::RowRefList, HashCRC32<unsigned
   0.14%  clickhouse          [.] LZ4_compress_fast_extState
   0.13%  libc-2.31.so        [.] __memset_avx2_erms
   0.13%  [kernel]            [k] get_page_from_freelist
   0.13%  clickhouse          [.] DB::TargetSpecific::AVX2::RandImpl::execute
```
```
0 rows in set. Elapsed: 12.946 sec. Processed 100.00 million rows, 800.01 MB (7.72 million rows/s., 61.79 MB/s.)

```

At present, each time `addJoinedBlock` is called, `JoinUsedFlags::reinit` is called. There is no need for the case with one disjunct clause. So we reinit used flags only when the hash table's size becomes larger. With this improvement, we have the following result
```
  66.27%  clickhouse          [.] DB::(anonymous namespace)::joinRightColumns<(DB::JoinKind)2, (DB::JoinStrictness)3, DB
   5.23%  clickhouse          [.] DB::(anonymous namespace)::AddedColumns::appendFromBlock<false>
   4.92%  clickhouse          [.] DB::(anonymous namespace)::insertFromBlockImplTypeCase<(DB::JoinStrictness)3, DB::Colu
   1.91%  clickhouse          [.] DB::ColumnVector<unsigned long>::replicate
   1.34%  clickhouse          [.] std::__1::__hash_table<std::__1::__hash_value_type<DB::Block const*, std::__1::vector<
   1.08%  [kernel]            [k] clear_page_erms
   0.96%  clickhouse          [.] HashTable<unsigned long, HashMapCell<unsigned long, DB::RowRefList, HashCRC32<unsigned
   0.96%  clickhouse          [.] DB::ColumnVector<unsigned long>::insertFrom
   0.88%  clickhouse          [.] DB::ColumnString::replicate
   0.82%  [kernel]            [k] _raw_spin_lock
   0.80%  [kernel]            [k] native_irq_return_iret
   0.71%  clickhouse          [.] DB::JoinCommon::filterWithBlanks
   0.62%  [kernel]            [k] rmqueue
   0.58%  [kernel]            [k] mem_cgroup_try_charge
   0.51%  [kernel]            [k] sync_regs
   0.46%  [kernel]            [k] try_charge
   0.46%  [kernel]            [k] free_pcppages_bulk
   0.43%  clickhouse          [.] memcpy
   0.42%  [kernel]            [k] zap_pte_range.isra.0
   0.37%  clickhouse          [.] DB::(anonymous namespace)::ModuloByConstantImpl<unsigned long, unsigned short>::vector
   0.29%  [kernel]            [k] get_mem_cgroup_from_mm
   0.27%  clickhouse          [.] DB::ConvertImpl<DB::DataTypeNumber<long>, DB::DataTypeNumber<unsigned long>, DB::NameT
   0.25%  [kernel]            [k] __handle_mm_fault
   0.23%  clickhouse          [.] DB::impl_::BinaryOperation<unsigned long, char8_t, DB::MinusImpl<unsigned long, char8_
   0.23%  [kernel]            [k] release_pages
   0.23%  [kernel]            [k] prep_new_page
   0.21%  [kernel]            [k] mem_cgroup_throttle_swaprate
   0.21%  clickhouse          [.] DB::ConvertImpl<DB::DataTypeNumber<unsigned int>, DB::DataTypeNumber<unsigned long>, D
   0.21%  clickhouse          [.] DB::ConvertImpl<DB::DataTypeNumber<unsigned short>, DB::DataTypeNumber<unsigned long>,
   0.20%  [kernel]            [k] __default_send_IPI_dest_field
   0.19%  [kernel]            [k] flush_smp_call_function_queue
   0.19%  [kernel]            [k] page_remove_rmap
   0.18%  [kernel]            [k] llist_reverse_order
   0.16%  [kernel]            [k] handle_mm_fault
   0.16%  [kernel]            [k] __pagevec_lru_add_fn
```

```
   0 rows in set. Elapsed: 6.504 sec. Processed 100.00 million rows, 800.01 MB (15.38 million rows/s., 123.00 MB/s.)
```



<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
