### PR TITLE
Add trash

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -253,6 +253,9 @@
 [submodule "contrib/qpl"]
 	path = contrib/qpl
 	url = https://github.com/intel/qpl
+[submodule "contrib/idxd-config"]
+	path = contrib/idxd-config
+	url = https://github.com/intel/idxd-config
 [submodule "contrib/wyhash"]
 	path = contrib/wyhash
 	url = https://github.com/wangyi-fudan/wyhash


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#49423

Broke `cmake -S . -B build -DENABLE_AVX2=1 -DENABLE_QPL=1`, sorry. Contrib "idxd-config" is a build dependency since #45809. I am happy to discuss how to proceed with QPL in general but let's not rip out random parts of it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)