### PR TITLE
Fix typo: "as much slots" -> "as many slots"

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -27,7 +27,6 @@
 #include <Common/ConcurrencyControl.h>
 #include <Common/Macros.h>
 #include <Common/ShellCommand.h>
-#include <Common/StringUtils/StringUtils.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/ZooKeeper/ZooKeeperNodeCache.h>
 #include <Common/getMultipleKeysFromConfig.h>
@@ -98,9 +97,7 @@
 #include "config_version.h"
 
 #if defined(OS_LINUX)
-#    include <cstddef>
 #    include <cstdlib>
-#    include <sys/socket.h>
 #    include <sys/un.h>
 #    include <sys/mman.h>
 #    include <sys/ptrace.h>
@@ -108,7 +105,6 @@
 #endif
 
 #if USE_SSL
-#    include <Poco/Net/Context.h>
 #    include <Poco/Net/SecureServerSocket.h>
 #endif
 

--- a/src/Common/ConcurrencyControl.cpp
+++ b/src/Common/ConcurrencyControl.cpp
@@ -1,0 +1,173 @@
+#include <Common/ConcurrencyControl.h>
+#include <Common/Exception.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+ConcurrencyControl::Slot::~Slot()
+{
+    allocation->release();
+}
+
+ConcurrencyControl::Slot::Slot(AllocationPtr && allocation_)
+    : allocation(std::move(allocation_))
+{
+}
+
+ConcurrencyControl::Allocation::~Allocation()
+{
+    // We have to lock parent's mutex to avoid race with grant()
+    // NOTE: shortcut can be added, but it requires Allocation::mutex lock even to check if shortcut is possible
+    parent.free(this);
+}
+
+[[nodiscard]] ConcurrencyControl::SlotPtr ConcurrencyControl::Allocation::tryAcquire()
+{
+    SlotCount value = granted.load();
+    while (value)
+    {
+        if (granted.compare_exchange_strong(value, value - 1))
+        {
+            std::unique_lock lock{mutex};
+            return SlotPtr(new Slot(shared_from_this())); // can't use std::make_shared due to private ctor
+        }
+    }
+    return {}; // avoid unnecessary locking
+}
+
+ConcurrencyControl::SlotCount ConcurrencyControl::Allocation::grantedCount() const
+{
+    return granted;
+}
+
+ConcurrencyControl::Allocation::Allocation(ConcurrencyControl & parent_, SlotCount limit_, SlotCount granted_, Waiters::iterator waiter_)
+    : parent(parent_)
+    , limit(limit_)
+    , allocated(granted_)
+    , granted(granted_)
+    , waiter(waiter_)
+{
+    if (allocated < limit)
+        *waiter = this;
+}
+
+// Grant single slot to allocation, returns true iff more slot(s) are required
+bool ConcurrencyControl::Allocation::grant()
+{
+    std::unique_lock lock{mutex};
+    granted++;
+    allocated++;
+    return allocated < limit;
+}
+
+// Release one slot and grant it to other allocation if required
+void ConcurrencyControl::Allocation::release()
+{
+    parent.release(1);
+    std::unique_lock lock{mutex};
+    released++;
+    if (released > allocated)
+        abort();
+}
+
+ConcurrencyControl::ConcurrencyControl()
+    : cur_waiter(waiters.end())
+{
+}
+
+ConcurrencyControl::~ConcurrencyControl()
+{
+    if (!waiters.empty())
+        abort();
+}
+
+[[nodiscard]] ConcurrencyControl::AllocationPtr ConcurrencyControl::allocate(SlotCount min, SlotCount max)
+{
+    if (min > max)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "ConcurrencyControl: invalid allocation requirements");
+
+    std::unique_lock lock{mutex};
+
+    // Acquire as many slots as we can, but not lower than `min`
+    SlotCount granted = std::max(min, std::min(max, available(lock)));
+    cur_concurrency += granted;
+
+    // Create allocation and start waiting if more slots are required
+    if (granted < max)
+        return AllocationPtr(new Allocation(*this, max, granted,
+            waiters.insert(cur_waiter, nullptr /* pointer is set by Allocation ctor */)));
+    else
+        return AllocationPtr(new Allocation(*this, max, granted));
+}
+
+void ConcurrencyControl::setMaxConcurrency(ConcurrencyControl::SlotCount value)
+{
+    std::unique_lock lock{mutex};
+    max_concurrency = std::max<SlotCount>(1, value); // never allow max_concurrency to be zero
+    schedule(lock);
+}
+
+ConcurrencyControl & ConcurrencyControl::instance()
+{
+    static ConcurrencyControl result;
+    return result;
+}
+
+void ConcurrencyControl::free(Allocation * allocation)
+{
+    // Allocation is allowed to be canceled even if there are:
+    //  - `amount`: granted slots (acquired slots are not possible, because Slot holds AllocationPtr)
+    //  - `waiter`: active waiting for more slots to be allocated
+    // Thus Allocation destruction may require the following lock, to avoid race conditions
+    std::unique_lock lock{mutex};
+    auto [amount, waiter] = allocation->cancel();
+
+    cur_concurrency -= amount;
+    if (waiter)
+    {
+        if (cur_waiter == *waiter)
+            cur_waiter = waiters.erase(*waiter);
+        else
+            waiters.erase(*waiter);
+    }
+    schedule(lock);
+}
+
+void ConcurrencyControl::release(SlotCount amount)
+{
+    std::unique_lock lock{mutex};
+    cur_concurrency -= amount;
+    schedule(lock);
+}
+
+// Round-robin scheduling of available slots among waiting allocations
+void ConcurrencyControl::schedule(std::unique_lock<std::mutex> &)
+{
+    while (cur_concurrency < max_concurrency && !waiters.empty())
+    {
+        cur_concurrency++;
+        if (cur_waiter == waiters.end())
+            cur_waiter = waiters.begin();
+        Allocation * allocation = *cur_waiter;
+        if (allocation->grant())
+            ++cur_waiter;
+        else
+            cur_waiter = waiters.erase(cur_waiter); // last required slot has just been granted -- stop waiting
+    }
+}
+
+ConcurrencyControl::SlotCount ConcurrencyControl::available(std::unique_lock<std::mutex> &) const
+{
+    if (cur_concurrency < max_concurrency)
+        return max_concurrency - cur_concurrency;
+    else
+        return 0;
+}
+
+}

--- a/src/Common/ConcurrencyControl.h
+++ b/src/Common/ConcurrencyControl.h
@@ -5,17 +5,10 @@
 #include <mutex>
 #include <memory>
 #include <list>
-#include <condition_variable>
 
-#include <Common/Exception.h>
 
 namespace DB
 {
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
-}
 
 /*
  * Controls how many threads can be allocated for a query (or another activity).
@@ -53,17 +46,12 @@ public:
     // Scoped guard for acquired slot, see Allocation::tryAcquire()
     struct Slot : boost::noncopyable
     {
-        ~Slot()
-        {
-            allocation->release();
-        }
+        ~Slot();
 
     private:
         friend struct Allocation; // for ctor
 
-        explicit Slot(AllocationPtr && allocation_)
-            : allocation(std::move(allocation_))
-        {}
+        explicit Slot(AllocationPtr && allocation_);
 
         AllocationPtr allocation;
     };
@@ -74,47 +62,18 @@ public:
     // Manages group of slots for a single query, see ConcurrencyControl::allocate(min, max)
     struct Allocation : std::enable_shared_from_this<Allocation>, boost::noncopyable
     {
-        ~Allocation()
-        {
-            // We have to lock parent's mutex to avoid race with grant()
-            // NOTE: shortcut can be added, but it requires Allocation::mutex lock even to check if shortcut is possible
-            parent.free(this);
-        }
+        ~Allocation();
 
         // Take one already granted slot if available. Lock-free iff there is no granted slot.
-        [[nodiscard]] SlotPtr tryAcquire()
-        {
-            SlotCount value = granted.load();
-            while (value)
-            {
-                if (granted.compare_exchange_strong(value, value - 1))
-                {
-                    std::unique_lock lock{mutex};
-                    return SlotPtr(new Slot(shared_from_this())); // can't use std::make_shared due to private ctor
-                }
-            }
-            return {}; // avoid unnecessary locking
-        }
+        [[nodiscard]] SlotPtr tryAcquire();
 
-        SlotCount grantedCount() const
-        {
-            return granted;
-        }
+        SlotCount grantedCount() const;
 
     private:
         friend struct Slot; // for release()
         friend class ConcurrencyControl; // for grant(), free() and ctor
 
-        Allocation(ConcurrencyControl & parent_, SlotCount limit_, SlotCount granted_, Waiters::iterator waiter_ = {})
-            : parent(parent_)
-            , limit(limit_)
-            , allocated(granted_)
-            , granted(granted_)
-            , waiter(waiter_)
-        {
-            if (allocated < limit)
-                *waiter = this;
-        }
+        Allocation(ConcurrencyControl & parent_, SlotCount limit_, SlotCount granted_, Waiters::iterator waiter_ = {});
 
         auto cancel()
         {
@@ -126,23 +85,10 @@ public:
         }
 
         // Grant single slot to allocation, returns true iff more slot(s) are required
-        bool grant()
-        {
-            std::unique_lock lock{mutex};
-            granted++;
-            allocated++;
-            return allocated < limit;
-        }
+        bool grant();
 
         // Release one slot and grant it to other allocation if required
-        void release()
-        {
-            parent.release(1);
-            std::unique_lock lock{mutex};
-            released++;
-            if (released > allocated)
-                abort();
-        }
+        void release();
 
         ConcurrencyControl & parent;
         const SlotCount limit;
@@ -157,106 +103,32 @@ public:
     };
 
 public:
-    ConcurrencyControl()
-        : cur_waiter(waiters.end())
-    {}
+    ConcurrencyControl();
 
     // WARNING: all Allocation objects MUST be destructed before ConcurrencyControl
     // NOTE: Recommended way to achieve this is to use `instance()` and do graceful shutdown of queries
-    ~ConcurrencyControl()
-    {
-        if (!waiters.empty())
-            abort();
-    }
+    ~ConcurrencyControl();
 
     // Allocate at least `min` and at most `max` slots.
     // If not all `max` slots were successfully allocated, a subscription for later allocation is created
     // Use `Allocation::tryAcquire()` to acquire allocated slot, before running a thread.
-    [[nodiscard]] AllocationPtr allocate(SlotCount min, SlotCount max)
-    {
-        if (min > max)
-            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "ConcurrencyControl: invalid allocation requirements");
+    [[nodiscard]] AllocationPtr allocate(SlotCount min, SlotCount max);
 
-        std::unique_lock lock{mutex};
+    void setMaxConcurrency(SlotCount value);
 
-        // Acquire as much slots as we can, but not lower than `min`
-        SlotCount granted = std::max(min, std::min(max, available(lock)));
-        cur_concurrency += granted;
-
-        // Create allocation and start waiting if more slots are required
-        if (granted < max)
-            return AllocationPtr(new Allocation(*this, max, granted,
-                waiters.insert(cur_waiter, nullptr /* pointer is set by Allocation ctor */)));
-        else
-            return AllocationPtr(new Allocation(*this, max, granted));
-    }
-
-    void setMaxConcurrency(SlotCount value)
-    {
-        std::unique_lock lock{mutex};
-        max_concurrency = std::max<SlotCount>(1, value); // never allow max_concurrency to be zero
-        schedule(lock);
-    }
-
-    static ConcurrencyControl & instance()
-    {
-        static ConcurrencyControl result;
-        return result;
-    }
+    static ConcurrencyControl & instance();
 
 private:
     friend struct Allocation; // for free() and release()
 
-    void free(Allocation * allocation)
-    {
-        // Allocation is allowed to be canceled even if there are:
-        //  - `amount`: granted slots (acquired slots are not possible, because Slot holds AllocationPtr)
-        //  - `waiter`: active waiting for more slots to be allocated
-        // Thus Allocation destruction may require the following lock, to avoid race conditions
-        std::unique_lock lock{mutex};
-        auto [amount, waiter] = allocation->cancel();
+    void free(Allocation * allocation);
 
-        cur_concurrency -= amount;
-        if (waiter)
-        {
-            if (cur_waiter == *waiter)
-                cur_waiter = waiters.erase(*waiter);
-            else
-                waiters.erase(*waiter);
-        }
-        schedule(lock);
-    }
-
-    void release(SlotCount amount)
-    {
-        std::unique_lock lock{mutex};
-        cur_concurrency -= amount;
-        schedule(lock);
-    }
+    void release(SlotCount amount);
 
     // Round-robin scheduling of available slots among waiting allocations
-    void schedule(std::unique_lock<std::mutex> &)
-    {
-        while (cur_concurrency < max_concurrency && !waiters.empty())
-        {
-            cur_concurrency++;
-            if (cur_waiter == waiters.end())
-                cur_waiter = waiters.begin();
-            Allocation * allocation = *cur_waiter;
-            if (allocation->grant())
-                ++cur_waiter;
-            else
-                cur_waiter = waiters.erase(cur_waiter); // last required slot has just been granted -- stop waiting
-        }
-    }
+    void schedule(std::unique_lock<std::mutex> &);
 
-    SlotCount available(std::unique_lock<std::mutex> &) const
-    {
-        if (cur_concurrency < max_concurrency)
-            return max_concurrency - cur_concurrency;
-        else
-            return 0;
-    }
+    SlotCount available(std::unique_lock<std::mutex> &) const;
 
     std::mutex mutex;
     Waiters waiters;
@@ -264,3 +136,5 @@ private:
     SlotCount max_concurrency = Unlimited;
     SlotCount cur_concurrency = 0;
 };
+
+}

--- a/src/Common/tests/gtest_concurrency_control.cpp
+++ b/src/Common/tests/gtest_concurrency_control.cpp
@@ -9,6 +9,8 @@
 #include <Common/ConcurrencyControl.h>
 #include <Common/randomSeed.h>
 
+using namespace DB;
+
 struct ConcurrencyControlTest
 {
     ConcurrencyControl cc;
@@ -276,9 +278,9 @@ TEST(ConcurrencyControl, MultipleThreads)
             queries.emplace_back([&, max_threads = max_threads_distribution(rng)]
             {
                 run_query(max_threads);
-                finished++;
+                ++finished;
             });
-            started++;
+            ++started;
         }
         sleepForMicroseconds(5); // wait some queries to finish
         t.cc.setMaxConcurrency(cfg_max_concurrency - started % 3); // emulate configuration updates


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
