### PR TITLE
Do not launch workflows for PRs w/o "can be tested"

### DIFF
--- a/tests/ci/autoscale_runners_lambda/requirements.txt
+++ b/tests/ci/autoscale_runners_lambda/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests<2.30

--- a/tests/ci/cancel_and_rerun_workflow_lambda/requirements.txt
+++ b/tests/ci/cancel_and_rerun_workflow_lambda/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests<2.30
 PyJWT
-cryptography==37.0.4
+cryptography<38

--- a/tests/ci/ci_runners_metrics_lambda/requirements.txt
+++ b/tests/ci/ci_runners_metrics_lambda/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests<2.30
 PyJWT
-cryptography==37.0.4
+cryptography<38

--- a/tests/ci/runner_token_rotation_lambda/requirements.txt
+++ b/tests/ci/runner_token_rotation_lambda/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests<2.30
 PyJWT
-cryptography==37.0.4
+cryptography<38

--- a/tests/ci/team_keys_lambda/build_and_deploy_archive.sh
+++ b/tests/ci/team_keys_lambda/build_and_deploy_archive.sh
@@ -5,7 +5,7 @@ WORKDIR=$(dirname "$0")
 WORKDIR=$(readlink -f "${WORKDIR}")
 cd "$WORKDIR"
 
-PY_VERSION=3.9
+PY_VERSION=3.10
 PY_EXEC="python${PY_VERSION}"
 DOCKER_IMAGE="python:${PY_VERSION}-slim"
 LAMBDA_NAME=$(basename "$WORKDIR")

--- a/tests/ci/team_keys_lambda/requirements.txt
+++ b/tests/ci/team_keys_lambda/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests<2.30

--- a/tests/ci/terminate_runner_lambda/requirements.txt
+++ b/tests/ci/terminate_runner_lambda/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests<2.30
 PyJWT
-cryptography==37.0.4
+cryptography<38

--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -313,11 +313,12 @@ def check_suspicious_changed_files(changed_files):
                 )
                 return True
 
-    print("No changed files match suspicious patterns, run will be approved")
+    print("No changed files match suspicious patterns, run could be approved")
     return False
 
 
 def approve_run(workflow_description: WorkflowDescription, token: str) -> None:
+    print("Approving run")
     url = f"{workflow_description.api_url}/approve"
     _exec_post_with_retry(url, token)
 
@@ -478,6 +479,11 @@ def main(event):
     if is_trusted_contributor(author, author_orgs):
         print("Contributor is trusted, approving run")
         approve_run(workflow_description, token)
+        return
+
+    labels = {label["name"] for label in pull_request["labels"]}
+    if "can be tested" not in labels:
+        print("Label 'can be tested' is required for untrusted users")
         return
 
     changed_files = get_changed_files_for_pull_request(pull_request, token)

--- a/tests/ci/workflow_approve_rerun_lambda/app.py
+++ b/tests/ci/workflow_approve_rerun_lambda/app.py
@@ -12,12 +12,11 @@ import boto3  # type: ignore
 SUSPICIOUS_CHANGED_FILES_NUMBER = 200
 
 SUSPICIOUS_PATTERNS = [
-    "tests/ci/*",
-    "docs/tools/*",
     ".github/*",
-    "utils/release/*",
     "docker/*",
-    "release",
+    "docs/tools/*",
+    "packages/*",
+    "tests/ci/*",
 ]
 
 # Number of retries for API calls.

--- a/tests/ci/workflow_approve_rerun_lambda/requirements.txt
+++ b/tests/ci/workflow_approve_rerun_lambda/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests<2.30
 PyJWT
-cryptography==37.0.4
+cryptography<38

--- a/tests/ci/workflow_jobs_lambda/app.py
+++ b/tests/ci/workflow_jobs_lambda/app.py
@@ -251,14 +251,20 @@ def send_event_workflow_job(workflow_job: WorkflowJob) -> None:
         clickhouse_client.insert_event_into(**kwargs)
 
 
-def handler(event: dict, _: Any) -> dict:
+def handler(event: dict, context: Any) -> dict:
     if event["isBase64Encoded"]:
         event_data = json.loads(b64decode(event["body"]))
     else:
         event_data = json.loads(event["body"])
 
     repo = event_data["repository"]
-    wf_job = event_data["workflow_job"]
+    try:
+        wf_job = event_data["workflow_job"]
+    except KeyError:
+        logging.error("The event does not contain valid workflow_jobs data")
+        logging.error("The event data: %s", event)
+        logging.error("The context data: %s", context)
+
     workflow_job = WorkflowJob(
         wf_job["id"],
         wf_job["run_id"],

--- a/tests/ci/workflow_jobs_lambda/requirements.txt
+++ b/tests/ci/workflow_jobs_lambda/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests<2.30


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Our CI used to approve runs w/o `can be tested` label. It's fixed here