### PR TITLE
Remove commented code

### DIFF
--- a/src/Processors/Transforms/WindowTransform.cpp
+++ b/src/Processors/Transforms/WindowTransform.cpp
@@ -19,6 +19,30 @@
 #include <DataTypes/DataTypeDateTime64.h>
 
 
+/// See https://fmt.dev/latest/api.html#formatting-user-defined-types
+template <>
+struct fmt::formatter<DB::RowNumber>
+{
+    static constexpr auto parse(format_parse_context & ctx)
+    {
+        const auto * it = ctx.begin();
+        const auto * end = ctx.end();
+
+        /// Only support {}.
+        if (it != end && *it != '}')
+            throw fmt::format_error("Invalid format");
+
+        return it;
+    }
+
+    template <typename FormatContext>
+    auto format(const DB::RowNumber & x, FormatContext & ctx)
+    {
+        return fmt::format_to(ctx.out(), "{}:{}", x.block, x.row);
+    }
+};
+
+
 namespace DB
 {
 
@@ -34,7 +58,7 @@ namespace ErrorCodes
 // Interface for true window functions. It's not much of an interface, they just
 // accept the guts of WindowTransform and do 'something'. Given a small number of
 // true window functions, and the fact that the WindowTransform internals are
-// pretty much well defined in domain terms (e.g. frame boundaries), this is
+// pretty much well-defined in domain terms (e.g. frame boundaries), this is
 // somewhat acceptable.
 class IWindowFunction
 {
@@ -483,9 +507,9 @@ auto WindowTransform::moveRowNumberNoCheck(const RowNumber & _x, int64_t offset)
     return std::tuple<RowNumber, int64_t>{x, offset};
 }
 
-auto WindowTransform::moveRowNumber(const RowNumber & _x, int64_t offset) const
+auto WindowTransform::moveRowNumber(const RowNumber & row_number, int64_t offset) const
 {
-    auto [x, o] = moveRowNumberNoCheck(_x, offset);
+    auto [x, o] = moveRowNumberNoCheck(row_number, offset);
 
 #ifndef NDEBUG
     // Check that it was reversible.

--- a/src/Processors/Transforms/WindowTransform.h
+++ b/src/Processors/Transforms/WindowTransform.h
@@ -38,7 +38,7 @@ struct WindowFunctionWorkspace
 
     // Argument columns. Be careful, this is a per-block cache.
     std::vector<const IColumn *> argument_columns;
-    uint64_t cached_block_number = std::numeric_limits<uint64_t>::max();
+    UInt64 cached_block_number = std::numeric_limits<UInt64>::max();
 };
 
 struct WindowTransformBlock
@@ -52,8 +52,8 @@ struct WindowTransformBlock
 
 struct RowNumber
 {
-    uint64_t block = 0;
-    uint64_t row = 0;
+    UInt64 block = 0;
+    UInt64 row = 0;
 
     auto operator <=>(const RowNumber &) const = default;
 };
@@ -93,19 +93,16 @@ public:
 
     static Block transformHeader(Block header, const ExpressionActionsPtr & expression);
 
-    /*
-     * (former) Implementation of ISimpleTransform.
+    /* (former) Implementation of ISimpleTransform.
      */
     void appendChunk(Chunk & chunk) /*override*/;
 
-    /*
-     * Implementation of IProcessor;
+    /* Implementation of IProcessor;
      */
     Status prepare() override;
     void work() override;
 
-    /*
-     * Implementation details.
+    /* Implementation details.
      */
     void advancePartitionEnd();
 
@@ -136,14 +133,14 @@ public:
         return const_cast<WindowTransform *>(this)->inputAt(x);
     }
 
-    auto & blockAt(const uint64_t block_number)
+    auto & blockAt(const UInt64 block_number)
     {
         assert(block_number >= first_block_number);
         assert(block_number - first_block_number < blocks.size());
         return blocks[block_number - first_block_number];
     }
 
-    const auto & blockAt(const uint64_t block_number) const
+    const auto & blockAt(const UInt64 block_number) const
     {
         return const_cast<WindowTransform *>(this)->blockAt(block_number);
     }
@@ -227,8 +224,8 @@ public:
         return result;
     }
 
-    auto moveRowNumber(const RowNumber & row_number, int64_t offset) const;
-    auto moveRowNumberNoCheck(const RowNumber & row_number, int64_t offset) const;
+    auto moveRowNumber(const RowNumber & original_row_number, Int64 offset) const;
+    auto moveRowNumberNoCheck(const RowNumber & original_row_number, Int64 offset) const;
 
     void assertValid(const RowNumber & x) const
     {
@@ -284,9 +281,9 @@ public:
     // have an always-incrementing index. The index of the first block is in
     // `first_block_number`.
     std::deque<WindowTransformBlock> blocks;
-    uint64_t first_block_number = 0;
+    UInt64 first_block_number = 0;
     // The next block we are going to pass to the consumer.
-    uint64_t next_output_block_number = 0;
+    UInt64 next_output_block_number = 0;
     // The first row for which we still haven't calculated the window functions.
     // Used to determine which resulting blocks we can pass to the consumer.
     RowNumber first_not_ready_row;
@@ -310,9 +307,9 @@ public:
     RowNumber peer_group_start;
 
     // Row and group numbers in partition for calculating rank() and friends.
-    uint64_t current_row_number = 1;
-    uint64_t peer_group_start_row_number = 1;
-    uint64_t peer_group_number = 1;
+    UInt64 current_row_number = 1;
+    UInt64 peer_group_start_row_number = 1;
+    UInt64 peer_group_number = 1;
 
     // The frame is [frame_start, frame_end) if frame_ended && frame_started,
     // and unknown otherwise. Note that when we move to the next row, both the


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Leaving commented code is against our code style.
See https://s3.amazonaws.com/clickhouse-test-reports/0/983e37048c345fd331e71a1af037d9a282ffe860/fuzzer_astfuzzerdebug/report.html

PS. Also found nauseous stuff:
```
auto WindowTransform::moveRowNumber(const RowNumber & _x, int64_t offset) const
{
    auto [x, o] = moveRowNumberNoCheck(_x, offset);

#ifndef NDEBUG
    // Check that it was reversible.
    auto [xx, oo] = moveRowNumberNoCheck(x, -(offset - o));

    assert(xx == _x);
    assert(oo == 0);
#endif

    return std::tuple<RowNumber, int64_t>{x, o};
}
```

CC @akuzm