### PR TITLE
CMake: Don't build utils unless explicitly requested

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory (config-processor)
 add_subdirectory (report)
 
 # Not used in package
-if (NOT DEFINED ENABLE_UTILS OR ENABLE_UTILS)
+if (ENABLE_UTILS)
     add_subdirectory (compressor)
     add_subdirectory (corrector_utf8)
     add_subdirectory (zookeeper-cli)


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Utilities are now only build if explicitly requested ("-DENABLE_UTILS=1") instead of by default, this reduces link times in typical development builds